### PR TITLE
Eine Seite erfährt, wenn ihr Beitrag drüben gefällt (v7.261.0)

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -883,9 +883,16 @@ answering `Accept`/`Reject` and tracking a pending request
 (`fediverse_remote_follows`) is still member-shaped. It is the last open point
 of #1336 and the natural next step.
 
-A page also receives no reactions or replies from other networks: those land
-against a member's post today, and giving a page the same would mean widening
-the reaction and remote-reply tables plus the surfaces that render them.
+A page **does** receive favourites and re-shares from other networks now: its
+inbox takes `Like` and `Announce` (and their `Undo`), and the counts need no
+special handling because `fediverse_reactions` hangs off the post rather than
+off a member, so `Posts.shown_counts/1` folds them in by itself.
+
+What a page still does not receive is **replies** from other networks. Those are
+stored text from a stranger under a retention model with a takedown ledger and a
+six-month expiry (issues #1069/#1071), and the surfaces that render them —
+the permalink's conversation, the notification quote — are member-shaped
+throughout. That is its own feature, not a widened column.
 
 ## Deliberate v1 limits
 

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -3452,6 +3452,74 @@ defmodule Vutuv.Fediverse do
     end
   end
 
+  @doc """
+  A favourite or re-share of a **page's** post, from another network (issue
+  #1334 completing #1068 for pages).
+
+  Without this a page publishes outward and learns nothing back: its post can
+  travel and be re-shared and the team would see a flat zero. The counts need no
+  work — `fediverse_reactions` hangs off the post, not off a member, so
+  `Posts.shown_counts/1` folds a stored row in by itself. What was missing was
+  only the way in.
+
+  There is no per-page reactions switch to check. `users.fediverse_reactions?`
+  lets a member federate without collecting strangers' reactions; a page that
+  deliberately publishes outward has no comparable reason to want the traffic
+  and not the tally, so it is not asked twice.
+  """
+  def record_organization_reaction(%Organization{} = page, object, kind, actor)
+      when kind in ~w(like announce) do
+    %{uri: actor_uri} = actor = actor_attrs(actor)
+
+    with true <- enabled?(),
+         true <- federated?(page),
+         %Post{} = post <- resolve_own_organization_note(page, object),
+         :ok <- check_inbound_cap(actor_uri),
+         {:ok, _reaction} <- insert_reaction(post, actor, kind) do
+      Posts.broadcast_post_counters(post.id)
+      :ok
+    else
+      _ -> :skip
+    end
+  end
+
+  @doc """
+  The page twin of `remove_reaction/4`. Unconditional like its sibling: an
+  upstream withdrawal is the deletion path that makes storing the row
+  defensible, so it must not depend on any switch still being on.
+  """
+  def remove_organization_reaction(%Organization{} = page, object, kind, actor_uri)
+      when kind in ~w(like announce) do
+    with %Post{} = post <- resolve_own_organization_note(page, object) do
+      {count, _} =
+        Repo.delete_all(
+          from(r in Reaction,
+            where: r.post_id == ^post.id and r.actor_uri == ^actor_uri and r.kind == ^kind
+          )
+        )
+
+      if count > 0, do: Posts.broadcast_post_counters(post.id)
+    end
+
+    :ok
+  end
+
+  # The page's own note, by the permalink shape `Docs.note_url/2` mints for it.
+  # A member's note lives at `/:handle/posts/:id`, a page's under
+  # `/organizations/:slug/posts/:id`, so this cannot share `resolve_own_note/2`
+  # — and the ownership check is the point: a Like naming somebody else's post
+  # must not be recorded against this page.
+  defp resolve_own_organization_note(%Organization{id: page_id, slug: slug}, object) do
+    with uri when is_binary(uri) <- activity_object_id(object),
+         ["organizations", ^slug, "posts", post_id] <- local_path(uri),
+         %Post{organization_id: ^page_id} = post <-
+           UUIDv7.with_cast(post_id, &Repo.get(Post, &1)) do
+      post
+    else
+      _ -> nil
+    end
+  end
+
   # Both call shapes as one map. A bare URI is what an `Undo` and the tests
   # carry; the inbox passes the actor document's `preferredUsername` along.
   defp actor_attrs(uri) when is_binary(uri), do: %{uri: uri, handle: nil}

--- a/lib/vutuv_web/controllers/fediverse_controller.ex
+++ b/lib/vutuv_web/controllers/fediverse_controller.ex
@@ -595,6 +595,38 @@ defmodule VutuvWeb.FediverseController do
     :ok
   end
 
+  # Somebody on another network favourited or re-shared one of the page's posts
+  # (issue #1334, completing #1068 for pages). Without this a page publishes
+  # outward and learns nothing back: its post could travel and the team would
+  # see a flat zero.
+  defp perform_for_organization(organization, %{"type" => kind} = activity, remote)
+       when kind in ["Like", "Announce"] do
+    Fediverse.record_organization_reaction(
+      organization,
+      activity["object"],
+      String.downcase(kind),
+      %{uri: remote.id, handle: remote.preferred_username}
+    )
+
+    :ok
+  end
+
+  defp perform_for_organization(
+         organization,
+         %{"type" => "Undo", "object" => %{"type" => kind} = object},
+         remote
+       )
+       when kind in ["Like", "Announce"] do
+    Fediverse.remove_organization_reaction(
+      organization,
+      object["object"],
+      String.downcase(kind),
+      remote.id
+    )
+
+    :ok
+  end
+
   # Everything else: acknowledged and dropped, like the member inbox.
   defp perform_for_organization(_organization, _activity, _remote), do: :ok
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.260.0",
+      version: "7.261.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/organization_fediverse_reactions_test.exs
+++ b/test/vutuv/organization_fediverse_reactions_test.exs
@@ -1,0 +1,137 @@
+defmodule Vutuv.OrganizationFediverseReactionsTest do
+  @moduledoc """
+  A page's post can be favourited or re-shared on another network, and the team
+  sees it (issue #1334, completing #1068 for pages).
+
+  Without this a page publishes outward and learns nothing back: its post could
+  travel and the team would read a flat zero. The counts needed no work —
+  `fediverse_reactions` hangs off the post, not off a member, so
+  `Posts.shown_counts/1` folds a stored row in by itself. What was missing was
+  only the way in.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Organizations
+  alias Vutuv.Posts
+  alias Vutuv.Repo
+  alias VutuvWeb.Fediverse.Docs
+
+  @actor "https://social.example/users/alice"
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp published_post(opts \\ []) do
+    owner = insert(:activated_user)
+    page = active_organization_for(owner)
+    {:ok, _} = Organizations.add_role(page, owner, "publisher", owner)
+
+    page =
+      page
+      |> Ecto.Changeset.change(Enum.into(opts, %{fediverse_followers?: true, username: "acme"}))
+      |> Repo.update!()
+
+    if page.fediverse_followers?, do: {:ok, _} = Fediverse.ensure_organization_actor(page)
+    {:ok, post} = Posts.create_organization_post(page, owner, %{body: "Nach draußen."})
+    {page, post}
+  end
+
+  defp counts(post), do: post.id |> Posts.engagement_counts() |> Posts.shown_counts()
+
+  test "a Like from another network raises the page post's like count" do
+    {page, post} = published_post()
+
+    assert counts(post).likes == 0
+
+    :ok =
+      Fediverse.record_organization_reaction(
+        page,
+        Docs.note_url(page, post.id),
+        "like",
+        %{uri: @actor, handle: "@alice@social.example"}
+      )
+
+    assert counts(post).likes == 1
+  end
+
+  test "an Announce raises the repost count, and an Undo takes it back" do
+    {page, post} = published_post()
+    uri = Docs.note_url(page, post.id)
+
+    :ok = Fediverse.record_organization_reaction(page, uri, "announce", %{uri: @actor})
+    assert counts(post).reposts == 1
+
+    # Unconditional by design: an upstream withdrawal is the deletion path that
+    # makes storing somebody else's act defensible in the first place.
+    :ok = Fediverse.remove_organization_reaction(page, uri, "announce", @actor)
+    assert counts(post).reposts == 0
+  end
+
+  test "the same actor liking twice counts once" do
+    {page, post} = published_post()
+    uri = Docs.note_url(page, post.id)
+
+    :ok = Fediverse.record_organization_reaction(page, uri, "like", %{uri: @actor})
+    :ok = Fediverse.record_organization_reaction(page, uri, "like", %{uri: @actor})
+
+    # A redelivery is normal traffic, not a second favourite.
+    assert counts(post).likes == 1
+  end
+
+  test "a Like naming another page's post is not recorded against this one" do
+    {page, _post} = published_post()
+
+    other_owner = insert(:activated_user)
+
+    other =
+      active_organization_for(other_owner, %{
+        "name" => "Zweite AG",
+        "website_url" => "https://zweite.example"
+      })
+
+    {:ok, _} = Organizations.add_role(other, other_owner, "publisher", other_owner)
+
+    {:ok, other_post} =
+      Posts.create_organization_post(other, other_owner, %{body: "Woanders."})
+
+    # Addressed to `page` but naming a post that is not its own: the ownership
+    # check is the point, or one page could inflate another's counts.
+    assert :skip =
+             Fediverse.record_organization_reaction(
+               page,
+               Docs.note_url(other, other_post.id),
+               "like",
+               %{uri: @actor}
+             )
+
+    assert counts(other_post).likes == 0
+  end
+
+  test "a page that does not federate collects nothing" do
+    {page, post} = published_post(fediverse_followers?: false)
+
+    assert :skip =
+             Fediverse.record_organization_reaction(
+               page,
+               Docs.note_url(page, post.id),
+               "like",
+               %{uri: @actor}
+             )
+
+    assert counts(post).likes == 0
+  end
+end


### PR DESCRIPTION
Die Lücke, die ich selbst in die Doku geschrieben hatte: eine Seite hat nach draußen veröffentlicht und **nichts zurück erfahren**. Ihr Beitrag konnte reisen und weitergereicht werden, und das Team las eine glatte Null.

Der Posteingang einer Seite nimmt jetzt `Like` und `Announce` an, dazu deren `Undo`.

**An den Zählern war nichts zu tun**, und das ist die angenehme Überraschung: `fediverse_reactions` hängt am *Beitrag*, nicht an einem Mitglied, also faltet `Posts.shown_counts/1` eine gespeicherte Zeile von selbst ein. Gefehlt hat nur der Weg hinein.

Keine zweite Frage an die Seite: `users.fediverse_reactions?` lässt ein Mitglied föderieren, ohne die Reaktionen Fremder zu sammeln — eine Seite, die absichtlich nach draußen veröffentlicht, hat keinen vergleichbaren Grund, den Verkehr zu wollen und die Zählung nicht. Ein Schalter, den niemand aus einem nachvollziehbaren Grund umlegen würde, ist keine Wahlfreiheit, sondern eine Frage zu viel.

**Die Eigentumsprüfung ist der Punkt.** `resolve_own_organization_note/2` verlangt, dass der Beitrag dieser Seite gehört — sonst könnte eine Seite die Zahlen einer anderen aufblähen. Ein Test schickt genau das und erwartet, dass nichts passiert.

Nebenbei hat der **Typprüfer einen echten Fehler gefunden**: ich hatte `remote.handle` geschrieben, das Feld heißt `preferred_username`. Die Klausel wäre zur Laufzeit immer gescheitert. Die Warnung lautete „never used (**or it will always fail**)" — gemeint war der zweite Teil, und ich hätte den ersten fast für einen Sortierfehler meiner Klauseln gehalten.

Die Doku sagt jetzt, was wirklich noch fehlt: **Antworten** von drüben. Die sind gespeicherter Text eines Fremden mit Aufbewahrungsmodell, Takedown-Register und Sechs-Monats-Verfall (#1069/#1071), und die Oberflächen dafür — die Unterhaltung am Permalink, das Zitat in den Benachrichtigungen — sind durchgehend mitgliedsförmig. Das ist eine eigene Funktion, keine erweiterte Spalte.

`mix precommit` grün (7341 Tests).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01MMwsQi49FP21xuSoPEkMnN
