### PR TITLE
Das Postfach einer Seite (v7.264.0)

### DIFF
--- a/docs/architecture/messages.md
+++ b/docs/architecture/messages.md
@@ -60,3 +60,50 @@ emailed about **every** unread message or only the **first** of a burst (the
 default), and how long a message may sit unread before the email goes out (0 to
 120 minutes, default 15); every such email says which mode is active and
 deep-links to those settings.
+
+## Writing to a page (issue #1336)
+
+A conversation can have a **page** on the other side. `conversations` grew a
+nullable `organization_id` beside `user_b_id` with a CHECK that exactly one of
+them is set, so there are two shapes:
+
+    member <-> member: user_a_id + user_b_id (sorted), organization_id NULL
+    member <-> page:   user_a_id = the member, user_b_id NULL, organization set
+
+`user_a_id` is always the member. The sorted pair was **not** generalised:
+sorting exists to break the symmetry between two ids from the same table, and
+these two come from different ones, so the pair is already canonical and a
+second unique index is the whole story.
+
+**There is no second messages page.** A publisher who switched into a page
+(`acting_as`, issue #1335) opens the same `/messages` and finds the *page's*
+inbox; everybody else finds their own. `MessageLive.Index` resolves one
+`:viewer` assign at mount — `acting_as || current_user` — and every `Chat` call
+on the page goes through it. That identity is re-derived from the roles on every
+mount, so a withdrawn publisher lands on their own inbox rather than the page's.
+
+What differs on the page's side, and why:
+
+  * **No request/accept dance.** A page publishes in order to be addressed, so
+    there is nothing for it to approve, and a "pending" state would make its
+    team's first reply look like an acceptance.
+  * **One participant row for the whole team**, not one per publisher: read
+    means somebody read it, never that everybody did — the model
+    `organizations.activity_read_at` already sets. A row per publisher would
+    also have to be minted and retired as roles change.
+  * **A reply is the page's**, with `messages.acting_user_id` recording who
+    typed it and never showing it — the same split `posts` makes for authorship,
+    so the message does not walk out of the door with the person.
+  * **No block, no online dot.** Both are about people.
+  * **The right to answer follows the role**, asked live on every send.
+
+### The nullable column charged its usual toll
+
+Everything above is cheap. The readers were not. `conversations.user_b_id`
+became nullable, and a member's own list matches on `user_a_id`, so a page
+conversation turned up in it immediately — where `other_user/2` resolved a nil
+id and `Repo.one!` **raised**. Three more places tested `sender_id != <id>`,
+which is NULL and not true for a page's message, so its reply counted as unread
+nowhere and its notification mail never went out. `Chat.other_party/2` and
+`Chat.own_message/1` are the two functions that now own those questions; a call
+site naming either column directly is the bug to look for.

--- a/docs/architecture/organizations.md
+++ b/docs/architecture/organizations.md
@@ -267,6 +267,18 @@ piece lives:
   on the page and not a row per member. The marker is the newest entry's
   timestamp rather than the wall clock (second-precision tables + a strict `>`),
   and an empty list stamps nothing.
+- **It can be written to** (#1336). `conversations` carries a nullable
+  `organization_id` beside `user_b_id` (CHECK: exactly one other side), so a
+  member↔page conversation is `user_a_id` = the member, `user_b_id` NULL. The
+  sorted pair did **not** have to be generalised: sorting exists to break the
+  symmetry between two ids from the *same* table, and a member and a page come
+  from different ones, so `(user_a_id, organization_id)` is already canonical.
+  There is no request/accept dance (a page publishes in order to be addressed),
+  the page's side of `conversation_participants` is **one row for the whole
+  team** like `activity_read_at`, and a reply is sent in the page's name with
+  `messages.acting_user_id` recorded and never shown. Reading and answering
+  happen at the ordinary `/messages`, whose inbox is whichever identity the
+  session is currently speaking as — see `messages.md`.
 - **It is mentionable** by its root handle, and reachable from search, the tag
   pages, the sitemap, `/llms.txt`, its own RSS feed and the agent formats.
 
@@ -292,6 +304,16 @@ daily report mail). None was reported by a user; all were found by sweeping.
 So when the next kind of actor arrives: enumerate every module that **reads**
 the thing, not the one that stores it, and route the URL through the function
 that owns it.
+
+`conversations` then charged the same toll a second time, in the same three
+flavours: `Repo.one!(where: u.id == ^nil)` **raised** (the member's whole
+`/messages` was a 500 once they had written to a page), and three separate
+`sender_id != <id>` tests answered NULL rather than true for a page's message,
+so its reply counted as unread nowhere and the notification mail for it was
+never sent. A fourth hid in the *fix* and was caught only because the test
+asserted both directions. The lesson holds: for a column that is now nullable,
+`x != v` and `x == v` both need an explicit `is_nil` arm, and the test has to
+watch the un-fixed code fail.
 
 ## Multi-domain management (`/organizations/:slug/domains`, #930)
 

--- a/lib/vutuv/chat.ex
+++ b/lib/vutuv/chat.ex
@@ -335,6 +335,20 @@ defmodule Vutuv.Chat do
     end)
   end
 
+  def get_conversation(%Organization{id: page_id}, conversation_id) do
+    # No status arm: a page conversation is never a request, so there is no
+    # declined state for it to be hidden by (see find_or_create_conversation/2).
+    Vutuv.UUIDv7.with_cast(conversation_id, fn conversation_id ->
+      Repo.one(
+        from(c in Conversation,
+          where: c.id == ^conversation_id,
+          where: c.organization_id == ^page_id,
+          where: is_nil(c.frozen_at)
+        )
+      )
+    end)
+  end
+
   # The participant-scoped fetch every conversation action starts from;
   # `narrow` adds the action's extra conditions. cast_or_nil: ids arrive from
   # URLs and phx-value attributes; garbage must read as "no such
@@ -754,19 +768,30 @@ defmodule Vutuv.Chat do
   # When the caller already holds an authorized conversation (e.g. MessageLive
   # just loaded it to render the thread), pass the struct so this skips the
   # second get_conversation lookup the id form would run.
+  def messages_page(%Organization{id: page_id}, %Conversation{} = conversation, opts) do
+    thread_page({:organization, page_id}, conversation, opts)
+  end
+
   def messages_page(%User{} = me, %Conversation{} = conversation, opts) do
+    thread_page({:user, me.id}, conversation, opts)
+  end
+
+  defp thread_page(party, %Conversation{} = conversation, opts) do
     limit = Keyword.get(opts, :limit, 30)
     cursor = Keyword.get(opts, :cursor)
+    # The moderation freezer: a frozen message is hidden from the other
+    # participant but stays visible to its sender — which since issue #1336 can
+    # be a page, so the test goes through own_message/1 rather than naming a
+    # column that would be NULL on the other side's rows.
+    shown = dynamic([m], is_nil(m.frozen_at) or ^own_message(party))
 
     entries =
       from(m in Message,
         where: m.conversation_id == ^conversation.id,
-        # The moderation freezer: a frozen message is hidden from the
-        # other participant but stays visible to its sender.
-        where: is_nil(m.frozen_at) or m.sender_id == ^me.id,
+        where: ^shown,
         order_by: [desc: m.inserted_at, desc: m.id],
         limit: ^(limit + 1),
-        preload: :sender
+        preload: [:sender, :sender_organization]
       )
       |> before_cursor(cursor)
       |> Repo.all()
@@ -814,14 +839,22 @@ defmodule Vutuv.Chat do
   # read marker, looked up with a MAX. A caller already holding the just-arrived
   # message passes its inserted_at (the new newest) to skip that scan.
   def mark_read(%User{} = me, conversation_id, nil) do
-    marker =
-      from(m in Message,
-        where: m.conversation_id == ^conversation_id,
-        select: max(m.inserted_at)
-      )
-      |> Repo.one() || NaiveDateTime.utc_now(:microsecond)
+    mark_read(me, conversation_id, newest_message_at(conversation_id))
+  end
 
-    mark_read(me, conversation_id, marker)
+  def mark_read(%Organization{} = page, conversation_id, nil) do
+    mark_read(page, conversation_id, newest_message_at(conversation_id))
+  end
+
+  # ONE marker for the page, not one per publisher: read means somebody on the
+  # team read it, the same model as `organizations.activity_read_at`.
+  def mark_read(%Organization{id: page_id}, conversation_id, %NaiveDateTime{} = marker) do
+    from(p in Participant,
+      where: p.conversation_id == ^conversation_id and p.organization_id == ^page_id
+    )
+    |> Repo.update_all(set: [last_read_at: marker, notified_at: nil])
+
+    :ok
   end
 
   def mark_read(%User{id: me_id}, conversation_id, %NaiveDateTime{} = marker) do
@@ -832,6 +865,14 @@ defmodule Vutuv.Chat do
 
     Activity.mark_messages_read(me_id)
     :ok
+  end
+
+  defp newest_message_at(conversation_id) do
+    from(m in Message,
+      where: m.conversation_id == ^conversation_id,
+      select: max(m.inserted_at)
+    )
+    |> Repo.one() || NaiveDateTime.utc_now(:microsecond)
   end
 
   @doc """

--- a/lib/vutuv_web/live/message_live/index.ex
+++ b/lib/vutuv_web/live/message_live/index.ex
@@ -17,8 +17,12 @@ defmodule VutuvWeb.MessageLive.Index do
   """
   use VutuvWeb, :live_view
 
+  import VutuvWeb.OrganizationComponents, only: [organization_logo: 1]
+
   alias Vutuv.Chat
   alias Vutuv.Chat.{Conversation, Message}
+  alias Vutuv.Organizations
+  alias Vutuv.Organizations.Organization
   alias VutuvWeb.{Markdown, Presence}
 
   @typing_clear_ms 2500
@@ -42,6 +46,7 @@ defmodule VutuvWeb.MessageLive.Index do
 
     {:ok,
      socket
+     |> assign_viewer()
      |> assign(:page_title, gettext("Messages"))
      |> assign(:user_name, display_name(user))
      |> assign(:typing_tokens, %{})
@@ -54,6 +59,17 @@ defmodule VutuvWeb.MessageLive.Index do
      |> stream(:messages, [], dom_id: &"message-#{&1.id}")
      |> assign_form()}
   end
+
+  # Whose inbox this is. A publisher who switched into a page (issue #1335)
+  # reads the PAGE's messages at this same URL and answers in its name; anybody
+  # else reads their own. `:acting_as` is resolved by `Live.InitAssigns` from
+  # the roles on every mount, never trusted out of the session, so a stale
+  # session naming a page the member no longer speaks for lands on themselves.
+  defp assign_viewer(socket),
+    do: assign(socket, :viewer, socket.assigns[:acting_as] || socket.assigns.current_user)
+
+  defp page_viewer?(%Organization{}), do: true
+  defp page_viewer?(_), do: false
 
   # The sidebar lists load only on the connected mount (the page is
   # login-required, so the static render is replaced a moment later — no
@@ -77,25 +93,28 @@ defmodule VutuvWeb.MessageLive.Index do
   end
 
   defp apply_action(socket, :show, %{"id" => id} = params) do
-    user = socket.assigns.current_user
+    viewer = socket.assigns.viewer
 
-    case Chat.get_conversation(user, id) do
+    case Chat.get_conversation(viewer, id) do
       nil ->
         push_navigate(socket, to: ~p"/messages")
 
       %Conversation{} = conversation ->
         if connected?(socket) do
           Chat.subscribe(conversation.id)
-          Chat.mark_read(user, conversation.id)
+          Chat.mark_read(viewer, conversation.id)
         end
 
         # Pass the already-authorized conversation so messages_page doesn't
         # re-run get_conversation for the same row.
-        page = Chat.messages_page(user, conversation, limit: @page_size)
+        page = Chat.messages_page(viewer, conversation, limit: @page_size)
 
         socket
         |> assign(:conversation, conversation)
-        |> assign(:other, Chat.other_user(conversation, user.id))
+        # `other_user/2` cannot answer here: on a member-page conversation it
+        # resolves a nil id and `Repo.one!` RAISES rather than answering
+        # nothing, which was a 500 on this page for anybody who wrote to a page.
+        |> assign(:other, Chat.other_party(conversation, viewer.id))
         |> assign(:more?, page.more?)
         |> assign(:cursor, page.next_cursor)
         |> stream(:messages, Enum.reverse(page.entries), reset: true)
@@ -133,6 +152,29 @@ defmodule VutuvWeb.MessageLive.Index do
     end
   end
 
+  # The page's "Message" button, the twin of the profile one above.
+  defp apply_action(socket, :new_organization, %{"slug" => slug} = params) do
+    viewer = socket.assigns.current_user
+
+    case Organizations.fetch_visible_organization(slug, viewer) do
+      {:error, :not_found} ->
+        socket
+        |> put_flash(:error, gettext("This page cannot receive messages."))
+        |> push_navigate(to: ~p"/messages")
+
+      {:ok, page} ->
+        case Chat.find_or_create_conversation(viewer, page) do
+          {:ok, conversation} ->
+            push_navigate(socket, to: new_conversation_path(conversation.id, params["body"]))
+
+          {:error, _reason} ->
+            socket
+            |> put_flash(:error, gettext("This page cannot receive messages."))
+            |> push_navigate(to: ~p"/messages")
+        end
+    end
+  end
+
   # A `?body=` param prefills the composer once, on open.
   defp seed_draft(socket, body) when is_binary(body) and body != "",
     do: assign(socket, :form, to_form(%{"body" => body}, as: :message))
@@ -146,6 +188,25 @@ defmodule VutuvWeb.MessageLive.Index do
 
   ## Events
 
+  # Sent in the page's name, with the member who typed it recorded internally -
+  # the same split `posts` makes for authorship. The right follows the ROLE, so
+  # `send_message_as_organization/4` asks for it live rather than trusting the
+  # identity this socket mounted with.
+  defp send_as(socket, body) do
+    case socket.assigns.viewer do
+      %Organization{} = page ->
+        Chat.send_message_as_organization(
+          page,
+          socket.assigns.current_user,
+          socket.assigns.conversation.id,
+          body
+        )
+
+      user ->
+        Chat.send_message(user, socket.assigns.conversation.id, body)
+    end
+  end
+
   @impl true
   def handle_event("send", %{"message" => %{"body" => body}}, socket) do
     body = String.trim(body)
@@ -153,7 +214,7 @@ defmodule VutuvWeb.MessageLive.Index do
     if body == "" or is_nil(socket.assigns.conversation) do
       {:noreply, socket}
     else
-      case Chat.send_message(socket.assigns.current_user, socket.assigns.conversation.id, body) do
+      case send_as(socket, body) do
         # The echo arrives via the conversation topic broadcast, so all
         # sessions (including this one) render it the same way — its handler
         # runs the one refresh_conversation, so none is needed here (this
@@ -233,7 +294,7 @@ defmodule VutuvWeb.MessageLive.Index do
 
   def handle_event("load-older", _params, socket) do
     page =
-      Chat.messages_page(socket.assigns.current_user, socket.assigns.conversation,
+      Chat.messages_page(socket.assigns.viewer, socket.assigns.conversation,
         limit: @page_size,
         cursor: socket.assigns.cursor
       )
@@ -271,14 +332,14 @@ defmodule VutuvWeb.MessageLive.Index do
   @impl true
   # Full message on the open conversation's topic (sender or recipient side).
   def handle_info({:new_message, %Message{} = message}, socket) do
-    user = socket.assigns.current_user
+    viewer = socket.assigns.viewer
 
-    # The member is watching the message arrive, so it is already read; this
+    # The reader is watching the message arrive, so it is already read; this
     # also broadcasts :messages_read, keeping the shell badge at zero. The
     # arriving message is the newest, so hand its time straight to mark_read
     # instead of making it re-scan the thread for the max.
-    if message.sender_id != user.id && socket.assigns.conversation do
-      Chat.mark_read(user, socket.assigns.conversation.id, message.inserted_at)
+    if not mine?(message, viewer) && socket.assigns.conversation do
+      Chat.mark_read(viewer, socket.assigns.conversation.id, message.inserted_at)
     end
 
     {:noreply,
@@ -361,11 +422,19 @@ defmodule VutuvWeb.MessageLive.Index do
   ## Helpers
 
   defp assign_lists(socket) do
-    user = socket.assigns.current_user
+    case socket.assigns.viewer do
+      %Organization{} = page ->
+        # A page publishes in order to be addressed, so it has no request queue
+        # to triage - see `Chat.find_or_create_conversation/2`.
+        socket
+        |> assign(:conversations, put_previews(Chat.list_organization_conversations(page)))
+        |> assign(:requests, [])
 
-    socket
-    |> assign(:conversations, put_previews(Chat.list_conversations(user)))
-    |> assign(:requests, put_previews(Chat.list_requests(user)))
+      user ->
+        socket
+        |> assign(:conversations, put_previews(Chat.list_conversations(user)))
+        |> assign(:requests, put_previews(Chat.list_requests(user)))
+    end
   end
 
   # A message body is Markdown *source* (the composer is Milkdown), so a sidebar
@@ -436,7 +505,7 @@ defmodule VutuvWeb.MessageLive.Index do
         socket
 
       %Conversation{id: id} ->
-        case Chat.get_conversation(socket.assigns.current_user, id) do
+        case Chat.get_conversation(socket.assigns.viewer, id) do
           nil -> socket
           conversation -> assign(socket, :conversation, conversation)
         end
@@ -450,6 +519,8 @@ defmodule VutuvWeb.MessageLive.Index do
 
   defp display_name(nil), do: gettext("Deleted account")
 
+  defp display_name(%Organization{name: name}), do: name
+
   defp display_name(user) do
     case VutuvWeb.UserHelpers.full_name(user) do
       "" -> gettext("Member")
@@ -457,7 +528,46 @@ defmodule VutuvWeb.MessageLive.Index do
     end
   end
 
-  defp mine?(%Message{sender_id: sender_id}, user_id),
+  # The picture of whichever kind of party this is. A page has a logo, not an
+  # avatar, and no online state - it is a desk, not a person, so a presence dot
+  # on it would be a promise nobody is keeping.
+  attr(:party, :any, required: true)
+  attr(:size, :string, default: "sm")
+
+  defp party_avatar(%{party: %Organization{}} = assigns) do
+    ~H"""
+    <.organization_logo organization={@party} class={logo_class(@size)} />
+    """
+  end
+
+  defp party_avatar(assigns) do
+    ~H"""
+    <.avatar user={@party} size={@size} />
+    """
+  end
+
+  defp logo_class("sm"), do: "h-9 w-9 shrink-0"
+  defp logo_class(_), do: "h-10 w-10 shrink-0"
+
+  # Where the name links to. A page lives under /organizations/<slug>, and a
+  # member at the root - one function so no call site has to remember which.
+  defp party_path(%Organization{} = page), do: Organizations.canonical_path(page)
+  defp party_path(user), do: ~p"/#{user}"
+
+  # Only a member can be online, blocked, or the far side of a request.
+  defp member_party?(%Organization{}), do: false
+  defp member_party?(nil), do: false
+  defp member_party?(_), do: true
+
+  # Exactly one of the two sender columns is filled, so each side asks about
+  # its own; a bare `sender_id == id` would answer NULL for the other's rows.
+  defp mine?(%Message{sender_organization_id: page_id}, %Organization{id: page_id})
+       when is_binary(page_id),
+       do: true
+
+  defp mine?(%Message{}, %Organization{}), do: false
+
+  defp mine?(%Message{sender_id: sender_id}, %{id: user_id}),
     do: not is_nil(sender_id) and sender_id == user_id
 
   # The Accept/Decline pair, shared by the sidebar request rows and the
@@ -524,7 +634,7 @@ defmodule VutuvWeb.MessageLive.Index do
           <ul>
             <li :for={entry <- @requests} class="px-4 py-3">
               <.link navigate={~p"/messages/#{entry.conversation.id}"} class="flex items-center gap-3">
-                <.avatar user={entry.other} size="sm" />
+                <.party_avatar party={entry.other} />
                 <span class="min-w-0">
                   <span class="block truncate text-sm font-medium text-slate-800 dark:text-slate-100">
                     {display_name(entry.other)}
@@ -548,8 +658,12 @@ defmodule VutuvWeb.MessageLive.Index do
               ]}
             >
               <span class="relative shrink-0">
-                <.avatar user={entry.other} size="sm" />
-                <.presence_dot online={Presence.online?(@online_ids, entry.other.id)} size="sm" />
+                <.party_avatar party={entry.other} />
+                <.presence_dot
+                  :if={member_party?(entry.other)}
+                  online={Presence.online?(@online_ids, entry.other.id)}
+                  size="sm"
+                />
               </span>
               <span class="min-w-0 flex-1">
                 <span class="block truncate text-sm font-medium text-slate-800 dark:text-slate-100">
@@ -593,8 +707,8 @@ defmodule VutuvWeb.MessageLive.Index do
                 <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
               </svg>
             </.link>
-            <.link navigate={~p"/#{@other}"} class="flex min-w-0 items-center gap-2">
-              <.avatar user={@other} size="sm" />
+            <.link navigate={party_path(@other)} class="flex min-w-0 items-center gap-2">
+              <.party_avatar party={@other} />
               <h1 class="truncate font-semibold text-slate-800 dark:text-slate-100">
                 {display_name(@other)}
               </h1>
@@ -605,7 +719,7 @@ defmodule VutuvWeb.MessageLive.Index do
               <span class="text-xs font-medium text-brand-600 dark:text-brand-400">{typing_label(@typing_tokens)}</span>
             <% else %>
               <span
-                :if={Presence.online?(@online_ids, @other.id)}
+                :if={member_party?(@other) and Presence.online?(@online_ids, @other.id)}
                 id="other-online"
                 class="text-xs text-emerald-600 dark:text-emerald-400"
               >
@@ -618,7 +732,7 @@ defmodule VutuvWeb.MessageLive.Index do
             <details data-menu>; app.js closes it on outside click and Escape).
             Blocking severs follows + the connection, freezes this conversation
             and stops all interaction both ways; unblocking restores nothing. --%>
-            <.card_menu :if={@other} id="thread-menu">
+            <.card_menu :if={member_party?(@other)} id="thread-menu">
               <:item
                 id="block-from-thread"
                 click="block"
@@ -641,7 +755,7 @@ defmodule VutuvWeb.MessageLive.Index do
           <div
             :for={{dom_id, m} <- @streams.messages}
             id={dom_id}
-            class={["group flex items-center gap-1.5", mine?(m, @current_user.id) && "justify-end"]}
+            class={["group flex items-center gap-1.5", mine?(m, @viewer) && "justify-end"]}
           >
             <div class={[
               "max-w-[75%] break-words rounded-2xl px-3 py-2 text-sm",
@@ -649,13 +763,13 @@ defmodule VutuvWeb.MessageLive.Index do
               "[&_code]:rounded [&_code]:px-1 [&_code]:font-mono [&_code]:text-[0.85em]",
               "[&_ol]:list-decimal [&_ol]:pl-[2.25em] [&_p+p]:mt-1 [&_ul]:list-disc [&_ul]:pl-[2.25em]",
               m.frozen_at && "opacity-60",
-              if(mine?(m, @current_user.id),
+              if(mine?(m, @viewer),
                 do: "bg-brand-600 text-white [&_a]:text-white [&_code]:bg-white/20",
                 else:
                   "bg-slate-100 text-slate-800 dark:bg-slate-800 dark:text-slate-100 [&_a]:text-brand-700 dark:[&_a]:text-brand-300 [&_code]:bg-black/10 dark:[&_code]:bg-white/10"
               )
             ]}>
-              <span :if={not mine?(m, @current_user.id)} class="mb-0.5 block text-xs font-semibold text-brand-700 dark:text-brand-300">
+              <span :if={not mine?(m, @viewer)} class="mb-0.5 block text-xs font-semibold text-brand-700 dark:text-brand-300">
                 {display_name(m.sender)}
               </span>
               {VutuvWeb.Markdown.render(m.body)}
@@ -670,7 +784,7 @@ defmodule VutuvWeb.MessageLive.Index do
                 format="%d.%m.%Y %H:%M"
                 class={[
                   "mt-1 block text-right text-[10px] leading-none",
-                  if(mine?(m, @current_user.id), do: "text-white/70", else: "text-slate-600 dark:text-slate-400")
+                  if(mine?(m, @viewer), do: "text-white/70", else: "text-slate-600 dark:text-slate-400")
                 ]}
               />
             </div>
@@ -678,7 +792,7 @@ defmodule VutuvWeb.MessageLive.Index do
             bubbles. Faint until the row is hovered or the flag is focused, so
             it never crowds the conversation; always tappable on touch. --%>
             <.link
-              :if={not mine?(m, @current_user.id)}
+              :if={not mine?(m, @viewer)}
               id={"#{dom_id}-report"}
               navigate={~p"/reports/new?#{[type: "message", id: m.id, return_to: "/messages/#{m.conversation_id}"]}"}
               title={gettext("Report this message")}
@@ -714,7 +828,7 @@ defmodule VutuvWeb.MessageLive.Index do
         </div>
 
         <div
-          :if={Chat.request_recipient?(@conversation, @current_user.id)}
+          :if={member_party?(@other) and Chat.request_recipient?(@conversation, @viewer.id)}
           id="request-banner"
           class="flex flex-wrap items-center justify-center gap-2 border-t border-slate-200 p-3 text-sm text-slate-600 dark:border-slate-800 dark:text-slate-300"
         >
@@ -730,7 +844,7 @@ defmodule VutuvWeb.MessageLive.Index do
         (flex-col): the editor takes the full width on top and the Send button sits
         below it as a full-width horizontal bar, rather than riding beside it. --%>
         <.form
-          :if={Chat.can_send?(@conversation, @current_user.id)}
+          :if={page_viewer?(@viewer) or Chat.can_send?(@conversation, @viewer.id)}
           for={@form}
           id="message-form"
           phx-submit="send"
@@ -758,8 +872,9 @@ defmodule VutuvWeb.MessageLive.Index do
 
         <p
           :if={
-            not Chat.can_send?(@conversation, @current_user.id) and
-              not Chat.request_recipient?(@conversation, @current_user.id)
+            member_party?(@other) and
+              not Chat.can_send?(@conversation, @viewer.id) and
+              not Chat.request_recipient?(@conversation, @viewer.id)
           }
           id="awaiting-acceptance"
           class="border-t border-slate-200 p-4 text-center text-sm text-slate-600 dark:text-slate-400 dark:border-slate-800"

--- a/lib/vutuv_web/live/organization_live/show.ex
+++ b/lib/vutuv_web/live/organization_live/show.ex
@@ -99,6 +99,11 @@ defmodule VutuvWeb.OrganizationLive.Show do
     |> assign(:people_offset, page.next_offset)
   end
 
+  # Am I currently speaking as the very page I am looking at? Then a "Message"
+  # button would open a conversation with myself.
+  defp own_page?(%{acting_as: %Organization{id: id}, organization: %{id: id}}), do: true
+  defp own_page?(_assigns), do: false
+
   defp assign_organization(socket, organization, viewer) do
     # One query for every domain, partitioned in memory (an organization has few).
     domains = Organizations.list_domains(organization)
@@ -407,6 +412,21 @@ defmodule VutuvWeb.OrganizationLive.Show do
                   {gettext("Unfollow")}
                 </span>
               </button>
+
+              <%!-- Writing to the page (issue #1336). A quiet secondary next to
+              the follow pill: following is the act this header is built around,
+              and a second brand-weight control beside it would make the reader
+              choose. Hidden while you are writing AS this page, where it would
+              offer a conversation with yourself. --%>
+              <.link
+                :if={@current_user && not own_page?(assigns)}
+                navigate={~p"/messages/organization/#{@organization.slug}"}
+                id="message-organization"
+                data-message-organization
+                class="inline-flex min-h-10 items-center rounded-full bg-slate-100 px-4 text-sm font-semibold text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+              >
+                {gettext("Message")}
+              </.link>
 
               <span
                 :if={@follower_count > 0}

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -547,6 +547,10 @@ defmodule VutuvWeb.Router do
       # The profile "Message" button: open my conversation with that member
       # (find-or-create), then land in the thread.
       live("/messages/with/:slug", MessageLive.Index, :new)
+      # The same for a page (issue #1336). A separate segment rather than
+      # reusing `/with/:slug`: a page's slug and a member's handle are
+      # different namespaces, so one path could name both.
+      live("/messages/organization/:slug", MessageLive.Index, :new_organization)
       live("/messages/:id", MessageLive.Index, :show)
 
       # The post editor ("posts" is a ReservedSlug). Auth is checked in the

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.263.0",
+      version: "7.264.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -33,7 +33,7 @@ msgstr "Eintrag hinzufügen"
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
 #: lib/vutuv_web/live/organization_live/fediverse.ex:104
-#: lib/vutuv_web/live/organization_live/show.ex:600
+#: lib/vutuv_web/live/organization_live/show.ex:620
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
@@ -216,7 +216,7 @@ msgstr "Download"
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
 #: lib/vutuv_web/live/job_posting_live/show.ex:178
-#: lib/vutuv_web/live/organization_live/show.ex:429
+#: lib/vutuv_web/live/organization_live/show.ex:449
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:7
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:19
@@ -333,7 +333,7 @@ msgstr "Follower"
 #: lib/vutuv_web/components/ui.ex:2014
 #: lib/vutuv_web/components/ui.ex:2072
 #: lib/vutuv_web/controllers/followee_controller.ex:29
-#: lib/vutuv_web/live/organization_live/show.ex:404
+#: lib/vutuv_web/live/organization_live/show.ex:409
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:53
 #: lib/vutuv_web/templates/user/show.html.heex:955
@@ -1720,7 +1720,7 @@ msgstr "Empfehlen"
 #: lib/vutuv_web/live/fediverse_following_live.ex:313
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:363
 #: lib/vutuv_web/live/organization_live/following.ex:218
-#: lib/vutuv_web/live/organization_live/show.ex:402
+#: lib/vutuv_web/live/organization_live/show.ex:407
 #: lib/vutuv_web/templates/user/show.html.heex:1069
 #: lib/vutuv_web/templates/user/show.html.heex:1322
 #, elixir-autogen, elixir-format
@@ -1752,7 +1752,7 @@ msgstr "Ausloggen"
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
 #: lib/vutuv_web/live/admin/user_delete_live.ex:143
 #: lib/vutuv_web/live/admin/user_live.ex:154
-#: lib/vutuv_web/live/message_live/index.ex:455
+#: lib/vutuv_web/live/message_live/index.ex:526
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:32
 #: lib/vutuv_web/templates/admin/account/index.html.heex:55
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:28
@@ -1761,13 +1761,14 @@ msgstr "Ausloggen"
 msgid "Member"
 msgstr "Mitglied"
 
+#: lib/vutuv_web/live/organization_live/show.ex:428
 #: lib/vutuv_web/templates/user/show.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr "Nachricht"
 
-#: lib/vutuv_web/live/message_live/index.ex:45
-#: lib/vutuv_web/live/message_live/index.ex:512
+#: lib/vutuv_web/live/message_live/index.ex:50
+#: lib/vutuv_web/live/message_live/index.ex:622
 #: lib/vutuv_web/live/shell_live.ex:652
 #: lib/vutuv_web/live/shell_live.ex:790
 #: lib/vutuv_web/templates/layout/app.html.heex:123
@@ -1821,7 +1822,7 @@ msgid "Pardon us! Something went wrong."
 msgstr "Entschuldigung! Etwas ist schiefgelaufen."
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:130
-#: lib/vutuv_web/live/message_live/index.ex:755
+#: lib/vutuv_web/live/message_live/index.ex:869
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Send"
@@ -1902,8 +1903,8 @@ msgstr ""
 msgid "Who to follow"
 msgstr "Vorgeschlagene Profile"
 
-#: lib/vutuv_web/live/message_live/index.ex:744
-#: lib/vutuv_web/live/message_live/index.ex:745
+#: lib/vutuv_web/live/message_live/index.ex:858
+#: lib/vutuv_web/live/message_live/index.ex:859
 #, elixir-autogen, elixir-format
 msgid "Write a message…"
 msgstr "Nachricht schreiben…"
@@ -1958,7 +1959,7 @@ msgstr "Seitennavigation"
 #: lib/vutuv_web/components/ui.ex:3461
 #: lib/vutuv_web/live/organization_live/activity.ex:146
 #: lib/vutuv_web/live/organization_live/feed.ex:101
-#: lib/vutuv_web/live/organization_live/show.ex:540
+#: lib/vutuv_web/live/organization_live/show.ex:560
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr "Mehr laden"
@@ -2240,7 +2241,7 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:382
 #: lib/vutuv_web/live/notification_live/index.ex:882
-#: lib/vutuv_web/live/organization_live/show.ex:467
+#: lib/vutuv_web/live/organization_live/show.ex:487
 #: lib/vutuv_web/live/post_live/saved.ex:495
 #: lib/vutuv_web/live/search_live.ex:205
 #: lib/vutuv_web/live/search_live.ex:551
@@ -2505,7 +2506,7 @@ msgstr "Gefällt mir entfernen"
 #: lib/vutuv_web/components/ui.ex:2073
 #: lib/vutuv_web/live/organization_live/following.ex:197
 #: lib/vutuv_web/live/organization_live/following.ex:256
-#: lib/vutuv_web/live/organization_live/show.ex:407
+#: lib/vutuv_web/live/organization_live/show.ex:412
 #: lib/vutuv_web/live/post_live/feed.ex:1187
 #: lib/vutuv_web/templates/followee/index.html.heex:44
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
@@ -2579,89 +2580,89 @@ msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
 
-#: lib/vutuv_web/live/message_live/index.ex:493
+#: lib/vutuv_web/live/message_live/index.ex:603
 #, elixir-autogen, elixir-format
 msgid "%{names} are typing…"
 msgstr "%{names} schreiben…"
 
-#: lib/vutuv_web/live/message_live/index.ex:492
+#: lib/vutuv_web/live/message_live/index.ex:602
 #, elixir-autogen, elixir-format
 msgid "%{name} is typing…"
 msgstr "%{name} schreibt…"
 
-#: lib/vutuv_web/live/message_live/index.ex:767
+#: lib/vutuv_web/live/message_live/index.ex:882
 #, elixir-autogen, elixir-format
 msgid "@%{slug} has not accepted your message request yet."
 msgstr "@%{slug} hat Ihre Nachrichtenanfrage noch nicht angenommen."
 
-#: lib/vutuv_web/live/message_live/index.ex:721
+#: lib/vutuv_web/live/message_live/index.ex:835
 #, elixir-autogen, elixir-format
 msgid "@%{slug} wants to message you."
 msgstr "@%{slug} möchte Ihnen Nachrichten schicken."
 
-#: lib/vutuv_web/live/message_live/index.ex:476
+#: lib/vutuv_web/live/message_live/index.ex:586
 #, elixir-autogen, elixir-format
 msgid "Accept"
 msgstr "Annehmen"
 
-#: lib/vutuv_web/live/message_live/index.ex:590
+#: lib/vutuv_web/live/message_live/index.ex:704
 #, elixir-autogen, elixir-format
 msgid "Back to conversations"
 msgstr "Zurück zu den Unterhaltungen"
 
-#: lib/vutuv_web/live/message_live/index.ex:483
+#: lib/vutuv_web/live/message_live/index.ex:593
 #, elixir-autogen, elixir-format
 msgid "Decline"
 msgstr "Ablehnen"
 
-#: lib/vutuv_web/live/message_live/index.ex:451
+#: lib/vutuv_web/live/message_live/index.ex:520
 #, elixir-autogen, elixir-format
 msgid "Deleted account"
 msgstr "Gelöschtes Konto"
 
-#: lib/vutuv_web/live/message_live/index.ex:636
+#: lib/vutuv_web/live/message_live/index.ex:750
 #, elixir-autogen, elixir-format
 msgid "Load older messages"
 msgstr "Ältere Nachrichten laden"
 
 #: lib/vutuv_web/controllers/admin/tag_member_controller.ex:55
-#: lib/vutuv_web/live/message_live/index.ex:115
+#: lib/vutuv_web/live/message_live/index.ex:134
 #, elixir-autogen, elixir-format
 msgid "Member not found."
 msgstr "Mitglied nicht gefunden."
 
-#: lib/vutuv_web/live/message_live/index.ex:569
+#: lib/vutuv_web/live/message_live/index.ex:683
 #, elixir-autogen, elixir-format
 msgid "No conversations yet."
 msgstr "Noch keine Unterhaltungen."
 
 #: lib/vutuv_web/components/ui.ex:2407
-#: lib/vutuv_web/live/message_live/index.ex:612
+#: lib/vutuv_web/live/message_live/index.ex:726
 #, elixir-autogen, elixir-format
 msgid "Online"
 msgstr "Online"
 
-#: lib/vutuv_web/live/message_live/index.ex:522
+#: lib/vutuv_web/live/message_live/index.ex:632
 #, elixir-autogen, elixir-format
 msgid "Requests"
 msgstr "Anfragen"
 
-#: lib/vutuv_web/live/message_live/index.ex:776
+#: lib/vutuv_web/live/message_live/index.ex:891
 #, elixir-autogen, elixir-format
 msgid "Select a conversation."
 msgstr "Wählen Sie eine Unterhaltung aus."
 
-#: lib/vutuv_web/live/message_live/index.ex:130
+#: lib/vutuv_web/live/message_live/index.ex:149
 #, elixir-autogen, elixir-format
 msgid "This member cannot receive messages."
 msgstr "Dieses Mitglied kann keine Nachrichten empfangen."
 
-#: lib/vutuv_web/live/message_live/index.ex:173
+#: lib/vutuv_web/live/message_live/index.ex:234
 #, elixir-autogen, elixir-format
 msgid "This message could not be sent."
 msgstr "Diese Nachricht konnte nicht gesendet werden."
 
-#: lib/vutuv_web/live/message_live/index.ex:125
+#: lib/vutuv_web/live/message_live/index.ex:144
 #, elixir-autogen, elixir-format
 msgid "Too many new conversations. Please try again later."
 msgstr "Zu viele neue Unterhaltungen. Bitte versuchen Sie es später erneut."
@@ -2884,7 +2885,7 @@ msgstr[1] "Vernetzungen"
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
 
-#: lib/vutuv_web/live/message_live/index.ex:570
+#: lib/vutuv_web/live/message_live/index.ex:684
 #, elixir-autogen, elixir-format
 msgid "Open someone's profile to message them."
 msgstr "Öffnen Sie ein Profil, um jemandem zu schreiben."
@@ -3059,7 +3060,7 @@ msgstr ""
 msgid "Hidden. You can settle this yourself - see below."
 msgstr "Verborgen. Sie können das selbst klären, siehe unten."
 
-#: lib/vutuv_web/live/message_live/index.ex:665
+#: lib/vutuv_web/live/message_live/index.ex:779
 #, elixir-autogen, elixir-format
 msgid "Hidden: reported, under review"
 msgstr "Verborgen: gemeldet, wird geprüft"
@@ -3242,7 +3243,7 @@ msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 #: lib/vutuv_web/components/post_components.ex:1050
 #: lib/vutuv_web/components/post_components.ex:2026
 #: lib/vutuv_web/components/post_components.ex:2751
-#: lib/vutuv_web/live/organization_live/show.ex:450
+#: lib/vutuv_web/live/organization_live/show.ex:470
 #: lib/vutuv_web/templates/user/show.html.heex:219
 #, elixir-autogen, elixir-format
 msgid "Report"
@@ -3269,8 +3270,8 @@ msgstr "Meldung abgelehnt; der Inhalt ist wieder sichtbar."
 msgid "Report this content"
 msgstr "Diesen Inhalt melden"
 
-#: lib/vutuv_web/live/message_live/index.ex:684
-#: lib/vutuv_web/live/message_live/index.ex:685
+#: lib/vutuv_web/live/message_live/index.ex:798
+#: lib/vutuv_web/live/message_live/index.ex:799
 #, elixir-autogen, elixir-format
 msgid "Report this message"
 msgstr "Diese Nachricht melden"
@@ -4709,7 +4710,7 @@ msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
 
-#: lib/vutuv_web/live/message_live/index.ex:573
+#: lib/vutuv_web/live/message_live/index.ex:687
 #, elixir-autogen, elixir-format
 msgid "Find members"
 msgstr "Mitglieder finden"
@@ -4765,7 +4766,7 @@ msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:516
 #: lib/vutuv_web/live/notification_live/index.ex:883
-#: lib/vutuv_web/live/organization_live/show.ex:550
+#: lib/vutuv_web/live/organization_live/show.ex:570
 #: lib/vutuv_web/live/post_live/saved.ex:498
 #: lib/vutuv_web/live/search_live.ex:203
 #: lib/vutuv_web/live/search_live.ex:493
@@ -5941,7 +5942,7 @@ msgstr "Wenn jemand beginnt, Ihnen zu folgen."
 msgid "@handle"
 msgstr "@handle"
 
-#: lib/vutuv_web/live/message_live/index.ex:628
+#: lib/vutuv_web/live/message_live/index.ex:742
 #, elixir-autogen, elixir-format
 msgid "Block @%{slug}"
 msgstr "@%{slug} blockieren"
@@ -10775,7 +10776,7 @@ msgid_plural "%{count} stars"
 msgstr[0] "%{count} Stern"
 msgstr[1] "%{count} Sterne"
 
-#: lib/vutuv_web/live/organization_live/show.ex:416
+#: lib/vutuv_web/live/organization_live/show.ex:436
 #: lib/vutuv_web/views/user_html.ex:534
 #: lib/vutuv_web/views/user_html.ex:713
 #, elixir-autogen, elixir-format
@@ -11656,7 +11657,7 @@ msgstr "Ihre Liste ist leer. Es ist noch niemand ausgeschlossen."
 msgid "AI agents"
 msgstr "KI-Agenten"
 
-#: lib/vutuv_web/live/organization_live/show.ex:457
+#: lib/vutuv_web/live/organization_live/show.ex:477
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "Über die Organisation"
@@ -11669,7 +11670,7 @@ msgstr "Weiter zur Verifizierung"
 #: lib/vutuv_web/live/organization_live/domains.ex:248
 #: lib/vutuv_web/live/organization_live/domains.ex:288
 #: lib/vutuv_web/live/organization_live/new.ex:146
-#: lib/vutuv_web/live/organization_live/show.ex:674
+#: lib/vutuv_web/live/organization_live/show.ex:694
 #: lib/vutuv_web/templates/url/verify.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "DNS TXT record"
@@ -11677,8 +11678,8 @@ msgstr "DNS-TXT-Eintrag"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:153
 #: lib/vutuv_web/live/organization_live/domains.ex:167
-#: lib/vutuv_web/live/organization_live/show.ex:328
-#: lib/vutuv_web/live/organization_live/show.ex:733
+#: lib/vutuv_web/live/organization_live/show.ex:333
+#: lib/vutuv_web/live/organization_live/show.ex:753
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr "Die Domain-Verifizierung ist auf dieser Installation deaktiviert."
@@ -11718,7 +11719,7 @@ msgstr ""
 msgid "Please log in first."
 msgstr "Bitte loggen Sie sich zuerst ein."
 
-#: lib/vutuv_web/live/organization_live/show.ex:647
+#: lib/vutuv_web/live/organization_live/show.ex:667
 #, elixir-autogen, elixir-format
 msgid "Prove you control %{domain} to publish this page."
 msgstr "Weisen Sie nach, dass Ihnen %{domain} gehört, um diese Seite zu veröffentlichen."
@@ -11745,7 +11746,7 @@ msgid "Select a country"
 msgstr "Land auswählen"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:307
-#: lib/vutuv_web/live/organization_live/show.ex:709
+#: lib/vutuv_web/live/organization_live/show.ex:729
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr "Stellen Sie diese Datei bereit unter:"
@@ -11772,12 +11773,12 @@ msgid "The upload failed."
 msgstr "Der Upload ist fehlgeschlagen."
 
 #: lib/vutuv_web/live/organization_live/new.ex:131
-#: lib/vutuv_web/live/organization_live/show.ex:662
+#: lib/vutuv_web/live/organization_live/show.ex:682
 #, elixir-autogen, elixir-format
 msgid "Verification method"
 msgstr "Verifizierungsmethode"
 
-#: lib/vutuv_web/live/organization_live/show.ex:622
+#: lib/vutuv_web/live/organization_live/show.ex:642
 #, elixir-autogen, elixir-format
 msgid "Verified domains"
 msgstr "Verifizierte Domains"
@@ -11793,19 +11794,19 @@ msgstr "Verifiziert über"
 msgid "Verified via %{domain}"
 msgstr "Verifiziert über %{domain}"
 
-#: lib/vutuv_web/live/organization_live/show.ex:644
+#: lib/vutuv_web/live/organization_live/show.ex:664
 #, elixir-autogen, elixir-format
 msgid "Verify %{name}"
 msgstr "%{name} verifizieren"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:320
-#: lib/vutuv_web/live/organization_live/show.ex:729
+#: lib/vutuv_web/live/organization_live/show.ex:749
 #, elixir-autogen, elixir-format
 msgid "Verify now"
 msgstr "Jetzt verifizieren"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:149
-#: lib/vutuv_web/live/organization_live/show.ex:323
+#: lib/vutuv_web/live/organization_live/show.ex:328
 #, elixir-autogen, elixir-format
 msgid "We could not find the record or file yet. It can take a while to propagate. Please try again."
 msgstr ""
@@ -11822,7 +11823,7 @@ msgstr "Website"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:249
 #: lib/vutuv_web/live/organization_live/domains.ex:298
-#: lib/vutuv_web/live/organization_live/show.ex:685
+#: lib/vutuv_web/live/organization_live/show.ex:705
 #: lib/vutuv_web/templates/url/verify.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Website file"
@@ -11846,7 +11847,7 @@ msgstr ""
 "die Kontrolle über die Domain nachzuweisen."
 
 #: lib/vutuv_web/live/organization_live/domains.ex:309
-#: lib/vutuv_web/live/organization_live/show.ex:715
+#: lib/vutuv_web/live/organization_live/show.ex:735
 #: lib/vutuv_web/templates/url/verify.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
@@ -11897,7 +11898,7 @@ msgstr "Alias entfernt."
 #: lib/vutuv_web/agent_docs/markdown.ex:357
 #: lib/vutuv_web/agent_docs/text.ex:378
 #: lib/vutuv_web/live/organization_live/edit.ex:353
-#: lib/vutuv_web/live/organization_live/show.ex:610
+#: lib/vutuv_web/live/organization_live/show.ex:630
 #: lib/vutuv_web/templates/tag/single_card.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Also known as"
@@ -11967,7 +11968,7 @@ msgstr "Domain verifiziert."
 #: lib/vutuv_web/components/organization_components.ex:212
 #: lib/vutuv_web/live/admin/organization_live.ex:305
 #: lib/vutuv_web/live/organization_live/domains.ex:161
-#: lib/vutuv_web/live/organization_live/show.ex:443
+#: lib/vutuv_web/live/organization_live/show.ex:463
 #, elixir-autogen, elixir-format
 msgid "Domains"
 msgstr "Domains"
@@ -12085,7 +12086,7 @@ msgstr "Name, Alias oder Domain suchen"
 #: lib/vutuv_web/components/organization_components.ex:209
 #: lib/vutuv_web/live/admin/organization_live.ex:321
 #: lib/vutuv_web/live/organization_live/roles.ex:165
-#: lib/vutuv_web/live/organization_live/show.ex:436
+#: lib/vutuv_web/live/organization_live/show.ex:456
 #, elixir-autogen, elixir-format
 msgid "Team"
 msgstr "Team"
@@ -12275,7 +12276,7 @@ msgstr "verifizierte Webseite"
 msgid "%{min} to %{max} characters: letters (a-z), numbers (0-9) and underscores."
 msgstr "%{min} bis %{max} Zeichen: Buchstaben (a-z), Zahlen (0-9) und Unterstriche."
 
-#: lib/vutuv_web/live/organization_live/show.ex:565
+#: lib/vutuv_web/live/organization_live/show.ex:585
 #, elixir-autogen, elixir-format
 msgid "Former"
 msgstr "Ehemalig"
@@ -12407,7 +12408,7 @@ msgstr "Vielleicht brauchen Sie Hilfe von Ihrer IT"
 msgid "The proof is a small technical change to your domain: a DNS entry or a file on your website. If you don't manage the website yourself, ask the person or team who does. That is usually your IT department or the company that runs your website. We show the exact instructions on the next step, so you can simply pass them on."
 msgstr "Der Nachweis ist eine kleine technische Änderung an Ihrer Domain: ein DNS-Eintrag oder eine Datei auf Ihrer Website. Wenn Sie die Website nicht selbst verwalten, fragen Sie die Person oder das Team, das dies tut. Das ist meist Ihre IT-Abteilung oder die Firma, die Ihre Website betreut. Die genaue Anleitung zeigen wir Ihnen im nächsten Schritt, Sie können sie einfach weitergeben."
 
-#: lib/vutuv_web/live/organization_live/show.ex:656
+#: lib/vutuv_web/live/organization_live/show.ex:676
 #, elixir-autogen, elixir-format
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr "Diese Schritte sind technisch. Wenn Sie %{domain} nicht selbst verwalten, kopieren Sie den unten gezeigten Eintrag oder die Datei und senden Sie ihn an Ihre IT-Abteilung oder die Firma, die Ihre Website betreut. Sobald sie ihn hinzugefügt hat, kommen Sie hierher zurück und klicken auf „Jetzt verifizieren“."
@@ -12578,7 +12579,7 @@ msgstr "Dieser Name ist für diese Organisation bereits eingetragen."
 msgid "The organization page was deleted."
 msgstr "Die Organisationsseite wurde gelöscht."
 
-#: lib/vutuv_web/live/organization_live/show.ex:335
+#: lib/vutuv_web/live/organization_live/show.ex:340
 #, elixir-autogen, elixir-format
 msgid "This organization page was reported and is hidden while it is reviewed. Only you and the moderators can see it."
 msgstr ""
@@ -12614,7 +12615,7 @@ msgstr "Sie dürfen diese Organisation nicht löschen."
 msgid "Your organization handle is set."
 msgstr "Ihr Organisations-Handle ist gesetzt."
 
-#: lib/vutuv_web/live/organization_live/show.ex:261
+#: lib/vutuv_web/live/organization_live/show.ex:266
 #, elixir-autogen, elixir-format
 msgid "Your organization page is verified and now live."
 msgstr "Ihre Organisationsseite ist verifiziert und jetzt live."
@@ -13319,13 +13320,13 @@ msgid "Getting an error, or is %{host} a CNAME / alias to another address? A TXT
 msgstr "Bekommen Sie einen Fehler, oder ist %{host} ein CNAME / Alias auf eine andere Adresse? Ein TXT-Eintrag kann nicht denselben Namen wie ein CNAME haben. Verwenden Sie stattdessen diesen Namen, mit exakt demselben Wert wie oben:"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:305
-#: lib/vutuv_web/live/organization_live/show.ex:702
+#: lib/vutuv_web/live/organization_live/show.ex:722
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr "Ist %{domain} ein CNAME / Alias (ein TXT-Eintrag kann nicht denselben Namen wie ein CNAME haben), legen Sie den Eintrag stattdessen auf %{name} an, mit demselben Wert."
 
 #: lib/vutuv_web/live/organization_live/domains.ex:303
-#: lib/vutuv_web/live/organization_live/show.ex:693
+#: lib/vutuv_web/live/organization_live/show.ex:713
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
 msgstr "Legen Sie in Ihren DNS-Einstellungen einen TXT-Eintrag auf dem Namen %{domain} mit diesem Wert an:"
@@ -13421,7 +13422,7 @@ msgid "Minimum yearly salary"
 msgstr "Mindestgehalt pro Jahr"
 
 #: lib/vutuv_web/live/job_board_live.ex:324
-#: lib/vutuv_web/live/organization_live/show.ex:592
+#: lib/vutuv_web/live/organization_live/show.ex:612
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr "Weitere Stellen"
@@ -13450,7 +13451,7 @@ msgstr "Keine passenden Stellen. Passen Sie die Filter an."
 #: lib/vutuv_web/agent_docs/markdown.ex:435
 #: lib/vutuv_web/agent_docs/text.ex:442
 #: lib/vutuv_web/agent_docs/text.ex:454
-#: lib/vutuv_web/live/organization_live/show.ex:579
+#: lib/vutuv_web/live/organization_live/show.ex:599
 #: lib/vutuv_web/templates/tag/show.html.heex:45
 #, elixir-autogen, elixir-format
 msgid "Open positions"
@@ -20853,33 +20854,33 @@ msgstr "Schreibt Beiträge im Namen der Organisation."
 msgid "The owner gives other members their roles on the page, and can hand ownership over to someone else at any time. Someone can hold several roles, and writing in the organization's name is always granted on its own."
 msgstr "Der Besitzer vergibt die Rollen der anderen Mitglieder auf der Seite und kann den Besitz jederzeit an jemand anderen übergeben. Jemand kann mehrere Rollen haben, und das Schreiben im Namen der Organisation wird immer einzeln vergeben."
 
-#: lib/vutuv_web/live/organization_live/show.ex:535
+#: lib/vutuv_web/live/organization_live/show.ex:555
 #, elixir-autogen, elixir-format
 msgid "Nothing published yet."
 msgstr "Noch nichts veröffentlicht."
 
-#: lib/vutuv_web/live/organization_live/show.ex:517
+#: lib/vutuv_web/live/organization_live/show.ex:537
 #: lib/vutuv_web/live/post_live/composer.ex:1814
 #, elixir-autogen, elixir-format
 msgid "Post as %{name}"
 msgstr "Als %{name} veröffentlichen"
 
-#: lib/vutuv_web/live/organization_live/show.ex:191
+#: lib/vutuv_web/live/organization_live/show.ex:196
 #, elixir-autogen, elixir-format
 msgid "Published as %{name}."
 msgstr "Als %{name} veröffentlicht."
 
-#: lib/vutuv_web/live/organization_live/show.ex:203
+#: lib/vutuv_web/live/organization_live/show.ex:208
 #, elixir-autogen, elixir-format
 msgid "That post could not be published."
 msgstr "Dieser Beitrag konnte nicht veröffentlicht werden."
 
-#: lib/vutuv_web/live/organization_live/show.ex:509
+#: lib/vutuv_web/live/organization_live/show.ex:529
 #, elixir-autogen, elixir-format
 msgid "Write something as %{name}"
 msgstr "Schreiben Sie etwas als %{name}"
 
-#: lib/vutuv_web/live/organization_live/show.ex:197
+#: lib/vutuv_web/live/organization_live/show.ex:202
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr "Sie dürfen nicht mehr im Namen dieser Organisation schreiben."
@@ -20904,7 +20905,7 @@ msgstr "Begonnen, im Namen einer Organisation zu schreiben"
 msgid "Stopped writing as an organization"
 msgstr "Beendet, im Namen einer Organisation zu schreiben"
 
-#: lib/vutuv_web/live/organization_live/show.ex:493
+#: lib/vutuv_web/live/organization_live/show.ex:513
 #, elixir-autogen, elixir-format
 msgid "Write as %{name} for now"
 msgstr "Vorerst als %{name} schreiben"
@@ -21141,3 +21142,9 @@ msgstr "Zu viele Versuche. Bitte versuchen Sie es später erneut."
 #, elixir-autogen, elixir-format
 msgid "New message from %{sender} on vutuv"
 msgstr "Neue Nachricht von %{sender} auf vutuv"
+
+#: lib/vutuv_web/live/message_live/index.ex:162
+#: lib/vutuv_web/live/message_live/index.ex:172
+#, elixir-autogen, elixir-format
+msgid "This page cannot receive messages."
+msgstr "Diese Organisation kann keine Nachrichten empfangen."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -35,7 +35,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
 #: lib/vutuv_web/live/organization_live/fediverse.ex:104
-#: lib/vutuv_web/live/organization_live/show.ex:600
+#: lib/vutuv_web/live/organization_live/show.ex:620
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
@@ -216,7 +216,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
 #: lib/vutuv_web/live/job_posting_live/show.ex:178
-#: lib/vutuv_web/live/organization_live/show.ex:429
+#: lib/vutuv_web/live/organization_live/show.ex:449
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:7
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:19
@@ -333,7 +333,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:2014
 #: lib/vutuv_web/components/ui.ex:2072
 #: lib/vutuv_web/controllers/followee_controller.ex:29
-#: lib/vutuv_web/live/organization_live/show.ex:404
+#: lib/vutuv_web/live/organization_live/show.ex:409
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:53
 #: lib/vutuv_web/templates/user/show.html.heex:955
@@ -1688,7 +1688,7 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_following_live.ex:313
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:363
 #: lib/vutuv_web/live/organization_live/following.ex:218
-#: lib/vutuv_web/live/organization_live/show.ex:402
+#: lib/vutuv_web/live/organization_live/show.ex:407
 #: lib/vutuv_web/templates/user/show.html.heex:1069
 #: lib/vutuv_web/templates/user/show.html.heex:1322
 #, elixir-autogen, elixir-format
@@ -1717,7 +1717,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
 #: lib/vutuv_web/live/admin/user_delete_live.ex:143
 #: lib/vutuv_web/live/admin/user_live.ex:154
-#: lib/vutuv_web/live/message_live/index.ex:455
+#: lib/vutuv_web/live/message_live/index.ex:526
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:32
 #: lib/vutuv_web/templates/admin/account/index.html.heex:55
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:28
@@ -1726,13 +1726,14 @@ msgstr ""
 msgid "Member"
 msgstr ""
 
+#: lib/vutuv_web/live/organization_live/show.ex:428
 #: lib/vutuv_web/templates/user/show.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:45
-#: lib/vutuv_web/live/message_live/index.ex:512
+#: lib/vutuv_web/live/message_live/index.ex:50
+#: lib/vutuv_web/live/message_live/index.ex:622
 #: lib/vutuv_web/live/shell_live.ex:652
 #: lib/vutuv_web/live/shell_live.ex:790
 #: lib/vutuv_web/templates/layout/app.html.heex:123
@@ -1786,7 +1787,7 @@ msgid "Pardon us! Something went wrong."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:130
-#: lib/vutuv_web/live/message_live/index.ex:755
+#: lib/vutuv_web/live/message_live/index.ex:869
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Send"
@@ -1861,8 +1862,8 @@ msgstr ""
 msgid "Who to follow"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:744
-#: lib/vutuv_web/live/message_live/index.ex:745
+#: lib/vutuv_web/live/message_live/index.ex:858
+#: lib/vutuv_web/live/message_live/index.ex:859
 #, elixir-autogen, elixir-format
 msgid "Write a message…"
 msgstr ""
@@ -1917,7 +1918,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3461
 #: lib/vutuv_web/live/organization_live/activity.ex:146
 #: lib/vutuv_web/live/organization_live/feed.ex:101
-#: lib/vutuv_web/live/organization_live/show.ex:540
+#: lib/vutuv_web/live/organization_live/show.ex:560
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr ""
@@ -2195,7 +2196,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:382
 #: lib/vutuv_web/live/notification_live/index.ex:882
-#: lib/vutuv_web/live/organization_live/show.ex:467
+#: lib/vutuv_web/live/organization_live/show.ex:487
 #: lib/vutuv_web/live/post_live/saved.ex:495
 #: lib/vutuv_web/live/search_live.ex:205
 #: lib/vutuv_web/live/search_live.ex:551
@@ -2458,7 +2459,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:2073
 #: lib/vutuv_web/live/organization_live/following.ex:197
 #: lib/vutuv_web/live/organization_live/following.ex:256
-#: lib/vutuv_web/live/organization_live/show.ex:407
+#: lib/vutuv_web/live/organization_live/show.ex:412
 #: lib/vutuv_web/live/post_live/feed.ex:1187
 #: lib/vutuv_web/templates/followee/index.html.heex:44
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
@@ -2532,89 +2533,89 @@ msgstr ""
 msgid "Replying to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:493
+#: lib/vutuv_web/live/message_live/index.ex:603
 #, elixir-autogen, elixir-format
 msgid "%{names} are typing…"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:492
+#: lib/vutuv_web/live/message_live/index.ex:602
 #, elixir-autogen, elixir-format
 msgid "%{name} is typing…"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:767
+#: lib/vutuv_web/live/message_live/index.ex:882
 #, elixir-autogen, elixir-format
 msgid "@%{slug} has not accepted your message request yet."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:721
+#: lib/vutuv_web/live/message_live/index.ex:835
 #, elixir-autogen, elixir-format
 msgid "@%{slug} wants to message you."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:476
+#: lib/vutuv_web/live/message_live/index.ex:586
 #, elixir-autogen, elixir-format
 msgid "Accept"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:590
+#: lib/vutuv_web/live/message_live/index.ex:704
 #, elixir-autogen, elixir-format
 msgid "Back to conversations"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:483
+#: lib/vutuv_web/live/message_live/index.ex:593
 #, elixir-autogen, elixir-format
 msgid "Decline"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:451
+#: lib/vutuv_web/live/message_live/index.ex:520
 #, elixir-autogen, elixir-format
 msgid "Deleted account"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:636
+#: lib/vutuv_web/live/message_live/index.ex:750
 #, elixir-autogen, elixir-format
 msgid "Load older messages"
 msgstr ""
 
 #: lib/vutuv_web/controllers/admin/tag_member_controller.ex:55
-#: lib/vutuv_web/live/message_live/index.ex:115
+#: lib/vutuv_web/live/message_live/index.ex:134
 #, elixir-autogen, elixir-format
 msgid "Member not found."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:569
+#: lib/vutuv_web/live/message_live/index.ex:683
 #, elixir-autogen, elixir-format
 msgid "No conversations yet."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2407
-#: lib/vutuv_web/live/message_live/index.ex:612
+#: lib/vutuv_web/live/message_live/index.ex:726
 #, elixir-autogen, elixir-format
 msgid "Online"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:522
+#: lib/vutuv_web/live/message_live/index.ex:632
 #, elixir-autogen, elixir-format
 msgid "Requests"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:776
+#: lib/vutuv_web/live/message_live/index.ex:891
 #, elixir-autogen, elixir-format
 msgid "Select a conversation."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:130
+#: lib/vutuv_web/live/message_live/index.ex:149
 #, elixir-autogen, elixir-format
 msgid "This member cannot receive messages."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:173
+#: lib/vutuv_web/live/message_live/index.ex:234
 #, elixir-autogen, elixir-format
 msgid "This message could not be sent."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:125
+#: lib/vutuv_web/live/message_live/index.ex:144
 #, elixir-autogen, elixir-format
 msgid "Too many new conversations. Please try again later."
 msgstr ""
@@ -2833,7 +2834,7 @@ msgstr[1] ""
 msgid "people who aren't your connections"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:570
+#: lib/vutuv_web/live/message_live/index.ex:684
 #, elixir-autogen, elixir-format
 msgid "Open someone's profile to message them."
 msgstr ""
@@ -2999,7 +3000,7 @@ msgstr ""
 msgid "Hidden. You can settle this yourself - see below."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:665
+#: lib/vutuv_web/live/message_live/index.ex:779
 #, elixir-autogen, elixir-format
 msgid "Hidden: reported, under review"
 msgstr ""
@@ -3169,7 +3170,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1050
 #: lib/vutuv_web/components/post_components.ex:2026
 #: lib/vutuv_web/components/post_components.ex:2751
-#: lib/vutuv_web/live/organization_live/show.ex:450
+#: lib/vutuv_web/live/organization_live/show.ex:470
 #: lib/vutuv_web/templates/user/show.html.heex:219
 #, elixir-autogen, elixir-format
 msgid "Report"
@@ -3196,8 +3197,8 @@ msgstr ""
 msgid "Report this content"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:684
-#: lib/vutuv_web/live/message_live/index.ex:685
+#: lib/vutuv_web/live/message_live/index.ex:798
+#: lib/vutuv_web/live/message_live/index.ex:799
 #, elixir-autogen, elixir-format
 msgid "Report this message"
 msgstr ""
@@ -4538,7 +4539,7 @@ msgstr ""
 msgid "Discover people to follow"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:573
+#: lib/vutuv_web/live/message_live/index.ex:687
 #, elixir-autogen, elixir-format
 msgid "Find members"
 msgstr ""
@@ -4592,7 +4593,7 @@ msgstr ""
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:516
 #: lib/vutuv_web/live/notification_live/index.ex:883
-#: lib/vutuv_web/live/organization_live/show.ex:550
+#: lib/vutuv_web/live/organization_live/show.ex:570
 #: lib/vutuv_web/live/post_live/saved.ex:498
 #: lib/vutuv_web/live/search_live.ex:203
 #: lib/vutuv_web/live/search_live.ex:493
@@ -5711,7 +5712,7 @@ msgstr ""
 msgid "@handle"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:628
+#: lib/vutuv_web/live/message_live/index.ex:742
 #, elixir-autogen, elixir-format
 msgid "Block @%{slug}"
 msgstr ""
@@ -10242,7 +10243,7 @@ msgid_plural "%{count} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:416
+#: lib/vutuv_web/live/organization_live/show.ex:436
 #: lib/vutuv_web/views/user_html.ex:534
 #: lib/vutuv_web/views/user_html.ex:713
 #, elixir-autogen, elixir-format
@@ -11047,7 +11048,7 @@ msgstr ""
 msgid "AI agents"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:457
+#: lib/vutuv_web/live/organization_live/show.ex:477
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
@@ -11060,7 +11061,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:248
 #: lib/vutuv_web/live/organization_live/domains.ex:288
 #: lib/vutuv_web/live/organization_live/new.ex:146
-#: lib/vutuv_web/live/organization_live/show.ex:674
+#: lib/vutuv_web/live/organization_live/show.ex:694
 #: lib/vutuv_web/templates/url/verify.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "DNS TXT record"
@@ -11068,8 +11069,8 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:153
 #: lib/vutuv_web/live/organization_live/domains.ex:167
-#: lib/vutuv_web/live/organization_live/show.ex:328
-#: lib/vutuv_web/live/organization_live/show.ex:733
+#: lib/vutuv_web/live/organization_live/show.ex:333
+#: lib/vutuv_web/live/organization_live/show.ex:753
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr ""
@@ -11106,7 +11107,7 @@ msgstr ""
 msgid "Please log in first."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:647
+#: lib/vutuv_web/live/organization_live/show.ex:667
 #, elixir-autogen, elixir-format
 msgid "Prove you control %{domain} to publish this page."
 msgstr ""
@@ -11133,7 +11134,7 @@ msgid "Select a country"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:307
-#: lib/vutuv_web/live/organization_live/show.ex:709
+#: lib/vutuv_web/live/organization_live/show.ex:729
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr ""
@@ -11160,12 +11161,12 @@ msgid "The upload failed."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/new.ex:131
-#: lib/vutuv_web/live/organization_live/show.ex:662
+#: lib/vutuv_web/live/organization_live/show.ex:682
 #, elixir-autogen, elixir-format
 msgid "Verification method"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:622
+#: lib/vutuv_web/live/organization_live/show.ex:642
 #, elixir-autogen, elixir-format
 msgid "Verified domains"
 msgstr ""
@@ -11181,19 +11182,19 @@ msgstr ""
 msgid "Verified via %{domain}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:644
+#: lib/vutuv_web/live/organization_live/show.ex:664
 #, elixir-autogen, elixir-format
 msgid "Verify %{name}"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:320
-#: lib/vutuv_web/live/organization_live/show.ex:729
+#: lib/vutuv_web/live/organization_live/show.ex:749
 #, elixir-autogen, elixir-format
 msgid "Verify now"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:149
-#: lib/vutuv_web/live/organization_live/show.ex:323
+#: lib/vutuv_web/live/organization_live/show.ex:328
 #, elixir-autogen, elixir-format
 msgid "We could not find the record or file yet. It can take a while to propagate. Please try again."
 msgstr ""
@@ -11208,7 +11209,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:249
 #: lib/vutuv_web/live/organization_live/domains.ex:298
-#: lib/vutuv_web/live/organization_live/show.ex:685
+#: lib/vutuv_web/live/organization_live/show.ex:705
 #: lib/vutuv_web/templates/url/verify.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Website file"
@@ -11230,7 +11231,7 @@ msgid "You will publish a record or file to prove control of the domain on the n
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:309
-#: lib/vutuv_web/live/organization_live/show.ex:715
+#: lib/vutuv_web/live/organization_live/show.ex:735
 #: lib/vutuv_web/templates/url/verify.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
@@ -11281,7 +11282,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:357
 #: lib/vutuv_web/agent_docs/text.ex:378
 #: lib/vutuv_web/live/organization_live/edit.ex:353
-#: lib/vutuv_web/live/organization_live/show.ex:610
+#: lib/vutuv_web/live/organization_live/show.ex:630
 #: lib/vutuv_web/templates/tag/single_card.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Also known as"
@@ -11347,7 +11348,7 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:212
 #: lib/vutuv_web/live/admin/organization_live.ex:305
 #: lib/vutuv_web/live/organization_live/domains.ex:161
-#: lib/vutuv_web/live/organization_live/show.ex:443
+#: lib/vutuv_web/live/organization_live/show.ex:463
 #, elixir-autogen, elixir-format
 msgid "Domains"
 msgstr ""
@@ -11463,7 +11464,7 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:209
 #: lib/vutuv_web/live/admin/organization_live.ex:321
 #: lib/vutuv_web/live/organization_live/roles.ex:165
-#: lib/vutuv_web/live/organization_live/show.ex:436
+#: lib/vutuv_web/live/organization_live/show.ex:456
 #, elixir-autogen, elixir-format
 msgid "Team"
 msgstr ""
@@ -11645,7 +11646,7 @@ msgstr ""
 msgid "%{min} to %{max} characters: letters (a-z), numbers (0-9) and underscores."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:565
+#: lib/vutuv_web/live/organization_live/show.ex:585
 #, elixir-autogen, elixir-format
 msgid "Former"
 msgstr ""
@@ -11755,7 +11756,7 @@ msgstr ""
 msgid "The proof is a small technical change to your domain: a DNS entry or a file on your website. If you don't manage the website yourself, ask the person or team who does. That is usually your IT department or the company that runs your website. We show the exact instructions on the next step, so you can simply pass them on."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:656
+#: lib/vutuv_web/live/organization_live/show.ex:676
 #, elixir-autogen, elixir-format
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr ""
@@ -11923,7 +11924,7 @@ msgstr ""
 msgid "The organization page was deleted."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:335
+#: lib/vutuv_web/live/organization_live/show.ex:340
 #, elixir-autogen, elixir-format
 msgid "This organization page was reported and is hidden while it is reviewed. Only you and the moderators can see it."
 msgstr ""
@@ -11953,7 +11954,7 @@ msgstr ""
 msgid "Your organization handle is set."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:261
+#: lib/vutuv_web/live/organization_live/show.ex:266
 #, elixir-autogen, elixir-format
 msgid "Your organization page is verified and now live."
 msgstr ""
@@ -12653,13 +12654,13 @@ msgid "Getting an error, or is %{host} a CNAME / alias to another address? A TXT
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:305
-#: lib/vutuv_web/live/organization_live/show.ex:702
+#: lib/vutuv_web/live/organization_live/show.ex:722
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:303
-#: lib/vutuv_web/live/organization_live/show.ex:693
+#: lib/vutuv_web/live/organization_live/show.ex:713
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
 msgstr ""
@@ -12755,7 +12756,7 @@ msgid "Minimum yearly salary"
 msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:324
-#: lib/vutuv_web/live/organization_live/show.ex:592
+#: lib/vutuv_web/live/organization_live/show.ex:612
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr ""
@@ -12784,7 +12785,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:435
 #: lib/vutuv_web/agent_docs/text.ex:442
 #: lib/vutuv_web/agent_docs/text.ex:454
-#: lib/vutuv_web/live/organization_live/show.ex:579
+#: lib/vutuv_web/live/organization_live/show.ex:599
 #: lib/vutuv_web/templates/tag/show.html.heex:45
 #, elixir-autogen, elixir-format
 msgid "Open positions"
@@ -20069,33 +20070,33 @@ msgstr ""
 msgid "The owner gives other members their roles on the page, and can hand ownership over to someone else at any time. Someone can hold several roles, and writing in the organization's name is always granted on its own."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:535
+#: lib/vutuv_web/live/organization_live/show.ex:555
 #, elixir-autogen, elixir-format
 msgid "Nothing published yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:517
+#: lib/vutuv_web/live/organization_live/show.ex:537
 #: lib/vutuv_web/live/post_live/composer.ex:1814
 #, elixir-autogen, elixir-format
 msgid "Post as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:191
+#: lib/vutuv_web/live/organization_live/show.ex:196
 #, elixir-autogen, elixir-format
 msgid "Published as %{name}."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:203
+#: lib/vutuv_web/live/organization_live/show.ex:208
 #, elixir-autogen, elixir-format
 msgid "That post could not be published."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:509
+#: lib/vutuv_web/live/organization_live/show.ex:529
 #, elixir-autogen, elixir-format
 msgid "Write something as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:197
+#: lib/vutuv_web/live/organization_live/show.ex:202
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr ""
@@ -20120,7 +20121,7 @@ msgstr ""
 msgid "Stopped writing as an organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:493
+#: lib/vutuv_web/live/organization_live/show.ex:513
 #, elixir-autogen, elixir-format
 msgid "Write as %{name} for now"
 msgstr ""
@@ -20356,4 +20357,10 @@ msgstr ""
 #: lib/vutuv/notifications/emailer.ex:282
 #, elixir-autogen, elixir-format
 msgid "New message from %{sender} on vutuv"
+msgstr ""
+
+#: lib/vutuv_web/live/message_live/index.ex:162
+#: lib/vutuv_web/live/message_live/index.ex:172
+#, elixir-autogen, elixir-format
+msgid "This page cannot receive messages."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -33,7 +33,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
 #: lib/vutuv_web/live/organization_live/fediverse.ex:104
-#: lib/vutuv_web/live/organization_live/show.ex:600
+#: lib/vutuv_web/live/organization_live/show.ex:620
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
@@ -214,7 +214,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
 #: lib/vutuv_web/live/job_posting_live/show.ex:178
-#: lib/vutuv_web/live/organization_live/show.ex:429
+#: lib/vutuv_web/live/organization_live/show.ex:449
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:7
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:19
@@ -331,7 +331,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:2014
 #: lib/vutuv_web/components/ui.ex:2072
 #: lib/vutuv_web/controllers/followee_controller.ex:29
-#: lib/vutuv_web/live/organization_live/show.ex:404
+#: lib/vutuv_web/live/organization_live/show.ex:409
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:53
 #: lib/vutuv_web/templates/user/show.html.heex:955
@@ -1686,7 +1686,7 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_following_live.ex:313
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:363
 #: lib/vutuv_web/live/organization_live/following.ex:218
-#: lib/vutuv_web/live/organization_live/show.ex:402
+#: lib/vutuv_web/live/organization_live/show.ex:407
 #: lib/vutuv_web/templates/user/show.html.heex:1069
 #: lib/vutuv_web/templates/user/show.html.heex:1322
 #, elixir-autogen, elixir-format
@@ -1715,7 +1715,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
 #: lib/vutuv_web/live/admin/user_delete_live.ex:143
 #: lib/vutuv_web/live/admin/user_live.ex:154
-#: lib/vutuv_web/live/message_live/index.ex:455
+#: lib/vutuv_web/live/message_live/index.ex:526
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:32
 #: lib/vutuv_web/templates/admin/account/index.html.heex:55
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:28
@@ -1724,13 +1724,14 @@ msgstr ""
 msgid "Member"
 msgstr ""
 
+#: lib/vutuv_web/live/organization_live/show.ex:428
 #: lib/vutuv_web/templates/user/show.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:45
-#: lib/vutuv_web/live/message_live/index.ex:512
+#: lib/vutuv_web/live/message_live/index.ex:50
+#: lib/vutuv_web/live/message_live/index.ex:622
 #: lib/vutuv_web/live/shell_live.ex:652
 #: lib/vutuv_web/live/shell_live.ex:790
 #: lib/vutuv_web/templates/layout/app.html.heex:123
@@ -1784,7 +1785,7 @@ msgid "Pardon us! Something went wrong."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:130
-#: lib/vutuv_web/live/message_live/index.ex:755
+#: lib/vutuv_web/live/message_live/index.ex:869
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Send"
@@ -1859,8 +1860,8 @@ msgstr ""
 msgid "Who to follow"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:744
-#: lib/vutuv_web/live/message_live/index.ex:745
+#: lib/vutuv_web/live/message_live/index.ex:858
+#: lib/vutuv_web/live/message_live/index.ex:859
 #, elixir-autogen, elixir-format
 msgid "Write a message…"
 msgstr ""
@@ -1915,7 +1916,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3461
 #: lib/vutuv_web/live/organization_live/activity.ex:146
 #: lib/vutuv_web/live/organization_live/feed.ex:101
-#: lib/vutuv_web/live/organization_live/show.ex:540
+#: lib/vutuv_web/live/organization_live/show.ex:560
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr ""
@@ -2193,7 +2194,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:382
 #: lib/vutuv_web/live/notification_live/index.ex:882
-#: lib/vutuv_web/live/organization_live/show.ex:467
+#: lib/vutuv_web/live/organization_live/show.ex:487
 #: lib/vutuv_web/live/post_live/saved.ex:495
 #: lib/vutuv_web/live/search_live.ex:205
 #: lib/vutuv_web/live/search_live.ex:551
@@ -2456,7 +2457,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:2073
 #: lib/vutuv_web/live/organization_live/following.ex:197
 #: lib/vutuv_web/live/organization_live/following.ex:256
-#: lib/vutuv_web/live/organization_live/show.ex:407
+#: lib/vutuv_web/live/organization_live/show.ex:412
 #: lib/vutuv_web/live/post_live/feed.ex:1187
 #: lib/vutuv_web/templates/followee/index.html.heex:44
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
@@ -2530,89 +2531,89 @@ msgstr ""
 msgid "Replying to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:493
+#: lib/vutuv_web/live/message_live/index.ex:603
 #, elixir-autogen, elixir-format
 msgid "%{names} are typing…"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:492
+#: lib/vutuv_web/live/message_live/index.ex:602
 #, elixir-autogen, elixir-format
 msgid "%{name} is typing…"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:767
+#: lib/vutuv_web/live/message_live/index.ex:882
 #, elixir-autogen, elixir-format
 msgid "@%{slug} has not accepted your message request yet."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:721
+#: lib/vutuv_web/live/message_live/index.ex:835
 #, elixir-autogen, elixir-format
 msgid "@%{slug} wants to message you."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:476
+#: lib/vutuv_web/live/message_live/index.ex:586
 #, elixir-autogen, elixir-format
 msgid "Accept"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:590
+#: lib/vutuv_web/live/message_live/index.ex:704
 #, elixir-autogen, elixir-format
 msgid "Back to conversations"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:483
+#: lib/vutuv_web/live/message_live/index.ex:593
 #, elixir-autogen, elixir-format
 msgid "Decline"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:451
+#: lib/vutuv_web/live/message_live/index.ex:520
 #, elixir-autogen, elixir-format
 msgid "Deleted account"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:636
+#: lib/vutuv_web/live/message_live/index.ex:750
 #, elixir-autogen, elixir-format
 msgid "Load older messages"
 msgstr ""
 
 #: lib/vutuv_web/controllers/admin/tag_member_controller.ex:55
-#: lib/vutuv_web/live/message_live/index.ex:115
+#: lib/vutuv_web/live/message_live/index.ex:134
 #, elixir-autogen, elixir-format
 msgid "Member not found."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:569
+#: lib/vutuv_web/live/message_live/index.ex:683
 #, elixir-autogen, elixir-format
 msgid "No conversations yet."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2407
-#: lib/vutuv_web/live/message_live/index.ex:612
+#: lib/vutuv_web/live/message_live/index.ex:726
 #, elixir-autogen, elixir-format
 msgid "Online"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:522
+#: lib/vutuv_web/live/message_live/index.ex:632
 #, elixir-autogen, elixir-format
 msgid "Requests"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:776
+#: lib/vutuv_web/live/message_live/index.ex:891
 #, elixir-autogen, elixir-format
 msgid "Select a conversation."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:130
+#: lib/vutuv_web/live/message_live/index.ex:149
 #, elixir-autogen, elixir-format
 msgid "This member cannot receive messages."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:173
+#: lib/vutuv_web/live/message_live/index.ex:234
 #, elixir-autogen, elixir-format
 msgid "This message could not be sent."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:125
+#: lib/vutuv_web/live/message_live/index.ex:144
 #, elixir-autogen, elixir-format
 msgid "Too many new conversations. Please try again later."
 msgstr ""
@@ -2831,7 +2832,7 @@ msgstr[1] ""
 msgid "people who aren't your connections"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:570
+#: lib/vutuv_web/live/message_live/index.ex:684
 #, elixir-autogen, elixir-format
 msgid "Open someone's profile to message them."
 msgstr ""
@@ -2997,7 +2998,7 @@ msgstr ""
 msgid "Hidden. You can settle this yourself - see below."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:665
+#: lib/vutuv_web/live/message_live/index.ex:779
 #, elixir-autogen, elixir-format
 msgid "Hidden: reported, under review"
 msgstr ""
@@ -3167,7 +3168,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1050
 #: lib/vutuv_web/components/post_components.ex:2026
 #: lib/vutuv_web/components/post_components.ex:2751
-#: lib/vutuv_web/live/organization_live/show.ex:450
+#: lib/vutuv_web/live/organization_live/show.ex:470
 #: lib/vutuv_web/templates/user/show.html.heex:219
 #, elixir-autogen, elixir-format
 msgid "Report"
@@ -3194,8 +3195,8 @@ msgstr ""
 msgid "Report this content"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:684
-#: lib/vutuv_web/live/message_live/index.ex:685
+#: lib/vutuv_web/live/message_live/index.ex:798
+#: lib/vutuv_web/live/message_live/index.ex:799
 #, elixir-autogen, elixir-format
 msgid "Report this message"
 msgstr ""
@@ -4536,7 +4537,7 @@ msgstr ""
 msgid "Discover people to follow"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:573
+#: lib/vutuv_web/live/message_live/index.ex:687
 #, elixir-autogen, elixir-format
 msgid "Find members"
 msgstr ""
@@ -4590,7 +4591,7 @@ msgstr ""
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:516
 #: lib/vutuv_web/live/notification_live/index.ex:883
-#: lib/vutuv_web/live/organization_live/show.ex:550
+#: lib/vutuv_web/live/organization_live/show.ex:570
 #: lib/vutuv_web/live/post_live/saved.ex:498
 #: lib/vutuv_web/live/search_live.ex:203
 #: lib/vutuv_web/live/search_live.ex:493
@@ -5709,7 +5710,7 @@ msgstr ""
 msgid "@handle"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:628
+#: lib/vutuv_web/live/message_live/index.ex:742
 #, elixir-autogen, elixir-format
 msgid "Block @%{slug}"
 msgstr ""
@@ -10240,7 +10241,7 @@ msgid_plural "%{count} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:416
+#: lib/vutuv_web/live/organization_live/show.ex:436
 #: lib/vutuv_web/views/user_html.ex:534
 #: lib/vutuv_web/views/user_html.ex:713
 #, elixir-autogen, elixir-format
@@ -11045,7 +11046,7 @@ msgstr ""
 msgid "AI agents"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:457
+#: lib/vutuv_web/live/organization_live/show.ex:477
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
@@ -11058,7 +11059,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:248
 #: lib/vutuv_web/live/organization_live/domains.ex:288
 #: lib/vutuv_web/live/organization_live/new.ex:146
-#: lib/vutuv_web/live/organization_live/show.ex:674
+#: lib/vutuv_web/live/organization_live/show.ex:694
 #: lib/vutuv_web/templates/url/verify.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "DNS TXT record"
@@ -11066,8 +11067,8 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:153
 #: lib/vutuv_web/live/organization_live/domains.ex:167
-#: lib/vutuv_web/live/organization_live/show.ex:328
-#: lib/vutuv_web/live/organization_live/show.ex:733
+#: lib/vutuv_web/live/organization_live/show.ex:333
+#: lib/vutuv_web/live/organization_live/show.ex:753
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr ""
@@ -11104,7 +11105,7 @@ msgstr ""
 msgid "Please log in first."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:647
+#: lib/vutuv_web/live/organization_live/show.ex:667
 #, elixir-autogen, elixir-format
 msgid "Prove you control %{domain} to publish this page."
 msgstr ""
@@ -11131,7 +11132,7 @@ msgid "Select a country"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:307
-#: lib/vutuv_web/live/organization_live/show.ex:709
+#: lib/vutuv_web/live/organization_live/show.ex:729
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr ""
@@ -11158,12 +11159,12 @@ msgid "The upload failed."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/new.ex:131
-#: lib/vutuv_web/live/organization_live/show.ex:662
+#: lib/vutuv_web/live/organization_live/show.ex:682
 #, elixir-autogen, elixir-format
 msgid "Verification method"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:622
+#: lib/vutuv_web/live/organization_live/show.ex:642
 #, elixir-autogen, elixir-format
 msgid "Verified domains"
 msgstr ""
@@ -11179,19 +11180,19 @@ msgstr ""
 msgid "Verified via %{domain}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:644
+#: lib/vutuv_web/live/organization_live/show.ex:664
 #, elixir-autogen, elixir-format
 msgid "Verify %{name}"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:320
-#: lib/vutuv_web/live/organization_live/show.ex:729
+#: lib/vutuv_web/live/organization_live/show.ex:749
 #, elixir-autogen, elixir-format
 msgid "Verify now"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:149
-#: lib/vutuv_web/live/organization_live/show.ex:323
+#: lib/vutuv_web/live/organization_live/show.ex:328
 #, elixir-autogen, elixir-format
 msgid "We could not find the record or file yet. It can take a while to propagate. Please try again."
 msgstr ""
@@ -11206,7 +11207,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:249
 #: lib/vutuv_web/live/organization_live/domains.ex:298
-#: lib/vutuv_web/live/organization_live/show.ex:685
+#: lib/vutuv_web/live/organization_live/show.ex:705
 #: lib/vutuv_web/templates/url/verify.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Website file"
@@ -11228,7 +11229,7 @@ msgid "You will publish a record or file to prove control of the domain on the n
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:309
-#: lib/vutuv_web/live/organization_live/show.ex:715
+#: lib/vutuv_web/live/organization_live/show.ex:735
 #: lib/vutuv_web/templates/url/verify.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
@@ -11279,7 +11280,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:357
 #: lib/vutuv_web/agent_docs/text.ex:378
 #: lib/vutuv_web/live/organization_live/edit.ex:353
-#: lib/vutuv_web/live/organization_live/show.ex:610
+#: lib/vutuv_web/live/organization_live/show.ex:630
 #: lib/vutuv_web/templates/tag/single_card.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Also known as"
@@ -11345,7 +11346,7 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:212
 #: lib/vutuv_web/live/admin/organization_live.ex:305
 #: lib/vutuv_web/live/organization_live/domains.ex:161
-#: lib/vutuv_web/live/organization_live/show.ex:443
+#: lib/vutuv_web/live/organization_live/show.ex:463
 #, elixir-autogen, elixir-format
 msgid "Domains"
 msgstr ""
@@ -11461,7 +11462,7 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:209
 #: lib/vutuv_web/live/admin/organization_live.ex:321
 #: lib/vutuv_web/live/organization_live/roles.ex:165
-#: lib/vutuv_web/live/organization_live/show.ex:436
+#: lib/vutuv_web/live/organization_live/show.ex:456
 #, elixir-autogen, elixir-format
 msgid "Team"
 msgstr ""
@@ -11643,7 +11644,7 @@ msgstr ""
 msgid "%{min} to %{max} characters: letters (a-z), numbers (0-9) and underscores."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:565
+#: lib/vutuv_web/live/organization_live/show.ex:585
 #, elixir-autogen, elixir-format
 msgid "Former"
 msgstr ""
@@ -11753,7 +11754,7 @@ msgstr ""
 msgid "The proof is a small technical change to your domain: a DNS entry or a file on your website. If you don't manage the website yourself, ask the person or team who does. That is usually your IT department or the company that runs your website. We show the exact instructions on the next step, so you can simply pass them on."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:656
+#: lib/vutuv_web/live/organization_live/show.ex:676
 #, elixir-autogen, elixir-format
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr ""
@@ -11921,7 +11922,7 @@ msgstr ""
 msgid "The organization page was deleted."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:335
+#: lib/vutuv_web/live/organization_live/show.ex:340
 #, elixir-autogen, elixir-format
 msgid "This organization page was reported and is hidden while it is reviewed. Only you and the moderators can see it."
 msgstr ""
@@ -11951,7 +11952,7 @@ msgstr ""
 msgid "Your organization handle is set."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:261
+#: lib/vutuv_web/live/organization_live/show.ex:266
 #, elixir-autogen, elixir-format
 msgid "Your organization page is verified and now live."
 msgstr ""
@@ -12651,13 +12652,13 @@ msgid "Getting an error, or is %{host} a CNAME / alias to another address? A TXT
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:305
-#: lib/vutuv_web/live/organization_live/show.ex:702
+#: lib/vutuv_web/live/organization_live/show.ex:722
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:303
-#: lib/vutuv_web/live/organization_live/show.ex:693
+#: lib/vutuv_web/live/organization_live/show.ex:713
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
 msgstr ""
@@ -12753,7 +12754,7 @@ msgid "Minimum yearly salary"
 msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:324
-#: lib/vutuv_web/live/organization_live/show.ex:592
+#: lib/vutuv_web/live/organization_live/show.ex:612
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr ""
@@ -12782,7 +12783,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:435
 #: lib/vutuv_web/agent_docs/text.ex:442
 #: lib/vutuv_web/agent_docs/text.ex:454
-#: lib/vutuv_web/live/organization_live/show.ex:579
+#: lib/vutuv_web/live/organization_live/show.ex:599
 #: lib/vutuv_web/templates/tag/show.html.heex:45
 #, elixir-autogen, elixir-format
 msgid "Open positions"
@@ -20067,33 +20068,33 @@ msgstr ""
 msgid "The owner gives other members their roles on the page, and can hand ownership over to someone else at any time. Someone can hold several roles, and writing in the organization's name is always granted on its own."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:535
+#: lib/vutuv_web/live/organization_live/show.ex:555
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing published yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:517
+#: lib/vutuv_web/live/organization_live/show.ex:537
 #: lib/vutuv_web/live/post_live/composer.ex:1814
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:191
+#: lib/vutuv_web/live/organization_live/show.ex:196
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Published as %{name}."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:203
+#: lib/vutuv_web/live/organization_live/show.ex:208
 #, elixir-autogen, elixir-format
 msgid "That post could not be published."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:509
+#: lib/vutuv_web/live/organization_live/show.ex:529
 #, elixir-autogen, elixir-format
 msgid "Write something as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:197
+#: lib/vutuv_web/live/organization_live/show.ex:202
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr ""
@@ -20118,7 +20119,7 @@ msgstr ""
 msgid "Stopped writing as an organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:493
+#: lib/vutuv_web/live/organization_live/show.ex:513
 #, elixir-autogen, elixir-format
 msgid "Write as %{name} for now"
 msgstr ""
@@ -20354,4 +20355,10 @@ msgstr ""
 #: lib/vutuv/notifications/emailer.ex:282
 #, elixir-autogen, elixir-format, fuzzy
 msgid "New message from %{sender} on vutuv"
+msgstr ""
+
+#: lib/vutuv_web/live/message_live/index.ex:162
+#: lib/vutuv_web/live/message_live/index.ex:172
+#, elixir-autogen, elixir-format, fuzzy
+msgid "This page cannot receive messages."
 msgstr ""

--- a/test/vutuv/organization_messages_test.exs
+++ b/test/vutuv/organization_messages_test.exs
@@ -200,4 +200,42 @@ defmodule Vutuv.OrganizationMessagesTest do
     # Any publisher, not only whoever happened to be addressed.
     assert Organizations.publisher?(page, owner)
   end
+
+  test "the page reads its own thread, and only its own" do
+    {page, _owner} = page_with_publisher()
+    member = insert(:activated_user)
+
+    {:ok, conversation} = Chat.find_or_create_conversation(member, page)
+    {:ok, _} = Chat.send_message(member, conversation.id, "Guten Tag.")
+
+    assert %Conversation{id: id} = Chat.get_conversation(page, conversation.id)
+    assert id == conversation.id
+
+    page_of_messages = Chat.messages_page(page, conversation, limit: 20)
+    assert [%{body: "Guten Tag."}] = page_of_messages.entries
+
+    # Somebody else's conversation is not the page's to read.
+    other_member = insert(:activated_user)
+    third = insert(:activated_user)
+    {:ok, foreign} = Chat.find_or_create_conversation(other_member, third)
+    assert is_nil(Chat.get_conversation(page, foreign.id))
+  end
+
+  test "reading marks the thread read for the whole team, not for one publisher" do
+    {page, owner} = page_with_publisher()
+    second = insert(:activated_user)
+    {:ok, _} = Organizations.add_role(page, second, "publisher", owner)
+    member = insert(:activated_user)
+
+    {:ok, conversation} = Chat.find_or_create_conversation(member, page)
+    {:ok, _} = Chat.send_message(member, conversation.id, "Guten Tag.")
+
+    assert [%{unread: 1}] = Chat.list_organization_conversations(page)
+
+    :ok = Chat.mark_read(page, conversation.id)
+
+    # One marker for the page, so the colleague who did not open it sees the
+    # same thing — the model `organizations.activity_read_at` already sets.
+    assert [%{unread: 0}] = Chat.list_organization_conversations(page)
+  end
 end

--- a/test/vutuv_web/organization_messages_live_test.exs
+++ b/test/vutuv_web/organization_messages_live_test.exs
@@ -1,0 +1,216 @@
+defmodule VutuvWeb.OrganizationMessagesLiveTest do
+  @moduledoc """
+  `/messages` when one side is a page (issue #1336).
+
+  There is **no second messages page**. A publisher reads the page's inbox by
+  switching into the page (issue #1335's acting-as mode) and opening the same
+  `/messages` they always use — the identity the session already carries
+  decides whose inbox it is. A separate `/organizations/:slug/messages` would
+  have meant two message surfaces to keep in step, and somebody who publishes
+  for three pages would have had four inboxes to check.
+
+  The acting-as session value is a **hint, never a credential**: the LiveView
+  re-asks the roles on mount like every other surface, so a captured session
+  payload naming a page the member no longer speaks for is worth nothing.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Chat
+  alias Vutuv.Organizations
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  # A page whose owner is nobody this test logs in as.
+  defp page_with_owner do
+    owner = insert_activated_user()
+    page = active_organization_for(owner)
+    {:ok, _} = Organizations.add_role(page, owner, "publisher", owner)
+    # Creating the page mails its owner, and `sent_pin/0` reads the OLDEST mail
+    # in the mailbox — leave those there and the next login reads a page notice
+    # looking for a six-digit PIN, which fails as "no match of nil".
+    drain_emails()
+    {page, owner}
+  end
+
+  defp drain_emails do
+    receive do
+      {:email, _} -> drain_emails()
+    after
+      0 -> :ok
+    end
+  end
+
+  # Carries the session (and its acting-as value) into the next request the way
+  # a browser does.
+  defp recycle_login(conn),
+    do: conn |> recycle() |> Map.put(:secret_key_base, conn.secret_key_base)
+
+  defp act_as(conn, page),
+    do: conn |> post(~p"/organizations/#{page.slug}/act_as") |> recycle_login()
+
+  describe "the member's side" do
+    test "the page's conversation is listed and opens", %{conn: conn} do
+      {page, owner} = page_with_owner()
+      {conn, member} = create_and_login_user(conn)
+      # The struct `register_user/2` hands back predates the PIN, so it still
+      # reads `email_confirmed?: false` and the gate would refuse them.
+      member = Vutuv.Repo.reload!(member)
+
+      {:ok, conversation} = Chat.find_or_create_conversation(member, page)
+      {:ok, _} = Chat.send_message(member, conversation.id, "Haben Sie offene Stellen?")
+      {:ok, _} = Chat.send_message_as_organization(page, owner, conversation.id, "Ja, mehrere.")
+
+      # The list. `other_user/2` used to resolve a nil id here and RAISE, so
+      # this whole page was a 500 for anybody who had written to a page.
+      {:ok, _live, html} = live(conn, ~p"/messages")
+      assert html =~ page.name
+
+      # And the thread, with the page's answer in it.
+      {:ok, _thread, html} = live(conn, ~p"/messages/#{conversation.id}")
+      assert html =~ "Ja, mehrere."
+      assert html =~ page.name
+
+      # A page is not a member, so nothing offers to block it.
+      refute html =~ ~s(id="thread-menu")
+    end
+
+    test "the member can still write into it", %{conn: conn} do
+      {page, _owner} = page_with_owner()
+      {conn, member} = create_and_login_user(conn)
+      member = Vutuv.Repo.reload!(member)
+
+      {:ok, conversation} = Chat.find_or_create_conversation(member, page)
+
+      {:ok, live, _html} = live(conn, ~p"/messages/#{conversation.id}")
+
+      live
+      |> form("#message-form", message: %{body: "Noch eine Frage."})
+      |> render_submit()
+
+      assert render(live) =~ "Noch eine Frage."
+    end
+  end
+
+  describe "the page's side" do
+    test "a publisher acting as the page reads its inbox and answers in its name",
+         %{conn: conn} do
+      {conn, owner} = create_and_login_user(conn)
+      page = active_organization_for(owner)
+      {:ok, _} = Organizations.add_role(page, owner, "publisher", owner)
+
+      member = insert_activated_user(first_name: "Frida", last_name: "Folger")
+      {:ok, conversation} = Chat.find_or_create_conversation(member, page)
+      {:ok, _} = Chat.send_message(member, conversation.id, "Haben Sie offene Stellen?")
+
+      conn = act_as(conn, page)
+
+      # The same URL, a different inbox: the member who wrote in, not the
+      # publisher's own conversations.
+      {:ok, _live, html} = live(conn, ~p"/messages")
+      assert html =~ "Frida Folger"
+
+      {:ok, thread, _html} = live(conn, ~p"/messages/#{conversation.id}")
+
+      thread
+      |> form("#message-form", message: %{body: "Ja, mehrere."})
+      |> render_submit()
+
+      assert render(thread) =~ "Ja, mehrere."
+
+      # It left in the page's name, with the publisher recorded but not shown.
+      entries = Chat.messages_page(page, conversation, limit: 20).entries
+      reply = List.first(entries)
+      assert reply.body == "Ja, mehrere."
+      assert reply.sender_organization_id == page.id
+      assert is_nil(reply.sender_id)
+      assert reply.acting_user_id == owner.id
+    end
+
+    test "somebody who stopped being a publisher no longer reaches the inbox", %{conn: conn} do
+      {page, owner} = page_with_owner()
+      {conn, helper} = create_and_login_user(conn)
+      {:ok, _} = Organizations.add_role(page, helper, "publisher", owner)
+
+      member = insert_activated_user()
+      {:ok, conversation} = Chat.find_or_create_conversation(member, page)
+      {:ok, _} = Chat.send_message(member, conversation.id, "Guten Tag.")
+
+      conn = act_as(conn, page)
+
+      {:ok, _live, html} = live(conn, ~p"/messages")
+      assert html =~ "Guten Tag."
+
+      # The role goes away while the session still names the page. The mount
+      # re-asks rather than trusting the session, so they are themselves again
+      # and see their own (empty) inbox instead of the page's.
+      role_row =
+        Vutuv.Repo.get_by!(Vutuv.Organizations.OrganizationRole,
+          organization_id: page.id,
+          user_id: helper.id,
+          role: "publisher"
+        )
+
+      {:ok, _} = Organizations.remove_role(role_row)
+
+      {:ok, _live, html} = live(conn, ~p"/messages")
+      refute html =~ "Guten Tag."
+    end
+  end
+
+  describe "getting there" do
+    test "the page offers a Message button, and it opens the conversation", %{conn: conn} do
+      {page, _owner} = page_with_owner()
+      {conn, member} = create_and_login_user(conn)
+      _ = member
+
+      {:ok, _live, html} = live(conn, ~p"/organizations/#{page.slug}")
+      assert html =~ ~s(data-message-organization)
+
+      # Follow the button's own href rather than a path this test invented: a
+      # hand-built route proves nothing about what the page actually links to.
+      [tag] = Regex.run(~r/<a[^>]*id="message-organization"[^>]*>/, html)
+      [_, href] = Regex.run(~r/href="([^"]+)"/, tag)
+
+      # It finds-or-creates, then hands over to the thread.
+      assert {:error, {:live_redirect, %{to: thread_path}}} = live(conn, href)
+      {:ok, _thread, html} = live(conn, thread_path)
+      assert html =~ page.name
+    end
+
+    test "a page that nobody may see cannot be written to", %{conn: conn} do
+      {page, _owner} = page_with_owner()
+      {:ok, _} = Organizations.admin_set_frozen(page, true)
+
+      {conn, _member} = create_and_login_user(conn)
+
+      assert {:error, {:live_redirect, %{to: "/messages"}}} =
+               live(conn, ~p"/messages/organization/#{page.slug}")
+    end
+
+    test "a publisher writing as the page is not offered a button to itself", %{conn: conn} do
+      {conn, owner} = create_and_login_user(conn)
+      page = active_organization_for(owner)
+      {:ok, _} = Organizations.add_role(page, owner, "publisher", owner)
+
+      conn = act_as(conn, page)
+
+      {:ok, _live, html} = live(conn, ~p"/organizations/#{page.slug}")
+      refute html =~ ~s(data-message-organization)
+    end
+  end
+end


### PR DESCRIPTION
Die Oberfläche zu #1336. Der vorige PR (#1403) hat die Fähigkeit in den Kontext gelegt; erreichbar war sie noch nicht.

## Es gibt bewusst keine zweite Nachrichtenseite

Wer in eine Organisation gewechselt ist (das acting-as aus #1335), öffnet **dasselbe** `/messages` und findet dort das Postfach der Seite; alle anderen finden ihr eigenes. `MessageLive.Index` löst beim Mount ein einziges `:viewer`-Assign auf — `acting_as || current_user` — und schickt jeden `Chat`-Aufruf hindurch.

Ein eigener Pfad unter `/organizations/:slug/messages` hätte zwei Nachrichtenoberflächen bedeutet, die man synchron halten muss, und wer für drei Seiten schreibt, hätte vier Postfächer zu prüfen gehabt.

Die Identität wird beim Mount **neu aus den Rollen abgeleitet**, nicht aus der Session geglaubt (die ist signiert, aber nicht verschlüsselt, und tagelang gültig). Wem die Publisher-Rolle entzogen wurde, landet beim nächsten Aufruf in seinem eigenen Postfach — ein Test deckt genau das ab.

## Der Weg hinein

Auf der Seite steht jetzt ein "Nachricht"-Knopf neben dem Folgen-Pill, plus die Route `/messages/organization/:slug` (eigenes Segment statt `/with/:slug`, weil der Slug einer Seite und das Handle eines Mitglieds verschiedene Namensräume sind und ein Pfad sonst beides benennen könnte).

Er ist bewusst ein **ruhiger sekundärer** Knopf: Folgen ist die Handlung, um die dieser Kopfbereich gebaut ist, und ein zweiter Knopf in Markenfarbe daneben hätte den Leser zu einer Wahl gezwungen. Wer gerade als diese Seite schreibt, sieht ihn nicht — er böte ein Gespräch mit sich selbst an.

Der Test folgt dem **gerenderten `href`** statt einer selbstgebauten Route: ein Pfad, den der Test kennt, sagt nichts darüber, wohin die Seite wirklich verlinkt (die `/settings`-Formulare haben das hier schon einmal gekostet).

## Was auf der Seiten-Seite fehlt, fehlt mit Grund

| Fehlt | Warum |
|---|---|
| Anfrage / Annehmen | Eine Seite veröffentlicht, um angeschrieben zu werden. Ein "pending" ließe die erste Antwort ihres Teams wie eine Zustimmung aussehen. |
| Blockieren | Betrifft Menschen. |
| Online-Punkt | Eine Seite ist ein Schreibtisch, kein Mensch — der Punkt wäre ein Versprechen, das niemand hält. |
| Eine Gelesen-Marke pro Person | Gelesen heißt, jemand aus dem Team hat gelesen. Eine Zeile pro Publisher müsste außerdem mit jeder Rollenänderung angelegt und wieder abgeräumt werden. |

## Nebenbei

`gettext.extract --merge` hat den neuen String wieder fuzzy gefüllt, diesmal mit "Dieses **Mitglied** kann keine Nachrichten empfangen." statt der Organisation. Von Hand korrigiert. Das ist in zwei aufeinanderfolgenden PRs zweimal passiert, jedes Mal mit einer Übersetzung, die plausibel aussieht und das Falsche sagt.

`docs/architecture/messages.md` und `organizations.md` sind nachgezogen.

`mix precommit` grün, 7365 Tests.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01MMwsQi49FP21xuSoPEkMnN
