### PR TITLE
Beiträge von Organisationen stehen in der Sitemap (v7.243.1)

### DIFF
--- a/lib/vutuv/sitemap.ex
+++ b/lib/vutuv/sitemap.ex
@@ -15,6 +15,7 @@ defmodule Vutuv.Sitemap do
 
   import Ecto.Query
 
+  alias Vutuv.Organizations.Organization
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias Vutuv.Repo
@@ -68,6 +69,7 @@ defmodule Vutuv.Sitemap do
       posts: chunks(Repo.aggregate(indexable_posts(), :count)),
       tags: chunks(Repo.aggregate(Tags.indexable_tags_query(), :count)),
       organizations: chunks(Repo.aggregate(indexable_organizations(), :count)),
+      organization_posts: chunks(Repo.aggregate(indexable_organization_posts(), :count)),
       jobs: chunks(Repo.aggregate(indexable_jobs(), :count))
     }
   end
@@ -91,6 +93,26 @@ defmodule Vutuv.Sitemap do
     |> Repo.all()
     |> Enum.map(fn {slug, id, updated_at} ->
       {"/#{slug}/posts/#{id}", NaiveDateTime.to_date(updated_at)}
+    end)
+  end
+
+  @doc """
+  `{path, lastmod_date}` entries of one organization-posts chunk (1-based).
+
+  Its own type rather than a widened `post_entries/1`: that one inner-joins
+  `users` to read the author's handle for the URL and to honour their
+  `noindex?`, and an organization post has neither — its URL is built from the
+  page's slug and its indexability is the page's `seo?` flag. Without this the
+  join simply dropped every one of them from the sitemap, silently.
+  """
+  def organization_post_entries(chunk) do
+    indexable_organization_posts()
+    |> order_by([p], p.id)
+    |> window(chunk)
+    |> select([p, o], {o.slug, p.id, p.updated_at})
+    |> Repo.all()
+    |> Enum.map(fn {slug, id, updated_at} ->
+      {"/organizations/#{slug}/posts/#{id}", NaiveDateTime.to_date(updated_at)}
     end)
   end
 
@@ -156,6 +178,16 @@ defmodule Vutuv.Sitemap do
     |> Posts.scope_visible(nil)
     |> join(:inner, [p], u in assoc(p, :user))
     |> where([p, u], u.email_confirmed? and not u.noindex?)
+  end
+
+  # A post published in an organization's name (issue #1334) is public by
+  # construction — it carries no denials — so what decides indexability is the
+  # page (active, not frozen, `seo?`) plus the post's own moderation state.
+  defp indexable_organization_posts do
+    Post
+    |> join(:inner, [p], o in Organization, on: o.id == p.organization_id)
+    |> where([p, o], o.status == "active" and is_nil(o.frozen_at) and o.seo?)
+    |> where([p], not p.images_pending? and is_nil(p.frozen_at))
   end
 
   defp chunks(0), do: 0

--- a/lib/vutuv_web/controllers/page_controller.ex
+++ b/lib/vutuv_web/controllers/page_controller.ex
@@ -311,6 +311,8 @@ defmodule VutuvWeb.PageController do
   - `/system/markdown` — what members may write in a post: the Markdown
     reference, also raw at `/system/markdown.md` (`?lang=de` for German)
   - `/organizations` — the verified organization directory; one organization at `/organizations/<slug>`
+  - `/organizations/<slug>/posts/<id>` — a post published in an organization's own
+    name; the organization is the author, so there is no member behind it to look up
   - `/jobs` — the public job board: open positions, filterable, newest first
   - `/jobs/<slug>` — a job posting: role, location, pay range, tags and how to apply
   {{ads}}

--- a/lib/vutuv_web/controllers/sitemap_controller.ex
+++ b/lib/vutuv_web/controllers/sitemap_controller.ex
@@ -18,6 +18,7 @@ defmodule VutuvWeb.SitemapController do
     "posts" => &Sitemap.post_entries/1,
     "tags" => &Sitemap.tag_entries/1,
     "organizations" => &Sitemap.organization_entries/1,
+    "organization_posts" => &Sitemap.organization_post_entries/1,
     "jobs" => &Sitemap.job_entries/1
   }
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.243.0",
+      version: "7.243.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/organization_posts_web_test.exs
+++ b/test/vutuv_web/organization_posts_web_test.exs
@@ -145,6 +145,31 @@ defmodule VutuvWeb.OrganizationPostsWebTest do
     end
   end
 
+  describe "discoverability" do
+    test "an organization post is in the sitemap, and drops out when the page opts out", ctx do
+      %{conn: conn} = ctx
+      owner = insert(:activated_user)
+      organization = active_organization_for(owner)
+      {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+      {:ok, post} = Posts.create_organization_post(organization, owner, %{body: "Findbar."})
+
+      # `post_entries/1` inner-joins users to build the URL, so an organization
+      # post is invisible to it — silently. Its own chunk type is what puts it
+      # in front of a crawler at all.
+      paths = Vutuv.Sitemap.organization_post_entries(1) |> Enum.map(&elem(&1, 0))
+      assert Posts.path(post) in paths
+
+      {:ok, _} = Organizations.update_organization(organization, %{"seo?" => false})
+
+      refute Posts.path(post) in (Vutuv.Sitemap.organization_post_entries(1)
+                                  |> Enum.map(&elem(&1, 0)))
+
+      # And /llms.txt names the shape so an agent knows the URL exists.
+      assert conn |> get(~p"/llms.txt") |> response(200) =~
+               "/organizations/<slug>/posts/<id>"
+    end
+  end
+
   describe "replies" do
     test "an organization post cannot be answered yet", %{conn: _conn} do
       owner = insert(:activated_user)


### PR DESCRIPTION
`indexable_posts/0` inner-joins `users` because it needs the author's handle for the URL and has to honour their `noindex?`. An organization post has neither, so it fell out of the sitemap — no error, no trace. That is the second of the three traps now written down in `CLAUDE.md`: an inner join to the old owner table makes the new rows disappear.

`organization_post_entries/1` is therefore its own chunk type rather than a widened `post_entries/1`. The URL comes from the page's slug, and indexability is decided by the page (active, not frozen, `seo?`) plus the post's own moderation state.

Plus a line in `/llms.txt` so an agent knows the URL shape exists and that there is no member behind such a post to look up.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*