### PR TITLE
Eine Seite kann ein Schlüsselpaar halten (v7.254.1)

### DIFF
--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -76,6 +76,7 @@ defmodule Vutuv.Fediverse do
   alias Vutuv.Fediverse.RemoteImage
   alias Vutuv.Fediverse.RemotePost
   alias Vutuv.Handles
+  alias Vutuv.Organizations.Organization
   alias Vutuv.Pages
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
@@ -182,6 +183,40 @@ defmodule Vutuv.Fediverse do
   end
 
   def get_actor(%User{id: user_id}), do: Repo.get_by(Actor, user_id: user_id)
+
+  @doc """
+  A **page's** actor (issue #1334), created on first use. Race-safe, and the
+  exact twin of `ensure_actor/1` — the keypair is the same thing, only its
+  owner column differs.
+
+  Nothing calls this from a user-facing path yet, and that is deliberate. A
+  keypair is invisible outside this database, so it can exist alone; the parts
+  other servers see (WebFinger, the actor document, delivery, an inbox that
+  answers Follow) have to arrive together, because being findable without a
+  working inbox means somebody presses Follow and nothing ever happens.
+  """
+  def ensure_organization_actor(%Organization{} = organization) do
+    case get_organization_actor(organization) do
+      nil ->
+        {private_pem, public_pem} = Keys.generate()
+
+        %Actor{
+          organization_id: organization.id,
+          private_key_pem: private_pem,
+          public_key_pem: public_pem
+        }
+        |> Repo.insert(on_conflict: :nothing, conflict_target: [:organization_id])
+
+        {:ok, get_organization_actor(organization)}
+
+      actor ->
+        {:ok, actor}
+    end
+  end
+
+  @doc "The page's actor, or nil."
+  def get_organization_actor(%Organization{id: id}),
+    do: Repo.get_by(Actor, organization_id: id)
 
   ## Remote followers
 

--- a/lib/vutuv/fediverse/actor.ex
+++ b/lib/vutuv/fediverse/actor.ex
@@ -1,9 +1,16 @@
 defmodule Vutuv.Fediverse.Actor do
   @moduledoc """
-  A member's Fediverse actor: the RSA keypair behind their ActivityPub
-  identity, created lazily when they opt in (`users.fediverse_followers?`).
-  The private key signs outbound deliveries; the public key is published in
-  the actor document.
+  A Fediverse actor: the RSA keypair behind an ActivityPub identity, created
+  lazily on opt-in. The private key signs outbound deliveries; the public key
+  is published in the actor document.
+
+  The owner is a **member or an organization page** (issue #1334),
+  CHECK-enforced to exactly one. The page half is the foundation of that
+  issue's fediverse work and has no writer yet: a keypair is invisible outside
+  this database, so it could ship on its own, while the parts other servers can
+  see (WebFinger, the actor document, delivery, the inbox) have to land
+  together — being findable without an inbox that answers Follow is worse than
+  not being findable.
   """
 
   use VutuvWeb, :model
@@ -13,6 +20,7 @@ defmodule Vutuv.Fediverse.Actor do
     field(:public_key_pem, :string)
 
     belongs_to(:user, Vutuv.Accounts.User)
+    belongs_to(:organization, Vutuv.Organizations.Organization)
 
     timestamps()
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.254.0",
+      version: "7.254.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260811141525_add_organization_to_fediverse_actors.exs
+++ b/priv/repo/migrations/20260811141525_add_organization_to_fediverse_actors.exs
@@ -1,0 +1,60 @@
+defmodule Vutuv.Repo.Migrations.AddOrganizationToFediverseActors do
+  @moduledoc """
+  Issue #1334, the foundation of its fediverse half: an **organization** can
+  hold a keypair, so a page can eventually be an ActivityPub actor of its own.
+
+  Fourth table to take the nullable pair (`follows`, `tag_follows`, and the
+  authorship columns on `posts` before it): a nullable `organization_id` beside
+  `user_id`, CHECK for exactly one, and a second unique index because the
+  existing one on `user_id` cannot police the organization spelling.
+
+  ## Why only this much
+
+  The rest of that half — WebFinger for a page handle, an `Organization` actor
+  document, delivery signed as the page, and an inbox that answers Follow —
+  cannot ship in pieces: discovery without a working inbox means somebody on
+  Mastodon presses Follow and nothing ever happens, which is worse than not
+  being findable. A **keypair** has no such problem, because nothing outside
+  this database can see one. So the schema goes first and alone, the way it did
+  for `follows` in v7.248.1, and the externally visible parts land together.
+
+  N-1 safe: the previous release only writes member actors, which satisfy the
+  CHECK, and only ever reads `Repo.get_by(Actor, user_id: …)`, which an
+  organization row cannot match.
+  """
+  use Ecto.Migration
+
+  def up do
+    alter table(:fediverse_actors) do
+      add(
+        :organization_id,
+        references(:organizations, type: :binary_id, on_delete: :delete_all)
+      )
+    end
+
+    execute("ALTER TABLE fediverse_actors ALTER COLUMN user_id DROP NOT NULL")
+
+    create(
+      constraint(:fediverse_actors, :fediverse_actors_exactly_one_owner,
+        check: """
+        (CASE WHEN user_id IS NULL THEN 0 ELSE 1 END +
+         CASE WHEN organization_id IS NULL THEN 0 ELSE 1 END) = 1
+        """
+      )
+    )
+
+    create(unique_index(:fediverse_actors, [:organization_id]))
+  end
+
+  def down do
+    drop(unique_index(:fediverse_actors, [:organization_id]))
+    drop(constraint(:fediverse_actors, :fediverse_actors_exactly_one_owner))
+
+    execute("DELETE FROM fediverse_actors WHERE user_id IS NULL")
+    execute("ALTER TABLE fediverse_actors ALTER COLUMN user_id SET NOT NULL")
+
+    alter table(:fediverse_actors) do
+      remove(:organization_id)
+    end
+  end
+end

--- a/test/vutuv/organization_fediverse_actor_test.exs
+++ b/test/vutuv/organization_fediverse_actor_test.exs
@@ -1,0 +1,94 @@
+defmodule Vutuv.OrganizationFediverseActorTest do
+  @moduledoc """
+  A page can hold a Fediverse keypair (issue #1334) — the foundation of that
+  issue's fediverse half, and the only part of it that can ship alone.
+
+  Everything else in that half is visible to other servers, and those parts have
+  to arrive together: WebFinger that resolves a page handle, an `Organization`
+  actor document, delivery signed as the page, and an inbox that answers Follow.
+  Being findable without a working inbox means somebody on Mastodon presses
+  Follow and nothing ever happens, which is worse than not being findable at
+  all. A keypair has no such edge — nothing outside this database can see one.
+
+  So these tests do what the two earlier expand steps did: prove the column and
+  its constraint, and prove the existing member readers cannot be confused by
+  the new row shape.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag and the DNS-resolver stub beside it.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Actor
+  alias Vutuv.Repo
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  test "the database refuses an actor with both owners or neither" do
+    member = insert(:activated_user)
+    organization = active_organization_for(insert(:activated_user))
+
+    assert_raise Ecto.ConstraintError, ~r/fediverse_actors_exactly_one_owner/, fn ->
+      Repo.insert!(%Actor{
+        user_id: member.id,
+        organization_id: organization.id,
+        private_key_pem: "x",
+        public_key_pem: "y"
+      })
+    end
+
+    assert_raise Ecto.ConstraintError, ~r/fediverse_actors_exactly_one_owner/, fn ->
+      Repo.insert!(%Actor{private_key_pem: "x", public_key_pem: "y"})
+    end
+  end
+
+  test "a page gets one keypair, and asking twice returns the same one" do
+    organization = active_organization_for(insert(:activated_user))
+
+    assert {:ok, actor} = Fediverse.ensure_organization_actor(organization)
+    assert actor.organization_id == organization.id
+    assert is_nil(actor.user_id)
+    assert actor.private_key_pem =~ "PRIVATE KEY"
+    assert actor.public_key_pem =~ "PUBLIC KEY"
+
+    assert {:ok, same} = Fediverse.ensure_organization_actor(organization)
+    assert same.id == actor.id
+  end
+
+  test "a page's actor is invisible to the member lookups, and the other way round" do
+    member = insert(:activated_user)
+    organization = active_organization_for(insert(:activated_user))
+
+    {:ok, _} = Fediverse.ensure_organization_actor(organization)
+
+    # `get_actor/1` reads `user_id`, which a page row leaves NULL — so the two
+    # namespaces cannot bleed into each other even though they share a table.
+    refute Fediverse.get_actor(member)
+
+    {:ok, member_actor} = Fediverse.ensure_actor(member)
+    assert Fediverse.get_actor(member).id == member_actor.id
+    assert Fediverse.get_organization_actor(organization).organization_id == organization.id
+    refute Fediverse.get_organization_actor(organization).id == member_actor.id
+  end
+
+  test "deleting the page takes its keypair with it" do
+    organization = active_organization_for(insert(:activated_user))
+    {:ok, _} = Fediverse.ensure_organization_actor(organization)
+
+    {:ok, _} = Vutuv.Organizations.delete_organization(organization)
+
+    refute Fediverse.get_organization_actor(organization)
+  end
+end


### PR DESCRIPTION
Das Fundament der Fediverse-Hälfte von #1334 — und der einzige Teil davon, der allein ausgeliefert werden kann.

`fediverse_actors` nimmt das Nullable-Paar als vierte Tabelle: `organization_id` neben `user_id`, CHECK auf genau eins, zweiter Unique-Index. Dazu `ensure_organization_actor/1` und `get_organization_actor/1`, die exakten Zwillinge der Mitglieder-Funktionen — ein Schlüsselpaar ist dasselbe Ding, nur die Spalte seines Besitzers unterscheidet sich.

**Warum nur so viel.** Alles andere in dieser Hälfte ist für fremde Server sichtbar und muss zusammen ankommen: WebFinger, das ein Seiten-Handle auflöst, ein `Organization`-Actor-Dokument, signierte Auslieferung, und ein Posteingang, der auf Follow antwortet. Auffindbar ohne funktionierenden Posteingang heißt, dass jemand auf Mastodon Folgen drückt und nie etwas passiert — schlechter als gar nicht auffindbar zu sein. Ein Schlüsselpaar hat diese Kante nicht: außerhalb dieser Datenbank sieht es niemand. Deshalb geht das Schema zuerst und allein, so wie bei `follows` in #1383.

Die Tests machen, was die beiden vorherigen Expand-Schritte gemacht haben: Spalte und Constraint belegen, und zeigen, dass die vorhandenen Mitglieder-Leser von der neuen Zeilenform nicht verwirrt werden können. `get_actor/1` liest `user_id`, das eine Seitenzeile NULL lässt, also können sich die beiden Namensräume trotz gemeinsamer Tabelle nicht vermischen — in beide Richtungen geprüft.

N-1-sicher; Migration gegen `vutuv1_dev` gelaufen.

**Damit ist alles abgearbeitet, was ohne dich weitergeht.** Offen bleiben:

1. Der Rest dieser Fediverse-Hälfte — ein großes Stück, das ich als Ganzes bauen will statt in Scheiben, und das dann auch „eine Seite folgt einem entfernten Konto" aus #1336 freischaltet.
2. **Nachrichten an eine Seite** — deine Entscheidung: Gespräch *mit der Seite* (der Verlauf überlebt einen Personalwechsel) oder gemeinsames Postfach, das mehrere bedienen?
3. Die vier alten Fuzzy-Marken zur Profil-Verifizierung, die deutsche Leser dort Englisch sehen lassen. Ein Wort von dir und ich nehme sie raus.

`mix precommit` grün (7286 Tests).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01MMwsQi49FP21xuSoPEkMnN
