### PR TITLE
Eine Seite entscheidet selbst, ob sie föderiert (v7.254.2)

### DIFF
--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -76,6 +76,7 @@ defmodule Vutuv.Fediverse do
   alias Vutuv.Fediverse.RemoteImage
   alias Vutuv.Fediverse.RemotePost
   alias Vutuv.Handles
+  alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
   alias Vutuv.Pages
   alias Vutuv.Posts
@@ -133,13 +134,25 @@ defmodule Vutuv.Fediverse do
   def enabled?, do: Application.get_env(:vutuv, :fediverse_enabled, true)
 
   @doc """
-  Whether this member takes part: the global switch, their opt-in, a
-  confirmed address and an account in good standing (a frozen, suspended or
-  deactivated profile is hidden on vutuv, so it must not keep federating).
+  Whether this member or **page** takes part.
+
+  For a member: the global switch, their opt-in, a confirmed address and an
+  account in good standing (a frozen, suspended or deactivated profile is hidden
+  on vutuv, so it must not keep federating).
+
+  For a page (issue #1334): the global switch, its opt-in, and
+  `Organizations.public_visible?/1` — active **and** not frozen. `status` stays
+  "active" through a freeze, so a gate reading only that would keep answering
+  for a page vutuv is hiding, on a network where nobody can see why.
   """
   def federated?(%User{} = user) do
     enabled?() and user.fediverse_followers? and user.email_confirmed? and
       is_nil(user.frozen_at) and is_nil(user.deactivated_at) and not suspended?(user)
+  end
+
+  def federated?(%Organization{} = organization) do
+    enabled?() and organization.fediverse_followers? and
+      Organizations.public_visible?(organization)
   end
 
   defp suspended?(%User{suspended_until: nil}), do: false
@@ -163,6 +176,12 @@ defmodule Vutuv.Fediverse do
   followed them still hold everything published before the move.
   """
   def ever_federated?(%User{} = user), do: enabled?() and get_actor(user) != nil
+
+  # The page twin (issue #1334): it holds a keypair, whatever its switch says
+  # now. Turning the switch off does not unsend what other servers already have,
+  # so anything that still has to reach them keys on this, not on `federated?/1`.
+  def ever_federated?(%Organization{} = organization),
+    do: enabled?() and get_organization_actor(organization) != nil
 
   ## Actors
 

--- a/lib/vutuv/organizations/organization.ex
+++ b/lib/vutuv/organizations/organization.ex
@@ -59,6 +59,11 @@ defmodule Vutuv.Organizations.Organization do
     field(:country, :string)
     field(:seo?, :boolean, default: true)
     field(:geo?, :boolean, default: true)
+    # Whether this page federates (issue #1334), the twin of
+    # `users.fediverse_followers?`. Off until somebody deliberately turns it on:
+    # every externally visible part of that half is gated on it, and federating
+    # cannot be fully taken back once a remote server holds a copy.
+    field(:fediverse_followers?, :boolean, default: false)
     field(:status, :string, default: "pending")
     field(:verified_at, :naive_datetime)
     field(:frozen_at, :naive_datetime)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.254.1",
+      version: "7.254.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260811154700_add_fediverse_opt_in_to_organizations.exs
+++ b/priv/repo/migrations/20260811154700_add_fediverse_opt_in_to_organizations.exs
@@ -1,0 +1,27 @@
+defmodule Vutuv.Repo.Migrations.AddFediverseOptInToOrganizations do
+  @moduledoc """
+  Issue #1334: a page decides for itself whether it federates, the way a member
+  does through `users.fediverse_followers?`.
+
+  **Default false, and that is the load-bearing part.** Everything else in this
+  half — WebFinger, the actor document, the collections, the inbox, delivery —
+  is gated on this flag, which is what lets those pieces land one at a time
+  without any of them being visible to another server before the chain is
+  complete. A page that never switches it on behaves exactly as it does today:
+  its actor URLs 404, the same way an un-federated member's do.
+
+  Federating is also the kind of decision that cannot be fully taken back — once
+  a remote server holds a copy of a post, deleting here only *asks* it to
+  forget — so the default has to be off and the switch has to be deliberate.
+
+  N-1 safe: a plain nullable column with a default; the previous release never
+  reads it.
+  """
+  use Ecto.Migration
+
+  def change do
+    alter table(:organizations) do
+      add(:fediverse_followers?, :boolean, default: false, null: false)
+    end
+  end
+end

--- a/test/vutuv/organization_fediverse_gate_test.exs
+++ b/test/vutuv/organization_fediverse_gate_test.exs
@@ -1,0 +1,113 @@
+defmodule Vutuv.OrganizationFediverseGateTest do
+  @moduledoc """
+  Whether a page federates (issue #1334) — the gate every other piece of that
+  half hangs off.
+
+  It ships **off**, and that is what lets the rest land one piece at a time:
+  WebFinger, the actor document, the collections, the inbox and delivery are all
+  refused for a page that has not opted in, so none of them is visible to
+  another server before the chain is complete. A page that never switches it on
+  behaves exactly as it does today.
+
+  The predicate mirrors the member one (`enabled?` AND opted in AND the account
+  is in good standing) with the page's own notion of standing: active and not
+  frozen, which is `Organizations.public_visible?/1`. A page nobody may open
+  must not be answering for itself on another network either.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag and the DNS-resolver stub beside it.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Organizations
+  alias Vutuv.Organizations.Organization
+  alias Vutuv.Repo
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp opted_in(organization) do
+    organization
+    |> Ecto.Changeset.change(%{fediverse_followers?: true})
+    |> Repo.update!()
+  end
+
+  test "a page does not federate until somebody says so" do
+    organization = active_organization_for(insert(:activated_user))
+
+    refute organization.fediverse_followers?
+    refute Fediverse.federated?(organization)
+  end
+
+  test "an opted-in active page federates" do
+    organization = active_organization_for(insert(:activated_user)) |> opted_in()
+
+    assert Fediverse.federated?(organization)
+  end
+
+  test "a frozen page does not, however it is flagged" do
+    organization = active_organization_for(insert(:activated_user)) |> opted_in()
+    {:ok, frozen} = Organizations.admin_set_frozen(organization, true)
+
+    # `status` stays "active" through a freeze, so a gate reading only that
+    # would keep answering for a page the site itself hides.
+    refute Fediverse.federated?(frozen)
+  end
+
+  test "a pending page does not" do
+    owner = insert(:activated_user)
+
+    {:ok, %{organization: pending}} =
+      Organizations.create_pending_organization(owner, valid_organization_attrs(), "dns")
+
+    pending = opted_in(pending)
+
+    refute Fediverse.federated?(pending)
+  end
+
+  test "ever_federated? asks whether a keypair was ever minted, not the switch" do
+    organization = active_organization_for(insert(:activated_user)) |> opted_in()
+
+    # The distinction matters for takedowns: turning the switch off does not
+    # unsend what other servers already hold, so anything that has to reach them
+    # afterwards keys on the keypair having existed, not on the current flag.
+    refute Fediverse.ever_federated?(organization)
+
+    {:ok, _} = Fediverse.ensure_organization_actor(organization)
+    assert Fediverse.ever_federated?(organization)
+
+    switched_off =
+      Ecto.Changeset.change(organization, %{fediverse_followers?: false}) |> Repo.update!()
+
+    refute Fediverse.federated?(switched_off)
+    assert Fediverse.ever_federated?(switched_off)
+  end
+
+  test "the whole installation switch still wins" do
+    organization = active_organization_for(insert(:activated_user)) |> opted_in()
+
+    original = Application.fetch_env(:vutuv, :fediverse_enabled)
+    Application.put_env(:vutuv, :fediverse_enabled, false)
+
+    on_exit(fn ->
+      case original do
+        {:ok, was} -> Application.put_env(:vutuv, :fediverse_enabled, was)
+        :error -> Application.delete_env(:vutuv, :fediverse_enabled)
+      end
+    end)
+
+    refute Fediverse.federated?(organization)
+    assert %Organization{} = organization
+  end
+end


### PR DESCRIPTION
Erstes Stück der Fediverse-Hälfte von #1334: das Tor, an dem alles Weitere hängt.

`organizations.fediverse_followers?`, **voreingestellt aus**, der Zwilling von `users.fediverse_followers?`, plus `federated?/1` und `ever_federated?/1` für eine Seite.

**Voreingestellt aus ist der tragende Teil**, nicht Vorsicht um ihrer selbst willen. Ich hatte auf #1334 geschrieben, diese Hälfte müsse als ein Stück kommen, weil auffindbar ohne funktionierenden Posteingang bedeutet, dass jemand auf Mastodon Folgen drückt und nie etwas passiert. Mit diesem Schalter stimmt das weiterhin — nur muss „ein Stück" jetzt nicht heißen „ein Branch über Wochen": WebFinger, Actor-Dokument, Collections, Posteingang und Auslieferung hängen alle daran, also kann jedes für sich landen, ohne dass irgendetwas davon für einen fremden Server sichtbar wird, bevor die Kette vollständig ist. Eine Seite, die den Schalter nie umlegt, verhält sich exakt wie heute: ihre Actor-URLs antworten 404, so wie bei einem Mitglied, das nicht föderiert.

Der Standing-Teil der Prüfung ist `Organizations.public_visible?/1` — aktiv **und** nicht eingefroren. `status` bleibt beim Einfrieren „active"; ein Tor, das nur das liest, würde also weiter für eine Seite antworten, die vutuv gerade verbirgt, auf einem Netz, wo niemand sehen kann warum. Ein Test hält genau diesen Fall fest.

`ever_federated?/1` fragt nach dem **Schlüsselpaar**, nicht nach dem Schalter. Den Schalter auszuschalten nimmt nicht zurück, was andere Server schon haben, also richtet sich alles, was sie danach noch erreichen muss, nach dem Schlüsselpaar — dieselbe Unterscheidung, die die Mitgliederseite für Takedowns trifft.

Der Rest der Hälfte steht als F2–F6 auf meiner Liste: `fediverse_followers` bekommt das Nullable-Paar, dann WebFinger und Actor-Dokument, dann der Posteingang, dann die Auslieferung, zuletzt der Schalter in der Oberfläche der Seite. Bis der letzte Punkt da ist, ist die Funktion nur aus dem Code erreichbar — was genau der sichere Zustand ist.

`mix precommit` grün (7292 Tests). Migration gegen `vutuv1_dev` gelaufen.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01MMwsQi49FP21xuSoPEkMnN
