### PR TITLE
Die Autorschaft eines Beitrags hängt nicht mehr am Preload (v7.247.8)

### DIFF
--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -55,6 +55,7 @@ defmodule Vutuv.Posts do
   import Vutuv.Organizations.Query, only: [organization_public_row: 1]
   import Vutuv.SearchText, only: [contains: 1, normalize_search: 1, name_ilike: 3]
 
+  alias Ecto.Association.NotLoaded
   alias Vutuv.Accounts.User
   alias Vutuv.Fediverse.Note
   alias Vutuv.Fediverse.PostRepost, as: FediversePostRepost
@@ -830,9 +831,23 @@ defmodule Vutuv.Posts do
   (`acting_user`) is deliberately **not** the public author — they are the
   internal record of who spoke, kept for moderation, disputes and departures.
 
-  Needs `:user` / `:organization` preloaded, which `post_preloads/0` does.
+  `:user` / `:organization` are normally preloaded (`post_preloads/0` does it);
+  when they are not, this loads the one it needs rather than handing back an
+  `%Ecto.Association.NotLoaded{}`. That costs a query on the paths that forgot,
+  and it is worth it: the alternative shipped twice already, as clauses like
+  `def f(%Post{organization: %Organization{}})` written all over the display
+  layer. Those read as a *type* check and behave as a *preload* check — hand one
+  a bare `%Post{}` from a query and the organization branch quietly does not
+  match, so the post is drawn as a member's and the member is `nil`.
   """
+  def author(%Post{organization_id: nil, user: %NotLoaded{}, user_id: user_id}),
+    do: Repo.get(User, user_id)
+
   def author(%Post{organization_id: nil} = post), do: post.user
+
+  def author(%Post{organization: %NotLoaded{}, organization_id: organization_id}),
+    do: Repo.get(Organization, organization_id)
+
   def author(%Post{} = post), do: post.organization
 
   @doc "The author's id, whichever kind of author it is."
@@ -2892,6 +2907,12 @@ defmodule Vutuv.Posts do
 
     from(p in Post,
       as: :post,
+      # An INNER join, so the rail is members only — and that is the intent, not
+      # an oversight of #1334: every tier here is about people (strangers you do
+      # not follow, one post per author), and `Enum.uniq_by(& &1.user_id)` in the
+      # caller would collapse every page's post into one. Widening it to pages
+      # means giving them their own tier and their own uniqueness key; until
+      # then, keep the join inner — the rail's template reads `post.user`.
       join: u in assoc(p, :user),
       as: :author,
       left_join: f in Follow,
@@ -4016,7 +4037,7 @@ defmodule Vutuv.Posts do
   @doc """
   The given post ids **visible to `viewer`** as a `%{id => %Post{}}` map with
   `:user` preloaded, for building the notification-page post previews (the shared
-  `<.post_preview>` needs the author + permalink, not just the body) in one round
+  the row needs the author + permalink, not just the body) in one round
   trip. Missing, deleted or denied ids are simply absent; a `nil`/empty id list
   makes no query. `viewer`'s own posts always pass (so the recipient's own post
   that a reply/like is about is always quotable), while another member's post (a
@@ -4148,12 +4169,15 @@ defmodule Vutuv.Posts do
   is identified by and what somebody pastes a year later. One shape that always
   works beats two that depend on whether a handle was claimed.
   """
-  def path(%Post{organization: %Organization{slug: slug}, id: id}) do
+  def path(%Post{organization_id: organization_id, id: id} = post)
+      when is_binary(organization_id) do
+    %Organization{slug: slug} = author(post)
     "/organizations/#{slug}/posts/#{id}"
   end
 
-  def path(%Post{user: %User{} = user, id: id}) do
-    "/#{user.username}/posts/#{id}"
+  def path(%Post{id: id} = post) do
+    %User{username: username} = author(post)
+    "/#{username}/posts/#{id}"
   end
 
   ## Images

--- a/lib/vutuv_web/agent_docs/post_doc.ex
+++ b/lib/vutuv_web/agent_docs/post_doc.ex
@@ -176,8 +176,10 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
 
   # The name a timeline entry is signed with. A page is named by its own name;
   # the member who published for it stays internal, exactly as on the HTML card.
-  defp timeline_author(%Post{organization: %Organization{name: name}}), do: name
-  defp timeline_author(%Post{user: user}), do: UserHelpers.full_name(user)
+  defp timeline_author(%Post{} = post), do: author_label(Posts.author(post))
+
+  defp author_label(%Organization{name: name}), do: name
+  defp author_label(author), do: UserHelpers.full_name(author)
 
   # The organization's own reference, the counterpart of `AgentDocs.person_ref/1`.
   # `canonical_path/1` prefers the page's opt-in root handle, so the URL here is

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -309,16 +309,20 @@ defmodule VutuvWeb.PostComponents do
   # Where the author's name and avatar link to. A member's profile lives at
   # their handle; an organization's page at `Organizations.canonical_path/1`,
   # which prefers its opt-in root handle over `/organizations/:slug`.
-  defp author_path(%Post{organization: %Organization{} = organization}),
-    do: Organizations.canonical_path(organization)
-
-  defp author_path(%Post{user: user}), do: "/#{user.username}"
+  # Both dispatch on what `Posts.author/1` hands back rather than on a pattern
+  # over the preloaded association: the association-shaped clause reads as a
+  # type check but behaves as a preload check, so a bare %Post{} from a query
+  # drew a page's post as a nil member's.
+  defp author_path(%Post{} = post), do: author_path(Posts.author(post))
+  defp author_path(%Organization{} = organization), do: Organizations.canonical_path(organization)
+  defp author_path(%User{} = user), do: "/#{user.username}"
 
   # The visible author name. An organization is named by its own name and has no
   # `@handle` line beside it: a page's identity is the name, and the handle is
   # an optional address it may never have claimed.
-  defp author_name(%Post{organization: %Organization{name: name}}), do: name
-  defp author_name(%Post{user: user}), do: full_name(user)
+  defp author_name(%Post{} = post), do: author_name(Posts.author(post))
+  defp author_name(%Organization{name: name}), do: name
+  defp author_name(%User{} = user), do: full_name(user)
 
   @doc """
   The shared shell for a threaded post list: a `divide-y` column of
@@ -2556,68 +2560,6 @@ defmodule VutuvWeb.PostComponents do
       {:parent, parent} -> [parent]
       _ -> []
     end
-  end
-
-  @doc """
-  A compact, read-only, linked preview of one post — the shared "referenced post"
-  rendering. Its home is the notification page's quoted post. Read-only on
-  purpose (no action bar, no live component), so a 50-row notification page stays
-  cheap. (The feed/profile thread used to nest the parent through this too, but
-  now renders it as a full `<.post_card>` so every element of a thread keeps its
-  own action bar.)
-
-  Renders the author (linked avatar + name → profile, `@handle` · time) and a
-  clamped excerpt that links to the post permalink. `text` is the already-prepared
-  excerpt: the notification page pre-clamps to three lines server-side (its own
-  visibility rules must strip a denied body) and passes
-  `clamp="line-clamp-3 whitespace-pre-line"` + `truncated?`. `label` is the
-  optional uppercase caption that tells a reply notification's two quotes apart
-  ("Your post" / "Reply"); the global `rest` carries the
-  `data-post-preview` / `data-reply-preview` hooks onto the excerpt link (the
-  element that owns the permalink).
-  """
-  attr(:post, :any, required: true, doc: "preloaded %Vutuv.Posts.Post{} with :user")
-  attr(:time_id, :string, required: true)
-  attr(:text, :string, required: true)
-  attr(:truncated?, :boolean, default: false)
-  attr(:clamp, :string, default: "truncate")
-  attr(:label, :any, default: nil)
-  attr(:class, :string, default: nil, doc: "outer wrapper utilities (e.g. mt-2 in notifications)")
-  attr(:rest, :global, doc: "data-* hooks land on the excerpt link, which owns the permalink")
-
-  def post_preview(assigns) do
-    ~H"""
-    <div class={["flex items-start gap-3", @class]}>
-      <.link href={~p"/#{@post.user}"} class="shrink-0" aria-hidden="true" tabindex="-1">
-        <.avatar user={@post.user} size="sm" />
-      </.link>
-      <div class="min-w-0 flex-1">
-        <div class="flex flex-wrap items-baseline gap-x-2">
-          <.link
-            href={~p"/#{@post.user}"}
-            class="font-semibold text-slate-900 hover:text-brand-700 dark:text-white"
-          >
-            {full_name(@post.user)}
-          </.link>
-          <span class="text-xs text-slate-600 dark:text-slate-400">
-            {"@" <> @post.user.username} ·
-            <.post_time id={@time_id} at={@post.inserted_at} />
-          </span>
-        </div>
-        <span
-          :if={@label}
-          class="mt-0.5 block text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400"
-        >
-          {@label}
-        </span>
-        <.link href={Posts.path(@post)} class="mt-0.5 block" {@rest}>
-          <p class={["text-sm text-slate-700 hover:text-brand-700 dark:text-slate-300", @clamp]}>
-            {@text}<span :if={@truncated?}>…</span>
-          </p>
-        </.link>
-      </div>
-    </div>
-    """
   end
 
   attr(:variant, :string, required: true)

--- a/lib/vutuv_web/controllers/api_v2/post_controller.ex
+++ b/lib/vutuv_web/controllers/api_v2/post_controller.ex
@@ -39,10 +39,11 @@ defmodule VutuvWeb.ApiV2.PostController do
   # conversation and no remote reactions, so it gets the smaller builder rather
   # than the full one with every field nil. Handing `build/3` a nil author
   # simply raised.
-  defp post_doc(%Post{organization: %Organization{} = organization} = post, _viewer),
-    do: PostDoc.build_organization_post(organization, post)
+  defp post_doc(%Post{organization_id: id} = post, _viewer) when is_binary(id),
+    do: PostDoc.build_organization_post(Posts.author(post), post)
 
-  defp post_doc(%Post{} = post, viewer), do: PostDoc.build(post.user, post, viewer: viewer)
+  defp post_doc(%Post{} = post, viewer),
+    do: PostDoc.build(Posts.author(post), post, viewer: viewer)
 
   def archive(conn, %{"slug" => slug} = params) do
     viewer = conn.assigns.current_user

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.247.7",
+      version: "7.247.8",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/post_author_preload_test.exs
+++ b/test/vutuv/post_author_preload_test.exs
@@ -1,0 +1,81 @@
+defmodule Vutuv.PostAuthorPreloadTest do
+  @moduledoc """
+  Every surface that draws a post's author dispatched on the **preloaded
+  association** (`%Post{organization: %Organization{}}`) rather than on the
+  `organization_id` column. That reads as a type check and behaves as a preload
+  check: hand any of them a bare `%Post{}` straight out of a query and the
+  organization clause quietly does not match, so the post is drawn as a
+  member's — and the member is `nil`.
+
+  It is the same shape as the `visible_to?/2` bug (a permission answer that
+  depended on whether somebody remembered a preload), one layer up. These tests
+  hand each surface a deliberately un-preloaded organization post.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag and the DNS-resolver stub beside it.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Accounts.User
+  alias Vutuv.Organizations
+  alias Vutuv.Organizations.Organization
+  alias Vutuv.Posts
+  alias Vutuv.Posts.Post
+  alias Vutuv.Repo
+  alias VutuvWeb.AgentDocs.PostDoc
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  # A post exactly as a query hands it over: no :user, no :organization.
+  defp bare_organization_post do
+    owner = insert(:activated_user)
+    organization = active_organization_for(owner, %{"name" => "Bare AG"})
+    {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+    {:ok, post} = Posts.create_organization_post(organization, owner, %{body: "Ohne Preload."})
+
+    {Repo.get!(Post, post.id), organization}
+  end
+
+  test "author/1 answers the page even when nothing is preloaded" do
+    {post, organization} = bare_organization_post()
+
+    assert %Organization{id: id} = Posts.author(post)
+    assert id == organization.id
+  end
+
+  test "author/1 answers the member even when nothing is preloaded" do
+    author = insert(:activated_user)
+    {:ok, post} = Posts.create_post(author, %{body: "Auch ohne Preload."})
+
+    assert %User{id: id} = Posts.author(Repo.get!(Post, post.id))
+    assert id == author.id
+  end
+
+  test "path/1 builds the page's permalink from the column, not the preload" do
+    {post, organization} = bare_organization_post()
+
+    assert Posts.path(post) == "/organizations/#{organization.slug}/posts/#{post.id}"
+  end
+
+  test "the agent timeline entry names the page without a preload" do
+    {post, organization} = bare_organization_post()
+
+    # timeline_entry/1 is what every listing's .md/.json/.xml sibling renders a
+    # row with; a nil author there took the whole document down, not one line.
+    entry = PostDoc.timeline_entry(%{post: post})
+
+    assert entry.author == organization.name
+    assert entry.url =~ "/organizations/#{organization.slug}/posts/#{post.id}"
+  end
+end


### PR DESCRIPTION
Ich hatte nach dem Nullable-Machen von `posts.user_id` elf stille Fehler gefunden und behoben, aber nicht die **Form**, die sie erzeugt hat. Sechs Stellen entschieden so, ob ein Beitrag von einer Seite stammt:

```elixir
def author_name(%Post{organization: %Organization{name: name}}), do: name
def author_name(%Post{user: user}), do: full_name(user)
```

Das liest sich wie eine Typprüfung und ist eine Preload-Prüfung. Gibt man dem ein blankes `%Post{}` aus einer Query, trifft die erste Klausel nicht, der Beitrag wird als der eines Mitglieds gezeichnet, und dieses Mitglied ist `nil`. Genau diese Form hatte schon `visible_to?/2` kaputt gemacht, nur eine Ebene tiefer, und dort habe ich sie auf die Spalte umgestellt, ohne zu merken, dass die Anzeigeschicht voll davon ist.

`Posts.author/1` ist jetzt der Resolver: es entscheidet an `organization_id` und **lädt die Assoziation nach**, wenn sie fehlt. Das kostet auf einem Pfad, der den Preload vergessen hat, eine Query, und dafür kann keiner mehr in den falschen Zweig laufen. `Posts.path/1`, `author_path/1`, `author_name/1`, `timeline_author/1` und der API-Dokumentbauer gehen darüber und dispatchen auf dem, was zurückkommt.

Zwei Funde beim Durchgehen habe ich gleich mitgenommen:

- Der Join des Discovery-Rails zu `users` ist ein INNER JOIN, schließt Seitenbeiträge also aus. Das ist richtig so (jede Stufe dort dreht sich um Personen, und `uniq_by(& &1.user_id)` würde sämtliche Seitenbeiträge zu einem einzigen zusammenfallen lassen), stand aber nirgends, während das Template daneben `post.user` ungeschützt liest. Jetzt steht es als Kommentar da, mit der Bedingung, unter der man es aufmachen dürfte.
- `post_preview/1` in `PostComponents` hat seit dem Notifications-Redesign keinen Aufrufer mehr und besteht aus sieben ungeschützten `@post.user`. Gelöscht statt repariert — die Notifications-Seite baut ihre Zitate längst selbst.

Der Test gibt jeder Oberfläche absichtlich einen Beitrag ohne Preloads. Vor dem Fix sind alle vier rot, geprüft.

`mix precommit` grün (7228 Tests).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01MMwsQi49FP21xuSoPEkMnN
