### PR TITLE
Rollen einer Organisation werden als Liste gelesen (v7.238.3)

### DIFF
--- a/lib/vutuv/organizations.ex
+++ b/lib/vutuv/organizations.ex
@@ -142,27 +142,40 @@ defmodule Vutuv.Organizations do
 
   def can_manage?(_, _), do: false
 
-  @doc ~S|The `user`'s role on `organization` ("owner"/"admin"/"recruiter"), or nil.|
-  def role_of(%Organization{id: id}, %User{id: user_id}) do
-    Repo.one(
+  @doc ~S"""
+  Every role `user` holds on `organization`, ranked owner → admin → recruiter,
+  as a list of strings (`[]` for a non-member).
+
+  This replaced `role_of/2`, which answered with a single role string, when
+  issue #1333 let a member hold several roles at once. It was **renamed** rather
+  than quietly changed: a permission accessor whose return type moves from
+  `"owner" | nil` to a list under the same name is how a check ends up reading a
+  non-empty list as truthy and waving everyone through.
+  """
+  def roles_of(%Organization{id: id}, %User{id: user_id}) do
+    Repo.all(
       from(r in OrganizationRole,
         where: r.organization_id == ^id and r.user_id == ^user_id,
         select: r.role
       )
     )
+    |> rank_roles()
   end
 
-  def role_of(_, _), do: nil
+  def roles_of(_, _), do: []
+
+  @doc "Sorts a list of role strings into the canonical owner → admin → recruiter order."
+  def rank_roles(roles), do: Enum.sort_by(roles, &role_rank/1)
 
   @doc "Whether `user` is an owner of `organization` (manage roles + domains)."
   def owner?(%Organization{} = organization, %User{} = user),
-    do: role_of(organization, user) == "owner"
+    do: "owner" in roles_of(organization, user)
 
   def owner?(_, _), do: false
 
   @doc "Whether `user` may edit the organization page + aliases (owner or admin)."
   def can_edit_page?(%Organization{} = organization, %User{} = user),
-    do: role_of(organization, user) in ["owner", "admin"]
+    do: Enum.any?(roles_of(organization, user), &(&1 in ["owner", "admin"]))
 
   def can_edit_page?(_, _), do: false
 
@@ -191,14 +204,15 @@ defmodule Vutuv.Organizations do
   end
 
   @doc """
-  Every organization the member helps run, as `{organization, role}` pairs
-  ordered by name. Covers each page the member holds any role on (owner / admin
-  / recruiter) — the claim wizard always makes the creator an `owner`, so a
-  member's own pages are included too. **Pending** pages (still finishing domain
-  verification) and **frozen** ones are kept so the member can act on them;
-  **archived** pages are dropped. Powers the member's "Your organizations" page
-  at `/settings/organizations` (distinct from `postable_organizations/1`, which
-  is the active-only job-posting attribution set).
+  Every organization the member helps run, as `{organization, roles}` pairs
+  ordered by name, where `roles` is the ranked list of every role they hold
+  there. Covers each page the member holds any role on — the claim wizard always
+  makes the creator an `owner`, so a member's own pages are included too.
+  **Pending** pages (still finishing domain verification) and **frozen** ones are
+  kept so the member can act on them; **archived** pages are dropped. Powers the
+  member's "Your organizations" page at `/settings/organizations` (distinct from
+  `postable_organizations/1`, which is the active-only job-posting attribution
+  set).
   """
   def member_organizations(%User{id: user_id}) do
     Repo.all(
@@ -206,10 +220,14 @@ defmodule Vutuv.Organizations do
         join: o in Organization,
         on: o.id == r.organization_id,
         where: r.user_id == ^user_id and o.status != "archived",
-        order_by: [asc: fragment("lower(?)", o.name)],
+        order_by: [asc: fragment("lower(?)", o.name), asc: o.id],
         select: {o, r.role}
       )
     )
+    |> Enum.chunk_by(fn {organization, _role} -> organization.id end)
+    |> Enum.map(fn [{organization, _} | _] = rows ->
+      {organization, rank_roles(Enum.map(rows, fn {_, role} -> role end))}
+    end)
   end
 
   @doc "An organization's roles, owner → admin → recruiter, each oldest first, user preloaded."

--- a/lib/vutuv/organizations/organization_role.ex
+++ b/lib/vutuv/organizations/organization_role.ex
@@ -26,6 +26,11 @@ defmodule Vutuv.Organizations.OrganizationRole do
     |> cast(attrs, [:organization_id, :user_id, :role, :granted_by_user_id])
     |> validate_required([:organization_id, :user_id, :role])
     |> validate_inclusion(:role, @roles)
+    # Both indexes exist during the issue #1333 rollout. The pair is the one that
+    # still enforces one-role-per-member and therefore the one that fires today;
+    # the triple takes over the moment the pair is dropped (deploy 2), and both
+    # put their error on `:organization_id`, so `add_role/4`'s mapping is unchanged.
     |> unique_constraint([:organization_id, :user_id])
+    |> unique_constraint([:organization_id, :user_id, :role])
   end
 end

--- a/lib/vutuv_web/templates/settings/organizations.html.heex
+++ b/lib/vutuv_web/templates/settings/organizations.html.heex
@@ -37,7 +37,7 @@ happen on the organization's own pages. --%>
     <.card :if={@organizations != []} id="your-organizations">
       <.section_title>{gettext("Your organizations")}</.section_title>
       <ul class="mt-2 divide-y divide-slate-100 dark:divide-slate-800">
-        <li :for={{organization, role} <- @organizations} class="flex items-center gap-4 py-4">
+        <li :for={{organization, roles} <- @organizations} class="flex items-center gap-4 py-4">
           <.link navigate={~p"/organizations/#{organization.slug}"} class="shrink-0">
             <.organization_logo organization={organization} class="h-12 w-12" />
           </.link>
@@ -60,13 +60,15 @@ happen on the organization's own pages. --%>
               ]}>
                 {organization_status_label(organization)}
               </span>
+              <%!-- One line however many roles the member holds here, since the
+              question it answers ("what am I on this page?") is one question. --%>
               <span class="text-xs text-slate-600 dark:text-slate-400">
-                {gettext("Your role")}: {role_label(role)}
+                {ngettext("Your role", "Your roles", length(roles))}: {Enum.map_join(roles, ", ", &role_label/1)}
               </span>
             </div>
           </div>
           <.link
-            :if={role in ["owner", "admin"]}
+            :if={Enum.any?(roles, &(&1 in ["owner", "admin"]))}
             navigate={~p"/organizations/#{organization.slug}/edit"}
             class="shrink-0 text-sm font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
           >

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.238.2",
+      version: "7.238.3",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260810161750_widen_organization_role_unique_index.exs
+++ b/priv/repo/migrations/20260810161750_widen_organization_role_unique_index.exs
@@ -1,0 +1,22 @@
+defmodule Vutuv.Repo.Migrations.WidenOrganizationRoleUniqueIndex do
+  @moduledoc """
+  Issue #1333, step 1 of 2. A member holds exactly one role per organization
+  today because of the unique index on `[organization_id, user_id]`. The
+  `publisher` role only means something if it can be held *beside* `owner` or
+  `admin`, so the pair has to become a triple.
+
+  This step only **adds** `[organization_id, user_id, role]`; the old pair index
+  stays and keeps enforcing one-role-per-member for one more deploy. Dropping it
+  here would not be safe, contrary to what the issue assumed: the previous
+  release is still serving traffic while migrations run, its roster still inserts
+  role rows, and with the pair index gone its own "already on the team" refusal
+  disappears with it — so it could write the second row that its own
+  `role_of/2` (`Repo.one`) then raises on. The drop ships in the next deploy,
+  by which time every release in play reads roles as a list.
+  """
+  use Ecto.Migration
+
+  def change do
+    create(unique_index(:organization_roles, [:organization_id, :user_id, :role]))
+  end
+end

--- a/test/vutuv/organizations_management_test.exs
+++ b/test/vutuv/organizations_management_test.exs
@@ -134,6 +134,31 @@ defmodule Vutuv.OrganizationsManagementTest do
       assert {:ok, _} = Organizations.update_role(owner_role, "admin", owner)
     end
 
+    test "roles_of answers with a ranked list, and the permission predicates read it" do
+      {organization, owner} = active_organization()
+      recruiter = insert(:activated_user)
+      stranger = insert(:activated_user)
+      {:ok, _} = Organizations.add_role(organization, recruiter, "recruiter", owner)
+
+      assert Organizations.roles_of(organization, owner) == ["owner"]
+      assert Organizations.roles_of(organization, recruiter) == ["recruiter"]
+      assert Organizations.roles_of(organization, stranger) == []
+      assert Organizations.roles_of(organization, nil) == []
+
+      assert Organizations.owner?(organization, owner)
+      refute Organizations.owner?(organization, recruiter)
+      assert Organizations.can_edit_page?(organization, owner)
+      refute Organizations.can_edit_page?(organization, recruiter)
+      refute Organizations.can_edit_page?(organization, stranger)
+    end
+
+    test "member_organizations pairs each page with the member's ranked roles" do
+      {organization, owner} = active_organization()
+
+      assert [{listed, ["owner"]}] = Organizations.member_organizations(owner)
+      assert listed.id == organization.id
+    end
+
     test "list_roles orders owner, admin, recruiter" do
       {organization, owner} = active_organization()
       r = insert(:activated_user)

--- a/test/vutuv_web/organization_management_test.exs
+++ b/test/vutuv_web/organization_management_test.exs
@@ -40,7 +40,7 @@ defmodule VutuvWeb.OrganizationManagementTest do
       |> render_submit(%{"identifier" => "@" <> member.username, "role" => "admin"})
 
       assert render(view) =~ member.username
-      assert Organizations.role_of(organization, member) == "admin"
+      assert Organizations.roles_of(organization, member) == ["admin"]
     end
 
     test "the last owner cannot leave", %{conn: conn} do
@@ -48,13 +48,14 @@ defmodule VutuvWeb.OrganizationManagementTest do
       organization = active_organization_for(owner)
 
       role =
-        Organizations.role_of(organization, owner) && hd(Organizations.list_roles(organization))
+        Organizations.roles_of(organization, owner) != [] and
+          hd(Organizations.list_roles(organization))
 
       {:ok, view, _html} = live(conn, ~p"/organizations/#{organization.slug}/roles")
       html = view |> element("#role-#{role.id} button", "Leave") |> render_click()
 
       assert html =~ "at least one owner"
-      assert Organizations.role_of(organization, owner) == "owner"
+      assert Organizations.roles_of(organization, owner) == ["owner"]
     end
 
     test "a logged-in non-member cannot open the roles page", %{conn: conn} do


### PR DESCRIPTION
Step 1 of 2 for #1333. It makes the **reading** side of organization roles list-shaped and nothing else; writing a second role for a member still cannot happen.

- `role_of/2` → **`roles_of/2`**, returning the ranked list of roles a member holds (`[]` for a non-member). Renamed rather than quietly re-typed, as the issue asks: a permission accessor whose return type moves from `"owner" | nil` to a list under the same name is exactly how a check ends up reading a non-empty list as truthy. `owner?/2`, `can_edit_page?/2`, `member_organizations/1` and the "Your organizations" page follow.
- Migration **adds** the unique index `[organization_id, user_id, role]` and keeps the old pair.

### One correction to the plan in the issue

The issue says dropping the old pair index is safe on its own "because no code yet writes a second row for a member". It isn't, and the order has to be the other way round. During a blue/green deploy the previous release keeps serving traffic while migrations run, its roster still inserts role rows, and the pair index **is** its "already on the team" refusal (`add_role/4` maps that constraint error to `{:error, :already_member}`). Drop the pair first and that release can write the second row its own `role_of/2` (`Repo.one`) then raises on: the exact N-1 breakage the ordering was meant to avoid.

So: this deploy teaches every reader to take a list, the next one drops the pair index and opens up multi-role writes. By then every release in play reads roles as a list, and a second row is harmless to all of them.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*
