### PR TITLE
Der Beitrag einer Seite erreicht ihre entfernten Follower (v7.257.0)

### DIFF
--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -700,6 +700,17 @@ defmodule Vutuv.Fediverse do
     )
   end
 
+  @doc "The distinct inboxes of a page's remote followers (issue #1334)."
+  def organization_delivery_inboxes(%Organization{id: id}) do
+    Repo.all(
+      from(f in Follower,
+        where: f.organization_id == ^id,
+        distinct: true,
+        select: coalesce(f.shared_inbox_uri, f.inbox_uri)
+      )
+    )
+  end
+
   # The distinct inboxes of the accounts this member **follows** (issue #1160).
   #
   # Deliberately separate from `delivery_inboxes/1` and never used for posts: an
@@ -6853,6 +6864,24 @@ defmodule Vutuv.Fediverse do
   # create, update and the unfreeze republish. Without it `Repo.get(User, nil)`
   # **raises** rather than answering nil, so unfreezing an organization post
   # would crash the moderation action rather than skip a delivery.
+  # A page's post (issue #1334). The member branch below cannot serve it: it
+  # loads a %User{} from `post.user_id`, and every gate it applies afterwards is
+  # about an account. What a page needs instead is its own opt-in and its own
+  # followers — and no `restricted?` check, because an organization post carries
+  # no audience by construction.
+  defp maybe_federate(%Post{organization_id: id} = post, builder, kind) when is_binary(id) do
+    with true <- enabled?(),
+         %Organization{} = page <- Organizations.get_organization(id),
+         true <- federated?(page),
+         post = Repo.preload(post, Docs.note_preloads()),
+         [_ | _] = inboxes <- organization_delivery_inboxes(page) do
+      record_post_deliveries(page, post, inboxes)
+      enqueue(page, inboxes, builder.(post, page), hold_opts(post, kind))
+    else
+      _ -> :skip
+    end
+  end
+
   defp maybe_federate(%Post{user_id: nil}, _builder, _kind), do: :skip
 
   defp maybe_federate(%Post{} = post, builder, kind) do
@@ -6993,6 +7022,13 @@ defmodule Vutuv.Fediverse do
     count
   end
 
+  # The page twin. Explicit rather than a cascade for the reason the column has
+  # no foreign key: these rows outlive the post and its author on purpose.
+  def drop_post_deliveries(%Organization{id: id}) do
+    {count, _} = Repo.delete_all(from(d in PostDelivery, where: d.organization_id == ^id))
+    count
+  end
+
   @doc """
   The takedowns that never arrived, newest first — a `Delete` or `Flag` dropped
   after the last attempt. The operator's list on `/admin/fediverse`, so an
@@ -7035,20 +7071,27 @@ defmodule Vutuv.Fediverse do
     end
   end
 
+  defp record_post_deliveries(%Organization{} = page, %Post{} = post, inboxes) do
+    record_post_deliveries(page, post, inboxes, organization_id: page.id)
+  end
+
   defp record_post_deliveries(%User{} = user, %Post{} = post, inboxes) do
-    object_uri = Docs.note_url(user, post.id)
+    record_post_deliveries(user, post, inboxes, user_id: user.id)
+  end
+
+  defp record_post_deliveries(sender, %Post{} = post, inboxes, owner) do
+    object_uri = Docs.note_url(sender, post.id)
     stamp = NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
 
     rows =
       Enum.map(inboxes, fn inbox ->
-        %{
+        Enum.into(owner, %{
           id: UUIDv7.generate(),
           post_id: post.id,
-          user_id: user.id,
           inbox_uri: inbox,
           object_uri: object_uri,
           inserted_at: stamp
-        }
+        })
       end)
 
     Repo.insert_all(PostDelivery, rows,

--- a/lib/vutuv/fediverse/post_delivery.ex
+++ b/lib/vutuv/fediverse/post_delivery.ex
@@ -32,6 +32,11 @@ defmodule Vutuv.Fediverse.PostDelivery do
   schema "fediverse_post_deliveries" do
     field(:post_id, :binary_id)
     field(:user_id, :binary_id)
+    # The page that sent it (issue #1334). Exactly one of the two is set — an
+    # invariant of `record_post_deliveries/3`, not of the schema, because a
+    # revocation has to outlive both the post and its author and a foreign key
+    # would take these rows with them.
+    field(:organization_id, :binary_id)
     field(:inbox_uri, :string)
     field(:object_uri, :string)
 

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -190,6 +190,10 @@ defmodule Vutuv.Posts do
           post = preload_post(post)
           broadcast_new_post(post)
           sync_mentions(post)
+          # A federating page's post goes out to its remote followers (issue
+          # #1334); a no-op for every page that has not opted in, which is all
+          # of them until an owner switches it on.
+          Vutuv.Fediverse.federate_new_post(post)
           reconcile_screenshot(post)
           ReviewCovers.reconcile(post)
           {:ok, post}

--- a/lib/vutuv_web/fediverse/docs.ex
+++ b/lib/vutuv_web/fediverse/docs.ex
@@ -47,6 +47,12 @@ defmodule VutuvWeb.Fediverse.Docs do
   def actor_url(%Organization{slug: slug}), do: "#{base()}/organizations/#{slug}/actor"
   def actor_url(user), do: "#{base()}/#{user.username}/actor"
   def key_id(user), do: actor_url(user) <> "#main-key"
+  # A page's post lives under its slug, matching `Vutuv.Posts.path/1` — the
+  # permalink is what a federated Note is identified BY, so the two spellings
+  # must not drift.
+  def note_url(%Organization{slug: slug}, post_id),
+    do: "#{base()}/organizations/#{slug}/posts/#{post_id}"
+
   def note_url(user, post_id), do: "#{base()}/#{user.username}/posts/#{post_id}"
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.256.0",
+      version: "7.257.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260811164934_add_organization_to_fediverse_post_deliveries.exs
+++ b/priv/repo/migrations/20260811164934_add_organization_to_fediverse_post_deliveries.exs
@@ -1,0 +1,45 @@
+defmodule Vutuv.Repo.Migrations.AddOrganizationToFediversePostDeliveries do
+  @moduledoc """
+  Issue #1334: the ledger of where a post's copies went can name a **page** as
+  the sender.
+
+  `fediverse_post_deliveries` is the takedown ledger (issue #1102): it remembers
+  which inbox got which object URI, so a revocation is addressed to the servers
+  that actually received a copy rather than broadcast at whoever follows today.
+  A page's post needs the same, or taking one down would reach nobody.
+
+  Like `user_id` beside it, this is a **plain column, not a reference**, and
+  carries no CHECK. That is the existing shape of this table and it is
+  deliberate: a revocation has to outlive the post *and* its author, so a
+  foreign key would delete the very rows the takedown still needs. The pair is
+  therefore an invariant of the writer (`record_post_deliveries/3` sets exactly
+  one), not of the schema — which is why `drop_post_deliveries/1` has to be
+  explicit for both kinds instead of relying on a cascade.
+
+  N-1 safe: a plain nullable column the previous release never reads.
+  """
+  use Ecto.Migration
+
+  def up do
+    alter table(:fediverse_post_deliveries) do
+      add(:organization_id, :binary_id)
+    end
+
+    # `user_id` has to give up NOT NULL, or a page's row cannot be written at
+    # all — which is how the first attempt failed, loudly and immediately.
+    execute("ALTER TABLE fediverse_post_deliveries ALTER COLUMN user_id DROP NOT NULL")
+
+    create(index(:fediverse_post_deliveries, [:organization_id]))
+  end
+
+  def down do
+    drop(index(:fediverse_post_deliveries, [:organization_id]))
+
+    execute("DELETE FROM fediverse_post_deliveries WHERE user_id IS NULL")
+    execute("ALTER TABLE fediverse_post_deliveries ALTER COLUMN user_id SET NOT NULL")
+
+    alter table(:fediverse_post_deliveries) do
+      remove(:organization_id)
+    end
+  end
+end

--- a/test/vutuv/organization_fediverse_publish_test.exs
+++ b/test/vutuv/organization_fediverse_publish_test.exs
@@ -1,0 +1,128 @@
+defmodule Vutuv.OrganizationFediversePublishTest do
+  @moduledoc """
+  A federating page's post reaches its remote followers (issue #1334) — the
+  last functional piece of that half, and what the whole chain was for.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag and the DNS-resolver stub beside it.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Delivery
+  alias Vutuv.Fediverse.PostDelivery
+  alias Vutuv.Organizations
+  alias Vutuv.Posts
+  alias Vutuv.Repo
+  alias VutuvWeb.Fediverse.Docs
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp publishing_page(opts \\ []) do
+    owner = insert(:activated_user)
+    page = active_organization_for(owner)
+    {:ok, _} = Organizations.add_role(page, owner, "publisher", owner)
+
+    page =
+      page
+      |> Ecto.Changeset.change(Enum.into(opts, %{fediverse_followers?: true, username: "acme"}))
+      |> Repo.update!()
+
+    {:ok, _} = Fediverse.ensure_organization_actor(page)
+    {page, owner}
+  end
+
+  defp remote_follower(page, inbox \\ "https://social.example/users/alice/inbox") do
+    {:ok, follower} =
+      Fediverse.add_organization_follower(page, %{
+        actor_uri: "https://social.example/users/alice",
+        inbox_uri: inbox
+      })
+
+    follower
+  end
+
+  test "a page's post is queued to its remote followers as the page" do
+    {page, owner} = publishing_page()
+    remote_follower(page)
+
+    {:ok, post} = Posts.create_organization_post(page, owner, %{body: "Neu bei uns."})
+
+    delivery = Repo.one!(from(d in Delivery, where: d.organization_id == ^page.id))
+
+    # The sender is the page, not the member who pressed publish — that person
+    # stays internal, exactly as they do on the vutuv-facing card.
+    assert is_nil(delivery.user_id)
+    assert delivery.inbox_uri == "https://social.example/users/alice/inbox"
+
+    activity = Jason.decode!(delivery.activity_json)
+    assert activity["type"] == "Create"
+    assert activity["actor"] == Docs.actor_url(page)
+    assert activity["object"]["attributedTo"] == Docs.actor_url(page)
+    assert activity["object"]["content"] =~ "Neu bei uns."
+
+    # The Note's id is the page's permalink, which is what a federated post is
+    # identified BY — so it must match what the site itself serves.
+    assert activity["object"]["id"] =~ "/organizations/#{page.slug}/posts/#{post.id}"
+    assert activity["object"]["id"] =~ Posts.path(post) |> String.trim_leading("/")
+  end
+
+  test "the takedown ledger records the page, so a revocation can be addressed" do
+    {page, owner} = publishing_page()
+    remote_follower(page)
+
+    {:ok, post} = Posts.create_organization_post(page, owner, %{body: "Später zurückgenommen."})
+
+    ledger = Repo.one!(from(d in PostDelivery, where: d.post_id == ^post.id))
+    assert ledger.organization_id == page.id
+    assert is_nil(ledger.user_id)
+    assert ledger.inbox_uri == "https://social.example/users/alice/inbox"
+  end
+
+  test "a page that has not opted in publishes nothing outward" do
+    {page, owner} = publishing_page(fediverse_followers?: false)
+    remote_follower(page)
+
+    {:ok, _} = Posts.create_organization_post(page, owner, %{body: "Bleibt hier."})
+
+    assert Repo.aggregate(from(d in Delivery, where: d.organization_id == ^page.id), :count) == 0
+    assert Repo.aggregate(PostDelivery, :count) == 0
+  end
+
+  test "a federating page with no remote followers queues nothing" do
+    {page, owner} = publishing_page()
+
+    {:ok, _} = Posts.create_organization_post(page, owner, %{body: "Niemand da."})
+
+    # Nothing to deliver is not an error, and it must not leave an empty row
+    # behind for the deliverer to trip over.
+    assert Repo.aggregate(from(d in Delivery, where: d.organization_id == ^page.id), :count) == 0
+  end
+
+  test "a member's post is unaffected" do
+    author = insert(:activated_user, fediverse_followers?: true)
+    {:ok, _} = Fediverse.ensure_actor(author)
+
+    {:ok, _} =
+      Fediverse.add_follower(author, %{
+        actor_uri: "https://social.example/users/bob",
+        inbox_uri: "https://social.example/users/bob/inbox"
+      })
+
+    {:ok, _} = Posts.create_post(author, %{body: "Von einer Person."})
+
+    delivery = Repo.one!(from(d in Delivery, where: d.user_id == ^author.id))
+    assert is_nil(delivery.organization_id)
+  end
+end


### PR DESCRIPTION
F5 der Fediverse-Hälfte von #1334 — das letzte funktionale Stück. Ein Seitenbeitrag geht als `Create(Note)` an die Posteingänge der entfernten Follower, signiert von der Seite.

**Fast alles war schon allgemein genug.** `note/2`, `create_activity/2` und `envelope/4` lesen den Autor nur über `actor_url/1`, das seit #1394 beide Sorten kennt. Nötig war eigentlich nur `note_url/2` für die Seite — der Permalink ist das, worüber ein föderierter Beitrag *identifiziert* wird, also darf er nicht von dem abweichen, was die Seite selbst ausliefert. Der Test vergleicht ihn gegen `Posts.path/1`, damit die beiden Schreibweisen nicht auseinanderlaufen können.

Dazu ein eigener `maybe_federate`-Zweig. Der Mitglieds-Zweig kann das nicht mitmachen: er lädt ein `%User{}` aus `post.user_id`, und jede Prüfung danach handelt von einem Konto. Eine Seite braucht ihr eigenes Opt-in und ihre eigenen Follower — und keine `restricted?`-Prüfung, weil ein Organisationsbeitrag konstruktionsbedingt kein Publikum trägt.

`fediverse_post_deliveries`, das Takedown-Register aus #1102, trägt jetzt `organization_id` — sonst wäre eine Rücknahme an niemanden adressierbar. Wie `user_id` daneben ist das eine schlichte Spalte ohne Fremdschlüssel und ohne CHECK, und das ist die bestehende Form dieser Tabelle mit gutem Grund: eine Rücknahme muss den Beitrag *und* seinen Autor überleben, ein Fremdschlüssel würde genau die Zeilen löschen, die sie noch braucht.

**Zwei Funde, beide vom Test:**

1. `create_organization_post/3` hat `federate_new_post/1` **nie aufgerufen**. Mein ganzer Zweig wäre toter Code geblieben — das Stück hätte grün ausgesehen und nichts getan.
2. Danach ein lautes Postgres `23502`: `user_id` in `fediverse_post_deliveries` war NOT NULL, die Zeile einer Seite also gar nicht schreibbar. Die Migration hatte ich schon geschrieben und für vollständig gehalten.

Beides kam heraus, weil die Tests auf der **Zeile in der Datenbank** bestehen statt darauf, dass es nicht gekracht hat.

Damit ist die Kette funktional vollständig: eine Seite ist auffindbar, hat eine Identität, nimmt Follows an, bestätigt sie und liefert ihre Beiträge aus. Es fehlt nur noch F6 — der Schalter in der Oberfläche der Seite. Bis dahin ist das Ganze weiterhin nur aus dem Code erreichbar, was der sichere Zustand ist.

`mix precommit` grün (7315 Tests). Migration gegen `vutuv1_dev` gelaufen.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01MMwsQi49FP21xuSoPEkMnN
