### PR TITLE
Wenn eine Seite dir folgt, erfährst du es (v7.254.0)

### DIFF
--- a/lib/vutuv/activity.ex
+++ b/lib/vutuv/activity.ex
@@ -59,6 +59,23 @@ defmodule Vutuv.Activity do
   def subscribe(nil), do: :ok
   def subscribe(user_id), do: Phoenix.PubSub.subscribe(@pubsub, topic(user_id))
 
+  # Whether a follow row has a follower worth showing. The member side is left
+  # exactly as it was — the row existing is the whole test, no moderation gate,
+  # which is what the old inner join amounted to — so this changes nothing for
+  # members. The page side additionally has to be one a reader may open, or the
+  # notification would link somewhere they are turned away from.
+  #
+  # It lives here, shared by the list and both badge queries, because those
+  # three drifting apart is exactly the bug: a badge counting what the list
+  # cannot show.
+  defmacrop shown_follower(u, o) do
+    quote do
+      not is_nil(unquote(u).id) or
+        (not is_nil(unquote(o).id) and unquote(o).status == "active" and
+           is_nil(unquote(o).frozen_at))
+    end
+  end
+
   @doc "Broadcast a raw event to a user's topic (no-op for a nil recipient)."
   def broadcast(nil, _event), do: :ok
   def broadcast(user_id, event), do: Phoenix.PubSub.broadcast(@pubsub, topic(user_id), event)
@@ -106,8 +123,17 @@ defmodule Vutuv.Activity do
   # The read-marker MAX arms, one `%{ts: ...}` query per event family. Each
   # mirrors the filters of its kind's items/count queries below.
 
-  defp follower_max(user_id),
-    do: from(c in Follow, where: c.followee_id == ^user_id, select: %{ts: max(c.inserted_at)})
+  defp follower_max(user_id) do
+    from(c in Follow,
+      left_join: u in User,
+      on: u.id == c.follower_id,
+      left_join: o in Organization,
+      on: o.id == c.follower_organization_id,
+      where: c.followee_id == ^user_id,
+      where: shown_follower(u, o),
+      select: %{ts: max(c.inserted_at)}
+    )
+  end
 
   defp endorsement_max(user_id) do
     from(e in UserTagEndorsement,
@@ -970,25 +996,38 @@ defmodule Vutuv.Activity do
   # the cheap follows rows first and attaching the actor to the survivors turns
   # it into `limit` primary-key lookups: measured 9.4 ms -> 0.6 ms on the
   # production data. `connection_items/3` below is the same shape.
+  # A follower is a member **or** a page (issue #1336). Both id columns ride
+  # along and the outer query LEFT joins each, so a page row is built from the
+  # organization rather than dropped — which is what it used to be, while
+  # `count_followers/2` counted it: badge one, list empty, and a badge that lies
+  # once is a badge nobody trusts again.
   defp follower_items(user_id, limit, cursor) do
     newest =
       from(c in Follow,
         where: c.followee_id == ^user_id,
         order_by: [desc: c.inserted_at, desc: c.id],
         limit: ^limit,
-        select: %{id: c.id, at: c.inserted_at, actor_id: c.follower_id}
+        select: %{
+          id: c.id,
+          at: c.inserted_at,
+          actor_id: c.follower_id,
+          actor_organization_id: c.follower_organization_id
+        }
       )
       |> at_or_before(cursor)
 
     from(e in subquery(newest),
-      join: f in User,
+      left_join: f in User,
       on: f.id == e.actor_id,
+      left_join: o in Organization,
+      on: o.id == e.actor_organization_id,
+      where: shown_follower(f, o),
       order_by: [desc: e.at, desc: e.id],
-      select: {e.id, e.at, struct(f, ^User.listing_fields())}
+      select: {e.id, e.at, struct(f, ^User.listing_fields()), o}
     )
     |> Repo.all()
-    |> Enum.map(fn {id, at, follower} ->
-      actor_item("follower-#{id}", "follower", at, follower)
+    |> Enum.map(fn {id, at, follower, organization} ->
+      actor_item("follower-#{id}", "follower", at, follower || organization)
     end)
   end
 
@@ -1676,11 +1715,21 @@ defmodule Vutuv.Activity do
   defp actor_fields(actor) do
     %{
       actor_id: actor_id(actor),
+      actor_kind: actor_kind(actor),
       actor_name: display_name(actor),
       actor_param: actor_param(actor),
       actor_avatar: actor_avatar(actor)
     }
   end
+
+  # Which sort of actor this is (issue #1336), because `actor_param` alone
+  # cannot say: a member's param is their handle and lives at `/handle`, while a
+  # page's is a slug that lives under `/organizations/:slug`. Building the link
+  # from the param alone would send a reader into the member namespace, at a
+  # word somebody else may hold.
+  defp actor_kind(%Organization{}), do: "organization"
+  defp actor_kind(%User{}), do: "user"
+  defp actor_kind(_), do: "user"
 
   defp actor_id(%User{id: id}), do: id
   defp actor_id(%Organization{id: id}), do: id
@@ -1689,7 +1738,15 @@ defmodule Vutuv.Activity do
   # Each count helper returns a query selecting a single count, so total_count/2
   # can fold all three into one round trip via scalar subqueries.
   defp count_followers(user_id, read_at) do
-    from(c in Follow, where: c.followee_id == ^user_id, select: %{count: count()})
+    from(c in Follow,
+      left_join: u in User,
+      on: u.id == c.follower_id,
+      left_join: o in Organization,
+      on: o.id == c.follower_organization_id,
+      where: c.followee_id == ^user_id,
+      where: shown_follower(u, o),
+      select: %{count: count()}
+    )
     |> since(read_at)
   end
 

--- a/lib/vutuv/social.ex
+++ b/lib/vutuv/social.ex
@@ -198,6 +198,11 @@ defmodule Vutuv.Social do
 
     case result do
       {:ok, _follow} = ok ->
+        # A member learns that a page followed them, the same way they learn
+        # about a person (issue #1336). A page has no inbox, so the mirror case
+        # (following a page) still notifies nobody.
+        notify_new_page_follower(page, followee)
+
         # The followee's own profile recomputes: a page counts as a follower.
         broadcast_social_graph_changed([followee_id])
         ok
@@ -251,6 +256,11 @@ defmodule Vutuv.Social do
     {column, followee_id} = followee_column(followee)
     organization_follow_edge(page.id, column, followee_id) != nil
   end
+
+  defp notify_new_page_follower(%Organization{} = page, %User{id: id}),
+    do: Vutuv.Activity.notify_new_follower(id, page)
+
+  defp notify_new_page_follower(_page, _followee), do: :ok
 
   defp followee_column(%Organization{id: id}), do: {:followee_organization_id, id}
   defp followee_column(%User{id: id}), do: {:followee_id, id}

--- a/lib/vutuv_web/live/notification_live/groups.ex
+++ b/lib/vutuv_web/live/notification_live/groups.ex
@@ -163,6 +163,9 @@ defmodule VutuvWeb.NotificationLive.Groups do
         id: &1[:actor_id],
         name: &1[:actor_name],
         param: &1[:actor_param],
+        # Which namespace `param` belongs to (issue #1336): a member's handle
+        # lives at the root, a page's slug under /organizations/:slug.
+        kind: &1[:actor_kind],
         avatar: &1[:actor_avatar],
         # Somebody on another network (issue #1069): no vutuv profile to link
         # to, so the row links out to their account instead and names them by

--- a/lib/vutuv_web/live/notification_live/index.ex
+++ b/lib/vutuv_web/live/notification_live/index.ex
@@ -780,8 +780,12 @@ defmodule VutuvWeb.NotificationLive.Index do
     ~H"""
     <%= cond do %>
       <% @actor.param -> %>
+        <%!-- `actor_path/1`, never `~p"/#{@actor.param}"`: a page's param is a
+        slug under /organizations/:slug, and the root belongs to member handles
+        (issue #1336). This is the second link on the row and the one that is
+        easy to miss — `actor_target/1` below covers the row's own href. --%>
         <.link
-          href={~p"/#{@actor.param}"}
+          href={actor_path(@actor)}
           class="font-semibold text-slate-900 hover:text-brand-700 dark:text-white dark:hover:text-brand-300"
         >{@actor.name}</.link>
       <% @actor[:url] -> %>
@@ -1213,9 +1217,25 @@ defmodule VutuvWeb.NotificationLive.Index do
     end
   end
 
+  # A member's param is their handle and lives at the root; a page's is a slug
+  # that lives under /organizations/:slug (issue #1336). Building this from the
+  # param alone would point into the member namespace, at a word somebody else
+  # may hold — so the row's own `actor_kind` decides, and a row without one
+  # reads as the member it was.
+  defp actor_target(%{actor_kind: "organization", actor_param: slug}) when is_binary(slug),
+    do: ~p"/organizations/#{slug}"
+
   defp actor_target(n) do
     if is_binary(n[:actor_param]), do: ~p"/#{n.actor_param}"
   end
+
+  # The same decision for the grouped-actor shape, whose keys are `kind` /
+  # `param` rather than the row's `actor_*`. One function per shape, both
+  # branching on the kind, so neither can be the one that forgets.
+  defp actor_path(%{kind: "organization", param: slug}) when is_binary(slug),
+    do: ~p"/organizations/#{slug}"
+
+  defp actor_path(%{param: param}), do: ~p"/#{param}"
 
   # The event text for the ungrouped kinds, rendered from the kind (not
   # stored) so it translates with the viewer's locale. Unknown kinds fall

--- a/lib/vutuv_web/views/notification_digest_text.ex
+++ b/lib/vutuv_web/views/notification_digest_text.ex
@@ -92,6 +92,9 @@ defmodule VutuvWeb.NotificationDigestText do
   # Handles, never display names: the house rule for anything the system says
   # about somebody, and the only name a reader can act on. `actor_param` is the
   # handle `Vutuv.Activity.actor_fields/1` puts on every actor-bearing item.
+  # A page is named, not @-handled: its param is a slug, and it may never have
+  # claimed a handle at all (issue #1336).
+  defp handle(%{actor_kind: "organization", actor_name: name}) when is_binary(name), do: name
   defp handle(%{actor_param: param}) when is_binary(param), do: "@" <> param
   defp handle(%{username: username}) when is_binary(username), do: "@" <> username
   defp handle(_item), do: gettext("Somebody")

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.253.0",
+      version: "7.254.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/organization_follower_notification_test.exs
+++ b/test/vutuv/organization_follower_notification_test.exs
@@ -1,0 +1,89 @@
+defmodule Vutuv.OrganizationFollowerNotificationTest do
+  @moduledoc """
+  A page follows you, and you are told (issue #1336).
+
+  The badge and the list are built from two different queries over the same
+  table: `count_followers/2` counts every row, `follower_items/3` inner-joins
+  `users` to build the actor. That was harmless while only members could follow
+  — and became a phantom unread the moment a page could (v7.249.0): the badge
+  says one, the list shows nothing, and a badge that lies once is a badge nobody
+  trusts again.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag and the DNS-resolver stub beside it.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Activity
+  alias Vutuv.Social
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp follower_entries(member) do
+    member.id
+    |> Activity.notifications_page(limit: 20)
+    |> Map.fetch!(:entries)
+    |> Enum.filter(&(&1.kind == "follower"))
+  end
+
+  test "the page shows up in the list, with its name and its own page's link" do
+    page = active_organization_for(insert(:activated_user))
+    member = insert(:activated_user)
+
+    {:ok, _} = Social.follow_as_organization(page, member)
+
+    assert [entry] = follower_entries(member)
+    assert entry.actor_name == page.name
+    assert entry.actor_kind == "organization"
+
+    # The link must not be built from the param alone: a page's slug lives under
+    # /organizations/:slug, while the root namespace belongs to member handles,
+    # so `/#{param}` would point at somebody else entirely — or nowhere.
+    assert entry.actor_param == page.slug
+  end
+
+  test "the unread count agrees with the list" do
+    page = active_organization_for(insert(:activated_user))
+    member = insert(:activated_user)
+    person = insert(:activated_user)
+
+    {:ok, _} = Social.follow(person, member.id)
+    {:ok, _} = Social.follow_as_organization(page, member)
+
+    assert length(follower_entries(member)) == 2
+    assert Activity.unread_notification_count(member) == 2
+  end
+
+  test "a frozen page neither shows nor counts" do
+    page = active_organization_for(insert(:activated_user))
+    member = insert(:activated_user)
+
+    {:ok, _} = Social.follow_as_organization(page, member)
+    {:ok, _} = Vutuv.Organizations.admin_set_frozen(page, true)
+
+    assert follower_entries(member) == []
+    assert Activity.unread_notification_count(member) == 0
+  end
+
+  test "the member's own follower notifications still read as before" do
+    member = insert(:activated_user)
+    person = insert(:activated_user, first_name: "Frida", last_name: "Folger")
+
+    {:ok, _} = Social.follow(person, member.id)
+
+    assert [entry] = follower_entries(member)
+    assert entry.actor_name =~ "Frida"
+    assert entry.actor_kind == "user"
+  end
+end

--- a/test/vutuv_web/organization_follows_member_test.exs
+++ b/test/vutuv_web/organization_follows_member_test.exs
@@ -96,4 +96,20 @@ defmodule VutuvWeb.OrganizationFollowsMemberTest do
     back = conn |> get(~p"/#{member}") |> html_response(200)
     refute back =~ "follow-as-page"
   end
+
+  test "the notification links to the page, not into the handle namespace", %{conn: conn} do
+    # Log the member in FIRST: creating a page mails its owner, and `sent_pin/0`
+    # reads the oldest email in the mailbox.
+    {conn, member} = create_and_login_user(conn)
+    page = active_organization_for(insert(:activated_user))
+    {:ok, _} = Social.follow_as_organization(page, member)
+
+    html = conn |> get(~p"/notifications") |> html_response(200)
+
+    assert html =~ page.name
+    assert html =~ "/organizations/#{page.slug}"
+    # `/<slug>` at the root is the member handle namespace, where another member
+    # may hold that very word — the link must not be built from the param alone.
+    refute html =~ ~s(href="/#{page.slug}")
+  end
 end


### PR DESCRIPTION
Der letzte offene Punkt aus #1336 — und einer, den ich selbst eingebaut hatte. Seit #1385 kann eine Seite folgen, aber die Benachrichtigungsliste hat sie weggelassen, während der Zähler sie mitgezählt hat: **Badge sagt eins, Liste zeigt nichts.** Ein Badge, das einmal lügt, ist ein Badge, dem niemand mehr glaubt.

Das war kein Zufall, sondern die übliche Form: Liste und Zähler sind zwei Abfragen über dieselbe Tabelle, und nur die Liste hatte einen Join. Solange nur Mitglieder folgen konnten, war das harmlos.

`follower_items/3` joint jetzt links auf beide Sorten und baut den Actor aus der Organisation, wenn kein Mitglied dasteht. `follower_max/1` und `count_followers/2` bekommen dasselbe Tor über **dasselbe Makro**, weil genau ihr Auseinanderdriften der Fehler war. Die Mitgliederseite bleibt exakt wie sie war — die Zeile existiert, das ist die ganze Prüfung, mehr war der alte Inner Join auch nicht. Neu ist nur, dass eine Seite zusätzlich sichtbar sein muss, sonst führte die Benachrichtigung irgendwohin, wo der Leser abgewiesen wird.

**Neu ist `actor_kind` in den Actor-Feldern, und das ist keine Zierde.** Der Param eines Mitglieds ist sein Handle und wohnt an der Wurzel; der einer Seite ist ein Slug unter `/organizations/:slug`. Ein Link aus dem Param allein zeigt also in den Handle-Namensraum — auf ein Wort, das ein anderes Mitglied halten kann.

Und genau das hätte ich fast ausgeliefert. Der Test verneint den falschen Link (`refute html =~ ~s(href="/#{slug}")`), und er ging rot: es gibt **zwei** Linkstellen, nicht eine. Die Zeile hat ihren eigenen href, und der Name darin noch einen — die zweite hatte ich beim Lesen übersehen. Beide entscheiden jetzt anhand der Sorte, jede über eine eigene kleine Funktion für ihre Datenform (`actor_target/1` für die Zeile, `actor_path/1` für die gruppierten Actors), damit keine von beiden die Vergessene sein kann. Ohne das negative Assert wäre der Fehler durchgegangen, weil das positive `assert html =~ "/organizations/#{slug}"` von der einen richtigen Stelle bereits erfüllt war.

Der Digest-Text nennt eine Seite beim Namen statt mit `@slug` — sie muss nie ein Handle beansprucht haben.

`mix precommit` grün (7282 Tests).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01MMwsQi49FP21xuSoPEkMnN
