### PR TITLE
Die Architektur-Doku beschreibt Seiten als Absender (v7.247.7)

### DIFF
--- a/docs/architecture/mentions.md
+++ b/docs/architecture/mentions.md
@@ -39,6 +39,24 @@ them). Without it, a bad actor could seed `@wanted` into a post to *reserve* it
 — the availability rule below would then treat `@wanted` as "used in a post" and
 block everyone, forever.
 
+**An organization handle is a real mention** (#1336), not merely a valid one.
+For a long while validation accepted it — members and pages share one handle
+namespace — while the renderer looked handles up among members only, so `@acme`
+saved and then rendered as plain text: accepted as real and drawn as if it were
+not. It links to the page now, with the page's name as the `title`, and
+`Mentions.mentioned_organizations/1` resolves the page side while
+`mentioned_users/2` resolves the member side. The two never overlap, because a
+handle belongs to at most one of them; members win the merge anyway, since a
+person's profile is the destination you do not want to get wrong. A page nobody
+may see (pending, frozen, archived) is deliberately **not** linked — the text
+stays readable, but no link leads where the reader would be turned away.
+
+Such a mention is recorded: `post_mentions` carries `user_id | organization_id`
+(CHECK exactly one), and the page's own `/organizations/:slug/activity` list
+reads it. The rows are a reconciled index of the body, so editing the mention
+out takes the entry with it, and a page naming *itself* is not news to its own
+team.
+
 - Detection skips code spans/blocks, emails and fediverse handles, and matches
   whole handles (so `@old` is not found inside `@older`).
 - Detection **sees through a Markdown escape** inside a handle. The Milkdown

--- a/docs/architecture/organizations.md
+++ b/docs/architecture/organizations.md
@@ -194,26 +194,95 @@ mail's recipient would arrive at a green "Verified" badge contradicting it.
 A page is run by a team, not just its claimant. Each `OrganizationRole` grants a
 proof-derived **power**, never an employment claim:
 
-- **owner** — everything: roles, domains, the page + aliases, and (from issue 5)
-  job postings.
+- **owner** — everything: roles, domains, the page + aliases, and job postings.
 - **admin** — the page + aliases and job postings, but not roles or domains.
+- **publisher** — speaking in the organization's name: publishing, editing and
+  deleting its posts, and switching into it (#1333, #1334, #1335). Nothing
+  administrative.
 - **recruiter** — job postings only.
 
-The predicates live in `Vutuv.Organizations`: `owner?/2`, `can_edit_page?/2`
-(owner ∪ admin), `can_manage_roles?/2` and `can_manage_domains?/2` (owner). The
-older `can_manage?/2` is the *staff* predicate (creator ∪ any role holder) used
-for **visibility** — a recruiter still sees a pending/frozen page — not for
-writes.
+**A member holds any number of roles on any number of pages** (#1333). The
+unique index is `[organization_id, user_id, role]`, effective powers are the
+union, and `roles_of/2` answers with a ranked list. It was renamed from
+`role_of/2` rather than quietly re-typed: a permission accessor whose return
+moves from `"owner" | nil` to a list under the same name is how a check ends up
+reading a non-empty list as truthy.
 
-Invariant: **every organization keeps ≥ 1 owner.** `remove_role/1` and `update_role/3`
-refuse to remove or demote the last owner (`{:error, :last_owner}`), exactly like
-the last-domain rule. A grant is a notification: the `organization_roles` row is a
+**`publisher` is never implied**, not by `owner` and not by `admin`. Speaking
+for a page and administering it are different powers that usually belong to
+different people, so a freshly claimed page cannot post until its owner grants
+it once. The separation holds structurally rather than by convention, because
+`can_manage_roles?/2` is owner-only: an admin cannot grant themselves the right
+to post. German label "Redaktion" — it names the function, not a rank.
+
+The predicates live in `Vutuv.Organizations`: `owner?/2`, `can_edit_page?/2`
+(owner ∪ admin), `publisher?/2`, `can_manage_roles?/2` and
+`can_manage_domains?/2` (owner). The older `can_manage?/2` is the *staff*
+predicate (creator ∪ any role holder) used for **visibility** — a recruiter
+still sees a pending/frozen page — not for writes.
+
+Invariant: **every organization keeps ≥ 1 owner.** `remove_role/1` and
+`set_roles/4` refuse to remove or demote the last owner (`{:error, :last_owner}`),
+exactly like the last-domain rule. `set_roles/4` is the roster's one write — it
+diffs against what is held, so an unchanged role keeps its `granted_by` and its
+age — and it replaced the single-role `update_role/3` when the roster became a
+checkbox set. That shape is deliberate: with a select, granting `publisher` to
+an admin would silently have taken their `admin` away. A grant is a notification: the `organization_roles` row is a
 source of the derived notification feed (`Vutuv.Activity.organization_role_items/3`,
 self-grants excluded so the claim wizard's owner row is not "news"), and
 `Activity.notify_organization_role/4` pushes the live badge/toast at grant time. The
 owner-only roster lives at `/organizations/:slug/roles`
 (`VutuvWeb.OrganizationLive.Roles`, add by `@handle`/email with a live typeahead
-`Organizations.suggest_members/2`).
+`Organizations.suggest_members/2`). It is **one row per member with a checkbox
+set** (`list_team/1`), not one row per role; nothing is pre-ticked on the add
+form, because with four roles a guessed default is wrong more often than right
+and `publisher` must never arrive by accident.
+
+## Speaking as a page (#1334, #1335, #1336)
+
+A page is an identity, not only a brochure. What it can do now, and where each
+piece lives:
+
+- **It publishes.** `posts` carries `user_id | organization_id` (CHECK exactly
+  one) plus `acting_user_id` — who pressed publish, `nilify_all`, never shown.
+  **`Vutuv.Posts.author/1` is the one accessor**; reading `post.user` on an
+  organization post is the bug to look for. Editing and deleting follow the
+  **role, not the person**: any current publisher may, because the post belongs
+  to the page. Organization posts carry no audience and cannot be replied to
+  (both refused outright rather than half-working).
+- **A member switches into it** for a session (#1335). The session carries only
+  `acting_as_organization_id`, and it is a **hint, never a credential**:
+  `VutuvWeb.Plug.ActingAs` and `Live.InitAssigns.acting_as/2` re-ask
+  `organization_roles` on every request and every socket mount, so a withdrawn
+  role ends the mode on the next action. Both directions are in the account
+  activity log under their own kinds.
+- **Members follow it.** `follows.followee_organization_id` (nullable pair +
+  CHECK, #1336) — only the followee side; a page following somebody is not built.
+  Its posts then reach the follower's feed through `feed_organization_post_items/3`.
+- **It sees what happens to it** at `/organizations/:slug/activity`: new
+  followers, likes and reposts of its posts, and posts naming it by handle.
+  Derived from the source tables, so an unliked post is not "read" — it never
+  happened. **One read marker for the whole team** (`activity_read_at`): read
+  means somebody read it, never that everybody did, which is why it is a column
+  on the page and not a row per member. The marker is the newest entry's
+  timestamp rather than the wall clock (second-precision tables + a strict `>`),
+  and an empty list stamps nothing.
+- **It is mentionable** by its root handle, and reachable from search, the tag
+  pages, the sitemap, `/llms.txt`, its own RSS feed and the agent formats.
+
+### The trap this shape carries
+
+Every one of those surfaces reaches the author. Widening `posts.user_id` to
+nullable produced **eleven silent failures**, in three flavours: `NOT IN` over a
+nullable column (never true — it emptied the discovery rail), an inner join
+through `users` (dropped the rows entirely — search, reposts, the saved list,
+tag pages, the site feed), and reading `post.user` or hand-building
+`~p"/#{post.user}/posts/…"` (raised — notifications, the admin gallery, the
+daily report mail). None was reported by a user; all were found by sweeping.
+
+So when the next kind of actor arrives: enumerate every module that **reads**
+the thing, not the one that stores it, and route the URL through the function
+that owns it.
 
 ## Multi-domain management (`/organizations/:slug/domains`, #930)
 

--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -44,6 +44,41 @@ or an inline code span a URL is sample text, so it is left verbatim
 (`VutuvWeb.Markdown.map_outside_code/2`); rewriting it turned `curl
 https://vutuv.de` into visible Markdown link syntax.
 
+### Who a post is by (issue #1334)
+
+A post is authored by a **member or an organization**, never both and never
+neither:
+
+| column | personal post | organization post |
+|---|---|---|
+| `user_id` | the member, `delete_all` | NULL |
+| `organization_id` | NULL | the page, `delete_all` |
+| `acting_user_id` | NULL | who pressed publish, `nilify_all` |
+
+Three columns rather than one because two promises collide. `posts.user_id` was
+`null: false, on_delete: :delete_all` — deleting your account deletes your posts
+— but a post published for a page must survive the person who wrote it leaving.
+Keeping the human in `user_id` would delete the page's content with their
+account; dropping the human entirely would leave nobody accountable for what was
+said in the page's name.
+
+**`Vutuv.Posts.author/1` is the single accessor.** The author is read in ~70
+places; reading `post.user` directly is a bug on an organization post, and so is
+hand-building `~p"/#{post.user}/posts/#{post.id}"` instead of calling
+`Posts.path/1`. Both mistakes shipped and broke live pages — see the trap
+section in `organizations.md`.
+
+Consequences worth knowing:
+
+- Organization posts carry **no audience** (the deny model is built on the
+  author's own follower graph and blocks) and **cannot be replied to**. Both are
+  refused outright rather than silently reaching nobody.
+- They have their own feed source (`feed_organization_post_items/3`), so
+  `feed_post_items/3` stays deliberately the member half.
+- Personal scopes exclude them: a member's profile, archive and feed never show
+  what they published for a page. That association is what `acting_user_id`
+  keeps internal.
+
 ### The author's own, proven webpage (issue #1246)
 
 A link in a post that points at a webpage the **post's author** has proved is

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.247.6",
+      version: "7.247.7",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Die Architektur-Doku beschrieb noch das Drei-Rollen-Modell und `update_role/3` — also genau das, was seit #1333 nicht mehr existiert. Das ist die schlechtere Sorte veralteter Doku: sie liest sich stimmig und schickt den nächsten Leser auf eine Funktion, die es nicht mehr gibt.

**`docs/architecture/organizations.md`**

- Vier Rollen statt drei, mehrere Rollen pro Mitglied, mehrere Organisationen pro Mitglied.
- Warum `publisher` weder aus `owner` noch aus `admin` folgt, und warum das strukturell hält und nicht per Konvention: `can_manage_roles?/2` ist owner-only, ein Admin kann sich das Posten also nicht selbst geben.
- Warum `role_of/2` umbenannt und nicht nur umgetypt wurde — ein Rückgabewert, der von `"owner" | nil` auf eine Liste wechselt, während der Name gleich bleibt, ist genau die Art Änderung, nach der eine Prüfung eine leere Liste für wahr hält.
- Neuer Abschnitt „Speaking as a page" mit den vier Bausteinen aus #1334/#1335/#1336: Veröffentlichen, Identitätswechsel, Folgen, Aktivitätsliste — samt dem einen Lesezeichen fürs ganze Team und der Begründung, warum es eine Spalte an der Seite ist und keine Zeile pro Mitglied.
- Und der Teil, der mir am wichtigsten war: die elf stillen Fehler aus dem Nullable-Machen von `posts.user_id`, nach ihren drei Sorten sortiert (`NOT IN` über eine nullable Spalte, Inner Join durch `users`, direkter Zugriff auf `post.user`). Keiner davon wurde gemeldet, alle wurden beim Durchkämmen gefunden. Der nächste Akteurstyp läuft in dieselben drei Fallen, wenn das nirgends steht.

**`docs/architecture/posts-and-feed.md`** erklärt jetzt die Drei-Spalten-Autorschaft (`user_id | organization_id` + `acting_user_id`), warum es drei sind und nicht eine, und dass `Posts.author/1` der einzige Zugriff ist.

**`docs/architecture/mentions.md`** hält fest, dass ein Organisations-Handle eine echte Erwähnung ist — sie wurde lange als gültig akzeptiert, aber als reiner Text gezeichnet — und dass sie in `post_mentions` landet.

Nur Doku, kein Code. `mix precommit` grün (7224 Tests).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01MMwsQi49FP21xuSoPEkMnN
