### PR TITLE
Eine Eingabe von Tags nennt jedes Thema nur einmal (v7.238.0)

### DIFF
--- a/docs/architecture/social-graph.md
+++ b/docs/architecture/social-graph.md
@@ -142,6 +142,26 @@ That shape buys three things at once:
 
 `Tag.find_by_value/1` follows the pointer, so typing any spelling attaches the
 topic instead of minting a duplicate — that is what stops the sprawl regrowing.
+
+One name at a time is not enough, though: every tag field on the site takes a
+**batch** ("PHP, ROR, Ruby on Rails"), and once two of those names resolve to
+one topic the batch is naming it twice — which the member cannot see, the
+spellings looking nothing alike. So a batch goes through
+**`Vutuv.Tags.canonical_tag_names/1`** first: it resolves the whole list in one
+query, exactly the way `find_by_value/1` resolves one name, and drops the
+duplicates that resolution creates, keeping the first spelling typed. Without
+it the second spelling comes back as a failed duplicate on a form that had just
+promised both. Four callers owe it — the add-tag form's live preview and its
+save (`VutuvWeb.TagNewLive`), sign-up (`Accounts.register_user/3` **and**
+`User.registration_changeset/2`, so the three-tag minimum counts topics rather
+than spellings and an account can never land holding fewer tags than the form
+demanded), and the post composer (`Vutuv.Posts`, where the count is also the
+five-tag cap). It deliberately does not judge a name: a value `add_user_tag/2`
+refuses — a web address, punctuation — passes through untouched, so each caller
+keeps its own refusal and its own error message for it. Job postings resolve
+per name and dedupe on the resulting tag ids instead
+(`Vutuv.Jobs.resolve_tag_ids/1`), which lands in the same place.
+
 The price is one rule every tag query owes: **an alternative name is never a
 topic of its own** (`Tag.not_merged/1`). Forgetting it puts a second page for one
 topic back in front of a reader, silently, so

--- a/lib/vutuv/accounts.ex
+++ b/lib/vutuv/accounts.ex
@@ -64,15 +64,17 @@ defmodule Vutuv.Accounts do
         # it into real user tags now that the user row exists. The field is
         # split on commas only (`parse_tag_names/1`), so a member who types
         # "Ruby on Rails, Go" gets those two tags and not four;
-        # case-insensitive de-duplication then drops a repeated tag
-        # ("Go, go") before it can trip the unique constraint, so no per-tag
-        # insert error is silently swallowed here. The insert above only
-        # succeeds when this same parse+dedup yields at least three tags
+        # `canonical_tag_names/1` then resolves each name to the tag it really
+        # names — an alternative name becomes its topic (issue #1338) — and
+        # drops the repeats ("Go, go", "ROR, Ruby on Rails") before they can
+        # trip the unique constraint, so no per-tag insert error is silently
+        # swallowed here. The insert above only succeeds when this same
+        # parse+resolve yields at least three tags
         # (User.registration_changeset/2's minimum), so a fresh account always
         # lands with tags attached.
         user_params["tag_list"]
         |> Vutuv.Tags.parse_tag_names()
-        |> Enum.uniq_by(&String.downcase/1)
+        |> Vutuv.Tags.canonical_tag_names()
         |> Enum.each(&Vutuv.Tags.add_user_tag(user, &1))
 
         user = Repo.preload(user, user_tags: [:tag])

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -927,28 +927,42 @@ defmodule Vutuv.Accounts.User do
   def registration_changeset(model, params \\ %{}) do
     model
     |> changeset(params)
-    |> validate_minimum_tags()
-    |> validate_maximum_tags()
-    |> validate_usable_tags()
+    |> validate_tag_list()
     |> cast_assoc(:emails)
+  end
+
+  # The three tag rules share one resolved list: `distinct_tag_names/1` asks the
+  # database what each typed name really names, and running that per rule would
+  # cost three lookups for one sign-up.
+  defp validate_tag_list(changeset) do
+    names = distinct_tag_names(changeset)
+
+    changeset
+    |> validate_minimum_tags(names)
+    |> validate_maximum_tags(names)
+    |> validate_usable_tags(names)
   end
 
   # How many distinct tags a sign-up must bring.
   @min_registration_tags 3
 
   # Counts exactly what Accounts.register_user/3 later materializes as tags:
-  # the tag_list split on commas (Vutuv.Tags.parse_tag_names/1), then
-  # case-insensitively de-duplicated, so a padded "Go, go, GO" is one tag,
-  # not three.
+  # the tag_list split on commas (Vutuv.Tags.parse_tag_names/1), then resolved
+  # to the tags those names really name (Vutuv.Tags.canonical_tag_names/1), so
+  # a padded "Go, go, GO" is one tag and so is "ROR, Ruby on Rails" — two
+  # spellings of one topic (issue #1338), which the member cannot tell apart by
+  # looking. Counting them separately would pass the minimum below and then
+  # land an account holding one tag, the extra spellings dying silently on the
+  # unique index.
   defp distinct_tag_names(changeset) do
     changeset
     |> get_field(:tag_list)
     |> Vutuv.Tags.parse_tag_names()
-    |> Enum.uniq_by(&String.downcase/1)
+    |> Vutuv.Tags.canonical_tag_names()
   end
 
-  defp validate_minimum_tags(changeset) do
-    if length(distinct_tag_names(changeset)) >= @min_registration_tags do
+  defp validate_minimum_tags(changeset, names) do
+    if length(names) >= @min_registration_tags do
       changeset
     else
       add_error(
@@ -963,10 +977,10 @@ defmodule Vutuv.Accounts.User do
   # The profile tag ceiling (Vutuv.Tags.max_user_tags/0) applies to new accounts
   # too: account setup only materializes tags up to the cap, so rejecting the
   # excess here keeps the form honest instead of silently dropping tags.
-  defp validate_maximum_tags(changeset) do
+  defp validate_maximum_tags(changeset, names) do
     max = Vutuv.Tags.max_user_tags()
 
-    if length(distinct_tag_names(changeset)) <= max do
+    if length(names) <= max do
       changeset
     else
       add_error(changeset, :tag_list, "Please enter at most %{max} different tags.", max: max)
@@ -979,9 +993,7 @@ defmodule Vutuv.Accounts.User do
   # and ignores per-tag failures, so without this the account would be created
   # with that tag quietly missing. Naming the offending token here lets the
   # sign-up form say what to fix instead.
-  defp validate_usable_tags(changeset) do
-    names = distinct_tag_names(changeset)
-
+  defp validate_usable_tags(changeset, names) do
     cond do
       address = Enum.find(names, &WebAddress.link_only?/1) ->
         add_error(

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -4311,11 +4311,17 @@ defmodule Vutuv.Posts do
   # The count is NOT enforced here: the caller (`validate_tag_count/2`) turns a
   # sixth tag into a changeset error, so this returns everything that survived
   # normalisation and the dedupe.
+  #
+  # `Tags.canonical_tag_names/1` does that dedupe, and it dedupes by the tag a
+  # name resolves to rather than by the spelling: an alternative name is one
+  # writing of its topic (issue #1338), so "ROR, Ruby on Rails" is one tag —
+  # which matters here because the cap is counted on what comes back, and being
+  # refused a sixth tag for typing one tag twice is exactly what it must not do.
   defp parse_tag_values(values) when is_list(values) do
     values
     |> Enum.map(&Tag.normalize_value/1)
     |> Enum.reject(&(Tag.punctuation_only?(&1) or WebAddress.link_only?(&1)))
-    |> Enum.uniq_by(&String.downcase/1)
+    |> Tags.canonical_tag_names()
   end
 
   # Find-or-create by name/slug (case-insensitive), racing gracefully.

--- a/lib/vutuv/tags.ex
+++ b/lib/vutuv/tags.ex
@@ -82,46 +82,84 @@ defmodule Vutuv.Tags do
   def parse_tag_names(_), do: []
 
   @doc """
+  The tags a batch of typed `names` really names, in typed order: every name
+  replaced by the display name of the tag it resolves to, and every duplicate
+  that resolution creates dropped.
+
+  Resolution is exactly what `Tag.create_or_link_tag/2` does one name at a
+  time, batched into a single query for the whole list: an existing tag matched
+  case-insensitively by name **or** slug contributes its stored display name
+  (typing `"AhmetSun"` when the tag `ahmetsun` exists yields `ahmetsun`), an
+  **alternative name** contributes the topic it points at (issue #1338, so
+  `"ROR"` yields `Ruby on Rails`), and a name nothing matches passes through
+  exactly as typed — it is about to become a fresh tag.
+
+  The dedupe is what an alias makes necessary. `"ROR, Ruby on Rails"` is one
+  topic under two names, and the member cannot see that: the two spellings look
+  nothing alike, so without this the second one comes back as a failed
+  duplicate on a form that had just promised both. Duplicates are dropped by
+  the tag they resolve to, keeping the first spelling typed, which also
+  subsumes the plain case-insensitive dedupe (`"php, PHP"`).
+
+  **Every entry point that takes a batch owes this call**: the add-tag form,
+  its live preview and sign-up all route through here, so the preview, the
+  minimum-tags rule and what actually lands on the profile agree. It does not
+  judge a name — a value `add_user_tag/2` refuses (a web address, punctuation)
+  passes through untouched, so each caller keeps its own refusal, and its
+  error, for it.
+  """
+  def canonical_tag_names([]), do: []
+
+  def canonical_tag_names(names) when is_list(names) do
+    resolved = resolution_by_key(names)
+
+    names
+    |> Enum.map(fn name ->
+      key = String.downcase(name)
+      Map.get(resolved, key, {{:new, key}, name})
+    end)
+    |> Enum.uniq_by(&elem(&1, 0))
+    |> Enum.map(&elem(&1, 1))
+  end
+
+  # `{typed key => {identity, display name}}` for every name that matches a
+  # stored tag, both by lowercased name and by slug (the two things
+  # `Tag.find_by_value/1` matches on). The identity is the **canonical** tag's
+  # id, which is what makes two different spellings of one topic collapse.
+  defp resolution_by_key(names) do
+    downcased = Enum.map(names, &String.downcase/1)
+
+    from(t in Tag,
+      left_join: c in assoc(t, :merged_into),
+      where: fragment("lower(?)", t.name) in ^downcased or t.slug in ^downcased,
+      select:
+        {fragment("lower(?)", t.name), t.slug, coalesce(c.id, t.id), coalesce(c.name, t.name)}
+    )
+    |> Repo.all()
+    |> Enum.flat_map(fn {lower_name, slug, id, name} ->
+      entry = {{:tag, id}, name}
+      [{lower_name, entry}, {slug, entry}]
+    end)
+    |> Map.new()
+  end
+
+  @doc """
   The display names a submit of `value` on the add-tag form will actually
-  attach, in typed order — the live preview of issue #848. Each parsed name is
-  resolved the way `Tag.create_or_link_tag/2` links: an existing tag matched
-  case-insensitively by name or slug keeps its stored display name (typing
-  `"AhmetSun"` when the tag `ahmetsun` exists yields the chip `ahmetsun`),
-  while an unmatched name becomes a fresh tag displaying exactly as typed.
-  Case-insensitive duplicates collapse to the first spelling, mirroring the
-  single row the profile would end up with (the form's save path dedupes the
-  same way, so preview and outcome always agree). A name `add_user_tag/2` would
-  refuse drops out for the same reason — one that is nothing but a web or email
-  address, or one that is only punctuation — since promising it here would be a
-  lie the submit then takes back.
+  attach, in typed order — the live preview of issue #848.
+
+  `canonical_tag_names/1` does the resolving and the deduping (and the save
+  path calls it too, so preview and outcome always agree); this only drops
+  first what `add_user_tag/2` would refuse — a name that is nothing but a web
+  or email address, or one that is only punctuation — since promising such a
+  name here would be a lie the submit then takes back. The drop happens on the
+  **typed** name, before resolution, because `Tag.create_or_link_tag/2` refuses
+  it before its lookup too.
   """
   def preview_tag_names(value) do
-    case value
-         |> parse_tag_names()
-         |> Enum.reject(&(WebAddress.link_only?(&1) or Tag.punctuation_only?(&1)))
-         |> Enum.uniq_by(&String.downcase/1) do
-      [] ->
-        []
-
-      names ->
-        downcased = Enum.map(names, &String.downcase/1)
-
-        # The displayed name is the topic's, not the typed spelling's: someone
-        # typing an alternative name (issue #1338) gets the chip they will
-        # actually end up with, the same way a case variant already resolves to
-        # the stored casing.
-        display_by_key =
-          from(t in Tag,
-            left_join: c in assoc(t, :merged_into),
-            where: fragment("lower(?)", t.name) in ^downcased or t.slug in ^downcased,
-            select: {fragment("lower(?)", t.name), t.slug, coalesce(c.name, t.name)}
-          )
-          |> Repo.all()
-          |> Enum.flat_map(fn {lower_name, slug, name} -> [{lower_name, name}, {slug, name}] end)
-          |> Map.new()
-
-        Enum.map(names, &Map.get(display_by_key, String.downcase(&1), &1))
-    end
+    value
+    |> parse_tag_names()
+    |> Enum.reject(&(WebAddress.link_only?(&1) or Tag.punctuation_only?(&1)))
+    |> canonical_tag_names()
   end
 
   @doc """

--- a/lib/vutuv_web/live/tag_new_live.ex
+++ b/lib/vutuv_web/live/tag_new_live.ex
@@ -12,9 +12,11 @@ defmodule VutuvWeb.TagNewLive do
   Submitting saves over the socket through the same `Vutuv.Tags.add_user_tag/2`
   chokepoint the retired controller create action used: a single tag keeps the
   inline error re-render (duplicate / invalid), a batch redirects with a count.
-  The parsed names are deduplicated case-insensitively first, so the outcome
-  always matches the preview. Styled as a classic editform page
-  (components.css), like its /settings siblings.
+  The parsed names go through `Vutuv.Tags.canonical_tag_names/1` first — the
+  same call the preview uses, so the outcome always matches it: an alternative
+  name becomes its topic (typing `ROR` adds `Ruby on Rails`, issue #1338) and
+  the duplicates that creates collapse before anything is saved. Styled as a
+  classic editform page (components.css), like its /settings siblings.
   """
 
   use VutuvWeb, :live_view
@@ -112,7 +114,7 @@ defmodule VutuvWeb.TagNewLive do
   end
 
   defp save_tags(socket, user, value) do
-    case value |> Tags.parse_tag_names() |> Enum.uniq_by(&String.downcase/1) do
+    case value |> Tags.parse_tag_names() |> Tags.canonical_tag_names() do
       # Nothing usable typed: keep the form, show the error banner (the same
       # empty-changeset re-render the controller create used to do).
       [] ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.237.0",
+      version: "7.238.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/posts_test.exs
+++ b/test/vutuv/posts_test.exs
@@ -240,6 +240,29 @@ defmodule Vutuv.PostsTest do
       assert Enum.sort(Enum.map(post.tags, & &1.name)) == Enum.sort(names)
     end
 
+    test "an alternative name is the same tag, so typing both does not trip the cap" do
+      # Two names of one topic (issue #1338): the composer must file the topic
+      # once and count it once, or a member is refused a sixth tag for having
+      # typed a fifth one twice — under two spellings that look nothing alike.
+      canonical_name = unique_tag_name("Ruby on Rails")
+      canonical = insert(:tag, name: canonical_name, slug: canonical_name)
+      abbreviation = unique_tag_name("ROR")
+
+      insert(:tag,
+        name: abbreviation,
+        slug: abbreviation,
+        merged_into_id: canonical.id,
+        alias_kind: "abbreviation"
+      )
+
+      others = Enum.map(2..Posts.max_tags_per_post(), &unique_tag_name("tag#{&1}"))
+      tags = Enum.join([abbreviation | others] ++ [canonical_name], ", ")
+
+      post = create_post!(user(), %{body: "tagged", tags: tags})
+
+      assert Enum.sort(Enum.map(post.tags, & &1.name)) == Enum.sort([canonical_name | others])
+    end
+
     test "stores wildcard and per-user denials" do
       author = user()
       denied = user()

--- a/test/vutuv/tags/tag_alias_input_test.exs
+++ b/test/vutuv/tags/tag_alias_input_test.exs
@@ -1,0 +1,143 @@
+defmodule Vutuv.Tags.TagAliasInputTest do
+  use Vutuv.DataCase, async: true
+
+  @moduledoc """
+  What a typed tag name really stands for.
+
+  Issue #1338 files an alternative name as a tag row pointing at its topic, so
+  `ROR` and `Ruby on Rails` are one subject under two names. The lookup has
+  followed that pointer since then — but the two spellings look nothing alike,
+  so a member typing both in one go is naming one topic twice without any way
+  of seeing it. Everything that takes a batch of typed names therefore
+  resolves first and drops the duplicates the resolution creates
+  (`Vutuv.Tags.canonical_tag_names/1`), instead of reporting the second
+  spelling back as a failed duplicate.
+  """
+
+  alias Vutuv.Accounts
+  alias Vutuv.Accounts.User
+  alias Vutuv.Tags
+  alias Vutuv.Tags.Tag
+
+  setup do
+    canonical_name = unique_tag_name("Ruby on Rails")
+    canonical = insert(:tag, name: canonical_name, slug: slugify(canonical_name))
+
+    %{canonical: canonical, abbreviation: alias_for(canonical, "ROR", "abbreviation")}
+  end
+
+  defp alias_for(canonical, base, kind) do
+    name = unique_tag_name(base)
+
+    insert(:tag,
+      name: name,
+      slug: slugify(name),
+      merged_into_id: canonical.id,
+      alias_kind: kind
+    )
+  end
+
+  defp slugify(name), do: Vutuv.SlugHelpers.gen_slug_unique(name, Tag, :slug)
+
+  describe "canonical_tag_names/1" do
+    test "replaces an alternative name with the topic it points at", ctx do
+      assert Tags.canonical_tag_names([ctx.abbreviation.name]) == [ctx.canonical.name]
+    end
+
+    test "matches an alternative name case-insensitively, like any tag", ctx do
+      assert Tags.canonical_tag_names([String.upcase(ctx.abbreviation.name)]) ==
+               [ctx.canonical.name]
+    end
+
+    test "names the topic once when both spellings are typed", ctx do
+      assert Tags.canonical_tag_names([ctx.abbreviation.name, ctx.canonical.name]) ==
+               [ctx.canonical.name]
+    end
+
+    test "collapses two alternative names of one topic", ctx do
+      former = alias_for(ctx.canonical, "rubyonrails", "former")
+
+      assert Tags.canonical_tag_names([ctx.abbreviation.name, former.name]) ==
+               [ctx.canonical.name]
+    end
+
+    test "keeps the typed order and the other tags around the duplicate", ctx do
+      elixir = unique_tag_name("Elixir")
+      go = unique_tag_name("Go")
+
+      assert Tags.canonical_tag_names([elixir, ctx.abbreviation.name, go, ctx.canonical.name]) ==
+               [elixir, ctx.canonical.name, go]
+    end
+
+    test "passes a name no tag matches through exactly as typed" do
+      fresh = unique_tag_name("WebAssembly")
+
+      assert Tags.canonical_tag_names([fresh]) == [fresh]
+    end
+
+    test "collapses case variants of a name no tag matches yet" do
+      fresh = unique_tag_name("Rust")
+
+      assert Tags.canonical_tag_names([fresh, String.downcase(fresh)]) == [fresh]
+    end
+
+    test "answers an empty list without a lookup" do
+      assert Tags.canonical_tag_names([]) == []
+    end
+  end
+
+  describe "the add-tag preview" do
+    test "shows the topic once for both of its names", ctx do
+      value = "#{ctx.abbreviation.name}, #{ctx.canonical.name}"
+
+      assert Tags.preview_tag_names(value) == [ctx.canonical.name]
+    end
+  end
+
+  describe "sign-up" do
+    setup do
+      n = System.unique_integer([:positive])
+
+      %{
+        attrs: %{
+          "emails" => %{"0" => %{"value" => "alias-input-#{n}@example.com"}},
+          "first_name" => "Alias",
+          "last_name" => "Input#{n}"
+        }
+      }
+    end
+
+    test "counts one topic once, however many of its names are typed", ctx do
+      former = alias_for(ctx.canonical, "rubyonrails", "former")
+      tag_list = "#{ctx.abbreviation.name}, #{former.name}, #{ctx.canonical.name}"
+
+      changeset = User.registration_changeset(%User{}, Map.put(ctx.attrs, "tag_list", tag_list))
+
+      # Without the collapse this passes the three-tag minimum and then lands
+      # an account holding one tag — the two extra spellings fail the unique
+      # index on their way in, silently.
+      assert "Please enter at least 3 different tags." in errors_on(changeset).tag_list
+    end
+
+    test "materializes an alternative name as the topic itself", ctx do
+      tag_list =
+        "#{ctx.abbreviation.name}, #{unique_tag_name("Cooking")}, #{unique_tag_name("Origami")}"
+
+      attrs = Map.put(ctx.attrs, "tag_list", tag_list)
+
+      assert {:ok, %User{} = user} = Accounts.register_user(build_conn(), attrs)
+
+      names = Enum.map(user.user_tags, & &1.tag.name)
+      assert ctx.canonical.name in names
+      refute ctx.abbreviation.name in names
+    end
+  end
+
+  defp build_conn do
+    %Plug.Conn{
+      assigns: %{locale: "en"},
+      private: %{plug_session: %{}, plug_session_fetch: :done}
+    }
+    |> Plug.Test.init_test_session(%{})
+  end
+end

--- a/test/vutuv_web/live/tag_new_live_test.exs
+++ b/test/vutuv_web/live/tag_new_live_test.exs
@@ -19,6 +19,8 @@ defmodule VutuvWeb.TagNewLiveTest do
   defp tag_count(user),
     do: Repo.aggregate(from(ut in UserTag, where: ut.user_id == ^user.id), :count)
 
+  defp slugify(name), do: Vutuv.SlugHelpers.gen_slug_unique(name, Vutuv.Tags.Tag, :slug)
+
   # Type `value` into the form and return the previewed chip texts, in order.
   defp preview(live, value) do
     live
@@ -202,6 +204,35 @@ defmodule VutuvWeb.TagNewLiveTest do
       flash = assert_redirect(live, ~p"/settings/tags")
       assert flash["info"] == "Added 1 of 2 tags (the rest were duplicates or invalid)."
       assert tag_count(user) == base + 2
+    end
+
+    test "attaches the topic once when both of its names are typed", %{
+      live: live,
+      user: user,
+      base: base
+    } do
+      # An alternative name (issue #1338) resolves to its topic, so typing both
+      # names is naming one tag twice — which a member cannot see, the two
+      # spellings looking nothing alike. The batch must collapse to the one tag
+      # instead of reporting its second half as a failed duplicate.
+      canonical_name = unique_tag_name("Ruby on Rails")
+      canonical = insert(:tag, name: canonical_name, slug: slugify(canonical_name))
+      abbreviation = unique_tag_name("ROR")
+
+      insert(:tag,
+        name: abbreviation,
+        slug: slugify(abbreviation),
+        merged_into_id: canonical.id,
+        alias_kind: "abbreviation"
+      )
+
+      live
+      |> form("#tag-form", tag_param: %{value: "#{abbreviation}, #{canonical_name}"})
+      |> render_submit()
+
+      flash = assert_redirect(live, ~p"/settings/tags")
+      assert flash["info"] == "User tag created successfully."
+      assert tag_count(user) == base + 1
     end
 
     test "previews no chip for a name the save would refuse", %{live: live} do


### PR DESCRIPTION
**TL;DR** Eine Liste eingetippter Tags wird jetzt als Ganzes aufgelöst: Zweitnamen werden durch ihr Thema ersetzt und die dabei entstehenden Dubletten verworfen, bevor gespeichert wird.

Seit #1338 zeigt ein Zweitname auf sein Thema, und die Suche nach einem einzelnen Namen folgt dem Zeiger — wer `ROR` eintippt, bekommt `Ruby on Rails`. Jedes Tag-Feld nimmt aber eine ganze Liste entgegen, und sobald zwei Namen darin dasselbe Thema meinen, nennt die Eingabe es zweimal. Sehen kann das niemand: `ROR` und `Ruby on Rails` haben keinen Buchstaben gemeinsam. Bisher fiel das erst beim Speichern auf, als "1 von 2 Tags hinzugefügt" auf einem Formular, das eine Zeile vorher beide versprochen hatte.

**Neu:** `Vutuv.Tags.canonical_tag_names/1` löst eine ganze Liste in einer Abfrage auf — genau so, wie `Tag.find_by_value/1` einen einzelnen Namen auflöst — und verwirft die Dubletten, die diese Auflösung erzeugt. Vier Aufrufer:

- **Tag-Formular** (`VutuvWeb.TagNewLive`) — Vorschau *und* Speicherpfad, die damit nicht auseinanderlaufen können
- **Anmeldung** (`Accounts.register_user/3` und `User.registration_changeset/2`) — die Mindestzahl von drei Tags zählt jetzt Themen statt Schreibweisen. Das war ein echter Fehler: `ROR, rails, rubyonrails` bestand die Prüfung und legte dann ein Konto mit genau einem Tag an, die anderen beiden starben still im Unique-Index.
- **Beitrags-Editor** (`Vutuv.Posts`) — die Obergrenze von fünf Tags zählt aus demselben Grund Themen; ein sechstes Tag abgelehnt zu bekommen, weil man ein fünftes zweimal geschrieben hat, ist genau das, was die Grenze nicht tun soll.

Stellenanzeigen brauchten nichts: `Jobs.resolve_tag_ids/1` dedupliziert bereits über die aufgelösten Tag-IDs.

Bewusst **kein** Urteil über den Namen selbst — eine Web-Adresse oder reine Satzzeichen laufen unverändert durch, damit jeder Aufrufer seine eigene Ablehnung und seine eigene Fehlermeldung behält. Und bewusst **kein** Raten: ersetzt wird nur, was als Zweitname eingetragen ist (`/admin/tag_merges`), nicht was ähnlich aussieht.

**Geprüft:** neue Tests in `test/vutuv/tags/tag_alias_input_test.exs` (gegengeprüft, dass sie ohne die Auflösung rot werden), dazu je ein Fall im Tag-Formular- und im Posts-Test. `mix precommit` grün. Im Browser gegen die echten Dev-Daten: `ROR, Ruby on Rails, rails, Barista` eingegeben, Vorschau zeigte `Ruby on Rails` und `Barista`, gespeichert wurden genau diese zwei; die dabei angelegten Zeilen sind wieder entfernt.

**Deploy:** hot (keine Migration, keine Änderung an Startup, Config oder Abhängigkeiten). **Version:** 7.238.0.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*
