### PR TITLE
CI läuft nur noch einmal pro Änderung (v7.243.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,24 @@
 name: CI
 
 # Runs the same checks as `mix precommit` (compile --warnings-as-errors,
-# unused-deps, format, credo --strict, tests) on every PR and on pushes to
-# main, so the deploy on main only fires for code that already passed.
+# unused-deps, format, credo --strict, tests) on every PR. `precommit` is a
+# required status check on main, so nothing reaches main without a green run
+# here.
+#
+# Deliberately NOT triggered on pushes to main. Every merge used to run this
+# job a second time on the resulting main commit, ~6 minutes of duplicate work
+# per deploy, and that second run gated nothing: `deploy.yml` triggers on the
+# same push with no `needs:`/`workflow_run:` dependency, so CI and Deploy start
+# in the same second and race. The PR's required check is the real gate.
 on:
-  push:
-    branches: [main]
   pull_request:
+
+# One CI run per pull request. Pushing a fixup to a PR branch supersedes the
+# previous run, which otherwise keeps a runner busy for its full ~6 minutes
+# testing a tree nobody will merge.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   precommit:

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.243.1",
+      version: "7.243.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
**TL;DR** Die CI lief zweimal pro Deploy (Pull Request + Merge-Commit auf `main`); der zweite Lauf sicherte nichts ab. Der Trigger auf `main` entfällt, dazu bricht eine `concurrency`-Gruppe überholte PR-Läufe ab.

## Warum

**Der Lauf auf `main` war kein Tor.** Der Kommentar in `ci.yml` behauptete, der Deploy feuere nur für Code, der schon durch die CI ist. So funktioniert es nicht: `deploy.yml` triggert auf denselben Push und hat kein `needs:` und kein `workflow_run:`, beide Workflows starten in derselben Sekunde und laufen parallel. Nachgemessen an den letzten Läufen auf `main`:

```
CI      created=2026-08-11T05:31:44Z
Deploy  created=2026-08-11T05:31:44Z
```

Abgesichert wird `main` tatsächlich durch den Pflicht-Check `precommit` am Pull Request (Branch Protection). Der Lauf auf `main` hat also dieselbe Arbeit ein zweites Mal gemacht und das Ergebnis kam zu spät, um den Deploy aufzuhalten.

**Umfang:** 64 solcher Läufe seit dem 1. August, gemessene Job-Dauer 5,7 bis 6,5 Minuten, macht rund 6,5 Stunden Rechenzeit ohne Gegenwert.

**Zusätzlich eine `concurrency`-Gruppe pro Pull Request.** Bisher belegt ein überholter Lauf nach einem Fixup weiter die vollen sechs Minuten einen Runner für einen Stand, den niemand mehr mergen wird. `cancel-in-progress: true` bricht ihn ab. Die Gruppe hängt an `github.ref`, bei `pull_request` also `refs/pull/<nr>/merge`, damit trifft sie nie einen fremden PR.

## Was das nicht ist

Anlass war die Frage nach dem Actions-Budget, aber gespart wird hier **kein Geld**. vutuv ist ein öffentliches Repository, Standard-Runner sind dort kostenlos, und der Deploy läuft auf dem eigenen `vutuv3`-Runner. Die Timing-API meldet für die letzten CI-Läufe durchgehend `UBUNTU=0s` abrechenbar. Gewonnen sind Wartezeit und Runner-Kapazität, nicht Minuten.

## Bekannter Nebeneffekt

Branch Protection steht auf `strict: false`, ein PR muss vor dem Merge also nicht auf aktuellem `main` sitzen. Der Lauf auf `main` war bisher das einzige Signal, wenn genau diese Kombination etwas kaputt macht, und dieses Signal entfällt. Wer es zurück will, schaltet "Require branches to be up to date before merging" ein; das kostet dann allerdings bei jedem Merge einen Rebase und einen neuen CI-Lauf für alle offenen PRs. Bei der Merge-Frequenz hier ist das vermutlich teurer als das Problem. Bewusst nicht Teil dieses PRs.

## Test

`mix precommit` lokal grün: 7181 Tests (4 doctests), 0 Fehler.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*