### PR TITLE
Das Actor-Dokument einer Seite verspricht nichts mehr, was es nicht hält (v7.262.1)

### DIFF
--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -669,6 +669,16 @@ defmodule Vutuv.Fediverse do
   end
 
   @doc """
+  How many posts a **page** has published (issue #1334) — what its `outbox`
+  collection reports.
+
+  No denial check, unlike the member twin: an organization post carries no
+  audience by construction, so every one of them is public.
+  """
+  def organization_public_post_count(%Organization{id: id}),
+    do: Repo.aggregate(from(p in Post, where: p.organization_id == ^id), :count)
+
+  @doc """
   What the `featured` collection holds (issue #1110): the member's pinned post
   when the **anonymous public** may see it, else nothing. A list, because that
   is the collection's shape — one entry today.

--- a/lib/vutuv_web/controllers/fediverse_controller.ex
+++ b/lib/vutuv_web/controllers/fediverse_controller.ex
@@ -652,6 +652,27 @@ defmodule VutuvWeb.FediverseController do
     end
   end
 
+  @doc """
+  The page's outbox, count-only like a member's.
+
+  It exists because the actor document names it. An actor that advertises an
+  endpoint answering 404 is not merely untidy — a remote server fetches the
+  outbox while building its picture of an account, and a page whose own document
+  points at nothing reads as broken from outside. This shipped that way for one
+  commit; the check is now part of the test.
+  """
+  def organization_outbox(conn, %{"slug" => slug}) do
+    with_federated_organization(conn, slug, fn organization ->
+      send_activity_json(
+        conn,
+        Docs.count_collection(
+          Docs.actor_url(organization) <> "/outbox",
+          Fediverse.organization_public_post_count(organization)
+        )
+      )
+    end)
+  end
+
   defp with_federated_organization(conn, slug, fun) do
     with true <- Fediverse.enabled?(),
          %Organization{} = organization <- Organizations.get_organization_by_slug(slug) do

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -185,6 +185,7 @@ defmodule VutuvWeb.Router do
     # handles. 404s until the page opts in.
     get("/organizations/:slug/actor", FediverseController, :organization_actor)
     get("/organizations/:slug/actor/followers", FediverseController, :organization_followers)
+    get("/organizations/:slug/actor/outbox", FediverseController, :organization_outbox)
     post("/organizations/:slug/actor/inbox", FediverseController, :organization_inbox)
     # The installation-wide inbox (issue #1073), so a server with many
     # followers here delivers a broadcast once instead of once per member.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.262.0",
+      version: "7.262.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/organization_fediverse_actor_web_test.exs
+++ b/test/vutuv_web/organization_fediverse_actor_web_test.exs
@@ -121,4 +121,26 @@ defmodule VutuvWeb.OrganizationFediverseActorWebTest do
 
     assert conn |> ap() |> get(~p"/organizations/#{page.slug}/actor") |> response(404)
   end
+
+  test "every endpoint the actor document advertises actually answers", %{conn: conn} do
+    page = federating_page()
+
+    json = conn |> ap() |> get(~p"/organizations/#{page.slug}/actor") |> json_response(200)
+
+    # The document is a promise to strangers: a remote server fetches these
+    # while building its picture of an account, so one that 404s reads as a
+    # broken actor from outside. The outbox did exactly that for one commit,
+    # which is why this walks the document instead of naming paths by hand.
+    for key <- ~w(followers outbox) do
+      url = json[key]
+      assert is_binary(url), "the actor document names no #{key}"
+
+      path = URI.parse(url).path
+      assert conn |> ap() |> get(path) |> json_response(200)
+    end
+
+    # The inbox is a POST target, so a GET is not the check — but it must at
+    # least be a route, not a 404 from the router.
+    assert json["inbox"] =~ "/organizations/#{page.slug}/actor/inbox"
+  end
 end


### PR DESCRIPTION
Beim Abschluss-Durchsehen gefunden, und es war mein eigener Fehler aus #1394: das Actor-Dokument einer Seite nennt eine `outbox`, aber die Route dafür gab es nie.

```json
"inbox":     ".../actor/inbox"      ✓ Route da
"followers": ".../actor/followers"  ✓ Route da
"outbox":    ".../actor/outbox"     ✗ 404
```

Ein fremder Server, der beim Aufbau seines Bildes von einem Konto dort nachfragt, bekam 404. Von außen liest sich das als kaputter Actor, und niemand hier hätte es je gemerkt — kein Test schaute hin, weil ich die Endpunkte beim Testen von Hand aufgezählt hatte und dabei denselben vergessen habe wie im Router.

Die Route gibt es jetzt, nur mit der Anzahl wie beim Mitglied. Ohne Denial-Prüfung, weil ein Organisationsbeitrag konstruktionsbedingt kein Publikum trägt und damit jeder öffentlich ist.

**Der Test läuft jetzt das Dokument ab**, statt Pfade aufzuzählen: für jeden Endpunkt, den der Actor nennt, wird er abgerufen und muss antworten. Das ist der Unterschied zwischen „ich prüfe, woran ich denke" und „ich prüfe, was das Dokument verspricht" — nur die zweite Form hätte diesen Fehler beim Schreiben gefangen.

`mix precommit` grün (7347 Tests).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01MMwsQi49FP21xuSoPEkMnN
