### PR TITLE
Der Followerzähler einer Seite verspricht keine Follower mehr, die sie nie nennt (v7.248.2)

### DIFF
--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -1728,9 +1728,16 @@ defmodule Vutuv.Fediverse do
 
   # The same rule the local feed uses: a muted follow keeps the relationship and
   # drops that member's posts out of this feed — including what they reshare.
+  # The `not is_nil` is not decoration: since #1336 a followed **page** leaves
+  # `followee_id` NULL, so this list carries nils. Both current callers use a
+  # positive `in subquery(...)`, where a nil is merely ignored — but the same
+  # list negated (`not in`) is false for every row, silently, which is how the
+  # discovery rail emptied itself for anyone who followed a page. Guarding here
+  # means the next caller cannot inherit that, whichever way it asks.
   defp unmuted_followees(viewer_id) do
     from(f in Vutuv.Social.Follow,
       where: f.follower_id == ^viewer_id and f.muted == false,
+      where: not is_nil(f.followee_id),
       select: f.followee_id
     )
   end

--- a/lib/vutuv/social.ex
+++ b/lib/vutuv/social.ex
@@ -138,9 +138,26 @@ defmodule Vutuv.Social do
   def follows_organization?(follower, %Organization{id: organization_id}),
     do: organization_follow(follower_id(follower), organization_id) != nil
 
-  @doc "How many members follow `organization`."
+  @doc """
+  How many members follow `organization`.
+
+  Gated exactly like the follower rows on the page's activity list
+  (`Organizations.activity_follows/3`), which is the member-side rule too: a
+  count and the list it stands for must agree. Without the join this counted
+  every row — unconfirmed and moderation-hidden members, and now that the column
+  exists, a page following a page — so the figure above the page could promise
+  followers it would never name.
+  """
   def organization_follower_count(%Organization{id: id}) do
-    Repo.aggregate(from(f in Follow, where: f.followee_organization_id == ^id), :count)
+    Repo.aggregate(
+      from(f in Follow,
+        join: u in User,
+        on: u.id == f.follower_id,
+        where: f.followee_organization_id == ^id,
+        where: account_confirmed_row(u) and not account_hidden_row(u)
+      ),
+      :count
+    )
   end
 
   defp follower_id(%Vutuv.Accounts.User{id: id}), do: id

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.248.1",
+      version: "7.248.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/organization_follower_gate_test.exs
+++ b/test/vutuv/organization_follower_gate_test.exs
@@ -1,0 +1,82 @@
+defmodule Vutuv.OrganizationFollowerGateTest do
+  @moduledoc """
+  Two leftovers from the nullable-pair milestone, both about a gate that one
+  side of a pair applies and the other does not.
+
+  A page's follower **count** gated on nothing while the follower list on its
+  activity page gated on confirmed-and-not-hidden, so the number above the page
+  could exceed everyone it would ever name. The member side has kept those two
+  in step from the start — `follower_count_query/1` carries a comment saying it
+  matches `Follow.latest/2` — and the organization twin was written without it.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag and the DNS-resolver stub beside it.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Organizations
+  alias Vutuv.Repo
+  alias Vutuv.Social
+  alias Vutuv.Social.Follow
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp activity_follower_ids(organization) do
+    organization
+    |> Organizations.activity_page()
+    |> Map.fetch!(:entries)
+    |> Enum.filter(&(&1.kind == "follow"))
+    |> Enum.map(& &1.actor.id)
+  end
+
+  test "an unconfirmed follower is left out of the count, as it is out of the list" do
+    owner = insert(:activated_user)
+    organization = active_organization_for(owner)
+
+    shown = insert(:activated_user)
+    hidden = insert(:user, email_confirmed?: false)
+
+    {:ok, _} = Social.follow_organization(shown, organization)
+    {:ok, _} = Social.follow_organization(hidden, organization)
+
+    assert activity_follower_ids(organization) == [shown.id]
+    assert Social.organization_follower_count(organization) == 1
+  end
+
+  test "a page following a page is not counted as one of its members" do
+    owner = insert(:activated_user)
+    organization = active_organization_for(owner)
+
+    other =
+      active_organization_for(insert(:activated_user), %{
+        "name" => "Zweite AG",
+        "website_url" => "https://zweite.example"
+      })
+
+    member = insert(:activated_user)
+    {:ok, _} = Social.follow_organization(member, organization)
+
+    Repo.insert!(%Follow{
+      follower_organization_id: other.id,
+      followee_organization_id: organization.id
+    })
+
+    # The activity list joins `users` on the follower, so it can never show a
+    # page; a count that includes one would promise a follower nobody can see.
+    # (Whether a page's followers should list pages at all is the writer's
+    # decision — see the plan on issue #1336. Until then the two agree.)
+    assert activity_follower_ids(organization) == [member.id]
+    assert Social.organization_follower_count(organization) == 1
+  end
+end


### PR DESCRIPTION
Zwei Nachzügler aus dem Nullable-Paar-Meilenstein, beide von der Sorte „ein Tor, das die eine Seite eines Paares kennt und die andere nicht".

**Der Followerzähler einer Seite versprach Follower, die sie nie nennt.** `organization_follower_count/1` zählte jede Zeile, während die Followerliste auf der Aktivitätsseite über einen Join auf `users` geht und auf bestätigt-und-nicht-moderationsversteckt filtert. Auf der Mitgliederseite stehen diese beiden seit jeher im Gleichschritt — `follower_count_query/1` trägt sogar einen Kommentar, der sagt, dass es zu `Follow.latest/2` passt — beim Organisations-Zwilling ist es untergegangen. Er bekommt jetzt dasselbe Tor, was zugleich den Fall miterledigt, den die Spalte aus #1383 möglich macht: eine Seite, die einer Seite folgt, würde gezählt und von der Liste nie gezeigt.

**`unmuted_followees/1` bekommt sein `not is_nil`.** Seit #1336 lässt ein gefolgter Seiten-Eintrag `followee_id` NULL, die Liste trägt also nils. Beide heutigen Aufrufer benutzen ein positives `in subquery(...)`, wo ein nil schlicht ignoriert wird — dieselbe Liste negiert ist aber für *jede* Zeile falsch, still, und genau so hat sich die Discovery-Leiste seinerzeit für jeden geleert, der einer Seite folgt. Das Tor gehört an die Quelle, damit der nächste Aufrufer es nicht erben muss, egal wie herum er fragt. Ihre drei Geschwister in `posts.ex` haben es längst.

Beide Tests sind vor dem Fix rot (Zähler 2, Liste 1).

**Was ich bewusst nicht angefasst habe:** den Schreiber und den eigenen Feed einer Seite. Beim Aufmessen kam heraus, dass das keine Programmier-, sondern eine Produktfrage ist. Der Feed zieht aus sechs Quellen, die durchweg `%User{}`-förmig sind, und eine Seite hat noch keine eigenen Likes oder Lesezeichen — die Aktionsleiste unter jeder Karte hätte also keinen Besitzer, und „gehört dem handelnden Mitglied" verwischt genau die Trennung, für die der Identitätswechsel da ist. Dazu zwei offene Fragen: wo der Feed einer Seite wohnt (`/organizations/:slug/feed`, nur für Redaktion?) und ob eine folgende Seite in der Followerliste eines Mitglieds auftaucht (meine Neigung: ja, sonst lügt der Zähler). Beides steht auf #1336; ich rate da lieber nicht.

`mix precommit` grün (7245 Tests).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01MMwsQi49FP21xuSoPEkMnN
