### PR TITLE
Eine erwähnte Seite erfährt davon (v7.246.1)

### DIFF
--- a/lib/vutuv/mentions.ex
+++ b/lib/vutuv/mentions.ex
@@ -50,6 +50,7 @@ defmodule Vutuv.Mentions do
   alias Vutuv.Chat.Message
   alias Vutuv.Handles
   alias Vutuv.Jobs.JobPosting
+  alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
   alias Vutuv.Posts.Post
   alias Vutuv.Profiles.Education
@@ -152,10 +153,9 @@ defmodule Vutuv.Mentions do
   The **members** `text` names, as `%User{}` structs, excluding `except_id`.
 
   The resolution behind the `"mention"` notification kind (`Vutuv.Posts`
-  reconciles `post_mentions` from it). Organizations share the handle
-  namespace but have no notification feed, so only the member table is
-  queried — a `@acme_gmbh` in a body resolves to nobody here, even though the
-  renderer links it.
+  reconciles `post_mentions` from it). Organizations share the handle namespace
+  and are resolved separately by `mentioned_organizations/1` — one handle is a
+  member's or a page's, never both, so the two never overlap.
   """
   def mentioned_users(text, except_id \\ nil) do
     case local_handles(text) do
@@ -171,6 +171,21 @@ defmodule Vutuv.Mentions do
 
   defp reject_user(query, nil), do: query
   defp reject_user(query, id), do: where(query, [u], u.id != ^id)
+
+  @doc """
+  The **publicly visible** organizations `text` names by their root handle
+  (issue #1336) — the organization twin of `mentioned_users/2`.
+
+  A handle belongs to a member or to a page, never both (one namespace, the
+  `handles` registry), so the two lists cannot overlap and no precedence rule
+  is needed here.
+  """
+  def mentioned_organizations(text) do
+    case local_handles(text) do
+      [] -> []
+      handles -> handles |> Organizations.get_organizations_by_usernames() |> Map.values()
+    end
+  end
 
   ## Rewrite ----------------------------------------------------------------
 

--- a/lib/vutuv/organizations.ex
+++ b/lib/vutuv/organizations.ex
@@ -35,6 +35,7 @@ defmodule Vutuv.Organizations do
   alias Vutuv.Pages
   alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostLike
+  alias Vutuv.Posts.PostMention
   alias Vutuv.Posts.PostRepost
   alias Vutuv.Profiles.WorkExperience
   alias Vutuv.Repo
@@ -400,7 +401,8 @@ defmodule Vutuv.Organizations do
         [
           &activity_follows(organization, &1, &2),
           &activity_post_engagement(organization, PostLike, "post_like", &1, &2),
-          &activity_post_engagement(organization, PostRepost, "post_repost", &1, &2)
+          &activity_post_engagement(organization, PostRepost, "post_repost", &1, &2),
+          &activity_mentions(organization, &1, &2)
         ],
         limit,
         offset
@@ -487,9 +489,48 @@ defmodule Vutuv.Organizations do
     end)
   end
 
+  # Posts that named the page by its root handle (issue #1336). Read off the
+  # `post_mentions` rows `Vutuv.Posts` reconciles at save time, so an edit that
+  # drops the mention drops the entry with it.
+  #
+  # The page's OWN posts are excluded: a page naming itself is not news to its
+  # team, and every organization post already sits on the page above.
+  defp activity_mentions(%Organization{id: id}, fetch_n, _cursor) do
+    from(m in PostMention,
+      join: p in Post,
+      on: p.id == m.post_id,
+      # Inner join, so a mention written BY another organization's page is not
+      # listed. Accepted for now: a page cannot yet name another page (its
+      # composer has no mention flow of its own), so there is nothing to miss.
+      join: u in User,
+      on: u.id == p.user_id,
+      where: m.organization_id == ^id,
+      where: account_confirmed_row(u) and not account_hidden_row(u),
+      where: not p.images_pending? and is_nil(p.frozen_at),
+      order_by: [desc: m.inserted_at, desc: m.id],
+      limit: ^fetch_n,
+      select: {m.id, m.inserted_at, u, p}
+    )
+    |> Repo.all()
+    |> Enum.map(fn {row_id, at, actor, post} ->
+      # `Vutuv.Posts.path/1` matches on the preloaded author, so the post has to
+      # carry one or the link raises rather than renders. Here the actor IS that
+      # author (the join is on `p.user_id`), so no query and no `preload:` —
+      # which a tuple `select` could not have carried anyway.
+      post = %{post | user: actor}
+      %{id: "mention-#{row_id}", kind: "mention", at: at, actor: actor, post: post}
+    end)
+  end
+
   # Likes and reposts of the page's own posts. One function for both because
   # the two tables are the same shape and the only difference is the word.
-  defp activity_post_engagement(%Organization{id: id}, schema, kind, fetch_n, _cursor) do
+  defp activity_post_engagement(
+         %Organization{id: id} = organization,
+         schema,
+         kind,
+         fetch_n,
+         _cursor
+       ) do
     from(e in schema,
       join: p in Post,
       on: p.id == e.post_id,
@@ -503,6 +544,9 @@ defmodule Vutuv.Organizations do
     )
     |> Repo.all()
     |> Enum.map(fn {row_id, at, actor, post} ->
+      # Same reason as above, without the query: these are the page's OWN
+      # posts, and the caller is holding the page.
+      post = %{post | organization: organization}
       %{id: "#{kind}-#{row_id}", kind: kind, at: at, actor: actor, post: post}
     end)
   end

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -4812,12 +4812,74 @@ defmodule Vutuv.Posts do
       |> Mentions.mentioned_users(post.user_id)
       |> Enum.filter(&visible_to?(post, &1))
 
-    existing = Repo.all(from(m in PostMention, where: m.post_id == ^post.id, select: m.user_id))
+    existing =
+      Repo.all(
+        from(m in PostMention,
+          where: m.post_id == ^post.id and not is_nil(m.user_id),
+          select: m.user_id
+        )
+      )
+
     added = Enum.reject(wanted, &(&1.id in existing))
 
     drop_mentions(post, existing -- Enum.map(wanted, & &1.id))
     insert_mentions(post, added)
     Enum.each(added, &notify_mentioned(post, &1))
+    sync_organization_mentions(post)
+    :ok
+  end
+
+  # The same reconcile for the pages a body names by their root handle (issue
+  # #1336). Its own pass rather than a widened one above: an organization has no
+  # visibility to check (a page is public or it is not, which
+  # `mentioned_organizations/1` already asked) and nobody to notify — the
+  # mention shows up in the page's own activity list, which reads these rows.
+  defp sync_organization_mentions(%Post{} = post) do
+    wanted = post.body |> Mentions.mentioned_organizations() |> Enum.map(& &1.id)
+
+    existing =
+      Repo.all(
+        from(m in PostMention,
+          where: m.post_id == ^post.id and not is_nil(m.organization_id),
+          select: m.organization_id
+        )
+      )
+
+    drop_organization_mentions(post, existing -- wanted)
+    insert_organization_mentions(post, wanted -- existing)
+    :ok
+  end
+
+  defp drop_organization_mentions(_post, []), do: :ok
+
+  defp drop_organization_mentions(%Post{} = post, organization_ids) do
+    Repo.delete_all(
+      from(m in PostMention,
+        where: m.post_id == ^post.id and m.organization_id in ^organization_ids
+      )
+    )
+
+    :ok
+  end
+
+  defp insert_organization_mentions(_post, []), do: :ok
+
+  defp insert_organization_mentions(%Post{} = post, organization_ids) do
+    now = NaiveDateTime.utc_now(:second)
+
+    rows =
+      Enum.map(
+        organization_ids,
+        &%{
+          id: Vutuv.UUIDv7.generate(),
+          post_id: post.id,
+          organization_id: &1,
+          inserted_at: now,
+          updated_at: now
+        }
+      )
+
+    Repo.insert_all(PostMention, rows, on_conflict: :nothing)
     :ok
   end
 

--- a/lib/vutuv/posts/post_mention.ex
+++ b/lib/vutuv/posts/post_mention.ex
@@ -1,6 +1,7 @@
 defmodule Vutuv.Posts.PostMention do
   @moduledoc """
-  One member a post names with `@handle`, resolved at save time.
+  One member **or organization** a post names with `@handle`, resolved at save
+  time.
 
   The mention itself stays plain text in the body (`Vutuv.Mentions` owns the
   grammar); this row is only the resolved index behind the `"mention"`
@@ -13,7 +14,11 @@ defmodule Vutuv.Posts.PostMention do
 
   schema "post_mentions" do
     belongs_to(:post, Vutuv.Posts.Post)
+    # A member OR an organization (issue #1336), CHECK-enforced to exactly one:
+    # members and organizations share one handle namespace, so `@acme` names
+    # one of the two and never both.
     belongs_to(:user, Vutuv.Accounts.User)
+    belongs_to(:organization, Vutuv.Organizations.Organization)
 
     timestamps()
   end

--- a/lib/vutuv_web/live/organization_live/activity.ex
+++ b/lib/vutuv_web/live/organization_live/activity.ex
@@ -1,7 +1,8 @@
 defmodule VutuvWeb.OrganizationLive.Activity do
   @moduledoc """
   What happened to an organization page (`/organizations/:slug/activity`,
-  issue #1336): who followed it, and who liked or reposted what it published.
+  issue #1336): who followed it, who liked or reposted what it published, and
+  who named it by its handle.
 
   **One read marker for the whole team.** Opening this page stamps
   `organizations.activity_read_at`, and it is stamped for everybody — "read"
@@ -78,6 +79,9 @@ defmodule VutuvWeb.OrganizationLive.Activity do
 
   defp line(%{kind: "post_repost"} = entry),
     do: gettext("%{name} reposted a post.", name: full_name(entry.actor))
+
+  defp line(%{kind: "mention"} = entry),
+    do: gettext("%{name} mentioned this page.", name: full_name(entry.actor))
 
   @impl true
   def render(assigns) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.246.0",
+      version: "7.246.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -473,7 +473,7 @@ msgid "Name"
 msgstr "Name"
 
 #: lib/vutuv_web/live/notification_live/index.ex:636
-#: lib/vutuv_web/live/organization_live/activity.ex:112
+#: lib/vutuv_web/live/organization_live/activity.ex:116
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:3
@@ -1959,7 +1959,7 @@ msgid "Pagination"
 msgstr "Seitennavigation"
 
 #: lib/vutuv_web/components/ui.ex:3461
-#: lib/vutuv_web/live/organization_live/activity.ex:135
+#: lib/vutuv_web/live/organization_live/activity.ex:139
 #: lib/vutuv_web/live/organization_live/show.ex:498
 #, elixir-autogen, elixir-format
 msgid "Load more"
@@ -2888,7 +2888,7 @@ msgstr "Öffnen Sie ein Profil, um jemandem zu schreiben."
 
 #: lib/vutuv_web/components/organization_components.ex:220
 #: lib/vutuv_web/live/notification_live/index.ex:1035
-#: lib/vutuv_web/live/organization_live/activity.ex:88
+#: lib/vutuv_web/live/organization_live/activity.ex:92
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr "Aktivität"
@@ -5711,7 +5711,7 @@ msgstr ""
 msgid "Email addresses"
 msgstr "E-Mail-Adressen"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:536
+#: lib/vutuv_web/controllers/settings_controller.ex:537
 #, elixir-autogen, elixir-format
 msgid "Notification settings saved."
 msgstr "Benachrichtigungseinstellungen gespeichert."
@@ -5738,7 +5738,7 @@ msgstr "Fotos"
 msgid "Privacy"
 msgstr "Privatsphäre"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:188
+#: lib/vutuv_web/controllers/settings_controller.ex:189
 #, elixir-autogen, elixir-format
 msgid "Privacy settings saved."
 msgstr "Datenschutzeinstellungen gespeichert."
@@ -5795,7 +5795,7 @@ msgstr "Sprache der Oberfläche"
 msgid "Language & region"
 msgstr "Sprache & Region"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:692
+#: lib/vutuv_web/controllers/settings_controller.ex:693
 #, elixir-autogen, elixir-format
 msgid "Language updated."
 msgstr "Sprache aktualisiert."
@@ -5879,7 +5879,7 @@ msgstr "Benachrichtigungen in der App"
 msgid "New followers"
 msgstr "Neue Follower"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:526
+#: lib/vutuv_web/controllers/settings_controller.ex:527
 #, elixir-autogen, elixir-format
 msgid "Notification settings"
 msgstr "Benachrichtigungseinstellungen"
@@ -6079,7 +6079,7 @@ msgid_plural "%{count} minutes ago"
 msgstr[0] "vor %{count} Minute"
 msgstr[1] "vor %{count} Minuten"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:810
+#: lib/vutuv_web/controllers/settings_controller.ex:811
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr "Alle anderen Geräte wurden abgemeldet."
@@ -6119,7 +6119,7 @@ msgstr "Neue Anmeldung bei Ihrem vutuv-Konto"
 msgid "Signed-in devices"
 msgstr "Angemeldete Geräte"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:797
+#: lib/vutuv_web/controllers/settings_controller.ex:798
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr "Dieses Gerät wurde abgemeldet."
@@ -6494,7 +6494,7 @@ msgstr "Empfehlung zurücknehmen"
 msgid "Default map"
 msgstr "Standardkarte"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:707
+#: lib/vutuv_web/controllers/settings_controller.ex:708
 #, elixir-autogen, elixir-format
 msgid "Map preferences saved."
 msgstr "Karteneinstellungen gespeichert."
@@ -9073,8 +9073,8 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/agent_docs/text.ex:492
 #: lib/vutuv_web/components/ui.ex:3688
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
-#: lib/vutuv_web/controllers/settings_controller.ex:322
-#: lib/vutuv_web/controllers/settings_controller.ex:389
+#: lib/vutuv_web/controllers/settings_controller.ex:323
+#: lib/vutuv_web/controllers/settings_controller.ex:390
 #: lib/vutuv_web/live/fediverse_followers_live.ex:169
 #: lib/vutuv_web/live/fediverse_following_live.ex:286
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:341
@@ -9108,7 +9108,7 @@ msgstr ""
 "als Link in Ihren Mastodon-Profileinstellungen ein, und Mastodon zeigt ihn "
 "grün als bestätigt an."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:402
+#: lib/vutuv_web/controllers/settings_controller.ex:403
 #, elixir-autogen, elixir-format
 msgid "Fediverse settings saved."
 msgstr "Fediverse-Einstellungen gespeichert."
@@ -11115,7 +11115,7 @@ msgstr ""
 "Längere Beiträge erhalten einen „Weiterlesen“-Link. Mit 0 (oder leer) wird "
 "nie gekürzt."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:720
+#: lib/vutuv_web/controllers/settings_controller.ex:721
 #, elixir-autogen, elixir-format
 msgid "Post display settings saved."
 msgstr "Anzeige-Einstellungen für Beiträge gespeichert."
@@ -11174,7 +11174,7 @@ msgstr ""
 msgid "Installation default (%{value})"
 msgstr "Standard der Installation (%{value})"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:751
+#: lib/vutuv_web/controllers/settings_controller.ex:752
 #, elixir-autogen, elixir-format
 msgid "Map preferences reset to the site defaults."
 msgstr "Karteneinstellungen auf die Standardwerte zurückgesetzt."
@@ -11193,7 +11193,7 @@ msgstr ""
 "Eigener Wert; leeren Sie das Feld, um zum Standard der Installation "
 "zurückzukehren."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:747
+#: lib/vutuv_web/controllers/settings_controller.ex:748
 #, elixir-autogen, elixir-format
 msgid "Post display settings reset to the site defaults."
 msgstr ""
@@ -12513,7 +12513,7 @@ msgstr "Organisation wieder freigegeben."
 
 #: lib/vutuv_web/agent_docs/organization_doc.ex:108
 #: lib/vutuv_web/components/ui.ex:3719
-#: lib/vutuv_web/controllers/settings_controller.ex:178
+#: lib/vutuv_web/controllers/settings_controller.ex:179
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:501
@@ -13076,7 +13076,7 @@ msgstr "Gehalt"
 msgid "Salary on request"
 msgstr "Gehalt auf Anfrage"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:360
+#: lib/vutuv_web/controllers/settings_controller.ex:361
 #: lib/vutuv_web/live/job_posting_live/form.ex:231
 #, elixir-autogen, elixir-format
 msgid "Saved."
@@ -13666,7 +13666,7 @@ msgstr[1] "%{count} neue Treffer für Ihre gespeicherten Suchen"
 msgid "Alert frequency"
 msgstr "Häufigkeit der Benachrichtigung"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:645
+#: lib/vutuv_web/controllers/settings_controller.ex:646
 #, elixir-autogen, elixir-format
 msgid "Alert updated."
 msgstr "Benachrichtigung aktualisiert."
@@ -13739,13 +13739,13 @@ msgstr ""
 msgid "Save search"
 msgstr "Suche speichern"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:663
+#: lib/vutuv_web/controllers/settings_controller.ex:664
 #, elixir-autogen, elixir-format
 msgid "Saved search deleted."
 msgstr "Gespeicherte Suche gelöscht."
 
 #: lib/vutuv_web/components/ui.ex:3665
-#: lib/vutuv_web/controllers/settings_controller.ex:555
+#: lib/vutuv_web/controllers/settings_controller.ex:556
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
 #, elixir-autogen, elixir-format
@@ -13766,8 +13766,8 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2156
 #: lib/vutuv_web/components/saved_search_components.ex:43
-#: lib/vutuv_web/controllers/settings_controller.ex:650
-#: lib/vutuv_web/controllers/settings_controller.ex:668
+#: lib/vutuv_web/controllers/settings_controller.ex:651
+#: lib/vutuv_web/controllers/settings_controller.ex:669
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "That did not work."
@@ -14215,7 +14215,7 @@ msgstr ""
 "Seite."
 
 #: lib/vutuv_web/components/ui.ex:3661
-#: lib/vutuv_web/controllers/settings_controller.ex:569
+#: lib/vutuv_web/controllers/settings_controller.ex:570
 #: lib/vutuv_web/live/post_live/feed.ex:1173
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
@@ -15026,7 +15026,7 @@ msgstr "Konto, zu dem Sie umziehen"
 msgid "Cancel redirect"
 msgstr "Weiterleitung aufheben"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:454
+#: lib/vutuv_web/controllers/settings_controller.ex:455
 #, elixir-autogen, elixir-format
 msgid "Done. Your Fediverse followers have been asked to follow your new account, and new posts are no longer federated from here. Your vutuv profile is unchanged."
 msgstr "Fertig. Ihre Fediverse-Follower wurden gebeten, Ihrem neuen Konto zu folgen, und neue Beiträge werden von hier nicht mehr föderiert. Ihr vutuv-Profil bleibt unverändert."
@@ -15041,12 +15041,12 @@ msgstr "Tragen Sie unten die Adresse dieses Kontos ein und leiten Sie weiter."
 msgid "On your other account, add your vutuv handle"
 msgstr "Fügen Sie auf Ihrem anderen Konto Ihr vutuv-Handle"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:493
+#: lib/vutuv_web/controllers/settings_controller.ex:494
 #, elixir-autogen, elixir-format
 msgid "Please enter the full https address of the account you are moving to."
 msgstr "Bitte geben Sie die vollständige https-Adresse des Kontos ein, zu dem Sie umziehen."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:479
+#: lib/vutuv_web/controllers/settings_controller.ex:480
 #, elixir-autogen, elixir-format
 msgid "Redirect cancelled. Your posts federate from here again."
 msgstr "Weiterleitung aufgehoben. Ihre Beiträge werden wieder von hier föderiert."
@@ -15061,17 +15061,17 @@ msgstr "Meine Follower weiterleiten"
 msgid "Redirected on %{date}"
 msgstr "Weitergeleitet am %{date}"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:506
+#: lib/vutuv_web/controllers/settings_controller.ex:507
 #, elixir-autogen, elixir-format
 msgid "That account could not be reached. Check the address, and that the other server is online."
 msgstr "Dieses Konto war nicht erreichbar. Prüfen Sie die Adresse und ob der andere Server online ist."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:500
+#: lib/vutuv_web/controllers/settings_controller.ex:501
 #, elixir-autogen, elixir-format
 msgid "That account does not list your vutuv profile as an alias yet. Add this profile's address there first, then try again."
 msgstr "Dieses Konto führt Ihr vutuv-Profil noch nicht als Alias. Fügen Sie dort zuerst die Adresse dieses Profils hinzu und versuchen Sie es dann erneut."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:496
+#: lib/vutuv_web/controllers/settings_controller.ex:497
 #, elixir-autogen, elixir-format
 msgid "That is this account. Enter the account you are moving to."
 msgstr "Das ist dieses Konto. Geben Sie das Konto an, zu dem Sie umziehen."
@@ -15081,12 +15081,12 @@ msgstr "Das ist dieses Konto. Geben Sie das Konto an, zu dem Sie umziehen."
 msgid "This tells your Fediverse followers to follow your new account instead, and stops federating your posts from here. Your vutuv profile is not affected. Continue?"
 msgstr "Damit werden Ihre Fediverse-Follower gebeten, stattdessen Ihrem neuen Konto zu folgen, und Ihre Beiträge werden von hier nicht mehr föderiert. Ihr vutuv-Profil ist nicht betroffen. Fortfahren?"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:484
+#: lib/vutuv_web/controllers/settings_controller.ex:485
 #, elixir-autogen, elixir-format
 msgid "Turn on federation first, then you can redirect your followers."
 msgstr "Schalten Sie zuerst die Föderation ein, dann können Sie Ihre Follower weiterleiten."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:488
+#: lib/vutuv_web/controllers/settings_controller.ex:489
 #, elixir-autogen, elixir-format
 msgid "You can only move once every %{days} days."
 msgstr "Sie können nur alle %{days} Tage umziehen."
@@ -15108,7 +15108,7 @@ msgstr[1] "%{formatted} Empfehlungen"
 msgid "All endorsers"
 msgstr "Alle Empfehlenden"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:594
+#: lib/vutuv_web/controllers/settings_controller.ex:595
 #, elixir-autogen, elixir-format
 msgid "Filter added. Matching posts are now hidden from your feed."
 msgstr "Filter hinzugefügt. Passende Beiträge sind jetzt in Ihrem Feed ausgeblendet."
@@ -15118,7 +15118,7 @@ msgstr "Filter hinzugefügt. Passende Beiträge sind jetzt in Ihrem Feed ausgebl
 msgid "Filter by a tag"
 msgstr "Nach einem Tag filtern"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:624
+#: lib/vutuv_web/controllers/settings_controller.ex:625
 #, elixir-autogen, elixir-format
 msgid "Filter removed."
 msgstr "Filter entfernt."
@@ -15139,7 +15139,7 @@ msgid "Match whole words only (word/phrase)"
 msgstr "Nur ganze Wörter treffen (Wort/Phrase)"
 
 #: lib/vutuv_web/components/ui.ex:3657
-#: lib/vutuv_web/controllers/settings_controller.ex:635
+#: lib/vutuv_web/controllers/settings_controller.ex:636
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
 #, elixir-autogen, elixir-format
@@ -15234,7 +15234,7 @@ msgstr "Sie dürfen den Benutzernamen dieser Organisation nicht ändern."
 msgid "You have not muted anything yet."
 msgstr "Sie haben noch nichts stummgeschaltet."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:602
+#: lib/vutuv_web/controllers/settings_controller.ex:603
 #, elixir-autogen, elixir-format
 msgid "You have reached the maximum of %{count} filters."
 msgstr "Sie haben das Maximum von %{count} Filtern erreicht."
@@ -15454,7 +15454,7 @@ msgstr "Verwandte Themen"
 msgid "Moving to or away from another Fediverse account?"
 msgstr "Ziehen Sie zu einem anderen Fediverse-Konto um oder von dort zu vutuv?"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:344
+#: lib/vutuv_web/controllers/settings_controller.ex:345
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:216
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:12
 #, elixir-autogen, elixir-format
@@ -19106,7 +19106,7 @@ msgstr "Meinen Namen bei Beiträgen zeigen, die mir gefallen"
 msgid "When off, other members no longer see you among the likes of a post. The author of the post still does: we named you in the notification they got when you liked it. Either way the post keeps the same number of likes."
 msgstr "Wenn aus, sehen andere Mitglieder Sie nicht mehr bei den Likes eines Beitrags. Die Autorin oder der Autor des Beitrags sieht es weiterhin: In der Benachrichtigung von damals haben wir Sie namentlich genannt. Der Beitrag hat in beiden Fällen gleich viele Likes."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:760
+#: lib/vutuv_web/controllers/settings_controller.ex:761
 #, elixir-autogen, elixir-format
 msgid "Your likes follow the site default again."
 msgstr "Ihre Likes folgen wieder dem Standardwert der Website."
@@ -19121,7 +19121,7 @@ msgstr "%{address} (nur diese Seite)"
 msgid "%{address} (whole website)"
 msgstr "%{address} (ganze Website)"
 
-#: lib/vutuv_web/markdown.ex:321
+#: lib/vutuv_web/markdown.ex:323
 #, elixir-autogen, elixir-format
 msgid "Verified webpage of the author (%{address})"
 msgstr "Verifizierte Webseite der Autorin oder des Autors (%{address})"
@@ -20206,9 +20206,9 @@ msgid "Always keep"
 msgstr "Immer behalten"
 
 #: lib/vutuv_web/components/ui.ex:3682
-#: lib/vutuv_web/controllers/settings_controller.ex:212
-#: lib/vutuv_web/controllers/settings_controller.ex:291
-#: lib/vutuv_web/controllers/settings_controller.ex:303
+#: lib/vutuv_web/controllers/settings_controller.ex:213
+#: lib/vutuv_web/controllers/settings_controller.ex:292
+#: lib/vutuv_web/controllers/settings_controller.ex:304
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:20
 #: lib/vutuv_web/views/account_event_text.ex:230
 #, elixir-autogen, elixir-format
@@ -20369,12 +20369,12 @@ msgid_plural "Saving this rule deletes %{formatted} posts straight away. This ca
 msgstr[0] "Mit dieser Regel wird %{count} Beitrag sofort gelöscht. Das lässt sich nicht rückgängig machen."
 msgstr[1] "Mit dieser Regel werden %{formatted} Beiträge sofort gelöscht. Das lässt sich nicht rückgängig machen."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:272
+#: lib/vutuv_web/controllers/settings_controller.ex:273
 #, elixir-autogen, elixir-format
 msgid "Settings saved."
 msgstr "Einstellungen gespeichert."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:275
+#: lib/vutuv_web/controllers/settings_controller.ex:276
 #, elixir-autogen, elixir-format
 msgid "Settings saved. %{count} post was deleted."
 msgid_plural "Settings saved. %{formatted} posts were deleted."
@@ -20916,32 +20916,32 @@ msgstr "Sie schreiben als %{name}."
 msgid "You are yourself again."
 msgstr "Sie sind wieder Sie selbst."
 
-#: lib/vutuv_web/live/organization_live/activity.ex:74
+#: lib/vutuv_web/live/organization_live/activity.ex:75
 #, elixir-autogen, elixir-format
 msgid "%{name} follows this page."
 msgstr "%{name} folgt dieser Seite."
 
-#: lib/vutuv_web/live/organization_live/activity.ex:77
+#: lib/vutuv_web/live/organization_live/activity.ex:78
 #, elixir-autogen, elixir-format
 msgid "%{name} liked a post."
 msgstr "%{name} gefällt ein Beitrag."
 
-#: lib/vutuv_web/live/organization_live/activity.ex:80
+#: lib/vutuv_web/live/organization_live/activity.ex:81
 #, elixir-autogen, elixir-format
 msgid "%{name} reposted a post."
 msgstr "%{name} hat einen Beitrag geteilt."
 
-#: lib/vutuv_web/live/organization_live/activity.ex:46
+#: lib/vutuv_web/live/organization_live/activity.ex:47
 #, elixir-autogen, elixir-format
 msgid "Activity – %{name}"
 msgstr "Aktivität – %{name}"
 
-#: lib/vutuv_web/live/organization_live/activity.ex:95
+#: lib/vutuv_web/live/organization_live/activity.ex:99
 #, elixir-autogen, elixir-format
 msgid "Nothing has happened yet."
 msgstr "Bisher ist nichts passiert."
 
-#: lib/vutuv_web/live/organization_live/activity.ex:90
+#: lib/vutuv_web/live/organization_live/activity.ex:94
 #, elixir-autogen, elixir-format
 msgid "What happened to this page. Everyone on the team sees the same list, and opening it marks it read for all of you."
 msgstr "Was auf dieser Seite passiert ist. Alle im Team sehen dieselbe Liste, und wer sie öffnet, markiert sie für alle als gelesen."
@@ -20952,3 +20952,8 @@ msgid "%{formatted} new"
 msgid_plural "%{formatted} new"
 msgstr[0] "%{formatted} neu"
 msgstr[1] "%{formatted} neu"
+
+#: lib/vutuv_web/live/organization_live/activity.ex:84
+#, elixir-autogen, elixir-format
+msgid "%{name} mentioned this page."
+msgstr "%{name} hat diese Seite erwähnt."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -473,7 +473,7 @@ msgid "Name"
 msgstr ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:636
-#: lib/vutuv_web/live/organization_live/activity.ex:112
+#: lib/vutuv_web/live/organization_live/activity.ex:116
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:3
@@ -1918,7 +1918,7 @@ msgid "Pagination"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3461
-#: lib/vutuv_web/live/organization_live/activity.ex:135
+#: lib/vutuv_web/live/organization_live/activity.ex:139
 #: lib/vutuv_web/live/organization_live/show.ex:498
 #, elixir-autogen, elixir-format
 msgid "Load more"
@@ -2837,7 +2837,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:220
 #: lib/vutuv_web/live/notification_live/index.ex:1035
-#: lib/vutuv_web/live/organization_live/activity.ex:88
+#: lib/vutuv_web/live/organization_live/activity.ex:92
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
@@ -5485,7 +5485,7 @@ msgstr ""
 msgid "Email addresses"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:536
+#: lib/vutuv_web/controllers/settings_controller.ex:537
 #, elixir-autogen, elixir-format
 msgid "Notification settings saved."
 msgstr ""
@@ -5512,7 +5512,7 @@ msgstr ""
 msgid "Privacy"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:188
+#: lib/vutuv_web/controllers/settings_controller.ex:189
 #, elixir-autogen, elixir-format
 msgid "Privacy settings saved."
 msgstr ""
@@ -5569,7 +5569,7 @@ msgstr ""
 msgid "Language & region"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:692
+#: lib/vutuv_web/controllers/settings_controller.ex:693
 #, elixir-autogen, elixir-format
 msgid "Language updated."
 msgstr ""
@@ -5651,7 +5651,7 @@ msgstr ""
 msgid "New followers"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:526
+#: lib/vutuv_web/controllers/settings_controller.ex:527
 #, elixir-autogen, elixir-format
 msgid "Notification settings"
 msgstr ""
@@ -5847,7 +5847,7 @@ msgid_plural "%{count} minutes ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:810
+#: lib/vutuv_web/controllers/settings_controller.ex:811
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr ""
@@ -5887,7 +5887,7 @@ msgstr ""
 msgid "Signed-in devices"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:797
+#: lib/vutuv_web/controllers/settings_controller.ex:798
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr ""
@@ -6244,7 +6244,7 @@ msgstr ""
 msgid "Default map"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:707
+#: lib/vutuv_web/controllers/settings_controller.ex:708
 #, elixir-autogen, elixir-format
 msgid "Map preferences saved."
 msgstr ""
@@ -8642,8 +8642,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:492
 #: lib/vutuv_web/components/ui.ex:3688
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
-#: lib/vutuv_web/controllers/settings_controller.ex:322
-#: lib/vutuv_web/controllers/settings_controller.ex:389
+#: lib/vutuv_web/controllers/settings_controller.ex:323
+#: lib/vutuv_web/controllers/settings_controller.ex:390
 #: lib/vutuv_web/live/fediverse_followers_live.ex:169
 #: lib/vutuv_web/live/fediverse_following_live.ex:286
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:341
@@ -8672,7 +8672,7 @@ msgstr ""
 msgid "as a link in your Mastodon profile settings, and Mastodon will show it as verified with a green check."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:402
+#: lib/vutuv_web/controllers/settings_controller.ex:403
 #, elixir-autogen, elixir-format
 msgid "Fediverse settings saved."
 msgstr ""
@@ -10555,7 +10555,7 @@ msgstr ""
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:720
+#: lib/vutuv_web/controllers/settings_controller.ex:721
 #, elixir-autogen, elixir-format
 msgid "Post display settings saved."
 msgstr ""
@@ -10604,7 +10604,7 @@ msgstr ""
 msgid "Installation default (%{value})"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:751
+#: lib/vutuv_web/controllers/settings_controller.ex:752
 #, elixir-autogen, elixir-format
 msgid "Map preferences reset to the site defaults."
 msgstr ""
@@ -10619,7 +10619,7 @@ msgstr ""
 msgid "Own value; blank the field to go back to the installation default."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:747
+#: lib/vutuv_web/controllers/settings_controller.ex:748
 #, elixir-autogen, elixir-format
 msgid "Post display settings reset to the site defaults."
 msgstr ""
@@ -11860,7 +11860,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/organization_doc.ex:108
 #: lib/vutuv_web/components/ui.ex:3719
-#: lib/vutuv_web/controllers/settings_controller.ex:178
+#: lib/vutuv_web/controllers/settings_controller.ex:179
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:501
@@ -12410,7 +12410,7 @@ msgstr ""
 msgid "Salary on request"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:360
+#: lib/vutuv_web/controllers/settings_controller.ex:361
 #: lib/vutuv_web/live/job_posting_live/form.ex:231
 #, elixir-autogen, elixir-format
 msgid "Saved."
@@ -13000,7 +13000,7 @@ msgstr[1] ""
 msgid "Alert frequency"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:645
+#: lib/vutuv_web/controllers/settings_controller.ex:646
 #, elixir-autogen, elixir-format
 msgid "Alert updated."
 msgstr ""
@@ -13068,13 +13068,13 @@ msgstr ""
 msgid "Save search"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:663
+#: lib/vutuv_web/controllers/settings_controller.ex:664
 #, elixir-autogen, elixir-format
 msgid "Saved search deleted."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3665
-#: lib/vutuv_web/controllers/settings_controller.ex:555
+#: lib/vutuv_web/controllers/settings_controller.ex:556
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
 #, elixir-autogen, elixir-format
@@ -13094,8 +13094,8 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2156
 #: lib/vutuv_web/components/saved_search_components.ex:43
-#: lib/vutuv_web/controllers/settings_controller.ex:650
-#: lib/vutuv_web/controllers/settings_controller.ex:668
+#: lib/vutuv_web/controllers/settings_controller.ex:651
+#: lib/vutuv_web/controllers/settings_controller.ex:669
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "That did not work."
@@ -13530,7 +13530,7 @@ msgid "Posts tagged with a tag you follow show up in your feed, and people known
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3661
-#: lib/vutuv_web/controllers/settings_controller.ex:569
+#: lib/vutuv_web/controllers/settings_controller.ex:570
 #: lib/vutuv_web/live/post_live/feed.ex:1173
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
@@ -14317,7 +14317,7 @@ msgstr ""
 msgid "Cancel redirect"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:454
+#: lib/vutuv_web/controllers/settings_controller.ex:455
 #, elixir-autogen, elixir-format
 msgid "Done. Your Fediverse followers have been asked to follow your new account, and new posts are no longer federated from here. Your vutuv profile is unchanged."
 msgstr ""
@@ -14332,12 +14332,12 @@ msgstr ""
 msgid "On your other account, add your vutuv handle"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:493
+#: lib/vutuv_web/controllers/settings_controller.ex:494
 #, elixir-autogen, elixir-format
 msgid "Please enter the full https address of the account you are moving to."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:479
+#: lib/vutuv_web/controllers/settings_controller.ex:480
 #, elixir-autogen, elixir-format
 msgid "Redirect cancelled. Your posts federate from here again."
 msgstr ""
@@ -14352,17 +14352,17 @@ msgstr ""
 msgid "Redirected on %{date}"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:506
+#: lib/vutuv_web/controllers/settings_controller.ex:507
 #, elixir-autogen, elixir-format
 msgid "That account could not be reached. Check the address, and that the other server is online."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:500
+#: lib/vutuv_web/controllers/settings_controller.ex:501
 #, elixir-autogen, elixir-format
 msgid "That account does not list your vutuv profile as an alias yet. Add this profile's address there first, then try again."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:496
+#: lib/vutuv_web/controllers/settings_controller.ex:497
 #, elixir-autogen, elixir-format
 msgid "That is this account. Enter the account you are moving to."
 msgstr ""
@@ -14372,12 +14372,12 @@ msgstr ""
 msgid "This tells your Fediverse followers to follow your new account instead, and stops federating your posts from here. Your vutuv profile is not affected. Continue?"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:484
+#: lib/vutuv_web/controllers/settings_controller.ex:485
 #, elixir-autogen, elixir-format
 msgid "Turn on federation first, then you can redirect your followers."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:488
+#: lib/vutuv_web/controllers/settings_controller.ex:489
 #, elixir-autogen, elixir-format
 msgid "You can only move once every %{days} days."
 msgstr ""
@@ -14399,7 +14399,7 @@ msgstr[1] ""
 msgid "All endorsers"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:594
+#: lib/vutuv_web/controllers/settings_controller.ex:595
 #, elixir-autogen, elixir-format
 msgid "Filter added. Matching posts are now hidden from your feed."
 msgstr ""
@@ -14409,7 +14409,7 @@ msgstr ""
 msgid "Filter by a tag"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:624
+#: lib/vutuv_web/controllers/settings_controller.ex:625
 #, elixir-autogen, elixir-format
 msgid "Filter removed."
 msgstr ""
@@ -14430,7 +14430,7 @@ msgid "Match whole words only (word/phrase)"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3657
-#: lib/vutuv_web/controllers/settings_controller.ex:635
+#: lib/vutuv_web/controllers/settings_controller.ex:636
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
 #, elixir-autogen, elixir-format
@@ -14523,7 +14523,7 @@ msgstr ""
 msgid "You have not muted anything yet."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:602
+#: lib/vutuv_web/controllers/settings_controller.ex:603
 #, elixir-autogen, elixir-format
 msgid "You have reached the maximum of %{count} filters."
 msgstr ""
@@ -14743,7 +14743,7 @@ msgstr ""
 msgid "Moving to or away from another Fediverse account?"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:344
+#: lib/vutuv_web/controllers/settings_controller.ex:345
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:216
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:12
 #, elixir-autogen, elixir-format
@@ -18346,7 +18346,7 @@ msgstr ""
 msgid "When off, other members no longer see you among the likes of a post. The author of the post still does: we named you in the notification they got when you liked it. Either way the post keeps the same number of likes."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:760
+#: lib/vutuv_web/controllers/settings_controller.ex:761
 #, elixir-autogen, elixir-format
 msgid "Your likes follow the site default again."
 msgstr ""
@@ -18361,7 +18361,7 @@ msgstr ""
 msgid "%{address} (whole website)"
 msgstr ""
 
-#: lib/vutuv_web/markdown.ex:321
+#: lib/vutuv_web/markdown.ex:323
 #, elixir-autogen, elixir-format
 msgid "Verified webpage of the author (%{address})"
 msgstr ""
@@ -19422,9 +19422,9 @@ msgid "Always keep"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3682
-#: lib/vutuv_web/controllers/settings_controller.ex:212
-#: lib/vutuv_web/controllers/settings_controller.ex:291
-#: lib/vutuv_web/controllers/settings_controller.ex:303
+#: lib/vutuv_web/controllers/settings_controller.ex:213
+#: lib/vutuv_web/controllers/settings_controller.ex:292
+#: lib/vutuv_web/controllers/settings_controller.ex:304
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:20
 #: lib/vutuv_web/views/account_event_text.ex:230
 #, elixir-autogen, elixir-format
@@ -19585,12 +19585,12 @@ msgid_plural "Saving this rule deletes %{formatted} posts straight away. This ca
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:272
+#: lib/vutuv_web/controllers/settings_controller.ex:273
 #, elixir-autogen, elixir-format
 msgid "Settings saved."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:275
+#: lib/vutuv_web/controllers/settings_controller.ex:276
 #, elixir-autogen, elixir-format
 msgid "Settings saved. %{count} post was deleted."
 msgid_plural "Settings saved. %{formatted} posts were deleted."
@@ -20132,32 +20132,32 @@ msgstr ""
 msgid "You are yourself again."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/activity.ex:74
+#: lib/vutuv_web/live/organization_live/activity.ex:75
 #, elixir-autogen, elixir-format
 msgid "%{name} follows this page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/activity.ex:77
+#: lib/vutuv_web/live/organization_live/activity.ex:78
 #, elixir-autogen, elixir-format
 msgid "%{name} liked a post."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/activity.ex:80
+#: lib/vutuv_web/live/organization_live/activity.ex:81
 #, elixir-autogen, elixir-format
 msgid "%{name} reposted a post."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/activity.ex:46
+#: lib/vutuv_web/live/organization_live/activity.ex:47
 #, elixir-autogen, elixir-format
 msgid "Activity – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/activity.ex:95
+#: lib/vutuv_web/live/organization_live/activity.ex:99
 #, elixir-autogen, elixir-format
 msgid "Nothing has happened yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/activity.ex:90
+#: lib/vutuv_web/live/organization_live/activity.ex:94
 #, elixir-autogen, elixir-format
 msgid "What happened to this page. Everyone on the team sees the same list, and opening it marks it read for all of you."
 msgstr ""
@@ -20168,3 +20168,8 @@ msgid "%{formatted} new"
 msgid_plural "%{formatted} new"
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/vutuv_web/live/organization_live/activity.ex:84
+#, elixir-autogen, elixir-format
+msgid "%{name} mentioned this page."
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -471,7 +471,7 @@ msgid "Name"
 msgstr ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:636
-#: lib/vutuv_web/live/organization_live/activity.ex:112
+#: lib/vutuv_web/live/organization_live/activity.ex:116
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:3
@@ -1916,7 +1916,7 @@ msgid "Pagination"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3461
-#: lib/vutuv_web/live/organization_live/activity.ex:135
+#: lib/vutuv_web/live/organization_live/activity.ex:139
 #: lib/vutuv_web/live/organization_live/show.ex:498
 #, elixir-autogen, elixir-format
 msgid "Load more"
@@ -2835,7 +2835,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:220
 #: lib/vutuv_web/live/notification_live/index.ex:1035
-#: lib/vutuv_web/live/organization_live/activity.ex:88
+#: lib/vutuv_web/live/organization_live/activity.ex:92
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
@@ -5483,7 +5483,7 @@ msgstr ""
 msgid "Email addresses"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:536
+#: lib/vutuv_web/controllers/settings_controller.ex:537
 #, elixir-autogen, elixir-format
 msgid "Notification settings saved."
 msgstr ""
@@ -5510,7 +5510,7 @@ msgstr ""
 msgid "Privacy"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:188
+#: lib/vutuv_web/controllers/settings_controller.ex:189
 #, elixir-autogen, elixir-format
 msgid "Privacy settings saved."
 msgstr ""
@@ -5567,7 +5567,7 @@ msgstr ""
 msgid "Language & region"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:692
+#: lib/vutuv_web/controllers/settings_controller.ex:693
 #, elixir-autogen, elixir-format
 msgid "Language updated."
 msgstr ""
@@ -5649,7 +5649,7 @@ msgstr ""
 msgid "New followers"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:526
+#: lib/vutuv_web/controllers/settings_controller.ex:527
 #, elixir-autogen, elixir-format
 msgid "Notification settings"
 msgstr ""
@@ -5845,7 +5845,7 @@ msgid_plural "%{count} minutes ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:810
+#: lib/vutuv_web/controllers/settings_controller.ex:811
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr ""
@@ -5885,7 +5885,7 @@ msgstr ""
 msgid "Signed-in devices"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:797
+#: lib/vutuv_web/controllers/settings_controller.ex:798
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr ""
@@ -6242,7 +6242,7 @@ msgstr ""
 msgid "Default map"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:707
+#: lib/vutuv_web/controllers/settings_controller.ex:708
 #, elixir-autogen, elixir-format
 msgid "Map preferences saved."
 msgstr ""
@@ -8640,8 +8640,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:492
 #: lib/vutuv_web/components/ui.ex:3688
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
-#: lib/vutuv_web/controllers/settings_controller.ex:322
-#: lib/vutuv_web/controllers/settings_controller.ex:389
+#: lib/vutuv_web/controllers/settings_controller.ex:323
+#: lib/vutuv_web/controllers/settings_controller.ex:390
 #: lib/vutuv_web/live/fediverse_followers_live.ex:169
 #: lib/vutuv_web/live/fediverse_following_live.ex:286
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:341
@@ -8670,7 +8670,7 @@ msgstr ""
 msgid "as a link in your Mastodon profile settings, and Mastodon will show it as verified with a green check."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:402
+#: lib/vutuv_web/controllers/settings_controller.ex:403
 #, elixir-autogen, elixir-format
 msgid "Fediverse settings saved."
 msgstr ""
@@ -10553,7 +10553,7 @@ msgstr ""
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:720
+#: lib/vutuv_web/controllers/settings_controller.ex:721
 #, elixir-autogen, elixir-format
 msgid "Post display settings saved."
 msgstr ""
@@ -10602,7 +10602,7 @@ msgstr ""
 msgid "Installation default (%{value})"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:751
+#: lib/vutuv_web/controllers/settings_controller.ex:752
 #, elixir-autogen, elixir-format
 msgid "Map preferences reset to the site defaults."
 msgstr ""
@@ -10617,7 +10617,7 @@ msgstr ""
 msgid "Own value; blank the field to go back to the installation default."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:747
+#: lib/vutuv_web/controllers/settings_controller.ex:748
 #, elixir-autogen, elixir-format
 msgid "Post display settings reset to the site defaults."
 msgstr ""
@@ -11858,7 +11858,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/organization_doc.ex:108
 #: lib/vutuv_web/components/ui.ex:3719
-#: lib/vutuv_web/controllers/settings_controller.ex:178
+#: lib/vutuv_web/controllers/settings_controller.ex:179
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:501
@@ -12408,7 +12408,7 @@ msgstr ""
 msgid "Salary on request"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:360
+#: lib/vutuv_web/controllers/settings_controller.ex:361
 #: lib/vutuv_web/live/job_posting_live/form.ex:231
 #, elixir-autogen, elixir-format
 msgid "Saved."
@@ -12998,7 +12998,7 @@ msgstr[1] ""
 msgid "Alert frequency"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:645
+#: lib/vutuv_web/controllers/settings_controller.ex:646
 #, elixir-autogen, elixir-format
 msgid "Alert updated."
 msgstr ""
@@ -13066,13 +13066,13 @@ msgstr ""
 msgid "Save search"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:663
+#: lib/vutuv_web/controllers/settings_controller.ex:664
 #, elixir-autogen, elixir-format
 msgid "Saved search deleted."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3665
-#: lib/vutuv_web/controllers/settings_controller.ex:555
+#: lib/vutuv_web/controllers/settings_controller.ex:556
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
 #, elixir-autogen, elixir-format
@@ -13092,8 +13092,8 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2156
 #: lib/vutuv_web/components/saved_search_components.ex:43
-#: lib/vutuv_web/controllers/settings_controller.ex:650
-#: lib/vutuv_web/controllers/settings_controller.ex:668
+#: lib/vutuv_web/controllers/settings_controller.ex:651
+#: lib/vutuv_web/controllers/settings_controller.ex:669
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "That did not work."
@@ -13528,7 +13528,7 @@ msgid "Posts tagged with a tag you follow show up in your feed, and people known
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3661
-#: lib/vutuv_web/controllers/settings_controller.ex:569
+#: lib/vutuv_web/controllers/settings_controller.ex:570
 #: lib/vutuv_web/live/post_live/feed.ex:1173
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
@@ -14315,7 +14315,7 @@ msgstr ""
 msgid "Cancel redirect"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:454
+#: lib/vutuv_web/controllers/settings_controller.ex:455
 #, elixir-autogen, elixir-format
 msgid "Done. Your Fediverse followers have been asked to follow your new account, and new posts are no longer federated from here. Your vutuv profile is unchanged."
 msgstr ""
@@ -14330,12 +14330,12 @@ msgstr ""
 msgid "On your other account, add your vutuv handle"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:493
+#: lib/vutuv_web/controllers/settings_controller.ex:494
 #, elixir-autogen, elixir-format
 msgid "Please enter the full https address of the account you are moving to."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:479
+#: lib/vutuv_web/controllers/settings_controller.ex:480
 #, elixir-autogen, elixir-format
 msgid "Redirect cancelled. Your posts federate from here again."
 msgstr ""
@@ -14350,17 +14350,17 @@ msgstr ""
 msgid "Redirected on %{date}"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:506
+#: lib/vutuv_web/controllers/settings_controller.ex:507
 #, elixir-autogen, elixir-format
 msgid "That account could not be reached. Check the address, and that the other server is online."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:500
+#: lib/vutuv_web/controllers/settings_controller.ex:501
 #, elixir-autogen, elixir-format
 msgid "That account does not list your vutuv profile as an alias yet. Add this profile's address there first, then try again."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:496
+#: lib/vutuv_web/controllers/settings_controller.ex:497
 #, elixir-autogen, elixir-format
 msgid "That is this account. Enter the account you are moving to."
 msgstr ""
@@ -14370,12 +14370,12 @@ msgstr ""
 msgid "This tells your Fediverse followers to follow your new account instead, and stops federating your posts from here. Your vutuv profile is not affected. Continue?"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:484
+#: lib/vutuv_web/controllers/settings_controller.ex:485
 #, elixir-autogen, elixir-format
 msgid "Turn on federation first, then you can redirect your followers."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:488
+#: lib/vutuv_web/controllers/settings_controller.ex:489
 #, elixir-autogen, elixir-format
 msgid "You can only move once every %{days} days."
 msgstr ""
@@ -14397,7 +14397,7 @@ msgstr[1] ""
 msgid "All endorsers"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:594
+#: lib/vutuv_web/controllers/settings_controller.ex:595
 #, elixir-autogen, elixir-format
 msgid "Filter added. Matching posts are now hidden from your feed."
 msgstr ""
@@ -14407,7 +14407,7 @@ msgstr ""
 msgid "Filter by a tag"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:624
+#: lib/vutuv_web/controllers/settings_controller.ex:625
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Filter removed."
 msgstr ""
@@ -14428,7 +14428,7 @@ msgid "Match whole words only (word/phrase)"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3657
-#: lib/vutuv_web/controllers/settings_controller.ex:635
+#: lib/vutuv_web/controllers/settings_controller.ex:636
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
 #, elixir-autogen, elixir-format
@@ -14521,7 +14521,7 @@ msgstr ""
 msgid "You have not muted anything yet."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:602
+#: lib/vutuv_web/controllers/settings_controller.ex:603
 #, elixir-autogen, elixir-format
 msgid "You have reached the maximum of %{count} filters."
 msgstr ""
@@ -14741,7 +14741,7 @@ msgstr ""
 msgid "Moving to or away from another Fediverse account?"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:344
+#: lib/vutuv_web/controllers/settings_controller.ex:345
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:216
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:12
 #, elixir-autogen, elixir-format
@@ -18344,7 +18344,7 @@ msgstr ""
 msgid "When off, other members no longer see you among the likes of a post. The author of the post still does: we named you in the notification they got when you liked it. Either way the post keeps the same number of likes."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:760
+#: lib/vutuv_web/controllers/settings_controller.ex:761
 #, elixir-autogen, elixir-format
 msgid "Your likes follow the site default again."
 msgstr ""
@@ -18359,7 +18359,7 @@ msgstr ""
 msgid "%{address} (whole website)"
 msgstr ""
 
-#: lib/vutuv_web/markdown.ex:321
+#: lib/vutuv_web/markdown.ex:323
 #, elixir-autogen, elixir-format
 msgid "Verified webpage of the author (%{address})"
 msgstr ""
@@ -19420,9 +19420,9 @@ msgid "Always keep"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3682
-#: lib/vutuv_web/controllers/settings_controller.ex:212
-#: lib/vutuv_web/controllers/settings_controller.ex:291
-#: lib/vutuv_web/controllers/settings_controller.ex:303
+#: lib/vutuv_web/controllers/settings_controller.ex:213
+#: lib/vutuv_web/controllers/settings_controller.ex:292
+#: lib/vutuv_web/controllers/settings_controller.ex:304
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:20
 #: lib/vutuv_web/views/account_event_text.ex:230
 #, elixir-autogen, elixir-format
@@ -19583,12 +19583,12 @@ msgid_plural "Saving this rule deletes %{formatted} posts straight away. This ca
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:272
+#: lib/vutuv_web/controllers/settings_controller.ex:273
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Settings saved."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:275
+#: lib/vutuv_web/controllers/settings_controller.ex:276
 #, elixir-autogen, elixir-format
 msgid "Settings saved. %{count} post was deleted."
 msgid_plural "Settings saved. %{formatted} posts were deleted."
@@ -20130,32 +20130,32 @@ msgstr ""
 msgid "You are yourself again."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/activity.ex:74
+#: lib/vutuv_web/live/organization_live/activity.ex:75
 #, elixir-autogen, elixir-format
 msgid "%{name} follows this page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/activity.ex:77
+#: lib/vutuv_web/live/organization_live/activity.ex:78
 #, elixir-autogen, elixir-format
 msgid "%{name} liked a post."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/activity.ex:80
+#: lib/vutuv_web/live/organization_live/activity.ex:81
 #, elixir-autogen, elixir-format
 msgid "%{name} reposted a post."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/activity.ex:46
+#: lib/vutuv_web/live/organization_live/activity.ex:47
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Activity – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/activity.ex:95
+#: lib/vutuv_web/live/organization_live/activity.ex:99
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing has happened yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/activity.ex:90
+#: lib/vutuv_web/live/organization_live/activity.ex:94
 #, elixir-autogen, elixir-format
 msgid "What happened to this page. Everyone on the team sees the same list, and opening it marks it read for all of you."
 msgstr ""
@@ -20166,3 +20166,8 @@ msgid "%{formatted} new"
 msgid_plural "%{formatted} new"
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/vutuv_web/live/organization_live/activity.ex:84
+#, elixir-autogen, elixir-format
+msgid "%{name} mentioned this page."
+msgstr ""

--- a/priv/repo/migrations/20260811070139_add_organization_to_post_mentions.exs
+++ b/priv/repo/migrations/20260811070139_add_organization_to_post_mentions.exs
@@ -1,0 +1,57 @@
+defmodule Vutuv.Repo.Migrations.AddOrganizationToPostMentions do
+  @moduledoc """
+  Issue #1336: a post may name an **organization** by its root handle, and the
+  page should learn about it.
+
+  The nullable pair with a CHECK, like `posts` and `follows` before it.
+
+  N-1 safe, and this time the walk the previous migrations earned found nothing
+  to fix: all four existing readers of this table (`Vutuv.Activity`'s
+  `mention_events/1` and the thread-precedence `NOT EXISTS`, plus the two
+  reconcile queries in `Vutuv.Posts`) compare `user_id` against a real member
+  id, so an organization row never matches one of them. No `NOT IN`, and no
+  inner join to `users` off the mention row.
+  """
+  use Ecto.Migration
+
+  def up do
+    alter table(:post_mentions) do
+      add(
+        :organization_id,
+        references(:organizations, type: :binary_id, on_delete: :delete_all)
+      )
+    end
+
+    execute("ALTER TABLE post_mentions ALTER COLUMN user_id DROP NOT NULL")
+
+    create(
+      constraint(:post_mentions, :post_mentions_exactly_one_target,
+        check: """
+        (CASE WHEN user_id IS NULL THEN 0 ELSE 1 END +
+         CASE WHEN organization_id IS NULL THEN 0 ELSE 1 END) = 1
+        """
+      )
+    )
+
+    # One row per post per page. The existing `[post_id, user_id]` unique index
+    # cannot stand in: an organization row leaves `user_id` NULL, and Postgres
+    # counts NULLs as distinct, so the `on_conflict: :nothing` reconcile would
+    # happily write the same mention twice.
+    create(unique_index(:post_mentions, [:post_id, :organization_id]))
+    # The page's own activity list reads this way round, newest first.
+    create(index(:post_mentions, [:organization_id, :inserted_at]))
+  end
+
+  def down do
+    drop(index(:post_mentions, [:organization_id, :inserted_at]))
+    drop(unique_index(:post_mentions, [:post_id, :organization_id]))
+    drop(constraint(:post_mentions, :post_mentions_exactly_one_target))
+
+    execute("DELETE FROM post_mentions WHERE user_id IS NULL")
+    execute("ALTER TABLE post_mentions ALTER COLUMN user_id SET NOT NULL")
+
+    alter table(:post_mentions) do
+      remove(:organization_id)
+    end
+  end
+end

--- a/test/vutuv/mention_notifications_test.exs
+++ b/test/vutuv/mention_notifications_test.exs
@@ -79,13 +79,20 @@ defmodule Vutuv.MentionNotificationsTest do
       assert kinds(mentioned.id) == %{}
     end
 
-    test "an organization handle notifies nobody (organizations have no feed)" do
+    test "an organization handle is recorded for the page, and pushes to no member" do
       author = mentionable()
       org = insert(:organization, username: unique_username())
 
       create_post!(author, %{body: "Now hiring at @#{org.username}."})
 
-      assert Repo.all(PostMention) == []
+      # It used to be recorded nowhere, on the grounds that organizations had no
+      # feed to read it in. They have one now (issue #1336), so the row exists
+      # and points at the page — but it is still a **member** id that is nil,
+      # and no member notification goes out: a page is nobody's mailbox.
+      assert [%PostMention{user_id: nil, organization_id: organization_id}] =
+               Repo.all(PostMention)
+
+      assert organization_id == org.id
     end
 
     test "an edit that adds a mention notifies the newly named member only" do

--- a/test/vutuv/organization_activity_test.exs
+++ b/test/vutuv/organization_activity_test.exs
@@ -62,6 +62,43 @@ defmodule Vutuv.OrganizationActivityTest do
     assert Enum.find(entries, &(&1.kind == "follow")).post == nil
   end
 
+  test "a post naming the page by its handle reaches its activity, and an edit undoes it" do
+    {organization, owner} = active_organization()
+    {:ok, organization} = Organizations.claim_handle(organization, %{"username" => "genanntag"})
+    author = insert(:activated_user)
+
+    {:ok, post} = Posts.create_post(author, %{body: "Schönes Ding von @genanntag."})
+
+    assert [%{kind: "mention", actor: actor, post: mentioned}] =
+             Organizations.activity_page(organization).entries
+
+    assert actor.id == author.id
+    assert mentioned.id == post.id
+    # The link the page's team clicks needs the post's own author preloaded.
+    assert Posts.path(mentioned) =~ author.username
+
+    # Editing the mention out takes the entry with it — the rows are a
+    # reconciled index of the body, never a log of what was once written.
+    {:ok, _} = Posts.update_post(post, %{body: "Schönes Ding."})
+    assert Organizations.activity_page(organization).entries == []
+
+    # The owner is untouched by all of this; it is the page that was named.
+    assert owner.id != author.id
+  end
+
+  test "the page naming itself is not news to its own team" do
+    {organization, owner} = active_organization()
+    {:ok, organization} = Organizations.claim_handle(organization, %{"username" => "selbstag"})
+    {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+
+    {:ok, _} =
+      Posts.create_organization_post(organization, owner, %{body: "Wir bei @selbstag freuen uns."})
+
+    # Its own post is already on the page above; a mention of itself inside it
+    # would be the same news twice.
+    assert Organizations.activity_page(organization).entries == []
+  end
+
   test "an event disappears with the row behind it" do
     {organization, owner} = publishing_organization()
     {:ok, post} = Posts.create_organization_post(organization, owner, %{body: "Kurz."})

--- a/test/vutuv_web/organization_activity_web_test.exs
+++ b/test/vutuv_web/organization_activity_web_test.exs
@@ -46,6 +46,20 @@ defmodule VutuvWeb.OrganizationActivityWebTest do
     refute has_element?(view, "[data-activity-new]")
   end
 
+  test "an entry that points at a post renders its link", %{conn: conn} do
+    {conn, owner} = create_and_login_user(conn)
+    organization = active_organization_for(owner)
+    {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+    {:ok, post} = Vutuv.Posts.create_organization_post(organization, owner, %{body: "Gefällt?"})
+    :ok = Vutuv.Posts.like_post(insert(:activated_user), post)
+
+    # `Posts.path/1` matches on the preloaded author, so an entry whose post
+    # arrived from a bare query would raise here rather than render.
+    {:ok, _view, html} = live(conn, ~p"/organizations/#{organization.slug}/activity")
+
+    assert html =~ Vutuv.Posts.path(post)
+  end
+
   test "an admin who is not a publisher still reaches it", %{conn: conn} do
     {conn, admin} = create_and_login_user(conn)
     owner = insert(:activated_user)


### PR DESCRIPTION
The second half of v7.246.0. `@acme` already linked; the page learned nothing. `post_mentions` gains a nullable `organization_id` with a CHECK — like `posts` and `follows` before it — and a mention now appears in the page's activity.

The rows are a reconciled index of the body, never a log: editing the mention out takes the entry with it. A page naming **itself** is not news to its own team — its post is already on the page above.

**The reader walk the earlier migrations made a rule found nothing this time**, which is worth saying out loud: all four existing readers of `post_mentions` compare `user_id` against a real member id, so an organization row matches none of them. No `NOT IN`, no inner join to `users` off the mention row.

### A bug I shipped in v7.245.0, found and fixed here

The activity list calls `Posts.path/1`, which matches on the **preloaded** author — and neither activity query preloaded one. **An entry carrying a post crashed the page.** My test for that PR only had a *follow* entry, and a follow carries no post, so it walked straight past it.

Both queries now attach the author with no extra query (the engagement one already holds the organization; the mention one already joins the post's author for its visibility gate), and there is a test for exactly that case.

### An obsolete test, updated rather than deleted

`"an organization handle notifies nobody (organizations have no feed)"` — that reasoning stopped being true when the activity list shipped. It now asserts the new behaviour: the row exists and points at the page, and still no member notification goes out. A page is nobody's mailbox.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*