### PR TITLE
Eine Organisation lässt sich beim Handle nennen (v7.246.0)

### DIFF
--- a/lib/vutuv/organizations.ex
+++ b/lib/vutuv/organizations.ex
@@ -76,6 +76,32 @@ defmodule Vutuv.Organizations do
 
   def get_organization_by_slug(_), do: nil
 
+  @doc """
+  The **publicly visible** organizations holding any of `usernames`, as a map
+  keyed by the lowercase handle — the batched lookup behind linking `@acme` in
+  a body (issue #1336), the organization twin of
+  `Vutuv.Accounts.get_users_by_usernames/1`.
+
+  One query per rendered body, never one per mention. A page that is pending,
+  frozen or archived is simply absent, so the mention stays plain text rather
+  than linking somewhere a reader cannot go.
+  """
+  def get_organizations_by_usernames(usernames) when is_list(usernames) do
+    case usernames |> Enum.map(&String.downcase/1) |> Enum.uniq() do
+      [] ->
+        %{}
+
+      names ->
+        from(o in Organization,
+          where: o.username in ^names,
+          where: organization_public_row(o),
+          select: struct(o, [:id, :name, :slug, :username])
+        )
+        |> Repo.all()
+        |> Map.new(&{&1.username, &1})
+    end
+  end
+
   @doc "Fetches an organization by its opt-in root handle (issue #941), or nil."
   def get_organization_by_username(username) when is_binary(username),
     do: Repo.get_by(Organization, username: username)

--- a/lib/vutuv_web/markdown.ex
+++ b/lib/vutuv_web/markdown.ex
@@ -30,6 +30,8 @@ defmodule VutuvWeb.Markdown do
 
   alias Vutuv.Accounts
   alias Vutuv.Fediverse
+  alias Vutuv.Organizations
+  alias Vutuv.Organizations.Organization
   alias Vutuv.Posts.PostImage
   alias Vutuv.Profiles.Url
   alias Vutuv.Profiles.VerifiedLinks
@@ -912,7 +914,7 @@ defmodule VutuvWeb.Markdown do
         # carrying only fediverse handles still reaches here (they need no
         # lookup, so both `mentions` and `hashtags` stay empty) and gets linked.
         users =
-          if mode == :all, do: Accounts.get_users_by_usernames(mentions), else: %{}
+          if mode == :all, do: mention_targets(mentions), else: %{}
 
         tags = Tags.linkable_slugs(hashtags)
 
@@ -1022,8 +1024,21 @@ defmodule VutuvWeb.Markdown do
   defp mention_link(whole, handle, users) do
     case Map.get(users, String.downcase(handle)) do
       nil -> whole
-      user -> mention_anchor(user, handle)
+      target -> mention_anchor(target, handle)
     end
+  end
+
+  # Members and organizations share one handle namespace (the `handles`
+  # registry, issue #941), so a handle belongs to at most one of them and the
+  # two maps cannot disagree. Merging members **over** organizations anyway is
+  # the safe direction if that invariant were ever broken: a person's profile
+  # is the more sensitive destination to get right.
+  #
+  # Two batched queries per rendered body, never one per mention.
+  defp mention_targets(handles) do
+    handles
+    |> Organizations.get_organizations_by_usernames()
+    |> Map.merge(Accounts.get_users_by_usernames(handles))
   end
 
   # The written hashtag keeps its casing in the text; the href is the slug
@@ -1040,6 +1055,11 @@ defmodule VutuvWeb.Markdown do
   # The display text is the handle the author typed (case preserved); the href
   # is the canonical lowercase slug; the title is the member's full name (or the
   # handle itself for a nameless member).
+  defp mention_anchor(%Organization{} = organization, typed_handle) do
+    ~s(<a href="#{Organizations.canonical_path(organization)}" ) <>
+      ~s(title="#{escape(organization.name)}" class="mention">@#{typed_handle}</a>)
+  end
+
   defp mention_anchor(user, typed_handle) do
     name =
       case UserHelpers.full_name(user) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.245.1",
+      version: "7.246.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/organization_mention_test.exs
+++ b/test/vutuv_web/organization_mention_test.exs
@@ -1,0 +1,79 @@
+defmodule VutuvWeb.OrganizationMentionTest do
+  @moduledoc """
+  Naming an organization by its root handle in a body (issue #1336).
+
+  It already **validated** — `Vutuv.Mentions` accepts an organization handle,
+  so the post saved — but the renderer only ever looked up members, so `@acme`
+  came out as plain text. A handle that is accepted as real and then rendered
+  as if it were not is the worst of both.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Organizations
+  alias VutuvWeb.Markdown
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp handled_organization(handle) do
+    {organization, _owner} = active_organization(unique_attrs(handle))
+    {:ok, organization} = Organizations.claim_handle(organization, %{"username" => handle})
+    organization
+  end
+
+  # Each page in a test needs its own domain: the claim refuses a second page
+  # on a domain that is already taken.
+  defp unique_attrs(handle),
+    do: %{"name" => "#{handle} AG", "website_url" => "https://#{handle}.example"}
+
+  defp render(body), do: body |> Markdown.render() |> Phoenix.HTML.safe_to_string()
+
+  test "an organization handle links to its page, titled with its name" do
+    organization = handled_organization("acmegmbh")
+
+    html = render("Wir arbeiten mit @acmegmbh zusammen.")
+
+    assert html =~ ~s(href="/acmegmbh")
+    assert html =~ ~s(class="mention")
+    assert html =~ ~s(title="#{organization.name}")
+  end
+
+  test "a member handle still wins, and an unknown handle stays plain text" do
+    member = insert(:activated_user, username: "einmitglied")
+    _organization = handled_organization("eineseite")
+
+    html = render("@einmitglied und @eineseite und @niemand")
+
+    assert html =~ ~s(href="/#{member.username}")
+    assert html =~ ~s(href="/eineseite")
+    # An unknown handle is left exactly as typed — never a link to nowhere.
+    assert html =~ "@niemand"
+    refute html =~ ~s(href="/niemand")
+  end
+
+  test "a page nobody may see is not linked" do
+    {organization, _owner} = active_organization(unique_attrs("verstecktag"))
+    {:ok, organization} = Organizations.claim_handle(organization, %{"username" => "verstecktag"})
+    {:ok, _} = Organizations.admin_set_frozen(organization, true)
+
+    html = render("Was ist mit @verstecktag?")
+
+    # Still readable as text, but no link into a page the reader would be
+    # refused at.
+    assert html =~ "@verstecktag"
+    refute html =~ ~s(href="/verstecktag")
+  end
+end


### PR DESCRIPTION
Writing `@acme` in a post, where `acme` is an organization's root handle, saved the post and then did nothing: the renderer only ever looked handles up among members, so the mention came out as plain text. `Vutuv.Mentions` already knew the handle and let the post through — so the result was the worst of both, **accepted as real and then rendered as if it were not**.

Such a mention now links to the page, with its name as the `title`, exactly as a member mention links to their profile.

Members and organizations share one handle namespace (the `handles` registry, #941), so a handle belongs to at most one of them and the two lookups cannot disagree. They are merged with **members winning** anyway: if that invariant ever broke, a person's profile is the destination you do not want to get wrong.

A page nobody may see — pending, frozen, archived — is **not** linked. The text stays readable, but no link leads somewhere the reader would be turned away. Two batched queries per rendered body, never one per mention.

**What this does not do yet:** the page learns nothing about the mention. That needs `post_mentions` to grow an `organization_id`, and it is the next step in #1336. Linking is complete on its own — `#hashtag` links and notifies nobody either.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*