### PR TITLE
Eine Seite hat einen eigenen Feed (v7.250.0)

### DIFF
--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -1925,6 +1925,92 @@ defmodule Vutuv.Posts do
   def render_preloads, do: post_preloads()
 
   @doc """
+  The feed a **page** reads (issue #1336): what the members and pages it follows
+  have published, newest first, same entry shape and cursor as `feed_page/2`.
+
+  Two sources, not six. A page can only follow members and other pages today, so
+  it has no tags, no reposts of its own and no fediverse follows to draw from —
+  a parallel copy of the member feed's other four sources would be four empty
+  queries per page load. When a page can follow tags and remote accounts, this
+  grows the sources it can actually fill.
+
+  **A member's post is visible here only if it is public.** Denials name users,
+  groups and follow relationships, and a page is none of those, so it can never
+  *be* the audience of a restricted post — `scope_visible(query, nil)`, the
+  anonymous public gate, is the honest reading rather than something new.
+
+  `viewer:` is the member currently acting as the page. It decorates the entries
+  (their own likes, bookmarks and reposts), because the action bar under each
+  card belongs to the person, not to the page: a page has no likes of its own.
+  It never widens what the feed contains — that is the page's follow graph
+  alone, so two publishers reading it see the same posts.
+  """
+  def organization_feed_page(%Organization{} = page, opts \\ []) do
+    limit = Keyword.get(opts, :limit, @default_feed_limit)
+    cursor = Keyword.get(opts, :cursor)
+    viewer = Keyword.get(opts, :viewer)
+
+    sources = [
+      &organization_feed_member_posts(page, &1, &2),
+      &organization_feed_page_posts(page, &1, &2)
+    ]
+
+    page_result = Vutuv.FeedPage.paginate(sources, limit, cursor)
+
+    %{page_result | entries: decorate_feed_entries(page_result.entries, viewer)}
+  end
+
+  defp organization_feed_member_posts(%Organization{id: page_id}, fetch_n, cursor) do
+    from(p in Post,
+      join: u in assoc(p, :user),
+      as: :author,
+      where: p.user_id in subquery(members_followed_by_organization(page_id)),
+      where: account_confirmed_row(u) and not account_hidden_row(u),
+      order_by: [desc: p.inserted_at, desc: p.id],
+      limit: ^fetch_n
+    )
+    |> scope_visible(nil)
+    |> posts_at_or_before(cursor)
+    |> Repo.all()
+    |> Enum.map(&%{id: "post-#{&1.id}", post: &1, reposted_by: nil, at: &1.inserted_at})
+  end
+
+  defp organization_feed_page_posts(%Organization{id: page_id}, fetch_n, cursor) do
+    from(p in Post,
+      join: o in Organization,
+      as: :organization,
+      on: o.id == p.organization_id,
+      where: p.organization_id in subquery(pages_followed_by_organization(page_id)),
+      where: organization_public_row(o),
+      where: not p.images_pending? and is_nil(p.frozen_at),
+      order_by: [desc: p.inserted_at, desc: p.id],
+      limit: ^fetch_n
+    )
+    |> posts_at_or_before(cursor)
+    |> Repo.all()
+    |> Enum.map(&%{id: "post-#{&1.id}", post: &1, reposted_by: nil, at: &1.inserted_at})
+  end
+
+  # The two halves of a page's follow graph. Named functions rather than inline
+  # subqueries for the reason the milestone keeps relearning: a nullable column
+  # feeding an `IN` needs one place to fix, not several.
+  defp members_followed_by_organization(page_id) do
+    from(c in Follow,
+      where: c.follower_organization_id == ^page_id and c.muted == false,
+      where: not is_nil(c.followee_id),
+      select: c.followee_id
+    )
+  end
+
+  defp pages_followed_by_organization(page_id) do
+    from(c in Follow,
+      where: c.follower_organization_id == ^page_id and c.muted == false,
+      where: not is_nil(c.followee_organization_id),
+      select: c.followee_organization_id
+    )
+  end
+
+  @doc """
   One page of `viewer`'s newsfeed: own posts plus posts **and reposts** of
   followed (activated) authors, visibility-filtered, newest first.
 
@@ -2494,6 +2580,11 @@ defmodule Vutuv.Posts do
   # whole page, regardless of which repost happened to carry the entry. The
   # roster is deliberately follow-scoped: it explains why the post is in
   # *this* feed; the global repost count already lives on the action bar.
+  # A page's feed carries no reposts (a page cannot repost, and it does not read
+  # the members' repost source), so there is no roster to attach and no viewer
+  # whose follow graph would scope one. Nil is a real case here, not a slip.
+  defp attach_reposters(entries, nil), do: Enum.map(entries, &Map.put(&1, :reposters, []))
+
   defp attach_reposters(entries, %User{} = viewer) do
     post_ids = for %{reposted_by: %User{}} = entry <- entries, do: entry.post.id
     rosters = reposter_rosters(post_ids, viewer)

--- a/lib/vutuv_web/components/organization_components.ex
+++ b/lib/vutuv_web/components/organization_components.ex
@@ -183,6 +183,7 @@ defmodule VutuvWeb.OrganizationComponents do
   attr(:active, :atom, required: true)
   attr(:owner?, :boolean, default: false)
   attr(:manage?, :boolean, default: false)
+  attr(:publisher?, :boolean, default: false)
 
   @doc """
   The header + tab bar shared by the organization management pages (issue #930): a
@@ -218,6 +219,12 @@ defmodule VutuvWeb.OrganizationComponents do
         speaking FOR it. --%>
         <.manage_tab :if={@manage?} active={@active == :activity} navigate={"/organizations/#{@organization.slug}/activity"}>
           {gettext("Activity")}
+        </.manage_tab>
+        <%!-- What the page reads (issue #1336). Publishers only, unlike
+        Activity beside it: this is the page's own reading, part of speaking
+        for it, not news about it. --%>
+        <.manage_tab :if={@publisher?} active={@active == :feed} navigate={"/organizations/#{@organization.slug}/feed"}>
+          {gettext("Feed")}
         </.manage_tab>
       </nav>
     </div>

--- a/lib/vutuv_web/controllers/organization_controller.ex
+++ b/lib/vutuv_web/controllers/organization_controller.ex
@@ -139,6 +139,14 @@ defmodule VutuvWeb.OrganizationController do
     do: manage(conn, slug, VutuvWeb.OrganizationLive.Activity, &Organizations.can_manage?/2)
 
   @doc """
+  What the page reads (issue #1336). **Publishers only**, where the activity
+  list above takes any role holder: activity is news about the page, this is
+  the page's own reading, which is part of speaking for it.
+  """
+  def feed(conn, %{"slug" => slug}),
+    do: manage(conn, slug, VutuvWeb.OrganizationLive.Feed, &Organizations.publisher?/2)
+
+  @doc """
   The permalink of a post published in this organization's name (issue #1334).
   404s for an unknown page, a page this viewer may not see, or an id that is not
   one of its posts — an id belonging to a member's post must not render under an

--- a/lib/vutuv_web/live/organization_live/activity.ex
+++ b/lib/vutuv_web/live/organization_live/activity.ex
@@ -43,6 +43,7 @@ defmodule VutuvWeb.OrganizationLive.Activity do
      socket
      |> assign(:organization, organization)
      |> assign(:owner?, Organizations.owner?(organization, socket.assigns.current_user))
+     |> assign(:publisher?, Organizations.publisher?(organization, socket.assigns.current_user))
      |> assign(:marker, marker)
      |> assign(:page_title, gettext("Activity – %{name}", name: organization.name))
      |> load_activity(0)}
@@ -87,7 +88,13 @@ defmodule VutuvWeb.OrganizationLive.Activity do
   def render(assigns) do
     ~H"""
     <div class="mx-auto max-w-2xl py-6">
-      <.manage_header organization={@organization} active={:activity} owner?={@owner?} manage?={true} />
+      <.manage_header
+        organization={@organization}
+        active={:activity}
+        owner?={@owner?}
+        manage?={true}
+        publisher?={@publisher?}
+      />
 
       <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100">{gettext("Activity")}</h1>
       <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">

--- a/lib/vutuv_web/live/organization_live/feed.ex
+++ b/lib/vutuv_web/live/organization_live/feed.ex
@@ -1,0 +1,107 @@
+defmodule VutuvWeb.OrganizationLive.Feed do
+  @moduledoc """
+  The feed a page reads (`/organizations/:slug/feed`, issue #1336) — what the
+  members and pages it follows have published. This is the direction #1334 and
+  #1335 deliberately left out: a page that can publish but not read is
+  one-directional, and a feed is derived from follows, so it could not exist
+  before a page could follow.
+
+  **Publishers only**, unlike the activity list beside it, and the difference is
+  the point: activity is news *about* the page, which the whole team may read,
+  while this is the page's own reading — part of speaking for it.
+
+  **The action bar under each card belongs to the acting member, not to the
+  page.** A page has no likes or bookmarks of its own yet, so a bar bound to it
+  would have no owner; a like here is the person's, from their own account. What
+  the viewer never does is widen the feed: its contents come from the page's
+  follow graph alone, so two publishers reading it see the same posts.
+
+  Embedded via `live_render` from `VutuvWeb.OrganizationController`, which gates
+  it before this ever mounts.
+  """
+
+  use VutuvWeb, :live_view
+
+  import VutuvWeb.OrganizationComponents, only: [manage_header: 1]
+  import VutuvWeb.PostComponents, only: [post_card: 1]
+
+  alias Vutuv.Organizations
+  alias Vutuv.Posts
+  alias VutuvWeb.Live.InitAssigns
+
+  @impl true
+  def mount(_params, session, socket) do
+    socket = InitAssigns.assign_embedded(socket, session)
+    organization = Organizations.get_organization!(session["organization_id"])
+
+    {:ok,
+     socket
+     |> assign(:organization, organization)
+     |> assign(:owner?, Organizations.owner?(organization, socket.assigns.current_user))
+     |> assign(:page_title, gettext("Feed – %{name}", name: organization.name))
+     |> load_feed(nil)}
+  end
+
+  defp load_feed(socket, cursor) do
+    page =
+      Posts.organization_feed_page(socket.assigns.organization,
+        cursor: cursor,
+        viewer: socket.assigns.current_user
+      )
+
+    existing = if cursor, do: socket.assigns.entries, else: []
+
+    socket
+    |> assign(:entries, existing ++ page.entries)
+    |> assign(:more?, page.more?)
+    |> assign(:cursor, page.next_cursor)
+  end
+
+  @impl true
+  def handle_event("load-more", _params, socket),
+    do: {:noreply, load_feed(socket, socket.assigns.cursor)}
+
+  @impl true
+  def handle_info(_message, socket), do: {:noreply, socket}
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="mx-auto max-w-2xl py-6">
+      <.manage_header
+        organization={@organization}
+        active={:feed}
+        owner?={@owner?}
+        manage?={true}
+        publisher?={true}
+      />
+
+      <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100">{gettext("Feed")}</h1>
+      <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+        {gettext("What the members and organizations this page follows have published. Liking or saving something here is done from your own account, not the page's.")}
+      </p>
+
+      <p :if={@entries == []} class="mt-6 text-sm text-slate-600 dark:text-slate-400">
+        {gettext("Nothing here yet. This page does not follow anyone, or nobody it follows has published.")}
+      </p>
+
+      <div :if={@entries != []} class="mt-6 space-y-4">
+        <.post_card
+          :for={entry <- @entries}
+          entry_id={entry.id}
+          post={entry.post}
+          viewer={@current_user}
+          conn_or_socket={@socket}
+          mode={:preview}
+        />
+      </div>
+
+      <div :if={@more?} class="mt-6 text-center">
+        <.button variant="secondary" phx-click="load-more" id="load-more-feed">
+          {gettext("Load more")}
+        </.button>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/vutuv_web/live/organization_live/show.ex
+++ b/lib/vutuv_web/live/organization_live/show.ex
@@ -21,6 +21,7 @@ defmodule VutuvWeb.OrganizationLive.Show do
   alias Vutuv.Countries
   alias Vutuv.Jobs
   alias Vutuv.Organizations
+  alias Vutuv.Organizations.Organization
   alias Vutuv.Posts
   alias Vutuv.Social
   alias VutuvWeb.JsonLd
@@ -120,7 +121,21 @@ defmodule VutuvWeb.OrganizationLive.Show do
     # Following a page (issue #1336): a private subscription that pulls its
     # posts into your feed. No approval and no notification — a page has no
     # inbox to be told, the same way following a member needs no permission.
-    |> assign(:following?, Social.follows_organization?(viewer, organization))
+    # While acting as another page, the pill follows **as that page** (the last
+    # writer #1336 needed): the follow belongs to whoever is speaking, and the
+    # feed it fills is that page's. `follower_of/1` is the one place that
+    # decides, so the state, the toggle and the label cannot disagree.
+    |> assign(
+      :following?,
+      follows?(
+        follower_of(%{
+          acting_as: socket.assigns[:acting_as],
+          organization: organization,
+          current_user: viewer
+        }),
+        organization
+      )
+    )
     |> assign(:follower_count, Social.organization_follower_count(organization))
     |> assign(:pending?, organization.status == "pending")
     |> assign(:frozen?, not is_nil(organization.frozen_at))
@@ -147,16 +162,15 @@ defmodule VutuvWeb.OrganizationLive.Show do
   end
 
   def handle_event("toggle-follow", _params, socket) do
-    %{organization: organization, current_user: viewer} = socket.assigns
+    organization = socket.assigns.organization
+    follower = follower_of(socket.assigns)
 
-    if viewer do
-      if socket.assigns.following?,
-        do: Social.unfollow_organization(viewer, organization),
-        else: Social.follow_organization(viewer, organization)
+    if follower do
+      toggle_follow(follower, organization, socket.assigns.following?)
 
       {:noreply,
        socket
-       |> assign(:following?, Social.follows_organization?(viewer, organization))
+       |> assign(:following?, follows?(follower, organization))
        |> assign(:follower_count, Social.organization_follower_count(organization))}
     else
       {:noreply, socket}
@@ -254,6 +268,34 @@ defmodule VutuvWeb.OrganizationLive.Show do
       {:noreply, socket}
     end
   end
+
+  # Who the follow belongs to: the page being acted as, else the member. A page
+  # can never follow itself, so acting as *this* page falls back to nobody
+  # rather than offering a control that could only fail.
+  defp follower_of(%{acting_as: %Organization{id: id}, organization: %Organization{id: id}}),
+    do: nil
+
+  defp follower_of(%{acting_as: %Organization{} = page}), do: page
+  defp follower_of(%{current_user: viewer}), do: viewer
+
+  defp follows?(nil, _organization), do: false
+
+  defp follows?(%Organization{} = page, organization),
+    do: Social.organization_follows?(page, organization)
+
+  defp follows?(viewer, organization), do: Social.follows_organization?(viewer, organization)
+
+  defp toggle_follow(%Organization{} = page, organization, true),
+    do: Social.unfollow_as_organization(page, organization)
+
+  defp toggle_follow(%Organization{} = page, organization, false),
+    do: Social.follow_as_organization(page, organization)
+
+  defp toggle_follow(viewer, organization, true),
+    do: Social.unfollow_organization(viewer, organization)
+
+  defp toggle_follow(viewer, organization, false),
+    do: Social.follow_organization(viewer, organization)
 
   @impl true
   def handle_info({:organization_counters, %{likes: likes}}, socket) do

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -276,6 +276,7 @@ defmodule VutuvWeb.Router do
     get("/organizations/:slug/exclusions", OrganizationController, :exclusions)
     # What happened to the page (issue #1336), for its whole team.
     get("/organizations/:slug/activity", OrganizationController, :activity)
+    get("/organizations/:slug/feed", OrganizationController, :feed)
     # The permalink of a post published in the organization's name (issue #1334).
     # Deliberately under the slug and not under the organization's opt-in root
     # handle: the handle route dispatches an organization only on the bare

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.249.0",
+      version: "7.250.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/organization_feed_test.exs
+++ b/test/vutuv/organization_feed_test.exs
@@ -1,0 +1,121 @@
+defmodule Vutuv.OrganizationFeedTest do
+  @moduledoc """
+  The feed a page reads (issue #1336) — what closes the loop the milestone
+  opened: a page that publishes but cannot read is one-directional on purpose,
+  and this is the other direction.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag and the DNS-resolver stub beside it.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Organizations
+  alias Vutuv.Posts
+  alias Vutuv.Repo
+  alias Vutuv.Social
+  alias Vutuv.Social.Follow
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp reader_page, do: active_organization_for(insert(:activated_user))
+
+  defp publishing_page(name, host) do
+    owner = insert(:activated_user)
+
+    organization =
+      active_organization_for(owner, %{"name" => name, "website_url" => "https://#{host}"})
+
+    {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+    {organization, owner}
+  end
+
+  defp feed_ids(page, opts \\ []) do
+    page |> Posts.organization_feed_page(opts) |> Map.fetch!(:entries) |> Enum.map(& &1.post.id)
+  end
+
+  test "carries the posts of the members and pages it follows" do
+    page = reader_page()
+    member = insert(:activated_user)
+    {other, other_owner} = publishing_page("Zweite AG", "zweite.example")
+
+    {:ok, from_member} = Posts.create_post(member, %{body: "Von einer Person."})
+
+    {:ok, from_page} =
+      Posts.create_organization_post(other, other_owner, %{body: "Von der Seite."})
+
+    {:ok, _} = Social.follow_as_organization(page, member)
+    {:ok, _} = Social.follow_as_organization(page, other)
+
+    ids = feed_ids(page)
+    assert from_member.id in ids
+    assert from_page.id in ids
+  end
+
+  test "shows nothing from somebody it does not follow" do
+    page = reader_page()
+    stranger = insert(:activated_user)
+    {:ok, _} = Posts.create_post(stranger, %{body: "Unbekannt."})
+
+    assert feed_ids(page) == []
+  end
+
+  test "a restricted post never reaches a page" do
+    page = reader_page()
+    member = insert(:activated_user)
+    {:ok, _} = Social.follow_as_organization(page, member)
+
+    {:ok, open} = Posts.create_post(member, %{body: "Für alle."})
+
+    {:ok, restricted} =
+      Posts.create_post(member, %{
+        body: "Nur für Follower.",
+        denials: [%{"wildcard" => "non_followers"}]
+      })
+
+    # A denial names users, groups and follow relationships. A page is none of
+    # those, so it can never *be* the intended audience — the anonymous public
+    # gate is the honest reading, not a special case.
+    ids = feed_ids(page)
+    assert open.id in ids
+    refute restricted.id in ids
+  end
+
+  test "the acting member's own engagement decorates the entries" do
+    page = reader_page()
+    member = insert(:activated_user)
+    {:ok, post} = Posts.create_post(member, %{body: "Zum Liken."})
+    {:ok, _} = Social.follow_as_organization(page, member)
+
+    reader = insert(:activated_user)
+    :ok = Posts.like_post(reader, post)
+
+    # The bar under each card belongs to the person, not to the page — a page
+    # has no likes of its own. What it must never do is change *what* the feed
+    # contains: two publishers reading the same page see the same posts.
+    assert feed_ids(page, viewer: reader) == feed_ids(page)
+  end
+
+  test "a muted follow drops that author, as it does on a member's feed" do
+    page = reader_page()
+    member = insert(:activated_user)
+    {:ok, post} = Posts.create_post(member, %{body: "Stummgeschaltet."})
+    {:ok, follow} = Social.follow_as_organization(page, member)
+
+    assert post.id in feed_ids(page)
+
+    follow |> Follow.mute_changeset(%{muted: true}) |> Repo.update!()
+
+    assert feed_ids(page) == []
+  end
+end

--- a/test/vutuv_web/organization_feed_web_test.exs
+++ b/test/vutuv_web/organization_feed_web_test.exs
@@ -1,0 +1,101 @@
+defmodule VutuvWeb.OrganizationFeedWebTest do
+  @moduledoc """
+  `/organizations/:slug/feed` (issue #1336) is **publishers only**, where the
+  activity list beside it takes any role holder. The difference is deliberate:
+  activity is news about the page, this is the page's own reading, which is part
+  of speaking for it.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag and the DNS-resolver stub beside it.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Organizations
+  alias Vutuv.Posts
+  alias Vutuv.Social
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  test "a publisher reads what the page follows", %{conn: conn} do
+    {conn, owner} = create_and_login_user(conn)
+    organization = active_organization_for(owner)
+    {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+
+    author = insert(:activated_user, first_name: "Frida", last_name: "Folger")
+    {:ok, _} = Posts.create_post(author, %{body: "Ein gefolgter Beitrag."})
+    {:ok, _} = Social.follow_as_organization(organization, author)
+
+    html = conn |> get(~p"/organizations/#{organization.slug}/feed") |> html_response(200)
+
+    assert html =~ "Ein gefolgter Beitrag."
+    assert html =~ "Frida"
+  end
+
+  test "a role holder who may not speak for the page is turned away", %{conn: conn} do
+    {conn, member} = create_and_login_user(conn)
+    owner = insert(:activated_user)
+    organization = active_organization_for(owner)
+    {:ok, _} = Organizations.add_role(organization, member, "recruiter", owner)
+
+    # A recruiter may manage postings and read the activity list, but the page's
+    # own reading is not theirs.
+    assert conn |> get(~p"/organizations/#{organization.slug}/feed") |> response(404)
+  end
+
+  test "the Feed tab shows only to a publisher", %{conn: conn} do
+    {conn, owner} = create_and_login_user(conn)
+    organization = active_organization_for(owner)
+
+    # The owner has not granted themselves `publisher` — the roles are separate
+    # by design (#1333), so the tab must not appear on the activity page either.
+    activity = conn |> get(~p"/organizations/#{organization.slug}/activity") |> html_response(200)
+    refute activity =~ "#{organization.slug}/feed"
+
+    {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+
+    with_tab = conn |> get(~p"/organizations/#{organization.slug}/activity") |> html_response(200)
+    assert with_tab =~ "#{organization.slug}/feed"
+  end
+
+  test "acting as a page, following another page fills the first page's feed", %{conn: conn} do
+    {conn, owner} = create_and_login_user(conn)
+    reader = active_organization_for(owner)
+    {:ok, _} = Organizations.add_role(reader, owner, "publisher", owner)
+
+    other_owner = insert(:activated_user)
+
+    other =
+      active_organization_for(other_owner, %{
+        "name" => "Zweite AG",
+        "website_url" => "https://zweite.example"
+      })
+
+    {:ok, _} = Organizations.add_role(other, other_owner, "publisher", other_owner)
+    {:ok, _} = Posts.create_organization_post(other, other_owner, %{body: "Von der Zweiten."})
+
+    # Speak as the reader page, then press Follow on the other page: the follow
+    # belongs to the page, not to the person, so it is the page's feed that
+    # fills. This is the one control that calls follow_as_organization/2.
+    conn = post(conn, ~p"/organizations/#{reader.slug}/act_as")
+
+    {:ok, view, _html} = live(conn, ~p"/organizations/#{other.slug}")
+    render_click(view, "toggle-follow", %{})
+
+    assert Social.organization_follows?(reader, other)
+
+    feed = conn |> get(~p"/organizations/#{reader.slug}/feed") |> html_response(200)
+    assert feed =~ "Von der Zweiten."
+  end
+end


### PR DESCRIPTION
Damit schließt sich die Schleife, die #1334 und #1335 absichtlich offen gelassen haben: eine Seite, die veröffentlicht, aber nicht lesen kann, ist eindirektional, und ein Feed leitet sich aus Follows ab — konnte also erst existieren, nachdem eine Seite folgen kann.

`/organizations/:slug/feed`, **nur für Redaktion**, anders als die Aktivitätsliste daneben, die das ganze Team liest. Der Unterschied ist der Punkt: Aktivität sind Nachrichten *über* die Seite, das hier ist ihre eigene Lektüre und damit Teil des Sprechens für sie.

**Zwei Quellen, nicht sechs.** Beim Aufmessen kam heraus, dass eine Seite heute nur Mitgliedern und Seiten folgen kann — weder Tags noch eigene Reposts noch Fediverse-Follows. Eine Parallelkopie der anderen vier Quellen des Mitglieder-Feeds wären vier leere Abfragen pro Seitenaufruf. Wenn Tags und entfernte Konten dazukommen, wächst es um genau die, die sich dann füllen können.

**Der Beitrag eines Mitglieds ist hier nur sichtbar, wenn er öffentlich ist.** Denials benennen Nutzer, Gruppen und Follow-Beziehungen, und eine Seite ist nichts davon — sie kann also nie das gemeinte Publikum eines eingeschränkten Beitrags *sein*. `scope_visible(query, nil)`, das anonyme öffentliche Tor, ist die ehrliche Lesart statt einer neuen Sonderregel, die man später pflegen müsste.

**Die Aktionsleiste gehört dem handelnden Mitglied**, wie du entschieden hast: eine Seite hat noch keine eigenen Likes, eine daran gebundene Leiste hätte keinen Besitzer. Was der Betrachter nie tut, ist den Feed erweitern — sein Inhalt kommt allein aus dem Follow-Graphen der Seite, zwei Redakteure sehen also dasselbe. Ein Test hält genau das fest.

**Dazu der letzte fehlende Schreiber.** Ohne ihn wäre der Feed für immer leer geblieben, denn `follow_as_organization/2` hatte bis eben keinen Aufrufer: die Follow-Pille auf einer Seite folgt jetzt *als* die Seite, in deren Namen man gerade spricht. `follower_of/1` ist die eine Stelle, die das entscheidet, damit Zustand, Umschalter und Beschriftung nicht auseinanderlaufen können — und wer gerade als *diese* Seite spricht, bekommt keinen Knopf, der nur scheitern könnte.

Der Test geht den ganzen Weg: als Seite sprechen, einer anderen Seite folgen, deren Beitrag im eigenen Feed wiederfinden.

Zweimal unterwegs in dieselbe Falle getappt wie schon letzte Woche — private Helfer zwischen zwei `handle_event/3`-Klauseln, und ein zweites `@doc` vor einer fremden Funktion. Beide Male hat `--warnings-as-errors` es sofort gefangen.

**Als nächstes**, wie von dir gewählt: Tags und entfernte Konten, damit der Feed mehr als Beiträge tragen kann.

`mix precommit` grün (7260 Tests).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01MMwsQi49FP21xuSoPEkMnN
