### PR TITLE
Zusammenlegen sammelt eine Liste statt eines Paares (v7.237.0)

### DIFF
--- a/docs/architecture/admin.md
+++ b/docs/architecture/admin.md
@@ -118,11 +118,18 @@ names** (issue #1338), marked and linked to the topic they belong to, so a tag
 looked up under an absorbed name is still findable here.
 
 **`/admin/tag_merges`** (`VutuvWeb.Admin.TagMergeLive`) folds several tags for one
-topic into one page. Pick the tag to absorb and the one that stays, and the
-screen says what would move **before** anything happens: how many profiles,
-posts, follows and job postings change hands, and how many rows would be dropped
-because their owner already carries both spellings. Every merge is listed below
-the form with a "Revert" that puts all of it back. The same screen files a name
+topic into one page. It collects a **set**, not a pair: a topic is spread over
+`rails`, `rubyonrails`, `Ruby on Rails` and `ROR`, and gathering those takes
+several searches, because "rails" cannot turn up `ROR` and does turn up `grails`,
+which is a different topic. So a search adds to a list, any entry can be taken
+back out with one click, and only then is one of them picked to survive. Then the
+screen says what would move **before** anything happens: how many profiles, posts,
+follows and job postings change hands, and how many rows are dropped because
+their owner already carries the surviving tag — the counts the sequence really
+produces (`Merge.preview_many/2`), not the sum of the pairs. Each absorbed tag
+becomes its own recorded merge, so the history below the form can take one back
+without undoing the rest, and a tag the merge refuses is named with its reason
+rather than quietly skipped. The same screen files a name
 as an alternative *before* anyone types it (so `ROR` never becomes a page of its
 own) and marks a pair as deliberately distinct, which refuses the merge for good.
 The mechanics, the four refusals and why an alternative name is a tag row rather

--- a/docs/architecture/social-graph.md
+++ b/docs/architecture/social-graph.md
@@ -153,7 +153,12 @@ their topic.
 
 **Merging** is `Vutuv.Tags.Merge`, driven from `/admin/tag_merges`
 (`VutuvWeb.Admin.TagMergeLive`; its own path segment because the earlier
-`resources("/tags", …)` in the router would read `merge` as a slug). It moves
+`resources("/tags", …)` in the router would read `merge` as a slug). The screen
+collects a **set** of spellings across several searches and absorbs them into
+one chosen survivor, each as its own recorded merge (`merge_all/3`), with
+`preview_many/2` counting what the sequence really does rather than summing the
+pairs — merging `A` and `B` into `C` for a member holding `A` and `B` moves one
+row and drops the other. A single merge moves
 every row filed under the absorbed tag — profile tags and the endorsements under
 them, post tags and body hashtags, tag follows, job postings, cached remote
 posts, newsletter audiences — and only deletes a row whose owner already holds

--- a/lib/vutuv/tags/merge.ex
+++ b/lib/vutuv/tags/merge.ex
@@ -68,20 +68,103 @@ defmodule Vutuv.Tags.Merge do
   """
   def preview(%Tag{} = absorbed, %Tag{} = canonical) do
     with :ok <- check(absorbed, canonical) do
-      counts =
-        Enum.reduce(@movable, %{moved: %{}, dropped: %{}}, fn {table, owner}, acc ->
-          moved = count_rows(movable_ids_sql(table, owner), params(owner, absorbed, canonical))
-
-          total =
-            count_rows("select 1 from #{table} where tag_id = $1::text::uuid", [absorbed.id])
-
-          acc
-          |> put_count(:moved, table, moved)
-          |> put_count(:dropped, table, total - moved)
-        end)
-
+      counts = count_move(List.wrap(absorbed.id), canonical)
       Map.merge(counts, %{absorbed: absorbed, canonical: canonical})
     end
+  end
+
+  @doc """
+  The same, for absorbing **several** tags into one — the way a topic is
+  actually tidied up, since `Ruby on Rails` is spread over four spellings and
+  not two.
+
+  Answers `%{moved:, dropped:, mergeable: [tag], refused: [{tag, reason}]}`: a
+  tag the merge would refuse is named with its reason rather than silently
+  dropped from the list, and the others can still go ahead.
+
+  The counts are the ones the sequence really produces, not the sum of the
+  pairs. Merging `A` and `B` into `C` for a member who holds `A` and `B` but not
+  `C` moves one row and drops the other, because by the time `B` is absorbed
+  that member already carries `C` — adding two separate previews would promise
+  two moves.
+  """
+  def preview_many(absorbed, %Tag{} = canonical) when is_list(absorbed) do
+    checked = Enum.map(absorbed, fn tag -> {tag, check(tag, canonical)} end)
+    mergeable = for {tag, :ok} <- checked, do: tag
+    refused = for {tag, {:error, reason}} <- checked, do: {tag, reason}
+
+    counts =
+      case mergeable do
+        [] -> %{moved: %{}, dropped: %{}}
+        tags -> count_move(Enum.map(tags, & &1.id), canonical)
+      end
+
+    Map.merge(counts, %{
+      mergeable: mergeable,
+      refused: refused,
+      canonical: canonical
+    })
+  end
+
+  # Per table: how many rows move and how many are dropped as duplicates when
+  # `absorbed_ids` are absorbed into `canonical`. One row per owner survives —
+  # the rest collide on the `(owner, tag)` unique index — which is what the
+  # window function counts, so the answer holds for one absorbed tag and for
+  # five.
+  defp count_move(absorbed_ids, canonical) do
+    Enum.reduce(@movable, %{moved: %{}, dropped: %{}}, fn {table, owner}, acc ->
+      %{rows: [[moved, dropped]]} =
+        Repo.query!(move_counts_sql(table, owner), [absorbed_ids, canonical.id])
+
+      acc
+      |> put_count(:moved, table, moved)
+      |> put_count(:dropped, table, dropped)
+    end)
+  end
+
+  # A table with no owner column cannot collide: every row simply moves.
+  defp move_counts_sql(table, nil) do
+    """
+    select count(*), 0
+    from #{table}
+    where tag_id = any($1::text[]::uuid[]) and $2::text::uuid is not null
+    """
+  end
+
+  defp move_counts_sql(table, owner) do
+    """
+    select
+      count(*) filter (where rn = 1 and not held),
+      count(*) filter (where rn > 1 or held)
+    from (
+      select
+        row_number() over (partition by a.#{owner} order by a.id) as rn,
+        exists (
+          select 1 from #{table} b
+          where b.tag_id = $2::text::uuid and b.#{owner} = a.#{owner}
+        ) as held
+      from #{table} a
+      where a.tag_id = any($1::text[]::uuid[])
+    ) rows
+    """
+  end
+
+  @doc """
+  Absorbs several tags into one, each as its own recorded merge so each can be
+  taken back on its own.
+
+  Answers `%{merged: [%TagMerge{}], failed: [{tag, reason}]}`. A refusal stops
+  that one tag, not the rest: the reviewer has already decided the others belong
+  together, and making them start over because one entry was an honor tag would
+  be the wrong lesson to teach.
+  """
+  def merge_all(absorbed, %Tag{} = canonical, opts \\ []) when is_list(absorbed) do
+    Enum.reduce(absorbed, %{merged: [], failed: []}, fn tag, acc ->
+      case merge(tag, canonical, opts) do
+        {:ok, merge} -> Map.update!(acc, :merged, &(&1 ++ [merge]))
+        {:error, reason} -> Map.update!(acc, :failed, &(&1 ++ [{tag, reason}]))
+      end
+    end)
   end
 
   @doc """
@@ -479,11 +562,6 @@ defmodule Vutuv.Tags.Merge do
   # takes one parameter; passing a second would be a bind error, not a no-op.
   defp params(nil, absorbed, _canonical), do: [absorbed.id]
   defp params(_owner, absorbed, canonical), do: [absorbed.id, canonical.id]
-
-  defp count_rows(sql, params) do
-    %{num_rows: count} = Repo.query!(sql, params)
-    count
-  end
 
   defp query_column(repo, sql, params) do
     %{rows: rows} = repo.query!(sql, params)

--- a/lib/vutuv_web/live/admin/tag_merge_live.ex
+++ b/lib/vutuv_web/live/admin/tag_merge_live.ex
@@ -1,13 +1,27 @@
 defmodule VutuvWeb.Admin.TagMergeLive do
   @moduledoc """
-  The tag merge screen (`/admin/tags/merge`, issue #1338): fold several tags for
+  The tag merge screen (`/admin/tag_merges`, issue #1338): fold several tags for
   one topic into one page.
 
-  Pick the tag to absorb and the tag that survives, and the screen says what the
-  merge would move **before** anything happens — how many profiles, posts,
-  follows and job postings change hands, and how many rows would be dropped
-  because their owner already carries both spellings. That preview is the point
+  **The screen collects a set, not a pair.** A topic is spread over `rails`,
+  `rubyonrails`, `Ruby on Rails` and `ROR`, and gathering those takes several
+  searches: "rails" cannot turn up `ROR`, and it does turn up `grails`, which is
+  a different topic. So a search **adds** to a list, every entry can be taken
+  back out with one click, and only then is one of them picked to survive. Its
+  first shape asked for one tag to absorb and one to keep, which made the
+  reviewer restart the whole thing whenever a search brought back the wrong
+  neighbour.
+
+  Once the list stands, the screen says what the merge would move **before**
+  anything happens: how many profiles, posts, follows and job postings change
+  hands, and how many rows are dropped because their owner already carries the
+  surviving tag. Those counts are the ones the sequence really produces
+  (`Merge.preview_many/2`), not the sum of the pairs. That preview is the point
   of the page: absorbing a tag moves rows people put there deliberately.
+
+  Each absorbed tag becomes its own recorded merge, so one of them can be taken
+  back without undoing the rest, and a tag the merge refuses is named with its
+  reason instead of being quietly skipped.
 
   Everything here is reversible. The merge history below the form lists what was
   done, by whom, and offers "Revert" on each entry, which puts every row back
@@ -40,94 +54,116 @@ defmodule VutuvWeb.Admin.TagMergeLive do
     {:ok,
      socket
      |> assign(:page_title, gettext("Merge tags"))
-     |> assign(:absorbed, nil)
-     |> assign(:canonical, nil)
-     |> assign(:absorbed_query, "")
-     |> assign(:canonical_query, "")
-     |> assign(:absorbed_results, [])
-     |> assign(:canonical_results, [])
+     # The tags collected so far, and which of them survives. A topic is spread
+     # over a *set* of spellings, so the screen collects a set.
+     |> assign(:basket, [])
+     |> assign(:keeper_id, nil)
+     |> assign(:query, "")
+     |> assign(:results, [])
      |> assign(:alias_name, "")
-     |> assign(:scanning?, false)
      |> load_preview()
      |> load_history()
      |> load_queue()}
   end
 
   @impl true
-  def handle_event("search", %{"side" => side, "q" => q}, socket) do
-    {:noreply,
-     socket
-     |> assign(:"#{side}_query", q)
-     |> assign(:"#{side}_results", search(q))}
+  def handle_event("search", %{"q" => q}, socket) do
+    {:noreply, socket |> assign(:query, q) |> assign(:results, search(q, socket.assigns.basket))}
   end
 
-  def handle_event("pick", %{"side" => side, "id" => id}, socket) do
-    {:noreply,
-     socket
-     |> assign(:"#{side}", Repo.get(Tag, id))
-     |> assign(:"#{side}_results", [])
-     |> assign(:"#{side}_query", "")
-     |> load_preview()}
-  end
+  # Collecting the spellings of one topic takes several searches — "rails" can
+  # never turn up "ROR" — so a result is **added** to the list rather than
+  # replacing a slot.
+  def handle_event("add", %{"id" => id}, socket) do
+    case Repo.get(Tag, id) do
+      nil ->
+        {:noreply, socket}
 
-  def handle_event("clear", %{"side" => side}, socket) do
-    {:noreply, socket |> assign(:"#{side}", nil) |> load_preview()}
-  end
-
-  # Which of two tags should survive is the actual decision on this screen, and
-  # it is usually made after seeing both: turning the pair round has to be one
-  # click, not two searches again.
-  def handle_event("swap", _params, socket) do
-    {:noreply,
-     socket
-     |> assign(:absorbed, socket.assigns.canonical)
-     |> assign(:canonical, socket.assigns.absorbed)
-     |> load_preview()}
-  end
-
-  def handle_event("merge", _params, socket) do
-    %{absorbed: absorbed, canonical: canonical} = socket.assigns
-
-    case Merge.merge(absorbed, canonical, actor: socket.assigns.current_user) do
-      {:ok, _merge} ->
-        # Decided, so it leaves the proposal queue whether it came from there
-        # or was picked by hand.
-        Assistant.drop_pair(absorbed, canonical)
+      tag ->
+        basket = socket.assigns.basket ++ [tag]
 
         {:noreply,
          socket
-         |> put_flash(
-           :info,
-           gettext("%{absorbed} is now an alternative name for %{canonical}.",
-             absorbed: absorbed.name,
-             canonical: canonical.name
-           )
-         )
-         |> assign(:absorbed, nil)
-         |> assign(:canonical, Repo.get(Tag, canonical.id))
-         |> load_preview()
-         |> load_history()
-         |> load_queue()}
-
-      {:error, reason} ->
-        {:noreply, put_flash(socket, :error, refusal(reason))}
+         |> assign(:basket, basket)
+         |> assign(:keeper_id, socket.assigns.keeper_id || tag.id)
+         |> assign(:results, search(socket.assigns.query, basket))
+         |> load_preview()}
     end
   end
 
-  def handle_event("mark-distinct", _params, socket) do
-    %{absorbed: absorbed, canonical: canonical} = socket.assigns
-    {:ok, _} = Merge.mark_distinct(absorbed, canonical, actor: socket.assigns.current_user)
-    Assistant.drop_pair(absorbed, canonical)
+  # A search for "rails" also finds "grails", which is a different topic. Taking
+  # one back out has to be as easy as putting it in, or the reviewer starts the
+  # whole list again.
+  def handle_event("remove", %{"id" => id}, socket) do
+    basket = Enum.reject(socket.assigns.basket, &(&1.id == id))
+
+    {:noreply,
+     socket
+     |> assign(:basket, basket)
+     |> assign(:keeper_id, keeper_after_removal(socket.assigns.keeper_id, id, basket))
+     |> assign(:results, search(socket.assigns.query, basket))
+     |> load_preview()}
+  end
+
+  def handle_event("clear-basket", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:basket, [])
+     |> assign(:keeper_id, nil)
+     |> assign(:results, search(socket.assigns.query, []))
+     |> load_preview()}
+  end
+
+  # Which of the collected spellings survives is the decision this screen is
+  # for, and it is made after seeing them all side by side with their counts.
+  def handle_event("keep", %{"id" => id}, socket) do
+    {:noreply, socket |> assign(:keeper_id, id) |> load_preview()}
+  end
+
+  def handle_event("merge", _params, socket) do
+    %{keeper: keeper, absorbed: absorbed} = split_basket(socket.assigns)
+
+    result = Merge.merge_all(absorbed, keeper, actor: socket.assigns.current_user)
+    Enum.each(result.merged, &Assistant.drop_pair(Repo.get(Tag, &1.absorbed_tag_id), keeper))
+
+    socket =
+      Enum.reduce(result.failed, socket, fn {tag, reason}, acc ->
+        put_flash(acc, :error, "#{tag.name}: #{refusal(reason)}")
+      end)
 
     {:noreply,
      socket
      |> put_flash(
        :info,
-       gettext("%{a} and %{b} are recorded as different topics.",
-         a: absorbed.name,
-         b: canonical.name
+       ngettext(
+         "%{count} tag is now an alternative name for %{canonical}.",
+         "%{count} tags are now alternative names for %{canonical}.",
+         length(result.merged),
+         canonical: keeper.name
        )
      )
+     |> assign(:basket, [Repo.get(Tag, keeper.id)])
+     |> assign(:keeper_id, keeper.id)
+     |> load_preview()
+     |> load_history()
+     |> load_queue()}
+  end
+
+  # Only meaningful for exactly two: "these are different topics" is a statement
+  # about a pair, and a list of five would mean ten of them.
+  def handle_event("mark-distinct", _params, socket) do
+    [a, b] = socket.assigns.basket
+    {:ok, _} = Merge.mark_distinct(a, b, actor: socket.assigns.current_user)
+    Assistant.drop_pair(a, b)
+
+    {:noreply,
+     socket
+     |> put_flash(
+       :info,
+       gettext("%{a} and %{b} are recorded as different topics.", a: a.name, b: b.name)
+     )
+     |> assign(:basket, [])
+     |> assign(:keeper_id, nil)
      |> load_preview()
      |> load_queue()}
   end
@@ -143,10 +179,7 @@ defmodule VutuvWeb.Admin.TagMergeLive do
             {:noreply,
              socket
              |> put_flash(:info, gettext("The merge was reverted."))
-             |> assign(
-               :canonical,
-               socket.assigns.canonical && Repo.get(Tag, socket.assigns.canonical.id)
-             )
+             |> reload_basket()
              |> load_preview()
              |> load_history()}
 
@@ -177,9 +210,9 @@ defmodule VutuvWeb.Admin.TagMergeLive do
   end
 
   # Approving a proposal is the ordinary merge, so it goes through the same
-  # preview: the pair is loaded into the pickers instead of being merged on the
-  # spot. A one-click merge from a queue row is exactly the unreviewed merge
-  # this feature exists to avoid.
+  # review: the pair lands in the list above, where it can be corrected, added
+  # to and previewed. A one-click merge from a queue row is exactly the
+  # unreviewed merge this feature exists to avoid.
   def handle_event("review", %{"id" => id}, socket) do
     case Assistant.get_candidate(id) do
       nil ->
@@ -190,8 +223,8 @@ defmodule VutuvWeb.Admin.TagMergeLive do
 
         {:noreply,
          socket
-         |> assign(:absorbed, absorbed)
-         |> assign(:canonical, canonical)
+         |> assign(:basket, [canonical, absorbed])
+         |> assign(:keeper_id, canonical.id)
          |> load_preview()}
     end
   end
@@ -221,7 +254,7 @@ defmodule VutuvWeb.Admin.TagMergeLive do
   end
 
   def handle_event("add-alias", %{"name" => name}, socket) do
-    case Merge.add_alias(socket.assigns.canonical, name) do
+    case Merge.add_alias(socket.assigns.keeper, name) do
       {:ok, _tag} ->
         {:noreply,
          socket
@@ -246,34 +279,60 @@ defmodule VutuvWeb.Admin.TagMergeLive do
 
   # Each result carries the number of profiles carrying it, batched into one
   # query for the whole list: with three spellings of one topic on screen, that
-  # number is usually what decides which of them should survive.
-  defp search(query) do
+  # number is usually what decides which of them should survive. Anything
+  # already collected drops out, so the list only ever offers something new.
+  defp search(query, basket) do
     case String.trim(to_string(query)) do
       "" ->
         []
 
       q ->
-        tags = q |> Tags.admin_search(limit: @results_limit) |> Repo.all()
+        collected = MapSet.new(basket, & &1.id)
+
+        tags =
+          q
+          |> Tags.admin_search(limit: @results_limit)
+          |> Repo.all()
+          |> Enum.reject(&MapSet.member?(collected, &1.id))
+
         counts = Tags.member_counts(Enum.map(tags, & &1.id))
 
         Enum.map(tags, &%{tag: &1, members: Map.get(counts, &1.id, 0)})
     end
   end
 
+  # A merge or a revert changes the rows the list is showing, so it is re-read
+  # rather than left holding what the tags looked like before.
+  defp reload_basket(socket) do
+    basket = socket.assigns.basket |> Enum.map(&Repo.get(Tag, &1.id)) |> Enum.reject(&is_nil/1)
+    assign(socket, :basket, basket)
+  end
+
+  # The collected tags split into the one that survives and the ones absorbed.
+  defp split_basket(%{basket: basket, keeper_id: keeper_id}) do
+    keeper = Enum.find(basket, &(&1.id == keeper_id))
+    %{keeper: keeper, absorbed: Enum.reject(basket, &(&1.id == keeper_id))}
+  end
+
+  # Removing the tag that was set to survive must not leave the list without a
+  # keeper: the next one takes over rather than the screen going blank.
+  defp keeper_after_removal(keeper_id, keeper_id, [next | _]), do: next.id
+  defp keeper_after_removal(keeper_id, keeper_id, []), do: nil
+  defp keeper_after_removal(keeper_id, _removed_id, _basket), do: keeper_id
+
   # The preview is recomputed on every pick, so what the screen shows is always
   # the answer for the pair currently named — including the refusal, which is
   # shown in place of the button rather than only after pressing it.
   defp load_preview(socket) do
-    %{absorbed: absorbed, canonical: canonical} = socket.assigns
+    %{keeper: keeper, absorbed: absorbed} = split_basket(socket.assigns)
 
-    preview =
-      case {absorbed, canonical} do
-        {%Tag{}, %Tag{}} -> Merge.preview(absorbed, canonical)
-        _ -> nil
-      end
+    preview = keeper && absorbed != [] && Merge.preview_many(absorbed, keeper)
 
-    assign(socket, :preview, preview)
-    |> assign(:aliases, canonical && Tag.aliases_of(canonical))
+    socket
+    |> assign(:keeper, keeper)
+    |> assign(:preview, preview || nil)
+    |> assign(:aliases, keeper && Tag.aliases_of(keeper))
+    |> assign(:members, Tags.member_counts(Enum.map(socket.assigns.basket, & &1.id)))
   end
 
   defp load_history(socket), do: assign(socket, :history, Merge.history())
@@ -419,113 +478,213 @@ defmodule VutuvWeb.Admin.TagMergeLive do
         </div>
 
         <div class="mt-6 grid gap-6 md:grid-cols-2">
-          <.tag_picker
-            side="absorbed"
-            id="absorbed"
-            step="1"
-            label={gettext("Tag to absorb")}
-            hint={
-              gettext(
-                "Stops being a topic of its own. Its profiles, posts and follows move over and its address redirects."
-              )
-            }
-            tag={@absorbed}
-            query={@absorbed_query}
-            results={@absorbed_results}
-          />
-          <.tag_picker
-            side="canonical"
-            id="canonical"
-            step="2"
-            label={gettext("Tag that stays")}
-            hint={
-              gettext("Keeps its page and its address and gains everything from the other one.")
-            }
-            tag={@canonical}
-            query={@canonical_query}
-            results={@canonical_results}
-          />
-        </div>
+          <%!-- Collecting the spellings of a topic takes several searches: a
+          search for "rails" can never turn up "ROR", and it does turn up
+          "grails", which is a different topic. So the search adds to a list
+          rather than filling one of two slots. --%>
+          <div>
+            <h2 class="card__label">
+              <span class="mr-1 text-slate-400 dark:text-slate-500">1.</span>{gettext(
+                "Collect the tags that mean one topic"
+              )}
+            </h2>
+            <p class="text-sm text-slate-600 dark:text-slate-400">
+              {gettext(
+                "Search as often as you like and add what belongs. Abbreviations will not turn up under the full name, so look for them separately."
+              )}
+            </p>
 
-        <div :if={@absorbed && @canonical} class="editform__actions mt-4">
-          <button
-            id="swap-sides"
-            type="button"
-            class="button button--cancel"
-            phx-click="swap"
-          >
-            {gettext("Swap: keep %{name} instead", name: @absorbed.name)}
-          </button>
+            <form id="tag-search" phx-change="search" phx-submit="search" class="mt-2">
+              <input
+                type="text"
+                id="q"
+                name="q"
+                value={@query}
+                autocomplete="off"
+                placeholder={gettext("Search by name or slug")}
+              />
+            </form>
+
+            <p :if={@query != "" and @results == []} class="card__empty">
+              {gettext("No tag matches that.")}
+            </p>
+
+            <ul :if={@results != []} class="mt-2 space-y-1">
+              <li :for={result <- @results}>
+                <button
+                  type="button"
+                  id={"add-#{result.tag.id}"}
+                  class="w-full rounded-lg px-3 py-2 text-left hover:bg-brand-50 dark:hover:bg-brand-900/40"
+                  phx-click="add"
+                  phx-value-id={result.tag.id}
+                >
+                  <span class="block font-semibold text-brand-700 dark:text-brand-200">
+                    + {result.tag.name}
+                  </span>
+                  <span class="block text-xs text-slate-600 dark:text-slate-400">
+                    /tags/{result.tag.slug} · {profile_count(result.members)}
+                  </span>
+                </button>
+              </li>
+            </ul>
+          </div>
+
+          <div>
+            <h2 class="card__label">
+              <span class="mr-1 text-slate-400 dark:text-slate-500">2.</span>{gettext(
+                "Pick the one that stays"
+              )}
+            </h2>
+            <p class="text-sm text-slate-600 dark:text-slate-400">
+              {gettext(
+                "It keeps its page and its address; every other one becomes an alternative name pointing at it."
+              )}
+            </p>
+
+            <p :if={@basket == []} class="card__empty">
+              {gettext("Nothing collected yet.")}
+            </p>
+
+            <ul :if={@basket != []} id="basket" class="mt-2 space-y-1">
+              <li
+                :for={tag <- @basket}
+                id={"basket-#{tag.id}"}
+                class={[
+                  "flex items-start gap-3 rounded-lg px-3 py-2",
+                  tag.id == @keeper_id && "bg-brand-50 dark:bg-brand-900/40"
+                ]}
+              >
+                <label class="flex min-w-0 grow cursor-pointer items-start gap-3">
+                  <input
+                    type="radio"
+                    name="keeper"
+                    checked={tag.id == @keeper_id}
+                    phx-click="keep"
+                    phx-value-id={tag.id}
+                    class={checkbox_class()}
+                  />
+                  <span class="min-w-0">
+                    <span class="block font-semibold">{tag.name}</span>
+                    <span class="block text-xs text-slate-600 dark:text-slate-400">
+                      /tags/{tag.slug} · {profile_count(Map.get(@members, tag.id, 0))}
+                    </span>
+                  </span>
+                </label>
+                <button
+                  type="button"
+                  id={"remove-#{tag.id}"}
+                  class="button button--cancel button--small"
+                  phx-click="remove"
+                  phx-value-id={tag.id}
+                  title={gettext("Does not belong here")}
+                >
+                  ✕
+                </button>
+              </li>
+            </ul>
+
+            <div :if={@basket != []} class="editform__actions mt-3">
+              <button
+                id="clear-basket"
+                type="button"
+                class="button button--cancel"
+                phx-click="clear-basket"
+              >
+                {gettext("Start over")}
+              </button>
+            </div>
+          </div>
         </div>
       </section>
 
       <section :if={@preview} class="card" id="merge-preview">
         <h2 class="card__label">{gettext("What this merge would move")}</h2>
 
-        <%= case @preview do %>
-          <% {:error, reason} -> %>
-            <p class="alert alert-danger" role="alert">{refusal(reason)}</p>
-          <% preview -> %>
-            <%!-- The table answers "how much"; this line answers "what am I
-            about to do", which is the question somebody presses the button
-            with. --%>
-            <p id="merge-sentence" class="text-sm">
-              {gettext(
-                "%{absorbed} becomes an alternative name for %{canonical}. %{absorbed_url} then redirects to %{canonical_url}.",
-                absorbed: preview.absorbed.name,
-                canonical: preview.canonical.name,
-                absorbed_url: "/tags/" <> preview.absorbed.slug,
-                canonical_url: "/tags/" <> preview.canonical.slug
-              )}
-            </p>
+        <%!-- The table answers "how much"; this line answers "what am I about
+        to do", which is the question somebody presses the button with. --%>
+        <p :if={@preview.mergeable != []} id="merge-sentence" class="text-sm">
+          {ngettext(
+            "%{names} becomes an alternative name for %{canonical} and %{urls} redirects to /tags/%{slug}.",
+            "%{names} become alternative names for %{canonical}, and their addresses redirect to /tags/%{slug}.",
+            length(@preview.mergeable),
+            names: Enum.map_join(@preview.mergeable, ", ", & &1.name),
+            canonical: @preview.canonical.name,
+            urls: Enum.map_join(@preview.mergeable, ", ", &("/tags/" <> &1.slug)),
+            slug: @preview.canonical.slug
+          )}
+        </p>
 
-            <div class="card__tablewrap mt-3">
-              <table class="pure-table">
-                <thead>
-                  <tr>
-                    <th>{gettext("What")}</th>
-                    <th>{gettext("Moves")}</th>
-                    <th>{gettext("Dropped as duplicate")}</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr :for={{table, _} <- Map.merge(preview.moved, preview.dropped)}>
-                    <td>{row_label(table)}</td>
-                    <td>{delimited_count(Map.get(preview.moved, table, 0))}</td>
-                    <td>{delimited_count(Map.get(preview.dropped, table, 0))}</td>
-                  </tr>
-                  <tr :if={total(preview.moved) == 0 and total(preview.dropped) == 0}>
-                    <td colspan="3">{gettext("Nothing is filed under this tag.")}</td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
+        <%!-- A tag the merge refuses is named with its reason rather than
+        quietly left out: the reviewer put it in the list on purpose. --%>
+        <ul :if={@preview.refused != []} id="refused" class="mt-3 space-y-1">
+          <li :for={{tag, reason} <- @preview.refused} class="alert alert-danger" role="alert">
+            <strong>{tag.name}:</strong> {refusal(reason)}
+          </li>
+        </ul>
 
-            <p :if={total(preview.dropped) > 0} class="mt-3 text-sm text-slate-600 dark:text-slate-400">
-              {gettext(
-                "A dropped row belongs to somebody who already carries the surviving tag, so they end up carrying the topic once. Endorsements move to the row that stays."
-              )}
-            </p>
+        <div :if={@preview.mergeable != []} class="card__tablewrap mt-3">
+          <table class="pure-table">
+            <thead>
+              <tr>
+                <th>{gettext("What")}</th>
+                <th>{gettext("Moves")}</th>
+                <th>{gettext("Dropped as duplicate")}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr :for={{table, _} <- Map.merge(@preview.moved, @preview.dropped)}>
+                <td>{row_label(table)}</td>
+                <td>{delimited_count(Map.get(@preview.moved, table, 0))}</td>
+                <td>{delimited_count(Map.get(@preview.dropped, table, 0))}</td>
+              </tr>
+              <tr :if={total(@preview.moved) == 0 and total(@preview.dropped) == 0}>
+                <td colspan="3">{gettext("Nothing is filed under these tags.")}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
 
-            <div class="editform__actions mt-4">
-              <button id="do-merge" type="button" class="button" phx-click="merge">
-                {gettext("Merge")}
-              </button>
-              <button
-                id="mark-distinct"
-                type="button"
-                class="button button--cancel"
-                phx-click="mark-distinct"
-              >
-                {gettext("These are different topics")}
-              </button>
-            </div>
-        <% end %>
+        <p
+          :if={total(@preview.dropped) > 0}
+          class="mt-3 text-sm text-slate-600 dark:text-slate-400"
+        >
+          {gettext(
+            "A dropped row belongs to somebody who already carries the surviving tag, so they end up carrying the topic once. Endorsements move to the row that stays."
+          )}
+        </p>
+
+        <div class="editform__actions mt-4">
+          <button
+            :if={@preview.mergeable != []}
+            id="do-merge"
+            type="button"
+            class="button"
+            phx-click="merge"
+          >
+            {ngettext(
+              "Merge %{count} tag into %{canonical}",
+              "Merge %{count} tags into %{canonical}",
+              length(@preview.mergeable),
+              canonical: @preview.canonical.name
+            )}
+          </button>
+          <%!-- Only for a pair: "these are different topics" is a statement
+          about two names, and a list of five would mean ten of them. --%>
+          <button
+            :if={length(@basket) == 2}
+            id="mark-distinct"
+            type="button"
+            class="button button--cancel"
+            phx-click="mark-distinct"
+          >
+            {gettext("These are different topics")}
+          </button>
+        </div>
       </section>
 
-      <section :if={@canonical} class="card" id="alias-editor">
+      <section :if={@keeper} class="card" id="alias-editor">
         <h2 class="card__label">
-          {gettext("Alternative names for %{tag}", tag: @canonical.name)}
+          {gettext("Alternative names for %{tag}", tag: @keeper.name)}
         </h2>
 
         <ul :if={@aliases != []} class="thumbs">
@@ -678,90 +837,6 @@ defmodule VutuvWeb.Admin.TagMergeLive do
           </table>
         </div>
       </section>
-    </div>
-    """
-  end
-
-  attr(:side, :string, required: true)
-  attr(:id, :string, required: true)
-  attr(:step, :string, required: true)
-  attr(:label, :string, required: true)
-  attr(:hint, :string, required: true)
-  attr(:tag, :any, default: nil)
-  attr(:query, :string, default: "")
-  attr(:results, :list, default: [])
-
-  # A search result is a **choice**, and it has to look like one. As a row of
-  # big blue chips the list read as a display of tags rather than as a picker,
-  # and it showed only the name — which is not enough to tell `rails` from
-  # `Ruby on Rails` from `rubyonrails` when all three are in the list. Each row
-  # is one wide button now, naming the tag, the address it lives at and how many
-  # profiles carry it, because that last number is usually what decides which of
-  # two spellings should survive.
-  defp tag_picker(assigns) do
-    ~H"""
-    <div>
-      <h2 class="card__label">
-        <span class="mr-1 text-slate-400 dark:text-slate-500">{@step}.</span>{@label}
-      </h2>
-      <p class="text-sm text-slate-600 dark:text-slate-400">{@hint}</p>
-
-      <div :if={@tag} class="mt-2 flex items-center gap-3" id={"picked-#{@id}"}>
-        <.chip navigate={~p"/tags/#{@tag}"}>{@tag.name}</.chip>
-        <button
-          type="button"
-          class="button button--cancel button--small"
-          phx-click="clear"
-          phx-value-side={@side}
-        >
-          {gettext("Change")}
-        </button>
-      </div>
-
-      <form
-        :if={is_nil(@tag)}
-        id={"search-#{@id}"}
-        phx-change="search"
-        phx-submit="search"
-        class="mt-2"
-      >
-        <input type="hidden" name="side" value={@side} />
-        <input
-          type="text"
-          id={"q-#{@id}"}
-          name="q"
-          value={@query}
-          autocomplete="off"
-          placeholder={gettext("Search by name or slug")}
-        />
-      </form>
-
-      <p
-        :if={is_nil(@tag) and @query != "" and @results == []}
-        class="card__empty"
-      >
-        {gettext("No tag matches that.")}
-      </p>
-
-      <ul :if={is_nil(@tag) and @results != []} class="mt-2 space-y-1">
-        <li :for={result <- @results}>
-          <button
-            type="button"
-            id={"pick-#{@side}-#{result.tag.id}"}
-            class="w-full rounded-lg px-3 py-2 text-left hover:bg-brand-50 dark:hover:bg-brand-900/40"
-            phx-click="pick"
-            phx-value-side={@side}
-            phx-value-id={result.tag.id}
-          >
-            <span class="block font-semibold text-brand-700 dark:text-brand-200">
-              {result.tag.name}
-            </span>
-            <span class="block text-xs text-slate-600 dark:text-slate-400">
-              /tags/{result.tag.slug} · {profile_count(result.members)}
-            </span>
-          </button>
-        </li>
-      </ul>
     </div>
     """
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.236.1",
+      version: "7.237.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -18,7 +18,7 @@ msgstr "Impressum"
 #: lib/vutuv_web/components/ui.ex:3434
 #: lib/vutuv_web/components/ui.ex:3439
 #: lib/vutuv_web/live/admin/screenshot_live.ex:245
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:559
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:718
 #: lib/vutuv_web/live/organization_live/domains.ex:255
 #: lib/vutuv_web/live/organization_live/edit.ex:396
 #: lib/vutuv_web/live/organization_live/roles.ex:202
@@ -82,8 +82,8 @@ msgstr "Schon ein Mitglied? Einloggen."
 #: lib/vutuv_web/components/ui.ex:3229
 #: lib/vutuv_web/components/ui.ex:3323
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:539
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:671
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:698
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:830
 #, elixir-autogen
 msgid "Are you sure?"
 msgstr "Sind Sie sicher?"
@@ -682,7 +682,7 @@ msgstr "Slug"
 #: lib/vutuv_web/cv/html.ex:223
 #: lib/vutuv_web/cv/latex.ex:179
 #: lib/vutuv_web/cv/odt.ex:185
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:590
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:749
 #: lib/vutuv_web/live/cv_live.ex:410
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/index.html.heex:10
@@ -1182,7 +1182,7 @@ msgstr "Lokalisierung hinzufügen"
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:693
 #: lib/vutuv_web/live/admin/organization_live.ex:189
 #: lib/vutuv_web/live/admin/screenshot_live.ex:172
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:373
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:432
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
@@ -1408,7 +1408,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/cv/html.ex:156
 #: lib/vutuv_web/cv/latex.ex:131
 #: lib/vutuv_web/cv/odt.ex:148
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:374
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:433
 #: lib/vutuv_web/live/cv_live.ex:315
 #: lib/vutuv_web/live/job_board_live.ex:277
 #: lib/vutuv_web/live/job_posting_live/form.ex:510
@@ -1782,9 +1782,9 @@ msgstr "Netzwerk"
 
 #: lib/vutuv_web/components/post_components.ex:391
 #: lib/vutuv_web/components/ui.ex:3436
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:546
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:583
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:634
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:705
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:742
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:793
 #: lib/vutuv_web/live/admin/user_live.ex:286
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
 #, elixir-autogen, elixir-format
@@ -2260,7 +2260,7 @@ msgstr "Weniger anzeigen"
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
 #: lib/vutuv_web/components/post_components.ex:1006
 #: lib/vutuv_web/live/admin/screenshot_live.ex:317
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:541
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:700
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:373
@@ -3317,7 +3317,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2751
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:614
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:773
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Review"
@@ -5673,7 +5673,6 @@ msgstr "Über Sie"
 msgid "Account"
 msgstr "Konto"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:717
 #: lib/vutuv_web/live/organization_live/edit.ex:443
 #, elixir-autogen, elixir-format
 msgid "Change"
@@ -6766,7 +6765,7 @@ msgstr "Das rohe Bounce-Protokoll, neueste zuerst."
 #: lib/vutuv_web/live/admin/activity_live.ex:142
 #: lib/vutuv_web/live/admin/deliverability_live.ex:213
 #: lib/vutuv_web/live/admin/deliverability_live.ex:250
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:643
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:802
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:189
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:230
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:27
@@ -6776,7 +6775,7 @@ msgid "When"
 msgstr "Wann"
 
 #: lib/vutuv_web/live/admin/deliverability_live.ex:216
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:591
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:750
 #, elixir-autogen, elixir-format
 msgid "Why"
 msgstr "Grund"
@@ -8049,7 +8048,7 @@ msgstr "Neue Mitglieder"
 
 #: lib/vutuv_web/components/job_components.ex:173
 #: lib/vutuv_web/live/admin/dashboard_live.ex:287
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:398
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:457
 #: lib/vutuv_web/live/notification_live/index.ex:904
 #, elixir-autogen, elixir-format
 msgid "Today"
@@ -13781,7 +13780,7 @@ msgstr ""
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:650
 #: lib/vutuv_web/controllers/settings_controller.ex:668
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:328
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr "Das hat nicht funktioniert."
@@ -16297,7 +16296,7 @@ msgstr "Diese Antwort können Sie nicht entfernen."
 msgid "View the original"
 msgstr "Original ansehen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:486
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:629
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:190
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:231
 #, elixir-autogen, elixir-format
@@ -20428,37 +20427,32 @@ msgstr "Ihre Regel"
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr "löschen entfernen beiträge alter alt ablaufen verfallen automatisch aufräumen aufbewahrung"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:101
-#, elixir-autogen, elixir-format
-msgid "%{absorbed} is now an alternative name for %{canonical}."
-msgstr "%{absorbed} ist jetzt ein Zweitname von %{canonical}."
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:126
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:163
 #, elixir-autogen, elixir-format
 msgid "%{a} and %{b} are recorded as different topics."
 msgstr "%{a} und %{b} sind als verschiedene Themen vermerkt."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:505
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:651
 #, elixir-autogen, elixir-format
 msgid "A dropped row belongs to somebody who already carries the surviving tag, so they end up carrying the topic once. Endorsements move to the row that stays."
 msgstr "Ein wegfallender Eintrag gehört jemandem, der das bleibende Tag schon trägt; danach trägt diese Person das Thema einmal. Empfehlungen ziehen auf den Eintrag um, der bleibt."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:300
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:359
 #, elixir-autogen, elixir-format
 msgid "A tag cannot absorb itself."
 msgstr "Ein Tag kann sich nicht selbst aufnehmen."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:640
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:799
 #, elixir-autogen, elixir-format
 msgid "Absorbed"
 msgstr "Aufgenommen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:550
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:709
 #, elixir-autogen, elixir-format
 msgid "Add an alternative name"
 msgstr "Zweitnamen hinzufügen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:228
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Added %{name} as an alternative name."
 msgstr "%{name} wurde als Zweitname hinzugefügt."
@@ -20468,35 +20462,30 @@ msgstr "%{name} wurde als Zweitname hinzugefügt."
 msgid "Alternative name for %{tag}"
 msgstr "Zweitname von %{tag}"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:528
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:687
 #, elixir-autogen, elixir-format
 msgid "Alternative names for %{tag}"
 msgstr "Zweitnamen von %{tag}"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:488
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:631
 #, elixir-autogen, elixir-format
 msgid "Dropped as duplicate"
 msgstr "Fällt als Dublette weg"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:553
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:712
 #, elixir-autogen, elixir-format
 msgid "For a name nobody has typed yet, so it never becomes a page of its own. A name that is already a tag has to be merged instead."
 msgstr "Für einen Namen, den noch niemand getippt hat, damit daraus nie eine eigene Seite wird. Ein Name, der bereits ein Tag ist, muss stattdessen zusammengelegt werden."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:641
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:800
 #, elixir-autogen, elixir-format
 msgid "Into"
 msgstr "Aufgenommen in"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:512
-#, elixir-autogen, elixir-format
-msgid "Merge"
-msgstr "Zusammenlegen"
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:42
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:371
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:375
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:381
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:56
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:430
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:434
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:440
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:258
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:261
 #, elixir-autogen, elixir-format
@@ -20508,42 +20497,37 @@ msgstr "Tags zusammenlegen"
 msgid "Merge tags ›"
 msgstr "Tags zusammenlegen ›"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:632
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:791
 #, elixir-autogen, elixir-format
 msgid "Merges so far"
 msgstr "Bisherige Zusammenlegungen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:487
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:630
 #, elixir-autogen, elixir-format
 msgid "Moves"
 msgstr "Zieht um"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:498
-#, elixir-autogen, elixir-format
-msgid "Nothing is filed under this tag."
-msgstr "Unter diesem Tag ist nichts abgelegt."
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:242
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:275
 #, elixir-autogen, elixir-format
 msgid "Removed."
 msgstr "Entfernt."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:673
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:832
 #, elixir-autogen, elixir-format
 msgid "Revert"
 msgstr "Rückgängig machen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:663
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:822
 #, elixir-autogen, elixir-format
 msgid "Reverted"
 msgstr "Rückgängig gemacht"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:642
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:801
 #, elixir-autogen, elixir-format
 msgid "Rows"
 msgstr "Einträge"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:735
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:504
 #, elixir-autogen, elixir-format
 msgid "Search by name or slug"
 msgstr "Nach Name oder Slug suchen"
@@ -20553,230 +20537,261 @@ msgstr "Nach Name oder Slug suchen"
 msgid "Several tags for one topic become one page: see what a merge would move, do it, and take it back if it was wrong."
 msgstr "Mehrere Tags für ein Thema werden eine Seite: sehen, was eine Zusammenlegung verschiebt, sie durchführen und wieder zurücknehmen, falls sie falsch war."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:440
-#, elixir-autogen, elixir-format
-msgid "Tag that stays"
-msgstr "Tag, das bleibt"
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:426
-#, elixir-autogen, elixir-format
-msgid "Tag to absorb"
-msgstr "Tag, das aufgenommen wird"
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:138
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:174
 #, elixir-autogen, elixir-format
 msgid "That merge is no longer on record."
 msgstr "Diese Zusammenlegung ist nicht mehr vermerkt."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:327
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "That merge was already reverted."
 msgstr "Diese Zusammenlegung wurde bereits rückgängig gemacht."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:321
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:380
 #, elixir-autogen, elixir-format
 msgid "That name is already a tag. Merge it instead, so its entries come along."
 msgstr "Dieser Name ist bereits ein Tag. Legen Sie es stattdessen zusammen, damit seine Einträge mitkommen."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:306
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:365
 #, elixir-autogen, elixir-format
 msgid "That tag is already an alternative name. Revert its merge first."
 msgstr "Dieses Tag ist bereits ein Zweitname. Machen Sie zuerst seine Zusammenlegung rückgängig."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:326
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "That tag is not an alternative name."
 msgstr "Dieses Tag ist kein Zweitname."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:145
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:181
 #, elixir-autogen, elixir-format
 msgid "The merge was reverted."
 msgstr "Die Zusammenlegung wurde rückgängig gemacht."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:309
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:368
 #, elixir-autogen, elixir-format
 msgid "The surviving tag is itself an alternative name. Pick its topic instead."
 msgstr "Das bleibende Tag ist selbst ein Zweitname. Wählen Sie stattdessen sein Thema."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:520
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:680
 #, elixir-autogen, elixir-format
 msgid "These are different topics"
 msgstr "Das sind verschiedene Themen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:316
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "These names differ only in characters the slug drops (like + or #), which is how C, C++ and C# tell each other apart. They are not merged."
 msgstr "Diese Namen unterscheiden sich nur in Zeichen, die der Slug weglässt (etwa + oder #). Genau daran unterscheiden sich C, C++ und C#. Sie werden nicht zusammengelegt."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:312
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:371
 #, elixir-autogen, elixir-format
 msgid "These two are recorded as different topics."
 msgstr "Diese beiden sind als verschiedene Themen vermerkt."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:324
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:383
 #, elixir-autogen, elixir-format
 msgid "This name came from a merge. Revert that merge to take it back."
 msgstr "Dieser Name stammt aus einer Zusammenlegung. Machen Sie diese rückgängig, um ihn zurückzunehmen."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:463
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:601
 #, elixir-autogen, elixir-format
 msgid "What this merge would move"
 msgstr "Was diese Zusammenlegung verschieben würde"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:360
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:419
 #, elixir-autogen, elixir-format
 msgid "hashtags in post bodies"
 msgstr "Hashtags in Beiträgen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:362
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:421
 #, elixir-autogen, elixir-format
 msgid "job postings"
 msgstr "Stellenanzeigen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:361
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:420
 #, elixir-autogen, elixir-format
 msgid "members following it"
 msgstr "Mitglieder, die ihm folgen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:364
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:423
 #, elixir-autogen, elixir-format
 msgid "newsletter audiences"
 msgstr "Newsletter-Zielgruppen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:359
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:418
 #, elixir-autogen, elixir-format
 msgid "posts filed under it"
 msgstr "Beiträge darunter"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:363
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:422
 #, elixir-autogen, elixir-format
 msgid "posts from other networks"
 msgstr "Beiträge aus anderen Netzwerken"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:358
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:417
 #, elixir-autogen, elixir-format
 msgid "profiles carrying the tag"
 msgstr "Profile mit diesem Tag"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:303
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:362
 #, elixir-autogen, elixir-format
 msgid "Honor tags are granted, not spelled. They are never merged."
 msgstr "Ehren-Tags werden vergeben, nicht geschrieben. Sie werden nie zusammengelegt."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:169
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:202
 #, elixir-autogen, elixir-format
 msgid "%{written} proposals, %{judged} of them judged by the model. %{dropped} more were found than the queue holds."
 msgstr "%{written} Vorschläge, davon %{judged} vom Modell beurteilt. %{dropped} weitere wurden gefunden, aber nicht aufgenommen."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:622
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:781
 #, elixir-autogen, elixir-format
 msgid "Different topics"
 msgstr "Verschiedene Themen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:576
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:735
 #, elixir-autogen, elixir-format
 msgid "Look for proposals"
 msgstr "Nach Vorschlägen suchen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:589
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:748
 #, elixir-autogen, elixir-format
 msgid "Pair"
 msgstr "Paar"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:569
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:728
 #, elixir-autogen, elixir-format
 msgid "Pairs of tags that might be one topic, found by rule and, where a local model is available, judged by it. Nothing here has happened yet: opening one loads it above, where you see what a merge would move before confirming."
 msgstr "Tag-Paare, die ein Thema sein könnten, nach festen Regeln gefunden und, wo ein lokales Modell verfügbar ist, von ihm beurteilt. Hier ist noch nichts passiert: Ein Vorschlag wird oben geladen, wo Sie vor dem Bestätigen sehen, was die Zusammenlegung verschieben würde."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:567
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:726
 #, elixir-autogen, elixir-format
 msgid "Proposals"
 msgstr "Vorschläge"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:214
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:247
 #, elixir-autogen, elixir-format
 msgid "Recorded as different topics."
 msgstr "Als verschiedene Themen vermerkt."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:186
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:202
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:219
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:235
 #, elixir-autogen, elixir-format
 msgid "That proposal is gone."
 msgstr "Diesen Vorschlag gibt es nicht mehr."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:579
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:738
 #, elixir-autogen, elixir-format
 msgid "The model is switched off; proposals are listed unjudged."
 msgstr "Das Modell ist abgeschaltet, die Vorschläge stehen unbeurteilt in der Liste."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:354
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:413
 #, elixir-autogen, elixir-format
 msgid "one is a word of the other"
 msgstr "eines ist ein Wort des anderen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:353
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:412
 #, elixir-autogen, elixir-format
 msgid "one is the other's initials"
 msgstr "eines sind die Initialen des anderen"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:352
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:411
 #, elixir-autogen, elixir-format
 msgid "the same name, written differently"
 msgstr "derselbe Name, anders geschrieben"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:415
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:474
 #, elixir-autogen, elixir-format
 msgid "\"rubyonrails\" was absorbed: nobody loses a tag, the name goes on working, and it is listed on the remaining page as an alternative name. Anyone typing it from now on gets the one page. Every merge can be undone at the bottom of this page."
 msgstr "„rubyonrails\" wurde aufgenommen: Niemand verliert ein Tag, der Name funktioniert weiter, und er steht auf der verbliebenen Seite als Zweitname. Wer ihn ab jetzt tippt, landet auf der einen Seite. Jede Zusammenlegung lässt sich unten wieder rückgängig machen."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:473
-#, elixir-autogen, elixir-format
-msgid "%{absorbed} becomes an alternative name for %{canonical}. %{absorbed_url} then redirects to %{canonical_url}."
-msgstr "%{absorbed} wird ein Zweitname von %{canonical}. %{absorbed_url} leitet dann auf %{canonical_url} weiter."
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:344
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:403
 #, elixir-autogen, elixir-format
 msgid "%{formatted} profile"
 msgid_plural "%{formatted} profiles"
 msgstr[0] "%{formatted} Profil"
 msgstr[1] "%{formatted} Profile"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:395
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:454
 #, elixir-autogen, elixir-format
 msgid "An example"
 msgstr "Ein Beispiel"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:442
-#, elixir-autogen, elixir-format
-msgid "Keeps its page and its address and gains everything from the other one."
-msgstr "Behält Seite und Adresse und bekommt alles vom anderen Tag dazu."
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:743
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:509
 #, elixir-autogen, elixir-format
 msgid "No tag matches that."
 msgstr "Dazu passt kein Tag."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:383
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:442
 #, elixir-autogen, elixir-format
 msgid "One topic sometimes ends up under several tags, so its members and its posts are split over two pages that never show each other. Merging puts them on one page."
 msgstr "Ein Thema landet manchmal unter mehreren Tags. Seine Mitglieder und seine Beiträge liegen dann auf zwei Seiten, die einander nie zeigen. Eine Zusammenlegung bringt beides auf eine Seite."
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:428
-#, elixir-autogen, elixir-format
-msgid "Stops being a topic of its own. Its profiles, posts and follows move over and its address redirects."
-msgstr "Hört auf, ein eigenes Thema zu sein. Seine Profile, Beiträge und Abos ziehen um, seine Adresse leitet weiter."
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:457
-#, elixir-autogen, elixir-format
-msgid "Swap: keep %{name} instead"
-msgstr "Tauschen: stattdessen %{name} behalten"
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:409
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:468
 #, elixir-autogen, elixir-format
 msgid "redirects there for good"
 msgstr "leitet dauerhaft dorthin weiter"
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:405
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:464
 #, elixir-autogen, elixir-format
 msgid "After the merge"
 msgstr "Nach der Zusammenlegung"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:138
+#, elixir-autogen, elixir-format
+msgid "%{count} tag is now an alternative name for %{canonical}."
+msgid_plural "%{count} tags are now alternative names for %{canonical}."
+msgstr[0] "%{count} Tag ist jetzt ein Zweitname von %{canonical}."
+msgstr[1] "%{count} Tags sind jetzt Zweitnamen von %{canonical}."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:606
+#, elixir-autogen, elixir-format
+msgid "%{names} becomes an alternative name for %{canonical} and %{urls} redirects to /tags/%{slug}."
+msgid_plural "%{names} become alternative names for %{canonical}, and their addresses redirect to /tags/%{slug}."
+msgstr[0] "%{names} wird ein Zweitname von %{canonical}, und %{urls} leitet auf /tags/%{slug} weiter."
+msgstr[1] "%{names} werden Zweitnamen von %{canonical}, und ihre Adressen leiten auf /tags/%{slug} weiter."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:487
+#, elixir-autogen, elixir-format
+msgid "Collect the tags that mean one topic"
+msgstr "Sammeln Sie die Tags, die ein Thema meinen"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:579
+#, elixir-autogen, elixir-format
+msgid "Does not belong here"
+msgstr "Gehört nicht dazu"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:539
+#, elixir-autogen, elixir-format
+msgid "It keeps its page and its address; every other one becomes an alternative name pointing at it."
+msgstr "Es behält Seite und Adresse; jedes andere wird zu einem Zweitnamen, der darauf zeigt."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:664
+#, elixir-autogen, elixir-format
+msgid "Merge %{count} tag into %{canonical}"
+msgid_plural "Merge %{count} tags into %{canonical}"
+msgstr[0] "%{count} Tag in %{canonical} aufnehmen"
+msgstr[1] "%{count} Tags in %{canonical} aufnehmen"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:545
+#, elixir-autogen, elixir-format
+msgid "Nothing collected yet."
+msgstr "Noch nichts gesammelt."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:641
+#, elixir-autogen, elixir-format
+msgid "Nothing is filed under these tags."
+msgstr "Unter diesen Tags ist nichts abgelegt."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:534
+#, elixir-autogen, elixir-format
+msgid "Pick the one that stays"
+msgstr "Wählen Sie das Tag, das bleibt"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:492
+#, elixir-autogen, elixir-format
+msgid "Search as often as you like and add what belongs. Abbreviations will not turn up under the full name, so look for them separately."
+msgstr "Suchen Sie so oft Sie möchten und nehmen Sie dazu, was gehört. Abkürzungen tauchen unter dem vollen Namen nicht auf, suchen Sie danach also einzeln."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:593
+#, elixir-autogen, elixir-format
+msgid "Start over"
+msgstr "Von vorn beginnen"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -20,7 +20,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3434
 #: lib/vutuv_web/components/ui.ex:3439
 #: lib/vutuv_web/live/admin/screenshot_live.ex:245
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:559
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:718
 #: lib/vutuv_web/live/organization_live/domains.ex:255
 #: lib/vutuv_web/live/organization_live/edit.ex:396
 #: lib/vutuv_web/live/organization_live/roles.ex:202
@@ -84,8 +84,8 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3229
 #: lib/vutuv_web/components/ui.ex:3323
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:539
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:671
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:698
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:830
 #, elixir-autogen
 msgid "Are you sure?"
 msgstr ""
@@ -682,7 +682,7 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:223
 #: lib/vutuv_web/cv/latex.ex:179
 #: lib/vutuv_web/cv/odt.ex:185
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:590
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:749
 #: lib/vutuv_web/live/cv_live.ex:410
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/index.html.heex:10
@@ -1158,7 +1158,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:693
 #: lib/vutuv_web/live/admin/organization_live.ex:189
 #: lib/vutuv_web/live/admin/screenshot_live.ex:172
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:373
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:432
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
@@ -1381,7 +1381,7 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:156
 #: lib/vutuv_web/cv/latex.ex:131
 #: lib/vutuv_web/cv/odt.ex:148
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:374
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:433
 #: lib/vutuv_web/live/cv_live.ex:315
 #: lib/vutuv_web/live/job_board_live.ex:277
 #: lib/vutuv_web/live/job_posting_live/form.ex:510
@@ -1747,9 +1747,9 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:391
 #: lib/vutuv_web/components/ui.ex:3436
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:546
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:583
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:634
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:705
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:742
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:793
 #: lib/vutuv_web/live/admin/user_live.ex:286
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
 #, elixir-autogen, elixir-format
@@ -2215,7 +2215,7 @@ msgstr ""
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
 #: lib/vutuv_web/components/post_components.ex:1006
 #: lib/vutuv_web/live/admin/screenshot_live.ex:317
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:541
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:700
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:373
@@ -3241,7 +3241,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2751
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:614
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:773
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Review"
@@ -5448,7 +5448,6 @@ msgstr ""
 msgid "Account"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:717
 #: lib/vutuv_web/live/organization_live/edit.ex:443
 #, elixir-autogen, elixir-format
 msgid "Change"
@@ -6497,7 +6496,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/activity_live.ex:142
 #: lib/vutuv_web/live/admin/deliverability_live.ex:213
 #: lib/vutuv_web/live/admin/deliverability_live.ex:250
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:643
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:802
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:189
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:230
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:27
@@ -6507,7 +6506,7 @@ msgid "When"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/deliverability_live.ex:216
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:591
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:750
 #, elixir-autogen, elixir-format
 msgid "Why"
 msgstr ""
@@ -7710,7 +7709,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:173
 #: lib/vutuv_web/live/admin/dashboard_live.ex:287
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:398
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:457
 #: lib/vutuv_web/live/notification_live/index.ex:904
 #, elixir-autogen, elixir-format
 msgid "Today"
@@ -13106,7 +13105,7 @@ msgstr ""
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:650
 #: lib/vutuv_web/controllers/settings_controller.ex:668
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:328
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr ""
@@ -15569,7 +15568,7 @@ msgstr ""
 msgid "View the original"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:486
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:629
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:190
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:231
 #, elixir-autogen, elixir-format
@@ -19641,37 +19640,32 @@ msgstr ""
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:101
-#, elixir-autogen, elixir-format
-msgid "%{absorbed} is now an alternative name for %{canonical}."
-msgstr ""
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:126
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:163
 #, elixir-autogen, elixir-format
 msgid "%{a} and %{b} are recorded as different topics."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:505
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:651
 #, elixir-autogen, elixir-format
 msgid "A dropped row belongs to somebody who already carries the surviving tag, so they end up carrying the topic once. Endorsements move to the row that stays."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:300
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:359
 #, elixir-autogen, elixir-format
 msgid "A tag cannot absorb itself."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:640
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:799
 #, elixir-autogen, elixir-format
 msgid "Absorbed"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:550
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:709
 #, elixir-autogen, elixir-format
 msgid "Add an alternative name"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:228
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Added %{name} as an alternative name."
 msgstr ""
@@ -19681,35 +19675,30 @@ msgstr ""
 msgid "Alternative name for %{tag}"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:528
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:687
 #, elixir-autogen, elixir-format
 msgid "Alternative names for %{tag}"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:488
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:631
 #, elixir-autogen, elixir-format
 msgid "Dropped as duplicate"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:553
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:712
 #, elixir-autogen, elixir-format
 msgid "For a name nobody has typed yet, so it never becomes a page of its own. A name that is already a tag has to be merged instead."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:641
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:800
 #, elixir-autogen, elixir-format
 msgid "Into"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:512
-#, elixir-autogen, elixir-format
-msgid "Merge"
-msgstr ""
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:42
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:371
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:375
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:381
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:56
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:430
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:434
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:440
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:258
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:261
 #, elixir-autogen, elixir-format
@@ -19721,42 +19710,37 @@ msgstr ""
 msgid "Merge tags ›"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:632
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:791
 #, elixir-autogen, elixir-format
 msgid "Merges so far"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:487
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:630
 #, elixir-autogen, elixir-format
 msgid "Moves"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:498
-#, elixir-autogen, elixir-format
-msgid "Nothing is filed under this tag."
-msgstr ""
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:242
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:275
 #, elixir-autogen, elixir-format
 msgid "Removed."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:673
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:832
 #, elixir-autogen, elixir-format
 msgid "Revert"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:663
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:822
 #, elixir-autogen, elixir-format
 msgid "Reverted"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:642
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:801
 #, elixir-autogen, elixir-format
 msgid "Rows"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:735
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:504
 #, elixir-autogen, elixir-format
 msgid "Search by name or slug"
 msgstr ""
@@ -19766,230 +19750,261 @@ msgstr ""
 msgid "Several tags for one topic become one page: see what a merge would move, do it, and take it back if it was wrong."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:440
-#, elixir-autogen, elixir-format
-msgid "Tag that stays"
-msgstr ""
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:426
-#, elixir-autogen, elixir-format
-msgid "Tag to absorb"
-msgstr ""
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:138
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:174
 #, elixir-autogen, elixir-format
 msgid "That merge is no longer on record."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:327
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "That merge was already reverted."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:321
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:380
 #, elixir-autogen, elixir-format
 msgid "That name is already a tag. Merge it instead, so its entries come along."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:306
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:365
 #, elixir-autogen, elixir-format
 msgid "That tag is already an alternative name. Revert its merge first."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:326
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "That tag is not an alternative name."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:145
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:181
 #, elixir-autogen, elixir-format
 msgid "The merge was reverted."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:309
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:368
 #, elixir-autogen, elixir-format
 msgid "The surviving tag is itself an alternative name. Pick its topic instead."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:520
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:680
 #, elixir-autogen, elixir-format
 msgid "These are different topics"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:316
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "These names differ only in characters the slug drops (like + or #), which is how C, C++ and C# tell each other apart. They are not merged."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:312
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:371
 #, elixir-autogen, elixir-format
 msgid "These two are recorded as different topics."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:324
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:383
 #, elixir-autogen, elixir-format
 msgid "This name came from a merge. Revert that merge to take it back."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:463
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:601
 #, elixir-autogen, elixir-format
 msgid "What this merge would move"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:360
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:419
 #, elixir-autogen, elixir-format
 msgid "hashtags in post bodies"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:362
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:421
 #, elixir-autogen, elixir-format
 msgid "job postings"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:361
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:420
 #, elixir-autogen, elixir-format
 msgid "members following it"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:364
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:423
 #, elixir-autogen, elixir-format
 msgid "newsletter audiences"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:359
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:418
 #, elixir-autogen, elixir-format
 msgid "posts filed under it"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:363
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:422
 #, elixir-autogen, elixir-format
 msgid "posts from other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:358
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:417
 #, elixir-autogen, elixir-format
 msgid "profiles carrying the tag"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:303
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:362
 #, elixir-autogen, elixir-format
 msgid "Honor tags are granted, not spelled. They are never merged."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:169
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:202
 #, elixir-autogen, elixir-format
 msgid "%{written} proposals, %{judged} of them judged by the model. %{dropped} more were found than the queue holds."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:622
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:781
 #, elixir-autogen, elixir-format
 msgid "Different topics"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:576
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:735
 #, elixir-autogen, elixir-format
 msgid "Look for proposals"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:589
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:748
 #, elixir-autogen, elixir-format
 msgid "Pair"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:569
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:728
 #, elixir-autogen, elixir-format
 msgid "Pairs of tags that might be one topic, found by rule and, where a local model is available, judged by it. Nothing here has happened yet: opening one loads it above, where you see what a merge would move before confirming."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:567
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:726
 #, elixir-autogen, elixir-format
 msgid "Proposals"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:214
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:247
 #, elixir-autogen, elixir-format
 msgid "Recorded as different topics."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:186
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:202
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:219
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:235
 #, elixir-autogen, elixir-format
 msgid "That proposal is gone."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:579
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:738
 #, elixir-autogen, elixir-format
 msgid "The model is switched off; proposals are listed unjudged."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:354
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:413
 #, elixir-autogen, elixir-format
 msgid "one is a word of the other"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:353
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:412
 #, elixir-autogen, elixir-format
 msgid "one is the other's initials"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:352
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:411
 #, elixir-autogen, elixir-format
 msgid "the same name, written differently"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:415
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:474
 #, elixir-autogen, elixir-format
 msgid "\"rubyonrails\" was absorbed: nobody loses a tag, the name goes on working, and it is listed on the remaining page as an alternative name. Anyone typing it from now on gets the one page. Every merge can be undone at the bottom of this page."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:473
-#, elixir-autogen, elixir-format
-msgid "%{absorbed} becomes an alternative name for %{canonical}. %{absorbed_url} then redirects to %{canonical_url}."
-msgstr ""
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:344
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:403
 #, elixir-autogen, elixir-format
 msgid "%{formatted} profile"
 msgid_plural "%{formatted} profiles"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:395
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:454
 #, elixir-autogen, elixir-format
 msgid "An example"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:442
-#, elixir-autogen, elixir-format
-msgid "Keeps its page and its address and gains everything from the other one."
-msgstr ""
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:743
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:509
 #, elixir-autogen, elixir-format
 msgid "No tag matches that."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:383
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:442
 #, elixir-autogen, elixir-format
 msgid "One topic sometimes ends up under several tags, so its members and its posts are split over two pages that never show each other. Merging puts them on one page."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:428
-#, elixir-autogen, elixir-format
-msgid "Stops being a topic of its own. Its profiles, posts and follows move over and its address redirects."
-msgstr ""
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:457
-#, elixir-autogen, elixir-format
-msgid "Swap: keep %{name} instead"
-msgstr ""
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:409
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:468
 #, elixir-autogen, elixir-format
 msgid "redirects there for good"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:405
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:464
 #, elixir-autogen, elixir-format
 msgid "After the merge"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:138
+#, elixir-autogen, elixir-format
+msgid "%{count} tag is now an alternative name for %{canonical}."
+msgid_plural "%{count} tags are now alternative names for %{canonical}."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:606
+#, elixir-autogen, elixir-format
+msgid "%{names} becomes an alternative name for %{canonical} and %{urls} redirects to /tags/%{slug}."
+msgid_plural "%{names} become alternative names for %{canonical}, and their addresses redirect to /tags/%{slug}."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:487
+#, elixir-autogen, elixir-format
+msgid "Collect the tags that mean one topic"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:579
+#, elixir-autogen, elixir-format
+msgid "Does not belong here"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:539
+#, elixir-autogen, elixir-format
+msgid "It keeps its page and its address; every other one becomes an alternative name pointing at it."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:664
+#, elixir-autogen, elixir-format
+msgid "Merge %{count} tag into %{canonical}"
+msgid_plural "Merge %{count} tags into %{canonical}"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:545
+#, elixir-autogen, elixir-format
+msgid "Nothing collected yet."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:641
+#, elixir-autogen, elixir-format
+msgid "Nothing is filed under these tags."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:534
+#, elixir-autogen, elixir-format
+msgid "Pick the one that stays"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:492
+#, elixir-autogen, elixir-format
+msgid "Search as often as you like and add what belongs. Abbreviations will not turn up under the full name, so look for them separately."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:593
+#, elixir-autogen, elixir-format
+msgid "Start over"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -18,7 +18,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3434
 #: lib/vutuv_web/components/ui.ex:3439
 #: lib/vutuv_web/live/admin/screenshot_live.ex:245
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:559
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:718
 #: lib/vutuv_web/live/organization_live/domains.ex:255
 #: lib/vutuv_web/live/organization_live/edit.ex:396
 #: lib/vutuv_web/live/organization_live/roles.ex:202
@@ -82,8 +82,8 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3229
 #: lib/vutuv_web/components/ui.ex:3323
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:539
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:671
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:698
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:830
 #, elixir-autogen
 msgid "Are you sure?"
 msgstr ""
@@ -680,7 +680,7 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:223
 #: lib/vutuv_web/cv/latex.ex:179
 #: lib/vutuv_web/cv/odt.ex:185
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:590
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:749
 #: lib/vutuv_web/live/cv_live.ex:410
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/index.html.heex:10
@@ -1156,7 +1156,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:693
 #: lib/vutuv_web/live/admin/organization_live.ex:189
 #: lib/vutuv_web/live/admin/screenshot_live.ex:172
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:373
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:432
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
@@ -1379,7 +1379,7 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:156
 #: lib/vutuv_web/cv/latex.ex:131
 #: lib/vutuv_web/cv/odt.ex:148
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:374
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:433
 #: lib/vutuv_web/live/cv_live.ex:315
 #: lib/vutuv_web/live/job_board_live.ex:277
 #: lib/vutuv_web/live/job_posting_live/form.ex:510
@@ -1745,9 +1745,9 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:391
 #: lib/vutuv_web/components/ui.ex:3436
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:546
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:583
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:634
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:705
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:742
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:793
 #: lib/vutuv_web/live/admin/user_live.ex:286
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
 #, elixir-autogen, elixir-format
@@ -2213,7 +2213,7 @@ msgstr ""
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
 #: lib/vutuv_web/components/post_components.ex:1006
 #: lib/vutuv_web/live/admin/screenshot_live.ex:317
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:541
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:700
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:373
@@ -3239,7 +3239,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2751
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:614
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:773
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Review"
@@ -5446,7 +5446,6 @@ msgstr ""
 msgid "Account"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:717
 #: lib/vutuv_web/live/organization_live/edit.ex:443
 #, elixir-autogen, elixir-format
 msgid "Change"
@@ -6495,7 +6494,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/activity_live.ex:142
 #: lib/vutuv_web/live/admin/deliverability_live.ex:213
 #: lib/vutuv_web/live/admin/deliverability_live.ex:250
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:643
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:802
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:189
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:230
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:27
@@ -6505,7 +6504,7 @@ msgid "When"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/deliverability_live.ex:216
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:591
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:750
 #, elixir-autogen, elixir-format
 msgid "Why"
 msgstr ""
@@ -7708,7 +7707,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:173
 #: lib/vutuv_web/live/admin/dashboard_live.ex:287
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:398
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:457
 #: lib/vutuv_web/live/notification_live/index.ex:904
 #, elixir-autogen, elixir-format
 msgid "Today"
@@ -13104,7 +13103,7 @@ msgstr ""
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:650
 #: lib/vutuv_web/controllers/settings_controller.ex:668
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:328
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr ""
@@ -15567,7 +15566,7 @@ msgstr ""
 msgid "View the original"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:486
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:629
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:190
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:231
 #, elixir-autogen, elixir-format
@@ -19639,37 +19638,32 @@ msgstr ""
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:101
-#, elixir-autogen, elixir-format
-msgid "%{absorbed} is now an alternative name for %{canonical}."
-msgstr ""
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:126
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:163
 #, elixir-autogen, elixir-format
 msgid "%{a} and %{b} are recorded as different topics."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:505
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:651
 #, elixir-autogen, elixir-format
 msgid "A dropped row belongs to somebody who already carries the surviving tag, so they end up carrying the topic once. Endorsements move to the row that stays."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:300
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:359
 #, elixir-autogen, elixir-format
 msgid "A tag cannot absorb itself."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:640
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:799
 #, elixir-autogen, elixir-format
 msgid "Absorbed"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:550
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:709
 #, elixir-autogen, elixir-format
 msgid "Add an alternative name"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:228
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Added %{name} as an alternative name."
 msgstr ""
@@ -19679,35 +19673,30 @@ msgstr ""
 msgid "Alternative name for %{tag}"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:528
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:687
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Alternative names for %{tag}"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:488
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:631
 #, elixir-autogen, elixir-format
 msgid "Dropped as duplicate"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:553
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:712
 #, elixir-autogen, elixir-format
 msgid "For a name nobody has typed yet, so it never becomes a page of its own. A name that is already a tag has to be merged instead."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:641
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:800
 #, elixir-autogen, elixir-format
 msgid "Into"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:512
-#, elixir-autogen, elixir-format
-msgid "Merge"
-msgstr ""
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:42
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:371
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:375
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:381
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:56
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:430
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:434
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:440
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:258
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:261
 #, elixir-autogen, elixir-format
@@ -19719,42 +19708,37 @@ msgstr ""
 msgid "Merge tags ›"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:632
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:791
 #, elixir-autogen, elixir-format
 msgid "Merges so far"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:487
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:630
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Moves"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:498
-#, elixir-autogen, elixir-format
-msgid "Nothing is filed under this tag."
-msgstr ""
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:242
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:275
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Removed."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:673
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:832
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Revert"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:663
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:822
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Reverted"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:642
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:801
 #, elixir-autogen, elixir-format
 msgid "Rows"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:735
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:504
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Search by name or slug"
 msgstr ""
@@ -19764,230 +19748,261 @@ msgstr ""
 msgid "Several tags for one topic become one page: see what a merge would move, do it, and take it back if it was wrong."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:440
-#, elixir-autogen, elixir-format
-msgid "Tag that stays"
-msgstr ""
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:426
-#, elixir-autogen, elixir-format
-msgid "Tag to absorb"
-msgstr ""
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:138
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:174
 #, elixir-autogen, elixir-format
 msgid "That merge is no longer on record."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:327
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "That merge was already reverted."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:321
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:380
 #, elixir-autogen, elixir-format
 msgid "That name is already a tag. Merge it instead, so its entries come along."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:306
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:365
 #, elixir-autogen, elixir-format
 msgid "That tag is already an alternative name. Revert its merge first."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:326
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "That tag is not an alternative name."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:145
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:181
 #, elixir-autogen, elixir-format
 msgid "The merge was reverted."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:309
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:368
 #, elixir-autogen, elixir-format
 msgid "The surviving tag is itself an alternative name. Pick its topic instead."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:520
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:680
 #, elixir-autogen, elixir-format
 msgid "These are different topics"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:316
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "These names differ only in characters the slug drops (like + or #), which is how C, C++ and C# tell each other apart. They are not merged."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:312
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:371
 #, elixir-autogen, elixir-format
 msgid "These two are recorded as different topics."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:324
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:383
 #, elixir-autogen, elixir-format
 msgid "This name came from a merge. Revert that merge to take it back."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:463
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:601
 #, elixir-autogen, elixir-format
 msgid "What this merge would move"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:360
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:419
 #, elixir-autogen, elixir-format
 msgid "hashtags in post bodies"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:362
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:421
 #, elixir-autogen, elixir-format, fuzzy
 msgid "job postings"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:361
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:420
 #, elixir-autogen, elixir-format, fuzzy
 msgid "members following it"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:364
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:423
 #, elixir-autogen, elixir-format, fuzzy
 msgid "newsletter audiences"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:359
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:418
 #, elixir-autogen, elixir-format
 msgid "posts filed under it"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:363
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:422
 #, elixir-autogen, elixir-format, fuzzy
 msgid "posts from other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:358
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:417
 #, elixir-autogen, elixir-format
 msgid "profiles carrying the tag"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:303
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:362
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Honor tags are granted, not spelled. They are never merged."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:169
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:202
 #, elixir-autogen, elixir-format
 msgid "%{written} proposals, %{judged} of them judged by the model. %{dropped} more were found than the queue holds."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:622
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:781
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Different topics"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:576
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:735
 #, elixir-autogen, elixir-format
 msgid "Look for proposals"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:589
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:748
 #, elixir-autogen, elixir-format
 msgid "Pair"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:569
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:728
 #, elixir-autogen, elixir-format
 msgid "Pairs of tags that might be one topic, found by rule and, where a local model is available, judged by it. Nothing here has happened yet: opening one loads it above, where you see what a merge would move before confirming."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:567
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:726
 #, elixir-autogen, elixir-format
 msgid "Proposals"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:214
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:247
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Recorded as different topics."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:186
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:202
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:219
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:235
 #, elixir-autogen, elixir-format
 msgid "That proposal is gone."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:579
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:738
 #, elixir-autogen, elixir-format
 msgid "The model is switched off; proposals are listed unjudged."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:354
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:413
 #, elixir-autogen, elixir-format
 msgid "one is a word of the other"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:353
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:412
 #, elixir-autogen, elixir-format
 msgid "one is the other's initials"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:352
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:411
 #, elixir-autogen, elixir-format
 msgid "the same name, written differently"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:415
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:474
 #, elixir-autogen, elixir-format
 msgid "\"rubyonrails\" was absorbed: nobody loses a tag, the name goes on working, and it is listed on the remaining page as an alternative name. Anyone typing it from now on gets the one page. Every merge can be undone at the bottom of this page."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:473
-#, elixir-autogen, elixir-format
-msgid "%{absorbed} becomes an alternative name for %{canonical}. %{absorbed_url} then redirects to %{canonical_url}."
-msgstr ""
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:344
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:403
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} profile"
 msgid_plural "%{formatted} profiles"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:395
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:454
 #, elixir-autogen, elixir-format
 msgid "An example"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:442
-#, elixir-autogen, elixir-format
-msgid "Keeps its page and its address and gains everything from the other one."
-msgstr ""
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:743
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:509
 #, elixir-autogen, elixir-format
 msgid "No tag matches that."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:383
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:442
 #, elixir-autogen, elixir-format
 msgid "One topic sometimes ends up under several tags, so its members and its posts are split over two pages that never show each other. Merging puts them on one page."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:428
-#, elixir-autogen, elixir-format
-msgid "Stops being a topic of its own. Its profiles, posts and follows move over and its address redirects."
-msgstr ""
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:457
-#, elixir-autogen, elixir-format
-msgid "Swap: keep %{name} instead"
-msgstr ""
-
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:409
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:468
 #, elixir-autogen, elixir-format
 msgid "redirects there for good"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/tag_merge_live.ex:405
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:464
 #, elixir-autogen, elixir-format
 msgid "After the merge"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:138
+#, elixir-autogen, elixir-format, fuzzy
+msgid "%{count} tag is now an alternative name for %{canonical}."
+msgid_plural "%{count} tags are now alternative names for %{canonical}."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:606
+#, elixir-autogen, elixir-format
+msgid "%{names} becomes an alternative name for %{canonical} and %{urls} redirects to /tags/%{slug}."
+msgid_plural "%{names} become alternative names for %{canonical}, and their addresses redirect to /tags/%{slug}."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:487
+#, elixir-autogen, elixir-format
+msgid "Collect the tags that mean one topic"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:579
+#, elixir-autogen, elixir-format
+msgid "Does not belong here"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:539
+#, elixir-autogen, elixir-format
+msgid "It keeps its page and its address; every other one becomes an alternative name pointing at it."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:664
+#, elixir-autogen, elixir-format
+msgid "Merge %{count} tag into %{canonical}"
+msgid_plural "Merge %{count} tags into %{canonical}"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:545
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Nothing collected yet."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:641
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Nothing is filed under these tags."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:534
+#, elixir-autogen, elixir-format
+msgid "Pick the one that stays"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:492
+#, elixir-autogen, elixir-format
+msgid "Search as often as you like and add what belongs. Abbreviations will not turn up under the full name, so look for them separately."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:593
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Start over"
 msgstr ""

--- a/test/vutuv/tags/merge_test.exs
+++ b/test/vutuv/tags/merge_test.exs
@@ -63,6 +63,67 @@ defmodule Vutuv.Tags.MergeTest do
     end
   end
 
+  describe "preview_many/2 and merge_all/3" do
+    test "counts what the sequence really does, not the sum of the pairs", ctx do
+      # A topic is spread over several spellings, so tidying it up is a set
+      # operation. One member carries two of the absorbed tags and not the
+      # surviving one: after the first is absorbed they already hold it, so the
+      # second row is dropped. Two independent previews would promise two moves.
+      other = tag(unique_tag_name("rails"))
+      both = insert(:activated_user)
+      insert(:user_tag, user: both, tag: ctx.absorbed)
+      insert(:user_tag, user: both, tag: other)
+
+      preview = Merge.preview_many([ctx.absorbed, other], ctx.canonical)
+
+      assert preview.moved["user_tags"] == 1
+      assert preview.dropped["user_tags"] == 1
+
+      %{merged: merged, failed: []} =
+        Merge.merge_all([ctx.absorbed, other], ctx.canonical, actor: ctx.admin)
+
+      assert length(merged) == 2
+      assert Repo.aggregate(from(ut in UserTag, where: ut.user_id == ^both.id), :count) == 1
+    end
+
+    test "names the tags it would refuse instead of dropping them quietly", ctx do
+      honor =
+        tag(unique_tag_name("badge")) |> Ecto.Changeset.change(honor?: true) |> Repo.update!()
+
+      preview = Merge.preview_many([ctx.absorbed, honor], ctx.canonical)
+
+      assert preview.mergeable == [ctx.absorbed]
+      assert [{^honor, :honor_tag}] = preview.refused
+    end
+
+    test "one refusal does not stop the others", ctx do
+      honor =
+        tag(unique_tag_name("badge")) |> Ecto.Changeset.change(honor?: true) |> Repo.update!()
+
+      result = Merge.merge_all([ctx.absorbed, honor], ctx.canonical, actor: ctx.admin)
+
+      assert [%{absorbed_tag_id: absorbed_id}] = result.merged
+      assert absorbed_id == ctx.absorbed.id
+      assert [{_, :honor_tag}] = result.failed
+    end
+
+    test "each absorbed tag is its own recorded merge, so each reverts alone", ctx do
+      other = tag(unique_tag_name("rails"))
+      user_tag = insert(:user_tag, user: insert(:activated_user), tag: other)
+
+      %{merged: [first, second]} =
+        Merge.merge_all([ctx.absorbed, other], ctx.canonical, actor: ctx.admin)
+
+      {:ok, _} = Merge.revert(second)
+
+      # Taking one back leaves the other one merged.
+      assert Repo.get!(UserTag, user_tag.id).tag_id == other.id
+      assert is_nil(Repo.get!(Tag, other.id).merged_into_id)
+      assert Repo.get!(Tag, ctx.absorbed.id).merged_into_id == ctx.canonical.id
+      assert first.absorbed_tag_id == ctx.absorbed.id
+    end
+  end
+
   describe "merge/3" do
     test "moves every kind of row over and files the tag as an alias", ctx do
       holder = insert(:activated_user)

--- a/test/vutuv_web/live/admin/tag_merge_live_test.exs
+++ b/test/vutuv_web/live/admin/tag_merge_live_test.exs
@@ -1,8 +1,9 @@
 defmodule VutuvWeb.Admin.TagMergeLiveTest do
   @moduledoc """
-  The tag merge screen (`/admin/tags` → "Merge tags", issue #1338): admins only,
-  pick two tags, see what the merge would move before confirming, do it, and
-  take it back from the history below.
+  The tag merge screen (`/admin/tag_merges`, issue #1338): admins only. Collect
+  the tags that mean one topic over as many searches as it takes, drop the ones
+  that do not belong, pick which survives, see what the merge would move before
+  confirming, and take any of it back from the history below.
   """
   use VutuvWeb.ConnCase
 
@@ -55,29 +56,79 @@ defmodule VutuvWeb.Admin.TagMergeLiveTest do
 
       html =
         lv
-        |> form("#search-absorbed", %{"side" => "absorbed", "q" => ctx.canonical.name})
+        |> form("#tag-search", %{"q" => ctx.canonical.name})
         |> render_change()
 
       assert html =~ "/tags/#{ctx.canonical.slug}"
       assert html =~ "1 profile"
     end
 
-    test "the pair can be turned round in one click", ctx do
+    test "which tag survives is chosen in the list, not by the order of picking", ctx do
       {:ok, lv, _html} = live(ctx.conn, ~p"/admin/tag_merges")
-      pick(lv, ctx.absorbed, "absorbed")
-      pick(lv, ctx.canonical, "canonical")
+      add(lv, ctx.absorbed)
+      add(lv, ctx.canonical)
 
-      html = lv |> element("#swap-sides") |> render_click()
+      # The first one added is the keeper until somebody says otherwise, and
+      # saying otherwise is one click on the row.
+      html = lv |> element("#basket-#{ctx.canonical.id} input[type=radio]") |> render_click()
 
-      # Which of the two survives is the real decision here, and it is usually
-      # made after seeing both.
-      assert html =~ "#{ctx.canonical.name} becomes an alternative name"
+      assert html =~ "#{ctx.absorbed.name} becomes an alternative name for #{ctx.canonical.name}"
+    end
+
+    test "a tag that does not belong can be taken back out", ctx do
+      # The reported case: searching "rails" also finds "grails", a different
+      # topic, and there was no way to drop it again.
+      grails = tag(unique_tag_name("grails"))
+
+      {:ok, lv, _html} = live(ctx.conn, ~p"/admin/tag_merges")
+      add(lv, ctx.canonical)
+      add(lv, grails)
+      assert has_element?(lv, "#basket-#{grails.id}")
+
+      lv |> element("#remove-#{grails.id}") |> render_click()
+
+      # Out of the list, but still findable: removing it says "not this topic",
+      # not "never show me this tag".
+      refute has_element?(lv, "#basket-#{grails.id}")
+      assert has_element?(lv, "#basket-#{ctx.canonical.id}")
+    end
+
+    test "a tag the search cannot reach is collected by searching for it", ctx do
+      # "ROR" never turns up under "rails", which is exactly why the screen
+      # collects across searches instead of filling two slots from one.
+      ror = tag(unique_tag_name("ROR"))
+
+      {:ok, lv, _html} = live(ctx.conn, ~p"/admin/tag_merges")
+      add(lv, ctx.canonical)
+      add(lv, ctx.absorbed)
+      add(lv, ror)
+
+      assert has_element?(lv, "#basket-#{ror.id}")
+
+      lv |> element("#do-merge") |> render_click()
+
+      assert Repo.get!(Tag, ror.id).merged_into_id == ctx.canonical.id
+      assert Repo.get!(Tag, ctx.absorbed.id).merged_into_id == ctx.canonical.id
+    end
+
+    test "several tags are absorbed in one go, each revertible on its own", ctx do
+      other = tag(unique_tag_name("rails"))
+      {:ok, lv, _html} = live(ctx.conn, ~p"/admin/tag_merges")
+      add(lv, ctx.canonical)
+      add(lv, ctx.absorbed)
+      add(lv, other)
+
+      lv |> element("#do-merge") |> render_click()
+
+      assert Repo.get!(Tag, ctx.absorbed.id).merged_into_id == ctx.canonical.id
+      assert Repo.get!(Tag, other.id).merged_into_id == ctx.canonical.id
+      assert length(Merge.history()) == 2
     end
 
     test "the preview says in words what pressing merge would do", ctx do
       {:ok, lv, _html} = live(ctx.conn, ~p"/admin/tag_merges")
-      pick(lv, ctx.absorbed, "absorbed")
-      html = pick(lv, ctx.canonical, "canonical")
+      collect(lv, ctx.absorbed, ctx.canonical)
+      html = render(lv)
 
       assert html =~ "#{ctx.absorbed.name} becomes an alternative name for #{ctx.canonical.name}"
       assert html =~ "/tags/#{ctx.absorbed.slug}"
@@ -89,8 +140,8 @@ defmodule VutuvWeb.Admin.TagMergeLiveTest do
 
       {:ok, lv, _html} = live(ctx.conn, ~p"/admin/tag_merges")
 
-      pick(lv, ctx.absorbed, "absorbed")
-      html = pick(lv, ctx.canonical, "canonical")
+      collect(lv, ctx.absorbed, ctx.canonical)
+      html = render(lv)
 
       assert has_element?(lv, "#merge-preview")
       assert html =~ "profiles carrying the tag"
@@ -102,8 +153,7 @@ defmodule VutuvWeb.Admin.TagMergeLiveTest do
       user_tag = insert(:user_tag, user: insert(:activated_user), tag: ctx.absorbed)
 
       {:ok, lv, _html} = live(ctx.conn, ~p"/admin/tag_merges")
-      pick(lv, ctx.absorbed, "absorbed")
-      pick(lv, ctx.canonical, "canonical")
+      collect(lv, ctx.absorbed, ctx.canonical)
 
       lv |> element("#do-merge") |> render_click()
 
@@ -117,8 +167,8 @@ defmodule VutuvWeb.Admin.TagMergeLiveTest do
       cpp = tag("c++")
 
       {:ok, lv, _html} = live(ctx.conn, ~p"/admin/tag_merges")
-      pick(lv, cpp, "absorbed")
-      html = pick(lv, c, "canonical")
+      collect(lv, cpp, c)
+      html = render(lv)
 
       # The #1337 bucket: four languages one normalization would fold into one.
       assert html =~ "differ only in characters"
@@ -136,8 +186,8 @@ defmodule VutuvWeb.Admin.TagMergeLiveTest do
         |> live(~p"/admin/tag_merges")
 
       assert html =~ "Tags zusammenlegen"
-      assert html =~ "Tag, das aufgenommen wird"
-      assert html =~ "Tag, das bleibt"
+      assert html =~ "Sammeln Sie die Tags"
+      assert html =~ "Wählen Sie das Tag, das bleibt"
       assert html =~ "Vorschläge"
       assert html =~ "Ein Beispiel"
       assert html =~ "Nach der Zusammenlegung"
@@ -161,8 +211,7 @@ defmodule VutuvWeb.Admin.TagMergeLiveTest do
 
     test "a pair can be marked as different topics", ctx do
       {:ok, lv, _html} = live(ctx.conn, ~p"/admin/tag_merges")
-      pick(lv, ctx.absorbed, "absorbed")
-      pick(lv, ctx.canonical, "canonical")
+      collect(lv, ctx.absorbed, ctx.canonical)
 
       lv |> element("#mark-distinct") |> render_click()
 
@@ -218,8 +267,7 @@ defmodule VutuvWeb.Admin.TagMergeLiveTest do
       assert [_] = Assistant.queue()
 
       {:ok, lv, _html} = live(ctx.conn, ~p"/admin/tag_merges")
-      pick(lv, b, "absorbed")
-      pick(lv, a, "canonical")
+      collect(lv, b, a)
       lv |> element("#do-merge") |> render_click()
 
       assert Assistant.queue() == []
@@ -234,7 +282,7 @@ defmodule VutuvWeb.Admin.TagMergeLiveTest do
 
     test "a name nobody has typed yet can be filed pre-emptively", ctx do
       {:ok, lv, _html} = live(ctx.conn, ~p"/admin/tag_merges")
-      pick(lv, ctx.canonical, "canonical")
+      add(lv, ctx.canonical)
 
       name = unique_tag_name("ROR")
       lv |> form("#add-alias", %{"name" => name}) |> render_submit()
@@ -247,7 +295,7 @@ defmodule VutuvWeb.Admin.TagMergeLiveTest do
       existing = tag(unique_tag_name("rails"))
 
       {:ok, lv, _html} = live(ctx.conn, ~p"/admin/tag_merges")
-      pick(lv, ctx.canonical, "canonical")
+      add(lv, ctx.canonical)
 
       html = lv |> form("#add-alias", %{"name" => existing.name}) |> render_submit()
 
@@ -256,10 +304,16 @@ defmodule VutuvWeb.Admin.TagMergeLiveTest do
     end
   end
 
-  # Search for a tag and click its result, the way an admin picks one.
-  defp pick(lv, tag, side) do
-    lv |> form("#search-#{side}", %{"side" => side, "q" => tag.name}) |> render_change()
+  # Search for a tag and add it to the list, the way an admin collects one.
+  defp add(lv, tag) do
+    lv |> form("#tag-search", %{"q" => tag.name}) |> render_change()
+    lv |> element("#add-#{tag.id}") |> render_click()
+  end
 
-    lv |> element("#pick-#{side}-#{tag.id}") |> render_click()
+  # Collect a pair and say which of the two survives.
+  defp collect(lv, absorbed, keeper) do
+    add(lv, absorbed)
+    add(lv, keeper)
+    lv |> element("#basket-#{keeper.id} input[type=radio]") |> render_click()
   end
 end


### PR DESCRIPTION
**TL;DR** `/admin/tag_merges` fragte nach einem Paar. Die Arbeit ist aber das Einsammeln einer *Menge* von Schreibweisen über mehrere Suchen. Jetzt fügt ein Treffer der Liste etwas hinzu, jeder Eintrag hat sein ✕, und erst danach wird bestimmt, welches Tag bleibt.

**Was nicht ging** (gemeldet mit Screenshot): eine Suche nach „rails" findet `grails`, das nicht dazugehört, und findet `ROR` nie. Mit zwei Feldern hieß das: von vorn anfangen, sobald die Suche den falschen Nachbarn brachte, und Abkürzungen gar nicht erreichen.

**Neu**

- Ein Treffer wird der Liste **hinzugefügt**, über beliebig viele Suchen hinweg. Schon Gesammeltes fällt aus den Treffern raus.
- Jeder Eintrag hat ein **✕**. Entfernt heißt „nicht dieses Thema", nicht „nie wieder zeigen": das Tag taucht danach wieder in den Treffern auf.
- Welches Tag bleibt, entscheidet ein **Radio pro Zeile**, nicht die Reihenfolge des Anklickens. Adresse und Profilzahl stehen an jeder Zeile, weil die Profilzahl die Entscheidung meist trägt.
- Ein Eintrag, den die Zusammenlegung ablehnt (Ehren-Tag, `c` gegen `c++`, als verschieden vermerkt), wird **mit seinem Grund benannt** statt still übergangen, und die anderen gehen trotzdem durch.

**Unter der Haube**

`Merge.preview_many/2` zählt, was die Reihenfolge wirklich tut, nicht die Summe der Paare: wer `A` und `B` trägt, aber nicht `C`, verliert beim Zusammenlegen nach `C` eine Zeile und behält eine. Zwei getrennte Vorschauen hätten zwei Umzüge versprochen. Eine Fensterfunktion pro Tabelle, also eine Abfrage für ein wie für fünf aufgenommene Tags. `Merge.merge_all/3` legt jedes Tag als **eigene** protokollierte Zusammenlegung ab, damit jede einzeln zurücknehmbar bleibt.

**Geprüft:** `mix precommit` grün (7104 Tests) und am Bildschirm mit genau dem gemeldeten Fall: nach „rails" gesucht, `grails` per ✕ entfernt, `ROR` über eine zweite Suche dazugenommen, beide aufgenommen, zwei getrennte Einträge in der Historie. Wegwerfdaten wieder aus `vutuv1_dev` entfernt (0 Tags, 0 Merges, 0 Zweitnamen).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*