### PR TITLE
Eine Seite kann jetzt föderieren, und ihr Eigentümer schaltet es ein (v7.258.0)

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -820,6 +820,73 @@ passes straight through. What the words say is what vutuv cannot do: a delivered
 post is beyond reach for good, and leaving is a request to those servers, not a
 guarantee.
 
+## A page federates too (issue #1334)
+
+An organization page can be an actor of its own: findable from Mastodon,
+followable, and its posts reach the accounts that follow it. Everything below is
+the member machinery with one owner column swapped, so what follows is only
+where a page differs and why.
+
+**The switch is the architecture.** `organizations.fediverse_followers?` ships
+`false`, and every externally visible part reads it: WebFinger, the actor
+document, the collections, the inbox and the delivery path. That is what let
+this land in six pieces without any of them being visible to another server
+before the chain was complete — a page that never switches it on answers `404`
+exactly as an un-federated member does. It is owner-only
+(`/organizations/:slug/fediverse`), unlike the feed and the follows list beside
+it, because it decides how the page appears on servers we do not run.
+
+**A handle is required.** `Fediverse.federated?/1` refuses a page that has not
+claimed one. The handle *is* the address out there — WebFinger's `subject` and
+the actor document's `preferredUsername` are both built from it — so opting in
+without one would not federate the page, it would publish an actor nobody can
+name. The switch page says so and links to where a handle is claimed.
+
+**Six tables took the nullable pair** on the way: `fediverse_actors` (the
+keypair), `fediverse_followers` (who follows the page), `fediverse_deliveries`
+(the outbound queue) and `fediverse_post_deliveries` (the takedown ledger),
+beside `follows` and `tag_follows` from #1336. Each carries a CHECK for exactly
+one owner — except `fediverse_post_deliveries`, where the pair is a **writer**
+invariant rather than a schema one, because those rows deliberately outlive the
+post and its author and a foreign key would delete what a revocation still
+needs.
+
+**The documents differ where a page differs.** `Docs.organization_actor/2` is
+its own builder, not a widened `actor/2`: AP type `Organization` (which is what
+makes a remote server render it as an organisation), no `alsoKnownAs`/`movedTo`
+(account migration is a person's decision about their own identity), and no
+`featured` collection (a page pins nothing — `pinned_post_id` hangs off a
+member). It keeps the shared inbox and `manuallyApprovesFollowers`, which are
+facts about this installation rather than about the actor. Everything else was
+already general: `note/2`, `create_activity/2` and `envelope/4` read the author
+only through `actor_url/1`, so only `note_url/2` needed to learn the page's
+permalink shape.
+
+**The inbox is deliberately narrower.** A page accepts `Follow` and
+`Undo(Follow)` and acknowledges everything else with the same `202` the member
+inbox gives anything it does not handle. It holds no conversations, answers no
+Follow of its own and does not migrate, so `Like`, `Announce`, `Create(Note)`,
+`Accept`/`Reject` and `Move` would have nothing to act on. Signature
+verification is unchanged — same keyId/actor host pinning, same refusal to
+believe an `actor` field the signature does not cover.
+
+**Answering a Follow is not optional politeness.** An unanswered Follow shows on
+Mastodon as pending forever, which is the "pressed Follow and nothing happened"
+failure the whole gate exists to prevent — which is why the delivery queue was
+widened together with the inbox rather than after it.
+
+### What is not built
+
+A page cannot **follow** a remote account. That needs it to send a signed
+`Follow`, which it can now do in principle, but the member-side plumbing for
+answering `Accept`/`Reject` and tracking a pending request
+(`fediverse_remote_follows`) is still member-shaped. It is the last open point
+of #1336 and the natural next step.
+
+A page also receives no reactions or replies from other networks: those land
+against a member's post today, and giving a page the same would mean widening
+the reaction and remote-reply tables plus the surfaces that render them.
+
 ## Deliberate v1 limits
 
 Inbound **reply text** is stored now (issues #1069 and #1071, see the bullet

--- a/docs/architecture/organizations.md
+++ b/docs/architecture/organizations.md
@@ -270,6 +270,15 @@ piece lives:
 - **It is mentionable** by its root handle, and reachable from search, the tag
   pages, the sitemap, `/llms.txt`, its own RSS feed and the agent formats.
 
+### It federates (issue #1334)
+
+A page can be an ActivityPub actor: findable from Mastodon, followable, and its
+posts reach the accounts that follow it. The whole of it hangs off one
+owner-only switch that ships **off** (`organizations.fediverse_followers?`), and
+a page must have claimed a handle first, because the handle is its address out
+there. The details live in `fediverse.md` under "A page federates too" — this
+note is here so nobody has to guess which document to open.
+
 ### The trap this shape carries
 
 Every one of those surfaces reaches the author. Widening `posts.user_id` to

--- a/lib/vutuv/organizations.ex
+++ b/lib/vutuv/organizations.ex
@@ -1844,6 +1844,15 @@ defmodule Vutuv.Organizations do
     end
   end
 
+  @doc """
+  Turns federating on or off for a page (issue #1334). Owner's decision: it
+  changes how the page appears on servers we do not run, and it cannot be fully
+  undone — a copy another server already holds can only be asked to go.
+  """
+  def set_fediverse_opt_in(%Organization{} = organization, on?) when is_boolean(on?) do
+    organization |> Ecto.Changeset.change(fediverse_followers?: on?) |> Repo.update()
+  end
+
   @doc "Admin freeze/unfreeze: sets/clears `frozen_at` (same effect as the report freeze)."
   def admin_set_frozen(%Organization{} = organization, frozen?) do
     frozen_at = if frozen?, do: now()

--- a/lib/vutuv_web/components/organization_components.ex
+++ b/lib/vutuv_web/components/organization_components.ex
@@ -232,6 +232,11 @@ defmodule VutuvWeb.OrganizationComponents do
         <.manage_tab :if={@publisher?} active={@active == :following} navigate={"/organizations/#{@organization.slug}/following"}>
           {gettext("Follows")}
         </.manage_tab>
+        <%!-- Owner-only (issue #1334): federating decides how the page appears
+        on servers we do not run, and cannot be fully taken back. --%>
+        <.manage_tab :if={@owner?} active={@active == :fediverse} navigate={"/organizations/#{@organization.slug}/fediverse"}>
+          {gettext("Fediverse")}
+        </.manage_tab>
       </nav>
     </div>
     """

--- a/lib/vutuv_web/controllers/organization_controller.ex
+++ b/lib/vutuv_web/controllers/organization_controller.ex
@@ -132,6 +132,14 @@ defmodule VutuvWeb.OrganizationController do
     do:
       manage(conn, slug, VutuvWeb.OrganizationLive.Domains, &Organizations.can_manage_domains?/2)
 
+  @doc """
+  The owner's federation switch (issue #1334). Owner-only, unlike the feed and
+  the following list: it decides how the page appears on servers we do not run,
+  and it cannot be fully taken back.
+  """
+  def fediverse(conn, %{"slug" => slug}),
+    do: manage(conn, slug, VutuvWeb.OrganizationLive.Fediverse, &Organizations.owner?/2)
+
   def exclusions(conn, %{"slug" => slug}),
     do: manage(conn, slug, VutuvWeb.OrganizationLive.Exclusions, &Organizations.can_manage?/2)
 

--- a/lib/vutuv_web/live/organization_live/fediverse.ex
+++ b/lib/vutuv_web/live/organization_live/fediverse.ex
@@ -1,0 +1,151 @@
+defmodule VutuvWeb.OrganizationLive.Fediverse do
+  @moduledoc """
+  The owner's switch for federating a page (`/organizations/:slug/fediverse`,
+  issue #1334) — the last piece of that half, and the one that makes any of it
+  reachable. Everything else refuses to answer until this is on.
+
+  **Owner-only**, unlike the feed and the following list beside it, which
+  publishers may read. Turning this on decides how the page appears on servers
+  we do not run, and it cannot be fully undone — a remote server that already
+  holds a copy of a post can be *asked* to forget it and no more. That is an
+  owner's decision, the same class as the domains and the roles.
+
+  Two things the page has to say plainly rather than bury, because both are
+  surprising if you meet them afterwards: the handle is the address (without one
+  there is nothing for anybody to follow), and leaving is not a delete.
+  """
+
+  use VutuvWeb, :live_view
+
+  import VutuvWeb.OrganizationComponents, only: [manage_header: 1]
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Organizations
+  alias VutuvWeb.Live.InitAssigns
+
+  @impl true
+  def mount(_params, session, socket) do
+    socket = InitAssigns.assign_embedded(socket, session)
+    organization = Organizations.get_organization!(session["organization_id"])
+
+    {:ok,
+     socket
+     |> assign(:page_title, gettext("Fediverse – %{name}", name: organization.name))
+     |> assign_state(organization)}
+  end
+
+  defp assign_state(socket, organization) do
+    socket
+    |> assign(:organization, organization)
+    |> assign(:owner?, true)
+    |> assign(:publisher?, Organizations.publisher?(organization, socket.assigns.current_user))
+    |> assign(:federated?, Fediverse.federated?(organization))
+    |> assign(:ever_federated?, Fediverse.ever_federated?(organization))
+    |> assign(:enabled?, Fediverse.enabled?())
+    |> assign(:remote_followers, Fediverse.organization_remote_follower_count(organization))
+  end
+
+  @impl true
+  def handle_event("toggle", _params, socket) do
+    organization = socket.assigns.organization
+    on? = not organization.fediverse_followers?
+
+    {:ok, organization} = Organizations.set_fediverse_opt_in(organization, on?)
+
+    # The keypair is minted on the way in, not lazily on the first request: a
+    # remote server that resolves the handle a second later must find a complete
+    # actor, and generating a key inside that request would be the slowest
+    # possible moment for it.
+    if on?, do: Fediverse.ensure_organization_actor(organization)
+
+    {:noreply, assign_state(socket, organization)}
+  end
+
+  @impl true
+  def handle_info(_message, socket), do: {:noreply, socket}
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="mx-auto max-w-2xl py-6">
+      <.manage_header
+        organization={@organization}
+        active={:fediverse}
+        owner?={true}
+        manage?={true}
+        publisher?={@publisher?}
+      />
+
+      <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100">{gettext("Fediverse")}</h1>
+      <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+        {gettext("Let people on Mastodon and other networks follow this page and receive its posts.")}
+      </p>
+
+      <.card :if={!@enabled?} class="mt-6">
+        <p class="text-sm text-slate-700 dark:text-slate-300">
+          {gettext("This installation has federation switched off, so nothing here has any effect.")}
+        </p>
+      </.card>
+
+      <.card :if={@enabled? and is_nil(@organization.username)} class="mt-6" id="needs-handle">
+        <.section_title>{gettext("A handle is needed first")}</.section_title>
+        <p class="mt-2 text-sm text-slate-700 dark:text-slate-300">
+          {gettext("Out there this page is addressed by its handle, the way a member is. Claim one on the page settings, then come back.")}
+        </p>
+        <.link
+          navigate={~p"/organizations/#{@organization.slug}/edit"}
+          class="mt-3 inline-block text-sm font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+        >
+          {gettext("Page settings")}
+        </.link>
+      </.card>
+
+      <.card :if={@enabled? and not is_nil(@organization.username)} class="mt-6">
+        <.section_title>{gettext("Address")}</.section_title>
+        <p class="mt-2 font-mono text-sm text-slate-800 dark:text-slate-200" id="fediverse-handle">
+          @{@organization.username}@{VutuvWeb.Endpoint.host()}
+        </p>
+
+        <p class="mt-4 text-sm text-slate-700 dark:text-slate-300">
+          <%= if @federated? do %>
+            {gettext("This page is being federated. %{count} accounts on other networks follow it.",
+              count: delimited_count(@remote_followers)
+            )}
+          <% else %>
+            {gettext("This page is not being federated. Nothing of it is visible on other networks.")}
+          <% end %>
+        </p>
+
+        <%!-- The thing people are surprised by afterwards, so it is said before
+        rather than after: switching off stops new posts leaving, but a copy
+        another server already keeps can only be ASKED to go. --%>
+        <p class="mt-3 text-sm text-slate-600 dark:text-slate-400">
+          {gettext("Switching this off stops new posts from leaving. Copies another server already holds can only be asked to delete them, never made to.")}
+        </p>
+
+        <.button
+          id="toggle-fediverse"
+          phx-click="toggle"
+          variant={if @federated?, do: "secondary", else: "primary"}
+          data-confirm={
+            if @federated?,
+              do: nil,
+              else:
+                gettext("Posts of this page will be sent to other servers from now on. Continue?")
+          }
+          class="mt-4"
+        >
+          {if @federated?, do: gettext("Stop federating"), else: gettext("Start federating")}
+        </.button>
+      </.card>
+
+      <p
+        :if={@ever_federated? and not @federated?}
+        class="mt-4 text-sm text-slate-600 dark:text-slate-400"
+      >
+        {gettext("This page federated before. Servers that still hold copies keep them until they act on a deletion request.")}
+      </p>
+    </div>
+    """
+  end
+end

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -284,6 +284,7 @@ defmodule VutuvWeb.Router do
     get("/organizations/:slug/activity", OrganizationController, :activity)
     get("/organizations/:slug/feed", OrganizationController, :feed)
     get("/organizations/:slug/following", OrganizationController, :following)
+    get("/organizations/:slug/fediverse", OrganizationController, :fediverse)
     # The permalink of a post published in the organization's name (issue #1334).
     # Deliberately under the slug and not under the organization's opt-in root
     # handle: the handle route dispatches an organization only on the bare

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.257.0",
+      version: "7.258.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -32,6 +32,7 @@ msgstr "Eintrag hinzufügen"
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
+#: lib/vutuv_web/live/organization_live/fediverse.ex:104
 #: lib/vutuv_web/live/organization_live/show.ex:600
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
@@ -314,7 +315,7 @@ msgstr "Vorname"
 #: lib/vutuv_web/agent_docs/text.ex:510
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
-#: lib/vutuv_web/live/notification_live/index.ex:956
+#: lib/vutuv_web/live/notification_live/index.ex:960
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:40
@@ -455,7 +456,7 @@ msgstr "Einloggen"
 msgid "Middle Name"
 msgstr "Zweiter Vorname"
 
-#: lib/vutuv_web/live/notification_live/index.ex:880
+#: lib/vutuv_web/live/notification_live/index.ex:884
 #, elixir-autogen
 msgid "More"
 msgstr "Mehr"
@@ -802,7 +803,7 @@ msgstr "User wurde verifiziert."
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
-#: lib/vutuv_web/live/notification_live/index.ex:1035
+#: lib/vutuv_web/live/notification_live/index.ex:1039
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -1170,7 +1171,7 @@ msgstr "Wählen Sie einen Social-Media-Anbieter aus"
 msgid "Add Localization"
 msgstr "Lokalisierung hinzufügen"
 
-#: lib/vutuv_web/components/organization_components.ex:264
+#: lib/vutuv_web/components/organization_components.ex:269
 #: lib/vutuv_web/live/admin/activity_live.ex:153
 #: lib/vutuv_web/live/admin/api_app_live.ex:58
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
@@ -1749,7 +1750,7 @@ msgstr ""
 msgid "Log out"
 msgstr "Ausloggen"
 
-#: lib/vutuv_web/components/organization_components.ex:270
+#: lib/vutuv_web/components/organization_components.ex:275
 #: lib/vutuv_web/live/admin/activity_live.ex:143
 #: lib/vutuv_web/live/admin/activity_live.ex:175
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
@@ -1936,17 +1937,17 @@ msgstr "folgt"
 msgid "submit a bug report"
 msgstr "einen Fehlerbericht erstellen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1057
+#: lib/vutuv_web/live/notification_live/index.ex:1061
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr "hat Sie für %{tag} empfohlen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1052
+#: lib/vutuv_web/live/notification_live/index.ex:1056
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr "ist jetzt mit Ihnen vernetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1047
+#: lib/vutuv_web/live/notification_live/index.ex:1051
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr "folgt Ihnen jetzt."
@@ -2242,7 +2243,7 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/gettext_extraction_anchors.ex:83
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:382
-#: lib/vutuv_web/live/notification_live/index.ex:878
+#: lib/vutuv_web/live/notification_live/index.ex:882
 #: lib/vutuv_web/live/organization_live/show.ex:467
 #: lib/vutuv_web/live/post_live/saved.ex:495
 #: lib/vutuv_web/live/search_live.ex:205
@@ -2434,7 +2435,7 @@ msgstr "Lesezeichen"
 #: lib/vutuv_web/components/post_components.ex:1551
 #: lib/vutuv_web/components/post_components.ex:4629
 #: lib/vutuv_web/components/ui.ex:2837
-#: lib/vutuv_web/live/notification_live/index.ex:1025
+#: lib/vutuv_web/live/notification_live/index.ex:1029
 #: lib/vutuv_web/views/user_html.ex:343
 #, elixir-autogen, elixir-format
 msgid "Like"
@@ -2442,7 +2443,7 @@ msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:995
 #: lib/vutuv_web/components/post_components.ex:4638
-#: lib/vutuv_web/live/notification_live/index.ex:958
+#: lib/vutuv_web/live/notification_live/index.ex:962
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
 #: lib/vutuv_web/live/shell_live.ex:714
@@ -2526,7 +2527,7 @@ msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
 
 #: lib/vutuv_web/components/post_components.ex:383
-#: lib/vutuv_web/live/notification_live/index.ex:959
+#: lib/vutuv_web/live/notification_live/index.ex:963
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Antworten"
@@ -2534,7 +2535,7 @@ msgstr "Antworten"
 #: lib/vutuv_web/components/post_components.ex:1562
 #: lib/vutuv_web/components/post_components.ex:4665
 #: lib/vutuv_web/components/post_components.ex:4666
-#: lib/vutuv_web/live/notification_live/index.ex:1022
+#: lib/vutuv_web/live/notification_live/index.ex:1026
 #: lib/vutuv_web/live/post_live/reply.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reply"
@@ -2556,7 +2557,7 @@ msgstr "Solange es geteilte Beiträge oder Antworten gibt, lässt sich der Empf�
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beiträge oder Antworten gibt, bleibt er öffentlich; löschen können Sie ihn weiterhin."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1241
+#: lib/vutuv_web/live/notification_live/index.ex:1261
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
@@ -2837,7 +2838,7 @@ msgstr[1] "+%{formatted} weitere Tags"
 #: lib/vutuv_web/agent_docs/markdown.ex:547
 #: lib/vutuv_web/agent_docs/text.ex:512
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:957
+#: lib/vutuv_web/live/notification_live/index.ex:961
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
@@ -2892,23 +2893,23 @@ msgid "Open someone's profile to message them."
 msgstr "Öffnen Sie ein Profil, um jemandem zu schreiben."
 
 #: lib/vutuv_web/components/organization_components.ex:221
-#: lib/vutuv_web/live/notification_live/index.ex:1037
+#: lib/vutuv_web/live/notification_live/index.ex:1041
 #: lib/vutuv_web/live/organization_live/activity.ex:99
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr "Aktivität"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1028
+#: lib/vutuv_web/live/notification_live/index.ex:1032
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr "Vernetzung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1021
+#: lib/vutuv_web/live/notification_live/index.ex:1025
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr "Empfehlung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1020
+#: lib/vutuv_web/live/notification_live/index.ex:1024
 #: lib/vutuv_web/templates/user/show.html.heex:933
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -2921,7 +2922,7 @@ msgstr[1] "Follower"
 msgid "Welcome to vutuv, %{name}!"
 msgstr "Willkommen bei vutuv, %{name}!"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1054
+#: lib/vutuv_web/live/notification_live/index.ex:1058
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr "gefällt Ihr Beitrag."
@@ -2953,12 +2954,12 @@ msgstr "(gelöschtes Konto)"
 msgid "(no text)"
 msgstr "(kein Text)"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1277
+#: lib/vutuv_web/live/notification_live/index.ex:1297
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr "Eine Meldung zu Ihrem Inhalt wurde bestätigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1278
+#: lib/vutuv_web/live/notification_live/index.ex:1298
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr "Eine Meldung zu Ihrem Inhalt wurde verworfen; er ist wieder sichtbar."
@@ -3073,7 +3074,7 @@ msgstr "Familienfreundlich bleiben"
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:1029
+#: lib/vutuv_web/live/notification_live/index.ex:1033
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3190,7 +3191,7 @@ msgstr "Warteschlange öffnen"
 msgid "Opened"
 msgstr "Eröffnet"
 
-#: lib/vutuv_web/components/organization_components.ex:263
+#: lib/vutuv_web/components/organization_components.ex:268
 #: lib/vutuv_web/live/admin/api_app_live.ex:72
 #: lib/vutuv_web/live/admin/deliverability_live.ex:171
 #: lib/vutuv_web/live/admin/moderation_live.ex:56
@@ -3533,12 +3534,12 @@ msgstr "Sie haben das bereits gemeldet. Unser Team kümmert sich darum."
 msgid "You cannot report your own content."
 msgstr "Eigene Inhalte können Sie nicht melden."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1280
+#: lib/vutuv_web/live/notification_live/index.ex:1300
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr "Sie haben gemeldeten Inhalt gelöscht; der Fall ist abgeschlossen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1279
+#: lib/vutuv_web/live/notification_live/index.ex:1299
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr "Sie haben gemeldeten Inhalt überarbeitet; der Fall ist abgeschlossen."
@@ -3548,7 +3549,7 @@ msgstr "Sie haben gemeldeten Inhalt überarbeitet; der Fall ist abgeschlossen."
 msgid "Your content was reported"
 msgstr "Ihr Inhalt wurde gemeldet"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1281
+#: lib/vutuv_web/live/notification_live/index.ex:1301
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3743,7 +3744,7 @@ msgstr "Verlauf"
 msgid "Open the profile"
 msgstr "Profil öffnen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1305
+#: lib/vutuv_web/live/notification_live/index.ex:1325
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3770,7 +3771,7 @@ msgstr "Besitzer hat den Inhalt bearbeitet"
 msgid "Report filed"
 msgstr "Meldung eingegangen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1031
+#: lib/vutuv_web/live/notification_live/index.ex:1035
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr "Schutz nach Meldung"
@@ -3852,7 +3853,7 @@ msgstr "Bestätigt"
 msgid "Waiting for the owner"
 msgstr "Wartet auf den Besitzer"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1310
+#: lib/vutuv_web/live/notification_live/index.ex:1330
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -4766,7 +4767,7 @@ msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
 #: lib/vutuv_web/agent_docs/text.ex:385
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:516
-#: lib/vutuv_web/live/notification_live/index.ex:879
+#: lib/vutuv_web/live/notification_live/index.ex:883
 #: lib/vutuv_web/live/organization_live/show.ex:550
 #: lib/vutuv_web/live/post_live/saved.ex:498
 #: lib/vutuv_web/live/search_live.ex:203
@@ -4791,7 +4792,7 @@ msgstr "Ähnliche Namen"
 #: lib/vutuv_web/components/post_components.ex:399
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
-#: lib/vutuv_web/live/notification_live/index.ex:877
+#: lib/vutuv_web/live/notification_live/index.ex:881
 #: lib/vutuv_web/live/search_live.ex:202
 #: lib/vutuv_web/views/qualification_html.ex:90
 #, elixir-autogen, elixir-format
@@ -5863,7 +5864,7 @@ msgid "Apps & API"
 msgstr "Apps & API-Zugang"
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:127
-#: lib/vutuv_web/live/notification_live/index.ex:960
+#: lib/vutuv_web/live/notification_live/index.ex:964
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:17
@@ -8069,13 +8070,13 @@ msgstr "Neue Mitglieder"
 #: lib/vutuv_web/components/job_components.ex:173
 #: lib/vutuv_web/live/admin/dashboard_live.ex:287
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:457
-#: lib/vutuv_web/live/notification_live/index.ex:906
+#: lib/vutuv_web/live/notification_live/index.ex:910
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr "Heute"
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:291
-#: lib/vutuv_web/live/notification_live/index.ex:909
+#: lib/vutuv_web/live/notification_live/index.ex:913
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr "Gestern"
@@ -9078,12 +9079,14 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/agent_docs/markdown.ex:540
 #: lib/vutuv_web/agent_docs/text.ex:501
 #: lib/vutuv_web/agent_docs/text.ex:505
+#: lib/vutuv_web/components/organization_components.ex:238
 #: lib/vutuv_web/components/ui.ex:3688
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:323
 #: lib/vutuv_web/controllers/settings_controller.ex:390
 #: lib/vutuv_web/live/fediverse_followers_live.ex:169
 #: lib/vutuv_web/live/fediverse_following_live.ex:286
+#: lib/vutuv_web/live/organization_live/fediverse.ex:79
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:341
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:5
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
@@ -11712,7 +11715,7 @@ msgstr ""
 "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) anbieten und für KI-"
 "Agenten auflisten."
 
-#: lib/vutuv_web/controllers/organization_controller.ex:206
+#: lib/vutuv_web/controllers/organization_controller.ex:214
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:31
 #, elixir-autogen, elixir-format
 msgid "Please log in first."
@@ -11857,7 +11860,7 @@ msgstr "mit genau diesem Inhalt:"
 msgid "@handle or email"
 msgstr "@handle oder E-Mail"
 
-#: lib/vutuv_web/components/organization_components.ex:282
+#: lib/vutuv_web/components/organization_components.ex:287
 #: lib/vutuv_web/live/organization_live/edit.ex:390
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
@@ -11878,7 +11881,7 @@ msgstr "Mitglied hinzufügen"
 msgid "Added @%{handle} to the team."
 msgstr "@%{handle} zum Team hinzugefügt."
 
-#: lib/vutuv_web/components/organization_components.ex:283
+#: lib/vutuv_web/components/organization_components.ex:288
 #: lib/vutuv_web/live/organization_live/edit.ex:388
 #, elixir-autogen, elixir-format
 msgid "Alias"
@@ -11924,7 +11927,7 @@ msgstr "Diese Seite archivieren?"
 msgid "Archived"
 msgstr "Archiviert"
 
-#: lib/vutuv_web/components/organization_components.ex:281
+#: lib/vutuv_web/components/organization_components.ex:286
 #: lib/vutuv_web/live/organization_live/edit.ex:389
 #, elixir-autogen, elixir-format
 msgid "Brand"
@@ -11977,7 +11980,7 @@ msgstr "Domains"
 msgid "Domains – %{name}"
 msgstr "Domains – %{name}"
 
-#: lib/vutuv_web/components/organization_components.ex:280
+#: lib/vutuv_web/components/organization_components.ex:285
 #, elixir-autogen, elixir-format
 msgid "Former name"
 msgstr "Früherer Name"
@@ -12057,7 +12060,7 @@ msgstr "Primär"
 msgid "Primary domain updated."
 msgstr "Primäre Domain aktualisiert."
 
-#: lib/vutuv_web/components/organization_components.ex:269
+#: lib/vutuv_web/components/organization_components.ex:274
 #, elixir-autogen, elixir-format
 msgid "Recruiter"
 msgstr "Recruiter"
@@ -12508,7 +12511,7 @@ msgstr "Organisationsseite"
 msgid "Organization pages"
 msgstr "Organisationsseiten"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1032
+#: lib/vutuv_web/live/notification_live/index.ex:1036
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr "Organisationsrolle"
@@ -12624,22 +12627,22 @@ msgstr "Ihre Organisationsseite ist verifiziert und jetzt live."
 msgid "Your organization page was updated."
 msgstr "Ihre Organisationsseite wurde aktualisiert."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1269
+#: lib/vutuv_web/live/notification_live/index.ex:1289
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr "hat Ihnen eine Rolle bei %{organization} gegeben."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1266
+#: lib/vutuv_web/live/notification_live/index.ex:1286
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr "hat Sie zum Recruiter für %{organization} gemacht."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1263
+#: lib/vutuv_web/live/notification_live/index.ex:1283
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr "hat Sie zum Administrator von %{organization} gemacht."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1260
+#: lib/vutuv_web/live/notification_live/index.ex:1280
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr "hat Sie zum Besitzer von %{organization} gemacht."
@@ -12659,32 +12662,32 @@ msgstr ""
 "Suchergebnissen erscheinen oder von KI verwendet werden soll. Seriöse "
 "Suchmaschinen und KI-Anbieter befolgen das; erzwingen können wir es nicht."
 
-#: lib/vutuv/organizations/organization.ex:99
+#: lib/vutuv/organizations/organization.ex:104
 #, elixir-autogen, elixir-format
 msgid "Association"
 msgstr "Verein / Verband"
 
-#: lib/vutuv/organizations/organization.ex:98
+#: lib/vutuv/organizations/organization.ex:103
 #, elixir-autogen, elixir-format
 msgid "Business"
 msgstr "Unternehmen"
 
-#: lib/vutuv/organizations/organization.ex:101
+#: lib/vutuv/organizations/organization.ex:106
 #, elixir-autogen, elixir-format
 msgid "Education / research"
 msgstr "Bildung / Forschung"
 
-#: lib/vutuv/organizations/organization.ex:102
+#: lib/vutuv/organizations/organization.ex:107
 #, elixir-autogen, elixir-format
 msgid "NGO / foundation"
 msgstr "NGO / Stiftung"
 
-#: lib/vutuv/organizations/organization.ex:103
+#: lib/vutuv/organizations/organization.ex:108
 #, elixir-autogen, elixir-format
 msgid "Other organization"
 msgstr "Sonstige"
 
-#: lib/vutuv/organizations/organization.ex:100
+#: lib/vutuv/organizations/organization.ex:105
 #, elixir-autogen, elixir-format
 msgid "Public authority"
 msgstr "Behörde / Öffentlich"
@@ -14034,7 +14037,7 @@ msgstr "%{pending} Bild(er) in der Warteschlange; %{rejected} in den letzten 7 T
 msgid "Image awaiting review, visible only to you"
 msgstr "Bild wird geprüft, nur für Sie sichtbar"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1030
+#: lib/vutuv_web/live/notification_live/index.ex:1034
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -14121,7 +14124,7 @@ msgstr[1] "%{formatted} Beiträge erwähnen aktuell %{handle} und werden beim Um
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr "Beim Ändern werden alle Erwähnungen Ihres alten Handles in Beiträgen automatisch auf den neuen umgeschrieben und die Verfasser dieser Beiträge benachrichtigt. Ihre alte Profiladresse funktioniert dann nicht mehr."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1033
+#: lib/vutuv_web/live/notification_live/index.ex:1037
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr "Handle-Änderung"
@@ -14133,7 +14136,7 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] "Wir haben %{formatted} Beitrag aktualisiert, der Ihren alten Handle erwähnt hat, und dessen Verfasser benachrichtigt."
 msgstr[1] "Wir haben %{formatted} Beiträge aktualisiert, die Ihren alten Handle erwähnt haben, und deren Verfasser benachrichtigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1319
+#: lib/vutuv_web/live/notification_live/index.ex:1339
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr "hat den Handle von @%{old} auf @%{new} geändert."
@@ -14347,22 +14350,22 @@ msgstr[1] "Meine %{formatted} Follower darüber informieren"
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr "Die Benachrichtigung enthält einen Link zu diesem Eintrag. Es wird keine E-Mail verschickt, und das passiert nur bei neuen Einträgen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1034
+#: lib/vutuv_web/live/notification_live/index.ex:1038
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr "Lebenslauf-Update"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1339
+#: lib/vutuv_web/live/notification_live/index.ex:1359
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr "hat eine neue Station im Lebenslauf: %{entry}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1331
+#: lib/vutuv_web/live/notification_live/index.ex:1351
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr "hat eine neue Ausbildung im Lebenslauf: %{entry}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1336
+#: lib/vutuv_web/live/notification_live/index.ex:1356
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr "hat ein neues Zertifikat im Lebenslauf: %{entry}"
@@ -14387,7 +14390,7 @@ msgstr "Über neue Lebenslauf-Einträge von Personen informieren, denen ich folg
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch immer."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1344
+#: lib/vutuv_web/live/notification_live/index.ex:1364
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
@@ -14518,14 +14521,14 @@ msgstr "Mit Qualifikation: %{name}"
 msgid "Publisher:"
 msgstr "Verlag:"
 
-#: lib/vutuv_web/live/notification_live/index.ex:898
+#: lib/vutuv_web/live/notification_live/index.ex:902
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] "%{formatted} neue Mitteilung"
 msgstr[1] "%{formatted} neue Mitteilungen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:912
+#: lib/vutuv_web/live/notification_live/index.ex:916
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr "%{day}. %{month} %{year}"
@@ -14540,23 +14543,23 @@ msgstr "Zurückfolgen"
 msgid "Last 30 days"
 msgstr "Letzte 30 Tage"
 
-#: lib/vutuv_web/live/notification_live/index.ex:864
-#: lib/vutuv_web/live/notification_live/index.ex:1113
+#: lib/vutuv_web/live/notification_live/index.ex:868
+#: lib/vutuv_web/live/notification_live/index.ex:1117
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr "und"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1050
+#: lib/vutuv_web/live/notification_live/index.ex:1054
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr "sind jetzt mit Ihnen vernetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1045
+#: lib/vutuv_web/live/notification_live/index.ex:1049
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr "folgen Ihnen jetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1060
+#: lib/vutuv_web/live/notification_live/index.ex:1064
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
@@ -14809,7 +14812,7 @@ msgstr "Verfügbarkeit"
 msgid "An automated check removed an image from your vutuv account"
 msgstr "Eine automatische Prüfung hat ein Bild aus Ihrem vutuv-Konto entfernt"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1293
+#: lib/vutuv_web/live/notification_live/index.ex:1313
 #, elixir-autogen, elixir-format
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
@@ -14817,12 +14820,12 @@ msgstr ""
 "familienfreundlich genug für ein Arbeitsumfeld. Sie kann sich irren, "
 "antworten Sie in dem Fall einfach auf unsere E-Mail."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1023
+#: lib/vutuv_web/live/notification_live/index.ex:1027
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr "Thread-Antwort"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1100
+#: lib/vutuv_web/live/notification_live/index.ex:1104
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -14841,12 +14844,12 @@ msgstr "Unterhaltung"
 msgid "Only part of this long conversation is shown."
 msgstr "Von dieser langen Unterhaltung wird nur ein Teil angezeigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1024
+#: lib/vutuv_web/live/notification_live/index.ex:1028
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr "Erwähnung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1243
+#: lib/vutuv_web/live/notification_live/index.ex:1263
 #, elixir-autogen, elixir-format
 msgid "mentioned you in a post."
 msgstr "hat Sie in einem Beitrag erwähnt."
@@ -16236,7 +16239,7 @@ msgstr "Vom Mitglied entfernt"
 msgid "Replies from other networks"
 msgstr "Antworten aus anderen Netzwerken"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1026
+#: lib/vutuv_web/live/notification_live/index.ex:1030
 #, elixir-autogen, elixir-format
 msgid "Reply from another network"
 msgstr "Antwort aus einem anderen Netzwerk"
@@ -16312,7 +16315,7 @@ msgstr "Was"
 msgid "You have reported a lot today. Please try again tomorrow."
 msgstr "Sie haben heute schon viel gemeldet. Bitte versuchen Sie es morgen wieder."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1246
+#: lib/vutuv_web/live/notification_live/index.ex:1266
 #, elixir-autogen, elixir-format
 msgid "replied to your post from another network."
 msgstr "hat aus einem anderen Netzwerk auf Ihren Beitrag geantwortet."
@@ -17332,7 +17335,7 @@ msgstr "Fediverse-Reaktionen"
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1027
+#: lib/vutuv_web/live/notification_live/index.ex:1031
 #, elixir-autogen, elixir-format
 msgid "Reaction from another network"
 msgstr "Reaktion aus einem anderen Netzwerk"
@@ -17352,21 +17355,21 @@ msgstr ""
 "Mehr speichern wir über diese Menschen nicht: keinen Namen, kein Bild, "
 "keinen Text. Ausschalten löscht, was dafür gespeichert ist."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1081
+#: lib/vutuv_web/live/notification_live/index.ex:1085
 #, elixir-autogen, elixir-format
 msgid "liked your post on another network."
 msgid_plural "liked your post on another network."
 msgstr[0] "gefällt Ihr Beitrag in einem anderen Netzwerk."
 msgstr[1] "gefällt Ihr Beitrag in einem anderen Netzwerk."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1089
+#: lib/vutuv_web/live/notification_live/index.ex:1093
 #, elixir-autogen, elixir-format
 msgid "reacted to your post from another network."
 msgid_plural "reacted to your post from another network."
 msgstr[0] "hat aus einem anderen Netzwerk auf Ihren Beitrag reagiert."
 msgstr[1] "haben aus einem anderen Netzwerk auf Ihren Beitrag reagiert."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1073
+#: lib/vutuv_web/live/notification_live/index.ex:1077
 #, elixir-autogen, elixir-format
 msgid "shared your post on another network."
 msgid_plural "shared your post on another network."
@@ -19646,7 +19649,7 @@ msgstr "Arbeitszeugnis geändert"
 msgid "Employment reference deleted"
 msgstr "Arbeitszeugnis gelöscht"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1036
+#: lib/vutuv_web/live/notification_live/index.ex:1040
 #, elixir-autogen, elixir-format
 msgid "Employment reference review"
 msgstr "Zeugnisprüfung"
@@ -19671,13 +19674,13 @@ msgstr "Ausstellungsdatum"
 msgid "Reviewing your reference. This usually takes about %{duration}."
 msgstr "Ihr Zeugnis wird geprüft. Das dauert erfahrungsgemäß etwa %{duration}."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1234
+#: lib/vutuv_web/live/notification_live/index.ex:1254
 #: lib/vutuv_web/views/notification_digest_text.ex:84
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready."
 msgstr "Die Prüfung von „%{title}“ ist fertig."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1231
+#: lib/vutuv_web/live/notification_live/index.ex:1251
 #: lib/vutuv_web/views/notification_digest_text.ex:81
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready: %{grade}."
@@ -19693,7 +19696,7 @@ msgstr "Erfahrungsgemäß etwa %{duration}."
 msgid "When the review of one of your employment references is finished. It takes minutes, so you can close the page and wait for the email."
 msgstr "Wenn die Prüfung eines Ihrer Arbeitszeugnisse fertig ist. Das dauert einige Minuten, Sie können die Seite also schließen und auf die E-Mail warten."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1237
+#: lib/vutuv_web/live/notification_live/index.ex:1257
 #, elixir-autogen, elixir-format
 msgid "Your employment reference has been reviewed."
 msgstr "Ihr Arbeitszeugnis wurde geprüft."
@@ -19861,7 +19864,7 @@ msgstr "GitHub-Account @Klotzkette"
 msgid "One of your images was removed by the image review."
 msgstr "Eines Ihrer Bilder wurde von der Bildprüfung entfernt."
 
-#: lib/vutuv_web/views/notification_digest_text.ex:97
+#: lib/vutuv_web/views/notification_digest_text.ex:100
 #, elixir-autogen, elixir-format
 msgid "Somebody"
 msgstr "Jemand"
@@ -20078,7 +20081,7 @@ msgstr ""
 msgid "Cancel registration"
 msgstr "Registrierung abbrechen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:831
+#: lib/vutuv_web/live/notification_live/index.ex:835
 #, elixir-autogen, elixir-format
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
@@ -20801,12 +20804,12 @@ msgstr "Von vorn beginnen"
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr "Ein Herz oder ein Repost geht zurück in das Netzwerk, aus dem dieser Beitrag stammt. Ihr Konto nimmt derzeit nicht am Fediverse teil. Einschalten können Sie das in den {settings}."
 
-#: lib/vutuv_web/components/organization_components.ex:268
+#: lib/vutuv_web/components/organization_components.ex:273
 #, elixir-autogen, elixir-format
 msgid "Editorial"
 msgstr "Redaktion"
 
-#: lib/vutuv_web/components/organization_components.ex:274
+#: lib/vutuv_web/components/organization_components.ex:279
 #, elixir-autogen, elixir-format
 msgid "Edits the page and posts jobs."
 msgstr "Bearbeitet die Seite und schreibt Stellen aus."
@@ -20816,7 +20819,7 @@ msgstr "Bearbeitet die Seite und schreibt Stellen aus."
 msgid "Give members their roles on this page. Someone can hold several at once, and every role is granted on its own."
 msgstr "Geben Sie Mitgliedern ihre Rollen auf dieser Seite. Jemand kann mehrere gleichzeitig haben, und jede Rolle wird einzeln vergeben."
 
-#: lib/vutuv_web/components/organization_components.ex:273
+#: lib/vutuv_web/components/organization_components.ex:278
 #, elixir-autogen, elixir-format
 msgid "Manages the team and the domains, and edits the page."
 msgstr "Verwaltet Team und Domains und bearbeitet die Seite."
@@ -20826,7 +20829,7 @@ msgstr "Verwaltet Team und Domains und bearbeitet die Seite."
 msgid "Pick at least one role."
 msgstr "Wählen Sie mindestens eine Rolle."
 
-#: lib/vutuv_web/components/organization_components.ex:276
+#: lib/vutuv_web/components/organization_components.ex:281
 #, elixir-autogen, elixir-format
 msgid "Posts jobs."
 msgstr "Schreibt Stellen aus."
@@ -20841,7 +20844,7 @@ msgstr "Rollen"
 msgid "Roles updated."
 msgstr "Rollen aktualisiert."
 
-#: lib/vutuv_web/components/organization_components.ex:275
+#: lib/vutuv_web/components/organization_components.ex:280
 #, elixir-autogen, elixir-format
 msgid "Writes posts in the organization's name."
 msgstr "Schreibt Beiträge im Namen der Organisation."
@@ -21029,3 +21032,68 @@ msgstr "Was die Mitglieder und Organisationen veröffentlicht haben, denen diese
 #, elixir-autogen, elixir-format
 msgid "Follows – %{name}"
 msgstr "Folgt – %{name}"
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:91
+#, elixir-autogen, elixir-format
+msgid "A handle is needed first"
+msgstr "Zuerst wird ein Handle gebraucht"
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:33
+#, elixir-autogen, elixir-format
+msgid "Fediverse – %{name}"
+msgstr "Fediverse – %{name}"
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:81
+#, elixir-autogen, elixir-format
+msgid "Let people on Mastodon and other networks follow this page and receive its posts."
+msgstr "Lassen Sie Leute auf Mastodon und anderen Netzwerken dieser Seite folgen und ihre Beiträge empfangen."
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:93
+#, elixir-autogen, elixir-format
+msgid "Out there this page is addressed by its handle, the way a member is. Claim one on the page settings, then come back."
+msgstr "Da draußen wird diese Seite über ihr Handle angesprochen, so wie ein Mitglied auch. Beanspruchen Sie eines in den Seiteneinstellungen und kommen Sie dann zurück."
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:99
+#, elixir-autogen, elixir-format
+msgid "Page settings"
+msgstr "Seiteneinstellungen"
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:134
+#, elixir-autogen, elixir-format
+msgid "Posts of this page will be sent to other servers from now on. Continue?"
+msgstr "Beiträge dieser Seite gehen ab jetzt an andere Server. Fortfahren?"
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:138
+#, elixir-autogen, elixir-format
+msgid "Start federating"
+msgstr "Föderieren starten"
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:138
+#, elixir-autogen, elixir-format
+msgid "Stop federating"
+msgstr "Föderieren beenden"
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:123
+#, elixir-autogen, elixir-format
+msgid "Switching this off stops new posts from leaving. Copies another server already holds can only be asked to delete them, never made to."
+msgstr "Das Ausschalten hält neue Beiträge zurück. Kopien, die ein anderer Server schon hat, kann man nur um Löschung bitten, nie dazu zwingen."
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:86
+#, elixir-autogen, elixir-format
+msgid "This installation has federation switched off, so nothing here has any effect."
+msgstr "Auf dieser Installation ist das Föderieren abgeschaltet, hier hat also nichts eine Wirkung."
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:146
+#, elixir-autogen, elixir-format
+msgid "This page federated before. Servers that still hold copies keep them until they act on a deletion request."
+msgstr "Diese Seite hat früher föderiert. Server, die noch Kopien halten, behalten sie, bis sie einer Löschbitte nachkommen."
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:111
+#, elixir-autogen, elixir-format
+msgid "This page is being federated. %{count} accounts on other networks follow it."
+msgstr "Diese Seite föderiert. %{count} Konten auf anderen Netzwerken folgen ihr."
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:115
+#, elixir-autogen, elixir-format
+msgid "This page is not being federated. Nothing of it is visible on other networks."
+msgstr "Diese Seite föderiert nicht. Nichts von ihr ist auf anderen Netzwerken sichtbar."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -34,6 +34,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
+#: lib/vutuv_web/live/organization_live/fediverse.ex:104
 #: lib/vutuv_web/live/organization_live/show.ex:600
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
@@ -314,7 +315,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:510
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
-#: lib/vutuv_web/live/notification_live/index.ex:956
+#: lib/vutuv_web/live/notification_live/index.ex:960
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:40
@@ -455,7 +456,7 @@ msgstr ""
 msgid "Middle Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:880
+#: lib/vutuv_web/live/notification_live/index.ex:884
 #, elixir-autogen
 msgid "More"
 msgstr ""
@@ -798,7 +799,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
-#: lib/vutuv_web/live/notification_live/index.ex:1035
+#: lib/vutuv_web/live/notification_live/index.ex:1039
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -1146,7 +1147,7 @@ msgstr ""
 msgid "Add Localization"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:264
+#: lib/vutuv_web/components/organization_components.ex:269
 #: lib/vutuv_web/live/admin/activity_live.ex:153
 #: lib/vutuv_web/live/admin/api_app_live.ex:58
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
@@ -1714,7 +1715,7 @@ msgstr ""
 msgid "Log out"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:270
+#: lib/vutuv_web/components/organization_components.ex:275
 #: lib/vutuv_web/live/admin/activity_live.ex:143
 #: lib/vutuv_web/live/admin/activity_live.ex:175
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
@@ -1895,17 +1896,17 @@ msgstr ""
 msgid "submit a bug report"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1057
+#: lib/vutuv_web/live/notification_live/index.ex:1061
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1052
+#: lib/vutuv_web/live/notification_live/index.ex:1056
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1047
+#: lib/vutuv_web/live/notification_live/index.ex:1051
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr ""
@@ -2197,7 +2198,7 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:83
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:382
-#: lib/vutuv_web/live/notification_live/index.ex:878
+#: lib/vutuv_web/live/notification_live/index.ex:882
 #: lib/vutuv_web/live/organization_live/show.ex:467
 #: lib/vutuv_web/live/post_live/saved.ex:495
 #: lib/vutuv_web/live/search_live.ex:205
@@ -2387,7 +2388,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1551
 #: lib/vutuv_web/components/post_components.ex:4629
 #: lib/vutuv_web/components/ui.ex:2837
-#: lib/vutuv_web/live/notification_live/index.ex:1025
+#: lib/vutuv_web/live/notification_live/index.ex:1029
 #: lib/vutuv_web/views/user_html.ex:343
 #, elixir-autogen, elixir-format
 msgid "Like"
@@ -2395,7 +2396,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:995
 #: lib/vutuv_web/components/post_components.ex:4638
-#: lib/vutuv_web/live/notification_live/index.ex:958
+#: lib/vutuv_web/live/notification_live/index.ex:962
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
 #: lib/vutuv_web/live/shell_live.ex:714
@@ -2479,7 +2480,7 @@ msgid "Only public posts can be answered."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:383
-#: lib/vutuv_web/live/notification_live/index.ex:959
+#: lib/vutuv_web/live/notification_live/index.ex:963
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
@@ -2487,7 +2488,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1562
 #: lib/vutuv_web/components/post_components.ex:4665
 #: lib/vutuv_web/components/post_components.ex:4666
-#: lib/vutuv_web/live/notification_live/index.ex:1022
+#: lib/vutuv_web/live/notification_live/index.ex:1026
 #: lib/vutuv_web/live/post_live/reply.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reply"
@@ -2509,7 +2510,7 @@ msgstr ""
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1241
+#: lib/vutuv_web/live/notification_live/index.ex:1261
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr ""
@@ -2786,7 +2787,7 @@ msgstr[1] ""
 #: lib/vutuv_web/agent_docs/markdown.ex:547
 #: lib/vutuv_web/agent_docs/text.ex:512
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:957
+#: lib/vutuv_web/live/notification_live/index.ex:961
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
@@ -2841,23 +2842,23 @@ msgid "Open someone's profile to message them."
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:221
-#: lib/vutuv_web/live/notification_live/index.ex:1037
+#: lib/vutuv_web/live/notification_live/index.ex:1041
 #: lib/vutuv_web/live/organization_live/activity.ex:99
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1028
+#: lib/vutuv_web/live/notification_live/index.ex:1032
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1021
+#: lib/vutuv_web/live/notification_live/index.ex:1025
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1020
+#: lib/vutuv_web/live/notification_live/index.ex:1024
 #: lib/vutuv_web/templates/user/show.html.heex:933
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -2870,7 +2871,7 @@ msgstr[1] ""
 msgid "Welcome to vutuv, %{name}!"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1054
+#: lib/vutuv_web/live/notification_live/index.ex:1058
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr ""
@@ -2902,12 +2903,12 @@ msgstr ""
 msgid "(no text)"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1277
+#: lib/vutuv_web/live/notification_live/index.ex:1297
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1278
+#: lib/vutuv_web/live/notification_live/index.ex:1298
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr ""
@@ -3013,7 +3014,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:1029
+#: lib/vutuv_web/live/notification_live/index.ex:1033
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3119,7 +3120,7 @@ msgstr ""
 msgid "Opened"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:263
+#: lib/vutuv_web/components/organization_components.ex:268
 #: lib/vutuv_web/live/admin/api_app_live.ex:72
 #: lib/vutuv_web/live/admin/deliverability_live.ex:171
 #: lib/vutuv_web/live/admin/moderation_live.ex:56
@@ -3437,12 +3438,12 @@ msgstr ""
 msgid "You cannot report your own content."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1280
+#: lib/vutuv_web/live/notification_live/index.ex:1300
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1279
+#: lib/vutuv_web/live/notification_live/index.ex:1299
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr ""
@@ -3452,7 +3453,7 @@ msgstr ""
 msgid "Your content was reported"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1281
+#: lib/vutuv_web/live/notification_live/index.ex:1301
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3636,7 +3637,7 @@ msgstr ""
 msgid "Open the profile"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1305
+#: lib/vutuv_web/live/notification_live/index.ex:1325
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3661,7 +3662,7 @@ msgstr ""
 msgid "Report filed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1031
+#: lib/vutuv_web/live/notification_live/index.ex:1035
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr ""
@@ -3736,7 +3737,7 @@ msgstr ""
 msgid "Waiting for the owner"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1310
+#: lib/vutuv_web/live/notification_live/index.ex:1330
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -4593,7 +4594,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:385
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:516
-#: lib/vutuv_web/live/notification_live/index.ex:879
+#: lib/vutuv_web/live/notification_live/index.ex:883
 #: lib/vutuv_web/live/organization_live/show.ex:550
 #: lib/vutuv_web/live/post_live/saved.ex:498
 #: lib/vutuv_web/live/search_live.ex:203
@@ -4616,7 +4617,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:399
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
-#: lib/vutuv_web/live/notification_live/index.ex:877
+#: lib/vutuv_web/live/notification_live/index.ex:881
 #: lib/vutuv_web/live/search_live.ex:202
 #: lib/vutuv_web/views/qualification_html.ex:90
 #, elixir-autogen, elixir-format
@@ -5635,7 +5636,7 @@ msgid "Apps & API"
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:127
-#: lib/vutuv_web/live/notification_live/index.ex:960
+#: lib/vutuv_web/live/notification_live/index.ex:964
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:17
@@ -7730,13 +7731,13 @@ msgstr ""
 #: lib/vutuv_web/components/job_components.ex:173
 #: lib/vutuv_web/live/admin/dashboard_live.ex:287
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:457
-#: lib/vutuv_web/live/notification_live/index.ex:906
+#: lib/vutuv_web/live/notification_live/index.ex:910
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:291
-#: lib/vutuv_web/live/notification_live/index.ex:909
+#: lib/vutuv_web/live/notification_live/index.ex:913
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr ""
@@ -8647,12 +8648,14 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:540
 #: lib/vutuv_web/agent_docs/text.ex:501
 #: lib/vutuv_web/agent_docs/text.ex:505
+#: lib/vutuv_web/components/organization_components.ex:238
 #: lib/vutuv_web/components/ui.ex:3688
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:323
 #: lib/vutuv_web/controllers/settings_controller.ex:390
 #: lib/vutuv_web/live/fediverse_followers_live.ex:169
 #: lib/vutuv_web/live/fediverse_following_live.ex:286
+#: lib/vutuv_web/live/organization_live/fediverse.ex:79
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:341
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:5
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
@@ -11100,7 +11103,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) and list them for AI agents."
 msgstr ""
 
-#: lib/vutuv_web/controllers/organization_controller.ex:206
+#: lib/vutuv_web/controllers/organization_controller.ex:214
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:31
 #, elixir-autogen, elixir-format
 msgid "Please log in first."
@@ -11241,7 +11244,7 @@ msgstr ""
 msgid "@handle or email"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:282
+#: lib/vutuv_web/components/organization_components.ex:287
 #: lib/vutuv_web/live/organization_live/edit.ex:390
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
@@ -11262,7 +11265,7 @@ msgstr ""
 msgid "Added @%{handle} to the team."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:283
+#: lib/vutuv_web/components/organization_components.ex:288
 #: lib/vutuv_web/live/organization_live/edit.ex:388
 #, elixir-autogen, elixir-format
 msgid "Alias"
@@ -11308,7 +11311,7 @@ msgstr ""
 msgid "Archived"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:281
+#: lib/vutuv_web/components/organization_components.ex:286
 #: lib/vutuv_web/live/organization_live/edit.ex:389
 #, elixir-autogen, elixir-format
 msgid "Brand"
@@ -11357,7 +11360,7 @@ msgstr ""
 msgid "Domains – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:280
+#: lib/vutuv_web/components/organization_components.ex:285
 #, elixir-autogen, elixir-format
 msgid "Former name"
 msgstr ""
@@ -11435,7 +11438,7 @@ msgstr ""
 msgid "Primary domain updated."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:269
+#: lib/vutuv_web/components/organization_components.ex:274
 #, elixir-autogen, elixir-format
 msgid "Recruiter"
 msgstr ""
@@ -11855,7 +11858,7 @@ msgstr ""
 msgid "Organization pages"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1032
+#: lib/vutuv_web/live/notification_live/index.ex:1036
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr ""
@@ -11963,22 +11966,22 @@ msgstr ""
 msgid "Your organization page was updated."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1269
+#: lib/vutuv_web/live/notification_live/index.ex:1289
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1266
+#: lib/vutuv_web/live/notification_live/index.ex:1286
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1263
+#: lib/vutuv_web/live/notification_live/index.ex:1283
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1260
+#: lib/vutuv_web/live/notification_live/index.ex:1280
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr ""
@@ -11993,32 +11996,32 @@ msgstr ""
 msgid "We can't stop a search engine or AI service from reading a page it can open. What we can do is tell them, in the machine-readable way they look for, that you don't want your profile listed in search results or used by AI. Reputable search engines and AI companies follow that request; we can't force the rest."
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:99
+#: lib/vutuv/organizations/organization.ex:104
 #, elixir-autogen, elixir-format
 msgid "Association"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:98
+#: lib/vutuv/organizations/organization.ex:103
 #, elixir-autogen, elixir-format
 msgid "Business"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:101
+#: lib/vutuv/organizations/organization.ex:106
 #, elixir-autogen, elixir-format
 msgid "Education / research"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:102
+#: lib/vutuv/organizations/organization.ex:107
 #, elixir-autogen, elixir-format
 msgid "NGO / foundation"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:103
+#: lib/vutuv/organizations/organization.ex:108
 #, elixir-autogen, elixir-format
 msgid "Other organization"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:100
+#: lib/vutuv/organizations/organization.ex:105
 #, elixir-autogen, elixir-format
 msgid "Public authority"
 msgstr ""
@@ -13354,7 +13357,7 @@ msgstr ""
 msgid "Image awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1030
+#: lib/vutuv_web/live/notification_live/index.ex:1034
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13441,7 +13444,7 @@ msgstr[1] ""
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1033
+#: lib/vutuv_web/live/notification_live/index.ex:1037
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr ""
@@ -13453,7 +13456,7 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1319
+#: lib/vutuv_web/live/notification_live/index.ex:1339
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
@@ -13660,22 +13663,22 @@ msgstr[1] ""
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1034
+#: lib/vutuv_web/live/notification_live/index.ex:1038
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1339
+#: lib/vutuv_web/live/notification_live/index.ex:1359
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1331
+#: lib/vutuv_web/live/notification_live/index.ex:1351
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1336
+#: lib/vutuv_web/live/notification_live/index.ex:1356
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr ""
@@ -13700,7 +13703,7 @@ msgstr ""
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1344
+#: lib/vutuv_web/live/notification_live/index.ex:1364
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr ""
@@ -13831,14 +13834,14 @@ msgstr ""
 msgid "Publisher:"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:898
+#: lib/vutuv_web/live/notification_live/index.ex:902
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:912
+#: lib/vutuv_web/live/notification_live/index.ex:916
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr ""
@@ -13853,23 +13856,23 @@ msgstr ""
 msgid "Last 30 days"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:864
-#: lib/vutuv_web/live/notification_live/index.ex:1113
+#: lib/vutuv_web/live/notification_live/index.ex:868
+#: lib/vutuv_web/live/notification_live/index.ex:1117
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1050
+#: lib/vutuv_web/live/notification_live/index.ex:1054
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1045
+#: lib/vutuv_web/live/notification_live/index.ex:1049
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1060
+#: lib/vutuv_web/live/notification_live/index.ex:1064
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr ""
@@ -14110,17 +14113,17 @@ msgstr ""
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1293
+#: lib/vutuv_web/live/notification_live/index.ex:1313
 #, elixir-autogen, elixir-format
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1023
+#: lib/vutuv_web/live/notification_live/index.ex:1027
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1100
+#: lib/vutuv_web/live/notification_live/index.ex:1104
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -14139,12 +14142,12 @@ msgstr ""
 msgid "Only part of this long conversation is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1024
+#: lib/vutuv_web/live/notification_live/index.ex:1028
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1243
+#: lib/vutuv_web/live/notification_live/index.ex:1263
 #, elixir-autogen, elixir-format
 msgid "mentioned you in a post."
 msgstr ""
@@ -15511,7 +15514,7 @@ msgstr ""
 msgid "Replies from other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1026
+#: lib/vutuv_web/live/notification_live/index.ex:1030
 #, elixir-autogen, elixir-format
 msgid "Reply from another network"
 msgstr ""
@@ -15587,7 +15590,7 @@ msgstr ""
 msgid "You have reported a lot today. Please try again tomorrow."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1246
+#: lib/vutuv_web/live/notification_live/index.ex:1266
 #, elixir-autogen, elixir-format
 msgid "replied to your post from another network."
 msgstr ""
@@ -16597,7 +16600,7 @@ msgstr ""
 msgid "From other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1027
+#: lib/vutuv_web/live/notification_live/index.ex:1031
 #, elixir-autogen, elixir-format
 msgid "Reaction from another network"
 msgstr ""
@@ -16612,21 +16615,21 @@ msgstr ""
 msgid "Show under each of your posts who out there liked or shared it, by their account address on their own server, linked to that account. Visible to everyone who sees the post. We keep nothing else about these people: no name, no picture, no text. Switching it off deletes what is stored for it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1081
+#: lib/vutuv_web/live/notification_live/index.ex:1085
 #, elixir-autogen, elixir-format
 msgid "liked your post on another network."
 msgid_plural "liked your post on another network."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1089
+#: lib/vutuv_web/live/notification_live/index.ex:1093
 #, elixir-autogen, elixir-format
 msgid "reacted to your post from another network."
 msgid_plural "reacted to your post from another network."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1073
+#: lib/vutuv_web/live/notification_live/index.ex:1077
 #, elixir-autogen, elixir-format
 msgid "shared your post on another network."
 msgid_plural "shared your post on another network."
@@ -18880,7 +18883,7 @@ msgstr ""
 msgid "Employment reference deleted"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1036
+#: lib/vutuv_web/live/notification_live/index.ex:1040
 #, elixir-autogen, elixir-format
 msgid "Employment reference review"
 msgstr ""
@@ -18905,13 +18908,13 @@ msgstr ""
 msgid "Reviewing your reference. This usually takes about %{duration}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1234
+#: lib/vutuv_web/live/notification_live/index.ex:1254
 #: lib/vutuv_web/views/notification_digest_text.ex:84
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1231
+#: lib/vutuv_web/live/notification_live/index.ex:1251
 #: lib/vutuv_web/views/notification_digest_text.ex:81
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready: %{grade}."
@@ -18927,7 +18930,7 @@ msgstr ""
 msgid "When the review of one of your employment references is finished. It takes minutes, so you can close the page and wait for the email."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1237
+#: lib/vutuv_web/live/notification_live/index.ex:1257
 #, elixir-autogen, elixir-format
 msgid "Your employment reference has been reviewed."
 msgstr ""
@@ -19095,7 +19098,7 @@ msgstr ""
 msgid "One of your images was removed by the image review."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:97
+#: lib/vutuv_web/views/notification_digest_text.ex:100
 #, elixir-autogen, elixir-format
 msgid "Somebody"
 msgstr ""
@@ -19301,7 +19304,7 @@ msgstr ""
 msgid "Cancel registration"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:831
+#: lib/vutuv_web/live/notification_live/index.ex:835
 #, elixir-autogen, elixir-format
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
@@ -20017,12 +20020,12 @@ msgstr ""
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:268
+#: lib/vutuv_web/components/organization_components.ex:273
 #, elixir-autogen, elixir-format
 msgid "Editorial"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:274
+#: lib/vutuv_web/components/organization_components.ex:279
 #, elixir-autogen, elixir-format
 msgid "Edits the page and posts jobs."
 msgstr ""
@@ -20032,7 +20035,7 @@ msgstr ""
 msgid "Give members their roles on this page. Someone can hold several at once, and every role is granted on its own."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:273
+#: lib/vutuv_web/components/organization_components.ex:278
 #, elixir-autogen, elixir-format
 msgid "Manages the team and the domains, and edits the page."
 msgstr ""
@@ -20042,7 +20045,7 @@ msgstr ""
 msgid "Pick at least one role."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:276
+#: lib/vutuv_web/components/organization_components.ex:281
 #, elixir-autogen, elixir-format
 msgid "Posts jobs."
 msgstr ""
@@ -20057,7 +20060,7 @@ msgstr ""
 msgid "Roles updated."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:275
+#: lib/vutuv_web/components/organization_components.ex:280
 #, elixir-autogen, elixir-format
 msgid "Writes posts in the organization's name."
 msgstr ""
@@ -20244,4 +20247,69 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:43
 #, elixir-autogen, elixir-format
 msgid "Follows – %{name}"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:91
+#, elixir-autogen, elixir-format
+msgid "A handle is needed first"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:33
+#, elixir-autogen, elixir-format
+msgid "Fediverse – %{name}"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:81
+#, elixir-autogen, elixir-format
+msgid "Let people on Mastodon and other networks follow this page and receive its posts."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:93
+#, elixir-autogen, elixir-format
+msgid "Out there this page is addressed by its handle, the way a member is. Claim one on the page settings, then come back."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:99
+#, elixir-autogen, elixir-format
+msgid "Page settings"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:134
+#, elixir-autogen, elixir-format
+msgid "Posts of this page will be sent to other servers from now on. Continue?"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:138
+#, elixir-autogen, elixir-format
+msgid "Start federating"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:138
+#, elixir-autogen, elixir-format
+msgid "Stop federating"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:123
+#, elixir-autogen, elixir-format
+msgid "Switching this off stops new posts from leaving. Copies another server already holds can only be asked to delete them, never made to."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:86
+#, elixir-autogen, elixir-format
+msgid "This installation has federation switched off, so nothing here has any effect."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:146
+#, elixir-autogen, elixir-format
+msgid "This page federated before. Servers that still hold copies keep them until they act on a deletion request."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:111
+#, elixir-autogen, elixir-format
+msgid "This page is being federated. %{count} accounts on other networks follow it."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:115
+#, elixir-autogen, elixir-format
+msgid "This page is not being federated. Nothing of it is visible on other networks."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -32,6 +32,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
+#: lib/vutuv_web/live/organization_live/fediverse.ex:104
 #: lib/vutuv_web/live/organization_live/show.ex:600
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
@@ -312,7 +313,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:510
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
-#: lib/vutuv_web/live/notification_live/index.ex:956
+#: lib/vutuv_web/live/notification_live/index.ex:960
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:40
@@ -453,7 +454,7 @@ msgstr ""
 msgid "Middle Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:880
+#: lib/vutuv_web/live/notification_live/index.ex:884
 #, elixir-autogen
 msgid "More"
 msgstr ""
@@ -796,7 +797,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
-#: lib/vutuv_web/live/notification_live/index.ex:1035
+#: lib/vutuv_web/live/notification_live/index.ex:1039
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -1144,7 +1145,7 @@ msgstr ""
 msgid "Add Localization"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:264
+#: lib/vutuv_web/components/organization_components.ex:269
 #: lib/vutuv_web/live/admin/activity_live.ex:153
 #: lib/vutuv_web/live/admin/api_app_live.ex:58
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
@@ -1712,7 +1713,7 @@ msgstr ""
 msgid "Log out"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:270
+#: lib/vutuv_web/components/organization_components.ex:275
 #: lib/vutuv_web/live/admin/activity_live.ex:143
 #: lib/vutuv_web/live/admin/activity_live.ex:175
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
@@ -1893,17 +1894,17 @@ msgstr ""
 msgid "submit a bug report"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1057
+#: lib/vutuv_web/live/notification_live/index.ex:1061
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1052
+#: lib/vutuv_web/live/notification_live/index.ex:1056
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1047
+#: lib/vutuv_web/live/notification_live/index.ex:1051
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr ""
@@ -2195,7 +2196,7 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:83
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:382
-#: lib/vutuv_web/live/notification_live/index.ex:878
+#: lib/vutuv_web/live/notification_live/index.ex:882
 #: lib/vutuv_web/live/organization_live/show.ex:467
 #: lib/vutuv_web/live/post_live/saved.ex:495
 #: lib/vutuv_web/live/search_live.ex:205
@@ -2385,7 +2386,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1551
 #: lib/vutuv_web/components/post_components.ex:4629
 #: lib/vutuv_web/components/ui.ex:2837
-#: lib/vutuv_web/live/notification_live/index.ex:1025
+#: lib/vutuv_web/live/notification_live/index.ex:1029
 #: lib/vutuv_web/views/user_html.ex:343
 #, elixir-autogen, elixir-format
 msgid "Like"
@@ -2393,7 +2394,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:995
 #: lib/vutuv_web/components/post_components.ex:4638
-#: lib/vutuv_web/live/notification_live/index.ex:958
+#: lib/vutuv_web/live/notification_live/index.ex:962
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
 #: lib/vutuv_web/live/shell_live.ex:714
@@ -2477,7 +2478,7 @@ msgid "Only public posts can be answered."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:383
-#: lib/vutuv_web/live/notification_live/index.ex:959
+#: lib/vutuv_web/live/notification_live/index.ex:963
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
@@ -2485,7 +2486,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1562
 #: lib/vutuv_web/components/post_components.ex:4665
 #: lib/vutuv_web/components/post_components.ex:4666
-#: lib/vutuv_web/live/notification_live/index.ex:1022
+#: lib/vutuv_web/live/notification_live/index.ex:1026
 #: lib/vutuv_web/live/post_live/reply.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reply"
@@ -2507,7 +2508,7 @@ msgstr ""
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1241
+#: lib/vutuv_web/live/notification_live/index.ex:1261
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr ""
@@ -2784,7 +2785,7 @@ msgstr[1] ""
 #: lib/vutuv_web/agent_docs/markdown.ex:547
 #: lib/vutuv_web/agent_docs/text.ex:512
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:957
+#: lib/vutuv_web/live/notification_live/index.ex:961
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
@@ -2839,23 +2840,23 @@ msgid "Open someone's profile to message them."
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:221
-#: lib/vutuv_web/live/notification_live/index.ex:1037
+#: lib/vutuv_web/live/notification_live/index.ex:1041
 #: lib/vutuv_web/live/organization_live/activity.ex:99
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1028
+#: lib/vutuv_web/live/notification_live/index.ex:1032
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1021
+#: lib/vutuv_web/live/notification_live/index.ex:1025
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1020
+#: lib/vutuv_web/live/notification_live/index.ex:1024
 #: lib/vutuv_web/templates/user/show.html.heex:933
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -2868,7 +2869,7 @@ msgstr[1] ""
 msgid "Welcome to vutuv, %{name}!"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1054
+#: lib/vutuv_web/live/notification_live/index.ex:1058
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr ""
@@ -2900,12 +2901,12 @@ msgstr ""
 msgid "(no text)"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1277
+#: lib/vutuv_web/live/notification_live/index.ex:1297
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1278
+#: lib/vutuv_web/live/notification_live/index.ex:1298
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr ""
@@ -3011,7 +3012,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:1029
+#: lib/vutuv_web/live/notification_live/index.ex:1033
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3117,7 +3118,7 @@ msgstr ""
 msgid "Opened"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:263
+#: lib/vutuv_web/components/organization_components.ex:268
 #: lib/vutuv_web/live/admin/api_app_live.ex:72
 #: lib/vutuv_web/live/admin/deliverability_live.ex:171
 #: lib/vutuv_web/live/admin/moderation_live.ex:56
@@ -3435,12 +3436,12 @@ msgstr ""
 msgid "You cannot report your own content."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1280
+#: lib/vutuv_web/live/notification_live/index.ex:1300
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1279
+#: lib/vutuv_web/live/notification_live/index.ex:1299
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr ""
@@ -3450,7 +3451,7 @@ msgstr ""
 msgid "Your content was reported"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1281
+#: lib/vutuv_web/live/notification_live/index.ex:1301
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3634,7 +3635,7 @@ msgstr ""
 msgid "Open the profile"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1305
+#: lib/vutuv_web/live/notification_live/index.ex:1325
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3659,7 +3660,7 @@ msgstr ""
 msgid "Report filed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1031
+#: lib/vutuv_web/live/notification_live/index.ex:1035
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr ""
@@ -3734,7 +3735,7 @@ msgstr ""
 msgid "Waiting for the owner"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1310
+#: lib/vutuv_web/live/notification_live/index.ex:1330
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -4591,7 +4592,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:385
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:516
-#: lib/vutuv_web/live/notification_live/index.ex:879
+#: lib/vutuv_web/live/notification_live/index.ex:883
 #: lib/vutuv_web/live/organization_live/show.ex:550
 #: lib/vutuv_web/live/post_live/saved.ex:498
 #: lib/vutuv_web/live/search_live.ex:203
@@ -4614,7 +4615,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:399
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
-#: lib/vutuv_web/live/notification_live/index.ex:877
+#: lib/vutuv_web/live/notification_live/index.ex:881
 #: lib/vutuv_web/live/search_live.ex:202
 #: lib/vutuv_web/views/qualification_html.ex:90
 #, elixir-autogen, elixir-format
@@ -5633,7 +5634,7 @@ msgid "Apps & API"
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:127
-#: lib/vutuv_web/live/notification_live/index.ex:960
+#: lib/vutuv_web/live/notification_live/index.ex:964
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:17
@@ -7728,13 +7729,13 @@ msgstr ""
 #: lib/vutuv_web/components/job_components.ex:173
 #: lib/vutuv_web/live/admin/dashboard_live.ex:287
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:457
-#: lib/vutuv_web/live/notification_live/index.ex:906
+#: lib/vutuv_web/live/notification_live/index.ex:910
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:291
-#: lib/vutuv_web/live/notification_live/index.ex:909
+#: lib/vutuv_web/live/notification_live/index.ex:913
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr ""
@@ -8645,12 +8646,14 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:540
 #: lib/vutuv_web/agent_docs/text.ex:501
 #: lib/vutuv_web/agent_docs/text.ex:505
+#: lib/vutuv_web/components/organization_components.ex:238
 #: lib/vutuv_web/components/ui.ex:3688
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:323
 #: lib/vutuv_web/controllers/settings_controller.ex:390
 #: lib/vutuv_web/live/fediverse_followers_live.ex:169
 #: lib/vutuv_web/live/fediverse_following_live.ex:286
+#: lib/vutuv_web/live/organization_live/fediverse.ex:79
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:341
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:5
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
@@ -11098,7 +11101,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) and list them for AI agents."
 msgstr ""
 
-#: lib/vutuv_web/controllers/organization_controller.ex:206
+#: lib/vutuv_web/controllers/organization_controller.ex:214
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:31
 #, elixir-autogen, elixir-format
 msgid "Please log in first."
@@ -11239,7 +11242,7 @@ msgstr ""
 msgid "@handle or email"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:282
+#: lib/vutuv_web/components/organization_components.ex:287
 #: lib/vutuv_web/live/organization_live/edit.ex:390
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
@@ -11260,7 +11263,7 @@ msgstr ""
 msgid "Added @%{handle} to the team."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:283
+#: lib/vutuv_web/components/organization_components.ex:288
 #: lib/vutuv_web/live/organization_live/edit.ex:388
 #, elixir-autogen, elixir-format
 msgid "Alias"
@@ -11306,7 +11309,7 @@ msgstr ""
 msgid "Archived"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:281
+#: lib/vutuv_web/components/organization_components.ex:286
 #: lib/vutuv_web/live/organization_live/edit.ex:389
 #, elixir-autogen, elixir-format
 msgid "Brand"
@@ -11355,7 +11358,7 @@ msgstr ""
 msgid "Domains – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:280
+#: lib/vutuv_web/components/organization_components.ex:285
 #, elixir-autogen, elixir-format
 msgid "Former name"
 msgstr ""
@@ -11433,7 +11436,7 @@ msgstr ""
 msgid "Primary domain updated."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:269
+#: lib/vutuv_web/components/organization_components.ex:274
 #, elixir-autogen, elixir-format
 msgid "Recruiter"
 msgstr ""
@@ -11853,7 +11856,7 @@ msgstr ""
 msgid "Organization pages"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1032
+#: lib/vutuv_web/live/notification_live/index.ex:1036
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr ""
@@ -11961,22 +11964,22 @@ msgstr ""
 msgid "Your organization page was updated."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1269
+#: lib/vutuv_web/live/notification_live/index.ex:1289
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1266
+#: lib/vutuv_web/live/notification_live/index.ex:1286
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1263
+#: lib/vutuv_web/live/notification_live/index.ex:1283
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1260
+#: lib/vutuv_web/live/notification_live/index.ex:1280
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr ""
@@ -11991,32 +11994,32 @@ msgstr ""
 msgid "We can't stop a search engine or AI service from reading a page it can open. What we can do is tell them, in the machine-readable way they look for, that you don't want your profile listed in search results or used by AI. Reputable search engines and AI companies follow that request; we can't force the rest."
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:99
+#: lib/vutuv/organizations/organization.ex:104
 #, elixir-autogen, elixir-format
 msgid "Association"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:98
+#: lib/vutuv/organizations/organization.ex:103
 #, elixir-autogen, elixir-format
 msgid "Business"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:101
+#: lib/vutuv/organizations/organization.ex:106
 #, elixir-autogen, elixir-format
 msgid "Education / research"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:102
+#: lib/vutuv/organizations/organization.ex:107
 #, elixir-autogen, elixir-format
 msgid "NGO / foundation"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:103
+#: lib/vutuv/organizations/organization.ex:108
 #, elixir-autogen, elixir-format
 msgid "Other organization"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:100
+#: lib/vutuv/organizations/organization.ex:105
 #, elixir-autogen, elixir-format
 msgid "Public authority"
 msgstr ""
@@ -13352,7 +13355,7 @@ msgstr ""
 msgid "Image awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1030
+#: lib/vutuv_web/live/notification_live/index.ex:1034
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13439,7 +13442,7 @@ msgstr[1] ""
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1033
+#: lib/vutuv_web/live/notification_live/index.ex:1037
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr ""
@@ -13451,7 +13454,7 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1319
+#: lib/vutuv_web/live/notification_live/index.ex:1339
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
@@ -13658,22 +13661,22 @@ msgstr[1] ""
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1034
+#: lib/vutuv_web/live/notification_live/index.ex:1038
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1339
+#: lib/vutuv_web/live/notification_live/index.ex:1359
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1331
+#: lib/vutuv_web/live/notification_live/index.ex:1351
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1336
+#: lib/vutuv_web/live/notification_live/index.ex:1356
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr ""
@@ -13698,7 +13701,7 @@ msgstr ""
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1344
+#: lib/vutuv_web/live/notification_live/index.ex:1364
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr ""
@@ -13829,14 +13832,14 @@ msgstr ""
 msgid "Publisher:"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:898
+#: lib/vutuv_web/live/notification_live/index.ex:902
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:912
+#: lib/vutuv_web/live/notification_live/index.ex:916
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr ""
@@ -13851,23 +13854,23 @@ msgstr ""
 msgid "Last 30 days"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:864
-#: lib/vutuv_web/live/notification_live/index.ex:1113
+#: lib/vutuv_web/live/notification_live/index.ex:868
+#: lib/vutuv_web/live/notification_live/index.ex:1117
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1050
+#: lib/vutuv_web/live/notification_live/index.ex:1054
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1045
+#: lib/vutuv_web/live/notification_live/index.ex:1049
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1060
+#: lib/vutuv_web/live/notification_live/index.ex:1064
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr ""
@@ -14108,17 +14111,17 @@ msgstr ""
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1293
+#: lib/vutuv_web/live/notification_live/index.ex:1313
 #, elixir-autogen, elixir-format
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1023
+#: lib/vutuv_web/live/notification_live/index.ex:1027
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1100
+#: lib/vutuv_web/live/notification_live/index.ex:1104
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -14137,12 +14140,12 @@ msgstr ""
 msgid "Only part of this long conversation is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1024
+#: lib/vutuv_web/live/notification_live/index.ex:1028
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1243
+#: lib/vutuv_web/live/notification_live/index.ex:1263
 #, elixir-autogen, elixir-format
 msgid "mentioned you in a post."
 msgstr ""
@@ -15509,7 +15512,7 @@ msgstr ""
 msgid "Replies from other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1026
+#: lib/vutuv_web/live/notification_live/index.ex:1030
 #, elixir-autogen, elixir-format
 msgid "Reply from another network"
 msgstr ""
@@ -15585,7 +15588,7 @@ msgstr ""
 msgid "You have reported a lot today. Please try again tomorrow."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1246
+#: lib/vutuv_web/live/notification_live/index.ex:1266
 #, elixir-autogen, elixir-format, fuzzy
 msgid "replied to your post from another network."
 msgstr ""
@@ -16595,7 +16598,7 @@ msgstr ""
 msgid "From other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1027
+#: lib/vutuv_web/live/notification_live/index.ex:1031
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Reaction from another network"
 msgstr ""
@@ -16610,21 +16613,21 @@ msgstr ""
 msgid "Show under each of your posts who out there liked or shared it, by their account address on their own server, linked to that account. Visible to everyone who sees the post. We keep nothing else about these people: no name, no picture, no text. Switching it off deletes what is stored for it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1081
+#: lib/vutuv_web/live/notification_live/index.ex:1085
 #, elixir-autogen, elixir-format
 msgid "liked your post on another network."
 msgid_plural "liked your post on another network."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1089
+#: lib/vutuv_web/live/notification_live/index.ex:1093
 #, elixir-autogen, elixir-format, fuzzy
 msgid "reacted to your post from another network."
 msgid_plural "reacted to your post from another network."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1073
+#: lib/vutuv_web/live/notification_live/index.ex:1077
 #, elixir-autogen, elixir-format
 msgid "shared your post on another network."
 msgid_plural "shared your post on another network."
@@ -18878,7 +18881,7 @@ msgstr ""
 msgid "Employment reference deleted"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1036
+#: lib/vutuv_web/live/notification_live/index.ex:1040
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Employment reference review"
 msgstr ""
@@ -18903,13 +18906,13 @@ msgstr ""
 msgid "Reviewing your reference. This usually takes about %{duration}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1234
+#: lib/vutuv_web/live/notification_live/index.ex:1254
 #: lib/vutuv_web/views/notification_digest_text.ex:84
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1231
+#: lib/vutuv_web/live/notification_live/index.ex:1251
 #: lib/vutuv_web/views/notification_digest_text.ex:81
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready: %{grade}."
@@ -18925,7 +18928,7 @@ msgstr ""
 msgid "When the review of one of your employment references is finished. It takes minutes, so you can close the page and wait for the email."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1237
+#: lib/vutuv_web/live/notification_live/index.ex:1257
 #, elixir-autogen, elixir-format
 msgid "Your employment reference has been reviewed."
 msgstr ""
@@ -19093,7 +19096,7 @@ msgstr ""
 msgid "One of your images was removed by the image review."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:97
+#: lib/vutuv_web/views/notification_digest_text.ex:100
 #, elixir-autogen, elixir-format
 msgid "Somebody"
 msgstr ""
@@ -19299,7 +19302,7 @@ msgstr ""
 msgid "Cancel registration"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:831
+#: lib/vutuv_web/live/notification_live/index.ex:835
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
@@ -20015,12 +20018,12 @@ msgstr ""
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:268
+#: lib/vutuv_web/components/organization_components.ex:273
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Editorial"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:274
+#: lib/vutuv_web/components/organization_components.ex:279
 #, elixir-autogen, elixir-format
 msgid "Edits the page and posts jobs."
 msgstr ""
@@ -20030,7 +20033,7 @@ msgstr ""
 msgid "Give members their roles on this page. Someone can hold several at once, and every role is granted on its own."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:273
+#: lib/vutuv_web/components/organization_components.ex:278
 #, elixir-autogen, elixir-format
 msgid "Manages the team and the domains, and edits the page."
 msgstr ""
@@ -20040,7 +20043,7 @@ msgstr ""
 msgid "Pick at least one role."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:276
+#: lib/vutuv_web/components/organization_components.ex:281
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Posts jobs."
 msgstr ""
@@ -20055,7 +20058,7 @@ msgstr ""
 msgid "Roles updated."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:275
+#: lib/vutuv_web/components/organization_components.ex:280
 #, elixir-autogen, elixir-format
 msgid "Writes posts in the organization's name."
 msgstr ""
@@ -20242,4 +20245,69 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:43
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follows – %{name}"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:91
+#, elixir-autogen, elixir-format
+msgid "A handle is needed first"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:33
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Fediverse – %{name}"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:81
+#, elixir-autogen, elixir-format
+msgid "Let people on Mastodon and other networks follow this page and receive its posts."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:93
+#, elixir-autogen, elixir-format
+msgid "Out there this page is addressed by its handle, the way a member is. Claim one on the page settings, then come back."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:99
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Page settings"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:134
+#, elixir-autogen, elixir-format
+msgid "Posts of this page will be sent to other servers from now on. Continue?"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:138
+#, elixir-autogen, elixir-format
+msgid "Start federating"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:138
+#, elixir-autogen, elixir-format
+msgid "Stop federating"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:123
+#, elixir-autogen, elixir-format
+msgid "Switching this off stops new posts from leaving. Copies another server already holds can only be asked to delete them, never made to."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:86
+#, elixir-autogen, elixir-format
+msgid "This installation has federation switched off, so nothing here has any effect."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:146
+#, elixir-autogen, elixir-format
+msgid "This page federated before. Servers that still hold copies keep them until they act on a deletion request."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:111
+#, elixir-autogen, elixir-format
+msgid "This page is being federated. %{count} accounts on other networks follow it."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:115
+#, elixir-autogen, elixir-format
+msgid "This page is not being federated. Nothing of it is visible on other networks."
 msgstr ""

--- a/test/vutuv_web/organization_fediverse_switch_test.exs
+++ b/test/vutuv_web/organization_fediverse_switch_test.exs
@@ -1,0 +1,136 @@
+defmodule VutuvWeb.OrganizationFediverseSwitchTest do
+  @moduledoc """
+  The owner's federation switch (issue #1334) — the last piece, and the one that
+  makes the rest reachable at all. Until it exists the whole half is code nobody
+  can turn on.
+
+  Owner-only, unlike the feed and the follows list beside it: it decides how the
+  page appears on servers we do not run, and it cannot be fully taken back.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag and the DNS-resolver stub beside it.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Organizations
+  alias Vutuv.Repo
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp owned_page(conn, handle \\ "acme") do
+    {conn, owner} = create_and_login_user(conn)
+
+    page =
+      active_organization_for(owner)
+      |> Ecto.Changeset.change(%{username: handle})
+      |> Repo.update!()
+
+    {conn, page, owner}
+  end
+
+  test "the owner switches federating on, and the keypair is there at once", %{conn: conn} do
+    {conn, page, _owner} = owned_page(conn)
+
+    refute Fediverse.federated?(page)
+
+    {:ok, view, html} = live(conn, ~p"/organizations/#{page.slug}/fediverse")
+    assert html =~ "@acme@#{VutuvWeb.Endpoint.host()}"
+
+    render_click(view, "toggle", %{})
+
+    page = Organizations.get_organization!(page.id)
+    assert Fediverse.federated?(page)
+
+    # Minted on the way in, not lazily on the first request: a remote server
+    # resolving the handle a second later must find a complete actor.
+    assert Fediverse.get_organization_actor(page)
+  end
+
+  test "switching off stops federating but keeps the keypair", %{conn: conn} do
+    {conn, page, _owner} = owned_page(conn)
+
+    {:ok, view, _html} = live(conn, ~p"/organizations/#{page.slug}/fediverse")
+    render_click(view, "toggle", %{})
+    render_click(view, "toggle", %{})
+
+    page = Organizations.get_organization!(page.id)
+
+    # `ever_federated?` keys on the keypair, not the switch, because turning it
+    # off does not unsend what other servers already hold.
+    refute Fediverse.federated?(page)
+    assert Fediverse.ever_federated?(page)
+  end
+
+  test "a page without a handle is told to claim one first", %{conn: conn} do
+    {conn, owner} = create_and_login_user(conn)
+    page = active_organization_for(owner)
+
+    html = conn |> get(~p"/organizations/#{page.slug}/fediverse") |> html_response(200)
+
+    assert html =~ "needs-handle"
+    refute html =~ "toggle-fediverse"
+  end
+
+  test "a publisher who is not the owner cannot reach it", %{conn: conn} do
+    {conn, member} = create_and_login_user(conn)
+    owner = insert(:activated_user)
+    page = active_organization_for(owner)
+    {:ok, _} = Organizations.add_role(page, member, "publisher", owner)
+
+    # Publishers speak for the page; only an owner decides that it appears on
+    # servers we do not run.
+    assert conn |> get(~p"/organizations/#{page.slug}/fediverse") |> response(404)
+  end
+
+  test "the owner sees the Fediverse tab", %{conn: conn} do
+    {conn, page, _owner} = owned_page(conn)
+
+    html = conn |> get(~p"/organizations/#{page.slug}/activity") |> html_response(200)
+    assert html =~ "#{page.slug}/fediverse"
+  end
+
+  test "a publisher does not", %{conn: conn} do
+    # Logged in as the publisher, with the page owned by somebody else: they may
+    # read the activity list and speak for the page, but the decision to appear
+    # on servers we do not run is not theirs.
+    {conn, publisher} = create_and_login_user(conn)
+    owner = insert(:activated_user)
+    page = active_organization_for(owner)
+    {:ok, _} = Organizations.add_role(page, publisher, "publisher", owner)
+
+    html = conn |> get(~p"/organizations/#{page.slug}/activity") |> html_response(200)
+    refute html =~ "#{page.slug}/fediverse"
+  end
+
+  test "the switch page reads as German", %{conn: conn} do
+    {conn, page, _owner} = owned_page(conn)
+
+    html =
+      conn
+      |> Phoenix.ConnTest.recycle()
+      |> Plug.Conn.put_req_header("accept-language", "de-DE,de")
+      |> get(~p"/organizations/#{page.slug}/fediverse")
+      |> html_response(200)
+
+    assert html =~ "Föderieren starten"
+    assert html =~ "Diese Seite föderiert nicht."
+
+    # The merge filled this one from "Einstellungen durchsuchen" (search
+    # settings) and "Fediverse" without the page name; both are named here so
+    # they cannot come back.
+    refute html =~ "Einstellungen durchsuchen"
+  end
+end


### PR DESCRIPTION
F6 — und damit ist die Fediverse-Hälfte von #1334 fertig. Unter `/organizations/:slug/fediverse` legt der Eigentümer den Schalter um, und erst damit ist überhaupt etwas von dieser Arbeit erreichbar.

**Nur der Eigentümer**, anders als Feed und Folgt-Liste daneben, die die Redaktion lesen darf. Das Föderieren entscheidet, wie die Seite auf Servern erscheint, die wir nicht betreiben, und es lässt sich nicht vollständig zurücknehmen — einen Server, der schon eine Kopie hat, kann man nur *bitten*, sie zu löschen. Das ist eine Entscheidung derselben Klasse wie Domains und Rollen.

**Zwei Dinge sagt die Seite deutlich statt sie zu verstecken**, weil beide unangenehm sind, wenn man sie erst hinterher merkt: das Handle ist die Adresse (ohne eines gibt es nichts, dem jemand folgen könnte — die Seite sagt das und verlinkt dorthin), und Ausschalten ist kein Löschen.

Das Schlüsselpaar entsteht **beim Einschalten**, nicht beim ersten Abruf: ein fremder Server, der das Handle eine Sekunde später auflöst, muss einen vollständigen Actor finden, und einen Schlüssel mitten in dieser Anfrage zu erzeugen wäre der denkbar schlechteste Moment dafür.

Dokumentiert in `docs/architecture/fediverse.md` unter „A page federates too", mit einem Verweis aus `organizations.md`, damit niemand raten muss, welches Dokument er aufmachen soll. Der Abschnitt sagt auch, **was nicht gebaut ist**: eine Seite kann keinem entfernten Konto folgen (der letzte offene Punkt von #1336) und bekommt keine Reaktionen oder Antworten von drüben.

Beim Extrahieren wieder zwei Fuzzy-Füllungen — `Page settings` kam als „Einstellungen durchsuchen" zurück, `Fediverse – %{name}` ohne den Namen. Dreizehn deutsche Strings von Hand, und ein Test rendert die Seite mit `Accept-Language` und verneint die falsche Übersetzung namentlich.

---

**Damit steht die ganze Kette** (v7.254.1 → v7.258.0, sechs Stücke): eine Seite hält ein Schlüsselpaar, entscheidet selbst über das Föderieren, ist per WebFinger auffindbar, hat ein `Organization`-Actor-Dokument, nimmt Follows an und bestätigt sie, und liefert ihre Beiträge an ihre entfernten Follower aus.

Dass das in sechs Schritten ging statt in einem großen Branch, lag allein am Schalter aus dem ersten Stück: solange er aus ist, antwortet jeder dieser Endpunkte mit 404, also war zu keinem Zeitpunkt etwas Halbfertiges von außen sichtbar.

`mix precommit` grün (7322 Tests).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01MMwsQi49FP21xuSoPEkMnN
