### PR TITLE
Eine Organisation schreibt unter eigenem Namen (v7.240.0)

### DIFF
--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -62,6 +62,8 @@ defmodule Vutuv.Posts do
   alias Vutuv.Fediverse.RemotePost
   alias Vutuv.Mentions
   alias Vutuv.Moderation.ImageScans
+  alias Vutuv.Organizations
+  alias Vutuv.Organizations.Organization
   alias Vutuv.Pages
   alias Vutuv.PostImageStore
   alias Vutuv.Posts.PhotoLicense
@@ -153,6 +155,46 @@ defmodule Vutuv.Posts do
   def create_post(%User{} = author, attrs) do
     with {:ok, denials} <- normalize_denials(author.id, fetch(attrs, :denials) || []) do
       do_create_post(author, attrs, denials, nil)
+    end
+  end
+
+  @doc """
+  Publishes a post in `organization`'s name, with `acting_user` recorded as the
+  member who pressed publish (issue #1334). Returns `{:error, :forbidden}` when
+  they do not hold the organization's `publisher` role.
+
+  An organization post is **public**: it carries no denials. The deny model is
+  built on the author's own follower graph and blocks, which an organization has
+  no equivalent of yet (that is issue #1336), and a half-applied audience would
+  read as a promise the site cannot keep. Publishing under a brand is a public
+  act; the way to say something to fewer people is to say it as yourself.
+  """
+  def create_organization_post(%Organization{} = organization, %User{} = acting_user, attrs) do
+    if Organizations.publisher?(organization, acting_user) do
+      do_create_organization_post(organization, acting_user, attrs)
+    else
+      {:error, :forbidden}
+    end
+  end
+
+  defp do_create_organization_post(organization, acting_user, attrs) do
+    image_ids = parse_ids(fetch(attrs, :image_ids) || [])
+    seed = %Post{organization_id: organization.id, acting_user_id: acting_user.id}
+
+    with :ok <- check_image_count(image_ids),
+         {:ok, changeset} <- build_changeset(seed, attrs, [], image_ids) do
+      case insert_post(changeset, image_ids, nil, nil) do
+        {:ok, post} ->
+          post = preload_post(post)
+          broadcast_new_post(post)
+          sync_mentions(post)
+          reconcile_screenshot(post)
+          ReviewCovers.reconcile(post)
+          {:ok, post}
+
+        {:error, _} = error ->
+          error
+      end
     end
   end
 
@@ -306,6 +348,13 @@ defmodule Vutuv.Posts do
 
   defp check_reply_allowed(%User{} = author, %Post{} = parent) do
     cond do
+      # An organization post cannot be answered yet (issue #1334). Everything
+      # downstream of a reply is member-shaped — the parent-author notification,
+      # the block check between the two authors, the thread's "Replying to
+      # @handle" line — and an organization has no inbox to be told about it
+      # until issue #1336 gives it a reading side. Refusing outright beats a
+      # reply that quietly reaches nobody.
+      organization_post?(parent) -> {:error, :restricted}
       not visible_to?(parent, author) -> {:error, :not_visible}
       # Query restriction fresh from the DB, not the (possibly stale) preloaded
       # denials: the reply LiveView holds the parent struct from mount, and the
@@ -768,13 +817,49 @@ defmodule Vutuv.Posts do
     if wildcard in PostDenial.wildcards(), do: {:ok, %{wildcard: wildcard}}, else: :error
   end
 
+  ## Authorship
+
+  @doc """
+  The post's author **as the world sees it**: the `%User{}` who wrote it, or the
+  `%Organization{}` it was published in the name of (issue #1334).
+
+  This is the one decision about which of the two nullable author columns
+  speaks, and roughly seventy places ask. Reading `post.user` directly is a bug
+  on an organization post: it is `nil` there, and the member who pressed publish
+  (`acting_user`) is deliberately **not** the public author — they are the
+  internal record of who spoke, kept for moderation, disputes and departures.
+
+  Needs `:user` / `:organization` preloaded, which `post_preloads/0` does.
+  """
+  def author(%Post{organization_id: nil} = post), do: post.user
+  def author(%Post{} = post), do: post.organization
+
+  @doc "The author's id, whichever kind of author it is."
+  def author_id(%Post{organization_id: nil, user_id: user_id}), do: user_id
+  def author_id(%Post{organization_id: organization_id}), do: organization_id
+
+  @doc "Whether this post was published in an organization's name rather than a member's."
+  def organization_post?(%Post{organization_id: nil}), do: false
+  def organization_post?(%Post{}), do: true
+
   ## Visibility
 
   @doc """
-  Whether `viewer` (a `%User{}` or `nil`) is the post's author — the one
+  Whether `viewer` (a `%User{}` or `nil`) may act as the post's author — the one
   predicate gating the Edit/Delete affordances wherever a post renders.
+
+  For an organization post that is every current **publisher** of the
+  organization, not the member who happened to press publish: the post belongs
+  to the organization, so the power to change it has to follow the role and not
+  the person, or it would walk out of the door with them. It is asked live
+  rather than from the stored `acting_user_id`, so a withdrawn role takes effect
+  at once.
   """
-  def author?(%Post{user_id: author_id}, %User{id: author_id}), do: true
+  def author?(%Post{organization_id: nil, user_id: author_id}, %User{id: author_id}), do: true
+
+  def author?(%Post{organization: %Organization{} = organization}, %User{} = viewer),
+    do: Organizations.publisher?(organization, viewer)
+
   def author?(%Post{}, _viewer), do: false
 
   @doc """
@@ -784,7 +869,14 @@ defmodule Vutuv.Posts do
   image proxy and the live-feed pill all call this. List queries use the
   equivalent `scope_visible/2`.
   """
-  def visible_to?(%Post{user_id: author_id}, %User{id: author_id}), do: true
+  def visible_to?(%Post{user_id: author_id}, %User{id: author_id}) when is_binary(author_id),
+    do: true
+
+  # An organization post carries no denials (see `create_organization_post/3`),
+  # so the only thing that can hide it is moderation — and its publishers still
+  # see it while it is held, the way a member sees their own frozen post.
+  def visible_to?(%Post{organization: %Organization{}} = post, %User{} = viewer),
+    do: author?(post, viewer) or not moderation_hidden?(post)
 
   def visible_to?(%Post{} = post, nil) do
     # Anonymous readers see a post only when it has no denials at all.
@@ -2892,15 +2984,19 @@ defmodule Vutuv.Posts do
   def recent_posts_by_authors(authors, viewer, opts \\ []) do
     per_author = Keyword.get(opts, :per_author, @posts_per_author)
     min_likes = Keyword.get(opts, :min_likes, @posts_min_likes)
-    author_ids = authors |> Enum.map(&author_id/1) |> Enum.uniq()
+    author_ids = authors |> Enum.map(&member_id/1) |> Enum.uniq()
 
     if author_ids == [],
       do: %{},
       else: fetch_recent_posts(author_ids, viewer, per_author, min_likes)
   end
 
-  defp author_id(%User{id: id}), do: id
-  defp author_id(id) when is_binary(id), do: id
+  # Normalizes the "authors" argument of the who-to-follow teaser rail, which
+  # its callers pass either as members or as bare ids. Renamed off `author_id`
+  # when that became the public accessor for a POST's author (issue #1334) —
+  # these two answer different questions and must not share a name.
+  defp member_id(%User{id: id}), do: id
+  defp member_id(id) when is_binary(id), do: id
 
   defp fetch_recent_posts(author_ids, viewer, per_author, min_likes) do
     candidates =
@@ -3001,6 +3097,69 @@ defmodule Vutuv.Posts do
       |> author_entries(author)
 
     {entries, total}
+  end
+
+  @organization_posts_per_page 10
+
+  @doc """
+  One page of `organization`'s own posts, newest first (issue #1334), in the
+  `%{entries:, total:, more?:, next_offset:}` shape the organization page's
+  other "Load more" lists use.
+
+  Much simpler than the member timeline: an organization publishes top-level
+  posts and nothing else — no reposts, no replies, no audience denials — so
+  there is one leg to page rather than a union to merge. Moderation-held posts
+  (a photo still in the AI scan, a frozen post) are kept for the organization's
+  own publishers and hidden from everyone else, the way a member sees their own.
+  """
+  def organization_posts_page(%Organization{} = organization, viewer, opts \\ []) do
+    limit = Keyword.get(opts, :limit, @organization_posts_per_page)
+    offset = Keyword.get(opts, :offset, 0)
+    query = organization_posts_query(organization, viewer)
+    total = Repo.aggregate(query, :count)
+
+    entries =
+      query
+      |> order_by([p], desc: p.id)
+      |> limit(^(limit + 1))
+      |> offset(^offset)
+      |> Repo.all()
+      |> Enum.map(&preload_post/1)
+
+    {shown, rest} = Enum.split(entries, limit)
+
+    %{entries: shown, total: total, more?: rest != [], next_offset: offset + length(shown)}
+  end
+
+  @doc """
+  One of `organization`'s posts by id as `viewer` may see it, or `nil` — the
+  permalink's lookup.
+
+  Scoped to the organization, so an id belonging to a member's post or to
+  another page does not resolve rather than rendering under the wrong name, and
+  a garbage id is a miss instead of a cast error. Moderation-held posts stay
+  visible to the organization's own publishers, like a member's own frozen post.
+  """
+  def get_organization_post(%Organization{} = organization, id, viewer) do
+    case Vutuv.UUIDv7.cast_or_nil(id) do
+      nil ->
+        nil
+
+      uuid ->
+        organization
+        |> organization_posts_query(viewer)
+        |> where([p], p.id == ^uuid)
+        |> Repo.one()
+        |> preload_post()
+    end
+  end
+
+  defp organization_posts_query(%Organization{id: id} = organization, viewer) do
+    query = from(p in Post, where: p.organization_id == ^id)
+
+    if match?(%User{}, viewer) and Organizations.publisher?(organization, viewer),
+      do: query,
+      else: where(query, [p], not p.images_pending? and is_nil(p.frozen_at))
   end
 
   defp scope_period(query, nil), do: query
@@ -3735,6 +3894,11 @@ defmodule Vutuv.Posts do
     # where an unbounded walk up the chain would start.
     [
       :images,
+      # The other kind of author (issue #1334) — nil on a personal post, and the
+      # one `Vutuv.Posts.author/1` names on an organization post. Deliberately
+      # not `:acting_user`: who pressed publish is never rendered, so paying a
+      # query for it on every page would buy nothing.
+      :organization,
       # The auto link screenshot rendered beside a single-URL post (nil for
       # every other post); the card shows it only once `status: "ready"`.
       :screenshot,
@@ -3790,8 +3954,20 @@ defmodule Vutuv.Posts do
   The root-relative permalink path, e.g.
   `/stefan/posts/019748c8-1a2b-7c3d-8e4f-5a6b7c8d9e0f`. Lives under the
   author archive (`/:slug/posts`), whose year/month/day pages stay
-  date-scoped index views. Requires `:user` to be preloaded.
+  date-scoped index views. Requires `:user` / `:organization` to be preloaded.
+
+  An organization post lives under the **slug** path (`/organizations/acme/posts/…`)
+  rather than under the organization's opt-in root handle, even when it holds
+  one. The handle route dispatches an organization only on the bare `/:slug`
+  page (`VutuvWeb.Plug.UserResolveSlug`), everything deeper is member-only, and
+  a permalink is the least forgiving URL there is: it is what a federated Note
+  is identified by and what somebody pastes a year later. One shape that always
+  works beats two that depend on whether a handle was claimed.
   """
+  def path(%Post{organization: %Organization{slug: slug}, id: id}) do
+    "/organizations/#{slug}/posts/#{id}"
+  end
+
   def path(%Post{user: %User{} = user, id: id}) do
     "/#{user.username}/posts/#{id}"
   end
@@ -4357,6 +4533,13 @@ defmodule Vutuv.Posts do
   # new post" pill for a post the feed query then filters out would be a dead
   # end. The followers are told instead at the moment the last photo clears
   # (`broadcast_images_settled/1`).
+  # An organization post has nobody to push to yet: the live fan-out rides the
+  # member follower graph, and an organization cannot be followed until issue
+  # #1336 gives it a reading side. It is not merely a no-op either — with a nil
+  # author `follower_ids/1` would build `where: c.followee_id == ^nil`, which
+  # Ecto **raises** on rather than silently matching nothing.
+  defp broadcast_new_post(%Post{user_id: nil}), do: :ok
+
   defp broadcast_new_post(%Post{images_pending?: true} = post) do
     Vutuv.Activity.broadcast(post.user_id, new_post_event(post.id, post.user_id))
   end

--- a/lib/vutuv/posts/post.ex
+++ b/lib/vutuv/posts/post.ex
@@ -50,7 +50,20 @@ defmodule Vutuv.Posts.Post do
     # only by search_public/2's fragments, never loaded or written by Ecto.
     field(:search_tsv, :string, load_in_query: false)
 
+    # The author, in exactly one of two shapes (issue #1334, CHECK-enforced):
+    # a member (`user`), or an organization (`organization`) with the member who
+    # pressed publish recorded beside it in `acting_user`. Never both, never
+    # neither. Read it through `Vutuv.Posts.author/1` rather than by picking one
+    # of these fields — that accessor is the single decision about which one
+    # speaks, and there are ~70 places that ask.
     belongs_to(:user, Vutuv.Accounts.User)
+    belongs_to(:organization, Vutuv.Organizations.Organization)
+
+    # Who published this in the organization's name. Public rendering never
+    # shows it — the author is the organization — but it survives that member
+    # leaving (`nilify_all`), because the organization's content must outlive
+    # them while the record of who spoke stays as long as it can.
+    belongs_to(:acting_user, Vutuv.Accounts.User, foreign_key: :acting_user_id)
 
     # Present iff this post is a reply; survives parent deletion (see PostReply).
     has_one(:reply_ref, Vutuv.Posts.PostReply, foreign_key: :post_id)

--- a/lib/vutuv_web/agent_docs/organization_doc.ex
+++ b/lib/vutuv_web/agent_docs/organization_doc.ex
@@ -14,6 +14,8 @@ defmodule VutuvWeb.AgentDocs.OrganizationDoc do
   alias Vutuv.Jobs
   alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
+  alias Vutuv.Posts
+  alias Vutuv.Posts.Post
   alias VutuvWeb.AgentDocs
   alias VutuvWeb.AgentDocs.JobPostingDoc
   alias VutuvWeb.UserHelpers
@@ -33,7 +35,8 @@ defmodule VutuvWeb.AgentDocs.OrganizationDoc do
       Organizations.list_aliases(organization),
       Organizations.organization_people_page(organization, limit: 200).entries,
       Organizations.organization_people_count(organization),
-      Jobs.list_organization_postings(organization, nil, limit: 200).entries
+      Jobs.list_organization_postings(organization, nil, limit: 200).entries,
+      Posts.organization_posts_page(organization, nil, limit: 50).entries
     )
   end
 
@@ -48,7 +51,8 @@ defmodule VutuvWeb.AgentDocs.OrganizationDoc do
         aliases,
         people,
         people_total,
-        open_positions
+        open_positions,
+        posts
       ) do
     AgentDocs.doc_meta("organization", canonical_path(organization),
       noindex: not organization.seo?,
@@ -71,8 +75,21 @@ defmodule VutuvWeb.AgentDocs.OrganizationDoc do
       address_line: address_line(organization),
       people_total: people_total,
       people: Enum.map(people, &person_entry/1),
-      open_positions: Enum.map(open_positions, &JobPostingDoc.summary/1)
+      open_positions: Enum.map(open_positions, &JobPostingDoc.summary/1),
+      # What the page published in its own name (issue #1334). The anonymous
+      # view, like every other part of this doc: `organization_posts_page/3` is
+      # asked with a nil viewer, so a post still held by moderation is absent
+      # here even though the page's own publishers see it in the HTML.
+      posts: Enum.map(posts, &post_entry/1)
     })
+  end
+
+  defp post_entry(%Post{} = post) do
+    %{
+      url: AgentDocs.abs_url(Posts.path(post)),
+      published_on: post.published_on,
+      body_markdown: post.body
+    }
   end
 
   defp person_entry(%{user: user, title: title, current?: current?}) do

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -25,6 +25,9 @@ defmodule VutuvWeb.PostComponents do
 
   import VutuvWeb.UI
   import VutuvWeb.UserHelpers, only: [full_name: 1]
+  # An organization post wears its organization's logo where a member's post
+  # wears an avatar (issue #1334).
+  import VutuvWeb.OrganizationComponents, only: [organization_logo: 1]
 
   alias Vutuv.Accounts.User
   alias Vutuv.Fediverse
@@ -35,9 +38,12 @@ defmodule VutuvWeb.PostComponents do
   alias Vutuv.Fediverse.RemotePost
   alias Vutuv.Isbn
   alias Vutuv.Moderation.ImageScans
+  alias Vutuv.Organizations
+  alias Vutuv.Organizations.Organization
   alias Vutuv.Posts
   alias Vutuv.Posts.GalleryLayout
   alias Vutuv.Posts.PhotoLicense
+  alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostImage
   alias Vutuv.Posts.PostRemoteReply
   alias Vutuv.Posts.PostReview
@@ -256,10 +262,20 @@ defmodule VutuvWeb.PostComponents do
       |> assign(:time_id, "post-time-#{entry_key}")
       |> assign(:body_id, "post-body-#{entry_key}")
       |> assign(:author?, Posts.author?(post, viewer))
+      # Who this post is BY, resolved once (issue #1334): a member, or the
+      # organization it was published in the name of. Everything the header
+      # needs is derived here rather than branched at each of the half-dozen
+      # places that name the author, and `Posts.author/1` is the single decision
+      # about which of the two author columns speaks.
+      |> assign(:author, Posts.author(post))
+      |> assign(:organization_author?, Posts.organization_post?(post))
+      |> assign(:author_path, author_path(post))
+      |> assign(:author_name, author_name(post))
       # Whether this post is the one its author pinned to their profile (issue
       # #1110) — read off the already-preloaded author, so it costs no query.
       # Drives the menu's Pin / Unpin label and its "replaces the other one"
       # prompt; the visible banner is the caller's `pinned?` (see the attr).
+      # An organization has no profile to pin to, so it is simply false there.
       |> assign(:pinned_to_profile?, Posts.pinned?(post.user, post))
       |> assign(:pin_replaces_other?, pin_replaces_other?(post))
       # The visible marker: wherever the caller says the pin is in effect, plus
@@ -289,6 +305,20 @@ defmodule VutuvWeb.PostComponents do
     </div>
     """
   end
+
+  # Where the author's name and avatar link to. A member's profile lives at
+  # their handle; an organization's page at `Organizations.canonical_path/1`,
+  # which prefers its opt-in root handle over `/organizations/:slug`.
+  defp author_path(%Post{organization: %Organization{} = organization}),
+    do: Organizations.canonical_path(organization)
+
+  defp author_path(%Post{user: user}), do: "/#{user.username}"
+
+  # The visible author name. An organization is named by its own name and has no
+  # `@handle` line beside it: a page's identity is the name, and the handle is
+  # an optional address it may never have claimed.
+  defp author_name(%Post{organization: %Organization{name: name}}), do: name
+  defp author_name(%Post{user: user}), do: full_name(user)
 
   @doc """
   The shared shell for a threaded post list: a `divide-y` column of
@@ -2679,8 +2709,12 @@ defmodule VutuvWeb.PostComponents do
         <%!-- Decorative duplicate of the author-name link below; hidden from
         assistive tech and the tab order so the name link is the one profile
         link (otherwise the avatar link has no accessible name). --%>
-        <.link href={~p"/#{@post.user}"} class="shrink-0" aria-hidden="true" tabindex="-1">
-          <.avatar user={@post.user} size="sm" presence />
+        <.link href={@author_path} class="shrink-0" aria-hidden="true" tabindex="-1">
+          <%!-- An organization wears its logo, not an avatar: it has no
+          presence dot to carry either, since nobody is ever "online" as a
+          page. --%>
+          <.organization_logo :if={@organization_author?} organization={@author} class="h-10 w-10" />
+          <.avatar :if={!@organization_author?} user={@post.user} size="sm" presence />
         </.link>
 
         <div class="min-w-0 flex-1">
@@ -2691,10 +2725,10 @@ defmodule VutuvWeb.PostComponents do
           <div class="flex items-start gap-2">
             <div class="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-2">
               <.link
-                href={~p"/#{@post.user}"}
+                href={@author_path}
                 class="font-semibold text-slate-900 hover:text-brand-700 dark:text-white"
               >
-                {full_name(@post.user)}
+                {@author_name}
               </.link>
               <.link href={@permalink} class="text-sm text-slate-600 dark:text-slate-400 hover:text-brand-700">
                 <.post_time id={@time_id} at={@post.inserted_at} />
@@ -2722,7 +2756,7 @@ defmodule VutuvWeb.PostComponents do
                 what it replaces — the rule is visible where it bites, not buried
                 in a help text. --%>
                 <:item
-                  :if={!@pinned_to_profile?}
+                  :if={!@organization_author? and !@pinned_to_profile?}
                   id={@pin_item_id}
                   href={~p"/posts/#{@post.id}/pin"}
                   method="put"
@@ -2738,7 +2772,7 @@ defmodule VutuvWeb.PostComponents do
                   {gettext("Pin to profile")}
                 </:item>
                 <:item
-                  :if={@pinned_to_profile?}
+                  :if={!@organization_author? and @pinned_to_profile?}
                   id={@unpin_item_id}
                   href={~p"/posts/#{@post.id}/pin"}
                   method="delete"
@@ -2763,7 +2797,7 @@ defmodule VutuvWeb.PostComponents do
             <div :if={@reporter?} class="-mr-1 -mt-1 shrink-0">
               <.card_menu id={@report_menu_id}>
                 <:item
-                  :if={@viewer_follow}
+                  :if={@viewer_follow && !@organization_author?}
                   href={~p"/follows/#{@viewer_follow.id}/mute"}
                   method="put"
                 >

--- a/lib/vutuv_web/controllers/organization_controller.ex
+++ b/lib/vutuv_web/controllers/organization_controller.ex
@@ -19,6 +19,8 @@ defmodule VutuvWeb.OrganizationController do
 
   alias Vutuv.Organizations
   alias Vutuv.Pages
+  alias Vutuv.Posts
+  alias Vutuv.Posts.Post
   alias VutuvWeb.AgentDocs
   alias VutuvWeb.AgentDocs.OrganizationDoc
   alias VutuvWeb.ControllerHelpers
@@ -131,6 +133,31 @@ defmodule VutuvWeb.OrganizationController do
 
   def exclusions(conn, %{"slug" => slug}),
     do: manage(conn, slug, VutuvWeb.OrganizationLive.Exclusions, &Organizations.can_manage?/2)
+
+  @doc """
+  The permalink of a post published in this organization's name (issue #1334).
+  404s for an unknown page, a page this viewer may not see, or an id that is not
+  one of its posts — an id belonging to a member's post must not render under an
+  organization's name.
+  """
+  def post(conn, %{"slug" => slug, "id" => id}) do
+    viewer = conn.assigns[:current_user]
+
+    with {:ok, organization} <- Organizations.fetch_visible_organization(slug, viewer),
+         %Post{} <- Posts.get_organization_post(organization, id, viewer) do
+      conn
+      |> put_layout(html: false)
+      |> live_render(VutuvWeb.OrganizationLive.Post,
+        session:
+          conn
+          |> ControllerHelpers.live_render_session()
+          |> Map.put("organization_id", organization.id)
+          |> Map.put("post_id", id)
+      )
+    else
+      _ -> ControllerHelpers.render_error(conn, 404)
+    end
+  end
 
   # Shared gate for the owner/admin management pages: log-in required, then the
   # per-page permission (`can?`); otherwise a 404 (never reveal the page exists).

--- a/lib/vutuv_web/live/organization_live/post.ex
+++ b/lib/vutuv_web/live/organization_live/post.ex
@@ -1,0 +1,70 @@
+defmodule VutuvWeb.OrganizationLive.Post do
+  @moduledoc """
+  The permalink of a post published in an organization's name
+  (`/organizations/:slug/posts/:id`, issue #1334). Embedded via `live_render`
+  from `VutuvWeb.OrganizationController`, like the organization page itself.
+
+  Deliberately just the post and the way back to the page that published it.
+  There is no conversation below it because an organization post cannot be
+  answered yet (`Vutuv.Posts.check_reply_allowed/2` refuses): everything a reply
+  sets in motion is member-shaped, and an organization has no inbox to be told
+  about one until issue #1336 gives it a reading side.
+  """
+
+  use VutuvWeb, :live_view
+
+  import VutuvWeb.OrganizationComponents, only: [organization_logo: 1]
+  import VutuvWeb.PostComponents, only: [post_card: 1]
+
+  alias Vutuv.Organizations
+  alias Vutuv.Posts
+  alias VutuvWeb.Live.InitAssigns
+
+  @impl true
+  def mount(_params, session, socket) do
+    socket = InitAssigns.assign_embedded(socket, session)
+    organization = Organizations.get_organization!(session["organization_id"])
+
+    # Resolved again on the socket rather than handed over in the session map:
+    # the controller's copy authenticated one HTTP request, and the live view
+    # re-asks who the viewer is on connect (`InitAssigns`), so what they may see
+    # is re-decided with it.
+    post =
+      Posts.get_organization_post(organization, session["post_id"], socket.assigns.current_user)
+
+    if post do
+      {:ok,
+       socket
+       |> assign(:organization, organization)
+       |> assign(:post, post)
+       |> assign(:page_title, organization.name)}
+    else
+      # The controller already refused an id that does not resolve, so reaching
+      # here means the answer changed between that request and this connect —
+      # a publisher role withdrawn while the page was open, on a held post.
+      {:ok, push_navigate(socket, to: Organizations.canonical_path(organization))}
+    end
+  end
+
+  @impl true
+  def handle_info(_message, socket), do: {:noreply, socket}
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div :if={@post} class="mx-auto max-w-2xl py-6">
+      <.link
+        navigate={Organizations.canonical_path(@organization)}
+        class="flex items-center gap-3 text-sm font-semibold text-slate-600 hover:text-brand-700 dark:text-slate-400 dark:hover:text-brand-300"
+      >
+        <.organization_logo organization={@organization} class="h-8 w-8" />
+        {@organization.name}
+      </.link>
+
+      <div class="mt-4">
+        <.post_card post={@post} viewer={@current_user} conn_or_socket={@socket} mode={:full} />
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/vutuv_web/live/organization_live/show.ex
+++ b/lib/vutuv_web/live/organization_live/show.ex
@@ -16,10 +16,12 @@ defmodule VutuvWeb.OrganizationLive.Show do
 
   import VutuvWeb.OrganizationComponents
   import VutuvWeb.JobComponents, only: [job_card: 1]
+  import VutuvWeb.PostComponents, only: [post_card: 1]
 
   alias Vutuv.Countries
   alias Vutuv.Jobs
   alias Vutuv.Organizations
+  alias Vutuv.Posts
   alias VutuvWeb.JsonLd
   alias VutuvWeb.Live.InitAssigns
   alias VutuvWeb.UserHelpers
@@ -37,8 +39,22 @@ defmodule VutuvWeb.OrganizationLive.Show do
       |> assign_organization(organization, current_user)
       |> assign_people(organization)
       |> assign_org_jobs(organization)
+      |> assign(:post_body, "")
+      |> assign_org_posts(organization)
 
     {:ok, socket}
+  end
+
+  # The organization's own posts (issue #1334), newest first, with their own
+  # "Load more" so it never collides with the People or Jobs lists'.
+  defp assign_org_posts(socket, organization) do
+    page = Posts.organization_posts_page(organization, socket.assigns.current_user)
+
+    socket
+    |> assign(:posts, page.entries)
+    |> assign(:posts_total, page.total)
+    |> assign(:posts_more?, page.more?)
+    |> assign(:posts_offset, page.next_offset)
   end
 
   # The organization page's "Offene Stellen" section (#933): the organization's
@@ -96,6 +112,10 @@ defmodule VutuvWeb.OrganizationLive.Show do
     |> assign(:can_manage?, Organizations.can_manage?(organization, viewer))
     |> assign(:can_edit?, Organizations.can_edit_page?(organization, viewer))
     |> assign(:owner?, Organizations.owner?(organization, viewer))
+    # Never implied by owner or admin (issue #1333): speaking for the page is
+    # its own grant, so this is asked on its own rather than derived from the
+    # two above.
+    |> assign(:publisher?, Organizations.publisher?(organization, viewer))
     |> assign(:pending?, organization.status == "pending")
     |> assign(:frozen?, not is_nil(organization.frozen_at))
     |> assign(:engagement, Organizations.organization_engagement(organization, viewer))
@@ -118,6 +138,46 @@ defmodule VutuvWeb.OrganizationLive.Show do
      |> assign(:people, socket.assigns.people ++ page.entries)
      |> assign(:people_more?, page.more?)
      |> assign(:people_offset, page.next_offset)}
+  end
+
+  def handle_event("publish", %{"body" => body}, socket) do
+    organization = socket.assigns.organization
+
+    # The role is re-checked by `create_organization_post/3` itself, so a
+    # withdrawn publisher cannot post through a page they still have open.
+    case Posts.create_organization_post(organization, socket.assigns.current_user, %{body: body}) do
+      {:ok, _post} ->
+        {:noreply,
+         socket
+         |> assign(:post_body, "")
+         |> assign_org_posts(organization)
+         |> put_flash(:info, gettext("Published as %{name}.", name: organization.name))}
+
+      {:error, :forbidden} ->
+        {:noreply,
+         socket
+         |> assign(:publisher?, false)
+         |> put_flash(:error, gettext("You may no longer write in this organization's name."))}
+
+      {:error, _changeset} ->
+        {:noreply,
+         socket
+         |> assign(:post_body, body)
+         |> put_flash(:error, gettext("That post could not be published."))}
+    end
+  end
+
+  def handle_event("load-more-posts", _params, socket) do
+    page =
+      Posts.organization_posts_page(socket.assigns.organization, socket.assigns.current_user,
+        offset: socket.assigns.posts_offset
+      )
+
+    {:noreply,
+     socket
+     |> assign(:posts, socket.assigns.posts ++ page.entries)
+     |> assign(:posts_more?, page.more?)
+     |> assign(:posts_offset, page.next_offset)}
   end
 
   def handle_event("load-more-jobs", _params, socket) do
@@ -290,6 +350,67 @@ defmodule VutuvWeb.OrganizationLive.Show do
           <.card :if={present?(@organization.description)}>
             <.section_title>{gettext("About")}</.section_title>
             <.markdown_prose text={@organization.description} class="mt-3 text-slate-800 dark:text-slate-200" />
+          </.card>
+
+          <%!-- Posts published in the organization's name (issue #1334). The
+          card shows for every viewer once there is something in it, and for a
+          publisher even when there is not — an empty card with a composer is
+          how they find out they may write here at all. --%>
+          <.card :if={@posts_total > 0 or @publisher?} id="organization-posts">
+            <div class="flex items-center justify-between">
+              <.section_title>{gettext("Posts")}</.section_title>
+              <span :if={@posts_total > 0} class="text-sm text-slate-600 dark:text-slate-400">
+                {compact_count(@posts_total)}
+              </span>
+            </div>
+
+            <%!-- The composer names the author right at the point of publishing,
+            in the button, because the characteristic failure of writing under a
+            brand is forgetting whose name is on it. --%>
+            <.form
+              :if={@publisher?}
+              for={%{}}
+              id="organization-post-form"
+              phx-submit="publish"
+              class="mt-3 space-y-3"
+            >
+              <textarea
+                name="body"
+                rows="3"
+                placeholder={gettext("Write something as %{name}", name: @organization.name)}
+                class={[input_class(), "resize-y"]}
+              >{@post_body}</textarea>
+              <div class="flex justify-end">
+                <button
+                  type="submit"
+                  class="rounded-lg bg-brand-600 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-700"
+                >
+                  {gettext("Post as %{name}", name: @organization.name)}
+                </button>
+              </div>
+            </.form>
+
+            <div :if={@posts != []} class="mt-4 divide-y divide-slate-100 dark:divide-slate-800">
+              <div :for={post <- @posts} class="py-4 first:pt-0 last:pb-0">
+                <.post_card
+                  post={post}
+                  viewer={@current_user}
+                  conn_or_socket={@socket}
+                  mode={:preview}
+                  surface={:flat}
+                />
+              </div>
+            </div>
+
+            <p :if={@posts == [] and @publisher?} class="mt-3 text-sm text-slate-600 dark:text-slate-400">
+              {gettext("Nothing published yet.")}
+            </p>
+
+            <div :if={@posts_more?} class="mt-4 text-center">
+              <.button variant="secondary" phx-click="load-more-posts" id="load-more-posts">
+                {gettext("Load more")}
+              </.button>
+            </div>
           </.card>
 
           <%!-- People: members who list this organization as an employer (issue #931).

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -267,6 +267,13 @@ defmodule VutuvWeb.Router do
     # The role-holder standing job-exclusion default (issue #939), live_render
     # like roles/domains. Inherited by every posting attributed to the organization.
     get("/organizations/:slug/exclusions", OrganizationController, :exclusions)
+    # The permalink of a post published in the organization's name (issue #1334).
+    # Deliberately under the slug and not under the organization's opt-in root
+    # handle: the handle route dispatches an organization only on the bare
+    # `/:slug` page, and a permalink is the least forgiving URL there is (it is
+    # what a federated Note is identified by), so it gets the one shape that
+    # works whether or not a handle was ever claimed.
+    get("/organizations/:slug/posts/:id", OrganizationController, :post)
 
     get("/new_registration", PageController, :redirect_index)
     post("/new_registration", PageController, :new_registration)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.239.0",
+      version: "7.240.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -21,7 +21,7 @@ msgstr "Impressum"
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:718
 #: lib/vutuv_web/live/organization_live/domains.ex:255
 #: lib/vutuv_web/live/organization_live/edit.ex:396
-#: lib/vutuv_web/live/organization_live/roles.ex:205
+#: lib/vutuv_web/live/organization_live/roles.ex:210
 #, elixir-autogen
 msgid "Add"
 msgstr "Eintrag hinzufügen"
@@ -32,7 +32,7 @@ msgstr "Eintrag hinzufügen"
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
-#: lib/vutuv_web/live/organization_live/show.ex:350
+#: lib/vutuv_web/live/organization_live/show.ex:471
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
@@ -160,7 +160,7 @@ msgstr "Kontakt"
 msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
-#: lib/vutuv_web/components/post_components.ex:2754
+#: lib/vutuv_web/components/post_components.ex:2788
 #: lib/vutuv_web/components/ui.ex:3326
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -209,13 +209,13 @@ msgstr "Inaktivieren"
 msgid "Download"
 msgstr "Download"
 
-#: lib/vutuv_web/components/post_components.ex:2719
+#: lib/vutuv_web/components/post_components.ex:2753
 #: lib/vutuv_web/components/ui.ex:3317
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
 #: lib/vutuv_web/live/job_posting_live/show.ex:178
-#: lib/vutuv_web/live/organization_live/show.ex:263
+#: lib/vutuv_web/live/organization_live/show.ex:323
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:7
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:19
@@ -653,7 +653,7 @@ msgstr "Speichern"
 msgid "Search"
 msgstr "Suche"
 
-#: lib/vutuv_web/components/post_components.ex:1369
+#: lib/vutuv_web/components/post_components.ex:1399
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -1646,7 +1646,7 @@ msgstr "Zur Startseite"
 msgid "Check your inbox"
 msgstr "Schauen Sie in Ihr Postfach"
 
-#: lib/vutuv_web/components/post_components.ex:3202
+#: lib/vutuv_web/components/post_components.ex:3236
 #: lib/vutuv_web/components/ui.ex:280
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
@@ -1780,7 +1780,7 @@ msgstr "Nachrichten"
 msgid "Network"
 msgstr "Netzwerk"
 
-#: lib/vutuv_web/components/post_components.ex:391
+#: lib/vutuv_web/components/post_components.ex:421
 #: lib/vutuv_web/components/ui.ex:3436
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:705
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:742
@@ -1956,6 +1956,7 @@ msgid "Pagination"
 msgstr "Seitennavigation"
 
 #: lib/vutuv_web/components/ui.ex:3461
+#: lib/vutuv_web/live/organization_live/show.ex:411
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr "Mehr laden"
@@ -2135,7 +2136,7 @@ msgstr "Upload abbrechen"
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
-#: lib/vutuv_web/components/post_components.ex:2751
+#: lib/vutuv_web/components/post_components.ex:2785
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2176,8 +2177,8 @@ msgstr "Vor einer bestimmten Person verbergen…"
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
 
-#: lib/vutuv_web/components/post_components.ex:2705
-#: lib/vutuv_web/components/post_components.ex:2707
+#: lib/vutuv_web/components/post_components.ex:2739
+#: lib/vutuv_web/components/post_components.ex:2741
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
@@ -2235,6 +2236,7 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:382
 #: lib/vutuv_web/live/notification_live/index.ex:876
+#: lib/vutuv_web/live/organization_live/show.ex:361
 #: lib/vutuv_web/live/post_live/saved.ex:495
 #: lib/vutuv_web/live/search_live.ex:200
 #: lib/vutuv_web/live/search_live.ex:530
@@ -2244,13 +2246,13 @@ msgstr "Beitrag erfolgreich gelöscht."
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:3138
-#: lib/vutuv_web/components/post_components.ex:3142
+#: lib/vutuv_web/components/post_components.ex:3172
+#: lib/vutuv_web/components/post_components.ex:3176
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:3139
+#: lib/vutuv_web/components/post_components.ex:3173
 #: lib/vutuv_web/live/fediverse_account_live.ex:320
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2258,13 +2260,13 @@ msgstr "Weniger anzeigen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:252
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:1006
+#: lib/vutuv_web/components/post_components.ex:1036
 #: lib/vutuv_web/live/admin/screenshot_live.ex:317
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:700
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:373
-#: lib/vutuv_web/live/organization_live/roles.ex:238
+#: lib/vutuv_web/live/organization_live/roles.ex:243
 #: lib/vutuv_web/live/post_live/composer.ex:1851
 #: lib/vutuv_web/live/post_live/saved.ex:619
 #: lib/vutuv_web/live/post_live/saved.ex:647
@@ -2342,27 +2344,27 @@ msgstr "Was gibt's Neues?"
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
 
-#: lib/vutuv_web/components/post_components.ex:2702
+#: lib/vutuv_web/components/post_components.ex:2736
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:4346
+#: lib/vutuv_web/components/post_components.ex:4380
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:4350
+#: lib/vutuv_web/components/post_components.ex:4384
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:4348
+#: lib/vutuv_web/components/post_components.ex:4382
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:4349
+#: lib/vutuv_web/components/post_components.ex:4383
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
@@ -2403,8 +2405,8 @@ msgstr "Alle %{count} Beiträge ansehen"
 msgid "All posts"
 msgstr "Alle Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:1553
-#: lib/vutuv_web/components/post_components.ex:4430
+#: lib/vutuv_web/components/post_components.ex:1583
+#: lib/vutuv_web/components/post_components.ex:4464
 #: lib/vutuv_web/components/ui.ex:2851
 #: lib/vutuv_web/views/user_html.ex:333
 #, elixir-autogen, elixir-format
@@ -2422,8 +2424,8 @@ msgstr "Lesezeichen setzen"
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/vutuv_web/components/post_components.ex:1517
-#: lib/vutuv_web/components/post_components.ex:4653
+#: lib/vutuv_web/components/post_components.ex:1547
+#: lib/vutuv_web/components/post_components.ex:4687
 #: lib/vutuv_web/components/ui.ex:2837
 #: lib/vutuv_web/live/notification_live/index.ex:1023
 #: lib/vutuv_web/views/user_html.ex:343
@@ -2432,7 +2434,7 @@ msgid "Like"
 msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:960
-#: lib/vutuv_web/components/post_components.ex:4662
+#: lib/vutuv_web/components/post_components.ex:4696
 #: lib/vutuv_web/live/notification_live/index.ex:956
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
@@ -2454,39 +2456,39 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:4419
+#: lib/vutuv_web/components/post_components.ex:4453
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
-#: lib/vutuv_web/components/post_components.ex:1553
-#: lib/vutuv_web/components/post_components.ex:4430
+#: lib/vutuv_web/components/post_components.ex:1583
+#: lib/vutuv_web/components/post_components.ex:4464
 #: lib/vutuv_web/live/post_live/saved.ex:775
 #: lib/vutuv_web/views/user_html.ex:333
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
-#: lib/vutuv_web/components/post_components.ex:1541
-#: lib/vutuv_web/components/post_components.ex:4416
+#: lib/vutuv_web/components/post_components.ex:1571
+#: lib/vutuv_web/components/post_components.ex:4450
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
-#: lib/vutuv_web/components/post_components.ex:1731
-#: lib/vutuv_web/components/post_components.ex:3718
+#: lib/vutuv_web/components/post_components.ex:1761
+#: lib/vutuv_web/components/post_components.ex:3752
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:1541
-#: lib/vutuv_web/components/post_components.ex:4416
+#: lib/vutuv_web/components/post_components.ex:1571
+#: lib/vutuv_web/components/post_components.ex:4450
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
-#: lib/vutuv_web/components/post_components.ex:4653
+#: lib/vutuv_web/components/post_components.ex:4687
 #: lib/vutuv_web/live/post_live/saved.ex:774
 #: lib/vutuv_web/views/user_html.ex:343
 #, elixir-autogen, elixir-format
@@ -2508,27 +2510,27 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:4706
+#: lib/vutuv_web/components/post_components.ex:4740
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
 
-#: lib/vutuv_web/components/post_components.ex:349
+#: lib/vutuv_web/components/post_components.ex:379
 #: lib/vutuv_web/live/notification_live/index.ex:957
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:1528
-#: lib/vutuv_web/components/post_components.ex:4689
-#: lib/vutuv_web/components/post_components.ex:4690
+#: lib/vutuv_web/components/post_components.ex:1558
+#: lib/vutuv_web/components/post_components.ex:4723
+#: lib/vutuv_web/components/post_components.ex:4724
 #: lib/vutuv_web/live/notification_live/index.ex:1020
 #: lib/vutuv_web/live/post_live/reply.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:2673
+#: lib/vutuv_web/components/post_components.ex:2703
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
@@ -2549,7 +2551,7 @@ msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beitr
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
 
-#: lib/vutuv_web/components/post_components.ex:2167
+#: lib/vutuv_web/components/post_components.ex:2197
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:59
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:50
@@ -2557,14 +2559,14 @@ msgstr "hat auf Ihren Beitrag geantwortet."
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
 
-#: lib/vutuv_web/components/post_components.ex:2649
+#: lib/vutuv_web/components/post_components.ex:2679
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:2643
-#: lib/vutuv_web/components/post_components.ex:2665
-#: lib/vutuv_web/components/post_components.ex:2668
+#: lib/vutuv_web/components/post_components.ex:2673
+#: lib/vutuv_web/components/post_components.ex:2695
+#: lib/vutuv_web/components/post_components.ex:2698
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
@@ -2869,7 +2871,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:4347
+#: lib/vutuv_web/components/post_components.ex:4381
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -3148,7 +3150,7 @@ msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:2619
+#: lib/vutuv_web/components/post_components.ex:2649
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solange eine Meldung zu diesem Beitrag bearbeitet wird, sehen nur Sie ihn."
@@ -3227,10 +3229,10 @@ msgstr "Abgelehnt"
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 
-#: lib/vutuv_web/components/post_components.ex:1016
-#: lib/vutuv_web/components/post_components.ex:1992
-#: lib/vutuv_web/components/post_components.ex:2775
-#: lib/vutuv_web/live/organization_live/show.ex:284
+#: lib/vutuv_web/components/post_components.ex:1046
+#: lib/vutuv_web/components/post_components.ex:2022
+#: lib/vutuv_web/components/post_components.ex:2809
+#: lib/vutuv_web/live/organization_live/show.ex:344
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Report"
@@ -4747,7 +4749,7 @@ msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:516
 #: lib/vutuv_web/live/notification_live/index.ex:877
-#: lib/vutuv_web/live/organization_live/show.ex:300
+#: lib/vutuv_web/live/organization_live/show.ex:421
 #: lib/vutuv_web/live/post_live/saved.ex:498
 #: lib/vutuv_web/live/search_live.ex:198
 #: lib/vutuv_web/live/search_live.ex:472
@@ -4767,8 +4769,8 @@ msgstr ""
 msgid "Similar names"
 msgstr "Ähnliche Namen"
 
-#: lib/vutuv_web/components/post_components.ex:346
-#: lib/vutuv_web/components/post_components.ex:365
+#: lib/vutuv_web/components/post_components.ex:376
+#: lib/vutuv_web/components/post_components.ex:395
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/notification_live/index.ex:875
@@ -5614,9 +5616,9 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:2838
-#: lib/vutuv_web/components/post_components.ex:2890
-#: lib/vutuv_web/components/post_components.ex:3282
+#: lib/vutuv_web/components/post_components.ex:2872
+#: lib/vutuv_web/components/post_components.ex:2924
+#: lib/vutuv_web/components/post_components.ex:3316
 #: lib/vutuv_web/live/notification_live/index.ex:680
 #: lib/vutuv_web/live/post_live/feed.ex:1259
 #: lib/vutuv_web/views/user_html.ex:111
@@ -6434,7 +6436,7 @@ msgid "Previous day"
 msgstr "Vorheriger Tag"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:960
-#: lib/vutuv_web/components/post_components.ex:348
+#: lib/vutuv_web/components/post_components.ex:378
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
@@ -6904,7 +6906,7 @@ msgstr "Folgen Sie einander, um mit %{name} vernetzt zu sein und ihn zu lesen."
 msgid "Go to profile to follow"
 msgstr "Zum Profil, um zu folgen"
 
-#: lib/vutuv_web/components/post_components.ex:2772
+#: lib/vutuv_web/components/post_components.ex:2806
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr "@%{handle} stummschalten"
@@ -6914,7 +6916,7 @@ msgstr "@%{handle} stummschalten"
 msgid "Professional"
 msgstr "Beruflich"
 
-#: lib/vutuv_web/components/post_components.ex:2771
+#: lib/vutuv_web/components/post_components.ex:2805
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr "@%{handle} nicht mehr stummschalten"
@@ -7620,7 +7622,7 @@ msgstr "Alle abwählen"
 msgid "applies to the whole list, not just this page"
 msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 
-#: lib/vutuv_web/components/post_components.ex:4575
+#: lib/vutuv_web/components/post_components.ex:4609
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -9226,7 +9228,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:3721
+#: lib/vutuv_web/components/post_components.ex:3755
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -11635,7 +11637,7 @@ msgstr "Ihre Liste ist leer. Es ist noch niemand ausgeschlossen."
 msgid "AI agents"
 msgstr "KI-Agenten"
 
-#: lib/vutuv_web/live/organization_live/show.ex:291
+#: lib/vutuv_web/live/organization_live/show.ex:351
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "Über die Organisation"
@@ -11648,7 +11650,7 @@ msgstr "Weiter zur Verifizierung"
 #: lib/vutuv_web/live/organization_live/domains.ex:248
 #: lib/vutuv_web/live/organization_live/domains.ex:288
 #: lib/vutuv_web/live/organization_live/new.ex:146
-#: lib/vutuv_web/live/organization_live/show.ex:424
+#: lib/vutuv_web/live/organization_live/show.ex:545
 #: lib/vutuv_web/templates/url/verify.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "DNS TXT record"
@@ -11656,8 +11658,8 @@ msgstr "DNS-TXT-Eintrag"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:153
 #: lib/vutuv_web/live/organization_live/domains.ex:167
-#: lib/vutuv_web/live/organization_live/show.ex:203
-#: lib/vutuv_web/live/organization_live/show.ex:483
+#: lib/vutuv_web/live/organization_live/show.ex:263
+#: lib/vutuv_web/live/organization_live/show.ex:604
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr "Die Domain-Verifizierung ist auf dieser Installation deaktiviert."
@@ -11691,13 +11693,13 @@ msgstr ""
 "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) anbieten und für KI-"
 "Agenten auflisten."
 
-#: lib/vutuv_web/controllers/organization_controller.ex:144
+#: lib/vutuv_web/controllers/organization_controller.ex:171
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:31
 #, elixir-autogen, elixir-format
 msgid "Please log in first."
 msgstr "Bitte loggen Sie sich zuerst ein."
 
-#: lib/vutuv_web/live/organization_live/show.ex:397
+#: lib/vutuv_web/live/organization_live/show.ex:518
 #, elixir-autogen, elixir-format
 msgid "Prove you control %{domain} to publish this page."
 msgstr "Weisen Sie nach, dass Ihnen %{domain} gehört, um diese Seite zu veröffentlichen."
@@ -11724,7 +11726,7 @@ msgid "Select a country"
 msgstr "Land auswählen"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:307
-#: lib/vutuv_web/live/organization_live/show.ex:459
+#: lib/vutuv_web/live/organization_live/show.ex:580
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr "Stellen Sie diese Datei bereit unter:"
@@ -11751,12 +11753,12 @@ msgid "The upload failed."
 msgstr "Der Upload ist fehlgeschlagen."
 
 #: lib/vutuv_web/live/organization_live/new.ex:131
-#: lib/vutuv_web/live/organization_live/show.ex:412
+#: lib/vutuv_web/live/organization_live/show.ex:533
 #, elixir-autogen, elixir-format
 msgid "Verification method"
 msgstr "Verifizierungsmethode"
 
-#: lib/vutuv_web/live/organization_live/show.ex:372
+#: lib/vutuv_web/live/organization_live/show.ex:493
 #, elixir-autogen, elixir-format
 msgid "Verified domains"
 msgstr "Verifizierte Domains"
@@ -11772,19 +11774,19 @@ msgstr "Verifiziert über"
 msgid "Verified via %{domain}"
 msgstr "Verifiziert über %{domain}"
 
-#: lib/vutuv_web/live/organization_live/show.ex:394
+#: lib/vutuv_web/live/organization_live/show.ex:515
 #, elixir-autogen, elixir-format
 msgid "Verify %{name}"
 msgstr "%{name} verifizieren"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:320
-#: lib/vutuv_web/live/organization_live/show.ex:479
+#: lib/vutuv_web/live/organization_live/show.ex:600
 #, elixir-autogen, elixir-format
 msgid "Verify now"
 msgstr "Jetzt verifizieren"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:149
-#: lib/vutuv_web/live/organization_live/show.ex:198
+#: lib/vutuv_web/live/organization_live/show.ex:258
 #, elixir-autogen, elixir-format
 msgid "We could not find the record or file yet. It can take a while to propagate. Please try again."
 msgstr ""
@@ -11801,7 +11803,7 @@ msgstr "Website"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:249
 #: lib/vutuv_web/live/organization_live/domains.ex:298
-#: lib/vutuv_web/live/organization_live/show.ex:435
+#: lib/vutuv_web/live/organization_live/show.ex:556
 #: lib/vutuv_web/templates/url/verify.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Website file"
@@ -11825,13 +11827,13 @@ msgstr ""
 "die Kontrolle über die Domain nachzuweisen."
 
 #: lib/vutuv_web/live/organization_live/domains.ex:309
-#: lib/vutuv_web/live/organization_live/show.ex:465
+#: lib/vutuv_web/live/organization_live/show.ex:586
 #: lib/vutuv_web/templates/url/verify.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
 msgstr "mit genau diesem Inhalt:"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:175
+#: lib/vutuv_web/live/organization_live/roles.ex:180
 #, elixir-autogen, elixir-format
 msgid "@handle or email"
 msgstr "@handle oder E-Mail"
@@ -11847,12 +11849,12 @@ msgstr "Abkürzung"
 msgid "Add a domain"
 msgstr "Domain hinzufügen"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:166
+#: lib/vutuv_web/live/organization_live/roles.ex:171
 #, elixir-autogen, elixir-format
 msgid "Add a member"
 msgstr "Mitglied hinzufügen"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:138
+#: lib/vutuv_web/live/organization_live/roles.ex:143
 #, elixir-autogen, elixir-format
 msgid "Added @%{handle} to the team."
 msgstr "@%{handle} zum Team hinzugefügt."
@@ -11876,7 +11878,7 @@ msgstr "Alias entfernt."
 #: lib/vutuv_web/agent_docs/markdown.ex:322
 #: lib/vutuv_web/agent_docs/text.ex:348
 #: lib/vutuv_web/live/organization_live/edit.ex:353
-#: lib/vutuv_web/live/organization_live/show.ex:360
+#: lib/vutuv_web/live/organization_live/show.ex:481
 #: lib/vutuv_web/templates/tag/single_card.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Also known as"
@@ -11914,7 +11916,7 @@ msgstr "Marke"
 msgid "Claimed by"
 msgstr "Beansprucht von"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:211
+#: lib/vutuv_web/live/organization_live/roles.ex:216
 #, elixir-autogen, elixir-format
 msgid "Current team"
 msgstr "Aktuelles Team"
@@ -11946,7 +11948,7 @@ msgstr "Domain verifiziert."
 #: lib/vutuv_web/components/organization_components.ex:211
 #: lib/vutuv_web/live/admin/organization_live.ex:305
 #: lib/vutuv_web/live/organization_live/domains.ex:161
-#: lib/vutuv_web/live/organization_live/show.ex:277
+#: lib/vutuv_web/live/organization_live/show.ex:337
 #, elixir-autogen, elixir-format
 msgid "Domains"
 msgstr "Domains"
@@ -11981,7 +11983,7 @@ msgstr ""
 msgid "Last checked"
 msgstr "Zuletzt geprüft"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:238
+#: lib/vutuv_web/live/organization_live/roles.ex:243
 #, elixir-autogen, elixir-format
 msgid "Leave"
 msgstr "Verlassen"
@@ -12046,7 +12048,7 @@ msgstr "Recruiter"
 msgid "Remove this domain?"
 msgstr "Diese Domain entfernen?"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:233
+#: lib/vutuv_web/live/organization_live/roles.ex:238
 #, elixir-autogen, elixir-format
 msgid "Remove this member from the team?"
 msgstr "Dieses Mitglied aus dem Team entfernen?"
@@ -12063,8 +12065,8 @@ msgstr "Name, Alias oder Domain suchen"
 
 #: lib/vutuv_web/components/organization_components.ex:208
 #: lib/vutuv_web/live/admin/organization_live.ex:321
-#: lib/vutuv_web/live/organization_live/roles.ex:160
-#: lib/vutuv_web/live/organization_live/show.ex:270
+#: lib/vutuv_web/live/organization_live/roles.ex:165
+#: lib/vutuv_web/live/organization_live/show.ex:330
 #, elixir-autogen, elixir-format
 msgid "Team"
 msgstr "Team"
@@ -12079,7 +12081,7 @@ msgstr "Team – %{name}"
 msgid "That is not a valid domain."
 msgstr "Das ist keine gültige Domain."
 
-#: lib/vutuv_web/live/organization_live/roles.ex:141
+#: lib/vutuv_web/live/organization_live/roles.ex:146
 #, elixir-autogen, elixir-format
 msgid "That member could not be added."
 msgstr "Dieses Mitglied konnte nicht hinzugefügt werden."
@@ -12254,7 +12256,7 @@ msgstr "verifizierte Webseite"
 msgid "%{min} to %{max} characters: letters (a-z), numbers (0-9) and underscores."
 msgstr "%{min} bis %{max} Zeichen: Buchstaben (a-z), Zahlen (0-9) und Unterstriche."
 
-#: lib/vutuv_web/live/organization_live/show.ex:315
+#: lib/vutuv_web/live/organization_live/show.ex:436
 #, elixir-autogen, elixir-format
 msgid "Former"
 msgstr "Ehemalig"
@@ -12332,7 +12334,7 @@ msgstr ""
 "Eine Organisation behält mindestens eine verifizierte Domain, daher kann diese "
 "nicht entfernt werden."
 
-#: lib/vutuv_web/live/organization_live/roles.ex:147
+#: lib/vutuv_web/live/organization_live/roles.ex:152
 #, elixir-autogen, elixir-format
 msgid "An organization must keep at least one owner, so the last owner cannot be changed."
 msgstr ""
@@ -12386,7 +12388,7 @@ msgstr "Vielleicht brauchen Sie Hilfe von Ihrer IT"
 msgid "The proof is a small technical change to your domain: a DNS entry or a file on your website. If you don't manage the website yourself, ask the person or team who does. That is usually your IT department or the company that runs your website. We show the exact instructions on the next step, so you can simply pass them on."
 msgstr "Der Nachweis ist eine kleine technische Änderung an Ihrer Domain: ein DNS-Eintrag oder eine Datei auf Ihrer Website. Wenn Sie die Website nicht selbst verwalten, fragen Sie die Person oder das Team, das dies tut. Das ist meist Ihre IT-Abteilung oder die Firma, die Ihre Website betreut. Die genaue Anleitung zeigen wir Ihnen im nächsten Schritt, Sie können sie einfach weitergeben."
 
-#: lib/vutuv_web/live/organization_live/show.ex:406
+#: lib/vutuv_web/live/organization_live/show.ex:527
 #, elixir-autogen, elixir-format
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr "Diese Schritte sind technisch. Wenn Sie %{domain} nicht selbst verwalten, kopieren Sie den unten gezeigten Eintrag oder die Datei und senden Sie ihn an Ihre IT-Abteilung oder die Firma, die Ihre Website betreut. Sobald sie ihn hinzugefügt hat, kommen Sie hierher zurück und klicken auf „Jetzt verifizieren“."
@@ -12407,7 +12409,7 @@ msgstr "Das Löschen dieser Organisationsseite ist endgültig. Ihre verifizierte
 msgid "Kind of organization"
 msgstr "Art der Organisation"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:232
+#: lib/vutuv_web/live/organization_live/roles.ex:237
 #, elixir-autogen, elixir-format
 msgid "Leave this organization team?"
 msgstr "Dieses Organisations-Team verlassen?"
@@ -12497,7 +12499,7 @@ msgstr "Organisationsrolle"
 msgid "Organization unfrozen."
 msgstr "Organisation wieder freigegeben."
 
-#: lib/vutuv_web/agent_docs/organization_doc.ex:91
+#: lib/vutuv_web/agent_docs/organization_doc.ex:108
 #: lib/vutuv_web/components/ui.ex:3719
 #: lib/vutuv_web/controllers/settings_controller.ex:178
 #: lib/vutuv_web/live/organization_live/index.ex:30
@@ -12516,14 +12518,14 @@ msgstr "Organisationen"
 msgid "Please choose"
 msgstr "Bitte wählen"
 
-#: lib/vutuv_web/controllers/organization_controller.ex:111
+#: lib/vutuv_web/controllers/organization_controller.ex:113
 #, elixir-autogen, elixir-format
 msgid "Please confirm your email address before claiming an organization page."
 msgstr ""
 "Bitte bestätigen Sie Ihre E-Mail-Adresse, bevor Sie eine Organisationsseite "
 "beanspruchen."
 
-#: lib/vutuv_web/controllers/organization_controller.ex:117
+#: lib/vutuv_web/controllers/organization_controller.ex:119
 #, elixir-autogen, elixir-format
 msgid "Please log in to claim an organization page."
 msgstr "Bitte loggen Sie sich ein, um eine Organisationsseite zu beanspruchen."
@@ -12553,7 +12555,7 @@ msgstr "Dieser Name ist für diese Organisation bereits eingetragen."
 msgid "The organization page was deleted."
 msgstr "Die Organisationsseite wurde gelöscht."
 
-#: lib/vutuv_web/live/organization_live/show.ex:210
+#: lib/vutuv_web/live/organization_live/show.ex:270
 #, elixir-autogen, elixir-format
 msgid "This organization page was reported and is hidden while it is reviewed. Only you and the moderators can see it."
 msgstr ""
@@ -12567,7 +12569,7 @@ msgstr ""
 "Verifizierte Organisationsseiten auf vutuv, jede mit einer nachgewiesenen Web-"
 "Domain."
 
-#: lib/vutuv_web/agent_docs/organization_doc.ex:92
+#: lib/vutuv_web/agent_docs/organization_doc.ex:109
 #, elixir-autogen, elixir-format
 msgid "Verified organization pages on vutuv."
 msgstr "Verifizierte Organisationsseiten auf vutuv."
@@ -12589,7 +12591,7 @@ msgstr "Sie dürfen diese Organisation nicht löschen."
 msgid "Your organization handle is set."
 msgstr "Ihr Organisations-Handle ist gesetzt."
 
-#: lib/vutuv_web/live/organization_live/show.ex:164
+#: lib/vutuv_web/live/organization_live/show.ex:224
 #, elixir-autogen, elixir-format
 msgid "Your organization page is verified and now live."
 msgstr "Ihre Organisationsseite ist verifiziert und jetzt live."
@@ -13294,13 +13296,13 @@ msgid "Getting an error, or is %{host} a CNAME / alias to another address? A TXT
 msgstr "Bekommen Sie einen Fehler, oder ist %{host} ein CNAME / Alias auf eine andere Adresse? Ein TXT-Eintrag kann nicht denselben Namen wie ein CNAME haben. Verwenden Sie stattdessen diesen Namen, mit exakt demselben Wert wie oben:"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:305
-#: lib/vutuv_web/live/organization_live/show.ex:452
+#: lib/vutuv_web/live/organization_live/show.ex:573
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr "Ist %{domain} ein CNAME / Alias (ein TXT-Eintrag kann nicht denselben Namen wie ein CNAME haben), legen Sie den Eintrag stattdessen auf %{name} an, mit demselben Wert."
 
 #: lib/vutuv_web/live/organization_live/domains.ex:303
-#: lib/vutuv_web/live/organization_live/show.ex:443
+#: lib/vutuv_web/live/organization_live/show.ex:564
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
 msgstr "Legen Sie in Ihren DNS-Einstellungen einen TXT-Eintrag auf dem Namen %{domain} mit diesem Wert an:"
@@ -13396,7 +13398,7 @@ msgid "Minimum yearly salary"
 msgstr "Mindestgehalt pro Jahr"
 
 #: lib/vutuv_web/live/job_board_live.ex:324
-#: lib/vutuv_web/live/organization_live/show.ex:342
+#: lib/vutuv_web/live/organization_live/show.ex:463
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr "Weitere Stellen"
@@ -13425,7 +13427,7 @@ msgstr "Keine passenden Stellen. Passen Sie die Filter an."
 #: lib/vutuv_web/agent_docs/markdown.ex:400
 #: lib/vutuv_web/agent_docs/text.ex:412
 #: lib/vutuv_web/agent_docs/text.ex:424
-#: lib/vutuv_web/live/organization_live/show.ex:329
+#: lib/vutuv_web/live/organization_live/show.ex:450
 #: lib/vutuv_web/templates/tag/show.html.heex:45
 #, elixir-autogen, elixir-format
 msgid "Open positions"
@@ -13750,7 +13752,7 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "E-Mail-Benachrichtigungen für Ihre gespeicherte Suche „%{label}“ stoppen?"
 
-#: lib/vutuv_web/components/post_components.ex:2126
+#: lib/vutuv_web/components/post_components.ex:2156
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:650
 #: lib/vutuv_web/controllers/settings_controller.ex:668
@@ -14172,22 +14174,22 @@ msgstr "Mobil (privat)"
 msgid "Work mobile"
 msgstr "Mobil (Arbeit)"
 
-#: lib/vutuv_web/components/post_components.ex:388
+#: lib/vutuv_web/components/post_components.ex:418
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr "Noch keine Beiträge."
 
-#: lib/vutuv_web/components/post_components.ex:390
+#: lib/vutuv_web/components/post_components.ex:420
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr "Noch keine Antworten."
 
-#: lib/vutuv_web/components/post_components.ex:389
+#: lib/vutuv_web/components/post_components.ex:419
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr "Noch keine Reposts."
 
-#: lib/vutuv_web/components/post_components.ex:347
+#: lib/vutuv_web/components/post_components.ex:377
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr "Eigene Beiträge"
@@ -14367,34 +14369,34 @@ msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch imm
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:4209
+#: lib/vutuv_web/components/post_components.ex:4243
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1049
-#: lib/vutuv_web/components/post_components.ex:4166
+#: lib/vutuv_web/components/post_components.ex:4200
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:4210
+#: lib/vutuv_web/components/post_components.ex:4244
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:4212
+#: lib/vutuv_web/components/post_components.ex:4246
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:4208
+#: lib/vutuv_web/components/post_components.ex:4242
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1049
-#: lib/vutuv_web/components/post_components.ex:4165
+#: lib/vutuv_web/components/post_components.ex:4199
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Filmbesprechung"
@@ -14405,12 +14407,12 @@ msgstr "Filmbesprechung"
 msgid "Look up"
 msgstr "Nachschlagen"
 
-#: lib/vutuv_web/components/post_components.ex:4207
+#: lib/vutuv_web/components/post_components.ex:4241
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
 
-#: lib/vutuv_web/components/post_components.ex:4211
+#: lib/vutuv_web/components/post_components.ex:4245
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14430,7 +14432,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:4248
+#: lib/vutuv_web/components/post_components.ex:4282
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14438,27 +14440,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:4278
+#: lib/vutuv_web/components/post_components.ex:4312
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:4279
+#: lib/vutuv_web/components/post_components.ex:4313
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:4277
+#: lib/vutuv_web/components/post_components.ex:4311
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:4237
+#: lib/vutuv_web/components/post_components.ex:4271
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:4284
+#: lib/vutuv_web/components/post_components.ex:4318
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14488,7 +14490,7 @@ msgstr "Mit Qualifikation:"
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:4051
+#: lib/vutuv_web/components/post_components.ex:4085
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
@@ -14536,7 +14538,7 @@ msgstr "folgen Ihnen jetzt."
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:4042
+#: lib/vutuv_web/components/post_components.ex:4076
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
@@ -14928,14 +14930,14 @@ msgstr "Konto zum Einfrieren suchen"
 msgid "See all frozen accounts"
 msgstr "Alle eingefrorenen Konten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2390
+#: lib/vutuv_web/components/post_components.ex:2420
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "%{formatted} früheren Beitrag anzeigen"
 msgstr[1] "%{formatted} frühere Beiträge anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2412
+#: lib/vutuv_web/components/post_components.ex:2442
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14962,7 +14964,7 @@ msgstr "Dieses Profil ist zurzeit nicht verfügbar."
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das Konto zu finden, das eingefroren werden soll."
 
-#: lib/vutuv_web/components/post_components.ex:4661
+#: lib/vutuv_web/components/post_components.ex:4695
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Der eigene Beitrag lässt sich nicht mit „Gefällt mir“ markieren."
@@ -16149,21 +16151,21 @@ msgstr ""
 "wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
-#: lib/vutuv_web/components/post_components.ex:4620
+#: lib/vutuv_web/components/post_components.ex:4654
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:4624
+#: lib/vutuv_web/components/post_components.ex:4658
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Like"
 msgstr[1] "%{formatted} Likes"
 
-#: lib/vutuv_web/components/post_components.ex:4628
+#: lib/vutuv_web/components/post_components.ex:4662
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -16171,7 +16173,7 @@ msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:998
-#: lib/vutuv_web/components/post_components.ex:4579
+#: lib/vutuv_web/components/post_components.ex:4613
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Bereits in den Zahlen oben enthalten."
@@ -16187,14 +16189,14 @@ msgstr "Antworten, die dort draußen geschrieben werden, erscheinen unter Ihrem 
 msgid "Content warning"
 msgstr "Inhaltswarnung"
 
-#: lib/vutuv_web/components/post_components.ex:1117
-#: lib/vutuv_web/components/post_components.ex:1673
+#: lib/vutuv_web/components/post_components.ex:1147
+#: lib/vutuv_web/components/post_components.ex:1703
 #: lib/vutuv_web/live/fediverse_account_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr "Aus einem anderen Netzwerk"
 
-#: lib/vutuv_web/components/post_components.ex:1004
+#: lib/vutuv_web/components/post_components.ex:1034
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr "Diese Antwort aus Ihrem Beitrag entfernen?"
@@ -16221,7 +16223,7 @@ msgstr "Antwort aus einem anderen Netzwerk"
 msgid "Reply removed."
 msgstr "Antwort entfernt."
 
-#: lib/vutuv_web/components/post_components.ex:1013
+#: lib/vutuv_web/components/post_components.ex:1043
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
@@ -16231,7 +16233,7 @@ msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
 msgid "Reported as not appropriate"
 msgstr "Als unangemessen gemeldet"
 
-#: lib/vutuv_web/components/post_components.ex:1027
+#: lib/vutuv_web/components/post_components.ex:1057
 #: lib/vutuv_web/live/notification_live/index.ex:534
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -16263,9 +16265,9 @@ msgid "That reply is not yours to remove."
 msgstr "Diese Antwort können Sie nicht entfernen."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1182
-#: lib/vutuv_web/components/post_components.ex:1048
-#: lib/vutuv_web/components/post_components.ex:1248
-#: lib/vutuv_web/components/post_components.ex:2046
+#: lib/vutuv_web/components/post_components.ex:1078
+#: lib/vutuv_web/components/post_components.ex:1278
+#: lib/vutuv_web/components/post_components.ex:2076
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr "Original ansehen"
@@ -16931,22 +16933,22 @@ msgstr "Was sich an welchem Konto geändert hat, wann, von welchem Gerät und wi
 msgid "device or detail"
 msgstr "Gerät oder Detail"
 
-#: lib/vutuv_web/components/post_components.ex:2631
+#: lib/vutuv_web/components/post_components.ex:2661
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Angehefteter Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:2738
+#: lib/vutuv_web/components/post_components.ex:2772
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "An Profil anheften"
 
-#: lib/vutuv_web/components/post_components.ex:2746
+#: lib/vutuv_web/components/post_components.ex:2780
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Vom Profil lösen"
 
-#: lib/vutuv_web/components/post_components.ex:2732
+#: lib/vutuv_web/components/post_components.ex:2766
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr "Es lässt sich nur ein Beitrag an Ihr Profil anheften. Diesen anheften und den anderen lösen?"
@@ -17038,7 +17040,7 @@ msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1110
 #: lib/vutuv_web/agent_docs/text.ex:665
-#: lib/vutuv_web/components/post_components.ex:3205
+#: lib/vutuv_web/components/post_components.ex:3239
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr "Original herunterladen"
@@ -17068,7 +17070,7 @@ msgstr "Volle Auflösung, direkt aus dem Beitrag."
 msgid "Just the picture"
 msgstr "Nur das Bild"
 
-#: lib/vutuv_web/components/post_components.ex:3204
+#: lib/vutuv_web/components/post_components.ex:3238
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr "Nächstes Foto"
@@ -17078,29 +17080,29 @@ msgstr "Nächstes Foto"
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
 
-#: lib/vutuv_web/components/post_components.ex:3585
+#: lib/vutuv_web/components/post_components.ex:3619
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post so far."
 msgstr "Bisher sehen nur Sie diesen Beitrag."
 
-#: lib/vutuv_web/components/post_components.ex:2179
+#: lib/vutuv_web/components/post_components.ex:2209
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Fediverse-Einstellungen öffnen"
 
-#: lib/vutuv_web/components/post_components.ex:3588
+#: lib/vutuv_web/components/post_components.ex:3622
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] "Unsere KI prüft das Foto. Sobald es durch ist, geht der Beitrag von selbst online."
 msgstr[1] "Unsere KI prüft die Fotos, %{done} von %{total} sind durch. Sobald das letzte durch ist, geht der Beitrag von selbst online."
 
-#: lib/vutuv_web/components/post_components.ex:3411
+#: lib/vutuv_web/components/post_components.ex:3445
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} von %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:2947
+#: lib/vutuv_web/components/post_components.ex:2981
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
@@ -17113,12 +17115,12 @@ msgstr "Foto-Einstellungen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1143
 #: lib/vutuv_web/agent_docs/text.ex:652
-#: lib/vutuv_web/components/post_components.ex:3622
+#: lib/vutuv_web/components/post_components.ex:3656
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Fotos:"
 
-#: lib/vutuv_web/components/post_components.ex:3203
+#: lib/vutuv_web/components/post_components.ex:3237
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr "Vorheriges Foto"
@@ -17139,7 +17141,7 @@ msgstr "Dieselben Bildpunkte, sonst nichts: Ort und Seriennummern entfernt, Qual
 msgid "Show camera settings"
 msgstr "Kameradaten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2232
+#: lib/vutuv_web/components/post_components.ex:2262
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr "Dieser Server ist auf dieser Seite gesperrt, deshalb kann keine Antwort dorthin gesendet werden."
@@ -17159,7 +17161,7 @@ msgstr "Dieses Dateiformat lässt sich nur unverändert weitergeben. Entfernen S
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr "Dieses Foto enthält den Ort, an dem es aufgenommen wurde. Wer die exakte Datei herunterlädt, kann ihn auslesen."
 
-#: lib/vutuv_web/components/post_components.ex:2223
+#: lib/vutuv_web/components/post_components.ex:2253
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht öffentlich beantworten."
@@ -17169,12 +17171,12 @@ msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht �
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr "Diese Antwort wurde in einem anderen Netzwerk geschrieben. Sie zu beantworten heißt, Ihre Worte in dieses Netzwerk zu senden, und das tut vutuv nur für Mitglieder, die die Fediverse-Teilnahme eingeschaltet haben."
 
-#: lib/vutuv_web/components/post_components.ex:2241
+#: lib/vutuv_web/components/post_components.ex:2271
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Diese Seite nimmt nicht am Fediverse teil."
 
-#: lib/vutuv_web/components/post_components.ex:2175
+#: lib/vutuv_web/components/post_components.ex:2205
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Fediverse-Teilnahme einschalten, um zu antworten"
@@ -17189,7 +17191,7 @@ msgstr "Wer diese Fotos weiterverwenden darf"
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke geschickt. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:2236
+#: lib/vutuv_web/components/post_components.ex:2266
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshalb werden von hier aus keine Antworten mehr gesendet."
@@ -17199,7 +17201,7 @@ msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshal
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr "Ihre Fediverse-Einstellungen erlauben es derzeit nicht, eine Antwort zu senden."
 
-#: lib/vutuv_web/components/post_components.ex:2189
+#: lib/vutuv_web/components/post_components.ex:2219
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr "Ihre Antwort geht an %{handle} auf dem eigenen Server und an Ihre Fediverse-Follower. Auf vutuv ist sie ebenfalls ein öffentlicher Beitrag."
@@ -17286,13 +17288,13 @@ msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exak
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1016
-#: lib/vutuv_web/components/post_components.ex:4617
+#: lib/vutuv_web/components/post_components.ex:4651
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1014
-#: lib/vutuv_web/components/post_components.ex:4614
+#: lib/vutuv_web/components/post_components.ex:4648
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} hat das geteilt"
@@ -17302,7 +17304,7 @@ msgstr "%{handle} hat das geteilt"
 msgid "Fediverse reactions"
 msgstr "Fediverse-Reaktionen"
 
-#: lib/vutuv_web/components/post_components.ex:4506
+#: lib/vutuv_web/components/post_components.ex:4540
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
@@ -17648,7 +17650,7 @@ msgstr "Von hier aus wird %{follows} Konten in anderen Netzwerken gefolgt, davon
 msgid "Cached posts"
 msgstr "Zwischengespeicherte Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:2001
+#: lib/vutuv_web/components/post_components.ex:2031
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr "Nur für die Follower dieses Kontos"
@@ -17662,7 +17664,7 @@ msgstr "Nur für die Follower dieses Kontos"
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Danke. Unsere Kopie wurde sofort gelöscht."
 
-#: lib/vutuv_web/components/post_components.ex:2045
+#: lib/vutuv_web/components/post_components.ex:2075
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Beim Original abstimmen"
@@ -17682,17 +17684,17 @@ msgstr "Zwischengespeicherter Beitrag gemeldet, hier für alle entfernt"
 msgid "Content from other networks taken down by members"
 msgstr "Von Mitgliedern entfernte Inhalte aus anderen Netzwerken"
 
-#: lib/vutuv_web/components/post_components.ex:1372
+#: lib/vutuv_web/components/post_components.ex:1402
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr "Verbergen"
 
-#: lib/vutuv_web/components/post_components.ex:2018
+#: lib/vutuv_web/components/post_components.ex:2048
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Von der verfassenden Person als sensibel markiert"
 
-#: lib/vutuv_web/components/post_components.ex:1980
+#: lib/vutuv_web/components/post_components.ex:2010
 #, elixir-autogen, elixir-format
 msgid "Mute %{handle}"
 msgstr "%{handle} stummschalten"
@@ -17709,7 +17711,7 @@ msgstr "Stummgeschaltet. Sie folgen dem Konto weiterhin; die Beiträge verschwin
 msgid "Nobody has removed or reported anything yet."
 msgstr "Bisher hat niemand etwas entfernt oder gemeldet."
 
-#: lib/vutuv_web/components/post_components.ex:1987
+#: lib/vutuv_web/components/post_components.ex:2017
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr "Diesen Beitrag als unangemessen melden? Unsere Kopie wird sofort für alle auf diesem vutuv gelöscht."
@@ -17931,27 +17933,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] "(ein Bild)"
 msgstr[1] "(%{count} Bilder)"
 
-#: lib/vutuv_web/components/post_components.ex:1776
+#: lib/vutuv_web/components/post_components.ex:1806
 #, elixir-autogen, elixir-format
 msgid "A picture is on its way."
 msgstr "Ein Bild ist unterwegs."
 
-#: lib/vutuv_web/components/post_components.ex:1805
+#: lib/vutuv_web/components/post_components.ex:1835
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr "Wieder verdecken"
 
-#: lib/vutuv_web/components/post_components.ex:1800
+#: lib/vutuv_web/components/post_components.ex:1830
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr "Heikles Motiv. Bild anzeigen."
 
-#: lib/vutuv_web/components/post_components.ex:2082
+#: lib/vutuv_web/components/post_components.ex:2112
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Das sind viele Likes in einer Stunde. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:2088
+#: lib/vutuv_web/components/post_components.ex:2118
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Diesen Beitrag gibt es hier nicht mehr."
@@ -17961,7 +17963,7 @@ msgstr "Diesen Beitrag gibt es hier nicht mehr."
 msgid "Back to the feed"
 msgstr "Zurück zum Feed"
 
-#: lib/vutuv_web/components/post_components.ex:2227
+#: lib/vutuv_web/components/post_components.ex:2257
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -18694,14 +18696,14 @@ msgstr "Seiten, von denen nie ein Screenshot entsteht, weil ein Browser ohne Anz
 msgid "Screenshot blocklist"
 msgstr "Screenshot-Blockliste"
 
-#: lib/vutuv_web/components/post_components.ex:380
+#: lib/vutuv_web/components/post_components.ex:410
 #, elixir-autogen, elixir-format
 msgid "Nothing from the fediverse yet. Follow accounts out there to fill this tab."
 msgstr ""
 "Noch nichts aus dem Fediverse. Folgen Sie Konten dort draußen, um diesen Tab "
 "zu füllen."
 
-#: lib/vutuv_web/components/post_components.ex:377
+#: lib/vutuv_web/components/post_components.ex:407
 #, elixir-autogen, elixir-format
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
@@ -18744,7 +18746,7 @@ msgstr "Auf vutuv gibt es zu diesem Tag noch keine Beiträge."
 msgid "word in a post"
 msgstr "Wort in einem Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:2085
+#: lib/vutuv_web/components/post_components.ex:2115
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr "Diese Antwort gibt es hier nicht mehr."
@@ -19060,19 +19062,19 @@ msgstr "Auf der Seite eines Beitrags stehen direkt unter der Zahl die Mitglieder
 msgid "Liked by"
 msgstr "Gefällt diesen Mitgliedern"
 
-#: lib/vutuv_web/components/post_components.ex:3788
+#: lib/vutuv_web/components/post_components.ex:3822
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Gefällt %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:3790
+#: lib/vutuv_web/components/post_components.ex:3824
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Gefällt %{name} und %{formatted} weiteren"
 msgstr[1] "Gefällt %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/components/post_components.ex:3801
+#: lib/vutuv_web/components/post_components.ex:3835
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr "Nur Sie sehen hier alle: Einige dieser Mitglieder werden anderen Lesern nicht genannt."
@@ -20771,7 +20773,7 @@ msgstr "Suchen Sie so oft Sie möchten und nehmen Sie dazu, was gehört. Abkürz
 msgid "Start over"
 msgstr "Von vorn beginnen"
 
-#: lib/vutuv_web/components/post_components.ex:2115
+#: lib/vutuv_web/components/post_components.ex:2145
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr "Ein Herz oder ein Repost geht zurück in das Netzwerk, aus dem dieser Beitrag stammt. Ihr Konto nimmt derzeit nicht am Fediverse teil. Einschalten können Sie das in den {settings}."
@@ -20786,7 +20788,7 @@ msgstr "Redaktion"
 msgid "Edits the page and posts jobs."
 msgstr "Bearbeitet die Seite und schreibt Stellen aus."
 
-#: lib/vutuv_web/live/organization_live/roles.ex:162
+#: lib/vutuv_web/live/organization_live/roles.ex:167
 #, elixir-autogen, elixir-format
 msgid "Give members their roles on this page. Someone can hold several at once, and every role is granted on its own."
 msgstr "Geben Sie Mitgliedern ihre Rollen auf dieser Seite. Jemand kann mehrere gleichzeitig haben, und jede Rolle wird einzeln vergeben."
@@ -20806,7 +20808,7 @@ msgstr "Wählen Sie mindestens eine Rolle."
 msgid "Posts jobs."
 msgstr "Schreibt Stellen aus."
 
-#: lib/vutuv_web/live/organization_live/roles.ex:265
+#: lib/vutuv_web/live/organization_live/roles.ex:270
 #, elixir-autogen, elixir-format
 msgid "Roles"
 msgstr "Rollen"
@@ -20825,3 +20827,33 @@ msgstr "Schreibt Beiträge im Namen der Organisation."
 #, elixir-autogen, elixir-format
 msgid "The owner gives other members their roles on the page, and can hand ownership over to someone else at any time. Someone can hold several roles, and writing in the organization's name is always granted on its own."
 msgstr "Der Besitzer vergibt die Rollen der anderen Mitglieder auf der Seite und kann den Besitz jederzeit an jemand anderen übergeben. Jemand kann mehrere Rollen haben, und das Schreiben im Namen der Organisation wird immer einzeln vergeben."
+
+#: lib/vutuv_web/live/organization_live/show.ex:406
+#, elixir-autogen, elixir-format
+msgid "Nothing published yet."
+msgstr "Noch nichts veröffentlicht."
+
+#: lib/vutuv_web/live/organization_live/show.ex:388
+#, elixir-autogen, elixir-format
+msgid "Post as %{name}"
+msgstr "Als %{name} veröffentlichen"
+
+#: lib/vutuv_web/live/organization_live/show.ex:154
+#, elixir-autogen, elixir-format
+msgid "Published as %{name}."
+msgstr "Als %{name} veröffentlicht."
+
+#: lib/vutuv_web/live/organization_live/show.ex:166
+#, elixir-autogen, elixir-format
+msgid "That post could not be published."
+msgstr "Dieser Beitrag konnte nicht veröffentlicht werden."
+
+#: lib/vutuv_web/live/organization_live/show.ex:380
+#, elixir-autogen, elixir-format
+msgid "Write something as %{name}"
+msgstr "Schreiben Sie etwas als %{name}"
+
+#: lib/vutuv_web/live/organization_live/show.ex:160
+#, elixir-autogen, elixir-format
+msgid "You may no longer write in this organization's name."
+msgstr "Sie dürfen nicht mehr im Namen dieser Organisation schreiben."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -23,7 +23,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:718
 #: lib/vutuv_web/live/organization_live/domains.ex:255
 #: lib/vutuv_web/live/organization_live/edit.ex:396
-#: lib/vutuv_web/live/organization_live/roles.ex:205
+#: lib/vutuv_web/live/organization_live/roles.ex:210
 #, elixir-autogen
 msgid "Add"
 msgstr ""
@@ -34,7 +34,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
-#: lib/vutuv_web/live/organization_live/show.ex:350
+#: lib/vutuv_web/live/organization_live/show.ex:471
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
@@ -160,7 +160,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2754
+#: lib/vutuv_web/components/post_components.ex:2788
 #: lib/vutuv_web/components/ui.ex:3326
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -209,13 +209,13 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2719
+#: lib/vutuv_web/components/post_components.ex:2753
 #: lib/vutuv_web/components/ui.ex:3317
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
 #: lib/vutuv_web/live/job_posting_live/show.ex:178
-#: lib/vutuv_web/live/organization_live/show.ex:263
+#: lib/vutuv_web/live/organization_live/show.ex:323
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:7
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:19
@@ -653,7 +653,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1369
+#: lib/vutuv_web/components/post_components.ex:1399
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -1614,7 +1614,7 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3202
+#: lib/vutuv_web/components/post_components.ex:3236
 #: lib/vutuv_web/components/ui.ex:280
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
@@ -1745,7 +1745,7 @@ msgstr ""
 msgid "Network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:391
+#: lib/vutuv_web/components/post_components.ex:421
 #: lib/vutuv_web/components/ui.ex:3436
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:705
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:742
@@ -1915,6 +1915,7 @@ msgid "Pagination"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3461
+#: lib/vutuv_web/live/organization_live/show.ex:411
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr ""
@@ -2092,7 +2093,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2751
+#: lib/vutuv_web/components/post_components.ex:2785
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2133,8 +2134,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2705
-#: lib/vutuv_web/components/post_components.ex:2707
+#: lib/vutuv_web/components/post_components.ex:2739
+#: lib/vutuv_web/components/post_components.ex:2741
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2190,6 +2191,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:382
 #: lib/vutuv_web/live/notification_live/index.ex:876
+#: lib/vutuv_web/live/organization_live/show.ex:361
 #: lib/vutuv_web/live/post_live/saved.ex:495
 #: lib/vutuv_web/live/search_live.ex:200
 #: lib/vutuv_web/live/search_live.ex:530
@@ -2199,13 +2201,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3138
-#: lib/vutuv_web/components/post_components.ex:3142
+#: lib/vutuv_web/components/post_components.ex:3172
+#: lib/vutuv_web/components/post_components.ex:3176
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3139
+#: lib/vutuv_web/components/post_components.ex:3173
 #: lib/vutuv_web/live/fediverse_account_live.ex:320
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2213,13 +2215,13 @@ msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:252
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:1006
+#: lib/vutuv_web/components/post_components.ex:1036
 #: lib/vutuv_web/live/admin/screenshot_live.ex:317
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:700
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:373
-#: lib/vutuv_web/live/organization_live/roles.ex:238
+#: lib/vutuv_web/live/organization_live/roles.ex:243
 #: lib/vutuv_web/live/post_live/composer.ex:1851
 #: lib/vutuv_web/live/post_live/saved.ex:619
 #: lib/vutuv_web/live/post_live/saved.ex:647
@@ -2295,27 +2297,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2702
+#: lib/vutuv_web/components/post_components.ex:2736
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4346
+#: lib/vutuv_web/components/post_components.ex:4380
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4350
+#: lib/vutuv_web/components/post_components.ex:4384
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4348
+#: lib/vutuv_web/components/post_components.ex:4382
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4349
+#: lib/vutuv_web/components/post_components.ex:4383
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2356,8 +2358,8 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1553
-#: lib/vutuv_web/components/post_components.ex:4430
+#: lib/vutuv_web/components/post_components.ex:1583
+#: lib/vutuv_web/components/post_components.ex:4464
 #: lib/vutuv_web/components/ui.ex:2851
 #: lib/vutuv_web/views/user_html.ex:333
 #, elixir-autogen, elixir-format
@@ -2375,8 +2377,8 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1517
-#: lib/vutuv_web/components/post_components.ex:4653
+#: lib/vutuv_web/components/post_components.ex:1547
+#: lib/vutuv_web/components/post_components.ex:4687
 #: lib/vutuv_web/components/ui.ex:2837
 #: lib/vutuv_web/live/notification_live/index.ex:1023
 #: lib/vutuv_web/views/user_html.ex:343
@@ -2385,7 +2387,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:960
-#: lib/vutuv_web/components/post_components.ex:4662
+#: lib/vutuv_web/components/post_components.ex:4696
 #: lib/vutuv_web/live/notification_live/index.ex:956
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
@@ -2407,39 +2409,39 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4419
+#: lib/vutuv_web/components/post_components.ex:4453
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1553
-#: lib/vutuv_web/components/post_components.ex:4430
+#: lib/vutuv_web/components/post_components.ex:1583
+#: lib/vutuv_web/components/post_components.ex:4464
 #: lib/vutuv_web/live/post_live/saved.ex:775
 #: lib/vutuv_web/views/user_html.ex:333
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1541
-#: lib/vutuv_web/components/post_components.ex:4416
+#: lib/vutuv_web/components/post_components.ex:1571
+#: lib/vutuv_web/components/post_components.ex:4450
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1731
-#: lib/vutuv_web/components/post_components.ex:3718
+#: lib/vutuv_web/components/post_components.ex:1761
+#: lib/vutuv_web/components/post_components.ex:3752
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1541
-#: lib/vutuv_web/components/post_components.ex:4416
+#: lib/vutuv_web/components/post_components.ex:1571
+#: lib/vutuv_web/components/post_components.ex:4450
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4653
+#: lib/vutuv_web/components/post_components.ex:4687
 #: lib/vutuv_web/live/post_live/saved.ex:774
 #: lib/vutuv_web/views/user_html.ex:343
 #, elixir-autogen, elixir-format
@@ -2461,27 +2463,27 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4706
+#: lib/vutuv_web/components/post_components.ex:4740
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:349
+#: lib/vutuv_web/components/post_components.ex:379
 #: lib/vutuv_web/live/notification_live/index.ex:957
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1528
-#: lib/vutuv_web/components/post_components.ex:4689
-#: lib/vutuv_web/components/post_components.ex:4690
+#: lib/vutuv_web/components/post_components.ex:1558
+#: lib/vutuv_web/components/post_components.ex:4723
+#: lib/vutuv_web/components/post_components.ex:4724
 #: lib/vutuv_web/live/notification_live/index.ex:1020
 #: lib/vutuv_web/live/post_live/reply.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2673
+#: lib/vutuv_web/components/post_components.ex:2703
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2502,7 +2504,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2167
+#: lib/vutuv_web/components/post_components.ex:2197
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:59
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:50
@@ -2510,14 +2512,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2649
+#: lib/vutuv_web/components/post_components.ex:2679
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2643
-#: lib/vutuv_web/components/post_components.ex:2665
-#: lib/vutuv_web/components/post_components.ex:2668
+#: lib/vutuv_web/components/post_components.ex:2673
+#: lib/vutuv_web/components/post_components.ex:2695
+#: lib/vutuv_web/components/post_components.ex:2698
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2818,7 +2820,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4347
+#: lib/vutuv_web/components/post_components.ex:4381
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3079,7 +3081,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2619
+#: lib/vutuv_web/components/post_components.ex:2649
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3154,10 +3156,10 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1016
-#: lib/vutuv_web/components/post_components.ex:1992
-#: lib/vutuv_web/components/post_components.ex:2775
-#: lib/vutuv_web/live/organization_live/show.ex:284
+#: lib/vutuv_web/components/post_components.ex:1046
+#: lib/vutuv_web/components/post_components.ex:2022
+#: lib/vutuv_web/components/post_components.ex:2809
+#: lib/vutuv_web/live/organization_live/show.ex:344
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Report"
@@ -4574,7 +4576,7 @@ msgstr ""
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:516
 #: lib/vutuv_web/live/notification_live/index.ex:877
-#: lib/vutuv_web/live/organization_live/show.ex:300
+#: lib/vutuv_web/live/organization_live/show.ex:421
 #: lib/vutuv_web/live/post_live/saved.ex:498
 #: lib/vutuv_web/live/search_live.ex:198
 #: lib/vutuv_web/live/search_live.ex:472
@@ -4592,8 +4594,8 @@ msgstr ""
 msgid "Similar names"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:346
-#: lib/vutuv_web/components/post_components.ex:365
+#: lib/vutuv_web/components/post_components.ex:376
+#: lib/vutuv_web/components/post_components.ex:395
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/notification_live/index.ex:875
@@ -5389,9 +5391,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2838
-#: lib/vutuv_web/components/post_components.ex:2890
-#: lib/vutuv_web/components/post_components.ex:3282
+#: lib/vutuv_web/components/post_components.ex:2872
+#: lib/vutuv_web/components/post_components.ex:2924
+#: lib/vutuv_web/components/post_components.ex:3316
 #: lib/vutuv_web/live/notification_live/index.ex:680
 #: lib/vutuv_web/live/post_live/feed.ex:1259
 #: lib/vutuv_web/views/user_html.ex:111
@@ -6186,7 +6188,7 @@ msgid "Previous day"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:960
-#: lib/vutuv_web/components/post_components.ex:348
+#: lib/vutuv_web/components/post_components.ex:378
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
@@ -6624,7 +6626,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2772
+#: lib/vutuv_web/components/post_components.ex:2806
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6634,7 +6636,7 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2771
+#: lib/vutuv_web/components/post_components.ex:2805
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -7316,7 +7318,7 @@ msgstr ""
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4575
+#: lib/vutuv_web/components/post_components.ex:4609
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8783,7 +8785,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3721
+#: lib/vutuv_web/components/post_components.ex:3755
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -11026,7 +11028,7 @@ msgstr ""
 msgid "AI agents"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:291
+#: lib/vutuv_web/live/organization_live/show.ex:351
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
@@ -11039,7 +11041,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:248
 #: lib/vutuv_web/live/organization_live/domains.ex:288
 #: lib/vutuv_web/live/organization_live/new.ex:146
-#: lib/vutuv_web/live/organization_live/show.ex:424
+#: lib/vutuv_web/live/organization_live/show.ex:545
 #: lib/vutuv_web/templates/url/verify.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "DNS TXT record"
@@ -11047,8 +11049,8 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:153
 #: lib/vutuv_web/live/organization_live/domains.ex:167
-#: lib/vutuv_web/live/organization_live/show.ex:203
-#: lib/vutuv_web/live/organization_live/show.ex:483
+#: lib/vutuv_web/live/organization_live/show.ex:263
+#: lib/vutuv_web/live/organization_live/show.ex:604
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr ""
@@ -11079,13 +11081,13 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) and list them for AI agents."
 msgstr ""
 
-#: lib/vutuv_web/controllers/organization_controller.ex:144
+#: lib/vutuv_web/controllers/organization_controller.ex:171
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:31
 #, elixir-autogen, elixir-format
 msgid "Please log in first."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:397
+#: lib/vutuv_web/live/organization_live/show.ex:518
 #, elixir-autogen, elixir-format
 msgid "Prove you control %{domain} to publish this page."
 msgstr ""
@@ -11112,7 +11114,7 @@ msgid "Select a country"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:307
-#: lib/vutuv_web/live/organization_live/show.ex:459
+#: lib/vutuv_web/live/organization_live/show.ex:580
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr ""
@@ -11139,12 +11141,12 @@ msgid "The upload failed."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/new.ex:131
-#: lib/vutuv_web/live/organization_live/show.ex:412
+#: lib/vutuv_web/live/organization_live/show.ex:533
 #, elixir-autogen, elixir-format
 msgid "Verification method"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:372
+#: lib/vutuv_web/live/organization_live/show.ex:493
 #, elixir-autogen, elixir-format
 msgid "Verified domains"
 msgstr ""
@@ -11160,19 +11162,19 @@ msgstr ""
 msgid "Verified via %{domain}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:394
+#: lib/vutuv_web/live/organization_live/show.ex:515
 #, elixir-autogen, elixir-format
 msgid "Verify %{name}"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:320
-#: lib/vutuv_web/live/organization_live/show.ex:479
+#: lib/vutuv_web/live/organization_live/show.ex:600
 #, elixir-autogen, elixir-format
 msgid "Verify now"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:149
-#: lib/vutuv_web/live/organization_live/show.ex:198
+#: lib/vutuv_web/live/organization_live/show.ex:258
 #, elixir-autogen, elixir-format
 msgid "We could not find the record or file yet. It can take a while to propagate. Please try again."
 msgstr ""
@@ -11187,7 +11189,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:249
 #: lib/vutuv_web/live/organization_live/domains.ex:298
-#: lib/vutuv_web/live/organization_live/show.ex:435
+#: lib/vutuv_web/live/organization_live/show.ex:556
 #: lib/vutuv_web/templates/url/verify.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Website file"
@@ -11209,13 +11211,13 @@ msgid "You will publish a record or file to prove control of the domain on the n
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:309
-#: lib/vutuv_web/live/organization_live/show.ex:465
+#: lib/vutuv_web/live/organization_live/show.ex:586
 #: lib/vutuv_web/templates/url/verify.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:175
+#: lib/vutuv_web/live/organization_live/roles.ex:180
 #, elixir-autogen, elixir-format
 msgid "@handle or email"
 msgstr ""
@@ -11231,12 +11233,12 @@ msgstr ""
 msgid "Add a domain"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:166
+#: lib/vutuv_web/live/organization_live/roles.ex:171
 #, elixir-autogen, elixir-format
 msgid "Add a member"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:138
+#: lib/vutuv_web/live/organization_live/roles.ex:143
 #, elixir-autogen, elixir-format
 msgid "Added @%{handle} to the team."
 msgstr ""
@@ -11260,7 +11262,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:322
 #: lib/vutuv_web/agent_docs/text.ex:348
 #: lib/vutuv_web/live/organization_live/edit.ex:353
-#: lib/vutuv_web/live/organization_live/show.ex:360
+#: lib/vutuv_web/live/organization_live/show.ex:481
 #: lib/vutuv_web/templates/tag/single_card.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Also known as"
@@ -11298,7 +11300,7 @@ msgstr ""
 msgid "Claimed by"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:211
+#: lib/vutuv_web/live/organization_live/roles.ex:216
 #, elixir-autogen, elixir-format
 msgid "Current team"
 msgstr ""
@@ -11326,7 +11328,7 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:211
 #: lib/vutuv_web/live/admin/organization_live.ex:305
 #: lib/vutuv_web/live/organization_live/domains.ex:161
-#: lib/vutuv_web/live/organization_live/show.ex:277
+#: lib/vutuv_web/live/organization_live/show.ex:337
 #, elixir-autogen, elixir-format
 msgid "Domains"
 msgstr ""
@@ -11359,7 +11361,7 @@ msgstr ""
 msgid "Last checked"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:238
+#: lib/vutuv_web/live/organization_live/roles.ex:243
 #, elixir-autogen, elixir-format
 msgid "Leave"
 msgstr ""
@@ -11424,7 +11426,7 @@ msgstr ""
 msgid "Remove this domain?"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:233
+#: lib/vutuv_web/live/organization_live/roles.ex:238
 #, elixir-autogen, elixir-format
 msgid "Remove this member from the team?"
 msgstr ""
@@ -11441,8 +11443,8 @@ msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:208
 #: lib/vutuv_web/live/admin/organization_live.ex:321
-#: lib/vutuv_web/live/organization_live/roles.ex:160
-#: lib/vutuv_web/live/organization_live/show.ex:270
+#: lib/vutuv_web/live/organization_live/roles.ex:165
+#: lib/vutuv_web/live/organization_live/show.ex:330
 #, elixir-autogen, elixir-format
 msgid "Team"
 msgstr ""
@@ -11457,7 +11459,7 @@ msgstr ""
 msgid "That is not a valid domain."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:141
+#: lib/vutuv_web/live/organization_live/roles.ex:146
 #, elixir-autogen, elixir-format
 msgid "That member could not be added."
 msgstr ""
@@ -11624,7 +11626,7 @@ msgstr ""
 msgid "%{min} to %{max} characters: letters (a-z), numbers (0-9) and underscores."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:315
+#: lib/vutuv_web/live/organization_live/show.ex:436
 #, elixir-autogen, elixir-format
 msgid "Former"
 msgstr ""
@@ -11685,7 +11687,7 @@ msgstr ""
 msgid "An organization keeps at least one verified domain, so this one cannot be removed."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:147
+#: lib/vutuv_web/live/organization_live/roles.ex:152
 #, elixir-autogen, elixir-format
 msgid "An organization must keep at least one owner, so the last owner cannot be changed."
 msgstr ""
@@ -11734,7 +11736,7 @@ msgstr ""
 msgid "The proof is a small technical change to your domain: a DNS entry or a file on your website. If you don't manage the website yourself, ask the person or team who does. That is usually your IT department or the company that runs your website. We show the exact instructions on the next step, so you can simply pass them on."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:406
+#: lib/vutuv_web/live/organization_live/show.ex:527
 #, elixir-autogen, elixir-format
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr ""
@@ -11755,7 +11757,7 @@ msgstr ""
 msgid "Kind of organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:232
+#: lib/vutuv_web/live/organization_live/roles.ex:237
 #, elixir-autogen, elixir-format
 msgid "Leave this organization team?"
 msgstr ""
@@ -11844,7 +11846,7 @@ msgstr ""
 msgid "Organization unfrozen."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/organization_doc.ex:91
+#: lib/vutuv_web/agent_docs/organization_doc.ex:108
 #: lib/vutuv_web/components/ui.ex:3719
 #: lib/vutuv_web/controllers/settings_controller.ex:178
 #: lib/vutuv_web/live/organization_live/index.ex:30
@@ -11863,12 +11865,12 @@ msgstr ""
 msgid "Please choose"
 msgstr ""
 
-#: lib/vutuv_web/controllers/organization_controller.ex:111
+#: lib/vutuv_web/controllers/organization_controller.ex:113
 #, elixir-autogen, elixir-format
 msgid "Please confirm your email address before claiming an organization page."
 msgstr ""
 
-#: lib/vutuv_web/controllers/organization_controller.ex:117
+#: lib/vutuv_web/controllers/organization_controller.ex:119
 #, elixir-autogen, elixir-format
 msgid "Please log in to claim an organization page."
 msgstr ""
@@ -11898,7 +11900,7 @@ msgstr ""
 msgid "The organization page was deleted."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:210
+#: lib/vutuv_web/live/organization_live/show.ex:270
 #, elixir-autogen, elixir-format
 msgid "This organization page was reported and is hidden while it is reviewed. Only you and the moderators can see it."
 msgstr ""
@@ -11908,7 +11910,7 @@ msgstr ""
 msgid "Verified organization pages on vutuv, each with a proven web domain."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/organization_doc.ex:92
+#: lib/vutuv_web/agent_docs/organization_doc.ex:109
 #, elixir-autogen, elixir-format
 msgid "Verified organization pages on vutuv."
 msgstr ""
@@ -11928,7 +11930,7 @@ msgstr ""
 msgid "Your organization handle is set."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:164
+#: lib/vutuv_web/live/organization_live/show.ex:224
 #, elixir-autogen, elixir-format
 msgid "Your organization page is verified and now live."
 msgstr ""
@@ -12628,13 +12630,13 @@ msgid "Getting an error, or is %{host} a CNAME / alias to another address? A TXT
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:305
-#: lib/vutuv_web/live/organization_live/show.ex:452
+#: lib/vutuv_web/live/organization_live/show.ex:573
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:303
-#: lib/vutuv_web/live/organization_live/show.ex:443
+#: lib/vutuv_web/live/organization_live/show.ex:564
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
 msgstr ""
@@ -12730,7 +12732,7 @@ msgid "Minimum yearly salary"
 msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:324
-#: lib/vutuv_web/live/organization_live/show.ex:342
+#: lib/vutuv_web/live/organization_live/show.ex:463
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr ""
@@ -12759,7 +12761,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:400
 #: lib/vutuv_web/agent_docs/text.ex:412
 #: lib/vutuv_web/agent_docs/text.ex:424
-#: lib/vutuv_web/live/organization_live/show.ex:329
+#: lib/vutuv_web/live/organization_live/show.ex:450
 #: lib/vutuv_web/templates/tag/show.html.heex:45
 #, elixir-autogen, elixir-format
 msgid "Open positions"
@@ -13078,7 +13080,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2126
+#: lib/vutuv_web/components/post_components.ex:2156
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:650
 #: lib/vutuv_web/controllers/settings_controller.ex:668
@@ -13490,22 +13492,22 @@ msgstr ""
 msgid "Work mobile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:388
+#: lib/vutuv_web/components/post_components.ex:418
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:390
+#: lib/vutuv_web/components/post_components.ex:420
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:389
+#: lib/vutuv_web/components/post_components.ex:419
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:347
+#: lib/vutuv_web/components/post_components.ex:377
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr ""
@@ -13680,34 +13682,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4209
+#: lib/vutuv_web/components/post_components.ex:4243
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1049
-#: lib/vutuv_web/components/post_components.ex:4166
+#: lib/vutuv_web/components/post_components.ex:4200
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4210
+#: lib/vutuv_web/components/post_components.ex:4244
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4212
+#: lib/vutuv_web/components/post_components.ex:4246
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4208
+#: lib/vutuv_web/components/post_components.ex:4242
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1049
-#: lib/vutuv_web/components/post_components.ex:4165
+#: lib/vutuv_web/components/post_components.ex:4199
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13718,12 +13720,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4207
+#: lib/vutuv_web/components/post_components.ex:4241
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4211
+#: lib/vutuv_web/components/post_components.ex:4245
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13743,7 +13745,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4248
+#: lib/vutuv_web/components/post_components.ex:4282
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13751,27 +13753,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4278
+#: lib/vutuv_web/components/post_components.ex:4312
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4279
+#: lib/vutuv_web/components/post_components.ex:4313
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4277
+#: lib/vutuv_web/components/post_components.ex:4311
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4237
+#: lib/vutuv_web/components/post_components.ex:4271
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4284
+#: lib/vutuv_web/components/post_components.ex:4318
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13801,7 +13803,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4051
+#: lib/vutuv_web/components/post_components.ex:4085
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13849,7 +13851,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4042
+#: lib/vutuv_web/components/post_components.ex:4076
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14219,14 +14221,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2390
+#: lib/vutuv_web/components/post_components.ex:2420
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2412
+#: lib/vutuv_web/components/post_components.ex:2442
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14253,7 +14255,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4661
+#: lib/vutuv_web/components/post_components.ex:4695
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -15424,21 +15426,21 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4620
+#: lib/vutuv_web/components/post_components.ex:4654
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4624
+#: lib/vutuv_web/components/post_components.ex:4658
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4628
+#: lib/vutuv_web/components/post_components.ex:4662
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15446,7 +15448,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:998
-#: lib/vutuv_web/components/post_components.ex:4579
+#: lib/vutuv_web/components/post_components.ex:4613
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15462,14 +15464,14 @@ msgstr ""
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1117
-#: lib/vutuv_web/components/post_components.ex:1673
+#: lib/vutuv_web/components/post_components.ex:1147
+#: lib/vutuv_web/components/post_components.ex:1703
 #: lib/vutuv_web/live/fediverse_account_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1004
+#: lib/vutuv_web/components/post_components.ex:1034
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15496,7 +15498,7 @@ msgstr ""
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1013
+#: lib/vutuv_web/components/post_components.ex:1043
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15506,7 +15508,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1027
+#: lib/vutuv_web/components/post_components.ex:1057
 #: lib/vutuv_web/live/notification_live/index.ex:534
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -15538,9 +15540,9 @@ msgid "That reply is not yours to remove."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1182
-#: lib/vutuv_web/components/post_components.ex:1048
-#: lib/vutuv_web/components/post_components.ex:1248
-#: lib/vutuv_web/components/post_components.ex:2046
+#: lib/vutuv_web/components/post_components.ex:1078
+#: lib/vutuv_web/components/post_components.ex:1278
+#: lib/vutuv_web/components/post_components.ex:2076
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -16202,22 +16204,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2631
+#: lib/vutuv_web/components/post_components.ex:2661
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2738
+#: lib/vutuv_web/components/post_components.ex:2772
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2746
+#: lib/vutuv_web/components/post_components.ex:2780
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2732
+#: lib/vutuv_web/components/post_components.ex:2766
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16303,7 +16305,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1110
 #: lib/vutuv_web/agent_docs/text.ex:665
-#: lib/vutuv_web/components/post_components.ex:3205
+#: lib/vutuv_web/components/post_components.ex:3239
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
@@ -16333,7 +16335,7 @@ msgstr ""
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3204
+#: lib/vutuv_web/components/post_components.ex:3238
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
@@ -16343,29 +16345,29 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3585
+#: lib/vutuv_web/components/post_components.ex:3619
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post so far."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2179
+#: lib/vutuv_web/components/post_components.ex:2209
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3588
+#: lib/vutuv_web/components/post_components.ex:3622
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3411
+#: lib/vutuv_web/components/post_components.ex:3445
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2947
+#: lib/vutuv_web/components/post_components.ex:2981
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16378,12 +16380,12 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1143
 #: lib/vutuv_web/agent_docs/text.ex:652
-#: lib/vutuv_web/components/post_components.ex:3622
+#: lib/vutuv_web/components/post_components.ex:3656
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3203
+#: lib/vutuv_web/components/post_components.ex:3237
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr ""
@@ -16404,7 +16406,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2232
+#: lib/vutuv_web/components/post_components.ex:2262
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16424,7 +16426,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2223
+#: lib/vutuv_web/components/post_components.ex:2253
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16434,12 +16436,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2241
+#: lib/vutuv_web/components/post_components.ex:2271
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2175
+#: lib/vutuv_web/components/post_components.ex:2205
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16454,7 +16456,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2236
+#: lib/vutuv_web/components/post_components.ex:2266
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16464,7 +16466,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2189
+#: lib/vutuv_web/components/post_components.ex:2219
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16551,13 +16553,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1016
-#: lib/vutuv_web/components/post_components.ex:4617
+#: lib/vutuv_web/components/post_components.ex:4651
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1014
-#: lib/vutuv_web/components/post_components.ex:4614
+#: lib/vutuv_web/components/post_components.ex:4648
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr ""
@@ -16567,7 +16569,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4506
+#: lib/vutuv_web/components/post_components.ex:4540
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr ""
@@ -16904,7 +16906,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2001
+#: lib/vutuv_web/components/post_components.ex:2031
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
@@ -16918,7 +16920,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2045
+#: lib/vutuv_web/components/post_components.ex:2075
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16938,17 +16940,17 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1372
+#: lib/vutuv_web/components/post_components.ex:1402
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2018
+#: lib/vutuv_web/components/post_components.ex:2048
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1980
+#: lib/vutuv_web/components/post_components.ex:2010
 #, elixir-autogen, elixir-format
 msgid "Mute %{handle}"
 msgstr ""
@@ -16965,7 +16967,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1987
+#: lib/vutuv_web/components/post_components.ex:2017
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -17187,27 +17189,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1776
+#: lib/vutuv_web/components/post_components.ex:1806
 #, elixir-autogen, elixir-format
 msgid "A picture is on its way."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1805
+#: lib/vutuv_web/components/post_components.ex:1835
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1800
+#: lib/vutuv_web/components/post_components.ex:1830
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2082
+#: lib/vutuv_web/components/post_components.ex:2112
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2088
+#: lib/vutuv_web/components/post_components.ex:2118
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr ""
@@ -17217,7 +17219,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2227
+#: lib/vutuv_web/components/post_components.ex:2257
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17937,12 +17939,12 @@ msgstr ""
 msgid "Screenshot blocklist"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:380
+#: lib/vutuv_web/components/post_components.ex:410
 #, elixir-autogen, elixir-format
 msgid "Nothing from the fediverse yet. Follow accounts out there to fill this tab."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:377
+#: lib/vutuv_web/components/post_components.ex:407
 #, elixir-autogen, elixir-format
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
@@ -17984,7 +17986,7 @@ msgstr ""
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2085
+#: lib/vutuv_web/components/post_components.ex:2115
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -18300,19 +18302,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3788
+#: lib/vutuv_web/components/post_components.ex:3822
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3790
+#: lib/vutuv_web/components/post_components.ex:3824
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3801
+#: lib/vutuv_web/components/post_components.ex:3835
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -19987,7 +19989,7 @@ msgstr ""
 msgid "Start over"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2115
+#: lib/vutuv_web/components/post_components.ex:2145
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -20002,7 +20004,7 @@ msgstr ""
 msgid "Edits the page and posts jobs."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:162
+#: lib/vutuv_web/live/organization_live/roles.ex:167
 #, elixir-autogen, elixir-format
 msgid "Give members their roles on this page. Someone can hold several at once, and every role is granted on its own."
 msgstr ""
@@ -20022,7 +20024,7 @@ msgstr ""
 msgid "Posts jobs."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:265
+#: lib/vutuv_web/live/organization_live/roles.ex:270
 #, elixir-autogen, elixir-format
 msgid "Roles"
 msgstr ""
@@ -20040,4 +20042,34 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/organizations.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "The owner gives other members their roles on the page, and can hand ownership over to someone else at any time. Someone can hold several roles, and writing in the organization's name is always granted on its own."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/show.ex:406
+#, elixir-autogen, elixir-format
+msgid "Nothing published yet."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/show.ex:388
+#, elixir-autogen, elixir-format
+msgid "Post as %{name}"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/show.ex:154
+#, elixir-autogen, elixir-format
+msgid "Published as %{name}."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/show.ex:166
+#, elixir-autogen, elixir-format
+msgid "That post could not be published."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/show.ex:380
+#, elixir-autogen, elixir-format
+msgid "Write something as %{name}"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/show.ex:160
+#, elixir-autogen, elixir-format
+msgid "You may no longer write in this organization's name."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -21,7 +21,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:718
 #: lib/vutuv_web/live/organization_live/domains.ex:255
 #: lib/vutuv_web/live/organization_live/edit.ex:396
-#: lib/vutuv_web/live/organization_live/roles.ex:205
+#: lib/vutuv_web/live/organization_live/roles.ex:210
 #, elixir-autogen
 msgid "Add"
 msgstr ""
@@ -32,7 +32,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
-#: lib/vutuv_web/live/organization_live/show.ex:350
+#: lib/vutuv_web/live/organization_live/show.ex:471
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
@@ -158,7 +158,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2754
+#: lib/vutuv_web/components/post_components.ex:2788
 #: lib/vutuv_web/components/ui.ex:3326
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -207,13 +207,13 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2719
+#: lib/vutuv_web/components/post_components.ex:2753
 #: lib/vutuv_web/components/ui.ex:3317
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
 #: lib/vutuv_web/live/job_posting_live/show.ex:178
-#: lib/vutuv_web/live/organization_live/show.ex:263
+#: lib/vutuv_web/live/organization_live/show.ex:323
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:7
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:19
@@ -651,7 +651,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1369
+#: lib/vutuv_web/components/post_components.ex:1399
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -1612,7 +1612,7 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3202
+#: lib/vutuv_web/components/post_components.ex:3236
 #: lib/vutuv_web/components/ui.ex:280
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
@@ -1743,7 +1743,7 @@ msgstr ""
 msgid "Network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:391
+#: lib/vutuv_web/components/post_components.ex:421
 #: lib/vutuv_web/components/ui.ex:3436
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:705
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:742
@@ -1913,6 +1913,7 @@ msgid "Pagination"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3461
+#: lib/vutuv_web/live/organization_live/show.ex:411
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr ""
@@ -2090,7 +2091,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2751
+#: lib/vutuv_web/components/post_components.ex:2785
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2131,8 +2132,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2705
-#: lib/vutuv_web/components/post_components.ex:2707
+#: lib/vutuv_web/components/post_components.ex:2739
+#: lib/vutuv_web/components/post_components.ex:2741
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2188,6 +2189,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:382
 #: lib/vutuv_web/live/notification_live/index.ex:876
+#: lib/vutuv_web/live/organization_live/show.ex:361
 #: lib/vutuv_web/live/post_live/saved.ex:495
 #: lib/vutuv_web/live/search_live.ex:200
 #: lib/vutuv_web/live/search_live.ex:530
@@ -2197,13 +2199,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3138
-#: lib/vutuv_web/components/post_components.ex:3142
+#: lib/vutuv_web/components/post_components.ex:3172
+#: lib/vutuv_web/components/post_components.ex:3176
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3139
+#: lib/vutuv_web/components/post_components.ex:3173
 #: lib/vutuv_web/live/fediverse_account_live.ex:320
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2211,13 +2213,13 @@ msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:252
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:1006
+#: lib/vutuv_web/components/post_components.ex:1036
 #: lib/vutuv_web/live/admin/screenshot_live.ex:317
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:700
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:373
-#: lib/vutuv_web/live/organization_live/roles.ex:238
+#: lib/vutuv_web/live/organization_live/roles.ex:243
 #: lib/vutuv_web/live/post_live/composer.ex:1851
 #: lib/vutuv_web/live/post_live/saved.ex:619
 #: lib/vutuv_web/live/post_live/saved.ex:647
@@ -2293,27 +2295,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2702
+#: lib/vutuv_web/components/post_components.ex:2736
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4346
+#: lib/vutuv_web/components/post_components.ex:4380
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4350
+#: lib/vutuv_web/components/post_components.ex:4384
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4348
+#: lib/vutuv_web/components/post_components.ex:4382
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4349
+#: lib/vutuv_web/components/post_components.ex:4383
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2354,8 +2356,8 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1553
-#: lib/vutuv_web/components/post_components.ex:4430
+#: lib/vutuv_web/components/post_components.ex:1583
+#: lib/vutuv_web/components/post_components.ex:4464
 #: lib/vutuv_web/components/ui.ex:2851
 #: lib/vutuv_web/views/user_html.ex:333
 #, elixir-autogen, elixir-format
@@ -2373,8 +2375,8 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1517
-#: lib/vutuv_web/components/post_components.ex:4653
+#: lib/vutuv_web/components/post_components.ex:1547
+#: lib/vutuv_web/components/post_components.ex:4687
 #: lib/vutuv_web/components/ui.ex:2837
 #: lib/vutuv_web/live/notification_live/index.ex:1023
 #: lib/vutuv_web/views/user_html.ex:343
@@ -2383,7 +2385,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:960
-#: lib/vutuv_web/components/post_components.ex:4662
+#: lib/vutuv_web/components/post_components.ex:4696
 #: lib/vutuv_web/live/notification_live/index.ex:956
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
@@ -2405,39 +2407,39 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4419
+#: lib/vutuv_web/components/post_components.ex:4453
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1553
-#: lib/vutuv_web/components/post_components.ex:4430
+#: lib/vutuv_web/components/post_components.ex:1583
+#: lib/vutuv_web/components/post_components.ex:4464
 #: lib/vutuv_web/live/post_live/saved.ex:775
 #: lib/vutuv_web/views/user_html.ex:333
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1541
-#: lib/vutuv_web/components/post_components.ex:4416
+#: lib/vutuv_web/components/post_components.ex:1571
+#: lib/vutuv_web/components/post_components.ex:4450
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1731
-#: lib/vutuv_web/components/post_components.ex:3718
+#: lib/vutuv_web/components/post_components.ex:1761
+#: lib/vutuv_web/components/post_components.ex:3752
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1541
-#: lib/vutuv_web/components/post_components.ex:4416
+#: lib/vutuv_web/components/post_components.ex:1571
+#: lib/vutuv_web/components/post_components.ex:4450
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4653
+#: lib/vutuv_web/components/post_components.ex:4687
 #: lib/vutuv_web/live/post_live/saved.ex:774
 #: lib/vutuv_web/views/user_html.ex:343
 #, elixir-autogen, elixir-format
@@ -2459,27 +2461,27 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4706
+#: lib/vutuv_web/components/post_components.ex:4740
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:349
+#: lib/vutuv_web/components/post_components.ex:379
 #: lib/vutuv_web/live/notification_live/index.ex:957
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1528
-#: lib/vutuv_web/components/post_components.ex:4689
-#: lib/vutuv_web/components/post_components.ex:4690
+#: lib/vutuv_web/components/post_components.ex:1558
+#: lib/vutuv_web/components/post_components.ex:4723
+#: lib/vutuv_web/components/post_components.ex:4724
 #: lib/vutuv_web/live/notification_live/index.ex:1020
 #: lib/vutuv_web/live/post_live/reply.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2673
+#: lib/vutuv_web/components/post_components.ex:2703
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2500,7 +2502,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2167
+#: lib/vutuv_web/components/post_components.ex:2197
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:59
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:50
@@ -2508,14 +2510,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2649
+#: lib/vutuv_web/components/post_components.ex:2679
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2643
-#: lib/vutuv_web/components/post_components.ex:2665
-#: lib/vutuv_web/components/post_components.ex:2668
+#: lib/vutuv_web/components/post_components.ex:2673
+#: lib/vutuv_web/components/post_components.ex:2695
+#: lib/vutuv_web/components/post_components.ex:2698
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2816,7 +2818,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4347
+#: lib/vutuv_web/components/post_components.ex:4381
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3077,7 +3079,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2619
+#: lib/vutuv_web/components/post_components.ex:2649
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3152,10 +3154,10 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1016
-#: lib/vutuv_web/components/post_components.ex:1992
-#: lib/vutuv_web/components/post_components.ex:2775
-#: lib/vutuv_web/live/organization_live/show.ex:284
+#: lib/vutuv_web/components/post_components.ex:1046
+#: lib/vutuv_web/components/post_components.ex:2022
+#: lib/vutuv_web/components/post_components.ex:2809
+#: lib/vutuv_web/live/organization_live/show.ex:344
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Report"
@@ -4572,7 +4574,7 @@ msgstr ""
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:516
 #: lib/vutuv_web/live/notification_live/index.ex:877
-#: lib/vutuv_web/live/organization_live/show.ex:300
+#: lib/vutuv_web/live/organization_live/show.ex:421
 #: lib/vutuv_web/live/post_live/saved.ex:498
 #: lib/vutuv_web/live/search_live.ex:198
 #: lib/vutuv_web/live/search_live.ex:472
@@ -4590,8 +4592,8 @@ msgstr ""
 msgid "Similar names"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:346
-#: lib/vutuv_web/components/post_components.ex:365
+#: lib/vutuv_web/components/post_components.ex:376
+#: lib/vutuv_web/components/post_components.ex:395
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/notification_live/index.ex:875
@@ -5387,9 +5389,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2838
-#: lib/vutuv_web/components/post_components.ex:2890
-#: lib/vutuv_web/components/post_components.ex:3282
+#: lib/vutuv_web/components/post_components.ex:2872
+#: lib/vutuv_web/components/post_components.ex:2924
+#: lib/vutuv_web/components/post_components.ex:3316
 #: lib/vutuv_web/live/notification_live/index.ex:680
 #: lib/vutuv_web/live/post_live/feed.ex:1259
 #: lib/vutuv_web/views/user_html.ex:111
@@ -6184,7 +6186,7 @@ msgid "Previous day"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:960
-#: lib/vutuv_web/components/post_components.ex:348
+#: lib/vutuv_web/components/post_components.ex:378
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
@@ -6622,7 +6624,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2772
+#: lib/vutuv_web/components/post_components.ex:2806
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6632,7 +6634,7 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2771
+#: lib/vutuv_web/components/post_components.ex:2805
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -7314,7 +7316,7 @@ msgstr ""
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4575
+#: lib/vutuv_web/components/post_components.ex:4609
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8781,7 +8783,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3721
+#: lib/vutuv_web/components/post_components.ex:3755
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -11024,7 +11026,7 @@ msgstr ""
 msgid "AI agents"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:291
+#: lib/vutuv_web/live/organization_live/show.ex:351
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
@@ -11037,7 +11039,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:248
 #: lib/vutuv_web/live/organization_live/domains.ex:288
 #: lib/vutuv_web/live/organization_live/new.ex:146
-#: lib/vutuv_web/live/organization_live/show.ex:424
+#: lib/vutuv_web/live/organization_live/show.ex:545
 #: lib/vutuv_web/templates/url/verify.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "DNS TXT record"
@@ -11045,8 +11047,8 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:153
 #: lib/vutuv_web/live/organization_live/domains.ex:167
-#: lib/vutuv_web/live/organization_live/show.ex:203
-#: lib/vutuv_web/live/organization_live/show.ex:483
+#: lib/vutuv_web/live/organization_live/show.ex:263
+#: lib/vutuv_web/live/organization_live/show.ex:604
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr ""
@@ -11077,13 +11079,13 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) and list them for AI agents."
 msgstr ""
 
-#: lib/vutuv_web/controllers/organization_controller.ex:144
+#: lib/vutuv_web/controllers/organization_controller.ex:171
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:31
 #, elixir-autogen, elixir-format
 msgid "Please log in first."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:397
+#: lib/vutuv_web/live/organization_live/show.ex:518
 #, elixir-autogen, elixir-format
 msgid "Prove you control %{domain} to publish this page."
 msgstr ""
@@ -11110,7 +11112,7 @@ msgid "Select a country"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:307
-#: lib/vutuv_web/live/organization_live/show.ex:459
+#: lib/vutuv_web/live/organization_live/show.ex:580
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr ""
@@ -11137,12 +11139,12 @@ msgid "The upload failed."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/new.ex:131
-#: lib/vutuv_web/live/organization_live/show.ex:412
+#: lib/vutuv_web/live/organization_live/show.ex:533
 #, elixir-autogen, elixir-format
 msgid "Verification method"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:372
+#: lib/vutuv_web/live/organization_live/show.ex:493
 #, elixir-autogen, elixir-format
 msgid "Verified domains"
 msgstr ""
@@ -11158,19 +11160,19 @@ msgstr ""
 msgid "Verified via %{domain}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:394
+#: lib/vutuv_web/live/organization_live/show.ex:515
 #, elixir-autogen, elixir-format
 msgid "Verify %{name}"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:320
-#: lib/vutuv_web/live/organization_live/show.ex:479
+#: lib/vutuv_web/live/organization_live/show.ex:600
 #, elixir-autogen, elixir-format
 msgid "Verify now"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:149
-#: lib/vutuv_web/live/organization_live/show.ex:198
+#: lib/vutuv_web/live/organization_live/show.ex:258
 #, elixir-autogen, elixir-format
 msgid "We could not find the record or file yet. It can take a while to propagate. Please try again."
 msgstr ""
@@ -11185,7 +11187,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:249
 #: lib/vutuv_web/live/organization_live/domains.ex:298
-#: lib/vutuv_web/live/organization_live/show.ex:435
+#: lib/vutuv_web/live/organization_live/show.ex:556
 #: lib/vutuv_web/templates/url/verify.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Website file"
@@ -11207,13 +11209,13 @@ msgid "You will publish a record or file to prove control of the domain on the n
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:309
-#: lib/vutuv_web/live/organization_live/show.ex:465
+#: lib/vutuv_web/live/organization_live/show.ex:586
 #: lib/vutuv_web/templates/url/verify.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:175
+#: lib/vutuv_web/live/organization_live/roles.ex:180
 #, elixir-autogen, elixir-format
 msgid "@handle or email"
 msgstr ""
@@ -11229,12 +11231,12 @@ msgstr ""
 msgid "Add a domain"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:166
+#: lib/vutuv_web/live/organization_live/roles.ex:171
 #, elixir-autogen, elixir-format
 msgid "Add a member"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:138
+#: lib/vutuv_web/live/organization_live/roles.ex:143
 #, elixir-autogen, elixir-format
 msgid "Added @%{handle} to the team."
 msgstr ""
@@ -11258,7 +11260,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:322
 #: lib/vutuv_web/agent_docs/text.ex:348
 #: lib/vutuv_web/live/organization_live/edit.ex:353
-#: lib/vutuv_web/live/organization_live/show.ex:360
+#: lib/vutuv_web/live/organization_live/show.ex:481
 #: lib/vutuv_web/templates/tag/single_card.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Also known as"
@@ -11296,7 +11298,7 @@ msgstr ""
 msgid "Claimed by"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:211
+#: lib/vutuv_web/live/organization_live/roles.ex:216
 #, elixir-autogen, elixir-format
 msgid "Current team"
 msgstr ""
@@ -11324,7 +11326,7 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:211
 #: lib/vutuv_web/live/admin/organization_live.ex:305
 #: lib/vutuv_web/live/organization_live/domains.ex:161
-#: lib/vutuv_web/live/organization_live/show.ex:277
+#: lib/vutuv_web/live/organization_live/show.ex:337
 #, elixir-autogen, elixir-format
 msgid "Domains"
 msgstr ""
@@ -11357,7 +11359,7 @@ msgstr ""
 msgid "Last checked"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:238
+#: lib/vutuv_web/live/organization_live/roles.ex:243
 #, elixir-autogen, elixir-format
 msgid "Leave"
 msgstr ""
@@ -11422,7 +11424,7 @@ msgstr ""
 msgid "Remove this domain?"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:233
+#: lib/vutuv_web/live/organization_live/roles.ex:238
 #, elixir-autogen, elixir-format
 msgid "Remove this member from the team?"
 msgstr ""
@@ -11439,8 +11441,8 @@ msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:208
 #: lib/vutuv_web/live/admin/organization_live.ex:321
-#: lib/vutuv_web/live/organization_live/roles.ex:160
-#: lib/vutuv_web/live/organization_live/show.ex:270
+#: lib/vutuv_web/live/organization_live/roles.ex:165
+#: lib/vutuv_web/live/organization_live/show.ex:330
 #, elixir-autogen, elixir-format
 msgid "Team"
 msgstr ""
@@ -11455,7 +11457,7 @@ msgstr ""
 msgid "That is not a valid domain."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:141
+#: lib/vutuv_web/live/organization_live/roles.ex:146
 #, elixir-autogen, elixir-format
 msgid "That member could not be added."
 msgstr ""
@@ -11622,7 +11624,7 @@ msgstr ""
 msgid "%{min} to %{max} characters: letters (a-z), numbers (0-9) and underscores."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:315
+#: lib/vutuv_web/live/organization_live/show.ex:436
 #, elixir-autogen, elixir-format
 msgid "Former"
 msgstr ""
@@ -11683,7 +11685,7 @@ msgstr ""
 msgid "An organization keeps at least one verified domain, so this one cannot be removed."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:147
+#: lib/vutuv_web/live/organization_live/roles.ex:152
 #, elixir-autogen, elixir-format
 msgid "An organization must keep at least one owner, so the last owner cannot be changed."
 msgstr ""
@@ -11732,7 +11734,7 @@ msgstr ""
 msgid "The proof is a small technical change to your domain: a DNS entry or a file on your website. If you don't manage the website yourself, ask the person or team who does. That is usually your IT department or the company that runs your website. We show the exact instructions on the next step, so you can simply pass them on."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:406
+#: lib/vutuv_web/live/organization_live/show.ex:527
 #, elixir-autogen, elixir-format
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr ""
@@ -11753,7 +11755,7 @@ msgstr ""
 msgid "Kind of organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:232
+#: lib/vutuv_web/live/organization_live/roles.ex:237
 #, elixir-autogen, elixir-format
 msgid "Leave this organization team?"
 msgstr ""
@@ -11842,7 +11844,7 @@ msgstr ""
 msgid "Organization unfrozen."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/organization_doc.ex:91
+#: lib/vutuv_web/agent_docs/organization_doc.ex:108
 #: lib/vutuv_web/components/ui.ex:3719
 #: lib/vutuv_web/controllers/settings_controller.ex:178
 #: lib/vutuv_web/live/organization_live/index.ex:30
@@ -11861,12 +11863,12 @@ msgstr ""
 msgid "Please choose"
 msgstr ""
 
-#: lib/vutuv_web/controllers/organization_controller.ex:111
+#: lib/vutuv_web/controllers/organization_controller.ex:113
 #, elixir-autogen, elixir-format
 msgid "Please confirm your email address before claiming an organization page."
 msgstr ""
 
-#: lib/vutuv_web/controllers/organization_controller.ex:117
+#: lib/vutuv_web/controllers/organization_controller.ex:119
 #, elixir-autogen, elixir-format
 msgid "Please log in to claim an organization page."
 msgstr ""
@@ -11896,7 +11898,7 @@ msgstr ""
 msgid "The organization page was deleted."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:210
+#: lib/vutuv_web/live/organization_live/show.ex:270
 #, elixir-autogen, elixir-format
 msgid "This organization page was reported and is hidden while it is reviewed. Only you and the moderators can see it."
 msgstr ""
@@ -11906,7 +11908,7 @@ msgstr ""
 msgid "Verified organization pages on vutuv, each with a proven web domain."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/organization_doc.ex:92
+#: lib/vutuv_web/agent_docs/organization_doc.ex:109
 #, elixir-autogen, elixir-format
 msgid "Verified organization pages on vutuv."
 msgstr ""
@@ -11926,7 +11928,7 @@ msgstr ""
 msgid "Your organization handle is set."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:164
+#: lib/vutuv_web/live/organization_live/show.ex:224
 #, elixir-autogen, elixir-format
 msgid "Your organization page is verified and now live."
 msgstr ""
@@ -12626,13 +12628,13 @@ msgid "Getting an error, or is %{host} a CNAME / alias to another address? A TXT
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:305
-#: lib/vutuv_web/live/organization_live/show.ex:452
+#: lib/vutuv_web/live/organization_live/show.ex:573
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:303
-#: lib/vutuv_web/live/organization_live/show.ex:443
+#: lib/vutuv_web/live/organization_live/show.ex:564
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
 msgstr ""
@@ -12728,7 +12730,7 @@ msgid "Minimum yearly salary"
 msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:324
-#: lib/vutuv_web/live/organization_live/show.ex:342
+#: lib/vutuv_web/live/organization_live/show.ex:463
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr ""
@@ -12757,7 +12759,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:400
 #: lib/vutuv_web/agent_docs/text.ex:412
 #: lib/vutuv_web/agent_docs/text.ex:424
-#: lib/vutuv_web/live/organization_live/show.ex:329
+#: lib/vutuv_web/live/organization_live/show.ex:450
 #: lib/vutuv_web/templates/tag/show.html.heex:45
 #, elixir-autogen, elixir-format
 msgid "Open positions"
@@ -13076,7 +13078,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2126
+#: lib/vutuv_web/components/post_components.ex:2156
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:650
 #: lib/vutuv_web/controllers/settings_controller.ex:668
@@ -13488,22 +13490,22 @@ msgstr ""
 msgid "Work mobile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:388
+#: lib/vutuv_web/components/post_components.ex:418
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:390
+#: lib/vutuv_web/components/post_components.ex:420
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:389
+#: lib/vutuv_web/components/post_components.ex:419
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:347
+#: lib/vutuv_web/components/post_components.ex:377
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr ""
@@ -13678,34 +13680,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4209
+#: lib/vutuv_web/components/post_components.ex:4243
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1049
-#: lib/vutuv_web/components/post_components.ex:4166
+#: lib/vutuv_web/components/post_components.ex:4200
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4210
+#: lib/vutuv_web/components/post_components.ex:4244
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4212
+#: lib/vutuv_web/components/post_components.ex:4246
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4208
+#: lib/vutuv_web/components/post_components.ex:4242
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1049
-#: lib/vutuv_web/components/post_components.ex:4165
+#: lib/vutuv_web/components/post_components.ex:4199
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13716,12 +13718,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4207
+#: lib/vutuv_web/components/post_components.ex:4241
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4211
+#: lib/vutuv_web/components/post_components.ex:4245
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13741,7 +13743,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4248
+#: lib/vutuv_web/components/post_components.ex:4282
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13749,27 +13751,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4278
+#: lib/vutuv_web/components/post_components.ex:4312
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4279
+#: lib/vutuv_web/components/post_components.ex:4313
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4277
+#: lib/vutuv_web/components/post_components.ex:4311
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4237
+#: lib/vutuv_web/components/post_components.ex:4271
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4284
+#: lib/vutuv_web/components/post_components.ex:4318
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13799,7 +13801,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4051
+#: lib/vutuv_web/components/post_components.ex:4085
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13847,7 +13849,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4042
+#: lib/vutuv_web/components/post_components.ex:4076
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14217,14 +14219,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2390
+#: lib/vutuv_web/components/post_components.ex:2420
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2412
+#: lib/vutuv_web/components/post_components.ex:2442
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14251,7 +14253,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4661
+#: lib/vutuv_web/components/post_components.ex:4695
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -15422,21 +15424,21 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4620
+#: lib/vutuv_web/components/post_components.ex:4654
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4624
+#: lib/vutuv_web/components/post_components.ex:4658
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4628
+#: lib/vutuv_web/components/post_components.ex:4662
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15444,7 +15446,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:998
-#: lib/vutuv_web/components/post_components.ex:4579
+#: lib/vutuv_web/components/post_components.ex:4613
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15460,14 +15462,14 @@ msgstr ""
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1117
-#: lib/vutuv_web/components/post_components.ex:1673
+#: lib/vutuv_web/components/post_components.ex:1147
+#: lib/vutuv_web/components/post_components.ex:1703
 #: lib/vutuv_web/live/fediverse_account_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1004
+#: lib/vutuv_web/components/post_components.ex:1034
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15494,7 +15496,7 @@ msgstr ""
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1013
+#: lib/vutuv_web/components/post_components.ex:1043
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15504,7 +15506,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1027
+#: lib/vutuv_web/components/post_components.ex:1057
 #: lib/vutuv_web/live/notification_live/index.ex:534
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -15536,9 +15538,9 @@ msgid "That reply is not yours to remove."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1182
-#: lib/vutuv_web/components/post_components.ex:1048
-#: lib/vutuv_web/components/post_components.ex:1248
-#: lib/vutuv_web/components/post_components.ex:2046
+#: lib/vutuv_web/components/post_components.ex:1078
+#: lib/vutuv_web/components/post_components.ex:1278
+#: lib/vutuv_web/components/post_components.ex:2076
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -16200,22 +16202,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2631
+#: lib/vutuv_web/components/post_components.ex:2661
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2738
+#: lib/vutuv_web/components/post_components.ex:2772
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2746
+#: lib/vutuv_web/components/post_components.ex:2780
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2732
+#: lib/vutuv_web/components/post_components.ex:2766
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16301,7 +16303,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1110
 #: lib/vutuv_web/agent_docs/text.ex:665
-#: lib/vutuv_web/components/post_components.ex:3205
+#: lib/vutuv_web/components/post_components.ex:3239
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
@@ -16331,7 +16333,7 @@ msgstr ""
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3204
+#: lib/vutuv_web/components/post_components.ex:3238
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
@@ -16341,29 +16343,29 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3585
+#: lib/vutuv_web/components/post_components.ex:3619
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Only you can see this post so far."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2179
+#: lib/vutuv_web/components/post_components.ex:2209
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3588
+#: lib/vutuv_web/components/post_components.ex:3622
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3411
+#: lib/vutuv_web/components/post_components.ex:3445
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2947
+#: lib/vutuv_web/components/post_components.ex:2981
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16376,12 +16378,12 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1143
 #: lib/vutuv_web/agent_docs/text.ex:652
-#: lib/vutuv_web/components/post_components.ex:3622
+#: lib/vutuv_web/components/post_components.ex:3656
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3203
+#: lib/vutuv_web/components/post_components.ex:3237
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Previous photo"
 msgstr ""
@@ -16402,7 +16404,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2232
+#: lib/vutuv_web/components/post_components.ex:2262
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16422,7 +16424,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2223
+#: lib/vutuv_web/components/post_components.ex:2253
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16432,12 +16434,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2241
+#: lib/vutuv_web/components/post_components.ex:2271
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2175
+#: lib/vutuv_web/components/post_components.ex:2205
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16452,7 +16454,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2236
+#: lib/vutuv_web/components/post_components.ex:2266
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16462,7 +16464,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2189
+#: lib/vutuv_web/components/post_components.ex:2219
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16549,13 +16551,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1016
-#: lib/vutuv_web/components/post_components.ex:4617
+#: lib/vutuv_web/components/post_components.ex:4651
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1014
-#: lib/vutuv_web/components/post_components.ex:4614
+#: lib/vutuv_web/components/post_components.ex:4648
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
 msgstr ""
@@ -16565,7 +16567,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4506
+#: lib/vutuv_web/components/post_components.ex:4540
 #, elixir-autogen, elixir-format, fuzzy
 msgid "From other networks"
 msgstr ""
@@ -16902,7 +16904,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2001
+#: lib/vutuv_web/components/post_components.ex:2031
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
@@ -16916,7 +16918,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2045
+#: lib/vutuv_web/components/post_components.ex:2075
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16936,17 +16938,17 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1372
+#: lib/vutuv_web/components/post_components.ex:1402
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2018
+#: lib/vutuv_web/components/post_components.ex:2048
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Marked as sensitive by its author"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1980
+#: lib/vutuv_web/components/post_components.ex:2010
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Mute %{handle}"
 msgstr ""
@@ -16963,7 +16965,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1987
+#: lib/vutuv_web/components/post_components.ex:2017
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -17185,27 +17187,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1776
+#: lib/vutuv_web/components/post_components.ex:1806
 #, elixir-autogen, elixir-format
 msgid "A picture is on its way."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1805
+#: lib/vutuv_web/components/post_components.ex:1835
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1800
+#: lib/vutuv_web/components/post_components.ex:1830
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2082
+#: lib/vutuv_web/components/post_components.ex:2112
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2088
+#: lib/vutuv_web/components/post_components.ex:2118
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That post is not here any more."
 msgstr ""
@@ -17215,7 +17217,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2227
+#: lib/vutuv_web/components/post_components.ex:2257
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17935,12 +17937,12 @@ msgstr ""
 msgid "Screenshot blocklist"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:380
+#: lib/vutuv_web/components/post_components.ex:410
 #, elixir-autogen, elixir-format
 msgid "Nothing from the fediverse yet. Follow accounts out there to fill this tab."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:377
+#: lib/vutuv_web/components/post_components.ex:407
 #, elixir-autogen, elixir-format
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
@@ -17982,7 +17984,7 @@ msgstr ""
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2085
+#: lib/vutuv_web/components/post_components.ex:2115
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -18298,19 +18300,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3788
+#: lib/vutuv_web/components/post_components.ex:3822
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3790
+#: lib/vutuv_web/components/post_components.ex:3824
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3801
+#: lib/vutuv_web/components/post_components.ex:3835
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -19985,7 +19987,7 @@ msgstr ""
 msgid "Start over"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2115
+#: lib/vutuv_web/components/post_components.ex:2145
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -20000,7 +20002,7 @@ msgstr ""
 msgid "Edits the page and posts jobs."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:162
+#: lib/vutuv_web/live/organization_live/roles.ex:167
 #, elixir-autogen, elixir-format
 msgid "Give members their roles on this page. Someone can hold several at once, and every role is granted on its own."
 msgstr ""
@@ -20020,7 +20022,7 @@ msgstr ""
 msgid "Posts jobs."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:265
+#: lib/vutuv_web/live/organization_live/roles.ex:270
 #, elixir-autogen, elixir-format
 msgid "Roles"
 msgstr ""
@@ -20038,4 +20040,34 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/organizations.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "The owner gives other members their roles on the page, and can hand ownership over to someone else at any time. Someone can hold several roles, and writing in the organization's name is always granted on its own."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/show.ex:406
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Nothing published yet."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/show.ex:388
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Post as %{name}"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/show.ex:154
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Published as %{name}."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/show.ex:166
+#, elixir-autogen, elixir-format
+msgid "That post could not be published."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/show.ex:380
+#, elixir-autogen, elixir-format
+msgid "Write something as %{name}"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/show.ex:160
+#, elixir-autogen, elixir-format
+msgid "You may no longer write in this organization's name."
 msgstr ""

--- a/priv/repo/migrations/20260810165508_add_organization_authorship_to_posts.exs
+++ b/priv/repo/migrations/20260810165508_add_organization_authorship_to_posts.exs
@@ -1,0 +1,67 @@
+defmodule Vutuv.Repo.Migrations.AddOrganizationAuthorshipToPosts do
+  @moduledoc """
+  Issue #1334: a post may now be authored by an organization instead of a member.
+
+  Three columns rather than one, because two promises collide.
+  `posts.user_id` is `null: false, on_delete: :delete_all` today, which is a
+  deliberate promise: deleting your account deletes your posts. But a post
+  published for an organization has to survive the person who wrote it leaving.
+  Keeping the human in `user_id` would delete the organization's content along
+  with their account; dropping the human entirely would leave nobody accountable
+  for what was said in the organization's name.
+
+    * `user_id`         — the member, for a personal post; NULL for an organization post
+    * `organization_id` — the organization, for an organization post; NULL otherwise
+    * `acting_user_id`  — who pressed publish for the organization, `nilify_all`
+
+  The CHECK enforces exactly one of the two authors. `acting_user_id` is not
+  optional on the organization path: an organization is a mouth several people
+  speak through, and moderation, disputes and departures all need to know which
+  one — but it is `nilify_all`, so the record survives that person's account.
+
+  N-1 safe: the previous release only ever writes `user_id`, which still passes
+  the CHECK, and the columns it does not know about default to NULL. Dropping
+  NOT NULL does not change the column's result type, so no cached prepared
+  statement is invalidated by it.
+  """
+  use Ecto.Migration
+
+  def up do
+    alter table(:posts) do
+      add(:organization_id, references(:organizations, type: :binary_id, on_delete: :delete_all))
+      add(:acting_user_id, references(:users, type: :binary_id, on_delete: :nilify_all))
+    end
+
+    execute("ALTER TABLE posts ALTER COLUMN user_id DROP NOT NULL")
+
+    create(
+      constraint(:posts, :posts_exactly_one_author,
+        check: """
+        (CASE WHEN user_id IS NULL THEN 0 ELSE 1 END +
+         CASE WHEN organization_id IS NULL THEN 0 ELSE 1 END) = 1
+        """
+      )
+    )
+
+    # An organization page lists its own posts newest-first, the same read the
+    # `[user_id, inserted_at]` index serves for a member.
+    create(index(:posts, [:organization_id, :inserted_at]))
+    # Every post a member published for an organization, for the moderation and
+    # departure questions `acting_user_id` exists to answer.
+    create(index(:posts, [:acting_user_id]))
+  end
+
+  def down do
+    drop(index(:posts, [:acting_user_id]))
+    drop(index(:posts, [:organization_id, :inserted_at]))
+    drop(constraint(:posts, :posts_exactly_one_author))
+
+    execute("DELETE FROM posts WHERE user_id IS NULL")
+    execute("ALTER TABLE posts ALTER COLUMN user_id SET NOT NULL")
+
+    alter table(:posts) do
+      remove(:acting_user_id)
+      remove(:organization_id)
+    end
+  end
+end

--- a/test/vutuv/organization_posts_test.exs
+++ b/test/vutuv/organization_posts_test.exs
@@ -1,0 +1,149 @@
+defmodule Vutuv.OrganizationPostsTest do
+  @moduledoc """
+  Posts published in an organization's name (issue #1334): the three-column
+  authorship, who may publish, and — the part that is easy to get wrong — that
+  none of the **personal** scopes pick such a post up. A member's own profile,
+  archive and feed must not show what they published for an organization; that
+  association is exactly what `acting_user_id` keeps internal.
+
+  `async: false` for the same reason the other organization suites are: the
+  helpers flip the global `:verify_organization_domains` flag.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Organizations
+  alias Vutuv.Posts
+  alias Vutuv.Posts.Post
+  alias Vutuv.Repo
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  # An organization plus its owner, who has been granted the publisher role
+  # (never implied — see issue #1333).
+  defp publishing_organization do
+    {organization, owner} = active_organization()
+    {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+    {organization, owner}
+  end
+
+  describe "create_organization_post/3" do
+    test "records the organization as author and the member as who pressed publish" do
+      {organization, owner} = publishing_organization()
+
+      assert {:ok, post} =
+               Posts.create_organization_post(organization, owner, %{body: "We are hiring."})
+
+      assert post.organization_id == organization.id
+      assert post.acting_user_id == owner.id
+      assert is_nil(post.user_id)
+
+      # The public author is the organization; the human is internal.
+      assert %Organizations.Organization{} = author = Posts.author(post)
+      assert author.id == organization.id
+      assert Posts.author_id(post) == organization.id
+      assert Posts.organization_post?(post)
+    end
+
+    test "refuses a member without the publisher role, whatever else they hold" do
+      {organization, owner} = active_organization()
+      admin = insert(:activated_user)
+      {:ok, _} = Organizations.add_role(organization, admin, "admin", owner)
+      stranger = insert(:activated_user)
+
+      # The owner has not granted themselves publisher yet, and an admin
+      # administers the page rather than speaking for it.
+      assert {:error, :forbidden} =
+               Posts.create_organization_post(organization, owner, %{body: "x"})
+
+      assert {:error, :forbidden} =
+               Posts.create_organization_post(organization, admin, %{body: "x"})
+
+      assert {:error, :forbidden} =
+               Posts.create_organization_post(organization, stranger, %{body: "x"})
+    end
+
+    test "the database refuses a post that claims both authors or neither" do
+      {organization, owner} = publishing_organization()
+
+      both = %Post{
+        user_id: owner.id,
+        organization_id: organization.id,
+        body: "",
+        published_on: Vutuv.BerlinTime.today()
+      }
+
+      assert_raise Ecto.ConstraintError, ~r/posts_exactly_one_author/, fn ->
+        Repo.insert!(both)
+      end
+
+      neither = %Post{body: "", published_on: Vutuv.BerlinTime.today()}
+
+      assert_raise Ecto.ConstraintError, ~r/posts_exactly_one_author/, fn ->
+        Repo.insert!(neither)
+      end
+    end
+  end
+
+  describe "the author's own surfaces do not leak the organization post" do
+    setup do
+      {organization, owner} = publishing_organization()
+
+      {:ok, personal} = Posts.create_post(owner, %{body: "Something of my own."})
+
+      {:ok, organization_post} =
+        Posts.create_organization_post(organization, owner, %{body: "Something in our name."})
+
+      %{owner: owner, organization: organization, personal: personal, org_post: organization_post}
+    end
+
+    test "the member's post archive lists only their own", ctx do
+      %{owner: owner, personal: personal, org_post: org_post} = ctx
+      {entries, _total} = Posts.author_posts_page(owner, owner, %{})
+      ids = Enum.map(entries, & &1.post.id)
+
+      assert personal.id in ids
+      refute org_post.id in ids
+    end
+
+    test "the member's feed does not carry what they published for the organization", ctx do
+      %{owner: owner, personal: personal, org_post: org_post} = ctx
+      ids = owner |> Posts.feed_page() |> Map.fetch!(:entries) |> Enum.map(& &1.post.id)
+
+      assert personal.id in ids
+      refute org_post.id in ids
+    end
+  end
+
+  describe "editing and deleting follows the role, not the person" do
+    test "every current publisher may act as the author; a departed one may not" do
+      {organization, owner} = publishing_organization()
+      other = insert(:activated_user)
+      {:ok, _} = Organizations.add_role(organization, other, "publisher", owner)
+      outsider = insert(:activated_user)
+
+      {:ok, post} = Posts.create_organization_post(organization, owner, %{body: "Ours."})
+
+      assert Posts.author?(post, owner)
+      # Not the member who pressed publish — anyone the organization currently
+      # trusts to speak for it, because the post belongs to the organization.
+      assert Posts.author?(post, other)
+      refute Posts.author?(post, outsider)
+
+      # Withdrawing the role takes the power away at once, without touching the
+      # stored `acting_user_id`.
+      {:ok, _} = Organizations.set_roles(organization, other, [], owner)
+      refute Posts.author?(Repo.reload!(post) |> Repo.preload(:organization), other)
+    end
+  end
+end

--- a/test/vutuv_web/organization_posts_web_test.exs
+++ b/test/vutuv_web/organization_posts_web_test.exs
@@ -1,0 +1,121 @@
+defmodule VutuvWeb.OrganizationPostsWebTest do
+  @moduledoc """
+  The web surface of posts published in an organization's name (issue #1334):
+  the composer on the organization page, the post rendering under the
+  organization's own name, and the permalink's scoping. `async: false` because
+  the organization helpers flip the global `:verify_organization_domains` flag.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Organizations
+  alias Vutuv.Posts
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  describe "the composer on the organization page" do
+    test "a publisher writes as the organization and the post appears under its name",
+         %{conn: conn} do
+      {conn, owner} = create_and_login_user(conn)
+      organization = active_organization_for(owner)
+      {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+
+      {:ok, view, _html} = live(conn, ~p"/organizations/#{organization.slug}")
+
+      html =
+        view
+        |> element("#organization-post-form")
+        |> render_submit(%{"body" => "Wir stellen ein."})
+
+      # The post is signed by the organization, never by the member who wrote it.
+      assert html =~ "Wir stellen ein."
+      assert html =~ organization.name
+
+      [post] = Posts.organization_posts_page(organization, owner).entries
+      assert post.organization_id == organization.id
+      assert post.acting_user_id == owner.id
+    end
+
+    test "an owner without the publisher role gets no composer", %{conn: conn} do
+      {conn, owner} = create_and_login_user(conn)
+      organization = active_organization_for(owner)
+
+      {:ok, _view, html} = live(conn, ~p"/organizations/#{organization.slug}")
+
+      refute html =~ "organization-post-form"
+    end
+
+    test "a visitor sees the published post but no composer", %{conn: conn} do
+      owner = insert(:activated_user)
+      organization = active_organization_for(owner)
+      {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+      {:ok, _post} = Posts.create_organization_post(organization, owner, %{body: "Öffentlich."})
+
+      {:ok, _view, html} = live(conn, ~p"/organizations/#{organization.slug}")
+
+      assert html =~ "Öffentlich."
+      refute html =~ "organization-post-form"
+    end
+  end
+
+  describe "the permalink" do
+    setup do
+      owner = insert(:activated_user)
+      organization = active_organization_for(owner)
+      {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+      {:ok, post} = Posts.create_organization_post(organization, owner, %{body: "Unsere Worte."})
+
+      %{organization: organization, owner: owner, post: post}
+    end
+
+    test "lives under the organization slug and renders the post", ctx do
+      %{organization: organization, post: post, conn: conn} = ctx
+
+      assert Posts.path(post) == "/organizations/#{organization.slug}/posts/#{post.id}"
+
+      html = conn |> get(Posts.path(post)) |> html_response(200)
+      assert html =~ "Unsere Worte."
+    end
+
+    test "404s for an id that is not this organization's post", ctx do
+      %{organization: organization, conn: conn} = ctx
+      stranger = insert(:activated_user)
+      {:ok, personal} = Posts.create_post(stranger, %{body: "Meins."})
+
+      # A member's post must never render under an organization's name.
+      conn
+      |> get(~p"/organizations/#{organization.slug}/posts/#{personal.id}")
+      |> response(404)
+
+      conn
+      |> get(~p"/organizations/#{organization.slug}/posts/not-a-uuid")
+      |> response(404)
+    end
+  end
+
+  describe "replies" do
+    test "an organization post cannot be answered yet", %{conn: _conn} do
+      owner = insert(:activated_user)
+      organization = active_organization_for(owner)
+      {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+      {:ok, post} = Posts.create_organization_post(organization, owner, %{body: "Hallo."})
+
+      reader = insert(:activated_user)
+
+      # Refused outright rather than half-working: everything a reply sets in
+      # motion is member-shaped, and an organization has no inbox until #1336.
+      assert {:error, :restricted} = Posts.create_reply(reader, post, %{body: "Antwort"})
+    end
+  end
+end


### PR DESCRIPTION
Part 1 of #1334: an organization can author posts. The fediverse half (WebFinger, `Organization` actor document, per-page opt-in, delivery) ships in its own deploy.

### The authorship shape

The three columns the issue asks for, with a CHECK enforcing exactly one author:

| column | personal post | organization post |
|---|---|---|
| `user_id` | the member, `delete_all` | NULL |
| `organization_id` | NULL | the organization, `delete_all` |
| `acting_user_id` | NULL | who pressed publish, `nilify_all` |

And **one** author accessor, `Posts.author/1`, because the author is read in ~70 places and reading `post.user` directly is a bug on an organization post.

### Permissions

Publishing needs the `publisher` role from #1333 — not `owner`, not `admin`. The check lives in `create_organization_post/3` itself, so an open page is worth nothing once the role is withdrawn. Editing and deleting follow the **role, not the person**: every current publisher may act as the author even if somebody else pressed publish, because the post belongs to the organization and the power must not walk out of the door with them.

### Two deliberate limits

**No audience on an organization post.** The deny model is built on the author's own follower graph and blocks, and an organization has no equivalent until #1336. A half-applied audience would be a promise the site cannot keep.

**Replies to organization posts are refused, not silently dropped.** Everything a reply sets in motion is member-shaped (the parent-author notification, the block check between the two authors, the "Replying to @handle" line), and an organization has no inbox until #1336.

### Fixed on the way

- **`broadcast_new_post` raised on a nil author.** `follower_ids/1` builds `where: c.followee_id == ^nil`, which Ecto **raises** on rather than matching nothing — the same trap #1036 hit. The test found it on the first organization post.
- **A fuzzy translation.** `gettext.extract --merge` filled `"Post as %{name}"` with `"Beiträge von %{name}"` ("Posts by X"), turning a button into a heading.

### Permalink

`/organizations/:slug/posts/:id`, deliberately under the slug rather than the organization's opt-in root handle: the handle route dispatches an organization only on the bare `/:slug` page, and a permalink is the least forgiving URL there is (it is what a federated Note will be identified by), so it gets the one shape that works whether or not a handle was ever claimed.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*
