### PR TITLE
Der Gesamt-Feed kennt jetzt auch Organisationen (v7.247.4)

### DIFF
--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -2756,9 +2756,19 @@ defmodule Vutuv.Posts do
   end
 
   def recent_public_posts(:all, opts) do
+    # LEFT joins, so a page's posts join the aggregate too (issue #1334). The
+    # gate is the same idea on both sides — only authors who opted out of
+    # nothing — spelled with each side's own switches: `noindex?`/`noai?` for a
+    # member, `seo?`/`geo?` for a page. That is what keeps this feed's
+    # permissive Content-Signal honest.
     Post
-    |> join(:inner, [p], u in assoc(p, :user), as: :author)
-    |> where([p, u], u.email_confirmed? and not u.noindex? and not u.noai?)
+    |> join(:left, [p], u in assoc(p, :user), as: :author)
+    |> join(:left, [p], o in assoc(p, :organization), as: :site_feed_organization)
+    |> where(
+      [p, author: u, site_feed_organization: o],
+      (not is_nil(p.user_id) and u.email_confirmed? and not u.noindex? and not u.noai?) or
+        (not is_nil(p.organization_id) and organization_public_row(o) and o.seo? and o.geo?)
+    )
     |> recent_public(opts)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.247.3",
+      version: "7.247.4",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/organization_posts_web_test.exs
+++ b/test/vutuv_web/organization_posts_web_test.exs
@@ -221,6 +221,33 @@ defmodule VutuvWeb.OrganizationPostsWebTest do
     end
   end
 
+  describe "the site-wide feed" do
+    setup do
+      owner = insert(:activated_user)
+      organization = active_organization_for(owner)
+      {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+      {:ok, post} = Posts.create_organization_post(organization, owner, %{body: "Für alle."})
+
+      %{organization: organization, owner: owner, post: post}
+    end
+
+    test "carries a page's post", %{conn: conn, organization: organization} do
+      body = conn |> get(~p"/posts/feed.xml") |> response(200)
+
+      assert body =~ "Für alle."
+      assert body =~ "<dc:creator>#{organization.name}</dc:creator>"
+    end
+
+    test "leaves out a page that opted out of either machine channel", ctx do
+      %{conn: conn, organization: organization} = ctx
+
+      # The site feed aggregates only authors who opted out of nothing — for a
+      # member that is `noindex?`/`noai?`, for a page `seo?`/`geo?`.
+      {:ok, _} = Organizations.update_organization(organization, %{"geo?" => false})
+      refute conn |> get(~p"/posts/feed.xml") |> response(200) =~ "Für alle."
+    end
+  end
+
   describe "replies" do
     test "an organization post cannot be answered yet", %{conn: _conn} do
       owner = insert(:activated_user)


### PR DESCRIPTION
The last known site of the shape running through this milestone: `recent_public_posts(:all, …)` behind `/posts/feed.xml` inner-joined `users`, so pages' posts were missing from the site-wide feed.

Both joins are LEFT now, and the gate is the same idea on each side — only authors who opted out of nothing — spelled with that side's own switches: `noindex?`/`noai?` for a member, `seo?`/`geo?` for a page. That is what keeps this feed's permissive Content-Signal honest, and the test turns `geo?` off and asserts the post disappears.

**The class is closed, and that is counted rather than claimed.** Of the nine queries in `posts.ex` joining Post to `users`, four remain inner joins and all four are deliberately so: `feed_post_items` is the member half of the feed (pages have their own source beside it), and the three discovery queries are about finding *people* to follow.

For the record, the full tally of this class across the milestone — every one silent, none reported by a user:

| Where | How it failed |
|---|---|
| feed, discovery rail | `NOT IN` over a nullable column |
| search, mention list, reposts, saved list, tag page, tag feed, site feed | inner join through `users` |

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*