### PR TITLE
Wer im Namen einer Organisation schreiben darf (v7.239.0)

### DIFF
--- a/lib/vutuv/organizations.ex
+++ b/lib/vutuv/organizations.ex
@@ -37,6 +37,11 @@ defmodule Vutuv.Organizations do
   alias Vutuv.Repo
   alias Vutuv.SlugHelpers
 
+  # The role vocabulary, taken from the schema so the two can never disagree.
+  # It has to be an attribute rather than a call because `add_role/4` guards on
+  # it, and a guard cannot call a remote function.
+  @roles OrganizationRole.roles()
+
   # Slugs that would shadow a /organizations/<word> route.
   @reserved_slugs ~w(new)
   @directory_per_page 24
@@ -127,9 +132,13 @@ defmodule Vutuv.Organizations do
 
   # --- roles ------------------------------------------------------------------
   #
-  # Powers (issue #930): owner = roles + domains + page + job postings; admin =
-  # page + job postings; recruiter = job postings only. Every role is a
-  # proof-derived power, not an employment claim.
+  # Powers (issues #930, #1333): owner = roles + domains + page + job postings;
+  # admin = page + job postings; recruiter = job postings only; publisher =
+  # speaking in the organization's name (its posts) and nothing administrative.
+  # Every role is a proof-derived power, not an employment claim.
+  #
+  # A member may hold several roles and the effective powers are the union, but
+  # `publisher` is never implied by another role — see `publisher?/2`.
 
   @doc """
   Whether `user` is organization staff (creator or any role holder). This is the
@@ -164,7 +173,10 @@ defmodule Vutuv.Organizations do
 
   def roles_of(_, _), do: []
 
-  @doc "Sorts a list of role strings into the canonical owner → admin → recruiter order."
+  @doc "The role vocabulary, ranked owner → admin → publisher → recruiter."
+  def roles, do: rank_roles(@roles)
+
+  @doc "Sorts a list of role strings into the canonical owner → admin → publisher → recruiter order."
   def rank_roles(roles), do: Enum.sort_by(roles, &role_rank/1)
 
   @doc "Whether `user` is an owner of `organization` (manage roles + domains)."
@@ -178,6 +190,22 @@ defmodule Vutuv.Organizations do
     do: Enum.any?(roles_of(organization, user), &(&1 in ["owner", "admin"]))
 
   def can_edit_page?(_, _), do: false
+
+  @doc """
+  Whether `user` may speak in `organization`'s name: publish, edit and delete
+  its posts, and switch into it (issue #1335).
+
+  Deliberately **not** implied by `owner` or `admin`. That is the entire point of
+  the role: administering a page and speaking for it are different powers, and
+  a freshly claimed page therefore cannot post until its owner grants this once,
+  which is a visible step rather than a silent default. The separation holds
+  structurally rather than by convention, because `can_manage_roles?/2` is
+  owner-only — an admin cannot grant themselves the right to post.
+  """
+  def publisher?(%Organization{} = organization, %User{} = user),
+    do: "publisher" in roles_of(organization, user)
+
+  def publisher?(_, _), do: false
 
   @doc "Whether `user` may manage the roster (owner only)."
   def can_manage_roles?(organization, user), do: owner?(organization, user)
@@ -230,16 +258,43 @@ defmodule Vutuv.Organizations do
     end)
   end
 
-  @doc "An organization's roles, owner → admin → recruiter, each oldest first, user preloaded."
+  @doc """
+  An organization's role rows, ranked owner → admin → publisher → recruiter and
+  then oldest first, user preloaded. A member holding two roles appears twice —
+  this is the raw row listing (the admin drawer reads it); the roster UI wants
+  one entry per member and uses `list_team/1`.
+  """
   def list_roles(%Organization{id: id}) do
     Repo.all(from(r in OrganizationRole, where: r.organization_id == ^id, preload: [:user]))
     |> Enum.sort_by(&{role_rank(&1.role), &1.id})
   end
 
+  @doc """
+  An organization's team, **one entry per member**: `%{user:, roles:, since:}`
+  with `roles` ranked, ordered by the member's highest role and then by when
+  they joined the team. This is what the roster renders, because with several
+  roles per member a row-per-role list would show the same person twice with
+  half their powers in each row.
+  """
+  def list_team(%Organization{} = organization) do
+    organization
+    |> list_roles()
+    |> Enum.group_by(& &1.user_id)
+    |> Enum.map(fn {_user_id, [first | _] = rows} ->
+      %{
+        user: first.user,
+        roles: rank_roles(Enum.map(rows, & &1.role)),
+        since: Enum.min_by(rows, & &1.id).id
+      }
+    end)
+    |> Enum.sort_by(&{role_rank(hd(&1.roles)), &1.since})
+  end
+
   defp role_rank("owner"), do: 0
   defp role_rank("admin"), do: 1
-  defp role_rank("recruiter"), do: 2
-  defp role_rank(_), do: 3
+  defp role_rank("publisher"), do: 2
+  defp role_rank("recruiter"), do: 3
+  defp role_rank(_), do: 4
 
   @doc """
   Up to six member suggestions for the roles typeahead, matched by `@handle` or
@@ -277,13 +332,13 @@ defmodule Vutuv.Organizations do
   end
 
   @doc """
-  Grants `user` a role on `organization`. Notifies the member (the derived
+  Grants `user` one role on `organization`. Notifies the member (the derived
   notification feed picks up the row; a live push updates the badge). Returns
-  `{:ok, role}`, `{:error, :already_member}` when they already hold a role, or
-  `{:error, changeset}`.
+  `{:ok, role}`, `{:error, :already_member}` when they already hold **that**
+  role, or `{:error, changeset}`.
   """
   def add_role(%Organization{} = organization, %User{} = user, role, %User{} = granted_by)
-      when role in ~w(owner admin recruiter) do
+      when role in @roles do
     %OrganizationRole{}
     |> OrganizationRole.changeset(%{
       organization_id: organization.id,
@@ -305,34 +360,63 @@ defmodule Vutuv.Organizations do
   end
 
   @doc """
-  Changes an existing role. Refuses to demote the last owner (keeps the
-  ≥ 1-owner invariant). Notifies the member of an upgrade/downgrade.
-  """
-  def update_role(%OrganizationRole{} = role_row, new_role, %User{} = actor)
-      when new_role in ~w(owner admin recruiter) do
-    cond do
-      role_row.role == new_role ->
-        {:ok, role_row}
+  Sets the complete set of roles `user` holds on `organization` — the checkbox
+  roster's one operation, and the successor to the old single-role
+  `update_role/3`. An empty list removes them from the team.
 
-      role_row.role == "owner" and new_role != "owner" ->
-        # Demoting an owner races with a concurrent demotion of a DIFFERENT owner:
-        # both could read owner_count > 1 and commit, orphaning the org with zero
-        # owners (write skew). Serialize the check and the write under a row lock.
-        guard_last_owner(role_row.organization_id, fn ->
-          apply_role_change(role_row, new_role, actor)
+  Adds what is missing, removes what is no longer ticked, leaves the rest
+  untouched (so an unchanged role keeps its `granted_by` and its age), and
+  notifies the member once per newly granted role. Returns `{:ok, roles}` with
+  the ranked new set, or `{:error, :last_owner}` when the change would leave the
+  organization without an owner.
+
+  Taking `owner` away runs under the same `guard_last_owner/2` row lock the
+  single-role path used: two concurrent edits each dropping a *different* owner
+  could otherwise both read "there are two owners" and both commit, leaving zero.
+  """
+  def set_roles(%Organization{} = organization, %User{} = user, roles, %User{} = actor) do
+    wanted = roles |> Enum.filter(&(&1 in @roles)) |> Enum.uniq()
+    held = roles_of(organization, user)
+
+    cond do
+      MapSet.new(wanted) == MapSet.new(held) ->
+        {:ok, rank_roles(held)}
+
+      "owner" in held and "owner" not in wanted ->
+        guard_last_owner(organization.id, fn ->
+          apply_role_set(organization, user, wanted, held, actor)
         end)
 
       true ->
-        apply_role_change(role_row, new_role, actor)
+        apply_role_set(organization, user, wanted, held, actor)
     end
   end
 
-  defp apply_role_change(role_row, new_role, actor) do
-    with {:ok, updated} <- role_row |> Ecto.Changeset.change(role: new_role) |> Repo.update() do
-      organization = get_organization!(updated.organization_id)
-      Vutuv.Activity.notify_organization_role(updated.user_id, actor, organization, new_role)
-      {:ok, updated}
-    end
+  defp apply_role_set(organization, user, wanted, held, actor) do
+    granted = wanted -- held
+    revoked = held -- wanted
+
+    Repo.delete_all(
+      from(r in OrganizationRole,
+        where:
+          r.organization_id == ^organization.id and r.user_id == ^user.id and r.role in ^revoked
+      )
+    )
+
+    Enum.each(granted, fn role ->
+      %OrganizationRole{}
+      |> OrganizationRole.changeset(%{
+        organization_id: organization.id,
+        user_id: user.id,
+        role: role,
+        granted_by_user_id: actor.id
+      })
+      |> Repo.insert(on_conflict: :nothing)
+
+      Vutuv.Activity.notify_organization_role(user.id, actor, organization, role)
+    end)
+
+    {:ok, rank_roles(wanted)}
   end
 
   @doc """

--- a/lib/vutuv/organizations/organization_role.ex
+++ b/lib/vutuv/organizations/organization_role.ex
@@ -3,11 +3,18 @@ defmodule Vutuv.Organizations.OrganizationRole do
   A member's role on an organization page (issue #929). The claim wizard makes the
   creator an `owner`; the `admin`/`recruiter` grants and the management UI come
   in issue #930. Every role is a proof-derived power, not an employment claim.
+
+  A member may hold **several** roles here (issue #1333), which is why the unique
+  index is on `[organization_id, user_id, role]` rather than on the pair. The
+  role that needs it is `publisher`: speaking in an organization's name is a
+  different power from administering it, and the two belong to different people
+  more often than not, so `publisher` is **never** implied by `owner` or `admin`
+  and is always an explicit grant.
   """
 
   use VutuvWeb, :model
 
-  @roles ~w(owner admin recruiter)
+  @roles ~w(owner admin publisher recruiter)
 
   schema "organization_roles" do
     field(:role, :string)
@@ -26,11 +33,6 @@ defmodule Vutuv.Organizations.OrganizationRole do
     |> cast(attrs, [:organization_id, :user_id, :role, :granted_by_user_id])
     |> validate_required([:organization_id, :user_id, :role])
     |> validate_inclusion(:role, @roles)
-    # Both indexes exist during the issue #1333 rollout. The pair is the one that
-    # still enforces one-role-per-member and therefore the one that fires today;
-    # the triple takes over the moment the pair is dropped (deploy 2), and both
-    # put their error on `:organization_id`, so `add_role/4`'s mapping is unchanged.
-    |> unique_constraint([:organization_id, :user_id])
     |> unique_constraint([:organization_id, :user_id, :role])
   end
 end

--- a/lib/vutuv_web/components/organization_components.ex
+++ b/lib/vutuv_web/components/organization_components.ex
@@ -243,8 +243,19 @@ defmodule VutuvWeb.OrganizationComponents do
   @doc "The human, localized label for an organization role."
   def role_label("owner"), do: gettext("Owner")
   def role_label("admin"), do: gettext("Admin")
+  # "Editorial" / "Redaktion" names the function rather than the person, which
+  # is the point: this role says "may write in our name" and must not read as
+  # seniority. The code name stays `publisher`.
+  def role_label("publisher"), do: gettext("Editorial")
   def role_label("recruiter"), do: gettext("Recruiter")
   def role_label(_), do: gettext("Member")
+
+  @doc "One line saying what a role may do, for the roster's checkboxes."
+  def role_hint("owner"), do: gettext("Manages the team and the domains, and edits the page.")
+  def role_hint("admin"), do: gettext("Edits the page and posts jobs.")
+  def role_hint("publisher"), do: gettext("Writes posts in the organization's name.")
+  def role_hint("recruiter"), do: gettext("Posts jobs.")
+  def role_hint(_), do: ""
 
   @doc "The human, localized label for an alias kind."
   def alias_kind_label("former"), do: gettext("Former name")

--- a/lib/vutuv_web/live/organization_live/roles.ex
+++ b/lib/vutuv_web/live/organization_live/roles.ex
@@ -1,24 +1,29 @@
 defmodule VutuvWeb.OrganizationLive.Roles do
   @moduledoc """
   The owner-only organization team roster (`/organizations/:slug/roles`, issue #930). Add
-  a member by `@handle`/email (with a live typeahead), pick their role
-  (owner / admin / recruiter), change a role, or remove someone. The organization
-  always keeps ≥ 1 owner, so removing or demoting the last owner is refused.
+  a member by `@handle`/email (with a live typeahead), tick the roles they hold,
+  or remove them. The organization always keeps ≥ 1 owner, so removing or
+  un-ticking the last owner is refused.
+
+  Since issue #1333 a member may hold **several** roles, so each row is one
+  member with a set of checkboxes rather than one role with a select. That is
+  not only a wider control: with a select, granting `publisher` to an admin
+  would have silently taken their `admin` away, which is the mistake the whole
+  role separation exists to prevent.
+
   Embedded via `live_render` from `VutuvWeb.OrganizationController`, which gates it on
   an owner.
   """
 
   use VutuvWeb, :live_view
 
-  import VutuvWeb.OrganizationComponents, only: [manage_header: 1, role_label: 1]
+  import VutuvWeb.OrganizationComponents, only: [manage_header: 1, role_label: 1, role_hint: 1]
   import VutuvWeb.UserHelpers, only: [full_name: 1]
 
   alias Vutuv.Accounts
   alias Vutuv.Accounts.User
   alias Vutuv.Organizations
   alias VutuvWeb.Live.InitAssigns
-
-  @roles ~w(owner admin recruiter)
 
   @impl true
   def mount(_params, session, socket) do
@@ -30,25 +35,26 @@ defmodule VutuvWeb.OrganizationLive.Roles do
      |> assign(:organization, organization)
      |> assign(:page_title, gettext("Team – %{name}", name: organization.name))
      |> assign(:identifier, "")
-     |> assign(:add_role, "recruiter")
-     |> assign(:roles_options, @roles)
+     # Nothing pre-ticked: with four roles a guessed default is wrong more often
+     # than right, and `publisher` in particular must never arrive by accident.
+     |> assign(:add_roles, [])
+     |> assign(:roles_options, Organizations.roles())
      |> assign(:suggestions, [])
-     |> load_roles()}
+     |> load_team()}
   end
 
-  defp load_roles(socket) do
-    assign(socket, :roles, Organizations.list_roles(socket.assigns.organization))
+  defp load_team(socket) do
+    assign(socket, :team, Organizations.list_team(socket.assigns.organization))
   end
 
   @impl true
   def handle_event("suggest", %{"identifier" => term} = params, socket) do
-    exclude = Enum.map(socket.assigns.roles, & &1.user_id)
-    role = params["role"] || socket.assigns.add_role
+    exclude = Enum.map(socket.assigns.team, & &1.user.id)
 
     {:noreply,
      socket
      |> assign(:identifier, term)
-     |> assign(:add_role, role)
+     |> assign(:add_roles, checked_roles(params))
      |> assign(:suggestions, Organizations.suggest_members(term, exclude))}
   end
 
@@ -57,12 +63,15 @@ defmodule VutuvWeb.OrganizationLive.Roles do
   end
 
   def handle_event("add_member", %{"identifier" => identifier} = params, socket) do
-    role = params["role"] || socket.assigns.add_role
+    roles = checked_roles(params)
     organization = socket.assigns.organization
 
     case identifier |> String.trim() |> Accounts.get_user_by_handle_or_email() do
-      %User{} = user ->
-        add_and_flash(socket, organization, user, role)
+      %User{} = user when roles != [] ->
+        add_and_flash(socket, organization, user, roles)
+
+      %User{} ->
+        {:noreply, put_flash(socket, :error, gettext("Pick at least one role."))}
 
       nil ->
         {:noreply,
@@ -74,63 +83,66 @@ defmodule VutuvWeb.OrganizationLive.Roles do
     end
   end
 
-  def handle_event("change_role", %{"role_id" => role_id, "role" => role}, socket)
-      when role in @roles do
-    case Organizations.get_role(socket.assigns.organization, role_id) do
-      nil ->
-        {:noreply, socket}
+  def handle_event("set_roles", %{"user_id" => user_id} = params, socket) do
+    with_team_member(socket, user_id, fn user ->
+      apply_roles(socket, user, checked_roles(params), gettext("Roles updated."))
+    end)
+  end
 
-      role_row ->
-        socket.assigns.current_user
-        |> then(&Organizations.update_role(role_row, role, &1))
-        |> case do
-          {:ok, _} ->
-            {:noreply, socket |> load_roles() |> put_flash(:info, gettext("Role updated."))}
+  def handle_event("remove", %{"user_id" => user_id}, socket) do
+    with_team_member(socket, user_id, fn user ->
+      apply_roles(socket, user, [], gettext("Member removed."))
+    end)
+  end
 
-          {:error, :last_owner} ->
-            {:noreply, put_flash(socket, :error, last_owner_error())}
-
-          {:error, _} ->
-            {:noreply, put_flash(socket, :error, gettext("That change could not be saved."))}
-        end
+  # Resolves a roster row by member id. Scoping the lookup to the team the
+  # socket already holds is the authorization: an id that is not on this
+  # organization's roster simply does not resolve, so a forged `user_id` cannot
+  # reach `set_roles/4` for someone else's page.
+  defp with_team_member(socket, user_id, fun) do
+    case Enum.find(socket.assigns.team, &(&1.user.id == user_id)) do
+      nil -> {:noreply, socket}
+      entry -> fun.(entry.user)
     end
   end
 
-  def handle_event("remove", %{"id" => role_id}, socket) do
-    case Organizations.get_role(socket.assigns.organization, role_id) do
-      nil ->
-        {:noreply, socket}
+  defp apply_roles(socket, user, roles, message) do
+    case Organizations.set_roles(
+           socket.assigns.organization,
+           user,
+           roles,
+           socket.assigns.current_user
+         ) do
+      {:ok, _roles} ->
+        {:noreply, socket |> load_team() |> put_flash(:info, message)}
 
-      role_row ->
-        case Organizations.remove_role(role_row) do
-          {:ok, _} ->
-            {:noreply, socket |> load_roles() |> put_flash(:info, gettext("Member removed."))}
-
-          {:error, :last_owner} ->
-            {:noreply, put_flash(socket, :error, last_owner_error())}
-        end
+      {:error, :last_owner} ->
+        {:noreply, socket |> load_team() |> put_flash(:error, last_owner_error())}
     end
   end
 
-  defp add_and_flash(socket, organization, user, role) do
-    case Organizations.add_role(organization, user, role, socket.assigns.current_user) do
+  # The checkbox group posts one param per ticked role (`roles[publisher]="true"`),
+  # and nothing at all when every box is cleared, so a missing `"roles"` key means
+  # "none" rather than "unchanged".
+  defp checked_roles(params) do
+    params
+    |> Map.get("roles", %{})
+    |> Enum.filter(fn {_role, value} -> value in ["true", "on"] end)
+    |> Enum.map(fn {role, _} -> role end)
+    |> Organizations.rank_roles()
+  end
+
+  defp add_and_flash(socket, organization, user, roles) do
+    case Organizations.set_roles(organization, user, roles, socket.assigns.current_user) do
       {:ok, _} ->
         {:noreply,
          socket
          |> assign(:identifier, "")
          |> assign(:suggestions, [])
-         |> load_roles()
+         |> load_team()
          |> put_flash(:info, gettext("Added @%{handle} to the team.", handle: user.username))}
 
-      {:error, :already_member} ->
-        {:noreply,
-         put_flash(
-           socket,
-           :error,
-           gettext("@%{handle} is already on the team.", handle: user.username)
-         )}
-
-      {:error, _changeset} ->
+      {:error, _} ->
         {:noreply, put_flash(socket, :error, gettext("That member could not be added."))}
     end
   end
@@ -152,7 +164,7 @@ defmodule VutuvWeb.OrganizationLive.Roles do
 
       <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100">{gettext("Team")}</h1>
       <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
-        {gettext("Give members a role on this page. Owners manage the team and domains, admins edit the page, recruiters post jobs.")}
+        {gettext("Give members their roles on this page. Someone can hold several at once, and every role is granted on its own.")}
       </p>
 
       <.card class="mt-6">
@@ -189,62 +201,90 @@ defmodule VutuvWeb.OrganizationLive.Roles do
             </ul>
           </div>
 
-          <div class="flex flex-wrap items-center gap-3">
-            <select name="role" class={[input_class(), "w-auto"]}>
-              <option :for={role <- @roles_options} value={role} selected={role == @add_role}>
-                {role_label(role)}
-              </option>
-            </select>
-            <button
-              type="submit"
-              class="rounded-lg bg-brand-600 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-700"
-            >
-              {gettext("Add")}
-            </button>
-          </div>
+          <.role_checkboxes id="add" options={@roles_options} checked={@add_roles} hints={true} />
+
+          <button
+            type="submit"
+            class="rounded-lg bg-brand-600 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-700"
+          >
+            {gettext("Add")}
+          </button>
         </.form>
       </.card>
 
       <.card class="mt-6">
         <.section_title>{gettext("Current team")}</.section_title>
         <ul class="mt-3 divide-y divide-slate-100 dark:divide-slate-800">
-          <li :for={role <- @roles} id={"role-#{role.id}"} class="flex items-center gap-3 py-3">
-            <.avatar user={role.user} size="sm" shape="circle" />
-            <div class="min-w-0 flex-1">
-              <.link
-                navigate={"/#{role.user.username}"}
-                class="block truncate font-medium text-slate-900 hover:text-brand-700 dark:text-slate-100"
+          <li :for={entry <- @team} id={"member-#{entry.user.id}"} class="py-4">
+            <div class="flex items-center gap-3">
+              <.avatar user={entry.user} size="sm" shape="circle" />
+              <div class="min-w-0 flex-1">
+                <.link
+                  navigate={"/#{entry.user.username}"}
+                  class="block truncate font-medium text-slate-900 hover:text-brand-700 dark:text-slate-100"
+                >
+                  {full_name(entry.user)}
+                </.link>
+                <span class="block truncate text-xs text-slate-600 dark:text-slate-400">@{entry.user.username}</span>
+              </div>
+
+              <button
+                type="button"
+                phx-click="remove"
+                phx-value-user_id={entry.user.id}
+                data-confirm={
+                  if(entry.user.id == @current_user_id,
+                    do: gettext("Leave this organization team?"),
+                    else: gettext("Remove this member from the team?")
+                  )
+                }
+                class="shrink-0 text-sm font-semibold text-red-600 hover:text-red-700"
               >
-                {full_name(role.user)}
-              </.link>
-              <span class="block truncate text-xs text-slate-600 dark:text-slate-400">@{role.user.username}</span>
+                {if entry.user.id == @current_user_id, do: gettext("Leave"), else: gettext("Remove")}
+              </button>
             </div>
 
-            <form phx-change="change_role" class="shrink-0">
-              <input type="hidden" name="role_id" value={role.id} />
-              <select name="role" class={[input_class(), "w-auto py-1.5 text-xs"]}>
-                <option :for={r <- @roles_options} value={r} selected={r == role.role}>{role_label(r)}</option>
-              </select>
+            <form phx-change="set_roles" class="mt-2">
+              <input type="hidden" name="user_id" value={entry.user.id} />
+              <.role_checkboxes id={"member-#{entry.user.id}"} options={@roles_options} checked={entry.roles} />
             </form>
-
-            <button
-              type="button"
-              phx-click="remove"
-              phx-value-id={role.id}
-              data-confirm={
-                if(role.user_id == @current_user_id,
-                  do: gettext("Leave this organization team?"),
-                  else: gettext("Remove this member from the team?")
-                )
-              }
-              class="shrink-0 text-sm font-semibold text-red-600 hover:text-red-700"
-            >
-              {if role.user_id == @current_user_id, do: gettext("Leave"), else: gettext("Remove")}
-            </button>
           </li>
         </ul>
       </.card>
     </div>
+    """
+  end
+
+  # One checkbox per role. Each box carries a matching hidden "false" field so a
+  # box the owner CLEARS still reaches the server as a value — without it the
+  # browser simply omits it, and un-ticking the last box would send no `roles`
+  # key at all on a form whose other fields are unchanged.
+  attr(:id, :string, required: true)
+  attr(:options, :list, required: true)
+  attr(:checked, :list, required: true)
+  attr(:hints, :boolean, default: false)
+
+  defp role_checkboxes(assigns) do
+    ~H"""
+    <fieldset class="flex flex-wrap gap-x-5 gap-y-2">
+      <legend class="sr-only">{gettext("Roles")}</legend>
+      <label :for={role <- @options} for={"#{@id}-role-#{role}"} class="flex min-h-10 items-start gap-2">
+        <input type="hidden" name={"roles[#{role}]"} value="false" />
+        <input
+          type="checkbox"
+          id={"#{@id}-role-#{role}"}
+          name={"roles[#{role}]"}
+          value="true"
+          checked={role in @checked}
+          data-role-checkbox={role}
+          class={checkbox_class()}
+        />
+        <span class="min-w-0">
+          <span class="block text-sm font-medium text-slate-900 dark:text-slate-100">{role_label(role)}</span>
+          <span :if={@hints} class="block text-xs text-slate-600 dark:text-slate-400">{role_hint(role)}</span>
+        </span>
+      </label>
+    </fieldset>
     """
   end
 end

--- a/lib/vutuv_web/templates/settings/organizations.html.heex
+++ b/lib/vutuv_web/templates/settings/organizations.html.heex
@@ -23,7 +23,7 @@ happen on the organization's own pages. --%>
         </li>
         <li class="flex gap-2">
           <span aria-hidden="true" class="text-brand-600 dark:text-brand-300">•</span>
-          <span>{gettext("The owner can invite other members onto the page as admins or recruiters, and can hand ownership over to someone else at any time.")}</span>
+          <span>{gettext("The owner gives other members their roles on the page, and can hand ownership over to someone else at any time. Someone can hold several roles, and writing in the organization's name is always granted on its own.")}</span>
         </li>
         <li class="flex gap-2">
           <span aria-hidden="true" class="text-brand-600 dark:text-brand-300">•</span>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.238.3",
+      version: "7.239.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -21,7 +21,7 @@ msgstr "Impressum"
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:718
 #: lib/vutuv_web/live/organization_live/domains.ex:255
 #: lib/vutuv_web/live/organization_live/edit.ex:396
-#: lib/vutuv_web/live/organization_live/roles.ex:202
+#: lib/vutuv_web/live/organization_live/roles.ex:205
 #, elixir-autogen
 msgid "Add"
 msgstr "Eintrag hinzufügen"
@@ -1414,9 +1414,9 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/live/job_posting_live/form.ex:510
 #: lib/vutuv_web/live/search_live.ex:199
 #: lib/vutuv_web/live/search_live.ex:516
-#: lib/vutuv_web/live/tag_new_live.ex:34
-#: lib/vutuv_web/live/tag_new_live.ex:45
-#: lib/vutuv_web/live/tag_new_live.ex:52
+#: lib/vutuv_web/live/tag_new_live.ex:36
+#: lib/vutuv_web/live/tag_new_live.ex:47
+#: lib/vutuv_web/live/tag_new_live.ex:54
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:247
 #: lib/vutuv_web/templates/admin/tag/edit.html.heex:5
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:5
@@ -1556,7 +1556,7 @@ msgstr "Die am häufigsten empfohlenen Mitglieder mit diesem Tag"
 msgid "Unendorsed tag successfully."
 msgstr "Empfehlung zurückgenommen."
 
-#: lib/vutuv_web/live/tag_new_live.ex:127
+#: lib/vutuv_web/live/tag_new_live.ex:129
 #, elixir-autogen
 msgid "User tag created successfully."
 msgstr "Tag erfolgreich hinzugefügt."
@@ -1746,7 +1746,7 @@ msgstr ""
 msgid "Log out"
 msgstr "Ausloggen"
 
-#: lib/vutuv_web/components/organization_components.ex:247
+#: lib/vutuv_web/components/organization_components.ex:251
 #: lib/vutuv_web/live/admin/activity_live.ex:143
 #: lib/vutuv_web/live/admin/activity_live.ex:175
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
@@ -2264,7 +2264,7 @@ msgstr "Weniger anzeigen"
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:373
-#: lib/vutuv_web/live/organization_live/roles.ex:242
+#: lib/vutuv_web/live/organization_live/roles.ex:238
 #: lib/vutuv_web/live/post_live/composer.ex:1851
 #: lib/vutuv_web/live/post_live/saved.ex:619
 #: lib/vutuv_web/live/post_live/saved.ex:647
@@ -2779,7 +2779,7 @@ msgstr "Ersten Beitrag schreiben"
 #: lib/vutuv_web/components/ui.ex:3389
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
-#: lib/vutuv_web/templates/settings/organizations.html.heex:73
+#: lib/vutuv_web/templates/settings/organizations.html.heex:75
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:219
@@ -4556,7 +4556,7 @@ msgid "Edit the ad"
 msgstr "Anzeige bearbeiten"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1004
-#: lib/vutuv_web/live/tag_new_live.ex:77
+#: lib/vutuv_web/live/tag_new_live.ex:79
 #: lib/vutuv_web/templates/ad/preview.html.heex:3
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:122
 #, elixir-autogen, elixir-format
@@ -4819,7 +4819,7 @@ msgid "searches first names only (last: for last names)"
 msgstr "sucht nur in Vornamen (nachname: für Nachnamen)"
 
 #: lib/vutuv_web/live/job_board_live.ex:388
-#: lib/vutuv_web/live/tag_new_live.ex:46
+#: lib/vutuv_web/live/tag_new_live.ex:48
 #: lib/vutuv_web/live/user_profile_live.ex:1259
 #: lib/vutuv_web/templates/user/show.html.heex:549
 #, elixir-autogen, elixir-format
@@ -8299,8 +8299,8 @@ msgstr "Identität verifiziert. Das Mitglied wurde per E-Mail benachrichtigt."
 msgid "Identity-verified"
 msgstr "Identität verifiziert"
 
-#: lib/vutuv/accounts.ex:1311
-#: lib/vutuv/accounts.ex:1360
+#: lib/vutuv/accounts.ex:1313
+#: lib/vutuv/accounts.ex:1362
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -8341,7 +8341,7 @@ msgstr "Nicht bestätigt"
 msgid "Open the member browser"
 msgstr "Mitgliederübersicht öffnen"
 
-#: lib/vutuv/accounts.ex:1328
+#: lib/vutuv/accounts.ex:1330
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -9110,7 +9110,7 @@ msgstr "Social-Media-Konten verwalten"
 msgid "Your Fediverse handle"
 msgstr "Ihr Fediverse-Handle"
 
-#: lib/vutuv/accounts.ex:1323
+#: lib/vutuv/accounts.ex:1325
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -9203,12 +9203,12 @@ msgstr "Schulbildung"
 msgid "Vocational Training"
 msgstr "Berufsausbildung"
 
-#: lib/vutuv_web/live/tag_new_live.ex:78
+#: lib/vutuv_web/live/tag_new_live.ex:80
 #, elixir-autogen, elixir-format
 msgid "This will create the following tags:"
 msgstr "Die folgenden Tags werden erstellt:"
 
-#: lib/vutuv_web/live/tag_new_live.ex:54
+#: lib/vutuv_web/live/tag_new_live.ex:56
 #, elixir-autogen, elixir-format
 msgid "Tip:"
 msgstr "Tipp:"
@@ -9916,7 +9916,7 @@ msgstr "Yoruba"
 msgid "Employment status"
 msgstr "Beschäftigungsstatus"
 
-#: lib/vutuv/accounts/user.ex:1072
+#: lib/vutuv/accounts/user.ex:1084
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9927,7 +9927,7 @@ msgstr "Auf Jobsuche"
 msgid "Not open to work"
 msgstr "Nicht offen für Angebote"
 
-#: lib/vutuv/accounts/user.ex:1069
+#: lib/vutuv/accounts/user.ex:1081
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -11024,12 +11024,12 @@ msgstr ""
 msgid "At least three tags, separated by commas. A tag may be several words long, like Ruby on Rails."
 msgstr "Mindestens drei Tags, mit Komma getrennt. Ein Tag darf aus mehreren Wörtern bestehen, zum Beispiel Ruby on Rails."
 
-#: lib/vutuv_web/live/tag_new_live.ex:63
+#: lib/vutuv_web/live/tag_new_live.ex:65
 #, elixir-autogen, elixir-format
 msgid "PHP, JavaScript, Ruby on Rails"
 msgstr "PHP, JavaScript, Ruby on Rails"
 
-#: lib/vutuv_web/live/tag_new_live.ex:54
+#: lib/vutuv_web/live/tag_new_live.ex:56
 #, elixir-autogen, elixir-format
 msgid "Separate tags with a comma. A tag may be several words long, like Ruby on Rails."
 msgstr "Tags mit Komma trennen. Ein Tag darf aus mehreren Wörtern bestehen, zum Beispiel Ruby on Rails."
@@ -11418,19 +11418,19 @@ msgstr ""
 " Konto anlegen kann. Wählen Sie „Niemand“, um den Status zu speichern, ohne "
 "ihn anzuzeigen."
 
-#: lib/vutuv/accounts/user.ex:1110
+#: lib/vutuv/accounts/user.ex:1122
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Alle, auch nicht angemeldete Besucher"
 
-#: lib/vutuv/accounts/user.ex:1115
+#: lib/vutuv/accounts/user.ex:1127
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Niemand"
 
-#: lib/vutuv/accounts/user.ex:1113
+#: lib/vutuv/accounts/user.ex:1125
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:566
 #, elixir-autogen, elixir-format
@@ -11831,17 +11831,12 @@ msgstr ""
 msgid "with this exact content:"
 msgstr "mit genau diesem Inhalt:"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:130
-#, elixir-autogen, elixir-format
-msgid "@%{handle} is already on the team."
-msgstr "@%{handle} ist bereits im Team."
-
-#: lib/vutuv_web/live/organization_live/roles.ex:168
+#: lib/vutuv_web/live/organization_live/roles.ex:175
 #, elixir-autogen, elixir-format
 msgid "@handle or email"
 msgstr "@handle oder E-Mail"
 
-#: lib/vutuv_web/components/organization_components.ex:252
+#: lib/vutuv_web/components/organization_components.ex:263
 #: lib/vutuv_web/live/organization_live/edit.ex:390
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
@@ -11852,17 +11847,17 @@ msgstr "Abkürzung"
 msgid "Add a domain"
 msgstr "Domain hinzufügen"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:159
+#: lib/vutuv_web/live/organization_live/roles.ex:166
 #, elixir-autogen, elixir-format
 msgid "Add a member"
 msgstr "Mitglied hinzufügen"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:123
+#: lib/vutuv_web/live/organization_live/roles.ex:138
 #, elixir-autogen, elixir-format
 msgid "Added @%{handle} to the team."
 msgstr "@%{handle} zum Team hinzugefügt."
 
-#: lib/vutuv_web/components/organization_components.ex:253
+#: lib/vutuv_web/components/organization_components.ex:264
 #: lib/vutuv_web/live/organization_live/edit.ex:388
 #, elixir-autogen, elixir-format
 msgid "Alias"
@@ -11908,7 +11903,7 @@ msgstr "Diese Seite archivieren?"
 msgid "Archived"
 msgstr "Archiviert"
 
-#: lib/vutuv_web/components/organization_components.ex:251
+#: lib/vutuv_web/components/organization_components.ex:262
 #: lib/vutuv_web/live/organization_live/edit.ex:389
 #, elixir-autogen, elixir-format
 msgid "Brand"
@@ -11919,7 +11914,7 @@ msgstr "Marke"
 msgid "Claimed by"
 msgstr "Beansprucht von"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:209
+#: lib/vutuv_web/live/organization_live/roles.ex:211
 #, elixir-autogen, elixir-format
 msgid "Current team"
 msgstr "Aktuelles Team"
@@ -11961,7 +11956,7 @@ msgstr "Domains"
 msgid "Domains – %{name}"
 msgstr "Domains – %{name}"
 
-#: lib/vutuv_web/components/organization_components.ex:250
+#: lib/vutuv_web/components/organization_components.ex:261
 #, elixir-autogen, elixir-format
 msgid "Former name"
 msgstr "Früherer Name"
@@ -11980,21 +11975,13 @@ msgstr ""
 "Diese Seite einfrieren? Sie verschwindet für die Öffentlichkeit, bleibt aber "
 "für den Besitzer sichtbar."
 
-#: lib/vutuv_web/live/organization_live/roles.ex:155
-#, elixir-autogen, elixir-format
-msgid "Give members a role on this page. Owners manage the team and domains, admins edit the page, recruiters post jobs."
-msgstr ""
-"Geben Sie Mitgliedern eine Rolle auf dieser Seite. Besitzer verwalten Team "
-"und Domains, Administratoren bearbeiten die Seite, Recruiter schalten "
-"Stellenanzeigen."
-
 #: lib/vutuv_web/live/organization_live/domains.ex:189
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "Last checked"
 msgstr "Zuletzt geprüft"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:242
+#: lib/vutuv_web/live/organization_live/roles.ex:238
 #, elixir-autogen, elixir-format
 msgid "Leave"
 msgstr "Verlassen"
@@ -12014,7 +12001,7 @@ msgstr "Live"
 msgid "Make primary"
 msgstr "Als primär festlegen"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:107
+#: lib/vutuv_web/live/organization_live/roles.ex:94
 #, elixir-autogen, elixir-format
 msgid "Member removed."
 msgstr "Mitglied entfernt."
@@ -12029,7 +12016,7 @@ msgstr "Methode"
 msgid "Names & aliases"
 msgstr "Namen & Aliasse"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:72
+#: lib/vutuv_web/live/organization_live/roles.ex:81
 #, elixir-autogen, elixir-format
 msgid "No member found for “%{id}”."
 msgstr "Kein Mitglied für „%{id}“ gefunden."
@@ -12049,7 +12036,7 @@ msgstr "Primär"
 msgid "Primary domain updated."
 msgstr "Primäre Domain aktualisiert."
 
-#: lib/vutuv_web/components/organization_components.ex:246
+#: lib/vutuv_web/components/organization_components.ex:250
 #, elixir-autogen, elixir-format
 msgid "Recruiter"
 msgstr "Recruiter"
@@ -12059,7 +12046,7 @@ msgstr "Recruiter"
 msgid "Remove this domain?"
 msgstr "Diese Domain entfernen?"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:237
+#: lib/vutuv_web/live/organization_live/roles.ex:233
 #, elixir-autogen, elixir-format
 msgid "Remove this member from the team?"
 msgstr "Dieses Mitglied aus dem Team entfernen?"
@@ -12069,11 +12056,6 @@ msgstr "Dieses Mitglied aus dem Team entfernen?"
 msgid "Remove this name?"
 msgstr "Diesen Namen entfernen?"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:88
-#, elixir-autogen, elixir-format
-msgid "Role updated."
-msgstr "Rolle aktualisiert."
-
 #: lib/vutuv_web/live/admin/organization_live.ex:233
 #, elixir-autogen, elixir-format
 msgid "Search name, alias or domain"
@@ -12081,28 +12063,23 @@ msgstr "Name, Alias oder Domain suchen"
 
 #: lib/vutuv_web/components/organization_components.ex:208
 #: lib/vutuv_web/live/admin/organization_live.ex:321
-#: lib/vutuv_web/live/organization_live/roles.ex:153
+#: lib/vutuv_web/live/organization_live/roles.ex:160
 #: lib/vutuv_web/live/organization_live/show.ex:270
 #, elixir-autogen, elixir-format
 msgid "Team"
 msgstr "Team"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:31
+#: lib/vutuv_web/live/organization_live/roles.ex:36
 #, elixir-autogen, elixir-format
 msgid "Team – %{name}"
 msgstr "Team – %{name}"
-
-#: lib/vutuv_web/live/organization_live/roles.ex:94
-#, elixir-autogen, elixir-format
-msgid "That change could not be saved."
-msgstr "Diese Änderung konnte nicht gespeichert werden."
 
 #: lib/vutuv_web/live/organization_live/domains.ex:71
 #, elixir-autogen, elixir-format
 msgid "That is not a valid domain."
 msgstr "Das ist keine gültige Domain."
 
-#: lib/vutuv_web/live/organization_live/roles.ex:134
+#: lib/vutuv_web/live/organization_live/roles.ex:141
 #, elixir-autogen, elixir-format
 msgid "That member could not be added."
 msgstr "Dieses Mitglied konnte nicht hinzugefügt werden."
@@ -12355,7 +12332,7 @@ msgstr ""
 "Eine Organisation behält mindestens eine verifizierte Domain, daher kann diese "
 "nicht entfernt werden."
 
-#: lib/vutuv_web/live/organization_live/roles.ex:140
+#: lib/vutuv_web/live/organization_live/roles.ex:147
 #, elixir-autogen, elixir-format
 msgid "An organization must keep at least one owner, so the last owner cannot be changed."
 msgstr ""
@@ -12384,7 +12361,7 @@ msgstr "Reservieren Sie ein kurzes @handle, damit diese Organisation wie ein Mit
 #: lib/vutuv_web/live/organization_live/index.ex:101
 #: lib/vutuv_web/live/organization_live/new.ex:26
 #: lib/vutuv_web/live/organization_live/new.ex:80
-#: lib/vutuv_web/templates/settings/organizations.html.heex:87
+#: lib/vutuv_web/templates/settings/organizations.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Add your organization"
 msgstr "Ihre Organisation hinzufügen"
@@ -12430,7 +12407,7 @@ msgstr "Das Löschen dieser Organisationsseite ist endgültig. Ihre verifizierte
 msgid "Kind of organization"
 msgstr "Art der Organisation"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:236
+#: lib/vutuv_web/live/organization_live/roles.ex:232
 #, elixir-autogen, elixir-format
 msgid "Leave this organization team?"
 msgstr "Dieses Organisations-Team verlassen?"
@@ -12844,7 +12821,7 @@ msgstr "Halten Sie Strg / Cmd gedrückt, um mehrere auszuwählen."
 msgid "How to apply"
 msgstr "So bewerben Sie sich"
 
-#: lib/vutuv/accounts/user.ex:1084
+#: lib/vutuv/accounts/user.ex:1096
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12964,7 +12941,7 @@ msgstr "Hier ist noch nichts. Jobs, die Ihnen gefallen, erscheinen hier."
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) für KI-Agenten anbieten."
 
-#: lib/vutuv/accounts/user.ex:1083
+#: lib/vutuv/accounts/user.ex:1095
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -13046,7 +13023,7 @@ msgstr "Anzeige nicht gefunden."
 msgid "Publish"
 msgstr "Veröffentlichen"
 
-#: lib/vutuv/accounts/user.ex:1085
+#: lib/vutuv/accounts/user.ex:1097
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:497
 #: lib/vutuv_web/agent_docs/markdown.ex:353
@@ -13259,11 +13236,6 @@ msgstr "So funktioniert es"
 msgid "Whoever creates a page becomes its owner."
 msgstr "Wer eine Seite erstellt, wird ihr Besitzer."
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:26
-#, elixir-autogen, elixir-format
-msgid "The owner can invite other members onto the page as admins or recruiters, and can hand ownership over to someone else at any time."
-msgstr "Der Besitzer kann weitere Mitglieder als Admins oder Recruiter auf die Seite einladen und die Besitzerrolle jederzeit an eine andere Person übergeben."
-
 #: lib/vutuv_web/templates/settings/organizations.html.heex:30
 #, elixir-autogen, elixir-format
 msgid "A page can claim a short @handle, so it lives at a memorable address like %{example}."
@@ -13274,22 +13246,24 @@ msgstr "Eine Seite kann sich ein kurzes @handle sichern, sodass sie unter einer 
 msgid "Your organizations"
 msgstr "Ihre Organisationen"
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:64
+#: lib/vutuv_web/templates/settings/organizations.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "Your role"
-msgstr "Ihre Rolle"
+msgid_plural "Your roles"
+msgstr[0] "Ihre Rolle"
+msgstr[1] "Ihre Rollen"
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:82
+#: lib/vutuv_web/templates/settings/organizations.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "Add an organization"
 msgstr "Organisation hinzufügen"
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:84
+#: lib/vutuv_web/templates/settings/organizations.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "Represent a company, association or other group? Add its page and verify the domain to become its owner."
 msgstr "Vertreten Sie ein Unternehmen, einen Verein oder eine andere Gruppe? Fügen Sie die Seite hinzu und verifizieren Sie die Domain, um ihr Besitzer zu werden."
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:94
+#: lib/vutuv_web/templates/settings/organizations.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "Browse all organizations"
 msgstr "Alle Organisationen ansehen"
@@ -14076,7 +14050,7 @@ msgstr "Screenshot entfernt."
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr "Dieser Screenshot wurde automatisch aus dem Link in Ihrem Beitrag erstellt. Falls er unbrauchbar ist (zum Beispiel weil ein Cookie-Banner die Seite verdeckt), können Sie ihn entfernen."
 
-#: lib/vutuv/accounts/user.ex:1128
+#: lib/vutuv/accounts/user.ex:1140
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -14087,19 +14061,19 @@ msgstr "Nur das Alter, ohne das Datum"
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr "Wählen Sie, wie viel von Ihrem Geburtstag Ihr Profil zeigt. „Nur das Alter“ verbirgt das genaue Datum, „Tag und Monat“ verbirgt das Jahr (und Ihr Alter), und „Nicht anzeigen“ speichert ihn weiterhin, hält ihn aber von Ihrem Profil fern."
 
-#: lib/vutuv/accounts/user.ex:1131
+#: lib/vutuv/accounts/user.ex:1143
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Tag und Monat, ohne das Jahr"
 
-#: lib/vutuv/accounts/user.ex:1134
+#: lib/vutuv/accounts/user.ex:1146
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Geburtstag nicht anzeigen"
 
-#: lib/vutuv/accounts/user.ex:1125
+#: lib/vutuv/accounts/user.ex:1137
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -15712,7 +15686,7 @@ msgstr "Postleitzahl"
 msgid "Until"
 msgstr "Bis"
 
-#: lib/vutuv_web/live/tag_new_live.ex:84
+#: lib/vutuv_web/live/tag_new_live.ex:86
 #, elixir-autogen, elixir-format
 msgid "Add tags"
 msgstr "Tags hinzufügen"
@@ -20099,17 +20073,17 @@ msgstr ""
 "Kommt keine PIN an? Ist die E-Mail-Adresse {email} korrekt? Haben Sie einmal "
 "in Ihren Spam-Ordner geschaut?"
 
-#: lib/vutuv/accounts/user.ex:1231
+#: lib/vutuv/accounts/user.ex:1243
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/vutuv/accounts/user.ex:1229
+#: lib/vutuv/accounts/user.ex:1241
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr "Weiblich"
 
-#: lib/vutuv/accounts/user.ex:1230
+#: lib/vutuv/accounts/user.ex:1242
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Männlich"
@@ -20801,3 +20775,53 @@ msgstr "Von vorn beginnen"
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr "Ein Herz oder ein Repost geht zurück in das Netzwerk, aus dem dieser Beitrag stammt. Ihr Konto nimmt derzeit nicht am Fediverse teil. Einschalten können Sie das in den {settings}."
+
+#: lib/vutuv_web/components/organization_components.ex:249
+#, elixir-autogen, elixir-format
+msgid "Editorial"
+msgstr "Redaktion"
+
+#: lib/vutuv_web/components/organization_components.ex:255
+#, elixir-autogen, elixir-format
+msgid "Edits the page and posts jobs."
+msgstr "Bearbeitet die Seite und schreibt Stellen aus."
+
+#: lib/vutuv_web/live/organization_live/roles.ex:162
+#, elixir-autogen, elixir-format
+msgid "Give members their roles on this page. Someone can hold several at once, and every role is granted on its own."
+msgstr "Geben Sie Mitgliedern ihre Rollen auf dieser Seite. Jemand kann mehrere gleichzeitig haben, und jede Rolle wird einzeln vergeben."
+
+#: lib/vutuv_web/components/organization_components.ex:254
+#, elixir-autogen, elixir-format
+msgid "Manages the team and the domains, and edits the page."
+msgstr "Verwaltet Team und Domains und bearbeitet die Seite."
+
+#: lib/vutuv_web/live/organization_live/roles.ex:74
+#, elixir-autogen, elixir-format
+msgid "Pick at least one role."
+msgstr "Wählen Sie mindestens eine Rolle."
+
+#: lib/vutuv_web/components/organization_components.ex:257
+#, elixir-autogen, elixir-format
+msgid "Posts jobs."
+msgstr "Schreibt Stellen aus."
+
+#: lib/vutuv_web/live/organization_live/roles.ex:265
+#, elixir-autogen, elixir-format
+msgid "Roles"
+msgstr "Rollen"
+
+#: lib/vutuv_web/live/organization_live/roles.ex:88
+#, elixir-autogen, elixir-format
+msgid "Roles updated."
+msgstr "Rollen aktualisiert."
+
+#: lib/vutuv_web/components/organization_components.ex:256
+#, elixir-autogen, elixir-format
+msgid "Writes posts in the organization's name."
+msgstr "Schreibt Beiträge im Namen der Organisation."
+
+#: lib/vutuv_web/templates/settings/organizations.html.heex:26
+#, elixir-autogen, elixir-format
+msgid "The owner gives other members their roles on the page, and can hand ownership over to someone else at any time. Someone can hold several roles, and writing in the organization's name is always granted on its own."
+msgstr "Der Besitzer vergibt die Rollen der anderen Mitglieder auf der Seite und kann den Besitz jederzeit an jemand anderen übergeben. Jemand kann mehrere Rollen haben, und das Schreiben im Namen der Organisation wird immer einzeln vergeben."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -23,7 +23,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:718
 #: lib/vutuv_web/live/organization_live/domains.ex:255
 #: lib/vutuv_web/live/organization_live/edit.ex:396
-#: lib/vutuv_web/live/organization_live/roles.ex:202
+#: lib/vutuv_web/live/organization_live/roles.ex:205
 #, elixir-autogen
 msgid "Add"
 msgstr ""
@@ -1387,9 +1387,9 @@ msgstr ""
 #: lib/vutuv_web/live/job_posting_live/form.ex:510
 #: lib/vutuv_web/live/search_live.ex:199
 #: lib/vutuv_web/live/search_live.ex:516
-#: lib/vutuv_web/live/tag_new_live.ex:34
-#: lib/vutuv_web/live/tag_new_live.ex:45
-#: lib/vutuv_web/live/tag_new_live.ex:52
+#: lib/vutuv_web/live/tag_new_live.ex:36
+#: lib/vutuv_web/live/tag_new_live.ex:47
+#: lib/vutuv_web/live/tag_new_live.ex:54
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:247
 #: lib/vutuv_web/templates/admin/tag/edit.html.heex:5
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:5
@@ -1526,7 +1526,7 @@ msgstr ""
 msgid "Unendorsed tag successfully."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_new_live.ex:127
+#: lib/vutuv_web/live/tag_new_live.ex:129
 #, elixir-autogen
 msgid "User tag created successfully."
 msgstr ""
@@ -1711,7 +1711,7 @@ msgstr ""
 msgid "Log out"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:247
+#: lib/vutuv_web/components/organization_components.ex:251
 #: lib/vutuv_web/live/admin/activity_live.ex:143
 #: lib/vutuv_web/live/admin/activity_live.ex:175
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
@@ -2219,7 +2219,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:373
-#: lib/vutuv_web/live/organization_live/roles.ex:242
+#: lib/vutuv_web/live/organization_live/roles.ex:238
 #: lib/vutuv_web/live/post_live/composer.ex:1851
 #: lib/vutuv_web/live/post_live/saved.ex:619
 #: lib/vutuv_web/live/post_live/saved.ex:647
@@ -2730,7 +2730,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3389
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
-#: lib/vutuv_web/templates/settings/organizations.html.heex:73
+#: lib/vutuv_web/templates/settings/organizations.html.heex:75
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:219
@@ -4402,7 +4402,7 @@ msgid "Edit the ad"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1004
-#: lib/vutuv_web/live/tag_new_live.ex:77
+#: lib/vutuv_web/live/tag_new_live.ex:79
 #: lib/vutuv_web/templates/ad/preview.html.heex:3
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:122
 #, elixir-autogen, elixir-format
@@ -4644,7 +4644,7 @@ msgid "searches first names only (last: for last names)"
 msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:388
-#: lib/vutuv_web/live/tag_new_live.ex:46
+#: lib/vutuv_web/live/tag_new_live.ex:48
 #: lib/vutuv_web/live/user_profile_live.ex:1259
 #: lib/vutuv_web/templates/user/show.html.heex:549
 #, elixir-autogen, elixir-format
@@ -7939,8 +7939,8 @@ msgstr ""
 msgid "Identity-verified"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1311
-#: lib/vutuv/accounts.ex:1360
+#: lib/vutuv/accounts.ex:1313
+#: lib/vutuv/accounts.ex:1362
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -7979,7 +7979,7 @@ msgstr ""
 msgid "Open the member browser"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1328
+#: lib/vutuv/accounts.ex:1330
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -8674,7 +8674,7 @@ msgstr ""
 msgid "Your Fediverse handle"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1323
+#: lib/vutuv/accounts.ex:1325
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -8763,12 +8763,12 @@ msgstr ""
 msgid "Vocational Training"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_new_live.ex:78
+#: lib/vutuv_web/live/tag_new_live.ex:80
 #, elixir-autogen, elixir-format
 msgid "This will create the following tags:"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_new_live.ex:54
+#: lib/vutuv_web/live/tag_new_live.ex:56
 #, elixir-autogen, elixir-format
 msgid "Tip:"
 msgstr ""
@@ -9446,7 +9446,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1072
+#: lib/vutuv/accounts/user.ex:1084
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9457,7 +9457,7 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1069
+#: lib/vutuv/accounts/user.ex:1081
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -10470,12 +10470,12 @@ msgstr ""
 msgid "At least three tags, separated by commas. A tag may be several words long, like Ruby on Rails."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_new_live.ex:63
+#: lib/vutuv_web/live/tag_new_live.ex:65
 #, elixir-autogen, elixir-format
 msgid "PHP, JavaScript, Ruby on Rails"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_new_live.ex:54
+#: lib/vutuv_web/live/tag_new_live.ex:56
 #, elixir-autogen, elixir-format
 msgid "Separate tags with a comma. A tag may be several words long, like Ruby on Rails."
 msgstr ""
@@ -10824,19 +10824,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1110
+#: lib/vutuv/accounts/user.ex:1122
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1115
+#: lib/vutuv/accounts/user.ex:1127
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1113
+#: lib/vutuv/accounts/user.ex:1125
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:566
 #, elixir-autogen, elixir-format
@@ -11215,17 +11215,12 @@ msgstr ""
 msgid "with this exact content:"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:130
-#, elixir-autogen, elixir-format
-msgid "@%{handle} is already on the team."
-msgstr ""
-
-#: lib/vutuv_web/live/organization_live/roles.ex:168
+#: lib/vutuv_web/live/organization_live/roles.ex:175
 #, elixir-autogen, elixir-format
 msgid "@handle or email"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:252
+#: lib/vutuv_web/components/organization_components.ex:263
 #: lib/vutuv_web/live/organization_live/edit.ex:390
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
@@ -11236,17 +11231,17 @@ msgstr ""
 msgid "Add a domain"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:159
+#: lib/vutuv_web/live/organization_live/roles.ex:166
 #, elixir-autogen, elixir-format
 msgid "Add a member"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:123
+#: lib/vutuv_web/live/organization_live/roles.ex:138
 #, elixir-autogen, elixir-format
 msgid "Added @%{handle} to the team."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:253
+#: lib/vutuv_web/components/organization_components.ex:264
 #: lib/vutuv_web/live/organization_live/edit.ex:388
 #, elixir-autogen, elixir-format
 msgid "Alias"
@@ -11292,7 +11287,7 @@ msgstr ""
 msgid "Archived"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:251
+#: lib/vutuv_web/components/organization_components.ex:262
 #: lib/vutuv_web/live/organization_live/edit.ex:389
 #, elixir-autogen, elixir-format
 msgid "Brand"
@@ -11303,7 +11298,7 @@ msgstr ""
 msgid "Claimed by"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:209
+#: lib/vutuv_web/live/organization_live/roles.ex:211
 #, elixir-autogen, elixir-format
 msgid "Current team"
 msgstr ""
@@ -11341,7 +11336,7 @@ msgstr ""
 msgid "Domains – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:250
+#: lib/vutuv_web/components/organization_components.ex:261
 #, elixir-autogen, elixir-format
 msgid "Former name"
 msgstr ""
@@ -11358,18 +11353,13 @@ msgstr ""
 msgid "Freeze this page? It disappears for the public but stays visible to its owner."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:155
-#, elixir-autogen, elixir-format
-msgid "Give members a role on this page. Owners manage the team and domains, admins edit the page, recruiters post jobs."
-msgstr ""
-
 #: lib/vutuv_web/live/organization_live/domains.ex:189
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "Last checked"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:242
+#: lib/vutuv_web/live/organization_live/roles.ex:238
 #, elixir-autogen, elixir-format
 msgid "Leave"
 msgstr ""
@@ -11389,7 +11379,7 @@ msgstr ""
 msgid "Make primary"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:107
+#: lib/vutuv_web/live/organization_live/roles.ex:94
 #, elixir-autogen, elixir-format
 msgid "Member removed."
 msgstr ""
@@ -11404,7 +11394,7 @@ msgstr ""
 msgid "Names & aliases"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:72
+#: lib/vutuv_web/live/organization_live/roles.ex:81
 #, elixir-autogen, elixir-format
 msgid "No member found for “%{id}”."
 msgstr ""
@@ -11424,7 +11414,7 @@ msgstr ""
 msgid "Primary domain updated."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:246
+#: lib/vutuv_web/components/organization_components.ex:250
 #, elixir-autogen, elixir-format
 msgid "Recruiter"
 msgstr ""
@@ -11434,7 +11424,7 @@ msgstr ""
 msgid "Remove this domain?"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:237
+#: lib/vutuv_web/live/organization_live/roles.ex:233
 #, elixir-autogen, elixir-format
 msgid "Remove this member from the team?"
 msgstr ""
@@ -11444,11 +11434,6 @@ msgstr ""
 msgid "Remove this name?"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:88
-#, elixir-autogen, elixir-format
-msgid "Role updated."
-msgstr ""
-
 #: lib/vutuv_web/live/admin/organization_live.ex:233
 #, elixir-autogen, elixir-format
 msgid "Search name, alias or domain"
@@ -11456,20 +11441,15 @@ msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:208
 #: lib/vutuv_web/live/admin/organization_live.ex:321
-#: lib/vutuv_web/live/organization_live/roles.ex:153
+#: lib/vutuv_web/live/organization_live/roles.ex:160
 #: lib/vutuv_web/live/organization_live/show.ex:270
 #, elixir-autogen, elixir-format
 msgid "Team"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:31
+#: lib/vutuv_web/live/organization_live/roles.ex:36
 #, elixir-autogen, elixir-format
 msgid "Team – %{name}"
-msgstr ""
-
-#: lib/vutuv_web/live/organization_live/roles.ex:94
-#, elixir-autogen, elixir-format
-msgid "That change could not be saved."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:71
@@ -11477,7 +11457,7 @@ msgstr ""
 msgid "That is not a valid domain."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:134
+#: lib/vutuv_web/live/organization_live/roles.ex:141
 #, elixir-autogen, elixir-format
 msgid "That member could not be added."
 msgstr ""
@@ -11705,7 +11685,7 @@ msgstr ""
 msgid "An organization keeps at least one verified domain, so this one cannot be removed."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:140
+#: lib/vutuv_web/live/organization_live/roles.ex:147
 #, elixir-autogen, elixir-format
 msgid "An organization must keep at least one owner, so the last owner cannot be changed."
 msgstr ""
@@ -11729,7 +11709,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/index.ex:101
 #: lib/vutuv_web/live/organization_live/new.ex:26
 #: lib/vutuv_web/live/organization_live/new.ex:80
-#: lib/vutuv_web/templates/settings/organizations.html.heex:87
+#: lib/vutuv_web/templates/settings/organizations.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Add your organization"
 msgstr ""
@@ -11775,7 +11755,7 @@ msgstr ""
 msgid "Kind of organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:236
+#: lib/vutuv_web/live/organization_live/roles.ex:232
 #, elixir-autogen, elixir-format
 msgid "Leave this organization team?"
 msgstr ""
@@ -12175,7 +12155,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1084
+#: lib/vutuv/accounts/user.ex:1096
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12295,7 +12275,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1083
+#: lib/vutuv/accounts/user.ex:1095
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12377,7 +12357,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1085
+#: lib/vutuv/accounts/user.ex:1097
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:497
 #: lib/vutuv_web/agent_docs/markdown.ex:353
@@ -12590,11 +12570,6 @@ msgstr ""
 msgid "Whoever creates a page becomes its owner."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:26
-#, elixir-autogen, elixir-format
-msgid "The owner can invite other members onto the page as admins or recruiters, and can hand ownership over to someone else at any time."
-msgstr ""
-
 #: lib/vutuv_web/templates/settings/organizations.html.heex:30
 #, elixir-autogen, elixir-format
 msgid "A page can claim a short @handle, so it lives at a memorable address like %{example}."
@@ -12605,22 +12580,24 @@ msgstr ""
 msgid "Your organizations"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:64
+#: lib/vutuv_web/templates/settings/organizations.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "Your role"
-msgstr ""
+msgid_plural "Your roles"
+msgstr[0] ""
+msgstr[1] ""
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:82
+#: lib/vutuv_web/templates/settings/organizations.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "Add an organization"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:84
+#: lib/vutuv_web/templates/settings/organizations.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "Represent a company, association or other group? Add its page and verify the domain to become its owner."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:94
+#: lib/vutuv_web/templates/settings/organizations.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "Browse all organizations"
 msgstr ""
@@ -13393,7 +13370,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1128
+#: lib/vutuv/accounts/user.ex:1140
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13404,19 +13381,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1131
+#: lib/vutuv/accounts/user.ex:1143
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1134
+#: lib/vutuv/accounts/user.ex:1146
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1125
+#: lib/vutuv/accounts/user.ex:1137
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -14998,7 +14975,7 @@ msgstr ""
 msgid "Until"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_new_live.ex:84
+#: lib/vutuv_web/live/tag_new_live.ex:86
 #, elixir-autogen, elixir-format
 msgid "Add tags"
 msgstr ""
@@ -19314,17 +19291,17 @@ msgstr ""
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1231
+#: lib/vutuv/accounts/user.ex:1243
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1229
+#: lib/vutuv/accounts/user.ex:1241
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1230
+#: lib/vutuv/accounts/user.ex:1242
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -20013,4 +19990,54 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:2115
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
+msgstr ""
+
+#: lib/vutuv_web/components/organization_components.ex:249
+#, elixir-autogen, elixir-format
+msgid "Editorial"
+msgstr ""
+
+#: lib/vutuv_web/components/organization_components.ex:255
+#, elixir-autogen, elixir-format
+msgid "Edits the page and posts jobs."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/roles.ex:162
+#, elixir-autogen, elixir-format
+msgid "Give members their roles on this page. Someone can hold several at once, and every role is granted on its own."
+msgstr ""
+
+#: lib/vutuv_web/components/organization_components.ex:254
+#, elixir-autogen, elixir-format
+msgid "Manages the team and the domains, and edits the page."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/roles.ex:74
+#, elixir-autogen, elixir-format
+msgid "Pick at least one role."
+msgstr ""
+
+#: lib/vutuv_web/components/organization_components.ex:257
+#, elixir-autogen, elixir-format
+msgid "Posts jobs."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/roles.ex:265
+#, elixir-autogen, elixir-format
+msgid "Roles"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/roles.ex:88
+#, elixir-autogen, elixir-format
+msgid "Roles updated."
+msgstr ""
+
+#: lib/vutuv_web/components/organization_components.ex:256
+#, elixir-autogen, elixir-format
+msgid "Writes posts in the organization's name."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/organizations.html.heex:26
+#, elixir-autogen, elixir-format
+msgid "The owner gives other members their roles on the page, and can hand ownership over to someone else at any time. Someone can hold several roles, and writing in the organization's name is always granted on its own."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -21,7 +21,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:718
 #: lib/vutuv_web/live/organization_live/domains.ex:255
 #: lib/vutuv_web/live/organization_live/edit.ex:396
-#: lib/vutuv_web/live/organization_live/roles.ex:202
+#: lib/vutuv_web/live/organization_live/roles.ex:205
 #, elixir-autogen
 msgid "Add"
 msgstr ""
@@ -1385,9 +1385,9 @@ msgstr ""
 #: lib/vutuv_web/live/job_posting_live/form.ex:510
 #: lib/vutuv_web/live/search_live.ex:199
 #: lib/vutuv_web/live/search_live.ex:516
-#: lib/vutuv_web/live/tag_new_live.ex:34
-#: lib/vutuv_web/live/tag_new_live.ex:45
-#: lib/vutuv_web/live/tag_new_live.ex:52
+#: lib/vutuv_web/live/tag_new_live.ex:36
+#: lib/vutuv_web/live/tag_new_live.ex:47
+#: lib/vutuv_web/live/tag_new_live.ex:54
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:247
 #: lib/vutuv_web/templates/admin/tag/edit.html.heex:5
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:5
@@ -1524,7 +1524,7 @@ msgstr ""
 msgid "Unendorsed tag successfully."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_new_live.ex:127
+#: lib/vutuv_web/live/tag_new_live.ex:129
 #, elixir-autogen
 msgid "User tag created successfully."
 msgstr ""
@@ -1709,7 +1709,7 @@ msgstr ""
 msgid "Log out"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:247
+#: lib/vutuv_web/components/organization_components.ex:251
 #: lib/vutuv_web/live/admin/activity_live.ex:143
 #: lib/vutuv_web/live/admin/activity_live.ex:175
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
@@ -2217,7 +2217,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:373
-#: lib/vutuv_web/live/organization_live/roles.ex:242
+#: lib/vutuv_web/live/organization_live/roles.ex:238
 #: lib/vutuv_web/live/post_live/composer.ex:1851
 #: lib/vutuv_web/live/post_live/saved.ex:619
 #: lib/vutuv_web/live/post_live/saved.ex:647
@@ -2728,7 +2728,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3389
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
-#: lib/vutuv_web/templates/settings/organizations.html.heex:73
+#: lib/vutuv_web/templates/settings/organizations.html.heex:75
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:219
@@ -4400,7 +4400,7 @@ msgid "Edit the ad"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1004
-#: lib/vutuv_web/live/tag_new_live.ex:77
+#: lib/vutuv_web/live/tag_new_live.ex:79
 #: lib/vutuv_web/templates/ad/preview.html.heex:3
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:122
 #, elixir-autogen, elixir-format
@@ -4642,7 +4642,7 @@ msgid "searches first names only (last: for last names)"
 msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:388
-#: lib/vutuv_web/live/tag_new_live.ex:46
+#: lib/vutuv_web/live/tag_new_live.ex:48
 #: lib/vutuv_web/live/user_profile_live.ex:1259
 #: lib/vutuv_web/templates/user/show.html.heex:549
 #, elixir-autogen, elixir-format
@@ -7937,8 +7937,8 @@ msgstr ""
 msgid "Identity-verified"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1311
-#: lib/vutuv/accounts.ex:1360
+#: lib/vutuv/accounts.ex:1313
+#: lib/vutuv/accounts.ex:1362
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -7977,7 +7977,7 @@ msgstr ""
 msgid "Open the member browser"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1328
+#: lib/vutuv/accounts.ex:1330
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -8672,7 +8672,7 @@ msgstr ""
 msgid "Your Fediverse handle"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1323
+#: lib/vutuv/accounts.ex:1325
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -8761,12 +8761,12 @@ msgstr ""
 msgid "Vocational Training"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_new_live.ex:78
+#: lib/vutuv_web/live/tag_new_live.ex:80
 #, elixir-autogen, elixir-format
 msgid "This will create the following tags:"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_new_live.ex:54
+#: lib/vutuv_web/live/tag_new_live.ex:56
 #, elixir-autogen, elixir-format
 msgid "Tip:"
 msgstr ""
@@ -9444,7 +9444,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1072
+#: lib/vutuv/accounts/user.ex:1084
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9455,7 +9455,7 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1069
+#: lib/vutuv/accounts/user.ex:1081
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -10468,12 +10468,12 @@ msgstr ""
 msgid "At least three tags, separated by commas. A tag may be several words long, like Ruby on Rails."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_new_live.ex:63
+#: lib/vutuv_web/live/tag_new_live.ex:65
 #, elixir-autogen, elixir-format
 msgid "PHP, JavaScript, Ruby on Rails"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_new_live.ex:54
+#: lib/vutuv_web/live/tag_new_live.ex:56
 #, elixir-autogen, elixir-format
 msgid "Separate tags with a comma. A tag may be several words long, like Ruby on Rails."
 msgstr ""
@@ -10822,19 +10822,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1110
+#: lib/vutuv/accounts/user.ex:1122
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1115
+#: lib/vutuv/accounts/user.ex:1127
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1113
+#: lib/vutuv/accounts/user.ex:1125
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:566
 #, elixir-autogen, elixir-format
@@ -11213,17 +11213,12 @@ msgstr ""
 msgid "with this exact content:"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:130
-#, elixir-autogen, elixir-format
-msgid "@%{handle} is already on the team."
-msgstr ""
-
-#: lib/vutuv_web/live/organization_live/roles.ex:168
+#: lib/vutuv_web/live/organization_live/roles.ex:175
 #, elixir-autogen, elixir-format
 msgid "@handle or email"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:252
+#: lib/vutuv_web/components/organization_components.ex:263
 #: lib/vutuv_web/live/organization_live/edit.ex:390
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
@@ -11234,17 +11229,17 @@ msgstr ""
 msgid "Add a domain"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:159
+#: lib/vutuv_web/live/organization_live/roles.ex:166
 #, elixir-autogen, elixir-format
 msgid "Add a member"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:123
+#: lib/vutuv_web/live/organization_live/roles.ex:138
 #, elixir-autogen, elixir-format
 msgid "Added @%{handle} to the team."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:253
+#: lib/vutuv_web/components/organization_components.ex:264
 #: lib/vutuv_web/live/organization_live/edit.ex:388
 #, elixir-autogen, elixir-format
 msgid "Alias"
@@ -11290,7 +11285,7 @@ msgstr ""
 msgid "Archived"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:251
+#: lib/vutuv_web/components/organization_components.ex:262
 #: lib/vutuv_web/live/organization_live/edit.ex:389
 #, elixir-autogen, elixir-format
 msgid "Brand"
@@ -11301,7 +11296,7 @@ msgstr ""
 msgid "Claimed by"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:209
+#: lib/vutuv_web/live/organization_live/roles.ex:211
 #, elixir-autogen, elixir-format
 msgid "Current team"
 msgstr ""
@@ -11339,7 +11334,7 @@ msgstr ""
 msgid "Domains – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:250
+#: lib/vutuv_web/components/organization_components.ex:261
 #, elixir-autogen, elixir-format
 msgid "Former name"
 msgstr ""
@@ -11356,18 +11351,13 @@ msgstr ""
 msgid "Freeze this page? It disappears for the public but stays visible to its owner."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:155
-#, elixir-autogen, elixir-format
-msgid "Give members a role on this page. Owners manage the team and domains, admins edit the page, recruiters post jobs."
-msgstr ""
-
 #: lib/vutuv_web/live/organization_live/domains.ex:189
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "Last checked"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:242
+#: lib/vutuv_web/live/organization_live/roles.ex:238
 #, elixir-autogen, elixir-format
 msgid "Leave"
 msgstr ""
@@ -11387,7 +11377,7 @@ msgstr ""
 msgid "Make primary"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:107
+#: lib/vutuv_web/live/organization_live/roles.ex:94
 #, elixir-autogen, elixir-format
 msgid "Member removed."
 msgstr ""
@@ -11402,7 +11392,7 @@ msgstr ""
 msgid "Names & aliases"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:72
+#: lib/vutuv_web/live/organization_live/roles.ex:81
 #, elixir-autogen, elixir-format
 msgid "No member found for “%{id}”."
 msgstr ""
@@ -11422,7 +11412,7 @@ msgstr ""
 msgid "Primary domain updated."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:246
+#: lib/vutuv_web/components/organization_components.ex:250
 #, elixir-autogen, elixir-format
 msgid "Recruiter"
 msgstr ""
@@ -11432,7 +11422,7 @@ msgstr ""
 msgid "Remove this domain?"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:237
+#: lib/vutuv_web/live/organization_live/roles.ex:233
 #, elixir-autogen, elixir-format
 msgid "Remove this member from the team?"
 msgstr ""
@@ -11442,11 +11432,6 @@ msgstr ""
 msgid "Remove this name?"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:88
-#, elixir-autogen, elixir-format
-msgid "Role updated."
-msgstr ""
-
 #: lib/vutuv_web/live/admin/organization_live.ex:233
 #, elixir-autogen, elixir-format
 msgid "Search name, alias or domain"
@@ -11454,20 +11439,15 @@ msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:208
 #: lib/vutuv_web/live/admin/organization_live.ex:321
-#: lib/vutuv_web/live/organization_live/roles.ex:153
+#: lib/vutuv_web/live/organization_live/roles.ex:160
 #: lib/vutuv_web/live/organization_live/show.ex:270
 #, elixir-autogen, elixir-format
 msgid "Team"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:31
+#: lib/vutuv_web/live/organization_live/roles.ex:36
 #, elixir-autogen, elixir-format
 msgid "Team – %{name}"
-msgstr ""
-
-#: lib/vutuv_web/live/organization_live/roles.ex:94
-#, elixir-autogen, elixir-format
-msgid "That change could not be saved."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:71
@@ -11475,7 +11455,7 @@ msgstr ""
 msgid "That is not a valid domain."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:134
+#: lib/vutuv_web/live/organization_live/roles.ex:141
 #, elixir-autogen, elixir-format
 msgid "That member could not be added."
 msgstr ""
@@ -11703,7 +11683,7 @@ msgstr ""
 msgid "An organization keeps at least one verified domain, so this one cannot be removed."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:140
+#: lib/vutuv_web/live/organization_live/roles.ex:147
 #, elixir-autogen, elixir-format
 msgid "An organization must keep at least one owner, so the last owner cannot be changed."
 msgstr ""
@@ -11727,7 +11707,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/index.ex:101
 #: lib/vutuv_web/live/organization_live/new.ex:26
 #: lib/vutuv_web/live/organization_live/new.ex:80
-#: lib/vutuv_web/templates/settings/organizations.html.heex:87
+#: lib/vutuv_web/templates/settings/organizations.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Add your organization"
 msgstr ""
@@ -11773,7 +11753,7 @@ msgstr ""
 msgid "Kind of organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:236
+#: lib/vutuv_web/live/organization_live/roles.ex:232
 #, elixir-autogen, elixir-format
 msgid "Leave this organization team?"
 msgstr ""
@@ -12173,7 +12153,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1084
+#: lib/vutuv/accounts/user.ex:1096
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12293,7 +12273,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1083
+#: lib/vutuv/accounts/user.ex:1095
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12375,7 +12355,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1085
+#: lib/vutuv/accounts/user.ex:1097
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:497
 #: lib/vutuv_web/agent_docs/markdown.ex:353
@@ -12588,11 +12568,6 @@ msgstr ""
 msgid "Whoever creates a page becomes its owner."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:26
-#, elixir-autogen, elixir-format
-msgid "The owner can invite other members onto the page as admins or recruiters, and can hand ownership over to someone else at any time."
-msgstr ""
-
 #: lib/vutuv_web/templates/settings/organizations.html.heex:30
 #, elixir-autogen, elixir-format
 msgid "A page can claim a short @handle, so it lives at a memorable address like %{example}."
@@ -12603,22 +12578,24 @@ msgstr ""
 msgid "Your organizations"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:64
+#: lib/vutuv_web/templates/settings/organizations.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "Your role"
-msgstr ""
+msgid_plural "Your roles"
+msgstr[0] ""
+msgstr[1] ""
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:82
+#: lib/vutuv_web/templates/settings/organizations.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "Add an organization"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:84
+#: lib/vutuv_web/templates/settings/organizations.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "Represent a company, association or other group? Add its page and verify the domain to become its owner."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:94
+#: lib/vutuv_web/templates/settings/organizations.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "Browse all organizations"
 msgstr ""
@@ -13391,7 +13368,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1128
+#: lib/vutuv/accounts/user.ex:1140
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13402,19 +13379,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1131
+#: lib/vutuv/accounts/user.ex:1143
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1134
+#: lib/vutuv/accounts/user.ex:1146
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1125
+#: lib/vutuv/accounts/user.ex:1137
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -14996,7 +14973,7 @@ msgstr ""
 msgid "Until"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_new_live.ex:84
+#: lib/vutuv_web/live/tag_new_live.ex:86
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add tags"
 msgstr ""
@@ -19312,17 +19289,17 @@ msgstr ""
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1231
+#: lib/vutuv/accounts/user.ex:1243
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1229
+#: lib/vutuv/accounts/user.ex:1241
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1230
+#: lib/vutuv/accounts/user.ex:1242
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -20011,4 +19988,54 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:2115
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
+msgstr ""
+
+#: lib/vutuv_web/components/organization_components.ex:249
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Editorial"
+msgstr ""
+
+#: lib/vutuv_web/components/organization_components.ex:255
+#, elixir-autogen, elixir-format
+msgid "Edits the page and posts jobs."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/roles.ex:162
+#, elixir-autogen, elixir-format
+msgid "Give members their roles on this page. Someone can hold several at once, and every role is granted on its own."
+msgstr ""
+
+#: lib/vutuv_web/components/organization_components.ex:254
+#, elixir-autogen, elixir-format
+msgid "Manages the team and the domains, and edits the page."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/roles.ex:74
+#, elixir-autogen, elixir-format
+msgid "Pick at least one role."
+msgstr ""
+
+#: lib/vutuv_web/components/organization_components.ex:257
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Posts jobs."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/roles.ex:265
+#, elixir-autogen, elixir-format
+msgid "Roles"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/roles.ex:88
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Roles updated."
+msgstr ""
+
+#: lib/vutuv_web/components/organization_components.ex:256
+#, elixir-autogen, elixir-format
+msgid "Writes posts in the organization's name."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/organizations.html.heex:26
+#, elixir-autogen, elixir-format
+msgid "The owner gives other members their roles on the page, and can hand ownership over to someone else at any time. Someone can hold several roles, and writing in the organization's name is always granted on its own."
 msgstr ""

--- a/priv/repo/migrations/20260810163306_drop_organization_role_pair_unique_index.exs
+++ b/priv/repo/migrations/20260810163306_drop_organization_role_pair_unique_index.exs
@@ -1,0 +1,17 @@
+defmodule Vutuv.Repo.Migrations.DropOrganizationRolePairUniqueIndex do
+  @moduledoc """
+  Issue #1333, step 2 of 2. The previous deploy added the
+  `[organization_id, user_id, role]` unique index and taught every reader to
+  take a list of roles (`roles_of/2`). Now the old pair index goes, so a member
+  can hold `publisher` beside `owner` or `admin`.
+
+  Safe as an N-1 step because the release still serving traffic during this
+  migration is the one that already reads roles as a list, so a second row for a
+  member means nothing worse to it than a longer list.
+  """
+  use Ecto.Migration
+
+  def change do
+    drop(unique_index(:organization_roles, [:organization_id, :user_id]))
+  end
+end

--- a/test/vutuv/organizations_management_test.exs
+++ b/test/vutuv/organizations_management_test.exs
@@ -109,14 +109,59 @@ defmodule Vutuv.OrganizationsManagementTest do
       refute Organizations.can_manage?(organization, stranger)
     end
 
-    test "add_role notifies the member and rejects a duplicate" do
+    test "add_role notifies the member, allows a second role and rejects the same one twice" do
       {organization, owner} = active_organization()
       member = insert(:activated_user)
 
       assert {:ok, _role} = Organizations.add_role(organization, member, "admin", owner)
 
+      # A member may hold several roles (issue #1333) …
+      assert {:ok, _role} = Organizations.add_role(organization, member, "publisher", owner)
+      assert Organizations.roles_of(organization, member) == ["admin", "publisher"]
+
+      # … but not the same one twice.
       assert {:error, :already_member} =
-               Organizations.add_role(organization, member, "recruiter", owner)
+               Organizations.add_role(organization, member, "admin", owner)
+    end
+
+    test "publisher is never implied by owner or admin" do
+      {organization, owner} = active_organization()
+      admin = insert(:activated_user)
+      {:ok, _} = Organizations.add_role(organization, admin, "admin", owner)
+
+      # The whole point of the role: administering a page is not speaking for it,
+      # so a freshly claimed page cannot post until its owner says so once.
+      refute Organizations.publisher?(organization, owner)
+      refute Organizations.publisher?(organization, admin)
+
+      {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+      assert Organizations.publisher?(organization, owner)
+      # …and the grant does not cost them anything they already had.
+      assert Organizations.owner?(organization, owner)
+    end
+
+    test "set_roles adds, removes and leaves the rest alone" do
+      {organization, owner} = active_organization()
+      member = insert(:activated_user)
+
+      assert {:ok, ["admin", "publisher"]} =
+               Organizations.set_roles(organization, member, ["publisher", "admin"], owner)
+
+      granted_at =
+        Repo.get_by!(OrganizationRole,
+          organization_id: organization.id,
+          user_id: member.id,
+          role: "admin"
+        )
+
+      # Swapping publisher for recruiter must not disturb the untouched admin row.
+      assert {:ok, ["admin", "recruiter"]} =
+               Organizations.set_roles(organization, member, ["admin", "recruiter"], owner)
+
+      assert Repo.get(OrganizationRole, granted_at.id).inserted_at == granted_at.inserted_at
+
+      assert {:ok, []} = Organizations.set_roles(organization, member, [], owner)
+      assert Organizations.roles_of(organization, member) == []
     end
 
     test "the last owner cannot be removed or demoted" do
@@ -126,12 +171,35 @@ defmodule Vutuv.OrganizationsManagementTest do
         Repo.get_by(OrganizationRole, organization_id: organization.id, user_id: owner.id)
 
       assert {:error, :last_owner} = Organizations.remove_role(owner_role)
-      assert {:error, :last_owner} = Organizations.update_role(owner_role, "admin", owner)
 
-      # A second owner lifts the guard.
+      assert {:error, :last_owner} =
+               Organizations.set_roles(organization, owner, ["admin"], owner)
+
+      assert {:error, :last_owner} = Organizations.set_roles(organization, owner, [], owner)
+
+      # Holding another role beside owner does not weaken the guard.
+      {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+
+      assert {:error, :last_owner} =
+               Organizations.set_roles(organization, owner, ["publisher"], owner)
+
+      # A second owner lifts it.
       other = insert(:activated_user)
       {:ok, _} = Organizations.add_role(organization, other, "owner", owner)
-      assert {:ok, _} = Organizations.update_role(owner_role, "admin", owner)
+      assert {:ok, ["admin"]} = Organizations.set_roles(organization, owner, ["admin"], owner)
+    end
+
+    test "list_team gives one entry per member with every role they hold" do
+      {organization, owner} = active_organization()
+      member = insert(:activated_user)
+      {:ok, _} = Organizations.set_roles(organization, member, ["recruiter", "publisher"], owner)
+
+      assert [%{user: first, roles: ["owner"]}, %{user: second, roles: roles}] =
+               Organizations.list_team(organization)
+
+      assert first.id == owner.id
+      assert second.id == member.id
+      assert roles == ["publisher", "recruiter"]
     end
 
     test "roles_of answers with a ranked list, and the permission predicates read it" do

--- a/test/vutuv_web/organization_management_test.exs
+++ b/test/vutuv_web/organization_management_test.exs
@@ -37,9 +37,41 @@ defmodule VutuvWeb.OrganizationManagementTest do
 
       view
       |> element("#add-member-form")
-      |> render_submit(%{"identifier" => "@" <> member.username, "role" => "admin"})
+      |> render_submit(%{
+        "identifier" => "@" <> member.username,
+        "roles" => %{"admin" => "true"}
+      })
 
       assert render(view) =~ member.username
+      assert Organizations.roles_of(organization, member) == ["admin"]
+    end
+
+    test "the roster grants several roles at once, and un-ticking one keeps the rest",
+         %{conn: conn} do
+      {conn, owner} = create_and_login_user(conn)
+      organization = active_organization_for(owner)
+      member = insert(:activated_user)
+
+      {:ok, view, _html} = live(conn, ~p"/organizations/#{organization.slug}/roles")
+
+      view
+      |> element("#add-member-form")
+      |> render_submit(%{
+        "identifier" => "@" <> member.username,
+        "roles" => %{"admin" => "true", "publisher" => "true"}
+      })
+
+      assert Organizations.roles_of(organization, member) == ["admin", "publisher"]
+
+      # Clearing the publisher box must not take the admin role with it — the
+      # single-select roster this replaced would have done exactly that.
+      view
+      |> element("#member-#{member.id} form")
+      |> render_change(%{
+        "user_id" => member.id,
+        "roles" => %{"admin" => "true", "publisher" => "false"}
+      })
+
       assert Organizations.roles_of(organization, member) == ["admin"]
     end
 
@@ -47,12 +79,8 @@ defmodule VutuvWeb.OrganizationManagementTest do
       {conn, owner} = create_and_login_user(conn)
       organization = active_organization_for(owner)
 
-      role =
-        Organizations.roles_of(organization, owner) != [] and
-          hd(Organizations.list_roles(organization))
-
       {:ok, view, _html} = live(conn, ~p"/organizations/#{organization.slug}/roles")
-      html = view |> element("#role-#{role.id} button", "Leave") |> render_click()
+      html = view |> element("#member-#{owner.id} button", "Leave") |> render_click()
 
       assert html =~ "at least one owner"
       assert Organizations.roles_of(organization, owner) == ["owner"]

--- a/test/vutuv_web/organization_vocabulary_test.exs
+++ b/test/vutuv_web/organization_vocabulary_test.exs
@@ -66,14 +66,26 @@ defmodule VutuvWeb.OrganizationVocabularyTest do
     # The creator-becomes-owner rule.
     assert de("Whoever creates a page becomes its owner.") =~ "Besitzer"
 
-    # Invite others + transfer ownership, fully translated.
-    invite =
+    # Grant roles + transfer ownership, fully translated.
+    roles =
       de(
-        "The owner can invite other members onto the page as admins or recruiters, and can hand ownership over to someone else at any time."
+        "The owner gives other members their roles on the page, and can hand ownership over to someone else at any time. Someone can hold several roles, and writing in the organization's name is always granted on its own."
       )
 
-    assert invite =~ "einladen"
-    assert invite =~ "übergeben"
-    refute invite =~ "invite other members", "the German msgstr must not fall back to English"
+    assert roles =~ "Rollen"
+    assert roles =~ "übergeben"
+    refute roles =~ "The owner gives", "the German msgstr must not fall back to English"
+  end
+
+  test "the roles read as German role names, and 'publisher' is 'Redaktion'" do
+    assert de("Owner") == "Besitzer"
+    # Names the function, not the person: this role says "may write in our name"
+    # and must not read as seniority. `mix gettext.extract --merge` fuzzy-filled
+    # it with "Ändern" ("change") the first time, which is why it is asserted.
+    assert de("Editorial") == "Redaktion"
+    refute de("Editorial") =~ "Ändern"
+
+    assert de("Writes posts in the organization's name.") ==
+             "Schreibt Beiträge im Namen der Organisation."
   end
 end


### PR DESCRIPTION
Closes #1333. Step 2 of 2, on top of #1353.

- **`publisher`** joins the role vocabulary and grants exactly one thing: writing in the organization's name. Never implied by `owner` or `admin`, always an explicit grant, so a freshly claimed page cannot post until its owner says so once. `Organizations.publisher?/2` is the gate #1334 and #1335 will read.
- A member may hold **several roles**; the migration drops the old `[organization_id, user_id]` unique index (safe now: the release still serving traffic during it is v7.238.3, which already reads roles as a list).
- **`set_roles/4`** replaces the single-role `update_role/3` — it diffs against what is held, so an unchanged role keeps its `granted_by` and its age, and the last-owner row lock still guards `owner` coming off.
- The roster is **checkboxes**, one row per member (`list_team/1`), not one row per role with a select. With a select, granting `publisher` to an admin would have silently taken their `admin` away — precisely the mistake the role separation exists to prevent. Nothing is pre-ticked on the add form: with four roles a guessed default is wrong more often than right.
- German label **"Redaktion"**, naming the function rather than the person so it carries no seniority. Code name stays `publisher`.

### Two things fixed on the way

**A fuzzy translation.** `mix gettext.extract --merge` filled the new `"Editorial"` msgid with **"Ändern"** ("change") — confident nonsense that nothing would have failed on. Written by hand along with the other eight new strings, and `organization_vocabulary_test.exs` now asserts the German by name.

**Stale copy on `/settings/organizations`.** Its explainer said the owner invites people "as admins or recruiters", which stopped being the whole story with a fourth role; it now describes granting roles, several at a time, with the writing right always granted on its own.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*
