### PR TITLE
Drei Lücken, die der Seiten-Follow hinterlassen hat (v7.252.0)

### DIFF
--- a/lib/vutuv/export.ex
+++ b/lib/vutuv/export.ex
@@ -37,7 +37,11 @@ defmodule Vutuv.Export do
   # 7: the accounts followed on other networks (issue #1160).
   # 8: `fediverse_likes` covers liked **replies** too (issue #1270) and every
   #    entry names which it is in `kind`.
-  @schema_version 8
+  # 9: the organization pages on either side of a follow (issue #1336) —
+  #    `follower_organizations` and `following_organizations`. Their own keys
+  #    rather than rows in `followers` / `following`, which carry a `username` a
+  #    page need never have claimed.
+  @schema_version 9
 
   def build(%User{} = user) do
     user =
@@ -147,6 +151,14 @@ defmodule Vutuv.Export do
         Enum.map(user.username_changes, &%{username: &1.value, changed_at: &1.inserted_at}),
       followers: follow_side(user, :followee_id, :follower),
       following: follow_side(user, :follower_id, :followee),
+      # Pages are their own keys rather than rows in the two lists above (issue
+      # #1336): those carry a `username`, and a page need never have claimed
+      # one. Leaving them out entirely was the real problem — an export that
+      # answers "who follows me" has to name the pages too.
+      follower_organizations:
+        organization_follow_side(user, :followee_id, :follower_organization_id),
+      following_organizations:
+        organization_follow_side(user, :follower_id, :followee_organization_id),
       connections: connections(user),
       posts: posts(user),
       # Posts that were started and never sent (issue #1148). The composer
@@ -335,6 +347,19 @@ defmodule Vutuv.Export do
       where: field(f, ^filter_field) == ^user.id,
       join: u in assoc(f, ^other_assoc),
       select: %{username: u.username, since: f.inserted_at}
+    )
+    |> Repo.all()
+  end
+
+  # The organization half of the same two questions. Named by `name` + `slug`:
+  # a page is identified by its name, and its handle is an optional address it
+  # may never have claimed.
+  defp organization_follow_side(user, filter_field, organization_field) do
+    from(f in Follow,
+      join: o in Vutuv.Organizations.Organization,
+      on: o.id == field(f, ^organization_field),
+      where: field(f, ^filter_field) == ^user.id,
+      select: %{name: o.name, slug: o.slug, since: f.inserted_at}
     )
     |> Repo.all()
   end

--- a/lib/vutuv/social.ex
+++ b/lib/vutuv/social.ex
@@ -225,6 +225,27 @@ defmodule Vutuv.Social do
     end
   end
 
+  @doc """
+  Drops one of `page`'s own follow edges by id. Idempotent, and scoped to the
+  page: an id belonging to somebody else's edge removes nothing, so the client
+  cannot be trusted with more than a hint about which row it meant.
+  """
+  def unfollow_edge_as_organization(%Organization{id: page_id}, follow_id) do
+    case Vutuv.UUIDv7.cast_or_nil(follow_id) do
+      nil ->
+        0
+
+      follow_id ->
+        {count, _} =
+          from(f in Follow,
+            where: f.id == ^follow_id and f.follower_organization_id == ^page_id
+          )
+          |> Repo.delete_all()
+
+        count
+    end
+  end
+
   @doc "Whether `page` follows `followee`."
   def organization_follows?(%Organization{} = page, followee) do
     {column, followee_id} = followee_column(followee)
@@ -714,12 +735,19 @@ defmodule Vutuv.Social do
     # Count each followee's *visible* followers, so the ranking matches the
     # follower_count/1 shown on each profile and can't be inflated by
     # mass-registering never-activated follower accounts.
+    #
+    # That promise is why this counts pages too (issue #1336): the profile
+    # figure started counting them in v7.249.0, so an inner join to `users`
+    # here would have quietly ranked by a different number than the one beside
+    # each name. Same two LEFT joins and same gate per kind as
+    # `follower_count_query/1`.
     follower_counts =
       from(fl in Follow,
-        join: fr in Vutuv.Accounts.User,
-        on:
-          fr.id == fl.follower_id and account_confirmed_row(fr) and
-            not account_hidden_row(fr),
+        left_join: fr in User,
+        on: fr.id == fl.follower_id,
+        left_join: fo in Organization,
+        on: fo.id == fl.follower_organization_id,
+        where: visible_member(fr) or visible_page(fo),
         group_by: fl.followee_id,
         select: %{followee_id: fl.followee_id, count: count()}
       )

--- a/lib/vutuv_web/components/organization_components.ex
+++ b/lib/vutuv_web/components/organization_components.ex
@@ -226,6 +226,9 @@ defmodule VutuvWeb.OrganizationComponents do
         <.manage_tab :if={@publisher?} active={@active == :feed} navigate={"/organizations/#{@organization.slug}/feed"}>
           {gettext("Feed")}
         </.manage_tab>
+        <.manage_tab :if={@publisher?} active={@active == :following} navigate={"/organizations/#{@organization.slug}/following"}>
+          {gettext("Following")}
+        </.manage_tab>
       </nav>
     </div>
     """

--- a/lib/vutuv_web/controllers/organization_controller.ex
+++ b/lib/vutuv_web/controllers/organization_controller.ex
@@ -146,6 +146,10 @@ defmodule VutuvWeb.OrganizationController do
   def feed(conn, %{"slug" => slug}),
     do: manage(conn, slug, VutuvWeb.OrganizationLive.Feed, &Organizations.publisher?/2)
 
+  @doc "What the page follows (issue #1336). Publishers only, like the feed."
+  def following(conn, %{"slug" => slug}),
+    do: manage(conn, slug, VutuvWeb.OrganizationLive.Following, &Organizations.publisher?/2)
+
   @doc """
   The permalink of a post published in this organization's name (issue #1334).
   404s for an unknown page, a page this viewer may not see, or an id that is not

--- a/lib/vutuv_web/live/organization_live/following.ex
+++ b/lib/vutuv_web/live/organization_live/following.ex
@@ -1,0 +1,170 @@
+defmodule VutuvWeb.OrganizationLive.Following do
+  @moduledoc """
+  What a page follows (`/organizations/:slug/following`, issue #1336) — the
+  list behind the feed beside it, and the only place its team can take a
+  subscription back.
+
+  **Publishers only**, like the feed and for the same reason: this is the
+  page's own reading, which is part of speaking for it, not news about it.
+
+  Deliberately **not public**, unlike a member's Following page. What a page
+  reads is working material — which competitors and topics a company watches
+  says more about its plans than a member's reading list says about theirs —
+  and nothing in #1336 asks for it to be on show. Making it public later is an
+  easy step; taking it back would not be.
+
+  Embedded via `live_render` from `VutuvWeb.OrganizationController`, which gates
+  it before this ever mounts.
+  """
+
+  use VutuvWeb, :live_view
+
+  import VutuvWeb.OrganizationComponents,
+    only: [manage_header: 1, organization_logo: 1, organization_location: 1]
+
+  import VutuvWeb.UserHelpers, only: [full_name: 1]
+
+  alias Vutuv.Accounts.User
+  alias Vutuv.Organizations
+  alias Vutuv.Organizations.Organization
+  alias Vutuv.Social
+  alias Vutuv.Tags
+  alias VutuvWeb.Live.InitAssigns
+
+  @impl true
+  def mount(_params, session, socket) do
+    socket = InitAssigns.assign_embedded(socket, session)
+    organization = Organizations.get_organization!(session["organization_id"])
+
+    {:ok,
+     socket
+     |> assign(:organization, organization)
+     |> assign(:owner?, Organizations.owner?(organization, socket.assigns.current_user))
+     |> assign(:page_title, gettext("Following – %{name}", name: organization.name))
+     |> load_following()}
+  end
+
+  defp load_following(socket) do
+    organization = socket.assigns.organization
+
+    socket
+    |> assign(:followees, Social.organization_followees(organization))
+    |> assign(:tags, Tags.organization_followed_tags(organization))
+  end
+
+  @impl true
+  def handle_event("unfollow", %{"id" => follow_id}, socket) do
+    organization = socket.assigns.organization
+
+    # Scoped to this page's own edges: `organization_followees/1` only ever
+    # hands out follow ids belonging to it, and the delete re-checks rather
+    # than trusting the id that came back from the client.
+    Social.unfollow_edge_as_organization(organization, follow_id)
+
+    {:noreply, load_following(socket)}
+  end
+
+  def handle_event("unfollow-tag", %{"id" => tag_id}, socket) do
+    Tags.unfollow_tag_as_organization(socket.assigns.organization, tag_id)
+    {:noreply, load_following(socket)}
+  end
+
+  @impl true
+  def handle_info(_message, socket), do: {:noreply, socket}
+
+  defp followee_name(%Organization{name: name}), do: name
+  defp followee_name(%User{} = user), do: full_name(user)
+
+  defp followee_path(%Organization{} = organization),
+    do: Organizations.canonical_path(organization)
+
+  defp followee_path(%User{username: username}), do: "/#{username}"
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="mx-auto max-w-2xl py-6">
+      <.manage_header
+        organization={@organization}
+        active={:following}
+        owner?={@owner?}
+        manage?={true}
+        publisher?={true}
+      />
+
+      <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100">{gettext("Following")}</h1>
+      <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+        {gettext("The members, organizations and topics this page follows. Everything here shapes its feed, and only the team can see this list.")}
+      </p>
+
+      <.card class="mt-6" id="organization-followees">
+        <.section_title>{gettext("Members and organizations")}</.section_title>
+
+        <p :if={@followees == []} class="mt-2 text-sm text-slate-600 dark:text-slate-400">
+          {gettext("This page does not follow anyone yet.")}
+        </p>
+
+        <ul :if={@followees != []} class="mt-2 divide-y divide-slate-100 dark:divide-slate-800">
+          <li :for={{follow_id, followee} <- @followees} class="flex items-center gap-4 py-4">
+            <.link navigate={followee_path(followee)} class="shrink-0">
+              <.organization_logo
+                :if={match?(%Organization{}, followee)}
+                organization={followee}
+                class="h-12 w-12"
+              />
+              <.avatar :if={match?(%User{}, followee)} user={followee} size="md" shape="circle" />
+            </.link>
+
+            <div class="min-w-0 flex-1">
+              <.link
+                navigate={followee_path(followee)}
+                class="block truncate font-semibold text-slate-900 hover:text-brand-700 dark:text-slate-100 dark:hover:text-brand-300"
+              >
+                {followee_name(followee)}
+              </.link>
+              <.organization_location
+                :if={match?(%Organization{}, followee)}
+                organization={followee}
+                class="truncate text-sm text-slate-600 dark:text-slate-400"
+              />
+            </div>
+
+            <.button
+              variant="secondary"
+              phx-click="unfollow"
+              phx-value-id={follow_id}
+              class="shrink-0"
+            >
+              {gettext("Unfollow")}
+            </.button>
+          </li>
+        </ul>
+      </.card>
+
+      <.card class="mt-4" id="organization-followed-tags">
+        <.section_title>{gettext("Topics")}</.section_title>
+
+        <p :if={@tags == []} class="mt-2 text-sm text-slate-600 dark:text-slate-400">
+          {gettext("This page does not follow any topics yet.")}
+        </p>
+
+        <div :if={@tags != []} class="mt-3 flex flex-wrap gap-2">
+          <span :for={tag <- @tags} class="inline-flex items-center gap-1">
+            <.chip navigate={~p"/tags/#{tag.slug}"}>{tag.name}</.chip>
+            <button
+              type="button"
+              phx-click="unfollow-tag"
+              phx-value-id={tag.id}
+              title={gettext("Unfollow %{tag}", tag: tag.name)}
+              aria-label={gettext("Unfollow %{tag}", tag: tag.name)}
+              class="inline-flex h-10 w-10 items-center justify-center rounded-lg text-slate-600 hover:bg-slate-100 hover:text-rose-700 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-rose-300"
+            >
+              ✕
+            </button>
+          </span>
+        </div>
+      </.card>
+    </div>
+    """
+  end
+end

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -277,6 +277,7 @@ defmodule VutuvWeb.Router do
     # What happened to the page (issue #1336), for its whole team.
     get("/organizations/:slug/activity", OrganizationController, :activity)
     get("/organizations/:slug/feed", OrganizationController, :feed)
+    get("/organizations/:slug/following", OrganizationController, :following)
     # The permalink of a post published in the organization's name (issue #1334).
     # Deliberately under the slug and not under the organization's opt-in root
     # handle: the handle route dispatches an organization only on the bare

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.251.0",
+      version: "7.252.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/export_organizations_test.exs
+++ b/test/vutuv/export_organizations_test.exs
@@ -1,0 +1,55 @@
+defmodule Vutuv.ExportOrganizationsTest do
+  @moduledoc """
+  The pages on either side of a follow, in the personal data export (issue
+  #1336, schema v9). An export that answers "who follows me" has to name them:
+  leaving them out was the actual problem, and `followers` / `following` cannot
+  simply take them, because those entries carry a `username` a page need never
+  have claimed.
+
+  Its own file rather than a case in `export_test.exs`: that module is
+  `async: true`, and the organization helpers flip the global
+  `:verify_organization_domains` flag and the DNS-resolver stub beside it.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Export
+  alias Vutuv.Social
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  test "both directions of a page follow are named" do
+    member = insert(:activated_user)
+
+    followed = active_organization_for(insert(:activated_user))
+
+    follower =
+      active_organization_for(insert(:activated_user), %{
+        "name" => "Zweite AG",
+        "website_url" => "https://zweite.example"
+      })
+
+    {:ok, _} = Social.follow_organization(member, followed)
+    {:ok, _} = Social.follow_as_organization(follower, member)
+
+    data = Export.build(member)
+
+    assert data.schema_version >= 9
+    assert [%{name: "Acme GmbH", slug: _, since: _}] = data.following_organizations
+    assert [%{name: "Zweite AG"}] = data.follower_organizations
+
+    # The member lists stay members: a page has no username to put there.
+    assert data.followers == []
+    assert data.following == []
+  end
+end

--- a/test/vutuv/export_test.exs
+++ b/test/vutuv/export_test.exs
@@ -39,7 +39,9 @@ defmodule Vutuv.ExportTest do
 
     data = Export.build(user)
 
-    assert data.schema_version == 8
+    # The exact number moves with every new section; what this case is really
+    # about is the v3 content below it.
+    assert data.schema_version >= 8
     assert Enum.any?(data.blocked_members, &(&1.member == blocked.username))
     # The private content filters (issue #940) are owner-only, so they ride
     # along in the member's own GDPR export.

--- a/test/vutuv_web/organization_following_web_test.exs
+++ b/test/vutuv_web/organization_following_web_test.exs
@@ -1,0 +1,106 @@
+defmodule VutuvWeb.OrganizationFollowingWebTest do
+  @moduledoc """
+  What a page follows (`/organizations/:slug/following`, issue #1336): the list
+  behind the feed, and the only place its team can take a subscription back.
+  Publishers only, and deliberately not public — what a page reads is working
+  material, and nothing in the issue asks for it to be on show.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag and the DNS-resolver stub beside it.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Organizations
+  alias Vutuv.Social
+  alias Vutuv.Tags
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp publishing_page(conn) do
+    {conn, owner} = create_and_login_user(conn)
+    organization = active_organization_for(owner)
+    {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+    {conn, organization}
+  end
+
+  test "the list names every kind the page follows", %{conn: conn} do
+    {conn, organization} = publishing_page(conn)
+
+    member = insert(:activated_user, first_name: "Frida", last_name: "Folger")
+    tag = insert(:tag)
+
+    other =
+      active_organization_for(insert(:activated_user), %{
+        "name" => "Zweite AG",
+        "website_url" => "https://zweite.example"
+      })
+
+    {:ok, _} = Social.follow_as_organization(organization, member)
+    {:ok, _} = Social.follow_as_organization(organization, other)
+    {:ok, _} = Tags.follow_tag_as_organization(organization, tag.id)
+
+    html = conn |> get(~p"/organizations/#{organization.slug}/following") |> html_response(200)
+
+    assert html =~ "Frida"
+    assert html =~ "Zweite AG"
+    assert html =~ tag.name
+  end
+
+  test "a publisher can take a follow back from here", %{conn: conn} do
+    {conn, organization} = publishing_page(conn)
+    member = insert(:activated_user)
+    tag = insert(:tag)
+
+    {:ok, follow} = Social.follow_as_organization(organization, member)
+    {:ok, _} = Tags.follow_tag_as_organization(organization, tag.id)
+
+    {:ok, view, _html} = live(conn, ~p"/organizations/#{organization.slug}/following")
+
+    render_click(view, "unfollow", %{"id" => follow.id})
+    refute Social.organization_follows?(organization, member)
+
+    render_click(view, "unfollow-tag", %{"id" => tag.id})
+    refute Tags.tag_followed_by_organization?(organization, tag)
+  end
+
+  test "one page cannot drop another page's follow", %{conn: conn} do
+    {conn, organization} = publishing_page(conn)
+
+    other =
+      active_organization_for(insert(:activated_user), %{
+        "name" => "Zweite AG",
+        "website_url" => "https://zweite.example"
+      })
+
+    victim = insert(:activated_user)
+    {:ok, foreign} = Social.follow_as_organization(other, victim)
+
+    {:ok, view, _html} = live(conn, ~p"/organizations/#{organization.slug}/following")
+    render_click(view, "unfollow", %{"id" => foreign.id})
+
+    # The handler re-checks the edge belongs to this page rather than trusting
+    # the id that came back from the client.
+    assert Social.organization_follows?(other, victim)
+  end
+
+  test "a role holder who may not speak for the page is turned away", %{conn: conn} do
+    {conn, member} = create_and_login_user(conn)
+    owner = insert(:activated_user)
+    organization = active_organization_for(owner)
+    {:ok, _} = Organizations.add_role(organization, member, "recruiter", owner)
+
+    assert conn |> get(~p"/organizations/#{organization.slug}/following") |> response(404)
+  end
+end


### PR DESCRIPTION
Die beiden großen Reste von #1336 hängen — entfernte Konten hinter #1334, Nachrichten hinter deiner Entscheidung — also habe ich die kleinen offenen Enden zusammengefasst, die der Seiten-Follow hinterlassen hat.

**Eine Seite hat jetzt eine Following-Seite.** `organization_followees/1` gab es seit #1385, aber nichts hat sie gerendert: eine Seite konnte folgen, und ihr Team konnte nirgends nachsehen, wem. Neu unter `/organizations/:slug/following`, nur für Redaktion wie der Feed, mit Mitgliedern, Seiten und Themen und je einem Entfolgen.

Bewusst **nicht öffentlich**, anders als die Following-Seite eines Mitglieds. Was eine Seite liest, ist Arbeitsmaterial — welche Wettbewerber und Themen eine Firma beobachtet, sagt mehr über ihre Pläne als die Leseliste eines Menschen über seine — und #1336 verlangt es nirgends. Öffentlich machen ist später ein kleiner Schritt; zurücknehmen wäre keiner. Sag Bescheid, wenn du es andersherum willst.

Das Entfolgen prüft serverseitig nach, dass die Kante wirklich dieser Seite gehört, statt der id vom Client zu glauben. Ein Test schickt die Kante einer fremden Seite und erwartet, dass nichts passiert.

**Die Datenauskunft nennt die Seiten auf beiden Seiten eines Follows.** `followers` und `following` tragen einen `username`, den eine Seite nie beansprucht haben muss — also zwei eigene Schlüssel statt einer aufgeweichten Zeilenform. Schema-Version 9, mit Eintrag im Änderungsprotokoll der Datei. Ein Test hielt die Versionsnummer exakt fest, obwohl es ihm um den v3-Inhalt darunter geht; der prüft jetzt `>=`, sonst kostet jede neue Sektion einen Fehlschlag an einer Stelle, die damit nichts zu tun hat.

**`compute_most_followed/1` zählt jetzt auch Seiten.** Der eigene Kommentar der Funktion sagt, die Rangfolge müsse zu `follower_count/1` auf dem Profil passen — und die zählt seit #1385 beide Sorten. Sie war also von ihrer eigenen Zusage abgewichen, und zwar still: eine Rangliste sieht plausibel aus, egal nach welcher Zahl sie sortiert.

**Zwei Lücken habe ich stehen lassen**, beide mit echter Entwurfsfläche statt bloß Arbeit: eine Benachrichtigung, wenn eine Seite dir folgt (die Notification-Oberfläche rendert durchweg einen Mitglieds-Actor mit Avatar und Profillink — dieselbe Verbreiterung wie damals bei der Autorschaft, quer über die Seite), und ein Folgen-als-Seite auf dem Profil eines Mitglieds (die Pille dort zeigt beide Richtungen, und „folgt dir" bedeutet für eine handelnde Seite etwas anderes als für einen Menschen).

`mix precommit` grün (7270 Tests).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01MMwsQi49FP21xuSoPEkMnN
