### PR TITLE
Die Zusammenlegen-Seite erklärt sich selbst (v7.236.1)

### DIFF
--- a/lib/vutuv/tags.ex
+++ b/lib/vutuv/tags.ex
@@ -155,6 +155,23 @@ defmodule Vutuv.Tags do
     from(t in query, order_by: [asc: t.name], limit: ^limit)
   end
 
+  @doc """
+  How many profiles carry each of `tag_ids`, as a map — one query for the whole
+  list, so a screen showing several tags side by side costs one lookup rather
+  than one per row. Tags nobody carries are absent from the map.
+  """
+  def member_counts([]), do: %{}
+
+  def member_counts(tag_ids) when is_list(tag_ids) do
+    from(ut in UserTag,
+      where: ut.tag_id in ^tag_ids,
+      group_by: ut.tag_id,
+      select: {ut.tag_id, count(ut.id)}
+    )
+    |> Repo.all()
+    |> Map.new()
+  end
+
   @doc "The most tags one profile may carry (see `@max_user_tags`)."
   def max_user_tags, do: @max_user_tags
 

--- a/lib/vutuv_web/live/admin/tag_merge_live.ex
+++ b/lib/vutuv_web/live/admin/tag_merge_live.ex
@@ -74,6 +74,17 @@ defmodule VutuvWeb.Admin.TagMergeLive do
     {:noreply, socket |> assign(:"#{side}", nil) |> load_preview()}
   end
 
+  # Which of two tags should survive is the actual decision on this screen, and
+  # it is usually made after seeing both: turning the pair round has to be one
+  # click, not two searches again.
+  def handle_event("swap", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:absorbed, socket.assigns.canonical)
+     |> assign(:canonical, socket.assigns.absorbed)
+     |> load_preview()}
+  end
+
   def handle_event("merge", _params, socket) do
     %{absorbed: absorbed, canonical: canonical} = socket.assigns
 
@@ -233,10 +244,19 @@ defmodule VutuvWeb.Admin.TagMergeLive do
     end
   end
 
+  # Each result carries the number of profiles carrying it, batched into one
+  # query for the whole list: with three spellings of one topic on screen, that
+  # number is usually what decides which of them should survive.
   defp search(query) do
     case String.trim(to_string(query)) do
-      "" -> []
-      q -> q |> Tags.admin_search(limit: @results_limit) |> Repo.all()
+      "" ->
+        []
+
+      q ->
+        tags = q |> Tags.admin_search(limit: @results_limit) |> Repo.all()
+        counts = Tags.member_counts(Enum.map(tags, & &1.id))
+
+        Enum.map(tags, &%{tag: &1, members: Map.get(counts, &1.id, 0)})
     end
   end
 
@@ -316,6 +336,16 @@ defmodule VutuvWeb.Admin.TagMergeLive do
   defp total(nil), do: 0
   defp total(counts), do: counts |> Map.values() |> Enum.sum()
 
+  # "N profiles", the one phrase the picker rows and the worked example share —
+  # so the example is written in the same words the real rows use, and the
+  # number goes through the formatter like every other count in the app
+  # (`ngettext` binds %{count} to the raw integer, hence the second placeholder).
+  defp profile_count(members) do
+    ngettext("%{formatted} profile", "%{formatted} profiles", members,
+      formatted: delimited_count(members)
+    )
+  end
+
   # Which rule found a pair, for the rows the model has not judged (or could
   # not): the reviewer should know whether they are looking at two spellings of
   # one string or at two names that merely share a word.
@@ -351,16 +381,54 @@ defmodule VutuvWeb.Admin.TagMergeLive do
         <h1>{gettext("Merge tags")}</h1>
         <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
           {gettext(
-            "One topic sometimes ends up under several tags. Pick the tag to absorb and the tag that stays: everything filed under the first moves to the second, and the absorbed name becomes an alternative name that keeps pointing there. Every merge can be reverted below."
+            "One topic sometimes ends up under several tags, so its members and its posts are split over two pages that never show each other. Merging puts them on one page."
           )}
         </p>
+
+        <%!-- What a merge does, on a real pair. An abstract description of this
+        left the reader guessing which of the two names disappears, which is the
+        one thing the screen has to make obvious. --%>
+        <div
+          id="merge-example"
+          class="mt-4 rounded-lg bg-slate-50 p-4 text-sm dark:bg-slate-800/60"
+        >
+          <h2 class="card__label">{gettext("An example")}</h2>
+          <div class="grid gap-4 sm:grid-cols-2">
+            <div>
+              <p class="mb-1 font-semibold">{gettext("Today")}</p>
+              <ul class="space-y-1 text-slate-600 dark:text-slate-400">
+                <li><code>/tags/ruby_on_rails</code> · {profile_count(89)}</li>
+                <li><code>/tags/rubyonrails</code> · {profile_count(12)}</li>
+              </ul>
+            </div>
+            <div>
+              <p class="mb-1 font-semibold">{gettext("After the merge")}</p>
+              <ul class="space-y-1 text-slate-600 dark:text-slate-400">
+                <li><code>/tags/ruby_on_rails</code> · {profile_count(101)}</li>
+                <li>
+                  <code>/tags/rubyonrails</code> {gettext("redirects there for good")}
+                </li>
+              </ul>
+            </div>
+          </div>
+          <p class="mt-3 text-slate-600 dark:text-slate-400">
+            {gettext(
+              "\"rubyonrails\" was absorbed: nobody loses a tag, the name goes on working, and it is listed on the remaining page as an alternative name. Anyone typing it from now on gets the one page. Every merge can be undone at the bottom of this page."
+            )}
+          </p>
+        </div>
 
         <div class="mt-6 grid gap-6 md:grid-cols-2">
           <.tag_picker
             side="absorbed"
             id="absorbed"
+            step="1"
             label={gettext("Tag to absorb")}
-            hint={gettext("Its entries move away and its page redirects.")}
+            hint={
+              gettext(
+                "Stops being a topic of its own. Its profiles, posts and follows move over and its address redirects."
+              )
+            }
             tag={@absorbed}
             query={@absorbed_query}
             results={@absorbed_results}
@@ -368,12 +436,26 @@ defmodule VutuvWeb.Admin.TagMergeLive do
           <.tag_picker
             side="canonical"
             id="canonical"
+            step="2"
             label={gettext("Tag that stays")}
-            hint={gettext("The topic's one page from now on.")}
+            hint={
+              gettext("Keeps its page and its address and gains everything from the other one.")
+            }
             tag={@canonical}
             query={@canonical_query}
             results={@canonical_results}
           />
+        </div>
+
+        <div :if={@absorbed && @canonical} class="editform__actions mt-4">
+          <button
+            id="swap-sides"
+            type="button"
+            class="button button--cancel"
+            phx-click="swap"
+          >
+            {gettext("Swap: keep %{name} instead", name: @absorbed.name)}
+          </button>
         </div>
       </section>
 
@@ -384,7 +466,20 @@ defmodule VutuvWeb.Admin.TagMergeLive do
           <% {:error, reason} -> %>
             <p class="alert alert-danger" role="alert">{refusal(reason)}</p>
           <% preview -> %>
-            <div class="card__tablewrap">
+            <%!-- The table answers "how much"; this line answers "what am I
+            about to do", which is the question somebody presses the button
+            with. --%>
+            <p id="merge-sentence" class="text-sm">
+              {gettext(
+                "%{absorbed} becomes an alternative name for %{canonical}. %{absorbed_url} then redirects to %{canonical_url}.",
+                absorbed: preview.absorbed.name,
+                canonical: preview.canonical.name,
+                absorbed_url: "/tags/" <> preview.absorbed.slug,
+                canonical_url: "/tags/" <> preview.canonical.slug
+              )}
+            </p>
+
+            <div class="card__tablewrap mt-3">
               <table class="pure-table">
                 <thead>
                   <tr>
@@ -589,16 +684,26 @@ defmodule VutuvWeb.Admin.TagMergeLive do
 
   attr(:side, :string, required: true)
   attr(:id, :string, required: true)
+  attr(:step, :string, required: true)
   attr(:label, :string, required: true)
   attr(:hint, :string, required: true)
   attr(:tag, :any, default: nil)
   attr(:query, :string, default: "")
   attr(:results, :list, default: [])
 
+  # A search result is a **choice**, and it has to look like one. As a row of
+  # big blue chips the list read as a display of tags rather than as a picker,
+  # and it showed only the name — which is not enough to tell `rails` from
+  # `Ruby on Rails` from `rubyonrails` when all three are in the list. Each row
+  # is one wide button now, naming the tag, the address it lives at and how many
+  # profiles carry it, because that last number is usually what decides which of
+  # two spellings should survive.
   defp tag_picker(assigns) do
     ~H"""
     <div>
-      <h2 class="card__label">{@label}</h2>
+      <h2 class="card__label">
+        <span class="mr-1 text-slate-400 dark:text-slate-500">{@step}.</span>{@label}
+      </h2>
       <p class="text-sm text-slate-600 dark:text-slate-400">{@hint}</p>
 
       <div :if={@tag} class="mt-2 flex items-center gap-3" id={"picked-#{@id}"}>
@@ -613,7 +718,13 @@ defmodule VutuvWeb.Admin.TagMergeLive do
         </button>
       </div>
 
-      <form :if={is_nil(@tag)} id={"search-#{@id}"} phx-change="search" phx-submit="search" class="mt-2">
+      <form
+        :if={is_nil(@tag)}
+        id={"search-#{@id}"}
+        phx-change="search"
+        phx-submit="search"
+        class="mt-2"
+      >
         <input type="hidden" name="side" value={@side} />
         <input
           type="text"
@@ -625,17 +736,29 @@ defmodule VutuvWeb.Admin.TagMergeLive do
         />
       </form>
 
-      <ul :if={is_nil(@tag) and @results != []} class="thumbs mt-2">
+      <p
+        :if={is_nil(@tag) and @query != "" and @results == []}
+        class="card__empty"
+      >
+        {gettext("No tag matches that.")}
+      </p>
+
+      <ul :if={is_nil(@tag) and @results != []} class="mt-2 space-y-1">
         <li :for={result <- @results}>
           <button
             type="button"
-            id={"pick-#{@side}-#{result.id}"}
-            class="button button--small"
+            id={"pick-#{@side}-#{result.tag.id}"}
+            class="w-full rounded-lg px-3 py-2 text-left hover:bg-brand-50 dark:hover:bg-brand-900/40"
             phx-click="pick"
             phx-value-side={@side}
-            phx-value-id={result.id}
+            phx-value-id={result.tag.id}
           >
-            {result.name}
+            <span class="block font-semibold text-brand-700 dark:text-brand-200">
+              {result.tag.name}
+            </span>
+            <span class="block text-xs text-slate-600 dark:text-slate-400">
+              /tags/{result.tag.slug} · {profile_count(result.members)}
+            </span>
           </button>
         </li>
       </ul>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.236.0",
+      version: "7.236.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -18,7 +18,7 @@ msgstr "Impressum"
 #: lib/vutuv_web/components/ui.ex:3434
 #: lib/vutuv_web/components/ui.ex:3439
 #: lib/vutuv_web/live/admin/screenshot_live.ex:245
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:464
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:559
 #: lib/vutuv_web/live/organization_live/domains.ex:255
 #: lib/vutuv_web/live/organization_live/edit.ex:396
 #: lib/vutuv_web/live/organization_live/roles.ex:202
@@ -82,8 +82,8 @@ msgstr "Schon ein Mitglied? Einloggen."
 #: lib/vutuv_web/components/ui.ex:3229
 #: lib/vutuv_web/components/ui.ex:3323
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:444
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:576
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:539
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:671
 #, elixir-autogen
 msgid "Are you sure?"
 msgstr "Sind Sie sicher?"
@@ -682,7 +682,7 @@ msgstr "Slug"
 #: lib/vutuv_web/cv/html.ex:223
 #: lib/vutuv_web/cv/latex.ex:179
 #: lib/vutuv_web/cv/odt.ex:185
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:495
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:590
 #: lib/vutuv_web/live/cv_live.ex:410
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/index.html.heex:10
@@ -1182,7 +1182,7 @@ msgstr "Lokalisierung hinzufügen"
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:693
 #: lib/vutuv_web/live/admin/organization_live.ex:189
 #: lib/vutuv_web/live/admin/screenshot_live.ex:172
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:343
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:373
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
@@ -1408,7 +1408,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/cv/html.ex:156
 #: lib/vutuv_web/cv/latex.ex:131
 #: lib/vutuv_web/cv/odt.ex:148
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:344
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:374
 #: lib/vutuv_web/live/cv_live.ex:315
 #: lib/vutuv_web/live/job_board_live.ex:277
 #: lib/vutuv_web/live/job_posting_live/form.ex:510
@@ -1782,9 +1782,9 @@ msgstr "Netzwerk"
 
 #: lib/vutuv_web/components/post_components.ex:391
 #: lib/vutuv_web/components/ui.ex:3436
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:451
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:488
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:539
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:546
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:583
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:634
 #: lib/vutuv_web/live/admin/user_live.ex:286
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
 #, elixir-autogen, elixir-format
@@ -2260,7 +2260,7 @@ msgstr "Weniger anzeigen"
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
 #: lib/vutuv_web/components/post_components.ex:1006
 #: lib/vutuv_web/live/admin/screenshot_live.ex:317
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:446
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:541
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:373
@@ -3317,7 +3317,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2751
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:519
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:614
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Review"
@@ -5673,7 +5673,7 @@ msgstr "Über Sie"
 msgid "Account"
 msgstr "Konto"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:612
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:717
 #: lib/vutuv_web/live/organization_live/edit.ex:443
 #, elixir-autogen, elixir-format
 msgid "Change"
@@ -6766,7 +6766,7 @@ msgstr "Das rohe Bounce-Protokoll, neueste zuerst."
 #: lib/vutuv_web/live/admin/activity_live.ex:142
 #: lib/vutuv_web/live/admin/deliverability_live.ex:213
 #: lib/vutuv_web/live/admin/deliverability_live.ex:250
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:548
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:643
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:189
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:230
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:27
@@ -6776,7 +6776,7 @@ msgid "When"
 msgstr "Wann"
 
 #: lib/vutuv_web/live/admin/deliverability_live.ex:216
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:496
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:591
 #, elixir-autogen, elixir-format
 msgid "Why"
 msgstr "Grund"
@@ -8049,6 +8049,7 @@ msgstr "Neue Mitglieder"
 
 #: lib/vutuv_web/components/job_components.ex:173
 #: lib/vutuv_web/live/admin/dashboard_live.ex:287
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:398
 #: lib/vutuv_web/live/notification_live/index.ex:904
 #, elixir-autogen, elixir-format
 msgid "Today"
@@ -13780,7 +13781,7 @@ msgstr ""
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:650
 #: lib/vutuv_web/controllers/settings_controller.ex:668
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:308
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:328
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr "Das hat nicht funktioniert."
@@ -16296,7 +16297,7 @@ msgstr "Diese Antwort können Sie nicht entfernen."
 msgid "View the original"
 msgstr "Original ansehen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:391
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:486
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:190
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:231
 #, elixir-autogen, elixir-format
@@ -20427,37 +20428,37 @@ msgstr "Ihre Regel"
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr "löschen entfernen beiträge alter alt ablaufen verfallen automatisch aufräumen aufbewahrung"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:90
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:101
 #, elixir-autogen, elixir-format
 msgid "%{absorbed} is now an alternative name for %{canonical}."
 msgstr "%{absorbed} ist jetzt ein Zweitname von %{canonical}."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:115
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "%{a} and %{b} are recorded as different topics."
 msgstr "%{a} und %{b} sind als verschiedene Themen vermerkt."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:410
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:505
 #, elixir-autogen, elixir-format
 msgid "A dropped row belongs to somebody who already carries the surviving tag, so they end up carrying the topic once. Endorsements move to the row that stays."
 msgstr "Ein wegfallender Eintrag gehört jemandem, der das bleibende Tag schon trägt; danach trägt diese Person das Thema einmal. Empfehlungen ziehen auf den Eintrag um, der bleibt."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:280
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "A tag cannot absorb itself."
 msgstr "Ein Tag kann sich nicht selbst aufnehmen."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:545
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:640
 #, elixir-autogen, elixir-format
 msgid "Absorbed"
 msgstr "Aufgenommen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:455
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:550
 #, elixir-autogen, elixir-format
 msgid "Add an alternative name"
 msgstr "Zweitnamen hinzufügen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:217
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:228
 #, elixir-autogen, elixir-format
 msgid "Added %{name} as an alternative name."
 msgstr "%{name} wurde als Zweitname hinzugefügt."
@@ -20467,40 +20468,35 @@ msgstr "%{name} wurde als Zweitname hinzugefügt."
 msgid "Alternative name for %{tag}"
 msgstr "Zweitname von %{tag}"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:433
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:528
 #, elixir-autogen, elixir-format
 msgid "Alternative names for %{tag}"
 msgstr "Zweitnamen von %{tag}"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:393
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:488
 #, elixir-autogen, elixir-format
 msgid "Dropped as duplicate"
 msgstr "Fällt als Dublette weg"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:458
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:553
 #, elixir-autogen, elixir-format
 msgid "For a name nobody has typed yet, so it never becomes a page of its own. A name that is already a tag has to be merged instead."
 msgstr "Für einen Namen, den noch niemand getippt hat, damit daraus nie eine eigene Seite wird. Ein Name, der bereits ein Tag ist, muss stattdessen zusammengelegt werden."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:546
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:641
 #, elixir-autogen, elixir-format
 msgid "Into"
 msgstr "Aufgenommen in"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:363
-#, elixir-autogen, elixir-format
-msgid "Its entries move away and its page redirects."
-msgstr "Seine Einträge ziehen um, seine Seite leitet weiter."
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:417
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:512
 #, elixir-autogen, elixir-format
 msgid "Merge"
 msgstr "Zusammenlegen"
 
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:42
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:341
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:345
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:351
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:371
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:375
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:381
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:258
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:261
 #, elixir-autogen, elixir-format
@@ -20512,47 +20508,42 @@ msgstr "Tags zusammenlegen"
 msgid "Merge tags ›"
 msgstr "Tags zusammenlegen ›"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:537
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:632
 #, elixir-autogen, elixir-format
 msgid "Merges so far"
 msgstr "Bisherige Zusammenlegungen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:392
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:487
 #, elixir-autogen, elixir-format
 msgid "Moves"
 msgstr "Zieht um"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:403
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:498
 #, elixir-autogen, elixir-format
 msgid "Nothing is filed under this tag."
 msgstr "Unter diesem Tag ist nichts abgelegt."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:353
-#, elixir-autogen, elixir-format
-msgid "One topic sometimes ends up under several tags. Pick the tag to absorb and the tag that stays: everything filed under the first moves to the second, and the absorbed name becomes an alternative name that keeps pointing there. Every merge can be reverted below."
-msgstr "Ein Thema landet manchmal unter mehreren Tags. Wählen Sie das Tag, das aufgenommen wird, und das Tag, das bleibt: Alles, was unter dem ersten liegt, zieht zum zweiten um, und der aufgenommene Name wird zu einem Zweitnamen, der weiter dorthin zeigt. Jede Zusammenlegung lässt sich unten rückgängig machen."
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:231
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "Removed."
 msgstr "Entfernt."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:578
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:673
 #, elixir-autogen, elixir-format
 msgid "Revert"
 msgstr "Rückgängig machen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:568
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:663
 #, elixir-autogen, elixir-format
 msgid "Reverted"
 msgstr "Rückgängig gemacht"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:547
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:642
 #, elixir-autogen, elixir-format
 msgid "Rows"
 msgstr "Einträge"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:624
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:735
 #, elixir-autogen, elixir-format
 msgid "Search by name or slug"
 msgstr "Nach Name oder Slug suchen"
@@ -20562,178 +20553,230 @@ msgstr "Nach Name oder Slug suchen"
 msgid "Several tags for one topic become one page: see what a merge would move, do it, and take it back if it was wrong."
 msgstr "Mehrere Tags für ein Thema werden eine Seite: sehen, was eine Zusammenlegung verschiebt, sie durchführen und wieder zurücknehmen, falls sie falsch war."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:371
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:440
 #, elixir-autogen, elixir-format
 msgid "Tag that stays"
 msgstr "Tag, das bleibt"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:362
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "Tag to absorb"
 msgstr "Tag, das aufgenommen wird"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:127
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:138
 #, elixir-autogen, elixir-format
 msgid "That merge is no longer on record."
 msgstr "Diese Zusammenlegung ist nicht mehr vermerkt."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:307
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:327
 #, elixir-autogen, elixir-format
 msgid "That merge was already reverted."
 msgstr "Diese Zusammenlegung wurde bereits rückgängig gemacht."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:301
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:321
 #, elixir-autogen, elixir-format
 msgid "That name is already a tag. Merge it instead, so its entries come along."
 msgstr "Dieser Name ist bereits ein Tag. Legen Sie es stattdessen zusammen, damit seine Einträge mitkommen."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:286
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "That tag is already an alternative name. Revert its merge first."
 msgstr "Dieses Tag ist bereits ein Zweitname. Machen Sie zuerst seine Zusammenlegung rückgängig."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:306
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:326
 #, elixir-autogen, elixir-format
 msgid "That tag is not an alternative name."
 msgstr "Dieses Tag ist kein Zweitname."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:134
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:145
 #, elixir-autogen, elixir-format
 msgid "The merge was reverted."
 msgstr "Die Zusammenlegung wurde rückgängig gemacht."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:289
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:309
 #, elixir-autogen, elixir-format
 msgid "The surviving tag is itself an alternative name. Pick its topic instead."
 msgstr "Das bleibende Tag ist selbst ein Zweitname. Wählen Sie stattdessen sein Thema."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:372
-#, elixir-autogen, elixir-format
-msgid "The topic's one page from now on."
-msgstr "Ab jetzt die eine Seite des Themas."
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:425
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:520
 #, elixir-autogen, elixir-format
 msgid "These are different topics"
 msgstr "Das sind verschiedene Themen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:296
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:316
 #, elixir-autogen, elixir-format
 msgid "These names differ only in characters the slug drops (like + or #), which is how C, C++ and C# tell each other apart. They are not merged."
 msgstr "Diese Namen unterscheiden sich nur in Zeichen, die der Slug weglässt (etwa + oder #). Genau daran unterscheiden sich C, C++ und C#. Sie werden nicht zusammengelegt."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:292
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:312
 #, elixir-autogen, elixir-format
 msgid "These two are recorded as different topics."
 msgstr "Diese beiden sind als verschiedene Themen vermerkt."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:304
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:324
 #, elixir-autogen, elixir-format
 msgid "This name came from a merge. Revert that merge to take it back."
 msgstr "Dieser Name stammt aus einer Zusammenlegung. Machen Sie diese rückgängig, um ihn zurückzunehmen."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:381
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:463
 #, elixir-autogen, elixir-format
 msgid "What this merge would move"
 msgstr "Was diese Zusammenlegung verschieben würde"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:330
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:360
 #, elixir-autogen, elixir-format
 msgid "hashtags in post bodies"
 msgstr "Hashtags in Beiträgen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:332
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:362
 #, elixir-autogen, elixir-format
 msgid "job postings"
 msgstr "Stellenanzeigen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:331
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:361
 #, elixir-autogen, elixir-format
 msgid "members following it"
 msgstr "Mitglieder, die ihm folgen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:334
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "newsletter audiences"
 msgstr "Newsletter-Zielgruppen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:329
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:359
 #, elixir-autogen, elixir-format
 msgid "posts filed under it"
 msgstr "Beiträge darunter"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:333
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "posts from other networks"
 msgstr "Beiträge aus anderen Netzwerken"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:328
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:358
 #, elixir-autogen, elixir-format
 msgid "profiles carrying the tag"
 msgstr "Profile mit diesem Tag"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:283
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:303
 #, elixir-autogen, elixir-format
 msgid "Honor tags are granted, not spelled. They are never merged."
 msgstr "Ehren-Tags werden vergeben, nicht geschrieben. Sie werden nie zusammengelegt."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:158
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "%{written} proposals, %{judged} of them judged by the model. %{dropped} more were found than the queue holds."
 msgstr "%{written} Vorschläge, davon %{judged} vom Modell beurteilt. %{dropped} weitere wurden gefunden, aber nicht aufgenommen."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:527
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Different topics"
 msgstr "Verschiedene Themen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:481
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:576
 #, elixir-autogen, elixir-format
 msgid "Look for proposals"
 msgstr "Nach Vorschlägen suchen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:494
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:589
 #, elixir-autogen, elixir-format
 msgid "Pair"
 msgstr "Paar"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:474
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:569
 #, elixir-autogen, elixir-format
 msgid "Pairs of tags that might be one topic, found by rule and, where a local model is available, judged by it. Nothing here has happened yet: opening one loads it above, where you see what a merge would move before confirming."
 msgstr "Tag-Paare, die ein Thema sein könnten, nach festen Regeln gefunden und, wo ein lokales Modell verfügbar ist, von ihm beurteilt. Hier ist noch nichts passiert: Ein Vorschlag wird oben geladen, wo Sie vor dem Bestätigen sehen, was die Zusammenlegung verschieben würde."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:472
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:567
 #, elixir-autogen, elixir-format
 msgid "Proposals"
 msgstr "Vorschläge"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:203
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:214
 #, elixir-autogen, elixir-format
 msgid "Recorded as different topics."
 msgstr "Als verschiedene Themen vermerkt."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:175
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:191
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:186
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:202
 #, elixir-autogen, elixir-format
 msgid "That proposal is gone."
 msgstr "Diesen Vorschlag gibt es nicht mehr."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:484
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:579
 #, elixir-autogen, elixir-format
 msgid "The model is switched off; proposals are listed unjudged."
 msgstr "Das Modell ist abgeschaltet, die Vorschläge stehen unbeurteilt in der Liste."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:324
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:354
 #, elixir-autogen, elixir-format
 msgid "one is a word of the other"
 msgstr "eines ist ein Wort des anderen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:323
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:353
 #, elixir-autogen, elixir-format
 msgid "one is the other's initials"
 msgstr "eines sind die Initialen des anderen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:322
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:352
 #, elixir-autogen, elixir-format
 msgid "the same name, written differently"
 msgstr "derselbe Name, anders geschrieben"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:415
+#, elixir-autogen, elixir-format
+msgid "\"rubyonrails\" was absorbed: nobody loses a tag, the name goes on working, and it is listed on the remaining page as an alternative name. Anyone typing it from now on gets the one page. Every merge can be undone at the bottom of this page."
+msgstr "„rubyonrails\" wurde aufgenommen: Niemand verliert ein Tag, der Name funktioniert weiter, und er steht auf der verbliebenen Seite als Zweitname. Wer ihn ab jetzt tippt, landet auf der einen Seite. Jede Zusammenlegung lässt sich unten wieder rückgängig machen."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:473
+#, elixir-autogen, elixir-format
+msgid "%{absorbed} becomes an alternative name for %{canonical}. %{absorbed_url} then redirects to %{canonical_url}."
+msgstr "%{absorbed} wird ein Zweitname von %{canonical}. %{absorbed_url} leitet dann auf %{canonical_url} weiter."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:344
+#, elixir-autogen, elixir-format
+msgid "%{formatted} profile"
+msgid_plural "%{formatted} profiles"
+msgstr[0] "%{formatted} Profil"
+msgstr[1] "%{formatted} Profile"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:395
+#, elixir-autogen, elixir-format
+msgid "An example"
+msgstr "Ein Beispiel"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:442
+#, elixir-autogen, elixir-format
+msgid "Keeps its page and its address and gains everything from the other one."
+msgstr "Behält Seite und Adresse und bekommt alles vom anderen Tag dazu."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:743
+#, elixir-autogen, elixir-format
+msgid "No tag matches that."
+msgstr "Dazu passt kein Tag."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:383
+#, elixir-autogen, elixir-format
+msgid "One topic sometimes ends up under several tags, so its members and its posts are split over two pages that never show each other. Merging puts them on one page."
+msgstr "Ein Thema landet manchmal unter mehreren Tags. Seine Mitglieder und seine Beiträge liegen dann auf zwei Seiten, die einander nie zeigen. Eine Zusammenlegung bringt beides auf eine Seite."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:428
+#, elixir-autogen, elixir-format
+msgid "Stops being a topic of its own. Its profiles, posts and follows move over and its address redirects."
+msgstr "Hört auf, ein eigenes Thema zu sein. Seine Profile, Beiträge und Abos ziehen um, seine Adresse leitet weiter."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:457
+#, elixir-autogen, elixir-format
+msgid "Swap: keep %{name} instead"
+msgstr "Tauschen: stattdessen %{name} behalten"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:409
+#, elixir-autogen, elixir-format
+msgid "redirects there for good"
+msgstr "leitet dauerhaft dorthin weiter"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:405
+#, elixir-autogen, elixir-format
+msgid "After the merge"
+msgstr "Nach der Zusammenlegung"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -20,7 +20,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3434
 #: lib/vutuv_web/components/ui.ex:3439
 #: lib/vutuv_web/live/admin/screenshot_live.ex:245
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:464
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:559
 #: lib/vutuv_web/live/organization_live/domains.ex:255
 #: lib/vutuv_web/live/organization_live/edit.ex:396
 #: lib/vutuv_web/live/organization_live/roles.ex:202
@@ -84,8 +84,8 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3229
 #: lib/vutuv_web/components/ui.ex:3323
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:444
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:576
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:539
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:671
 #, elixir-autogen
 msgid "Are you sure?"
 msgstr ""
@@ -682,7 +682,7 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:223
 #: lib/vutuv_web/cv/latex.ex:179
 #: lib/vutuv_web/cv/odt.ex:185
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:495
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:590
 #: lib/vutuv_web/live/cv_live.ex:410
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/index.html.heex:10
@@ -1158,7 +1158,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:693
 #: lib/vutuv_web/live/admin/organization_live.ex:189
 #: lib/vutuv_web/live/admin/screenshot_live.ex:172
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:343
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:373
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
@@ -1381,7 +1381,7 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:156
 #: lib/vutuv_web/cv/latex.ex:131
 #: lib/vutuv_web/cv/odt.ex:148
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:344
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:374
 #: lib/vutuv_web/live/cv_live.ex:315
 #: lib/vutuv_web/live/job_board_live.ex:277
 #: lib/vutuv_web/live/job_posting_live/form.ex:510
@@ -1747,9 +1747,9 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:391
 #: lib/vutuv_web/components/ui.ex:3436
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:451
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:488
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:539
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:546
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:583
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:634
 #: lib/vutuv_web/live/admin/user_live.ex:286
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
 #, elixir-autogen, elixir-format
@@ -2215,7 +2215,7 @@ msgstr ""
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
 #: lib/vutuv_web/components/post_components.ex:1006
 #: lib/vutuv_web/live/admin/screenshot_live.ex:317
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:446
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:541
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:373
@@ -3241,7 +3241,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2751
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:519
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:614
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Review"
@@ -5448,7 +5448,7 @@ msgstr ""
 msgid "Account"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:612
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:717
 #: lib/vutuv_web/live/organization_live/edit.ex:443
 #, elixir-autogen, elixir-format
 msgid "Change"
@@ -6497,7 +6497,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/activity_live.ex:142
 #: lib/vutuv_web/live/admin/deliverability_live.ex:213
 #: lib/vutuv_web/live/admin/deliverability_live.ex:250
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:548
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:643
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:189
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:230
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:27
@@ -6507,7 +6507,7 @@ msgid "When"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/deliverability_live.ex:216
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:496
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:591
 #, elixir-autogen, elixir-format
 msgid "Why"
 msgstr ""
@@ -7710,6 +7710,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:173
 #: lib/vutuv_web/live/admin/dashboard_live.ex:287
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:398
 #: lib/vutuv_web/live/notification_live/index.ex:904
 #, elixir-autogen, elixir-format
 msgid "Today"
@@ -13105,7 +13106,7 @@ msgstr ""
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:650
 #: lib/vutuv_web/controllers/settings_controller.ex:668
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:308
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:328
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr ""
@@ -15568,7 +15569,7 @@ msgstr ""
 msgid "View the original"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:391
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:486
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:190
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:231
 #, elixir-autogen, elixir-format
@@ -19640,37 +19641,37 @@ msgstr ""
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:90
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:101
 #, elixir-autogen, elixir-format
 msgid "%{absorbed} is now an alternative name for %{canonical}."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:115
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "%{a} and %{b} are recorded as different topics."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:410
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:505
 #, elixir-autogen, elixir-format
 msgid "A dropped row belongs to somebody who already carries the surviving tag, so they end up carrying the topic once. Endorsements move to the row that stays."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:280
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "A tag cannot absorb itself."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:545
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:640
 #, elixir-autogen, elixir-format
 msgid "Absorbed"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:455
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:550
 #, elixir-autogen, elixir-format
 msgid "Add an alternative name"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:217
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:228
 #, elixir-autogen, elixir-format
 msgid "Added %{name} as an alternative name."
 msgstr ""
@@ -19680,40 +19681,35 @@ msgstr ""
 msgid "Alternative name for %{tag}"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:433
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:528
 #, elixir-autogen, elixir-format
 msgid "Alternative names for %{tag}"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:393
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:488
 #, elixir-autogen, elixir-format
 msgid "Dropped as duplicate"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:458
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:553
 #, elixir-autogen, elixir-format
 msgid "For a name nobody has typed yet, so it never becomes a page of its own. A name that is already a tag has to be merged instead."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:546
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:641
 #, elixir-autogen, elixir-format
 msgid "Into"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:363
-#, elixir-autogen, elixir-format
-msgid "Its entries move away and its page redirects."
-msgstr ""
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:417
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:512
 #, elixir-autogen, elixir-format
 msgid "Merge"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:42
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:341
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:345
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:351
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:371
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:375
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:381
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:258
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:261
 #, elixir-autogen, elixir-format
@@ -19725,47 +19721,42 @@ msgstr ""
 msgid "Merge tags ›"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:537
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:632
 #, elixir-autogen, elixir-format
 msgid "Merges so far"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:392
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:487
 #, elixir-autogen, elixir-format
 msgid "Moves"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:403
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:498
 #, elixir-autogen, elixir-format
 msgid "Nothing is filed under this tag."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:353
-#, elixir-autogen, elixir-format
-msgid "One topic sometimes ends up under several tags. Pick the tag to absorb and the tag that stays: everything filed under the first moves to the second, and the absorbed name becomes an alternative name that keeps pointing there. Every merge can be reverted below."
-msgstr ""
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:231
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "Removed."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:578
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:673
 #, elixir-autogen, elixir-format
 msgid "Revert"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:568
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:663
 #, elixir-autogen, elixir-format
 msgid "Reverted"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:547
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:642
 #, elixir-autogen, elixir-format
 msgid "Rows"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:624
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:735
 #, elixir-autogen, elixir-format
 msgid "Search by name or slug"
 msgstr ""
@@ -19775,178 +19766,230 @@ msgstr ""
 msgid "Several tags for one topic become one page: see what a merge would move, do it, and take it back if it was wrong."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:371
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:440
 #, elixir-autogen, elixir-format
 msgid "Tag that stays"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:362
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "Tag to absorb"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:127
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:138
 #, elixir-autogen, elixir-format
 msgid "That merge is no longer on record."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:307
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:327
 #, elixir-autogen, elixir-format
 msgid "That merge was already reverted."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:301
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:321
 #, elixir-autogen, elixir-format
 msgid "That name is already a tag. Merge it instead, so its entries come along."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:286
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "That tag is already an alternative name. Revert its merge first."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:306
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:326
 #, elixir-autogen, elixir-format
 msgid "That tag is not an alternative name."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:134
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:145
 #, elixir-autogen, elixir-format
 msgid "The merge was reverted."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:289
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:309
 #, elixir-autogen, elixir-format
 msgid "The surviving tag is itself an alternative name. Pick its topic instead."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:372
-#, elixir-autogen, elixir-format
-msgid "The topic's one page from now on."
-msgstr ""
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:425
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:520
 #, elixir-autogen, elixir-format
 msgid "These are different topics"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:296
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:316
 #, elixir-autogen, elixir-format
 msgid "These names differ only in characters the slug drops (like + or #), which is how C, C++ and C# tell each other apart. They are not merged."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:292
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:312
 #, elixir-autogen, elixir-format
 msgid "These two are recorded as different topics."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:304
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:324
 #, elixir-autogen, elixir-format
 msgid "This name came from a merge. Revert that merge to take it back."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:381
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:463
 #, elixir-autogen, elixir-format
 msgid "What this merge would move"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:330
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:360
 #, elixir-autogen, elixir-format
 msgid "hashtags in post bodies"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:332
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:362
 #, elixir-autogen, elixir-format
 msgid "job postings"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:331
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:361
 #, elixir-autogen, elixir-format
 msgid "members following it"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:334
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "newsletter audiences"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:329
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:359
 #, elixir-autogen, elixir-format
 msgid "posts filed under it"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:333
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "posts from other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:328
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:358
 #, elixir-autogen, elixir-format
 msgid "profiles carrying the tag"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:283
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:303
 #, elixir-autogen, elixir-format
 msgid "Honor tags are granted, not spelled. They are never merged."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:158
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "%{written} proposals, %{judged} of them judged by the model. %{dropped} more were found than the queue holds."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:527
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Different topics"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:481
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:576
 #, elixir-autogen, elixir-format
 msgid "Look for proposals"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:494
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:589
 #, elixir-autogen, elixir-format
 msgid "Pair"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:474
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:569
 #, elixir-autogen, elixir-format
 msgid "Pairs of tags that might be one topic, found by rule and, where a local model is available, judged by it. Nothing here has happened yet: opening one loads it above, where you see what a merge would move before confirming."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:472
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:567
 #, elixir-autogen, elixir-format
 msgid "Proposals"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:203
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:214
 #, elixir-autogen, elixir-format
 msgid "Recorded as different topics."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:175
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:191
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:186
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:202
 #, elixir-autogen, elixir-format
 msgid "That proposal is gone."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:484
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:579
 #, elixir-autogen, elixir-format
 msgid "The model is switched off; proposals are listed unjudged."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:324
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:354
 #, elixir-autogen, elixir-format
 msgid "one is a word of the other"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:323
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:353
 #, elixir-autogen, elixir-format
 msgid "one is the other's initials"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:322
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:352
 #, elixir-autogen, elixir-format
 msgid "the same name, written differently"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:415
+#, elixir-autogen, elixir-format
+msgid "\"rubyonrails\" was absorbed: nobody loses a tag, the name goes on working, and it is listed on the remaining page as an alternative name. Anyone typing it from now on gets the one page. Every merge can be undone at the bottom of this page."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:473
+#, elixir-autogen, elixir-format
+msgid "%{absorbed} becomes an alternative name for %{canonical}. %{absorbed_url} then redirects to %{canonical_url}."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:344
+#, elixir-autogen, elixir-format
+msgid "%{formatted} profile"
+msgid_plural "%{formatted} profiles"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:395
+#, elixir-autogen, elixir-format
+msgid "An example"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:442
+#, elixir-autogen, elixir-format
+msgid "Keeps its page and its address and gains everything from the other one."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:743
+#, elixir-autogen, elixir-format
+msgid "No tag matches that."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:383
+#, elixir-autogen, elixir-format
+msgid "One topic sometimes ends up under several tags, so its members and its posts are split over two pages that never show each other. Merging puts them on one page."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:428
+#, elixir-autogen, elixir-format
+msgid "Stops being a topic of its own. Its profiles, posts and follows move over and its address redirects."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:457
+#, elixir-autogen, elixir-format
+msgid "Swap: keep %{name} instead"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:409
+#, elixir-autogen, elixir-format
+msgid "redirects there for good"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:405
+#, elixir-autogen, elixir-format
+msgid "After the merge"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -18,7 +18,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3434
 #: lib/vutuv_web/components/ui.ex:3439
 #: lib/vutuv_web/live/admin/screenshot_live.ex:245
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:464
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:559
 #: lib/vutuv_web/live/organization_live/domains.ex:255
 #: lib/vutuv_web/live/organization_live/edit.ex:396
 #: lib/vutuv_web/live/organization_live/roles.ex:202
@@ -82,8 +82,8 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3229
 #: lib/vutuv_web/components/ui.ex:3323
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:444
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:576
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:539
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:671
 #, elixir-autogen
 msgid "Are you sure?"
 msgstr ""
@@ -680,7 +680,7 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:223
 #: lib/vutuv_web/cv/latex.ex:179
 #: lib/vutuv_web/cv/odt.ex:185
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:495
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:590
 #: lib/vutuv_web/live/cv_live.ex:410
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/index.html.heex:10
@@ -1156,7 +1156,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:693
 #: lib/vutuv_web/live/admin/organization_live.ex:189
 #: lib/vutuv_web/live/admin/screenshot_live.ex:172
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:343
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:373
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
@@ -1379,7 +1379,7 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:156
 #: lib/vutuv_web/cv/latex.ex:131
 #: lib/vutuv_web/cv/odt.ex:148
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:344
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:374
 #: lib/vutuv_web/live/cv_live.ex:315
 #: lib/vutuv_web/live/job_board_live.ex:277
 #: lib/vutuv_web/live/job_posting_live/form.ex:510
@@ -1745,9 +1745,9 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:391
 #: lib/vutuv_web/components/ui.ex:3436
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:451
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:488
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:539
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:546
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:583
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:634
 #: lib/vutuv_web/live/admin/user_live.ex:286
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
 #, elixir-autogen, elixir-format
@@ -2213,7 +2213,7 @@ msgstr ""
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
 #: lib/vutuv_web/components/post_components.ex:1006
 #: lib/vutuv_web/live/admin/screenshot_live.ex:317
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:446
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:541
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:373
@@ -3239,7 +3239,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2751
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:519
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:614
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Review"
@@ -5446,7 +5446,7 @@ msgstr ""
 msgid "Account"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:612
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:717
 #: lib/vutuv_web/live/organization_live/edit.ex:443
 #, elixir-autogen, elixir-format
 msgid "Change"
@@ -6495,7 +6495,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/activity_live.ex:142
 #: lib/vutuv_web/live/admin/deliverability_live.ex:213
 #: lib/vutuv_web/live/admin/deliverability_live.ex:250
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:548
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:643
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:189
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:230
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:27
@@ -6505,7 +6505,7 @@ msgid "When"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/deliverability_live.ex:216
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:496
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:591
 #, elixir-autogen, elixir-format
 msgid "Why"
 msgstr ""
@@ -7708,6 +7708,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:173
 #: lib/vutuv_web/live/admin/dashboard_live.ex:287
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:398
 #: lib/vutuv_web/live/notification_live/index.ex:904
 #, elixir-autogen, elixir-format
 msgid "Today"
@@ -13103,7 +13104,7 @@ msgstr ""
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:650
 #: lib/vutuv_web/controllers/settings_controller.ex:668
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:308
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:328
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr ""
@@ -15566,7 +15567,7 @@ msgstr ""
 msgid "View the original"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:391
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:486
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:190
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:231
 #, elixir-autogen, elixir-format
@@ -19638,37 +19639,37 @@ msgstr ""
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:90
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:101
 #, elixir-autogen, elixir-format
 msgid "%{absorbed} is now an alternative name for %{canonical}."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:115
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "%{a} and %{b} are recorded as different topics."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:410
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:505
 #, elixir-autogen, elixir-format
 msgid "A dropped row belongs to somebody who already carries the surviving tag, so they end up carrying the topic once. Endorsements move to the row that stays."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:280
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "A tag cannot absorb itself."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:545
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:640
 #, elixir-autogen, elixir-format
 msgid "Absorbed"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:455
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:550
 #, elixir-autogen, elixir-format
 msgid "Add an alternative name"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:217
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:228
 #, elixir-autogen, elixir-format
 msgid "Added %{name} as an alternative name."
 msgstr ""
@@ -19678,40 +19679,35 @@ msgstr ""
 msgid "Alternative name for %{tag}"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:433
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:528
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Alternative names for %{tag}"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:393
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:488
 #, elixir-autogen, elixir-format
 msgid "Dropped as duplicate"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:458
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:553
 #, elixir-autogen, elixir-format
 msgid "For a name nobody has typed yet, so it never becomes a page of its own. A name that is already a tag has to be merged instead."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:546
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:641
 #, elixir-autogen, elixir-format
 msgid "Into"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:363
-#, elixir-autogen, elixir-format
-msgid "Its entries move away and its page redirects."
-msgstr ""
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:417
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:512
 #, elixir-autogen, elixir-format
 msgid "Merge"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:42
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:341
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:345
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:351
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:371
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:375
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:381
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:258
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:261
 #, elixir-autogen, elixir-format
@@ -19723,47 +19719,42 @@ msgstr ""
 msgid "Merge tags ›"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:537
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:632
 #, elixir-autogen, elixir-format
 msgid "Merges so far"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:392
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:487
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Moves"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:403
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:498
 #, elixir-autogen, elixir-format
 msgid "Nothing is filed under this tag."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:353
-#, elixir-autogen, elixir-format
-msgid "One topic sometimes ends up under several tags. Pick the tag to absorb and the tag that stays: everything filed under the first moves to the second, and the absorbed name becomes an alternative name that keeps pointing there. Every merge can be reverted below."
-msgstr ""
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:231
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:242
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Removed."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:578
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:673
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Revert"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:568
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:663
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Reverted"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:547
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:642
 #, elixir-autogen, elixir-format
 msgid "Rows"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:624
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:735
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Search by name or slug"
 msgstr ""
@@ -19773,178 +19764,230 @@ msgstr ""
 msgid "Several tags for one topic become one page: see what a merge would move, do it, and take it back if it was wrong."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:371
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:440
 #, elixir-autogen, elixir-format
 msgid "Tag that stays"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:362
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "Tag to absorb"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:127
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:138
 #, elixir-autogen, elixir-format
 msgid "That merge is no longer on record."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:307
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:327
 #, elixir-autogen, elixir-format
 msgid "That merge was already reverted."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:301
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:321
 #, elixir-autogen, elixir-format
 msgid "That name is already a tag. Merge it instead, so its entries come along."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:286
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "That tag is already an alternative name. Revert its merge first."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:306
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:326
 #, elixir-autogen, elixir-format
 msgid "That tag is not an alternative name."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:134
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:145
 #, elixir-autogen, elixir-format
 msgid "The merge was reverted."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:289
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:309
 #, elixir-autogen, elixir-format
 msgid "The surviving tag is itself an alternative name. Pick its topic instead."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:372
-#, elixir-autogen, elixir-format
-msgid "The topic's one page from now on."
-msgstr ""
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:425
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:520
 #, elixir-autogen, elixir-format
 msgid "These are different topics"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:296
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:316
 #, elixir-autogen, elixir-format
 msgid "These names differ only in characters the slug drops (like + or #), which is how C, C++ and C# tell each other apart. They are not merged."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:292
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:312
 #, elixir-autogen, elixir-format
 msgid "These two are recorded as different topics."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:304
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:324
 #, elixir-autogen, elixir-format
 msgid "This name came from a merge. Revert that merge to take it back."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:381
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:463
 #, elixir-autogen, elixir-format
 msgid "What this merge would move"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:330
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:360
 #, elixir-autogen, elixir-format
 msgid "hashtags in post bodies"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:332
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:362
 #, elixir-autogen, elixir-format, fuzzy
 msgid "job postings"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:331
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:361
 #, elixir-autogen, elixir-format, fuzzy
 msgid "members following it"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:334
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:364
 #, elixir-autogen, elixir-format, fuzzy
 msgid "newsletter audiences"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:329
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:359
 #, elixir-autogen, elixir-format
 msgid "posts filed under it"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:333
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:363
 #, elixir-autogen, elixir-format, fuzzy
 msgid "posts from other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:328
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:358
 #, elixir-autogen, elixir-format
 msgid "profiles carrying the tag"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:283
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:303
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Honor tags are granted, not spelled. They are never merged."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:158
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "%{written} proposals, %{judged} of them judged by the model. %{dropped} more were found than the queue holds."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:527
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:622
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Different topics"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:481
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:576
 #, elixir-autogen, elixir-format
 msgid "Look for proposals"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:494
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:589
 #, elixir-autogen, elixir-format
 msgid "Pair"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:474
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:569
 #, elixir-autogen, elixir-format
 msgid "Pairs of tags that might be one topic, found by rule and, where a local model is available, judged by it. Nothing here has happened yet: opening one loads it above, where you see what a merge would move before confirming."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:472
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:567
 #, elixir-autogen, elixir-format
 msgid "Proposals"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:203
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:214
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Recorded as different topics."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:175
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:191
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:186
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:202
 #, elixir-autogen, elixir-format
 msgid "That proposal is gone."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:484
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:579
 #, elixir-autogen, elixir-format
 msgid "The model is switched off; proposals are listed unjudged."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:324
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:354
 #, elixir-autogen, elixir-format
 msgid "one is a word of the other"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:323
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:353
 #, elixir-autogen, elixir-format
 msgid "one is the other's initials"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:322
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:352
 #, elixir-autogen, elixir-format
 msgid "the same name, written differently"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:415
+#, elixir-autogen, elixir-format
+msgid "\"rubyonrails\" was absorbed: nobody loses a tag, the name goes on working, and it is listed on the remaining page as an alternative name. Anyone typing it from now on gets the one page. Every merge can be undone at the bottom of this page."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:473
+#, elixir-autogen, elixir-format
+msgid "%{absorbed} becomes an alternative name for %{canonical}. %{absorbed_url} then redirects to %{canonical_url}."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:344
+#, elixir-autogen, elixir-format, fuzzy
+msgid "%{formatted} profile"
+msgid_plural "%{formatted} profiles"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:395
+#, elixir-autogen, elixir-format
+msgid "An example"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:442
+#, elixir-autogen, elixir-format
+msgid "Keeps its page and its address and gains everything from the other one."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:743
+#, elixir-autogen, elixir-format
+msgid "No tag matches that."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:383
+#, elixir-autogen, elixir-format
+msgid "One topic sometimes ends up under several tags, so its members and its posts are split over two pages that never show each other. Merging puts them on one page."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:428
+#, elixir-autogen, elixir-format
+msgid "Stops being a topic of its own. Its profiles, posts and follows move over and its address redirects."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:457
+#, elixir-autogen, elixir-format
+msgid "Swap: keep %{name} instead"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:409
+#, elixir-autogen, elixir-format
+msgid "redirects there for good"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:405
+#, elixir-autogen, elixir-format
+msgid "After the merge"
 msgstr ""

--- a/test/vutuv_web/live/admin/tag_merge_live_test.exs
+++ b/test/vutuv_web/live/admin/tag_merge_live_test.exs
@@ -36,6 +36,54 @@ defmodule VutuvWeb.Admin.TagMergeLiveTest do
       }
     end
 
+    test "the page shows what a merge does before anything is picked", ctx do
+      # The screen was reported as not explaining itself: two column headings
+      # and no way to tell which of the two names disappears.
+      {:ok, lv, html} = live(ctx.conn, ~p"/admin/tag_merges")
+
+      assert has_element?(lv, "#merge-example")
+      assert html =~ "/tags/rubyonrails"
+      assert html =~ "/tags/ruby_on_rails"
+    end
+
+    test "a search result names the address and the profile count, not just the tag", ctx do
+      # Three spellings of one topic look identical by name alone; the number
+      # of profiles is usually what decides which one survives.
+      insert(:user_tag, user: insert(:activated_user), tag: ctx.canonical)
+
+      {:ok, lv, _html} = live(ctx.conn, ~p"/admin/tag_merges")
+
+      html =
+        lv
+        |> form("#search-absorbed", %{"side" => "absorbed", "q" => ctx.canonical.name})
+        |> render_change()
+
+      assert html =~ "/tags/#{ctx.canonical.slug}"
+      assert html =~ "1 profile"
+    end
+
+    test "the pair can be turned round in one click", ctx do
+      {:ok, lv, _html} = live(ctx.conn, ~p"/admin/tag_merges")
+      pick(lv, ctx.absorbed, "absorbed")
+      pick(lv, ctx.canonical, "canonical")
+
+      html = lv |> element("#swap-sides") |> render_click()
+
+      # Which of the two survives is the real decision here, and it is usually
+      # made after seeing both.
+      assert html =~ "#{ctx.canonical.name} becomes an alternative name"
+    end
+
+    test "the preview says in words what pressing merge would do", ctx do
+      {:ok, lv, _html} = live(ctx.conn, ~p"/admin/tag_merges")
+      pick(lv, ctx.absorbed, "absorbed")
+      html = pick(lv, ctx.canonical, "canonical")
+
+      assert html =~ "#{ctx.absorbed.name} becomes an alternative name for #{ctx.canonical.name}"
+      assert html =~ "/tags/#{ctx.absorbed.slug}"
+      assert has_element?(lv, "#merge-sentence")
+    end
+
     test "shows what the merge would move before it is confirmed", ctx do
       insert(:user_tag, user: insert(:activated_user), tag: ctx.absorbed)
 
@@ -91,6 +139,11 @@ defmodule VutuvWeb.Admin.TagMergeLiveTest do
       assert html =~ "Tag, das aufgenommen wird"
       assert html =~ "Tag, das bleibt"
       assert html =~ "Vorschläge"
+      assert html =~ "Ein Beispiel"
+      assert html =~ "Nach der Zusammenlegung"
+      # The example's counts go through the plural formatter, which the extract
+      # had fuzzy-filled with "%{formatted} Likes".
+      assert html =~ "89 Profile"
       refute html =~ "Tag to absorb"
       refute html =~ "Look for proposals"
     end


### PR DESCRIPTION
**TL;DR** `/admin/tag_merges` war nicht zu verstehen. Die Seite zeigt jetzt an einem Beispiel, was eine Zusammenlegung tut, sagt pro Spalte die Folgen, macht aus der Trefferliste eine echte Auswahl und lässt das Paar mit einem Klick umdrehen.

**Was nicht ging** (Screenshot im Chat): zwei Spaltenüberschriften mit je einer knappen Zeile, und nirgends stand, was eine Zusammenlegung bewirkt oder welcher der beiden Namen verschwindet. Die Treffer waren große blaue Kacheln, die wie eine Anzeige von Tags aussahen statt wie eine Auswahl, und zeigten nur den Namen: bei „rails", „Ruby on Rails" und „rubyonrails" untereinander weiß man damit nicht, was man anklickt.

**Vier Änderungen**

1. **Ein Beispiel oben auf der Seite**, vorher/nachher an einem echten Paar: zwei Seiten mit 89 und 12 Profilen werden eine mit 101, die aufgegebene Adresse leitet dauerhaft weiter, der Name steht als Zweitname auf der verbliebenen Seite. Dazu der Satz, dass niemand ein Tag verliert und alles rückgängig zu machen ist.
2. **Die Spalten sind nummeriert und nennen die Folgen** statt nur die Rolle: „Hört auf, ein eigenes Thema zu sein. Seine Profile, Beiträge und Abos ziehen um, seine Adresse leitet weiter" gegen „Behält Seite und Adresse und bekommt alles vom anderen Tag dazu".
3. **Jeder Treffer ist eine Zeile mit Name, Adresse und Zahl der Profile.** Die Zahl trägt meist die Entscheidung, welche Schreibweise bleiben soll; sie kommt aus einer Abfrage für die ganze Liste (`Tags.member_counts/1`).
4. **Ein Knopf dreht das Paar um**, weil „welches bleibt" die eigentliche Entscheidung ist und man sie meist erst trifft, wenn man beide sieht. Über der Tabelle steht außerdem in einem Satz, was das Drücken bewirken würde.

**Geprüft:** `mix precommit` grün (7097 Tests) und diesmal wirklich am Bildschirm angesehen — angemeldet als Admin auf einem eigenen Port, auf Deutsch, mit echten Tags: Beispielblock, Trefferzeilen mit Profilzahlen, Auswahl beider Seiten, Tauschen, Satz und Vorschau. Die Wegwerfdaten sind wieder aus `vutuv1_dev` entfernt.

**Deutsch:** alle zwölf neuen Strings von Hand. Der Extract hatte die Pluralform mit „%{formatted} Likes" vorbelegt und „After" mit „Nach 1 Stunde".

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*