### PR TITLE
Das Postfach einer Seite läutet jetzt (v7.265.0)

### DIFF
--- a/lib/vutuv/activity.ex
+++ b/lib/vutuv/activity.ex
@@ -54,10 +54,11 @@ defmodule Vutuv.Activity do
   @pubsub Vutuv.PubSub
   @default_limit 50
 
+  defp topic(%Vutuv.Organizations.Organization{id: id}), do: "organization:#{id}"
   defp topic(user_id), do: "user:#{user_id}"
 
   def subscribe(nil), do: :ok
-  def subscribe(user_id), do: Phoenix.PubSub.subscribe(@pubsub, topic(user_id))
+  def subscribe(party), do: Phoenix.PubSub.subscribe(@pubsub, topic(party))
 
   # Whether a follow row has a follower worth showing. The member side is left
   # exactly as it was — the row existing is the whole test, no moderation gate,
@@ -78,7 +79,7 @@ defmodule Vutuv.Activity do
 
   @doc "Broadcast a raw event to a user's topic (no-op for a nil recipient)."
   def broadcast(nil, _event), do: :ok
-  def broadcast(user_id, event), do: Phoenix.PubSub.broadcast(@pubsub, topic(user_id), event)
+  def broadcast(party, event), do: Phoenix.PubSub.broadcast(@pubsub, topic(party), event)
 
   @doc """
   Persist the read marker (`users.notifications_read_at`) and tell the user's
@@ -325,7 +326,7 @@ defmodule Vutuv.Activity do
   def subject_post_id(_item), do: nil
 
   @doc "Tell a user's shell their messages were just read (clears the badge)."
-  def mark_messages_read(user_id), do: broadcast(user_id, :messages_read)
+  def mark_messages_read(party), do: broadcast(party, :messages_read)
 
   @doc "Push a new in-app notification to `user_id`."
   def notify(nil, _notification), do: :ok

--- a/lib/vutuv/chat.ex
+++ b/lib/vutuv/chat.ex
@@ -891,12 +891,13 @@ defmodule Vutuv.Chat do
 
   # ONE marker for the page, not one per publisher: read means somebody on the
   # team read it, the same model as `organizations.activity_read_at`.
-  def mark_read(%Organization{id: page_id}, conversation_id, %NaiveDateTime{} = marker) do
+  def mark_read(%Organization{id: page_id} = page, conversation_id, %NaiveDateTime{} = marker) do
     from(p in Participant,
       where: p.conversation_id == ^conversation_id and p.organization_id == ^page_id
     )
     |> Repo.update_all(set: [last_read_at: marker, notified_at: nil])
 
+    Activity.mark_messages_read(page)
     :ok
   end
 
@@ -919,13 +920,43 @@ defmodule Vutuv.Chat do
   end
 
   @doc """
-  How many conversations hold unread messages for the user — the shell badge.
-  Pending requests count for their recipient (that is how requests get
-  noticed); declined conversations count for nobody.
+  How many conversations hold unread messages for a party — the shell badge.
+
+  For a **member**: pending requests count for their recipient (that is how
+  requests get noticed); declined conversations count for nobody.
+
+  For a **page** (issue #1336) it is a separate query rather than a party
+  argument on the member one, because the member version carries a
+  request-state clause that a page conversation has no analogue for (it is
+  created `accepted` and cannot leave that state) and the EXISTS gate has to
+  test the other sender column. Sharing one query would mean two dead branches.
   """
   def unread_conversations_count(nil), do: 0
 
   def unread_conversations_count(%User{id: me_id}), do: unread_conversations_count(me_id)
+
+  def unread_conversations_count(%Organization{id: page_id}) do
+    from(c in Conversation,
+      join: p in Participant,
+      on: p.conversation_id == c.id and p.organization_id == ^page_id,
+      where: is_nil(c.frozen_at),
+      where:
+        fragment(
+          """
+          EXISTS (SELECT 1 FROM messages m
+                  WHERE m.conversation_id = ?
+                    AND m.sender_organization_id IS NULL
+                    AND m.frozen_at IS NULL
+                    AND (? IS NULL OR m.inserted_at > ?))
+          """,
+          c.id,
+          p.last_read_at,
+          p.last_read_at
+        ),
+      select: count(c.id)
+    )
+    |> Repo.one()
+  end
 
   def unread_conversations_count(me_id) do
     # An EXISTS test per conversation instead of joining messages: it stops at the
@@ -1229,6 +1260,17 @@ defmodule Vutuv.Chat do
     )
   end
 
+  # Who a message is FOR: the other member, or the page it was addressed to.
+  defp recipient(%Conversation{organization_id: page_id} = conversation, %Message{} = message)
+       when is_binary(page_id) do
+    if is_nil(message.sender_organization_id),
+      do: Repo.get(Organization, page_id),
+      else: conversation.user_a_id
+  end
+
+  defp recipient(%Conversation{} = conversation, %Message{} = message),
+    do: other_user_id(conversation, message.sender_id)
+
   defp topic(conversation_id), do: "conversation:#{conversation_id}"
 
   # The open thread gets the full message; the recipient's activity topic gets
@@ -1236,8 +1278,16 @@ defmodule Vutuv.Chat do
   defp broadcast_new_message(conversation, message) do
     Phoenix.PubSub.broadcast(@pubsub, topic(conversation.id), {:new_message, message})
 
-    recipient_id = other_user_id(conversation, message.sender_id)
-    Activity.broadcast(recipient_id, {:new_message, %{conversation_id: conversation.id}})
+    # `other_user_id/2` answers nil when the far side is a page, so the recipient
+    # is the page itself — its team's shell subscribes to that topic while they
+    # are speaking as it. Without this the badge only moved on a full reload.
+    Activity.broadcast(
+      recipient(conversation, message),
+      {:new_message,
+       %{
+         conversation_id: conversation.id
+       }}
+    )
   end
 
   # A request was accepted: nudge the conversation's open threads (the

--- a/lib/vutuv_web/live/shell_live.ex
+++ b/lib/vutuv_web/live/shell_live.ex
@@ -93,6 +93,8 @@ defmodule VutuvWeb.ShellLive do
   # the logged-in chrome that would crash on `~p"/#{nil}"`. cast_or_nil also
   # tolerates the integer ids in cookies from before the UUID cutover.
   defp mount_static(socket, session, path) do
+    socket = assign(socket, :acting_as, nil)
+
     user_param = session["user_param"]
     user_id = user_param && Vutuv.UUIDv7.cast_or_nil(session["user_id"])
 
@@ -117,6 +119,7 @@ defmodule VutuvWeb.ShellLive do
   # no subscriptions, no counts, no presence.
   defp mount_authenticated(socket, nil, _session, path) do
     socket
+    |> assign(:acting_as, nil)
     |> assign(:acting_as_name, nil)
     |> assign(:acting_as_path, nil)
     |> assign(:user_id, nil)
@@ -140,7 +143,13 @@ defmodule VutuvWeb.ShellLive do
     # name the member is writing under (issue #1335).
     acting_as = InitAssigns.acting_as(user, session)
 
+    # The page's own topic, so a message addressed to it moves the badge without
+    # a reload. Subscribed to only while really speaking as it — the assign
+    # above is the re-authorized answer, not the session's claim.
+    Activity.subscribe(acting_as)
+
     socket
+    |> assign(:acting_as, acting_as)
     |> assign(:acting_as_name, acting_as && acting_as.name)
     |> assign(:acting_as_path, acting_as && Organizations.canonical_path(acting_as))
     |> assign(:user_id, user_id)
@@ -203,8 +212,17 @@ defmodule VutuvWeb.ShellLive do
     if connected?(socket) do
       socket
       |> assign(
+        # Whichever identity is speaking owns the inbox this badge counts: a
+        # publisher who switched into a page is shown the PAGE's unread, the
+        # same inbox `/messages` gives them. Notifications stay personal - news
+        # about a page has its own list and its own read marker.
         :messages_count,
-        initial_count(path, "/messages", user.id, &Vutuv.Chat.unread_conversations_count/1)
+        initial_count(
+          path,
+          "/messages",
+          socket.assigns.acting_as || user.id,
+          &Vutuv.Chat.unread_conversations_count/1
+        )
       )
       |> assign(
         # The full struct, so the count skips the read-marker re-read the
@@ -382,7 +400,10 @@ defmodule VutuvWeb.ShellLive do
 
   defp recount_messages(socket) do
     socket
-    |> assign(:messages_count, Vutuv.Chat.unread_conversations_count(socket.assigns.user_id))
+    |> assign(
+      :messages_count,
+      Vutuv.Chat.unread_conversations_count(socket.assigns.acting_as || socket.assigns.user_id)
+    )
     |> push_badge()
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.264.1",
+      version: "7.265.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/organization_message_badge_test.exs
+++ b/test/vutuv_web/organization_message_badge_test.exs
@@ -1,0 +1,176 @@
+defmodule VutuvWeb.OrganizationMessageBadgeTest do
+  @moduledoc """
+  The shell's message badge while writing as a page (issue #1336 follow-up).
+
+  A page could be written to from v7.264.0 on, but nothing told its team: the
+  badge counted the publisher's own inbox whatever identity they were speaking
+  as, so the only way to find a message was to open `/messages` on spec. That is
+  the difference between a mailbox and a mailbox with a doorbell.
+
+  The count and the live tick are separate mechanisms and both are tested here:
+  a badge that is right on load and then frozen looks *worse* than one that is
+  always zero, because it invites you to trust it.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag, and because the shell writes to the
+  global `VutuvWeb.Presence` topic.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Chat
+  alias Vutuv.Organizations
+  alias Vutuv.Sessions
+
+  # The same selector the member-side shell tests use.
+  @mail_badge ~s(a[title="Messages"] span.bg-accent)
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  # The shell is a nested `live_render` inside the page layout, so a `live/2` on
+  # any route hands back the PAGE's LiveView, not this one - `send(view.pid, …)`
+  # would reach the wrong process. Mounting it isolated is also the honest unit:
+  # what is under test is the shell's own count, not the feed's markup.
+  defp session_for(user, extra \\ %{}) do
+    {token, _session} = Sessions.start_session(user, build_conn(), alert: false)
+    Map.merge(%{"session_token" => token, "path" => "/feed"}, extra)
+  end
+
+  defp page_with_publisher do
+    owner = insert_activated_user()
+    page = active_organization_for(owner)
+    {:ok, _} = Organizations.add_role(page, owner, "publisher", owner)
+    {page, owner}
+  end
+
+  # The session a publisher's browser carries while switched into the page.
+  defp speaking_as(user, page),
+    do: session_for(user, %{"acting_as_organization_id" => page.id})
+
+  test "the count is the page's inbox, not the publisher's own", %{conn: conn} do
+    {page, owner} = page_with_publisher()
+
+    # Two unread threads for the publisher PERSONALLY, and one for the page.
+    # The numbers differ on purpose: a badge reading the wrong inbox would show
+    # 2 where it should show 1, which a single-message fixture could not tell
+    # apart from the count simply working.
+    for greeting <- ["Für Sie persönlich.", "Und noch etwas."] do
+      stranger = insert_activated_user()
+      {:ok, personal} = Chat.find_or_create_conversation(stranger, owner)
+      {:ok, _} = Chat.send_message(stranger, personal.id, greeting)
+    end
+
+    member = insert_activated_user()
+    {:ok, conversation} = Chat.find_or_create_conversation(member, page)
+    {:ok, _} = Chat.send_message(member, conversation.id, "Haben Sie offene Stellen?")
+
+    assert Chat.unread_conversations_count(owner) == 2
+    assert Chat.unread_conversations_count(page) == 1
+
+    # Themselves: their own two.
+    {:ok, own_shell, _html} =
+      live_isolated(conn, VutuvWeb.ShellLive, session: session_for(owner))
+
+    assert has_element?(own_shell, @mail_badge, "2")
+
+    # Speaking as the page: the page's one.
+    {:ok, shell, _html} =
+      live_isolated(conn, VutuvWeb.ShellLive, session: speaking_as(owner, page))
+
+    assert has_element?(shell, @mail_badge, "1")
+
+    # Reading it as the page clears it for the whole team.
+    :ok = Chat.mark_read(page, conversation.id)
+    assert Chat.unread_conversations_count(page) == 0
+  end
+
+  test "a message to a page is announced on the page's own topic", %{conn: _conn} do
+    {page, _owner} = page_with_publisher()
+    member = insert_activated_user()
+
+    # What the page's team listens on while speaking as it.
+    :ok = Vutuv.Activity.subscribe(page)
+
+    {:ok, conversation} = Chat.find_or_create_conversation(member, page)
+    {:ok, _} = Chat.send_message(member, conversation.id, "Guten Tag.")
+
+    # `other_user_id/2` answers nil when the far side is a page, so without a
+    # recipient of its own this broadcast went nowhere and the badge only moved
+    # on a full reload.
+    assert_receive {:new_message, %{conversation_id: id}}
+    assert id == conversation.id
+  end
+
+  test "the shell recounts the page's inbox when one arrives", %{conn: conn} do
+    {page, owner} = page_with_publisher()
+    member = insert_activated_user()
+
+    {:ok, shell, _html} =
+      live_isolated(conn, VutuvWeb.ShellLive, session: speaking_as(owner, page))
+
+    refute has_element?(shell, @mail_badge)
+
+    {:ok, conversation} = Chat.find_or_create_conversation(member, page)
+    {:ok, _} = Chat.send_message(member, conversation.id, "Guten Tag.")
+
+    # Delivered straight to the shell, the way the sibling shell tests do it:
+    # PubSub across processes is not deterministic under the SQL sandbox, and
+    # the topic itself is covered by the test above.
+    send(shell.pid, {:new_message, %{conversation_id: conversation.id}})
+
+    assert has_element?(shell, @mail_badge, "1")
+  end
+
+  test "a member who is not speaking as anything still sees their own", %{conn: conn} do
+    me = insert_activated_user()
+    other = insert_activated_user()
+
+    {:ok, conversation} = Chat.find_or_create_conversation(other, me)
+    {:ok, _} = Chat.send_message(other, conversation.id, "Hallo.")
+
+    {:ok, shell, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(me))
+    assert has_element?(shell, @mail_badge, "1")
+  end
+
+  test "a session naming a page the member may no longer speak for counts their own",
+       %{conn: conn} do
+    {page, owner} = page_with_publisher()
+
+    stranger = insert_activated_user()
+    {:ok, personal} = Chat.find_or_create_conversation(stranger, owner)
+    {:ok, _} = Chat.send_message(stranger, personal.id, "Für Sie persönlich.")
+
+    member = insert_activated_user()
+    {:ok, conversation} = Chat.find_or_create_conversation(member, page)
+    {:ok, _} = Chat.send_message(member, conversation.id, "Guten Tag.")
+
+    role =
+      Vutuv.Repo.get_by!(Vutuv.Organizations.OrganizationRole,
+        organization_id: page.id,
+        user_id: owner.id,
+        role: "publisher"
+      )
+
+    {:ok, _} = Organizations.remove_role(role)
+
+    # The session still names the page - it is signed, not encrypted, and valid
+    # for days - but the mount re-asks the roles, so the badge counts the
+    # member's own inbox and the page's mail stays out of reach.
+    {:ok, shell, _html} =
+      live_isolated(conn, VutuvWeb.ShellLive, session: speaking_as(owner, page))
+
+    assert has_element?(shell, @mail_badge, "1")
+    refute has_element?(shell, ~s(#acting-as-banner))
+  end
+end


### PR DESCRIPTION
Der erste der beiden Punkte, die ich beim Schließen von #1336 offen gelassen hatte.

Eine Seite konnte seit v7.264.0 angeschrieben werden, aber **niemand hat es erfahren**: der Zähler in der Kopfleiste zählte immer das eigene Postfach der Person, egal als wen sie gerade schreibt. Man musste `/messages` auf Verdacht öffnen. Das ist der Unterschied zwischen einem Briefkasten und einem Briefkasten mit Klingel.

## Drei Teile, und alle drei mussten sein

**1. Der Zähler kennt das Postfach einer Seite.** `unread_conversations_count/1` bekommt eine eigene Abfrage statt eines Partei-Arguments an der bestehenden: die Mitglieder-Version trägt eine Klausel über den Anfrage-Zustand (`accepted`, oder `pending` und nicht von mir), für die es bei einer Seite keine Entsprechung gibt, und die EXISTS-Prüfung muss die andere Absenderspalte lesen. Eine gemeinsame Abfrage hätte zwei tote Zweige.

**2. Eine Seite bekommt ein eigenes PubSub-Thema** (`organization:<id>`). Eine Nachricht an eine Seite hat keinen Mitglieds-Empfänger — `other_user_id/2` antwortet dort `nil` — also ging der Broadcast bisher an niemanden und der Zähler bewegte sich erst beim nächsten Seitenaufbau. `Chat.recipient/2` beantwortet jetzt "für wen ist diese Nachricht" an einer Stelle.

**3. Die Kopfleiste folgt der Identität**, als die gerade geschrieben wird. Die **Benachrichtigungen bleiben persönlich**: Neuigkeiten über eine Seite haben ihre eigene Liste unter `/organizations/:slug/activity` und ihre eigene Gelesen-Marke, die wären hier doppelt.

## Sicherheit

Die Identität wird beim Mount neu aus den Rollen abgeleitet, wie überall seit #1035 — die Sitzung ist signiert, aber nicht verschlüsselt und tagelang gültig. Ein eigener Test hält fest: eine Sitzung, die eine Seite nennt, für die man nicht mehr sprechen darf, zählt wieder das eigene Postfach und bekommt auch kein "Sie schreiben als …"-Banner.

## Zu den Tests

Zwei Dinge, über die ich beim Schreiben gestolpert bin und die im Test dokumentiert sind:

- Die Kopfleiste ist ein verschachteltes `live_render`, also liefert `live(conn, ~p"/feed")` die LiveView der **Seite**, nicht die der Leiste — `send(view.pid, …)` wäre an den falschen Prozess gegangen. Die Tests mounten sie mit `live_isolated`, wie die bestehenden Kopfleisten-Tests.
- Der Zähler-Test gibt der Person **zwei** eigene ungelesene Gespräche und der Seite **eines**. Mit je einem hätte man ein Postfach, das die falsche Zahl liest, nicht von einem unterscheiden können, das einfach funktioniert.

`mix precommit` grün, 7371 Tests.

Der zweite offene Punkt (eine Seite kann noch nicht liken, reposten oder als Lesezeichen speichern) kommt als eigener PR.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01MMwsQi49FP21xuSoPEkMnN
