### PR TITLE
Eine Seite hat eine ActivityPub-Identität (v7.255.0)

### DIFF
--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -140,10 +140,15 @@ defmodule Vutuv.Fediverse do
   account in good standing (a frozen, suspended or deactivated profile is hidden
   on vutuv, so it must not keep federating).
 
-  For a page (issue #1334): the global switch, its opt-in, and
-  `Organizations.public_visible?/1` — active **and** not frozen. `status` stays
-  "active" through a freeze, so a gate reading only that would keep answering
-  for a page vutuv is hiding, on a network where nobody can see why.
+  For a page (issue #1334): the global switch, its opt-in, a **claimed handle**,
+  and `Organizations.public_visible?/1` — active **and** not frozen.
+
+  Two of those are easy to get wrong. `status` stays "active" through a freeze,
+  so a gate reading only it would keep answering for a page vutuv is hiding, on
+  a network where nobody can see why. And the handle is not decoration: it is
+  the page's address out there — WebFinger's `subject` and the actor document's
+  `preferredUsername` are both built from it — so a page that never claimed one
+  cannot be federated, only unreachable.
   """
   def federated?(%User{} = user) do
     enabled?() and user.fediverse_followers? and user.email_confirmed? and
@@ -152,6 +157,7 @@ defmodule Vutuv.Fediverse do
 
   def federated?(%Organization{} = organization) do
     enabled?() and organization.fediverse_followers? and
+      is_binary(organization.username) and
       Organizations.public_visible?(organization)
   end
 

--- a/lib/vutuv_web/controllers/fediverse_controller.ex
+++ b/lib/vutuv_web/controllers/fediverse_controller.ex
@@ -35,6 +35,8 @@ defmodule VutuvWeb.FediverseController do
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.HttpSignature
   alias Vutuv.Handles
+  alias Vutuv.Organizations
+  alias Vutuv.Organizations.Organization
   alias VutuvWeb.Fediverse.Docs
   alias VutuvWeb.RawBodyReader
 
@@ -48,13 +50,13 @@ defmodule VutuvWeb.FediverseController do
 
   def webfinger(conn, params) do
     with true <- Fediverse.enabled?(),
-         %User{} = user <- resolve_resource(params["resource"]) do
-      if Fediverse.federated?(user) do
+         subject when not is_nil(subject) <- resolve_resource(params["resource"]) do
+      if Fediverse.federated?(subject) do
         conn
         |> put_resp_content_type("application/jrd+json")
-        |> send_resp(200, Jason.encode!(jrd(user)))
+        |> send_resp(200, Jason.encode!(jrd(subject)))
       else
-        refuse(conn, user)
+        refuse(conn, subject)
       end
     else
       _ -> send_resp(conn, 404, "")
@@ -492,6 +494,43 @@ defmodule VutuvWeb.FediverseController do
 
   defp signer([]), do: nil
 
+  @doc """
+  A page's actor document (issue #1334). 404s for a page that has not opted in,
+  exactly as a member's does — which is what lets every piece of this half land
+  on its own without being visible to another server first.
+  """
+  def organization_actor(conn, %{"slug" => slug}) do
+    with_federated_organization(conn, slug, fn organization ->
+      {:ok, actor} = Fediverse.ensure_organization_actor(organization)
+
+      send_activity_json(conn, Docs.organization_actor(organization, actor))
+    end)
+  end
+
+  @doc "The page's followers collection — count only, like a member's."
+  def organization_followers(conn, %{"slug" => slug}) do
+    with_federated_organization(conn, slug, fn organization ->
+      send_activity_json(
+        conn,
+        Docs.count_collection(
+          Docs.actor_url(organization) <> "/followers",
+          Fediverse.organization_remote_follower_count(organization)
+        )
+      )
+    end)
+  end
+
+  defp with_federated_organization(conn, slug, fun) do
+    with true <- Fediverse.enabled?(),
+         %Organization{} = organization <- Organizations.get_organization_by_slug(slug) do
+      if Fediverse.federated?(organization),
+        do: fun.(organization),
+        else: send_resp(conn, 404, "")
+    else
+      _ -> send_resp(conn, 404, "")
+    end
+  end
+
   defp with_federated_user(conn, slug, fun) do
     with true <- Fediverse.enabled?(),
          %User{} = user <- Accounts.get_user_by_username(slug) do
@@ -541,7 +580,7 @@ defmodule VutuvWeb.FediverseController do
          # `local_host?/1` folds case, port and the `www.` alias — a member
          # pastes whatever spelling their browser showed them (issue #1211).
          true <- Fediverse.local_host?(host) do
-      Accounts.get_user_by_username(Handles.normalize(handle))
+      by_handle(Handles.normalize(handle))
     else
       _ -> nil
     end
@@ -552,13 +591,45 @@ defmodule VutuvWeb.FediverseController do
     # what somebody pastes; the trailing slash a browser adds falls away in
     # `local_path/1`, which also accepts the `www.`/`http` spellings.
     case Fediverse.local_path(url) do
-      [handle] -> Accounts.get_user_by_username(Handles.normalize(handle))
-      [handle, "actor"] -> Accounts.get_user_by_username(Handles.normalize(handle))
+      [handle] -> by_handle(Handles.normalize(handle))
+      [handle, "actor"] -> by_handle(Handles.normalize(handle))
+      # The page's own URLs, which is what somebody pastes after finding it on
+      # this site rather than through search.
+      ["organizations", slug] -> Organizations.get_organization_by_slug(slug)
+      ["organizations", slug, "actor"] -> Organizations.get_organization_by_slug(slug)
       _ -> nil
     end
   end
 
   defp resolve_resource(_), do: nil
+
+  # Members and pages share one handle namespace (issue #941), so a handle
+  # resolves to at most one of them and the order is a fast path, not a
+  # precedence rule.
+  defp by_handle(handle) do
+    Accounts.get_user_by_username(handle) || Organizations.get_organization_by_username(handle)
+  end
+
+  # A page's JRD (issue #1334). Shorter than a member's by two links: no
+  # `subscribe` template, because that is where a *member* confirms a follow
+  # they started elsewhere, and a page starts none.
+  defp jrd(%Organization{} = organization) do
+    page_url =
+      "#{String.trim_trailing(VutuvWeb.Endpoint.url(), "/")}/organizations/#{organization.slug}"
+
+    %{
+      "subject" => "acct:#{organization.username}@#{VutuvWeb.Endpoint.host()}",
+      "aliases" => [page_url, Docs.actor_url(organization)],
+      "links" => [
+        %{"rel" => "self", "type" => @activity_json, "href" => Docs.actor_url(organization)},
+        %{
+          "rel" => "http://webfinger.net/rel/profile-page",
+          "type" => "text/html",
+          "href" => page_url
+        }
+      ]
+    }
+  end
 
   defp jrd(user) do
     base = String.trim_trailing(VutuvWeb.Endpoint.url(), "/")

--- a/lib/vutuv_web/fediverse/docs.ex
+++ b/lib/vutuv_web/fediverse/docs.ex
@@ -23,6 +23,7 @@ defmodule VutuvWeb.Fediverse.Docs do
   """
 
   alias Vutuv.Fediverse.Actor
+  alias Vutuv.Organizations.Organization
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostImage
@@ -43,6 +44,7 @@ defmodule VutuvWeb.Fediverse.Docs do
   @doc "The associations `note/2` needs loaded on a post."
   def note_preloads, do: @note_preloads
 
+  def actor_url(%Organization{slug: slug}), do: "#{base()}/organizations/#{slug}/actor"
   def actor_url(user), do: "#{base()}/#{user.username}/actor"
   def key_id(user), do: actor_url(user) <> "#main-key"
   def note_url(user, post_id), do: "#{base()}/#{user.username}/posts/#{post_id}"
@@ -153,6 +155,53 @@ defmodule VutuvWeb.Fediverse.Docs do
     }
     |> put_also_known_as(user)
     |> put_moved_to(user)
+  end
+
+  @doc """
+  A **page's** actor document (issue #1334): AP type `Organization`, which is
+  what tells a remote server to render it as an organisation rather than as a
+  person.
+
+  Its own builder rather than a widened `actor/2`, because half of the member
+  document has no meaning here and silently emitting those fields as nil would
+  be worse than leaving them out: no `alsoKnownAs`/`movedTo` (account migration
+  is a person's decision about their own identity, issue #986), and no
+  `featured` collection (a page pins nothing — `posts.pinned_post_id` hangs off
+  a member).
+
+  What it does keep is the shared inbox and `manuallyApprovesFollowers: false`,
+  because both are facts about this installation rather than about who the actor
+  is.
+  """
+  def organization_actor(%Organization{} = organization, %Actor{} = actor) do
+    actor_url = actor_url(organization)
+
+    %{
+      "@context" => [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1"
+      ],
+      "id" => actor_url,
+      "type" => "Organization",
+      # The page's claimed handle. Federating without one is not possible —
+      # WebFinger's `subject` and this field both need an address — which is why
+      # `Fediverse.federated?/1` refuses a page that has not claimed one.
+      "preferredUsername" => organization.username,
+      "name" => organization.name,
+      "summary" => organization.description,
+      "url" => "#{base()}/organizations/#{organization.slug}",
+      "inbox" => actor_url <> "/inbox",
+      "outbox" => actor_url <> "/outbox",
+      "followers" => actor_url <> "/followers",
+      "endpoints" => %{"sharedInbox" => shared_inbox_url()},
+      "manuallyApprovesFollowers" => false,
+      "published" => iso8601(organization.inserted_at),
+      "publicKey" => %{
+        "id" => actor_url <> "#main-key",
+        "owner" => actor_url,
+        "publicKeyPem" => actor.public_key_pem
+      }
+    }
   end
 
   # The accounts the member is migrating *from* (issue #986). Rendered only

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -180,6 +180,11 @@ defmodule VutuvWeb.Router do
     # The pinned post (issue #1110), at the path other servers already look for.
     get("/:slug/actor/collections/featured", FediverseController, :featured)
     post("/:slug/actor/inbox", FediverseController, :inbox)
+    # A page's ActivityPub identity (issue #1334). Under /organizations/ rather
+    # than at a root word, like every other page URL: the root belongs to member
+    # handles. 404s until the page opts in.
+    get("/organizations/:slug/actor", FediverseController, :organization_actor)
+    get("/organizations/:slug/actor/followers", FediverseController, :organization_followers)
     # The installation-wide inbox (issue #1073), so a server with many
     # followers here delivers a broadcast once instead of once per member.
     # Under /system/ rather than at a root word, which profiles own; remote

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.254.3",
+      version: "7.255.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/organization_fediverse_gate_test.exs
+++ b/test/vutuv/organization_fediverse_gate_test.exs
@@ -37,9 +37,11 @@ defmodule Vutuv.OrganizationFediverseGateTest do
     :ok
   end
 
-  defp opted_in(organization) do
+  # Opting in AND claiming a handle: the handle is the page's address out there,
+  # so both are required before it federates.
+  defp opted_in(organization, handle \\ "acme") do
     organization
-    |> Ecto.Changeset.change(%{fediverse_followers?: true})
+    |> Ecto.Changeset.change(%{fediverse_followers?: true, username: handle})
     |> Repo.update!()
   end
 
@@ -54,6 +56,19 @@ defmodule Vutuv.OrganizationFediverseGateTest do
     organization = active_organization_for(insert(:activated_user)) |> opted_in()
 
     assert Fediverse.federated?(organization)
+  end
+
+  test "an opted-in page without a handle does not federate" do
+    organization =
+      active_organization_for(insert(:activated_user))
+      |> Ecto.Changeset.change(%{fediverse_followers?: true})
+      |> Repo.update!()
+
+    # WebFinger's `subject` and the actor document's `preferredUsername` are
+    # both built from the handle, so opting in without one would not federate
+    # the page — it would publish an actor nobody can address.
+    assert is_nil(organization.username)
+    refute Fediverse.federated?(organization)
   end
 
   test "a frozen page does not, however it is flagged" do

--- a/test/vutuv_web/organization_fediverse_actor_web_test.exs
+++ b/test/vutuv_web/organization_fediverse_actor_web_test.exs
@@ -1,0 +1,124 @@
+defmodule VutuvWeb.OrganizationFediverseActorWebTest do
+  @moduledoc """
+  A page's ActivityPub identity (issue #1334): WebFinger resolves its handle,
+  and `/organizations/:slug/actor` serves an `Organization` document.
+
+  Everything here is gated on the page's opt-in, so an un-opted page answers 404
+  exactly as an un-federated member does. That gate is what lets this land
+  before the inbox exists: nothing is reachable from outside until a page owner
+  switches it on, and by then the whole chain will be in place.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag and the DNS-resolver stub beside it.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Organizations
+  alias Vutuv.Repo
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp federating_page(handle \\ "acme") do
+    active_organization_for(insert(:activated_user))
+    |> Ecto.Changeset.change(%{fediverse_followers?: true, username: handle})
+    |> Repo.update!()
+  end
+
+  defp ap(conn), do: put_req_header(conn, "accept", "application/activity+json")
+
+  test "WebFinger resolves the page's handle to its actor", %{conn: conn} do
+    page = federating_page()
+
+    json =
+      conn
+      |> get(~p"/.well-known/webfinger", resource: "acct:acme@#{VutuvWeb.Endpoint.host()}")
+      |> json_response(200)
+
+    assert json["subject"] == "acct:acme@#{VutuvWeb.Endpoint.host()}"
+
+    self_link = Enum.find(json["links"], &(&1["rel"] == "self"))
+    assert self_link["href"] =~ "/organizations/#{page.slug}/actor"
+  end
+
+  test "the actor document says Organization, not Person", %{conn: conn} do
+    page = federating_page()
+
+    json = conn |> ap() |> get(~p"/organizations/#{page.slug}/actor") |> json_response(200)
+
+    # The type is the whole point: it is what tells a remote server to render
+    # this as an organisation rather than as a person.
+    assert json["type"] == "Organization"
+    assert json["preferredUsername"] == "acme"
+    assert json["name"] == page.name
+    assert json["publicKey"]["publicKeyPem"] =~ "PUBLIC KEY"
+    assert json["inbox"] =~ "/organizations/#{page.slug}/actor/inbox"
+    assert json["endpoints"]["sharedInbox"] =~ "/system/inbox"
+
+    # A page pins nothing and migrates nowhere: those fields belong to a person
+    # deciding about their own identity, and emitting them empty would be worse
+    # than leaving them out.
+    refute Map.has_key?(json, "featured")
+    refute Map.has_key?(json, "alsoKnownAs")
+    refute Map.has_key?(json, "movedTo")
+  end
+
+  test "the followers collection counts the remote followers", %{conn: conn} do
+    page = federating_page()
+
+    {:ok, _} =
+      Vutuv.Fediverse.add_organization_follower(page, %{
+        actor_uri: "https://remote.example/users/frida",
+        inbox_uri: "https://remote.example/users/frida/inbox"
+      })
+
+    json =
+      conn |> ap() |> get(~p"/organizations/#{page.slug}/actor/followers") |> json_response(200)
+
+    assert json["totalItems"] == 1
+  end
+
+  test "a page that has not opted in is invisible", %{conn: conn} do
+    page = active_organization_for(insert(:activated_user))
+
+    assert conn |> ap() |> get(~p"/organizations/#{page.slug}/actor") |> response(404)
+
+    assert conn
+           |> get(~p"/.well-known/webfinger",
+             resource: "acct:#{page.slug}@#{VutuvWeb.Endpoint.host()}"
+           )
+           |> response(404)
+  end
+
+  test "a page without a claimed handle cannot federate", %{conn: conn} do
+    page =
+      active_organization_for(insert(:activated_user))
+      |> Ecto.Changeset.change(%{fediverse_followers?: true})
+      |> Repo.update!()
+
+    # The handle IS the address out there — WebFinger's subject and the actor
+    # document's preferredUsername are both built from it — so opting in without
+    # one would only make the page unreachable, not federated.
+    assert is_nil(page.username)
+    assert conn |> ap() |> get(~p"/organizations/#{page.slug}/actor") |> response(404)
+  end
+
+  test "a frozen page stops answering", %{conn: conn} do
+    page = federating_page()
+    assert conn |> ap() |> get(~p"/organizations/#{page.slug}/actor") |> response(200)
+
+    {:ok, _} = Organizations.admin_set_frozen(page, true)
+
+    assert conn |> ap() |> get(~p"/organizations/#{page.slug}/actor") |> response(404)
+  end
+end


### PR DESCRIPTION
F3 der Fediverse-Hälfte von #1334. WebFinger löst das Handle einer Seite auf, und `/organizations/:slug/actor` liefert ein Actor-Dokument vom **Typ `Organization`** — genau das sagt einem fremden Server, dass er hier eine Organisation und keine Person zeichnen soll. Dazu die Followers-Collection, wie beim Mitglied nur eine Zahl.

Das Dokument ist ein **eigener Bauer** statt eines aufgeweichten `actor/2`. Die Hälfte der Mitgliedsfelder hat für eine Seite keine Bedeutung, und sie leer mitzusenden wäre schlechter als sie wegzulassen: kein `alsoKnownAs` und kein `movedTo`, weil Kontenumzug die Entscheidung eines Menschen über seine eigene Identität ist (#986), und keine `featured`-Collection, weil eine Seite nichts anheftet — `pinned_post_id` hängt an einem Mitglied. Was bleibt, sind die Angaben über *diese Installation* statt über den Actor: der gemeinsame Posteingang und `manuallyApprovesFollowers`.

**Eine Bedingung ist beim Bauen dazugekommen:** eine Seite muss ein Handle beansprucht haben, um zu föderieren. Das Handle ist ihre Adresse da draußen — WebFinger baut `subject` daraus, das Actor-Dokument `preferredUsername` — also wäre eine Seite, die ohne Handle einschaltet, nicht föderiert, sondern nur unerreichbar. `federated?/1` verlangt es jetzt. Ein Test aus #1392 hielt die alte Regel fest; den habe ich umgeschrieben statt ihn zu löschen, mit dem Grund im Text.

WebFinger fällt auf eine Seite zurück, wenn kein Mitglied das Handle hält. Beide teilen sich einen Namensraum (#941), ein Handle gehört also höchstens einem von beiden — die Reihenfolge ist ein schneller Pfad, keine Rangfolge.

Alles hängt weiter am Opt-in aus #1392, das aus ist: eine Seite, die nicht eingeschaltet hat, antwortet 404, so wie ein Mitglied, das nicht föderiert. Bis F4 (Posteingang) da ist, kann also niemand von außen ein Follow schicken, das ins Leere liefe.

Als nächstes F4 Posteingang, F5 Auslieferung, F6 der Schalter in der Oberfläche.

`mix precommit` grün (7305 Tests).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01MMwsQi49FP21xuSoPEkMnN
