### PR TITLE
Der eigene Feed als Dokument brach an einer gefolgten Seite (v7.247.5)

### DIFF
--- a/lib/vutuv_web/agent_docs/post_doc.ex
+++ b/lib/vutuv_web/agent_docs/post_doc.ex
@@ -174,6 +174,11 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
     })
   end
 
+  # The name a timeline entry is signed with. A page is named by its own name;
+  # the member who published for it stays internal, exactly as on the HTML card.
+  defp timeline_author(%Post{organization: %Organization{name: name}}), do: name
+  defp timeline_author(%Post{user: user}), do: UserHelpers.full_name(user)
+
   # The organization's own reference, the counterpart of `AgentDocs.person_ref/1`.
   # `canonical_path/1` prefers the page's opt-in root handle, so the URL here is
   # the one the page answers to rather than the slug form the post lives under.
@@ -278,7 +283,9 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
     %{
       id: post.id,
       url: AgentDocs.abs_url(Posts.path(post)),
-      author: UserHelpers.full_name(post.user),
+      # Whichever kind of author the post has (issue #1334) — the reposters
+      # below stay members, since only a member can repost.
+      author: timeline_author(post),
       published_on: post.published_on,
       excerpt: AgentDocs.excerpt(post.body),
       reposted_by: entry[:reposted_by] && UserHelpers.full_name(entry[:reposted_by]),

--- a/lib/vutuv_web/controllers/api_v2/post_controller.ex
+++ b/lib/vutuv_web/controllers/api_v2/post_controller.ex
@@ -19,6 +19,7 @@ defmodule VutuvWeb.ApiV2.PostController do
 
   use VutuvWeb, :controller
 
+  alias Vutuv.Organizations.Organization
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias VutuvWeb.AgentDocs.PostDoc
@@ -29,12 +30,19 @@ defmodule VutuvWeb.ApiV2.PostController do
 
   def show(conn, %{"id" => id}) do
     with_visible_post(conn, id, fn conn, post ->
-      ApiV2.send_json(
-        conn,
-        PostDoc.build(post.user, post, viewer: conn.assigns.current_user)
-      )
+      ApiV2.send_json(conn, post_doc(post, conn.assigns.current_user))
     end)
   end
+
+  # A post is by a member or by an organization (issue #1334), and the two have
+  # genuinely different documents: an organization post has no audience, no
+  # conversation and no remote reactions, so it gets the smaller builder rather
+  # than the full one with every field nil. Handing `build/3` a nil author
+  # simply raised.
+  defp post_doc(%Post{organization: %Organization{} = organization} = post, _viewer),
+    do: PostDoc.build_organization_post(organization, post)
+
+  defp post_doc(%Post{} = post, viewer), do: PostDoc.build(post.user, post, viewer: viewer)
 
   def archive(conn, %{"slug" => slug} = params) do
     viewer = conn.assigns.current_user

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.247.4",
+      version: "7.247.5",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/organization_post_docs_test.exs
+++ b/test/vutuv_web/organization_post_docs_test.exs
@@ -1,0 +1,73 @@
+defmodule VutuvWeb.OrganizationPostDocsTest do
+  @moduledoc """
+  The machine renderings of a timeline that contains an organization post
+  (issues #1334, #1336).
+
+  The `users`-join sweep covered `posts.ex`; these are the same shape one layer
+  up, in the doc builders. `PostDoc.timeline_entry/1` names the author with
+  `full_name(post.user)`, so every reader who follows a page broke their own
+  `/feed.md` / `/feed.json` — and the API's `GET /posts/:id` handed
+  `PostDoc.build/3` a nil author.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Organizations
+  alias Vutuv.Posts
+  alias Vutuv.Social
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  test "the API serves an organization post as its own document kind", %{conn: conn} do
+    {organization, owner} = active_organization()
+    {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+    {:ok, post} = Posts.create_organization_post(organization, owner, %{body: "Per API."})
+
+    reader = insert(:activated_user)
+
+    {:ok, token, _} =
+      Vutuv.ApiAuth.create_pat(reader, %{"name" => "t", "scopes" => ["posts:read"]})
+
+    json =
+      conn
+      |> Plug.Conn.put_req_header("authorization", "Bearer " <> token)
+      |> get("/api/2.0/posts/#{post.id}")
+      |> json_response(200)
+
+    # The smaller document, not the member one with every field nil: an
+    # organization post has no audience, no conversation, no remote reactions.
+    assert json["type"] == "organization_post"
+    assert json["author"]["name"] == organization.name
+    refute json |> Jason.encode!() |> String.contains?(owner.username)
+  end
+
+  test "a follower's feed documents render the page's post", %{conn: conn} do
+    {conn, member} = create_and_login_user(conn)
+    {organization, owner} = active_organization()
+    {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+    {:ok, _} = Posts.create_organization_post(organization, owner, %{body: "Aus dem Haus."})
+    {:ok, _} = Social.follow_organization(member, organization)
+
+    # The reader's own feed, as a machine document. The entry is named by the
+    # page, never by the member who pressed publish.
+    json = conn |> get(~p"/feed.json") |> json_response(200)
+
+    entry = Enum.find(json["posts"], &(&1["excerpt"] =~ "Aus dem Haus."))
+    assert entry
+    assert entry["author"] == organization.name
+    refute json |> Jason.encode!() |> String.contains?(owner.username)
+  end
+end


### PR DESCRIPTION
The `users`-join sweep closed `posts.ex` — but only `posts.ex`. One layer up, in the doc builders, the same shape survives twice.

**`PostDoc.timeline_entry/1` named the author with `full_name(post.user)`.** So `/feed.md`, `/feed.json` and the API feed broke for any reader who follows a page — which is exactly the people the follow feature was built for. The entry now carries the page's name; whoever published for it stays internal, as on the HTML card.

**`GET /api/2.0/posts/:id` handed `PostDoc.build/3` a nil author.** Rather than guard it, the action now picks the builder by author kind: an organization post has no audience, no conversation and no remote reactions, so it gets the smaller document that already exists instead of the big one with every field nil.

**The lesson is not the fix, it is the reach of my last claim.** I said "the class is closed" and meant one file. A grep over `posts.ex` proves nothing about `post_doc.ex`. When the next author kind, actor kind or owner kind arrives, the sweep is over every module that *reads* the thing, not the one that stores it.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*