### PR TITLE
Eine Seite kann folgen, und man sieht es (v7.249.0)

### DIFF
--- a/lib/vutuv/social.ex
+++ b/lib/vutuv/social.ex
@@ -26,6 +26,24 @@ defmodule Vutuv.Social do
   alias Vutuv.Social.UserLike
   alias Vutuv.UUIDv7
 
+  # The two halves of "this follow names somebody who may still be shown", as
+  # macros so both the count and the list read the same rule. A page is gated
+  # exactly like `Organizations.public_visible?/1`: active AND not frozen — the
+  # frozen half is easy to forget, because `status` stays "active" through a
+  # freeze.
+  defmacrop visible_member(u) do
+    quote do
+      not is_nil(unquote(u).id) and account_confirmed_row(unquote(u)) and
+        not account_hidden_row(unquote(u))
+    end
+  end
+
+  defmacrop visible_page(o) do
+    quote do
+      not is_nil(unquote(o).id) and unquote(o).status == "active" and is_nil(unquote(o).frozen_at)
+    end
+  end
+
   # ── Follows ──
 
   @doc """
@@ -160,6 +178,101 @@ defmodule Vutuv.Social do
     )
   end
 
+  @doc """
+  A page follows a member or another page (issue #1336) — the writer for the
+  column that shipped in v7.248.1. Idempotent, like its member twin.
+
+  No notification and no block check, for the same reasons `follow_organization/2`
+  has neither: a page has no inbox, and a block is between two people.
+  """
+  def follow_as_organization(%Organization{} = page, followee) do
+    {column, followee_id} = followee_column(followee)
+
+    result =
+      %Follow{}
+      |> Follow.organization_follower_changeset(column, %{
+        :follower_organization_id => page.id,
+        column => followee_id
+      })
+      |> Repo.insert()
+
+    case result do
+      {:ok, _follow} = ok ->
+        # The followee's own profile recomputes: a page counts as a follower.
+        broadcast_social_graph_changed([followee_id])
+        ok
+
+      {:error, _changeset} ->
+        case organization_follow_edge(page.id, column, followee_id) do
+          %Follow{} = existing -> {:ok, existing}
+          nil -> result
+        end
+    end
+  end
+
+  @doc "Drops a page's follow of `followee`. Idempotent."
+  def unfollow_as_organization(%Organization{} = page, followee) do
+    {column, followee_id} = followee_column(followee)
+
+    case organization_follow_edge(page.id, column, followee_id) do
+      %Follow{} = follow ->
+        Repo.delete!(follow)
+        broadcast_social_graph_changed([followee_id])
+        :ok
+
+      nil ->
+        :ok
+    end
+  end
+
+  @doc "Whether `page` follows `followee`."
+  def organization_follows?(%Organization{} = page, followee) do
+    {column, followee_id} = followee_column(followee)
+    organization_follow_edge(page.id, column, followee_id) != nil
+  end
+
+  defp followee_column(%Organization{id: id}), do: {:followee_organization_id, id}
+  defp followee_column(%User{id: id}), do: {:followee_id, id}
+
+  defp organization_follow_edge(page_id, column, followee_id) do
+    Repo.get_by(Follow, [{:follower_organization_id, page_id}, {column, followee_id}])
+  end
+
+  @doc """
+  What `page` follows, newest first, as `[{follow_id, member_or_page}]` — the
+  page's own Following list. Only followees that are still shown, the same gate
+  a member's list applies to each kind.
+  """
+  def organization_followees(%Organization{id: page_id}, limit \\ 100) do
+    Repo.all(
+      from(f in Follow,
+        left_join: u in assoc(f, :followee),
+        left_join: o in Organization,
+        on: o.id == f.followee_organization_id,
+        where: f.follower_organization_id == ^page_id,
+        where: visible_member(u) or visible_page(o),
+        order_by: [desc: f.inserted_at, desc: f.id],
+        limit: ^limit,
+        select: {f.id, u, o}
+      )
+    )
+    |> Enum.map(fn {id, user, organization} -> {id, user || organization} end)
+  end
+
+  @doc "How many things `page` follows."
+  def organization_followee_count(%Organization{id: page_id}) do
+    Repo.aggregate(
+      from(f in Follow,
+        left_join: u in assoc(f, :followee),
+        left_join: o in Organization,
+        on: o.id == f.followee_organization_id,
+        where: f.follower_organization_id == ^page_id,
+        where: visible_member(u) or visible_page(o)
+      ),
+      :count
+    )
+  end
+
   defp follower_id(%Vutuv.Accounts.User{id: id}), do: id
   defp follower_id(id), do: id
 
@@ -252,11 +365,17 @@ defmodule Vutuv.Social do
   # The tagged single-count queries behind both the single accessors and
   # `social_counts/1`'s union (a union's arms must share one select shape, so
   # the singles carry the tag too and read `.total` off the one row).
+  # Followers are members **and** pages (issue #1336). A page that follows you
+  # is shown and counted: hiding it would make the number lie, and would let a
+  # page know something about you that you cannot see. Hence LEFT joins and one
+  # gate per kind — the inner join this used to be dropped a page silently.
   defp follower_count_query(user_id) do
     from(c in Follow,
-      join: u in assoc(c, :follower),
-      where: account_confirmed_row(u) and not account_hidden_row(u),
+      left_join: u in assoc(c, :follower),
+      left_join: o in Organization,
+      on: o.id == c.follower_organization_id,
       where: c.followee_id == ^user_id,
+      where: visible_member(u) or visible_page(o),
       select: %{kind: type(^"followers", :string), total: count(c.id)}
     )
   end
@@ -276,10 +395,17 @@ defmodule Vutuv.Social do
       left_join: o in Organization,
       on: o.id == c.followee_organization_id,
       where: c.follower_id == ^user_id,
-      where:
-        (not is_nil(u.id) and account_confirmed_row(u) and not account_hidden_row(u)) or
-          (not is_nil(o.id) and o.status == "active"),
+      where: visible_member(u) or visible_page(o),
       select: %{kind: type(^"followees", :string), total: count(c.id)}
+    )
+  end
+
+  defp follower_member_count_query(user_id) do
+    from(c in Follow,
+      join: u in assoc(c, :follower),
+      where: account_confirmed_row(u) and not account_hidden_row(u),
+      where: c.followee_id == ^user_id,
+      select: %{kind: type(^"followers", :string), total: count(c.id)}
     )
   end
 
@@ -330,7 +456,8 @@ defmodule Vutuv.Social do
     from(c in Follow,
       join: o in Organization,
       on: o.id == c.followee_organization_id,
-      where: c.follower_id == ^user_id and o.status == "active"
+      where: c.follower_id == ^user_id,
+      where: visible_page(o)
     )
   end
 
@@ -345,11 +472,12 @@ defmodule Vutuv.Social do
   def follows_page(%User{} = user, side, params) when side in [:followers, :followees] do
     {total, assoc, person} =
       case side do
+        # Members only on both sides. Pages are their own section on each page
+        # (`follower_organizations/1`, `followed_organizations/1`), so neither
+        # pager may count them; the profile-header figures do.
         :followers ->
-          {follower_count(user), :inbound_follows, :follower}
+          {Repo.one(follower_member_count_query(user.id)).total, :inbound_follows, :follower}
 
-        # Members only: the pages this member follows are their own section
-        # (`followed_organizations/1`), so this pager must not count them.
         :followees ->
           {Repo.one(followee_member_count_query(user.id)).total, :outbound_follows, :followee}
       end
@@ -386,11 +514,48 @@ defmodule Vutuv.Social do
       from(c in Follow,
         join: o in Organization,
         on: o.id == c.followee_organization_id,
-        where: c.follower_id == ^user_id and o.status == "active",
+        where: c.follower_id == ^user_id,
+        where: visible_page(o),
         order_by: [desc: c.inserted_at, desc: c.id],
         limit: ^limit,
         select: {c.id, o}
       )
+    )
+  end
+
+  @doc """
+  The pages that follow `user`, newest first, as `[{follow_id, organization}]` —
+  the "Organizations" section of their Followers page (issue #1336), the mirror
+  of `followed_organizations/1`.
+
+  No unfollow control here: this follow belongs to the page, not to the member
+  being followed. A member who does not want it has blocking, which is a
+  different question and not yet answered for pages.
+  """
+  def follower_organizations(%User{id: user_id}, limit \\ 100) do
+    Repo.all(
+      from(c in Follow,
+        join: o in Organization,
+        on: o.id == c.follower_organization_id,
+        where: c.followee_id == ^user_id,
+        where: visible_page(o),
+        order_by: [desc: c.inserted_at, desc: c.id],
+        limit: ^limit,
+        select: {c.id, o}
+      )
+    )
+  end
+
+  @doc "How many shown pages follow `user`."
+  def follower_organization_count(%User{id: user_id}) do
+    Repo.aggregate(
+      from(c in Follow,
+        join: o in Organization,
+        on: o.id == c.follower_organization_id,
+        where: c.followee_id == ^user_id,
+        where: visible_page(o)
+      ),
+      :count
     )
   end
 
@@ -400,7 +565,8 @@ defmodule Vutuv.Social do
       from(c in Follow,
         join: o in Organization,
         on: o.id == c.followee_organization_id,
-        where: c.follower_id == ^user_id and o.status == "active"
+        where: c.follower_id == ^user_id,
+        where: visible_page(o)
       ),
       :count
     )

--- a/lib/vutuv/social/follow.ex
+++ b/lib/vutuv/social/follow.ex
@@ -52,6 +52,33 @@ defmodule Vutuv.Social.Follow do
   end
 
   @doc """
+  A follow **by** a page (issue #1336): of a member when `followee` is
+  `:followee_id`, of another page when it is `:followee_organization_id`.
+
+  One function with the target column as an argument rather than a fourth
+  near-identical changeset — the two differ only in which column carries the
+  target, and a copy would be a fourth place to forget a constraint. A page
+  cannot follow itself; the pair is unique per spelling.
+  """
+  def organization_follower_changeset(model, followee, params \\ %{})
+      when followee in [:followee_id, :followee_organization_id] do
+    model
+    |> cast(params, [:follower_organization_id, followee, :muted])
+    |> validate_required([:follower_organization_id, followee])
+    |> validate_page_not_following_itself()
+    |> unique_constraint([:follower_organization_id, followee])
+    |> foreign_key_constraint(:follower_organization_id)
+    |> foreign_key_constraint(followee)
+  end
+
+  defp validate_page_not_following_itself(
+         %{changes: %{follower_organization_id: same, followee_organization_id: same}} = changeset
+       ),
+       do: add_error(changeset, :follower_organization_id, "Cannot follow yourself")
+
+  defp validate_page_not_following_itself(changeset), do: changeset
+
+  @doc """
   Flips the follower's own mute flag on a row that already exists.
 
   Its own changeset because `changeset/2` re-validates the identity columns, and

--- a/lib/vutuv_web/controllers/follower_controller.ex
+++ b/lib/vutuv_web/controllers/follower_controller.ex
@@ -14,11 +14,17 @@ defmodule VutuvWeb.FollowerController do
     %{user: user, users: followers, total: total} =
       Vutuv.Social.follows_page(conn.assigns[:user], :followers, conn.params)
 
+    # The pages that follow this member are their own section (issue #1336),
+    # the mirror of the Following page's.
+    organizations = Vutuv.Social.follower_organizations(user)
+
     AgentDocs.respond(conn,
       html: fn conn ->
         render(conn, "index.html",
           user: user,
           followers: followers,
+          organizations: organizations,
+          total_organizations: Vutuv.Social.follower_organization_count(user),
           total_followers: total,
           page_title: VutuvWeb.UserHelpers.member_page_title(user, gettext("Followers")),
           work_info_by_id: VutuvWeb.UserHelpers.work_information_map(followers, 45),
@@ -30,7 +36,9 @@ defmodule VutuvWeb.FollowerController do
         )
       end,
       doc: fn ->
-        ListDocs.build_follow_list(user, :followers, followers, total)
+        ListDocs.build_follow_list(user, :followers, followers, total,
+          organizations: organizations
+        )
       end
     )
   end

--- a/lib/vutuv_web/templates/follower/index.html.heex
+++ b/lib/vutuv_web/templates/follower/index.html.heex
@@ -4,6 +4,37 @@
   gettext("Followers")
 ]} />
 
+<%!-- The pages following this member (issue #1336), the mirror of the
+Organizations section on the Following page — same row shape, but no unfollow
+control: this follow belongs to the page, not to the member being followed. --%>
+<div :if={@organizations != []} class="card-list">
+  <section class="card" id="follower-organizations">
+    <h2 class="card__label">
+      {gettext("Organizations")} ({compact_count(@total_organizations)})
+    </h2>
+
+    <ul class="mt-2 divide-y divide-slate-100 dark:divide-slate-800">
+      <li :for={{_follow_id, organization} <- @organizations} class="flex items-center gap-4 py-4">
+        <.link navigate={Vutuv.Organizations.canonical_path(organization)} class="shrink-0">
+          <.organization_logo organization={organization} class="h-12 w-12" />
+        </.link>
+        <div class="min-w-0 flex-1">
+          <.link
+            navigate={Vutuv.Organizations.canonical_path(organization)}
+            class="block truncate font-semibold text-slate-900 hover:text-brand-700 dark:text-slate-100 dark:hover:text-brand-300"
+          >
+            {organization.name}
+          </.link>
+          <.organization_location
+            organization={organization}
+            class="truncate text-sm text-slate-600 dark:text-slate-400"
+          />
+        </div>
+      </li>
+    </ul>
+  </section>
+</div>
+
 <div class="card-list">
   <section class="card">
     <h1><%= gettext "Followers" %></h1>

--- a/lib/vutuv_web/views/follower_html.ex
+++ b/lib/vutuv_web/views/follower_html.ex
@@ -3,5 +3,9 @@ defmodule VutuvWeb.FollowerHTML do
   use VutuvWeb, :html
   import VutuvWeb.UserHelpers
 
+  # The "Organizations" section renders the pages following this member in the
+  # same row shape the Following page and /settings/organizations use.
+  import VutuvWeb.OrganizationComponents, only: [organization_logo: 1, organization_location: 1]
+
   embed_templates("../templates/follower/*")
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.248.2",
+      version: "7.249.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/organization_as_follower_test.exs
+++ b/test/vutuv/organization_as_follower_test.exs
@@ -1,0 +1,141 @@
+defmodule Vutuv.OrganizationAsFollowerTest do
+  @moduledoc """
+  A page can follow (issue #1336). The column shipped ahead of its writer in
+  v7.248.1; this is the writer, and the readers Stefan decided must now show
+  such a follow.
+
+  **The decision the sweep rests on:** a page that follows you appears in your
+  followers list and your follower count. Hiding it would make the number lie,
+  and it would let a page know something about you that you cannot see. That is
+  what turns the follower-side inner joins into left joins — and every one of
+  them is a place a nil `%User{}` could reach a rendered row, so each is
+  asserted here rather than trusted.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag and the DNS-resolver stub beside it.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Accounts.User
+  alias Vutuv.Organizations.Organization
+  alias Vutuv.Social
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp second_page do
+    active_organization_for(insert(:activated_user), %{
+      "name" => "Zweite AG",
+      "website_url" => "https://zweite.example"
+    })
+  end
+
+  describe "a page follows" do
+    test "a member, once" do
+      page = active_organization_for(insert(:activated_user))
+      member = insert(:activated_user)
+
+      assert {:ok, follow} = Social.follow_as_organization(page, member)
+      assert follow.follower_organization_id == page.id
+      assert follow.followee_id == member.id
+      assert Social.organization_follows?(page, member)
+
+      # Idempotent like its member twin: the control is a toggle, so a double
+      # click must return the edge rather than read as a failure.
+      assert {:ok, same} = Social.follow_as_organization(page, member)
+      assert same.id == follow.id
+    end
+
+    test "another page, but never itself" do
+      page = second_page()
+      other = active_organization_for(insert(:activated_user))
+
+      assert {:ok, _} = Social.follow_as_organization(page, other)
+      assert Social.organization_follows?(page, other)
+
+      assert {:error, changeset} = Social.follow_as_organization(page, page)
+      refute changeset.valid?
+    end
+
+    test "and unfollows again" do
+      page = active_organization_for(insert(:activated_user))
+      member = insert(:activated_user)
+
+      {:ok, _} = Social.follow_as_organization(page, member)
+      assert :ok = Social.unfollow_as_organization(page, member)
+      refute Social.organization_follows?(page, member)
+
+      # Idempotent both ways.
+      assert :ok = Social.unfollow_as_organization(page, member)
+    end
+  end
+
+  describe "the member being followed sees it" do
+    test "the header count adds the page, and the two sections sum to it" do
+      page = active_organization_for(insert(:activated_user))
+      person = insert(:activated_user)
+      member = insert(:activated_user)
+
+      {:ok, _} = Social.follow(person, member.id)
+      {:ok, _} = Social.follow_as_organization(page, member)
+
+      # The profile header counts both kinds; the Followers page splits them,
+      # exactly as the Following page does, because `card_list` renders people
+      # and a page has a logo and neither work history nor tags.
+      assert Social.follower_count(member) == 2
+      assert Social.social_counts(member).followers == 2
+
+      people = Social.follows_page(member, :followers, %{})
+      assert people.total == 1
+      assert [%User{id: id}] = people.users
+      assert id == person.id
+
+      assert Social.follower_organization_count(member) == 1
+      assert [{_follow_id, %Organization{id: page_id}}] = Social.follower_organizations(member)
+      assert page_id == page.id
+    end
+
+    test "a frozen page is neither shown nor counted" do
+      page = active_organization_for(insert(:activated_user))
+      member = insert(:activated_user)
+
+      {:ok, _} = Social.follow_as_organization(page, member)
+      assert Social.follower_count(member) == 1
+
+      {:ok, _} = Vutuv.Organizations.admin_set_frozen(page, true)
+
+      # The page gate mirrors the member gate: a follower nobody may look at is
+      # not shown and not counted. `status` stays "active" through a freeze, so
+      # a gate that only reads it would still show this one.
+      assert Social.follower_count(member) == 0
+      assert Social.follower_organizations(member) == []
+    end
+  end
+
+  describe "what a page follows" do
+    test "is listed on the page with its own count" do
+      page = active_organization_for(insert(:activated_user))
+      member = insert(:activated_user)
+      other = second_page()
+
+      {:ok, _} = Social.follow_as_organization(page, member)
+      {:ok, _} = Social.follow_as_organization(page, other)
+
+      assert Social.organization_followee_count(page) == 2
+
+      followees = Social.organization_followees(page)
+      assert Enum.any?(followees, &match?({_id, %User{id: id}} when id == member.id, &1))
+      assert Enum.any?(followees, &match?({_id, %Organization{id: id}} when id == other.id, &1))
+    end
+  end
+end

--- a/test/vutuv/organization_follower_rows_test.exs
+++ b/test/vutuv/organization_follower_rows_test.exs
@@ -84,24 +84,26 @@ defmodule Vutuv.OrganizationFollowerRowsTest do
   end
 
   describe "the readers of the follower side" do
-    test "a member's follower count and list both leave a page out, and agree" do
+    test "a member's follower count and list now show the page" do
       member = insert(:activated_user)
       person = insert(:activated_user)
       {:ok, _} = Social.follow(person, member.id)
       {_organization, _follow} = page_follows(member)
 
-      # Shape 2, and the reason this whole step needed no sweep: every reader of
-      # the follower side reaches it through an INNER JOIN to `users`, so they
-      # all drop an organization follower *consistently*. Count and list agree
-      # at 1, the member, and nothing renders a nil row.
+      # This test used to assert the opposite, and the reversal is Stefan's
+      # call (v7.248.3): a page that follows you is counted and shown, because
+      # hiding it makes the number lie and lets a page know something about you
+      # that you cannot see. The follower-side joins are LEFT joins now.
       #
-      # This is the current behaviour, not a verdict. When a page can really
-      # follow (the writer is the next step), decide then whether it belongs in
-      # a member's follower list — hiding it would make the count lie — and that
-      # decision is what turns those inner joins into left joins. Until then,
-      # excluding it everywhere is the coherent answer.
+      # The header counts both kinds; the page splits them into two sections,
+      # so `follows_page/3` still answers with people alone. The full behaviour
+      # lives in organization_as_follower_test.exs — what this file still owns
+      # is that a raw row inserted straight into the table behaves the same as
+      # one the writer made.
+      assert Social.follower_count(member) == 2
+      assert Social.follower_organization_count(member) == 1
+
       page = Social.follows_page(member, :followers, %{})
-      assert Social.follower_count(member) == 1
       assert page.total == 1
       assert [%Vutuv.Accounts.User{id: id}] = page.users
       assert id == person.id


### PR DESCRIPTION
Der Schreiber zu der Spalte, die #1383 vorausgeschickt hat, plus die Leser, die so eine Beziehung nach deiner Entscheidung zeigen müssen.

`Social.follow_as_organization/2` nimmt ein Mitglied **oder** eine andere Seite, `unfollow_as_organization/2` und `organization_follows?/2` daneben, alle idempotent wie ihre Mitglieder-Zwillinge. Im Schema ist es *eine* Changeset-Funktion mit der Zielspalte als Argument statt einer vierten fast identischen Kopie: die beiden Schreibweisen unterscheiden sich nur darin, welche Spalte das Ziel trägt, und eine Kopie wäre bloß eine vierte Stelle, an der man ein Constraint vergessen kann. Eine Seite kann sich nicht selbst folgen.

**Deine Entscheidung, umgesetzt:** eine Seite, die dir folgt, taucht in deiner Followerliste und deinem Zähler auf. Das ist es, was aus den Inner Joins auf der Follower-Seite Left Joins macht — und jeder davon ist eine Stelle, an der ein nil `%User{}` in eine gerenderte Zeile laufen könnte, deshalb ist jeder einzeln behauptet statt geglaubt.

Aufgeteilt wie schon bei Following, damit die beiden Seiten sich gleich lesen: die Kopfzahl im Profil zählt beide Sorten, die Seite selbst hat zwei Abschnitte mit je eigenem Zähler, und der Pager der Personenliste zählt weiter nur Personen. **Kein Entfolgen-Knopf** im Organisationsabschnitt der Followerliste, anders als auf der Following-Seite: dieser Follow gehört der Seite, nicht dem Gefolgten. Wer ihn loswerden will, bräuchte Blocken, und das ist für Seiten noch nicht beantwortet.

**Nebenbei ein Tor geradegezogen, das ich selbst schief eingebaut hatte:** jede Prüfung „diese Seite darf man zeigen" läuft jetzt durch dasselbe Makro und liest `status = "active"` **und** `frozen_at IS NULL`. Die frozene Hälfte hatte ich in v7.247.10 vergessen; sie ist leicht zu übersehen, weil `status` beim Einfrieren „active" bleibt. Ein Test deckt genau das ab.

Ein Test hielt die alte Lesart fest („Zähler und Liste lassen eine Seite beide weg"). Den habe ich umgeschrieben statt gelöscht, mit dem Grund der Umkehr im Text, damit die nächste Person nicht rätselt, ob das mal Absicht war.

**Noch offen** und als nächstes dran: der eigene Feed einer Seite unter `/organizations/:slug/feed`, nur für Redaktion, Aktionsleiste am handelnden Mitglied — so wie du entschieden hast. Danach Tags und entfernte Konten.

`mix precommit` grün (7251 Tests).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01MMwsQi49FP21xuSoPEkMnN
