### PR TITLE
Eine Organisation hat einen eigenen RSS-Feed (v7.244.0)

### DIFF
--- a/lib/vutuv_web/controllers/feed_controller.ex
+++ b/lib/vutuv_web/controllers/feed_controller.ex
@@ -32,6 +32,36 @@ defmodule VutuvWeb.FeedController do
     end
   end
 
+  @doc """
+  A page's own posts (issue #1334). The **anonymous** view — the same set the
+  page's agent formats serve — so a post still held by moderation is absent
+  here even though the organization's own publishers see it on the page.
+
+  Gated on `public_visible?/1` rather than on `agent_visible?/1`: a feed is a
+  subscription somebody asked for, not a crawl, so the page's `geo?` opt-out
+  (which is about machine readers helping themselves) does not silence it. The
+  page's `seo?` choice still rides along in the headers below, exactly as a
+  member's `noindex?` does on theirs.
+  """
+  def organization(conn, %{"slug" => slug}) do
+    organization = Vutuv.Organizations.get_organization_by_slug(slug)
+
+    if organization && Vutuv.Organizations.public_visible?(organization) do
+      posts = Posts.organization_posts_page(organization, nil, limit: @feed_limit).entries
+
+      send_feed(
+        conn,
+        Feeds.render_organization_feed(organization, posts),
+        not organization.seo?,
+        not organization.geo?
+      )
+    else
+      conn
+      |> put_resp_content_type("text/plain")
+      |> send_resp(404, "Not Found")
+    end
+  end
+
   # The site-wide feed only aggregates members who opted out of nothing
   # (Posts.recent_public_posts/2), so it carries the permissive signals.
   def site(conn, _params) do

--- a/lib/vutuv_web/feeds.ex
+++ b/lib/vutuv_web/feeds.ex
@@ -10,6 +10,8 @@ defmodule VutuvWeb.Feeds do
   `published_on` is date-only and RSS wants a timestamp.
   """
 
+  alias Vutuv.Organizations
+  alias Vutuv.Organizations.Organization
   alias Vutuv.Posts
   alias VutuvWeb.AgentDocs
   alias VutuvWeb.PostComponents
@@ -28,6 +30,15 @@ defmodule VutuvWeb.Feeds do
   """
   def user_feed_suffix, do: "/posts/feed.xml"
 
+  @doc """
+  The one source of an organization's feed path (issue #1334). Built on the
+  **slug** path, like the post permalinks it lists, rather than on the page's
+  opt-in root handle: a feed URL is subscribed to once and then re-fetched for
+  years, so it gets the shape that works whether or not a handle was claimed.
+  """
+  def organization_feed_path(organization),
+    do: "/organizations/#{organization.slug}" <> user_feed_suffix()
+
   @doc "The site-wide feed path."
   def site_feed_path, do: "/posts/feed.xml"
 
@@ -39,6 +50,21 @@ defmodule VutuvWeb.Feeds do
       link: AgentDocs.abs_url("/" <> author.username),
       self: AgentDocs.abs_url(user_feed_path(author)),
       description: "Posts by #{name} on vutuv",
+      posts: posts
+    )
+  end
+
+  @doc """
+  The feed of a page's own posts (issue #1334). An organization publishes under
+  one name, which is the whole point of the feature, so a feed is the one
+  distribution channel it should not have to do without.
+  """
+  def render_organization_feed(organization, posts) do
+    render_feed(
+      title: "#{organization.name} · vutuv",
+      link: AgentDocs.abs_url(Organizations.canonical_path(organization)),
+      self: AgentDocs.abs_url(organization_feed_path(organization)),
+      description: "Posts by #{organization.name} on vutuv",
       posts: posts
     )
   end
@@ -81,7 +107,8 @@ defmodule VutuvWeb.Feeds do
 
   defp item(post) do
     permalink = AgentDocs.abs_url(Posts.path(post))
-    title = "#{UserHelpers.full_name(post.user)} · #{Date.to_iso8601(post.published_on)}"
+    author = author_name(post)
+    title = "#{author} · #{Date.to_iso8601(post.published_on)}"
 
     [
       "  <item>\n",
@@ -89,12 +116,22 @@ defmodule VutuvWeb.Feeds do
       "    <link>#{Xml.escape(permalink)}</link>\n",
       ~s(    <guid isPermaLink="true">#{Xml.escape(permalink)}</guid>\n),
       "    <pubDate>#{rfc1123(post.inserted_at)}</pubDate>\n",
-      "    <dc:creator>#{Xml.escape(UserHelpers.full_name(post.user))}</dc:creator>\n",
+      "    <dc:creator>#{Xml.escape(author)}</dc:creator>\n",
       Enum.map(post.tags, &"    <category>#{Xml.escape(&1.name)}</category>\n"),
       "    <description>#{html_text(AgentDocs.excerpt(post.body))}</description>\n",
       "    <content:encoded><![CDATA[#{cdata_safe(rendered_body(post))}]]></content:encoded>\n",
       "  </item>\n"
     ]
+  end
+
+  # Whichever kind of author the post has (issue #1334). A reader sees the name
+  # the post is signed with; the member who pressed publish for an organization
+  # is internal and never appears in a feed.
+  defp author_name(post) do
+    case Posts.author(post) do
+      %Organization{name: name} -> name
+      author -> UserHelpers.full_name(author)
+    end
   end
 
   defp rendered_body(post) do

--- a/lib/vutuv_web/live/organization_live/show.ex
+++ b/lib/vutuv_web/live/organization_live/show.ex
@@ -421,11 +421,20 @@ defmodule VutuvWeb.OrganizationLive.Show do
           publisher even when there is not — an empty card with a composer is
           how they find out they may write here at all. --%>
           <.card :if={@posts_total > 0 or @publisher?} id="organization-posts">
-            <div class="flex items-center justify-between">
+            <div class="flex items-center justify-between gap-3">
               <.section_title>{gettext("Posts")}</.section_title>
-              <span :if={@posts_total > 0} class="text-sm text-slate-600 dark:text-slate-400">
-                {compact_count(@posts_total)}
-              </span>
+              <div class="flex items-center gap-3">
+                <span :if={@posts_total > 0} class="text-sm text-slate-600 dark:text-slate-400">
+                  {compact_count(@posts_total)}
+                </span>
+                <%!-- The page's own feed, the same pill the profile's Posts card
+                carries. Shown once there is something to subscribe to. --%>
+                <.feed_button
+                  :if={@posts_total > 0}
+                  id="organization-posts-feed"
+                  href={VutuvWeb.Feeds.organization_feed_path(@organization)}
+                />
+              </div>
             </div>
 
             <%!-- Switching into the organization for the rest of the session

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -152,6 +152,8 @@ defmodule VutuvWeb.Router do
     # must beat the catch-all /:slug routes further down, and feed readers
     # send Accept: application/rss+xml, which the browser pipeline rejects.
     get("/posts/feed.xml", FeedController, :site)
+    # Before /:slug/posts/feed.xml, or "organizations" would be read as a handle.
+    get("/organizations/:slug/posts/feed.xml", FeedController, :organization)
     get("/:slug/posts/feed.xml", FeedController, :user)
     # Link-preview images (VutuvWeb.OpenGraph): the brand card and the
     # member avatar as a scraper-friendly JPEG. The consumers are the

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.243.2",
+      version: "7.244.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/organization_posts_web_test.exs
+++ b/test/vutuv_web/organization_posts_web_test.exs
@@ -170,6 +170,37 @@ defmodule VutuvWeb.OrganizationPostsWebTest do
     end
   end
 
+  describe "the RSS feed" do
+    test "serves the page's own posts, signed by the page", %{conn: conn} do
+      owner = insert(:activated_user)
+      organization = active_organization_for(owner)
+      {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+      {:ok, _} = Posts.create_organization_post(organization, owner, %{body: "Neuigkeit."})
+
+      path = VutuvWeb.Feeds.organization_feed_path(organization)
+      assert path == "/organizations/#{organization.slug}/posts/feed.xml"
+
+      conn = get(conn, path)
+      assert response_content_type(conn, :xml) =~ "application/rss+xml"
+
+      body = response(conn, 200)
+      assert body =~ "Neuigkeit."
+      assert body =~ "<dc:creator>#{organization.name}</dc:creator>"
+      # The member who pressed publish never appears in a feed.
+      refute body =~ owner.username
+    end
+
+    test "a page still in the moderation freezer serves no feed", %{conn: conn} do
+      owner = insert(:activated_user)
+      organization = active_organization_for(owner)
+      {:ok, _} = Organizations.admin_set_frozen(organization, true)
+
+      conn
+      |> get(VutuvWeb.Feeds.organization_feed_path(organization))
+      |> response(404)
+    end
+  end
+
   describe "replies" do
     test "an organization post cannot be answered yet", %{conn: _conn} do
       owner = insert(:activated_user)


### PR DESCRIPTION
An organization page publishes under one name — that is the whole point of the feature — and the channel people actually subscribe to such a thing with was missing. It exists now at `/organizations/<slug>/posts/feed.xml`, with the same RSS pill in the Posts card that a profile carries.

The feed path hangs off the **slug**, not the page's optional root handle, like the permalinks it lists: a feed URL is subscribed to once and then re-fetched for years, so it gets the shape that works whether or not a handle was ever claimed.

`item/1` read the author name from `post.user` twice, which is nil on an organization post. It comes from `Posts.author/1` now, and the member who pressed publish appears in no feed — there is a test for that.

**Visible for every public page, not only a `geo?` one.** A feed is a subscription somebody asked for rather than a crawl, so the machine-reader opt-out does not silence it; the page's `seo?` choice still rides along in the headers, exactly as a member's `noindex?` does on theirs.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*