### PR TITLE
Löschen eines Organisationsbeitrags stürzte ab (v7.247.1)

### DIFF
--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -473,7 +473,7 @@ defmodule Vutuv.Posts do
         if post.screenshot, do: Screenshots.delete(post.screenshot)
         # Same for a book review's fetched cover files.
         if post.review, do: ReviewCovers.delete_files(post.review)
-        broadcast_post_deleted(post.id, post.user_id)
+        broadcast_post_deleted(post.id, deletion_recipients(post))
         if parent_id, do: broadcast_reply_count(parent_id)
         # Deleting reported content settles its moderation case.
         Vutuv.Moderation.content_deleted(deleted)
@@ -4964,6 +4964,26 @@ defmodule Vutuv.Posts do
     event = {:post_deleted, %{post_id: post_id}}
     Phoenix.PubSub.broadcast(Vutuv.PubSub, post_topic(post_id), event)
     Enum.each(recipient_ids, &Vutuv.Activity.broadcast(&1, event))
+  end
+
+  # Whose open feed has to drop this entry. A member's post reaches them and
+  # their followers; an organization post reaches the people who follow the
+  # **page** (issue #1336) — it never sat in the publishers' own feeds, so
+  # there is nobody else to tell. Without this clause a nil author matched
+  # neither head and deleting an organization post raised (issue #1334).
+  defp deletion_recipients(%Post{organization_id: id}) when is_binary(id),
+    do: organization_follower_ids(id)
+
+  defp deletion_recipients(%Post{user_id: user_id}),
+    do: [user_id | follower_ids(user_id)]
+
+  defp organization_follower_ids(organization_id) do
+    Repo.all(
+      from(f in Follow,
+        where: f.followee_organization_id == ^organization_id,
+        select: f.follower_id
+      )
+    )
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.247.0",
+      version: "7.247.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/organization_post_edit_delete_test.exs
+++ b/test/vutuv_web/organization_post_edit_delete_test.exs
@@ -1,0 +1,98 @@
+defmodule VutuvWeb.OrganizationPostEditDeleteTest do
+  @moduledoc """
+  Editing and deleting a post published in an organization's name (issue #1334).
+
+  The post card already offered both controls to a publisher — `Posts.author?/2`
+  says yes for them — so these were live buttons from the day organization posts
+  shipped. Delete raised: `broadcast_post_deleted/2` matched on a binary author
+  id or a list, and an organization post has neither.
+
+  Both powers follow the **role**, not the person: any current publisher may
+  edit or delete, including one who did not write the post.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Organizations
+  alias Vutuv.Posts
+  alias Vutuv.Social
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp setup_post(conn) do
+    {conn, owner} = create_and_login_user(conn)
+    organization = active_organization_for(owner)
+    {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+    {:ok, post} = Posts.create_organization_post(organization, owner, %{body: "Erste Fassung."})
+    %{conn: conn, owner: owner, organization: organization, post: post}
+  end
+
+  test "a publisher opens the edit page and saves", %{conn: conn} do
+    %{conn: conn, post: post} = setup_post(conn)
+
+    {:ok, view, html} = live(conn, ~p"/posts/#{post.id}/edit")
+    assert html =~ "Erste Fassung."
+
+    view
+    |> form("#composer-form", %{"post" => %{"body" => "Zweite Fassung."}})
+    |> render_submit()
+
+    assert Posts.get_post(post.id).body == "Zweite Fassung."
+  end
+
+  test "a publisher deletes it, and the page's followers are told", %{conn: conn} do
+    %{conn: conn, post: post, organization: organization} = setup_post(conn)
+
+    follower = insert(:activated_user)
+    {:ok, _} = Social.follow_organization(follower, organization)
+    Vutuv.Activity.subscribe(follower.id)
+
+    conn = delete(conn, ~p"/posts/#{post.id}")
+    assert redirected_to(conn)
+    refute Posts.get_post(post.id)
+
+    # Their open feed has to drop the card. The recipients of an organization
+    # post's deletion are the people who follow the page — the publishers never
+    # had it in their own feeds.
+    post_id = post.id
+    assert_receive {:post_deleted, %{post_id: ^post_id}}
+  end
+
+  test "a publisher who did not write it may still delete it", %{conn: conn} do
+    {conn, other} = create_and_login_user(conn)
+    author = insert(:activated_user)
+    organization = active_organization_for(author)
+    {:ok, _} = Organizations.add_role(organization, author, "publisher", author)
+    {:ok, _} = Organizations.add_role(organization, other, "publisher", author)
+    {:ok, post} = Posts.create_organization_post(organization, author, %{body: "Von der Seite."})
+
+    conn = delete(conn, ~p"/posts/#{post.id}")
+    assert redirected_to(conn)
+    refute Posts.get_post(post.id)
+  end
+
+  test "somebody off the team cannot delete it", %{conn: conn} do
+    {stranger_conn, _stranger} = create_and_login_user(conn)
+    owner = insert(:activated_user)
+    organization = active_organization_for(owner)
+    {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+    {:ok, post} = Posts.create_organization_post(organization, owner, %{body: "Unseres."})
+
+    stranger_conn |> delete(~p"/posts/#{post.id}") |> response(404)
+    assert Posts.get_post(post.id)
+  end
+end


### PR DESCRIPTION
The post card offers Edit and Delete to a publisher on an organization post — `Posts.author?/2` says yes for them — so these have been **live buttons since v7.240.0**. Edit worked. Delete raised: `broadcast_post_deleted/2` matches a binary author id or a list, and an organization post has neither.

**The obvious fix would have been the wrong one.** Guarding nil and moving on would have been quiet and incorrect, because there *are* recipients: since v7.242.0 members can follow a page, and their open feed has to drop the card. So the recipients of an organization post's deletion are the **page's followers** — it never sat in the publishers' own feeds, so there is nobody else to tell. The test subscribes a follower and asserts the event arrives.

Both powers still follow the **role, not the person**: any current publisher may delete, including one who did not write it. Somebody off the team gets a 404.

Walked into a documented trap while writing it: the private helpers landed *between* the two clauses of `broadcast_post_deleted/2`, splitting the clause group, which `--warnings-as-errors` rightly refuses (`.claude/rules/phoenix.md`). They sit below the last clause now.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*