### PR TITLE
Ein getaggter Organisationsbeitrag stand auf keiner Tag-Seite (v7.247.3)

### DIFF
--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -1875,13 +1875,21 @@ defmodule Vutuv.Posts do
         ^from(ph in PostHashtag, select: %{post_id: ph.post_id, tag_id: ph.tag_id})
       )
 
+    # LEFT joins, because a page files posts under tags exactly as a member
+    # does — a `#hashtag` in the body writes the same `post_hashtags` row. With
+    # an inner join to `users` the filing happened and the tag page did not show
+    # it, which is the worst of the two states: the data says it is there.
     from(p in Post,
-      join: u in assoc(p, :user),
+      left_join: u in assoc(p, :user),
       as: :author,
+      left_join: o in assoc(p, :organization),
+      as: :tag_organization,
       join: pt in subquery(filings),
       as: :post_tag,
       on: pt.post_id == p.id,
-      where: u.email_confirmed? == true
+      where:
+        (not is_nil(p.user_id) and u.email_confirmed? == true) or
+          (not is_nil(p.organization_id) and organization_public_row(o))
     )
     |> scope_visible(nil)
   end
@@ -2239,12 +2247,12 @@ defmodule Vutuv.Posts do
 
         from(p in Post,
           as: :post,
-          join: u in assoc(p, :user),
+          left_join: u in assoc(p, :user),
           as: :author,
-          where: p.user_id != ^viewer_id,
-          where: p.user_id not in subquery(all_followees_of(viewer_id)),
-          where: p.user_id not in subquery(blocked_either_way(viewer_id)),
-          where: account_confirmed_row(u),
+          left_join: o in assoc(p, :organization),
+          as: :tag_organization,
+          where: ^tag_source_member_gate(viewer_id),
+          where: ^tag_source_organization_gate(viewer_id),
           where: exists(subquery(tag_match)),
           order_by: [desc: p.inserted_at, desc: p.id],
           limit: ^fetch_n
@@ -2268,6 +2276,47 @@ defmodule Vutuv.Posts do
     from(c in Follow,
       where: c.follower_id == ^viewer_id and c.muted == false and not is_nil(c.followee_id),
       select: c.followee_id
+    )
+  end
+
+  # "Somebody new to me, whom I am allowed to see", for a post written by a
+  # member. Guarded by `is_nil(p.user_id)` first, because `NULL != id` and
+  # `NULL NOT IN (…)` are both NULL: without the guard all three conditions
+  # would read false on an organization post and drop it — three separate
+  # silent exclusions in one query.
+  defp tag_source_member_gate(viewer_id) do
+    dynamic(
+      [post: p, author: u],
+      is_nil(p.user_id) or
+        (p.user_id != ^viewer_id and
+           p.user_id not in subquery(all_followees_of(viewer_id)) and
+           p.user_id not in subquery(blocked_either_way(viewer_id)) and
+           account_confirmed_row(u))
+    )
+  end
+
+  # The same rule for a post written by a page: it must be public, and it must
+  # not be one I already follow — a page I follow reaches me through
+  # `feed_organization_post_items/3`, so letting its tagged posts in here too
+  # would show them twice. Muted follows count as followed, exactly as
+  # `all_followees_of/1` treats members.
+  defp tag_source_organization_gate(viewer_id) do
+    dynamic(
+      [post: p, tag_organization: o],
+      is_nil(p.organization_id) or
+        (organization_public_row(o) and
+           p.organization_id not in subquery(all_followed_organizations_of(viewer_id)))
+    )
+  end
+
+  # Every page the viewer follows, muted or not — the dedupe set for the tag
+  # source, the organization twin of `all_followees_of/1`. Muting a page means
+  # "not in my feed", so a muted page's tagged post must not sneak back in by
+  # the side door.
+  defp all_followed_organizations_of(viewer_id) do
+    from(c in Follow,
+      where: c.follower_id == ^viewer_id and not is_nil(c.followee_organization_id),
+      select: c.followee_organization_id
     )
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.247.2",
+      version: "7.247.3",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/organization_post_tags_test.exs
+++ b/test/vutuv/organization_post_tags_test.exs
@@ -1,0 +1,122 @@
+defmodule Vutuv.OrganizationPostTagsTest do
+  @moduledoc """
+  An organization post reaching the tags it files itself under (issues #1334,
+  #1336).
+
+  A `#hashtag` in the body already writes its `post_hashtags` row — filing has
+  worked all along — but the two queries that *read* those filings inner-join
+  `users` on the post's author, so a page could tag a post and the tag page
+  would not show it. Filed and invisible is the worst of the two states: the
+  data says it is there.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Organizations
+  alias Vutuv.Posts
+  alias Vutuv.Repo
+  alias Vutuv.Tags
+  alias Vutuv.Tags.Tag
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  # A `#hashtag` files a post only against a tag that already exists, so each
+  # test mints its own first. Hardcoded literals are safe here because the
+  # module is `async: false` (see the tag-uniqueness rule in the Elixir rules).
+  defp tag!(slug), do: insert(:tag, name: slug, slug: slug)
+
+  # Filed through the composer's tag field, which is what the tag feed reads.
+  defp tagged_organization_post_with_tag(tag_name) do
+    {organization, owner} = active_organization()
+    {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+
+    {:ok, post} =
+      Posts.create_organization_post(organization, owner, %{
+        body: "Wir bauen etwas.",
+        tags: tag_name
+      })
+
+    {organization, post}
+  end
+
+  defp tagged_organization_post(hashtag) do
+    tag!(hashtag)
+    {organization, owner} = active_organization()
+    {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+
+    {:ok, post} =
+      Posts.create_organization_post(organization, owner, %{body: "Wir bauen mit ##{hashtag}."})
+
+    {organization, post}
+  end
+
+  defp tag_post_ids(tag) do
+    tag |> Posts.tag_posts_query() |> Repo.all() |> Enum.map(& &1.id)
+  end
+
+  test "the post is filed under its hashtag and the tag page shows it" do
+    {_organization, post} = tagged_organization_post("orgtagtest")
+    tag = Repo.get_by!(Tag, slug: "orgtagtest")
+
+    # Filing already worked; being read back is what did not.
+    assert tag
+    assert post.id in tag_post_ids(tag)
+  end
+
+  test "a frozen page takes its tagged posts off the tag page" do
+    {organization, post} = tagged_organization_post("frozentagtest")
+    tag = Repo.get_by!(Tag, slug: "frozentagtest")
+
+    assert post.id in tag_post_ids(tag)
+
+    {:ok, _} = Organizations.admin_set_frozen(organization, true)
+    refute post.id in tag_post_ids(tag)
+  end
+
+  test "a followed tag brings a page's post into the feed" do
+    # An explicit tag, not a body hashtag: the tag FEED source matches
+    # `post_tags` only, while the tag PAGE unions in `post_hashtags` too. That
+    # split is pre-existing and member posts share it, so it is not this
+    # milestone's to change — but it is why this test files the tag properly.
+    tag = tag!("feedtagtest")
+    {_organization, post} = tagged_organization_post_with_tag("feedtagtest")
+    reader = insert(:activated_user)
+    {:ok, _} = Tags.follow_tag(reader, tag.id)
+
+    ids = reader |> Posts.feed_page() |> Map.fetch!(:entries) |> Enum.map(& &1.post.id)
+    assert post.id in ids
+  end
+
+  test "a page the reader already follows is not shown twice by its tag" do
+    tag = tag!("dupetagtest")
+    {organization, post} = tagged_organization_post_with_tag("dupetagtest")
+    reader = insert(:activated_user)
+    {:ok, _} = Tags.follow_tag(reader, tag.id)
+    {:ok, _} = Vutuv.Social.follow_organization(reader, organization)
+
+    ids = reader |> Posts.feed_page() |> Map.fetch!(:entries) |> Enum.map(& &1.post.id)
+    assert Enum.count(ids, &(&1 == post.id)) == 1
+  end
+
+  test "member posts still reach their tag page" do
+    tag!("membertagtest")
+    author = insert(:activated_user)
+    {:ok, post} = Posts.create_post(author, %{body: "Ich baue mit #membertagtest."})
+    tag = Repo.get_by!(Tag, slug: "membertagtest")
+
+    assert post.id in tag_post_ids(tag)
+  end
+end


### PR DESCRIPTION
This time I **enumerated the class** instead of finding one more site at a time: nine queries in `posts.ex` join Post to `users`. Seven are correct as they stand — `post_likers` joins the *liker*, `feed_post_items` is deliberately the member half, the discovery rail is about finding people to follow. Two were wrong.

**The tag page.** A `#hashtag` in the body writes its `post_hashtags` row for a page exactly as for a member, so filing always worked. Reading it back did not: `visible_tagged_posts_query` inner-joined `users`. **Filed and invisible is the worst of the two states** — the data says it is there.

**The tag-follow feed source** had three silent exclusions in one query: `p.user_id != viewer`, `NOT IN followees`, `NOT IN blocked`. On NULL each is NULL, hence false. Pages now get the matching rule: public, and not one I already follow — a page I follow arrives through its own feed source, so its tagged posts must not appear twice. Muted follows count as followed, exactly as `all_followees_of/1` treats members.

Credo then rightly called the conditions too complex; they are two named expressions beside the query now and read better for it.

**Noticed and deliberately not touched:** the tag page unions `post_tags` and `post_hashtags`, while the tag feed source reads `post_tags` only. So a post carrying only a hashtag shows on the page but not in a tag-follower's feed. Member posts behave identically, so that is a pre-existing split and not this milestone's to change — but it is worth knowing, and it is why the feed tests here file the tag through the composer field.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*