### PR TITLE
Wer nur Seiten folgt, folgt trotzdem jemandem (v7.247.10)

### DIFF
--- a/lib/vutuv/social.ex
+++ b/lib/vutuv/social.ex
@@ -181,7 +181,7 @@ defmodule Vutuv.Social do
     follow = Repo.get_by!(Follow, id: follow_id, follower_id: follower_id)
 
     follow
-    |> Follow.changeset(%{muted: not follow.muted})
+    |> Follow.mute_changeset(%{muted: not follow.muted})
     |> Repo.update!()
   end
 
@@ -260,16 +260,38 @@ defmodule Vutuv.Social do
   Drives where a member's "home" is (`VutuvWeb.Home`): the newsfeed only has
   something to show once you follow someone, so until then (most visibly right
   after sign-up) home is the member's own profile instead of an empty feed.
+
+  **A followed page counts** (issue #1336). The member arm reaches the followee
+  through an inner join to `users`, so an organization follow — `followee_id IS
+  NULL` — was invisible to it, and somebody who followed three company pages was
+  told they follow nobody and sent to their own profile while their feed was
+  filling up with those pages' posts. The two arms are separate `EXISTS` queries
+  rather than one union because `or` short-circuits: the ordinary case (a member
+  who follows members) costs exactly what it cost before.
   """
   def follows_anyone?(%User{id: id}), do: follows_anyone?(id)
 
   def follows_anyone?(user_id) do
-    Repo.exists?(
-      from(c in Follow,
-        join: u in assoc(c, :followee),
-        where: account_confirmed_row(u) and not account_hidden_row(u),
-        where: c.follower_id == ^user_id
-      )
+    Repo.exists?(followed_member_query(user_id)) or
+      Repo.exists?(followed_page_query(user_id))
+  end
+
+  defp followed_member_query(user_id) do
+    from(c in Follow,
+      join: u in assoc(c, :followee),
+      where: account_confirmed_row(u) and not account_hidden_row(u),
+      where: c.follower_id == ^user_id
+    )
+  end
+
+  # A page the member follows that is still shown. `status` is the page's own
+  # gate, the organization twin of the confirmed/not-hidden pair above: a
+  # follower of a frozen page should not be sent to a feed it cannot fill.
+  defp followed_page_query(user_id) do
+    from(c in Follow,
+      join: o in Organization,
+      on: o.id == c.followee_organization_id,
+      where: c.follower_id == ^user_id and o.status == "active"
     )
   end
 

--- a/lib/vutuv/social/follow.ex
+++ b/lib/vutuv/social/follow.ex
@@ -45,6 +45,21 @@ defmodule Vutuv.Social.Follow do
     |> foreign_key_constraint(:followee_organization_id)
   end
 
+  @doc """
+  Flips the follower's own mute flag on a row that already exists.
+
+  Its own changeset because `changeset/2` re-validates the identity columns, and
+  an organization follow legitimately has no `followee_id` — so muting a page
+  raised `Ecto.InvalidChangesetError`, i.e. a 500 on `PUT /follows/:id/mute`,
+  which is reachable with any follow id the member owns. Nothing here may cast
+  an identity column: who follows whom is not what a mute changes.
+  """
+  def mute_changeset(model, params \\ %{}) do
+    model
+    |> cast(params, [:muted])
+    |> validate_required([:muted])
+  end
+
   @required_fields ~w(follower_id followee_id)a
   @optional_fields ~w(muted)a
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.247.9",
+      version: "7.247.10",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/organization_follow_gaps_test.exs
+++ b/test/vutuv/organization_follow_gaps_test.exs
@@ -1,0 +1,70 @@
+defmodule Vutuv.OrganizationFollowGapsTest do
+  @moduledoc """
+  Following a page is following, and two surfaces disagreed.
+
+  `follows_anyone?/1` reaches the followee through an INNER JOIN to `users`, and
+  an organization follow has `followee_id IS NULL` — the second of the three
+  shapes the nullable-pair model keeps producing, and the one that fails
+  silently. `toggle_follow_mute!/2` went through a changeset that re-validates
+  `followee_id`, which fails loudly instead.
+
+  Still open, and deliberately not asserted here: the Following **list** and its
+  count omit followed pages the same way, so a member cannot see or unfollow a
+  page except by returning to it. That one is not a query fix — a page has a
+  logo and no work history or tags, so it needs its own section rather than a
+  row in `card_list`, plus the agent-format siblings and the API.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag and the DNS-resolver stub beside it.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Organizations
+  alias Vutuv.Posts
+  alias Vutuv.Social
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp page_with_a_post do
+    owner = insert(:activated_user)
+    organization = active_organization_for(owner)
+    {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+    {:ok, post} = Posts.create_organization_post(organization, owner, %{body: "Neu bei uns."})
+    {organization, post}
+  end
+
+  test "a member who follows only pages is sent to their feed, not their profile" do
+    {organization, _post} = page_with_a_post()
+    member = insert(:activated_user)
+    {:ok, _} = Social.follow_organization(member, organization)
+
+    # Their feed really does have something in it — the page's post arrives
+    # through feed_organization_post_items/3. Sending them to their own profile
+    # instead is the app telling them they follow nobody while showing them
+    # posts from somebody.
+    assert %{entries: [_ | _]} = Posts.feed_page(member)
+    assert Social.follows_anyone?(member)
+  end
+
+  test "muting a page's follow works instead of raising" do
+    {organization, _post} = page_with_a_post()
+    member = insert(:activated_user)
+    {:ok, follow} = Social.follow_organization(member, organization)
+
+    # PUT /follows/:id/mute is reachable with any follow id the member owns, so
+    # a changeset that still demands followee_id turns it into a 500.
+    muted = Social.toggle_follow_mute!(member.id, follow.id)
+    assert muted.muted
+  end
+end


### PR DESCRIPTION
Zwei Fehler aus dem Organisations-Meilenstein, beide von mir eingebaut, beide dieselbe Form: die Abfrage erreicht den Gefolgten über einen INNER JOIN auf `users`, und ein Seiten-Follow hat `followee_id IS NULL`.

**1. Wer nur Seiten folgt, landete auf dem eigenen Profil.** `follows_anyone?/1` entscheidet, wo das Zuhause eines Mitglieds ist. Drei Firmenseiten gefolgt, und die App sagte „du folgst niemandem" und schickte einen aufs eigene Profil — während sich der Feed mit genau den Beiträgen dieser Seiten füllte. Die Funktion hat jetzt einen zweiten Arm, gegatet auf `status = "active"`, das organisationsseitige Gegenstück zum bestätigt-und-nicht-versteckt-Paar der Mitgliederseite. Zwei getrennte `EXISTS` statt einer Union, weil `or` kurzschließt: der Normalfall (ein Mitglied, das Mitgliedern folgt) kostet genau so viel wie vorher.

**2. Eine Seite stummschalten war ein 500.** `toggle_follow_mute!/2` ging durch `changeset/2`, das die Identitätsspalten erneut prüft — also `validate_required([:followee_id])` auf einer Zeile, die zu Recht keine hat. `PUT /follows/:id/mute` ist mit jeder Follow-id erreichbar, die dem Mitglied gehört, also war das kein theoretischer Pfad. Neu ist `mute_changeset/2`, das nichts außer `:muted` castet: wer wem folgt, ist nicht das, was ein Mute ändert.

Gefunden habe ich beide beim Kartieren der 119 Lesestellen von `follower_id` für den nächsten Schritt von #1336 — die Karte hat unterwegs diese zwei fertigen Fehler ausgeworfen.

**Noch offen**, im Moduldoc des Tests vermerkt und nicht mit rot-gelassenem Test „markiert": die Following-Liste und ihr Zähler lassen gefolgte Seiten aus demselben Grund weg, sodass man eine Seite nur wieder loswird, indem man sie erneut aufsucht. Das ist kein Query-Fix — eine Seite hat ein Logo und weder Berufserfahrung noch Tags, braucht in `card_list` also einen eigenen Abschnitt statt einer Zeile, dazu die `.md`/`.txt`/`.json`/`.xml`-Geschwister und die API. Kommt als eigenes Stück.

Beide Tests sind vor dem Fix rot, geprüft. `mix precommit` grün (7230 Tests).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01MMwsQi49FP21xuSoPEkMnN
