### PR TITLE
Die Zahl neben der Seite sagt, dass es etwas zu sehen gibt (v7.245.1)

### DIFF
--- a/lib/vutuv/organizations.ex
+++ b/lib/vutuv/organizations.ex
@@ -402,6 +402,21 @@ defmodule Vutuv.Organizations do
     do: NaiveDateTime.compare(at, read_at) == :gt
 
   @doc """
+  Fills in `activity_unread` on each page of a `{organization, roles}` list —
+  the member's own "Your organizations" listing and nothing else.
+
+  Deliberately per page rather than one clever batched query: a member helps
+  run a handful of pages, this is a settings page and not a hot path, and the
+  shared read marker lives on each row so a batched version would have to carry
+  three per-organization joins to save queries nobody is counting.
+  """
+  def with_activity_unread(entries) do
+    Enum.map(entries, fn {organization, roles} ->
+      {%{organization | activity_unread: unread_activity_count(organization)}, roles}
+    end)
+  end
+
+  @doc """
   Stamps the shared read marker. Whoever on the team opens the list clears it
   for all of them — that is the point of one marker.
 

--- a/lib/vutuv/organizations/organization.ex
+++ b/lib/vutuv/organizations/organization.ex
@@ -68,6 +68,13 @@ defmodule Vutuv.Organizations.Organization do
     # params — `Vutuv.Organizations.mark_activity_read/1` owns it.
     field(:activity_read_at, :naive_datetime)
 
+    # How much has happened since the team last looked, filled in only where a
+    # page is listed for one of its own people (`with_activity_unread/1`).
+    # Virtual because it is a question about the reader's context, not a fact
+    # about the page — every other caller would be paying for an answer it
+    # never shows.
+    field(:activity_unread, :integer, virtual: true, default: 0)
+
     belongs_to(:created_by, Vutuv.Accounts.User, foreign_key: :created_by_user_id)
     has_many(:domains, Vutuv.Organizations.OrganizationDomain)
     has_many(:roles, Vutuv.Organizations.OrganizationRole)

--- a/lib/vutuv_web/controllers/settings_controller.ex
+++ b/lib/vutuv_web/controllers/settings_controller.ex
@@ -174,7 +174,8 @@ defmodule VutuvWeb.SettingsController do
 
     render(conn, "organizations.html",
       user: user,
-      organizations: Organizations.member_organizations(user),
+      organizations:
+        user |> Organizations.member_organizations() |> Organizations.with_activity_unread(),
       page_title: gettext("Organizations")
     )
   end

--- a/lib/vutuv_web/templates/settings/organizations.html.heex
+++ b/lib/vutuv_web/templates/settings/organizations.html.heex
@@ -67,6 +67,20 @@ happen on the organization's own pages. --%>
               </span>
             </div>
           </div>
+          <%!-- What has happened to the page since anybody on its team last
+          looked (issue #1336). The count is the reason to go and look at all,
+          so it is a link to the list rather than a decoration. --%>
+          <.link
+            :if={organization.activity_unread > 0}
+            navigate={~p"/organizations/#{organization.slug}/activity"}
+            data-organization-activity
+            class="shrink-0 inline-flex items-center gap-1.5 rounded-full bg-brand-50 px-3 py-1 text-sm font-semibold text-brand-700 hover:bg-brand-100 dark:bg-brand-900/40 dark:text-brand-100 dark:hover:bg-brand-900/70"
+          >
+            {ngettext("%{formatted} new", "%{formatted} new", organization.activity_unread,
+              formatted: compact_count(organization.activity_unread)
+            )}
+          </.link>
+
           <.link
             :if={Enum.any?(roles, &(&1 in ["owner", "admin"]))}
             navigate={~p"/organizations/#{organization.slug}/edit"}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.245.0",
+      version: "7.245.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -2786,7 +2786,7 @@ msgstr "Ersten Beitrag schreiben"
 #: lib/vutuv_web/components/ui.ex:3389
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
-#: lib/vutuv_web/templates/settings/organizations.html.heex:75
+#: lib/vutuv_web/templates/settings/organizations.html.heex:89
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:219
@@ -12375,7 +12375,7 @@ msgstr "Reservieren Sie ein kurzes @handle, damit diese Organisation wie ein Mit
 #: lib/vutuv_web/live/organization_live/index.ex:101
 #: lib/vutuv_web/live/organization_live/new.ex:26
 #: lib/vutuv_web/live/organization_live/new.ex:80
-#: lib/vutuv_web/templates/settings/organizations.html.heex:89
+#: lib/vutuv_web/templates/settings/organizations.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Add your organization"
 msgstr "Ihre Organisation hinzufügen"
@@ -12648,32 +12648,32 @@ msgstr ""
 "Suchergebnissen erscheinen oder von KI verwendet werden soll. Seriöse "
 "Suchmaschinen und KI-Anbieter befolgen das; erzwingen können wir es nicht."
 
-#: lib/vutuv/organizations/organization.ex:92
+#: lib/vutuv/organizations/organization.ex:99
 #, elixir-autogen, elixir-format
 msgid "Association"
 msgstr "Verein / Verband"
 
-#: lib/vutuv/organizations/organization.ex:91
+#: lib/vutuv/organizations/organization.ex:98
 #, elixir-autogen, elixir-format
 msgid "Business"
 msgstr "Unternehmen"
 
-#: lib/vutuv/organizations/organization.ex:94
+#: lib/vutuv/organizations/organization.ex:101
 #, elixir-autogen, elixir-format
 msgid "Education / research"
 msgstr "Bildung / Forschung"
 
-#: lib/vutuv/organizations/organization.ex:95
+#: lib/vutuv/organizations/organization.ex:102
 #, elixir-autogen, elixir-format
 msgid "NGO / foundation"
 msgstr "NGO / Stiftung"
 
-#: lib/vutuv/organizations/organization.ex:96
+#: lib/vutuv/organizations/organization.ex:103
 #, elixir-autogen, elixir-format
 msgid "Other organization"
 msgstr "Sonstige"
 
-#: lib/vutuv/organizations/organization.ex:93
+#: lib/vutuv/organizations/organization.ex:100
 #, elixir-autogen, elixir-format
 msgid "Public authority"
 msgstr "Behörde / Öffentlich"
@@ -13267,17 +13267,17 @@ msgid_plural "Your roles"
 msgstr[0] "Ihre Rolle"
 msgstr[1] "Ihre Rollen"
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:84
+#: lib/vutuv_web/templates/settings/organizations.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "Add an organization"
 msgstr "Organisation hinzufügen"
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:86
+#: lib/vutuv_web/templates/settings/organizations.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "Represent a company, association or other group? Add its page and verify the domain to become its owner."
 msgstr "Vertreten Sie ein Unternehmen, einen Verein oder eine andere Gruppe? Fügen Sie die Seite hinzu und verifizieren Sie die Domain, um ihr Besitzer zu werden."
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:96
+#: lib/vutuv_web/templates/settings/organizations.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Browse all organizations"
 msgstr "Alle Organisationen ansehen"
@@ -20945,3 +20945,10 @@ msgstr "Bisher ist nichts passiert."
 #, elixir-autogen, elixir-format
 msgid "What happened to this page. Everyone on the team sees the same list, and opening it marks it read for all of you."
 msgstr "Was auf dieser Seite passiert ist. Alle im Team sehen dieselbe Liste, und wer sie öffnet, markiert sie für alle als gelesen."
+
+#: lib/vutuv_web/templates/settings/organizations.html.heex:79
+#, elixir-autogen, elixir-format
+msgid "%{formatted} new"
+msgid_plural "%{formatted} new"
+msgstr[0] "%{formatted} neu"
+msgstr[1] "%{formatted} neu"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -2737,7 +2737,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3389
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
-#: lib/vutuv_web/templates/settings/organizations.html.heex:75
+#: lib/vutuv_web/templates/settings/organizations.html.heex:89
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:219
@@ -11723,7 +11723,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/index.ex:101
 #: lib/vutuv_web/live/organization_live/new.ex:26
 #: lib/vutuv_web/live/organization_live/new.ex:80
-#: lib/vutuv_web/templates/settings/organizations.html.heex:89
+#: lib/vutuv_web/templates/settings/organizations.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Add your organization"
 msgstr ""
@@ -11982,32 +11982,32 @@ msgstr ""
 msgid "We can't stop a search engine or AI service from reading a page it can open. What we can do is tell them, in the machine-readable way they look for, that you don't want your profile listed in search results or used by AI. Reputable search engines and AI companies follow that request; we can't force the rest."
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:92
+#: lib/vutuv/organizations/organization.ex:99
 #, elixir-autogen, elixir-format
 msgid "Association"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:91
+#: lib/vutuv/organizations/organization.ex:98
 #, elixir-autogen, elixir-format
 msgid "Business"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:94
+#: lib/vutuv/organizations/organization.ex:101
 #, elixir-autogen, elixir-format
 msgid "Education / research"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:95
+#: lib/vutuv/organizations/organization.ex:102
 #, elixir-autogen, elixir-format
 msgid "NGO / foundation"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:96
+#: lib/vutuv/organizations/organization.ex:103
 #, elixir-autogen, elixir-format
 msgid "Other organization"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:93
+#: lib/vutuv/organizations/organization.ex:100
 #, elixir-autogen, elixir-format
 msgid "Public authority"
 msgstr ""
@@ -12601,17 +12601,17 @@ msgid_plural "Your roles"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:84
+#: lib/vutuv_web/templates/settings/organizations.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "Add an organization"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:86
+#: lib/vutuv_web/templates/settings/organizations.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "Represent a company, association or other group? Add its page and verify the domain to become its owner."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:96
+#: lib/vutuv_web/templates/settings/organizations.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Browse all organizations"
 msgstr ""
@@ -20161,3 +20161,10 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "What happened to this page. Everyone on the team sees the same list, and opening it marks it read for all of you."
 msgstr ""
+
+#: lib/vutuv_web/templates/settings/organizations.html.heex:79
+#, elixir-autogen, elixir-format
+msgid "%{formatted} new"
+msgid_plural "%{formatted} new"
+msgstr[0] ""
+msgstr[1] ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -2735,7 +2735,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3389
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
-#: lib/vutuv_web/templates/settings/organizations.html.heex:75
+#: lib/vutuv_web/templates/settings/organizations.html.heex:89
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:219
@@ -11721,7 +11721,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/index.ex:101
 #: lib/vutuv_web/live/organization_live/new.ex:26
 #: lib/vutuv_web/live/organization_live/new.ex:80
-#: lib/vutuv_web/templates/settings/organizations.html.heex:89
+#: lib/vutuv_web/templates/settings/organizations.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Add your organization"
 msgstr ""
@@ -11980,32 +11980,32 @@ msgstr ""
 msgid "We can't stop a search engine or AI service from reading a page it can open. What we can do is tell them, in the machine-readable way they look for, that you don't want your profile listed in search results or used by AI. Reputable search engines and AI companies follow that request; we can't force the rest."
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:92
+#: lib/vutuv/organizations/organization.ex:99
 #, elixir-autogen, elixir-format
 msgid "Association"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:91
+#: lib/vutuv/organizations/organization.ex:98
 #, elixir-autogen, elixir-format
 msgid "Business"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:94
+#: lib/vutuv/organizations/organization.ex:101
 #, elixir-autogen, elixir-format
 msgid "Education / research"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:95
+#: lib/vutuv/organizations/organization.ex:102
 #, elixir-autogen, elixir-format
 msgid "NGO / foundation"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:96
+#: lib/vutuv/organizations/organization.ex:103
 #, elixir-autogen, elixir-format
 msgid "Other organization"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:93
+#: lib/vutuv/organizations/organization.ex:100
 #, elixir-autogen, elixir-format
 msgid "Public authority"
 msgstr ""
@@ -12599,17 +12599,17 @@ msgid_plural "Your roles"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:84
+#: lib/vutuv_web/templates/settings/organizations.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "Add an organization"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:86
+#: lib/vutuv_web/templates/settings/organizations.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "Represent a company, association or other group? Add its page and verify the domain to become its owner."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:96
+#: lib/vutuv_web/templates/settings/organizations.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Browse all organizations"
 msgstr ""
@@ -20159,3 +20159,10 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "What happened to this page. Everyone on the team sees the same list, and opening it marks it read for all of you."
 msgstr ""
+
+#: lib/vutuv_web/templates/settings/organizations.html.heex:79
+#, elixir-autogen, elixir-format, fuzzy
+msgid "%{formatted} new"
+msgid_plural "%{formatted} new"
+msgstr[0] ""
+msgstr[1] ""

--- a/test/vutuv_web/organization_activity_web_test.exs
+++ b/test/vutuv_web/organization_activity_web_test.exs
@@ -59,6 +59,21 @@ defmodule VutuvWeb.OrganizationActivityWebTest do
            |> html_response(200) =~ "Activity"
   end
 
+  test "the member's own organizations list shows the count and links to it", %{conn: conn} do
+    {conn, owner} = create_and_login_user(conn)
+    organization = active_organization_for(owner)
+
+    # Nothing yet: no badge, so the row stays quiet.
+    refute conn |> get(~p"/settings/organizations") |> html_response(200) =~
+             "data-organization-activity"
+
+    {:ok, _} = Social.follow_organization(insert(:activated_user), organization)
+
+    html = conn |> get(~p"/settings/organizations") |> html_response(200)
+    assert html =~ "data-organization-activity"
+    assert html =~ "/organizations/#{organization.slug}/activity"
+  end
+
   test "someone outside the team gets a 404", %{conn: conn} do
     {stranger_conn, _stranger} = create_and_login_user(conn)
     owner = insert(:activated_user)


### PR DESCRIPTION
v7.245.0 built the activity list and computed the unread count, then showed it nowhere. Nobody had a reason to open the page, and a feature you only find if you already know it is there is not one.

The count now sits beside the page in "Your organizations", and it is **a link to the list rather than a decoration** — the number is the reason to look, so it goes where looking happens. With nothing new the row stays quiet.

`activity_unread` is a **virtual** field, filled in only where a page is shown to one of its own people. It is a question about the reader's context, not a fact about the page; every other caller would otherwise pay for an answer it never shows.

Counted per page rather than in one clever batched query, on purpose: a member helps run a handful of pages, this is a settings page and not a hot path, and the shared read marker lives on each row — a batched version would need three per-organization joins to save queries nobody is counting.

One more fuzzy fill on the way: `gettext.extract --merge` turned `"%{formatted} new"` into `"%{formatted} Minute"`.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*