### PR TITLE
Die Following-Seite zeigt die Seiten, denen man folgt (v7.248.0)

### DIFF
--- a/lib/vutuv/social.ex
+++ b/lib/vutuv/social.ex
@@ -244,7 +244,29 @@ defmodule Vutuv.Social do
     )
   end
 
+  # Following counts **both kinds** (issue #1336): a followed page is something
+  # the member follows, so leaving it out made the profile header disagree with
+  # what they had done. Hence two LEFT joins and one gate per kind rather than
+  # the inner join this used to be — an organization follow has `followee_id IS
+  # NULL` and an inner join to `users` drops it silently.
+  #
+  # The list underneath splits the two into their own sections, so its pager
+  # counts members alone (`followee_member_count_query/1`). This one is the
+  # figure a person reads.
   defp followee_count_query(user_id) do
+    from(c in Follow,
+      left_join: u in assoc(c, :followee),
+      left_join: o in Organization,
+      on: o.id == c.followee_organization_id,
+      where: c.follower_id == ^user_id,
+      where:
+        (not is_nil(u.id) and account_confirmed_row(u) and not account_hidden_row(u)) or
+          (not is_nil(o.id) and o.status == "active"),
+      select: %{kind: type(^"followees", :string), total: count(c.id)}
+    )
+  end
+
+  defp followee_member_count_query(user_id) do
     from(c in Follow,
       join: u in assoc(c, :followee),
       where: account_confirmed_row(u) and not account_hidden_row(u),
@@ -306,8 +328,13 @@ defmodule Vutuv.Social do
   def follows_page(%User{} = user, side, params) when side in [:followers, :followees] do
     {total, assoc, person} =
       case side do
-        :followers -> {follower_count(user), :inbound_follows, :follower}
-        :followees -> {followee_count(user), :outbound_follows, :followee}
+        :followers ->
+          {follower_count(user), :inbound_follows, :follower}
+
+        # Members only: the pages this member follows are their own section
+        # (`followed_organizations/1`), so this pager must not count them.
+        :followees ->
+          {Repo.one(followee_member_count_query(user.id)).total, :outbound_follows, :followee}
       end
 
     query = Follow.latest(100, person) |> Pages.paginate(params, total)
@@ -318,6 +345,48 @@ defmodule Vutuv.Social do
       users: user |> Map.fetch!(assoc) |> Enum.map(&Map.fetch!(&1, person)),
       total: total
     }
+  end
+
+  @doc """
+  The pages `user` follows, newest follow first, as `[{follow_id, organization}]`
+  — the "Organizations" section of their Following page (issue #1336).
+
+  Its own function rather than another arm of `follows_page/3` because a page is
+  not a row in `card_list`: it has a logo and neither work history nor tags, and
+  the two kinds read better as two sections than as one interleaved list. Only
+  **active** pages, matching the count and `follows_anyone?/1` — a follower of a
+  frozen page is not shown a link that turns them away.
+
+  The follow id rides along so the section can offer `DELETE /follows/:id`,
+  which already handles an organization follow: its broadcast drops the nil
+  followee. Without it the only way to unfollow a page was to find it again.
+
+  Capped at `limit` (100, the same ceiling `Follow.latest/2` applies to the
+  member list) — the count beside the section is the honest total.
+  """
+  def followed_organizations(%User{id: user_id}, limit \\ 100) do
+    Repo.all(
+      from(c in Follow,
+        join: o in Organization,
+        on: o.id == c.followee_organization_id,
+        where: c.follower_id == ^user_id and o.status == "active",
+        order_by: [desc: c.inserted_at, desc: c.id],
+        limit: ^limit,
+        select: {c.id, o}
+      )
+    )
+  end
+
+  @doc "How many active pages `user` follows — the Organizations section's count."
+  def followed_organization_count(%User{id: user_id}) do
+    Repo.aggregate(
+      from(c in Follow,
+        join: o in Organization,
+        on: o.id == c.followee_organization_id,
+        where: c.follower_id == ^user_id and o.status == "active"
+      ),
+      :count
+    )
   end
 
   def user_follows_user?(follower_id, followee_id) do

--- a/lib/vutuv_web/agent_docs/list_docs.ex
+++ b/lib/vutuv_web/agent_docs/list_docs.ex
@@ -22,6 +22,7 @@ defmodule VutuvWeb.AgentDocs.ListDocs do
   alias VutuvWeb.UI
   alias VutuvWeb.UserHelpers
 
+  alias Vutuv.Organizations
   alias Vutuv.Tags.Tag
   alias Vutuv.Tags.UserTag
 
@@ -39,7 +40,7 @@ defmodule VutuvWeb.AgentDocs.ListDocs do
   One page of `/:slug/followers`, `/:slug/following` or `/:slug/connections`
   (for connections: the accepted ones — the public part of the page).
   """
-  def build_follow_list(user, side, people, total) when side in @sides do
+  def build_follow_list(user, side, people, total, opts \\ []) when side in @sides do
     path = "/#{user.username}/#{side}"
     name = UserHelpers.full_name(user)
 
@@ -70,6 +71,28 @@ defmodule VutuvWeb.AgentDocs.ListDocs do
       total: total,
       people: Enum.map(people, &person_entry(&1, work_info_by_id, tags_by_id))
     })
+    |> put_followed_organizations(opts[:organizations])
+  end
+
+  # The pages a member follows (issue #1336), as their own key rather than mixed
+  # into `people`: an agent reading this document must be able to tell a person
+  # from an organization, and `person_ref/1` cannot describe a page anyway. Only
+  # the Following list has them, so the key is absent everywhere else instead of
+  # being an empty list on the follower and connection documents.
+  defp put_followed_organizations(doc, nil), do: doc
+
+  defp put_followed_organizations(doc, organizations) do
+    Map.put(
+      doc,
+      :organizations,
+      Enum.map(organizations, fn {_follow_id, organization} ->
+        %{
+          name: organization.name,
+          slug: organization.slug,
+          url: AgentDocs.abs_url(Organizations.canonical_path(organization))
+        }
+      end)
+    )
   end
 
   @doc """

--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -182,7 +182,8 @@ defmodule VutuvWeb.AgentDocs.Markdown do
       "# #{doc.title}",
       gettext("%{count} total", count: doc.total) <>
         page_hint(doc.total, doc.people, &paren_hint/1),
-      Enum.map_join(doc.people, "\n\n", &person_line/1)
+      Enum.map_join(doc.people, "\n\n", &person_line/1),
+      followed_organizations(doc)
     ]
     |> join_blocks()
   end
@@ -337,6 +338,19 @@ defmodule VutuvWeb.AgentDocs.Markdown do
     ]
     |> join_blocks()
   end
+
+  # The pages this member follows (issue #1336), under their own heading rather
+  # than among the people: a reader has to be able to tell a person from an
+  # organization. Only the Following document carries the key, so every other
+  # people list skips the block entirely.
+  defp followed_organizations(%{organizations: [_ | _] = organizations}) do
+    join_blocks([
+      "## " <> gettext("Organizations"),
+      Enum.map_join(organizations, "\n", &"- [#{&1.name}](#{&1.url})")
+    ])
+  end
+
+  defp followed_organizations(_doc), do: nil
 
   # An organization's alternative names (issue #930), or nil when it has none.
   defp also_known_as(%{also_known_as: [_ | _] = names}),

--- a/lib/vutuv_web/agent_docs/text.ex
+++ b/lib/vutuv_web/agent_docs/text.ex
@@ -167,6 +167,7 @@ defmodule VutuvWeb.AgentDocs.Text do
       gettext("%{count} total", count: doc.total) <>
         Markdown.page_hint(doc.total, doc.people, &dash_hint/1),
       Enum.map(doc.people, &person_line/1),
+      followed_organizations(doc),
       footer(doc)
     ]
     |> join_blocks()
@@ -312,6 +313,18 @@ defmodule VutuvWeb.AgentDocs.Text do
     ]
     |> join_blocks()
   end
+
+  # The pages this member follows (issue #1336) — the plain-text twin of the
+  # Markdown block, under their own heading so a reader can tell a person from
+  # an organization. Absent on every other people list.
+  defp followed_organizations(%{organizations: [_ | _] = organizations}) do
+    join_blocks([
+      gettext("Organizations"),
+      Enum.map(organizations, &"- #{&1.name} — #{&1.url}")
+    ])
+  end
+
+  defp followed_organizations(_doc), do: nil
 
   # Hard-wraps `text` at @width columns. Existing newlines are kept;
   # wrapped continuation lines get `indent`. A single word longer than the

--- a/lib/vutuv_web/controllers/followee_controller.ex
+++ b/lib/vutuv_web/controllers/followee_controller.ex
@@ -14,11 +14,17 @@ defmodule VutuvWeb.FolloweeController do
     %{user: user, users: followees, total: total} =
       Vutuv.Social.follows_page(conn.assigns[:user], :followees, conn.params)
 
+    # The pages this member follows are their own section (issue #1336) — a page
+    # has a logo and neither work history nor tags, so it is not a card_list row.
+    organizations = Vutuv.Social.followed_organizations(user)
+
     AgentDocs.respond(conn,
       html: fn conn ->
         render(conn, "index.html",
           user: user,
           followees: followees,
+          organizations: organizations,
+          total_organizations: Vutuv.Social.followed_organization_count(user),
           total_followees: total,
           page_title: VutuvWeb.UserHelpers.member_page_title(user, gettext("Following")),
           work_info_by_id: VutuvWeb.UserHelpers.work_information_map(followees, 45),
@@ -34,7 +40,9 @@ defmodule VutuvWeb.FolloweeController do
         )
       end,
       doc: fn ->
-        ListDocs.build_follow_list(user, :following, followees, total)
+        ListDocs.build_follow_list(user, :following, followees, total,
+          organizations: organizations
+        )
       end
     )
   end

--- a/lib/vutuv_web/templates/followee/index.html.heex
+++ b/lib/vutuv_web/templates/followee/index.html.heex
@@ -4,6 +4,50 @@
   if(same_user?(@user, @current_user), do: gettext("Following"), else: gettext("Follows"))
 ]} />
 
+<%!-- The pages this member follows (issue #1336), above the people and in their
+own card: a page has a logo and neither work history nor tags, so it is not a
+`card_list` row. Before this section existed a followed page appeared nowhere at
+all, and the only way to unfollow one was to find it again. --%>
+<div :if={@organizations != []} class="card-list">
+  <section class="card" id="followed-organizations">
+    <h2 class="card__label">
+      {gettext("Organizations")} ({compact_count(@total_organizations)})
+    </h2>
+
+    <ul class="mt-2 divide-y divide-slate-100 dark:divide-slate-800">
+      <li :for={{follow_id, organization} <- @organizations} class="flex items-center gap-4 py-4">
+        <.link navigate={Vutuv.Organizations.canonical_path(organization)} class="shrink-0">
+          <.organization_logo organization={organization} class="h-12 w-12" />
+        </.link>
+        <div class="min-w-0 flex-1">
+          <.link
+            navigate={Vutuv.Organizations.canonical_path(organization)}
+            class="block truncate font-semibold text-slate-900 hover:text-brand-700 dark:text-slate-100 dark:hover:text-brand-300"
+          >
+            {organization.name}
+          </.link>
+          <.organization_location
+            organization={organization}
+            class="truncate text-sm text-slate-600 dark:text-slate-400"
+          />
+        </div>
+        <%!-- Owner only: unfollowing is the whole reason this list is reachable.
+        `DELETE /follows/:id` already handles a page follow — its broadcast drops
+        the nil followee — so no second route is needed. --%>
+        <.button
+          :if={same_user?(@user, @current_user)}
+          href={~p"/follows/#{follow_id}"}
+          method="delete"
+          variant="secondary"
+          class="shrink-0"
+        >
+          {gettext("Unfollow")}
+        </.button>
+      </li>
+    </ul>
+  </section>
+</div>
+
 <div class="card-list">
   <section class="card">
     <h1><%= if same_user?(@user, @current_user), do: gettext("Following"), else: gettext("Follows") %></h1>

--- a/lib/vutuv_web/views/followee_html.ex
+++ b/lib/vutuv_web/views/followee_html.ex
@@ -3,5 +3,10 @@ defmodule VutuvWeb.FolloweeHTML do
   use VutuvWeb, :html
   import VutuvWeb.UserHelpers
 
+  # The "Organizations" section renders the pages this member follows in the
+  # same row shape /settings/organizations uses, so a page reads the same
+  # wherever it is listed.
+  import VutuvWeb.OrganizationComponents, only: [organization_logo: 1, organization_location: 1]
+
   embed_templates("../templates/followee/*")
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.247.10",
+      version: "7.248.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/organization_follows_test.exs
+++ b/test/vutuv/organization_follows_test.exs
@@ -141,7 +141,7 @@ defmodule Vutuv.OrganizationFollowsTest do
       assert post.id in discovered_ids(member)
     end
 
-    test "the member following-count ignores organizations" do
+    test "the member following-count includes organizations" do
       {organization, _owner} = publishing_organization()
       member = insert(:activated_user)
       friend = insert(:activated_user)
@@ -149,9 +149,14 @@ defmodule Vutuv.OrganizationFollowsTest do
       {:ok, _} = Social.follow(member, friend.id)
       {:ok, _} = Social.follow_organization(member, organization)
 
-      # "Following" on a profile means people. The organization follow is a
-      # subscription, counted on the page rather than on the member.
-      assert Social.followee_count(member) == 1
+      # This reverses the earlier decision that "Following" on a profile means
+      # people and a page is counted on the page instead. The Following list now
+      # has an Organizations section, and the two have to agree: a member who
+      # follows only pages would otherwise read "Following 0" above a link to a
+      # page that lists them. A total of both is not a contradiction — the list
+      # underneath splits it and counts each section.
+      assert Social.followee_count(member) == 2
+      assert Social.followed_organization_count(member) == 1
     end
   end
 

--- a/test/vutuv_web/following_list_organizations_test.exs
+++ b/test/vutuv_web/following_list_organizations_test.exs
@@ -1,0 +1,106 @@
+defmodule VutuvWeb.FollowingListOrganizationsTest do
+  @moduledoc """
+  A member's "Following" page left out the pages they follow, so once you
+  followed one the only way to unfollow it was to find it again. Same shape as
+  the two fixed in v7.247.10: the list and its count reach the followee through
+  an INNER JOIN to `users`, and an organization follow has `followee_id IS NULL`.
+
+  Pages get their own section rather than a `card_list` row — a page has a logo
+  and neither work history nor tags — so the assertions here are about the
+  section, the count, the agent-format sibling and the unfollow control.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag and the DNS-resolver stub beside it.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Organizations.Organization
+  alias Vutuv.Repo
+  alias Vutuv.Social
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp member_following_a_page do
+    owner = insert(:activated_user)
+    organization = active_organization_for(owner)
+    member = insert(:activated_user)
+    {:ok, follow} = Social.follow_organization(member, organization)
+    {member, organization, follow}
+  end
+
+  test "the Following page names the page and links to it", %{conn: conn} do
+    {member, organization, _follow} = member_following_a_page()
+
+    html = conn |> get(~p"/#{member}/following") |> html_response(200)
+
+    assert html =~ organization.name
+    assert html =~ "/organizations/#{organization.slug}"
+  end
+
+  test "a followed page counts towards Following", %{conn: _conn} do
+    {member, _organization, _follow} = member_following_a_page()
+
+    # The profile header's "Following" figure reads this, so leaving pages out
+    # made the number disagree with what the member had actually done.
+    assert Social.followee_count(member) == 1
+    assert Social.social_counts(member).followees == 1
+  end
+
+  test "the member can unfollow the page from their own list", %{conn: conn} do
+    # Log in FIRST: creating a page mails its owner, and `sent_pin/0` reads the
+    # oldest email in the mailbox, so the notice would be taken for the PIN.
+    {conn, member} = create_and_login_user(conn)
+    owner = insert(:activated_user)
+    organization = active_organization_for(owner)
+    {:ok, follow} = Social.follow_organization(member, organization)
+
+    html = conn |> get(~p"/#{member}/following") |> html_response(200)
+    assert html =~ ~s(/follows/#{follow.id})
+
+    conn |> delete(~p"/follows/#{follow.id}") |> response(302)
+    refute Social.follows_organization?(member, organization)
+  end
+
+  test "a page nobody may see yet is left out", %{conn: conn} do
+    owner = insert(:activated_user)
+    organization = active_organization_for(owner)
+    member = insert(:activated_user)
+    {:ok, _} = Social.follow_organization(member, organization)
+
+    {:ok, _frozen} =
+      organization
+      |> Organization.status_changeset("frozen")
+      |> Repo.update()
+
+    html = conn |> get(~p"/#{member}/following") |> html_response(200)
+
+    refute html =~ organization.name
+    assert Social.followee_count(member) == 0
+  end
+
+  test "every agent-format sibling carries the followed page", %{conn: conn} do
+    {member, organization, _follow} = member_following_a_page()
+
+    json = conn |> get(~p"/#{member}/following.json") |> json_response(200)
+    assert Enum.any?(json["organizations"] || [], &(&1["name"] == organization.name))
+
+    # The four formats render one doc map, so a key added for JSON alone is
+    # drift: .md and .txt build their bodies field by field and would have gone
+    # on listing people only.
+    for extension <- ~w(md txt xml) do
+      body = conn |> get("/#{member.username}/following.#{extension}") |> response(200)
+      assert body =~ organization.name, "#{extension} left the followed page out"
+    end
+  end
+end


### PR DESCRIPTION
Wer einer Organisationsseite folgte, fand sie danach nirgends wieder. Die Following-Liste erreicht den Gefolgten über einen INNER JOIN auf `users`, und ein Seiten-Follow hat `followee_id IS NULL` — dieselbe Form wie die zwei Fehler aus v7.247.10. Der einzige Weg zum Entfolgen war, die Seite erneut aufzusuchen.

**Seiten bekommen einen eigenen Abschnitt** über den Personen, keine Zeile in `card_list`: eine Seite hat ein Logo und weder Berufserfahrung noch Tags, und zwei Sorten in einer Liste zu mischen liest sich schlechter als zwei Abschnitte. Die Zeile hat dieselbe Form wie unter `/settings/organizations`, damit eine Seite überall gleich aussieht. Für den Eigentümer trägt sie einen Entfolgen-Knopf; `DELETE /follows/:id` konnte das übrigens längst, weil sein Broadcast den nil-Followee wegwirft, also braucht es keine zweite Route.

**Eine frühere Entscheidung kehre ich hier bewusst um**, deshalb sage ich es lieber deutlich: `followee_count/1` zählt jetzt beide Sorten. Bisher hieß „Following" auf einem Profil *Personen*, und ein Seiten-Follow wurde an der Seite gezählt — ich hatte das seinerzeit so festgelegt und in einem Test festgeschrieben. Sobald die Liste einen Abschnitt für Seiten hat, geht das nicht mehr auf: wer nur Seiten folgt, läse „Following 0" über einem Link auf eine Seite, die sie auflistet. Eine Gesamtzahl ist dagegen kein Widerspruch, weil die Liste darunter aufteilt und jeden Abschnitt einzeln zählt. Der Pager der Personenliste zählt weiterhin nur Personen (`followee_member_count_query/1`). Wenn du die alte Lesart lieber behalten willst, sag Bescheid — dann drehe ich es zurück und die Kopfzahl bleibt bei Personen.

Gelistet wird nur, was auch sichtbar ist (`status = "active"`), genau wie bei `follows_anyone?/1`: einen Link anzubieten, der den Leser abweist, ist keine Hilfe.

**Alle vier Agent-Formate** tragen den neuen Schlüssel. Das war nicht geschenkt: `.md` und `.txt` bauen ihren Körper Feld für Feld und hätten weiter nur Personen aufgezählt, während JSON und XML die Map generisch serialisieren. Der Test prüft deshalb md, txt, xml **und** json, nicht nur json.

Unterwegs zweimal in bekannte Fallen getappt und beide Male von der eigenen Regel eingefangen: die privaten Helfer landeten zwischen zwei `render/1`-Klauseln (`--warnings-as-errors`), und `sent_pin/0` liest die *älteste* Mail im Postfach, also muss man sich einloggen, bevor eine Seite ihre Eigentümer-Benachrichtigung verschickt.

`mix precommit` grün (7235 Tests).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01MMwsQi49FP21xuSoPEkMnN
