### PR TITLE
Eine Seite kann angeschrieben werden (v7.263.0)

### DIFF
--- a/lib/vutuv/chat.ex
+++ b/lib/vutuv/chat.ex
@@ -23,6 +23,8 @@ defmodule Vutuv.Chat do
   alias Vutuv.Activity
   alias Vutuv.Chat.{Conversation, Message, Participant}
   alias Vutuv.Notifications.Emailer
+  alias Vutuv.Organizations
+  alias Vutuv.Organizations.Organization
   alias Vutuv.Repo
 
   @pubsub Vutuv.PubSub
@@ -82,6 +84,137 @@ defmodule Vutuv.Chat do
 
       true ->
         find_or_create_unblocked(me, other)
+    end
+  end
+
+  # The page clause (issue #1336). Simpler than the member one above, and every
+  # omission is a real difference rather than a shortcut. No sorted pair: the
+  # two sides come from different tables, so `(user_a_id, organization_id)` is
+  # already canonical. No block check: a block is between two people. No
+  # request/accept dance either — a page publishes to be addressed, so there is
+  # nothing for it to approve, and a "pending" state would only make its team's
+  # first message look like an acceptance.
+  #
+  # The one gate is that the page is one anybody may see: writing into a frozen
+  # or not-yet-active page would put a message where nobody can answer it.
+  def find_or_create_conversation(%User{} = me, %Organization{} = page) do
+    cond do
+      not me.email_confirmed? ->
+        {:error, :not_activated}
+
+      # Re-read rather than trust the struct handed in: this decides whether a
+      # message may be planted, and a caller holding a copy loaded before a
+      # freeze would otherwise walk straight past the gate. Same reasoning as
+      # the acting-as session id being a hint rather than a credential.
+      not page_visible?(page) ->
+        {:error, :frozen}
+
+      true ->
+        find_or_create_organization_conversation(me, page)
+    end
+  end
+
+  defp page_visible?(%Organization{id: id}) do
+    case Organizations.get_organization(id) do
+      %Organization{} = fresh -> Organizations.public_visible?(fresh)
+      nil -> false
+    end
+  end
+
+  defp find_or_create_organization_conversation(%User{} = me, %Organization{} = page) do
+    case Repo.get_by(Conversation, user_a_id: me.id, organization_id: page.id) do
+      %Conversation{frozen_at: %NaiveDateTime{}} ->
+        {:error, :frozen}
+
+      %Conversation{} = conversation ->
+        {:ok, conversation}
+
+      nil ->
+        insert_organization_conversation(me, page)
+    end
+  end
+
+  defp insert_organization_conversation(%User{} = me, %Organization{} = page) do
+    changeset =
+      %Conversation{
+        user_a_id: me.id,
+        organization_id: page.id,
+        initiator_id: me.id,
+        status: "accepted"
+      }
+      |> Conversation.changeset()
+
+    result =
+      Repo.transaction(fn ->
+        case Repo.insert(changeset) do
+          {:ok, conversation} ->
+            Repo.insert!(%Participant{conversation_id: conversation.id, user_id: me.id})
+            # One row for the page, not one per publisher.
+            Repo.insert!(%Participant{
+              conversation_id: conversation.id,
+              organization_id: page.id
+            })
+
+            conversation
+
+          {:error, _changeset} ->
+            Repo.rollback(:exists)
+        end
+      end)
+
+    case result do
+      {:ok, conversation} ->
+        {:ok, conversation}
+
+      {:error, :exists} ->
+        {:ok, Repo.get_by(Conversation, user_a_id: me.id, organization_id: page.id)}
+    end
+  end
+
+  @doc """
+  A publisher answers in the **page's** name (issue #1336).
+
+  `acting_user` is recorded and never shown, the same split `posts` makes for
+  authorship: the message belongs to the page, so it must not walk out of the
+  door with the person who typed it. The right to send follows the **role**, not
+  the person, so it is asked live — a withdrawn publisher stops being able to
+  answer at once.
+  """
+  def send_message_as_organization(%Organization{} = page, %User{} = acting_user, id, body) do
+    conversation = Repo.get_by(Conversation, id: id, organization_id: page.id)
+
+    cond do
+      is_nil(conversation) ->
+        {:error, :not_participant}
+
+      not Organizations.publisher?(page, acting_user) ->
+        {:error, :not_allowed}
+
+      not is_nil(conversation.frozen_at) ->
+        {:ok, :dropped}
+
+      true ->
+        deliver_as_organization(conversation, page, acting_user, body)
+    end
+  end
+
+  defp deliver_as_organization(conversation, page, acting_user, body) do
+    changeset =
+      %Message{
+        conversation_id: conversation.id,
+        sender_organization_id: page.id,
+        acting_user_id: acting_user.id
+      }
+      |> Message.changeset(%{body: body})
+
+    case Repo.transaction(fn -> insert_and_bump(changeset, conversation, false) end) do
+      {:ok, message} ->
+        message = %{message | sender_organization: page}
+        broadcast_new_message(conversation, message)
+        {:ok, message}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:error, changeset}
     end
   end
 
@@ -232,6 +365,29 @@ defmodule Vutuv.Chat do
     # listing columns rather than the whole wide user row.
     Repo.one!(from(u in User, where: u.id == ^id, select: struct(u, ^User.listing_fields())))
   end
+
+  @doc """
+  The other side of a conversation - a member **or a page** (issue #1336).
+
+  `other_user/2` above cannot answer this: for a member-page conversation it
+  resolves a nil id, and `Repo.one!(where: u.id == ^nil)` RAISES rather than
+  answering nothing. Every caller that can see a page conversation must come
+  through here.
+  """
+  def other_party(%Conversation{} = conversation, me_id) do
+    case other_key(conversation, party(me_id, conversation)) do
+      {:user, id} ->
+        Repo.one!(from(u in User, where: u.id == ^id, select: struct(u, ^User.listing_fields())))
+
+      {:organization, id} ->
+        Repo.get!(Organization, id)
+    end
+  end
+
+  # `me_id` names either the member or the page, and only the conversation can
+  # say which - a page conversation's `user_a_id` is always the member.
+  defp party(me_id, %Conversation{organization_id: me_id}), do: {:organization, me_id}
+  defp party(me_id, %Conversation{}), do: {:user, me_id}
 
   @doc """
   The status a conversation shows to its initiator: a declined request
@@ -404,6 +560,24 @@ defmodule Vutuv.Chat do
   end
 
   @doc """
+  A page's inbox (issue #1336) - every conversation addressed to it.
+
+  No request/accept dance and so no pending state to filter: a page publishes
+  in order to be addressed. The whole team sees one list, the same shared view
+  as the page's activity.
+  """
+  def list_organization_conversations(%Organization{id: page_id}) do
+    from(c in Conversation,
+      where: c.organization_id == ^page_id,
+      where: is_nil(c.frozen_at),
+      where: not is_nil(c.last_message_at),
+      order_by: [desc_nulls_last: c.last_message_at, desc: c.id]
+    )
+    |> Repo.all()
+    |> hydrate({:organization, page_id})
+  end
+
+  @doc """
   Message requests: pending conversations with at least one message where
   `me` is the recipient.
   """
@@ -419,22 +593,30 @@ defmodule Vutuv.Chat do
     |> hydrate(me_id)
   end
 
-  # Resolve the other user, last-message preview and unread count for a page
-  # of conversations in three batched queries — no per-row queries.
-  defp hydrate([], _me_id), do: []
+  # Resolve the other side, last-message preview and unread count for a page of
+  # conversations in three batched queries — no per-row queries. `party` is
+  # `{:user, id}` or `{:organization, id}`: since issue #1336 the viewer of a
+  # conversation list is a member or a page, and so is the other side.
+  defp hydrate([], _party), do: []
 
-  defp hydrate(conversations, me_id) do
+  defp hydrate(conversations, me_id) when is_binary(me_id),
+    do: hydrate(conversations, {:user, me_id})
+
+  defp hydrate(conversations, party) do
     ids = Enum.map(conversations, & &1.id)
-    other_ids = Enum.map(conversations, &other_user_id(&1, me_id))
-
-    others = listing_users_by_id(other_ids)
+    keys = Enum.map(conversations, &other_key(&1, party))
+    others = parties_by_key(keys)
+    # A dynamic composes only inside another dynamic, never inline in a query
+    # expression, so the whole condition is built here.
+    mine = own_message(party)
+    shown = dynamic([m], is_nil(m.frozen_at) or ^mine)
 
     previews =
       from(m in Message,
         where: m.conversation_id in ^ids,
         # A frozen message must not leak into the sidebar preview of the
         # other participant; the sender still sees their own.
-        where: is_nil(m.frozen_at) or m.sender_id == ^me_id,
+        where: ^shown,
         distinct: m.conversation_id,
         order_by: [asc: m.conversation_id, desc: m.inserted_at, desc: m.id],
         # Only a short prefix leaves Postgres: the sidebar CSS-truncates to one
@@ -445,20 +627,72 @@ defmodule Vutuv.Chat do
       |> Repo.all()
       |> Map.new()
 
-    unreads = unread_counts(ids, me_id)
+    unreads = unread_counts(ids, party)
 
-    Enum.map(conversations, fn conversation ->
+    Enum.zip_with(conversations, keys, fn conversation, key ->
       {last_body, last_at} = Map.get(previews, conversation.id, {nil, nil})
 
       %{
         conversation: conversation,
-        other: Map.fetch!(others, other_user_id(conversation, me_id)),
+        other: Map.fetch!(others, key),
         last_body: last_body,
         last_at: last_at,
         unread: Map.get(unreads, conversation.id, 0)
       }
     end)
   end
+
+  # Who is on the far side, as a `{kind, id}` key. `user_a_id` is always the
+  # member, so a page conversation reads the answer off a column rather than
+  # arriving at it by elimination.
+  defp other_key(%Conversation{organization_id: page_id} = conversation, {:user, me_id})
+       when is_binary(page_id) do
+    if conversation.user_a_id == me_id, do: {:organization, page_id}, else: {:user, me_id}
+  end
+
+  defp other_key(%Conversation{} = conversation, {:user, me_id}),
+    do: {:user, other_user_id(conversation, me_id)}
+
+  defp other_key(%Conversation{user_a_id: member_id}, {:organization, _page_id}),
+    do: {:user, member_id}
+
+  # One batched load per kind, into a single `{kind, id} => struct` map.
+  defp parties_by_key(keys) do
+    grouped = Enum.group_by(keys, &elem(&1, 0), &elem(&1, 1))
+
+    users =
+      grouped
+      |> Map.get(:user, [])
+      |> listing_users_by_id()
+      |> Map.new(fn {id, user} -> {{:user, id}, user} end)
+
+    pages =
+      case Map.get(grouped, :organization, []) do
+        [] ->
+          %{}
+
+        ids ->
+          from(o in Organization, where: o.id in ^ids)
+          |> Repo.all()
+          |> Map.new(&{{:organization, &1.id}, &1})
+      end
+
+    Map.merge(users, pages)
+  end
+
+  # "Sent by me", as a query fragment. Since issue #1336 exactly one of the two
+  # sender columns is filled, so **both** arms must survive the other being
+  # NULL: a bare `m.sender_id == ^id` answers NULL rather than false for a
+  # page's message, and the `not (…)` in unread_counts/2 below then answers
+  # NULL too, which excludes the row. Written this way the negation is honest
+  # in both directions, and the unread badge counts what the reader has not
+  # read whichever side wrote it.
+  defp own_message({:user, me_id}),
+    do: dynamic([m], not is_nil(m.sender_id) and m.sender_id == ^me_id)
+
+  defp own_message({:organization, page_id}),
+    do:
+      dynamic([m], not is_nil(m.sender_organization_id) and m.sender_organization_id == ^page_id)
 
   # Load the listing columns for a set of user ids into an id->user map.
   # The email/sidebar only needs the narrow listing_fields, not the wide row.
@@ -468,12 +702,23 @@ defmodule Vutuv.Chat do
     |> Map.new(&{&1.id, &1})
   end
 
-  defp unread_counts(conversation_ids, me_id) do
+  defp unread_counts(conversation_ids, me_id) when is_binary(me_id),
+    do: unread_counts(conversation_ids, {:user, me_id})
+
+  defp unread_counts(conversation_ids, party) do
+    from_them = dynamic([m], not (^own_message(party)))
+    joined = dynamic([m, p], p.conversation_id == m.conversation_id and ^participant_is(party))
+
     from(m in Message,
       join: p in Participant,
-      on: p.conversation_id == m.conversation_id and p.user_id == ^me_id,
+      on: ^joined,
       where: m.conversation_id in ^conversation_ids,
-      where: m.sender_id != ^me_id,
+      # NOT `m.sender_id != ^me_id`: a page's message has a NULL `sender_id`,
+      # and `NULL != <id>` is NULL rather than true, so a page's reply would
+      # never have counted as unread for the member it answered. The same trap
+      # as the `NOT IN (…, NULL)` ones this milestone has already paid for, and
+      # just as quiet — the badge simply stays at zero.
+      where: ^from_them,
       # Frozen messages are invisible to the recipient, so they must not
       # count as unread either (the badge would point at nothing).
       where: is_nil(m.frozen_at),
@@ -484,6 +729,11 @@ defmodule Vutuv.Chat do
     |> Repo.all()
     |> Map.new()
   end
+
+  defp participant_is({:user, me_id}), do: dynamic([_m, p], p.user_id == ^me_id)
+
+  defp participant_is({:organization, page_id}),
+    do: dynamic([_m, p], p.organization_id == ^page_id)
 
   ## Thread pagination
 
@@ -659,7 +909,7 @@ defmodule Vutuv.Chat do
             """
             EXISTS (SELECT 1 FROM messages m
                     WHERE m.conversation_id = ?
-                      AND m.sender_id <> ?
+                      AND (m.sender_id IS NULL OR m.sender_id <> ?)
                       AND m.frozen_at IS NULL
                       AND (? IS NULL OR m.inserted_at > ?)
                       AND (? IS NULL OR m.inserted_at > ?)
@@ -678,20 +928,22 @@ defmodule Vutuv.Chat do
       )
 
     # The recipient rides along on the join (its settings drive everything); the
-    # counterpart (named by @handle in the email) is the one per-row lookup left,
-    # resolved once per row here and batch-loaded, the way hydrate/2 does.
+    # counterpart the email names is the one per-row lookup left, resolved once
+    # per row here and batch-loaded, the way hydrate/2 does. Since issue #1336
+    # that counterpart can be a page, so it is a `{kind, id}` key - resolving it
+    # as a bare user id used to yield nil and take the whole batch down with a
+    # KeyError on the very first page conversation.
     rows =
       Repo.all(query)
       |> Enum.map(fn {participant, conversation, recipient} ->
-        {participant, conversation, recipient, other_user_id(conversation, participant.user_id)}
+        {participant, conversation, recipient,
+         other_key(conversation, {:user, participant.user_id})}
       end)
 
-    # The email only names this counterpart by @handle, so load just the listing
-    # columns (see listing_users_by_id/1) rather than the whole wide user row.
-    others = listing_users_by_id(Enum.map(rows, &elem(&1, 3)))
+    others = parties_by_key(Enum.map(rows, &elem(&1, 3)))
 
-    Enum.reduce(rows, 0, fn {participant, conversation, recipient, other_id}, sent ->
-      other = Map.fetch!(others, other_id)
+    Enum.reduce(rows, 0, fn {participant, conversation, recipient, key}, sent ->
+      other = Map.fetch!(others, key)
       sent + notify_participant(participant, conversation, recipient, other, now)
     end)
   end
@@ -739,7 +991,10 @@ defmodule Vutuv.Chat do
     query =
       from(m in Message,
         where: m.conversation_id == ^participant.conversation_id,
-        where: m.sender_id != ^participant.user_id,
+        # A page's message has a NULL `sender_id`, and `NULL != <id>` is NULL,
+        # not true - without the is_nil arm the burst would find no bodies and
+        # the member would never hear that the page had answered.
+        where: is_nil(m.sender_id) or m.sender_id != ^participant.user_id,
         where: is_nil(m.frozen_at),
         where: m.inserted_at < ^cutoff,
         order_by: [asc: m.inserted_at],

--- a/lib/vutuv/chat/conversation.ex
+++ b/lib/vutuv/chat/conversation.ex
@@ -6,11 +6,21 @@ defmodule Vutuv.Chat.Conversation do
   @statuses ~w(pending accepted declined)
 
   schema "conversations" do
-    # The unordered pair stored sorted (user_a_id < user_b_id, enforced by a
-    # check constraint) so the unique index allows exactly one conversation
-    # per pair. All four user fields are set programmatically, never cast.
+    # Two shapes (issue #1336):
+    #
+    #   member <-> member: user_a + user_b, stored SORTED (user_a_id <
+    #     user_b_id, CHECK-enforced) so one unique index allows exactly one
+    #     conversation per pair. Sorting breaks a symmetry: two ids from the
+    #     same table mean (a, b) and (b, a) name the same conversation.
+    #   member <-> page:   user_a is the member, user_b NULL, organization set.
+    #     No sorting, because two ids from DIFFERENT tables carry no such
+    #     symmetry — the pair is already canonical.
+    #
+    # A CHECK says the other side is exactly one of the two. All of these are
+    # set programmatically, never cast.
     belongs_to(:user_a, Vutuv.Accounts.User)
     belongs_to(:user_b, Vutuv.Accounts.User)
+    belongs_to(:organization, Vutuv.Organizations.Organization)
     # The party who opened the conversation (set when the first message is
     # sent). A standing role on the conversation, not a per-message field.
     belongs_to(:initiator, Vutuv.Accounts.User)

--- a/lib/vutuv/chat/message.ex
+++ b/lib/vutuv/chat/message.ex
@@ -17,6 +17,11 @@ defmodule Vutuv.Chat.Message do
     belongs_to(:conversation, Vutuv.Chat.Conversation)
     # Nullable: a deleted sender's messages survive for the other participant.
     belongs_to(:sender, Vutuv.Accounts.User)
+    # Sent in a page's name (issue #1336), with the member who wrote it kept
+    # internally — the same split `posts` uses for authorship: the message
+    # belongs to the page, so it must not leave with the person who typed it.
+    belongs_to(:sender_organization, Vutuv.Organizations.Organization)
+    belongs_to(:acting_user, Vutuv.Accounts.User)
 
     # Microsecond precision (not the default second) so the read marker
     # `max(inserted_at)` can distinguish a message arriving in the same

--- a/lib/vutuv/chat/participant.ex
+++ b/lib/vutuv/chat/participant.ex
@@ -5,7 +5,13 @@ defmodule Vutuv.Chat.Participant do
 
   schema "conversation_participants" do
     belongs_to(:conversation, Vutuv.Chat.Conversation)
+    # The party this row's read state belongs to: a member, or a page (issue
+    # #1336). For a page it is ONE row for the whole team, not one per
+    # publisher — read means somebody read it, never that everybody did, the
+    # same model as `organizations.activity_read_at`. A row per publisher would
+    # also have to be minted and retired as roles change.
     belongs_to(:user, Vutuv.Accounts.User)
+    belongs_to(:organization, Vutuv.Organizations.Organization)
 
     # null = never opened the conversation. Microsecond precision so the read
     # marker (`max(messages.inserted_at)`) keeps its sub-second resolution and

--- a/lib/vutuv/notifications/emailer.ex
+++ b/lib/vutuv/notifications/emailer.ex
@@ -26,6 +26,7 @@ defmodule Vutuv.Notifications.Emailer do
   alias Vutuv.Accounts
   alias Vutuv.Accounts.User
   alias Vutuv.Notifications.Bounces
+  alias Vutuv.Organizations.Organization
   alias Vutuv.Reports.DailyReport
   alias Vutuv.SavedSearches
   alias VutuvWeb.EmailComponents
@@ -278,14 +279,12 @@ defmodule Vutuv.Notifications.Emailer do
     |> unsubscribe_headers(unsubscribe_url)
     |> subject(
       recipient_subject(locale, fn ->
-        gettext("New message from @%{slug} on vutuv",
-          slug: other.username
-        )
+        gettext("New message from %{sender} on vutuv", sender: sender_label(other))
       end)
     )
     |> render_bodies("unread_messages", locale, %{
       user: user,
-      other_slug: other.username,
+      other_label: sender_label(other),
       conversation_id: conversation_id,
       # A DM is Markdown source (the composer is Milkdown), so the quote is
       # rendered, not printed: the HTML body runs the source through
@@ -1037,6 +1036,19 @@ defmodule Vutuv.Notifications.Emailer do
   # The body template is selected by the recipient's locale; render the
   # subject in that same locale, not the ambient process locale (which is the
   # *sender's* — e.g. the admin verifying another member).
+  # How the counterpart of a conversation is named in a message email. A member
+  # is always an @handle (the system-message convention: never the clear name).
+  # A page's handle is OPTIONAL - it only has one once it claims a root word -
+  # so a page without one is named by its name, which is the only thing it is
+  # certain to have. Hence the label carries its own "@" rather than the
+  # templates hardcoding one.
+  defp sender_label(%User{username: username}), do: "@" <> username
+
+  defp sender_label(%Organization{username: username}) when is_binary(username),
+    do: "@" <> username
+
+  defp sender_label(%Organization{name: name}), do: name
+
   defp recipient_subject(locale, subject_fun) do
     in_locale(locale, subject_fun)
   end

--- a/lib/vutuv_web/templates/email/unread_messages_de.text.eex
+++ b/lib/vutuv_web/templates/email/unread_messages_de.text.eex
@@ -1,6 +1,6 @@
 <%= email_greeting(@user) %>,
 
-Sie haben eine neue Nachricht von @<%= @other_slug %> auf vutuv:
+Sie haben eine neue Nachricht von <%= @other_label %> auf vutuv:
 <%= if @message_body do %>
 <%= @message_text %>
 <% end %>

--- a/lib/vutuv_web/templates/email/unread_messages_en.text.eex
+++ b/lib/vutuv_web/templates/email/unread_messages_en.text.eex
@@ -1,6 +1,6 @@
 <%= email_greeting(@user) %>,
 
-you have a new message from @<%= @other_slug %> on vutuv:
+you have a new message from <%= @other_label %> on vutuv:
 <%= if @message_body do %>
 <%= @message_text %>
 <% end %>

--- a/lib/vutuv_web/templates/email_body/unread_messages_de.html.heex
+++ b/lib/vutuv_web/templates/email_body/unread_messages_de.html.heex
@@ -1,6 +1,6 @@
 <.email_layout preheader="Sie haben eine neue Nachricht auf vutuv" locale={@locale}>
   <.email_p>{email_greeting(@user)},</.email_p>
-  <.email_p>Sie haben eine neue Nachricht von @{@other_slug} auf vutuv:</.email_p>
+  <.email_p>Sie haben eine neue Nachricht von {@other_label} auf vutuv:</.email_p>
   <.email_markdown :if={@message_body} body={@message_body} />
   <.email_button href={"#{@url}messages/#{@conversation_id}"}>Lesen und antworten</.email_button>
   <.email_p>

--- a/lib/vutuv_web/templates/email_body/unread_messages_en.html.heex
+++ b/lib/vutuv_web/templates/email_body/unread_messages_en.html.heex
@@ -1,6 +1,6 @@
 <.email_layout preheader="You have a new message on vutuv" locale={@locale}>
   <.email_p>{email_greeting(@user)},</.email_p>
-  <.email_p>you have a new message from @{@other_slug} on vutuv:</.email_p>
+  <.email_p>you have a new message from {@other_label} on vutuv:</.email_p>
   <.email_markdown :if={@message_body} body={@message_body} />
   <.email_button href={"#{@url}messages/#{@conversation_id}"}>Read and reply</.email_button>
   <.email_p>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.262.1",
+      version: "7.263.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -484,11 +484,6 @@ msgstr "Name"
 msgid "New"
 msgstr "Neu"
 
-#: lib/vutuv/notifications/emailer.ex:281
-#, elixir-autogen
-msgid "New message from @%{slug} on vutuv"
-msgstr "Neue Nachricht von @%{slug} auf vutuv"
-
 #: lib/vutuv_web/agent_docs/markdown.ex:514
 #: lib/vutuv_web/templates/user/edit.html.heex:140
 #, elixir-autogen
@@ -1074,22 +1069,22 @@ msgstr "Allgemeines"
 msgid "Verify"
 msgstr "Verifizieren"
 
-#: lib/vutuv/notifications/emailer.ex:212
+#: lib/vutuv/notifications/emailer.ex:213
 #, elixir-autogen
 msgid "Confirm your account deletion"
 msgstr "PIN zum Löschen eines vutuv-Kontos"
 
-#: lib/vutuv/notifications/emailer.ex:206
+#: lib/vutuv/notifications/emailer.ex:207
 #, elixir-autogen
 msgid "Confirm your email"
 msgstr "Weitere E-Mail-Adresse für ein vutuv-Konto bestätigen"
 
-#: lib/vutuv/notifications/emailer.ex:194
+#: lib/vutuv/notifications/emailer.ex:195
 #, elixir-autogen
 msgid "Confirm your vutuv account"
 msgstr "vutuv-Konto einrichten"
 
-#: lib/vutuv/notifications/emailer.ex:200
+#: lib/vutuv/notifications/emailer.ex:201
 #, elixir-autogen
 msgid "Login to vutuv"
 msgstr "vutuv Login-PIN"
@@ -1582,7 +1577,7 @@ msgstr "Verwandte Tags anzeigen"
 msgid "tag name"
 msgstr "Tag-Name"
 
-#: lib/vutuv/notifications/emailer.ex:252
+#: lib/vutuv/notifications/emailer.ex:253
 #, elixir-autogen
 msgid "vutuv Account verified"
 msgstr "verifizierter Account"
@@ -3589,42 +3584,42 @@ msgstr ""
 msgid "yes"
 msgstr "ja"
 
-#: lib/vutuv/notifications/emailer.ex:901
+#: lib/vutuv/notifications/emailer.ex:900
 #, elixir-autogen, elixir-format
 msgid "A warning for your vutuv account"
 msgstr "Eine Verwarnung für Ihr vutuv-Konto"
 
-#: lib/vutuv/notifications/emailer.ex:985
+#: lib/vutuv/notifications/emailer.ex:984
 #, elixir-autogen, elixir-format
 msgid "Moderation: %{count} cases are waiting"
 msgstr "Moderation: %{count} Fälle warten"
 
-#: lib/vutuv/notifications/emailer.ex:963
+#: lib/vutuv/notifications/emailer.ex:962
 #, elixir-autogen, elixir-format
 msgid "Moderation: a profile was reported"
 msgstr "Moderation: Ein Profil wurde gemeldet"
 
-#: lib/vutuv/notifications/emailer.ex:875
+#: lib/vutuv/notifications/emailer.ex:874
 #, elixir-autogen, elixir-format
 msgid "The content you reported was revised"
 msgstr "Der von Ihnen gemeldete Inhalt wurde überarbeitet"
 
-#: lib/vutuv/notifications/emailer.ex:868
+#: lib/vutuv/notifications/emailer.ex:867
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv is under review"
 msgstr "Ihr Inhalt auf vutuv wird geprüft"
 
-#: lib/vutuv/notifications/emailer.ex:861
+#: lib/vutuv/notifications/emailer.ex:860
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv was reported and is hidden"
 msgstr "Ihr Inhalt auf vutuv wurde gemeldet und ist verborgen"
 
-#: lib/vutuv/notifications/emailer.ex:915
+#: lib/vutuv/notifications/emailer.ex:914
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account has been deactivated"
 msgstr "Ihr vutuv-Konto wurde deaktiviert"
 
-#: lib/vutuv/notifications/emailer.ex:908
+#: lib/vutuv/notifications/emailer.ex:907
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account is suspended"
 msgstr "Ihr vutuv-Konto ist gesperrt"
@@ -5647,7 +5642,7 @@ msgstr "Fußzeilen-Navigation"
 msgid "View post"
 msgstr "Beitrag ansehen"
 
-#: lib/vutuv/notifications/emailer.ex:244
+#: lib/vutuv/notifications/emailer.ex:245
 #, elixir-autogen, elixir-format
 msgid "Someone tried to register with your email address"
 msgstr "Registrierungsversuch mit Ihrer E-Mail-Adresse"
@@ -5844,12 +5839,12 @@ msgstr "z. B. Dr. oder Prof."
 msgid "e.g. Jr. or PhD"
 msgstr "z. B. jun. oder B.Sc."
 
-#: lib/vutuv/notifications/emailer.ex:347
+#: lib/vutuv/notifications/emailer.ex:346
 #, elixir-autogen, elixir-format
 msgid "@%{slug} endorsed you on vutuv"
 msgstr "@%{slug} hat Sie auf vutuv empfohlen"
 
-#: lib/vutuv/notifications/emailer.ex:333
+#: lib/vutuv/notifications/emailer.ex:332
 #, elixir-autogen, elixir-format
 msgid "@%{slug} started following you on vutuv"
 msgstr "@%{slug} folgt Ihnen jetzt auf vutuv"
@@ -6094,7 +6089,7 @@ msgstr[1] "vor %{count} Minuten"
 msgid "All other devices have been logged out."
 msgstr "Alle anderen Geräte wurden abgemeldet."
 
-#: lib/vutuv/notifications/emailer.ex:645
+#: lib/vutuv/notifications/emailer.ex:644
 #, elixir-autogen, elixir-format
 msgid "Another session was already active on your account."
 msgstr "Auf Ihrem Konto war bereits eine andere Sitzung aktiv."
@@ -6119,7 +6114,7 @@ msgstr "Von allen Geräten außer diesem abmelden?"
 msgid "Log this device out of your account?"
 msgstr "Dieses Gerät von Ihrem Konto abmelden?"
 
-#: lib/vutuv/notifications/emailer.ex:620
+#: lib/vutuv/notifications/emailer.ex:619
 #, elixir-autogen, elixir-format
 msgid "New sign-in to your vutuv account"
 msgstr "Neue Anmeldung bei Ihrem vutuv-Konto"
@@ -6134,7 +6129,7 @@ msgstr "Angemeldete Geräte"
 msgid "That device has been logged out."
 msgstr "Dieses Gerät wurde abgemeldet."
 
-#: lib/vutuv/notifications/emailer.ex:648
+#: lib/vutuv/notifications/emailer.ex:647
 #, elixir-autogen, elixir-format
 msgid "The location looks different from where you usually sign in."
 msgstr "Der Ort weicht von dem ab, von dem Sie sich üblicherweise anmelden."
@@ -6144,7 +6139,7 @@ msgstr "Der Ort weicht von dem ab, von dem Sie sich üblicherweise anmelden."
 msgid "This device"
 msgstr "Dieses Gerät"
 
-#: lib/vutuv/notifications/emailer.ex:642
+#: lib/vutuv/notifications/emailer.ex:641
 #, elixir-autogen, elixir-format
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
@@ -13055,7 +13050,7 @@ msgstr "Veröffentlichen"
 
 #: lib/vutuv/accounts/user.ex:1097
 #: lib/vutuv/jobs/job_posting.ex:164
-#: lib/vutuv/notifications/emailer.ex:497
+#: lib/vutuv/notifications/emailer.ex:496
 #: lib/vutuv_web/agent_docs/markdown.ex:388
 #: lib/vutuv_web/agent_docs/markdown.ex:390
 #: lib/vutuv_web/agent_docs/text.ex:408
@@ -13190,12 +13185,12 @@ msgstr "Arbeitsort"
 msgid "You already have the maximum number of published postings."
 msgstr "Sie haben bereits die maximale Anzahl veröffentlichter Anzeigen."
 
-#: lib/vutuv/notifications/emailer.ex:931
+#: lib/vutuv/notifications/emailer.ex:930
 #, elixir-autogen, elixir-format
 msgid "Your job posting on vutuv expires soon"
 msgstr "Ihre Stellenanzeige auf vutuv läuft bald ab"
 
-#: lib/vutuv/notifications/emailer.ex:834
+#: lib/vutuv/notifications/emailer.ex:833
 #, elixir-autogen, elixir-format
 msgid "A domain of your organization page on vutuv is about to be dropped"
 msgstr "Eine Domain Ihrer Organisationsseite auf vutuv entfällt bald"
@@ -13215,12 +13210,12 @@ msgstr "Nachweis fehlt"
 msgid "We could not read this domain's proof on the last check. Restore it and check again, or the domain loses its verification."
 msgstr "Der Nachweis dieser Domain war bei der letzten Prüfung nicht abrufbar. Stellen Sie ihn wieder her und prüfen Sie erneut, sonst verliert die Domain ihre Verifizierung."
 
-#: lib/vutuv/notifications/emailer.ex:831
+#: lib/vutuv/notifications/emailer.ex:830
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is about to lose its verification"
 msgstr "Ihre Organisationsseite auf vutuv verliert bald ihre Verifizierung"
 
-#: lib/vutuv/notifications/emailer.ex:852
+#: lib/vutuv/notifications/emailer.ex:851
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is no longer public"
 msgstr "Ihre Organisationsseite auf vutuv ist nicht mehr öffentlich"
@@ -13670,7 +13665,7 @@ msgstr "verifizierte Organisationsseite"
 msgid "—"
 msgstr "—"
 
-#: lib/vutuv/notifications/emailer.ex:446
+#: lib/vutuv/notifications/emailer.ex:445
 #, elixir-autogen, elixir-format
 msgid "%{count} new match for your saved searches"
 msgid_plural "%{count} new matches for your saved searches"
@@ -14810,7 +14805,7 @@ msgstr "Bevorzugte Arbeitsform"
 msgid "Availability"
 msgstr "Verfügbarkeit"
 
-#: lib/vutuv/notifications/emailer.ex:893
+#: lib/vutuv/notifications/emailer.ex:892
 #, elixir-autogen, elixir-format
 msgid "An automated check removed an image from your vutuv account"
 msgstr "Eine automatische Prüfung hat ein Bild aus Ihrem vutuv-Konto entfernt"
@@ -16394,7 +16389,7 @@ msgstr "Bitte bestätigen Sie die Änderung, bevor wir Ihr Konto umbenennen."
 msgid "This confirmation expired. Please start again."
 msgstr "Diese Bestätigung ist abgelaufen. Bitte beginnen Sie von vorn."
 
-#: lib/vutuv/notifications/emailer.ex:226
+#: lib/vutuv/notifications/emailer.ex:227
 #, elixir-autogen, elixir-format
 msgid "Confirm your new username"
 msgstr "Bestätigen Sie Ihren neuen Benutzernamen"
@@ -19705,7 +19700,7 @@ msgstr "Wenn die Prüfung eines Ihrer Arbeitszeugnisse fertig ist. Das dauert ei
 msgid "Your employment reference has been reviewed."
 msgstr "Ihr Arbeitszeugnis wurde geprüft."
 
-#: lib/vutuv/notifications/emailer.ex:410
+#: lib/vutuv/notifications/emailer.ex:409
 #, elixir-autogen, elixir-format
 msgid "Your reference “%{title}” has been reviewed"
 msgstr "Ihr Zeugnis „%{title}“ wurde geprüft"
@@ -19780,7 +19775,7 @@ msgstr "Nur nötig, wenn Sie keine Datei zum Hochladen haben."
 msgid "Upload the PDF or the scan. We read the text out of it, and the review always reads that text, never the file itself."
 msgstr "Laden Sie das PDF oder den Scan hoch. Wir lesen den Text daraus aus, und die Prüfung liest immer diesen Text, nie die Datei selbst."
 
-#: lib/vutuv/notifications/emailer.ex:391
+#: lib/vutuv/notifications/emailer.ex:390
 #, elixir-autogen, elixir-format
 msgid "%{count} new notification on vutuv"
 msgid_plural "%{count} new notifications on vutuv"
@@ -21141,3 +21136,8 @@ msgstr "Diese Seite folgt noch niemandem auf einem anderen Netzwerk."
 #, elixir-autogen, elixir-format
 msgid "Too many attempts for now. Try again later."
 msgstr "Zu viele Versuche. Bitte versuchen Sie es später erneut."
+
+#: lib/vutuv/notifications/emailer.ex:282
+#, elixir-autogen, elixir-format
+msgid "New message from %{sender} on vutuv"
+msgstr "Neue Nachricht von %{sender} auf vutuv"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -484,11 +484,6 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:281
-#, elixir-autogen
-msgid "New message from @%{slug} on vutuv"
-msgstr ""
-
 #: lib/vutuv_web/agent_docs/markdown.ex:514
 #: lib/vutuv_web/templates/user/edit.html.heex:140
 #, elixir-autogen
@@ -1053,22 +1048,22 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:212
+#: lib/vutuv/notifications/emailer.ex:213
 #, elixir-autogen
 msgid "Confirm your account deletion"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:206
+#: lib/vutuv/notifications/emailer.ex:207
 #, elixir-autogen
 msgid "Confirm your email"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:194
+#: lib/vutuv/notifications/emailer.ex:195
 #, elixir-autogen
 msgid "Confirm your vutuv account"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:200
+#: lib/vutuv/notifications/emailer.ex:201
 #, elixir-autogen
 msgid "Login to vutuv"
 msgstr ""
@@ -1552,7 +1547,7 @@ msgstr ""
 msgid "tag name"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:252
+#: lib/vutuv/notifications/emailer.ex:253
 #, elixir-autogen
 msgid "vutuv Account verified"
 msgstr ""
@@ -3486,42 +3481,42 @@ msgstr ""
 msgid "yes"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:901
+#: lib/vutuv/notifications/emailer.ex:900
 #, elixir-autogen, elixir-format
 msgid "A warning for your vutuv account"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:985
+#: lib/vutuv/notifications/emailer.ex:984
 #, elixir-autogen, elixir-format
 msgid "Moderation: %{count} cases are waiting"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:963
+#: lib/vutuv/notifications/emailer.ex:962
 #, elixir-autogen, elixir-format
 msgid "Moderation: a profile was reported"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:875
+#: lib/vutuv/notifications/emailer.ex:874
 #, elixir-autogen, elixir-format
 msgid "The content you reported was revised"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:868
+#: lib/vutuv/notifications/emailer.ex:867
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv is under review"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:861
+#: lib/vutuv/notifications/emailer.ex:860
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv was reported and is hidden"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:915
+#: lib/vutuv/notifications/emailer.ex:914
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account has been deactivated"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:908
+#: lib/vutuv/notifications/emailer.ex:907
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account is suspended"
 msgstr ""
@@ -5422,7 +5417,7 @@ msgstr ""
 msgid "View post"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:244
+#: lib/vutuv/notifications/emailer.ex:245
 #, elixir-autogen, elixir-format
 msgid "Someone tried to register with your email address"
 msgstr ""
@@ -5616,12 +5611,12 @@ msgstr ""
 msgid "e.g. Jr. or PhD"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:347
+#: lib/vutuv/notifications/emailer.ex:346
 #, elixir-autogen, elixir-format
 msgid "@%{slug} endorsed you on vutuv"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:333
+#: lib/vutuv/notifications/emailer.ex:332
 #, elixir-autogen, elixir-format
 msgid "@%{slug} started following you on vutuv"
 msgstr ""
@@ -5862,7 +5857,7 @@ msgstr[1] ""
 msgid "All other devices have been logged out."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:645
+#: lib/vutuv/notifications/emailer.ex:644
 #, elixir-autogen, elixir-format
 msgid "Another session was already active on your account."
 msgstr ""
@@ -5887,7 +5882,7 @@ msgstr ""
 msgid "Log this device out of your account?"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:620
+#: lib/vutuv/notifications/emailer.ex:619
 #, elixir-autogen, elixir-format
 msgid "New sign-in to your vutuv account"
 msgstr ""
@@ -5902,7 +5897,7 @@ msgstr ""
 msgid "That device has been logged out."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:648
+#: lib/vutuv/notifications/emailer.ex:647
 #, elixir-autogen, elixir-format
 msgid "The location looks different from where you usually sign in."
 msgstr ""
@@ -5912,7 +5907,7 @@ msgstr ""
 msgid "This device"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:642
+#: lib/vutuv/notifications/emailer.ex:641
 #, elixir-autogen, elixir-format
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
@@ -12389,7 +12384,7 @@ msgstr ""
 
 #: lib/vutuv/accounts/user.ex:1097
 #: lib/vutuv/jobs/job_posting.ex:164
-#: lib/vutuv/notifications/emailer.ex:497
+#: lib/vutuv/notifications/emailer.ex:496
 #: lib/vutuv_web/agent_docs/markdown.ex:388
 #: lib/vutuv_web/agent_docs/markdown.ex:390
 #: lib/vutuv_web/agent_docs/text.ex:408
@@ -12524,12 +12519,12 @@ msgstr ""
 msgid "You already have the maximum number of published postings."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:931
+#: lib/vutuv/notifications/emailer.ex:930
 #, elixir-autogen, elixir-format
 msgid "Your job posting on vutuv expires soon"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:834
+#: lib/vutuv/notifications/emailer.ex:833
 #, elixir-autogen, elixir-format
 msgid "A domain of your organization page on vutuv is about to be dropped"
 msgstr ""
@@ -12549,12 +12544,12 @@ msgstr ""
 msgid "We could not read this domain's proof on the last check. Restore it and check again, or the domain loses its verification."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:831
+#: lib/vutuv/notifications/emailer.ex:830
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is about to lose its verification"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:852
+#: lib/vutuv/notifications/emailer.ex:851
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is no longer public"
 msgstr ""
@@ -13004,7 +12999,7 @@ msgstr ""
 msgid "—"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:446
+#: lib/vutuv/notifications/emailer.ex:445
 #, elixir-autogen, elixir-format
 msgid "%{count} new match for your saved searches"
 msgid_plural "%{count} new matches for your saved searches"
@@ -14111,7 +14106,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:893
+#: lib/vutuv/notifications/emailer.ex:892
 #, elixir-autogen, elixir-format
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
@@ -15669,7 +15664,7 @@ msgstr ""
 msgid "This confirmation expired. Please start again."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:226
+#: lib/vutuv/notifications/emailer.ex:227
 #, elixir-autogen, elixir-format
 msgid "Confirm your new username"
 msgstr ""
@@ -18939,7 +18934,7 @@ msgstr ""
 msgid "Your employment reference has been reviewed."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:410
+#: lib/vutuv/notifications/emailer.ex:409
 #, elixir-autogen, elixir-format
 msgid "Your reference “%{title}” has been reviewed"
 msgstr ""
@@ -19014,7 +19009,7 @@ msgstr ""
 msgid "Upload the PDF or the scan. We read the text out of it, and the review always reads that text, never the file itself."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:391
+#: lib/vutuv/notifications/emailer.ex:390
 #, elixir-autogen, elixir-format
 msgid "%{count} new notification on vutuv"
 msgid_plural "%{count} new notifications on vutuv"
@@ -20356,4 +20351,9 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:135
 #, elixir-autogen, elixir-format
 msgid "Too many attempts for now. Try again later."
+msgstr ""
+
+#: lib/vutuv/notifications/emailer.ex:282
+#, elixir-autogen, elixir-format
+msgid "New message from %{sender} on vutuv"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -482,11 +482,6 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:281
-#, elixir-autogen
-msgid "New message from @%{slug} on vutuv"
-msgstr ""
-
 #: lib/vutuv_web/agent_docs/markdown.ex:514
 #: lib/vutuv_web/templates/user/edit.html.heex:140
 #, elixir-autogen
@@ -1051,22 +1046,22 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:212
+#: lib/vutuv/notifications/emailer.ex:213
 #, elixir-autogen
 msgid "Confirm your account deletion"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:206
+#: lib/vutuv/notifications/emailer.ex:207
 #, elixir-autogen
 msgid "Confirm your email"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:194
+#: lib/vutuv/notifications/emailer.ex:195
 #, elixir-autogen
 msgid "Confirm your vutuv account"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:200
+#: lib/vutuv/notifications/emailer.ex:201
 #, elixir-autogen
 msgid "Login to vutuv"
 msgstr ""
@@ -1550,7 +1545,7 @@ msgstr ""
 msgid "tag name"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:252
+#: lib/vutuv/notifications/emailer.ex:253
 #, elixir-autogen
 msgid "vutuv Account verified"
 msgstr ""
@@ -3484,42 +3479,42 @@ msgstr ""
 msgid "yes"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:901
+#: lib/vutuv/notifications/emailer.ex:900
 #, elixir-autogen, elixir-format
 msgid "A warning for your vutuv account"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:985
+#: lib/vutuv/notifications/emailer.ex:984
 #, elixir-autogen, elixir-format
 msgid "Moderation: %{count} cases are waiting"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:963
+#: lib/vutuv/notifications/emailer.ex:962
 #, elixir-autogen, elixir-format
 msgid "Moderation: a profile was reported"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:875
+#: lib/vutuv/notifications/emailer.ex:874
 #, elixir-autogen, elixir-format
 msgid "The content you reported was revised"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:868
+#: lib/vutuv/notifications/emailer.ex:867
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv is under review"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:861
+#: lib/vutuv/notifications/emailer.ex:860
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv was reported and is hidden"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:915
+#: lib/vutuv/notifications/emailer.ex:914
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account has been deactivated"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:908
+#: lib/vutuv/notifications/emailer.ex:907
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account is suspended"
 msgstr ""
@@ -5420,7 +5415,7 @@ msgstr ""
 msgid "View post"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:244
+#: lib/vutuv/notifications/emailer.ex:245
 #, elixir-autogen, elixir-format
 msgid "Someone tried to register with your email address"
 msgstr ""
@@ -5614,12 +5609,12 @@ msgstr ""
 msgid "e.g. Jr. or PhD"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:347
+#: lib/vutuv/notifications/emailer.ex:346
 #, elixir-autogen, elixir-format
 msgid "@%{slug} endorsed you on vutuv"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:333
+#: lib/vutuv/notifications/emailer.ex:332
 #, elixir-autogen, elixir-format
 msgid "@%{slug} started following you on vutuv"
 msgstr ""
@@ -5860,7 +5855,7 @@ msgstr[1] ""
 msgid "All other devices have been logged out."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:645
+#: lib/vutuv/notifications/emailer.ex:644
 #, elixir-autogen, elixir-format
 msgid "Another session was already active on your account."
 msgstr ""
@@ -5885,7 +5880,7 @@ msgstr ""
 msgid "Log this device out of your account?"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:620
+#: lib/vutuv/notifications/emailer.ex:619
 #, elixir-autogen, elixir-format
 msgid "New sign-in to your vutuv account"
 msgstr ""
@@ -5900,7 +5895,7 @@ msgstr ""
 msgid "That device has been logged out."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:648
+#: lib/vutuv/notifications/emailer.ex:647
 #, elixir-autogen, elixir-format
 msgid "The location looks different from where you usually sign in."
 msgstr ""
@@ -5910,7 +5905,7 @@ msgstr ""
 msgid "This device"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:642
+#: lib/vutuv/notifications/emailer.ex:641
 #, elixir-autogen, elixir-format
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
@@ -12387,7 +12382,7 @@ msgstr ""
 
 #: lib/vutuv/accounts/user.ex:1097
 #: lib/vutuv/jobs/job_posting.ex:164
-#: lib/vutuv/notifications/emailer.ex:497
+#: lib/vutuv/notifications/emailer.ex:496
 #: lib/vutuv_web/agent_docs/markdown.ex:388
 #: lib/vutuv_web/agent_docs/markdown.ex:390
 #: lib/vutuv_web/agent_docs/text.ex:408
@@ -12522,12 +12517,12 @@ msgstr ""
 msgid "You already have the maximum number of published postings."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:931
+#: lib/vutuv/notifications/emailer.ex:930
 #, elixir-autogen, elixir-format
 msgid "Your job posting on vutuv expires soon"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:834
+#: lib/vutuv/notifications/emailer.ex:833
 #, elixir-autogen, elixir-format
 msgid "A domain of your organization page on vutuv is about to be dropped"
 msgstr ""
@@ -12547,12 +12542,12 @@ msgstr ""
 msgid "We could not read this domain's proof on the last check. Restore it and check again, or the domain loses its verification."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:831
+#: lib/vutuv/notifications/emailer.ex:830
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is about to lose its verification"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:852
+#: lib/vutuv/notifications/emailer.ex:851
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is no longer public"
 msgstr ""
@@ -13002,7 +12997,7 @@ msgstr ""
 msgid "—"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:446
+#: lib/vutuv/notifications/emailer.ex:445
 #, elixir-autogen, elixir-format
 msgid "%{count} new match for your saved searches"
 msgid_plural "%{count} new matches for your saved searches"
@@ -14109,7 +14104,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:893
+#: lib/vutuv/notifications/emailer.ex:892
 #, elixir-autogen, elixir-format
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
@@ -15667,7 +15662,7 @@ msgstr ""
 msgid "This confirmation expired. Please start again."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:226
+#: lib/vutuv/notifications/emailer.ex:227
 #, elixir-autogen, elixir-format
 msgid "Confirm your new username"
 msgstr ""
@@ -18937,7 +18932,7 @@ msgstr ""
 msgid "Your employment reference has been reviewed."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:410
+#: lib/vutuv/notifications/emailer.ex:409
 #, elixir-autogen, elixir-format
 msgid "Your reference “%{title}” has been reviewed"
 msgstr ""
@@ -19012,7 +19007,7 @@ msgstr ""
 msgid "Upload the PDF or the scan. We read the text out of it, and the review always reads that text, never the file itself."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:391
+#: lib/vutuv/notifications/emailer.ex:390
 #, elixir-autogen, elixir-format
 msgid "%{count} new notification on vutuv"
 msgid_plural "%{count} new notifications on vutuv"
@@ -20354,4 +20349,9 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:135
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Too many attempts for now. Try again later."
+msgstr ""
+
+#: lib/vutuv/notifications/emailer.ex:282
+#, elixir-autogen, elixir-format, fuzzy
+msgid "New message from %{sender} on vutuv"
 msgstr ""

--- a/priv/repo/migrations/20260811204959_add_organization_to_conversations.exs
+++ b/priv/repo/migrations/20260811204959_add_organization_to_conversations.exs
@@ -1,0 +1,129 @@
+defmodule Vutuv.Repo.Migrations.AddOrganizationToConversations do
+  @moduledoc """
+  Issue #1336's last point: somebody can write **to a page**.
+
+  ## The sorted pair does not have to be generalised
+
+  I had this filed for months as the hard one, because `conversations` stores
+  its pair sorted (`user_a_id < user_b_id`) so that one unique index can allow
+  exactly one conversation per pair. Sorting exists to break a symmetry: with
+  two ids from the *same* table, `(a, b)` and `(b, a)` name the same
+  conversation and something has to pick a canonical order.
+
+  A member↔page conversation has no such symmetry. The two sides come from
+  different tables, so `(user_a_id, organization_id)` is already canonical and
+  needs no sorting at all — a second unique index is the whole story. The
+  existing `sorted_pair` CHECK is re-created to apply only when `user_b_id` is
+  present, which is exactly the case it was written for.
+
+  ## The shape
+
+    * member↔member: `user_a_id` + `user_b_id` (sorted), `organization_id` NULL
+    * member↔page:   `user_a_id` = the member, `user_b_id` NULL, `organization_id` set
+
+  So `user_a_id` is always the member, and the CHECK says the other side is
+  exactly one of the two kinds.
+
+  The page's side of `conversation_participants` is **one row for the page**,
+  not one per publisher — the same model as `organizations.activity_read_at`:
+  read means somebody on the team read it, never that everybody did. A row per
+  publisher would also have to be invented and retired as roles change, and
+  would leave a conversation's read state depending on who still holds a role.
+
+  N-1 safe: the previous release only writes member conversations, which satisfy
+  both CHECKs, and every query it runs names `user_a_id`/`user_b_id`.
+  """
+  use Ecto.Migration
+
+  def up do
+    alter table(:conversations) do
+      add(
+        :organization_id,
+        references(:organizations, type: :binary_id, on_delete: :delete_all)
+      )
+    end
+
+    execute("ALTER TABLE conversations ALTER COLUMN user_b_id DROP NOT NULL")
+
+    # Only meaningful for a member↔member row; a page conversation has no
+    # second user id to order against.
+    execute("ALTER TABLE conversations DROP CONSTRAINT sorted_pair")
+
+    execute("""
+    ALTER TABLE conversations
+      ADD CONSTRAINT sorted_pair
+      CHECK (user_b_id IS NULL OR user_a_id < user_b_id)
+    """)
+
+    create(
+      constraint(:conversations, :conversations_exactly_one_other_side,
+        check: """
+        (CASE WHEN user_b_id IS NULL THEN 0 ELSE 1 END +
+         CASE WHEN organization_id IS NULL THEN 0 ELSE 1 END) = 1
+        """
+      )
+    )
+
+    create(unique_index(:conversations, [:user_a_id, :organization_id]))
+
+    # The page's side of a conversation: one row for the whole team.
+    alter table(:conversation_participants) do
+      add(
+        :organization_id,
+        references(:organizations, type: :binary_id, on_delete: :delete_all)
+      )
+    end
+
+    execute("ALTER TABLE conversation_participants ALTER COLUMN user_id DROP NOT NULL")
+
+    create(
+      constraint(:conversation_participants, :conversation_participants_exactly_one_party,
+        check: """
+        (CASE WHEN user_id IS NULL THEN 0 ELSE 1 END +
+         CASE WHEN organization_id IS NULL THEN 0 ELSE 1 END) = 1
+        """
+      )
+    )
+
+    create(unique_index(:conversation_participants, [:conversation_id, :organization_id]))
+
+    # A message sent in the page's name, with the member who wrote it recorded
+    # internally — the same split `posts` uses for authorship (issue #1334).
+    alter table(:messages) do
+      add(
+        :sender_organization_id,
+        references(:organizations, type: :binary_id, on_delete: :delete_all)
+      )
+
+      add(:acting_user_id, references(:users, type: :binary_id, on_delete: :nilify_all))
+    end
+  end
+
+  def down do
+    alter table(:messages) do
+      remove(:acting_user_id)
+      remove(:sender_organization_id)
+    end
+
+    drop(unique_index(:conversation_participants, [:conversation_id, :organization_id]))
+    drop(constraint(:conversation_participants, :conversation_participants_exactly_one_party))
+    execute("DELETE FROM conversation_participants WHERE user_id IS NULL")
+    execute("ALTER TABLE conversation_participants ALTER COLUMN user_id SET NOT NULL")
+
+    alter table(:conversation_participants) do
+      remove(:organization_id)
+    end
+
+    drop(unique_index(:conversations, [:user_a_id, :organization_id]))
+    drop(constraint(:conversations, :conversations_exactly_one_other_side))
+
+    execute("DELETE FROM conversations WHERE user_b_id IS NULL")
+    execute("ALTER TABLE conversations DROP CONSTRAINT sorted_pair")
+    execute("ALTER TABLE conversations ADD CONSTRAINT sorted_pair CHECK (user_a_id < user_b_id)")
+    execute("ALTER TABLE conversations ALTER COLUMN user_b_id SET NOT NULL")
+
+    alter table(:conversations) do
+      remove(:organization_id)
+    end
+  end
+end

--- a/test/vutuv/organization_messages_test.exs
+++ b/test/vutuv/organization_messages_test.exs
@@ -1,0 +1,203 @@
+defmodule Vutuv.OrganizationMessagesTest do
+  @moduledoc """
+  Writing to a page, and the page answering (issue #1336's last point).
+
+  The model follows the one this milestone already set for posts: the
+  conversation belongs to the **page**, so it survives the person who handled
+  it; any publisher may read and answer; a reply is sent in the page's name with
+  the member who wrote it kept internally; and the page's read state is one
+  marker for the whole team, like its activity list.
+
+  The schema turned out not to need the sorted pair generalised. Sorting exists
+  to break the symmetry between two ids from the *same* table; a member and a
+  page come from different tables, so `(user_a_id, organization_id)` is already
+  canonical.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Chat
+  alias Vutuv.Chat.Conversation
+  alias Vutuv.Chat.Participant
+  alias Vutuv.Organizations
+  alias Vutuv.Repo
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp page_with_publisher do
+    owner = insert(:activated_user)
+    page = active_organization_for(owner)
+    {:ok, _} = Organizations.add_role(page, owner, "publisher", owner)
+    {page, owner}
+  end
+
+  test "the database refuses a conversation naming both other sides or neither" do
+    {page, _owner} = page_with_publisher()
+    a = insert(:activated_user)
+    b = insert(:activated_user)
+
+    assert_raise Ecto.ConstraintError, ~r/conversations_exactly_one_other_side/, fn ->
+      Repo.insert!(%Conversation{
+        user_a_id: a.id,
+        user_b_id: b.id,
+        organization_id: page.id,
+        initiator_id: a.id
+      })
+    end
+
+    assert_raise Ecto.ConstraintError, ~r/conversations_exactly_one_other_side/, fn ->
+      Repo.insert!(%Conversation{user_a_id: a.id, initiator_id: a.id})
+    end
+  end
+
+  test "a member opens a conversation with a page, once" do
+    {page, _owner} = page_with_publisher()
+    member = insert(:activated_user)
+
+    assert {:ok, conversation} = Chat.find_or_create_conversation(member, page)
+    assert conversation.user_a_id == member.id
+    assert is_nil(conversation.user_b_id)
+    assert conversation.organization_id == page.id
+
+    assert {:ok, same} = Chat.find_or_create_conversation(member, page)
+    assert same.id == conversation.id
+  end
+
+  test "the page's side is one participant row for the whole team" do
+    {page, _owner} = page_with_publisher()
+    member = insert(:activated_user)
+
+    {:ok, conversation} = Chat.find_or_create_conversation(member, page)
+
+    rows = Repo.all(from(p in Participant, where: p.conversation_id == ^conversation.id))
+    assert length(rows) == 2
+
+    # Read means somebody on the team read it, never that everybody did — the
+    # same model as the page's activity marker. A row per publisher would also
+    # have to be minted and retired as roles change.
+    assert Enum.any?(rows, &(&1.user_id == member.id))
+    assert Enum.any?(rows, &(&1.organization_id == page.id))
+  end
+
+  test "a publisher answers in the page's name, and who typed it stays internal" do
+    {page, owner} = page_with_publisher()
+    member = insert(:activated_user)
+
+    {:ok, conversation} = Chat.find_or_create_conversation(member, page)
+    {:ok, _} = Chat.send_message(member, conversation.id, "Guten Tag.")
+
+    assert {:ok, reply} =
+             Chat.send_message_as_organization(page, owner, conversation.id, "Guten Tag zurück.")
+
+    assert reply.sender_organization_id == page.id
+    assert is_nil(reply.sender_id)
+
+    # The member who pressed send is recorded, never shown — the same split the
+    # authorship work made for posts, and for the same reason: the message
+    # belongs to the page and must not leave with the person who typed it.
+    assert reply.acting_user_id == owner.id
+  end
+
+  test "somebody who may not speak for the page cannot answer" do
+    {page, _owner} = page_with_publisher()
+    member = insert(:activated_user)
+    stranger = insert(:activated_user)
+
+    {:ok, conversation} = Chat.find_or_create_conversation(member, page)
+
+    assert {:error, :not_allowed} =
+             Chat.send_message_as_organization(page, stranger, conversation.id, "Hallo.")
+  end
+
+  test "a page cannot answer somebody else's conversation" do
+    {page, owner} = page_with_publisher()
+
+    other_owner = insert(:activated_user)
+
+    other =
+      active_organization_for(other_owner, %{
+        "name" => "Zweite AG",
+        "website_url" => "https://zweite.example"
+      })
+
+    member = insert(:activated_user)
+    {:ok, foreign} = Chat.find_or_create_conversation(member, other)
+
+    assert {:error, :not_participant} =
+             Chat.send_message_as_organization(page, owner, foreign.id, "Nicht meins.")
+  end
+
+  test "a page nobody may see cannot be written to" do
+    {page, _owner} = page_with_publisher()
+    member = insert(:activated_user)
+
+    {:ok, _} = Organizations.admin_set_frozen(page, true)
+
+    # Deliberately the STALE struct: the gate re-reads, so a caller holding a
+    # copy loaded before the freeze must not get through.
+    assert {:error, :frozen} = Chat.find_or_create_conversation(member, page)
+  end
+
+  test "the member's own conversation list shows the page, and opening it works" do
+    {page, owner} = page_with_publisher()
+    member = insert(:activated_user)
+
+    {:ok, conversation} = Chat.find_or_create_conversation(member, page)
+    {:ok, _} = Chat.send_message(member, conversation.id, "Guten Tag.")
+
+    # `list_conversations/1` matches on `user_a_id`, so a page conversation was
+    # always going to appear here — and then `other_user/2` resolved a nil id.
+    # `Repo.one!(where: u.id == ^nil)` RAISES rather than answering nothing, so
+    # this was a 500 on the messages page for anybody who wrote to a page.
+    [entry] = Chat.list_conversations(member)
+    assert entry.conversation.id == conversation.id
+    assert %Vutuv.Organizations.Organization{} = entry.other
+
+    assert %Vutuv.Organizations.Organization{id: id} =
+             Chat.other_party(conversation, member.id)
+
+    assert id == page.id
+
+    # And the page's answer counts as unread for the member. `sender_id` is
+    # NULL on it, so every `!= me_id` test in the unread machinery had to learn
+    # to see it; a badge that stays at zero is how this would have shipped.
+    {:ok, _} = Chat.send_message_as_organization(page, owner, conversation.id, "Guten Tag.")
+
+    [entry] = Chat.list_conversations(member)
+    assert entry.unread == 1
+    assert entry.last_body == "Guten Tag."
+  end
+
+  test "the page's team sees the conversation, and the member is its other party" do
+    {page, owner} = page_with_publisher()
+    member = insert(:activated_user, first_name: "Frida", last_name: "Folger")
+
+    {:ok, conversation} = Chat.find_or_create_conversation(member, page)
+    {:ok, _} = Chat.send_message(member, conversation.id, "Guten Tag.")
+
+    [entry] = Chat.list_organization_conversations(page)
+    assert entry.conversation.id == conversation.id
+    assert entry.last_body == "Guten Tag."
+    # The member wrote it, so it is unread for the page's whole team.
+    assert entry.unread == 1
+
+    assert %Vutuv.Accounts.User{id: id} = Chat.other_party(conversation, page.id)
+    assert id == member.id
+
+    # Any publisher, not only whoever happened to be addressed.
+    assert Organizations.publisher?(page, owner)
+  end
+end


### PR DESCRIPTION
Der letzte offene Punkt aus #1336: bisher konnte man einer Organisation nicht schreiben.

## Das Modell

Es folgt dem, was dieser Meilenstein für Beiträge schon gesetzt hat:

- die Unterhaltung gehört der **Seite**, überlebt also die Person, die sie bearbeitet hat
- jede Person mit Publisher-Rolle darf lesen und antworten, und das Recht wird **live** gefragt, nicht beim Öffnen
- eine Antwort geht im Namen der Seite raus; wer sie getippt hat, steht als `acting_user_id` intern dabei und wird nie gezeigt
- der Gelesen-Stand ist **eine** Marke für das ganze Team, wie `organizations.activity_read_at` — gelesen heißt, jemand hat gelesen, nie dass alle gelesen haben

Kein Anfrage-/Annahme-Tanz: eine Seite veröffentlicht, um angeschrieben zu werden. Ein "pending" würde die erste Antwort ihres Teams wie eine Zustimmung aussehen lassen.

## Das sortierte Paar musste nicht verallgemeinert werden

Ich hatte das seit Monaten als das harte Stück im Kopf. Sortiert wird aber, um die Symmetrie zwischen zwei IDs aus **derselben** Tabelle zu brechen. Ein Mitglied und eine Seite kommen aus verschiedenen Tabellen, also ist `(user_a_id, organization_id)` schon kanonisch — ein zweiter Unique-Index ist die ganze Geschichte, und der alte `sorted_pair`-CHECK gilt jetzt nur noch, wenn `user_b_id` überhaupt gesetzt ist.

## Teurer als das Schema waren die Leser

`conversations.user_b_id` ist jetzt nullable, und die Liste eines Mitglieds trifft eine Seiten-Unterhaltung sehr wohl (sie matcht auf `user_a_id`). Vier Treffer, alle aus derselben Familie wie die elf aus diesem Meilenstein:

| Stelle | Was passiert wäre |
|---|---|
| `other_user/2` in der Nachrichtenliste | `Repo.one!(where: u.id == ^nil)` **fliegt** → 500er auf `/messages` für jeden, der einer Seite geschrieben hat |
| `unread_counts/2` | `NULL != <id>` ist NULL, nicht wahr → die Antwort einer Seite zählt nie als ungelesen, Badge bleibt still auf null |
| `send_unread_notifications` EXISTS-Klausel | dieselbe Sorte in rohem SQL → die Benachrichtigungsmail geht nie raus |
| `unread_bodies_to_notify/3` | dieselbe Sorte → auch mit gefixter EXISTS-Klausel keine Bodies |

Ein **fünfter** steckte in meiner eigenen Korrektur (`own_message/1` verglich die neue Spalte genauso naiv) und ist erst durch den Test aufgefallen, der beide Richtungen prüft.

## Nebenbei

Die Mail benennt die Gegenseite über ein Label statt über einen Handle: eine Seite hat nur dann einen, wenn sie sich ein Wort geholt hat, also nennt sie sich sonst bei ihrem Namen. Das `@` ist damit aus den vier Templates ins Label gewandert.

`mix precommit` grün, 7356 Tests. Der neue deutsche String wurde von `gettext.extract --merge` fuzzy mit dem alten Platzhalter `@%{slug}` gefüllt und ist von Hand korrigiert.

Die Oberfläche dazu (die Nachrichtenseite zeigt Seiten-Unterhaltungen, Antworten im Namen der Seite) kommt als eigener PR — `send_message_as_organization/4` hat noch keinen Aufrufer aus dem UI.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01MMwsQi49FP21xuSoPEkMnN