### PR TITLE
Vier weitere Stellen, die den Autor eines Beitrags lesen (v7.247.6)

### DIFF
--- a/lib/vutuv/reports.ex
+++ b/lib/vutuv/reports.ex
@@ -55,7 +55,9 @@ defmodule Vutuv.Reports do
       spam_removals: count_spam_removals(day_start, day_end),
       details: %{
         registrations: registration_sample(day_start, day_end, limit),
-        posts: sample(Post, [:user], day_start, day_end, limit),
+        # Both author kinds (issue #1334): the day's posts include what
+        # organizations published, and the detail lines name whoever wrote them.
+        posts: sample(Post, [:user, :organization], day_start, day_end, limit),
         reposts: sample(PostRepost, [:user, :post], day_start, day_end, limit),
         likes: sample(PostLike, [:user, :post], day_start, day_end, limit),
         bookmarks: sample(PostBookmark, [:user, :post], day_start, day_end, limit),

--- a/lib/vutuv_web/controllers/api_v2/post_controller.ex
+++ b/lib/vutuv_web/controllers/api_v2/post_controller.ex
@@ -174,6 +174,11 @@ defmodule VutuvWeb.ApiV2.PostController do
     end
   end
 
+  defp author_ref(%Organization{} = organization),
+    do: %{name: organization.name, slug: organization.slug}
+
+  defp author_ref(author), do: VutuvWeb.AgentDocs.person_ref(author)
+
   defp engagement_doc(%Post{} = post, viewer) do
     post.id
     |> Posts.post_engagement(viewer)
@@ -187,7 +192,9 @@ defmodule VutuvWeb.ApiV2.PostController do
     %{
       id: post.id,
       url: VutuvWeb.AgentDocs.abs_url(Posts.path(post)),
-      author: VutuvWeb.AgentDocs.person_ref(post.user),
+      # A feed entry may be by a page (issue #1336), which `person_ref/1`
+      # cannot describe — `Posts.author/1` decides which of the two speaks.
+      author: author_ref(Posts.author(post)),
       published_on: post.published_on,
       body_markdown: post.body,
       tags: Enum.map(post.tags, & &1.name),

--- a/lib/vutuv_web/report_details.ex
+++ b/lib/vutuv_web/report_details.ex
@@ -94,7 +94,7 @@ defmodule VutuvWeb.ReportDetails do
   defp entry(:registrations, user), do: person_entry(user)
   defp entry(:spam_removals, event), do: person_entry(event.case.owner)
 
-  defp entry(:posts, post), do: post_entry(post, post.user)
+  defp entry(:posts, post), do: post_entry(post, Vutuv.Posts.author(post))
   defp entry(:reposts, repost), do: post_entry(repost.post, repost.user)
   defp entry(:likes, like), do: post_entry(like.post, like.user)
   defp entry(:bookmarks, bookmark), do: post_entry(bookmark.post, bookmark.user)
@@ -138,10 +138,16 @@ defmodule VutuvWeb.ReportDetails do
   # line.
   defp post_entry(post, actor) do
     case AgentDocs.excerpt(post.body) do
-      "" -> %{primary: "@" <> actor.username, secondary: nil, path: "/posts/" <> post.id}
-      line -> %{primary: line, secondary: "@" <> actor.username, path: "/posts/" <> post.id}
+      "" -> %{primary: actor_label(actor), secondary: nil, path: "/posts/" <> post.id}
+      line -> %{primary: line, secondary: actor_label(actor), path: "/posts/" <> post.id}
     end
   end
+
+  # A member is named by handle, an organization by its name — it may never have
+  # claimed a handle. Without this the daily report crashed on the first day any
+  # page published (issue #1334).
+  defp actor_label(%Vutuv.Organizations.Organization{name: name}), do: name
+  defp actor_label(actor), do: "@" <> actor.username
 
   # The remote actor's own label, best first: its @handle, then its display
   # name, falling back to the raw actor URI (always present).

--- a/lib/vutuv_web/views/post_json.ex
+++ b/lib/vutuv_web/views/post_json.ex
@@ -11,6 +11,7 @@ defmodule VutuvWeb.PostJSON do
   """
 
   alias Vutuv.Accounts.User
+  alias Vutuv.Organizations.Organization
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostImage
@@ -24,7 +25,7 @@ defmodule VutuvWeb.PostJSON do
     %{
       id: post.id,
       url: VutuvWeb.Endpoint.url() <> Posts.path(post),
-      author: author_ref(post.user),
+      author: author_ref(Posts.author(post)),
       body_markdown: post.body,
       body_html:
         post.body
@@ -84,6 +85,12 @@ defmodule VutuvWeb.PostJSON do
 
   defp author_ref(%User{} = user) do
     %{username: user.username, name: VutuvWeb.UserHelpers.full_name(user)}
+  end
+
+  # A page has a name and a slug where a member has a handle (issue #1334); it
+  # may hold no handle at all, so `username` would be a lie rather than a gap.
+  defp author_ref(%Organization{} = organization) do
+    %{slug: organization.slug, name: organization.name}
   end
 
   defp image(%PostImage{} = image) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.247.5",
+      version: "7.247.6",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/organization_post_docs_test.exs
+++ b/test/vutuv_web/organization_post_docs_test.exs
@@ -54,6 +54,43 @@ defmodule VutuvWeb.OrganizationPostDocsTest do
     refute json |> Jason.encode!() |> String.contains?(owner.username)
   end
 
+  test "the daily admin report names the page instead of crashing" do
+    {organization, owner} = active_organization()
+    {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+    {:ok, _} = Posts.create_organization_post(organization, owner, %{body: "Tagesmeldung."})
+
+    # The report samples the day's posts. Once any page publishes, an entry has
+    # no member behind it — and the line was built from `actor.username`, so the
+    # operator's daily mail stopped arriving rather than merely reading oddly.
+    sections =
+      Vutuv.BerlinTime.today() |> Vutuv.Reports.daily() |> VutuvWeb.ReportDetails.sections()
+
+    posts = Enum.find(sections, &(&1.key == :posts))
+    assert posts
+    assert Enum.any?(posts.entries, &(&1.primary =~ "Tagesmeldung."))
+  end
+
+  test "the API feed names the page", %{conn: conn} do
+    {organization, owner} = active_organization()
+    {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+    {:ok, _} = Posts.create_organization_post(organization, owner, %{body: "Im API-Feed."})
+
+    reader = insert(:activated_user)
+    {:ok, _} = Social.follow_organization(reader, organization)
+
+    {:ok, token, _} =
+      Vutuv.ApiAuth.create_pat(reader, %{"name" => "t", "scopes" => ["posts:read"]})
+
+    json =
+      conn
+      |> Plug.Conn.put_req_header("authorization", "Bearer " <> token)
+      |> get("/api/2.0/feed")
+      |> json_response(200)
+
+    entry = Enum.find(json["posts"], &(&1["body_markdown"] =~ "Im API-Feed."))
+    assert entry["author"]["name"] == organization.name
+  end
+
   test "a follower's feed documents render the page's post", %{conn: conn} do
     {conn, member} = create_and_login_user(conn)
     {organization, owner} = active_organization()


### PR DESCRIPTION
The wider sweep I promised: over every module that **reads** a post, not just the one that stores it. Four hits, fixed in one batch rather than four PRs.

**The one that matters most is the operator's daily report.** It samples the day's posts and built each line from `actor.username`. The first day any page publishes, the report raises — so the mail stops arriving rather than merely reading oddly. The sample now loads both author kinds, and the line names a page by its name, because it may never have claimed a handle.

The other three:

- **`GET /api/2.0/feed`** builds its own entries and called `person_ref(post.user)` — `timeline_entry/1` was fixed in v7.247.5 but the API does not use it.
- **`GET /api/2.0/posts/:id`** now picks the doc builder by author kind.
- **`PostJSON`** serialises the author polymorphically (`slug`+`name` for a page, since `username` would be a lie rather than a gap).

**The report test is calibrated**: with the fix reverted it raises, with it in place it names the page. A test that passes either way would have been worth nothing here — which is the whole reason this one exists.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*