### PR TITLE
Für eine Organisation sprechen, statt jedes Mal zu wählen (v7.241.0)

### DIFF
--- a/lib/vutuv/account_events.ex
+++ b/lib/vutuv/account_events.ex
@@ -144,7 +144,15 @@ defmodule Vutuv.AccountEvents do
     "account_restored" => [],
     "identity_verified" => [],
     "preferences_overridden" => ["fields"],
-    "activity_log_viewed" => ["member"]
+    "activity_log_viewed" => ["member"],
+    # Speaking in an organization's name (issue #1335). Their own kinds rather
+    # than folded into an existing one, because the log's closed vocabulary IS
+    # the security boundary: "this member spoke as Acme" is a different claim
+    # from anything already listed, and a reader has to be able to filter for
+    # it. Both name the organization, so the log answers "when was I acting as
+    # them" without a join.
+    "acted_as_organization" => ["organization", "organization_slug"],
+    "stopped_acting_as_organization" => ["organization", "organization_slug"]
   }
 
   @factors ~w(passkey authenticator list_code pin session admin)

--- a/lib/vutuv/organizations.ex
+++ b/lib/vutuv/organizations.ex
@@ -207,6 +207,51 @@ defmodule Vutuv.Organizations do
 
   def publisher?(_, _), do: false
 
+  @doc """
+  The organization `user` is currently acting as, given the id their session
+  carries — or `nil` (issue #1335).
+
+  **This is re-asked on every request and every socket mount, and the session's
+  value is never trusted on its own.** The session is signed but not encrypted
+  and stays valid for days, so a captured payload replays; that is the trap
+  #1034 and #1036 already cost. Two things follow from asking live rather than
+  from a stored claim: a withdrawn `publisher` role takes effect on the member's
+  very next action instead of at their next login, and a page that is frozen,
+  archived or otherwise no longer public stops being speakable-for at once.
+  """
+  def acting_organization(%User{} = user, organization_id) when is_binary(organization_id) do
+    case get_organization(organization_id) do
+      %Organization{} = organization ->
+        if publisher?(organization, user) and organization_visible_to?(organization, user),
+          do: organization,
+          else: nil
+
+      _ ->
+        nil
+    end
+  end
+
+  def acting_organization(_user, _organization_id), do: nil
+
+  @doc """
+  The organizations `user` may switch into (issue #1335): the pages they hold
+  the `publisher` role on and may see, by name. Powers the identity menu.
+  """
+  def actable_organizations(%User{id: user_id} = user) do
+    Repo.all(
+      from(r in OrganizationRole,
+        join: o in Organization,
+        on: o.id == r.organization_id,
+        where: r.user_id == ^user_id and r.role == "publisher",
+        order_by: [asc: fragment("lower(?)", o.name)],
+        select: o
+      )
+    )
+    |> Enum.filter(&organization_visible_to?(&1, user))
+  end
+
+  def actable_organizations(_user), do: []
+
   @doc "Whether `user` may manage the roster (owner only)."
   def can_manage_roles?(organization, user), do: owner?(organization, user)
 

--- a/lib/vutuv_web/controllers/acting_as_controller.ex
+++ b/lib/vutuv_web/controllers/acting_as_controller.ex
@@ -1,0 +1,72 @@
+defmodule VutuvWeb.ActingAsController do
+  @moduledoc """
+  Switching into an organization and back out again (issue #1335).
+
+  The session carries only `acting_as_organization_id`, and it is a hint rather
+  than a credential: `VutuvWeb.Plug.ActingAs` re-asks `organization_roles` on
+  every request and `VutuvWeb.Live.InitAssigns` on every socket mount, so what
+  is written here can never by itself grant anything.
+
+  It is a **session** value with no expiry of its own, which is exactly the
+  "the switch does not outlive the session" rule: come back tomorrow with a new
+  session and you are yourself again. Both directions are POST/DELETE with CSRF
+  — a `GET` that changes who you are speaking as would fire on a link prefetch.
+  """
+
+  use VutuvWeb, :controller
+
+  alias Vutuv.AccountEvents
+  alias Vutuv.Organizations
+  alias VutuvWeb.ControllerHelpers
+
+  def create(conn, %{"slug" => slug}) do
+    user = conn.assigns[:current_user]
+    organization = user && Organizations.get_organization_by_slug(slug)
+
+    # The same predicate the plug will apply on the next request, asked here so
+    # a member without the role never gets a mode that immediately evaporates.
+    if organization && Organizations.acting_organization(user, organization.id) do
+      AccountEvents.record(user, "acted_as_organization",
+        conn: conn,
+        details: %{"organization" => organization.name, "organization_slug" => organization.slug}
+      )
+
+      conn
+      |> put_session(:acting_as_organization_id, organization.id)
+      |> put_flash(
+        :info,
+        gettext("You are writing as %{name} now.", name: organization.name)
+      )
+      |> redirect(to: Organizations.canonical_path(organization))
+    else
+      ControllerHelpers.render_error(conn, 404)
+    end
+  end
+
+  def delete(conn, _params) do
+    user = conn.assigns[:current_user]
+    organization = conn.assigns[:acting_as]
+
+    if organization do
+      AccountEvents.record(user, "stopped_acting_as_organization",
+        conn: conn,
+        details: %{"organization" => organization.name, "organization_slug" => organization.slug}
+      )
+    end
+
+    conn
+    |> delete_session(:acting_as_organization_id)
+    |> put_flash(:info, gettext("You are yourself again."))
+    |> redirect(to: return_to(conn))
+  end
+
+  # Back where they were, so leaving the mode is not also a navigation. Only a
+  # same-site path is honored: an absolute URL in a parameter is an open
+  # redirect, and this one is reachable from every page.
+  defp return_to(conn) do
+    case conn.params["return_to"] do
+      "/" <> _ = path -> if String.starts_with?(path, "//"), do: ~p"/feed", else: path
+      _ -> ~p"/feed"
+    end
+  end
+end

--- a/lib/vutuv_web/live/init_assigns.ex
+++ b/lib/vutuv_web/live/init_assigns.ex
@@ -24,6 +24,7 @@ defmodule VutuvWeb.Live.InitAssigns do
 
   alias Vutuv.Accounts.User
   alias Vutuv.Moderation
+  alias Vutuv.Organizations
   alias Vutuv.Sessions
 
   def on_mount(:default, _params, session, socket) do
@@ -36,6 +37,7 @@ defmodule VutuvWeb.Live.InitAssigns do
     socket =
       socket
       |> assign(:current_user, user)
+      |> assign(:acting_as, acting_as(user, session))
       |> Phoenix.LiveView.attach_hook(:shell_path, :handle_params, &assign_shell_path/3)
 
     {:cont, socket}
@@ -104,9 +106,27 @@ defmodule VutuvWeb.Live.InitAssigns do
     socket
     |> assign(:current_user, user)
     |> assign(:current_user_id, user && user.id)
+    |> assign(:acting_as, acting_as(user, session))
     |> assign(:locale, session["locale"])
     |> assign(:shell_path, session["request_path"])
   end
+
+  @doc """
+  The organization this socket is acting as, or `nil` (issue #1335). The socket
+  twin of `VutuvWeb.Plug.ActingAs`, and it re-asks `organization_roles` for
+  exactly the same reason `session_user/1` re-asks the session rows: the mount
+  session map is signed but not encrypted, so the id in it is a hint and never a
+  credential. Reading it as one would let a captured payload keep speaking in an
+  organization's name after the role was withdrawn.
+
+  The cookie session is merged into every mount session — including the
+  off-router `live_render` children — so the id is there without anything having
+  to pass it along.
+  """
+  def acting_as(%User{} = user, session) when is_map(session),
+    do: Organizations.acting_organization(user, Map.get(session, "acting_as_organization_id"))
+
+  def acting_as(_user, _session), do: nil
 
   @doc """
   The one place a mount decides who the visitor is, shared by the `:default`

--- a/lib/vutuv_web/live/organization_live/show.ex
+++ b/lib/vutuv_web/live/organization_live/show.ex
@@ -364,6 +364,20 @@ defmodule VutuvWeb.OrganizationLive.Show do
               </span>
             </div>
 
+            <%!-- Switching into the organization for the rest of the session
+            (issue #1335), offered where a publisher already is. A CSRF POST,
+            never a GET: a request that changes whose name you speak in must not
+            fire on a link prefetch or a Back button. --%>
+            <.link
+              :if={@publisher? and !@acting_as}
+              href={~p"/organizations/#{@organization.slug}/act_as"}
+              method="post"
+              id="start-acting-as"
+              class="mt-3 inline-flex min-h-10 items-center rounded-lg bg-slate-100 px-4 text-sm font-semibold text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+            >
+              {gettext("Write as %{name} for now", name: @organization.name)}
+            </.link>
+
             <%!-- The composer names the author right at the point of publishing,
             in the button, because the characteristic failure of writing under a
             brand is forgetting whose name is on it. --%>

--- a/lib/vutuv_web/live/post_live/composer.ex
+++ b/lib/vutuv_web/live/post_live/composer.ex
@@ -56,6 +56,7 @@ defmodule VutuvWeb.PostLive.Composer do
 
   alias Vutuv.Fediverse.Note
   alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.Organizations.Organization
   alias Vutuv.Posts
   alias Vutuv.Posts.GalleryLayout
   alias Vutuv.Posts.PhotoLicense
@@ -82,6 +83,9 @@ defmodule VutuvWeb.PostLive.Composer do
         Map.take(assigns, [
           :id,
           :current_user,
+          # The organization this member is writing as, or nil (issue #1335).
+          # Only the feed passes it; every other host composes personally.
+          :acting_as,
           :post,
           :parent,
           :remote_note,
@@ -90,6 +94,11 @@ defmodule VutuvWeb.PostLive.Composer do
           :preloaded_draft
         ])
       )
+
+    # Only the feed passes `acting_as`; every other host (edit, reply, the
+    # answer to a remote post) composes personally, so the key has to exist
+    # either way or the template raises on a missing assign.
+    socket = Phoenix.Component.assign_new(socket, :acting_as, fn -> nil end)
 
     socket =
       if socket.assigns[:composer_ready?] do
@@ -931,6 +940,17 @@ defmodule VutuvWeb.PostLive.Composer do
   defp save_post(%{post: nil, parent: %Post{} = parent, current_user: author}, attrs),
     do: Posts.create_reply(author, parent, attrs)
 
+  # Writing as an organization (issue #1335). Below the reply clauses on
+  # purpose: a reply is always personal, because an organization cannot answer
+  # anything until issue #1336 gives it a reading side. The role is re-checked
+  # inside `create_organization_post/3`, so a withdrawn publisher cannot publish
+  # through a composer they still have open.
+  defp save_post(
+         %{post: nil, acting_as: %Organization{} = organization, current_user: author},
+         attrs
+       ),
+       do: Posts.create_organization_post(organization, author, attrs)
+
   defp save_post(%{post: nil, current_user: author}, attrs), do: Posts.create_post(author, attrs)
   defp save_post(%{post: post}, attrs), do: Posts.update_post(post, attrs)
 
@@ -1764,9 +1784,15 @@ defmodule VutuvWeb.PostLive.Composer do
 
             <div class="ml-auto flex items-center gap-3">
               <span
-                :if={@audience_locked?}
+                :if={@audience_locked? or @acting_as}
                 id={"#{@id}-audience-locked"}
-                title={gettext("The audience cannot be restricted while reposts or replies exist.")}
+                title={
+                  if(@acting_as,
+                    do: gettext("A post in an organization's name is always public."),
+                    else:
+                      gettext("The audience cannot be restricted while reposts or replies exist.")
+                  )
+                }
                 class="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-500 dark:border-slate-700 dark:text-slate-400"
               >
                 🌐 {gettext("Public")}
@@ -1778,7 +1804,16 @@ defmodule VutuvWeb.PostLive.Composer do
                 disabled={@uploads.images.entries != []}
                 phx-disable-with={gettext("Saving…")}
               >
-                {if @post, do: gettext("Save"), else: gettext("Post")}
+                <%!-- The button names the author while writing as an
+                organization (issue #1335), so the last thing seen before
+                publishing is whose name goes on it. The mode's own banner is at
+                the top of the page and may well have scrolled away by now;
+                this is the reminder that cannot. --%>
+                {cond do
+                  @post -> gettext("Save")
+                  @acting_as -> gettext("Post as %{name}", name: @acting_as.name)
+                  true -> gettext("Post")
+                end}
               </.button>
             </div>
           </div>

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -1017,6 +1017,7 @@ defmodule VutuvWeb.PostLive.Feed do
               module={VutuvWeb.PostLive.Composer}
               id="composer"
               current_user={@current_user}
+              acting_as={@acting_as}
               post={nil}
               preloaded_draft={{:loaded, @draft}}
             />

--- a/lib/vutuv_web/live/shell_live.ex
+++ b/lib/vutuv_web/live/shell_live.ex
@@ -38,6 +38,7 @@ defmodule VutuvWeb.ShellLive do
   alias Vutuv.Activity
   alias Vutuv.Dashboard
   alias Vutuv.DayClock
+  alias Vutuv.Organizations
   alias Vutuv.Social
   alias VutuvWeb.Live.InitAssigns
   alias VutuvWeb.Presence
@@ -70,7 +71,7 @@ defmodule VutuvWeb.ShellLive do
         # another member's chrome or subscribe to their "user:<id>" unread-badge
         # topic. All identity therefore comes from the resolved user, not the
         # curated map.
-        mount_authenticated(socket, InitAssigns.session_user(session), path)
+        mount_authenticated(socket, InitAssigns.session_user(session), session, path)
       else
         # The throwaway dead render, authenticated by the HTTP request that built
         # shell_session/1 from the validated current_user — so its curated
@@ -96,6 +97,10 @@ defmodule VutuvWeb.ShellLive do
     user_id = user_param && Vutuv.UUIDv7.cast_or_nil(session["user_id"])
 
     socket
+    # The mode the HTTP request behind this dead render already verified. It is
+    # replaced the instant the socket connects and re-asks the roles table.
+    |> assign(:acting_as_name, session["acting_as_name"])
+    |> assign(:acting_as_path, session["acting_as_path"])
     |> assign(:user_id, user_id)
     |> assign(:user_name, session["user_name"])
     # Initials are built from first+last (matching <.avatar>); fall back to the
@@ -110,8 +115,10 @@ defmodule VutuvWeb.ShellLive do
   # The connected socket, authenticated from the session token. A nil user
   # (missing / revoked / suspended / deactivated token) is the anonymous shell —
   # no subscriptions, no counts, no presence.
-  defp mount_authenticated(socket, nil, path) do
+  defp mount_authenticated(socket, nil, _session, path) do
     socket
+    |> assign(:acting_as_name, nil)
+    |> assign(:acting_as_path, nil)
     |> assign(:user_id, nil)
     |> assign(:user_name, nil)
     |> assign(:user_initials, nil)
@@ -124,11 +131,18 @@ defmodule VutuvWeb.ShellLive do
   # Everything the chrome shows is derived from the resolved user (recomputed the
   # same way shell_session/1 builds the curated map), so a replayed curated map
   # can neither render nor subscribe as another member.
-  defp mount_authenticated(socket, %User{} = user, path) do
+  defp mount_authenticated(socket, %User{} = user, session, path) do
     user_id = user.id
     Activity.subscribe(user_id)
+    # Re-asked from the cookie session's id against `organization_roles`, never
+    # taken from the curated map: the shell is on every page, so a mode it drew
+    # from a replayable payload would be the loudest possible lie about whose
+    # name the member is writing under (issue #1335).
+    acting_as = InitAssigns.acting_as(user, session)
 
     socket
+    |> assign(:acting_as_name, acting_as && acting_as.name)
+    |> assign(:acting_as_path, acting_as && Organizations.canonical_path(acting_as))
     |> assign(:user_id, user_id)
     |> assign(:user_name, full_name(user))
     |> assign(:user_initials, name_initials(user))
@@ -447,6 +461,42 @@ defmodule VutuvWeb.ShellLive do
       Fed by push_badge/1 + the {:new_post} handler; phx-update="ignore" because
       the hook owns document.title, not this node. --%>
       <div :if={@user_id} id="tab-badge" phx-hook="TabBadge" phx-update="ignore" class="hidden"></div>
+      <%!-- Writing as an organization (issue #1335). The characteristic failure
+      of this mode everywhere it exists is somebody posting something personal
+      from the brand account, and a discreet badge does not prevent it — so the
+      chrome changes unmistakably: a full-width brand bar above the top bar,
+      naming the organization, with the way out in it. It sits ABOVE the sticky
+      header rather than inside it so the bar's three-track width budget (see
+      the design rule) is untouched, and it scrolls away while the header stays,
+      which is right: the reminder is loudest where you start writing. --%>
+      <div
+        :if={@acting_as_name}
+        id="acting-as-banner"
+        class="bg-brand-700 text-white dark:bg-brand-800"
+      >
+        <div class="mx-auto flex max-w-6xl flex-wrap items-center gap-x-3 gap-y-1 px-4 py-2 text-sm">
+          <span class="font-semibold">
+            {gettext("You are writing as %{name}.", name: @acting_as_name)}
+          </span>
+          <.link
+            navigate={@acting_as_path}
+            class="underline decoration-white/50 underline-offset-2 hover:decoration-white"
+          >
+            {gettext("Open the page")}
+          </.link>
+          <%!-- Leaving is reachable from anywhere the banner is, in one click.
+          A CSRF DELETE, never a GET: a link prefetch must not end the mode. --%>
+          <.link
+            href={~p"/system/act_as"}
+            method="delete"
+            id="stop-acting-as"
+            class="ml-auto inline-flex min-h-10 items-center rounded-lg bg-white/15 px-3 font-semibold hover:bg-white/25"
+          >
+            {gettext("Write as myself again")}
+          </.link>
+        </div>
+      </div>
+
       <header class="sticky top-0 z-30 border-b border-slate-200 bg-white/90 backdrop-blur dark:border-slate-800 dark:bg-slate-900/90">
         <%!-- Three tracks, so the member total in the middle one is centred on
         the bar itself rather than on whatever space the flanking content leaves

--- a/lib/vutuv_web/plugs/acting_as.ex
+++ b/lib/vutuv_web/plugs/acting_as.ex
@@ -1,0 +1,43 @@
+defmodule VutuvWeb.Plug.ActingAs do
+  @moduledoc """
+  Resolves which identity the member is currently acting as (issue #1335) and
+  assigns `:acting_as` — an `%Vutuv.Organizations.Organization{}` while they are
+  switched into one, `nil` while they are themselves.
+
+  Runs after `VutuvWeb.Plug.ConfigureSession`, which decides *who* they are;
+  this decides *as whom they are speaking*.
+
+  **The session's `acting_as_organization_id` is a hint, never a credential.**
+  It is signed but not encrypted and valid for days, so a captured payload
+  replays — the trap #1034 and #1036 already cost this app twice. Every request
+  therefore re-asks `organization_roles` through
+  `Vutuv.Organizations.acting_organization/2` instead of trusting the value, so
+  a withdrawn `publisher` role takes effect on the very next action rather than
+  at the next login. The socket side of the same decision is
+  `VutuvWeb.Live.InitAssigns`.
+
+  When the id no longer resolves the plug also **drops it from the session**, so
+  the member is not left with a stale mode that silently does nothing: their
+  next page is plainly their own again.
+  """
+
+  import Plug.Conn
+
+  alias Vutuv.Organizations
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    id = get_session(conn, :acting_as_organization_id)
+    organization = Organizations.acting_organization(conn.assigns[:current_user], id)
+
+    conn
+    |> assign(:acting_as, organization)
+    |> clear_stale(id, organization)
+  end
+
+  defp clear_stale(conn, id, nil) when is_binary(id),
+    do: delete_session(conn, :acting_as_organization_id)
+
+  defp clear_stale(conn, _id, _organization), do: conn
+end

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -30,6 +30,10 @@ defmodule VutuvWeb.Router do
     plug(Plugs.AgentLinks)
     plug(:put_root_layout, html: {VutuvWeb.LayoutHTML, :root})
     plug(Plugs.ConfigureSession, repo: Vutuv.Repo)
+    # Which identity the member is speaking as (issue #1335). Right after the
+    # plug that decides WHO they are, and re-asked here on every request rather
+    # than trusted from the session.
+    plug(Plugs.ActingAs)
     plug(Plugs.Locale)
     # The daily text ad between navigation and content (1/hour per session).
     plug(Plugs.AdBanner)
@@ -110,6 +114,7 @@ defmodule VutuvWeb.Router do
     plug(Plugs.ContentSecurityPolicy)
     plug(:put_root_layout, html: {VutuvWeb.LayoutHTML, :root})
     plug(Plugs.ConfigureSession, repo: Vutuv.Repo)
+    plug(Plugs.ActingAs)
     plug(Plugs.Locale)
   end
 
@@ -274,6 +279,15 @@ defmodule VutuvWeb.Router do
     # what a federated Note is identified by), so it gets the one shape that
     # works whether or not a handle was ever claimed.
     get("/organizations/:slug/posts/:id", OrganizationController, :post)
+
+    # Switching into an organization and back (issue #1335). Never GET: a
+    # request that changes whose name you are speaking in must not be fired by
+    # a link prefetch or a Back button.
+    post("/organizations/:slug/act_as", ActingAsController, :create)
+    # Under /system/, not at a root word: profiles own the URL root, so every
+    # new root segment permanently burns a handle a member could have claimed.
+    # `system` is already reserved (`Vutuv.Accounts.ReservedSlugs`).
+    delete("/system/act_as", ActingAsController, :delete)
 
     get("/new_registration", PageController, :redirect_index)
     post("/new_registration", PageController, :new_registration)

--- a/lib/vutuv_web/views/account_event_text.ex
+++ b/lib/vutuv_web/views/account_event_text.ex
@@ -72,6 +72,15 @@ defmodule VutuvWeb.AccountEventText do
     do: gettext("Employment reference reviewed by the AI")
 
   def event_label("activity_log_viewed"), do: gettext("Activity log opened")
+
+  # Issue #1335. Deliberately worded as speaking rather than as switching: what
+  # the reader needs to recognise months later is that anything published in
+  # that window carried the organization's name, not their own.
+  def event_label("acted_as_organization"), do: gettext("Started writing as an organization")
+
+  def event_label("stopped_acting_as_organization"),
+    do: gettext("Stopped writing as an organization")
+
   def event_label(other), do: other
 
   @doc """
@@ -130,6 +139,11 @@ defmodule VutuvWeb.AccountEventText do
 
   defp detail("activity_log_viewed", %{"member" => member}) when is_binary(member),
     do: "@" <> member
+
+  defp detail(kind, %{"organization" => name})
+       when kind in ~w(acted_as_organization stopped_acting_as_organization) and
+              is_binary(name),
+       do: name
 
   # How many posts that day's pass took (issue #1255). The count is the whole
   # detail the log keeps — which posts they were is what is gone.

--- a/lib/vutuv_web/views/layout_html.ex
+++ b/lib/vutuv_web/views/layout_html.ex
@@ -185,6 +185,13 @@ defmodule VutuvWeb.LayoutHTML do
           "user_avatar" => Vutuv.Avatar.user_url(user, :thumb),
           "user_admin?" => user.admin?,
           "show_online" => user.show_online_status?,
+          # The identity they are speaking as (issue #1335), for the throwaway
+          # dead render only — `VutuvWeb.Plug.ActingAs` verified it on this very
+          # request, which is the one sanctioned use of a curated display field.
+          # The connected shell re-resolves it from the cookie session and
+          # replaces these.
+          "acting_as_name" => acting_as_name(assigns),
+          "acting_as_path" => acting_as_path(assigns),
           "path" => current_path(assigns)
         }
 
@@ -192,6 +199,14 @@ defmodule VutuvWeb.LayoutHTML do
         %{}
     end
   end
+
+  defp acting_as_name(%{acting_as: %Vutuv.Organizations.Organization{name: name}}), do: name
+  defp acting_as_name(_assigns), do: nil
+
+  defp acting_as_path(%{acting_as: %Vutuv.Organizations.Organization{} = organization}),
+    do: Vutuv.Organizations.canonical_path(organization)
+
+  defp acting_as_path(_assigns), do: nil
 
   @doc """
   The `<title>` for the self-contained `error.html.heex` layout (the

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.240.0",
+      version: "7.241.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -32,7 +32,7 @@ msgstr "Eintrag hinzufügen"
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
-#: lib/vutuv_web/live/organization_live/show.ex:471
+#: lib/vutuv_web/live/organization_live/show.ex:485
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
@@ -115,7 +115,7 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/live/job_posting_live/form.ex:605
 #: lib/vutuv_web/live/organization_live/edit.ex:347
 #: lib/vutuv_web/live/organization_live/new.ex:173
-#: lib/vutuv_web/live/post_live/composer.ex:1350
+#: lib/vutuv_web/live/post_live/composer.ex:1370
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
@@ -201,7 +201,7 @@ msgid "Disable"
 msgstr "Inaktivieren"
 
 #: lib/vutuv_web/live/cv_live.ex:438
-#: lib/vutuv_web/live/post_live/composer.ex:1674
+#: lib/vutuv_web/live/post_live/composer.ex:1694
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/templates/user/show.html.heex:310
 #: lib/vutuv_web/views/qualification_html.ex:237
@@ -342,7 +342,7 @@ msgstr "Folge ich"
 #: lib/vutuv_web/live/admin/dashboard_live.ex:195
 #: lib/vutuv_web/templates/page/index.html.heex:93
 #: lib/vutuv_web/templates/user/edit.html.heex:162
-#: lib/vutuv_web/views/account_event_text.ex:182
+#: lib/vutuv_web/views/account_event_text.ex:195
 #, elixir-autogen
 msgid "Gender"
 msgstr "Geschlecht"
@@ -440,8 +440,8 @@ msgstr "Einloggen"
 msgid "Log Out"
 msgstr "Ausloggen"
 
-#: lib/vutuv_web/live/shell_live.ex:718
-#: lib/vutuv_web/live/shell_live.ex:755
+#: lib/vutuv_web/live/shell_live.ex:768
+#: lib/vutuv_web/live/shell_live.ex:805
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -604,7 +604,7 @@ msgstr "Profile von "
 msgid "Provider"
 msgstr "Provider"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1772
+#: lib/vutuv_web/live/post_live/composer.ex:1798
 #: lib/vutuv_web/live/section_reorder_live.ex:258
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -616,7 +616,7 @@ msgstr "Öffentlich"
 
 #: lib/vutuv_web/components/ui.ex:3222
 #: lib/vutuv_web/live/organization_live/edit.ex:341
-#: lib/vutuv_web/live/post_live/composer.ex:1781
+#: lib/vutuv_web/live/post_live/composer.ex:1813
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:196
@@ -642,8 +642,8 @@ msgstr "Speichern"
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:37
 #: lib/vutuv_web/live/search_live.ex:378
-#: lib/vutuv_web/live/shell_live.ex:586
-#: lib/vutuv_web/live/shell_live.ex:738
+#: lib/vutuv_web/live/shell_live.ex:636
+#: lib/vutuv_web/live/shell_live.ex:788
 #: lib/vutuv_web/live/tag_live/timeline.ex:255
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
@@ -867,7 +867,7 @@ msgstr "Alle anzeigen"
 #: lib/vutuv_web/templates/email/show.html.heex:24
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:295
 #: lib/vutuv_web/templates/settings/privacy.html.heex:14
-#: lib/vutuv_web/views/account_event_text.ex:192
+#: lib/vutuv_web/views/account_event_text.ex:205
 #, elixir-autogen
 msgid "Visibility"
 msgstr "Sichtbarkeit"
@@ -934,7 +934,7 @@ msgstr ""
 msgid "You follow back %{name}."
 msgstr "Sie folgen %{name} jetzt zurück."
 
-#: lib/vutuv_web/live/init_assigns.ex:52
+#: lib/vutuv_web/live/init_assigns.ex:54
 #: lib/vutuv_web/live/post_live/feed.ex:76
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
@@ -1186,7 +1186,7 @@ msgstr "Lokalisierung hinzufügen"
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:690
+#: lib/vutuv_web/live/shell_live.ex:740
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1627,7 +1627,7 @@ msgstr "Adressen von %{name}"
 msgid "Admin control panel"
 msgstr "Admin-Bereich"
 
-#: lib/vutuv_web/live/shell_live.ex:741
+#: lib/vutuv_web/live/shell_live.ex:791
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "Mitteilungen"
@@ -1651,9 +1651,9 @@ msgstr "Schauen Sie in Ihr Postfach"
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
-#: lib/vutuv_web/live/post_live/composer.ex:1311
-#: lib/vutuv_web/live/post_live/composer.ex:1312
-#: lib/vutuv_web/live/post_live/composer.ex:2214
+#: lib/vutuv_web/live/post_live/composer.ex:1331
+#: lib/vutuv_web/live/post_live/composer.ex:1332
+#: lib/vutuv_web/live/post_live/composer.ex:2249
 #: lib/vutuv_web/templates/layout/app.html.heex:159
 #: lib/vutuv_web/templates/layout/app.html.heex:165
 #: lib/vutuv_web/views/layout_html.ex:40
@@ -1740,7 +1740,7 @@ msgstr ""
 " von jemandem, den Sie kennen oder interessant finden, und klicken Sie auf "
 "Folgen!"
 
-#: lib/vutuv_web/live/shell_live.ex:709
+#: lib/vutuv_web/live/shell_live.ex:759
 #: lib/vutuv_web/views/settings_html.ex:261
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1768,14 +1768,14 @@ msgstr "Nachricht"
 
 #: lib/vutuv_web/live/message_live/index.ex:45
 #: lib/vutuv_web/live/message_live/index.ex:512
-#: lib/vutuv_web/live/shell_live.ex:602
-#: lib/vutuv_web/live/shell_live.ex:740
+#: lib/vutuv_web/live/shell_live.ex:652
+#: lib/vutuv_web/live/shell_live.ex:790
 #: lib/vutuv_web/templates/layout/app.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr "Nachrichten"
 
-#: lib/vutuv_web/live/shell_live.ex:496
+#: lib/vutuv_web/live/shell_live.ex:546
 #, elixir-autogen, elixir-format
 msgid "Network"
 msgstr "Netzwerk"
@@ -1799,7 +1799,7 @@ msgstr "Noch nichts Neues."
 #: lib/vutuv_web/components/ui.ex:3653
 #: lib/vutuv_web/live/notification_live/index.ex:105
 #: lib/vutuv_web/live/notification_live/index.ex:329
-#: lib/vutuv_web/live/shell_live.ex:613
+#: lib/vutuv_web/live/shell_live.ex:663
 #: lib/vutuv_web/templates/layout/app.html.heex:124
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -1896,7 +1896,7 @@ msgstr ""
 "Wir haben eine PIN an Ihre neue E-Mail-Adresse geschickt. Geben Sie sie "
 "unten ein, um die Adresse zu bestätigen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1197
+#: lib/vutuv_web/live/post_live/feed.ex:1198
 #: lib/vutuv_web/views/user_html.ex:206
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
@@ -1956,7 +1956,7 @@ msgid "Pagination"
 msgstr "Seitennavigation"
 
 #: lib/vutuv_web/components/ui.ex:3461
-#: lib/vutuv_web/live/organization_live/show.ex:411
+#: lib/vutuv_web/live/organization_live/show.ex:425
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr "Mehr laden"
@@ -2115,7 +2115,7 @@ msgstr "Markdown wird unterstützt: Fett, Kursiv, Links und Listen."
 msgid "Add images"
 msgstr "Bilder hinzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1889
+#: lib/vutuv_web/live/post_live/composer.ex:1924
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr "Sobald irgendetwas ausgeblendet ist, sehen auch abgemeldete Besucher und Suchmaschinen den Beitrag nicht mehr."
@@ -2126,7 +2126,7 @@ msgstr "Sobald irgendetwas ausgeblendet ist, sehen auch abgemeldete Besucher und
 msgid "Back to the post"
 msgstr "Zurück zum Beitrag"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1594
+#: lib/vutuv_web/live/post_live/composer.ex:1614
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr "Upload abbrechen"
@@ -2150,8 +2150,8 @@ msgstr "Beitrag bearbeiten"
 
 #: lib/vutuv_web/live/post_live/feed.ex:158
 #: lib/vutuv_web/live/post_live/feed.ex:952
-#: lib/vutuv_web/live/shell_live.ex:476
-#: lib/vutuv_web/live/shell_live.ex:736
+#: lib/vutuv_web/live/shell_live.ex:526
+#: lib/vutuv_web/live/shell_live.ex:786
 #: lib/vutuv_web/templates/layout/app.html.heex:122
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2167,12 +2167,12 @@ msgstr "Folgen Sie %{name}, um ihn zu lesen."
 msgid "Hidden from:"
 msgstr "Verborgen vor:"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1865
+#: lib/vutuv_web/live/post_live/composer.ex:1900
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr "Vor einer bestimmten Person verbergen…"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1793
+#: lib/vutuv_web/live/post_live/composer.ex:1828
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
@@ -2183,41 +2183,41 @@ msgstr "Diesen Beitrag verbergen vor…"
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1835
+#: lib/vutuv_web/live/post_live/composer.ex:1870
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr "Nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1037
-#: lib/vutuv_web/live/post_live/composer.ex:1085
+#: lib/vutuv_web/live/post_live/composer.ex:1057
+#: lib/vutuv_web/live/post_live/composer.ex:1105
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1136
+#: lib/vutuv_web/live/post_live/feed.ex:1137
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 "Hier ist noch nichts. Folgen Sie anderen, um Ihren Feed zu füllen, oder "
 "schreiben Sie Ihren ersten Beitrag."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1010
+#: lib/vutuv_web/live/post_live/composer.ex:1030
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr "Eines der Bilder konnte nicht angehängt werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1825
+#: lib/vutuv_web/live/post_live/composer.ex:1860
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr "Personen, denen ich nicht folge"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1815
+#: lib/vutuv_web/live/post_live/composer.ex:1850
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr "Personen, die mir nicht folgen"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:406
-#: lib/vutuv_web/live/post_live/composer.ex:1781
+#: lib/vutuv_web/live/post_live/composer.ex:1815
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2267,7 +2267,7 @@ msgstr "Weniger anzeigen"
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:373
 #: lib/vutuv_web/live/organization_live/roles.ex:243
-#: lib/vutuv_web/live/post_live/composer.ex:1851
+#: lib/vutuv_web/live/post_live/composer.ex:1886
 #: lib/vutuv_web/live/post_live/saved.ex:619
 #: lib/vutuv_web/live/post_live/saved.ex:647
 #: lib/vutuv_web/templates/connection/index.html.heex:40
@@ -2283,29 +2283,29 @@ msgstr ""
 "Eingeschränkte Beiträge sind auch für nicht eingeloggte Besucher und "
 "Suchmaschinen unsichtbar."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1779
+#: lib/vutuv_web/live/post_live/composer.ex:1805
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1045
+#: lib/vutuv_web/live/post_live/feed.ex:1046
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
 msgstr[0] "%{formatted} neuen Beitrag anzeigen"
 msgstr[1] "%{formatted} neue Beiträge anzeigen"
 
-#: lib/vutuv_web/live/init_assigns.ex:81
+#: lib/vutuv_web/live/init_assigns.ex:83
 #, elixir-autogen, elixir-format
 msgid "Sorry, that page could not be found."
 msgstr "Diese Seite konnte leider nicht gefunden werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1111
+#: lib/vutuv_web/live/post_live/composer.ex:1131
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr "Diese Datei konnte nicht verarbeitet werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:992
+#: lib/vutuv_web/live/post_live/composer.ex:1012
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr "Die Sichtbarkeitsauswahl ist ungültig."
@@ -2315,18 +2315,18 @@ msgstr "Die Sichtbarkeitsauswahl ist ungültig."
 msgid "This post is for followers of %{name}"
 msgstr "Dieser Beitrag ist für Follower von %{name}"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2363
+#: lib/vutuv_web/live/post_live/composer.ex:2398
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Zu viele Dateien."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2364
+#: lib/vutuv_web/live/post_live/composer.ex:2399
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
 
 #: lib/vutuv_web/components/ui.ex:3917
-#: lib/vutuv_web/live/shell_live.ex:656
+#: lib/vutuv_web/live/shell_live.ex:706
 #: lib/vutuv_web/templates/post/index.html.heex:17
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:208
@@ -2334,12 +2334,12 @@ msgstr "Upload fehlgeschlagen."
 msgid "View profile"
 msgstr "Profil ansehen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1932
+#: lib/vutuv_web/live/post_live/composer.ex:1967
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr "Was gibt's Neues?"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1933
+#: lib/vutuv_web/live/post_live/composer.ex:1968
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
@@ -2375,17 +2375,17 @@ msgstr "Personen, denen Sie nicht folgen"
 msgid "unknown"
 msgstr "unbekannt"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1731
+#: lib/vutuv_web/live/post_live/composer.ex:1751
 #, elixir-autogen, elixir-format
 msgid "Tags, separated by commas (max. %{max})"
 msgstr "Tags, durch Komma getrennt (max. %{max})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2354
+#: lib/vutuv_web/live/post_live/composer.ex:2389
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr "Die Datei ist größer als %{mb} MB."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2358
+#: lib/vutuv_web/live/post_live/composer.ex:2393
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr "Dateityp wird nicht unterstützt (erlaubt: %{types})."
@@ -2416,8 +2416,8 @@ msgstr "Lesezeichen setzen"
 #: lib/vutuv_web/agent_docs/markdown.ex:961
 #: lib/vutuv_web/live/post_live/saved.ex:175
 #: lib/vutuv_web/live/post_live/saved.ex:488
-#: lib/vutuv_web/live/shell_live.ex:595
-#: lib/vutuv_web/live/shell_live.ex:661
+#: lib/vutuv_web/live/shell_live.ex:645
+#: lib/vutuv_web/live/shell_live.ex:711
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2438,7 +2438,7 @@ msgstr "Gefällt mir"
 #: lib/vutuv_web/live/notification_live/index.ex:956
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
-#: lib/vutuv_web/live/shell_live.ex:664
+#: lib/vutuv_web/live/shell_live.ex:714
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2499,7 +2499,7 @@ msgstr "Gefällt mir entfernen"
 #: lib/vutuv_web/components/ui.ex:1936
 #: lib/vutuv_web/components/ui.ex:1936
 #: lib/vutuv_web/components/ui.ex:2073
-#: lib/vutuv_web/live/post_live/feed.ex:1186
+#: lib/vutuv_web/live/post_live/feed.ex:1187
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
@@ -2535,13 +2535,13 @@ msgstr "Antworten"
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
 
-#: lib/vutuv_web/live/post_live/composer.ex:995
-#: lib/vutuv_web/live/post_live/composer.ex:1769
+#: lib/vutuv_web/live/post_live/composer.ex:1015
+#: lib/vutuv_web/live/post_live/composer.ex:1793
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr "Solange es geteilte Beiträge oder Antworten gibt, lässt sich der Empfängerkreis nicht einschränken."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1896
+#: lib/vutuv_web/live/post_live/composer.ex:1931
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beiträge oder Antworten gibt, bleibt er öffentlich; löschen können Sie ihn weiterhin."
@@ -2848,7 +2848,7 @@ msgstr "Noch keine Vernetzungen."
 msgid "Other formats"
 msgstr "Andere Formate"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1805
+#: lib/vutuv_web/live/post_live/composer.ex:1840
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr "Personen, mit denen ich nicht vernetzt bin"
@@ -3204,8 +3204,8 @@ msgid "Private message"
 msgstr "Private Nachricht"
 
 #: lib/vutuv_web/components/ui.ex:3585
-#: lib/vutuv_web/live/shell_live.ex:489
-#: lib/vutuv_web/live/shell_live.ex:745
+#: lib/vutuv_web/live/shell_live.ex:539
+#: lib/vutuv_web/live/shell_live.ex:795
 #: lib/vutuv_web/templates/import/new.html.heex:15
 #: lib/vutuv_web/templates/import/preview.html.heex:55
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
@@ -4690,7 +4690,7 @@ msgstr "Sie haben niemanden blockiert."
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1141
+#: lib/vutuv_web/live/post_live/feed.ex:1142
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
@@ -4749,7 +4749,7 @@ msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:516
 #: lib/vutuv_web/live/notification_live/index.ex:877
-#: lib/vutuv_web/live/organization_live/show.ex:421
+#: lib/vutuv_web/live/organization_live/show.ex:435
 #: lib/vutuv_web/live/post_live/saved.ex:498
 #: lib/vutuv_web/live/search_live.ex:198
 #: lib/vutuv_web/live/search_live.ex:472
@@ -5500,7 +5500,7 @@ msgstr ""
 "dauerhaft. Wir senden Ihnen zur Bestätigung eine PIN per E-Mail. Es kann "
 "nicht rückgängig gemacht werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1013
+#: lib/vutuv_web/live/post_live/composer.ex:1033
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
@@ -5510,7 +5510,7 @@ msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
 msgid "Content under review"
 msgstr "Inhalte in Prüfung"
 
-#: lib/vutuv_web/live/shell_live.ex:643
+#: lib/vutuv_web/live/shell_live.ex:693
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr "Kontomenü"
@@ -5532,7 +5532,7 @@ msgstr "Menüs und Dialoge schließen"
 msgid "General"
 msgstr "Allgemeines"
 
-#: lib/vutuv_web/live/shell_live.ex:700
+#: lib/vutuv_web/live/shell_live.ex:750
 #: lib/vutuv_web/templates/layout/app.html.heex:154
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5551,7 +5551,7 @@ msgstr "Navigation"
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:285
-#: lib/vutuv_web/live/shell_live.ex:680
+#: lib/vutuv_web/live/shell_live.ex:730
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5605,8 +5605,8 @@ msgstr "Nächster Beitrag im Feed"
 msgid "Previous post in the feed"
 msgstr "Vorheriger Beitrag im Feed"
 
-#: lib/vutuv_web/live/shell_live.ex:469
-#: lib/vutuv_web/live/shell_live.ex:729
+#: lib/vutuv_web/live/shell_live.ex:519
+#: lib/vutuv_web/live/shell_live.ex:779
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr "Hauptnavigation"
@@ -5620,7 +5620,7 @@ msgstr "Fußzeilen-Navigation"
 #: lib/vutuv_web/components/post_components.ex:2924
 #: lib/vutuv_web/components/post_components.ex:3316
 #: lib/vutuv_web/live/notification_live/index.ex:680
-#: lib/vutuv_web/live/post_live/feed.ex:1259
+#: lib/vutuv_web/live/post_live/feed.ex:1260
 #: lib/vutuv_web/views/user_html.ex:111
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5774,7 +5774,7 @@ msgid "Email notifications"
 msgstr "E-Mail-Benachrichtigungen"
 
 #: lib/vutuv_web/templates/settings/preferences.html.heex:18
-#: lib/vutuv_web/views/account_event_text.ex:185
+#: lib/vutuv_web/views/account_event_text.ex:198
 #, elixir-autogen, elixir-format
 msgid "Interface language"
 msgstr "Sprache der Oberfläche"
@@ -6143,7 +6143,7 @@ msgstr ""
 " online sind."
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:124
-#: lib/vutuv_web/views/account_event_text.ex:196
+#: lib/vutuv_web/views/account_event_text.ex:209
 #, elixir-autogen, elixir-format
 msgid "Online status"
 msgstr "Online-Status"
@@ -6277,7 +6277,7 @@ msgstr "Kurzbeschreibung hinzufügen"
 
 #: lib/vutuv_web/live/cv_live.ex:148
 #: lib/vutuv_web/templates/user/edit.html.heex:206
-#: lib/vutuv_web/views/account_event_text.ex:175
+#: lib/vutuv_web/views/account_event_text.ex:188
 #, elixir-autogen, elixir-format
 msgid "Tagline"
 msgstr "Kurzbeschreibung"
@@ -6345,7 +6345,7 @@ msgstr "Foto positionieren"
 msgid "Use photo"
 msgstr "Foto verwenden"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1352
+#: lib/vutuv_web/live/post_live/composer.ex:1372
 #: lib/vutuv_web/templates/user/edit.html.heex:51
 #: lib/vutuv_web/templates/user/edit.html.heex:104
 #, elixir-autogen, elixir-format
@@ -7189,7 +7189,7 @@ msgstr "Neuer Newsletter"
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:223
 #: lib/vutuv_web/templates/settings/notifications.html.heex:73
-#: lib/vutuv_web/views/account_event_text.ex:200
+#: lib/vutuv_web/views/account_event_text.ex:213
 #, elixir-autogen, elixir-format
 msgid "Newsletter"
 msgstr "Newsletter"
@@ -8835,13 +8835,13 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr "Geben Sie zur Bestätigung Ihren Benutzernamen ein:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1226
 #: lib/vutuv_web/live/post_live/feed.ex:1227
+#: lib/vutuv_web/live/post_live/feed.ex:1228
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr "Andere Beiträge anzeigen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1221
+#: lib/vutuv_web/live/post_live/feed.ex:1222
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr "Vorgeschlagene Beiträge"
@@ -9268,7 +9268,7 @@ msgid "Open CV"
 msgstr "Lebenslauf öffnen"
 
 #: lib/vutuv_web/live/cv_live.ex:146
-#: lib/vutuv_web/views/account_event_text.ex:183
+#: lib/vutuv_web/views/account_event_text.ex:196
 #, elixir-autogen, elixir-format
 msgid "Photo"
 msgstr "Foto"
@@ -10204,7 +10204,7 @@ msgstr "+%{code} ist die Ländervorwahl von %{region}"
 #: lib/vutuv_web/cv/latex.ex:69
 #: lib/vutuv_web/cv/odt.ex:109
 #: lib/vutuv_web/live/cv_live.ex:153
-#: lib/vutuv_web/views/account_event_text.ex:177
+#: lib/vutuv_web/views/account_event_text.ex:190
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr "Geburtsdatum"
@@ -10228,13 +10228,13 @@ msgstr ""
 " angezeigt. Sie können es jederzeit wieder hinzufügen."
 
 #: lib/vutuv_web/templates/page/index.html.heex:65
-#: lib/vutuv_web/views/account_event_text.ex:173
+#: lib/vutuv_web/views/account_event_text.ex:186
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr "Vorname"
 
 #: lib/vutuv_web/templates/page/index.html.heex:70
-#: lib/vutuv_web/views/account_event_text.ex:174
+#: lib/vutuv_web/views/account_event_text.ex:187
 #, elixir-autogen, elixir-format
 msgid "Last name"
 msgstr "Nachname"
@@ -10780,7 +10780,7 @@ msgid "Code"
 msgstr "Code"
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:159
-#: lib/vutuv_web/views/account_event_text.ex:198
+#: lib/vutuv_web/views/account_event_text.ex:211
 #, elixir-autogen, elixir-format
 msgid "Code statistics"
 msgstr "Code-Statistiken"
@@ -11632,7 +11632,7 @@ msgid "Your list is empty. Nobody is excluded yet."
 msgstr "Ihre Liste ist leer. Es ist noch niemand ausgeschlossen."
 
 #: lib/vutuv_web/live/organization_live/edit.ex:328
-#: lib/vutuv_web/views/account_event_text.ex:195
+#: lib/vutuv_web/views/account_event_text.ex:208
 #, elixir-autogen, elixir-format
 msgid "AI agents"
 msgstr "KI-Agenten"
@@ -11650,7 +11650,7 @@ msgstr "Weiter zur Verifizierung"
 #: lib/vutuv_web/live/organization_live/domains.ex:248
 #: lib/vutuv_web/live/organization_live/domains.ex:288
 #: lib/vutuv_web/live/organization_live/new.ex:146
-#: lib/vutuv_web/live/organization_live/show.ex:545
+#: lib/vutuv_web/live/organization_live/show.ex:559
 #: lib/vutuv_web/templates/url/verify.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "DNS TXT record"
@@ -11659,7 +11659,7 @@ msgstr "DNS-TXT-Eintrag"
 #: lib/vutuv_web/live/organization_live/domains.ex:153
 #: lib/vutuv_web/live/organization_live/domains.ex:167
 #: lib/vutuv_web/live/organization_live/show.ex:263
-#: lib/vutuv_web/live/organization_live/show.ex:604
+#: lib/vutuv_web/live/organization_live/show.ex:618
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr "Die Domain-Verifizierung ist auf dieser Installation deaktiviert."
@@ -11699,7 +11699,7 @@ msgstr ""
 msgid "Please log in first."
 msgstr "Bitte loggen Sie sich zuerst ein."
 
-#: lib/vutuv_web/live/organization_live/show.ex:518
+#: lib/vutuv_web/live/organization_live/show.ex:532
 #, elixir-autogen, elixir-format
 msgid "Prove you control %{domain} to publish this page."
 msgstr "Weisen Sie nach, dass Ihnen %{domain} gehört, um diese Seite zu veröffentlichen."
@@ -11715,7 +11715,7 @@ msgid "Search by name or city"
 msgstr "Nach Name oder Stadt suchen"
 
 #: lib/vutuv_web/live/organization_live/edit.ex:312
-#: lib/vutuv_web/views/account_event_text.ex:194
+#: lib/vutuv_web/views/account_event_text.ex:207
 #, elixir-autogen, elixir-format
 msgid "Search engines"
 msgstr "Suchmaschinen"
@@ -11726,7 +11726,7 @@ msgid "Select a country"
 msgstr "Land auswählen"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:307
-#: lib/vutuv_web/live/organization_live/show.ex:580
+#: lib/vutuv_web/live/organization_live/show.ex:594
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr "Stellen Sie diese Datei bereit unter:"
@@ -11753,12 +11753,12 @@ msgid "The upload failed."
 msgstr "Der Upload ist fehlgeschlagen."
 
 #: lib/vutuv_web/live/organization_live/new.ex:131
-#: lib/vutuv_web/live/organization_live/show.ex:533
+#: lib/vutuv_web/live/organization_live/show.ex:547
 #, elixir-autogen, elixir-format
 msgid "Verification method"
 msgstr "Verifizierungsmethode"
 
-#: lib/vutuv_web/live/organization_live/show.ex:493
+#: lib/vutuv_web/live/organization_live/show.ex:507
 #, elixir-autogen, elixir-format
 msgid "Verified domains"
 msgstr "Verifizierte Domains"
@@ -11774,13 +11774,13 @@ msgstr "Verifiziert über"
 msgid "Verified via %{domain}"
 msgstr "Verifiziert über %{domain}"
 
-#: lib/vutuv_web/live/organization_live/show.ex:515
+#: lib/vutuv_web/live/organization_live/show.ex:529
 #, elixir-autogen, elixir-format
 msgid "Verify %{name}"
 msgstr "%{name} verifizieren"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:320
-#: lib/vutuv_web/live/organization_live/show.ex:600
+#: lib/vutuv_web/live/organization_live/show.ex:614
 #, elixir-autogen, elixir-format
 msgid "Verify now"
 msgstr "Jetzt verifizieren"
@@ -11803,7 +11803,7 @@ msgstr "Website"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:249
 #: lib/vutuv_web/live/organization_live/domains.ex:298
-#: lib/vutuv_web/live/organization_live/show.ex:556
+#: lib/vutuv_web/live/organization_live/show.ex:570
 #: lib/vutuv_web/templates/url/verify.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Website file"
@@ -11827,7 +11827,7 @@ msgstr ""
 "die Kontrolle über die Domain nachzuweisen."
 
 #: lib/vutuv_web/live/organization_live/domains.ex:309
-#: lib/vutuv_web/live/organization_live/show.ex:586
+#: lib/vutuv_web/live/organization_live/show.ex:600
 #: lib/vutuv_web/templates/url/verify.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
@@ -11878,7 +11878,7 @@ msgstr "Alias entfernt."
 #: lib/vutuv_web/agent_docs/markdown.ex:322
 #: lib/vutuv_web/agent_docs/text.ex:348
 #: lib/vutuv_web/live/organization_live/edit.ex:353
-#: lib/vutuv_web/live/organization_live/show.ex:481
+#: lib/vutuv_web/live/organization_live/show.ex:495
 #: lib/vutuv_web/templates/tag/single_card.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Also known as"
@@ -12256,7 +12256,7 @@ msgstr "verifizierte Webseite"
 msgid "%{min} to %{max} characters: letters (a-z), numbers (0-9) and underscores."
 msgstr "%{min} bis %{max} Zeichen: Buchstaben (a-z), Zahlen (0-9) und Unterstriche."
 
-#: lib/vutuv_web/live/organization_live/show.ex:436
+#: lib/vutuv_web/live/organization_live/show.ex:450
 #, elixir-autogen, elixir-format
 msgid "Former"
 msgstr "Ehemalig"
@@ -12388,7 +12388,7 @@ msgstr "Vielleicht brauchen Sie Hilfe von Ihrer IT"
 msgid "The proof is a small technical change to your domain: a DNS entry or a file on your website. If you don't manage the website yourself, ask the person or team who does. That is usually your IT department or the company that runs your website. We show the exact instructions on the next step, so you can simply pass them on."
 msgstr "Der Nachweis ist eine kleine technische Änderung an Ihrer Domain: ein DNS-Eintrag oder eine Datei auf Ihrer Website. Wenn Sie die Website nicht selbst verwalten, fragen Sie die Person oder das Team, das dies tut. Das ist meist Ihre IT-Abteilung oder die Firma, die Ihre Website betreut. Die genaue Anleitung zeigen wir Ihnen im nächsten Schritt, Sie können sie einfach weitergeben."
 
-#: lib/vutuv_web/live/organization_live/show.ex:527
+#: lib/vutuv_web/live/organization_live/show.ex:541
 #, elixir-autogen, elixir-format
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr "Diese Schritte sind technisch. Wenn Sie %{domain} nicht selbst verwalten, kopieren Sie den unten gezeigten Eintrag oder die Datei und senden Sie ihn an Ihre IT-Abteilung oder die Firma, die Ihre Website betreut. Sobald sie ihn hinzugefügt hat, kommen Sie hierher zurück und klicken auf „Jetzt verifizieren“."
@@ -12505,7 +12505,7 @@ msgstr "Organisation wieder freigegeben."
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:501
-#: lib/vutuv_web/live/shell_live.ex:671
+#: lib/vutuv_web/live/shell_live.ex:721
 #: lib/vutuv_web/templates/layout/app.html.heex:83
 #: lib/vutuv_web/templates/settings/organizations.html.heex:6
 #, elixir-autogen, elixir-format
@@ -12770,7 +12770,7 @@ msgstr "Anzeige bearbeiten"
 #: lib/vutuv_web/agent_docs/text.ex:392
 #: lib/vutuv_web/live/admin/job_live.ex:344
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:17
-#: lib/vutuv_web/views/account_event_text.ex:188
+#: lib/vutuv_web/views/account_event_text.ex:201
 #, elixir-autogen, elixir-format
 msgid "Employer"
 msgstr "Arbeitgeber"
@@ -12849,7 +12849,7 @@ msgstr "Stellenbezeichnung"
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:504
-#: lib/vutuv_web/live/shell_live.ex:503
+#: lib/vutuv_web/live/shell_live.ex:553
 #: lib/vutuv_web/templates/layout/app.html.heex:81
 #: lib/vutuv_web/templates/qualification/show.html.heex:38
 #, elixir-autogen, elixir-format
@@ -13296,13 +13296,13 @@ msgid "Getting an error, or is %{host} a CNAME / alias to another address? A TXT
 msgstr "Bekommen Sie einen Fehler, oder ist %{host} ein CNAME / Alias auf eine andere Adresse? Ein TXT-Eintrag kann nicht denselben Namen wie ein CNAME haben. Verwenden Sie stattdessen diesen Namen, mit exakt demselben Wert wie oben:"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:305
-#: lib/vutuv_web/live/organization_live/show.ex:573
+#: lib/vutuv_web/live/organization_live/show.ex:587
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr "Ist %{domain} ein CNAME / Alias (ein TXT-Eintrag kann nicht denselben Namen wie ein CNAME haben), legen Sie den Eintrag stattdessen auf %{name} an, mit demselben Wert."
 
 #: lib/vutuv_web/live/organization_live/domains.ex:303
-#: lib/vutuv_web/live/organization_live/show.ex:564
+#: lib/vutuv_web/live/organization_live/show.ex:578
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
 msgstr "Legen Sie in Ihren DNS-Einstellungen einen TXT-Eintrag auf dem Namen %{domain} mit diesem Wert an:"
@@ -13398,7 +13398,7 @@ msgid "Minimum yearly salary"
 msgstr "Mindestgehalt pro Jahr"
 
 #: lib/vutuv_web/live/job_board_live.ex:324
-#: lib/vutuv_web/live/organization_live/show.ex:463
+#: lib/vutuv_web/live/organization_live/show.ex:477
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr "Weitere Stellen"
@@ -13427,7 +13427,7 @@ msgstr "Keine passenden Stellen. Passen Sie die Filter an."
 #: lib/vutuv_web/agent_docs/markdown.ex:400
 #: lib/vutuv_web/agent_docs/text.ex:412
 #: lib/vutuv_web/agent_docs/text.ex:424
-#: lib/vutuv_web/live/organization_live/show.ex:450
+#: lib/vutuv_web/live/organization_live/show.ex:464
 #: lib/vutuv_web/templates/tag/show.html.heex:45
 #, elixir-autogen, elixir-format
 msgid "Open positions"
@@ -14140,7 +14140,7 @@ msgstr "Volle Breite"
 msgid "Insert image"
 msgstr "Bild einfügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2333
+#: lib/vutuv_web/live/post_live/composer.ex:2368
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr "In den Text einfügen"
@@ -14204,14 +14204,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3661
 #: lib/vutuv_web/controllers/settings_controller.ex:569
-#: lib/vutuv_web/live/post_live/feed.ex:1172
+#: lib/vutuv_web/live/post_live/feed.ex:1173
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr "Tags, denen Sie folgen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1187
+#: lib/vutuv_web/live/post_live/feed.ex:1188
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr "#%{tag} entfolgen"
@@ -14555,7 +14555,7 @@ msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] "Empfohlen von %{name} und %{formatted} weiteren"
 msgstr[1] "Empfohlen von %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/live/shell_live.ex:389
+#: lib/vutuv_web/live/shell_live.ex:403
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -14828,13 +14828,13 @@ msgstr "Erwähnung"
 msgid "mentioned you in a post."
 msgstr "hat Sie in einem Beitrag erwähnt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1000
+#: lib/vutuv_web/live/post_live/composer.ex:1020
 #: lib/vutuv_web/live/post_live/edit.ex:57
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr "Dieser Beitrag lässt sich nicht mehr bearbeiten: jemand hat ihn geliked, geteilt oder beantwortet."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1003
+#: lib/vutuv_web/live/post_live/composer.ex:1023
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -16459,31 +16459,31 @@ msgstr "Wir haben eine PIN an %{email} geschickt."
 msgid "Ask for a PIN first, then enter it here."
 msgstr "Fordern Sie zuerst eine PIN an und geben Sie sie hier ein."
 
-#: lib/vutuv_web/views/account_event_text.ex:105
+#: lib/vutuv_web/views/account_event_text.ex:113
 #, elixir-autogen, elixir-format
 msgid "%{count} code"
 msgid_plural "%{count} codes"
 msgstr[0] "%{count} Code"
 msgstr[1] "%{count} Codes"
 
-#: lib/vutuv_web/views/account_event_text.ex:101
+#: lib/vutuv_web/views/account_event_text.ex:109
 #, elixir-autogen, elixir-format
 msgid "%{count} device"
 msgid_plural "%{count} devices"
 msgstr[0] "%{count} Gerät"
 msgstr[1] "%{count} Geräte"
 
-#: lib/vutuv_web/views/account_event_text.ex:93
+#: lib/vutuv_web/views/account_event_text.ex:101
 #, elixir-autogen, elixir-format
 msgid "%{email}, now hidden from your profile"
 msgstr "%{email}, jetzt nicht mehr auf Ihrem Profil sichtbar"
 
-#: lib/vutuv_web/views/account_event_text.ex:92
+#: lib/vutuv_web/views/account_event_text.ex:100
 #, elixir-autogen, elixir-format
 msgid "%{email}, now shown on your profile"
 msgstr "%{email}, jetzt auf Ihrem Profil sichtbar"
 
-#: lib/vutuv_web/views/account_event_text.ex:84
+#: lib/vutuv_web/views/account_event_text.ex:92
 #, elixir-autogen, elixir-format
 msgid "@%{from} to @%{to}"
 msgstr "@%{from} zu @%{to}"
@@ -16561,7 +16561,7 @@ msgstr "Authenticator-App ausgeschaltet"
 msgid "By %{name}"
 msgstr "Von %{name}"
 
-#: lib/vutuv_web/views/account_event_text.ex:206
+#: lib/vutuv_web/views/account_event_text.ex:219
 #, elixir-autogen, elixir-format
 msgid "CV update notifications"
 msgstr "Benachrichtigungen zu Lebenslauf-Änderungen"
@@ -16574,7 +16574,7 @@ msgstr "Benachrichtigungen zu Lebenslauf-Änderungen"
 msgid "Confirmed"
 msgstr "Bestätigt"
 
-#: lib/vutuv_web/views/account_event_text.ex:184
+#: lib/vutuv_web/views/account_event_text.ex:197
 #, elixir-autogen, elixir-format
 msgid "Cover picture"
 msgstr "Titelbild"
@@ -16604,7 +16604,7 @@ msgstr "E-Mail-Adresse geändert"
 msgid "Email address removed"
 msgstr "E-Mail-Adresse entfernt"
 
-#: lib/vutuv_web/views/account_event_text.ex:202
+#: lib/vutuv_web/views/account_event_text.ex:215
 #, elixir-autogen, elixir-format
 msgid "Endorsement emails"
 msgstr "E-Mails zu Empfehlungen"
@@ -16614,17 +16614,17 @@ msgstr "E-Mails zu Empfehlungen"
 msgid "Every change to your account: what changed, exactly when, from which device, and how it was confirmed. If a line surprises you, follow the link at the end of it."
 msgstr "Jede Änderung an Ihrem Konto: was geändert wurde, wann genau, von welchem Gerät und wie es bestätigt wurde. Wenn Sie eine Zeile überrascht, folgen Sie dem Link an ihrem Ende."
 
-#: lib/vutuv_web/views/account_event_text.ex:211
+#: lib/vutuv_web/views/account_event_text.ex:224
 #, elixir-autogen, elixir-format
 msgid "Fediverse aliases"
 msgstr "Fediverse-Aliase"
 
-#: lib/vutuv_web/views/account_event_text.ex:208
+#: lib/vutuv_web/views/account_event_text.ex:221
 #, elixir-autogen, elixir-format
 msgid "Fediverse participation"
 msgstr "Fediverse-Teilnahme"
 
-#: lib/vutuv_web/views/account_event_text.ex:210
+#: lib/vutuv_web/views/account_event_text.ex:223
 #, elixir-autogen, elixir-format
 msgid "Fediverse replies"
 msgstr "Fediverse-Antworten"
@@ -16664,12 +16664,12 @@ msgstr "Import übernommen"
 msgid "It is part of your data download, and it is deleted with your account."
 msgstr "Es ist Teil Ihres Datendownloads und wird mit Ihrem Konto gelöscht."
 
-#: lib/vutuv_web/views/account_event_text.ex:193
+#: lib/vutuv_web/views/account_event_text.ex:206
 #, elixir-autogen, elixir-format
 msgid "Job search"
 msgstr "Jobsuche"
 
-#: lib/vutuv_web/views/account_event_text.ex:197
+#: lib/vutuv_web/views/account_event_text.ex:210
 #, elixir-autogen, elixir-format
 msgid "Mastodon posts"
 msgstr "Mastodon-Beiträge"
@@ -16684,7 +16684,7 @@ msgstr "Mitglied blockiert"
 msgid "Member unblocked"
 msgstr "Blockierung aufgehoben"
 
-#: lib/vutuv_web/views/account_event_text.ex:201
+#: lib/vutuv_web/views/account_event_text.ex:214
 #, elixir-autogen, elixir-format
 msgid "New follower emails"
 msgstr "E-Mails zu neuen Followern"
@@ -16723,7 +16723,7 @@ msgstr "Dazu passt nichts. Versuchen Sie eine kürzere Suche oder setzen Sie die
 msgid "Nothing recorded yet."
 msgstr "Noch nichts aufgezeichnet."
 
-#: lib/vutuv_web/views/account_event_text.ex:199
+#: lib/vutuv_web/views/account_event_text.ex:212
 #, elixir-autogen, elixir-format
 msgid "Notification emails"
 msgstr "Benachrichtigungs-E-Mails"
@@ -16768,7 +16768,7 @@ msgstr "Profil geändert"
 msgid "Recent account activity"
 msgstr "Letzte Kontoaktivität"
 
-#: lib/vutuv_web/views/account_event_text.ex:205
+#: lib/vutuv_web/views/account_event_text.ex:218
 #, elixir-autogen, elixir-format
 msgid "Saved search alerts"
 msgstr "Benachrichtigungen zu gespeicherten Suchen"
@@ -16805,17 +16805,17 @@ msgid_plural "This log keeps %{formatted} days of history."
 msgstr[0] "Dieses Protokoll bewahrt einen Tag Verlauf auf."
 msgstr[1] "Dieses Protokoll bewahrt %{formatted} Tage Verlauf auf."
 
-#: lib/vutuv_web/views/account_event_text.ex:207
+#: lib/vutuv_web/views/account_event_text.ex:220
 #, elixir-autogen, elixir-format
 msgid "Thread notifications"
 msgstr "Benachrichtigungen zu Diskussionen"
 
-#: lib/vutuv_web/views/account_event_text.ex:204
+#: lib/vutuv_web/views/account_event_text.ex:217
 #, elixir-autogen, elixir-format
 msgid "Unread message delay"
 msgstr "Verzögerung bei ungelesenen Nachrichten"
 
-#: lib/vutuv_web/views/account_event_text.ex:203
+#: lib/vutuv_web/views/account_event_text.ex:216
 #, elixir-autogen, elixir-format
 msgid "Unread message emails"
 msgstr "E-Mails zu ungelesenen Nachrichten"
@@ -16861,22 +16861,22 @@ msgstr "Was geschehen ist"
 msgid "a deleted account"
 msgstr "einem gelöschten Konto"
 
-#: lib/vutuv_web/views/account_event_text.ex:115
+#: lib/vutuv_web/views/account_event_text.ex:123
 #, elixir-autogen, elixir-format
 msgid "a tag"
 msgstr "ein Tag"
 
-#: lib/vutuv_web/views/account_event_text.ex:116
+#: lib/vutuv_web/views/account_event_text.ex:124
 #, elixir-autogen, elixir-format
 msgid "a word or phrase"
 msgstr "ein Wort oder eine Wortgruppe"
 
-#: lib/vutuv_web/views/account_event_text.ex:164
+#: lib/vutuv_web/views/account_event_text.ex:177
 #, elixir-autogen, elixir-format
 msgid "by the site operators"
 msgstr "durch den Betreiber"
 
-#: lib/vutuv_web/views/account_event_text.ex:163
+#: lib/vutuv_web/views/account_event_text.ex:176
 #, elixir-autogen, elixir-format
 msgid "from a signed-in session"
 msgstr "aus einer angemeldeten Sitzung"
@@ -16886,32 +16886,32 @@ msgstr "aus einer angemeldeten Sitzung"
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr "protokoll verlauf historie chronik audit sicherheit war ich das wer hat wann geaendert geändert log"
 
-#: lib/vutuv_web/views/account_event_text.ex:144
+#: lib/vutuv_web/views/account_event_text.ex:157
 #, elixir-autogen, elixir-format
 msgid "not taking part in the Fediverse"
 msgstr "keine Teilnahme am Fediverse"
 
-#: lib/vutuv_web/views/account_event_text.ex:141
+#: lib/vutuv_web/views/account_event_text.ex:154
 #, elixir-autogen, elixir-format
 msgid "taking part in the Fediverse"
 msgstr "Teilnahme am Fediverse"
 
-#: lib/vutuv_web/views/account_event_text.ex:161
+#: lib/vutuv_web/views/account_event_text.ex:174
 #, elixir-autogen, elixir-format
 msgid "with a one-time list code"
 msgstr "mit einem Code aus Ihrer Kennwortliste"
 
-#: lib/vutuv_web/views/account_event_text.ex:159
+#: lib/vutuv_web/views/account_event_text.ex:172
 #, elixir-autogen, elixir-format
 msgid "with a passkey"
 msgstr "mit einem Passkey"
 
-#: lib/vutuv_web/views/account_event_text.ex:162
+#: lib/vutuv_web/views/account_event_text.ex:175
 #, elixir-autogen, elixir-format
 msgid "with an emailed PIN"
 msgstr "mit einer per E-Mail geschickten PIN"
 
-#: lib/vutuv_web/views/account_event_text.ex:160
+#: lib/vutuv_web/views/account_event_text.ex:173
 #, elixir-autogen, elixir-format
 msgid "with your authenticator app"
 msgstr "mit Ihrer Authenticator-App"
@@ -16979,7 +16979,7 @@ msgstr "angehefteter Beitrag"
 #: lib/vutuv_web/agent_docs/text.ex:434
 #: lib/vutuv_web/templates/user/edit.html.heex:180
 #: lib/vutuv_web/templates/user/show.html.heex:217
-#: lib/vutuv_web/views/account_event_text.ex:176
+#: lib/vutuv_web/views/account_event_text.ex:189
 #, elixir-autogen, elixir-format
 msgid "Name pronunciation"
 msgstr "Aussprache des Namens"
@@ -16998,7 +16998,7 @@ msgstr ""
 "in eckigen Klammern, wie eine Lautschrift geschrieben wird; die Klammern "
 "ergänzen wir für Sie. Bleibt das Feld leer, wird nichts angezeigt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2346
+#: lib/vutuv_web/live/post_live/composer.ex:2381
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr "Diese Einstellungen für alle Fotos übernehmen"
@@ -17028,12 +17028,12 @@ msgstr "CC BY-SA 4.0 (Namensnennung, gleiche Bedingungen)"
 msgid "CC0 1.0 (no rights reserved)"
 msgstr "CC0 1.0 (keine Rechte vorbehalten)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2013
+#: lib/vutuv_web/live/post_live/composer.ex:2048
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr "Titelbild"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2206
+#: lib/vutuv_web/live/post_live/composer.ex:2241
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
@@ -17045,27 +17045,27 @@ msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 msgid "Download the original"
 msgstr "Original herunterladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1431
+#: lib/vutuv_web/live/post_live/composer.ex:1451
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder. The first photo leads the gallery."
 msgstr "Zum Umsortieren ziehen. Das erste Foto führt die Galerie an."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2283
+#: lib/vutuv_web/live/post_live/composer.ex:2318
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr "Alle Metadaten bleiben erhalten, auch alles, was Ihre Kamera hineingeschrieben hat."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2239
+#: lib/vutuv_web/live/post_live/composer.ex:2274
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr "Alle dürfen dieses Foto herunterladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2241
+#: lib/vutuv_web/live/post_live/composer.ex:2276
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr "Volle Auflösung, direkt aus dem Beitrag."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2260
+#: lib/vutuv_web/live/post_live/composer.ex:2295
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr "Nur das Bild"
@@ -17075,7 +17075,7 @@ msgstr "Nur das Bild"
 msgid "Next photo"
 msgstr "Nächstes Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2032
+#: lib/vutuv_web/live/post_live/composer.ex:2067
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
@@ -17107,8 +17107,8 @@ msgstr "Foto %{n} von %{total}"
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1985
-#: lib/vutuv_web/live/post_live/composer.ex:1986
+#: lib/vutuv_web/live/post_live/composer.ex:2020
+#: lib/vutuv_web/live/post_live/composer.ex:2021
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr "Foto-Einstellungen"
@@ -17125,18 +17125,18 @@ msgstr "Fotos:"
 msgid "Previous photo"
 msgstr "Vorheriges Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2045
-#: lib/vutuv_web/live/post_live/composer.ex:2046
+#: lib/vutuv_web/live/post_live/composer.ex:2080
+#: lib/vutuv_web/live/post_live/composer.ex:2081
 #, elixir-autogen, elixir-format
 msgid "Remove photo"
 msgstr "Foto entfernen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2262
+#: lib/vutuv_web/live/post_live/composer.ex:2297
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr "Dieselben Bildpunkte, sonst nichts: Ort und Seriennummern entfernt, Qualität unverändert."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1403
+#: lib/vutuv_web/live/post_live/composer.ex:1423
 #, elixir-autogen, elixir-format
 msgid "Show camera settings"
 msgstr "Kameradaten anzeigen"
@@ -17146,17 +17146,17 @@ msgstr "Kameradaten anzeigen"
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr "Dieser Server ist auf dieser Seite gesperrt, deshalb kann keine Antwort dorthin gesendet werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2281
+#: lib/vutuv_web/live/post_live/composer.ex:2316
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr "Die Datei genau so, wie ich sie hochgeladen habe"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2317
+#: lib/vutuv_web/live/post_live/composer.ex:2352
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr "Dieses Dateiformat lässt sich nur unverändert weitergeben. Entfernen Sie das Foto, wenn Sie das nicht möchten."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2309
+#: lib/vutuv_web/live/post_live/composer.ex:2344
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr "Dieses Foto enthält den Ort, an dem es aufgenommen wurde. Wer die exakte Datei herunterlädt, kann ihn auslesen."
@@ -17181,12 +17181,12 @@ msgstr "Diese Seite nimmt nicht am Fediverse teil."
 msgid "Turn on Fediverse participation to answer"
 msgstr "Fediverse-Teilnahme einschalten, um zu antworten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1652
+#: lib/vutuv_web/live/post_live/composer.ex:1672
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr "Wer diese Fotos weiterverwenden darf"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1020
+#: lib/vutuv_web/live/post_live/composer.ex:1040
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke geschickt. Bitte versuchen Sie es später noch einmal."
@@ -17196,7 +17196,7 @@ msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke gesc
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshalb werden von hier aus keine Antworten mehr gesendet."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1034
+#: lib/vutuv_web/live/post_live/composer.ex:1054
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr "Ihre Fediverse-Einstellungen erlauben es derzeit nicht, eine Antwort zu senden."
@@ -17211,13 +17211,13 @@ msgstr "Ihre Antwort geht an %{handle} auf dem eigenen Server und an Ihre Fedive
 msgid "© All rights reserved"
 msgstr "© Alle Rechte vorbehalten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1422
-#: lib/vutuv_web/live/post_live/composer.ex:1761
+#: lib/vutuv_web/live/post_live/composer.ex:1442
+#: lib/vutuv_web/live/post_live/composer.ex:1781
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr "Fotos hinzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1647
+#: lib/vutuv_web/live/post_live/composer.ex:1667
 #, elixir-autogen, elixir-format
 msgid "Licence"
 msgstr "Lizenz"
@@ -17228,59 +17228,59 @@ msgstr "Lizenz"
 msgid "Post photos"
 msgstr "Fotos posten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1380
+#: lib/vutuv_web/live/post_live/composer.ex:1400
 #, elixir-autogen, elixir-format
 msgid "Caption (optional)"
 msgstr "Bildunterschrift (optional)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1248
-#: lib/vutuv_web/live/post_live/composer.ex:1306
+#: lib/vutuv_web/live/post_live/composer.ex:1268
+#: lib/vutuv_web/live/post_live/composer.ex:1326
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr "Entwurf verwerfen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1245
-#: lib/vutuv_web/live/post_live/composer.ex:1303
+#: lib/vutuv_web/live/post_live/composer.ex:1265
+#: lib/vutuv_web/live/post_live/composer.ex:1323
 #, elixir-autogen, elixir-format
 msgid "Discard the photos and text of this draft?"
 msgstr "Fotos und Text dieses Entwurfs verwerfen?"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1240
+#: lib/vutuv_web/live/post_live/composer.ex:1260
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr "Weiter, wo Sie aufgehört haben."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1718
+#: lib/vutuv_web/live/post_live/composer.ex:1738
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr "Eine Datei, deren Format sich nicht säubern lässt, wird exakt so weitergegeben, wie sie hochgeladen wurde."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1915
+#: lib/vutuv_web/live/post_live/composer.ex:1950
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr "Pro Foto verschieden"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1914
+#: lib/vutuv_web/live/post_live/composer.ex:1949
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr "Original, exakt wie hochgeladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1913
+#: lib/vutuv_web/live/post_live/composer.ex:1948
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr "Original, ohne Metadaten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1918
+#: lib/vutuv_web/live/post_live/composer.ex:1953
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr "Nur Web-Versionen (%{format})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1681
+#: lib/vutuv_web/live/post_live/composer.ex:1701
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr "Was Besucher speichern können"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1707
+#: lib/vutuv_web/live/post_live/composer.ex:1727
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -17299,7 +17299,7 @@ msgstr "%{handle} gefällt das"
 msgid "%{handle} shared this"
 msgstr "%{handle} hat das geteilt"
 
-#: lib/vutuv_web/views/account_event_text.ex:209
+#: lib/vutuv_web/views/account_event_text.ex:222
 #, elixir-autogen, elixir-format
 msgid "Fediverse reactions"
 msgstr "Fediverse-Reaktionen"
@@ -17399,7 +17399,7 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr "Rücknahme"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1635
+#: lib/vutuv_web/live/post_live/composer.ex:1655
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr "Fotodetails"
@@ -18356,135 +18356,135 @@ msgstr "Sie haben Ihre Fediverse-Follower auf ein anderes Konto umgeleitet, desh
 msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr "Einen nachgeschlagenen Beitrag bewahrt vutuv genauso sechs Monate lang auf wie jeden anderen Beitrag aus einem anderen Netzwerk. Der Server der verfassenden Person wird sonst nichts gefragt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1349
+#: lib/vutuv_web/live/post_live/composer.ex:1369
 #, elixir-autogen, elixir-format
 msgid "Apply crop"
 msgstr "Zuschnitt übernehmen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1465
+#: lib/vutuv_web/live/post_live/composer.ex:1485
 #, elixir-autogen, elixir-format
 msgid "Auto"
 msgstr "Automatisch"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2091
+#: lib/vutuv_web/live/post_live/composer.ex:2126
 #, elixir-autogen, elixir-format
 msgid "Big photo left"
 msgstr "Großes Foto links"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2092
+#: lib/vutuv_web/live/post_live/composer.ex:2127
 #, elixir-autogen, elixir-format
 msgid "Big photo right"
 msgstr "Großes Foto rechts"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2097
+#: lib/vutuv_web/live/post_live/composer.ex:2132
 #, elixir-autogen, elixir-format
 msgid "Columns"
 msgstr "Spalten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2094
+#: lib/vutuv_web/live/post_live/composer.ex:2129
 #, elixir-autogen, elixir-format
 msgid "Cover left"
 msgstr "Titelbild links"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2095
+#: lib/vutuv_web/live/post_live/composer.ex:2130
 #, elixir-autogen, elixir-format
 msgid "Cover on top"
 msgstr "Titelbild oben"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2096
+#: lib/vutuv_web/live/post_live/composer.ex:2131
 #, elixir-autogen, elixir-format
 msgid "Cover right"
 msgstr "Titelbild rechts"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1345
-#: lib/vutuv_web/live/post_live/composer.ex:2062
-#: lib/vutuv_web/live/post_live/composer.ex:2063
+#: lib/vutuv_web/live/post_live/composer.ex:1365
+#: lib/vutuv_web/live/post_live/composer.ex:2097
+#: lib/vutuv_web/live/post_live/composer.ex:2098
 #, elixir-autogen, elixir-format
 msgid "Crop photo"
 msgstr "Foto zuschneiden"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2021
+#: lib/vutuv_web/live/post_live/composer.ex:2056
 #, elixir-autogen, elixir-format
 msgid "Cropped"
 msgstr "Zugeschnitten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1276
+#: lib/vutuv_web/live/post_live/composer.ex:1296
 #, elixir-autogen, elixir-format
 msgid "Drop photos to add them"
 msgstr "Fotos hier ablegen, um sie hinzuzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1443
+#: lib/vutuv_web/live/post_live/composer.ex:1463
 #, elixir-autogen, elixir-format
 msgid "Gallery preview"
 msgstr "Galerie-Vorschau"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2098
+#: lib/vutuv_web/live/post_live/composer.ex:2133
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr "Raster"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2099
+#: lib/vutuv_web/live/post_live/composer.ex:2134
 #, elixir-autogen, elixir-format
 msgid "Mosaic"
 msgstr "Mosaik"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1347
+#: lib/vutuv_web/live/post_live/composer.ex:1367
 #, elixir-autogen, elixir-format
 msgid "Pick a shape, then drag and zoom. The framed part is what the post shows."
 msgstr "Wählen Sie ein Format, dann verschieben und zoomen Sie. Der gerahmte Ausschnitt ist das, was der Beitrag zeigt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2090
+#: lib/vutuv_web/live/post_live/composer.ex:2125
 #, elixir-autogen, elixir-format
 msgid "Side by side"
 msgstr "Nebeneinander"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2093
+#: lib/vutuv_web/live/post_live/composer.ex:2128
 #, elixir-autogen, elixir-format
 msgid "Stacked"
 msgstr "Übereinander"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1558
-#: lib/vutuv_web/live/post_live/composer.ex:1559
+#: lib/vutuv_web/live/post_live/composer.ex:1578
+#: lib/vutuv_web/live/post_live/composer.ex:1579
 #, elixir-autogen, elixir-format
 msgid "Swap this photo with another"
 msgstr "Dieses Foto mit einem anderen tauschen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1446
+#: lib/vutuv_web/live/post_live/composer.ex:1466
 #, elixir-autogen, elixir-format
 msgid "Tap two photos to swap them."
 msgstr "Tippen Sie zwei Fotos an, um sie zu tauschen."
 
-#: lib/vutuv_web/live/post_live/composer.ex:381
+#: lib/vutuv_web/live/post_live/composer.ex:390
 #, elixir-autogen, elixir-format
 msgid "The photo could not be cropped."
 msgstr "Das Foto konnte nicht zugeschnitten werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2296
+#: lib/vutuv_web/live/post_live/composer.ex:2331
 #, elixir-autogen, elixir-format
 msgid "This photo is cropped: downloads hand out the cropped picture, and the untouched upload stays private."
 msgstr "Dieses Foto ist zugeschnitten: Downloads geben das zugeschnittene Bild heraus, die unveränderte Originaldatei bleibt privat."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1351
+#: lib/vutuv_web/live/post_live/composer.ex:1371
 #, elixir-autogen, elixir-format
 msgid "Whole photo"
 msgstr "Ganzes Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1540
+#: lib/vutuv_web/live/post_live/composer.ex:1560
 #, elixir-autogen, elixir-format
 msgid "Each photo covers its tile and is cropped by it."
 msgstr "Jedes Foto füllt seine Kachel und wird von ihr beschnitten."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1541
+#: lib/vutuv_web/live/post_live/composer.ex:1561
 #, elixir-autogen, elixir-format
 msgid "Each photo shows whole inside its tile."
 msgstr "Jedes Foto ist ganz in seiner Kachel zu sehen."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1536
+#: lib/vutuv_web/live/post_live/composer.ex:1556
 #, elixir-autogen, elixir-format
 msgid "Fill the tiles"
 msgstr "Kacheln füllen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1520
+#: lib/vutuv_web/live/post_live/composer.ex:1540
 #, elixir-autogen, elixir-format
 msgid "Whole photos"
 msgstr "Ganze Fotos"
@@ -18766,7 +18766,7 @@ msgstr "Noch nichts aus anderen Netzwerken gespeichert. Das Lesezeichen an einem
 msgid "Other networks"
 msgstr "Andere Netzwerke"
 
-#: lib/vutuv_web/live/shell_live.ex:408
+#: lib/vutuv_web/live/shell_live.ex:422
 #, elixir-autogen, elixir-format
 msgid "%{formatted} member"
 msgid_plural "%{formatted} members"
@@ -18980,7 +18980,7 @@ msgstr "Beiträge, Nachrichten und das Fediverse gleich dazu"
 msgid "Write a post, react with a heart, a repost or a reply, or message somebody privately. And you are not stuck among vutuv members: vutuv is part of the Fediverse, the union of independent networks that Mastodon belongs to as well. Follow an account over there and its posts arrive in your feed; the other way round, people there can follow you and see your public posts. Both directions, and entirely your choice: at sign-up you decide whether to use vutuv with or without the Fediverse, and you can change that at any time in the settings."
 msgstr "Beitrag schreiben, mit Herz, Repost oder Antwort reagieren, oder jemandem privat schreiben. Und Sie bleiben nicht unter vutuv-Mitgliedern: vutuv gehört zum Fediverse, dem Verbund unabhängiger Netzwerke, zu dem auch Mastodon zählt. Folgen Sie dort einem Konto, und dessen Beiträge landen in Ihrem Feed; umgekehrt können Leute von dort Ihnen folgen und Ihre öffentlichen Beiträge sehen. In beide Richtungen, und ganz Ihre Entscheidung: Sie wählen bei der Anmeldung, ob Sie vutuv mit oder ohne Fediverse benutzen möchten, und können das jederzeit in den Einstellungen ändern."
 
-#: lib/vutuv_web/live/shell_live.ex:401
+#: lib/vutuv_web/live/shell_live.ex:415
 #, elixir-autogen, elixir-format
 msgid "member"
 msgid_plural "members"
@@ -19235,7 +19235,7 @@ msgstr "Arbeitszeugnisse"
 msgid "Employment references of "
 msgstr "Arbeitszeugnisse von "
 
-#: lib/vutuv_web/views/account_event_text.ex:191
+#: lib/vutuv_web/views/account_event_text.ex:204
 #, elixir-autogen, elixir-format
 msgid "File"
 msgstr "Datei"
@@ -19329,7 +19329,7 @@ msgstr "Dieses Zeugnis öffentlich auf meinem Profil zeigen"
 
 #: lib/vutuv_web/templates/job_reference/show.html.heex:39
 #: lib/vutuv_web/templates/job_reference/view.html.heex:89
-#: lib/vutuv_web/views/account_event_text.ex:190
+#: lib/vutuv_web/views/account_event_text.ex:203
 #, elixir-autogen, elixir-format
 msgid "Text"
 msgstr "Text"
@@ -19638,7 +19638,7 @@ msgstr "Arbeitszeugnis von der KI geprüft"
 msgid "Employment reference reviews"
 msgstr "Zeugnisprüfungen"
 
-#: lib/vutuv_web/views/account_event_text.ex:189
+#: lib/vutuv_web/views/account_event_text.ex:202
 #, elixir-autogen, elixir-format
 msgid "Issue date"
 msgstr "Ausstellungsdatum"
@@ -20007,7 +20007,7 @@ msgstr "Herr"
 msgid "Ms."
 msgstr "Frau"
 
-#: lib/vutuv_web/views/account_event_text.ex:178
+#: lib/vutuv_web/views/account_event_text.ex:191
 #, elixir-autogen, elixir-format
 msgid "Salutation"
 msgstr "Anrede"
@@ -20126,7 +20126,7 @@ msgid_plural "%{formatted} of your posts are currently past this age."
 msgstr[0] "Derzeit ist %{count} Ihrer Beiträge älter als diese Zeitspanne."
 msgstr[1] "Derzeit sind %{formatted} Ihrer Beiträge älter als diese Zeitspanne."
 
-#: lib/vutuv_web/views/account_event_text.ex:137
+#: lib/vutuv_web/views/account_event_text.ex:150
 #, elixir-autogen, elixir-format
 msgid "%{count} post"
 msgid_plural "%{formatted} posts"
@@ -20198,7 +20198,7 @@ msgstr "Immer behalten"
 #: lib/vutuv_web/controllers/settings_controller.ex:291
 #: lib/vutuv_web/controllers/settings_controller.ex:303
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:20
-#: lib/vutuv_web/views/account_event_text.ex:216
+#: lib/vutuv_web/views/account_event_text.ex:229
 #, elixir-autogen, elixir-format
 msgid "Automatic post deletion"
 msgstr "Automatisches Löschen von Beiträgen"
@@ -20208,7 +20208,7 @@ msgstr "Automatisches Löschen von Beiträgen"
 msgid "Automatic post deletion changed"
 msgstr "Automatisches Löschen von Beiträgen geändert"
 
-#: lib/vutuv_web/views/account_event_text.ex:223
+#: lib/vutuv_web/views/account_event_text.ex:236
 #, elixir-autogen, elixir-format
 msgid "Bookmark floor"
 msgstr "Mindestzahl Lesezeichen"
@@ -20250,7 +20250,7 @@ msgstr "Meine Beiträge automatisch löschen"
 msgid "Delete posts older than"
 msgstr "Beiträge löschen, die älter sind als"
 
-#: lib/vutuv_web/views/account_event_text.ex:221
+#: lib/vutuv_web/views/account_event_text.ex:234
 #, elixir-autogen, elixir-format
 msgid "Delete replies too"
 msgstr "Antworten mitlöschen"
@@ -20270,17 +20270,17 @@ msgstr "Wenn Sie einen Beitrag löschen, aus dem ein Gespräch entstanden ist, s
 msgid "If a post of yours reached other networks (Mastodon and the rest), we ask every server that received it to delete its copy. We cannot make them. A server that is switched off, that no longer talks to us, or that simply ignores the request keeps what it has."
 msgstr "Wenn ein Beitrag von Ihnen in andere Netzwerke gelangt ist (Mastodon und die übrigen), bitten wir jeden Server, der ihn bekommen hat, seine Kopie zu löschen. Zwingen können wir ihn nicht. Ein Server, der abgeschaltet ist, der nicht mehr mit uns spricht oder der die Bitte schlicht ignoriert, behält, was er hat."
 
-#: lib/vutuv_web/views/account_event_text.ex:219
+#: lib/vutuv_web/views/account_event_text.ex:232
 #, elixir-autogen, elixir-format
 msgid "Keep answered posts"
 msgstr "Beantwortete Beiträge behalten"
 
-#: lib/vutuv_web/views/account_event_text.ex:220
+#: lib/vutuv_web/views/account_event_text.ex:233
 #, elixir-autogen, elixir-format
 msgid "Keep bookmarked posts"
 msgstr "Beiträge mit Lesezeichen behalten"
 
-#: lib/vutuv_web/views/account_event_text.ex:218
+#: lib/vutuv_web/views/account_event_text.ex:231
 #, elixir-autogen, elixir-format
 msgid "Keep photo posts"
 msgstr "Fotobeiträge behalten"
@@ -20295,7 +20295,7 @@ msgstr "Beiträge behalten, die gut liefen"
 msgid "Let your posts age out after a time you set"
 msgstr "Ihre Beiträge nach einer selbst gewählten Zeit auslaufen lassen"
 
-#: lib/vutuv_web/views/account_event_text.ex:222
+#: lib/vutuv_web/views/account_event_text.ex:235
 #, elixir-autogen, elixir-format
 msgid "Like floor"
 msgstr "Mindestzahl Likes"
@@ -20320,7 +20320,7 @@ msgstr "Standardmäßig aus: Eine Antwort ist ein Beitrag zu einem Gespräch, da
 msgid "Photo posts and book or film reviews are kept whatever their age."
 msgstr "Fotobeiträge sowie Buch- und Filmkritiken bleiben unabhängig vom Alter erhalten."
 
-#: lib/vutuv_web/views/account_event_text.ex:217
+#: lib/vutuv_web/views/account_event_text.ex:230
 #, elixir-autogen, elixir-format
 msgid "Post age"
 msgstr "Alter der Beiträge"
@@ -20345,7 +20345,7 @@ msgstr "Beiträge mit Fotos oder einer Kritik"
 msgid "Posts you bookmarked yourself"
 msgstr "Beiträge, auf die Sie selbst ein Lesezeichen gesetzt haben"
 
-#: lib/vutuv_web/views/account_event_text.ex:224
+#: lib/vutuv_web/views/account_event_text.ex:237
 #, elixir-autogen, elixir-format
 msgid "Repost floor"
 msgstr "Mindestzahl Reposts"
@@ -20828,12 +20828,13 @@ msgstr "Schreibt Beiträge im Namen der Organisation."
 msgid "The owner gives other members their roles on the page, and can hand ownership over to someone else at any time. Someone can hold several roles, and writing in the organization's name is always granted on its own."
 msgstr "Der Besitzer vergibt die Rollen der anderen Mitglieder auf der Seite und kann den Besitz jederzeit an jemand anderen übergeben. Jemand kann mehrere Rollen haben, und das Schreiben im Namen der Organisation wird immer einzeln vergeben."
 
-#: lib/vutuv_web/live/organization_live/show.ex:406
+#: lib/vutuv_web/live/organization_live/show.ex:420
 #, elixir-autogen, elixir-format
 msgid "Nothing published yet."
 msgstr "Noch nichts veröffentlicht."
 
-#: lib/vutuv_web/live/organization_live/show.ex:388
+#: lib/vutuv_web/live/organization_live/show.ex:402
+#: lib/vutuv_web/live/post_live/composer.ex:1814
 #, elixir-autogen, elixir-format
 msgid "Post as %{name}"
 msgstr "Als %{name} veröffentlichen"
@@ -20848,7 +20849,7 @@ msgstr "Als %{name} veröffentlicht."
 msgid "That post could not be published."
 msgstr "Dieser Beitrag konnte nicht veröffentlicht werden."
 
-#: lib/vutuv_web/live/organization_live/show.ex:380
+#: lib/vutuv_web/live/organization_live/show.ex:394
 #, elixir-autogen, elixir-format
 msgid "Write something as %{name}"
 msgstr "Schreiben Sie etwas als %{name}"
@@ -20857,3 +20858,48 @@ msgstr "Schreiben Sie etwas als %{name}"
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr "Sie dürfen nicht mehr im Namen dieser Organisation schreiben."
+
+#: lib/vutuv_web/live/post_live/composer.ex:1791
+#, elixir-autogen, elixir-format
+msgid "A post in an organization's name is always public."
+msgstr "Ein Beitrag im Namen einer Organisation ist immer öffentlich."
+
+#: lib/vutuv_web/live/shell_live.ex:485
+#, elixir-autogen, elixir-format
+msgid "Open the page"
+msgstr "Seite öffnen"
+
+#: lib/vutuv_web/views/account_event_text.ex:79
+#, elixir-autogen, elixir-format
+msgid "Started writing as an organization"
+msgstr "Begonnen, im Namen einer Organisation zu schreiben"
+
+#: lib/vutuv_web/views/account_event_text.ex:82
+#, elixir-autogen, elixir-format
+msgid "Stopped writing as an organization"
+msgstr "Beendet, im Namen einer Organisation zu schreiben"
+
+#: lib/vutuv_web/live/organization_live/show.ex:378
+#, elixir-autogen, elixir-format
+msgid "Write as %{name} for now"
+msgstr "Vorerst als %{name} schreiben"
+
+#: lib/vutuv_web/live/shell_live.ex:495
+#, elixir-autogen, elixir-format
+msgid "Write as myself again"
+msgstr "Wieder als ich selbst schreiben"
+
+#: lib/vutuv_web/controllers/acting_as_controller.ex:38
+#, elixir-autogen, elixir-format
+msgid "You are writing as %{name} now."
+msgstr "Sie schreiben jetzt als %{name}."
+
+#: lib/vutuv_web/live/shell_live.ex:479
+#, elixir-autogen, elixir-format
+msgid "You are writing as %{name}."
+msgstr "Sie schreiben als %{name}."
+
+#: lib/vutuv_web/controllers/acting_as_controller.ex:59
+#, elixir-autogen, elixir-format
+msgid "You are yourself again."
+msgstr "Sie sind wieder Sie selbst."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -34,7 +34,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
-#: lib/vutuv_web/live/organization_live/show.ex:471
+#: lib/vutuv_web/live/organization_live/show.ex:485
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
@@ -117,7 +117,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_posting_live/form.ex:605
 #: lib/vutuv_web/live/organization_live/edit.ex:347
 #: lib/vutuv_web/live/organization_live/new.ex:173
-#: lib/vutuv_web/live/post_live/composer.ex:1350
+#: lib/vutuv_web/live/post_live/composer.ex:1370
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
@@ -201,7 +201,7 @@ msgid "Disable"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:438
-#: lib/vutuv_web/live/post_live/composer.ex:1674
+#: lib/vutuv_web/live/post_live/composer.ex:1694
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/templates/user/show.html.heex:310
 #: lib/vutuv_web/views/qualification_html.ex:237
@@ -342,7 +342,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/dashboard_live.ex:195
 #: lib/vutuv_web/templates/page/index.html.heex:93
 #: lib/vutuv_web/templates/user/edit.html.heex:162
-#: lib/vutuv_web/views/account_event_text.ex:182
+#: lib/vutuv_web/views/account_event_text.ex:195
 #, elixir-autogen
 msgid "Gender"
 msgstr ""
@@ -440,8 +440,8 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:718
-#: lib/vutuv_web/live/shell_live.ex:755
+#: lib/vutuv_web/live/shell_live.ex:768
+#: lib/vutuv_web/live/shell_live.ex:805
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -604,7 +604,7 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1772
+#: lib/vutuv_web/live/post_live/composer.ex:1798
 #: lib/vutuv_web/live/section_reorder_live.ex:258
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -616,7 +616,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3222
 #: lib/vutuv_web/live/organization_live/edit.ex:341
-#: lib/vutuv_web/live/post_live/composer.ex:1781
+#: lib/vutuv_web/live/post_live/composer.ex:1813
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:196
@@ -642,8 +642,8 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:37
 #: lib/vutuv_web/live/search_live.ex:378
-#: lib/vutuv_web/live/shell_live.ex:586
-#: lib/vutuv_web/live/shell_live.ex:738
+#: lib/vutuv_web/live/shell_live.ex:636
+#: lib/vutuv_web/live/shell_live.ex:788
 #: lib/vutuv_web/live/tag_live/timeline.ex:255
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
@@ -863,7 +863,7 @@ msgstr ""
 #: lib/vutuv_web/templates/email/show.html.heex:24
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:295
 #: lib/vutuv_web/templates/settings/privacy.html.heex:14
-#: lib/vutuv_web/views/account_event_text.ex:192
+#: lib/vutuv_web/views/account_event_text.ex:205
 #, elixir-autogen
 msgid "Visibility"
 msgstr ""
@@ -924,7 +924,7 @@ msgstr ""
 msgid "You follow back %{name}."
 msgstr ""
 
-#: lib/vutuv_web/live/init_assigns.ex:52
+#: lib/vutuv_web/live/init_assigns.ex:54
 #: lib/vutuv_web/live/post_live/feed.ex:76
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
@@ -1162,7 +1162,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:690
+#: lib/vutuv_web/live/shell_live.ex:740
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1595,7 +1595,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:741
+#: lib/vutuv_web/live/shell_live.ex:791
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1619,9 +1619,9 @@ msgstr ""
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
-#: lib/vutuv_web/live/post_live/composer.ex:1311
-#: lib/vutuv_web/live/post_live/composer.ex:1312
-#: lib/vutuv_web/live/post_live/composer.ex:2214
+#: lib/vutuv_web/live/post_live/composer.ex:1331
+#: lib/vutuv_web/live/post_live/composer.ex:1332
+#: lib/vutuv_web/live/post_live/composer.ex:2249
 #: lib/vutuv_web/templates/layout/app.html.heex:159
 #: lib/vutuv_web/templates/layout/app.html.heex:165
 #: lib/vutuv_web/views/layout_html.ex:40
@@ -1705,7 +1705,7 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:709
+#: lib/vutuv_web/live/shell_live.ex:759
 #: lib/vutuv_web/views/settings_html.ex:261
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1733,14 +1733,14 @@ msgstr ""
 
 #: lib/vutuv_web/live/message_live/index.ex:45
 #: lib/vutuv_web/live/message_live/index.ex:512
-#: lib/vutuv_web/live/shell_live.ex:602
-#: lib/vutuv_web/live/shell_live.ex:740
+#: lib/vutuv_web/live/shell_live.ex:652
+#: lib/vutuv_web/live/shell_live.ex:790
 #: lib/vutuv_web/templates/layout/app.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:496
+#: lib/vutuv_web/live/shell_live.ex:546
 #, elixir-autogen, elixir-format
 msgid "Network"
 msgstr ""
@@ -1764,7 +1764,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3653
 #: lib/vutuv_web/live/notification_live/index.ex:105
 #: lib/vutuv_web/live/notification_live/index.ex:329
-#: lib/vutuv_web/live/shell_live.ex:613
+#: lib/vutuv_web/live/shell_live.ex:663
 #: lib/vutuv_web/templates/layout/app.html.heex:124
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -1855,7 +1855,7 @@ msgstr ""
 msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1197
+#: lib/vutuv_web/live/post_live/feed.ex:1198
 #: lib/vutuv_web/views/user_html.ex:206
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
@@ -1915,7 +1915,7 @@ msgid "Pagination"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3461
-#: lib/vutuv_web/live/organization_live/show.ex:411
+#: lib/vutuv_web/live/organization_live/show.ex:425
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr ""
@@ -2072,7 +2072,7 @@ msgstr ""
 msgid "Add images"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1889
+#: lib/vutuv_web/live/post_live/composer.ex:1924
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2083,7 +2083,7 @@ msgstr ""
 msgid "Back to the post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1594
+#: lib/vutuv_web/live/post_live/composer.ex:1614
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr ""
@@ -2107,8 +2107,8 @@ msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:158
 #: lib/vutuv_web/live/post_live/feed.ex:952
-#: lib/vutuv_web/live/shell_live.ex:476
-#: lib/vutuv_web/live/shell_live.ex:736
+#: lib/vutuv_web/live/shell_live.ex:526
+#: lib/vutuv_web/live/shell_live.ex:786
 #: lib/vutuv_web/templates/layout/app.html.heex:122
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2124,12 +2124,12 @@ msgstr ""
 msgid "Hidden from:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1865
+#: lib/vutuv_web/live/post_live/composer.ex:1900
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1793
+#: lib/vutuv_web/live/post_live/composer.ex:1828
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr ""
@@ -2140,39 +2140,39 @@ msgstr ""
 msgid "Limited audience"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1835
+#: lib/vutuv_web/live/post_live/composer.ex:1870
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1037
-#: lib/vutuv_web/live/post_live/composer.ex:1085
+#: lib/vutuv_web/live/post_live/composer.ex:1057
+#: lib/vutuv_web/live/post_live/composer.ex:1105
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1136
+#: lib/vutuv_web/live/post_live/feed.ex:1137
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1010
+#: lib/vutuv_web/live/post_live/composer.ex:1030
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1825
+#: lib/vutuv_web/live/post_live/composer.ex:1860
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1815
+#: lib/vutuv_web/live/post_live/composer.ex:1850
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:406
-#: lib/vutuv_web/live/post_live/composer.ex:1781
+#: lib/vutuv_web/live/post_live/composer.ex:1815
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2222,7 +2222,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:373
 #: lib/vutuv_web/live/organization_live/roles.ex:243
-#: lib/vutuv_web/live/post_live/composer.ex:1851
+#: lib/vutuv_web/live/post_live/composer.ex:1886
 #: lib/vutuv_web/live/post_live/saved.ex:619
 #: lib/vutuv_web/live/post_live/saved.ex:647
 #: lib/vutuv_web/templates/connection/index.html.heex:40
@@ -2236,29 +2236,29 @@ msgstr ""
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1779
+#: lib/vutuv_web/live/post_live/composer.ex:1805
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1045
+#: lib/vutuv_web/live/post_live/feed.ex:1046
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/init_assigns.ex:81
+#: lib/vutuv_web/live/init_assigns.ex:83
 #, elixir-autogen, elixir-format
 msgid "Sorry, that page could not be found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1111
+#: lib/vutuv_web/live/post_live/composer.ex:1131
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:992
+#: lib/vutuv_web/live/post_live/composer.ex:1012
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr ""
@@ -2268,18 +2268,18 @@ msgstr ""
 msgid "This post is for followers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2363
+#: lib/vutuv_web/live/post_live/composer.ex:2398
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2364
+#: lib/vutuv_web/live/post_live/composer.ex:2399
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3917
-#: lib/vutuv_web/live/shell_live.ex:656
+#: lib/vutuv_web/live/shell_live.ex:706
 #: lib/vutuv_web/templates/post/index.html.heex:17
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:208
@@ -2287,12 +2287,12 @@ msgstr ""
 msgid "View profile"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1932
+#: lib/vutuv_web/live/post_live/composer.ex:1967
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1933
+#: lib/vutuv_web/live/post_live/composer.ex:1968
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr ""
@@ -2328,17 +2328,17 @@ msgstr ""
 msgid "unknown"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1731
+#: lib/vutuv_web/live/post_live/composer.ex:1751
 #, elixir-autogen, elixir-format
 msgid "Tags, separated by commas (max. %{max})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2354
+#: lib/vutuv_web/live/post_live/composer.ex:2389
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2358
+#: lib/vutuv_web/live/post_live/composer.ex:2393
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr ""
@@ -2369,8 +2369,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:961
 #: lib/vutuv_web/live/post_live/saved.ex:175
 #: lib/vutuv_web/live/post_live/saved.ex:488
-#: lib/vutuv_web/live/shell_live.ex:595
-#: lib/vutuv_web/live/shell_live.ex:661
+#: lib/vutuv_web/live/shell_live.ex:645
+#: lib/vutuv_web/live/shell_live.ex:711
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2391,7 +2391,7 @@ msgstr ""
 #: lib/vutuv_web/live/notification_live/index.ex:956
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
-#: lib/vutuv_web/live/shell_live.ex:664
+#: lib/vutuv_web/live/shell_live.ex:714
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2452,7 +2452,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1936
 #: lib/vutuv_web/components/ui.ex:1936
 #: lib/vutuv_web/components/ui.ex:2073
-#: lib/vutuv_web/live/post_live/feed.ex:1186
+#: lib/vutuv_web/live/post_live/feed.ex:1187
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
@@ -2488,13 +2488,13 @@ msgstr ""
 msgid "Reply to a deleted post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:995
-#: lib/vutuv_web/live/post_live/composer.ex:1769
+#: lib/vutuv_web/live/post_live/composer.ex:1015
+#: lib/vutuv_web/live/post_live/composer.ex:1793
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1896
+#: lib/vutuv_web/live/post_live/composer.ex:1931
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
@@ -2797,7 +2797,7 @@ msgstr ""
 msgid "Other formats"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1805
+#: lib/vutuv_web/live/post_live/composer.ex:1840
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr ""
@@ -3131,8 +3131,8 @@ msgid "Private message"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3585
-#: lib/vutuv_web/live/shell_live.ex:489
-#: lib/vutuv_web/live/shell_live.ex:745
+#: lib/vutuv_web/live/shell_live.ex:539
+#: lib/vutuv_web/live/shell_live.ex:795
 #: lib/vutuv_web/templates/import/new.html.heex:15
 #: lib/vutuv_web/templates/import/preview.html.heex:55
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
@@ -4519,7 +4519,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1141
+#: lib/vutuv_web/live/post_live/feed.ex:1142
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -4576,7 +4576,7 @@ msgstr ""
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:516
 #: lib/vutuv_web/live/notification_live/index.ex:877
-#: lib/vutuv_web/live/organization_live/show.ex:421
+#: lib/vutuv_web/live/organization_live/show.ex:435
 #: lib/vutuv_web/live/post_live/saved.ex:498
 #: lib/vutuv_web/live/search_live.ex:198
 #: lib/vutuv_web/live/search_live.ex:472
@@ -5275,7 +5275,7 @@ msgstr ""
 msgid "This permanently removes your profile, posts, messages and everything else. We email you a PIN to confirm. It cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1013
+#: lib/vutuv_web/live/post_live/composer.ex:1033
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr ""
@@ -5285,7 +5285,7 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:643
+#: lib/vutuv_web/live/shell_live.ex:693
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
@@ -5307,7 +5307,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:700
+#: lib/vutuv_web/live/shell_live.ex:750
 #: lib/vutuv_web/templates/layout/app.html.heex:154
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5326,7 +5326,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:285
-#: lib/vutuv_web/live/shell_live.ex:680
+#: lib/vutuv_web/live/shell_live.ex:730
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5380,8 +5380,8 @@ msgstr ""
 msgid "Previous post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:469
-#: lib/vutuv_web/live/shell_live.ex:729
+#: lib/vutuv_web/live/shell_live.ex:519
+#: lib/vutuv_web/live/shell_live.ex:779
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -5395,7 +5395,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:2924
 #: lib/vutuv_web/components/post_components.ex:3316
 #: lib/vutuv_web/live/notification_live/index.ex:680
-#: lib/vutuv_web/live/post_live/feed.ex:1259
+#: lib/vutuv_web/live/post_live/feed.ex:1260
 #: lib/vutuv_web/views/user_html.ex:111
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5548,7 +5548,7 @@ msgid "Email notifications"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/preferences.html.heex:18
-#: lib/vutuv_web/views/account_event_text.ex:185
+#: lib/vutuv_web/views/account_event_text.ex:198
 #, elixir-autogen, elixir-format
 msgid "Interface language"
 msgstr ""
@@ -5907,7 +5907,7 @@ msgid "A green dot on your avatar tells other members you are online right now."
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:124
-#: lib/vutuv_web/views/account_event_text.ex:196
+#: lib/vutuv_web/views/account_event_text.ex:209
 #, elixir-autogen, elixir-format
 msgid "Online status"
 msgstr ""
@@ -6033,7 +6033,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:148
 #: lib/vutuv_web/templates/user/edit.html.heex:206
-#: lib/vutuv_web/views/account_event_text.ex:175
+#: lib/vutuv_web/views/account_event_text.ex:188
 #, elixir-autogen, elixir-format
 msgid "Tagline"
 msgstr ""
@@ -6099,7 +6099,7 @@ msgstr ""
 msgid "Use photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1352
+#: lib/vutuv_web/live/post_live/composer.ex:1372
 #: lib/vutuv_web/templates/user/edit.html.heex:51
 #: lib/vutuv_web/templates/user/edit.html.heex:104
 #, elixir-autogen, elixir-format
@@ -6899,7 +6899,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:223
 #: lib/vutuv_web/templates/settings/notifications.html.heex:73
-#: lib/vutuv_web/views/account_event_text.ex:200
+#: lib/vutuv_web/views/account_event_text.ex:213
 #, elixir-autogen, elixir-format
 msgid "Newsletter"
 msgstr ""
@@ -8428,13 +8428,13 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1226
 #: lib/vutuv_web/live/post_live/feed.ex:1227
+#: lib/vutuv_web/live/post_live/feed.ex:1228
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1221
+#: lib/vutuv_web/live/post_live/feed.ex:1222
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr ""
@@ -8825,7 +8825,7 @@ msgid "Open CV"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:146
-#: lib/vutuv_web/views/account_event_text.ex:183
+#: lib/vutuv_web/views/account_event_text.ex:196
 #, elixir-autogen, elixir-format
 msgid "Photo"
 msgstr ""
@@ -9718,7 +9718,7 @@ msgstr ""
 #: lib/vutuv_web/cv/latex.ex:69
 #: lib/vutuv_web/cv/odt.ex:109
 #: lib/vutuv_web/live/cv_live.ex:153
-#: lib/vutuv_web/views/account_event_text.ex:177
+#: lib/vutuv_web/views/account_event_text.ex:190
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
@@ -9740,13 +9740,13 @@ msgid "Your date of birth will be removed and your age will no longer be shown o
 msgstr ""
 
 #: lib/vutuv_web/templates/page/index.html.heex:65
-#: lib/vutuv_web/views/account_event_text.ex:173
+#: lib/vutuv_web/views/account_event_text.ex:186
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
 #: lib/vutuv_web/templates/page/index.html.heex:70
-#: lib/vutuv_web/views/account_event_text.ex:174
+#: lib/vutuv_web/views/account_event_text.ex:187
 #, elixir-autogen, elixir-format
 msgid "Last name"
 msgstr ""
@@ -10247,7 +10247,7 @@ msgid "Code"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:159
-#: lib/vutuv_web/views/account_event_text.ex:198
+#: lib/vutuv_web/views/account_event_text.ex:211
 #, elixir-autogen, elixir-format
 msgid "Code statistics"
 msgstr ""
@@ -11023,7 +11023,7 @@ msgid "Your list is empty. Nobody is excluded yet."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:328
-#: lib/vutuv_web/views/account_event_text.ex:195
+#: lib/vutuv_web/views/account_event_text.ex:208
 #, elixir-autogen, elixir-format
 msgid "AI agents"
 msgstr ""
@@ -11041,7 +11041,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:248
 #: lib/vutuv_web/live/organization_live/domains.ex:288
 #: lib/vutuv_web/live/organization_live/new.ex:146
-#: lib/vutuv_web/live/organization_live/show.ex:545
+#: lib/vutuv_web/live/organization_live/show.ex:559
 #: lib/vutuv_web/templates/url/verify.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "DNS TXT record"
@@ -11050,7 +11050,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:153
 #: lib/vutuv_web/live/organization_live/domains.ex:167
 #: lib/vutuv_web/live/organization_live/show.ex:263
-#: lib/vutuv_web/live/organization_live/show.ex:604
+#: lib/vutuv_web/live/organization_live/show.ex:618
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr ""
@@ -11087,7 +11087,7 @@ msgstr ""
 msgid "Please log in first."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:518
+#: lib/vutuv_web/live/organization_live/show.ex:532
 #, elixir-autogen, elixir-format
 msgid "Prove you control %{domain} to publish this page."
 msgstr ""
@@ -11103,7 +11103,7 @@ msgid "Search by name or city"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:312
-#: lib/vutuv_web/views/account_event_text.ex:194
+#: lib/vutuv_web/views/account_event_text.ex:207
 #, elixir-autogen, elixir-format
 msgid "Search engines"
 msgstr ""
@@ -11114,7 +11114,7 @@ msgid "Select a country"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:307
-#: lib/vutuv_web/live/organization_live/show.ex:580
+#: lib/vutuv_web/live/organization_live/show.ex:594
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr ""
@@ -11141,12 +11141,12 @@ msgid "The upload failed."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/new.ex:131
-#: lib/vutuv_web/live/organization_live/show.ex:533
+#: lib/vutuv_web/live/organization_live/show.ex:547
 #, elixir-autogen, elixir-format
 msgid "Verification method"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:493
+#: lib/vutuv_web/live/organization_live/show.ex:507
 #, elixir-autogen, elixir-format
 msgid "Verified domains"
 msgstr ""
@@ -11162,13 +11162,13 @@ msgstr ""
 msgid "Verified via %{domain}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:515
+#: lib/vutuv_web/live/organization_live/show.ex:529
 #, elixir-autogen, elixir-format
 msgid "Verify %{name}"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:320
-#: lib/vutuv_web/live/organization_live/show.ex:600
+#: lib/vutuv_web/live/organization_live/show.ex:614
 #, elixir-autogen, elixir-format
 msgid "Verify now"
 msgstr ""
@@ -11189,7 +11189,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:249
 #: lib/vutuv_web/live/organization_live/domains.ex:298
-#: lib/vutuv_web/live/organization_live/show.ex:556
+#: lib/vutuv_web/live/organization_live/show.ex:570
 #: lib/vutuv_web/templates/url/verify.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Website file"
@@ -11211,7 +11211,7 @@ msgid "You will publish a record or file to prove control of the domain on the n
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:309
-#: lib/vutuv_web/live/organization_live/show.ex:586
+#: lib/vutuv_web/live/organization_live/show.ex:600
 #: lib/vutuv_web/templates/url/verify.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
@@ -11262,7 +11262,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:322
 #: lib/vutuv_web/agent_docs/text.ex:348
 #: lib/vutuv_web/live/organization_live/edit.ex:353
-#: lib/vutuv_web/live/organization_live/show.ex:481
+#: lib/vutuv_web/live/organization_live/show.ex:495
 #: lib/vutuv_web/templates/tag/single_card.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Also known as"
@@ -11626,7 +11626,7 @@ msgstr ""
 msgid "%{min} to %{max} characters: letters (a-z), numbers (0-9) and underscores."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:436
+#: lib/vutuv_web/live/organization_live/show.ex:450
 #, elixir-autogen, elixir-format
 msgid "Former"
 msgstr ""
@@ -11736,7 +11736,7 @@ msgstr ""
 msgid "The proof is a small technical change to your domain: a DNS entry or a file on your website. If you don't manage the website yourself, ask the person or team who does. That is usually your IT department or the company that runs your website. We show the exact instructions on the next step, so you can simply pass them on."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:527
+#: lib/vutuv_web/live/organization_live/show.ex:541
 #, elixir-autogen, elixir-format
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr ""
@@ -11852,7 +11852,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:501
-#: lib/vutuv_web/live/shell_live.ex:671
+#: lib/vutuv_web/live/shell_live.ex:721
 #: lib/vutuv_web/templates/layout/app.html.heex:83
 #: lib/vutuv_web/templates/settings/organizations.html.heex:6
 #, elixir-autogen, elixir-format
@@ -12104,7 +12104,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:392
 #: lib/vutuv_web/live/admin/job_live.ex:344
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:17
-#: lib/vutuv_web/views/account_event_text.ex:188
+#: lib/vutuv_web/views/account_event_text.ex:201
 #, elixir-autogen, elixir-format
 msgid "Employer"
 msgstr ""
@@ -12183,7 +12183,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:504
-#: lib/vutuv_web/live/shell_live.ex:503
+#: lib/vutuv_web/live/shell_live.ex:553
 #: lib/vutuv_web/templates/layout/app.html.heex:81
 #: lib/vutuv_web/templates/qualification/show.html.heex:38
 #, elixir-autogen, elixir-format
@@ -12630,13 +12630,13 @@ msgid "Getting an error, or is %{host} a CNAME / alias to another address? A TXT
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:305
-#: lib/vutuv_web/live/organization_live/show.ex:573
+#: lib/vutuv_web/live/organization_live/show.ex:587
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:303
-#: lib/vutuv_web/live/organization_live/show.ex:564
+#: lib/vutuv_web/live/organization_live/show.ex:578
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
 msgstr ""
@@ -12732,7 +12732,7 @@ msgid "Minimum yearly salary"
 msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:324
-#: lib/vutuv_web/live/organization_live/show.ex:463
+#: lib/vutuv_web/live/organization_live/show.ex:477
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr ""
@@ -12761,7 +12761,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:400
 #: lib/vutuv_web/agent_docs/text.ex:412
 #: lib/vutuv_web/agent_docs/text.ex:424
-#: lib/vutuv_web/live/organization_live/show.ex:450
+#: lib/vutuv_web/live/organization_live/show.ex:464
 #: lib/vutuv_web/templates/tag/show.html.heex:45
 #, elixir-autogen, elixir-format
 msgid "Open positions"
@@ -13460,7 +13460,7 @@ msgstr ""
 msgid "Insert image"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2333
+#: lib/vutuv_web/live/post_live/composer.ex:2368
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr ""
@@ -13519,14 +13519,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3661
 #: lib/vutuv_web/controllers/settings_controller.ex:569
-#: lib/vutuv_web/live/post_live/feed.ex:1172
+#: lib/vutuv_web/live/post_live/feed.ex:1173
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1187
+#: lib/vutuv_web/live/post_live/feed.ex:1188
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr ""
@@ -13868,7 +13868,7 @@ msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:389
+#: lib/vutuv_web/live/shell_live.ex:403
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -14126,13 +14126,13 @@ msgstr ""
 msgid "mentioned you in a post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1000
+#: lib/vutuv_web/live/post_live/composer.ex:1020
 #: lib/vutuv_web/live/post_live/edit.ex:57
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1003
+#: lib/vutuv_web/live/post_live/composer.ex:1023
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -15730,31 +15730,31 @@ msgstr ""
 msgid "Ask for a PIN first, then enter it here."
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:105
+#: lib/vutuv_web/views/account_event_text.ex:113
 #, elixir-autogen, elixir-format
 msgid "%{count} code"
 msgid_plural "%{count} codes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/account_event_text.ex:101
+#: lib/vutuv_web/views/account_event_text.ex:109
 #, elixir-autogen, elixir-format
 msgid "%{count} device"
 msgid_plural "%{count} devices"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/account_event_text.ex:93
+#: lib/vutuv_web/views/account_event_text.ex:101
 #, elixir-autogen, elixir-format
 msgid "%{email}, now hidden from your profile"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:92
+#: lib/vutuv_web/views/account_event_text.ex:100
 #, elixir-autogen, elixir-format
 msgid "%{email}, now shown on your profile"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:84
+#: lib/vutuv_web/views/account_event_text.ex:92
 #, elixir-autogen, elixir-format
 msgid "@%{from} to @%{to}"
 msgstr ""
@@ -15832,7 +15832,7 @@ msgstr ""
 msgid "By %{name}"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:206
+#: lib/vutuv_web/views/account_event_text.ex:219
 #, elixir-autogen, elixir-format
 msgid "CV update notifications"
 msgstr ""
@@ -15845,7 +15845,7 @@ msgstr ""
 msgid "Confirmed"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:184
+#: lib/vutuv_web/views/account_event_text.ex:197
 #, elixir-autogen, elixir-format
 msgid "Cover picture"
 msgstr ""
@@ -15875,7 +15875,7 @@ msgstr ""
 msgid "Email address removed"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:202
+#: lib/vutuv_web/views/account_event_text.ex:215
 #, elixir-autogen, elixir-format
 msgid "Endorsement emails"
 msgstr ""
@@ -15885,17 +15885,17 @@ msgstr ""
 msgid "Every change to your account: what changed, exactly when, from which device, and how it was confirmed. If a line surprises you, follow the link at the end of it."
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:211
+#: lib/vutuv_web/views/account_event_text.ex:224
 #, elixir-autogen, elixir-format
 msgid "Fediverse aliases"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:208
+#: lib/vutuv_web/views/account_event_text.ex:221
 #, elixir-autogen, elixir-format
 msgid "Fediverse participation"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:210
+#: lib/vutuv_web/views/account_event_text.ex:223
 #, elixir-autogen, elixir-format
 msgid "Fediverse replies"
 msgstr ""
@@ -15935,12 +15935,12 @@ msgstr ""
 msgid "It is part of your data download, and it is deleted with your account."
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:193
+#: lib/vutuv_web/views/account_event_text.ex:206
 #, elixir-autogen, elixir-format
 msgid "Job search"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:197
+#: lib/vutuv_web/views/account_event_text.ex:210
 #, elixir-autogen, elixir-format
 msgid "Mastodon posts"
 msgstr ""
@@ -15955,7 +15955,7 @@ msgstr ""
 msgid "Member unblocked"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:201
+#: lib/vutuv_web/views/account_event_text.ex:214
 #, elixir-autogen, elixir-format
 msgid "New follower emails"
 msgstr ""
@@ -15994,7 +15994,7 @@ msgstr ""
 msgid "Nothing recorded yet."
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:199
+#: lib/vutuv_web/views/account_event_text.ex:212
 #, elixir-autogen, elixir-format
 msgid "Notification emails"
 msgstr ""
@@ -16039,7 +16039,7 @@ msgstr ""
 msgid "Recent account activity"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:205
+#: lib/vutuv_web/views/account_event_text.ex:218
 #, elixir-autogen, elixir-format
 msgid "Saved search alerts"
 msgstr ""
@@ -16076,17 +16076,17 @@ msgid_plural "This log keeps %{formatted} days of history."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/account_event_text.ex:207
+#: lib/vutuv_web/views/account_event_text.ex:220
 #, elixir-autogen, elixir-format
 msgid "Thread notifications"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:204
+#: lib/vutuv_web/views/account_event_text.ex:217
 #, elixir-autogen, elixir-format
 msgid "Unread message delay"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:203
+#: lib/vutuv_web/views/account_event_text.ex:216
 #, elixir-autogen, elixir-format
 msgid "Unread message emails"
 msgstr ""
@@ -16132,22 +16132,22 @@ msgstr ""
 msgid "a deleted account"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:115
+#: lib/vutuv_web/views/account_event_text.ex:123
 #, elixir-autogen, elixir-format
 msgid "a tag"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:116
+#: lib/vutuv_web/views/account_event_text.ex:124
 #, elixir-autogen, elixir-format
 msgid "a word or phrase"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:164
+#: lib/vutuv_web/views/account_event_text.ex:177
 #, elixir-autogen, elixir-format
 msgid "by the site operators"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:163
+#: lib/vutuv_web/views/account_event_text.ex:176
 #, elixir-autogen, elixir-format
 msgid "from a signed-in session"
 msgstr ""
@@ -16157,32 +16157,32 @@ msgstr ""
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:144
+#: lib/vutuv_web/views/account_event_text.ex:157
 #, elixir-autogen, elixir-format
 msgid "not taking part in the Fediverse"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:141
+#: lib/vutuv_web/views/account_event_text.ex:154
 #, elixir-autogen, elixir-format
 msgid "taking part in the Fediverse"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:161
+#: lib/vutuv_web/views/account_event_text.ex:174
 #, elixir-autogen, elixir-format
 msgid "with a one-time list code"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:159
+#: lib/vutuv_web/views/account_event_text.ex:172
 #, elixir-autogen, elixir-format
 msgid "with a passkey"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:162
+#: lib/vutuv_web/views/account_event_text.ex:175
 #, elixir-autogen, elixir-format
 msgid "with an emailed PIN"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:160
+#: lib/vutuv_web/views/account_event_text.ex:173
 #, elixir-autogen, elixir-format
 msgid "with your authenticator app"
 msgstr ""
@@ -16248,7 +16248,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:434
 #: lib/vutuv_web/templates/user/edit.html.heex:180
 #: lib/vutuv_web/templates/user/show.html.heex:217
-#: lib/vutuv_web/views/account_event_text.ex:176
+#: lib/vutuv_web/views/account_event_text.ex:189
 #, elixir-autogen, elixir-format
 msgid "Name pronunciation"
 msgstr ""
@@ -16263,7 +16263,7 @@ msgstr ""
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2346
+#: lib/vutuv_web/live/post_live/composer.ex:2381
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr ""
@@ -16293,12 +16293,12 @@ msgstr ""
 msgid "CC0 1.0 (no rights reserved)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2013
+#: lib/vutuv_web/live/post_live/composer.ex:2048
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2206
+#: lib/vutuv_web/live/post_live/composer.ex:2241
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr ""
@@ -16310,27 +16310,27 @@ msgstr ""
 msgid "Download the original"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1431
+#: lib/vutuv_web/live/post_live/composer.ex:1451
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder. The first photo leads the gallery."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2283
+#: lib/vutuv_web/live/post_live/composer.ex:2318
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2239
+#: lib/vutuv_web/live/post_live/composer.ex:2274
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2241
+#: lib/vutuv_web/live/post_live/composer.ex:2276
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2260
+#: lib/vutuv_web/live/post_live/composer.ex:2295
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr ""
@@ -16340,7 +16340,7 @@ msgstr ""
 msgid "Next photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2032
+#: lib/vutuv_web/live/post_live/composer.ex:2067
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr ""
@@ -16372,8 +16372,8 @@ msgstr ""
 msgid "Photo is being checked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1985
-#: lib/vutuv_web/live/post_live/composer.ex:1986
+#: lib/vutuv_web/live/post_live/composer.ex:2020
+#: lib/vutuv_web/live/post_live/composer.ex:2021
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr ""
@@ -16390,18 +16390,18 @@ msgstr ""
 msgid "Previous photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2045
-#: lib/vutuv_web/live/post_live/composer.ex:2046
+#: lib/vutuv_web/live/post_live/composer.ex:2080
+#: lib/vutuv_web/live/post_live/composer.ex:2081
 #, elixir-autogen, elixir-format
 msgid "Remove photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2262
+#: lib/vutuv_web/live/post_live/composer.ex:2297
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1403
+#: lib/vutuv_web/live/post_live/composer.ex:1423
 #, elixir-autogen, elixir-format
 msgid "Show camera settings"
 msgstr ""
@@ -16411,17 +16411,17 @@ msgstr ""
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2281
+#: lib/vutuv_web/live/post_live/composer.ex:2316
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2317
+#: lib/vutuv_web/live/post_live/composer.ex:2352
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2309
+#: lib/vutuv_web/live/post_live/composer.ex:2344
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
@@ -16446,12 +16446,12 @@ msgstr ""
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1652
+#: lib/vutuv_web/live/post_live/composer.ex:1672
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1020
+#: lib/vutuv_web/live/post_live/composer.ex:1040
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
@@ -16461,7 +16461,7 @@ msgstr ""
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1034
+#: lib/vutuv_web/live/post_live/composer.ex:1054
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
@@ -16476,13 +16476,13 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1422
-#: lib/vutuv_web/live/post_live/composer.ex:1761
+#: lib/vutuv_web/live/post_live/composer.ex:1442
+#: lib/vutuv_web/live/post_live/composer.ex:1781
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1647
+#: lib/vutuv_web/live/post_live/composer.ex:1667
 #, elixir-autogen, elixir-format
 msgid "Licence"
 msgstr ""
@@ -16493,59 +16493,59 @@ msgstr ""
 msgid "Post photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1380
+#: lib/vutuv_web/live/post_live/composer.ex:1400
 #, elixir-autogen, elixir-format
 msgid "Caption (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1248
-#: lib/vutuv_web/live/post_live/composer.ex:1306
+#: lib/vutuv_web/live/post_live/composer.ex:1268
+#: lib/vutuv_web/live/post_live/composer.ex:1326
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1245
-#: lib/vutuv_web/live/post_live/composer.ex:1303
+#: lib/vutuv_web/live/post_live/composer.ex:1265
+#: lib/vutuv_web/live/post_live/composer.ex:1323
 #, elixir-autogen, elixir-format
 msgid "Discard the photos and text of this draft?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1240
+#: lib/vutuv_web/live/post_live/composer.ex:1260
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1718
+#: lib/vutuv_web/live/post_live/composer.ex:1738
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1915
+#: lib/vutuv_web/live/post_live/composer.ex:1950
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1914
+#: lib/vutuv_web/live/post_live/composer.ex:1949
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1913
+#: lib/vutuv_web/live/post_live/composer.ex:1948
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1918
+#: lib/vutuv_web/live/post_live/composer.ex:1953
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1681
+#: lib/vutuv_web/live/post_live/composer.ex:1701
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1707
+#: lib/vutuv_web/live/post_live/composer.ex:1727
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -16564,7 +16564,7 @@ msgstr ""
 msgid "%{handle} shared this"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:209
+#: lib/vutuv_web/views/account_event_text.ex:222
 #, elixir-autogen, elixir-format
 msgid "Fediverse reactions"
 msgstr ""
@@ -16655,7 +16655,7 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1635
+#: lib/vutuv_web/live/post_live/composer.ex:1655
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr ""
@@ -17599,135 +17599,135 @@ msgstr ""
 msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1349
+#: lib/vutuv_web/live/post_live/composer.ex:1369
 #, elixir-autogen, elixir-format
 msgid "Apply crop"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1465
+#: lib/vutuv_web/live/post_live/composer.ex:1485
 #, elixir-autogen, elixir-format
 msgid "Auto"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2091
+#: lib/vutuv_web/live/post_live/composer.ex:2126
 #, elixir-autogen, elixir-format
 msgid "Big photo left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2092
+#: lib/vutuv_web/live/post_live/composer.ex:2127
 #, elixir-autogen, elixir-format
 msgid "Big photo right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2097
+#: lib/vutuv_web/live/post_live/composer.ex:2132
 #, elixir-autogen, elixir-format
 msgid "Columns"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2094
+#: lib/vutuv_web/live/post_live/composer.ex:2129
 #, elixir-autogen, elixir-format
 msgid "Cover left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2095
+#: lib/vutuv_web/live/post_live/composer.ex:2130
 #, elixir-autogen, elixir-format
 msgid "Cover on top"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2096
+#: lib/vutuv_web/live/post_live/composer.ex:2131
 #, elixir-autogen, elixir-format
 msgid "Cover right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1345
-#: lib/vutuv_web/live/post_live/composer.ex:2062
-#: lib/vutuv_web/live/post_live/composer.ex:2063
+#: lib/vutuv_web/live/post_live/composer.ex:1365
+#: lib/vutuv_web/live/post_live/composer.ex:2097
+#: lib/vutuv_web/live/post_live/composer.ex:2098
 #, elixir-autogen, elixir-format
 msgid "Crop photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2021
+#: lib/vutuv_web/live/post_live/composer.ex:2056
 #, elixir-autogen, elixir-format
 msgid "Cropped"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1276
+#: lib/vutuv_web/live/post_live/composer.ex:1296
 #, elixir-autogen, elixir-format
 msgid "Drop photos to add them"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1443
+#: lib/vutuv_web/live/post_live/composer.ex:1463
 #, elixir-autogen, elixir-format
 msgid "Gallery preview"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2098
+#: lib/vutuv_web/live/post_live/composer.ex:2133
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2099
+#: lib/vutuv_web/live/post_live/composer.ex:2134
 #, elixir-autogen, elixir-format
 msgid "Mosaic"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1347
+#: lib/vutuv_web/live/post_live/composer.ex:1367
 #, elixir-autogen, elixir-format
 msgid "Pick a shape, then drag and zoom. The framed part is what the post shows."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2090
+#: lib/vutuv_web/live/post_live/composer.ex:2125
 #, elixir-autogen, elixir-format
 msgid "Side by side"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2093
+#: lib/vutuv_web/live/post_live/composer.ex:2128
 #, elixir-autogen, elixir-format
 msgid "Stacked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1558
-#: lib/vutuv_web/live/post_live/composer.ex:1559
+#: lib/vutuv_web/live/post_live/composer.ex:1578
+#: lib/vutuv_web/live/post_live/composer.ex:1579
 #, elixir-autogen, elixir-format
 msgid "Swap this photo with another"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1446
+#: lib/vutuv_web/live/post_live/composer.ex:1466
 #, elixir-autogen, elixir-format
 msgid "Tap two photos to swap them."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:381
+#: lib/vutuv_web/live/post_live/composer.ex:390
 #, elixir-autogen, elixir-format
 msgid "The photo could not be cropped."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2296
+#: lib/vutuv_web/live/post_live/composer.ex:2331
 #, elixir-autogen, elixir-format
 msgid "This photo is cropped: downloads hand out the cropped picture, and the untouched upload stays private."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1351
+#: lib/vutuv_web/live/post_live/composer.ex:1371
 #, elixir-autogen, elixir-format
 msgid "Whole photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1540
+#: lib/vutuv_web/live/post_live/composer.ex:1560
 #, elixir-autogen, elixir-format
 msgid "Each photo covers its tile and is cropped by it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1541
+#: lib/vutuv_web/live/post_live/composer.ex:1561
 #, elixir-autogen, elixir-format
 msgid "Each photo shows whole inside its tile."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1536
+#: lib/vutuv_web/live/post_live/composer.ex:1556
 #, elixir-autogen, elixir-format
 msgid "Fill the tiles"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1520
+#: lib/vutuv_web/live/post_live/composer.ex:1540
 #, elixir-autogen, elixir-format
 msgid "Whole photos"
 msgstr ""
@@ -18006,7 +18006,7 @@ msgstr ""
 msgid "Other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:408
+#: lib/vutuv_web/live/shell_live.ex:422
 #, elixir-autogen, elixir-format
 msgid "%{formatted} member"
 msgid_plural "%{formatted} members"
@@ -18220,7 +18220,7 @@ msgstr ""
 msgid "Write a post, react with a heart, a repost or a reply, or message somebody privately. And you are not stuck among vutuv members: vutuv is part of the Fediverse, the union of independent networks that Mastodon belongs to as well. Follow an account over there and its posts arrive in your feed; the other way round, people there can follow you and see your public posts. Both directions, and entirely your choice: at sign-up you decide whether to use vutuv with or without the Fediverse, and you can change that at any time in the settings."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:401
+#: lib/vutuv_web/live/shell_live.ex:415
 #, elixir-autogen, elixir-format
 msgid "member"
 msgid_plural "members"
@@ -18469,7 +18469,7 @@ msgstr ""
 msgid "Employment references of "
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:191
+#: lib/vutuv_web/views/account_event_text.ex:204
 #, elixir-autogen, elixir-format
 msgid "File"
 msgstr ""
@@ -18563,7 +18563,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/job_reference/show.html.heex:39
 #: lib/vutuv_web/templates/job_reference/view.html.heex:89
-#: lib/vutuv_web/views/account_event_text.ex:190
+#: lib/vutuv_web/views/account_event_text.ex:203
 #, elixir-autogen, elixir-format
 msgid "Text"
 msgstr ""
@@ -18872,7 +18872,7 @@ msgstr ""
 msgid "Employment reference reviews"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:189
+#: lib/vutuv_web/views/account_event_text.ex:202
 #, elixir-autogen, elixir-format
 msgid "Issue date"
 msgstr ""
@@ -19241,7 +19241,7 @@ msgstr ""
 msgid "Ms."
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:178
+#: lib/vutuv_web/views/account_event_text.ex:191
 #, elixir-autogen, elixir-format
 msgid "Salutation"
 msgstr ""
@@ -19342,7 +19342,7 @@ msgid_plural "%{formatted} of your posts are currently past this age."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/account_event_text.ex:137
+#: lib/vutuv_web/views/account_event_text.ex:150
 #, elixir-autogen, elixir-format
 msgid "%{count} post"
 msgid_plural "%{formatted} posts"
@@ -19414,7 +19414,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/settings_controller.ex:291
 #: lib/vutuv_web/controllers/settings_controller.ex:303
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:20
-#: lib/vutuv_web/views/account_event_text.ex:216
+#: lib/vutuv_web/views/account_event_text.ex:229
 #, elixir-autogen, elixir-format
 msgid "Automatic post deletion"
 msgstr ""
@@ -19424,7 +19424,7 @@ msgstr ""
 msgid "Automatic post deletion changed"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:223
+#: lib/vutuv_web/views/account_event_text.ex:236
 #, elixir-autogen, elixir-format
 msgid "Bookmark floor"
 msgstr ""
@@ -19466,7 +19466,7 @@ msgstr ""
 msgid "Delete posts older than"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:221
+#: lib/vutuv_web/views/account_event_text.ex:234
 #, elixir-autogen, elixir-format
 msgid "Delete replies too"
 msgstr ""
@@ -19486,17 +19486,17 @@ msgstr ""
 msgid "If a post of yours reached other networks (Mastodon and the rest), we ask every server that received it to delete its copy. We cannot make them. A server that is switched off, that no longer talks to us, or that simply ignores the request keeps what it has."
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:219
+#: lib/vutuv_web/views/account_event_text.ex:232
 #, elixir-autogen, elixir-format
 msgid "Keep answered posts"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:220
+#: lib/vutuv_web/views/account_event_text.ex:233
 #, elixir-autogen, elixir-format
 msgid "Keep bookmarked posts"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:218
+#: lib/vutuv_web/views/account_event_text.ex:231
 #, elixir-autogen, elixir-format
 msgid "Keep photo posts"
 msgstr ""
@@ -19511,7 +19511,7 @@ msgstr ""
 msgid "Let your posts age out after a time you set"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:222
+#: lib/vutuv_web/views/account_event_text.ex:235
 #, elixir-autogen, elixir-format
 msgid "Like floor"
 msgstr ""
@@ -19536,7 +19536,7 @@ msgstr ""
 msgid "Photo posts and book or film reviews are kept whatever their age."
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:217
+#: lib/vutuv_web/views/account_event_text.ex:230
 #, elixir-autogen, elixir-format
 msgid "Post age"
 msgstr ""
@@ -19561,7 +19561,7 @@ msgstr ""
 msgid "Posts you bookmarked yourself"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:224
+#: lib/vutuv_web/views/account_event_text.ex:237
 #, elixir-autogen, elixir-format
 msgid "Repost floor"
 msgstr ""
@@ -20044,12 +20044,13 @@ msgstr ""
 msgid "The owner gives other members their roles on the page, and can hand ownership over to someone else at any time. Someone can hold several roles, and writing in the organization's name is always granted on its own."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:406
+#: lib/vutuv_web/live/organization_live/show.ex:420
 #, elixir-autogen, elixir-format
 msgid "Nothing published yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:388
+#: lib/vutuv_web/live/organization_live/show.ex:402
+#: lib/vutuv_web/live/post_live/composer.ex:1814
 #, elixir-autogen, elixir-format
 msgid "Post as %{name}"
 msgstr ""
@@ -20064,7 +20065,7 @@ msgstr ""
 msgid "That post could not be published."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:380
+#: lib/vutuv_web/live/organization_live/show.ex:394
 #, elixir-autogen, elixir-format
 msgid "Write something as %{name}"
 msgstr ""
@@ -20072,4 +20073,49 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/show.ex:160
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1791
+#, elixir-autogen, elixir-format
+msgid "A post in an organization's name is always public."
+msgstr ""
+
+#: lib/vutuv_web/live/shell_live.ex:485
+#, elixir-autogen, elixir-format
+msgid "Open the page"
+msgstr ""
+
+#: lib/vutuv_web/views/account_event_text.ex:79
+#, elixir-autogen, elixir-format
+msgid "Started writing as an organization"
+msgstr ""
+
+#: lib/vutuv_web/views/account_event_text.ex:82
+#, elixir-autogen, elixir-format
+msgid "Stopped writing as an organization"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/show.ex:378
+#, elixir-autogen, elixir-format
+msgid "Write as %{name} for now"
+msgstr ""
+
+#: lib/vutuv_web/live/shell_live.ex:495
+#, elixir-autogen, elixir-format
+msgid "Write as myself again"
+msgstr ""
+
+#: lib/vutuv_web/controllers/acting_as_controller.ex:38
+#, elixir-autogen, elixir-format
+msgid "You are writing as %{name} now."
+msgstr ""
+
+#: lib/vutuv_web/live/shell_live.ex:479
+#, elixir-autogen, elixir-format
+msgid "You are writing as %{name}."
+msgstr ""
+
+#: lib/vutuv_web/controllers/acting_as_controller.ex:59
+#, elixir-autogen, elixir-format
+msgid "You are yourself again."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -32,7 +32,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
-#: lib/vutuv_web/live/organization_live/show.ex:471
+#: lib/vutuv_web/live/organization_live/show.ex:485
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
@@ -115,7 +115,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_posting_live/form.ex:605
 #: lib/vutuv_web/live/organization_live/edit.ex:347
 #: lib/vutuv_web/live/organization_live/new.ex:173
-#: lib/vutuv_web/live/post_live/composer.ex:1350
+#: lib/vutuv_web/live/post_live/composer.ex:1370
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
@@ -199,7 +199,7 @@ msgid "Disable"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:438
-#: lib/vutuv_web/live/post_live/composer.ex:1674
+#: lib/vutuv_web/live/post_live/composer.ex:1694
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/templates/user/show.html.heex:310
 #: lib/vutuv_web/views/qualification_html.ex:237
@@ -340,7 +340,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/dashboard_live.ex:195
 #: lib/vutuv_web/templates/page/index.html.heex:93
 #: lib/vutuv_web/templates/user/edit.html.heex:162
-#: lib/vutuv_web/views/account_event_text.ex:182
+#: lib/vutuv_web/views/account_event_text.ex:195
 #, elixir-autogen
 msgid "Gender"
 msgstr ""
@@ -438,8 +438,8 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:718
-#: lib/vutuv_web/live/shell_live.ex:755
+#: lib/vutuv_web/live/shell_live.ex:768
+#: lib/vutuv_web/live/shell_live.ex:805
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -602,7 +602,7 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1772
+#: lib/vutuv_web/live/post_live/composer.ex:1798
 #: lib/vutuv_web/live/section_reorder_live.ex:258
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -614,7 +614,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3222
 #: lib/vutuv_web/live/organization_live/edit.ex:341
-#: lib/vutuv_web/live/post_live/composer.ex:1781
+#: lib/vutuv_web/live/post_live/composer.ex:1813
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:196
@@ -640,8 +640,8 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:37
 #: lib/vutuv_web/live/search_live.ex:378
-#: lib/vutuv_web/live/shell_live.ex:586
-#: lib/vutuv_web/live/shell_live.ex:738
+#: lib/vutuv_web/live/shell_live.ex:636
+#: lib/vutuv_web/live/shell_live.ex:788
 #: lib/vutuv_web/live/tag_live/timeline.ex:255
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
@@ -861,7 +861,7 @@ msgstr ""
 #: lib/vutuv_web/templates/email/show.html.heex:24
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:295
 #: lib/vutuv_web/templates/settings/privacy.html.heex:14
-#: lib/vutuv_web/views/account_event_text.ex:192
+#: lib/vutuv_web/views/account_event_text.ex:205
 #, elixir-autogen
 msgid "Visibility"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "You follow back %{name}."
 msgstr ""
 
-#: lib/vutuv_web/live/init_assigns.ex:52
+#: lib/vutuv_web/live/init_assigns.ex:54
 #: lib/vutuv_web/live/post_live/feed.ex:76
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
@@ -1160,7 +1160,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:690
+#: lib/vutuv_web/live/shell_live.ex:740
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1593,7 +1593,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:741
+#: lib/vutuv_web/live/shell_live.ex:791
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1617,9 +1617,9 @@ msgstr ""
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
-#: lib/vutuv_web/live/post_live/composer.ex:1311
-#: lib/vutuv_web/live/post_live/composer.ex:1312
-#: lib/vutuv_web/live/post_live/composer.ex:2214
+#: lib/vutuv_web/live/post_live/composer.ex:1331
+#: lib/vutuv_web/live/post_live/composer.ex:1332
+#: lib/vutuv_web/live/post_live/composer.ex:2249
 #: lib/vutuv_web/templates/layout/app.html.heex:159
 #: lib/vutuv_web/templates/layout/app.html.heex:165
 #: lib/vutuv_web/views/layout_html.ex:40
@@ -1703,7 +1703,7 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:709
+#: lib/vutuv_web/live/shell_live.ex:759
 #: lib/vutuv_web/views/settings_html.ex:261
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1731,14 +1731,14 @@ msgstr ""
 
 #: lib/vutuv_web/live/message_live/index.ex:45
 #: lib/vutuv_web/live/message_live/index.ex:512
-#: lib/vutuv_web/live/shell_live.ex:602
-#: lib/vutuv_web/live/shell_live.ex:740
+#: lib/vutuv_web/live/shell_live.ex:652
+#: lib/vutuv_web/live/shell_live.ex:790
 #: lib/vutuv_web/templates/layout/app.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:496
+#: lib/vutuv_web/live/shell_live.ex:546
 #, elixir-autogen, elixir-format
 msgid "Network"
 msgstr ""
@@ -1762,7 +1762,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3653
 #: lib/vutuv_web/live/notification_live/index.ex:105
 #: lib/vutuv_web/live/notification_live/index.ex:329
-#: lib/vutuv_web/live/shell_live.ex:613
+#: lib/vutuv_web/live/shell_live.ex:663
 #: lib/vutuv_web/templates/layout/app.html.heex:124
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -1853,7 +1853,7 @@ msgstr ""
 msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1197
+#: lib/vutuv_web/live/post_live/feed.ex:1198
 #: lib/vutuv_web/views/user_html.ex:206
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
@@ -1913,7 +1913,7 @@ msgid "Pagination"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3461
-#: lib/vutuv_web/live/organization_live/show.ex:411
+#: lib/vutuv_web/live/organization_live/show.ex:425
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr ""
@@ -2070,7 +2070,7 @@ msgstr ""
 msgid "Add images"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1889
+#: lib/vutuv_web/live/post_live/composer.ex:1924
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2081,7 +2081,7 @@ msgstr ""
 msgid "Back to the post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1594
+#: lib/vutuv_web/live/post_live/composer.ex:1614
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr ""
@@ -2105,8 +2105,8 @@ msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:158
 #: lib/vutuv_web/live/post_live/feed.ex:952
-#: lib/vutuv_web/live/shell_live.ex:476
-#: lib/vutuv_web/live/shell_live.ex:736
+#: lib/vutuv_web/live/shell_live.ex:526
+#: lib/vutuv_web/live/shell_live.ex:786
 #: lib/vutuv_web/templates/layout/app.html.heex:122
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2122,12 +2122,12 @@ msgstr ""
 msgid "Hidden from:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1865
+#: lib/vutuv_web/live/post_live/composer.ex:1900
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1793
+#: lib/vutuv_web/live/post_live/composer.ex:1828
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr ""
@@ -2138,39 +2138,39 @@ msgstr ""
 msgid "Limited audience"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1835
+#: lib/vutuv_web/live/post_live/composer.ex:1870
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1037
-#: lib/vutuv_web/live/post_live/composer.ex:1085
+#: lib/vutuv_web/live/post_live/composer.ex:1057
+#: lib/vutuv_web/live/post_live/composer.ex:1105
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1136
+#: lib/vutuv_web/live/post_live/feed.ex:1137
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1010
+#: lib/vutuv_web/live/post_live/composer.ex:1030
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1825
+#: lib/vutuv_web/live/post_live/composer.ex:1860
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1815
+#: lib/vutuv_web/live/post_live/composer.ex:1850
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:406
-#: lib/vutuv_web/live/post_live/composer.ex:1781
+#: lib/vutuv_web/live/post_live/composer.ex:1815
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2220,7 +2220,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:373
 #: lib/vutuv_web/live/organization_live/roles.ex:243
-#: lib/vutuv_web/live/post_live/composer.ex:1851
+#: lib/vutuv_web/live/post_live/composer.ex:1886
 #: lib/vutuv_web/live/post_live/saved.ex:619
 #: lib/vutuv_web/live/post_live/saved.ex:647
 #: lib/vutuv_web/templates/connection/index.html.heex:40
@@ -2234,29 +2234,29 @@ msgstr ""
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1779
+#: lib/vutuv_web/live/post_live/composer.ex:1805
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1045
+#: lib/vutuv_web/live/post_live/feed.ex:1046
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/init_assigns.ex:81
+#: lib/vutuv_web/live/init_assigns.ex:83
 #, elixir-autogen, elixir-format
 msgid "Sorry, that page could not be found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1111
+#: lib/vutuv_web/live/post_live/composer.ex:1131
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:992
+#: lib/vutuv_web/live/post_live/composer.ex:1012
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr ""
@@ -2266,18 +2266,18 @@ msgstr ""
 msgid "This post is for followers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2363
+#: lib/vutuv_web/live/post_live/composer.ex:2398
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2364
+#: lib/vutuv_web/live/post_live/composer.ex:2399
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3917
-#: lib/vutuv_web/live/shell_live.ex:656
+#: lib/vutuv_web/live/shell_live.ex:706
 #: lib/vutuv_web/templates/post/index.html.heex:17
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:208
@@ -2285,12 +2285,12 @@ msgstr ""
 msgid "View profile"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1932
+#: lib/vutuv_web/live/post_live/composer.ex:1967
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1933
+#: lib/vutuv_web/live/post_live/composer.ex:1968
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr ""
@@ -2326,17 +2326,17 @@ msgstr ""
 msgid "unknown"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1731
+#: lib/vutuv_web/live/post_live/composer.ex:1751
 #, elixir-autogen, elixir-format
 msgid "Tags, separated by commas (max. %{max})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2354
+#: lib/vutuv_web/live/post_live/composer.ex:2389
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2358
+#: lib/vutuv_web/live/post_live/composer.ex:2393
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr ""
@@ -2367,8 +2367,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:961
 #: lib/vutuv_web/live/post_live/saved.ex:175
 #: lib/vutuv_web/live/post_live/saved.ex:488
-#: lib/vutuv_web/live/shell_live.ex:595
-#: lib/vutuv_web/live/shell_live.ex:661
+#: lib/vutuv_web/live/shell_live.ex:645
+#: lib/vutuv_web/live/shell_live.ex:711
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2389,7 +2389,7 @@ msgstr ""
 #: lib/vutuv_web/live/notification_live/index.ex:956
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
-#: lib/vutuv_web/live/shell_live.ex:664
+#: lib/vutuv_web/live/shell_live.ex:714
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2450,7 +2450,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1936
 #: lib/vutuv_web/components/ui.ex:1936
 #: lib/vutuv_web/components/ui.ex:2073
-#: lib/vutuv_web/live/post_live/feed.ex:1186
+#: lib/vutuv_web/live/post_live/feed.ex:1187
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
@@ -2486,13 +2486,13 @@ msgstr ""
 msgid "Reply to a deleted post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:995
-#: lib/vutuv_web/live/post_live/composer.ex:1769
+#: lib/vutuv_web/live/post_live/composer.ex:1015
+#: lib/vutuv_web/live/post_live/composer.ex:1793
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1896
+#: lib/vutuv_web/live/post_live/composer.ex:1931
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
@@ -2795,7 +2795,7 @@ msgstr ""
 msgid "Other formats"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1805
+#: lib/vutuv_web/live/post_live/composer.ex:1840
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr ""
@@ -3129,8 +3129,8 @@ msgid "Private message"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3585
-#: lib/vutuv_web/live/shell_live.ex:489
-#: lib/vutuv_web/live/shell_live.ex:745
+#: lib/vutuv_web/live/shell_live.ex:539
+#: lib/vutuv_web/live/shell_live.ex:795
 #: lib/vutuv_web/templates/import/new.html.heex:15
 #: lib/vutuv_web/templates/import/preview.html.heex:55
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
@@ -4517,7 +4517,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1141
+#: lib/vutuv_web/live/post_live/feed.ex:1142
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -4574,7 +4574,7 @@ msgstr ""
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:516
 #: lib/vutuv_web/live/notification_live/index.ex:877
-#: lib/vutuv_web/live/organization_live/show.ex:421
+#: lib/vutuv_web/live/organization_live/show.ex:435
 #: lib/vutuv_web/live/post_live/saved.ex:498
 #: lib/vutuv_web/live/search_live.ex:198
 #: lib/vutuv_web/live/search_live.ex:472
@@ -5273,7 +5273,7 @@ msgstr ""
 msgid "This permanently removes your profile, posts, messages and everything else. We email you a PIN to confirm. It cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1013
+#: lib/vutuv_web/live/post_live/composer.ex:1033
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr ""
@@ -5283,7 +5283,7 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:643
+#: lib/vutuv_web/live/shell_live.ex:693
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
@@ -5305,7 +5305,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:700
+#: lib/vutuv_web/live/shell_live.ex:750
 #: lib/vutuv_web/templates/layout/app.html.heex:154
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5324,7 +5324,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:285
-#: lib/vutuv_web/live/shell_live.ex:680
+#: lib/vutuv_web/live/shell_live.ex:730
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5378,8 +5378,8 @@ msgstr ""
 msgid "Previous post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:469
-#: lib/vutuv_web/live/shell_live.ex:729
+#: lib/vutuv_web/live/shell_live.ex:519
+#: lib/vutuv_web/live/shell_live.ex:779
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -5393,7 +5393,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:2924
 #: lib/vutuv_web/components/post_components.ex:3316
 #: lib/vutuv_web/live/notification_live/index.ex:680
-#: lib/vutuv_web/live/post_live/feed.ex:1259
+#: lib/vutuv_web/live/post_live/feed.ex:1260
 #: lib/vutuv_web/views/user_html.ex:111
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5546,7 +5546,7 @@ msgid "Email notifications"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/preferences.html.heex:18
-#: lib/vutuv_web/views/account_event_text.ex:185
+#: lib/vutuv_web/views/account_event_text.ex:198
 #, elixir-autogen, elixir-format
 msgid "Interface language"
 msgstr ""
@@ -5905,7 +5905,7 @@ msgid "A green dot on your avatar tells other members you are online right now."
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:124
-#: lib/vutuv_web/views/account_event_text.ex:196
+#: lib/vutuv_web/views/account_event_text.ex:209
 #, elixir-autogen, elixir-format
 msgid "Online status"
 msgstr ""
@@ -6031,7 +6031,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:148
 #: lib/vutuv_web/templates/user/edit.html.heex:206
-#: lib/vutuv_web/views/account_event_text.ex:175
+#: lib/vutuv_web/views/account_event_text.ex:188
 #, elixir-autogen, elixir-format
 msgid "Tagline"
 msgstr ""
@@ -6097,7 +6097,7 @@ msgstr ""
 msgid "Use photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1352
+#: lib/vutuv_web/live/post_live/composer.ex:1372
 #: lib/vutuv_web/templates/user/edit.html.heex:51
 #: lib/vutuv_web/templates/user/edit.html.heex:104
 #, elixir-autogen, elixir-format
@@ -6897,7 +6897,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:223
 #: lib/vutuv_web/templates/settings/notifications.html.heex:73
-#: lib/vutuv_web/views/account_event_text.ex:200
+#: lib/vutuv_web/views/account_event_text.ex:213
 #, elixir-autogen, elixir-format
 msgid "Newsletter"
 msgstr ""
@@ -8426,13 +8426,13 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1226
 #: lib/vutuv_web/live/post_live/feed.ex:1227
+#: lib/vutuv_web/live/post_live/feed.ex:1228
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1221
+#: lib/vutuv_web/live/post_live/feed.ex:1222
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr ""
@@ -8823,7 +8823,7 @@ msgid "Open CV"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:146
-#: lib/vutuv_web/views/account_event_text.ex:183
+#: lib/vutuv_web/views/account_event_text.ex:196
 #, elixir-autogen, elixir-format
 msgid "Photo"
 msgstr ""
@@ -9716,7 +9716,7 @@ msgstr ""
 #: lib/vutuv_web/cv/latex.ex:69
 #: lib/vutuv_web/cv/odt.ex:109
 #: lib/vutuv_web/live/cv_live.ex:153
-#: lib/vutuv_web/views/account_event_text.ex:177
+#: lib/vutuv_web/views/account_event_text.ex:190
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
@@ -9738,13 +9738,13 @@ msgid "Your date of birth will be removed and your age will no longer be shown o
 msgstr ""
 
 #: lib/vutuv_web/templates/page/index.html.heex:65
-#: lib/vutuv_web/views/account_event_text.ex:173
+#: lib/vutuv_web/views/account_event_text.ex:186
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
 #: lib/vutuv_web/templates/page/index.html.heex:70
-#: lib/vutuv_web/views/account_event_text.ex:174
+#: lib/vutuv_web/views/account_event_text.ex:187
 #, elixir-autogen, elixir-format
 msgid "Last name"
 msgstr ""
@@ -10245,7 +10245,7 @@ msgid "Code"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:159
-#: lib/vutuv_web/views/account_event_text.ex:198
+#: lib/vutuv_web/views/account_event_text.ex:211
 #, elixir-autogen, elixir-format
 msgid "Code statistics"
 msgstr ""
@@ -11021,7 +11021,7 @@ msgid "Your list is empty. Nobody is excluded yet."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:328
-#: lib/vutuv_web/views/account_event_text.ex:195
+#: lib/vutuv_web/views/account_event_text.ex:208
 #, elixir-autogen, elixir-format
 msgid "AI agents"
 msgstr ""
@@ -11039,7 +11039,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:248
 #: lib/vutuv_web/live/organization_live/domains.ex:288
 #: lib/vutuv_web/live/organization_live/new.ex:146
-#: lib/vutuv_web/live/organization_live/show.ex:545
+#: lib/vutuv_web/live/organization_live/show.ex:559
 #: lib/vutuv_web/templates/url/verify.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "DNS TXT record"
@@ -11048,7 +11048,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:153
 #: lib/vutuv_web/live/organization_live/domains.ex:167
 #: lib/vutuv_web/live/organization_live/show.ex:263
-#: lib/vutuv_web/live/organization_live/show.ex:604
+#: lib/vutuv_web/live/organization_live/show.ex:618
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr ""
@@ -11085,7 +11085,7 @@ msgstr ""
 msgid "Please log in first."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:518
+#: lib/vutuv_web/live/organization_live/show.ex:532
 #, elixir-autogen, elixir-format
 msgid "Prove you control %{domain} to publish this page."
 msgstr ""
@@ -11101,7 +11101,7 @@ msgid "Search by name or city"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:312
-#: lib/vutuv_web/views/account_event_text.ex:194
+#: lib/vutuv_web/views/account_event_text.ex:207
 #, elixir-autogen, elixir-format
 msgid "Search engines"
 msgstr ""
@@ -11112,7 +11112,7 @@ msgid "Select a country"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:307
-#: lib/vutuv_web/live/organization_live/show.ex:580
+#: lib/vutuv_web/live/organization_live/show.ex:594
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr ""
@@ -11139,12 +11139,12 @@ msgid "The upload failed."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/new.ex:131
-#: lib/vutuv_web/live/organization_live/show.ex:533
+#: lib/vutuv_web/live/organization_live/show.ex:547
 #, elixir-autogen, elixir-format
 msgid "Verification method"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:493
+#: lib/vutuv_web/live/organization_live/show.ex:507
 #, elixir-autogen, elixir-format
 msgid "Verified domains"
 msgstr ""
@@ -11160,13 +11160,13 @@ msgstr ""
 msgid "Verified via %{domain}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:515
+#: lib/vutuv_web/live/organization_live/show.ex:529
 #, elixir-autogen, elixir-format
 msgid "Verify %{name}"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:320
-#: lib/vutuv_web/live/organization_live/show.ex:600
+#: lib/vutuv_web/live/organization_live/show.ex:614
 #, elixir-autogen, elixir-format
 msgid "Verify now"
 msgstr ""
@@ -11187,7 +11187,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:249
 #: lib/vutuv_web/live/organization_live/domains.ex:298
-#: lib/vutuv_web/live/organization_live/show.ex:556
+#: lib/vutuv_web/live/organization_live/show.ex:570
 #: lib/vutuv_web/templates/url/verify.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Website file"
@@ -11209,7 +11209,7 @@ msgid "You will publish a record or file to prove control of the domain on the n
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:309
-#: lib/vutuv_web/live/organization_live/show.ex:586
+#: lib/vutuv_web/live/organization_live/show.ex:600
 #: lib/vutuv_web/templates/url/verify.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
@@ -11260,7 +11260,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:322
 #: lib/vutuv_web/agent_docs/text.ex:348
 #: lib/vutuv_web/live/organization_live/edit.ex:353
-#: lib/vutuv_web/live/organization_live/show.ex:481
+#: lib/vutuv_web/live/organization_live/show.ex:495
 #: lib/vutuv_web/templates/tag/single_card.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Also known as"
@@ -11624,7 +11624,7 @@ msgstr ""
 msgid "%{min} to %{max} characters: letters (a-z), numbers (0-9) and underscores."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:436
+#: lib/vutuv_web/live/organization_live/show.ex:450
 #, elixir-autogen, elixir-format
 msgid "Former"
 msgstr ""
@@ -11734,7 +11734,7 @@ msgstr ""
 msgid "The proof is a small technical change to your domain: a DNS entry or a file on your website. If you don't manage the website yourself, ask the person or team who does. That is usually your IT department or the company that runs your website. We show the exact instructions on the next step, so you can simply pass them on."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:527
+#: lib/vutuv_web/live/organization_live/show.ex:541
 #, elixir-autogen, elixir-format
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr ""
@@ -11850,7 +11850,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:501
-#: lib/vutuv_web/live/shell_live.ex:671
+#: lib/vutuv_web/live/shell_live.ex:721
 #: lib/vutuv_web/templates/layout/app.html.heex:83
 #: lib/vutuv_web/templates/settings/organizations.html.heex:6
 #, elixir-autogen, elixir-format
@@ -12102,7 +12102,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:392
 #: lib/vutuv_web/live/admin/job_live.ex:344
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:17
-#: lib/vutuv_web/views/account_event_text.ex:188
+#: lib/vutuv_web/views/account_event_text.ex:201
 #, elixir-autogen, elixir-format
 msgid "Employer"
 msgstr ""
@@ -12181,7 +12181,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:504
-#: lib/vutuv_web/live/shell_live.ex:503
+#: lib/vutuv_web/live/shell_live.ex:553
 #: lib/vutuv_web/templates/layout/app.html.heex:81
 #: lib/vutuv_web/templates/qualification/show.html.heex:38
 #, elixir-autogen, elixir-format
@@ -12628,13 +12628,13 @@ msgid "Getting an error, or is %{host} a CNAME / alias to another address? A TXT
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:305
-#: lib/vutuv_web/live/organization_live/show.ex:573
+#: lib/vutuv_web/live/organization_live/show.ex:587
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:303
-#: lib/vutuv_web/live/organization_live/show.ex:564
+#: lib/vutuv_web/live/organization_live/show.ex:578
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
 msgstr ""
@@ -12730,7 +12730,7 @@ msgid "Minimum yearly salary"
 msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:324
-#: lib/vutuv_web/live/organization_live/show.ex:463
+#: lib/vutuv_web/live/organization_live/show.ex:477
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr ""
@@ -12759,7 +12759,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:400
 #: lib/vutuv_web/agent_docs/text.ex:412
 #: lib/vutuv_web/agent_docs/text.ex:424
-#: lib/vutuv_web/live/organization_live/show.ex:450
+#: lib/vutuv_web/live/organization_live/show.ex:464
 #: lib/vutuv_web/templates/tag/show.html.heex:45
 #, elixir-autogen, elixir-format
 msgid "Open positions"
@@ -13458,7 +13458,7 @@ msgstr ""
 msgid "Insert image"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2333
+#: lib/vutuv_web/live/post_live/composer.ex:2368
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr ""
@@ -13517,14 +13517,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3661
 #: lib/vutuv_web/controllers/settings_controller.ex:569
-#: lib/vutuv_web/live/post_live/feed.ex:1172
+#: lib/vutuv_web/live/post_live/feed.ex:1173
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1187
+#: lib/vutuv_web/live/post_live/feed.ex:1188
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr ""
@@ -13866,7 +13866,7 @@ msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:389
+#: lib/vutuv_web/live/shell_live.ex:403
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -14124,13 +14124,13 @@ msgstr ""
 msgid "mentioned you in a post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1000
+#: lib/vutuv_web/live/post_live/composer.ex:1020
 #: lib/vutuv_web/live/post_live/edit.ex:57
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1003
+#: lib/vutuv_web/live/post_live/composer.ex:1023
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -15728,31 +15728,31 @@ msgstr ""
 msgid "Ask for a PIN first, then enter it here."
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:105
+#: lib/vutuv_web/views/account_event_text.ex:113
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} code"
 msgid_plural "%{count} codes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/account_event_text.ex:101
+#: lib/vutuv_web/views/account_event_text.ex:109
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} device"
 msgid_plural "%{count} devices"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/account_event_text.ex:93
+#: lib/vutuv_web/views/account_event_text.ex:101
 #, elixir-autogen, elixir-format
 msgid "%{email}, now hidden from your profile"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:92
+#: lib/vutuv_web/views/account_event_text.ex:100
 #, elixir-autogen, elixir-format
 msgid "%{email}, now shown on your profile"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:84
+#: lib/vutuv_web/views/account_event_text.ex:92
 #, elixir-autogen, elixir-format
 msgid "@%{from} to @%{to}"
 msgstr ""
@@ -15830,7 +15830,7 @@ msgstr ""
 msgid "By %{name}"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:206
+#: lib/vutuv_web/views/account_event_text.ex:219
 #, elixir-autogen, elixir-format
 msgid "CV update notifications"
 msgstr ""
@@ -15843,7 +15843,7 @@ msgstr ""
 msgid "Confirmed"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:184
+#: lib/vutuv_web/views/account_event_text.ex:197
 #, elixir-autogen, elixir-format
 msgid "Cover picture"
 msgstr ""
@@ -15873,7 +15873,7 @@ msgstr ""
 msgid "Email address removed"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:202
+#: lib/vutuv_web/views/account_event_text.ex:215
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Endorsement emails"
 msgstr ""
@@ -15883,17 +15883,17 @@ msgstr ""
 msgid "Every change to your account: what changed, exactly when, from which device, and how it was confirmed. If a line surprises you, follow the link at the end of it."
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:211
+#: lib/vutuv_web/views/account_event_text.ex:224
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Fediverse aliases"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:208
+#: lib/vutuv_web/views/account_event_text.ex:221
 #, elixir-autogen, elixir-format
 msgid "Fediverse participation"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:210
+#: lib/vutuv_web/views/account_event_text.ex:223
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Fediverse replies"
 msgstr ""
@@ -15933,12 +15933,12 @@ msgstr ""
 msgid "It is part of your data download, and it is deleted with your account."
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:193
+#: lib/vutuv_web/views/account_event_text.ex:206
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Job search"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:197
+#: lib/vutuv_web/views/account_event_text.ex:210
 #, elixir-autogen, elixir-format
 msgid "Mastodon posts"
 msgstr ""
@@ -15953,7 +15953,7 @@ msgstr ""
 msgid "Member unblocked"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:201
+#: lib/vutuv_web/views/account_event_text.ex:214
 #, elixir-autogen, elixir-format, fuzzy
 msgid "New follower emails"
 msgstr ""
@@ -15992,7 +15992,7 @@ msgstr ""
 msgid "Nothing recorded yet."
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:199
+#: lib/vutuv_web/views/account_event_text.ex:212
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Notification emails"
 msgstr ""
@@ -16037,7 +16037,7 @@ msgstr ""
 msgid "Recent account activity"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:205
+#: lib/vutuv_web/views/account_event_text.ex:218
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Saved search alerts"
 msgstr ""
@@ -16074,17 +16074,17 @@ msgid_plural "This log keeps %{formatted} days of history."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/account_event_text.ex:207
+#: lib/vutuv_web/views/account_event_text.ex:220
 #, elixir-autogen, elixir-format
 msgid "Thread notifications"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:204
+#: lib/vutuv_web/views/account_event_text.ex:217
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Unread message delay"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:203
+#: lib/vutuv_web/views/account_event_text.ex:216
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Unread message emails"
 msgstr ""
@@ -16130,22 +16130,22 @@ msgstr ""
 msgid "a deleted account"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:115
+#: lib/vutuv_web/views/account_event_text.ex:123
 #, elixir-autogen, elixir-format
 msgid "a tag"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:116
+#: lib/vutuv_web/views/account_event_text.ex:124
 #, elixir-autogen, elixir-format, fuzzy
 msgid "a word or phrase"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:164
+#: lib/vutuv_web/views/account_event_text.ex:177
 #, elixir-autogen, elixir-format
 msgid "by the site operators"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:163
+#: lib/vutuv_web/views/account_event_text.ex:176
 #, elixir-autogen, elixir-format
 msgid "from a signed-in session"
 msgstr ""
@@ -16155,32 +16155,32 @@ msgstr ""
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:144
+#: lib/vutuv_web/views/account_event_text.ex:157
 #, elixir-autogen, elixir-format
 msgid "not taking part in the Fediverse"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:141
+#: lib/vutuv_web/views/account_event_text.ex:154
 #, elixir-autogen, elixir-format, fuzzy
 msgid "taking part in the Fediverse"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:161
+#: lib/vutuv_web/views/account_event_text.ex:174
 #, elixir-autogen, elixir-format
 msgid "with a one-time list code"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:159
+#: lib/vutuv_web/views/account_event_text.ex:172
 #, elixir-autogen, elixir-format, fuzzy
 msgid "with a passkey"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:162
+#: lib/vutuv_web/views/account_event_text.ex:175
 #, elixir-autogen, elixir-format
 msgid "with an emailed PIN"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:160
+#: lib/vutuv_web/views/account_event_text.ex:173
 #, elixir-autogen, elixir-format
 msgid "with your authenticator app"
 msgstr ""
@@ -16246,7 +16246,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:434
 #: lib/vutuv_web/templates/user/edit.html.heex:180
 #: lib/vutuv_web/templates/user/show.html.heex:217
-#: lib/vutuv_web/views/account_event_text.ex:176
+#: lib/vutuv_web/views/account_event_text.ex:189
 #, elixir-autogen, elixir-format
 msgid "Name pronunciation"
 msgstr ""
@@ -16261,7 +16261,7 @@ msgstr ""
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2346
+#: lib/vutuv_web/live/post_live/composer.ex:2381
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr ""
@@ -16291,12 +16291,12 @@ msgstr ""
 msgid "CC0 1.0 (no rights reserved)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2013
+#: lib/vutuv_web/live/post_live/composer.ex:2048
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2206
+#: lib/vutuv_web/live/post_live/composer.ex:2241
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr ""
@@ -16308,27 +16308,27 @@ msgstr ""
 msgid "Download the original"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1431
+#: lib/vutuv_web/live/post_live/composer.ex:1451
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder. The first photo leads the gallery."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2283
+#: lib/vutuv_web/live/post_live/composer.ex:2318
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2239
+#: lib/vutuv_web/live/post_live/composer.ex:2274
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2241
+#: lib/vutuv_web/live/post_live/composer.ex:2276
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2260
+#: lib/vutuv_web/live/post_live/composer.ex:2295
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr ""
@@ -16338,7 +16338,7 @@ msgstr ""
 msgid "Next photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2032
+#: lib/vutuv_web/live/post_live/composer.ex:2067
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr ""
@@ -16370,8 +16370,8 @@ msgstr ""
 msgid "Photo is being checked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1985
-#: lib/vutuv_web/live/post_live/composer.ex:1986
+#: lib/vutuv_web/live/post_live/composer.ex:2020
+#: lib/vutuv_web/live/post_live/composer.ex:2021
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr ""
@@ -16388,18 +16388,18 @@ msgstr ""
 msgid "Previous photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2045
-#: lib/vutuv_web/live/post_live/composer.ex:2046
+#: lib/vutuv_web/live/post_live/composer.ex:2080
+#: lib/vutuv_web/live/post_live/composer.ex:2081
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2262
+#: lib/vutuv_web/live/post_live/composer.ex:2297
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1403
+#: lib/vutuv_web/live/post_live/composer.ex:1423
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Show camera settings"
 msgstr ""
@@ -16409,17 +16409,17 @@ msgstr ""
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2281
+#: lib/vutuv_web/live/post_live/composer.ex:2316
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2317
+#: lib/vutuv_web/live/post_live/composer.ex:2352
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2309
+#: lib/vutuv_web/live/post_live/composer.ex:2344
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
@@ -16444,12 +16444,12 @@ msgstr ""
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1652
+#: lib/vutuv_web/live/post_live/composer.ex:1672
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1020
+#: lib/vutuv_web/live/post_live/composer.ex:1040
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
@@ -16459,7 +16459,7 @@ msgstr ""
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1034
+#: lib/vutuv_web/live/post_live/composer.ex:1054
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
@@ -16474,13 +16474,13 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1422
-#: lib/vutuv_web/live/post_live/composer.ex:1761
+#: lib/vutuv_web/live/post_live/composer.ex:1442
+#: lib/vutuv_web/live/post_live/composer.ex:1781
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1647
+#: lib/vutuv_web/live/post_live/composer.ex:1667
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Licence"
 msgstr ""
@@ -16491,59 +16491,59 @@ msgstr ""
 msgid "Post photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1380
+#: lib/vutuv_web/live/post_live/composer.ex:1400
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Caption (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1248
-#: lib/vutuv_web/live/post_live/composer.ex:1306
+#: lib/vutuv_web/live/post_live/composer.ex:1268
+#: lib/vutuv_web/live/post_live/composer.ex:1326
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1245
-#: lib/vutuv_web/live/post_live/composer.ex:1303
+#: lib/vutuv_web/live/post_live/composer.ex:1265
+#: lib/vutuv_web/live/post_live/composer.ex:1323
 #, elixir-autogen, elixir-format
 msgid "Discard the photos and text of this draft?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1240
+#: lib/vutuv_web/live/post_live/composer.ex:1260
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1718
+#: lib/vutuv_web/live/post_live/composer.ex:1738
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1915
+#: lib/vutuv_web/live/post_live/composer.ex:1950
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1914
+#: lib/vutuv_web/live/post_live/composer.ex:1949
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1913
+#: lib/vutuv_web/live/post_live/composer.ex:1948
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1918
+#: lib/vutuv_web/live/post_live/composer.ex:1953
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1681
+#: lib/vutuv_web/live/post_live/composer.ex:1701
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1707
+#: lib/vutuv_web/live/post_live/composer.ex:1727
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -16562,7 +16562,7 @@ msgstr ""
 msgid "%{handle} shared this"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:209
+#: lib/vutuv_web/views/account_event_text.ex:222
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Fediverse reactions"
 msgstr ""
@@ -16653,7 +16653,7 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1635
+#: lib/vutuv_web/live/post_live/composer.ex:1655
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr ""
@@ -17597,135 +17597,135 @@ msgstr ""
 msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1349
+#: lib/vutuv_web/live/post_live/composer.ex:1369
 #, elixir-autogen, elixir-format
 msgid "Apply crop"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1465
+#: lib/vutuv_web/live/post_live/composer.ex:1485
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Auto"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2091
+#: lib/vutuv_web/live/post_live/composer.ex:2126
 #, elixir-autogen, elixir-format
 msgid "Big photo left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2092
+#: lib/vutuv_web/live/post_live/composer.ex:2127
 #, elixir-autogen, elixir-format
 msgid "Big photo right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2097
+#: lib/vutuv_web/live/post_live/composer.ex:2132
 #, elixir-autogen, elixir-format
 msgid "Columns"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2094
+#: lib/vutuv_web/live/post_live/composer.ex:2129
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2095
+#: lib/vutuv_web/live/post_live/composer.ex:2130
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover on top"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2096
+#: lib/vutuv_web/live/post_live/composer.ex:2131
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1345
-#: lib/vutuv_web/live/post_live/composer.ex:2062
-#: lib/vutuv_web/live/post_live/composer.ex:2063
+#: lib/vutuv_web/live/post_live/composer.ex:1365
+#: lib/vutuv_web/live/post_live/composer.ex:2097
+#: lib/vutuv_web/live/post_live/composer.ex:2098
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Crop photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2021
+#: lib/vutuv_web/live/post_live/composer.ex:2056
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cropped"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1276
+#: lib/vutuv_web/live/post_live/composer.ex:1296
 #, elixir-autogen, elixir-format
 msgid "Drop photos to add them"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1443
+#: lib/vutuv_web/live/post_live/composer.ex:1463
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Gallery preview"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2098
+#: lib/vutuv_web/live/post_live/composer.ex:2133
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2099
+#: lib/vutuv_web/live/post_live/composer.ex:2134
 #, elixir-autogen, elixir-format
 msgid "Mosaic"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1347
+#: lib/vutuv_web/live/post_live/composer.ex:1367
 #, elixir-autogen, elixir-format
 msgid "Pick a shape, then drag and zoom. The framed part is what the post shows."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2090
+#: lib/vutuv_web/live/post_live/composer.ex:2125
 #, elixir-autogen, elixir-format
 msgid "Side by side"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2093
+#: lib/vutuv_web/live/post_live/composer.ex:2128
 #, elixir-autogen, elixir-format
 msgid "Stacked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1558
-#: lib/vutuv_web/live/post_live/composer.ex:1559
+#: lib/vutuv_web/live/post_live/composer.ex:1578
+#: lib/vutuv_web/live/post_live/composer.ex:1579
 #, elixir-autogen, elixir-format
 msgid "Swap this photo with another"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1446
+#: lib/vutuv_web/live/post_live/composer.ex:1466
 #, elixir-autogen, elixir-format
 msgid "Tap two photos to swap them."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:381
+#: lib/vutuv_web/live/post_live/composer.ex:390
 #, elixir-autogen, elixir-format
 msgid "The photo could not be cropped."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2296
+#: lib/vutuv_web/live/post_live/composer.ex:2331
 #, elixir-autogen, elixir-format
 msgid "This photo is cropped: downloads hand out the cropped picture, and the untouched upload stays private."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1351
+#: lib/vutuv_web/live/post_live/composer.ex:1371
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Whole photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1540
+#: lib/vutuv_web/live/post_live/composer.ex:1560
 #, elixir-autogen, elixir-format
 msgid "Each photo covers its tile and is cropped by it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1541
+#: lib/vutuv_web/live/post_live/composer.ex:1561
 #, elixir-autogen, elixir-format
 msgid "Each photo shows whole inside its tile."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1536
+#: lib/vutuv_web/live/post_live/composer.ex:1556
 #, elixir-autogen, elixir-format
 msgid "Fill the tiles"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1520
+#: lib/vutuv_web/live/post_live/composer.ex:1540
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Whole photos"
 msgstr ""
@@ -18004,7 +18004,7 @@ msgstr ""
 msgid "Other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:408
+#: lib/vutuv_web/live/shell_live.ex:422
 #, elixir-autogen, elixir-format
 msgid "%{formatted} member"
 msgid_plural "%{formatted} members"
@@ -18218,7 +18218,7 @@ msgstr ""
 msgid "Write a post, react with a heart, a repost or a reply, or message somebody privately. And you are not stuck among vutuv members: vutuv is part of the Fediverse, the union of independent networks that Mastodon belongs to as well. Follow an account over there and its posts arrive in your feed; the other way round, people there can follow you and see your public posts. Both directions, and entirely your choice: at sign-up you decide whether to use vutuv with or without the Fediverse, and you can change that at any time in the settings."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:401
+#: lib/vutuv_web/live/shell_live.ex:415
 #, elixir-autogen, elixir-format
 msgid "member"
 msgid_plural "members"
@@ -18467,7 +18467,7 @@ msgstr ""
 msgid "Employment references of "
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:191
+#: lib/vutuv_web/views/account_event_text.ex:204
 #, elixir-autogen, elixir-format, fuzzy
 msgid "File"
 msgstr ""
@@ -18561,7 +18561,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/job_reference/show.html.heex:39
 #: lib/vutuv_web/templates/job_reference/view.html.heex:89
-#: lib/vutuv_web/views/account_event_text.ex:190
+#: lib/vutuv_web/views/account_event_text.ex:203
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Text"
 msgstr ""
@@ -18870,7 +18870,7 @@ msgstr ""
 msgid "Employment reference reviews"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:189
+#: lib/vutuv_web/views/account_event_text.ex:202
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Issue date"
 msgstr ""
@@ -19239,7 +19239,7 @@ msgstr ""
 msgid "Ms."
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:178
+#: lib/vutuv_web/views/account_event_text.ex:191
 #, elixir-autogen, elixir-format
 msgid "Salutation"
 msgstr ""
@@ -19340,7 +19340,7 @@ msgid_plural "%{formatted} of your posts are currently past this age."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/account_event_text.ex:137
+#: lib/vutuv_web/views/account_event_text.ex:150
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} post"
 msgid_plural "%{formatted} posts"
@@ -19412,7 +19412,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/settings_controller.ex:291
 #: lib/vutuv_web/controllers/settings_controller.ex:303
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:20
-#: lib/vutuv_web/views/account_event_text.ex:216
+#: lib/vutuv_web/views/account_event_text.ex:229
 #, elixir-autogen, elixir-format
 msgid "Automatic post deletion"
 msgstr ""
@@ -19422,7 +19422,7 @@ msgstr ""
 msgid "Automatic post deletion changed"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:223
+#: lib/vutuv_web/views/account_event_text.ex:236
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Bookmark floor"
 msgstr ""
@@ -19464,7 +19464,7 @@ msgstr ""
 msgid "Delete posts older than"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:221
+#: lib/vutuv_web/views/account_event_text.ex:234
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Delete replies too"
 msgstr ""
@@ -19484,17 +19484,17 @@ msgstr ""
 msgid "If a post of yours reached other networks (Mastodon and the rest), we ask every server that received it to delete its copy. We cannot make them. A server that is switched off, that no longer talks to us, or that simply ignores the request keeps what it has."
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:219
+#: lib/vutuv_web/views/account_event_text.ex:232
 #, elixir-autogen, elixir-format
 msgid "Keep answered posts"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:220
+#: lib/vutuv_web/views/account_event_text.ex:233
 #, elixir-autogen, elixir-format
 msgid "Keep bookmarked posts"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:218
+#: lib/vutuv_web/views/account_event_text.ex:231
 #, elixir-autogen, elixir-format
 msgid "Keep photo posts"
 msgstr ""
@@ -19509,7 +19509,7 @@ msgstr ""
 msgid "Let your posts age out after a time you set"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:222
+#: lib/vutuv_web/views/account_event_text.ex:235
 #, elixir-autogen, elixir-format
 msgid "Like floor"
 msgstr ""
@@ -19534,7 +19534,7 @@ msgstr ""
 msgid "Photo posts and book or film reviews are kept whatever their age."
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:217
+#: lib/vutuv_web/views/account_event_text.ex:230
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post age"
 msgstr ""
@@ -19559,7 +19559,7 @@ msgstr ""
 msgid "Posts you bookmarked yourself"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:224
+#: lib/vutuv_web/views/account_event_text.ex:237
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Repost floor"
 msgstr ""
@@ -20042,12 +20042,13 @@ msgstr ""
 msgid "The owner gives other members their roles on the page, and can hand ownership over to someone else at any time. Someone can hold several roles, and writing in the organization's name is always granted on its own."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:406
+#: lib/vutuv_web/live/organization_live/show.ex:420
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing published yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:388
+#: lib/vutuv_web/live/organization_live/show.ex:402
+#: lib/vutuv_web/live/post_live/composer.ex:1814
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post as %{name}"
 msgstr ""
@@ -20062,7 +20063,7 @@ msgstr ""
 msgid "That post could not be published."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:380
+#: lib/vutuv_web/live/organization_live/show.ex:394
 #, elixir-autogen, elixir-format
 msgid "Write something as %{name}"
 msgstr ""
@@ -20070,4 +20071,49 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/show.ex:160
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1791
+#, elixir-autogen, elixir-format
+msgid "A post in an organization's name is always public."
+msgstr ""
+
+#: lib/vutuv_web/live/shell_live.ex:485
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Open the page"
+msgstr ""
+
+#: lib/vutuv_web/views/account_event_text.ex:79
+#, elixir-autogen, elixir-format
+msgid "Started writing as an organization"
+msgstr ""
+
+#: lib/vutuv_web/views/account_event_text.ex:82
+#, elixir-autogen, elixir-format
+msgid "Stopped writing as an organization"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/show.ex:378
+#, elixir-autogen, elixir-format
+msgid "Write as %{name} for now"
+msgstr ""
+
+#: lib/vutuv_web/live/shell_live.ex:495
+#, elixir-autogen, elixir-format
+msgid "Write as myself again"
+msgstr ""
+
+#: lib/vutuv_web/controllers/acting_as_controller.ex:38
+#, elixir-autogen, elixir-format
+msgid "You are writing as %{name} now."
+msgstr ""
+
+#: lib/vutuv_web/live/shell_live.ex:479
+#, elixir-autogen, elixir-format
+msgid "You are writing as %{name}."
+msgstr ""
+
+#: lib/vutuv_web/controllers/acting_as_controller.ex:59
+#, elixir-autogen, elixir-format
+msgid "You are yourself again."
 msgstr ""

--- a/test/vutuv_web/acting_as_organization_test.exs
+++ b/test/vutuv_web/acting_as_organization_test.exs
@@ -1,0 +1,154 @@
+defmodule VutuvWeb.ActingAsOrganizationTest do
+  @moduledoc """
+  Switching into an organization for a session (issue #1335).
+
+  The security half is the point of most of these: the session's
+  `acting_as_organization_id` is signed but not encrypted and valid for days, so
+  it is re-authorized on **every** request and **every** socket mount rather than
+  trusted — the trap #1034 and #1036 already cost this app twice.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.AccountEvents
+  alias Vutuv.Organizations
+  alias Vutuv.Posts
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp switched_in(conn) do
+    {conn, owner} = create_and_login_user(conn)
+    organization = active_organization_for(owner)
+    {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+
+    conn = post(conn, ~p"/organizations/#{organization.slug}/act_as")
+    %{conn: recycle_login(conn), owner: owner, organization: organization}
+  end
+
+  # Carries the session (and its acting-as value) into the next request the way
+  # a browser does.
+  defp recycle_login(conn),
+    do: conn |> recycle() |> Map.put(:secret_key_base, conn.secret_key_base)
+
+  describe "switching in" do
+    test "a publisher may, and the chrome says so unmistakably", %{conn: conn} do
+      %{conn: conn, organization: organization} = switched_in(conn)
+
+      html = conn |> get(~p"/feed") |> html_response(200)
+
+      assert html =~ "acting-as-banner"
+      assert html =~ organization.name
+      # Leaving is reachable from wherever the banner is.
+      assert html =~ "stop-acting-as"
+    end
+
+    test "a member without the publisher role cannot", %{conn: conn} do
+      {conn, owner} = create_and_login_user(conn)
+      organization = active_organization_for(owner)
+
+      # An owner who never granted themselves publisher is not a publisher.
+      conn |> post(~p"/organizations/#{organization.slug}/act_as") |> response(404)
+    end
+
+    test "both directions are logged, naming the organization", %{conn: conn} do
+      %{conn: conn, owner: owner, organization: organization} = switched_in(conn)
+
+      conn |> delete(~p"/system/act_as") |> response(302)
+
+      events = AccountEvents.page(owner, %{})
+      kinds = Enum.map(events, & &1.kind)
+      assert "acted_as_organization" in kinds
+      assert "stopped_acting_as_organization" in kinds
+
+      event = Enum.find(events, &(&1.kind == "acted_as_organization"))
+      assert event.details["organization"] == organization.name
+    end
+  end
+
+  describe "the mode is re-authorized, never trusted" do
+    test "a withdrawn publisher role ends the mode on the next request", %{conn: conn} do
+      %{conn: conn, owner: owner, organization: organization} = switched_in(conn)
+
+      # Still in the mode …
+      assert conn |> get(~p"/feed") |> html_response(200) =~ "acting-as-banner"
+
+      # … and the moment the role goes, the very next request is themselves
+      # again — not at the next login. The session still carries the id. Only
+      # the publisher role is withdrawn: they are the page's only owner, and
+      # the last-owner guard rightly refuses to strip that one.
+      {:ok, ["owner"]} = Organizations.set_roles(organization, owner, ["owner"], owner)
+
+      refute conn |> recycle_login() |> get(~p"/feed") |> html_response(200) =~ "acting-as-banner"
+    end
+
+    test "posting in the organization's name stops working at once too", %{conn: conn} do
+      %{owner: owner, organization: organization} = switched_in(conn)
+
+      assert {:ok, _} = Posts.create_organization_post(organization, owner, %{body: "Ours."})
+
+      {:ok, ["owner"]} = Organizations.set_roles(organization, owner, ["owner"], owner)
+
+      # The context re-checks rather than trusting whatever the session says.
+      assert {:error, :forbidden} =
+               Posts.create_organization_post(organization, owner, %{body: "Still ours?"})
+    end
+  end
+
+  describe "leaving" do
+    test "one click, and the member is themselves again", %{conn: conn} do
+      %{conn: conn} = switched_in(conn)
+
+      conn = delete(conn, ~p"/system/act_as", %{"return_to" => "/feed"})
+      assert redirected_to(conn) == "/feed"
+
+      refute conn |> recycle_login() |> get(~p"/feed") |> html_response(200) =~ "acting-as-banner"
+    end
+
+    test "an absolute return_to is refused — this control is on every page", %{conn: conn} do
+      %{conn: conn} = switched_in(conn)
+
+      conn = delete(conn, ~p"/system/act_as", %{"return_to" => "https://example.com/"})
+      assert redirected_to(conn) == "/feed"
+
+      conn =
+        conn |> recycle_login() |> delete(~p"/system/act_as", %{"return_to" => "//example.com/"})
+
+      assert redirected_to(conn) == "/feed"
+    end
+  end
+
+  describe "the feed composer" do
+    test "names the organization on the button and publishes in its name", %{conn: conn} do
+      %{conn: conn, owner: owner, organization: organization} = switched_in(conn)
+
+      {:ok, view, html} = live(conn, ~p"/feed")
+
+      # The last thing seen before publishing is whose name goes on it.
+      assert html =~ organization.name
+
+      view |> element("#open-composer") |> render_click()
+
+      view
+      |> form("#composer-form", %{"post" => %{"body" => "Aus dem Haus."}})
+      |> render_submit()
+
+      [post] = Posts.organization_posts_page(organization, owner).entries
+      assert post.body == "Aus dem Haus."
+      assert post.acting_user_id == owner.id
+    end
+  end
+end


### PR DESCRIPTION
Closes #1335. A member holding the `publisher` role can switch into an organization and act as it, instead of picking an author per action.

### The security rules, which are most of the work

`acting_as_organization_id` in the session is a **hint, never a credential**. `VutuvWeb.Plug.ActingAs` re-asks `organization_roles` on **every request** and `VutuvWeb.Live.InitAssigns` on **every socket mount** — including the off-router `live_render` children, which is exactly where #1036 went wrong. Consequences, both covered by tests:

- **A withdrawn role takes effect on the next action**, not at the next login. The test switches in, strips the role, and asserts the very next request renders as the member again with the session still carrying the id.
- A frozen or archived page stops being speakable-for at once.
- The plug also **clears a stale id** from the session, so nobody is left in a mode that silently does nothing.
- **Both directions are logged** (#1087) under their own kinds, `acted_as_organization` / `stopped_acting_as_organization`, rather than folded into an existing one — that log's closed vocabulary is the security boundary.
- The switch is a plain session value, so it **does not outlive the session**.
- Both directions are POST/DELETE with CSRF. A `GET` that changes whose name you speak in would fire on a link prefetch.

### The mode error is the product risk

- **The chrome changes unmistakably**: a full-width brand bar above the top bar naming the organization, with the way out in it. Above the sticky header rather than inside it, so the top bar's tight width budget (768px is the binding case) is untouched.
- **The composer's submit button names the author** — "Post as Acme" — because the banner scrolls away and the button does not. Publishing from the feed while switched in publishes in the organization's name.
- **Leaving is one click** from wherever the banner is. `return_to` only honours a same-site path: this control is on every page, so an absolute URL in it would be an open redirect.

### Fixed on the way

- **`/act_as` burned a root URL word.** Profiles own the URL root, so every new root segment permanently costs a handle a member could have claimed — the project's own `reserved_slugs_router_test` caught it. It is `/system/act_as` now.
- **Another fuzzy translation**: `gettext.extract --merge` filled `"Open the page"` with `"Datei öffnen"` ("Open file").

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*
