### PR TITLE
Beiträge von Organisationen sind auffindbar (v7.247.0)

### DIFF
--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -1768,17 +1768,32 @@ defmodule Vutuv.Posts do
     # (no denials, unfrozen, non-hidden author); only the search-specific
     # filters stay here. Search keeps the stricter `email_confirmed? == true`
     # (not the confirmed-or-legacy-NULL gate) deliberately.
+    #
+    # Both joins are LEFT because a post has one of two kinds of author (issue
+    # #1334) and the `where` below then says which one this row must satisfy.
+    # An inner join to `users` was what kept every organization post out of
+    # search — silently, since a missing result looks like a missing post.
+    #
+    # `scope_visible(nil)` needs nothing added for them: an organization post
+    # carries no denials, and the author-hidden arm reads the left-joined row
+    # with `IS NOT NULL` tests, which are `false` (never NULL) on the absent
+    # row — so the post passes rather than being swallowed by three-valued
+    # logic. The page's own standing is the `organization_public_row/1` below.
     from(p in Post,
       as: :post,
-      join: u in assoc(p, :user),
+      left_join: u in assoc(p, :user),
       as: :author,
-      where: u.email_confirmed? == true
+      left_join: o in assoc(p, :organization),
+      as: :search_organization,
+      where:
+        (not is_nil(p.user_id) and u.email_confirmed? == true) or
+          (not is_nil(p.organization_id) and organization_public_row(o))
     )
     |> filter_body_search(value)
     |> filter_posts_by_tag(tag, Keyword.get(opts, :exact, false))
     |> order_public_search(value)
     |> limit(^limit)
-    |> preload([p, u], user: u)
+    |> preload([author: u, search_organization: o], user: u, organization: o)
     |> scope_visible(nil)
     |> Repo.all()
   end

--- a/lib/vutuv_web/live/search_live.ex
+++ b/lib/vutuv_web/live/search_live.ex
@@ -20,8 +20,12 @@ defmodule VutuvWeb.SearchLive do
 
   import VutuvWeb.SavedSearchComponents
 
+  import VutuvWeb.OrganizationComponents, only: [organization_logo: 1]
+
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.RemoteFollow
+  alias Vutuv.Organizations
+  alias Vutuv.Organizations.Organization
   alias Vutuv.Posts
   alias Vutuv.Search
   alias VutuvWeb.UserHelpers
@@ -370,6 +374,22 @@ defmodule VutuvWeb.SearchLive do
     """
   end
 
+  # Where a result's author link goes and what it reads, for whichever kind of
+  # author the post has (issue #1334).
+  defp author_path(post) do
+    case Posts.author(post) do
+      %Organization{} = organization -> Organizations.canonical_path(organization)
+      author -> "/" <> author.username
+    end
+  end
+
+  defp author_name(post) do
+    case Posts.author(post) do
+      %Organization{name: name} -> name
+      author -> UserHelpers.full_name(author)
+    end
+  end
+
   @impl true
   def render(assigns) do
     ~H"""
@@ -532,16 +552,32 @@ defmodule VutuvWeb.SearchLive do
           </.section_title>
           <ul class="mt-4 divide-y divide-slate-100 dark:divide-slate-800">
             <li :for={post <- @results.posts} class="flex items-start gap-3 py-4 first:pt-0 last:pb-0">
-              <.avatar user={post.user} size="sm" shape="circle" presence />
+              <%!-- A post is by a member or by an organization (issue #1334):
+              an organization wears its logo and has no @handle line beside its
+              name, which it may never have claimed. --%>
+              <.organization_logo
+                :if={Posts.organization_post?(post)}
+                organization={post.organization}
+                class="h-8 w-8"
+              />
+              <.avatar
+                :if={!Posts.organization_post?(post)}
+                user={post.user}
+                size="sm"
+                shape="circle"
+                presence
+              />
               <div class="min-w-0">
                 <p class="mb-0 text-sm">
                   <.link
-                    href={~p"/#{post.user}"}
+                    href={author_path(post)}
                     class="font-medium text-slate-800 hover:text-brand-700 dark:text-slate-100"
                   >
-                    {UserHelpers.full_name(post.user)}
+                    {author_name(post)}
                   </.link>
-                  <span class="text-slate-600 dark:text-slate-400">@{post.user.username}</span>
+                  <span :if={!Posts.organization_post?(post)} class="text-slate-600 dark:text-slate-400">
+                    @{post.user.username}
+                  </span>
                   <span class="text-slate-600 dark:text-slate-400">· {post.published_on}</span>
                 </p>
                 <.link

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.246.2",
+      version: "7.247.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/organization_post_search_test.exs
+++ b/test/vutuv/organization_post_search_test.exs
@@ -1,0 +1,91 @@
+defmodule Vutuv.OrganizationPostSearchTest do
+  @moduledoc """
+  Organization posts in public search (issues #1334, #1336).
+
+  They were absent, and absent in the way that is hardest to notice: the query
+  inner-joined `users` to gate on the author's confirmed address, so a post with
+  no member author matched nothing. A missing search result looks like a missing
+  post, not like a bug.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Organizations
+  alias Vutuv.Posts
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp publishing_organization(overrides \\ %{}) do
+    {organization, owner} = active_organization(overrides)
+    {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+    {organization, owner}
+  end
+
+  defp found_ids(term), do: term |> Posts.search_public() |> Enum.map(& &1.id)
+
+  test "a page's post is findable, with its author preloaded for rendering" do
+    {organization, owner} = publishing_organization()
+
+    {:ok, post} =
+      Posts.create_organization_post(organization, owner, %{body: "Quantenkompressor gebaut."})
+
+    assert [found] = Posts.search_public("Quantenkompressor")
+    assert found.id == post.id
+
+    # The results page names and links the author, so the row has to carry one.
+    assert found.organization.id == organization.id
+    assert Posts.path(found) =~ organization.slug
+  end
+
+  test "member posts are unaffected, and both kinds come back together" do
+    member = insert(:activated_user)
+    {:ok, mine} = Posts.create_post(member, %{body: "Quantenkompressor privat."})
+
+    {organization, owner} = publishing_organization()
+
+    {:ok, theirs} =
+      Posts.create_organization_post(organization, owner, %{body: "Quantenkompressor bei uns."})
+
+    ids = found_ids("Quantenkompressor")
+    assert mine.id in ids
+    assert theirs.id in ids
+  end
+
+  test "a page that is not public keeps its posts out of search" do
+    {organization, owner} = publishing_organization()
+
+    {:ok, post} =
+      Posts.create_organization_post(organization, owner, %{body: "Quantenkompressor."})
+
+    assert post.id in found_ids("Quantenkompressor")
+
+    # Frozen by moderation: the page is off the public site, and so is what it
+    # said. The member equivalent is a hidden author's posts vanishing.
+    {:ok, _} = Organizations.admin_set_frozen(organization, true)
+    refute post.id in found_ids("Quantenkompressor")
+  end
+
+  test "a post still held by the image scan is not findable either" do
+    {organization, owner} = publishing_organization()
+
+    {:ok, post} =
+      Posts.create_organization_post(organization, owner, %{body: "Quantenkompressor."})
+
+    Repo.update!(Ecto.Changeset.change(post, images_pending?: true))
+
+    refute post.id in found_ids("Quantenkompressor")
+  end
+end

--- a/test/vutuv_web/organization_posts_web_test.exs
+++ b/test/vutuv_web/organization_posts_web_test.exs
@@ -201,6 +201,26 @@ defmodule VutuvWeb.OrganizationPostsWebTest do
     end
   end
 
+  describe "public search" do
+    test "the results page renders an organization row without a member author",
+         %{conn: conn} do
+      owner = insert(:activated_user)
+      organization = active_organization_for(owner)
+      {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+
+      {:ok, _} =
+        Posts.create_organization_post(organization, owner, %{body: "Quantenkompressor."})
+
+      # The query change is only half of it: the last three crashes in this
+      # milestone were all a page reading `post.user` on an organization post,
+      # so the row has to draw as well as be found.
+      {:ok, _view, html} = live(conn, ~p"/search?q=Quantenkompressor")
+
+      assert html =~ organization.name
+      assert html =~ "Quantenkompressor"
+    end
+  end
+
   describe "replies" do
     test "an organization post cannot be answered yet", %{conn: _conn} do
       owner = insert(:activated_user)


### PR DESCRIPTION
`search_public/2` inner-joined `users` to check the author's confirmed address, so a post with no member author matched nothing. That is the most unpleasant way to be missing: an absent result looks like an absent post, not like a bug. A company published news that search did not know about.

Both joins are LEFT now, and the `where` says which kind of author the row must satisfy. **`scope_visible(nil)` needed nothing added:** an organization post carries no denials, and the author-hidden arm reads the empty left-joined row with `IS NOT NULL` tests, which are `false` there rather than `NULL` — so the row is not swallowed by three-valued logic. The page's own standing is `organization_public_row/1`, so a frozen page takes its posts out of search with it.

**The query is only half of it.** The last three crashes in this milestone were all a page reading `post.user` on an organization post, so the result row now draws too: the logo instead of an avatar, the page's name, and no `@handle` line beside it — a page may never have claimed one. There is a test for the rendering, not only for the finding.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*