### PR TITLE
Zwei stille Lücken im Seiten-Postfach, und Aufräumen (v7.264.1)

### DIFF
--- a/lib/vutuv/chat.ex
+++ b/lib/vutuv/chat.ex
@@ -19,6 +19,7 @@ defmodule Vutuv.Chat do
 
   import Ecto.Query
 
+  alias Ecto.Association.NotLoaded
   alias Vutuv.Accounts.User
   alias Vutuv.Activity
   alias Vutuv.Chat.{Conversation, Message, Participant}
@@ -181,7 +182,11 @@ defmodule Vutuv.Chat do
   answer at once.
   """
   def send_message_as_organization(%Organization{} = page, %User{} = acting_user, id, body) do
-    conversation = Repo.get_by(Conversation, id: id, organization_id: page.id)
+    # Through the same participant-scoped fetch the read path uses, rather than
+    # a fourth hand-rolled `Repo.get_by`: that one skipped the `UUIDv7.with_cast`
+    # guard, so a malformed id RAISED here where everywhere else it simply means
+    # "no such conversation", and it did not filter a moderation-frozen thread.
+    conversation = get_conversation(page, id)
 
     cond do
       is_nil(conversation) ->
@@ -208,13 +213,8 @@ defmodule Vutuv.Chat do
       |> Message.changeset(%{body: body})
 
     case Repo.transaction(fn -> insert_and_bump(changeset, conversation, false) end) do
-      {:ok, message} ->
-        message = %{message | sender_organization: page}
-        broadcast_new_message(conversation, message)
-        {:ok, message}
-
-      {:error, %Ecto.Changeset{} = changeset} ->
-        {:error, changeset}
+      {:ok, message} -> delivered(conversation, message, page)
+      {:error, %Ecto.Changeset{} = changeset} -> {:error, changeset}
     end
   end
 
@@ -365,7 +365,12 @@ defmodule Vutuv.Chat do
   end
 
   @doc """
-  The other user of a 1:1 conversation, from `me`'s perspective.
+  The other **member's id** in a conversation, from `me`'s perspective.
+
+  Answers `nil` for the page side of a member-page conversation (issue #1336),
+  which is what the delivery chokepoints want - `Activity.broadcast/2` and
+  `Webhooks.emit/3` both treat a nil recipient as "nobody to tell". Anything
+  that needs the other *party* rather than a member id wants `other_party/2`.
   """
   def other_user_id(%Conversation{} = conversation, me_id) do
     if conversation.user_a_id == me_id,
@@ -373,23 +378,49 @@ defmodule Vutuv.Chat do
       else: conversation.user_a_id
   end
 
-  def other_user(%Conversation{} = conversation, me_id) do
-    id = other_user_id(conversation, me_id)
-    # The thread header only renders the avatar, name and @handle, so select the
-    # listing columns rather than the whole wide user row.
-    Repo.one!(from(u in User, where: u.id == ^id, select: struct(u, ^User.listing_fields())))
-  end
+  @doc """
+  Who sent a message - a member **or a page** (issue #1336).
+
+  The twin of `Vutuv.Posts.author/1`, and here for the same reason: `messages`
+  carries the nullable pair `sender_id | sender_organization_id`, so a call site
+  reading either column directly is right for one kind of sender and silently
+  wrong for the other. Reading `message.sender` on a page's message hands back
+  `nil`, which the display layer renders as "Deleted account" - the page's own
+  reply attributed to a departed member.
+
+  Takes the preload when it is there (`thread_page/3` loads both sides) and
+  falls back to a lookup when it is not, rather than handing back an
+  `%Ecto.Association.NotLoaded{}`.
+  """
+  def sender(%Message{sender_organization_id: nil, sender: %NotLoaded{}, sender_id: nil}), do: nil
+
+  def sender(%Message{sender_organization_id: nil, sender: %NotLoaded{}, sender_id: id}),
+    do: Repo.get(User, id)
+
+  def sender(%Message{sender_organization_id: nil} = message), do: message.sender
+
+  def sender(%Message{sender_organization: %NotLoaded{}, sender_organization_id: id}),
+    do: Repo.get(Organization, id)
+
+  def sender(%Message{} = message), do: message.sender_organization
 
   @doc """
   The other side of a conversation - a member **or a page** (issue #1336).
 
-  `other_user/2` above cannot answer this: for a member-page conversation it
-  resolves a nil id, and `Repo.one!(where: u.id == ^nil)` RAISES rather than
-  answering nothing. Every caller that can see a page conversation must come
-  through here.
+  Resolving the far side by elimination cannot work: for a member-page
+  conversation there is no second user id, and a lookup on the nil it produces
+  RAISES rather than answering nothing (`Repo.one!(where: u.id == ^nil)`), which
+  is how the whole messages page became a 500 for anybody who wrote to a page.
+  Every caller that can see a page conversation must come through here.
   """
-  def other_party(%Conversation{} = conversation, me_id) do
-    case other_key(conversation, party(me_id, conversation)) do
+  def other_party(%Conversation{} = conversation, %User{id: id}),
+    do: other_party(conversation, {:user, id})
+
+  def other_party(%Conversation{} = conversation, %Organization{id: id}),
+    do: other_party(conversation, {:organization, id})
+
+  def other_party(%Conversation{} = conversation, party) do
+    case other_key(conversation, party) do
       {:user, id} ->
         Repo.one!(from(u in User, where: u.id == ^id, select: struct(u, ^User.listing_fields())))
 
@@ -397,11 +428,6 @@ defmodule Vutuv.Chat do
         Repo.get!(Organization, id)
     end
   end
-
-  # `me_id` names either the member or the page, and only the conversation can
-  # say which - a page conversation's `user_a_id` is always the member.
-  defp party(me_id, %Conversation{organization_id: me_id}), do: {:organization, me_id}
-  defp party(me_id, %Conversation{}), do: {:user, me_id}
 
   @doc """
   The status a conversation shows to its initiator: a declined request
@@ -484,23 +510,40 @@ defmodule Vutuv.Chat do
       |> Message.changeset(%{body: body})
 
     case Repo.transaction(fn -> insert_and_bump(changeset, conversation, accept?) end) do
-      {:ok, message} ->
-        message = %{message | sender: sender}
-        broadcast_new_message(conversation, message)
-
-        # Webhooks hear about it on the recipient's side (their grant, their
-        # messages:read scope) — a thin envelope, never the message body.
-        Vutuv.Webhooks.emit(other_user_id(conversation, sender.id), "message.created", %{
-          "conversation_id" => conversation.id,
-          "from" => sender.username
-        })
-
-        {:ok, message}
-
-      {:error, %Ecto.Changeset{} = changeset} ->
-        {:error, changeset}
+      {:ok, message} -> delivered(conversation, message, sender)
+      {:error, %Ecto.Changeset{} = changeset} -> {:error, changeset}
     end
   end
+
+  # Everything that happens once a message is in the table, for BOTH kinds of
+  # sender. It lives in one place because the organization path started life as
+  # a copy of the member one and quietly left the webhook out: a page's reply
+  # was the single kind of message that told nobody.
+  defp delivered(conversation, message, sender) do
+    message = put_sender(message, sender)
+    broadcast_new_message(conversation, message)
+
+    # Webhooks hear about it on the recipient's side (their grant, their
+    # messages:read scope) — a thin envelope, never the message body. The
+    # recipient is read off the stored row rather than from the sender we were
+    # handed, so a page (whose `sender_id` is NULL) resolves to the member it
+    # answered instead of to nobody.
+    Vutuv.Webhooks.emit(other_user_id(conversation, message.sender_id), "message.created", %{
+      "conversation_id" => conversation.id,
+      "from" => sender_handle(sender)
+    })
+
+    {:ok, message}
+  end
+
+  defp put_sender(message, %Organization{} = page), do: %{message | sender_organization: page}
+  defp put_sender(message, %User{} = user), do: %{message | sender: user}
+
+  # A page has a handle only once it has claimed a root word, so it falls back
+  # to its slug — the payload names the sender, and nil would name nobody.
+  defp sender_handle(%Organization{username: nil, slug: slug}), do: slug
+  defp sender_handle(%Organization{username: username}), do: username
+  defp sender_handle(%User{username: username}), do: username
 
   # Message insert + the conversation bump (last_message_at, plus the implicit
   # accept when the request's recipient replies) — one transaction.
@@ -570,7 +613,7 @@ defmodule Vutuv.Chat do
       order_by: [desc_nulls_last: c.last_message_at, desc: c.id]
     )
     |> Repo.all()
-    |> hydrate(me_id)
+    |> hydrate({:user, me_id})
   end
 
   @doc """
@@ -604,7 +647,7 @@ defmodule Vutuv.Chat do
       order_by: [desc: c.last_message_at, desc: c.id]
     )
     |> Repo.all()
-    |> hydrate(me_id)
+    |> hydrate({:user, me_id})
   end
 
   # Resolve the other side, last-message preview and unread count for a page of
@@ -613,17 +656,11 @@ defmodule Vutuv.Chat do
   # conversation list is a member or a page, and so is the other side.
   defp hydrate([], _party), do: []
 
-  defp hydrate(conversations, me_id) when is_binary(me_id),
-    do: hydrate(conversations, {:user, me_id})
-
   defp hydrate(conversations, party) do
     ids = Enum.map(conversations, & &1.id)
     keys = Enum.map(conversations, &other_key(&1, party))
     others = parties_by_key(keys)
-    # A dynamic composes only inside another dynamic, never inline in a query
-    # expression, so the whole condition is built here.
-    mine = own_message(party)
-    shown = dynamic([m], is_nil(m.frozen_at) or ^mine)
+    shown = visible_message(party)
 
     previews =
       from(m in Message,
@@ -672,24 +709,15 @@ defmodule Vutuv.Chat do
 
   # One batched load per kind, into a single `{kind, id} => struct` map.
   defp parties_by_key(keys) do
-    grouped = Enum.group_by(keys, &elem(&1, 0), &elem(&1, 1))
-
     users =
-      grouped
-      |> Map.get(:user, [])
+      for({:user, id} <- keys, do: id)
       |> listing_users_by_id()
       |> Map.new(fn {id, user} -> {{:user, id}, user} end)
 
     pages =
-      case Map.get(grouped, :organization, []) do
-        [] ->
-          %{}
-
-        ids ->
-          from(o in Organization, where: o.id in ^ids)
-          |> Repo.all()
-          |> Map.new(&{{:organization, &1.id}, &1})
-      end
+      for({:organization, id} <- keys, do: id)
+      |> listing_organizations_by_id()
+      |> Map.new(fn {id, page} -> {{:organization, id}, page} end)
 
     Map.merge(users, pages)
   end
@@ -701,6 +729,13 @@ defmodule Vutuv.Chat do
   # NULL too, which excludes the row. Written this way the negation is honest
   # in both directions, and the unread badge counts what the reader has not
   # read whichever side wrote it.
+  # A frozen message is hidden from the other participant but stays visible to
+  # its sender - which since issue #1336 can be a page, so the test goes through
+  # own_message/1 rather than naming a column that is NULL on the other's rows.
+  # A dynamic composes only inside another dynamic, never inline in a query
+  # expression, which is why this is built rather than written at the two sites.
+  defp visible_message(party), do: dynamic([m], is_nil(m.frozen_at) or ^own_message(party))
+
   defp own_message({:user, me_id}),
     do: dynamic([m], not is_nil(m.sender_id) and m.sender_id == ^me_id)
 
@@ -710,22 +745,38 @@ defmodule Vutuv.Chat do
 
   # Load the listing columns for a set of user ids into an id->user map.
   # The email/sidebar only needs the narrow listing_fields, not the wide row.
+  #
+  # The empty clause is not just a shortcut: a PINNED empty list is not folded
+  # away, it compiles to `= ANY($1)` with an empty array and costs a real round
+  # trip. A sidebar whose every counterpart is a page hits exactly that.
+  defp listing_users_by_id([]), do: %{}
+
   defp listing_users_by_id(ids) do
     from(u in User, where: u.id in ^ids, select: struct(u, ^User.listing_fields()))
     |> Repo.all()
     |> Map.new(&{&1.id, &1})
   end
 
-  defp unread_counts(conversation_ids, me_id) when is_binary(me_id),
-    do: unread_counts(conversation_ids, {:user, me_id})
+  # The same narrowing for pages: a sidebar row needs the name, the logo and
+  # the handle, never the whole wide row with its 10k-char description.
+  defp listing_organizations_by_id([]), do: %{}
+
+  defp listing_organizations_by_id(ids) do
+    from(o in Organization,
+      where: o.id in ^ids,
+      select: struct(o, [:id, :name, :username, :slug, :logo])
+    )
+    |> Repo.all()
+    |> Map.new(&{&1.id, &1})
+  end
 
   defp unread_counts(conversation_ids, party) do
     from_them = dynamic([m], not (^own_message(party)))
-    joined = dynamic([m, p], p.conversation_id == m.conversation_id and ^participant_is(party))
 
     from(m in Message,
       join: p in Participant,
-      on: ^joined,
+      on: p.conversation_id == m.conversation_id,
+      where: ^participant_is(party),
       where: m.conversation_id in ^conversation_ids,
       # NOT `m.sender_id != ^me_id`: a page's message has a NULL `sender_id`,
       # and `NULL != <id>` is NULL rather than true, so a page's reply would
@@ -779,11 +830,7 @@ defmodule Vutuv.Chat do
   defp thread_page(party, %Conversation{} = conversation, opts) do
     limit = Keyword.get(opts, :limit, 30)
     cursor = Keyword.get(opts, :cursor)
-    # The moderation freezer: a frozen message is hidden from the other
-    # participant but stays visible to its sender — which since issue #1336 can
-    # be a page, so the test goes through own_message/1 rather than naming a
-    # column that would be NULL on the other side's rows.
-    shown = dynamic([m], is_nil(m.frozen_at) or ^own_message(party))
+    shown = visible_message(party)
 
     entries =
       from(m in Message,
@@ -838,12 +885,8 @@ defmodule Vutuv.Chat do
   # No marker given (opening a conversation): the newest message's time is the
   # read marker, looked up with a MAX. A caller already holding the just-arrived
   # message passes its inserted_at (the new newest) to skip that scan.
-  def mark_read(%User{} = me, conversation_id, nil) do
-    mark_read(me, conversation_id, newest_message_at(conversation_id))
-  end
-
-  def mark_read(%Organization{} = page, conversation_id, nil) do
-    mark_read(page, conversation_id, newest_message_at(conversation_id))
+  def mark_read(party, conversation_id, nil) do
+    mark_read(party, conversation_id, newest_message_at(conversation_id))
   end
 
   # ONE marker for the page, not one per publisher: read means somebody on the

--- a/lib/vutuv_web/live/message_live/index.ex
+++ b/lib/vutuv_web/live/message_live/index.ex
@@ -68,9 +68,6 @@ defmodule VutuvWeb.MessageLive.Index do
   defp assign_viewer(socket),
     do: assign(socket, :viewer, socket.assigns[:acting_as] || socket.assigns.current_user)
 
-  defp page_viewer?(%Organization{}), do: true
-  defp page_viewer?(_), do: false
-
   # The sidebar lists load only on the connected mount (the page is
   # login-required, so the static render is replaced a moment later — no
   # reason to run the 8 sidebar queries twice per visit). `loaded?` keeps the
@@ -111,10 +108,11 @@ defmodule VutuvWeb.MessageLive.Index do
 
         socket
         |> assign(:conversation, conversation)
-        # `other_user/2` cannot answer here: on a member-page conversation it
-        # resolves a nil id and `Repo.one!` RAISES rather than answering
-        # nothing, which was a 500 on this page for anybody who wrote to a page.
-        |> assign(:other, Chat.other_party(conversation, viewer.id))
+        # The far side is a member OR a page, so it cannot be found by
+        # elimination: a page conversation has no second user id, and looking up
+        # the nil that produces RAISES rather than answering nothing - a 500 on
+        # this page for anybody who had written to a page.
+        |> assign(:other, Chat.other_party(conversation, viewer))
         |> assign(:more?, page.more?)
         |> assign(:cursor, page.next_cursor)
         |> stream(:messages, Enum.reverse(page.entries), reset: true)
@@ -193,6 +191,8 @@ defmodule VutuvWeb.MessageLive.Index do
   # `send_message_as_organization/4` asks for it live rather than trusting the
   # identity this socket mounted with.
   defp send_as(socket, body) do
+    # `socket.assigns.viewer` is the identity being SPOKEN AS; `current_user` is
+    # always the human at the keyboard. A page's reply needs both.
     case socket.assigns.viewer do
       %Organization{} = page ->
         Chat.send_message_as_organization(
@@ -532,29 +532,29 @@ defmodule VutuvWeb.MessageLive.Index do
   # avatar, and no online state - it is a desk, not a person, so a presence dot
   # on it would be a promise nobody is keeping.
   attr(:party, :any, required: true)
-  attr(:size, :string, default: "sm")
 
   defp party_avatar(%{party: %Organization{}} = assigns) do
     ~H"""
-    <.organization_logo organization={@party} class={logo_class(@size)} />
+    <.organization_logo organization={@party} class="h-9 w-9 shrink-0" />
     """
   end
 
   defp party_avatar(assigns) do
     ~H"""
-    <.avatar user={@party} size={@size} />
+    <.avatar user={@party} size="sm" />
     """
   end
-
-  defp logo_class("sm"), do: "h-9 w-9 shrink-0"
-  defp logo_class(_), do: "h-10 w-10 shrink-0"
 
   # Where the name links to. A page lives under /organizations/<slug>, and a
   # member at the root - one function so no call site has to remember which.
   defp party_path(%Organization{} = page), do: Organizations.canonical_path(page)
   defp party_path(user), do: ~p"/#{user}"
 
-  # Only a member can be online, blocked, or the far side of a request.
+  # Only a member can be online or blocked. Deliberately NOT used for "is there
+  # a request to answer" or "may I write here": a page conversation is created
+  # `accepted` and cannot leave that state, so `Chat.can_send?/2` and
+  # `Chat.request_recipient?/2` already give the right answer for it, and asking
+  # the kind in front of them would put the same rule in two layers.
   defp member_party?(%Organization{}), do: false
   defp member_party?(nil), do: false
   defp member_party?(_), do: true
@@ -770,7 +770,7 @@ defmodule VutuvWeb.MessageLive.Index do
               )
             ]}>
               <span :if={not mine?(m, @viewer)} class="mb-0.5 block text-xs font-semibold text-brand-700 dark:text-brand-300">
-                {display_name(m.sender)}
+                {display_name(Chat.sender(m))}
               </span>
               {VutuvWeb.Markdown.render(m.body)}
               <%!-- Only the sender ever sees a frozen message; tell them why
@@ -828,7 +828,7 @@ defmodule VutuvWeb.MessageLive.Index do
         </div>
 
         <div
-          :if={member_party?(@other) and Chat.request_recipient?(@conversation, @viewer.id)}
+          :if={Chat.request_recipient?(@conversation, @viewer.id)}
           id="request-banner"
           class="flex flex-wrap items-center justify-center gap-2 border-t border-slate-200 p-3 text-sm text-slate-600 dark:border-slate-800 dark:text-slate-300"
         >
@@ -844,7 +844,7 @@ defmodule VutuvWeb.MessageLive.Index do
         (flex-col): the editor takes the full width on top and the Send button sits
         below it as a full-width horizontal bar, rather than riding beside it. --%>
         <.form
-          :if={page_viewer?(@viewer) or Chat.can_send?(@conversation, @viewer.id)}
+          :if={Chat.can_send?(@conversation, @viewer.id)}
           for={@form}
           id="message-form"
           phx-submit="send"
@@ -872,8 +872,7 @@ defmodule VutuvWeb.MessageLive.Index do
 
         <p
           :if={
-            member_party?(@other) and
-              not Chat.can_send?(@conversation, @viewer.id) and
+            not Chat.can_send?(@conversation, @viewer.id) and
               not Chat.request_recipient?(@conversation, @viewer.id)
           }
           id="awaiting-acceptance"

--- a/lib/vutuv_web/live/organization_live/show.ex
+++ b/lib/vutuv_web/live/organization_live/show.ex
@@ -100,9 +100,11 @@ defmodule VutuvWeb.OrganizationLive.Show do
   end
 
   # Am I currently speaking as the very page I am looking at? Then a "Message"
-  # button would open a conversation with myself.
-  defp own_page?(%{acting_as: %Organization{id: id}, organization: %{id: id}}), do: true
-  defp own_page?(_assigns), do: false
+  # button would open a conversation with myself. Takes the two things it
+  # compares rather than the whole assigns map, so the template expression stays
+  # change-tracked and the clause head cannot drift from `follower_of/1`'s.
+  defp own_page?(%Organization{id: id}, %Organization{id: id}), do: true
+  defp own_page?(_acting_as, _organization), do: false
 
   defp assign_organization(socket, organization, viewer) do
     # One query for every domain, partitioned in memory (an organization has few).
@@ -419,7 +421,7 @@ defmodule VutuvWeb.OrganizationLive.Show do
               choose. Hidden while you are writing AS this page, where it would
               offer a conversation with yourself. --%>
               <.link
-                :if={@current_user && not own_page?(assigns)}
+                :if={@current_user && not own_page?(@acting_as, @organization)}
                 navigate={~p"/messages/organization/#{@organization.slug}"}
                 id="message-organization"
                 data-message-organization

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.264.0",
+      version: "7.264.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260811220905_index_organization_conversations.exs
+++ b/priv/repo/migrations/20260811220905_index_organization_conversations.exs
@@ -1,0 +1,34 @@
+defmodule Vutuv.Repo.Migrations.IndexOrganizationConversations do
+  @moduledoc """
+  The indexes the page side of `conversations` was missing (issue #1336).
+
+  The member side of the inbox query has had a purpose-built index per column
+  since it was written — `conversations_user_a_id_last_message_at_index` and its
+  `user_b_id` twin. The page side shipped with only
+  `unique_index(:conversations, [:user_a_id, :organization_id])`, whose *leading*
+  column is `user_a_id`, so nothing in the table could serve
+
+      WHERE organization_id = $1 AND frozen_at IS NULL AND last_message_at IS NOT NULL
+      ORDER BY last_message_at DESC
+
+  and Postgres answered it with a sequential scan plus a sort of the whole
+  table — sized by the installation's total conversations rather than by the
+  page's inbox, on every load of that inbox. (Postgres 17 has no btree skip
+  scan, so the composite unique index cannot stand in.)
+
+  `messages.acting_user_id` gets one too. It is `nilify_all`, so deleting a
+  member makes Postgres' referential-integrity trigger look for that member's
+  rows in `messages` — and with no index that is a full scan of the biggest
+  table in this subsystem, on a flow members really do use
+  (`Accounts.delete_user/1`). `sender_id` has had an index all along for exactly
+  this reason.
+
+  Plain additions, so N-1 safe.
+  """
+  use Ecto.Migration
+
+  def change do
+    create(index(:conversations, [:organization_id, :last_message_at]))
+    create(index(:messages, [:acting_user_id]))
+  end
+end

--- a/test/vutuv/organization_messages_test.exs
+++ b/test/vutuv/organization_messages_test.exs
@@ -20,11 +20,15 @@ defmodule Vutuv.OrganizationMessagesTest do
 
   import Vutuv.OrganizationsHelpers
 
+  alias Vutuv.ApiAuth
+  alias Vutuv.ApiAuth.OAuth
   alias Vutuv.Chat
   alias Vutuv.Chat.Conversation
   alias Vutuv.Chat.Participant
   alias Vutuv.Organizations
   alias Vutuv.Repo
+  alias Vutuv.Webhooks
+  alias Vutuv.Webhooks.Delivery
 
   setup do
     Application.put_env(:vutuv, :verify_organization_domains, true)
@@ -138,6 +142,11 @@ defmodule Vutuv.OrganizationMessagesTest do
 
     assert {:error, :not_participant} =
              Chat.send_message_as_organization(page, owner, foreign.id, "Nicht meins.")
+
+    # And a malformed id is "no such conversation", not a crash — the read path
+    # has always answered that way, and the send path used to skip the cast.
+    assert {:error, :not_participant} =
+             Chat.send_message_as_organization(page, owner, "not-a-uuid", "Nicht meins.")
   end
 
   test "a page nobody may see cannot be written to" do
@@ -167,7 +176,7 @@ defmodule Vutuv.OrganizationMessagesTest do
     assert %Vutuv.Organizations.Organization{} = entry.other
 
     assert %Vutuv.Organizations.Organization{id: id} =
-             Chat.other_party(conversation, member.id)
+             Chat.other_party(conversation, member)
 
     assert id == page.id
 
@@ -194,7 +203,7 @@ defmodule Vutuv.OrganizationMessagesTest do
     # The member wrote it, so it is unread for the page's whole team.
     assert entry.unread == 1
 
-    assert %Vutuv.Accounts.User{id: id} = Chat.other_party(conversation, page.id)
+    assert %Vutuv.Accounts.User{id: id} = Chat.other_party(conversation, page)
     assert id == member.id
 
     # Any publisher, not only whoever happened to be addressed.
@@ -237,5 +246,54 @@ defmodule Vutuv.OrganizationMessagesTest do
     # One marker for the page, so the colleague who did not open it sees the
     # same thing — the model `organizations.activity_read_at` already sets.
     assert [%{unread: 0}] = Chat.list_organization_conversations(page)
+  end
+
+  test "a page's reply reaches the member's webhook like any other message" do
+    {page, owner} = page_with_publisher()
+    member = insert(:activated_user)
+    developer = insert(:activated_user)
+
+    redirect = "https://app.example.org/callback"
+
+    {:ok, app, _secret} =
+      ApiAuth.create_app(developer, %{"name" => "Hook App", "redirect_uris" => [redirect]})
+
+    {:ok, _subscription, _secret} =
+      Webhooks.create_subscription(app, %{
+        "url" => "https://hooks.example.org/vutuv",
+        "events" => ["message.created"]
+      })
+
+    {:ok, request} =
+      OAuth.validate_authorize(%{
+        "response_type" => "code",
+        "client_id" => app.client_id,
+        "redirect_uri" => redirect,
+        "scope" => "messages:read",
+        "code_challenge" => Base.url_encode64(:crypto.hash(:sha256, "vvvvv"), padding: false),
+        "code_challenge_method" => "S256"
+      })
+
+    {:ok, _code} = OAuth.approve(member, request)
+
+    {:ok, conversation} = Chat.find_or_create_conversation(member, page)
+
+    # The member's own send tells the PAGE, which has no webhooks of its own -
+    # so nothing is queued and the recipient id is nil rather than wrong.
+    {:ok, _} = Chat.send_message(member, conversation.id, "Guten Tag.")
+    assert Repo.aggregate(Delivery, :count) == 0
+
+    # The page answering is an ordinary incoming message for the member, and it
+    # was silently the one kind of send that told nobody: the organization path
+    # was a second copy of `deliver/4` that had simply left the emit out.
+    {:ok, _} = Chat.send_message_as_organization(page, owner, conversation.id, "Ja, gerne.")
+
+    assert [delivery] = Repo.all(Delivery)
+    assert delivery.event == "message.created"
+    assert delivery.payload["member"] == member.username
+    assert delivery.payload["data"]["conversation_id"] == conversation.id
+    # A page names itself by its handle when it has claimed one, by its slug
+    # when it has not - never nil, which is what `username` alone would give.
+    assert delivery.payload["data"]["from"] == page.slug
   end
 end

--- a/test/vutuv_web/organization_messages_live_test.exs
+++ b/test/vutuv_web/organization_messages_live_test.exs
@@ -75,8 +75,9 @@ defmodule VutuvWeb.OrganizationMessagesLiveTest do
       {:ok, _} = Chat.send_message(member, conversation.id, "Haben Sie offene Stellen?")
       {:ok, _} = Chat.send_message_as_organization(page, owner, conversation.id, "Ja, mehrere.")
 
-      # The list. `other_user/2` used to resolve a nil id here and RAISE, so
-      # this whole page was a 500 for anybody who had written to a page.
+      # The list. Resolving the far side by elimination used to hand a nil id
+      # to a lookup that RAISES, so this whole page was a 500 for anybody who
+      # had written to a page.
       {:ok, _live, html} = live(conn, ~p"/messages")
       assert html =~ page.name
 
@@ -87,6 +88,13 @@ defmodule VutuvWeb.OrganizationMessagesLiveTest do
 
       # A page is not a member, so nothing offers to block it.
       refute html =~ ~s(id="thread-menu")
+
+      # And the reply's bubble is labelled with the PAGE, not "Deleted account".
+      # A page's message has a NULL `sender_id`, so a label reading that column
+      # reports the sender as gone - and the thread header carrying the page's
+      # name right above it is exactly what hid this from the first version of
+      # this test.
+      refute html =~ "Deleted account"
     end
 
     test "the member can still write into it", %{conn: conn} do


### PR DESCRIPTION
Ein `/simplify`-Durchlauf über #1403 und #1404. Vier Prüfer parallel (Wiederverwendung, Vereinfachung, Effizienz, Flughöhe) — und zwei davon haben echte Fehler gefunden, beide unsichtbar.

## Die zwei Fehler

**Über der Antwort einer Seite stand "Deleted account".** Die Blase liest den Absender aus `messages.sender_id`, und die Spalte ist bei einer Seite NULL. Dass die Kopfzeile des Gesprächs den Namen der Seite direkt darüber zeigt, hat das vor meinem eigenen Test verborgen — der Test prüfte `html =~ page.name` und war deshalb grün.

Jetzt gibt es **`Chat.sender/1`** als Zwilling von `Posts.author/1`: dieselbe Frage, eine Funktion, Preload wenn vorhanden, sonst ein Lookup.

**Beim Antworten einer Seite ging kein `message.created`-Webhook raus.** Der Organisationspfad war eine Kopie von `deliver/4`, in der der Aufruf schlicht fehlte — die eine Art Nachricht, die niemandem Bescheid sagte. Beide Pfade teilen sich jetzt denselben Abschluss (`delivered/3`), also kann das nicht wieder auseinanderlaufen. Der Empfänger wird dabei aus der **gespeicherten Zeile** gelesen statt aus dem übergebenen Absender, sonst löst eine Seite (deren `sender_id` NULL ist) auf niemanden auf.

## Ein fehlender Index

Die Mitgliederseite von `conversations` hat pro Spalte einen Index (`user_a_id, last_message_at` und den `user_b_id`-Zwilling). Die Seiten-Seite bekam nur `unique_index(:conversations, [:user_a_id, :organization_id])`, dessen **führende** Spalte `user_a_id` ist — also konnte nichts in der Tabelle den Posteingang einer Seite bedienen, und Postgres hat ihn mit `Seq Scan` + `Sort` über die ganze Tabelle beantwortet (PG 17 kann keinen btree skip scan). `messages.acting_user_id` bekommt auch einen: er ist `nilify_all`, und ohne Index sucht der RI-Trigger beim Löschen eines Mitglieds die ganze `messages`-Tabelle ab.

## Aufgeräumt

| Was | Warum |
|---|---|
| `other_user/2` gelöscht | Kein Aufrufer mehr, und der Körper war Zeichen für Zeichen der `{:user, id}`-Zweig von `other_party/2` |
| `other_party/2` nimmt die Partei | Nahm eine ID und hat die Art daraus **wieder erraten** — genau die Umkehrung, die `Posts.author/1` verhindern soll |
| Drei Template-Gatter weg | Sie fragten nach der Art, wo `can_send?/2` und `request_recipient?/2` die Frage schon richtig beantworten: ein Seiten-Gespräch entsteht als `accepted` und kann den Zustand nie verlassen |
| Das Senden einer Seite läuft über `get_conversation/2` | Der vierte handgeschriebene `Repo.get_by` hatte die `UUIDv7`-Prüfung nicht, eine kaputte ID flog also statt "gibt es nicht" zu heißen |
| Sidebar lädt fünf Spalten statt der ganzen Zeile | Die Mitglieder-Seite tat das längst (`listing_fields`), die Seiten-Seite zog die 10k-Zeichen-Beschreibung mit |
| `listing_users_by_id([])` kurzgeschlossen | Eine **gepinnte** leere Liste wird nicht wegoptimiert, sie wird zu `= ANY($1)` und kostet einen echten Roundtrip |
| Diverses | Tote Klauseln, ein überflüssiges `dynamic`, `own_page?/2` nimmt was es vergleicht statt der ganzen assigns |

## Was ich bewusst nicht gemacht habe

Der **Zähler in der Kopfleiste** kennt den Posteingang einer Seite noch nicht, das Team sieht also keinen Badge und muss `/messages` von sich aus öffnen. Das ist kein Aufräumen mehr, sondern eine Erweiterung an einer sicherheitsrelevanten Stelle (die Identität müsste beim Socket-Mount neu geprüft werden, siehe #1034/#1036), also gehört sie in einen eigenen PR statt ans Ende eines Cleanups.

Ebenfalls stehen gelassen: `insert_organization_conversation/2` ist immer noch eine Beinahe-Kopie von `insert_conversation/5` (~20 Zeilen), und `fetch_as_participant/3` könnte die Partei nehmen statt nur Mitglieder zu kennen. Beides richtig, beides ein Umbau am Autorisierungspfad der Mitglieder — nicht am Ende einer langen Sitzung.

`mix precommit` grün, 7366 Tests.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01MMwsQi49FP21xuSoPEkMnN
