### PR TITLE
Der Assistent schlägt Zusammenlegungen vor (v7.236.0)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -109,6 +109,15 @@ config :vutuv, :moderate_images, true
 config :vutuv, :ollama_url, "http://localhost:11434"
 config :vutuv, :ollama_vision_model, "qwen3-vl:8b"
 
+# The assisted tag pass (Vutuv.Tags.Assistant, issue #1338): an admin-triggered
+# batch that proposes which tags name one topic. It never merges anything — a
+# human approves each proposal on /admin/tag_merges — and the candidate pairs
+# are generated deterministically, so with this off (or Ollama unreachable) the
+# queue still fills and is administered by hand. That is the air-gapped case.
+# Runtime overrides: TAG_MERGE_ASSIST, TAG_MERGE_ASSIST_MODEL.
+config :vutuv, :tag_merge_assist, true
+config :vutuv, :tag_merge_assist_model, "qwen3.5:9b"
+
 # Arbeitszeugnis analysis (Vutuv.References.Checks): a member may have an
 # uploaded employment reference reviewed by a text model against an open
 # skill. Shares :ollama_url with the image moderation above.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -364,6 +364,16 @@ if config_env() == :prod do
     config :vutuv, :ollama_url, ollama_url
   end
 
+  # TAG_MERGE_ASSIST=false leaves the tag merge queue to be filled by the
+  # deterministic rules alone and judged by a human (issue #1338).
+  if System.get_env("TAG_MERGE_ASSIST") == "false" do
+    config :vutuv, :tag_merge_assist, false
+  end
+
+  if model = System.get_env("TAG_MERGE_ASSIST_MODEL") do
+    config :vutuv, :tag_merge_assist_model, model
+  end
+
   if ollama_model = System.get_env("OLLAMA_VISION_MODEL") do
     config :vutuv, :ollama_vision_model, ollama_model
   end

--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -160,6 +160,8 @@ Everything else has a default (the vutuv.de production value):
 | `OLLAMA_VISION_MODEL` | `qwen3-vl:8b` | The vision model used for the safety verdict. Pull it once (`ollama pull qwen3-vl:8b`); any Ollama vision model works (`qwen3-vl:4b` halves the load on CPU-only servers) |
 | `IMAGE_SCAN_VOTES` | `3` | How many opinions the vision model gives on an image it called **unsafe**. The first answer is deterministic and decides alone when it says "safe" (so an ordinary upload costs one inference); a suspicion buys this many opinions in total, sampled so they are genuinely independent. Raising it makes borderline cases slower but steadier |
 | `IMAGE_SCAN_REJECT_VOTES` | `3` | How many of those opinions must call the image unsafe before it is really deleted. The default is unanimous out of three: a model's answer on a harmless-but-dramatic picture (a cartoon skull, a horror-film still, a joke image) flips between runs, and deleting a member's picture on a coin flip is the worse error — a released image is still reportable by every reader. Set both vote variables to `1` for the old "one answer decides" behaviour, or lower this to `2` for a stricter installation |
+| `TAG_MERGE_ASSIST` | `true` | Whether the tag merge screen (`/admin/tag_merges`) may ask a local model which of its proposed tag pairs name one topic. It only ever **proposes**: an admin approves each merge and sees what it would move first. With this `false` (or Ollama unreachable) the queue still fills from the deterministic rules and is administered by hand, which is the air-gapped case. The one thing it costs: a pair found only because the two names share a word (`Linux` / `embedded linux`) is left out unless a model has vouched for it, since unjudged it is nearly always wrong |
+| `TAG_MERGE_ASSIST_MODEL` | `qwen3.5:9b` | The text model that judges those pairs. Pull it once (`ollama pull qwen3.5:9b`); it is asked one narrow question per pair and told to answer "different topics" whenever unsure |
 | `DEFAULT_COUNTRY` | `DE` | ISO 3166-1 alpha-2 code that preselects country inputs (job postings, organization pages, employment references) |
 | `REFERENCE_CHECKS_ENABLED` | `true` | Whether members may have an uploaded Arbeitszeugnis reviewed by a text model. Off = they can still upload, attach and publish references; only the review disappears |
 | `REFERENCE_CHECK_MODEL` | `qwen3.6:27b` | The text model that performs the review. Pull it once (`ollama pull qwen3.6:27b`). A smaller model fits the prompt but grades German wording measurably worse |
@@ -353,6 +355,11 @@ vutuv runs fine without internet access:
   while you still have internet access (`ollama pull qwen3-vl:8b`), and keep
   `IMAGE_MODERATION_ENABLED=true`. Only an installation without Ollama should
   set it to `false` (images then publish unmoderated, as before the feature).
+- The tag merge assistant works offline for the same reason (local inference),
+  so `TAG_MERGE_ASSIST=true` is fine with Ollama installed. Without Ollama, set
+  it to `false`: the merge screen still proposes the pairs its deterministic
+  rules find and an admin decides them by hand, which is the whole feature minus
+  the second opinion.
 - The map links on profile addresses (Google/OSM/Apple) are plain link-outs
   rendered in the visitor's browser; they simply won't resolve offline.
 - Job postings need no configuration to work offline: their zip → coordinate

--- a/docs/architecture/social-graph.md
+++ b/docs/architecture/social-graph.md
@@ -181,6 +181,55 @@ Typos are deliberately out of scope. There is no `misspelling` kind: a typo is
 unbounded, a near-miss pair is exactly where a wrong merge does the most damage,
 and catching one buys almost nothing.
 
+### The assisted pass (`Vutuv.Tags.Assistant`)
+
+An admin-triggered batch that **proposes** merges and never applies one. Three
+deterministic rules over the tag *names* generate the candidates, and only then
+does a local model judge them:
+
+| rule | finds | measured on the real catalog |
+|---|---|---|
+| `same_key` | the names agree once case and separators are folded away (`javascript` / `java script`) | 318 pairs |
+| `acronym` | a multi-word name's initials are another tag's whole name (`ROR` / `Ruby on Rails`) | 496 pairs |
+| `token` | a short name is one whole word of a longer one (`rails` / `Ruby on Rails`) | 4,182 pairs |
+
+Those figures are why the code is shaped the way it is, and they came from
+running the generators against a copy of production rather than from reading
+them. `token` is four fifths of everything found and almost none of it is a
+merge: `Linux` shares a word with `embedded linux`, `arch linux`, `linux kernel`
+and twenty more, all of which are specializations, not spellings. So two things
+follow. A `token` pair is written **only** when the model has vouched for it —
+unjudged it is a chore, not a proposal. And the queue is ranked by **rule
+first**, size second: ordering by members affected alone (what the issue asked
+for) puts every one of those `Linux` rows above the obvious `javascript` /
+`java script`, because the biggest tag is exactly the one every specialization
+shares a word with.
+
+There is deliberately **no edit distance and no trigram similarity**, although
+`pg_trgm` is installed: both are typo catchers, and typos are out of scope.
+
+The cap (500 by default) is what one pass may **add**; pairs already waiting do
+not spend it, so scanning again reaches further down the list instead of
+re-offering the same top rows. What was dropped is reported and logged, never
+silently trimmed.
+
+The refusals from the merge apply to the proposal too, so the queue can never
+offer something that would be refused on approval — but they are applied in
+bulk, one query and a string comparison, **not** by calling `Merge.preview/2`
+per pair: the preview counts rows in seven tables and the catalog generates
+about 5,000 pairs. The preview belongs on the review screen, asked once about
+the pair an admin is actually looking at.
+
+The model (`:tag_merge_assist`, `Vutuv.Ollama`, structured output) is asked one
+narrow question per pair and told to answer "different topics" whenever unsure,
+because the two errors do not cost the same: a missed duplicate stays a
+duplicate, a wrong merge moves other people's rows. It is the guard for cases no
+rule can settle — the catalog offers `seo` / `search engine optimization` (a
+merge) beside `seo` / `search experience optimization` (not one). With the flag
+off or Ollama unreachable, the queue fills unjudged and a human decides.
+Approving a proposal does not merge it: it loads the pair into the pickers
+above, where the preview shows what would move.
+
 ## Blocking
 
 Reachable wherever you decide to block someone — a quiet "Block" next to the

--- a/lib/vutuv/tags/assistant.ex
+++ b/lib/vutuv/tags/assistant.ex
@@ -1,0 +1,424 @@
+defmodule Vutuv.Tags.Assistant do
+  @moduledoc """
+  The assisted pass over the tag catalog (issue #1338): propose consolidations
+  for a human to approve, never apply one.
+
+  Four rules decide whether this is useful or destructive, and they are the
+  reason the module is shaped the way it is.
+
+  **1. Candidates are generated cheaply and deterministically, not by a model.**
+  Three rules over the *names*, each cheap enough to run over the whole catalog
+  in one query plus a fold:
+
+    * `same_key` — the names agree once case and separators are folded away, so
+      `rubyonrails` meets `Ruby on Rails` and `OpenSource` meets `open source`.
+    * `acronym` — a multi-word name's initials are another tag's whole name, so
+      `ROR` meets `Ruby on Rails` and `CRM` meets `Customer Relationship
+      Management`.
+    * `token` — a short name is one whole word of a longer one, so `rails` meets
+      `Ruby on Rails`. This is the noisy rule and the reason a judge exists: it
+      also produces `Ruby` / `Ruby on Rails`, which must never be merged.
+
+  There is deliberately **no edit distance and no trigram similarity**, although
+  `pg_trgm` is installed and would be the obvious reach. Both are typo catchers,
+  typos are out of scope for this issue, and a near-miss pair is exactly where a
+  wrong merge does the most damage.
+
+  **2. It proposes, it never applies.** The output is a `Vutuv.Tags.MergeCandidate`
+  row with a suggested canonical, a kind and a one-line reason. A human approves
+  it on `/admin/tag_merges`.
+
+  **3. The dangerous cases are excluded by rule, not by prompt.** Before a pair
+  can reach the model it must survive `Vutuv.Tags.Merge.preview/2`'s own refusals
+  — an honor tag, an alternative name, a pair already called distinct, and above
+  all a pair whose names differ only in characters the slugifier deletes, which
+  is the `c` / `c++` / `c#` / `µc` bucket from #1337. Asking a model to be
+  careful about those is not a guardrail.
+
+  **4. It runs through the existing local-model seam** (`Vutuv.Ollama`, shared
+  with image moderation and the Arbeitszeugnis analysis) as an admin-triggered
+  batch, never a runtime path, and it is gated by `:tag_merge_assist`. With the
+  flag off, or Ollama unreachable, `scan/1` still fills the queue and a human
+  administers it by hand — which is what an air-gapped installation does.
+  """
+
+  require Logger
+
+  import Ecto.Query
+
+  alias Vutuv.Repo
+  alias Vutuv.Tags.Merge
+  alias Vutuv.Tags.MergeCandidate
+  alias Vutuv.Tags.Tag
+  alias Vutuv.Tags.TagDistinction
+  alias Vutuv.Tags.UserTag
+
+  # A name shorter than this is not a word anyone shares a topic under, and as a
+  # `token` candidate it would pair half the catalog with the other half.
+  @min_token_length 3
+
+  # How many proposals one scan may leave behind. The queue is meant to be read,
+  # and what is dropped is logged rather than silently trimmed.
+  @default_cap 500
+
+  @req_options_key :tag_merge_assist_req_options
+
+  @doc """
+  Runs the pass: generate candidates, judge as many as the model will, and write
+  the queue. Returns `%{generated:, refused:, judged:, written:, dropped:}`.
+
+  `opts` takes `:cap` (how many proposals to keep, default #{@default_cap}) and
+  `:judge` (false to skip the model entirely, which is also what a disabled
+  `:tag_merge_assist` or an unreachable Ollama amounts to).
+  """
+  def scan(opts \\ []) do
+    cap = Keyword.get(opts, :cap, @default_cap)
+    tags = catalog()
+    pairs = generate(tags)
+
+    allowed = refuse(pairs)
+    refused = length(pairs) - length(allowed)
+
+    # Pairs already waiting are not re-proposed, and above all they do not spend
+    # this run's budget: the cap is what one pass may ADD. Otherwise the queue
+    # would fill with the same top 500 every time and the long tail — which is
+    # where the `token` rule lives — could never be reached at all.
+    queued = queued_pairs()
+
+    fresh =
+      Enum.reject(allowed, fn {a, b, _generator} ->
+        MapSet.member?(queued, MergeCandidate.ordered(a.id, b.id))
+      end)
+
+    ranked = rank(fresh, member_counts())
+    kept = Enum.take(ranked, cap)
+    dropped = length(ranked) - length(kept)
+
+    if dropped > 0 do
+      Logger.info(
+        "tag merge assistant: #{dropped} candidate pairs past the cap of #{cap} were not written"
+      )
+    end
+
+    judge? = Keyword.get(opts, :judge, enabled?())
+    results = kept |> Enum.map(&write(&1, judge?)) |> Enum.reject(&is_nil/1)
+
+    %{
+      generated: length(pairs),
+      refused: refused,
+      written: Enum.count(results, &match?({:ok, _}, &1)),
+      judged: Enum.count(results, fn r -> match?({:ok, %{judged_at: %{}}}, r) end),
+      dropped: dropped
+    }
+  end
+
+  @doc "Whether the model half of the pass is switched on for this installation."
+  def enabled?, do: Application.get_env(:vutuv, :tag_merge_assist, true)
+
+  @doc """
+  The queue, most members affected first — the consequential merges get looked
+  at before the trivia.
+  """
+  def queue(limit \\ 100) do
+    Repo.all(
+      from(c in MergeCandidate,
+        order_by: [desc: c.members_affected, asc: c.id],
+        limit: ^limit,
+        preload: [:tag_a, :tag_b, :suggested_canonical]
+      )
+    )
+  end
+
+  @doc "How many proposals are waiting."
+  def queue_size, do: Repo.aggregate(MergeCandidate, :count)
+
+  @doc "One proposal, with its tags loaded."
+  def get_candidate(id) do
+    Vutuv.UUIDv7.with_cast(id, fn uuid ->
+      Repo.one(
+        from(c in MergeCandidate,
+          where: c.id == ^uuid,
+          preload: [:tag_a, :tag_b, :suggested_canonical]
+        )
+      )
+    end)
+  end
+
+  @doc """
+  Takes a proposal off the queue. The decision itself (a merge, a distinction)
+  is the caller's; this only clears the row so it is not proposed again.
+  """
+  def drop(%MergeCandidate{} = candidate), do: Repo.delete(candidate)
+
+  @doc """
+  Takes this pair off the queue however it was decided — merged by hand, called
+  distinct by hand — so a decided pair is never proposed a second time.
+  """
+  def drop_pair(%Tag{} = a, %Tag{} = b) do
+    {tag_a_id, tag_b_id} = MergeCandidate.ordered(a.id, b.id)
+
+    Repo.delete_all(
+      from(c in MergeCandidate, where: c.tag_a_id == ^tag_a_id and c.tag_b_id == ^tag_b_id)
+    )
+  end
+
+  @doc "Empties the queue without deciding anything."
+  def clear, do: Repo.delete_all(MergeCandidate)
+
+  # --- generating -----------------------------------------------------------
+
+  # Every tag that can take part: a real topic, not an honor badge.
+  defp catalog do
+    Repo.all(from(t in Tag.not_merged(), where: not t.honor?, select: %{id: t.id, name: t.name}))
+  end
+
+  @doc """
+  The candidate pairs the three rules find in `tags` (a list of `%{id:, name:}`).
+
+  Public because it is the part worth testing on its own: given a catalog, these
+  pairs and no others.
+  """
+  def generate(tags) do
+    by_key = Enum.group_by(tags, &fold(&1.name))
+
+    [same_key(by_key), acronyms(tags, by_key), tokens(tags, by_key)]
+    |> Enum.concat()
+    |> Enum.uniq_by(fn {a, b, _} -> Enum.sort([a.id, b.id]) end)
+  end
+
+  # Two spellings that fold to the same thing.
+  defp same_key(by_key) do
+    for {_key, [_, _ | _] = group} <- by_key,
+        [a, b] <- pairs(group),
+        do: {a, b, "same_key"}
+  end
+
+  # A multi-word name's initials as somebody else's whole name.
+  defp acronyms(tags, by_key) do
+    for tag <- tags,
+        words = words(tag.name),
+        length(words) > 1,
+        initials = Enum.map_join(words, &String.first/1),
+        String.length(initials) > 1,
+        other <- Map.get(by_key, fold(initials), []),
+        other.id != tag.id,
+        do: {tag, other, "acronym"}
+  end
+
+  # A short name that is one whole word of a longer one. The rule that needs a
+  # judge: `rails` belongs to `Ruby on Rails`, `Ruby` does not.
+  defp tokens(tags, by_key) do
+    for tag <- tags,
+        words = words(tag.name),
+        length(words) > 1,
+        word <- words,
+        String.length(word) >= @min_token_length,
+        other <- Map.get(by_key, fold(word), []),
+        other.id != tag.id,
+        do: {tag, other, "token"}
+  end
+
+  # Every unordered pair in a group, each once. The drop walks the **sorted**
+  # list, not the original: dropping from the unsorted one pairs a tag with
+  # itself as soon as the two orders differ.
+  defp pairs(group) do
+    sorted = Enum.sort_by(group, & &1.id)
+
+    sorted
+    |> Enum.with_index()
+    |> Enum.flat_map(fn {a, i} -> sorted |> Enum.drop(i + 1) |> Enum.map(&[a, &1]) end)
+  end
+
+  defp words(name), do: name |> String.split(~r/[\s_-]+/u, trim: true)
+
+  # Case and separators folded away; punctuation deliberately kept, so `c` and
+  # `c++` never share a key and the bucket from #1337 is not even generated.
+  defp fold(name), do: name |> String.downcase() |> String.replace(~r/[\s_-]+/u, "")
+
+  # --- refusing -------------------------------------------------------------
+
+  # A proposal must be something a merge would actually accept, so the queue can
+  # never offer a pair that is refused on approval. Two of `Vutuv.Tags.Merge`'s
+  # four refusals are already spent by the catalog query (an honor tag and an
+  # alternative name are not in it); the other two are applied here in bulk.
+  #
+  # In bulk, and deliberately **not** by calling `Merge.preview/2` per pair: the
+  # preview counts rows in seven tables, and the real catalog generates about
+  # 5,000 pairs, which would be some 75,000 queries to answer a question that
+  # needs one query and a string comparison. The preview belongs on the review
+  # screen, where it is asked once about the pair an admin is looking at.
+  defp refuse(pairs) do
+    distinct =
+      Repo.all(from(d in TagDistinction, select: {d.tag_a_id, d.tag_b_id})) |> MapSet.new()
+
+    Enum.reject(pairs, fn {a, b, _generator} ->
+      MapSet.member?(distinct, TagDistinction.ordered(a.id, b.id)) or
+        Merge.punctuation_only_difference?(a.name, b.name)
+    end)
+  end
+
+  # The pairs already waiting, read once per run.
+  defp queued_pairs do
+    Repo.all(from(c in MergeCandidate, select: {c.tag_a_id, c.tag_b_id})) |> MapSet.new()
+  end
+
+  # --- ranking --------------------------------------------------------------
+
+  # How many profiles a merge would touch, in one query for the whole catalog.
+  defp member_counts do
+    Repo.all(from(ut in UserTag, group_by: ut.tag_id, select: {ut.tag_id, count(ut.id)}))
+    |> Map.new()
+  end
+
+  # Rule first, then how many members the merge would touch.
+  #
+  # Members alone is the ordering the issue asks for, and measured against the
+  # real catalog it puts the **worst** proposals on top: the biggest tags are
+  # the ones every specialization shares a word with, so `Linux` arrives with
+  # twenty rows like `embedded linux` and `arch linux`, none of them a merge,
+  # and the reviewer meets them before the obvious `javascript` / `java script`.
+  # So the rule that found a pair ranks above its size: two spellings of one
+  # string first, then initials, then the merely-shares-a-word bucket.
+  @rule_order %{"same_key" => 0, "acronym" => 1, "token" => 2}
+
+  defp rank(pairs, counts) do
+    pairs
+    |> Enum.map(fn {a, b, generator} ->
+      members = Map.get(counts, a.id, 0) + Map.get(counts, b.id, 0)
+      {a, b, generator, members}
+    end)
+    |> Enum.sort_by(fn {_, _, generator, members} ->
+      {Map.get(@rule_order, generator, 9), -members}
+    end)
+  end
+
+  # --- writing + judging ----------------------------------------------------
+
+  defp write({a, b, generator, members}, judge?) do
+    {tag_a_id, tag_b_id} = MergeCandidate.ordered(a.id, b.id)
+    verdict = if judge?, do: judge(a, b, generator), else: nil
+
+    # A `token` pair only reaches the queue when the model has said it is one
+    # topic. That rule pairs `Linux` with every specialization somebody named
+    # after it, and an unjudged row of that kind is not a proposal, it is a
+    # chore — measured on the real catalog it is four fifths of everything the
+    # generators find. The other two rules stand on their own: two spellings of
+    # one string are worth a human's glance with or without a verdict.
+    if generator == "token" and is_nil(verdict) do
+      nil
+    else
+      attrs =
+        %{
+          tag_a_id: tag_a_id,
+          tag_b_id: tag_b_id,
+          generator: generator,
+          members_affected: members
+        }
+        |> Map.merge(verdict || %{})
+
+      %MergeCandidate{}
+      |> MergeCandidate.changeset(attrs)
+      |> Repo.insert(
+        on_conflict: {:replace, [:generator, :members_affected, :updated_at]},
+        conflict_target: [:tag_a_id, :tag_b_id]
+      )
+    end
+  end
+
+  @doc """
+  Asks the local model whether two names are one topic, and which should survive.
+
+  Answers a map of changeset attributes, or `nil` when the model is off,
+  unreachable or says these are different topics — in which case the pair stays
+  in the queue unjudged rather than being decided by silence.
+  """
+  def judge(a, b, generator) do
+    with true <- enabled?(),
+         {:ok, %{"message" => %{"content" => content}}} <- ask(a, b, generator),
+         {:ok, verdict} <- Jason.decode(content),
+         true <- verdict["same_topic"] == true do
+      canonical = if verdict["canonical"] == "b", do: b, else: a
+
+      %{
+        suggested_canonical_id: canonical.id,
+        kind: kind(verdict["kind"]),
+        reason: verdict["reason"] && String.slice(to_string(verdict["reason"]), 0, 1_000),
+        judged_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+      }
+    else
+      _ -> nil
+    end
+  end
+
+  defp kind(kind) when kind in ["alias", "abbreviation", "former"], do: kind
+  defp kind(_), do: "alias"
+
+  defp ask(a, b, generator) do
+    Vutuv.Ollama.post(
+      "/api/chat",
+      %{
+        model: model(),
+        stream: false,
+        think: false,
+        format: schema(),
+        options: %{temperature: 0},
+        messages: [
+          %{role: "system", content: system_prompt()},
+          %{
+            role: "user",
+            content: """
+            Tag A: #{a.name}
+            Tag B: #{b.name}
+            Found by rule: #{generator}
+            """
+          }
+        ]
+      },
+      timeout: timeout(),
+      req_options_key: @req_options_key
+    )
+  end
+
+  # The model is asked one narrow question and told to refuse when unsure,
+  # because the cost of the two answers is not the same: a missed duplicate
+  # stays a duplicate, a wrong merge moves other people's rows.
+  defp system_prompt do
+    """
+    You decide whether two tag names on a professional network name the SAME topic.
+
+    Say they are the same only when a reader would expect one page for both, like
+    "Ruby on Rails" and "rails", or "Customer Relationship Management" and "CRM".
+
+    Say they are DIFFERENT whenever one is broader than the other or they are
+    merely related: "Ruby" (the language) and "Ruby on Rails" (the framework) are
+    different, so are "Java" and "JavaScript", "Design" and "Interior Design".
+
+    If you are not sure, answer that they are different.
+
+    When they are the same, canonical is the name most people would search for:
+    the established full spelling rather than an abbreviation or a run-together
+    form. kind describes the OTHER name: "abbreviation" for a short form,
+    otherwise "alias". Give one short sentence as the reason, in English.
+    """
+  end
+
+  # Ollama structured output: the model may only answer this shape.
+  defp schema do
+    %{
+      type: "object",
+      properties: %{
+        same_topic: %{type: "boolean"},
+        canonical: %{type: "string", enum: ["a", "b"]},
+        kind: %{type: "string", enum: ["alias", "abbreviation"]},
+        reason: %{type: "string"}
+      },
+      required: ["same_topic", "canonical", "kind", "reason"]
+    }
+  end
+
+  defp model do
+    Application.get_env(:vutuv, :tag_merge_assist_model, "qwen3.5:9b")
+  end
+
+  defp timeout, do: Application.get_env(:vutuv, :tag_merge_assist_timeout, 60_000)
+end

--- a/lib/vutuv/tags/merge_candidate.ex
+++ b/lib/vutuv/tags/merge_candidate.ex
@@ -1,0 +1,54 @@
+defmodule Vutuv.Tags.MergeCandidate do
+  @moduledoc """
+  A pair of tags that might be one topic, waiting for a human (issue #1338).
+
+  Written by `Vutuv.Tags.Assistant` and emptied by a decision on
+  `/admin/tag_merges`: approving leaves a `Vutuv.Tags.TagMerge` behind, rejecting
+  a `Vutuv.Tags.TagDistinction`, and either way the pair is never proposed again.
+
+  `suggested_canonical_id`, `kind` and `reason` are the local model's proposal
+  and stay `nil` until it has judged the pair — the queue is usable without one.
+  """
+
+  use VutuvWeb, :model
+
+  alias Vutuv.Tags.Tag
+  alias Vutuv.Tags.TagDistinction
+
+  @kinds Tag.alias_kinds()
+
+  schema "tag_merge_candidates" do
+    belongs_to(:tag_a, Tag)
+    belongs_to(:tag_b, Tag)
+    belongs_to(:suggested_canonical, Tag)
+
+    field(:kind, :string)
+    field(:reason, :string)
+    field(:judged_at, :naive_datetime)
+    field(:generator, :string)
+    field(:members_affected, :integer, default: 0)
+
+    timestamps()
+  end
+
+  def changeset(candidate, attrs) do
+    candidate
+    |> cast(attrs, [
+      :tag_a_id,
+      :tag_b_id,
+      :suggested_canonical_id,
+      :kind,
+      :reason,
+      :judged_at,
+      :generator,
+      :members_affected
+    ])
+    |> validate_required([:tag_a_id, :tag_b_id, :generator])
+    |> validate_inclusion(:kind, @kinds)
+    |> validate_length(:reason, max: 1_000)
+    |> unique_constraint([:tag_a_id, :tag_b_id])
+  end
+
+  @doc "The pair in stored order, so one pair is one row (see `TagDistinction`)."
+  defdelegate ordered(a, b), to: TagDistinction
+end

--- a/lib/vutuv_web/live/admin/tag_merge_live.ex
+++ b/lib/vutuv_web/live/admin/tag_merge_live.ex
@@ -27,6 +27,7 @@ defmodule VutuvWeb.Admin.TagMergeLive do
 
   alias Vutuv.Repo
   alias Vutuv.Tags
+  alias Vutuv.Tags.Assistant
   alias Vutuv.Tags.Merge
   alias Vutuv.Tags.Tag
 
@@ -46,8 +47,10 @@ defmodule VutuvWeb.Admin.TagMergeLive do
      |> assign(:absorbed_results, [])
      |> assign(:canonical_results, [])
      |> assign(:alias_name, "")
+     |> assign(:scanning?, false)
      |> load_preview()
-     |> load_history()}
+     |> load_history()
+     |> load_queue()}
   end
 
   @impl true
@@ -76,6 +79,10 @@ defmodule VutuvWeb.Admin.TagMergeLive do
 
     case Merge.merge(absorbed, canonical, actor: socket.assigns.current_user) do
       {:ok, _merge} ->
+        # Decided, so it leaves the proposal queue whether it came from there
+        # or was picked by hand.
+        Assistant.drop_pair(absorbed, canonical)
+
         {:noreply,
          socket
          |> put_flash(
@@ -88,7 +95,8 @@ defmodule VutuvWeb.Admin.TagMergeLive do
          |> assign(:absorbed, nil)
          |> assign(:canonical, Repo.get(Tag, canonical.id))
          |> load_preview()
-         |> load_history()}
+         |> load_history()
+         |> load_queue()}
 
       {:error, reason} ->
         {:noreply, put_flash(socket, :error, refusal(reason))}
@@ -98,6 +106,7 @@ defmodule VutuvWeb.Admin.TagMergeLive do
   def handle_event("mark-distinct", _params, socket) do
     %{absorbed: absorbed, canonical: canonical} = socket.assigns
     {:ok, _} = Merge.mark_distinct(absorbed, canonical, actor: socket.assigns.current_user)
+    Assistant.drop_pair(absorbed, canonical)
 
     {:noreply,
      socket
@@ -108,7 +117,8 @@ defmodule VutuvWeb.Admin.TagMergeLive do
          b: canonical.name
        )
      )
-     |> load_preview()}
+     |> load_preview()
+     |> load_queue()}
   end
 
   def handle_event("revert", %{"id" => id}, socket) do
@@ -132,6 +142,66 @@ defmodule VutuvWeb.Admin.TagMergeLive do
           {:error, reason} ->
             {:noreply, put_flash(socket, :error, refusal(reason))}
         end
+    end
+  end
+
+  # The assisted pass (issue #1338): generate proposals, judge them with the
+  # local model where it is available, and put them in the queue below. Never a
+  # runtime path — it happens because an admin asked for it.
+  def handle_event("scan", _params, socket) do
+    report = Assistant.scan()
+
+    {:noreply,
+     socket
+     |> put_flash(
+       :info,
+       gettext(
+         "%{written} proposals, %{judged} of them judged by the model. %{dropped} more were found than the queue holds.",
+         written: report.written,
+         judged: report.judged,
+         dropped: report.dropped
+       )
+     )
+     |> load_queue()}
+  end
+
+  # Approving a proposal is the ordinary merge, so it goes through the same
+  # preview: the pair is loaded into the pickers instead of being merged on the
+  # spot. A one-click merge from a queue row is exactly the unreviewed merge
+  # this feature exists to avoid.
+  def handle_event("review", %{"id" => id}, socket) do
+    case Assistant.get_candidate(id) do
+      nil ->
+        {:noreply, put_flash(socket, :error, gettext("That proposal is gone."))}
+
+      candidate ->
+        {absorbed, canonical} = sides(candidate)
+
+        {:noreply,
+         socket
+         |> assign(:absorbed, absorbed)
+         |> assign(:canonical, canonical)
+         |> load_preview()}
+    end
+  end
+
+  def handle_event("reject", %{"id" => id}, socket) do
+    case Assistant.get_candidate(id) do
+      nil ->
+        {:noreply, put_flash(socket, :error, gettext("That proposal is gone."))}
+
+      candidate ->
+        {:ok, _} =
+          Merge.mark_distinct(candidate.tag_a, candidate.tag_b,
+            actor: socket.assigns.current_user
+          )
+
+        {:ok, _} = Assistant.drop(candidate)
+
+        {:noreply,
+         socket
+         |> put_flash(:info, gettext("Recorded as different topics."))
+         |> load_queue()}
     end
   end
 
@@ -188,6 +258,24 @@ defmodule VutuvWeb.Admin.TagMergeLive do
 
   defp load_history(socket), do: assign(socket, :history, Merge.history())
 
+  defp load_queue(socket) do
+    socket
+    |> assign(:queue, Assistant.queue())
+    |> assign(:queue_size, Assistant.queue_size())
+  end
+
+  # Which of a proposal's two tags is absorbed: the model's suggestion decides
+  # when there is one, otherwise the pair is handed over as it stands and the
+  # admin picks. Never guessed from the counts — "the smaller one loses" is a
+  # judgement, and this screen's whole point is that a human makes it.
+  defp sides(candidate) do
+    case candidate.suggested_canonical_id do
+      nil -> {candidate.tag_a, candidate.tag_b}
+      id when id == candidate.tag_a.id -> {candidate.tag_b, candidate.tag_a}
+      _ -> {candidate.tag_a, candidate.tag_b}
+    end
+  end
+
   # Why a merge is refused, in the reviewer's words rather than the code's.
   defp refusal(:same_tag), do: gettext("A tag cannot absorb itself.")
 
@@ -227,6 +315,14 @@ defmodule VutuvWeb.Admin.TagMergeLive do
 
   defp total(nil), do: 0
   defp total(counts), do: counts |> Map.values() |> Enum.sum()
+
+  # Which rule found a pair, for the rows the model has not judged (or could
+  # not): the reviewer should know whether they are looking at two spellings of
+  # one string or at two names that merely share a word.
+  defp generator_label("same_key"), do: gettext("the same name, written differently")
+  defp generator_label("acronym"), do: gettext("one is the other's initials")
+  defp generator_label("token"), do: gettext("one is a word of the other")
+  defp generator_label(other), do: other
 
   # The tables named in a preview, in the words an admin thinks in.
   defp row_label("user_tags"), do: gettext("profiles carrying the tag")
@@ -368,6 +464,73 @@ defmodule VutuvWeb.Admin.TagMergeLive do
             <button type="submit" class="button">{gettext("Add")}</button>
           </div>
         </form>
+      </section>
+
+      <%!-- The assisted pass: proposals a human approves, never applies
+      anything itself (issue #1338). --%>
+      <section class="card" id="candidate-queue">
+        <h2 class="card__label">{gettext("Proposals")}</h2>
+        <p class="text-sm text-slate-600 dark:text-slate-400">
+          {gettext(
+            "Pairs of tags that might be one topic, found by rule and, where a local model is available, judged by it. Nothing here has happened yet: opening one loads it above, where you see what a merge would move before confirming."
+          )}
+        </p>
+
+        <div class="editform__actions mt-3">
+          <button id="scan-candidates" type="button" class="button" phx-click="scan">
+            {gettext("Look for proposals")}
+          </button>
+          <span :if={not Assistant.enabled?()} class="text-sm text-slate-600 dark:text-slate-400">
+            {gettext("The model is switched off; proposals are listed unjudged.")}
+          </span>
+        </div>
+
+        <p :if={@queue == []} class="card__empty">{gettext("Nothing here yet.")}</p>
+
+        <div :if={@queue != []} class="card__tablewrap">
+          <table class="pure-table">
+            <thead>
+              <tr>
+                <th>{gettext("Pair")}</th>
+                <th>{gettext("Profiles")}</th>
+                <th>{gettext("Why")}</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr :for={candidate <- @queue} id={"candidate-#{candidate.id}"}>
+                <td>
+                  {candidate.tag_a.name} · {candidate.tag_b.name}
+                </td>
+                <td>{delimited_count(candidate.members_affected)}</td>
+                <td>
+                  <span :if={candidate.reason}>{candidate.reason}</span>
+                  <span :if={is_nil(candidate.reason)} class="text-slate-600 dark:text-slate-400">
+                    {generator_label(candidate.generator)}
+                  </span>
+                </td>
+                <td class="text-right">
+                  <button
+                    type="button"
+                    class="button button--small"
+                    phx-click="review"
+                    phx-value-id={candidate.id}
+                  >
+                    {gettext("Review")}
+                  </button>
+                  <button
+                    type="button"
+                    class="button button--cancel button--small"
+                    phx-click="reject"
+                    phx-value-id={candidate.id}
+                  >
+                    {gettext("Different topics")}
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </section>
 
       <section class="card" id="merge-history">

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.235.0",
+      version: "7.236.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -18,7 +18,7 @@ msgstr "Impressum"
 #: lib/vutuv_web/components/ui.ex:3434
 #: lib/vutuv_web/components/ui.ex:3439
 #: lib/vutuv_web/live/admin/screenshot_live.ex:245
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:365
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:464
 #: lib/vutuv_web/live/organization_live/domains.ex:255
 #: lib/vutuv_web/live/organization_live/edit.ex:396
 #: lib/vutuv_web/live/organization_live/roles.ex:202
@@ -82,8 +82,8 @@ msgstr "Schon ein Mitglied? Einloggen."
 #: lib/vutuv_web/components/ui.ex:3229
 #: lib/vutuv_web/components/ui.ex:3323
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:345
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:410
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:444
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:576
 #, elixir-autogen
 msgid "Are you sure?"
 msgstr "Sind Sie sicher?"
@@ -682,6 +682,7 @@ msgstr "Slug"
 #: lib/vutuv_web/cv/html.ex:223
 #: lib/vutuv_web/cv/latex.ex:179
 #: lib/vutuv_web/cv/odt.ex:185
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:495
 #: lib/vutuv_web/live/cv_live.ex:410
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/index.html.heex:10
@@ -1181,7 +1182,7 @@ msgstr "Lokalisierung hinzufügen"
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:693
 #: lib/vutuv_web/live/admin/organization_live.ex:189
 #: lib/vutuv_web/live/admin/screenshot_live.ex:172
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:244
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:343
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
@@ -1407,7 +1408,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/cv/html.ex:156
 #: lib/vutuv_web/cv/latex.ex:131
 #: lib/vutuv_web/cv/odt.ex:148
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:245
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:344
 #: lib/vutuv_web/live/cv_live.ex:315
 #: lib/vutuv_web/live/job_board_live.ex:277
 #: lib/vutuv_web/live/job_posting_live/form.ex:510
@@ -1781,8 +1782,9 @@ msgstr "Netzwerk"
 
 #: lib/vutuv_web/components/post_components.ex:391
 #: lib/vutuv_web/components/ui.ex:3436
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:352
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:373
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:451
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:488
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:539
 #: lib/vutuv_web/live/admin/user_live.ex:286
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
 #, elixir-autogen, elixir-format
@@ -2258,7 +2260,7 @@ msgstr "Weniger anzeigen"
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
 #: lib/vutuv_web/components/post_components.ex:1006
 #: lib/vutuv_web/live/admin/screenshot_live.ex:317
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:347
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:446
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:373
@@ -3315,6 +3317,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2751
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:519
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Review"
@@ -5670,7 +5673,7 @@ msgstr "Über Sie"
 msgid "Account"
 msgstr "Konto"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:446
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:612
 #: lib/vutuv_web/live/organization_live/edit.ex:443
 #, elixir-autogen, elixir-format
 msgid "Change"
@@ -6763,7 +6766,7 @@ msgstr "Das rohe Bounce-Protokoll, neueste zuerst."
 #: lib/vutuv_web/live/admin/activity_live.ex:142
 #: lib/vutuv_web/live/admin/deliverability_live.ex:213
 #: lib/vutuv_web/live/admin/deliverability_live.ex:250
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:382
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:548
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:189
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:230
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:27
@@ -6773,6 +6776,7 @@ msgid "When"
 msgstr "Wann"
 
 #: lib/vutuv_web/live/admin/deliverability_live.ex:216
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:496
 #, elixir-autogen, elixir-format
 msgid "Why"
 msgstr "Grund"
@@ -13776,7 +13780,7 @@ msgstr ""
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:650
 #: lib/vutuv_web/controllers/settings_controller.ex:668
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:217
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr "Das hat nicht funktioniert."
@@ -16292,7 +16296,7 @@ msgstr "Diese Antwort können Sie nicht entfernen."
 msgid "View the original"
 msgstr "Original ansehen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:292
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:391
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:190
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:231
 #, elixir-autogen, elixir-format
@@ -20423,37 +20427,37 @@ msgstr "Ihre Regel"
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr "löschen entfernen beiträge alter alt ablaufen verfallen automatisch aufräumen aufbewahrung"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:83
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "%{absorbed} is now an alternative name for %{canonical}."
 msgstr "%{absorbed} ist jetzt ein Zweitname von %{canonical}."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:106
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:115
 #, elixir-autogen, elixir-format
 msgid "%{a} and %{b} are recorded as different topics."
 msgstr "%{a} und %{b} sind als verschiedene Themen vermerkt."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:311
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:410
 #, elixir-autogen, elixir-format
 msgid "A dropped row belongs to somebody who already carries the surviving tag, so they end up carrying the topic once. Endorsements move to the row that stays."
 msgstr "Ein wegfallender Eintrag gehört jemandem, der das bleibende Tag schon trägt; danach trägt diese Person das Thema einmal. Empfehlungen ziehen auf den Eintrag um, der bleibt."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:189
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "A tag cannot absorb itself."
 msgstr "Ein Tag kann sich nicht selbst aufnehmen."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:379
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:545
 #, elixir-autogen, elixir-format
 msgid "Absorbed"
 msgstr "Aufgenommen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:356
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:455
 #, elixir-autogen, elixir-format
 msgid "Add an alternative name"
 msgstr "Zweitnamen hinzufügen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:144
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "Added %{name} as an alternative name."
 msgstr "%{name} wurde als Zweitname hinzugefügt."
@@ -20463,40 +20467,40 @@ msgstr "%{name} wurde als Zweitname hinzugefügt."
 msgid "Alternative name for %{tag}"
 msgstr "Zweitname von %{tag}"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:334
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:433
 #, elixir-autogen, elixir-format
 msgid "Alternative names for %{tag}"
 msgstr "Zweitnamen von %{tag}"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:294
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:393
 #, elixir-autogen, elixir-format
 msgid "Dropped as duplicate"
 msgstr "Fällt als Dublette weg"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:359
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:458
 #, elixir-autogen, elixir-format
 msgid "For a name nobody has typed yet, so it never becomes a page of its own. A name that is already a tag has to be merged instead."
 msgstr "Für einen Namen, den noch niemand getippt hat, damit daraus nie eine eigene Seite wird. Ein Name, der bereits ein Tag ist, muss stattdessen zusammengelegt werden."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:380
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:546
 #, elixir-autogen, elixir-format
 msgid "Into"
 msgstr "Aufgenommen in"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:264
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "Its entries move away and its page redirects."
 msgstr "Seine Einträge ziehen um, seine Seite leitet weiter."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:318
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:417
 #, elixir-autogen, elixir-format
 msgid "Merge"
 msgstr "Zusammenlegen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:41
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:242
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:246
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:252
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:42
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:341
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:345
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:351
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:258
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:261
 #, elixir-autogen, elixir-format
@@ -20508,47 +20512,47 @@ msgstr "Tags zusammenlegen"
 msgid "Merge tags ›"
 msgstr "Tags zusammenlegen ›"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:371
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:537
 #, elixir-autogen, elixir-format
 msgid "Merges so far"
 msgstr "Bisherige Zusammenlegungen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:293
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:392
 #, elixir-autogen, elixir-format
 msgid "Moves"
 msgstr "Zieht um"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:304
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:403
 #, elixir-autogen, elixir-format
 msgid "Nothing is filed under this tag."
 msgstr "Unter diesem Tag ist nichts abgelegt."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:254
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:353
 #, elixir-autogen, elixir-format
 msgid "One topic sometimes ends up under several tags. Pick the tag to absorb and the tag that stays: everything filed under the first moves to the second, and the absorbed name becomes an alternative name that keeps pointing there. Every merge can be reverted below."
 msgstr "Ein Thema landet manchmal unter mehreren Tags. Wählen Sie das Tag, das aufgenommen wird, und das Tag, das bleibt: Alles, was unter dem ersten liegt, zieht zum zweiten um, und der aufgenommene Name wird zu einem Zweitnamen, der weiter dorthin zeigt. Jede Zusammenlegung lässt sich unten rückgängig machen."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:158
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:231
 #, elixir-autogen, elixir-format
 msgid "Removed."
 msgstr "Entfernt."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:412
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:578
 #, elixir-autogen, elixir-format
 msgid "Revert"
 msgstr "Rückgängig machen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:402
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:568
 #, elixir-autogen, elixir-format
 msgid "Reverted"
 msgstr "Rückgängig gemacht"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:381
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:547
 #, elixir-autogen, elixir-format
 msgid "Rows"
 msgstr "Einträge"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:458
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:624
 #, elixir-autogen, elixir-format
 msgid "Search by name or slug"
 msgstr "Nach Name oder Slug suchen"
@@ -20558,117 +20562,178 @@ msgstr "Nach Name oder Slug suchen"
 msgid "Several tags for one topic become one page: see what a merge would move, do it, and take it back if it was wrong."
 msgstr "Mehrere Tags für ein Thema werden eine Seite: sehen, was eine Zusammenlegung verschiebt, sie durchführen und wieder zurücknehmen, falls sie falsch war."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:272
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:371
 #, elixir-autogen, elixir-format
 msgid "Tag that stays"
 msgstr "Tag, das bleibt"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:263
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:362
 #, elixir-autogen, elixir-format
 msgid "Tag to absorb"
 msgstr "Tag, das aufgenommen wird"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:117
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:127
 #, elixir-autogen, elixir-format
 msgid "That merge is no longer on record."
 msgstr "Diese Zusammenlegung ist nicht mehr vermerkt."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:216
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:307
 #, elixir-autogen, elixir-format
 msgid "That merge was already reverted."
 msgstr "Diese Zusammenlegung wurde bereits rückgängig gemacht."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:210
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "That name is already a tag. Merge it instead, so its entries come along."
 msgstr "Dieser Name ist bereits ein Tag. Legen Sie es stattdessen zusammen, damit seine Einträge mitkommen."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:195
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:286
 #, elixir-autogen, elixir-format
 msgid "That tag is already an alternative name. Revert its merge first."
 msgstr "Dieses Tag ist bereits ein Zweitname. Machen Sie zuerst seine Zusammenlegung rückgängig."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:215
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "That tag is not an alternative name."
 msgstr "Dieses Tag ist kein Zweitname."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:124
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:134
 #, elixir-autogen, elixir-format
 msgid "The merge was reverted."
 msgstr "Die Zusammenlegung wurde rückgängig gemacht."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:198
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:289
 #, elixir-autogen, elixir-format
 msgid "The surviving tag is itself an alternative name. Pick its topic instead."
 msgstr "Das bleibende Tag ist selbst ein Zweitname. Wählen Sie stattdessen sein Thema."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:273
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:372
 #, elixir-autogen, elixir-format
 msgid "The topic's one page from now on."
 msgstr "Ab jetzt die eine Seite des Themas."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:326
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:425
 #, elixir-autogen, elixir-format
 msgid "These are different topics"
 msgstr "Das sind verschiedene Themen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:205
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "These names differ only in characters the slug drops (like + or #), which is how C, C++ and C# tell each other apart. They are not merged."
 msgstr "Diese Namen unterscheiden sich nur in Zeichen, die der Slug weglässt (etwa + oder #). Genau daran unterscheiden sich C, C++ und C#. Sie werden nicht zusammengelegt."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:201
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:292
 #, elixir-autogen, elixir-format
 msgid "These two are recorded as different topics."
 msgstr "Diese beiden sind als verschiedene Themen vermerkt."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:213
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:304
 #, elixir-autogen, elixir-format
 msgid "This name came from a merge. Revert that merge to take it back."
 msgstr "Dieser Name stammt aus einer Zusammenlegung. Machen Sie diese rückgängig, um ihn zurückzunehmen."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:282
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:381
 #, elixir-autogen, elixir-format
 msgid "What this merge would move"
 msgstr "Was diese Zusammenlegung verschieben würde"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:231
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "hashtags in post bodies"
 msgstr "Hashtags in Beiträgen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:233
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "job postings"
 msgstr "Stellenanzeigen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:232
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:331
 #, elixir-autogen, elixir-format
 msgid "members following it"
 msgstr "Mitglieder, die ihm folgen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:235
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:334
 #, elixir-autogen, elixir-format
 msgid "newsletter audiences"
 msgstr "Newsletter-Zielgruppen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:230
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:329
 #, elixir-autogen, elixir-format
 msgid "posts filed under it"
 msgstr "Beiträge darunter"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:234
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:333
 #, elixir-autogen, elixir-format
 msgid "posts from other networks"
 msgstr "Beiträge aus anderen Netzwerken"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:229
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:328
 #, elixir-autogen, elixir-format
 msgid "profiles carrying the tag"
 msgstr "Profile mit diesem Tag"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:192
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:283
 #, elixir-autogen, elixir-format
 msgid "Honor tags are granted, not spelled. They are never merged."
 msgstr "Ehren-Tags werden vergeben, nicht geschrieben. Sie werden nie zusammengelegt."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:158
+#, elixir-autogen, elixir-format
+msgid "%{written} proposals, %{judged} of them judged by the model. %{dropped} more were found than the queue holds."
+msgstr "%{written} Vorschläge, davon %{judged} vom Modell beurteilt. %{dropped} weitere wurden gefunden, aber nicht aufgenommen."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:527
+#, elixir-autogen, elixir-format
+msgid "Different topics"
+msgstr "Verschiedene Themen"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:481
+#, elixir-autogen, elixir-format
+msgid "Look for proposals"
+msgstr "Nach Vorschlägen suchen"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:494
+#, elixir-autogen, elixir-format
+msgid "Pair"
+msgstr "Paar"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:474
+#, elixir-autogen, elixir-format
+msgid "Pairs of tags that might be one topic, found by rule and, where a local model is available, judged by it. Nothing here has happened yet: opening one loads it above, where you see what a merge would move before confirming."
+msgstr "Tag-Paare, die ein Thema sein könnten, nach festen Regeln gefunden und, wo ein lokales Modell verfügbar ist, von ihm beurteilt. Hier ist noch nichts passiert: Ein Vorschlag wird oben geladen, wo Sie vor dem Bestätigen sehen, was die Zusammenlegung verschieben würde."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:472
+#, elixir-autogen, elixir-format
+msgid "Proposals"
+msgstr "Vorschläge"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:203
+#, elixir-autogen, elixir-format
+msgid "Recorded as different topics."
+msgstr "Als verschiedene Themen vermerkt."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:175
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:191
+#, elixir-autogen, elixir-format
+msgid "That proposal is gone."
+msgstr "Diesen Vorschlag gibt es nicht mehr."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:484
+#, elixir-autogen, elixir-format
+msgid "The model is switched off; proposals are listed unjudged."
+msgstr "Das Modell ist abgeschaltet, die Vorschläge stehen unbeurteilt in der Liste."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:324
+#, elixir-autogen, elixir-format
+msgid "one is a word of the other"
+msgstr "eines ist ein Wort des anderen"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:323
+#, elixir-autogen, elixir-format
+msgid "one is the other's initials"
+msgstr "eines sind die Initialen des anderen"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:322
+#, elixir-autogen, elixir-format
+msgid "the same name, written differently"
+msgstr "derselbe Name, anders geschrieben"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -20,7 +20,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3434
 #: lib/vutuv_web/components/ui.ex:3439
 #: lib/vutuv_web/live/admin/screenshot_live.ex:245
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:365
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:464
 #: lib/vutuv_web/live/organization_live/domains.ex:255
 #: lib/vutuv_web/live/organization_live/edit.ex:396
 #: lib/vutuv_web/live/organization_live/roles.ex:202
@@ -84,8 +84,8 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3229
 #: lib/vutuv_web/components/ui.ex:3323
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:345
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:410
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:444
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:576
 #, elixir-autogen
 msgid "Are you sure?"
 msgstr ""
@@ -682,6 +682,7 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:223
 #: lib/vutuv_web/cv/latex.ex:179
 #: lib/vutuv_web/cv/odt.ex:185
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:495
 #: lib/vutuv_web/live/cv_live.ex:410
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/index.html.heex:10
@@ -1157,7 +1158,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:693
 #: lib/vutuv_web/live/admin/organization_live.ex:189
 #: lib/vutuv_web/live/admin/screenshot_live.ex:172
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:244
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:343
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
@@ -1380,7 +1381,7 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:156
 #: lib/vutuv_web/cv/latex.ex:131
 #: lib/vutuv_web/cv/odt.ex:148
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:245
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:344
 #: lib/vutuv_web/live/cv_live.ex:315
 #: lib/vutuv_web/live/job_board_live.ex:277
 #: lib/vutuv_web/live/job_posting_live/form.ex:510
@@ -1746,8 +1747,9 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:391
 #: lib/vutuv_web/components/ui.ex:3436
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:352
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:373
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:451
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:488
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:539
 #: lib/vutuv_web/live/admin/user_live.ex:286
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
 #, elixir-autogen, elixir-format
@@ -2213,7 +2215,7 @@ msgstr ""
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
 #: lib/vutuv_web/components/post_components.ex:1006
 #: lib/vutuv_web/live/admin/screenshot_live.ex:317
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:347
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:446
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:373
@@ -3239,6 +3241,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2751
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:519
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Review"
@@ -5445,7 +5448,7 @@ msgstr ""
 msgid "Account"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:446
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:612
 #: lib/vutuv_web/live/organization_live/edit.ex:443
 #, elixir-autogen, elixir-format
 msgid "Change"
@@ -6494,7 +6497,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/activity_live.ex:142
 #: lib/vutuv_web/live/admin/deliverability_live.ex:213
 #: lib/vutuv_web/live/admin/deliverability_live.ex:250
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:382
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:548
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:189
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:230
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:27
@@ -6504,6 +6507,7 @@ msgid "When"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/deliverability_live.ex:216
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:496
 #, elixir-autogen, elixir-format
 msgid "Why"
 msgstr ""
@@ -13101,7 +13105,7 @@ msgstr ""
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:650
 #: lib/vutuv_web/controllers/settings_controller.ex:668
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:217
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr ""
@@ -15564,7 +15568,7 @@ msgstr ""
 msgid "View the original"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:292
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:391
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:190
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:231
 #, elixir-autogen, elixir-format
@@ -19636,37 +19640,37 @@ msgstr ""
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:83
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "%{absorbed} is now an alternative name for %{canonical}."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:106
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:115
 #, elixir-autogen, elixir-format
 msgid "%{a} and %{b} are recorded as different topics."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:311
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:410
 #, elixir-autogen, elixir-format
 msgid "A dropped row belongs to somebody who already carries the surviving tag, so they end up carrying the topic once. Endorsements move to the row that stays."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:189
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "A tag cannot absorb itself."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:379
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:545
 #, elixir-autogen, elixir-format
 msgid "Absorbed"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:356
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:455
 #, elixir-autogen, elixir-format
 msgid "Add an alternative name"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:144
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "Added %{name} as an alternative name."
 msgstr ""
@@ -19676,40 +19680,40 @@ msgstr ""
 msgid "Alternative name for %{tag}"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:334
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:433
 #, elixir-autogen, elixir-format
 msgid "Alternative names for %{tag}"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:294
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:393
 #, elixir-autogen, elixir-format
 msgid "Dropped as duplicate"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:359
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:458
 #, elixir-autogen, elixir-format
 msgid "For a name nobody has typed yet, so it never becomes a page of its own. A name that is already a tag has to be merged instead."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:380
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:546
 #, elixir-autogen, elixir-format
 msgid "Into"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:264
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "Its entries move away and its page redirects."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:318
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:417
 #, elixir-autogen, elixir-format
 msgid "Merge"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:41
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:242
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:246
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:252
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:42
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:341
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:345
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:351
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:258
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:261
 #, elixir-autogen, elixir-format
@@ -19721,47 +19725,47 @@ msgstr ""
 msgid "Merge tags ›"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:371
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:537
 #, elixir-autogen, elixir-format
 msgid "Merges so far"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:293
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:392
 #, elixir-autogen, elixir-format
 msgid "Moves"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:304
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:403
 #, elixir-autogen, elixir-format
 msgid "Nothing is filed under this tag."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:254
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:353
 #, elixir-autogen, elixir-format
 msgid "One topic sometimes ends up under several tags. Pick the tag to absorb and the tag that stays: everything filed under the first moves to the second, and the absorbed name becomes an alternative name that keeps pointing there. Every merge can be reverted below."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:158
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:231
 #, elixir-autogen, elixir-format
 msgid "Removed."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:412
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:578
 #, elixir-autogen, elixir-format
 msgid "Revert"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:402
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:568
 #, elixir-autogen, elixir-format
 msgid "Reverted"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:381
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:547
 #, elixir-autogen, elixir-format
 msgid "Rows"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:458
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:624
 #, elixir-autogen, elixir-format
 msgid "Search by name or slug"
 msgstr ""
@@ -19771,117 +19775,178 @@ msgstr ""
 msgid "Several tags for one topic become one page: see what a merge would move, do it, and take it back if it was wrong."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:272
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:371
 #, elixir-autogen, elixir-format
 msgid "Tag that stays"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:263
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:362
 #, elixir-autogen, elixir-format
 msgid "Tag to absorb"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:117
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:127
 #, elixir-autogen, elixir-format
 msgid "That merge is no longer on record."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:216
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:307
 #, elixir-autogen, elixir-format
 msgid "That merge was already reverted."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:210
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "That name is already a tag. Merge it instead, so its entries come along."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:195
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:286
 #, elixir-autogen, elixir-format
 msgid "That tag is already an alternative name. Revert its merge first."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:215
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "That tag is not an alternative name."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:124
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:134
 #, elixir-autogen, elixir-format
 msgid "The merge was reverted."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:198
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:289
 #, elixir-autogen, elixir-format
 msgid "The surviving tag is itself an alternative name. Pick its topic instead."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:273
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:372
 #, elixir-autogen, elixir-format
 msgid "The topic's one page from now on."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:326
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:425
 #, elixir-autogen, elixir-format
 msgid "These are different topics"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:205
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "These names differ only in characters the slug drops (like + or #), which is how C, C++ and C# tell each other apart. They are not merged."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:201
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:292
 #, elixir-autogen, elixir-format
 msgid "These two are recorded as different topics."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:213
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:304
 #, elixir-autogen, elixir-format
 msgid "This name came from a merge. Revert that merge to take it back."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:282
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:381
 #, elixir-autogen, elixir-format
 msgid "What this merge would move"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:231
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "hashtags in post bodies"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:233
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "job postings"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:232
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:331
 #, elixir-autogen, elixir-format
 msgid "members following it"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:235
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:334
 #, elixir-autogen, elixir-format
 msgid "newsletter audiences"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:230
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:329
 #, elixir-autogen, elixir-format
 msgid "posts filed under it"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:234
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:333
 #, elixir-autogen, elixir-format
 msgid "posts from other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:229
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:328
 #, elixir-autogen, elixir-format
 msgid "profiles carrying the tag"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:192
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:283
 #, elixir-autogen, elixir-format
 msgid "Honor tags are granted, not spelled. They are never merged."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:158
+#, elixir-autogen, elixir-format
+msgid "%{written} proposals, %{judged} of them judged by the model. %{dropped} more were found than the queue holds."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:527
+#, elixir-autogen, elixir-format
+msgid "Different topics"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:481
+#, elixir-autogen, elixir-format
+msgid "Look for proposals"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:494
+#, elixir-autogen, elixir-format
+msgid "Pair"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:474
+#, elixir-autogen, elixir-format
+msgid "Pairs of tags that might be one topic, found by rule and, where a local model is available, judged by it. Nothing here has happened yet: opening one loads it above, where you see what a merge would move before confirming."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:472
+#, elixir-autogen, elixir-format
+msgid "Proposals"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:203
+#, elixir-autogen, elixir-format
+msgid "Recorded as different topics."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:175
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:191
+#, elixir-autogen, elixir-format
+msgid "That proposal is gone."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:484
+#, elixir-autogen, elixir-format
+msgid "The model is switched off; proposals are listed unjudged."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:324
+#, elixir-autogen, elixir-format
+msgid "one is a word of the other"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:323
+#, elixir-autogen, elixir-format
+msgid "one is the other's initials"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:322
+#, elixir-autogen, elixir-format
+msgid "the same name, written differently"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -18,7 +18,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3434
 #: lib/vutuv_web/components/ui.ex:3439
 #: lib/vutuv_web/live/admin/screenshot_live.ex:245
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:365
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:464
 #: lib/vutuv_web/live/organization_live/domains.ex:255
 #: lib/vutuv_web/live/organization_live/edit.ex:396
 #: lib/vutuv_web/live/organization_live/roles.ex:202
@@ -82,8 +82,8 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3229
 #: lib/vutuv_web/components/ui.ex:3323
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:345
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:410
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:444
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:576
 #, elixir-autogen
 msgid "Are you sure?"
 msgstr ""
@@ -680,6 +680,7 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:223
 #: lib/vutuv_web/cv/latex.ex:179
 #: lib/vutuv_web/cv/odt.ex:185
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:495
 #: lib/vutuv_web/live/cv_live.ex:410
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/index.html.heex:10
@@ -1155,7 +1156,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:693
 #: lib/vutuv_web/live/admin/organization_live.ex:189
 #: lib/vutuv_web/live/admin/screenshot_live.ex:172
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:244
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:343
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
@@ -1378,7 +1379,7 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:156
 #: lib/vutuv_web/cv/latex.ex:131
 #: lib/vutuv_web/cv/odt.ex:148
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:245
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:344
 #: lib/vutuv_web/live/cv_live.ex:315
 #: lib/vutuv_web/live/job_board_live.ex:277
 #: lib/vutuv_web/live/job_posting_live/form.ex:510
@@ -1744,8 +1745,9 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:391
 #: lib/vutuv_web/components/ui.ex:3436
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:352
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:373
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:451
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:488
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:539
 #: lib/vutuv_web/live/admin/user_live.ex:286
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
 #, elixir-autogen, elixir-format
@@ -2211,7 +2213,7 @@ msgstr ""
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
 #: lib/vutuv_web/components/post_components.ex:1006
 #: lib/vutuv_web/live/admin/screenshot_live.ex:317
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:347
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:446
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:373
@@ -3237,6 +3239,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2751
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:519
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Review"
@@ -5443,7 +5446,7 @@ msgstr ""
 msgid "Account"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:446
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:612
 #: lib/vutuv_web/live/organization_live/edit.ex:443
 #, elixir-autogen, elixir-format
 msgid "Change"
@@ -6492,7 +6495,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/activity_live.ex:142
 #: lib/vutuv_web/live/admin/deliverability_live.ex:213
 #: lib/vutuv_web/live/admin/deliverability_live.ex:250
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:382
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:548
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:189
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:230
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:27
@@ -6502,6 +6505,7 @@ msgid "When"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/deliverability_live.ex:216
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:496
 #, elixir-autogen, elixir-format
 msgid "Why"
 msgstr ""
@@ -13099,7 +13103,7 @@ msgstr ""
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:650
 #: lib/vutuv_web/controllers/settings_controller.ex:668
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:217
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr ""
@@ -15562,7 +15566,7 @@ msgstr ""
 msgid "View the original"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:292
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:391
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:190
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:231
 #, elixir-autogen, elixir-format
@@ -19634,37 +19638,37 @@ msgstr ""
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:83
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "%{absorbed} is now an alternative name for %{canonical}."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:106
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:115
 #, elixir-autogen, elixir-format
 msgid "%{a} and %{b} are recorded as different topics."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:311
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:410
 #, elixir-autogen, elixir-format
 msgid "A dropped row belongs to somebody who already carries the surviving tag, so they end up carrying the topic once. Endorsements move to the row that stays."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:189
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "A tag cannot absorb itself."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:379
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:545
 #, elixir-autogen, elixir-format
 msgid "Absorbed"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:356
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:455
 #, elixir-autogen, elixir-format
 msgid "Add an alternative name"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:144
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "Added %{name} as an alternative name."
 msgstr ""
@@ -19674,40 +19678,40 @@ msgstr ""
 msgid "Alternative name for %{tag}"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:334
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:433
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Alternative names for %{tag}"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:294
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:393
 #, elixir-autogen, elixir-format
 msgid "Dropped as duplicate"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:359
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:458
 #, elixir-autogen, elixir-format
 msgid "For a name nobody has typed yet, so it never becomes a page of its own. A name that is already a tag has to be merged instead."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:380
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:546
 #, elixir-autogen, elixir-format
 msgid "Into"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:264
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "Its entries move away and its page redirects."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:318
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:417
 #, elixir-autogen, elixir-format
 msgid "Merge"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:41
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:242
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:246
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:252
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:42
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:341
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:345
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:351
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:258
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:261
 #, elixir-autogen, elixir-format
@@ -19719,47 +19723,47 @@ msgstr ""
 msgid "Merge tags ›"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:371
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:537
 #, elixir-autogen, elixir-format
 msgid "Merges so far"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:293
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:392
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Moves"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:304
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:403
 #, elixir-autogen, elixir-format
 msgid "Nothing is filed under this tag."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:254
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:353
 #, elixir-autogen, elixir-format
 msgid "One topic sometimes ends up under several tags. Pick the tag to absorb and the tag that stays: everything filed under the first moves to the second, and the absorbed name becomes an alternative name that keeps pointing there. Every merge can be reverted below."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:158
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:231
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Removed."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:412
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:578
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Revert"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:402
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:568
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Reverted"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:381
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:547
 #, elixir-autogen, elixir-format
 msgid "Rows"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:458
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:624
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Search by name or slug"
 msgstr ""
@@ -19769,117 +19773,178 @@ msgstr ""
 msgid "Several tags for one topic become one page: see what a merge would move, do it, and take it back if it was wrong."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:272
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:371
 #, elixir-autogen, elixir-format
 msgid "Tag that stays"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:263
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:362
 #, elixir-autogen, elixir-format
 msgid "Tag to absorb"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:117
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:127
 #, elixir-autogen, elixir-format
 msgid "That merge is no longer on record."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:216
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:307
 #, elixir-autogen, elixir-format
 msgid "That merge was already reverted."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:210
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "That name is already a tag. Merge it instead, so its entries come along."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:195
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:286
 #, elixir-autogen, elixir-format
 msgid "That tag is already an alternative name. Revert its merge first."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:215
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "That tag is not an alternative name."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:124
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:134
 #, elixir-autogen, elixir-format
 msgid "The merge was reverted."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:198
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:289
 #, elixir-autogen, elixir-format
 msgid "The surviving tag is itself an alternative name. Pick its topic instead."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:273
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:372
 #, elixir-autogen, elixir-format
 msgid "The topic's one page from now on."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:326
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:425
 #, elixir-autogen, elixir-format
 msgid "These are different topics"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:205
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "These names differ only in characters the slug drops (like + or #), which is how C, C++ and C# tell each other apart. They are not merged."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:201
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:292
 #, elixir-autogen, elixir-format
 msgid "These two are recorded as different topics."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:213
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:304
 #, elixir-autogen, elixir-format
 msgid "This name came from a merge. Revert that merge to take it back."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:282
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:381
 #, elixir-autogen, elixir-format
 msgid "What this merge would move"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:231
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "hashtags in post bodies"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:233
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:332
 #, elixir-autogen, elixir-format, fuzzy
 msgid "job postings"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:232
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:331
 #, elixir-autogen, elixir-format, fuzzy
 msgid "members following it"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:235
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:334
 #, elixir-autogen, elixir-format, fuzzy
 msgid "newsletter audiences"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:230
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:329
 #, elixir-autogen, elixir-format
 msgid "posts filed under it"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:234
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:333
 #, elixir-autogen, elixir-format, fuzzy
 msgid "posts from other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:229
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:328
 #, elixir-autogen, elixir-format
 msgid "profiles carrying the tag"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:192
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:283
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Honor tags are granted, not spelled. They are never merged."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:158
+#, elixir-autogen, elixir-format
+msgid "%{written} proposals, %{judged} of them judged by the model. %{dropped} more were found than the queue holds."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:527
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Different topics"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:481
+#, elixir-autogen, elixir-format
+msgid "Look for proposals"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:494
+#, elixir-autogen, elixir-format
+msgid "Pair"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:474
+#, elixir-autogen, elixir-format
+msgid "Pairs of tags that might be one topic, found by rule and, where a local model is available, judged by it. Nothing here has happened yet: opening one loads it above, where you see what a merge would move before confirming."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:472
+#, elixir-autogen, elixir-format
+msgid "Proposals"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:203
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Recorded as different topics."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:175
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:191
+#, elixir-autogen, elixir-format
+msgid "That proposal is gone."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:484
+#, elixir-autogen, elixir-format
+msgid "The model is switched off; proposals are listed unjudged."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:324
+#, elixir-autogen, elixir-format
+msgid "one is a word of the other"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:323
+#, elixir-autogen, elixir-format
+msgid "one is the other's initials"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:322
+#, elixir-autogen, elixir-format
+msgid "the same name, written differently"
 msgstr ""

--- a/priv/repo/migrations/20260810113930_add_tag_merge_candidates.exs
+++ b/priv/repo/migrations/20260810113930_add_tag_merge_candidates.exs
@@ -1,0 +1,44 @@
+defmodule Vutuv.Repo.Migrations.AddTagMergeCandidates do
+  use Ecto.Migration
+
+  # The queue behind the assisted pass (issue #1338): pairs of tags that might
+  # be one topic, for a human to approve or reject.
+  #
+  # Candidates are generated cheaply and deterministically and only then judged
+  # by the local model, so `generator` says which rule produced the pair and
+  # `judged_at` whether a model has looked at it yet — an installation with no
+  # Ollama still fills the queue and administers it by hand.
+  #
+  # The pair is stored with the smaller id first, like `tag_distinctions`, so a
+  # pair is one row however it was generated. A decision empties the row: an
+  # approval leaves a `tag_merges` entry behind, a rejection a `tag_distinctions`
+  # one, and either way the pair is not proposed again.
+  def change do
+    create table(:tag_merge_candidates, primary_key: false) do
+      add(:id, :binary_id, primary_key: true)
+
+      add(:tag_a_id, references(:tags, type: :binary_id, on_delete: :delete_all), null: false)
+      add(:tag_b_id, references(:tags, type: :binary_id, on_delete: :delete_all), null: false)
+
+      # The model's proposal, all three nil until it has judged: which of the
+      # two should survive, what kind of name the other becomes, and one line
+      # saying why. A human still decides.
+      add(:suggested_canonical_id, references(:tags, type: :binary_id, on_delete: :nilify_all))
+      add(:kind, :string)
+      add(:reason, :text)
+      add(:judged_at, :naive_datetime)
+
+      # Which rule found the pair, and how many members it would touch — the
+      # queue is ordered by that, so the consequential merges are looked at
+      # first.
+      add(:generator, :string, null: false)
+      add(:members_affected, :integer, null: false, default: 0)
+
+      timestamps()
+    end
+
+    create(unique_index(:tag_merge_candidates, [:tag_a_id, :tag_b_id]))
+    create(index(:tag_merge_candidates, [:tag_b_id]))
+    create(index(:tag_merge_candidates, [:members_affected]))
+  end
+end

--- a/test/vutuv/tags/assistant_test.exs
+++ b/test/vutuv/tags/assistant_test.exs
@@ -1,0 +1,236 @@
+defmodule Vutuv.Tags.AssistantTest do
+  @moduledoc """
+  The assisted pass (issue #1338). It proposes, a human decides, and the pairs
+  it may propose are bounded by rule rather than by prompt — which is what this
+  file guards.
+
+  `async: false` because the judging half is switched by `:tag_merge_assist`, an
+  application env every other test in the run would see (see the test guidelines).
+  """
+  use Vutuv.DataCase, async: false
+
+  alias Vutuv.Tags.Assistant
+  alias Vutuv.Tags.Merge
+  alias Vutuv.Tags.MergeCandidate
+  alias Vutuv.Tags.Tag
+
+  setup do
+    original = Application.fetch_env(:vutuv, :tag_merge_assist)
+    Application.put_env(:vutuv, :tag_merge_assist, false)
+
+    on_exit(fn ->
+      case original do
+        {:ok, was} -> Application.put_env(:vutuv, :tag_merge_assist, was)
+        :error -> Application.delete_env(:vutuv, :tag_merge_assist)
+      end
+    end)
+
+    :ok
+  end
+
+  defp tag(name) do
+    insert(:tag, name: name, slug: Vutuv.SlugHelpers.gen_slug_unique(name, Tag, :slug))
+  end
+
+  defp entry(name), do: %{id: Vutuv.UUIDv7.generate(), name: name}
+
+  defp generated(names) do
+    names
+    |> Enum.map(&entry/1)
+    |> Assistant.generate()
+    |> Enum.map(fn {a, b, rule} -> {Enum.sort([a.name, b.name]), rule} end)
+    |> Enum.sort()
+  end
+
+  describe "the deterministic generators" do
+    test "same_key: the names agree once case and separators are folded away" do
+      assert {["Ruby on Rails", "rubyonrails"], "same_key"} in generated([
+               "Ruby on Rails",
+               "rubyonrails"
+             ])
+
+      assert {["Open-Source", "open source"], "same_key"} in generated([
+               "open source",
+               "Open-Source"
+             ])
+    end
+
+    test "acronym: a multi-word name's initials are another tag's whole name" do
+      assert {["ROR", "Ruby on Rails"], "acronym"} in generated(["Ruby on Rails", "ROR"])
+
+      assert {["CRM", "Customer Relationship Management"], "acronym"} in generated([
+               "Customer Relationship Management",
+               "CRM"
+             ])
+    end
+
+    test "token: a short name is one whole word of a longer one" do
+      pairs = generated(["Ruby on Rails", "rails", "Ruby"])
+
+      # Both are generated, and that is the point: one of them is a merge and
+      # the other never is. Telling them apart is the judge's job, not the
+      # generator's.
+      assert {["Ruby on Rails", "rails"], "token"} in pairs
+      assert {["Ruby", "Ruby on Rails"], "token"} in pairs
+    end
+
+    test "a two-letter word is not a token candidate" do
+      # Otherwise "on" would pair "Ruby on Rails" with every tag called "on".
+      assert generated(["Ruby on Rails", "on"]) == []
+    end
+
+    test "no edit distance: a typo is not a candidate" do
+      # Typos are out of scope (#1338), so a one-character difference produces
+      # nothing at all.
+      assert generated(["Ruby on Rails", "Ryby on Rails"]) == []
+    end
+
+    test "the punctuation bucket is never even generated" do
+      # `c`, `c++` and `c#` fold to different keys, so no rule pairs them.
+      assert generated(["c", "c++", "c#", "µc"]) == []
+    end
+  end
+
+  describe "scan/1" do
+    test "writes one queue row per pair, ranked by the members it would touch" do
+      big_a = tag("Ruby on Rails")
+      big_b = tag("rubyonrails")
+      small_a = tag("Elixir Language")
+      small_b = tag("elixirlanguage")
+
+      for _ <- 1..3, do: insert(:user_tag, user: insert(:activated_user), tag: big_a)
+      insert(:user_tag, user: insert(:activated_user), tag: small_a)
+
+      report = Assistant.scan(judge: false)
+
+      assert report.written == 2
+
+      assert [first, second] = Assistant.queue()
+      assert Enum.sort([first.tag_a_id, first.tag_b_id]) == Enum.sort([big_a.id, big_b.id])
+      assert Enum.sort([second.tag_a_id, second.tag_b_id]) == Enum.sort([small_a.id, small_b.id])
+      assert first.members_affected == 3
+    end
+
+    test "an unjudged shares-a-word pair is not put in the queue" do
+      # Measured against the real catalog, this rule is four fifths of
+      # everything the generators find and almost none of it is a merge
+      # ("embedded linux" is not "Linux"). Without a verdict it is a chore, not
+      # a proposal.
+      tag("Ruby on Rails")
+      tag("rails")
+
+      assert Assistant.scan(judge: false).written == 0
+      assert Assistant.queue() == []
+    end
+
+    test "the obvious pairs are ranked above the ones that merely share a word" do
+      # Ordering by members alone puts the worst rows on top, because the
+      # biggest tag is the one every specialization shares a word with.
+      big = tag("Linux")
+      for _ <- 1..5, do: insert(:user_tag, user: insert(:activated_user), tag: big)
+      tag("embedded Linux")
+
+      small = tag("java script")
+      insert(:user_tag, user: insert(:activated_user), tag: small)
+      tag("javascript")
+
+      report = Assistant.scan(judge: false)
+
+      # The shares-a-word pair is generated and counted, but the queue leads
+      # with the two spellings of one string.
+      assert report.generated == 2
+      assert [candidate] = Assistant.queue()
+      assert candidate.generator == "same_key"
+    end
+
+    test "a pair the merge would refuse never reaches the queue" do
+      # The guardrail is applied to the candidate, not left to the model: the
+      # generator would not produce this pair anyway, and a pair already called
+      # distinct is refused here too.
+      a = tag("Ruby on Rails")
+      b = tag("rubyonrails")
+      {:ok, _} = Merge.mark_distinct(a, b)
+
+      assert Assistant.scan(judge: false).written == 0
+      assert Assistant.queue() == []
+    end
+
+    test "an honor tag is left out of the catalog entirely" do
+      tag("Ruby on Rails") |> Ecto.Changeset.change(honor?: true) |> Repo.update!()
+      tag("rubyonrails")
+
+      assert Assistant.scan(judge: false).written == 0
+    end
+
+    test "an alternative name is not proposed again" do
+      canonical = tag("Ruby on Rails")
+      absorbed = tag("rubyonrails")
+      {:ok, _} = Merge.merge(absorbed, canonical)
+
+      assert Assistant.scan(judge: false).written == 0
+    end
+
+    test "running it twice leaves one row per pair" do
+      tag("Ruby on Rails")
+      tag("rubyonrails")
+
+      Assistant.scan(judge: false)
+      Assistant.scan(judge: false)
+
+      assert Repo.aggregate(MergeCandidate, :count) == 1
+    end
+
+    test "a second run spends its budget on pairs that are not queued yet" do
+      # Otherwise the cap would hand back the same top rows every time and the
+      # long tail would be unreachable, however often an admin scanned.
+      tag("java script")
+      tag("javascript")
+      tag("Ruby on Rails")
+      tag("rubyonrails")
+
+      first = Assistant.scan(judge: false, cap: 1)
+      assert first.written == 1
+      assert first.dropped == 1
+
+      second = Assistant.scan(judge: false, cap: 1)
+      assert second.written == 1
+      assert second.dropped == 0
+
+      assert Repo.aggregate(MergeCandidate, :count) == 2
+    end
+
+    test "with the model off the queue still fills, unjudged" do
+      # The air-gapped case: proposals a human reads, no verdict attached.
+      tag("Ruby on Rails")
+      tag("rubyonrails")
+
+      report = Assistant.scan()
+
+      assert report.written == 1
+      assert report.judged == 0
+      assert [candidate] = Assistant.queue()
+      assert is_nil(candidate.judged_at)
+      assert is_nil(candidate.suggested_canonical_id)
+    end
+
+    test "the cap reports what it dropped rather than trimming silently" do
+      tag("Ruby on Rails")
+      tag("rubyonrails")
+      tag("Elixir Language")
+      tag("elixirlanguage")
+
+      report = Assistant.scan(judge: false, cap: 1)
+
+      # A queue that quietly stops at its cap reads as "that was everything".
+      assert report.written == 1
+      assert report.dropped == 1
+      assert Repo.aggregate(MergeCandidate, :count) == 1
+    end
+  end
+
+  describe "judge/3" do
+    test "answers nothing while the model is switched off" do
+      assert is_nil(Assistant.judge(entry("Ruby on Rails"), entry("ROR"), "acronym"))
+    end
+  end
+end

--- a/test/vutuv_web/live/admin/tag_merge_live_test.exs
+++ b/test/vutuv_web/live/admin/tag_merge_live_test.exs
@@ -8,6 +8,7 @@ defmodule VutuvWeb.Admin.TagMergeLiveTest do
 
   import Phoenix.LiveViewTest
 
+  alias Vutuv.Tags.Assistant
   alias Vutuv.Tags.Merge
   alias Vutuv.Tags.Tag
   alias Vutuv.Tags.UserTag
@@ -89,7 +90,9 @@ defmodule VutuvWeb.Admin.TagMergeLiveTest do
       assert html =~ "Tags zusammenlegen"
       assert html =~ "Tag, das aufgenommen wird"
       assert html =~ "Tag, das bleibt"
+      assert html =~ "Vorschläge"
       refute html =~ "Tag to absorb"
+      refute html =~ "Look for proposals"
     end
 
     test "a merge can be reverted from the history", ctx do
@@ -114,6 +117,59 @@ defmodule VutuvWeb.Admin.TagMergeLiveTest do
       # And the merge is refused from now on, whoever tries it.
       assert {:error, :marked_distinct} =
                Merge.merge(ctx.absorbed, ctx.canonical, actor: ctx.admin)
+    end
+  end
+
+  describe "the proposal queue" do
+    setup %{conn: conn} do
+      {conn, admin} = create_and_login_admin(conn)
+      %{conn: conn, admin: admin}
+    end
+
+    test "scanning lists pairs, and opening one loads it into the preview", ctx do
+      a = tag("Ruby on Rails")
+      b = tag("rubyonrails")
+      insert(:user_tag, user: insert(:activated_user), tag: a)
+
+      {:ok, lv, _html} = live(ctx.conn, ~p"/admin/tag_merges")
+      html = lv |> element("#scan-candidates") |> render_click()
+
+      assert html =~ "Ruby on Rails"
+      assert [candidate] = Assistant.queue()
+
+      # Opening a proposal does not merge it: it loads the pair above, where the
+      # preview says what a merge would move.
+      lv |> element("#candidate-#{candidate.id} button", "Review") |> render_click()
+
+      assert has_element?(lv, "#merge-preview")
+      assert is_nil(Repo.get!(Tag, b.id).merged_into_id)
+    end
+
+    test "rejecting a proposal records the pair as different topics", ctx do
+      a = tag("Ruby on Rails")
+      b = tag("rubyonrails")
+      Assistant.scan(judge: false)
+      [candidate] = Assistant.queue()
+
+      {:ok, lv, _html} = live(ctx.conn, ~p"/admin/tag_merges")
+      lv |> element("#candidate-#{candidate.id} button", "Different topics") |> render_click()
+
+      assert Assistant.queue() == []
+      assert Merge.distinct?(a, b)
+    end
+
+    test "a merged pair leaves the queue", ctx do
+      a = tag("Ruby on Rails")
+      b = tag("rubyonrails")
+      Assistant.scan(judge: false)
+      assert [_] = Assistant.queue()
+
+      {:ok, lv, _html} = live(ctx.conn, ~p"/admin/tag_merges")
+      pick(lv, b, "absorbed")
+      pick(lv, a, "canonical")
+      lv |> element("#do-merge") |> render_click()
+
+      assert Assistant.queue() == []
     end
   end
 


### PR DESCRIPTION
**TL;DR** Dritter und letzter Schritt zu #1338: ein admin-ausgelöster Durchlauf schlägt vor, welche Tags ein Thema sind. Er legt nie selbst zusammen; jeder Vorschlag geht durch denselben Preview wie eine Zusammenlegung von Hand.

**Kandidaten entstehen billig und deterministisch**, nicht durch ein Modell: `same_key` (gleicher Name, anders geschrieben), `acronym` (Initialen), `token` (das kurze Wort ist ein ganzes Wort des langen). Keine Editierdistanz, keine Trigramm-Ähnlichkeit, obwohl `pg_trgm` installiert ist: beides fängt Tippfehler, und die sind hier bewusst außen vor.

**Der Zuschnitt kommt aus der Messung gegen eine Produktionskopie**, nicht aus dem Lesen des Codes:

| Regel | gefundene Paare |
|---|---|
| `same_key` | 318 |
| `acronym` | 496 |
| `token` | 4.182 |

`token` ist vier Fünftel von allem und fast nie eine Zusammenlegung: `Linux` teilt ein Wort mit `embedded linux`, `arch linux`, `linux kernel` und zwanzig weiteren. Daraus folgen zwei Entscheidungen, die vom Issue-Text abweichen und beide in der Doku begründet sind:

1. Ein `token`-Paar wird **nur geschrieben, wenn das Modell dafür eingestanden ist**. Unbeurteilt ist es keine Empfehlung, sondern Arbeit.
2. Die Warteschlange sortiert **nach Regel vor Größe**. Nach betroffenen Mitgliedern allein (so stand es im Issue) stünden genau jene Linux-Zeilen ganz oben, weil das größte Tag das ist, mit dem jeder Spezialfall ein Wort teilt; das offensichtliche `javascript` / `java script` käme darunter.

**Weitere Messergebnisse:** der ganze Durchlauf braucht 0,2 s über 8.022 Tags. Das Limit von 500 ist das, was *ein* Durchlauf hinzufügen darf, wartende Paare verbrauchen es nicht: Lauf 1 schreibt 500, Lauf 2 weitere 314, also kommt wiederholtes Suchen weiter, statt dieselben Zeilen erneut anzubieten. Die Ablehnungen laufen in einem Rutsch (eine Abfrage plus ein Stringvergleich) statt `Merge.preview/2` pro Paar – der zählt Zeilen in sieben Tabellen, das wären rund 75.000 Abfragen gewesen.

**Das Modell** (`TAG_MERGE_ASSIST`, über `Vutuv.Ollama` mit erzwungenem JSON-Schema) bekommt eine enge Frage pro Paar und die Anweisung, im Zweifel „verschiedene Themen" zu antworten: die beiden Fehler kosten nicht dasselbe. Es ist für die Fälle da, die keine Regel entscheidet – der Katalog liefert `seo` / `search engine optimization` (eine Zusammenlegung) neben `seo` / `search experience optimization` (keine). Flag aus oder Ollama weg: die Warteschlange füllt sich unbeurteilt und ein Mensch entscheidet, der Fall einer Installation ohne Internet.

**Doku:** `TAG_MERGE_ASSIST` und `TAG_MERGE_ASSIST_MODEL` in der Env-Tabelle und im Intranet-Abschnitt von `docs/ADMINS.md`, die Mechanik samt Messwerten in `docs/architecture/social-graph.md`.

**Geprüft:** `mix precommit` grün (7093 Tests), Migration und der echte Durchlauf gegen `vutuv1_dev` gelaufen, alle 12 neuen deutschen Strings von Hand geschrieben (der Extract hatte „Different topics" als „Pro Foto verschieden" vorbelegt), deutsche Ausgabe mit `Accept-Language: de-DE,de` getestet.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*