### PR TITLE
Eine Seite kann gefolgt werden, und antwortet auch (v7.256.0)

### DIFF
--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -2801,6 +2801,9 @@ defmodule Vutuv.Fediverse do
   defp signer_for(%User{} = user, %Actor{} = actor),
     do: {Docs.key_id(user), actor.private_key_pem}
 
+  defp signer_for(%Organization{} = organization, %Actor{} = actor),
+    do: {Docs.actor_url(organization) <> "#main-key", actor.private_key_pem}
+
   defp signer_for(_user, _actor), do: nil
 
   ## Blocked instances and inbound caps (issue #1067)
@@ -7227,6 +7230,15 @@ defmodule Vutuv.Fediverse do
     enqueue(user, [inbox_uri], Docs.accept_activity(user, follow_object))
   end
 
+  # The page twin (issue #1334). Not optional politeness: an unanswered Follow
+  # shows on Mastodon as pending forever, which is exactly the "pressed Follow
+  # and nothing happened" failure the opt-in gate exists to prevent.
+  # `Docs.accept_activity/2` already names the right actor, because
+  # `actor_url/1` knows both kinds.
+  def accept_follow(%Organization{} = organization, follow_object, inbox_uri) do
+    enqueue(organization, [inbox_uri], Docs.accept_activity(organization, follow_object))
+  end
+
   # One document to many inboxes — the usual case, so it is encoded once.
   defp enqueue(user, inboxes, activity, opts \\ []) do
     json = Jason.encode!(activity)
@@ -7254,7 +7266,8 @@ defmodule Vutuv.Fediverse do
       Enum.map(pairs, fn {inbox, json} ->
         %{
           id: Vutuv.UUIDv7.generate(),
-          user_id: user.id,
+          user_id: sender_column(user, :user),
+          organization_id: sender_column(user, :organization),
           inbox_uri: inbox,
           activity_json: json,
           rebuild_from: rebuild_from,
@@ -7269,6 +7282,12 @@ defmodule Vutuv.Fediverse do
     Deliverer.nudge()
     :ok
   end
+
+  # Exactly one of the two sender columns is set, whichever kind was handed in.
+  defp sender_column(%Organization{id: id}, :organization), do: id
+  defp sender_column(%Organization{}, :user), do: nil
+  defp sender_column(%User{id: id}, :user), do: id
+  defp sender_column(%User{}, :organization), do: nil
 
   ## Account deletion broadcast (issue #985)
 
@@ -7357,16 +7376,19 @@ defmodule Vutuv.Fediverse do
         from(d in Delivery,
           where: d.attempts < @max_attempts and d.next_attempt_at <= ^now,
           limit: 100,
-          preload: [:user]
+          preload: [:user, :organization]
         )
       )
 
-    # Load each user's actor once — a burst of deliveries for one member all
-    # share the same actor row — instead of re-querying it per delivery.
+    # Load each sender's actor once — a burst of deliveries for one member (or
+    # one page) all share the same actor row — instead of re-querying per
+    # delivery. Two maps rather than one keyed on a mixed id, so a page and a
+    # member can never collide on a lookup.
     actors = actors_by_user_id(due)
+    organization_actors = actors_by_organization_id(due)
 
     due
-    |> Task.async_stream(&attempt(&1, actors[&1.user_id]),
+    |> Task.async_stream(&attempt(&1, signing_actor(&1, actors, organization_actors)),
       max_concurrency: 5,
       timeout: 30_000,
       on_timeout: :kill_task
@@ -7384,6 +7406,35 @@ defmodule Vutuv.Fediverse do
     from(a in Actor, where: a.user_id in ^user_ids)
     |> Repo.all()
     |> Map.new(&{&1.user_id, &1})
+  end
+
+  defp actors_by_organization_id(rows) do
+    ids = rows |> Enum.map(& &1.organization_id) |> Enum.reject(&is_nil/1) |> Enum.uniq()
+
+    from(a in Actor, where: a.organization_id in ^ids)
+    |> Repo.all()
+    |> Map.new(&{&1.organization_id, &1})
+  end
+
+  defp signing_actor(%Delivery{organization_id: id}, _actors, organization_actors)
+       when is_binary(id),
+       do: organization_actors[id]
+
+  defp signing_actor(%Delivery{user_id: id}, actors, _organization_actors), do: actors[id]
+
+  # A page's delivery (issue #1334). Same guards as a member's — https, no
+  # internal address, not a blocked instance — minus `rebuilt/2`: that re-renders
+  # a held post, and the only thing a page sends today is an `Accept`, which has
+  # nothing to rebuild. When a page publishes (F5) this grows the same branch.
+  defp attempt(%Delivery{organization: %Organization{} = organization} = delivery, actor) do
+    with %Actor{} = actor <- actor,
+         %URI{scheme: "https", host: host} <- URI.parse(delivery.inbox_uri),
+         false <- Vutuv.Ssrf.resolves_to_internal?(host),
+         false <- instance_blocked?(delivery.inbox_uri) do
+      post_activity(delivery, organization, actor)
+    else
+      _ -> Repo.delete(delivery)
+    end
   end
 
   defp attempt(%Delivery{user: %User{} = user} = delivery, actor) do

--- a/lib/vutuv/fediverse/delivery.ex
+++ b/lib/vutuv/fediverse/delivery.ex
@@ -24,7 +24,10 @@ defmodule Vutuv.Fediverse.Delivery do
     field(:next_attempt_at, :utc_datetime)
     field(:last_error, :string)
 
+    # The sender is a member OR a page (issue #1334), CHECK-enforced to exactly
+    # one. No unique index: a delivery row is a queue entry, not a relationship.
     belongs_to(:user, Vutuv.Accounts.User)
+    belongs_to(:organization, Vutuv.Organizations.Organization)
 
     timestamps()
   end

--- a/lib/vutuv_web/controllers/fediverse_controller.ex
+++ b/lib/vutuv_web/controllers/fediverse_controller.ex
@@ -520,6 +520,74 @@ defmodule VutuvWeb.FediverseController do
     end)
   end
 
+  @doc """
+  A page's inbox (issue #1334): signed `Follow` and `Undo(Follow)` addressed to
+  the page.
+
+  Deliberately narrower than the member inbox. A page has no conversations, no
+  reactions of its own to receive and no account migration, so `Like`,
+  `Announce`, `Create(Note)`, `Accept`/`Reject` and `Move` have nothing to act
+  on here — they are acknowledged with the same `202` and dropped, which is what
+  the member inbox does with anything it does not handle either. That keeps the
+  surface a page exposes to strangers as small as what it actually offers.
+  """
+  def organization_inbox(conn, %{"slug" => slug}) do
+    with_federated_organization(conn, slug, fn organization ->
+      guarded(conn, fn -> verify_and_perform_for_organization(conn, organization) end)
+    end)
+  end
+
+  # The member path's `verify_and_perform/2` shape, with the page as the signer
+  # for the actor fetch and the page's own two handlers after it. Verification
+  # itself is identical — same signature check, same keyId/actor host pinning,
+  # same refusal to trust an `actor` the signature does not cover.
+  defp verify_and_perform_for_organization(conn, organization) do
+    activity = conn.body_params
+
+    with {:ok, key_id} <- signature_key_id(conn),
+         {:ok, remote} <- Fediverse.fetch_remote_actor(key_id, organization_signer(organization)),
+         true <- Fediverse.same_host?(remote.id, key_id),
+         :ok <- verify_signature(conn, remote),
+         true <- activity["actor"] == remote.id do
+      perform_for_organization(organization, activity, remote)
+      send_resp(conn, 202, "")
+    else
+      _ -> send_resp(conn, 401, "")
+    end
+  end
+
+  defp perform_for_organization(organization, %{"type" => "Follow"} = activity, remote) do
+    # The object must be THIS page's actor: a signed Follow naming somebody
+    # else's actor is not a follow of this page, whoever delivered it here.
+    if activity["object"] == Docs.actor_url(organization) do
+      case Fediverse.add_organization_follower(organization, follower_attrs(remote)) do
+        {:ok, _} -> Fediverse.accept_follow(organization, activity, remote.inbox)
+        {:error, _} -> :ok
+      end
+    end
+
+    :ok
+  end
+
+  defp perform_for_organization(
+         organization,
+         %{"type" => "Undo", "object" => %{"type" => "Follow"}},
+         remote
+       ) do
+    Fediverse.remove_organization_follower(organization, remote.id)
+    :ok
+  end
+
+  # Everything else: acknowledged and dropped, like the member inbox.
+  defp perform_for_organization(_organization, _activity, _remote), do: :ok
+
+  defp organization_signer(organization) do
+    case Fediverse.get_organization_actor(organization) do
+      nil -> nil
+      actor -> {Docs.actor_url(organization) <> "#main-key", actor.private_key_pem}
+    end
+  end
+
   defp with_federated_organization(conn, slug, fun) do
     with true <- Fediverse.enabled?(),
          %Organization{} = organization <- Organizations.get_organization_by_slug(slug) do

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -185,6 +185,7 @@ defmodule VutuvWeb.Router do
     # handles. 404s until the page opts in.
     get("/organizations/:slug/actor", FediverseController, :organization_actor)
     get("/organizations/:slug/actor/followers", FediverseController, :organization_followers)
+    post("/organizations/:slug/actor/inbox", FediverseController, :organization_inbox)
     # The installation-wide inbox (issue #1073), so a server with many
     # followers here delivers a broadcast once instead of once per member.
     # Under /system/ rather than at a root word, which profiles own; remote

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.255.0",
+      version: "7.256.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260811163343_add_organization_to_fediverse_deliveries.exs
+++ b/priv/repo/migrations/20260811163343_add_organization_to_fediverse_deliveries.exs
@@ -1,0 +1,55 @@
+defmodule Vutuv.Repo.Migrations.AddOrganizationToFediverseDeliveries do
+  @moduledoc """
+  Issue #1334: an outbound delivery can belong to a **page**, so a page can sign
+  and send what it owes another server.
+
+  This is what couples the inbox to the delivery queue. A page's inbox can
+  *record* a Follow without any of this — but it cannot answer it, and an
+  unanswered Follow shows on Mastodon as pending forever, which is precisely the
+  "presses Follow and nothing happens" failure the whole opt-in gate exists to
+  prevent. So the queue is widened together with the inbox, not after it.
+
+  Sixth table to take the nullable pair. No unique index this time: a delivery
+  row is a queue entry, not a relationship — the same page may legitimately owe
+  the same inbox several documents at once.
+
+  N-1 safe: the previous release only writes member deliveries, which satisfy
+  the CHECK, and its deliverer selects rows and joins `users`, so a page row is
+  invisible to it rather than confusing.
+  """
+  use Ecto.Migration
+
+  def up do
+    alter table(:fediverse_deliveries) do
+      add(
+        :organization_id,
+        references(:organizations, type: :binary_id, on_delete: :delete_all)
+      )
+    end
+
+    execute("ALTER TABLE fediverse_deliveries ALTER COLUMN user_id DROP NOT NULL")
+
+    create(
+      constraint(:fediverse_deliveries, :fediverse_deliveries_exactly_one_sender,
+        check: """
+        (CASE WHEN user_id IS NULL THEN 0 ELSE 1 END +
+         CASE WHEN organization_id IS NULL THEN 0 ELSE 1 END) = 1
+        """
+      )
+    )
+
+    create(index(:fediverse_deliveries, [:organization_id]))
+  end
+
+  def down do
+    drop(index(:fediverse_deliveries, [:organization_id]))
+    drop(constraint(:fediverse_deliveries, :fediverse_deliveries_exactly_one_sender))
+
+    execute("DELETE FROM fediverse_deliveries WHERE user_id IS NULL")
+    execute("ALTER TABLE fediverse_deliveries ALTER COLUMN user_id SET NOT NULL")
+
+    alter table(:fediverse_deliveries) do
+      remove(:organization_id)
+    end
+  end
+end

--- a/test/vutuv_web/organization_fediverse_inbox_test.exs
+++ b/test/vutuv_web/organization_fediverse_inbox_test.exs
@@ -1,0 +1,176 @@
+defmodule VutuvWeb.OrganizationFediverseInboxTest do
+  @moduledoc """
+  A page's inbox (issue #1334) — the piece that makes discovery honest. Without
+  it a page could be found and followed and the follow would sit pending
+  forever, which is worse than not being findable at all.
+
+  Deliberately narrower than the member inbox: a page receives `Follow` and
+  `Undo(Follow)` and acknowledges everything else. It holds no conversations,
+  answers no Follow of its own and does not migrate accounts, so those handlers
+  would have nothing to act on.
+
+  `async: false` because remote-actor fetching is stubbed through the
+  application env, and the organization helpers flip the DNS-verification flag.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Delivery
+  alias Vutuv.Fediverse.HttpSignature
+  alias Vutuv.Fediverse.Keys
+  alias Vutuv.Repo
+  alias VutuvWeb.Fediverse.Docs
+
+  @remote_actor "https://social.example/users/alice"
+  @remote_key_id @remote_actor <> "#main-key"
+  @remote_inbox @remote_actor <> "/inbox"
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp federating_page do
+    page =
+      active_organization_for(insert(:activated_user))
+      |> Ecto.Changeset.change(%{fediverse_followers?: true, username: "acme"})
+      |> Repo.update!()
+
+    {:ok, _} = Fediverse.ensure_organization_actor(page)
+    page
+  end
+
+  defp host, do: VutuvWeb.Endpoint.host()
+
+  defp stub_remote_actor(pub_pem) do
+    doc =
+      Jason.encode!(%{
+        "id" => @remote_actor,
+        "type" => "Person",
+        "inbox" => @remote_inbox,
+        "publicKey" => %{"id" => @remote_key_id, "publicKeyPem" => pub_pem}
+      })
+
+    Application.put_env(:vutuv, :fediverse_req_options,
+      plug: fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/activity+json")
+        |> Plug.Conn.send_resp(200, doc)
+      end
+    )
+
+    on_exit(fn -> Application.delete_env(:vutuv, :fediverse_req_options) end)
+  end
+
+  defp signed_post(conn, page, activity, private_pem) do
+    path = "/organizations/#{page.slug}/actor/inbox"
+    body = Jason.encode!(activity)
+
+    headers =
+      HttpSignature.signed_headers(
+        "post",
+        "https://#{host()}#{path}",
+        body,
+        @remote_key_id,
+        private_pem
+      )
+
+    conn = %{conn | host: host()}
+
+    headers
+    |> Enum.reject(fn {name, _} -> name == "host" end)
+    |> Enum.reduce(conn, fn {name, value}, conn -> put_req_header(conn, name, value) end)
+    |> put_req_header("content-type", "application/activity+json")
+    |> post(path, body)
+  end
+
+  defp follow_activity(page) do
+    %{
+      "@context" => "https://www.w3.org/ns/activitystreams",
+      "id" => "https://social.example/follows/1",
+      "type" => "Follow",
+      "actor" => @remote_actor,
+      "object" => Docs.actor_url(page)
+    }
+  end
+
+  test "a signed Follow is recorded and answered with an Accept", %{conn: conn} do
+    page = federating_page()
+    {priv, pub} = Keys.generate()
+    stub_remote_actor(pub)
+
+    assert conn |> signed_post(page, follow_activity(page), priv) |> response(202)
+
+    assert Fediverse.organization_remote_follower_count(page) == 1
+
+    # The Accept is what stops Mastodon showing the follow as pending forever,
+    # so its absence would be the actual failure, not a missing nicety.
+    accept = Repo.one!(from(d in Delivery, where: d.organization_id == ^page.id))
+    assert accept.inbox_uri == @remote_inbox
+    assert accept.activity_json =~ ~s("type":"Accept")
+    assert accept.activity_json =~ Docs.actor_url(page)
+    assert is_nil(accept.user_id)
+  end
+
+  test "an Undo drops the follower again", %{conn: conn} do
+    page = federating_page()
+    {priv, pub} = Keys.generate()
+    stub_remote_actor(pub)
+
+    conn |> signed_post(page, follow_activity(page), priv) |> response(202)
+    assert Fediverse.organization_remote_follower_count(page) == 1
+
+    undo = %{
+      "@context" => "https://www.w3.org/ns/activitystreams",
+      "id" => "https://social.example/undos/1",
+      "type" => "Undo",
+      "actor" => @remote_actor,
+      "object" => %{"type" => "Follow", "object" => Docs.actor_url(page)}
+    }
+
+    assert build_conn() |> signed_post(page, undo, priv) |> response(202)
+    assert Fediverse.organization_remote_follower_count(page) == 0
+  end
+
+  test "a Follow naming another actor is not a follow of this page", %{conn: conn} do
+    page = federating_page()
+    {priv, pub} = Keys.generate()
+    stub_remote_actor(pub)
+
+    elsewhere = %{follow_activity(page) | "object" => "https://social.example/users/bob"}
+
+    # Acknowledged — the signature was valid — but it must not mint a follower.
+    assert conn |> signed_post(page, elsewhere, priv) |> response(202)
+    assert Fediverse.organization_remote_follower_count(page) == 0
+  end
+
+  test "an unsigned delivery is refused", %{conn: conn} do
+    page = federating_page()
+
+    assert conn
+           |> put_req_header("content-type", "application/activity+json")
+           |> post(
+             "/organizations/#{page.slug}/actor/inbox",
+             Jason.encode!(follow_activity(page))
+           )
+           |> response(401)
+
+    assert Fediverse.organization_remote_follower_count(page) == 0
+  end
+
+  test "a page that has not opted in has no inbox", %{conn: conn} do
+    page = active_organization_for(insert(:activated_user))
+    {priv, pub} = Keys.generate()
+    stub_remote_actor(pub)
+
+    assert conn |> signed_post(page, follow_activity(page), priv) |> response(404)
+  end
+end


### PR DESCRIPTION
F4 der Fediverse-Hälfte von #1334 — das Stück, das die Auffindbarkeit ehrlich macht. `/organizations/:slug/actor/inbox` nimmt signierte `Follow`- und `Undo(Follow)`-Aktivitäten an, legt den entfernten Follower an der Seite ab und schickt das `Accept` zurück.

**Beim Bauen kam heraus, dass F4 und F5 nicht trennbar sind.** Der Posteingang kann ein Follow zwar aufzeichnen, aber nicht beantworten — und ein unbeantwortetes Follow steht auf Mastodon für immer auf „angefragt", also genau der Fehler, gegen den das ganze Opt-in-Tor gedacht ist. Deshalb ist die Warteschlange (`fediverse_deliveries`) hier mitgewandert, als sechste Tabelle mit dem Nullable-Paar. Kein Unique-Index diesmal: eine Zeile dort ist ein Warteschlangeneintrag, keine Beziehung, und dieselbe Seite darf demselben Posteingang mehrere Dokumente gleichzeitig schulden.

**Der Posteingang einer Seite ist bewusst schmaler als der eines Mitglieds.** Er kennt `Follow` und `Undo`; `Like`, `Announce`, `Create(Note)`, `Accept`, `Reject` und `Move` werden mit demselben `202` quittiert und verworfen — wie es der Mitglieds-Posteingang mit allem tut, was er nicht behandelt. Eine Seite führt keine Gespräche, beantwortet kein eigenes Follow und zieht nicht um; diese Handler hätten nichts, worauf sie wirken könnten. So bleibt die Fläche, die eine Seite Fremden zeigt, so groß wie das, was sie wirklich anbietet.

Die Signaturprüfung ist unverändert dieselbe: derselbe keyId-Abgleich gegen den Host der Actor-id, dieselbe Weigerung, einem `actor`-Feld zu glauben, das die Signatur nicht deckt. Ein Test schickt ein Follow, das einen **fremden** Actor als Objekt nennt, und erwartet `202` ohne neuen Follower — die Signatur war gültig, die Aussage nicht.

Der Deliverer lädt jetzt beide Actor-Sorten in getrennten Maps statt in einer über gemischte ids, damit eine Seite und ein Mitglied bei der Suche nach dem Signierschlüssel nicht kollidieren können.

Damit ist die Kette bis auf das Veröffentlichen vollständig: eine Seite ist auffindbar, hat eine Identität, nimmt Follows an und bestätigt sie. Es fehlen F5 (ihre Beiträge ausliefern) und F6 (der Schalter in der Oberfläche) — bis der da ist, ist das Ganze nur aus dem Code erreichbar.

`mix precommit` grün (7310 Tests). Migration gegen `vutuv1_dev` gelaufen.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01MMwsQi49FP21xuSoPEkMnN
