### PR TITLE
Ein geteilter Organisationsbeitrag kam nirgends an (v7.247.2)

### DIFF
--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -2185,11 +2185,22 @@ defmodule Vutuv.Posts do
       on: r.post_id == p.id,
       join: reposter in User,
       on: reposter.id == r.user_id,
-      join: u in assoc(p, :user),
+      # LEFT, because the reposted post may have been published by an
+      # organization (issue #1334). An inner join here meant a member could
+      # repost a page's news and it reached nobody — the act succeeded and its
+      # whole point silently did not.
+      left_join: u in assoc(p, :user),
       as: :author,
+      left_join: o in assoc(p, :organization),
+      as: :repost_organization,
       where: r.user_id == ^viewer_id or r.user_id in subquery(followees_of(viewer_id)),
       where: r.user_id == ^viewer_id or account_confirmed_row(reposter),
-      where: p.user_id == ^viewer_id or account_confirmed_row(u),
+      # A repost must not amplify an author the site hides. For a member that is
+      # their account standing; for a page it is the page's own
+      # (`organization_public_row/1`), so a frozen page stops being passed on.
+      where:
+        (not is_nil(p.user_id) and (p.user_id == ^viewer_id or account_confirmed_row(u))) or
+          (not is_nil(p.organization_id) and organization_public_row(o)),
       # A third party's repost must not carry a blocked author's post into
       # the viewer's feed (the direct path is already cut: blocking severed
       # the follow).
@@ -3870,8 +3881,13 @@ defmodule Vutuv.Posts do
         join: e in ^schema,
         as: :engagement,
         on: e.post_id == p.id,
-        join: a in assoc(p, :user),
+        # LEFT for the same reason as the repost source: a bookmarked
+        # organization post used to vanish from the saved list, and an empty
+        # saved list looks exactly like an empty saved list.
+        left_join: a in assoc(p, :user),
         as: :author,
+        left_join: o in assoc(p, :organization),
+        as: :engaged_organization,
         where: e.user_id == ^user_id,
         select: {p, e.inserted_at, e.id}
       )
@@ -3893,8 +3909,14 @@ defmodule Vutuv.Posts do
   defp filter_engaged_search(query, term) do
     pattern = contains(term)
 
-    from([p, author: a] in query,
-      where: ilike(p.body, ^pattern) or name_ilike(a.first_name, a.last_name, ^pattern)
+    # The page's name is searchable beside the member's: somebody looking for
+    # what they saved from a company types the company. Without the third arm
+    # an organization post could only be found by its body, which is the same
+    # silent half-answer the inner join used to give.
+    from([p, author: a, engaged_organization: o] in query,
+      where:
+        ilike(p.body, ^pattern) or name_ilike(a.first_name, a.last_name, ^pattern) or
+          ilike(o.name, ^pattern)
     )
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.247.1",
+      version: "7.247.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/organization_post_engagement_surfaces_test.exs
+++ b/test/vutuv/organization_post_engagement_surfaces_test.exs
@@ -1,0 +1,102 @@
+defmodule Vutuv.OrganizationPostEngagementSurfacesTest do
+  @moduledoc """
+  Where an organization post shows up **after** somebody engages with it
+  (issues #1334, #1336).
+
+  v7.242.1 made liking, reposting and bookmarking one work. What it did not
+  check is whether the result then appears anywhere, and two queries inner-join
+  `users` on the post's author — so the acts succeeded and their consequences
+  vanished. Silent in both cases: an empty saved list looks like an empty saved
+  list.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Organizations
+  alias Vutuv.Posts
+  alias Vutuv.Social
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp organization_post(body \\ "Von der Seite.") do
+    {organization, owner} = active_organization()
+    {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+    {:ok, post} = Posts.create_organization_post(organization, owner, %{body: body})
+    {organization, post}
+  end
+
+  defp feed_ids(member) do
+    member |> Posts.feed_page() |> Map.fetch!(:entries) |> Enum.map(& &1.post.id)
+  end
+
+  test "a repost of an organization post reaches the reposter's followers" do
+    {_organization, post} = organization_post()
+    reposter = insert(:activated_user)
+    reader = insert(:activated_user)
+    {:ok, _} = Social.follow(reader, reposter.id)
+
+    :ok = Posts.repost_post(reposter, post)
+
+    # Reposting is how a member passes a page's news on. Without it the act
+    # succeeded and reached nobody.
+    assert post.id in feed_ids(reader)
+    # …and the reposter sees their own.
+    assert post.id in feed_ids(reposter)
+  end
+
+  test "a frozen page's post is not amplified by a repost" do
+    {organization, post} = organization_post()
+    reposter = insert(:activated_user)
+    reader = insert(:activated_user)
+    {:ok, _} = Social.follow(reader, reposter.id)
+    :ok = Posts.repost_post(reposter, post)
+
+    assert post.id in feed_ids(reader)
+
+    {:ok, _} = Organizations.admin_set_frozen(organization, true)
+    refute post.id in feed_ids(reader)
+  end
+
+  test "a bookmarked organization post appears on the saved page" do
+    {organization, post} = organization_post("Zum Merken.")
+    member = insert(:activated_user)
+
+    :ok = Posts.bookmark_post(member, post)
+
+    ids = member |> Posts.bookmarked_posts_page() |> Map.fetch!(:entries) |> Enum.map(& &1.id)
+    assert post.id in ids
+
+    # …and it is findable there by the page's name, not only by its body.
+    found =
+      member
+      |> Posts.bookmarked_posts_page(search: organization.name)
+      |> Map.fetch!(:entries)
+      |> Enum.map(& &1.id)
+
+    assert post.id in found
+  end
+
+  test "the saved page still lists a bookmarked member post" do
+    author = insert(:activated_user)
+    {:ok, post} = Posts.create_post(author, %{body: "Von einem Menschen."})
+    member = insert(:activated_user)
+
+    :ok = Posts.bookmark_post(member, post)
+
+    ids = member |> Posts.bookmarked_posts_page() |> Map.fetch!(:entries) |> Enum.map(& &1.id)
+    assert post.id in ids
+  end
+end


### PR DESCRIPTION
v7.242.1 made liking, reposting and bookmarking an organization post work. What it did not check is whether the **result** then appears anywhere — and two queries inner-join `users` on the post's author. So the act succeeded and its consequence vanished.

- **Reposting a page's post reached nobody.** The reposter's followers' feed dropped it, which is the entire point of a repost.
- **A bookmarked organization post was missing from the saved list.** Silent, and an empty saved list looks exactly like an empty saved list.

Both joins are LEFT now, with a `where` saying which kind of author the row must satisfy. The repost rule is preserved rather than dropped: a repost must not amplify an author the site hides — for a member that is their account standing, for a page its own, so a frozen page stops being passed on. There is a test for that direction too.

The saved list also **searches the page's name** now. Somebody looking for what they saved from a company types the company; without that arm an organization post would only be findable by its body — the same half-answer the inner join was already giving.

This is the third and fourth instance of one shape in this milestone: a query that reaches the author through `users`. The ones found so far were an inner join (this, search, the mention list) or a `NOT IN` over a nullable column (the feed, the discovery rail). Both fail silently, which is why they need looking for rather than waiting for.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*