### PR TITLE
Eine Seite kann liken, reposten und speichern (v7.266.0)

### DIFF
--- a/lib/vutuv/activity.ex
+++ b/lib/vutuv/activity.ex
@@ -1406,19 +1406,25 @@ defmodule Vutuv.Activity do
   # can link to it. No self-like filter: a member cannot like their own post
   # (enforced in Posts.like_post/2, issue #1030).
   defp like_items(user_id, limit, cursor) do
+    # LEFT joins on both actor sides (issue #1336). An inner join to `users` was
+    # right while only a member could like, and became a silent filter the day a
+    # page could: the row simply never reached the list, so the author was never
+    # told. The same shape emptied search, the saved list and the tag pages when
+    # `posts.user_id` went nullable.
     from(l in PostLike,
       join: p in assoc(l, :post),
-      join: liker in assoc(l, :user),
+      left_join: liker in assoc(l, :user),
+      left_join: page in assoc(l, :organization),
       where: p.user_id == ^user_id,
       order_by: [desc: l.inserted_at, desc: l.id],
       limit: ^limit,
-      select: {l.id, l.inserted_at, struct(liker, ^User.listing_fields()), p.id}
+      select: {l.id, l.inserted_at, struct(liker, ^User.listing_fields()), page, p.id}
     )
     |> at_or_before(cursor)
     |> Repo.all()
-    |> Enum.map(fn {id, at, liker, post_id} ->
+    |> Enum.map(fn {id, at, liker, page, post_id} ->
       "like-#{id}"
-      |> actor_item("like", at, liker)
+      |> actor_item("like", at, liker || page)
       |> Map.put(:post_id, post_id)
     end)
   end

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -880,6 +880,11 @@ defmodule Vutuv.Posts do
   def author?(%Post{organization_id: id} = post, %User{} = viewer) when is_binary(id),
     do: organization_author?(post, viewer)
 
+  # A page asking about its OWN post (issue #1336). Without this clause the
+  # catch-all below answered false, and the self-vote rule that stops a member
+  # inflating their own like count would not have applied to a page at all.
+  def author?(%Post{organization_id: id}, %Organization{id: id}) when is_binary(id), do: true
+
   def author?(%Post{}, _viewer), do: false
 
   # Whether `viewer` may currently speak for the post's organization. Takes the
@@ -910,6 +915,17 @@ defmodule Vutuv.Posts do
   """
   def visible_to?(%Post{user_id: author_id}, %User{id: author_id}) when is_binary(author_id),
     do: true
+
+  # A page as the VIEWER (issue #1336). It is not a member: no block applies to
+  # it and no denial can name it, so it sees exactly what an anonymous reader
+  # sees - deliberately conservative, since a restricted audience is a list of
+  # members and a page is not on it. Plus its own posts while moderation holds
+  # them, the way an author sees theirs.
+  def visible_to?(%Post{organization_id: id}, %Organization{id: id}) when is_binary(id),
+    do: true
+
+  def visible_to?(%Post{} = post, %Organization{}),
+    do: not moderation_hidden?(post) and not restricted?(post)
 
   # An organization post carries no denials (see `create_organization_post/3`),
   # so the only thing that can hide it is moderation — and its publishers still
@@ -1139,6 +1155,43 @@ defmodule Vutuv.Posts do
     end
   end
 
+  @doc """
+  The same, as a **page** (issue #1336). `acting_user` is the publisher who
+  pressed it: recorded, never shown.
+
+  The self-vote rule is about the **author**, so a page cannot like its own
+  post — its publishers personally still can, because they are not the author.
+  There is no block arm: a block is between two people.
+  """
+  def like_post(%Organization{} = page, %User{} = acting_user, %Post{} = post) do
+    cond do
+      not Organizations.publisher?(page, acting_user) -> {:error, :not_allowed}
+      author?(post, page) -> {:error, :self}
+      true -> do_page_like(page, acting_user, post)
+    end
+  end
+
+  defp do_page_like(%Organization{} = page, %User{} = acting_user, %Post{} = post) do
+    case engage(PostLike, :like, page, post, acting_user) do
+      {:ok, %PostLike{}} ->
+        Vutuv.Activity.notify_like(post.user_id, page, post.id)
+        :ok
+
+      {:ok, :noop} ->
+        :ok
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  # The right to act in a page's name follows the ROLE, so it is asked live
+  # rather than trusted from whatever identity the caller arrived with — a
+  # withdrawn publisher stops being able to act at once.
+  defp may_act_as(%Organization{} = page, %User{} = user) do
+    if Organizations.publisher?(page, user), do: :ok, else: {:error, :not_allowed}
+  end
+
   defp do_like_post(%User{} = user, %Post{} = post) do
     case engage(PostLike, :like, user, post) do
       {:ok, %PostLike{}} ->
@@ -1155,17 +1208,28 @@ defmodule Vutuv.Posts do
     end
   end
 
-  @doc "Removes `user`'s like (idempotent)."
-  def unlike_post(%User{} = user, %Post{} = post), do: disengage(PostLike, :like, user, post)
+  @doc "Removes the actor's like (idempotent)."
+  def unlike_post(actor, %Post{} = post), do: disengage(PostLike, :like, actor, post)
 
   @doc "Bookmarks `post` for `user` (idempotent). Only visible posts."
   def bookmark_post(%User{} = user, %Post{} = post) do
     with {:ok, _} <- engage(PostBookmark, :bookmark, user, post), do: :ok
   end
 
-  @doc "Removes `user`'s bookmark (idempotent)."
-  def unbookmark_post(%User{} = user, %Post{} = post),
-    do: disengage(PostBookmark, :bookmark, user, post)
+  @doc """
+  The same, as a **page** — a shared reading list for its team (issue #1336).
+  Private, so unlike a like it needs no self-vote rule: a page may save its own
+  post the way a member may save theirs.
+  """
+  def bookmark_post(%Organization{} = page, %User{} = acting_user, %Post{} = post) do
+    with :ok <- may_act_as(page, acting_user),
+         {:ok, _} <- engage(PostBookmark, :bookmark, page, post, acting_user),
+         do: :ok
+  end
+
+  @doc "Removes the actor's bookmark (idempotent)."
+  def unbookmark_post(actor, %Post{} = post),
+    do: disengage(PostBookmark, :bookmark, actor, post)
 
   @doc """
   Reposts `post` as `user` (idempotent). Only **public** posts (no denials)
@@ -1200,7 +1264,36 @@ defmodule Vutuv.Posts do
     end
   end
 
-  @doc "Removes `user`'s repost (idempotent). The last one lifts the audience lock."
+  @doc """
+  The same, as a **page** (issue #1336) — a company amplifying a member's post
+  to its own followers.
+
+  It deliberately does **not** federate. A member's repost sends an `Announce`
+  from their actor; the page equivalent needs the page's actor and its own
+  delivery run, which is its own piece of work. Until that exists a page's
+  repost is a vutuv-side reshare, which is the honest subset rather than a
+  half-built one.
+  """
+  def repost_post(%Organization{} = page, %User{} = acting_user, %Post{} = post) do
+    cond do
+      not Organizations.publisher?(page, acting_user) -> {:error, :not_allowed}
+      restricted?(post) -> {:error, :restricted}
+      true -> do_page_repost(page, acting_user, post)
+    end
+  end
+
+  defp do_page_repost(%Organization{} = page, %User{} = acting_user, %Post{} = post) do
+    case engage(PostRepost, :repost, page, post, acting_user) do
+      {:ok, %PostRepost{} = repost} -> broadcast_new_repost(repost)
+      {:ok, :noop} -> :ok
+      {:error, _} = error -> error
+    end
+  end
+
+  @doc "Removes the actor's repost (idempotent). The last one lifts the audience lock."
+  def unrepost_post(%Organization{} = page, %Post{} = post),
+    do: disengage(PostRepost, :repost, page, post)
+
   def unrepost_post(%User{} = user, %Post{} = post) do
     # Only federate the Undo when there really was a repost to undo, so an
     # idempotent unrepost of a post the member never boosted stays silent.
@@ -1352,24 +1445,22 @@ defmodule Vutuv.Posts do
     end
   end
 
-  defp engage(schema, kind, %User{} = user, %Post{} = post) do
-    if visible_to?(post, user) do
-      # Liking, bookmarking or reposting a post is proof the member read it, so
+  defp engage(schema, kind, actor, %Post{} = post, acting_user \\ nil) do
+    if visible_to?(post, actor) do
+      # Liking, bookmarking or reposting a post is proof the actor read it, so
       # whatever the notifications feed has to say about that post is old news
-      # — including on the idempotent repeat, which is still a member acting on
-      # a post in front of them.
-      Vutuv.Activity.mark_post_seen(user.id, post.id)
+      # — including on the idempotent repeat, which is still somebody acting on
+      # a post in front of them. A page has no such feed, so nothing to mark.
+      if match?(%User{}, actor), do: Vutuv.Activity.mark_post_seen(actor.id, post.id)
 
-      case Vutuv.Engagement.insert_if_new(
-             schema,
-             %{user_id: user.id, post_id: post.id},
-             [:post_id, :user_id]
-           ) do
+      {fields, conflict_target} = engagement_keys(actor, post, acting_user)
+
+      case Vutuv.Engagement.insert_if_new(schema, fields, conflict_target) do
         :exists ->
           {:ok, :noop}
 
         {:inserted, row} ->
-          broadcast_engagement(kind, user.id, post.id, true)
+          broadcast_engagement(kind, actor.id, post.id, true)
           {:ok, row}
       end
     else
@@ -1377,14 +1468,38 @@ defmodule Vutuv.Posts do
     end
   end
 
-  # Removing your own engagement needs no visibility check.
-  defp disengage(schema, kind, %User{} = user, %Post{} = post) do
-    {count, _} =
-      Repo.delete_all(from(e in schema, where: e.post_id == ^post.id and e.user_id == ^user.id))
+  # Which actor column the row is keyed on — and therefore which unique index
+  # the upsert has to name. `(post_id, user_id)` cannot serve both: Postgres
+  # treats NULLs as distinct, so a page's rows would not conflict with each
+  # other at all and it could like the same post without limit.
+  defp engagement_keys(%User{} = user, %Post{} = post, _acting_user),
+    do: {%{user_id: user.id, post_id: post.id}, [:post_id, :user_id]}
 
-    if count > 0, do: broadcast_engagement(kind, user.id, post.id, false)
+  defp engagement_keys(%Organization{} = page, %Post{} = post, acting_user) do
+    {%{
+       organization_id: page.id,
+       post_id: post.id,
+       acting_user_id: acting_user && acting_user.id
+     }, [:post_id, :organization_id]}
+  end
+
+  # Removing your own engagement needs no visibility check.
+  defp disengage(schema, kind, actor, %Post{} = post) do
+    # Built as one dynamic: a dynamic composes only inside another dynamic,
+    # never inline in a query expression.
+    mine = dynamic([e], e.post_id == ^post.id and ^engaged_by(actor))
+
+    {count, _} = Repo.delete_all(from(e in schema, where: ^mine))
+
+    if count > 0, do: broadcast_engagement(kind, actor.id, post.id, false)
     :ok
   end
+
+  # "This actor's row", as a query fragment. Never a bare `e.user_id == ^id`:
+  # that column is NULL on a page's row, and the comparison would answer NULL
+  # rather than false — the trap this milestone has already paid for repeatedly.
+  defp engaged_by(%User{id: id}), do: dynamic([e], e.user_id == ^id)
+  defp engaged_by(%Organization{id: id}), do: dynamic([e], e.organization_id == ^id)
 
   # The four engagement counters (likes / bookmarks / reposts / replies),
   # counted live from the rows. Defined once here so both `engagement_counts/1`
@@ -1582,12 +1697,18 @@ defmodule Vutuv.Posts do
   end
 
   defp engagement_viewer_id(%User{id: id}), do: id
+  defp engagement_viewer_id(%Organization{id: id}), do: id
   defp engagement_viewer_id(id) when is_binary(id), do: id
   # The nil UUID can never match a row: "anonymous" without a NULL arm.
   defp engagement_viewer_id(nil), do: "00000000-0000-0000-0000-000000000000"
 
   # The shared SELECT behind post_engagement/2 and post_engagement_map/2, so the
   # single-post and batched paths can never drift in what the action bar reads.
+  #
+  # Each EXISTS tests BOTH actor columns against the one viewer id (issue
+  # #1336). That is safe because ids are UUIDs drawn from different tables, so a
+  # value can only ever match one of them, and both columns carry a unique index
+  # on `(post_id, <actor>)` for the planner to use.
   defp engagement_select(query, viewer_id) do
     query
     |> select([p], engagement_count_select(p))
@@ -1595,20 +1716,23 @@ defmodule Vutuv.Posts do
       id: p.id,
       liked?:
         fragment(
-          "EXISTS (SELECT 1 FROM post_likes l WHERE l.post_id = ? AND l.user_id = ?)",
+          "EXISTS (SELECT 1 FROM post_likes l WHERE l.post_id = ? AND ((l.user_id = ?) OR (l.organization_id = ?)))",
           p.id,
+          type(^viewer_id, UUIDv7),
           type(^viewer_id, UUIDv7)
         ),
       bookmarked?:
         fragment(
-          "EXISTS (SELECT 1 FROM post_bookmarks b WHERE b.post_id = ? AND b.user_id = ?)",
+          "EXISTS (SELECT 1 FROM post_bookmarks b WHERE b.post_id = ? AND ((b.user_id = ?) OR (b.organization_id = ?)))",
           p.id,
+          type(^viewer_id, UUIDv7),
           type(^viewer_id, UUIDv7)
         ),
       reposted?:
         fragment(
-          "EXISTS (SELECT 1 FROM post_reposts r WHERE r.post_id = ? AND r.user_id = ?)",
+          "EXISTS (SELECT 1 FROM post_reposts r WHERE r.post_id = ? AND ((r.user_id = ?) OR (r.organization_id = ?)))",
           p.id,
+          type(^viewer_id, UUIDv7),
           type(^viewer_id, UUIDv7)
         ),
       restricted?: fragment("EXISTS (SELECT 1 FROM post_denials d WHERE d.post_id = ?)", p.id),
@@ -4981,10 +5105,12 @@ defmodule Vutuv.Posts do
   # A fresh repost distributes like a fresh post — to the reposter's own
   # sessions and their followers' feeds.
   defp broadcast_new_repost(%PostRepost{} = repost) do
-    event =
-      {:new_repost, %{repost_id: repost.id, post_id: repost.post_id, reposter_id: repost.user_id}}
+    reposter_id = repost.user_id || repost.organization_id
 
-    broadcast_to_followers(repost.user_id, event)
+    event =
+      {:new_repost, %{repost_id: repost.id, post_id: repost.post_id, reposter_id: reposter_id}}
+
+    broadcast_to_followers(repost, event)
   end
 
   # A new reply ticks the parent's open action bars, notifies its author
@@ -5257,6 +5383,18 @@ defmodule Vutuv.Posts do
 
     %{post_ids: post_ids, follower_ids: follower_ids(user_id), reply_parent_ids: reply_parent_ids}
   end
+
+  defp broadcast_to_followers(%PostRepost{organization_id: page_id}, event)
+       when is_binary(page_id) do
+    # The people to tell are the PAGE's followers, and they hang off
+    # `followee_organization_id`. Handing the page's id to the member query
+    # would have compared `followee_id` with a nil reposter and RAISED - the
+    # `where: x == ^nil` trap this milestone has paid for more than once.
+    Enum.each(organization_follower_ids(page_id), &Vutuv.Activity.broadcast(&1, event))
+  end
+
+  defp broadcast_to_followers(%PostRepost{user_id: user_id}, event),
+    do: broadcast_to_followers(user_id, event)
 
   defp broadcast_to_followers(user_id, event) do
     Enum.each([user_id | follower_ids(user_id)], &Vutuv.Activity.broadcast(&1, event))

--- a/lib/vutuv/posts/post_bookmark.ex
+++ b/lib/vutuv/posts/post_bookmark.ex
@@ -5,7 +5,13 @@ defmodule Vutuv.Posts.PostBookmark do
 
   schema "post_bookmarks" do
     belongs_to(:post, Vutuv.Posts.Post)
+    # Exactly one of these two is set (CHECK): a member's act, or a page's
+    # (issue #1336). `acting_user` records which publisher pressed the button -
+    # kept for accountability, never shown, `nilify_all` so the page's act
+    # survives them leaving. Same split as `posts` and `messages`.
     belongs_to(:user, Vutuv.Accounts.User)
+    belongs_to(:organization, Vutuv.Organizations.Organization)
+    belongs_to(:acting_user, Vutuv.Accounts.User)
 
     timestamps()
   end

--- a/lib/vutuv/posts/post_like.ex
+++ b/lib/vutuv/posts/post_like.ex
@@ -5,7 +5,13 @@ defmodule Vutuv.Posts.PostLike do
 
   schema "post_likes" do
     belongs_to(:post, Vutuv.Posts.Post)
+    # Exactly one of these two is set (CHECK): a member's act, or a page's
+    # (issue #1336). `acting_user` records which publisher pressed the button -
+    # kept for accountability, never shown, `nilify_all` so the page's act
+    # survives them leaving. Same split as `posts` and `messages`.
     belongs_to(:user, Vutuv.Accounts.User)
+    belongs_to(:organization, Vutuv.Organizations.Organization)
+    belongs_to(:acting_user, Vutuv.Accounts.User)
 
     timestamps()
   end

--- a/lib/vutuv/posts/post_repost.ex
+++ b/lib/vutuv/posts/post_repost.ex
@@ -5,7 +5,13 @@ defmodule Vutuv.Posts.PostRepost do
 
   schema "post_reposts" do
     belongs_to(:post, Vutuv.Posts.Post)
+    # Exactly one of these two is set (CHECK): a member's act, or a page's
+    # (issue #1336). `acting_user` records which publisher pressed the button -
+    # kept for accountability, never shown, `nilify_all` so the page's act
+    # survives them leaving. Same split as `posts` and `messages`.
     belongs_to(:user, Vutuv.Accounts.User)
+    belongs_to(:organization, Vutuv.Organizations.Organization)
+    belongs_to(:acting_user, Vutuv.Accounts.User)
 
     timestamps()
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.265.0",
+      version: "7.266.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260812051818_add_organization_engagement.exs
+++ b/priv/repo/migrations/20260812051818_add_organization_engagement.exs
@@ -1,0 +1,73 @@
+defmodule Vutuv.Repo.Migrations.AddOrganizationEngagement do
+  @moduledoc """
+  A page can like, bookmark and repost (issue #1336's last loose end).
+
+  The three engagement tables take the same shape the rest of this milestone
+  settled on: a nullable `organization_id` beside `user_id` with a CHECK that
+  exactly one is set, plus `acting_user_id` for the member who pressed the
+  button — recorded, never shown, `nilify_all` so the page's act survives them
+  leaving. Same split as `posts.acting_user_id` and `messages.acting_user_id`.
+
+  ## Two unique indexes, not one widened one
+
+  Each table has `unique_index(post_id, user_id)` today. Postgres treats NULLs
+  as distinct in a unique index, so once `user_id` is nullable that index stops
+  constraining page rows entirely — a page could like the same post a thousand
+  times. Each table therefore gets a second unique index on
+  `(post_id, organization_id)`, and `Vutuv.Engagement.insert_if_new/3` picks the
+  conflict target that matches the party doing the engaging.
+
+  Leaving the old index alone rather than making it partial is deliberate: it
+  still does its whole job for member rows, and a partial index would have to be
+  matched by a partial conflict target at every call site.
+
+  N-1 safe: the previous release only writes member rows, which satisfy both the
+  CHECK and the old index, and every query it runs names `user_id`.
+  """
+  use Ecto.Migration
+
+  @tables [:post_likes, :post_bookmarks, :post_reposts]
+
+  def up do
+    for table <- @tables do
+      alter table(table) do
+        add(
+          :organization_id,
+          references(:organizations, type: :binary_id, on_delete: :delete_all)
+        )
+
+        add(:acting_user_id, references(:users, type: :binary_id, on_delete: :nilify_all))
+      end
+
+      execute("ALTER TABLE #{table} ALTER COLUMN user_id DROP NOT NULL")
+
+      create(
+        constraint(table, :"#{table}_exactly_one_actor",
+          check: """
+          (CASE WHEN user_id IS NULL THEN 0 ELSE 1 END +
+           CASE WHEN organization_id IS NULL THEN 0 ELSE 1 END) = 1
+          """
+        )
+      )
+
+      create(unique_index(table, [:post_id, :organization_id]))
+      create(index(table, [:acting_user_id]))
+    end
+  end
+
+  def down do
+    for table <- @tables do
+      drop(index(table, [:acting_user_id]))
+      drop(unique_index(table, [:post_id, :organization_id]))
+      drop(constraint(table, :"#{table}_exactly_one_actor"))
+
+      execute("DELETE FROM #{table} WHERE user_id IS NULL")
+      execute("ALTER TABLE #{table} ALTER COLUMN user_id SET NOT NULL")
+
+      alter table(table) do
+        remove(:acting_user_id)
+        remove(:organization_id)
+      end
+    end
+  end
+end

--- a/test/vutuv/organization_engagement_test.exs
+++ b/test/vutuv/organization_engagement_test.exs
@@ -1,0 +1,166 @@
+defmodule Vutuv.OrganizationEngagementTest do
+  @moduledoc """
+  A page likes, bookmarks and reposts (issue #1336's last loose end).
+
+  It read its feed from v7.242.0 on but could not react in it, which made the
+  page a spectator in a room it was otherwise a full member of.
+
+  Every act follows the shape the rest of this milestone settled on: the act
+  belongs to the **page**, `acting_user_id` records the member who pressed the
+  button and is never shown, and the right to press it follows the **role**, so
+  it is asked live rather than trusted from whatever the session says.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Organizations
+  alias Vutuv.Posts
+  alias Vutuv.Posts.{PostBookmark, PostLike, PostRepost}
+  alias Vutuv.Repo
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp page_with_publisher do
+    owner = insert(:activated_user)
+    page = active_organization_for(owner)
+    {:ok, _} = Organizations.add_role(page, owner, "publisher", owner)
+    {page, owner}
+  end
+
+  defp a_post do
+    author = insert(:activated_user)
+    {:ok, post} = Posts.create_post(author, %{body: "Hallo Welt"})
+    {post, author}
+  end
+
+  test "the database refuses a row naming both actors or neither" do
+    {page, _owner} = page_with_publisher()
+    {post, author} = a_post()
+
+    for schema <- [PostLike, PostBookmark, PostRepost] do
+      assert_raise Ecto.ConstraintError, ~r/exactly_one_actor/, fn ->
+        Repo.insert!(
+          struct(schema, post_id: post.id, user_id: author.id, organization_id: page.id)
+        )
+      end
+
+      assert_raise Ecto.ConstraintError, ~r/exactly_one_actor/, fn ->
+        Repo.insert!(struct(schema, post_id: post.id))
+      end
+    end
+  end
+
+  test "a page likes a post once, in its own name" do
+    {page, owner} = page_with_publisher()
+    {post, _author} = a_post()
+
+    assert :ok = Posts.like_post(page, owner, post)
+    assert :ok = Posts.like_post(page, owner, post)
+
+    assert [like] = Repo.all(from(l in PostLike, where: l.post_id == ^post.id))
+    assert like.organization_id == page.id
+    assert is_nil(like.user_id)
+    # Who pressed it is kept, the same split posts and messages make.
+    assert like.acting_user_id == owner.id
+
+    engagement = Posts.post_engagement(post.id, page)
+    assert engagement.likes == 1
+    assert engagement.liked?
+  end
+
+  test "the page's own count is not inflated by its own like" do
+    {page, owner} = page_with_publisher()
+    {:ok, post} = Posts.create_organization_post(page, owner, %{body: "Unser Beitrag"})
+
+    # The self-vote rule is about the AUTHOR, and for an organization post the
+    # author is the page.
+    assert {:error, :self} = Posts.like_post(page, owner, post)
+
+    # Its publishers are refused too, and that is the pre-existing rule rather
+    # than a new one: `author?/2` already treats anybody who may currently speak
+    # for the page as the post's author, which is what gives them edit and
+    # delete rights. A publisher liking the page's post is the same self-vote.
+    assert {:error, :self} = Posts.like_post(owner, post)
+    assert Posts.post_engagement(post.id, page).likes == 0
+
+    # Somebody outside the team is an ordinary reader.
+    outsider = insert(:activated_user)
+    assert :ok = Posts.like_post(outsider, post)
+    assert Posts.post_engagement(post.id, outsider).likes == 1
+  end
+
+  test "somebody who may not speak for the page cannot act as it" do
+    {page, _owner} = page_with_publisher()
+    {post, _author} = a_post()
+    stranger = insert(:activated_user)
+
+    assert {:error, :not_allowed} = Posts.like_post(page, stranger, post)
+    assert {:error, :not_allowed} = Posts.bookmark_post(page, stranger, post)
+    assert {:error, :not_allowed} = Posts.repost_post(page, stranger, post)
+
+    assert Posts.post_engagement(post.id, page).likes == 0
+  end
+
+  test "the page unlikes, unbookmarks and unreposts" do
+    {page, owner} = page_with_publisher()
+    {post, _author} = a_post()
+
+    assert :ok = Posts.like_post(page, owner, post)
+    assert :ok = Posts.bookmark_post(page, owner, post)
+    assert :ok = Posts.repost_post(page, owner, post)
+
+    engagement = Posts.post_engagement(post.id, page)
+    assert engagement.liked?
+    assert engagement.bookmarked?
+    assert engagement.reposted?
+
+    :ok = Posts.unlike_post(page, post)
+    :ok = Posts.unbookmark_post(page, post)
+    :ok = Posts.unrepost_post(page, post)
+
+    engagement = Posts.post_engagement(post.id, page)
+    refute engagement.liked?
+    refute engagement.bookmarked?
+    refute engagement.reposted?
+  end
+
+  test "a page's like and a member's like of the same post both count" do
+    {page, owner} = page_with_publisher()
+    {post, _author} = a_post()
+    member = insert(:activated_user)
+
+    assert :ok = Posts.like_post(page, owner, post)
+    assert :ok = Posts.like_post(member, post)
+
+    # The old unique index is `(post_id, user_id)`, and Postgres treats NULLs as
+    # distinct there - so without the second index on `(post_id,
+    # organization_id)` a page could like the same post without limit.
+    assert Posts.post_engagement(post.id, member).likes == 2
+  end
+
+  test "the author is told a page liked their post, named as the page" do
+    {page, owner} = page_with_publisher()
+    {post, author} = a_post()
+
+    assert :ok = Posts.like_post(page, owner, post)
+
+    %{entries: [entry]} = Vutuv.Activity.notifications_page(author.id)
+    assert entry.kind == "like"
+    # The page is the actor a reader sees; the publisher who pressed it is not
+    # named in the notification at all.
+    assert entry.actor_name == page.name
+  end
+end


### PR DESCRIPTION
Der zweite offene Punkt aus #1336. Eine Seite las ihren Feed seit v7.242.0, konnte darin aber nicht reagieren — Zuschauerin in einem Raum, in dem sie sonst vollwertig ist.

**Das ist die Kontextschicht, noch ohne Bedienelemente** — derselbe Schnitt wie bei den Nachrichten (#1403 Kontext, #1404 Oberfläche). Was unten unter "nicht enthalten" steht, steht dort mit Absicht.

## Das Modell

`post_likes`, `post_bookmarks` und `post_reposts` bekommen die Form, auf die sich dieser Meilenstein geeinigt hat: nullable `organization_id` neben `user_id` mit CHECK, dazu `acting_user_id` für die Person, die gedrückt hat — aufgehoben, nie gezeigt, `nilify_all`. Das Recht folgt der **Rolle** und wird bei jedem Versuch live gefragt.

Die Regel gegen die Selbst-Stimme gilt weiter und greift jetzt auch für Seiten: die Seite kann ihren eigenen Beitrag nicht liken, und **ihre Publisher auch nicht** — `author?/2` behandelt jeden, der gerade für die Seite sprechen darf, als Autor, und genau das gibt ihnen ja auch die Bearbeitungsrechte.

## Zwei Indizes statt eines geweiteten

Postgres behandelt NULLs in einem Unique-Index als verschieden. Sobald `user_id` nullable ist, hört `(post_id, user_id)` deshalb auf, Seiten-Zeilen überhaupt zu binden — eine Seite hätte denselben Beitrag beliebig oft liken können. Jede Tabelle bekommt einen zweiten Unique-Index auf `(post_id, organization_id)`, und `Engagement.insert_if_new/3` wählt das passende Conflict-Target. Ein Test hält das fest.

## Drei Fallen der bekannten Sorte

| Wo | Was passiert wäre |
|---|---|
| `Activity.like_items/3` | Innerer Join auf `users` → die Like einer Seite fiel aus der Liste, der Autor erfuhr **nie** davon |
| `broadcast_new_repost/1` | Reichte eine nil-Reposter-ID in einen Vergleich → `comparing with nil is forbidden`, also ein Absturz |
| `author?/2` | Keine Klausel für eine Seite, antwortete also `false` → die Regel gegen die Selbst-Stimme galt für Seiten schlicht nicht |

Die dritte hat der **Typechecker** gefunden, nicht ich: er meldete, dass ein `cond`-Zweig nie greifen kann, weil `author?(post, page)` statisch `false` ist. Ohne diese Warnung wäre sie durchgerutscht, denn ein fehlender Selbst-Stimmen-Schutz sieht in keinem Test nach einem Fehler aus, den man nicht selbst geschrieben hat.

## Nicht enthalten, jeweils mit Grund

- **Der Repost einer Seite föderiert nicht.** Ein `Announce` aus dem Actor der Seite braucht einen eigenen Zustellungslauf; bis den gibt, ist der Repost ein vutuv-seitiges Teilen. Der ehrliche Teilausschnitt statt eines halb gebauten.
- **Er taucht noch nicht im Feed der Follower auf.** `feed_repost_items/3` und `reposter_rosters/2` filtern auf Mitglieder-Follows (`followee_id`, `followees_of/1`); die Seiten-Variante ist eine eigene Runde, inklusive "Reposted by" auf der Karte.
- **Die Like einer Seite bekommt in der "Liked by"-Reihe kein Gesicht**, sondern fällt in das `+N` — dieselbe Behandlung wie bei jemandem, der die Namensnennung abgeschaltet hat. Der Zähler stimmt, die Reihe ist nur unvollständig.
- **Keine Bedienelemente.** Erreichbar ist das alles noch nicht.

`mix precommit` grün, 7378 Tests.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01MMwsQi49FP21xuSoPEkMnN
