### PR TITLE
Als Seite ein entferntes Konto folgen, jetzt auch per Knopf (v7.260.0)

### DIFF
--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -1596,6 +1596,41 @@ defmodule Vutuv.Fediverse do
     end
   end
 
+  @doc """
+  Drops a page's follow of a remote account: withdraws it out there (`Undo`) and
+  removes the row. Scoped to the page, so an id belonging to somebody else's
+  follow removes nothing.
+  """
+  def unfollow_remote_as_organization(%Organization{id: page_id} = page, follow_id) do
+    case Repo.get_by(Follow, id: follow_id, organization_id: page_id) do
+      nil ->
+        {:error, :not_found}
+
+      follow ->
+        follow = Repo.preload(follow, :remote_account)
+
+        # Best effort, and gated on `ever_federated?/1` rather than
+        # `federated?/1`: switching federation off is exactly when a page's
+        # follows are withdrawn, and that is the moment `federated?/1` turns
+        # false — the same trap the member path documents.
+        if ever_federated?(page) and follow.remote_account do
+          enqueue(
+            page,
+            [follow.remote_account.inbox_uri],
+            Docs.undo_follow_activity(
+              page,
+              follow.remote_account.actor_uri,
+              follow.follow_activity_id
+            )
+          )
+        end
+
+        Repo.delete(follow)
+        purge_unfollowed_remote_posts([follow.remote_account_id])
+        :ok
+    end
+  end
+
   @doc "Whether `page` already follows (or has asked to follow) this account."
   def organization_remote_follow_for(%Organization{id: id}, %RemoteAccount{id: account_id}) do
     Repo.get_by(Follow, organization_id: id, remote_account_id: account_id)

--- a/lib/vutuv_web/live/organization_live/following.ex
+++ b/lib/vutuv_web/live/organization_live/following.ex
@@ -13,6 +13,14 @@ defmodule VutuvWeb.OrganizationLive.Following do
   and nothing in #1336 asks for it to be on show. Making it public later is an
   easy step; taking it back would not be.
 
+  **Accounts on other networks live here too**, not on the Fediverse page beside
+  it. A member's equivalent sits under their fediverse settings because their
+  own following list is public and about people here; this page is already
+  publishers-only and already mixes members, pages and topics, so one list of
+  "what this page reads" is the honest shape — and it is exactly what the page's
+  feed is built from. The section shows only while the page federates, because
+  asking to follow somebody out there is impossible otherwise.
+
   Embedded via `live_render` from `VutuvWeb.OrganizationController`, which gates
   it before this ever mounts.
   """
@@ -25,6 +33,7 @@ defmodule VutuvWeb.OrganizationLive.Following do
   import VutuvWeb.UserHelpers, only: [full_name: 1]
 
   alias Vutuv.Accounts.User
+  alias Vutuv.Fediverse
   alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
   alias Vutuv.Social
@@ -41,6 +50,8 @@ defmodule VutuvWeb.OrganizationLive.Following do
      |> assign(:organization, organization)
      |> assign(:owner?, Organizations.owner?(organization, socket.assigns.current_user))
      |> assign(:page_title, gettext("Follows – %{name}", name: organization.name))
+     |> assign(:address, "")
+     |> assign(:follow_error, nil)
      |> load_following()}
   end
 
@@ -50,6 +61,8 @@ defmodule VutuvWeb.OrganizationLive.Following do
     socket
     |> assign(:followees, Social.organization_followees(organization))
     |> assign(:tags, Tags.organization_followed_tags(organization))
+    |> assign(:federated?, Fediverse.federated?(organization))
+    |> assign(:remote_follows, Fediverse.list_organization_remote_follows(organization))
   end
 
   @impl true
@@ -69,6 +82,33 @@ defmodule VutuvWeb.OrganizationLive.Following do
     {:noreply, load_following(socket)}
   end
 
+  def handle_event("follow-remote", %{"address" => address}, socket) do
+    case Fediverse.follow_remote_as_organization(socket.assigns.organization, address) do
+      {:ok, _follow} ->
+        {:noreply,
+         socket
+         |> assign(:address, "")
+         |> assign(:follow_error, nil)
+         |> load_following()}
+
+      {:error, reason} ->
+        # The address stays in the box: a refusal usually means a typo, and
+        # emptying it would make the reader retype what they just wrote.
+        {:noreply, socket |> assign(:address, address) |> assign(:follow_error, reason)}
+    end
+  end
+
+  # Typing again clears the last refusal, so the box is not still shouting about
+  # an address that has since been corrected.
+  def handle_event("typing", %{"address" => address}, socket) do
+    {:noreply, socket |> assign(:address, address) |> assign(:follow_error, nil)}
+  end
+
+  def handle_event("unfollow-remote", %{"id" => id}, socket) do
+    Fediverse.unfollow_remote_as_organization(socket.assigns.organization, id)
+    {:noreply, load_following(socket)}
+  end
+
   @impl true
   def handle_info(_message, socket), do: {:noreply, socket}
 
@@ -79,6 +119,25 @@ defmodule VutuvWeb.OrganizationLive.Following do
     do: Organizations.canonical_path(organization)
 
   defp followee_path(%User{username: username}), do: "/#{username}"
+
+  # `follow_remote_as_organization/2` speaks the same refusal vocabulary as the
+  # member path, so each one gets a sentence rather than an atom on screen.
+  defp follow_error_message(:invalid_address),
+    do: gettext("That does not look like a Fediverse address.")
+
+  defp follow_error_message(:already_following),
+    do: gettext("This page already follows that account.")
+
+  defp follow_error_message(:unreachable_actor),
+    do: gettext("That server did not answer.")
+
+  defp follow_error_message(:follow_capped),
+    do: gettext("Too many attempts for now. Try again later.")
+
+  defp follow_error_message(:blocked_instance),
+    do: gettext("That server is blocked on this installation.")
+
+  defp follow_error_message(_other), do: gettext("That did not work.")
 
   @impl true
   def render(assigns) do
@@ -133,6 +192,65 @@ defmodule VutuvWeb.OrganizationLive.Following do
               variant="secondary"
               phx-click="unfollow"
               phx-value-id={follow_id}
+              class="shrink-0"
+            >
+              {gettext("Unfollow")}
+            </.button>
+          </li>
+        </ul>
+      </.card>
+
+      <%!-- Only while the page federates: without that there is no actor to sign
+      a Follow with, so the box could not do anything but refuse. --%>
+      <.card :if={@federated?} class="mt-4" id="organization-remote-follows">
+        <.section_title>{gettext("Accounts on other networks")}</.section_title>
+
+        <form phx-submit="follow-remote" phx-change="typing" class="mt-3 flex flex-wrap gap-2">
+          <input
+            type="text"
+            name="address"
+            value={@address}
+            placeholder="@name@server.example"
+            autocomplete="off"
+            class={[input_class(), "min-w-0 flex-1"]}
+            aria-label={gettext("Fediverse address")}
+          />
+          <.button type="submit">{gettext("Follow")}</.button>
+        </form>
+
+        <p :if={@follow_error} class="editform__error mt-2" role="alert">
+          {follow_error_message(@follow_error)}
+        </p>
+
+        <p :if={@remote_follows == []} class="mt-3 text-sm text-slate-600 dark:text-slate-400">
+          {gettext("This page does not follow anyone on another network yet.")}
+        </p>
+
+        <ul :if={@remote_follows != []} class="mt-2 divide-y divide-slate-100 dark:divide-slate-800">
+          <li :for={follow <- @remote_follows} class="flex items-center gap-4 py-3">
+            <div class="min-w-0 flex-1">
+              <p class="truncate text-sm font-semibold text-slate-900 dark:text-slate-100">
+                {follow.remote_account.name || follow.remote_account.handle}
+              </p>
+              <p class="truncate text-sm text-slate-600 dark:text-slate-400">
+                {follow.remote_account.handle}
+              </p>
+            </div>
+
+            <%!-- "Requested" is the truth until the other server answers, and
+            an account that approves by hand may never do so. Showing
+            "Following" for an unanswered request would be a lie. --%>
+            <span
+              :if={follow.state == "requested"}
+              class="shrink-0 rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-200"
+            >
+              {gettext("Requested")}
+            </span>
+
+            <.button
+              variant="secondary"
+              phx-click="unfollow-remote"
+              phx-value-id={follow.id}
               class="shrink-0"
             >
               {gettext("Unfollow")}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.259.0",
+      version: "7.260.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -1724,6 +1724,7 @@ msgstr "Empfehlen"
 #: lib/vutuv_web/live/fediverse_account_live.ex:375
 #: lib/vutuv_web/live/fediverse_following_live.ex:313
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:363
+#: lib/vutuv_web/live/organization_live/following.ex:218
 #: lib/vutuv_web/live/organization_live/show.ex:402
 #: lib/vutuv_web/templates/user/show.html.heex:1069
 #: lib/vutuv_web/templates/user/show.html.heex:1322
@@ -2507,7 +2508,8 @@ msgstr "Gefällt mir entfernen"
 #: lib/vutuv_web/components/ui.ex:1936
 #: lib/vutuv_web/components/ui.ex:1936
 #: lib/vutuv_web/components/ui.ex:2073
-#: lib/vutuv_web/live/organization_live/following.ex:138
+#: lib/vutuv_web/live/organization_live/following.ex:197
+#: lib/vutuv_web/live/organization_live/following.ex:256
 #: lib/vutuv_web/live/organization_live/show.ex:407
 #: lib/vutuv_web/live/post_live/feed.ex:1187
 #: lib/vutuv_web/templates/followee/index.html.heex:44
@@ -4718,7 +4720,7 @@ msgid "Find members"
 msgstr "Mitglieder finden"
 
 #: lib/vutuv_web/components/organization_components.ex:233
-#: lib/vutuv_web/live/organization_live/following.ex:95
+#: lib/vutuv_web/live/organization_live/following.ex:154
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:53
 #: lib/vutuv_web/templates/user/show.html.heex:955
@@ -13783,9 +13785,10 @@ msgstr ""
 #: lib/vutuv_web/controllers/settings_controller.ex:651
 #: lib/vutuv_web/controllers/settings_controller.ex:669
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:387
+#: lib/vutuv_web/live/organization_live/following.ex:140
 #, elixir-autogen, elixir-format
 msgid "That did not work."
-msgstr "Das hat nicht funktioniert."
+msgstr "Das hat nicht geklappt."
 
 #: lib/vutuv_web/templates/saved_search_alert/show.html.heex:13
 #, elixir-autogen, elixir-format
@@ -17493,6 +17496,7 @@ msgid "Mastodon and the other networks work like email: an address is enough. Pa
 msgstr "Mastodon und die anderen Netzwerke funktionieren wie E-Mail: Eine Adresse genügt. Fügen Sie hier eine ein, und vutuv fragt den betreffenden Server, ob Sie dem Konto folgen dürfen."
 
 #: lib/vutuv_web/components/fediverse_components.ex:224
+#: lib/vutuv_web/live/organization_live/following.ex:247
 #, elixir-autogen, elixir-format
 msgid "Requested"
 msgstr "Angefragt"
@@ -20987,7 +20991,7 @@ msgstr "Feed – %{name}"
 msgid "Follow as %{name}"
 msgstr "Als %{name} folgen"
 
-#: lib/vutuv_web/live/organization_live/following.ex:101
+#: lib/vutuv_web/live/organization_live/following.ex:160
 #, elixir-autogen, elixir-format
 msgid "Members and organizations"
 msgstr "Mitglieder und Organisationen"
@@ -20997,28 +21001,28 @@ msgstr "Mitglieder und Organisationen"
 msgid "Nothing here yet. This page does not follow anyone, or nobody it follows has published."
 msgstr "Noch nichts da. Diese Seite folgt niemandem, oder niemand, dem sie folgt, hat etwas veröffentlicht."
 
-#: lib/vutuv_web/live/organization_live/following.ex:97
+#: lib/vutuv_web/live/organization_live/following.ex:156
 #, elixir-autogen, elixir-format
 msgid "The members, organizations and topics this page follows. Everything here shapes its feed, and only the team can see this list."
 msgstr "Die Mitglieder, Organisationen und Themen, denen diese Seite folgt. Alles hier prägt ihren Feed, und nur das Team sieht diese Liste."
 
-#: lib/vutuv_web/live/organization_live/following.ex:148
+#: lib/vutuv_web/live/organization_live/following.ex:266
 #, elixir-autogen, elixir-format
 msgid "This page does not follow any topics yet."
 msgstr "Diese Seite folgt noch keinem Thema."
 
-#: lib/vutuv_web/live/organization_live/following.ex:104
+#: lib/vutuv_web/live/organization_live/following.ex:163
 #, elixir-autogen, elixir-format
 msgid "This page does not follow anyone yet."
 msgstr "Diese Seite folgt noch niemandem."
 
-#: lib/vutuv_web/live/organization_live/following.ex:145
+#: lib/vutuv_web/live/organization_live/following.ex:263
 #, elixir-autogen, elixir-format
 msgid "Topics"
 msgstr "Themen"
 
-#: lib/vutuv_web/live/organization_live/following.ex:158
-#: lib/vutuv_web/live/organization_live/following.ex:159
+#: lib/vutuv_web/live/organization_live/following.ex:276
+#: lib/vutuv_web/live/organization_live/following.ex:277
 #, elixir-autogen, elixir-format
 msgid "Unfollow %{tag}"
 msgstr "%{tag} entfolgen"
@@ -21028,7 +21032,7 @@ msgstr "%{tag} entfolgen"
 msgid "What the members and organizations this page follows have published. Liking or saving something here is done from your own account, not the page's."
 msgstr "Was die Mitglieder und Organisationen veröffentlicht haben, denen diese Seite folgt. Wer hier etwas mag oder speichert, tut das aus dem eigenen Konto, nicht aus dem der Seite."
 
-#: lib/vutuv_web/live/organization_live/following.ex:43
+#: lib/vutuv_web/live/organization_live/following.ex:52
 #, elixir-autogen, elixir-format
 msgid "Follows – %{name}"
 msgstr "Folgt – %{name}"
@@ -21097,3 +21101,43 @@ msgstr "Diese Seite föderiert. %{count} Konten auf anderen Netzwerken folgen ih
 #, elixir-autogen, elixir-format
 msgid "This page is not being federated. Nothing of it is visible on other networks."
 msgstr "Diese Seite föderiert nicht. Nichts von ihr ist auf anderen Netzwerken sichtbar."
+
+#: lib/vutuv_web/live/organization_live/following.ex:206
+#, elixir-autogen, elixir-format
+msgid "Accounts on other networks"
+msgstr "Konten auf anderen Netzwerken"
+
+#: lib/vutuv_web/live/organization_live/following.ex:216
+#, elixir-autogen, elixir-format
+msgid "Fediverse address"
+msgstr "Fediverse-Adresse"
+
+#: lib/vutuv_web/live/organization_live/following.ex:126
+#, elixir-autogen, elixir-format
+msgid "That does not look like a Fediverse address."
+msgstr "Das sieht nicht nach einer Fediverse-Adresse aus."
+
+#: lib/vutuv_web/live/organization_live/following.ex:132
+#, elixir-autogen, elixir-format
+msgid "That server did not answer."
+msgstr "Dieser Server hat nicht geantwortet."
+
+#: lib/vutuv_web/live/organization_live/following.ex:138
+#, elixir-autogen, elixir-format
+msgid "That server is blocked on this installation."
+msgstr "Dieser Server ist auf dieser Installation gesperrt."
+
+#: lib/vutuv_web/live/organization_live/following.ex:129
+#, elixir-autogen, elixir-format
+msgid "This page already follows that account."
+msgstr "Diese Seite folgt diesem Konto bereits."
+
+#: lib/vutuv_web/live/organization_live/following.ex:226
+#, elixir-autogen, elixir-format
+msgid "This page does not follow anyone on another network yet."
+msgstr "Diese Seite folgt noch niemandem auf einem anderen Netzwerk."
+
+#: lib/vutuv_web/live/organization_live/following.ex:135
+#, elixir-autogen, elixir-format
+msgid "Too many attempts for now. Try again later."
+msgstr "Zu viele Versuche. Bitte versuchen Sie es später erneut."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1692,6 +1692,7 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_account_live.ex:375
 #: lib/vutuv_web/live/fediverse_following_live.ex:313
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:363
+#: lib/vutuv_web/live/organization_live/following.ex:218
 #: lib/vutuv_web/live/organization_live/show.ex:402
 #: lib/vutuv_web/templates/user/show.html.heex:1069
 #: lib/vutuv_web/templates/user/show.html.heex:1322
@@ -2460,7 +2461,8 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1936
 #: lib/vutuv_web/components/ui.ex:1936
 #: lib/vutuv_web/components/ui.ex:2073
-#: lib/vutuv_web/live/organization_live/following.ex:138
+#: lib/vutuv_web/live/organization_live/following.ex:197
+#: lib/vutuv_web/live/organization_live/following.ex:256
 #: lib/vutuv_web/live/organization_live/show.ex:407
 #: lib/vutuv_web/live/post_live/feed.ex:1187
 #: lib/vutuv_web/templates/followee/index.html.heex:44
@@ -4547,7 +4549,7 @@ msgid "Find members"
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:233
-#: lib/vutuv_web/live/organization_live/following.ex:95
+#: lib/vutuv_web/live/organization_live/following.ex:154
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:53
 #: lib/vutuv_web/templates/user/show.html.heex:955
@@ -13111,6 +13113,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/settings_controller.ex:651
 #: lib/vutuv_web/controllers/settings_controller.ex:669
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:387
+#: lib/vutuv_web/live/organization_live/following.ex:140
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr ""
@@ -16749,6 +16752,7 @@ msgid "Mastodon and the other networks work like email: an address is enough. Pa
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:224
+#: lib/vutuv_web/live/organization_live/following.ex:247
 #, elixir-autogen, elixir-format
 msgid "Requested"
 msgstr ""
@@ -20203,7 +20207,7 @@ msgstr ""
 msgid "Follow as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:101
+#: lib/vutuv_web/live/organization_live/following.ex:160
 #, elixir-autogen, elixir-format
 msgid "Members and organizations"
 msgstr ""
@@ -20213,28 +20217,28 @@ msgstr ""
 msgid "Nothing here yet. This page does not follow anyone, or nobody it follows has published."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:97
+#: lib/vutuv_web/live/organization_live/following.ex:156
 #, elixir-autogen, elixir-format
 msgid "The members, organizations and topics this page follows. Everything here shapes its feed, and only the team can see this list."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:148
+#: lib/vutuv_web/live/organization_live/following.ex:266
 #, elixir-autogen, elixir-format
 msgid "This page does not follow any topics yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:104
+#: lib/vutuv_web/live/organization_live/following.ex:163
 #, elixir-autogen, elixir-format
 msgid "This page does not follow anyone yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:145
+#: lib/vutuv_web/live/organization_live/following.ex:263
 #, elixir-autogen, elixir-format
 msgid "Topics"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:158
-#: lib/vutuv_web/live/organization_live/following.ex:159
+#: lib/vutuv_web/live/organization_live/following.ex:276
+#: lib/vutuv_web/live/organization_live/following.ex:277
 #, elixir-autogen, elixir-format
 msgid "Unfollow %{tag}"
 msgstr ""
@@ -20244,7 +20248,7 @@ msgstr ""
 msgid "What the members and organizations this page follows have published. Liking or saving something here is done from your own account, not the page's."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:43
+#: lib/vutuv_web/live/organization_live/following.ex:52
 #, elixir-autogen, elixir-format
 msgid "Follows – %{name}"
 msgstr ""
@@ -20312,4 +20316,44 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/fediverse.ex:115
 #, elixir-autogen, elixir-format
 msgid "This page is not being federated. Nothing of it is visible on other networks."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/following.ex:206
+#, elixir-autogen, elixir-format
+msgid "Accounts on other networks"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/following.ex:216
+#, elixir-autogen, elixir-format
+msgid "Fediverse address"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/following.ex:126
+#, elixir-autogen, elixir-format
+msgid "That does not look like a Fediverse address."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/following.ex:132
+#, elixir-autogen, elixir-format
+msgid "That server did not answer."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/following.ex:138
+#, elixir-autogen, elixir-format
+msgid "That server is blocked on this installation."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/following.ex:129
+#, elixir-autogen, elixir-format
+msgid "This page already follows that account."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/following.ex:226
+#, elixir-autogen, elixir-format
+msgid "This page does not follow anyone on another network yet."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/following.ex:135
+#, elixir-autogen, elixir-format
+msgid "Too many attempts for now. Try again later."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1690,6 +1690,7 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_account_live.ex:375
 #: lib/vutuv_web/live/fediverse_following_live.ex:313
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:363
+#: lib/vutuv_web/live/organization_live/following.ex:218
 #: lib/vutuv_web/live/organization_live/show.ex:402
 #: lib/vutuv_web/templates/user/show.html.heex:1069
 #: lib/vutuv_web/templates/user/show.html.heex:1322
@@ -2458,7 +2459,8 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1936
 #: lib/vutuv_web/components/ui.ex:1936
 #: lib/vutuv_web/components/ui.ex:2073
-#: lib/vutuv_web/live/organization_live/following.ex:138
+#: lib/vutuv_web/live/organization_live/following.ex:197
+#: lib/vutuv_web/live/organization_live/following.ex:256
 #: lib/vutuv_web/live/organization_live/show.ex:407
 #: lib/vutuv_web/live/post_live/feed.ex:1187
 #: lib/vutuv_web/templates/followee/index.html.heex:44
@@ -4545,7 +4547,7 @@ msgid "Find members"
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:233
-#: lib/vutuv_web/live/organization_live/following.ex:95
+#: lib/vutuv_web/live/organization_live/following.ex:154
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:53
 #: lib/vutuv_web/templates/user/show.html.heex:955
@@ -13109,6 +13111,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/settings_controller.ex:651
 #: lib/vutuv_web/controllers/settings_controller.ex:669
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:387
+#: lib/vutuv_web/live/organization_live/following.ex:140
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr ""
@@ -16747,6 +16750,7 @@ msgid "Mastodon and the other networks work like email: an address is enough. Pa
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:224
+#: lib/vutuv_web/live/organization_live/following.ex:247
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Requested"
 msgstr ""
@@ -20201,7 +20205,7 @@ msgstr ""
 msgid "Follow as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:101
+#: lib/vutuv_web/live/organization_live/following.ex:160
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Members and organizations"
 msgstr ""
@@ -20211,28 +20215,28 @@ msgstr ""
 msgid "Nothing here yet. This page does not follow anyone, or nobody it follows has published."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:97
+#: lib/vutuv_web/live/organization_live/following.ex:156
 #, elixir-autogen, elixir-format
 msgid "The members, organizations and topics this page follows. Everything here shapes its feed, and only the team can see this list."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:148
+#: lib/vutuv_web/live/organization_live/following.ex:266
 #, elixir-autogen, elixir-format, fuzzy
 msgid "This page does not follow any topics yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:104
+#: lib/vutuv_web/live/organization_live/following.ex:163
 #, elixir-autogen, elixir-format, fuzzy
 msgid "This page does not follow anyone yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:145
+#: lib/vutuv_web/live/organization_live/following.ex:263
 #, elixir-autogen, elixir-format
 msgid "Topics"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:158
-#: lib/vutuv_web/live/organization_live/following.ex:159
+#: lib/vutuv_web/live/organization_live/following.ex:276
+#: lib/vutuv_web/live/organization_live/following.ex:277
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Unfollow %{tag}"
 msgstr ""
@@ -20242,7 +20246,7 @@ msgstr ""
 msgid "What the members and organizations this page follows have published. Liking or saving something here is done from your own account, not the page's."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:43
+#: lib/vutuv_web/live/organization_live/following.ex:52
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follows – %{name}"
 msgstr ""
@@ -20310,4 +20314,44 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/fediverse.ex:115
 #, elixir-autogen, elixir-format
 msgid "This page is not being federated. Nothing of it is visible on other networks."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/following.ex:206
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Accounts on other networks"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/following.ex:216
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Fediverse address"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/following.ex:126
+#, elixir-autogen, elixir-format
+msgid "That does not look like a Fediverse address."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/following.ex:132
+#, elixir-autogen, elixir-format
+msgid "That server did not answer."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/following.ex:138
+#, elixir-autogen, elixir-format, fuzzy
+msgid "That server is blocked on this installation."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/following.ex:129
+#, elixir-autogen, elixir-format
+msgid "This page already follows that account."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/following.ex:226
+#, elixir-autogen, elixir-format, fuzzy
+msgid "This page does not follow anyone on another network yet."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/following.ex:135
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Too many attempts for now. Try again later."
 msgstr ""

--- a/test/vutuv_web/organization_remote_follow_web_test.exs
+++ b/test/vutuv_web/organization_remote_follow_web_test.exs
@@ -1,0 +1,160 @@
+defmodule VutuvWeb.OrganizationRemoteFollowWebTest do
+  @moduledoc """
+  Following an account on another network **as a page** (issue #1336), from the
+  page's Follows list.
+
+  It lives there rather than on the Fediverse page beside it: a member's
+  equivalent sits under their fediverse settings because their own following
+  list is public and about people here, while this page is already
+  publishers-only and already mixes members, pages and topics. One list of what
+  the page reads is the honest shape, and it is exactly what its feed is built
+  from.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag and the remote fetch is stubbed through
+  the application env.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Follow
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Organizations
+  alias Vutuv.Repo
+  alias VutuvWeb.Fediverse.Docs
+
+  @actor "https://social.example/users/alice"
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp publishing_page(conn, opts \\ []) do
+    {conn, owner} = create_and_login_user(conn)
+    page = active_organization_for(owner)
+    {:ok, _} = Organizations.add_role(page, owner, "publisher", owner)
+
+    page =
+      page
+      |> Ecto.Changeset.change(Enum.into(opts, %{fediverse_followers?: true, username: "acme"}))
+      |> Repo.update!()
+
+    if page.fediverse_followers?, do: {:ok, _} = Fediverse.ensure_organization_actor(page)
+    {conn, page}
+  end
+
+  defp existing_follow(page) do
+    account =
+      Repo.insert!(%RemoteAccount{
+        actor_uri: @actor,
+        host: "social.example",
+        inbox_uri: @actor <> "/inbox",
+        handle: "@alice@social.example",
+        name: "Alice"
+      })
+
+    id = Vutuv.UUIDv7.generate()
+
+    Repo.insert!(%Follow{
+      id: id,
+      organization_id: page.id,
+      remote_account_id: account.id,
+      state: "requested",
+      follow_activity_id: Docs.follow_activity_id(page, id)
+    })
+  end
+
+  test "the section lists what the page follows out there, and says Requested", %{conn: conn} do
+    {conn, page} = publishing_page(conn)
+    existing_follow(page)
+
+    html = conn |> get(~p"/organizations/#{page.slug}/following") |> html_response(200)
+
+    assert html =~ "organization-remote-follows"
+    assert html =~ "@alice@social.example"
+
+    # "Requested" is the truth until the other server answers, and an account
+    # that approves by hand may never do so.
+    assert html =~ "Requested"
+  end
+
+  test "a publisher can withdraw one", %{conn: conn} do
+    {conn, page} = publishing_page(conn)
+    follow = existing_follow(page)
+
+    {:ok, view, _html} = live(conn, ~p"/organizations/#{page.slug}/following")
+    render_click(view, "unfollow-remote", %{"id" => follow.id})
+
+    refute Repo.get(Follow, follow.id)
+  end
+
+  test "one page cannot withdraw another page's follow", %{conn: conn} do
+    {conn, page} = publishing_page(conn)
+
+    other =
+      active_organization_for(insert(:activated_user), %{
+        "name" => "Zweite AG",
+        "website_url" => "https://zweite.example"
+      })
+      |> Ecto.Changeset.change(%{fediverse_followers?: true, username: "zweite"})
+      |> Repo.update!()
+
+    foreign = existing_follow(other)
+
+    {:ok, view, _html} = live(conn, ~p"/organizations/#{page.slug}/following")
+    render_click(view, "unfollow-remote", %{"id" => foreign.id})
+
+    assert Repo.get(Follow, foreign.id)
+  end
+
+  test "a refused address keeps what was typed and says why", %{conn: conn} do
+    {conn, page} = publishing_page(conn)
+
+    {:ok, view, _html} = live(conn, ~p"/organizations/#{page.slug}/following")
+    html = render_submit(view, "follow-remote", %{"address" => "not-an-address"})
+
+    # The box keeps the text: a refusal is usually a typo, and emptying it would
+    # make the reader retype what they just wrote.
+    assert html =~ "not-an-address"
+    refute html =~ "invalid_address"
+  end
+
+  test "a page that does not federate is offered no box at all", %{conn: conn} do
+    {conn, page} = publishing_page(conn, fediverse_followers?: false)
+
+    html = conn |> get(~p"/organizations/#{page.slug}/following") |> html_response(200)
+
+    # Without an actor there is nothing to sign a Follow with, so the control
+    # could only ever refuse.
+    refute html =~ "organization-remote-follows"
+  end
+
+  test "the section reads as German", %{conn: conn} do
+    {conn, page} = publishing_page(conn)
+    existing_follow(page)
+
+    html =
+      conn
+      |> Phoenix.ConnTest.recycle()
+      |> Plug.Conn.put_req_header("accept-language", "de-DE,de")
+      |> get(~p"/organizations/#{page.slug}/following")
+      |> html_response(200)
+
+    assert html =~ "Konten auf anderen Netzwerken"
+    assert html =~ "Angefragt"
+
+    # The merge filled the address label from "Fediverse-Aliase" (aliases) and
+    # the empty line from the members one; both are named so they cannot return.
+    refute html =~ "Fediverse-Aliase"
+  end
+end


### PR DESCRIPTION
`follow_remote_as_organization/2` gab es seit #1398, aber nichts hat es aufgerufen. Ich hatte im letzten PR geschrieben, wo der Knopf hingehört sei eine Gestaltungsfrage, die ich nicht nebenbei entscheiden wollte — hier ist die Entscheidung samt Begründung.

**Er sitzt auf der Folgt-Seite der Organisation**, nicht auf der Fediverse-Seite daneben. Beim Mitglied liegt das Gegenstück unter den Fediverse-Einstellungen, weil dessen *eigene* Folgt-Liste öffentlich ist und von Menschen hier handelt. Die Folgt-Seite einer Organisation ist ohnehin nur für die Redaktion und mischt ohnehin schon Mitglieder, Seiten und Themen. Eine Liste dessen, was diese Seite liest, ist die ehrliche Form — und genau daraus wird ihr Feed gebaut. Sag Bescheid, wenn du es lieber bei den Fediverse-Einstellungen hättest; das ist ein kleiner Umzug.

Der Abschnitt erscheint **nur, solange die Seite föderiert**: ohne Actor gibt es nichts, womit ein Follow signiert werden könnte, der Knopf könnte also nur ablehnen.

Drei Kleinigkeiten, die ich bewusst so gebaut habe:

- Eine Zeile sagt **„Angefragt"**, solange die Gegenseite nicht geantwortet hat. Ein Konto, das seine Follower von Hand freigibt, antwortet vielleicht nie, und „Folgt" für eine unbeantwortete Anfrage wäre gelogen.
- Eine **abgelehnte Adresse bleibt im Feld** stehen. Eine Ablehnung ist meist ein Tippfehler, und das Feld zu leeren hieße, den Leser das gerade Getippte noch einmal schreiben zu lassen. Jede Ablehnung bekommt einen Satz statt eines Atoms auf dem Bildschirm.
- Das **Entfolgen zieht das Follow auch drüben zurück** (`Undo`) und ist auf die eigene Seite eingeschränkt; ein Test schickt die Kante einer fremden Seite und erwartet, dass nichts passiert.

Beim Extrahieren wieder vier Fuzzy-Füllungen, darunter `Fediverse address` als „Fediverse-**Aliase**". Zehn deutsche Strings von Hand, und ein Test rendert den Abschnitt auf Deutsch und verneint die falsche Übersetzung namentlich.

---

**Damit ist #1336 fertig bis auf die Nachrichten**, und die warten auf deine Entscheidung: Gespräch *mit der Seite* (der Verlauf überlebt einen Personalwechsel) oder gemeinsames Postfach, das mehrere bedienen? Das ist keine Spalte mehr, sondern eine andere Invariante — `conversations` speichert das Paar sortiert mit CHECK und Unique-Index.

`mix precommit` grün (7336 Tests).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01MMwsQi49FP21xuSoPEkMnN
