### PR TITLE
Ein entferntes Konto kann einer Seite folgen (v7.254.3)

### DIFF
--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -282,11 +282,63 @@ defmodule Vutuv.Fediverse do
            |> Repo.insert(
              on_conflict:
                {:replace, [:inbox_uri, :shared_inbox_uri, :handle, :name, :updated_at]},
-             conflict_target: [:user_id, :actor_uri]
+             conflict_target: [:user_id, :actor_uri],
+             # Without this a repeat Follow hands back the id Ecto minted for
+             # the INSERT that lost the conflict — an id no row ever had. The
+             # stored row is correct either way, so it stayed invisible; it
+             # would stop being invisible the first time a caller used the id.
+             returning: true
            ) do
       broadcast_remote_followers_changed([user.id])
       {:ok, follower}
     end
+  end
+
+  @doc """
+  The page twin of `add_follower/2` (issue #1334): records a remote follower of
+  an organization page, idempotent per remote actor.
+
+  Its own function rather than a widened `add_follower/2` because the upsert
+  target differs — `[:organization_id, :actor_uri]` against
+  `[:user_id, :actor_uri]` — and that target is what makes a repeat Follow a
+  re-sync instead of a duplicate. A repeat Follow from the same server is the
+  normal case, not the exception.
+  """
+  def add_organization_follower(%Organization{} = organization, attrs) do
+    with :ok <- check_inbound_cap(attrs[:actor_uri] || attrs["actor_uri"]) do
+      %Follower{organization_id: organization.id}
+      |> Follower.changeset(attrs)
+      |> Repo.insert(
+        on_conflict: {:replace, [:inbox_uri, :shared_inbox_uri, :handle, :name, :updated_at]},
+        conflict_target: [:organization_id, :actor_uri],
+        returning: true
+      )
+    end
+  end
+
+  @doc "Drops a page's remote follower (the inbox's Undo). Idempotent."
+  def remove_organization_follower(%Organization{id: id}, actor_uri) do
+    {count, _} =
+      Repo.delete_all(
+        from(f in Follower, where: f.organization_id == ^id and f.actor_uri == ^actor_uri)
+      )
+
+    count
+  end
+
+  @doc "How many remote accounts follow this page."
+  def organization_remote_follower_count(%Organization{id: id}),
+    do: Repo.aggregate(from(f in Follower, where: f.organization_id == ^id), :count)
+
+  @doc "A page's remote followers, newest first."
+  def list_organization_followers(%Organization{id: id}, limit \\ 50) do
+    Repo.all(
+      from(f in Follower,
+        where: f.organization_id == ^id,
+        order_by: [desc: f.inserted_at, desc: f.id],
+        limit: ^limit
+      )
+    )
   end
 
   @doc """

--- a/lib/vutuv/fediverse/follower.ex
+++ b/lib/vutuv/fediverse/follower.ex
@@ -36,7 +36,10 @@ defmodule Vutuv.Fediverse.Follower do
     field(:name, :string)
     field(:last_checked_at, :naive_datetime)
 
+    # A remote follower follows a member OR a page (issue #1334),
+    # CHECK-enforced to exactly one.
     belongs_to(:user, Vutuv.Accounts.User)
+    belongs_to(:organization, Vutuv.Organizations.Organization)
 
     timestamps()
   end
@@ -51,6 +54,7 @@ defmodule Vutuv.Fediverse.Follower do
     |> validate_length(:handle, max: @max_display)
     |> validate_length(:name, max: @max_display)
     |> unique_constraint([:user_id, :actor_uri])
+    |> unique_constraint([:organization_id, :actor_uri])
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.254.2",
+      version: "7.254.3",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260811160123_add_organization_to_fediverse_followers.exs
+++ b/priv/repo/migrations/20260811160123_add_organization_to_fediverse_followers.exs
@@ -1,0 +1,56 @@
+defmodule Vutuv.Repo.Migrations.AddOrganizationToFediverseFollowers do
+  @moduledoc """
+  Issue #1334: a remote follower can hang off a **page**, not only a member —
+  without this there is nowhere to put the follower a page's inbox accepts, so
+  the inbox (F4) has no landing place.
+
+  Fifth table to take the nullable pair, and by now the shape is routine:
+  `organization_id` beside `user_id`, CHECK for exactly one, and a second unique
+  index because the existing `[user_id, actor_uri]` cannot police the
+  organization spelling — those rows leave `user_id` NULL and Postgres treats
+  NULLs as distinct, so the same remote actor could be recorded twice.
+
+  That second index is not merely tidiness here: `add_follower/2` upserts on
+  `conflict_target: [:user_id, :actor_uri]`, so the page twin needs its own
+  target to be idempotent, and a repeat Follow from the same server is the
+  normal case rather than the exception.
+
+  N-1 safe: the previous release only writes member followers, which satisfy the
+  CHECK, and every query it runs is scoped to a real `user_id`.
+  """
+  use Ecto.Migration
+
+  def up do
+    alter table(:fediverse_followers) do
+      add(
+        :organization_id,
+        references(:organizations, type: :binary_id, on_delete: :delete_all)
+      )
+    end
+
+    execute("ALTER TABLE fediverse_followers ALTER COLUMN user_id DROP NOT NULL")
+
+    create(
+      constraint(:fediverse_followers, :fediverse_followers_exactly_one_target,
+        check: """
+        (CASE WHEN user_id IS NULL THEN 0 ELSE 1 END +
+         CASE WHEN organization_id IS NULL THEN 0 ELSE 1 END) = 1
+        """
+      )
+    )
+
+    create(unique_index(:fediverse_followers, [:organization_id, :actor_uri]))
+  end
+
+  def down do
+    drop(unique_index(:fediverse_followers, [:organization_id, :actor_uri]))
+    drop(constraint(:fediverse_followers, :fediverse_followers_exactly_one_target))
+
+    execute("DELETE FROM fediverse_followers WHERE user_id IS NULL")
+    execute("ALTER TABLE fediverse_followers ALTER COLUMN user_id SET NOT NULL")
+
+    alter table(:fediverse_followers) do
+      remove(:organization_id)
+    end
+  end
+end

--- a/test/vutuv/organization_fediverse_followers_test.exs
+++ b/test/vutuv/organization_fediverse_followers_test.exs
@@ -1,0 +1,137 @@
+defmodule Vutuv.OrganizationFediverseFollowersTest do
+  @moduledoc """
+  A remote account can follow a **page** (issue #1334) — the landing place the
+  page's inbox needs. Without it the inbox has nowhere to put what it accepts.
+
+  Fifth table to take the nullable pair. The second unique index is not tidiness
+  here: `add_follower/2` upserts on `[:user_id, :actor_uri]`, so the page twin
+  needs its own conflict target to stay idempotent, and a repeat Follow from the
+  same server is the normal case rather than the exception.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag and the DNS-resolver stub beside it.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Follower
+  alias Vutuv.Repo
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp page, do: active_organization_for(insert(:activated_user))
+
+  defp attrs(overrides \\ %{}) do
+    Map.merge(
+      %{
+        actor_uri: "https://remote.example/users/frida",
+        inbox_uri: "https://remote.example/users/frida/inbox",
+        handle: "@frida@remote.example",
+        name: "Frida"
+      },
+      overrides
+    )
+  end
+
+  test "the database refuses a row naming both targets or neither" do
+    organization = page()
+    member = insert(:activated_user)
+
+    assert_raise Ecto.ConstraintError, ~r/fediverse_followers_exactly_one_target/, fn ->
+      Repo.insert!(%Follower{
+        user_id: member.id,
+        organization_id: organization.id,
+        actor_uri: "https://remote.example/users/a",
+        inbox_uri: "https://remote.example/users/a/inbox"
+      })
+    end
+
+    assert_raise Ecto.ConstraintError, ~r/fediverse_followers_exactly_one_target/, fn ->
+      Repo.insert!(%Follower{
+        actor_uri: "https://remote.example/users/b",
+        inbox_uri: "https://remote.example/users/b/inbox"
+      })
+    end
+  end
+
+  test "a remote account follows a page, and a repeat Follow re-syncs rather than duplicates" do
+    organization = page()
+
+    assert {:ok, follower} = Fediverse.add_organization_follower(organization, attrs())
+    assert follower.organization_id == organization.id
+    assert is_nil(follower.user_id)
+
+    # The rename case the member side already handles: a second Follow carries
+    # fresh display fields and must update the row, not mint a second one.
+    assert {:ok, again} =
+             Fediverse.add_organization_follower(organization, attrs(%{name: "Frida F."}))
+
+    assert Fediverse.organization_remote_follower_count(organization) == 1
+    assert again.name == "Frida F."
+
+    # The returned struct must BE the stored row. With client-generated UUIDs an
+    # upsert otherwise hands back the id Ecto minted for the INSERT that lost —
+    # an id no row ever had — which is only invisible while nobody uses it.
+    assert again.id == follower.id
+  end
+
+  test "the same remote account may follow a member and a page independently" do
+    organization = page()
+    member = insert(:activated_user)
+
+    {:ok, _} = Fediverse.add_follower(member, attrs())
+    {:ok, _} = Fediverse.add_organization_follower(organization, attrs())
+
+    # Two different relationships, so two rows — and neither unique index may
+    # mistake one for the other.
+    assert Fediverse.follower_count(member) == 1
+    assert Fediverse.organization_remote_follower_count(organization) == 1
+  end
+
+  test "an Undo drops only that page's row" do
+    organization = page()
+    member = insert(:activated_user)
+
+    {:ok, _} = Fediverse.add_follower(member, attrs())
+    {:ok, _} = Fediverse.add_organization_follower(organization, attrs())
+
+    assert Fediverse.remove_organization_follower(organization, attrs().actor_uri) == 1
+
+    assert Fediverse.organization_remote_follower_count(organization) == 0
+    assert Fediverse.follower_count(member) == 1
+
+    # Idempotent: an Undo for a follow that is already gone is a no-op.
+    assert Fediverse.remove_organization_follower(organization, attrs().actor_uri) == 0
+  end
+
+  test "the member readers cannot see a page's followers" do
+    organization = page()
+    member = insert(:activated_user)
+
+    {:ok, _} = Fediverse.add_organization_follower(organization, attrs())
+
+    assert Fediverse.follower_count(member) == 0
+    assert Fediverse.list_followers(member) == []
+    assert [%Follower{}] = Fediverse.list_organization_followers(organization)
+  end
+
+  test "deleting the page takes its remote followers with it" do
+    organization = page()
+    {:ok, _} = Fediverse.add_organization_follower(organization, attrs())
+
+    {:ok, _} = Vutuv.Organizations.delete_organization(organization)
+
+    assert Fediverse.organization_remote_follower_count(organization) == 0
+  end
+end


### PR DESCRIPTION
F2 der Fediverse-Hälfte von #1334: `fediverse_followers` nimmt das Nullable-Paar als fünfte Tabelle, damit der Posteingang einer Seite überhaupt einen Ort hat, an dem er ablegen kann, was er annimmt. Dazu `add_organization_follower/2`, `remove_organization_follower/2`, Zählung und Liste.

Der zweite Unique-Index ist hier **keine Ordnungsliebe**: `add_follower/2` macht ein Upsert auf `[user_id, actor_uri]`, der Seiten-Zwilling braucht also sein eigenes Konfliktziel, um idempotent zu bleiben — und ein wiederholtes Follow vom selben Server ist der Normalfall, nicht die Ausnahme (so kommt eine Umbenennung drüben bei uns an).

**Dabei ist ein alter Fehler aufgefallen, den die Mitgliederseite seit jeher hat.** Bei einem Upsert mit clientseitig erzeugten UUIDs gibt Ecto ohne `returning: true` die Struktur zurück, die es *gesendet* hat — mitsamt der id, die es für das INSERT erzeugt hat, das den Konflikt verloren hat. Diese id hat nie eine Zeile getragen:

```elixir
{:ok, a} = add_follower(user, attrs)          # a.id = X, Zeile X existiert
{:ok, b} = add_follower(user, attrs)          # b.id = Y, Zeile Y existiert NICHT
```

Die gespeicherte Zeile war immer richtig, deshalb ist es nie aufgefallen — sichtbar würde es beim ersten Aufrufer, der die zurückgegebene id benutzt. Beide Pfade geben jetzt die gespeicherte Zeile zurück.

Gefunden hat es der Test, weil er auf `again.id == follower.id` besteht, statt sich mit „es gibt hinterher nur eine Zeile" zufriedenzugeben. Die schwächere Zusicherung wäre grün gewesen.

Der Rest der Hälfte: F3 WebFinger und Actor-Dokument, F4 Posteingang, F5 Auslieferung, F6 der Schalter in der Oberfläche. Alles hinter dem Opt-in aus #1392, das aus ist — von außen ist bis dahin nichts sichtbar.

`mix precommit` grün (7298 Tests). Migration gegen `vutuv1_dev` gelaufen.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01MMwsQi49FP21xuSoPEkMnN
