### PR TITLE
Ein Herz für einen Beitrag der Organisation (v7.242.1)

### DIFF
--- a/lib/vutuv/activity.ex
+++ b/lib/vutuv/activity.ex
@@ -1116,24 +1116,36 @@ defmodule Vutuv.Activity do
   # rows come from `post_mentions`, reconciled at save time by `Vutuv.Posts` —
   # deriving them here would mean an ILIKE over every post on every unread
   # count. Newest first, actor = the post's author.
+  # Both joins are LEFT: whoever named the member is a member or an
+  # organization (issue #1334), exactly one of the two per row, and an inner
+  # join to `users` dropped every mention a page made.
   defp mention_items(user_id, limit, cursor) do
     mention_events(user_id)
-    |> join(:inner, [mention_post: p], author in User, on: author.id == p.user_id, as: :author)
+    |> join(:left, [mention_post: p], author in User, on: author.id == p.user_id, as: :author)
+    |> join(:left, [mention_post: p], org in Organization,
+      on: org.id == p.organization_id,
+      as: :mention_organization
+    )
     |> order_by([mention: m], desc: m.inserted_at, desc: m.id)
     |> limit(^limit)
     |> select(
-      [mention: m, author: author],
-      {m.id, m.inserted_at, struct(author, ^User.listing_fields()), m.post_id}
+      [mention: m, author: author, mention_organization: org],
+      {m.id, m.inserted_at, struct(author, ^User.listing_fields()), org, m.post_id}
     )
     |> at_or_before(cursor)
     |> Repo.all()
-    |> Enum.map(fn {id, at, author, post_id} ->
+    |> Enum.map(fn {id, at, author, organization, post_id} ->
       "mention-#{id}"
-      |> actor_item("mention", at, author)
+      |> actor_item("mention", at, mention_actor(author, organization))
       # The post that named them — the author's, not the recipient's.
       |> Map.put(:post_id, post_id)
     end)
   end
+
+  # A missed LEFT join still yields a `%User{}` with every field nil rather than
+  # nil itself, so the id is what says which side actually matched.
+  defp mention_actor(%User{id: id} = author, _organization) when is_binary(id), do: author
+  defp mention_actor(_author, organization), do: organization
 
   # Replies written on other networks under the member's posts (issue #1069),
   # derived **straight from the notes table** rather than from a stored
@@ -1265,7 +1277,11 @@ defmodule Vutuv.Activity do
             select: 1
           )
         ),
-      where: p.user_id not in subquery(blocked_either_way(user_id))
+      # The block filter is about the *member* who named you. An organization
+      # post has no member author, and `NULL NOT IN (…)` is NULL — never true —
+      # so without the `is_nil` branch every mention by a page would silently
+      # vanish from both this list and its unread count (issue #1334).
+      where: is_nil(p.user_id) or p.user_id not in subquery(blocked_either_way(user_id))
     )
   end
 
@@ -1667,6 +1683,7 @@ defmodule Vutuv.Activity do
   end
 
   defp actor_id(%User{id: id}), do: id
+  defp actor_id(%Organization{id: id}), do: id
   defp actor_id(_), do: nil
 
   # Each count helper returns a query selecting a single count, so total_count/2
@@ -1819,6 +1836,9 @@ defmodule Vutuv.Activity do
   defp since(query, read_at), do: where(query, [event], event.inserted_at > ^read_at)
 
   defp actor_param(%User{} = user), do: Phoenix.Param.to_param(user)
+  # An organization is addressed by its slug; `Organizations.canonical_path/1`
+  # is what turns that into the page's URL, handle or not.
+  defp actor_param(%Organization{slug: slug}), do: slug
   defp actor_param(_), do: nil
 
   # nil (not the default-placeholder URL) when the actor has no picture, so
@@ -1829,7 +1849,13 @@ defmodule Vutuv.Activity do
   # as the grey placeholder display_url would fall back to.
   defp actor_avatar(%User{avatar_moderation: "pending"}), do: nil
   defp actor_avatar(%User{} = user), do: Vutuv.Avatar.display_url(user, :thumb)
+  # nil for an organization: the notifications page then draws its coloured kind
+  # glyph, which is honest, where a member's avatar helper would not know how to
+  # find a page's logo anyway.
+  defp actor_avatar(%Organization{}), do: nil
   defp actor_avatar(_), do: nil
+
+  defp display_name(%Organization{name: name}), do: name
 
   defp display_name(%{first_name: first, last_name: last}) do
     [first, last]

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -858,10 +858,29 @@ defmodule Vutuv.Posts do
   """
   def author?(%Post{organization_id: nil, user_id: author_id}, %User{id: author_id}), do: true
 
-  def author?(%Post{organization: %Organization{} = organization}, %User{} = viewer),
-    do: Organizations.publisher?(organization, viewer)
+  def author?(%Post{organization_id: id} = post, %User{} = viewer) when is_binary(id),
+    do: organization_author?(post, viewer)
 
   def author?(%Post{}, _viewer), do: false
+
+  # Whether `viewer` may currently speak for the post's organization. Takes the
+  # preloaded association when there is one and falls back to a lookup when
+  # there is not: several callers hand over a bare `%Post{}` from a query, and a
+  # permission answer must not depend on whether somebody remembered a preload.
+  defp organization_author?(
+         %Post{organization: %Organization{} = organization},
+         %User{} = viewer
+       ),
+       do: Organizations.publisher?(organization, viewer)
+
+  defp organization_author?(%Post{organization_id: id}, %User{} = viewer) when is_binary(id) do
+    case Organizations.get_organization(id) do
+      nil -> false
+      organization -> Organizations.publisher?(organization, viewer)
+    end
+  end
+
+  defp organization_author?(_post, _viewer), do: false
 
   @doc """
   Whether `viewer` (a `%User{}` or `nil` for anonymous) may see `post`.
@@ -876,8 +895,16 @@ defmodule Vutuv.Posts do
   # An organization post carries no denials (see `create_organization_post/3`),
   # so the only thing that can hide it is moderation — and its publishers still
   # see it while it is held, the way a member sees their own frozen post.
-  def visible_to?(%Post{organization: %Organization{}} = post, %User{} = viewer),
-    do: author?(post, viewer) or not moderation_hidden?(post)
+  #
+  # Matched on the **column**, not on a preloaded `:organization`. Half the
+  # callers here hand over a bare `%Post{}` straight from a query (the engage
+  # path does), and an association-shaped clause silently does not match those —
+  # which dropped them into the member branch and `Repo.get(User, nil)`.
+  def visible_to?(%Post{organization_id: id} = post, %User{} = viewer) when is_binary(id),
+    do: organization_author?(post, viewer) or not moderation_hidden?(post)
+
+  def visible_to?(%Post{organization_id: id} = post, nil) when is_binary(id),
+    do: not moderation_hidden?(post)
 
   def visible_to?(%Post{} = post, nil) do
     # Anonymous readers see a post only when it has no denials at all.
@@ -915,6 +942,12 @@ defmodule Vutuv.Posts do
   def moderation_hidden?(%Post{} = post) do
     post.frozen_at != nil or post.images_pending? == true or author_hidden?(post)
   end
+
+  # An organization is not an account and cannot be frozen, suspended or
+  # deactivated as one; whether its *page* is hidden is `organization_public_row`
+  # and belongs to the queries, not here. Answering false is also what keeps
+  # `Repo.get(User, nil)` out of every engagement path.
+  defp author_hidden?(%Post{organization_id: id}) when is_binary(id), do: false
 
   defp author_hidden?(%Post{user: %User{} = author}),
     do: Vutuv.Moderation.account_hidden?(author)
@@ -4821,9 +4854,16 @@ defmodule Vutuv.Posts do
     :ok
   end
 
+  # The actor is whoever the post is BY — the organization on an organization
+  # post, never the member who pressed publish, which is exactly the split
+  # `acting_user_id` exists to keep internal (issue #1334). `author/1` needs the
+  # preload, and the mention sync runs on a freshly preloaded post.
+  #
+  # A block only guards the member case: a block is a relationship between two
+  # people, and `blocked_between?/2` already answers false for a nil id.
   defp notify_mentioned(%Post{} = post, %User{} = mentioned) do
     unless Vutuv.Social.blocked_between?(mentioned.id, post.user_id) do
-      Vutuv.Activity.notify_mention(mentioned.id, post.user, post.id)
+      Vutuv.Activity.notify_mention(mentioned.id, author(post), post.id)
     end
   end
 

--- a/lib/vutuv/webhooks.ex
+++ b/lib/vutuv/webhooks.ex
@@ -98,7 +98,18 @@ defmodule Vutuv.Webhooks do
   (whose grant authorizes the delivery). Cheap when nobody subscribed:
   one indexed existence check.
   """
-  # No guard on member_id: it is only dereferenced when subscriptions
+  # A **nil** member is a no-op, like `Vutuv.Activity.notify/2` and
+  # `broadcast/2` before it. An event can now happen to something that is not a
+  # member — a like on a post an organization published (issue #1334) — and a
+  # webhook is a delivery to an app the *member* authorized, so with no member
+  # there is nobody whose grant could authorize it. Answering :ok here rather
+  # than in each caller is what keeps `do_emit/3`'s `g.user_id == ^member_id`
+  # from meeting a nil, which Ecto **raises** on rather than matching nothing.
+  # It only bit once an installation had its first subscriber for the event,
+  # since that existence check is what gates the query at all.
+  def emit(nil, event, _data) when is_map_key(@events, event), do: :ok
+
+  # No guard on a present member_id: it is only dereferenced when subscriptions
   # exist, so unit tests with bare fixture ids pass through the fast path.
   def emit(member_id, event, data) when is_map_key(@events, event) do
     if subscriptions_exist?(event) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.242.0",
+      version: "7.242.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/organization_post_engagement_test.exs
+++ b/test/vutuv/organization_post_engagement_test.exs
@@ -1,0 +1,95 @@
+defmodule Vutuv.OrganizationPostEngagementTest do
+  @moduledoc """
+  What happens when members act on a post an organization published (issue
+  #1334). Since v7.242.0 such posts reach feeds, so every engagement path meets
+  a post whose `user_id` is **nil** — and several of them were written when that
+  could not happen.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag, and because two of these tests insert a
+  webhook subscription, which is the condition that makes the emit path run at
+  all.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Organizations
+  alias Vutuv.Posts
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp organization_post(body \\ "Von uns.") do
+    {organization, owner} = active_organization()
+    {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+    {:ok, post} = Posts.create_organization_post(organization, owner, %{body: body})
+    {organization, owner, post}
+  end
+
+  describe "liking, reposting and bookmarking" do
+    test "a member may like an organization post" do
+      {_organization, _owner, post} = organization_post()
+      member = insert(:activated_user)
+
+      assert :ok = Posts.like_post(member, post)
+      assert Posts.post_engagement(post.id, member).liked?
+    end
+
+    test "a member may repost and bookmark one" do
+      {_organization, _owner, post} = organization_post()
+      member = insert(:activated_user)
+
+      assert :ok = Posts.repost_post(member, post)
+      assert :ok = Posts.bookmark_post(member, post)
+
+      engagement = Posts.post_engagement(post.id, member)
+      assert engagement.reposted?
+      assert engagement.bookmarked?
+    end
+
+    test "liking still works when a webhook subscription exists" do
+      # The regression: `Vutuv.Webhooks.emit/3` only reaches its query when some
+      # subscription is listening, and that query compared `g.user_id` with the
+      # post author — nil here, which Ecto **raises** on rather than treating as
+      # "matches nothing". So the bug was invisible until an installation had
+      # its first `post.liked` subscriber.
+      Repo.insert!(%Vutuv.Webhooks.Subscription{
+        app_id: insert(:oauth_app).id,
+        url: "https://example.com/hook",
+        secret: "s3cret",
+        events: ["post.liked"],
+        active?: true
+      })
+
+      {_organization, _owner, post} = organization_post()
+      member = insert(:activated_user)
+
+      assert :ok = Posts.like_post(member, post)
+    end
+  end
+
+  describe "mentions" do
+    test "a mention in an organization post names the organization, not nobody" do
+      mentioned = insert(:activated_user, username: "mentionedmember")
+      {organization, _owner, _post} = organization_post("Hallo @#{mentioned.username}!")
+
+      # The notification the mentioned member sees has to say who spoke. Before
+      # this it carried a nil actor — no name, no link, no picture — because the
+      # actor was read as `post.user`.
+      page = Vutuv.Activity.notifications_page(mentioned.id)
+      [notification | _] = page.entries
+
+      assert notification.actor_name == organization.name
+      assert notification.actor_param == organization.slug
+    end
+  end
+end


### PR DESCRIPTION
Since v7.242.0 organization posts reach other people's feeds, so they now meet every path that acts on a post. Four of those were written when a post always had a member author. **Three failed silently; one crashed.**

### Liking an organization post crashed outright

`visible_to?/2`'s organization clause matched on the **preloaded** `:organization`, but the engage path hands over a bare `%Post{}` straight from a query — so the clause did not match, the member branch ran, and `Repo.get(User, nil)` raised. It matches on the `organization_id` **column** now, and so does `author?/2`: a permission answer must not depend on whether somebody remembered a preload.

### `Webhooks.emit/3` raised on a nil recipient

`do_emit/3` builds `where: g.user_id == ^member_id`, which Ecto raises on for nil rather than matching nothing. `emit/3` is a no-op on a nil member now, like `Activity.notify/2` and `broadcast/2` beside it. **This one only bites once an installation has its first `post.liked` subscriber**, since that existence check is what gates the query at all — so it would have shipped looking fine.

### Mentions by an organization never arrived

Two causes in one query: the list inner-joined `users` on the author, and the block filter read `p.user_id NOT IN (…)`, which is never true for NULL. Both are handled explicitly, and the actor of such a notification is now the **organization** — its name, its page link — never the member who pressed publish. `Activity`'s four actor-field helpers gained an `Organization` clause.

### Worth noting for the next table

This is the **third** `IN`/`NOT IN` NULL trap in this milestone (after the feed's and the discovery rail's in #1358). Whoever makes the next column nullable should walk every `IN` and `NOT IN` on it first — the failure mode is always silence, never an error.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*