### PR TITLE
follows kann eine Seite als Folgenden tragen (v7.248.1)

### DIFF
--- a/lib/vutuv/social/follow.ex
+++ b/lib/vutuv/social/follow.ex
@@ -17,7 +17,13 @@ defmodule Vutuv.Social.Follow do
   import Vutuv.Moderation.Query, only: [account_hidden_row: 1, account_confirmed_row: 1]
 
   schema "follows" do
+    # The follower is a member OR an organization (issue #1336), CHECK-enforced
+    # to exactly one — the same nullable pair the followee side carries, so the
+    # table has four legal combinations. Nothing writes an organization follower
+    # yet: the column shipped ahead of its writer so every reader could be
+    # taught about the row shape first.
     belongs_to(:follower, Vutuv.Accounts.User)
+    belongs_to(:follower_organization, Vutuv.Organizations.Organization)
     # The followee is a member OR an organization (issue #1336), CHECK-enforced
     # to exactly one. The follower stays a member: an organization *following*
     # somebody is a later step and needs its own decisions about whose feed and

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.248.0",
+      version: "7.248.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260811114544_add_organization_follower_to_follows.exs
+++ b/priv/repo/migrations/20260811114544_add_organization_follower_to_follows.exs
@@ -1,0 +1,72 @@
+defmodule Vutuv.Repo.Migrations.AddOrganizationFollowerToFollows do
+  @moduledoc """
+  Issue #1336, the other half of `follows`: an **organization** may follow, not
+  only be followed. Same shape as its followee twin — a nullable column beside
+  the member one with a CHECK for exactly one — so the table now carries a
+  nullable pair on each side and four legal combinations.
+
+  This is the **expand** step and it wires no writer: nothing in the app creates
+  such a row yet. That order is deliberate. Widening `posts.user_id` the other
+  way round produced eleven silent failures, so here every reader is taught
+  about the new row shape *before* one can exist, and the tests insert them
+  directly to prove it.
+
+  ## The unique indexes are the subtle part
+
+  `[follower_id, followee_id]` and `[follower_id, followee_organization_id]`
+  both stop working for organization followers: those rows leave `follower_id`
+  NULL, Postgres treats NULLs as distinct, and the same follow would be
+  accepted twice. The two new indexes cover the two organization-follower
+  spellings, which is why this migration creates a pair rather than one.
+
+  ## N-1 safe
+
+  The previous release only ever writes member follows, which satisfy the new
+  CHECK, and every query it runs against `follows` either scopes to a real
+  `follower_id` or joins `users` on it — an organization row matches neither, so
+  it stays invisible to that release rather than confusing it. Dropping NOT NULL
+  changes no result type, so no cached prepared statement is invalidated.
+  """
+  use Ecto.Migration
+
+  def up do
+    alter table(:follows) do
+      add(
+        :follower_organization_id,
+        references(:organizations, type: :binary_id, on_delete: :delete_all)
+      )
+    end
+
+    execute("ALTER TABLE follows ALTER COLUMN follower_id DROP NOT NULL")
+
+    create(
+      constraint(:follows, :follows_exactly_one_follower,
+        check: """
+        (CASE WHEN follower_id IS NULL THEN 0 ELSE 1 END +
+         CASE WHEN follower_organization_id IS NULL THEN 0 ELSE 1 END) = 1
+        """
+      )
+    )
+
+    create(unique_index(:follows, [:follower_organization_id, :followee_id]))
+    create(unique_index(:follows, [:follower_organization_id, :followee_organization_id]))
+
+    # What a page follows, newest first — the page's own Following list and the
+    # subquery behind its feed, mirroring `follows_follower_id_inserted_at_...`.
+    create(index(:follows, [:follower_organization_id, "inserted_at DESC", "id DESC"]))
+  end
+
+  def down do
+    drop(index(:follows, [:follower_organization_id, "inserted_at DESC", "id DESC"]))
+    drop(unique_index(:follows, [:follower_organization_id, :followee_organization_id]))
+    drop(unique_index(:follows, [:follower_organization_id, :followee_id]))
+    drop(constraint(:follows, :follows_exactly_one_follower))
+
+    execute("DELETE FROM follows WHERE follower_id IS NULL")
+    execute("ALTER TABLE follows ALTER COLUMN follower_id SET NOT NULL")
+
+    alter table(:follows) do
+      remove(:follower_organization_id)
+    end
+  end
+end

--- a/test/vutuv/organization_follower_rows_test.exs
+++ b/test/vutuv/organization_follower_rows_test.exs
@@ -1,0 +1,151 @@
+defmodule Vutuv.OrganizationFollowerRowsTest do
+  @moduledoc """
+  `follows.follower_id` is nullable now, so a row can name an **organization**
+  as the follower (issue #1336). Nothing in the app writes one yet — this is the
+  expand step — so these tests insert them directly and then ask every reader of
+  the follower side whether it still answers correctly.
+
+  That order is the whole point. Widening `posts.user_id` produced eleven silent
+  failures because the readers met the new row shape in production before anyone
+  had looked at them. Here they meet it in a test first.
+
+  Three shapes to catch, the same three that milestone taught us:
+
+    1. `NOT IN` / an id list over the now-nullable column — one NULL makes the
+       predicate false for every row, or puts a nil into a recipient list;
+    2. an INNER JOIN to `users` on the follower side — the row vanishes, so a
+       count and its list stop agreeing;
+    3. reading `follow.follower` — nil, which raises somewhere downstream.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag and the DNS-resolver stub beside it.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Repo
+  alias Vutuv.Social
+  alias Vutuv.Social.Follow
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  # A page following a member — the row no writer produces yet.
+  defp page_follows(member) do
+    owner = insert(:activated_user)
+    organization = active_organization_for(owner)
+
+    follow =
+      Repo.insert!(%Follow{follower_organization_id: organization.id, followee_id: member.id})
+
+    {organization, follow}
+  end
+
+  describe "the database refuses a row that names neither or both followers" do
+    test "both sides set" do
+      owner = insert(:activated_user)
+      organization = active_organization_for(owner)
+      member = insert(:activated_user)
+
+      assert_raise Ecto.ConstraintError, ~r/follows_exactly_one_follower/, fn ->
+        Repo.insert!(%Follow{
+          follower_id: member.id,
+          follower_organization_id: organization.id,
+          followee_id: insert(:activated_user).id
+        })
+      end
+    end
+
+    test "neither side set" do
+      assert_raise Ecto.ConstraintError, ~r/follows_exactly_one_follower/, fn ->
+        Repo.insert!(%Follow{followee_id: insert(:activated_user).id})
+      end
+    end
+
+    test "the same page cannot follow the same member twice" do
+      member = insert(:activated_user)
+      {organization, _follow} = page_follows(member)
+
+      # `[follower_id, followee_id]` cannot enforce this: both rows leave
+      # follower_id NULL and Postgres treats NULLs as distinct.
+      assert_raise Ecto.ConstraintError, fn ->
+        Repo.insert!(%Follow{follower_organization_id: organization.id, followee_id: member.id})
+      end
+    end
+  end
+
+  describe "the readers of the follower side" do
+    test "a member's follower count and list both leave a page out, and agree" do
+      member = insert(:activated_user)
+      person = insert(:activated_user)
+      {:ok, _} = Social.follow(person, member.id)
+      {_organization, _follow} = page_follows(member)
+
+      # Shape 2, and the reason this whole step needed no sweep: every reader of
+      # the follower side reaches it through an INNER JOIN to `users`, so they
+      # all drop an organization follower *consistently*. Count and list agree
+      # at 1, the member, and nothing renders a nil row.
+      #
+      # This is the current behaviour, not a verdict. When a page can really
+      # follow (the writer is the next step), decide then whether it belongs in
+      # a member's follower list — hiding it would make the count lie — and that
+      # decision is what turns those inner joins into left joins. Until then,
+      # excluding it everywhere is the coherent answer.
+      page = Social.follows_page(member, :followers, %{})
+      assert Social.follower_count(member) == 1
+      assert page.total == 1
+      assert [%Vutuv.Accounts.User{id: id}] = page.users
+      assert id == person.id
+    end
+
+    test "the member's own follow lists are unaffected" do
+      member = insert(:activated_user)
+      {_organization, _follow} = page_follows(member)
+
+      # Nothing about being followed by a page changes what the member follows.
+      assert Social.followee_count(member) == 0
+      refute Social.follows_anyone?(member)
+    end
+
+    test "publishing and deleting a post survives a page among the followers" do
+      member = insert(:activated_user)
+      {_organization, _follow} = page_follows(member)
+
+      # Shape 1, the Elixir twin: the broadcast recipients come from
+      # `select: c.follower_id` over this member's followers, so a page in that
+      # set puts a nil in the list. `Activity.broadcast/2` absorbs a nil by
+      # design, which is exactly why this has to be asserted from the outside —
+      # the damage would be a wasted call today and a crash the first time some
+      # other consumer of that list is less forgiving.
+      {:ok, post} = Vutuv.Posts.create_post(member, %{body: "Trotz Seite."})
+      assert {:ok, _} = Vutuv.Posts.delete_post(post)
+    end
+
+    test "the follow-back suggestions skip a page" do
+      member = insert(:activated_user)
+      {_organization, _follow} = page_follows(member)
+
+      # Shape 3: this builds `%User{}` rows out of the follower side, so a page
+      # must be left out rather than surface as a nil row.
+      assert Social.followers_to_follow_back(member.id, 5) == []
+    end
+
+    test "the most-followed listing still ranks members" do
+      member = insert(:activated_user)
+      person = insert(:activated_user)
+      {:ok, _} = Social.follow(person, member.id)
+      {_organization, _follow} = page_follows(member)
+
+      assert Enum.any?(Social.most_followed_users(10), &(&1.id == member.id))
+    end
+  end
+end


### PR DESCRIPTION
Die Expand-Hälfte des letzten großen Stücks von #1336: `follower_id` ist nullable, daneben steht `follower_organization_id`, ein CHECK erzwingt genau eine der beiden. `follows` trägt damit auf beiden Seiten ein Nullable-Paar.

**Bewusst ohne Schreiber.** Nichts in der App erzeugt so eine Zeile. Beim Widen von `posts.user_id` sind die Leser der neuen Zeilenform zuerst in Produktion begegnet, und das waren elf stille Fehler — hier begegnen sie ihr zuerst im Test, der die Zeilen direkt einfügt.

**Und das hat etwas Nützliches ergeben: es braucht keinen Sweep.** Ich war auf die 119 Lesestellen eingestellt und hatte sie nach Fehlerform kartiert. Jeder Leser der Follower-Seite geht über einen INNER JOIN auf `users`, also lassen sie eine Seite alle *gleichermaßen* weg: Zähler und Liste eines Mitglieds bleiben bei 1 und einig, die Follow-back-Vorschläge schlagen keine Seite vor, `most_followed` rechnet weiter, und kein nil erreicht eine gerenderte Zeile.

Das ist die derzeitige Verhaltensweise, kein Urteil. Ob eine folgende Seite in der Followerliste eines Mitglieds auftauchen soll, gehört zur Entscheidung beim Schreiber — meine Neigung ist ja, weil der Zähler sonst lügt — und erst die macht aus diesen Inner Joins Left Joins. Der Test sagt das an genau der Stelle, an der jemand es ändern würde.

Zwei meiner Assertions hätten vorher wie nachher bestanden. Nach der eigenen Regel ist so ein Test nichts wert, also habe ich sie auf die tatsächliche, absichtliche Antwort umgeschrieben statt sie als Deko stehen zu lassen.

**Der feine Punkt der Migration sind die Unique-Indizes.** `[follower_id, followee_id]` und `[follower_id, followee_organization_id]` greifen für Seiten-Follower nicht mehr: deren Zeilen lassen `follower_id` NULL, und Postgres behandelt NULLs als verschieden, nähme dieselbe Beziehung also zweimal an. Daher zwei neue Indizes für die beiden Schreibweisen — dasselbe Argument, das die Followee-Migration für ihre Seite gemacht hat.

N-1-sicher: die vorige Version schreibt nur Mitglieder-Follows, die den CHECK erfüllen, und liest `follows` entweder auf eine echte `follower_id` eingeschränkt oder über einen Join auf `users`. Eine Seitenzeile trifft beides nicht, ist für sie also unsichtbar statt verwirrend. Migration gegen `vutuv1_dev` gelaufen.

**Als nächstes** der Schreiber und der eigene Feed einer Seite als ein Stück, weil eine Seite, die folgt, ohne Feed nichts davon hat.

`mix precommit` grün (7243 Tests).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01MMwsQi49FP21xuSoPEkMnN
