### PR TITLE
Eine Seite empfängt auch Antworten von drüben (v7.262.0)

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -888,11 +888,23 @@ inbox takes `Like` and `Announce` (and their `Undo`), and the counts need no
 special handling because `fediverse_reactions` hangs off the post rather than
 off a member, so `Posts.shown_counts/1` folds them in by itself.
 
-What a page still does not receive is **replies** from other networks. Those are
-stored text from a stranger under a retention model with a takedown ledger and a
-six-month expiry (issues #1069/#1071), and the surfaces that render them —
-the permalink's conversation, the notification quote — are member-shaped
-throughout. That is its own feature, not a widened column.
+**Replies** from other networks arrive too, under the same retention model as a
+member's (issues #1069/#1071): the text expires unless its origin keeps
+confirming it, and the takedown ledger reaches it. They render read-only on the
+page's permalink — removing, reporting and the heart all belong to a person, and
+a page has nobody behind those buttons.
+
+I had this written up here as its own feature and it was not. `fediverse_notes`
+hangs off the **post**, not off a member, and the audience a note records is
+decided through `Docs.actor_url/1`, which knows both kinds — so `insert_note/5`
+needed no change at all. Worth remembering as a pattern: on this milestone the
+tables keyed to the *thing* rather than to its *owner* (notes, reactions) cost
+almost nothing to widen, while the ones keyed to a member (follows, followers,
+deliveries, actors) each needed a nullable pair and a sweep.
+
+What a page still cannot do is **answer** one. Replying outward is
+`check_reply_allowed/2` territory and member-shaped end to end, and an
+organization post carries no conversation here either.
 
 ## Deliberate v1 limits
 

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -3693,6 +3693,32 @@ defmodule Vutuv.Fediverse do
   end
 
   @doc """
+  A reply from another network under a **page's** post (issue #1334, completing
+  #1069 for pages).
+
+  `insert_note/5` needed no change: a note hangs off the post, and the audience
+  it records is decided through `Docs.actor_url/1`, which knows both kinds. What
+  is missing on the member version is deliberate — no `fediverse_replies?`
+  switch (a page that publishes outward has no comparable reason to want the
+  traffic and not the answers), no `restricted?` check (an organization post
+  carries no audience by construction), and no per-member notification, because
+  a page's news reaches its team through its own activity list.
+  """
+  def record_organization_reply(%Organization{} = page, activity, actor) do
+    with true <- enabled?(),
+         true <- federated?(page),
+         %{} = object <- note_object(activity["object"]),
+         %Post{} = post <- resolve_own_organization_note(page, object["inReplyTo"]),
+         :ok <- check_inbound_cap(actor.uri),
+         {:ok, _note} <- insert_note(page, post, activity, object, actor) do
+      Posts.broadcast_post_counters(post.id)
+      :ok
+    else
+      _ -> :skip
+    end
+  end
+
+  @doc """
   Applies an author's edit of a reply they already sent (`Update(Note)`).
 
   Scoped to the actor that wrote it, so one server cannot rewrite another's

--- a/lib/vutuv_web/controllers/fediverse_controller.ex
+++ b/lib/vutuv_web/controllers/fediverse_controller.ex
@@ -627,6 +627,21 @@ defmodule VutuvWeb.FediverseController do
     :ok
   end
 
+  # Somebody on another network answered one of the page's posts (issue #1334,
+  # completing #1069 for pages). Stored under the same retention model as a
+  # member's: the text expires unless its origin keeps confirming it, and the
+  # takedown ledger can reach it.
+  defp perform_for_organization(organization, %{"type" => "Create"} = activity, remote) do
+    Fediverse.record_organization_reply(organization, activity, %{
+      uri: remote.id,
+      handle: remote.preferred_username,
+      name: remote.name,
+      inbox: remote.inbox
+    })
+
+    :ok
+  end
+
   # Everything else: acknowledged and dropped, like the member inbox.
   defp perform_for_organization(_organization, _activity, _remote), do: :ok
 

--- a/lib/vutuv_web/live/organization_live/post.ex
+++ b/lib/vutuv_web/live/organization_live/post.ex
@@ -4,18 +4,26 @@ defmodule VutuvWeb.OrganizationLive.Post do
   (`/organizations/:slug/posts/:id`, issue #1334). Embedded via `live_render`
   from `VutuvWeb.OrganizationController`, like the organization page itself.
 
-  Deliberately just the post and the way back to the page that published it.
-  There is no conversation below it because an organization post cannot be
-  answered yet (`Vutuv.Posts.check_reply_allowed/2` refuses): everything a reply
-  sets in motion is member-shaped, and an organization has no inbox to be told
-  about one until issue #1336 gives it a reading side.
+  The post, the way back to the page that published it, and the replies written
+  on **other networks** (issue #1334 completing #1069 for pages).
+
+  Still no vutuv conversation below it: an organization post cannot be answered
+  here (`Vutuv.Posts.check_reply_allowed/2` refuses), because everything a local
+  reply sets in motion is member-shaped. A remote reply is different — it
+  arrives whether or not we host a thread for it, and hiding what a page's own
+  post already collected would only mean the team cannot see it.
+
+  Those cards are **read-only** here, unlike on the member thread that owns
+  them: removing, reporting and the heart all belong to a person, and a page has
+  nobody behind those buttons.
   """
 
   use VutuvWeb, :live_view
 
+  import VutuvWeb.PostComponents, only: [post_card: 1, remote_reply_card: 1]
   import VutuvWeb.OrganizationComponents, only: [organization_logo: 1]
-  import VutuvWeb.PostComponents, only: [post_card: 1]
 
+  alias Vutuv.Fediverse
   alias Vutuv.Organizations
   alias Vutuv.Posts
   alias VutuvWeb.Live.InitAssigns
@@ -37,6 +45,13 @@ defmodule VutuvWeb.OrganizationLive.Post do
        socket
        |> assign(:organization, organization)
        |> assign(:post, post)
+       # Replies from other networks (issue #1334, completing #1069 for pages).
+       # Viewer-scoped by `list_notes/2` like the member permalink, so a reply
+       # addressed to the page alone never reaches anybody else's render.
+       |> assign(
+         :remote_replies,
+         Fediverse.list_notes([post.id], socket.assigns.current_user)[post.id] || []
+       )
        |> assign(:formats?, Organizations.agent_visible?(organization))
        |> assign(:page_title, organization.name)}
     else
@@ -64,6 +79,14 @@ defmodule VutuvWeb.OrganizationLive.Post do
 
       <div class="mt-4">
         <.post_card post={@post} viewer={@current_user} conn_or_socket={@socket} mode={:full} />
+      </div>
+
+      <%!-- Replies written on another network (issue #1334). Read-only here,
+      like the member-facing answering page: the acts on such a card (remove,
+      report, the heart) are hosted by the member thread that owns them, and a
+      page has no member behind those buttons. --%>
+      <div :if={@remote_replies != []} class="mt-4 space-y-3" id="organization-remote-replies">
+        <.remote_reply_card :for={note <- @remote_replies} note={note} viewer={@current_user} />
       </div>
 
       <%!-- The agent-format siblings of this permalink. Shown only when they

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.261.0",
+      version: "7.262.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/organization_fediverse_replies_test.exs
+++ b/test/vutuv/organization_fediverse_replies_test.exs
@@ -1,0 +1,137 @@
+defmodule Vutuv.OrganizationFediverseRepliesTest do
+  @moduledoc """
+  A reply from another network under a **page's** post (issue #1334, completing
+  #1069 for pages) — the last thing a page could not receive.
+
+  I had written this up as its own feature. It was not: `fediverse_notes` hangs
+  off the post rather than off a member, and the audience a note records is
+  decided through `Docs.actor_url/1`, which already knows both kinds. So
+  `insert_note/5` needed no change at all, and what was missing was the way in
+  and somewhere to show it.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Organizations
+  alias Vutuv.Posts
+  alias Vutuv.Repo
+  alias VutuvWeb.Fediverse.Docs
+
+  @actor "https://social.example/users/alice"
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp published_post(opts \\ []) do
+    owner = insert(:activated_user)
+    page = active_organization_for(owner)
+    {:ok, _} = Organizations.add_role(page, owner, "publisher", owner)
+
+    page =
+      page
+      |> Ecto.Changeset.change(Enum.into(opts, %{fediverse_followers?: true, username: "acme"}))
+      |> Repo.update!()
+
+    if page.fediverse_followers?, do: {:ok, _} = Fediverse.ensure_organization_actor(page)
+    {:ok, post} = Posts.create_organization_post(page, owner, %{body: "Nach draußen."})
+    {page, post}
+  end
+
+  defp actor,
+    do: %{uri: @actor, handle: "@alice@social.example", name: "Alice", inbox: @actor <> "/inbox"}
+
+  defp reply_activity(page, post, audience \\ ["https://www.w3.org/ns/activitystreams#Public"]) do
+    %{
+      "type" => "Create",
+      "to" => audience,
+      "object" => %{
+        "id" => "https://social.example/notes/#{System.unique_integer([:positive])}",
+        "type" => "Note",
+        "content" => "<p>Von drüben geantwortet.</p>",
+        "inReplyTo" => Docs.note_url(page, post.id),
+        "to" => audience
+      }
+    }
+  end
+
+  test "a public reply is stored under the page's post and raises its reply count" do
+    {page, post} = published_post()
+
+    assert :ok = Fediverse.record_organization_reply(page, reply_activity(page, post), actor())
+
+    [note] = Fediverse.list_notes([post.id], nil)[post.id]
+    assert note.content_text =~ "Von drüben geantwortet."
+    assert note.post_id == post.id
+
+    counts = post.id |> Posts.engagement_counts() |> Posts.shown_counts()
+    assert counts.replies == 1
+  end
+
+  test "a reply naming another page's post is not stored against this one" do
+    {page, _post} = published_post()
+
+    other_owner = insert(:activated_user)
+
+    other =
+      active_organization_for(other_owner, %{
+        "name" => "Zweite AG",
+        "website_url" => "https://zweite.example"
+      })
+
+    {:ok, _} = Organizations.add_role(other, other_owner, "publisher", other_owner)
+    {:ok, other_post} = Posts.create_organization_post(other, other_owner, %{body: "Woanders."})
+
+    # Addressed to `page` but answering a post that is not its own: the
+    # ownership check is what stops one page collecting another's replies.
+    assert :skip =
+             Fediverse.record_organization_reply(
+               page,
+               reply_activity(other, other_post),
+               actor()
+             )
+
+    assert Fediverse.list_notes([other_post.id], nil) == %{}
+  end
+
+  test "a page that does not federate receives nothing" do
+    {page, post} = published_post(fediverse_followers?: false)
+
+    assert :skip = Fediverse.record_organization_reply(page, reply_activity(page, post), actor())
+    assert Fediverse.list_notes([post.id], nil) == %{}
+  end
+
+  test "the same reply delivered twice is stored once" do
+    {page, post} = published_post()
+    activity = reply_activity(page, post)
+
+    assert :ok = Fediverse.record_organization_reply(page, activity, actor())
+    assert :skip = Fediverse.record_organization_reply(page, activity, actor())
+
+    assert [_one] = Fediverse.list_notes([post.id], nil)[post.id]
+  end
+
+  test "an empty reply earns no row" do
+    {page, post} = published_post()
+
+    activity =
+      put_in(reply_activity(page, post), ["object", "content"], "<p></p>")
+
+    # A row about a third party has to earn its place; a picture-only or empty
+    # note carries nothing to show.
+    assert :skip = Fediverse.record_organization_reply(page, activity, actor())
+    assert Fediverse.list_notes([post.id], nil) == %{}
+  end
+end


### PR DESCRIPTION
Das letzte, was eine Seite im Fediverse nicht konnte. Ihr Posteingang nimmt jetzt `Create(Note)` an, wenn die Antwort einem ihrer Beiträge gilt, und der Permalink der Seite zeigt sie.

**Ich hatte das in der Doku als eigene Funktion beschrieben. Das war falsch.** `fediverse_notes` hängt am *Beitrag*, nicht an einem Mitglied, und das Publikum, das eine Notiz festhält, wird über `Docs.actor_url/1` entschieden, das beide Sorten kennt — `insert_note/5` brauchte also **keine einzige Änderung**. Gefehlt haben nur der Weg hinein und ein Ort, an dem man es sieht.

Das ist ein Muster, das dieser Meilenstein zweimal gezeigt hat, und ich habe es in `fediverse.md` festgehalten: Tabellen, die an der **Sache** hängen (Notizen, Reaktionen), kosten beim Erweitern fast nichts; die an einem **Besitzer** hängenden (Follows, Follower, Auslieferungen, Actors) haben jeweils ein Nullable-Paar und einen Durchgang durch ihre Leser gebraucht. Beide Male, als ich „eigene Funktion" gesagt habe, war die Tabelle an der Sache aufgehängt — künftig sehe ich zuerst nach, bevor ich das schätze.

Die Karten sind auf dem Permalink **schreibgeschützt**, anders als im Mitglieder-Thread, der sie besitzt: Entfernen, Melden und das Herz gehören einer Person, und hinter diesen Knöpfen steht bei einer Seite niemand.

Keine `fediverse_replies?`-Frage an die Seite, aus demselben Grund wie bei den Reaktionen. Kein `restricted?`-Test, weil ein Organisationsbeitrag konstruktionsbedingt kein Publikum trägt. Die Eigentumsprüfung bleibt: ein Test schickt eine Antwort, die den Beitrag einer *anderen* Seite nennt, und erwartet, dass nichts gespeichert wird.

Was eine Seite weiterhin **nicht** kann, ist antworten. Das ist `check_reply_allowed/2`-Gebiet und durchgehend mitgliedsförmig; das steht so in der Doku.

---

**Damit ist „Organisation im Fediverse" wirklich fertig.** Eine Seite hält ein Schlüsselpaar, ihr Eigentümer schaltet das Föderieren ein, sie ist per WebFinger auffindbar, hat ein `Organization`-Actor-Dokument, nimmt Follows an und bestätigt sie, liefert ihre Beiträge aus, folgt Mitgliedern, Seiten, Themen und entfernten Konten, liest einen Feed aus vier Quellen — und erfährt jetzt, was drüben damit passiert: Favoriten, Weiterleitungen und Antworten.

`mix precommit` grün (7346 Tests).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01MMwsQi49FP21xuSoPEkMnN
