### PR TITLE
Eine Organisationsseite sieht, was mit ihr passiert (v7.245.0)

### DIFF
--- a/lib/vutuv/organizations.ex
+++ b/lib/vutuv/organizations.ex
@@ -33,6 +33,9 @@ defmodule Vutuv.Organizations do
   alias Vutuv.Organizations.OrganizationRole
   alias Vutuv.Organizations.Verification
   alias Vutuv.Pages
+  alias Vutuv.Posts.Post
+  alias Vutuv.Posts.PostLike
+  alias Vutuv.Posts.PostRepost
   alias Vutuv.Profiles.WorkExperience
   alias Vutuv.Repo
   alias Vutuv.SlugHelpers
@@ -340,6 +343,128 @@ defmodule Vutuv.Organizations do
   defp role_rank("publisher"), do: 2
   defp role_rank("recruiter"), do: 3
   defp role_rank(_), do: 4
+
+  # --- the page's own activity (issue #1336) ------------------------------
+  #
+  # What happened TO the page: somebody followed it, or liked or reposted
+  # something it published. Derived from the source tables the way
+  # `Vutuv.Activity` derives a member's notifications, so nothing has to be
+  # written twice and an event disappears with the row behind it — an unliked
+  # post is not "read", it simply never happened.
+  #
+  # The read marker is ONE timestamp on the page (`activity_read_at`), shared
+  # by the whole team. That is the model the issue asks for and it is a
+  # different one, not a wider one: "read" means somebody read it, never that
+  # everybody did.
+
+  @activity_per_page 25
+
+  @doc """
+  One page of `organization`'s activity, newest first, in the
+  `%{entries:, more?:}` shape. Each entry is
+  `%{id:, kind:, at:, actor:, post: }` — `kind` one of `"follow"`,
+  `"post_like"`, `"post_repost"`, `post` nil on a follow.
+  """
+  def activity_page(%Organization{} = organization, opts \\ []) do
+    limit = Keyword.get(opts, :limit, @activity_per_page)
+    offset = Keyword.get(opts, :offset, 0)
+
+    page =
+      Vutuv.FeedPage.paginate_offset(
+        [
+          &activity_follows(organization, &1, &2),
+          &activity_post_engagement(organization, PostLike, "post_like", &1, &2),
+          &activity_post_engagement(organization, PostRepost, "post_repost", &1, &2)
+        ],
+        limit,
+        offset
+      )
+
+    %{entries: page.entries, more?: page.more?, next_offset: offset + length(page.entries)}
+  end
+
+  @doc """
+  How many activity entries are newer than the team's shared read marker,
+  capped so a page nobody has looked at in a year does not turn the badge into
+  a census. `nil` marker means everything counts, which is right for a page
+  whose team has never opened the list.
+  """
+  def unread_activity_count(%Organization{} = organization) do
+    organization
+    |> activity_page(limit: @activity_per_page)
+    |> Map.fetch!(:entries)
+    |> Enum.count(&newer_than_marker?(&1, organization.activity_read_at))
+  end
+
+  defp newer_than_marker?(_entry, nil), do: true
+
+  defp newer_than_marker?(%{at: at}, read_at),
+    do: NaiveDateTime.compare(at, read_at) == :gt
+
+  @doc """
+  Stamps the shared read marker. Whoever on the team opens the list clears it
+  for all of them — that is the point of one marker.
+
+  The marker is the timestamp of the **newest entry**, not the wall clock, for
+  the same reason `Vutuv.Activity.mark_notifications_read/1` does it that way:
+  the source tables keep second precision and the unread test is a strict `>`,
+  so a wall-clock marker swallows anything that lands in the same second the
+  page was opened.
+
+  An **empty** list stamps nothing at all and leaves the marker NULL, which is
+  where this parts company with the member version. There the clock is written
+  because a NULL marker would read as "never read"; here NULL and a stamp
+  behave identically while the list is empty (both count zero), and NULL is
+  strictly better the moment something arrives — a follow one second after the
+  team looked at an empty page is news, and a wall-clock marker would have
+  swallowed it.
+  """
+  def mark_activity_read(%Organization{} = organization) do
+    case activity_page(organization, limit: 1) do
+      %{entries: [%{at: at} | _]} ->
+        organization |> Ecto.Changeset.change(activity_read_at: at) |> Repo.update()
+
+      _ ->
+        {:ok, organization}
+    end
+  end
+
+  # Members who followed the page.
+  defp activity_follows(%Organization{id: id}, fetch_n, _cursor) do
+    from(f in Vutuv.Social.Follow,
+      join: u in User,
+      on: u.id == f.follower_id,
+      where: f.followee_organization_id == ^id,
+      where: account_confirmed_row(u) and not account_hidden_row(u),
+      order_by: [desc: f.inserted_at, desc: f.id],
+      limit: ^fetch_n,
+      select: {f.id, f.inserted_at, u}
+    )
+    |> Repo.all()
+    |> Enum.map(fn {id, at, actor} ->
+      %{id: "follow-#{id}", kind: "follow", at: at, actor: actor, post: nil}
+    end)
+  end
+
+  # Likes and reposts of the page's own posts. One function for both because
+  # the two tables are the same shape and the only difference is the word.
+  defp activity_post_engagement(%Organization{id: id}, schema, kind, fetch_n, _cursor) do
+    from(e in schema,
+      join: p in Post,
+      on: p.id == e.post_id,
+      join: u in User,
+      on: u.id == e.user_id,
+      where: p.organization_id == ^id,
+      where: account_confirmed_row(u) and not account_hidden_row(u),
+      order_by: [desc: e.inserted_at, desc: e.id],
+      limit: ^fetch_n,
+      select: {e.id, e.inserted_at, u, p}
+    )
+    |> Repo.all()
+    |> Enum.map(fn {row_id, at, actor, post} ->
+      %{id: "#{kind}-#{row_id}", kind: kind, at: at, actor: actor, post: post}
+    end)
+  end
 
   @doc """
   Up to six member suggestions for the roles typeahead, matched by `@handle` or

--- a/lib/vutuv/organizations/organization.ex
+++ b/lib/vutuv/organizations/organization.ex
@@ -63,6 +63,11 @@ defmodule Vutuv.Organizations.Organization do
     field(:verified_at, :naive_datetime)
     field(:frozen_at, :naive_datetime)
 
+    # The team's ONE read marker for the page's activity (issue #1336):
+    # everything older than this counts as read, by everybody. Never cast from
+    # params — `Vutuv.Organizations.mark_activity_read/1` owns it.
+    field(:activity_read_at, :naive_datetime)
+
     belongs_to(:created_by, Vutuv.Accounts.User, foreign_key: :created_by_user_id)
     has_many(:domains, Vutuv.Organizations.OrganizationDomain)
     has_many(:roles, Vutuv.Organizations.OrganizationRole)

--- a/lib/vutuv_web/components/organization_components.ex
+++ b/lib/vutuv_web/components/organization_components.ex
@@ -213,6 +213,12 @@ defmodule VutuvWeb.OrganizationComponents do
         <.manage_tab :if={@manage?} active={@active == :exclusions} navigate={"/organizations/#{@organization.slug}/exclusions"}>
           {gettext("Job exclusions")}
         </.manage_tab>
+        <%!-- What happened to the page (issue #1336). Open to the whole team,
+        not only its publishers: this is news ABOUT the page rather than
+        speaking FOR it. --%>
+        <.manage_tab :if={@manage?} active={@active == :activity} navigate={"/organizations/#{@organization.slug}/activity"}>
+          {gettext("Activity")}
+        </.manage_tab>
       </nav>
     </div>
     """

--- a/lib/vutuv_web/controllers/organization_controller.ex
+++ b/lib/vutuv_web/controllers/organization_controller.ex
@@ -135,6 +135,9 @@ defmodule VutuvWeb.OrganizationController do
   def exclusions(conn, %{"slug" => slug}),
     do: manage(conn, slug, VutuvWeb.OrganizationLive.Exclusions, &Organizations.can_manage?/2)
 
+  def activity(conn, %{"slug" => slug}),
+    do: manage(conn, slug, VutuvWeb.OrganizationLive.Activity, &Organizations.can_manage?/2)
+
   @doc """
   The permalink of a post published in this organization's name (issue #1334).
   404s for an unknown page, a page this viewer may not see, or an id that is not

--- a/lib/vutuv_web/live/organization_live/activity.ex
+++ b/lib/vutuv_web/live/organization_live/activity.ex
@@ -1,0 +1,142 @@
+defmodule VutuvWeb.OrganizationLive.Activity do
+  @moduledoc """
+  What happened to an organization page (`/organizations/:slug/activity`,
+  issue #1336): who followed it, and who liked or reposted what it published.
+
+  **One read marker for the whole team.** Opening this page stamps
+  `organizations.activity_read_at`, and it is stamped for everybody — "read"
+  here means somebody read it, never that everybody did. That is the model the
+  issue asks for, and it is a different one rather than a wider one, which is
+  why it is a column on the page instead of a row per member.
+
+  Open to the whole team (`can_manage?/2`) rather than to publishers alone.
+  Deviating from the issue's "everyone who may act as it" on purpose: this is
+  news *about* the page, not speaking *for* it, and an owner who has not
+  granted themselves `publisher` would otherwise be locked out of their own
+  page's activity.
+
+  Embedded via `live_render` from `VutuvWeb.OrganizationController`, which
+  gates it before this ever mounts.
+  """
+
+  use VutuvWeb, :live_view
+
+  import VutuvWeb.OrganizationComponents, only: [manage_header: 1]
+  import VutuvWeb.UserHelpers, only: [full_name: 1]
+
+  alias Vutuv.Organizations
+  alias Vutuv.Posts
+  alias VutuvWeb.Live.InitAssigns
+
+  @impl true
+  def mount(_params, session, socket) do
+    socket = InitAssigns.assign_embedded(socket, session)
+    organization = Organizations.get_organization!(session["organization_id"])
+
+    # The marker is read BEFORE it is stamped, or the page would clear its own
+    # "new" marks before drawing them and nothing would ever look unread.
+    marker = organization.activity_read_at
+    if connected?(socket), do: Organizations.mark_activity_read(organization)
+
+    {:ok,
+     socket
+     |> assign(:organization, organization)
+     |> assign(:owner?, Organizations.owner?(organization, socket.assigns.current_user))
+     |> assign(:marker, marker)
+     |> assign(:page_title, gettext("Activity – %{name}", name: organization.name))
+     |> load_activity(0)}
+  end
+
+  defp load_activity(socket, offset) do
+    page = Organizations.activity_page(socket.assigns.organization, offset: offset)
+    existing = if offset == 0, do: [], else: socket.assigns.entries
+
+    socket
+    |> assign(:entries, existing ++ page.entries)
+    |> assign(:more?, page.more?)
+    |> assign(:offset, page.next_offset)
+  end
+
+  @impl true
+  def handle_event("load-more", _params, socket),
+    do: {:noreply, load_activity(socket, socket.assigns.offset)}
+
+  @impl true
+  def handle_info(_message, socket), do: {:noreply, socket}
+
+  # Whether this entry arrived after the team last looked. Drives the quiet
+  # "new" mark; a page nobody has opened yet has a nil marker, so everything
+  # on it is new, which is the honest answer.
+  defp new?(_entry, nil), do: true
+  defp new?(%{at: at}, marker), do: NaiveDateTime.compare(at, marker) == :gt
+
+  defp line(%{kind: "follow"} = entry),
+    do: gettext("%{name} follows this page.", name: full_name(entry.actor))
+
+  defp line(%{kind: "post_like"} = entry),
+    do: gettext("%{name} liked a post.", name: full_name(entry.actor))
+
+  defp line(%{kind: "post_repost"} = entry),
+    do: gettext("%{name} reposted a post.", name: full_name(entry.actor))
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="mx-auto max-w-2xl py-6">
+      <.manage_header organization={@organization} active={:activity} owner?={@owner?} manage?={true} />
+
+      <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100">{gettext("Activity")}</h1>
+      <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+        {gettext("What happened to this page. Everyone on the team sees the same list, and opening it marks it read for all of you.")}
+      </p>
+
+      <.card class="mt-6">
+        <p :if={@entries == []} class="text-sm text-slate-600 dark:text-slate-400">
+          {gettext("Nothing has happened yet.")}
+        </p>
+
+        <ul :if={@entries != []} class="divide-y divide-slate-100 dark:divide-slate-800">
+          <li :for={entry <- @entries} id={entry.id} class="flex items-start gap-3 py-3">
+            <.link navigate={"/#{entry.actor.username}"} class="shrink-0">
+              <.avatar user={entry.actor} size="sm" shape="circle" />
+            </.link>
+
+            <div class="min-w-0 flex-1">
+              <p class="text-sm text-slate-800 dark:text-slate-200">
+                {line(entry)}
+                <span
+                  :if={new?(entry, @marker)}
+                  data-activity-new
+                  class="ml-1 rounded-full bg-brand-100 px-2 py-0.5 text-xs font-semibold text-brand-700 dark:bg-brand-800 dark:text-brand-100"
+                >
+                  {gettext("New")}
+                </span>
+              </p>
+
+              <.link
+                :if={entry.post}
+                navigate={Posts.path(entry.post)}
+                class="mt-0.5 line-clamp-1 block text-sm text-slate-600 hover:text-brand-700 dark:text-slate-400 dark:hover:text-brand-300"
+              >
+                {VutuvWeb.Markdown.to_plain_text(entry.post.body)}
+              </.link>
+
+              <.local_time
+                at={entry.at}
+                id={"activity-time-#{entry.id}"}
+                class="mt-0.5 block text-xs text-slate-600 dark:text-slate-400"
+              />
+            </div>
+          </li>
+        </ul>
+
+        <div :if={@more?} class="mt-4 text-center">
+          <.button variant="secondary" phx-click="load-more" id="load-more-activity">
+            {gettext("Load more")}
+          </.button>
+        </div>
+      </.card>
+    </div>
+    """
+  end
+end

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -274,6 +274,8 @@ defmodule VutuvWeb.Router do
     # The role-holder standing job-exclusion default (issue #939), live_render
     # like roles/domains. Inherited by every posting attributed to the organization.
     get("/organizations/:slug/exclusions", OrganizationController, :exclusions)
+    # What happened to the page (issue #1336), for its whole team.
+    get("/organizations/:slug/activity", OrganizationController, :activity)
     # The permalink of a post published in the organization's name (issue #1334).
     # Deliberately under the slug and not under the organization's opt-in root
     # handle: the handle route dispatches an organization only on the bare

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.244.0",
+      version: "7.245.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -32,7 +32,7 @@ msgstr "Eintrag hinzufügen"
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
-#: lib/vutuv_web/live/organization_live/show.ex:549
+#: lib/vutuv_web/live/organization_live/show.ex:558
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
@@ -473,6 +473,7 @@ msgid "Name"
 msgstr "Name"
 
 #: lib/vutuv_web/live/notification_live/index.ex:636
+#: lib/vutuv_web/live/organization_live/activity.ex:112
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:3
@@ -1169,7 +1170,7 @@ msgstr "Wählen Sie einen Social-Media-Anbieter aus"
 msgid "Add Localization"
 msgstr "Lokalisierung hinzufügen"
 
-#: lib/vutuv_web/components/organization_components.ex:245
+#: lib/vutuv_web/components/organization_components.ex:251
 #: lib/vutuv_web/live/admin/activity_live.ex:153
 #: lib/vutuv_web/live/admin/api_app_live.ex:58
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
@@ -1748,7 +1749,7 @@ msgstr ""
 msgid "Log out"
 msgstr "Ausloggen"
 
-#: lib/vutuv_web/components/organization_components.ex:251
+#: lib/vutuv_web/components/organization_components.ex:257
 #: lib/vutuv_web/live/admin/activity_live.ex:143
 #: lib/vutuv_web/live/admin/activity_live.ex:175
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
@@ -1958,7 +1959,8 @@ msgid "Pagination"
 msgstr "Seitennavigation"
 
 #: lib/vutuv_web/components/ui.ex:3461
-#: lib/vutuv_web/live/organization_live/show.ex:489
+#: lib/vutuv_web/live/organization_live/activity.ex:135
+#: lib/vutuv_web/live/organization_live/show.ex:498
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr "Mehr laden"
@@ -2884,7 +2886,9 @@ msgstr "Personen, mit denen Sie nicht vernetzt sind"
 msgid "Open someone's profile to message them."
 msgstr "Öffnen Sie ein Profil, um jemandem zu schreiben."
 
+#: lib/vutuv_web/components/organization_components.ex:220
 #: lib/vutuv_web/live/notification_live/index.ex:1035
+#: lib/vutuv_web/live/organization_live/activity.ex:88
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr "Aktivität"
@@ -3181,7 +3185,7 @@ msgstr "Warteschlange öffnen"
 msgid "Opened"
 msgstr "Eröffnet"
 
-#: lib/vutuv_web/components/organization_components.ex:244
+#: lib/vutuv_web/components/organization_components.ex:250
 #: lib/vutuv_web/live/admin/api_app_live.ex:72
 #: lib/vutuv_web/live/admin/deliverability_live.ex:171
 #: lib/vutuv_web/live/admin/moderation_live.ex:56
@@ -4756,7 +4760,7 @@ msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:516
 #: lib/vutuv_web/live/notification_live/index.ex:877
-#: lib/vutuv_web/live/organization_live/show.ex:499
+#: lib/vutuv_web/live/organization_live/show.ex:508
 #: lib/vutuv_web/live/post_live/saved.ex:498
 #: lib/vutuv_web/live/search_live.ex:198
 #: lib/vutuv_web/live/search_live.ex:472
@@ -11658,7 +11662,7 @@ msgstr "Weiter zur Verifizierung"
 #: lib/vutuv_web/live/organization_live/domains.ex:248
 #: lib/vutuv_web/live/organization_live/domains.ex:288
 #: lib/vutuv_web/live/organization_live/new.ex:146
-#: lib/vutuv_web/live/organization_live/show.ex:623
+#: lib/vutuv_web/live/organization_live/show.ex:632
 #: lib/vutuv_web/templates/url/verify.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "DNS TXT record"
@@ -11667,7 +11671,7 @@ msgstr "DNS-TXT-Eintrag"
 #: lib/vutuv_web/live/organization_live/domains.ex:153
 #: lib/vutuv_web/live/organization_live/domains.ex:167
 #: lib/vutuv_web/live/organization_live/show.ex:286
-#: lib/vutuv_web/live/organization_live/show.ex:682
+#: lib/vutuv_web/live/organization_live/show.ex:691
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr "Die Domain-Verifizierung ist auf dieser Installation deaktiviert."
@@ -11701,13 +11705,13 @@ msgstr ""
 "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) anbieten und für KI-"
 "Agenten auflisten."
 
-#: lib/vutuv_web/controllers/organization_controller.ex:191
+#: lib/vutuv_web/controllers/organization_controller.ex:194
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:31
 #, elixir-autogen, elixir-format
 msgid "Please log in first."
 msgstr "Bitte loggen Sie sich zuerst ein."
 
-#: lib/vutuv_web/live/organization_live/show.ex:596
+#: lib/vutuv_web/live/organization_live/show.ex:605
 #, elixir-autogen, elixir-format
 msgid "Prove you control %{domain} to publish this page."
 msgstr "Weisen Sie nach, dass Ihnen %{domain} gehört, um diese Seite zu veröffentlichen."
@@ -11734,7 +11738,7 @@ msgid "Select a country"
 msgstr "Land auswählen"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:307
-#: lib/vutuv_web/live/organization_live/show.ex:658
+#: lib/vutuv_web/live/organization_live/show.ex:667
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr "Stellen Sie diese Datei bereit unter:"
@@ -11761,12 +11765,12 @@ msgid "The upload failed."
 msgstr "Der Upload ist fehlgeschlagen."
 
 #: lib/vutuv_web/live/organization_live/new.ex:131
-#: lib/vutuv_web/live/organization_live/show.ex:611
+#: lib/vutuv_web/live/organization_live/show.ex:620
 #, elixir-autogen, elixir-format
 msgid "Verification method"
 msgstr "Verifizierungsmethode"
 
-#: lib/vutuv_web/live/organization_live/show.ex:571
+#: lib/vutuv_web/live/organization_live/show.ex:580
 #, elixir-autogen, elixir-format
 msgid "Verified domains"
 msgstr "Verifizierte Domains"
@@ -11782,13 +11786,13 @@ msgstr "Verifiziert über"
 msgid "Verified via %{domain}"
 msgstr "Verifiziert über %{domain}"
 
-#: lib/vutuv_web/live/organization_live/show.ex:593
+#: lib/vutuv_web/live/organization_live/show.ex:602
 #, elixir-autogen, elixir-format
 msgid "Verify %{name}"
 msgstr "%{name} verifizieren"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:320
-#: lib/vutuv_web/live/organization_live/show.ex:678
+#: lib/vutuv_web/live/organization_live/show.ex:687
 #, elixir-autogen, elixir-format
 msgid "Verify now"
 msgstr "Jetzt verifizieren"
@@ -11811,7 +11815,7 @@ msgstr "Website"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:249
 #: lib/vutuv_web/live/organization_live/domains.ex:298
-#: lib/vutuv_web/live/organization_live/show.ex:634
+#: lib/vutuv_web/live/organization_live/show.ex:643
 #: lib/vutuv_web/templates/url/verify.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Website file"
@@ -11835,7 +11839,7 @@ msgstr ""
 "die Kontrolle über die Domain nachzuweisen."
 
 #: lib/vutuv_web/live/organization_live/domains.ex:309
-#: lib/vutuv_web/live/organization_live/show.ex:664
+#: lib/vutuv_web/live/organization_live/show.ex:673
 #: lib/vutuv_web/templates/url/verify.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
@@ -11846,7 +11850,7 @@ msgstr "mit genau diesem Inhalt:"
 msgid "@handle or email"
 msgstr "@handle oder E-Mail"
 
-#: lib/vutuv_web/components/organization_components.ex:263
+#: lib/vutuv_web/components/organization_components.ex:269
 #: lib/vutuv_web/live/organization_live/edit.ex:390
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
@@ -11867,7 +11871,7 @@ msgstr "Mitglied hinzufügen"
 msgid "Added @%{handle} to the team."
 msgstr "@%{handle} zum Team hinzugefügt."
 
-#: lib/vutuv_web/components/organization_components.ex:264
+#: lib/vutuv_web/components/organization_components.ex:270
 #: lib/vutuv_web/live/organization_live/edit.ex:388
 #, elixir-autogen, elixir-format
 msgid "Alias"
@@ -11886,7 +11890,7 @@ msgstr "Alias entfernt."
 #: lib/vutuv_web/agent_docs/markdown.ex:343
 #: lib/vutuv_web/agent_docs/text.ex:365
 #: lib/vutuv_web/live/organization_live/edit.ex:353
-#: lib/vutuv_web/live/organization_live/show.ex:559
+#: lib/vutuv_web/live/organization_live/show.ex:568
 #: lib/vutuv_web/templates/tag/single_card.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Also known as"
@@ -11913,7 +11917,7 @@ msgstr "Diese Seite archivieren?"
 msgid "Archived"
 msgstr "Archiviert"
 
-#: lib/vutuv_web/components/organization_components.ex:262
+#: lib/vutuv_web/components/organization_components.ex:268
 #: lib/vutuv_web/live/organization_live/edit.ex:389
 #, elixir-autogen, elixir-format
 msgid "Brand"
@@ -11966,7 +11970,7 @@ msgstr "Domains"
 msgid "Domains – %{name}"
 msgstr "Domains – %{name}"
 
-#: lib/vutuv_web/components/organization_components.ex:261
+#: lib/vutuv_web/components/organization_components.ex:267
 #, elixir-autogen, elixir-format
 msgid "Former name"
 msgstr "Früherer Name"
@@ -12046,7 +12050,7 @@ msgstr "Primär"
 msgid "Primary domain updated."
 msgstr "Primäre Domain aktualisiert."
 
-#: lib/vutuv_web/components/organization_components.ex:250
+#: lib/vutuv_web/components/organization_components.ex:256
 #, elixir-autogen, elixir-format
 msgid "Recruiter"
 msgstr "Recruiter"
@@ -12264,7 +12268,7 @@ msgstr "verifizierte Webseite"
 msgid "%{min} to %{max} characters: letters (a-z), numbers (0-9) and underscores."
 msgstr "%{min} bis %{max} Zeichen: Buchstaben (a-z), Zahlen (0-9) und Unterstriche."
 
-#: lib/vutuv_web/live/organization_live/show.ex:514
+#: lib/vutuv_web/live/organization_live/show.ex:523
 #, elixir-autogen, elixir-format
 msgid "Former"
 msgstr "Ehemalig"
@@ -12396,7 +12400,7 @@ msgstr "Vielleicht brauchen Sie Hilfe von Ihrer IT"
 msgid "The proof is a small technical change to your domain: a DNS entry or a file on your website. If you don't manage the website yourself, ask the person or team who does. That is usually your IT department or the company that runs your website. We show the exact instructions on the next step, so you can simply pass them on."
 msgstr "Der Nachweis ist eine kleine technische Änderung an Ihrer Domain: ein DNS-Eintrag oder eine Datei auf Ihrer Website. Wenn Sie die Website nicht selbst verwalten, fragen Sie die Person oder das Team, das dies tut. Das ist meist Ihre IT-Abteilung oder die Firma, die Ihre Website betreut. Die genaue Anleitung zeigen wir Ihnen im nächsten Schritt, Sie können sie einfach weitergeben."
 
-#: lib/vutuv_web/live/organization_live/show.ex:605
+#: lib/vutuv_web/live/organization_live/show.ex:614
 #, elixir-autogen, elixir-format
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr "Diese Schritte sind technisch. Wenn Sie %{domain} nicht selbst verwalten, kopieren Sie den unten gezeigten Eintrag oder die Datei und senden Sie ihn an Ihre IT-Abteilung oder die Firma, die Ihre Website betreut. Sobald sie ihn hinzugefügt hat, kommen Sie hierher zurück und klicken auf „Jetzt verifizieren“."
@@ -12644,32 +12648,32 @@ msgstr ""
 "Suchergebnissen erscheinen oder von KI verwendet werden soll. Seriöse "
 "Suchmaschinen und KI-Anbieter befolgen das; erzwingen können wir es nicht."
 
-#: lib/vutuv/organizations/organization.ex:87
+#: lib/vutuv/organizations/organization.ex:92
 #, elixir-autogen, elixir-format
 msgid "Association"
 msgstr "Verein / Verband"
 
-#: lib/vutuv/organizations/organization.ex:86
+#: lib/vutuv/organizations/organization.ex:91
 #, elixir-autogen, elixir-format
 msgid "Business"
 msgstr "Unternehmen"
 
-#: lib/vutuv/organizations/organization.ex:89
+#: lib/vutuv/organizations/organization.ex:94
 #, elixir-autogen, elixir-format
 msgid "Education / research"
 msgstr "Bildung / Forschung"
 
-#: lib/vutuv/organizations/organization.ex:90
+#: lib/vutuv/organizations/organization.ex:95
 #, elixir-autogen, elixir-format
 msgid "NGO / foundation"
 msgstr "NGO / Stiftung"
 
-#: lib/vutuv/organizations/organization.ex:91
+#: lib/vutuv/organizations/organization.ex:96
 #, elixir-autogen, elixir-format
 msgid "Other organization"
 msgstr "Sonstige"
 
-#: lib/vutuv/organizations/organization.ex:88
+#: lib/vutuv/organizations/organization.ex:93
 #, elixir-autogen, elixir-format
 msgid "Public authority"
 msgstr "Behörde / Öffentlich"
@@ -13304,13 +13308,13 @@ msgid "Getting an error, or is %{host} a CNAME / alias to another address? A TXT
 msgstr "Bekommen Sie einen Fehler, oder ist %{host} ein CNAME / Alias auf eine andere Adresse? Ein TXT-Eintrag kann nicht denselben Namen wie ein CNAME haben. Verwenden Sie stattdessen diesen Namen, mit exakt demselben Wert wie oben:"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:305
-#: lib/vutuv_web/live/organization_live/show.ex:651
+#: lib/vutuv_web/live/organization_live/show.ex:660
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr "Ist %{domain} ein CNAME / Alias (ein TXT-Eintrag kann nicht denselben Namen wie ein CNAME haben), legen Sie den Eintrag stattdessen auf %{name} an, mit demselben Wert."
 
 #: lib/vutuv_web/live/organization_live/domains.ex:303
-#: lib/vutuv_web/live/organization_live/show.ex:642
+#: lib/vutuv_web/live/organization_live/show.ex:651
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
 msgstr "Legen Sie in Ihren DNS-Einstellungen einen TXT-Eintrag auf dem Namen %{domain} mit diesem Wert an:"
@@ -13406,7 +13410,7 @@ msgid "Minimum yearly salary"
 msgstr "Mindestgehalt pro Jahr"
 
 #: lib/vutuv_web/live/job_board_live.ex:324
-#: lib/vutuv_web/live/organization_live/show.ex:541
+#: lib/vutuv_web/live/organization_live/show.ex:550
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr "Weitere Stellen"
@@ -13435,7 +13439,7 @@ msgstr "Keine passenden Stellen. Passen Sie die Filter an."
 #: lib/vutuv_web/agent_docs/markdown.ex:421
 #: lib/vutuv_web/agent_docs/text.ex:429
 #: lib/vutuv_web/agent_docs/text.ex:441
-#: lib/vutuv_web/live/organization_live/show.ex:528
+#: lib/vutuv_web/live/organization_live/show.ex:537
 #: lib/vutuv_web/templates/tag/show.html.heex:45
 #, elixir-autogen, elixir-format
 msgid "Open positions"
@@ -20786,12 +20790,12 @@ msgstr "Von vorn beginnen"
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr "Ein Herz oder ein Repost geht zurück in das Netzwerk, aus dem dieser Beitrag stammt. Ihr Konto nimmt derzeit nicht am Fediverse teil. Einschalten können Sie das in den {settings}."
 
-#: lib/vutuv_web/components/organization_components.ex:249
+#: lib/vutuv_web/components/organization_components.ex:255
 #, elixir-autogen, elixir-format
 msgid "Editorial"
 msgstr "Redaktion"
 
-#: lib/vutuv_web/components/organization_components.ex:255
+#: lib/vutuv_web/components/organization_components.ex:261
 #, elixir-autogen, elixir-format
 msgid "Edits the page and posts jobs."
 msgstr "Bearbeitet die Seite und schreibt Stellen aus."
@@ -20801,7 +20805,7 @@ msgstr "Bearbeitet die Seite und schreibt Stellen aus."
 msgid "Give members their roles on this page. Someone can hold several at once, and every role is granted on its own."
 msgstr "Geben Sie Mitgliedern ihre Rollen auf dieser Seite. Jemand kann mehrere gleichzeitig haben, und jede Rolle wird einzeln vergeben."
 
-#: lib/vutuv_web/components/organization_components.ex:254
+#: lib/vutuv_web/components/organization_components.ex:260
 #, elixir-autogen, elixir-format
 msgid "Manages the team and the domains, and edits the page."
 msgstr "Verwaltet Team und Domains und bearbeitet die Seite."
@@ -20811,7 +20815,7 @@ msgstr "Verwaltet Team und Domains und bearbeitet die Seite."
 msgid "Pick at least one role."
 msgstr "Wählen Sie mindestens eine Rolle."
 
-#: lib/vutuv_web/components/organization_components.ex:257
+#: lib/vutuv_web/components/organization_components.ex:263
 #, elixir-autogen, elixir-format
 msgid "Posts jobs."
 msgstr "Schreibt Stellen aus."
@@ -20826,7 +20830,7 @@ msgstr "Rollen"
 msgid "Roles updated."
 msgstr "Rollen aktualisiert."
 
-#: lib/vutuv_web/components/organization_components.ex:256
+#: lib/vutuv_web/components/organization_components.ex:262
 #, elixir-autogen, elixir-format
 msgid "Writes posts in the organization's name."
 msgstr "Schreibt Beiträge im Namen der Organisation."
@@ -20836,12 +20840,12 @@ msgstr "Schreibt Beiträge im Namen der Organisation."
 msgid "The owner gives other members their roles on the page, and can hand ownership over to someone else at any time. Someone can hold several roles, and writing in the organization's name is always granted on its own."
 msgstr "Der Besitzer vergibt die Rollen der anderen Mitglieder auf der Seite und kann den Besitz jederzeit an jemand anderen übergeben. Jemand kann mehrere Rollen haben, und das Schreiben im Namen der Organisation wird immer einzeln vergeben."
 
-#: lib/vutuv_web/live/organization_live/show.ex:484
+#: lib/vutuv_web/live/organization_live/show.ex:493
 #, elixir-autogen, elixir-format
 msgid "Nothing published yet."
 msgstr "Noch nichts veröffentlicht."
 
-#: lib/vutuv_web/live/organization_live/show.ex:466
+#: lib/vutuv_web/live/organization_live/show.ex:475
 #: lib/vutuv_web/live/post_live/composer.ex:1814
 #, elixir-autogen, elixir-format
 msgid "Post as %{name}"
@@ -20857,7 +20861,7 @@ msgstr "Als %{name} veröffentlicht."
 msgid "That post could not be published."
 msgstr "Dieser Beitrag konnte nicht veröffentlicht werden."
 
-#: lib/vutuv_web/live/organization_live/show.ex:458
+#: lib/vutuv_web/live/organization_live/show.ex:467
 #, elixir-autogen, elixir-format
 msgid "Write something as %{name}"
 msgstr "Schreiben Sie etwas als %{name}"
@@ -20887,7 +20891,7 @@ msgstr "Begonnen, im Namen einer Organisation zu schreiben"
 msgid "Stopped writing as an organization"
 msgstr "Beendet, im Namen einer Organisation zu schreiben"
 
-#: lib/vutuv_web/live/organization_live/show.ex:442
+#: lib/vutuv_web/live/organization_live/show.ex:451
 #, elixir-autogen, elixir-format
 msgid "Write as %{name} for now"
 msgstr "Vorerst als %{name} schreiben"
@@ -20911,3 +20915,33 @@ msgstr "Sie schreiben als %{name}."
 #, elixir-autogen, elixir-format
 msgid "You are yourself again."
 msgstr "Sie sind wieder Sie selbst."
+
+#: lib/vutuv_web/live/organization_live/activity.ex:74
+#, elixir-autogen, elixir-format
+msgid "%{name} follows this page."
+msgstr "%{name} folgt dieser Seite."
+
+#: lib/vutuv_web/live/organization_live/activity.ex:77
+#, elixir-autogen, elixir-format
+msgid "%{name} liked a post."
+msgstr "%{name} gefällt ein Beitrag."
+
+#: lib/vutuv_web/live/organization_live/activity.ex:80
+#, elixir-autogen, elixir-format
+msgid "%{name} reposted a post."
+msgstr "%{name} hat einen Beitrag geteilt."
+
+#: lib/vutuv_web/live/organization_live/activity.ex:46
+#, elixir-autogen, elixir-format
+msgid "Activity – %{name}"
+msgstr "Aktivität – %{name}"
+
+#: lib/vutuv_web/live/organization_live/activity.ex:95
+#, elixir-autogen, elixir-format
+msgid "Nothing has happened yet."
+msgstr "Bisher ist nichts passiert."
+
+#: lib/vutuv_web/live/organization_live/activity.ex:90
+#, elixir-autogen, elixir-format
+msgid "What happened to this page. Everyone on the team sees the same list, and opening it marks it read for all of you."
+msgstr "Was auf dieser Seite passiert ist. Alle im Team sehen dieselbe Liste, und wer sie öffnet, markiert sie für alle als gelesen."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -34,7 +34,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
-#: lib/vutuv_web/live/organization_live/show.ex:549
+#: lib/vutuv_web/live/organization_live/show.ex:558
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
@@ -473,6 +473,7 @@ msgid "Name"
 msgstr ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:636
+#: lib/vutuv_web/live/organization_live/activity.ex:112
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:3
@@ -1145,7 +1146,7 @@ msgstr ""
 msgid "Add Localization"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:245
+#: lib/vutuv_web/components/organization_components.ex:251
 #: lib/vutuv_web/live/admin/activity_live.ex:153
 #: lib/vutuv_web/live/admin/api_app_live.ex:58
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
@@ -1713,7 +1714,7 @@ msgstr ""
 msgid "Log out"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:251
+#: lib/vutuv_web/components/organization_components.ex:257
 #: lib/vutuv_web/live/admin/activity_live.ex:143
 #: lib/vutuv_web/live/admin/activity_live.ex:175
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
@@ -1917,7 +1918,8 @@ msgid "Pagination"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3461
-#: lib/vutuv_web/live/organization_live/show.ex:489
+#: lib/vutuv_web/live/organization_live/activity.ex:135
+#: lib/vutuv_web/live/organization_live/show.ex:498
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr ""
@@ -2833,7 +2835,9 @@ msgstr ""
 msgid "Open someone's profile to message them."
 msgstr ""
 
+#: lib/vutuv_web/components/organization_components.ex:220
 #: lib/vutuv_web/live/notification_live/index.ex:1035
+#: lib/vutuv_web/live/organization_live/activity.ex:88
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
@@ -3110,7 +3114,7 @@ msgstr ""
 msgid "Opened"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:244
+#: lib/vutuv_web/components/organization_components.ex:250
 #: lib/vutuv_web/live/admin/api_app_live.ex:72
 #: lib/vutuv_web/live/admin/deliverability_live.ex:171
 #: lib/vutuv_web/live/admin/moderation_live.ex:56
@@ -4583,7 +4587,7 @@ msgstr ""
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:516
 #: lib/vutuv_web/live/notification_live/index.ex:877
-#: lib/vutuv_web/live/organization_live/show.ex:499
+#: lib/vutuv_web/live/organization_live/show.ex:508
 #: lib/vutuv_web/live/post_live/saved.ex:498
 #: lib/vutuv_web/live/search_live.ex:198
 #: lib/vutuv_web/live/search_live.ex:472
@@ -11049,7 +11053,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:248
 #: lib/vutuv_web/live/organization_live/domains.ex:288
 #: lib/vutuv_web/live/organization_live/new.ex:146
-#: lib/vutuv_web/live/organization_live/show.ex:623
+#: lib/vutuv_web/live/organization_live/show.ex:632
 #: lib/vutuv_web/templates/url/verify.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "DNS TXT record"
@@ -11058,7 +11062,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:153
 #: lib/vutuv_web/live/organization_live/domains.ex:167
 #: lib/vutuv_web/live/organization_live/show.ex:286
-#: lib/vutuv_web/live/organization_live/show.ex:682
+#: lib/vutuv_web/live/organization_live/show.ex:691
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr ""
@@ -11089,13 +11093,13 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) and list them for AI agents."
 msgstr ""
 
-#: lib/vutuv_web/controllers/organization_controller.ex:191
+#: lib/vutuv_web/controllers/organization_controller.ex:194
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:31
 #, elixir-autogen, elixir-format
 msgid "Please log in first."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:596
+#: lib/vutuv_web/live/organization_live/show.ex:605
 #, elixir-autogen, elixir-format
 msgid "Prove you control %{domain} to publish this page."
 msgstr ""
@@ -11122,7 +11126,7 @@ msgid "Select a country"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:307
-#: lib/vutuv_web/live/organization_live/show.ex:658
+#: lib/vutuv_web/live/organization_live/show.ex:667
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr ""
@@ -11149,12 +11153,12 @@ msgid "The upload failed."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/new.ex:131
-#: lib/vutuv_web/live/organization_live/show.ex:611
+#: lib/vutuv_web/live/organization_live/show.ex:620
 #, elixir-autogen, elixir-format
 msgid "Verification method"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:571
+#: lib/vutuv_web/live/organization_live/show.ex:580
 #, elixir-autogen, elixir-format
 msgid "Verified domains"
 msgstr ""
@@ -11170,13 +11174,13 @@ msgstr ""
 msgid "Verified via %{domain}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:593
+#: lib/vutuv_web/live/organization_live/show.ex:602
 #, elixir-autogen, elixir-format
 msgid "Verify %{name}"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:320
-#: lib/vutuv_web/live/organization_live/show.ex:678
+#: lib/vutuv_web/live/organization_live/show.ex:687
 #, elixir-autogen, elixir-format
 msgid "Verify now"
 msgstr ""
@@ -11197,7 +11201,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:249
 #: lib/vutuv_web/live/organization_live/domains.ex:298
-#: lib/vutuv_web/live/organization_live/show.ex:634
+#: lib/vutuv_web/live/organization_live/show.ex:643
 #: lib/vutuv_web/templates/url/verify.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Website file"
@@ -11219,7 +11223,7 @@ msgid "You will publish a record or file to prove control of the domain on the n
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:309
-#: lib/vutuv_web/live/organization_live/show.ex:664
+#: lib/vutuv_web/live/organization_live/show.ex:673
 #: lib/vutuv_web/templates/url/verify.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
@@ -11230,7 +11234,7 @@ msgstr ""
 msgid "@handle or email"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:263
+#: lib/vutuv_web/components/organization_components.ex:269
 #: lib/vutuv_web/live/organization_live/edit.ex:390
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
@@ -11251,7 +11255,7 @@ msgstr ""
 msgid "Added @%{handle} to the team."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:264
+#: lib/vutuv_web/components/organization_components.ex:270
 #: lib/vutuv_web/live/organization_live/edit.ex:388
 #, elixir-autogen, elixir-format
 msgid "Alias"
@@ -11270,7 +11274,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:343
 #: lib/vutuv_web/agent_docs/text.ex:365
 #: lib/vutuv_web/live/organization_live/edit.ex:353
-#: lib/vutuv_web/live/organization_live/show.ex:559
+#: lib/vutuv_web/live/organization_live/show.ex:568
 #: lib/vutuv_web/templates/tag/single_card.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Also known as"
@@ -11297,7 +11301,7 @@ msgstr ""
 msgid "Archived"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:262
+#: lib/vutuv_web/components/organization_components.ex:268
 #: lib/vutuv_web/live/organization_live/edit.ex:389
 #, elixir-autogen, elixir-format
 msgid "Brand"
@@ -11346,7 +11350,7 @@ msgstr ""
 msgid "Domains – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:261
+#: lib/vutuv_web/components/organization_components.ex:267
 #, elixir-autogen, elixir-format
 msgid "Former name"
 msgstr ""
@@ -11424,7 +11428,7 @@ msgstr ""
 msgid "Primary domain updated."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:250
+#: lib/vutuv_web/components/organization_components.ex:256
 #, elixir-autogen, elixir-format
 msgid "Recruiter"
 msgstr ""
@@ -11634,7 +11638,7 @@ msgstr ""
 msgid "%{min} to %{max} characters: letters (a-z), numbers (0-9) and underscores."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:514
+#: lib/vutuv_web/live/organization_live/show.ex:523
 #, elixir-autogen, elixir-format
 msgid "Former"
 msgstr ""
@@ -11744,7 +11748,7 @@ msgstr ""
 msgid "The proof is a small technical change to your domain: a DNS entry or a file on your website. If you don't manage the website yourself, ask the person or team who does. That is usually your IT department or the company that runs your website. We show the exact instructions on the next step, so you can simply pass them on."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:605
+#: lib/vutuv_web/live/organization_live/show.ex:614
 #, elixir-autogen, elixir-format
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr ""
@@ -11978,32 +11982,32 @@ msgstr ""
 msgid "We can't stop a search engine or AI service from reading a page it can open. What we can do is tell them, in the machine-readable way they look for, that you don't want your profile listed in search results or used by AI. Reputable search engines and AI companies follow that request; we can't force the rest."
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:87
+#: lib/vutuv/organizations/organization.ex:92
 #, elixir-autogen, elixir-format
 msgid "Association"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:86
+#: lib/vutuv/organizations/organization.ex:91
 #, elixir-autogen, elixir-format
 msgid "Business"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:89
+#: lib/vutuv/organizations/organization.ex:94
 #, elixir-autogen, elixir-format
 msgid "Education / research"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:90
+#: lib/vutuv/organizations/organization.ex:95
 #, elixir-autogen, elixir-format
 msgid "NGO / foundation"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:91
+#: lib/vutuv/organizations/organization.ex:96
 #, elixir-autogen, elixir-format
 msgid "Other organization"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:88
+#: lib/vutuv/organizations/organization.ex:93
 #, elixir-autogen, elixir-format
 msgid "Public authority"
 msgstr ""
@@ -12638,13 +12642,13 @@ msgid "Getting an error, or is %{host} a CNAME / alias to another address? A TXT
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:305
-#: lib/vutuv_web/live/organization_live/show.ex:651
+#: lib/vutuv_web/live/organization_live/show.ex:660
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:303
-#: lib/vutuv_web/live/organization_live/show.ex:642
+#: lib/vutuv_web/live/organization_live/show.ex:651
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
 msgstr ""
@@ -12740,7 +12744,7 @@ msgid "Minimum yearly salary"
 msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:324
-#: lib/vutuv_web/live/organization_live/show.ex:541
+#: lib/vutuv_web/live/organization_live/show.ex:550
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr ""
@@ -12769,7 +12773,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:421
 #: lib/vutuv_web/agent_docs/text.ex:429
 #: lib/vutuv_web/agent_docs/text.ex:441
-#: lib/vutuv_web/live/organization_live/show.ex:528
+#: lib/vutuv_web/live/organization_live/show.ex:537
 #: lib/vutuv_web/templates/tag/show.html.heex:45
 #, elixir-autogen, elixir-format
 msgid "Open positions"
@@ -20002,12 +20006,12 @@ msgstr ""
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:249
+#: lib/vutuv_web/components/organization_components.ex:255
 #, elixir-autogen, elixir-format
 msgid "Editorial"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:255
+#: lib/vutuv_web/components/organization_components.ex:261
 #, elixir-autogen, elixir-format
 msgid "Edits the page and posts jobs."
 msgstr ""
@@ -20017,7 +20021,7 @@ msgstr ""
 msgid "Give members their roles on this page. Someone can hold several at once, and every role is granted on its own."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:254
+#: lib/vutuv_web/components/organization_components.ex:260
 #, elixir-autogen, elixir-format
 msgid "Manages the team and the domains, and edits the page."
 msgstr ""
@@ -20027,7 +20031,7 @@ msgstr ""
 msgid "Pick at least one role."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:257
+#: lib/vutuv_web/components/organization_components.ex:263
 #, elixir-autogen, elixir-format
 msgid "Posts jobs."
 msgstr ""
@@ -20042,7 +20046,7 @@ msgstr ""
 msgid "Roles updated."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:256
+#: lib/vutuv_web/components/organization_components.ex:262
 #, elixir-autogen, elixir-format
 msgid "Writes posts in the organization's name."
 msgstr ""
@@ -20052,12 +20056,12 @@ msgstr ""
 msgid "The owner gives other members their roles on the page, and can hand ownership over to someone else at any time. Someone can hold several roles, and writing in the organization's name is always granted on its own."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:484
+#: lib/vutuv_web/live/organization_live/show.ex:493
 #, elixir-autogen, elixir-format
 msgid "Nothing published yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:466
+#: lib/vutuv_web/live/organization_live/show.ex:475
 #: lib/vutuv_web/live/post_live/composer.ex:1814
 #, elixir-autogen, elixir-format
 msgid "Post as %{name}"
@@ -20073,7 +20077,7 @@ msgstr ""
 msgid "That post could not be published."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:458
+#: lib/vutuv_web/live/organization_live/show.ex:467
 #, elixir-autogen, elixir-format
 msgid "Write something as %{name}"
 msgstr ""
@@ -20103,7 +20107,7 @@ msgstr ""
 msgid "Stopped writing as an organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:442
+#: lib/vutuv_web/live/organization_live/show.ex:451
 #, elixir-autogen, elixir-format
 msgid "Write as %{name} for now"
 msgstr ""
@@ -20126,4 +20130,34 @@ msgstr ""
 #: lib/vutuv_web/controllers/acting_as_controller.ex:59
 #, elixir-autogen, elixir-format
 msgid "You are yourself again."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/activity.ex:74
+#, elixir-autogen, elixir-format
+msgid "%{name} follows this page."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/activity.ex:77
+#, elixir-autogen, elixir-format
+msgid "%{name} liked a post."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/activity.ex:80
+#, elixir-autogen, elixir-format
+msgid "%{name} reposted a post."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/activity.ex:46
+#, elixir-autogen, elixir-format
+msgid "Activity – %{name}"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/activity.ex:95
+#, elixir-autogen, elixir-format
+msgid "Nothing has happened yet."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/activity.ex:90
+#, elixir-autogen, elixir-format
+msgid "What happened to this page. Everyone on the team sees the same list, and opening it marks it read for all of you."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -32,7 +32,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
-#: lib/vutuv_web/live/organization_live/show.ex:549
+#: lib/vutuv_web/live/organization_live/show.ex:558
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
@@ -471,6 +471,7 @@ msgid "Name"
 msgstr ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:636
+#: lib/vutuv_web/live/organization_live/activity.ex:112
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:3
@@ -1143,7 +1144,7 @@ msgstr ""
 msgid "Add Localization"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:245
+#: lib/vutuv_web/components/organization_components.ex:251
 #: lib/vutuv_web/live/admin/activity_live.ex:153
 #: lib/vutuv_web/live/admin/api_app_live.ex:58
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
@@ -1711,7 +1712,7 @@ msgstr ""
 msgid "Log out"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:251
+#: lib/vutuv_web/components/organization_components.ex:257
 #: lib/vutuv_web/live/admin/activity_live.ex:143
 #: lib/vutuv_web/live/admin/activity_live.ex:175
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
@@ -1915,7 +1916,8 @@ msgid "Pagination"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3461
-#: lib/vutuv_web/live/organization_live/show.ex:489
+#: lib/vutuv_web/live/organization_live/activity.ex:135
+#: lib/vutuv_web/live/organization_live/show.ex:498
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr ""
@@ -2831,7 +2833,9 @@ msgstr ""
 msgid "Open someone's profile to message them."
 msgstr ""
 
+#: lib/vutuv_web/components/organization_components.ex:220
 #: lib/vutuv_web/live/notification_live/index.ex:1035
+#: lib/vutuv_web/live/organization_live/activity.ex:88
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
@@ -3108,7 +3112,7 @@ msgstr ""
 msgid "Opened"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:244
+#: lib/vutuv_web/components/organization_components.ex:250
 #: lib/vutuv_web/live/admin/api_app_live.ex:72
 #: lib/vutuv_web/live/admin/deliverability_live.ex:171
 #: lib/vutuv_web/live/admin/moderation_live.ex:56
@@ -4581,7 +4585,7 @@ msgstr ""
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:516
 #: lib/vutuv_web/live/notification_live/index.ex:877
-#: lib/vutuv_web/live/organization_live/show.ex:499
+#: lib/vutuv_web/live/organization_live/show.ex:508
 #: lib/vutuv_web/live/post_live/saved.ex:498
 #: lib/vutuv_web/live/search_live.ex:198
 #: lib/vutuv_web/live/search_live.ex:472
@@ -11047,7 +11051,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:248
 #: lib/vutuv_web/live/organization_live/domains.ex:288
 #: lib/vutuv_web/live/organization_live/new.ex:146
-#: lib/vutuv_web/live/organization_live/show.ex:623
+#: lib/vutuv_web/live/organization_live/show.ex:632
 #: lib/vutuv_web/templates/url/verify.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "DNS TXT record"
@@ -11056,7 +11060,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:153
 #: lib/vutuv_web/live/organization_live/domains.ex:167
 #: lib/vutuv_web/live/organization_live/show.ex:286
-#: lib/vutuv_web/live/organization_live/show.ex:682
+#: lib/vutuv_web/live/organization_live/show.ex:691
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr ""
@@ -11087,13 +11091,13 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) and list them for AI agents."
 msgstr ""
 
-#: lib/vutuv_web/controllers/organization_controller.ex:191
+#: lib/vutuv_web/controllers/organization_controller.ex:194
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:31
 #, elixir-autogen, elixir-format
 msgid "Please log in first."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:596
+#: lib/vutuv_web/live/organization_live/show.ex:605
 #, elixir-autogen, elixir-format
 msgid "Prove you control %{domain} to publish this page."
 msgstr ""
@@ -11120,7 +11124,7 @@ msgid "Select a country"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:307
-#: lib/vutuv_web/live/organization_live/show.ex:658
+#: lib/vutuv_web/live/organization_live/show.ex:667
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr ""
@@ -11147,12 +11151,12 @@ msgid "The upload failed."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/new.ex:131
-#: lib/vutuv_web/live/organization_live/show.ex:611
+#: lib/vutuv_web/live/organization_live/show.ex:620
 #, elixir-autogen, elixir-format
 msgid "Verification method"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:571
+#: lib/vutuv_web/live/organization_live/show.ex:580
 #, elixir-autogen, elixir-format
 msgid "Verified domains"
 msgstr ""
@@ -11168,13 +11172,13 @@ msgstr ""
 msgid "Verified via %{domain}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:593
+#: lib/vutuv_web/live/organization_live/show.ex:602
 #, elixir-autogen, elixir-format
 msgid "Verify %{name}"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:320
-#: lib/vutuv_web/live/organization_live/show.ex:678
+#: lib/vutuv_web/live/organization_live/show.ex:687
 #, elixir-autogen, elixir-format
 msgid "Verify now"
 msgstr ""
@@ -11195,7 +11199,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:249
 #: lib/vutuv_web/live/organization_live/domains.ex:298
-#: lib/vutuv_web/live/organization_live/show.ex:634
+#: lib/vutuv_web/live/organization_live/show.ex:643
 #: lib/vutuv_web/templates/url/verify.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Website file"
@@ -11217,7 +11221,7 @@ msgid "You will publish a record or file to prove control of the domain on the n
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:309
-#: lib/vutuv_web/live/organization_live/show.ex:664
+#: lib/vutuv_web/live/organization_live/show.ex:673
 #: lib/vutuv_web/templates/url/verify.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
@@ -11228,7 +11232,7 @@ msgstr ""
 msgid "@handle or email"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:263
+#: lib/vutuv_web/components/organization_components.ex:269
 #: lib/vutuv_web/live/organization_live/edit.ex:390
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
@@ -11249,7 +11253,7 @@ msgstr ""
 msgid "Added @%{handle} to the team."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:264
+#: lib/vutuv_web/components/organization_components.ex:270
 #: lib/vutuv_web/live/organization_live/edit.ex:388
 #, elixir-autogen, elixir-format
 msgid "Alias"
@@ -11268,7 +11272,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:343
 #: lib/vutuv_web/agent_docs/text.ex:365
 #: lib/vutuv_web/live/organization_live/edit.ex:353
-#: lib/vutuv_web/live/organization_live/show.ex:559
+#: lib/vutuv_web/live/organization_live/show.ex:568
 #: lib/vutuv_web/templates/tag/single_card.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Also known as"
@@ -11295,7 +11299,7 @@ msgstr ""
 msgid "Archived"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:262
+#: lib/vutuv_web/components/organization_components.ex:268
 #: lib/vutuv_web/live/organization_live/edit.ex:389
 #, elixir-autogen, elixir-format
 msgid "Brand"
@@ -11344,7 +11348,7 @@ msgstr ""
 msgid "Domains – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:261
+#: lib/vutuv_web/components/organization_components.ex:267
 #, elixir-autogen, elixir-format
 msgid "Former name"
 msgstr ""
@@ -11422,7 +11426,7 @@ msgstr ""
 msgid "Primary domain updated."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:250
+#: lib/vutuv_web/components/organization_components.ex:256
 #, elixir-autogen, elixir-format
 msgid "Recruiter"
 msgstr ""
@@ -11632,7 +11636,7 @@ msgstr ""
 msgid "%{min} to %{max} characters: letters (a-z), numbers (0-9) and underscores."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:514
+#: lib/vutuv_web/live/organization_live/show.ex:523
 #, elixir-autogen, elixir-format
 msgid "Former"
 msgstr ""
@@ -11742,7 +11746,7 @@ msgstr ""
 msgid "The proof is a small technical change to your domain: a DNS entry or a file on your website. If you don't manage the website yourself, ask the person or team who does. That is usually your IT department or the company that runs your website. We show the exact instructions on the next step, so you can simply pass them on."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:605
+#: lib/vutuv_web/live/organization_live/show.ex:614
 #, elixir-autogen, elixir-format
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr ""
@@ -11976,32 +11980,32 @@ msgstr ""
 msgid "We can't stop a search engine or AI service from reading a page it can open. What we can do is tell them, in the machine-readable way they look for, that you don't want your profile listed in search results or used by AI. Reputable search engines and AI companies follow that request; we can't force the rest."
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:87
+#: lib/vutuv/organizations/organization.ex:92
 #, elixir-autogen, elixir-format
 msgid "Association"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:86
+#: lib/vutuv/organizations/organization.ex:91
 #, elixir-autogen, elixir-format
 msgid "Business"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:89
+#: lib/vutuv/organizations/organization.ex:94
 #, elixir-autogen, elixir-format
 msgid "Education / research"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:90
+#: lib/vutuv/organizations/organization.ex:95
 #, elixir-autogen, elixir-format
 msgid "NGO / foundation"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:91
+#: lib/vutuv/organizations/organization.ex:96
 #, elixir-autogen, elixir-format
 msgid "Other organization"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:88
+#: lib/vutuv/organizations/organization.ex:93
 #, elixir-autogen, elixir-format
 msgid "Public authority"
 msgstr ""
@@ -12636,13 +12640,13 @@ msgid "Getting an error, or is %{host} a CNAME / alias to another address? A TXT
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:305
-#: lib/vutuv_web/live/organization_live/show.ex:651
+#: lib/vutuv_web/live/organization_live/show.ex:660
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:303
-#: lib/vutuv_web/live/organization_live/show.ex:642
+#: lib/vutuv_web/live/organization_live/show.ex:651
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
 msgstr ""
@@ -12738,7 +12742,7 @@ msgid "Minimum yearly salary"
 msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:324
-#: lib/vutuv_web/live/organization_live/show.ex:541
+#: lib/vutuv_web/live/organization_live/show.ex:550
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr ""
@@ -12767,7 +12771,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:421
 #: lib/vutuv_web/agent_docs/text.ex:429
 #: lib/vutuv_web/agent_docs/text.ex:441
-#: lib/vutuv_web/live/organization_live/show.ex:528
+#: lib/vutuv_web/live/organization_live/show.ex:537
 #: lib/vutuv_web/templates/tag/show.html.heex:45
 #, elixir-autogen, elixir-format
 msgid "Open positions"
@@ -20000,12 +20004,12 @@ msgstr ""
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:249
+#: lib/vutuv_web/components/organization_components.ex:255
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Editorial"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:255
+#: lib/vutuv_web/components/organization_components.ex:261
 #, elixir-autogen, elixir-format
 msgid "Edits the page and posts jobs."
 msgstr ""
@@ -20015,7 +20019,7 @@ msgstr ""
 msgid "Give members their roles on this page. Someone can hold several at once, and every role is granted on its own."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:254
+#: lib/vutuv_web/components/organization_components.ex:260
 #, elixir-autogen, elixir-format
 msgid "Manages the team and the domains, and edits the page."
 msgstr ""
@@ -20025,7 +20029,7 @@ msgstr ""
 msgid "Pick at least one role."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:257
+#: lib/vutuv_web/components/organization_components.ex:263
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Posts jobs."
 msgstr ""
@@ -20040,7 +20044,7 @@ msgstr ""
 msgid "Roles updated."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:256
+#: lib/vutuv_web/components/organization_components.ex:262
 #, elixir-autogen, elixir-format
 msgid "Writes posts in the organization's name."
 msgstr ""
@@ -20050,12 +20054,12 @@ msgstr ""
 msgid "The owner gives other members their roles on the page, and can hand ownership over to someone else at any time. Someone can hold several roles, and writing in the organization's name is always granted on its own."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:484
+#: lib/vutuv_web/live/organization_live/show.ex:493
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing published yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:466
+#: lib/vutuv_web/live/organization_live/show.ex:475
 #: lib/vutuv_web/live/post_live/composer.ex:1814
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post as %{name}"
@@ -20071,7 +20075,7 @@ msgstr ""
 msgid "That post could not be published."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:458
+#: lib/vutuv_web/live/organization_live/show.ex:467
 #, elixir-autogen, elixir-format
 msgid "Write something as %{name}"
 msgstr ""
@@ -20101,7 +20105,7 @@ msgstr ""
 msgid "Stopped writing as an organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:442
+#: lib/vutuv_web/live/organization_live/show.ex:451
 #, elixir-autogen, elixir-format
 msgid "Write as %{name} for now"
 msgstr ""
@@ -20124,4 +20128,34 @@ msgstr ""
 #: lib/vutuv_web/controllers/acting_as_controller.ex:59
 #, elixir-autogen, elixir-format
 msgid "You are yourself again."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/activity.ex:74
+#, elixir-autogen, elixir-format
+msgid "%{name} follows this page."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/activity.ex:77
+#, elixir-autogen, elixir-format
+msgid "%{name} liked a post."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/activity.ex:80
+#, elixir-autogen, elixir-format
+msgid "%{name} reposted a post."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/activity.ex:46
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Activity – %{name}"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/activity.ex:95
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Nothing has happened yet."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/activity.ex:90
+#, elixir-autogen, elixir-format
+msgid "What happened to this page. Everyone on the team sees the same list, and opening it marks it read for all of you."
 msgstr ""

--- a/priv/repo/migrations/20260811061525_add_activity_read_at_to_organizations.exs
+++ b/priv/repo/migrations/20260811061525_add_activity_read_at_to_organizations.exs
@@ -1,0 +1,22 @@
+defmodule Vutuv.Repo.Migrations.AddActivityReadAtToOrganizations do
+  @moduledoc """
+  Issue #1336: an organization's activity has **one** read marker, shared by
+  everybody on its team, rather than one per person.
+
+  That is the part the issue calls subtle, and it is a different model rather
+  than a wider one: "read" here means *somebody* read it, not that everybody
+  did. Which is exactly why this is a column on the page and not a row per
+  member — the shape of the storage is the decision.
+
+  It mirrors `users.notifications_read_at` (one timestamp, everything older
+  counts as read), so the two sides of the app answer "what is new" the same
+  way and no second mechanism has to be learned.
+  """
+  use Ecto.Migration
+
+  def change do
+    alter table(:organizations) do
+      add(:activity_read_at, :naive_datetime)
+    end
+  end
+end

--- a/test/vutuv/organization_activity_test.exs
+++ b/test/vutuv/organization_activity_test.exs
@@ -1,0 +1,123 @@
+defmodule Vutuv.OrganizationActivityTest do
+  @moduledoc """
+  A page's own activity and its **shared** read marker (issue #1336).
+
+  The read state is the part the issue calls subtle, and the tests below are
+  what pin the chosen model down: one marker on the page, so "read" means
+  somebody on the team read it and never that everybody did. Storing it as a
+  column rather than a row per member is the decision, so a test that only
+  checked counts would not have caught the wrong shape.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Organizations
+  alias Vutuv.Posts
+  alias Vutuv.Social
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp publishing_organization do
+    {organization, owner} = active_organization()
+    {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+    {organization, owner}
+  end
+
+  test "collects follows, likes and reposts of the page, newest first" do
+    {organization, owner} = publishing_organization()
+    {:ok, post} = Posts.create_organization_post(organization, owner, %{body: "Unser Beitrag."})
+
+    follower = insert(:activated_user)
+    liker = insert(:activated_user)
+    reposter = insert(:activated_user)
+
+    {:ok, _} = Social.follow_organization(follower, organization)
+    :ok = Posts.like_post(liker, post)
+    :ok = Posts.repost_post(reposter, post)
+
+    %{entries: entries} = Organizations.activity_page(organization)
+    kinds = Enum.map(entries, & &1.kind)
+
+    assert "follow" in kinds
+    assert "post_like" in kinds
+    assert "post_repost" in kinds
+
+    # A like and a repost carry the post they are about; a follow does not.
+    like = Enum.find(entries, &(&1.kind == "post_like"))
+    assert like.post.id == post.id
+    assert like.actor.id == liker.id
+    assert Enum.find(entries, &(&1.kind == "follow")).post == nil
+  end
+
+  test "an event disappears with the row behind it" do
+    {organization, owner} = publishing_organization()
+    {:ok, post} = Posts.create_organization_post(organization, owner, %{body: "Kurz."})
+    liker = insert(:activated_user)
+
+    :ok = Posts.like_post(liker, post)
+    assert Organizations.activity_page(organization).entries != []
+
+    # Derived from the source tables rather than written twice, so unliking is
+    # not "read" — it never happened.
+    :ok = Posts.unlike_post(liker, post)
+    assert Organizations.activity_page(organization).entries == []
+  end
+
+  test "another page's activity never appears" do
+    {mine, _owner} = publishing_organization()
+
+    {theirs, their_owner} =
+      active_organization(%{"name" => "Fremd AG", "website_url" => "https://fremd.example"})
+
+    {:ok, _} = Organizations.add_role(theirs, their_owner, "publisher", their_owner)
+    {:ok, their_post} = Posts.create_organization_post(theirs, their_owner, %{body: "Ihres."})
+    :ok = Posts.like_post(insert(:activated_user), their_post)
+    {:ok, _} = Social.follow_organization(insert(:activated_user), theirs)
+
+    assert Organizations.activity_page(mine).entries == []
+  end
+
+  describe "the shared read marker" do
+    test "one member opening the list clears it for the whole team" do
+      {organization, owner} = publishing_organization()
+      other = insert(:activated_user)
+      {:ok, _} = Organizations.add_role(organization, other, "admin", owner)
+      {:ok, _} = Social.follow_organization(insert(:activated_user), organization)
+
+      # Nobody has looked yet: a nil marker means everything is new.
+      assert is_nil(organization.activity_read_at)
+      assert Organizations.unread_activity_count(organization) == 1
+
+      # One of them opens it …
+      {:ok, organization} = Organizations.mark_activity_read(organization)
+
+      # … and it is read for all of them. There is no per-member state to
+      # disagree with this, which is the whole design.
+      assert organization.activity_read_at
+      assert Organizations.unread_activity_count(organization) == 0
+    end
+
+    test "something that happens after the marker counts as unread again" do
+      {organization, _owner} = publishing_organization()
+      {:ok, organization} = Organizations.mark_activity_read(organization)
+      assert Organizations.unread_activity_count(organization) == 0
+
+      {:ok, _} = Social.follow_organization(insert(:activated_user), organization)
+
+      assert Organizations.unread_activity_count(Repo.reload!(organization)) == 1
+    end
+  end
+end

--- a/test/vutuv_web/organization_activity_web_test.exs
+++ b/test/vutuv_web/organization_activity_web_test.exs
@@ -1,0 +1,71 @@
+defmodule VutuvWeb.OrganizationActivityWebTest do
+  @moduledoc """
+  The organization activity page (issue #1336). `async: false` because the
+  organization helpers flip the global `:verify_organization_domains` flag.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Organizations
+  alias Vutuv.Social
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  test "the team sees what happened, marked new, and opening it clears the marker",
+       %{conn: conn} do
+    {conn, owner} = create_and_login_user(conn)
+    organization = active_organization_for(owner)
+    follower = insert(:activated_user, first_name: "Frida", last_name: "Folger")
+    {:ok, _} = Social.follow_organization(follower, organization)
+
+    {:ok, view, html} = live(conn, ~p"/organizations/#{organization.slug}/activity")
+
+    assert html =~ "Frida Folger"
+    # Nobody had looked, so the entry is marked new …
+    assert has_element?(view, "[data-activity-new]")
+
+    # … and the marker was stamped for the whole team, not for this member.
+    assert Organizations.get_organization!(organization.id).activity_read_at
+
+    assert Organizations.unread_activity_count(Organizations.get_organization!(organization.id)) ==
+             0
+
+    # A second visit shows the same entry without the new mark.
+    {:ok, view, _html} = live(conn, ~p"/organizations/#{organization.slug}/activity")
+    refute has_element?(view, "[data-activity-new]")
+  end
+
+  test "an admin who is not a publisher still reaches it", %{conn: conn} do
+    {conn, admin} = create_and_login_user(conn)
+    owner = insert(:activated_user)
+    organization = active_organization_for(owner)
+    {:ok, _} = Organizations.add_role(organization, admin, "admin", owner)
+
+    # Deliberately not gated on `publisher`: this is news ABOUT the page, not
+    # speaking FOR it, so it follows team membership.
+    assert conn
+           |> get(~p"/organizations/#{organization.slug}/activity")
+           |> html_response(200) =~ "Activity"
+  end
+
+  test "someone outside the team gets a 404", %{conn: conn} do
+    {stranger_conn, _stranger} = create_and_login_user(conn)
+    owner = insert(:activated_user)
+    organization = active_organization_for(owner)
+
+    stranger_conn
+    |> get(~p"/organizations/#{organization.slug}/activity")
+    |> response(404)
+  end
+end


### PR DESCRIPTION
Until now nobody on the team learned anything: somebody followed the page, somebody liked a post, somebody reposted it, and none of it was visible anywhere. It is at `/organizations/<slug>/activity` now, for the whole team.

The list is **derived from the source tables**, the way `Vutuv.Activity` derives a member's notifications. Nothing is written twice, and an event disappears with the row behind it — an unliked post is not "read", it simply never happened.

### The read state, which is the part #1336 calls subtle

**One marker on the page, shared by the whole team.** "Read" means somebody read it, never that everybody did. That is a *different* model rather than a wider one, which is why it is a column on the organization and not a row per member — the shape of the storage is the decision.

Two details, both learned from the member side:

- **The marker is the newest entry's timestamp, not the wall clock.** The source tables keep second precision and the unread test is a strict `>`, so a wall-clock marker swallows anything landing in the same second the page was opened. `Vutuv.Activity.mark_notifications_read/1` already solved this after #980, #930 and v7.200.1.
- **An empty list stamps nothing.** This is where it parts from the member version, and the test caught it: NULL and a stamp behave identically while there is nothing to show, but NULL is strictly better the moment something arrives. A follow one second after the team looked at an empty page is news, and the wall-clock fallback swallowed it.

### One deliberate deviation from the issue

The issue says these are "visible to everyone who may act as it", i.e. publishers. I opened it to the **whole team** (`can_manage?/2`) instead: this is news *about* the page, not speaking *for* it, and an owner who has not granted themselves `publisher` would otherwise be locked out of their own page's activity. Say the word if you want it narrowed.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*