### PR TITLE
Eine Seite kann einem Thema folgen (v7.251.0)

### DIFF
--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -1952,7 +1952,8 @@ defmodule Vutuv.Posts do
 
     sources = [
       &organization_feed_member_posts(page, &1, &2),
-      &organization_feed_page_posts(page, &1, &2)
+      &organization_feed_page_posts(page, &1, &2),
+      &organization_feed_tag_posts(page, &1, &2)
     ]
 
     page_result = Vutuv.FeedPage.paginate(sources, limit, cursor)
@@ -1989,6 +1990,38 @@ defmodule Vutuv.Posts do
     |> posts_at_or_before(cursor)
     |> Repo.all()
     |> Enum.map(&%{id: "post-#{&1.id}", post: &1, reposted_by: nil, at: &1.inserted_at})
+  end
+
+  # Posts carrying a tag the page follows (issue #1336) — the topic source, the
+  # third and last one a page can fill today. Members' posts only: a page's own
+  # posts already arrive through the source above when it follows that page, and
+  # letting a tag pull them in as well would show the same post twice.
+  #
+  # Public posts only, for the same reason as the member source: a page can
+  # never be a denial's audience.
+  defp organization_feed_tag_posts(%Organization{id: page_id}, fetch_n, cursor) do
+    from(p in Post,
+      join: u in assoc(p, :user),
+      as: :author,
+      join: pt in PostTag,
+      on: pt.post_id == p.id,
+      where: pt.tag_id in subquery(tags_followed_by_organization(page_id)),
+      where: account_confirmed_row(u) and not account_hidden_row(u),
+      distinct: true,
+      order_by: [desc: p.inserted_at, desc: p.id],
+      limit: ^fetch_n
+    )
+    |> scope_visible(nil)
+    |> posts_at_or_before(cursor)
+    |> Repo.all()
+    |> Enum.map(&%{id: "post-#{&1.id}", post: &1, reposted_by: nil, at: &1.inserted_at})
+  end
+
+  defp tags_followed_by_organization(page_id) do
+    from(tf in Vutuv.Tags.TagFollow,
+      where: tf.organization_id == ^page_id,
+      select: tf.tag_id
+    )
   end
 
   # The two halves of a page's follow graph. Named functions rather than inline

--- a/lib/vutuv/tags.ex
+++ b/lib/vutuv/tags.ex
@@ -12,6 +12,7 @@ defmodule Vutuv.Tags do
   import Ecto.Query
 
   alias Vutuv.Accounts.User
+  alias Vutuv.Organizations.Organization
   alias Vutuv.Posts
   alias Vutuv.Repo
   alias Vutuv.SearchText
@@ -681,9 +682,85 @@ defmodule Vutuv.Tags do
     Repo.all(from(tf in TagFollow, where: tf.user_id == ^user_id, select: tf.tag_id))
   end
 
-  @doc "How many members follow `tag` (the public aggregate on the tag page)."
+  @doc """
+  How many follow `tag` (the public aggregate on the tag page) — members and
+  pages alike, since both are subscriptions to the same topic.
+  """
   def tag_follower_count(%Tag{} = tag) do
     Repo.aggregate(from(tf in TagFollow, where: tf.tag_id == ^tag.id), :count)
+  end
+
+  @doc """
+  A page follows a tag (issue #1336), so the topic reaches its own feed.
+  Idempotent, like the member twin, and silent for the same reason: a tag has
+  no owner to notify.
+  """
+  def follow_tag_as_organization(%Organization{} = page, tag_id) when is_binary(tag_id) do
+    with tag_id when not is_nil(tag_id) <- Vutuv.UUIDv7.cast_or_nil(tag_id),
+         {:ok, _} <- insert_organization_tag_follow(page.id, tag_id),
+         %TagFollow{} = follow <-
+           Repo.get_by(TagFollow, organization_id: page.id, tag_id: tag_id) do
+      {:ok, follow}
+    else
+      nil -> {:error, :invalid}
+      {:error, _} = error -> error
+    end
+  end
+
+  def follow_tag_as_organization(%Organization{} = page, %Tag{id: id}),
+    do: follow_tag_as_organization(page, id)
+
+  defp insert_organization_tag_follow(organization_id, tag_id) do
+    %TagFollow{}
+    |> TagFollow.organization_changeset(%{organization_id: organization_id, tag_id: tag_id})
+    |> Repo.insert(on_conflict: :nothing, conflict_target: [:organization_id, :tag_id])
+  end
+
+  @doc "Unfollows a tag as `page`. Idempotent; returns the number of rows removed."
+  def unfollow_tag_as_organization(%Organization{} = page, %Tag{} = tag),
+    do: unfollow_tag_as_organization(page, tag.id)
+
+  def unfollow_tag_as_organization(%Organization{} = page, tag_id) do
+    case Vutuv.UUIDv7.cast_or_nil(tag_id) do
+      nil ->
+        0
+
+      tag_id ->
+        {count, _} =
+          from(tf in TagFollow,
+            where: tf.organization_id == ^page.id and tf.tag_id == ^tag_id
+          )
+          |> Repo.delete_all()
+
+        count
+    end
+  end
+
+  @doc "Whether `page` currently follows `tag`."
+  def tag_followed_by_organization?(%Organization{} = page, %Tag{} = tag),
+    do: tag_followed_by_organization?(page, tag.id)
+
+  def tag_followed_by_organization?(%Organization{} = page, tag_id) do
+    Repo.exists?(
+      from(tf in TagFollow, where: tf.organization_id == ^page.id and tf.tag_id == ^tag_id)
+    )
+  end
+
+  @doc "The tags `page` follows, most-recently-followed first."
+  def organization_followed_tags(%Organization{id: page_id}) do
+    Repo.all(
+      from(tf in TagFollow,
+        join: t in assoc(tf, :tag),
+        where: tf.organization_id == ^page_id,
+        order_by: [desc: tf.inserted_at, desc: tf.id],
+        select: t
+      )
+    )
+  end
+
+  @doc "The ids of the tags `page` follows — the set its feed's tag source joins against."
+  def organization_followed_tag_ids(%Organization{id: page_id}) do
+    Repo.all(from(tf in TagFollow, where: tf.organization_id == ^page_id, select: tf.tag_id))
   end
 
   @doc """

--- a/lib/vutuv/tags/tag_follow.ex
+++ b/lib/vutuv/tags/tag_follow.ex
@@ -14,7 +14,11 @@ defmodule Vutuv.Tags.TagFollow do
   use VutuvWeb, :model
 
   schema "tag_follows" do
+    # The follower is a member OR an organization page (issue #1336),
+    # CHECK-enforced to exactly one — a page follows a topic so its own feed
+    # can carry it.
     belongs_to(:user, Vutuv.Accounts.User)
+    belongs_to(:organization, Vutuv.Organizations.Organization)
     belongs_to(:tag, Vutuv.Tags.Tag)
 
     timestamps()
@@ -32,5 +36,23 @@ defmodule Vutuv.Tags.TagFollow do
     )
     |> foreign_key_constraint(:tag_id)
     |> foreign_key_constraint(:user_id)
+  end
+
+  @doc """
+  A page's subscription to a tag. Its own changeset rather than a widened
+  `changeset/2`: the two have different required fields and different unique
+  constraints, and one cast accepting either would also accept both or neither,
+  leaving only the database to catch it.
+  """
+  def organization_changeset(model, params \\ %{}) do
+    model
+    |> cast(params, [:organization_id, :tag_id])
+    |> validate_required([:organization_id, :tag_id])
+    |> unique_constraint(:tag_id,
+      name: :tag_follows_organization_id_tag_id_index,
+      message: "This page already follows this tag."
+    )
+    |> foreign_key_constraint(:tag_id)
+    |> foreign_key_constraint(:organization_id)
   end
 end

--- a/lib/vutuv_web/controllers/tag_controller.ex
+++ b/lib/vutuv_web/controllers/tag_controller.ex
@@ -1,7 +1,9 @@
 defmodule VutuvWeb.TagController do
   use VutuvWeb, :controller
 
+  alias Vutuv.Accounts.User
   alias Vutuv.Jobs
+  alias Vutuv.Organizations.Organization
   alias Vutuv.Pages
   alias Vutuv.Tags
   alias Vutuv.Tags.Tag
@@ -75,7 +77,11 @@ defmodule VutuvWeb.TagController do
     # viewer-specific, so it rides only on the HTML branch (the agent formats are
     # the anonymous public view). The count is a public aggregate shown as social
     # proof; it is UI chrome, not tag content, so it stays out of the agent docs.
-    following_tag? = not is_nil(current_user) and Tags.tag_followed?(current_user, tag)
+    # While speaking for a page the pill shows the **page's** subscription
+    # (issue #1336) — that is whose feed the topic would reach, so showing the
+    # member's state here would offer to unfollow something the page never
+    # followed.
+    following_tag? = tag_followed?(conn.assigns[:acting_as], current_user, tag)
     tag_follower_count = Tags.tag_follower_count(tag)
 
     # A tag page below the search-engine bar (fewer than
@@ -161,4 +167,13 @@ defmodule VutuvWeb.TagController do
 
     Timeline.page(tag, Keyword.put(opts, :page, page))
   end
+
+  # Who the pill speaks for: the page being acted as, else the member, else
+  # nobody. One decider, so the shown state and the toggle behind it cannot
+  # disagree — the same shape `follower_of/1` has on the organization page.
+  defp tag_followed?(%Organization{} = page, _member, tag),
+    do: Tags.tag_followed_by_organization?(page, tag)
+
+  defp tag_followed?(_acting_as, %User{} = member, tag), do: Tags.tag_followed?(member, tag)
+  defp tag_followed?(_acting_as, _member, _tag), do: false
 end

--- a/lib/vutuv_web/controllers/tag_follow_controller.ex
+++ b/lib/vutuv_web/controllers/tag_follow_controller.ex
@@ -1,12 +1,16 @@
 defmodule VutuvWeb.TagFollowController do
   use VutuvWeb, :controller
 
+  alias Vutuv.Organizations.Organization
   alias Vutuv.Tags
   alias VutuvWeb.ControllerHelpers
 
   plug(VutuvWeb.Plug.RequireLoginOr404)
   plug(:scrub_params, "tag_follow" when action in [:create])
 
+  # While speaking for a page, the subscription belongs to the page (issue
+  # #1336): it is the page's feed the topic would reach, not the person's.
+  #
   # Following a tag is silent and low-stakes, so both paths just toggle the
   # subscription and return to where the member was (the tag page, or the feed
   # rail / settings list). The follower is always the session user, never trusted
@@ -16,12 +20,20 @@ defmodule VutuvWeb.TagFollowController do
   # hence no flash on either path (the tag page's pill flips to its new state,
   # which is the confirmation the member needs).
   def create(conn, %{"tag_follow" => %{"tag_id" => tag_id}}) do
-    Tags.follow_tag(conn.assigns.current_user, tag_id)
+    case conn.assigns[:acting_as] do
+      %Organization{} = page -> Tags.follow_tag_as_organization(page, tag_id)
+      _member -> Tags.follow_tag(conn.assigns.current_user, tag_id)
+    end
+
     redirect(conn, to: referrer_url(conn))
   end
 
   def delete(conn, %{"id" => tag_id}) do
-    Tags.unfollow_tag(conn.assigns.current_user, tag_id)
+    case conn.assigns[:acting_as] do
+      %Organization{} = page -> Tags.unfollow_tag_as_organization(page, tag_id)
+      _member -> Tags.unfollow_tag(conn.assigns.current_user, tag_id)
+    end
+
     redirect(conn, to: referrer_url(conn))
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.250.0",
+      version: "7.251.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260811125954_add_organization_to_tag_follows.exs
+++ b/priv/repo/migrations/20260811125954_add_organization_to_tag_follows.exs
@@ -1,0 +1,59 @@
+defmodule Vutuv.Repo.Migrations.AddOrganizationToTagFollows do
+  @moduledoc """
+  Issue #1336: a **page** may follow a tag, so its feed can carry a topic and
+  not only the people and pages it follows.
+
+  Third table to take the nullable pair (`handles`, `posts`, `follows` before
+  it), and by now the shape is routine: a nullable `organization_id` beside
+  `user_id`, a CHECK for exactly one, and a second unique index because the
+  existing `[user_id, tag_id]` cannot police the organization spelling — those
+  rows leave `user_id` NULL and Postgres treats NULLs as distinct, so the same
+  subscription would be accepted twice.
+
+  Note this is where Stefan's "tags and remote accounts" splits in two. Tags
+  need nothing but this. A page following a *remote* account does not: the
+  fediverse actor is keyed to a member (`%Vutuv.Fediverse.Actor{user_id: …}`)
+  and carries the keypair that signs the outgoing Follow, so a page cannot send
+  one until it has an actor document of its own — which is #1334's fediverse
+  half. That table is deliberately left alone here.
+
+  N-1 safe. The previous release only writes member subscriptions, which
+  satisfy the CHECK, and every query it runs is scoped to a real `user_id`, so
+  an organization row is invisible to it rather than confusing.
+  """
+  use Ecto.Migration
+
+  def up do
+    alter table(:tag_follows) do
+      add(
+        :organization_id,
+        references(:organizations, type: :binary_id, on_delete: :delete_all)
+      )
+    end
+
+    execute("ALTER TABLE tag_follows ALTER COLUMN user_id DROP NOT NULL")
+
+    create(
+      constraint(:tag_follows, :tag_follows_exactly_one_follower,
+        check: """
+        (CASE WHEN user_id IS NULL THEN 0 ELSE 1 END +
+         CASE WHEN organization_id IS NULL THEN 0 ELSE 1 END) = 1
+        """
+      )
+    )
+
+    create(unique_index(:tag_follows, [:organization_id, :tag_id]))
+  end
+
+  def down do
+    drop(unique_index(:tag_follows, [:organization_id, :tag_id]))
+    drop(constraint(:tag_follows, :tag_follows_exactly_one_follower))
+
+    execute("DELETE FROM tag_follows WHERE user_id IS NULL")
+    execute("ALTER TABLE tag_follows ALTER COLUMN user_id SET NOT NULL")
+
+    alter table(:tag_follows) do
+      remove(:organization_id)
+    end
+  end
+end

--- a/test/vutuv/organization_tag_follow_test.exs
+++ b/test/vutuv/organization_tag_follow_test.exs
@@ -1,0 +1,127 @@
+defmodule Vutuv.OrganizationTagFollowTest do
+  @moduledoc """
+  A page follows a **tag** (issue #1336), so its feed carries a topic and not
+  only the people and pages it follows. Third table to take the nullable pair,
+  and by now the shape is routine.
+
+  Stefan's "tags and remote accounts" splits here: a page following a *remote*
+  account is not just another table. The fediverse actor is keyed to a member
+  and carries the keypair that signs the outgoing Follow, so a page cannot send
+  one until it has an actor document of its own — #1334's fediverse half.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag and the DNS-resolver stub beside it.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Posts
+  alias Vutuv.Repo
+  alias Vutuv.Tags
+  alias Vutuv.Tags.TagFollow
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp page, do: active_organization_for(insert(:activated_user))
+
+  test "the database refuses a row naming both or neither follower" do
+    tag = insert(:tag)
+    member = insert(:activated_user)
+    organization = page()
+
+    assert_raise Ecto.ConstraintError, ~r/tag_follows_exactly_one_follower/, fn ->
+      Repo.insert!(%TagFollow{
+        user_id: member.id,
+        organization_id: organization.id,
+        tag_id: tag.id
+      })
+    end
+
+    assert_raise Ecto.ConstraintError, ~r/tag_follows_exactly_one_follower/, fn ->
+      Repo.insert!(%TagFollow{tag_id: tag.id})
+    end
+  end
+
+  test "a page follows and unfollows a tag, idempotently" do
+    organization = page()
+    tag = insert(:tag)
+
+    assert {:ok, follow} = Tags.follow_tag_as_organization(organization, tag.id)
+    assert follow.organization_id == organization.id
+    assert Tags.tag_followed_by_organization?(organization, tag)
+
+    # `[user_id, tag_id]` cannot police this: both rows leave user_id NULL.
+    assert {:ok, same} = Tags.follow_tag_as_organization(organization, tag.id)
+    assert same.id == follow.id
+
+    assert Tags.unfollow_tag_as_organization(organization, tag) == 1
+    refute Tags.tag_followed_by_organization?(organization, tag)
+    assert Tags.unfollow_tag_as_organization(organization, tag) == 0
+  end
+
+  test "the member's own subscriptions are untouched by a page's" do
+    organization = page()
+    member = insert(:activated_user)
+    tag = insert(:tag)
+
+    {:ok, _} = Tags.follow_tag_as_organization(organization, tag.id)
+
+    refute Tags.tag_followed?(member, tag)
+    assert Tags.followed_tag_ids(member) == []
+    assert Tags.organization_followed_tag_ids(organization) == [tag.id]
+
+    # The tag's public aggregate counts both kinds: each is a subscription to
+    # the same topic.
+    assert Tags.tag_follower_count(tag) == 1
+  end
+
+  test "a followed tag's posts reach the page's feed" do
+    organization = page()
+    tag = insert(:tag)
+    author = insert(:activated_user)
+
+    {:ok, post} = Posts.create_post(author, %{body: "Zum Thema.", tags: [tag.name]})
+    {:ok, _} = Tags.follow_tag_as_organization(organization, tag.id)
+
+    ids =
+      organization
+      |> Posts.organization_feed_page()
+      |> Map.fetch!(:entries)
+      |> Enum.map(& &1.post.id)
+
+    assert post.id in ids
+  end
+
+  test "a restricted post with a followed tag still does not reach the page" do
+    organization = page()
+    tag = insert(:tag)
+    author = insert(:activated_user)
+
+    {:ok, hidden} =
+      Posts.create_post(author, %{
+        body: "Nur für Follower.",
+        tags: [tag.name],
+        denials: [%{"wildcard" => "non_followers"}]
+      })
+
+    {:ok, _} = Tags.follow_tag_as_organization(organization, tag.id)
+
+    ids =
+      organization
+      |> Posts.organization_feed_page()
+      |> Map.fetch!(:entries)
+      |> Enum.map(& &1.post.id)
+
+    refute hidden.id in ids
+  end
+end


### PR DESCRIPTION
`tag_follows` ist die dritte Tabelle mit dem Nullable-Paar, und die Form ist inzwischen Routine: `organization_id` neben `user_id`, CHECK auf genau eins, dazu ein zweiter Unique-Index, weil `[user_id, tag_id]` die Organisations-Schreibweise nicht überwachen kann — deren Zeilen lassen `user_id` NULL, und Postgres behandelt NULLs als verschieden.

Der Feed einer Seite hat damit **seine dritte Quelle**. Beiträge von Mitgliedern, nicht von Seiten: was eine gefolgte Seite schreibt, kommt schon über die zweite Quelle an, und ein Thema dürfte denselben Beitrag nicht ein zweites Mal hereinholen. Nur öffentliche Beiträge, aus demselben Grund wie bei der Mitglieder-Quelle — eine Seite kann nie das gemeinte Publikum eines eingeschränkten Beitrags sein. Beides ist getestet.

**Wer für eine Seite spricht, abonniert für die Seite.** Die Pille auf der Themenseite zeigt den Stand der Seite, und der Controller schreibt ihn auch dorthin. `tag_followed?/3` ist die eine Stelle, die das entscheidet — dieselbe Rolle, die `follower_of/1` auf der Organisationsseite hat. Ohne das böte die Seite an, etwas zu entfolgen, dem sie nie gefolgt ist.

**Hier teilt sich dein „Tags und entfernte Konten" in zwei Teile, und den zweiten kann ich heute nicht bauen.** Ich hatte es als eine Aufgabe eingeplant und beim Nachsehen gemerkt, dass es keine ist: eine Seite, die einem entfernten Konto folgt, braucht mehr als eine Spalte. Der Fediverse-Actor hängt an einem Mitglied (`%Vutuv.Fediverse.Actor{user_id: …}`) und trägt den Schlüssel, der das ausgehende Follow signiert. Ohne eigenes Actor-Dokument kann eine Seite keins senden — und genau das ist die Fediverse-Hälfte von #1334. Die Tabelle bleibt deshalb bewusst unangetastet, statt eine Spalte zu bekommen, die niemand füllen könnte.

Damit steht #1336 bis auf zwei Dinge: Nachrichten an eine Seite (wartet auf deine Entscheidung, siehe unten) und eben die entfernten Konten, die hinter #1334 stehen.

Zur Erinnerung die offene Frage: `conversations` speichert das Paar sortiert (`user_a_id < user_b_id`) mit CHECK und Unique-Index. Soll eine Nachricht an eine Seite ein **Gespräch mit der Seite** sein, dessen Verlauf einen Personalwechsel überlebt, oder ein **gemeinsames Postfach**, das mehrere bedienen?

`mix precommit` grün (7265 Tests). Migration gegen `vutuv1_dev` gelaufen.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01MMwsQi49FP21xuSoPEkMnN
