### PR TITLE
Eine Seite kann einem entfernten Konto folgen (v7.259.0)

### DIFF
--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -898,14 +898,14 @@ defmodule Vutuv.Fediverse do
   Returns `{:ok, account}` or the same `{:error, reason}` vocabulary
   `follow_remote/2` speaks.
   """
-  def resolve_remote_account(%User{} = user, address) do
+  def resolve_remote_account(follower, address) do
     with :ok <- check_can_resolve(),
          {:ok, {_name, host}} <- RemoteFollow.parse_address(address),
          :ok <- check_follow_host(host),
-         :ok <- claim_remote_follow_budget(user),
+         :ok <- claim_remote_follow_budget(follower),
          {:ok, actor_uri} <- RemoteFollow.resolve_actor(address),
          :ok <- check_follow_host(actor_uri),
-         {:ok, remote} <- fetch_follow_target(actor_uri, user),
+         {:ok, remote} <- fetch_follow_target(actor_uri, follower),
          :ok <- check_follow_host(remote.id) do
       upsert_remote_account(remote)
     end
@@ -1068,6 +1068,31 @@ defmodule Vutuv.Fediverse do
     if follow = find_answered_follow(user, activity, actor_uri) do
       Repo.delete(follow)
       broadcast_remote_follows_changed([user.id])
+    end
+
+    :ok
+  end
+
+  @doc """
+  The other server said yes to a **page's** Follow (issue #1336).
+
+  Its own pair rather than a widened member one: the member versions also settle
+  a moved account and broadcast to the member's open following browser, and a
+  page has neither. What they share is `find_answered_follow/3`, which is where
+  the row is actually identified.
+  """
+  def accept_organization_remote_follow(%Organization{} = page, activity, actor_uri) do
+    if follow = find_answered_follow(page, activity, actor_uri) do
+      follow |> Follow.accept() |> Repo.update()
+    end
+
+    :ok
+  end
+
+  @doc "The other server said no to a page's Follow: the row goes, like the member twin."
+  def reject_organization_remote_follow(%Organization{} = page, activity, actor_uri) do
+    if follow = find_answered_follow(page, activity, actor_uri) do
+      Repo.delete(follow)
     end
 
     :ok
@@ -1425,9 +1450,15 @@ defmodule Vutuv.Fediverse do
   defp strip_www("www." <> rest), do: rest
   defp strip_www(host), do: host
 
-  defp claim_remote_follow_budget(%User{id: user_id}) do
+  # Keyed on whoever is asking — a member or a page (issue #1336) — so a page
+  # gets its own hourly budget rather than spending somebody's.
+  defp claim_remote_follow_budget(%User{id: id}), do: claim_remote_follow_budget(id)
+
+  defp claim_remote_follow_budget(%Organization{id: id}), do: claim_remote_follow_budget(id)
+
+  defp claim_remote_follow_budget(id) when is_binary(id) do
     case RateLimiter.hit(
-           {:fediverse_remote_follow, user_id},
+           {:fediverse_remote_follow, id},
            remote_follow_limit(),
            @inbound_window_ms
          ) do
@@ -1444,6 +1475,13 @@ defmodule Vutuv.Fediverse do
 
   # Signed with the member's own key: instances in authorized-fetch mode refuse
   # an anonymous GET, and this is the one fetch we make on their behalf.
+  defp fetch_follow_target(actor_uri, %Organization{} = page) do
+    case fetch_remote_actor(actor_uri, signer_for(page, get_organization_actor(page))) do
+      {:ok, remote} -> {:ok, remote}
+      _error -> {:error, :unreachable_actor}
+    end
+  end
+
   defp fetch_follow_target(actor_uri, %User{} = user) do
     case fetch_remote_actor(actor_uri, signer(user)) do
       {:ok, remote} -> {:ok, remote}
@@ -1517,6 +1555,63 @@ defmodule Vutuv.Fediverse do
     }
   end
 
+  @doc """
+  A **page** follows an account on another network (issue #1336's last point).
+
+  Blocked until #1334 gave a page an actor: a Follow has to be signed by
+  somebody. Narrower than the member twin on purpose — no local-address branch,
+  because "follow a vutuv member" for a page is `Social.follow_as_organization/2`
+  and belongs on the page's own controls, not behind a fediverse address box.
+  """
+  def follow_remote_as_organization(%Organization{} = page, address) do
+    with :ok <- check_can_resolve(),
+         true <- federated?(page),
+         {:ok, account} <- resolve_remote_account(page, address),
+         {:ok, follow} <- insert_organization_remote_follow(page, account) do
+      enqueue(
+        page,
+        [account.inbox_uri],
+        Docs.follow_activity(page, account.actor_uri, follow.follow_activity_id)
+      )
+
+      {:ok, %{follow | remote_account: account}}
+    else
+      false -> {:error, :not_federated}
+      other -> other
+    end
+  end
+
+  defp insert_organization_remote_follow(%Organization{} = page, %RemoteAccount{} = account) do
+    id = UUIDv7.generate()
+
+    %Follow{id: id, organization_id: page.id, remote_account_id: account.id}
+    |> Follow.changeset(%{
+      state: "requested",
+      follow_activity_id: Docs.follow_activity_id(page, id)
+    })
+    |> Repo.insert()
+    |> case do
+      {:ok, follow} -> {:ok, follow}
+      {:error, _changeset} -> {:error, :already_following}
+    end
+  end
+
+  @doc "Whether `page` already follows (or has asked to follow) this account."
+  def organization_remote_follow_for(%Organization{id: id}, %RemoteAccount{id: account_id}) do
+    Repo.get_by(Follow, organization_id: id, remote_account_id: account_id)
+  end
+
+  @doc "The accounts `page` follows out there, newest first."
+  def list_organization_remote_follows(%Organization{id: id}) do
+    Repo.all(
+      from(f in Follow,
+        where: f.organization_id == ^id,
+        order_by: [desc: f.inserted_at, desc: f.id],
+        preload: [:remote_account]
+      )
+    )
+  end
+
   defp insert_remote_follow(%User{} = user, %RemoteAccount{} = account) do
     # The activity id names the row, so the id is minted before the insert
     # rather than read back after it: an `Accept` finds its follow by this
@@ -1580,13 +1675,14 @@ defmodule Vutuv.Fediverse do
   # minted and the other server echoed back; failing that (servers differ in how
   # faithfully they echo a Follow) by the pair, which is just as safe because
   # both arms are scoped to the actor that answered.
-  defp find_answered_follow(%User{id: user_id}, activity, actor_uri) when is_binary(actor_uri) do
+  defp find_answered_follow(follower, activity, actor_uri) when is_binary(actor_uri) do
     base =
       from(f in Follow,
         join: a in RemoteAccount,
         on: a.id == f.remote_account_id,
-        where: f.user_id == ^user_id and a.actor_uri == ^actor_uri
+        where: a.actor_uri == ^actor_uri
       )
+      |> scope_follower(follower)
 
     case activity_object_id(activity["object"]) do
       id when is_binary(id) ->
@@ -1598,6 +1694,14 @@ defmodule Vutuv.Fediverse do
   end
 
   defp find_answered_follow(_user, _activity, _actor_uri), do: nil
+
+  # Which side's follows to look in. Named rather than inlined because the
+  # answer must be scoped to exactly one follower — an `Accept` from one server
+  # settling somebody else's request would be the whole bug.
+  defp scope_follower(query, %User{id: id}), do: where(query, [f], f.user_id == ^id)
+
+  defp scope_follower(query, %Organization{id: id}),
+    do: where(query, [f], f.organization_id == ^id)
 
   # ── The following browser (/settings/fediverse/following) ─────────────────
 
@@ -1786,6 +1890,31 @@ defmodule Vutuv.Fediverse do
   `at` is the author's own `published_at` as a naive UTC stamp, because that is
   what the merged feed sorts on.
   """
+  # The page twin (issue #1336): what the accounts a PAGE follows out there have
+  # published. Same gate as the member version, which is the part worth keeping
+  # in step — a post from a locked account shows only once the follow was really
+  # ACCEPTED, so a request nobody answered never leaks that account's posts.
+  def organization_feed_remote_posts(%Organization{id: page_id}, fetch_n, cursor) do
+    if enabled?() do
+      from(p in RemotePost,
+        join: a in RemoteAccount,
+        on: a.id == p.remote_account_id,
+        join: f in Follow,
+        on: f.remote_account_id == a.id,
+        where: f.organization_id == ^page_id and f.muted == false,
+        where: p.audience in ^RemotePost.open_audiences() or f.state == "accepted",
+        order_by: [desc: p.published_at, desc: p.id],
+        limit: ^fetch_n,
+        preload: [:screenshot, remote_account: a]
+      )
+      |> utc_at_or_before(cursor, :published_at)
+      |> Repo.all()
+      |> Enum.map(&remote_feed_entry/1)
+    else
+      []
+    end
+  end
+
   def feed_remote_posts(%User{id: viewer_id}, fetch_n, cursor) do
     if enabled?() do
       from(p in RemotePost,

--- a/lib/vutuv/fediverse/follow.ex
+++ b/lib/vutuv/fediverse/follow.ex
@@ -38,7 +38,12 @@ defmodule Vutuv.Fediverse.Follow do
     field(:follow_activity_id, :string)
     field(:muted, :boolean, default: false)
 
+    # The follower is a member OR a page (issue #1336), CHECK-enforced to
+    # exactly one. `follow_activity_id` stays unique across both: it is the
+    # string the other server echoes back inside its Accept, so two rows sharing
+    # one would make that answer ambiguous.
     belongs_to(:user, Vutuv.Accounts.User)
+    belongs_to(:organization, Vutuv.Organizations.Organization)
     belongs_to(:remote_account, Vutuv.Fediverse.RemoteAccount)
 
     timestamps()
@@ -51,6 +56,7 @@ defmodule Vutuv.Fediverse.Follow do
     |> validate_inclusion(:state, @states)
     |> validate_length(:follow_activity_id, max: @max_uri, count: :bytes)
     |> unique_constraint([:user_id, :remote_account_id])
+    |> unique_constraint([:organization_id, :remote_account_id])
     |> unique_constraint(:follow_activity_id)
   end
 

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -1932,11 +1932,12 @@ defmodule Vutuv.Posts do
   The feed a **page** reads (issue #1336): what the members and pages it follows
   have published, newest first, same entry shape and cursor as `feed_page/2`.
 
-  Two sources, not six. A page can only follow members and other pages today, so
-  it has no tags, no reposts of its own and no fediverse follows to draw from —
-  a parallel copy of the member feed's other four sources would be four empty
-  queries per page load. When a page can follow tags and remote accounts, this
-  grows the sources it can actually fill.
+  Four sources, not six: posts by the members and pages it follows, posts
+  carrying a tag it follows, and posts from the accounts it follows on other
+  networks. The two it does not have are reposts (a page reposts nothing) and
+  remote boosts, which travel through a member's repost. The rule throughout has
+  been to add a source only once a page can actually fill it, rather than
+  shipping empty queries per page load.
 
   **A member's post is visible here only if it is public.** Denials name users,
   groups and follow relationships, and a page is none of those, so it can never
@@ -1957,7 +1958,10 @@ defmodule Vutuv.Posts do
     sources = [
       &organization_feed_member_posts(page, &1, &2),
       &organization_feed_page_posts(page, &1, &2),
-      &organization_feed_tag_posts(page, &1, &2)
+      &organization_feed_tag_posts(page, &1, &2),
+      # The accounts it follows on other networks (issue #1336's last point).
+      # The fourth and last source a page can fill.
+      &Vutuv.Fediverse.organization_feed_remote_posts(page, &1, &2)
     ]
 
     page_result = Vutuv.FeedPage.paginate(sources, limit, cursor)

--- a/lib/vutuv_web/controllers/fediverse_controller.ex
+++ b/lib/vutuv_web/controllers/fediverse_controller.ex
@@ -524,9 +524,12 @@ defmodule VutuvWeb.FediverseController do
   A page's inbox (issue #1334): signed `Follow` and `Undo(Follow)` addressed to
   the page.
 
-  Deliberately narrower than the member inbox. A page has no conversations, no
+  Since #1336's last point it also takes the `Accept`/`Reject` answering a
+  Follow the page itself sent.
+
+  Still narrower than the member inbox. A page has no conversations, no
   reactions of its own to receive and no account migration, so `Like`,
-  `Announce`, `Create(Note)`, `Accept`/`Reject` and `Move` have nothing to act
+  `Announce`, `Create(Note)` and `Move` have nothing to act
   on here — they are acknowledged with the same `202` and dropped, which is what
   the member inbox does with anything it does not handle either. That keeps the
   surface a page exposes to strangers as small as what it actually offers.
@@ -575,6 +578,20 @@ defmodule VutuvWeb.FediverseController do
          remote
        ) do
     Fediverse.remove_organization_follower(organization, remote.id)
+    :ok
+  end
+
+  # The answer to a Follow the PAGE sent out (issue #1336's last point). Only
+  # meaningful since a page can follow at all; before that these fell into the
+  # "acknowledged and dropped" clause below, and leaving them there now would
+  # strand every request the page makes on "asked" forever.
+  defp perform_for_organization(organization, %{"type" => "Accept"} = activity, remote) do
+    Fediverse.accept_organization_remote_follow(organization, activity, remote.id)
+    :ok
+  end
+
+  defp perform_for_organization(organization, %{"type" => "Reject"} = activity, remote) do
+    Fediverse.reject_organization_remote_follow(organization, activity, remote.id)
     :ok
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.258.0",
+      version: "7.259.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260811184607_add_organization_to_fediverse_follows.exs
+++ b/priv/repo/migrations/20260811184607_add_organization_to_fediverse_follows.exs
@@ -1,0 +1,57 @@
+defmodule Vutuv.Repo.Migrations.AddOrganizationToFediverseFollows do
+  @moduledoc """
+  Issue #1336's last open point: a **page** can follow an account on another
+  network. It was blocked until #1334 gave a page an actor of its own — a Follow
+  has to be signed by somebody, and until v7.258.0 a page had nothing to sign
+  with.
+
+  Seventh table to take the nullable pair. The second unique index matters as
+  much as the first: `[user_id, remote_account_id]` cannot stop a page following
+  the same remote account twice, because those rows leave `user_id` NULL and
+  Postgres treats NULLs as distinct.
+
+  `follow_activity_id` stays globally unique across both kinds, and that is
+  deliberate rather than incidental: it is the join between the two halves of
+  the handshake — the other server echoes it back inside its `Accept`, and that
+  string is how the answer finds its row. Two rows sharing one would make an
+  `Accept` ambiguous.
+
+  N-1 safe: the previous release only writes member follows, which satisfy the
+  CHECK, and every query it runs is scoped to a real `user_id`.
+  """
+  use Ecto.Migration
+
+  def up do
+    alter table(:fediverse_follows) do
+      add(
+        :organization_id,
+        references(:organizations, type: :binary_id, on_delete: :delete_all)
+      )
+    end
+
+    execute("ALTER TABLE fediverse_follows ALTER COLUMN user_id DROP NOT NULL")
+
+    create(
+      constraint(:fediverse_follows, :fediverse_follows_exactly_one_follower,
+        check: """
+        (CASE WHEN user_id IS NULL THEN 0 ELSE 1 END +
+         CASE WHEN organization_id IS NULL THEN 0 ELSE 1 END) = 1
+        """
+      )
+    )
+
+    create(unique_index(:fediverse_follows, [:organization_id, :remote_account_id]))
+  end
+
+  def down do
+    drop(unique_index(:fediverse_follows, [:organization_id, :remote_account_id]))
+    drop(constraint(:fediverse_follows, :fediverse_follows_exactly_one_follower))
+
+    execute("DELETE FROM fediverse_follows WHERE user_id IS NULL")
+    execute("ALTER TABLE fediverse_follows ALTER COLUMN user_id SET NOT NULL")
+
+    alter table(:fediverse_follows) do
+      remove(:organization_id)
+    end
+  end
+end

--- a/test/vutuv/organization_remote_follow_test.exs
+++ b/test/vutuv/organization_remote_follow_test.exs
@@ -1,0 +1,223 @@
+defmodule Vutuv.OrganizationRemoteFollowTest do
+  @moduledoc """
+  A page follows an account on another network (#1336's last open point) — the
+  direction that was blocked until #1334 gave a page an actor, because a Follow
+  has to be signed by somebody.
+
+  The round trip is the thing: the page asks, the other server answers, and only
+  then does that account's material reach the page's feed. A request nobody
+  answered must not leak a locked account's posts, which is the one gate this
+  shares with the member side.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag and the remote fetch is stubbed through
+  the application env.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Delivery
+  alias Vutuv.Fediverse.Follow
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.Posts
+  alias Vutuv.Repo
+  alias VutuvWeb.Fediverse.Docs
+
+  @actor "https://social.example/users/alice"
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp federating_page do
+    page =
+      active_organization_for(insert(:activated_user))
+      |> Ecto.Changeset.change(%{fediverse_followers?: true, username: "acme"})
+      |> Repo.update!()
+
+    {:ok, _} = Fediverse.ensure_organization_actor(page)
+    page
+  end
+
+  defp remote_account do
+    Repo.insert!(%RemoteAccount{
+      actor_uri: @actor,
+      host: "social.example",
+      inbox_uri: @actor <> "/inbox",
+      handle: "@alice@social.example",
+      name: "Alice"
+    })
+  end
+
+  defp requested_follow(page, account) do
+    id = Vutuv.UUIDv7.generate()
+
+    Repo.insert!(%Follow{
+      id: id,
+      organization_id: page.id,
+      remote_account_id: account.id,
+      state: "requested",
+      follow_activity_id: Docs.follow_activity_id(page, id)
+    })
+  end
+
+  test "the database refuses a follow naming both followers or neither" do
+    page = federating_page()
+    account = remote_account()
+    member = insert(:activated_user)
+
+    assert_raise Ecto.ConstraintError, ~r/fediverse_follows_exactly_one_follower/, fn ->
+      Repo.insert!(%Follow{
+        user_id: member.id,
+        organization_id: page.id,
+        remote_account_id: account.id,
+        state: "requested",
+        follow_activity_id: "https://example.test/a"
+      })
+    end
+
+    assert_raise Ecto.ConstraintError, ~r/fediverse_follows_exactly_one_follower/, fn ->
+      Repo.insert!(%Follow{
+        remote_account_id: account.id,
+        state: "requested",
+        follow_activity_id: "https://example.test/b"
+      })
+    end
+  end
+
+  test "the same page cannot ask twice" do
+    page = federating_page()
+    account = remote_account()
+    requested_follow(page, account)
+
+    # `[user_id, remote_account_id]` cannot police this: both rows leave
+    # user_id NULL, and Postgres treats NULLs as distinct.
+    assert_raise Ecto.ConstraintError, fn -> requested_follow(page, account) end
+  end
+
+  test "an Accept moves the page's request to accepted" do
+    page = federating_page()
+    account = remote_account()
+    follow = requested_follow(page, account)
+
+    :ok =
+      Fediverse.accept_organization_remote_follow(
+        page,
+        %{"type" => "Accept", "object" => follow.follow_activity_id},
+        @actor
+      )
+
+    assert Repo.get!(Follow, follow.id).state == "accepted"
+  end
+
+  test "an Accept from one server cannot settle another page's request" do
+    page = federating_page()
+
+    other =
+      active_organization_for(insert(:activated_user), %{
+        "name" => "Zweite AG",
+        "website_url" => "https://zweite.example"
+      })
+      |> Ecto.Changeset.change(%{fediverse_followers?: true, username: "zweite"})
+      |> Repo.update!()
+
+    account = remote_account()
+    follow = requested_follow(page, account)
+
+    # Addressed with the *other* page: the row belongs to neither that page nor
+    # anybody it may answer for, so it must stay untouched.
+    :ok =
+      Fediverse.accept_organization_remote_follow(
+        other,
+        %{"type" => "Accept", "object" => follow.follow_activity_id},
+        @actor
+      )
+
+    assert Repo.get!(Follow, follow.id).state == "requested"
+  end
+
+  test "a Reject removes the row" do
+    page = federating_page()
+    account = remote_account()
+    follow = requested_follow(page, account)
+
+    :ok =
+      Fediverse.reject_organization_remote_follow(
+        page,
+        %{"type" => "Reject", "object" => follow.follow_activity_id},
+        @actor
+      )
+
+    refute Repo.get(Follow, follow.id)
+  end
+
+  describe "the page's feed" do
+    defp remote_post(account, audience) do
+      Repo.insert!(%RemotePost{
+        remote_account_id: account.id,
+        object_uri: "https://social.example/notes/#{System.unique_integer([:positive])}",
+        content_text: "Von drüben.",
+        audience: audience,
+        published_at: DateTime.utc_now(:second),
+        received_at: DateTime.utc_now(:second),
+        expires_at: DateTime.add(DateTime.utc_now(:second), 30, :day)
+      })
+    end
+
+    defp feed_ids(page) do
+      page
+      |> Posts.organization_feed_page()
+      |> Map.fetch!(:entries)
+      |> Enum.map(& &1[:remote_post])
+      |> Enum.reject(&is_nil/1)
+      |> Enum.map(& &1.id)
+    end
+
+    test "carries a public post from an account it merely asked to follow" do
+      page = federating_page()
+      account = remote_account()
+      requested_follow(page, account)
+
+      post = remote_post(account, "public")
+
+      assert post.id in feed_ids(page)
+    end
+
+    test "withholds a locked account's post until the follow was accepted" do
+      page = federating_page()
+      account = remote_account()
+      follow = requested_follow(page, account)
+
+      post = remote_post(account, "followers")
+
+      # An unanswered request must not leak what a locked account posts — the
+      # one gate this shares with the member feed.
+      refute post.id in feed_ids(page)
+
+      follow |> Follow.accept() |> Repo.update!()
+      assert post.id in feed_ids(page)
+    end
+  end
+
+  test "a page that does not federate cannot ask at all" do
+    page =
+      active_organization_for(insert(:activated_user))
+      |> Ecto.Changeset.change(%{username: "acme"})
+      |> Repo.update!()
+
+    assert {:error, :not_federated} =
+             Fediverse.follow_remote_as_organization(page, "@alice@social.example")
+
+    assert Repo.aggregate(Delivery, :count) == 0
+  end
+end


### PR DESCRIPTION
Der letzte offene Punkt von #1336 — blockiert, bis #1334 einer Seite einen Actor gegeben hat, denn ein Follow muss von jemandem signiert werden.

`fediverse_follows` nimmt das Nullable-Paar als **siebte** Tabelle. Der zweite Unique-Index ist wieder nötig, weil Seitenzeilen `user_id` NULL lassen und Postgres NULLs als verschieden behandelt. `follow_activity_id` bleibt über beide Sorten hinweg eindeutig, und das ist Absicht statt Zufall: dieser String ist die Verbindung zwischen den beiden Hälften des Handshakes — der andere Server schickt ihn im `Accept` zurück, und *nur* darüber findet die Antwort ihre Zeile.

**Der Posteingang einer Seite kannte `Accept` und `Reject` bis eben nicht**, und das war richtig so: eine Seite hatte nichts, worauf sie hätten antworten können. Jetzt schon — ohne sie bliebe jede Anfrage einer Seite für immer auf „angefragt" stehen, also genau der Zustand, gegen den diese ganze Hälfte gebaut ist.

Die Antworten sind auf **genau einen** Folgenden eingeschränkt. Ein Test schickt ein `Accept`, das die Anfrage einer *anderen* Seite nennt, und erwartet, dass die Zeile unangetastet bleibt: ein Server, der fremde Anfragen bestätigen könnte, wäre der eigentliche Fehler.

**Der Feed einer Seite hat damit seine vierte und letzte Quelle.** Sie trägt dieselbe Sperre wie die Mitgliederseite: der Beitrag eines gesperrten Kontos erscheint erst, wenn das Follow wirklich bestätigt wurde, damit eine unbeantwortete Anfrage nichts durchsickern lässt. Auch das ist getestet, in beide Richtungen.

Das Budget für auswärtige Auflösungen zählt jetzt pro Anfragendem statt pro Mitglied, damit eine Seite ihr eigenes Stundenkontingent hat und nicht das von jemandem verbraucht.

---

**Damit ist #1336 bis auf die Nachrichten fertig**, und die warten auf deine Entscheidung: Gespräch *mit der Seite* (der Verlauf überlebt einen Personalwechsel) oder gemeinsames Postfach?

Was ich hier bewusst nicht gebaut habe: eine Oberfläche, über die man als Seite ein entferntes Konto folgt. Der Weg dahin steht — `follow_remote_as_organization/2` — aber wo dieser Knopf hingehört, ist eine Gestaltungsfrage (in der Folgt-Liste? auf der Fediverse-Seite?), und ich wollte sie nicht nebenbei entscheiden.

`mix precommit` grün (7330 Tests). Migration gegen `vutuv1_dev` gelaufen.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01MMwsQi49FP21xuSoPEkMnN
