### PR TITLE
Der Repost einer Seite kommt an, und die Knöpfe gibt es auch (v7.267.0)

### DIFF
--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -2457,18 +2457,23 @@ defmodule Vutuv.Posts do
       join: r in PostRepost,
       as: :repost,
       on: r.post_id == p.id,
-      join: reposter in User,
+      # LEFT on the resharer too (issue #1336): a page can repost now, and its
+      # row has a NULL `user_id`. An inner join to `users` was right while only
+      # a member could reshare and became a silent filter the day a page could —
+      # the same shape that, one join down, meant a member could repost a page's
+      # news and it reached nobody.
+      left_join: reposter in User,
       on: reposter.id == r.user_id,
+      left_join: rp in assoc(r, :organization),
+      as: :resharer_organization,
       # LEFT, because the reposted post may have been published by an
-      # organization (issue #1334). An inner join here meant a member could
-      # repost a page's news and it reached nobody — the act succeeded and its
-      # whole point silently did not.
+      # organization (issue #1334).
       left_join: u in assoc(p, :user),
       as: :author,
       left_join: o in assoc(p, :organization),
       as: :repost_organization,
-      where: r.user_id == ^viewer_id or r.user_id in subquery(followees_of(viewer_id)),
-      where: r.user_id == ^viewer_id or account_confirmed_row(reposter),
+      where: ^repost_reaches_me(viewer_id),
+      where: ^resharer_is_shown(viewer_id),
       # A repost must not amplify an author the site hides. For a member that is
       # their account standing; for a page it is the page's own
       # (`organization_public_row/1`), so a frozen page stops being passed on.
@@ -2481,14 +2486,41 @@ defmodule Vutuv.Posts do
       where: p.user_id not in subquery(blocked_either_way(viewer_id)),
       order_by: [desc: r.inserted_at, desc: r.id],
       limit: ^fetch_n,
-      select: {r.id, r.inserted_at, p, reposter}
+      select: {r.id, r.inserted_at, p, reposter, rp}
     )
     |> scope_visible(viewer)
     |> reposts_at_or_before(cursor)
     |> Repo.all()
-    |> Enum.map(fn {id, at, post, reposter} ->
-      %{id: "repost-#{id}", post: post, reposted_by: reposter, at: at}
+    |> Enum.map(fn {id, at, post, reposter, page} ->
+      %{id: "repost-#{id}", post: post, reposted_by: reposter || page, at: at}
     end)
+  end
+
+  # Reshared by me, by somebody I follow, or by a page I follow (issue #1336).
+  defp repost_reaches_me(viewer_id) do
+    dynamic(
+      [_p, r],
+      r.user_id == ^viewer_id or r.user_id in subquery(followees_of(viewer_id)) or
+        r.organization_id in subquery(followed_organizations_of(viewer_id))
+    )
+  end
+
+  # A reshare must not amplify a resharer the site hides: account standing for a
+  # member, the page's own standing for a page.
+  #
+  # Each gate is scoped to the actor it is about (`not is_nil(r.user_id) and …`)
+  # and never OR-ed bare. `account_confirmed_row/1` reads
+  # `is_nil(u.email_confirmed?) or …`, and on a LEFT-joined **missing** row that
+  # `is_nil` is TRUE — so the member gate passed vacuously for every page
+  # reshare and a frozen page kept being amplified. The macro was written for an
+  # inner join, where the row always exists.
+  defp resharer_is_shown(viewer_id) do
+    dynamic(
+      [_p, r, reposter, rp],
+      r.user_id == ^viewer_id or
+        (not is_nil(r.user_id) and account_confirmed_row(reposter)) or
+        (not is_nil(r.organization_id) and organization_public_row(rp))
+    )
   end
 
   # Third feed source (issue #872): posts carrying a tag the viewer follows, from
@@ -2745,39 +2777,53 @@ defmodule Vutuv.Posts do
   # whole page, regardless of which repost happened to carry the entry. The
   # roster is deliberately follow-scoped: it explains why the post is in
   # *this* feed; the global repost count already lives on the action bar.
-  # A page's feed carries no reposts (a page cannot repost, and it does not read
-  # the members' repost source), so there is no roster to attach and no viewer
-  # whose follow graph would scope one. Nil is a real case here, not a slip.
+  # A page reading its OWN feed carries no reposts (it does not read the
+  # members' repost source), so there is no roster to attach and no viewer whose
+  # follow graph would scope one. Nil is a real case here, not a slip.
   defp attach_reposters(entries, nil), do: Enum.map(entries, &Map.put(&1, :reposters, []))
 
   defp attach_reposters(entries, %User{} = viewer) do
-    post_ids = for %{reposted_by: %User{}} = entry <- entries, do: entry.post.id
+    # Keyed on "there is a resharer", not on "the resharer is a member": since
+    # issue #1336 a page can reshare too, and a `%User{}` pattern here quietly
+    # dropped those entries back to an empty roster — the banner then named
+    # nobody on a post that was in the feed precisely because a page reshared it.
+    post_ids = for %{reposted_by: by} = entry <- entries, not is_nil(by), do: entry.post.id
     rosters = reposter_rosters(post_ids, viewer)
 
     Enum.map(entries, fn
-      %{reposted_by: %User{}} = entry ->
-        reposters = Map.get(rosters, entry.post.id, [entry.reposted_by])
-        entry |> Map.put(:reposters, reposters) |> Map.put(:reposted_by, hd(reposters))
+      %{reposted_by: nil} = entry ->
+        Map.put(entry, :reposters, [])
 
       entry ->
-        Map.put(entry, :reposters, [])
+        reposters = Map.get(rosters, entry.post.id, [entry.reposted_by])
+        entry |> Map.put(:reposters, reposters) |> Map.put(:reposted_by, hd(reposters))
     end)
   end
 
   defp reposter_rosters([], _viewer), do: %{}
 
   defp reposter_rosters(post_ids, %User{id: viewer_id}) do
+    # Same widening as `feed_repost_items/3` above, and for the same reason: the
+    # banner names who reshared, and a page is now one of the answers.
     from(r in PostRepost,
-      join: u in User,
+      left_join: u in User,
       on: u.id == r.user_id,
+      left_join: rp in assoc(r, :organization),
       where: r.post_id in ^post_ids,
-      where: r.user_id == ^viewer_id or r.user_id in subquery(followees_of(viewer_id)),
-      where: r.user_id == ^viewer_id or account_confirmed_row(u),
+      where:
+        r.user_id == ^viewer_id or r.user_id in subquery(followees_of(viewer_id)) or
+          r.organization_id in subquery(followed_organizations_of(viewer_id)),
+      # Scoped per actor kind — see the note in `feed_repost_items/3`: a bare
+      # `account_confirmed_row(u)` is TRUE on a left-joined missing row.
+      where:
+        r.user_id == ^viewer_id or
+          (not is_nil(r.user_id) and account_confirmed_row(u)) or
+          (not is_nil(r.organization_id) and organization_public_row(rp)),
       order_by: [desc: r.inserted_at, desc: r.id],
-      select: {r.post_id, u}
+      select: {r.post_id, u, rp}
     )
     |> Repo.all()
-    |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
+    |> Enum.group_by(&elem(&1, 0), fn {_post_id, user, page} -> user || page end)
   end
 
   # The posts `post` answers, oldest first. Walk up the reply chain, preferring

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -74,6 +74,12 @@ defmodule VutuvWeb.PostComponents do
   attr(:post, :any, required: true, doc: "preloaded %Vutuv.Posts.Post{}")
   attr(:viewer, :any, default: nil)
 
+  attr(:acting_as, :any,
+    default: nil,
+    doc:
+      "the page the viewer is currently speaking as (issue #1336) — the action bar then likes and reshares in ITS name, the same way the composer already posts in it"
+  )
+
   attr(:viewer_follow, :any,
     default: nil,
     doc:
@@ -253,6 +259,10 @@ defmodule VutuvWeb.PostComponents do
       # the `false` an `&&` would yield) — Posts.post_engagement/2 only accepts a
       # user id or nil.
       |> assign(:viewer_id, if(user?, do: viewer.id))
+      # The identity the bar ACTS as. `/feed` stays the member's own reading
+      # surface while they are switched into a page — what changes is whose
+      # name the act goes out under, exactly the split the composer makes.
+      |> assign(:acting_as_id, assigns.acting_as && assigns.acting_as.id)
       |> assign(:menu_id, "post-menu-#{entry_key}")
       # Keyed on the timeline entry like every other id here, so the same post
       # rendered twice on a page keeps unique pin controls.
@@ -647,6 +657,8 @@ defmodule VutuvWeb.PostComponents do
   """
   attr(:post, :any, required: true, doc: "preloaded %Vutuv.Posts.Post{}")
   attr(:viewer, :any, default: nil)
+
+  attr(:acting_as, :any, default: nil)
   attr(:viewer_follow, :any, default: nil)
   attr(:engagement, :any, default: nil)
 
@@ -687,6 +699,7 @@ defmodule VutuvWeb.PostComponents do
       <.post_card
         post={@post}
         viewer={@viewer}
+        acting_as={@acting_as}
         viewer_follow={@viewer_follow}
         engagement={@engagement}
         reposted_by={@reposted_by}
@@ -787,6 +800,8 @@ defmodule VutuvWeb.PostComponents do
     doc: "these nodes answer a card above them, so each draws its connector back into its column"
   )
 
+  attr(:acting_as, :any, default: nil)
+
   defp thread_chain(assigns) do
     # `@thread_indent_cap` is a module attribute, not an assign, so resolve the
     # "still indenting?" flag here — inside ~H, `@name` would mean assigns.name.
@@ -885,6 +900,7 @@ defmodule VutuvWeb.PostComponents do
           <.post_card
             post={node.post}
             viewer={@viewer}
+            acting_as={@acting_as}
             viewer_follow={node.viewer_follow}
             engagement={node.engagement}
             reposted_by={node.reposted_by}
@@ -2966,6 +2982,7 @@ defmodule VutuvWeb.PostComponents do
               id={@actions_id}
               post_id={@post.id}
               viewer_id={@viewer_id}
+              acting_as_id={@acting_as_id}
               engagement={@engagement}
             />
           <% else %>
@@ -4343,6 +4360,11 @@ defmodule VutuvWeb.PostComponents do
     doc: "the viewer's user id (nil when logged out), to detect their own post"
   )
 
+  attr(:acting_as_id, :any,
+    default: nil,
+    doc: "the page this bar acts as, when the viewer is speaking as one (issue #1336)"
+  )
+
   attr(:target, :any,
     default: nil,
     doc: "phx-target: the LiveComponent's @myself on a host page, nil on a dead page"
@@ -4353,8 +4375,7 @@ defmodule VutuvWeb.PostComponents do
       assigns
       |> assign(
         :own?,
-        assigns.engagement != nil and assigns.viewer_id != nil and
-          assigns.engagement.author_id == assigns.viewer_id
+        own_post?(assigns)
       )
       # One number per act, vutuv's own and the other networks' together
       # (`Posts.shown_counts/1`); the panel below breaks it back down.
@@ -4604,6 +4625,17 @@ defmodule VutuvWeb.PostComponents do
     ngettext("%{formatted} repost", "%{formatted} reposts", count,
       formatted: compact_count(count)
     )
+  end
+
+  # Whether the acting identity is the post's own author, which is what turns
+  # the heart into a plain count. While speaking as a page the actor is the
+  # page, so that is the id to compare — asking about the member would offer a
+  # page a live heart on its own post and then refuse the click.
+  defp own_post?(%{engagement: nil}), do: false
+
+  defp own_post?(assigns) do
+    actor_id = assigns[:acting_as_id] || assigns.viewer_id
+    actor_id != nil and assigns.engagement.author_id == actor_id
   end
 
   # The Like control: a real toggle for everyone but the author. On your OWN

--- a/lib/vutuv_web/live/post_live/action_bar.ex
+++ b/lib/vutuv_web/live/post_live/action_bar.ex
@@ -20,6 +20,7 @@ defmodule VutuvWeb.PostLive.ActionBar do
     statics: ~w(assets fonts images favicon.ico)
 
   alias Vutuv.Accounts.User
+  alias Vutuv.Organizations.Organization
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias Vutuv.Repo
@@ -49,23 +50,47 @@ defmodule VutuvWeb.PostLive.ActionBar do
   defp do_toggle(kind, viewer_id, engagement, socket) do
     user = Repo.get(User, viewer_id)
     post = Repo.get(Post, socket.assigns.post_id)
+    page = acting_page(socket)
 
     if user && post do
-      # Errors (:not_visible, :restricted) mean the button should not have been
-      # live — the reload below shows the truth either way.
-      _ =
-        case {kind, engagement} do
-          {"like", %{liked?: true}} -> Posts.unlike_post(user, post)
-          {"like", _} -> Posts.like_post(user, post)
-          {"bookmark", %{bookmarked?: true}} -> Posts.unbookmark_post(user, post)
-          {"bookmark", _} -> Posts.bookmark_post(user, post)
-          {"repost", %{reposted?: true}} -> Posts.unrepost_post(user, post)
-          {"repost", _} -> Posts.repost_post(user, post)
-        end
+      # Errors (:not_visible, :restricted, :not_allowed) mean the button should
+      # not have been live — the reload below shows the truth either way.
+      _ = act(kind, engagement, page || user, user, post)
     end
 
     # The viewer's own filled-in flags are not in any broadcast, so reload them.
     load_engagement(socket)
+  end
+
+  # Undoing needs only the actor; doing it needs the acting member too, so the
+  # page's act can record who pressed the button (issue #1336). `actor` is the
+  # page when one is being spoken as, otherwise the member themselves.
+  defp act("like", %{liked?: true}, actor, _by, post), do: Posts.unlike_post(actor, post)
+
+  defp act("bookmark", %{bookmarked?: true}, actor, _by, post),
+    do: Posts.unbookmark_post(actor, post)
+
+  defp act("repost", %{reposted?: true}, actor, _by, post), do: Posts.unrepost_post(actor, post)
+
+  defp act("like", _, %Organization{} = page, by, post), do: Posts.like_post(page, by, post)
+  defp act("like", _, actor, _by, post), do: Posts.like_post(actor, post)
+
+  defp act("bookmark", _, %Organization{} = page, by, post),
+    do: Posts.bookmark_post(page, by, post)
+
+  defp act("bookmark", _, actor, _by, post), do: Posts.bookmark_post(actor, post)
+
+  defp act("repost", _, %Organization{} = page, by, post), do: Posts.repost_post(page, by, post)
+  defp act("repost", _, actor, _by, post), do: Posts.repost_post(actor, post)
+
+  # Re-read rather than trusted: the assign arrives from the host's own
+  # re-authorized `:acting_as`, but the row is what the act is written against,
+  # and `Posts` asks the role again before letting it through.
+  defp acting_page(socket) do
+    case socket.assigns[:acting_as_id] do
+      nil -> nil
+      id -> Repo.get(Organization, id)
+    end
   end
 
   @doc """
@@ -124,7 +149,10 @@ defmodule VutuvWeb.PostLive.ActionBar do
     assign(
       socket,
       :engagement,
-      Posts.post_engagement(socket.assigns.post_id, socket.assigns.viewer_id)
+      Posts.post_engagement(
+        socket.assigns.post_id,
+        socket.assigns[:acting_as_id] || socket.assigns.viewer_id
+      )
     )
   end
 end

--- a/lib/vutuv_web/live/post_live/actions_component.ex
+++ b/lib/vutuv_web/live/post_live/actions_component.ex
@@ -49,8 +49,13 @@ defmodule VutuvWeb.PostLive.ActionsComponent do
      |> assign(:id, assigns.id)
      |> assign(:post_id, assigns.post_id)
      |> assign(:viewer_id, assigns.viewer_id)
+     |> assign(:acting_as_id, assigns[:acting_as_id])
      |> assign_new(:engagement, fn ->
-       ActionBar.engagement_or_load(assigns[:engagement], assigns.post_id, assigns.viewer_id)
+       ActionBar.engagement_or_load(
+         assigns[:engagement],
+         assigns.post_id,
+         assigns[:acting_as_id] || assigns.viewer_id
+       )
      end)}
   end
 
@@ -68,6 +73,7 @@ defmodule VutuvWeb.PostLive.ActionsComponent do
         post_id={@post_id}
         engagement={@engagement}
         viewer_id={@viewer_id}
+        acting_as_id={@acting_as_id}
         target={@myself}
       />
     </div>

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -1106,6 +1106,7 @@ defmodule VutuvWeb.PostLive.Feed do
                   <.post_thread_entry
                     post={entry.post}
                     viewer={@current_user}
+                    acting_as={@acting_as}
                     viewer_follow={entry[:viewer_follow]}
                     ancestors={entry[:ancestors]}
                     ancestor_engagement={entry[:ancestor_engagement] || %{}}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.266.0",
+      version: "7.267.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/organization_engagement_test.exs
+++ b/test/vutuv/organization_engagement_test.exs
@@ -163,4 +163,54 @@ defmodule Vutuv.OrganizationEngagementTest do
     # named in the notification at all.
     assert entry.actor_name == page.name
   end
+
+  describe "a page's repost in the feed" do
+    test "reaches the page's followers, carrying the page as the resharer" do
+      {page, owner} = page_with_publisher()
+      {post, _author} = a_post()
+
+      follower = insert(:activated_user)
+      {:ok, _} = Vutuv.Social.follow_organization(follower, page)
+
+      assert :ok = Posts.repost_post(page, owner, post)
+
+      %{entries: entries} = Posts.feed_page(follower)
+      assert [entry] = Enum.filter(entries, &(&1.post.id == post.id))
+
+      # The reshare is the page's, so the card's banner names the page. The
+      # feed's repost source joined `users` on the reposter and filtered on
+      # member follows, so this entry did not exist at all: the act succeeded
+      # and its whole point silently did not happen.
+      assert %Vutuv.Organizations.Organization{id: id} = entry.reposted_by
+      assert id == page.id
+      assert [%Vutuv.Organizations.Organization{}] = entry.reposters
+    end
+
+    test "does not reach somebody who follows neither the page nor the author" do
+      {page, owner} = page_with_publisher()
+      {post, _author} = a_post()
+
+      stranger = insert(:activated_user)
+      assert :ok = Posts.repost_post(page, owner, post)
+
+      %{entries: entries} = Posts.feed_page(stranger)
+      assert Enum.filter(entries, &(&1.post.id == post.id)) == []
+    end
+
+    test "stops being passed on once the page is frozen" do
+      {page, owner} = page_with_publisher()
+      {post, _author} = a_post()
+
+      follower = insert(:activated_user)
+      {:ok, _} = Vutuv.Social.follow_organization(follower, page)
+      assert :ok = Posts.repost_post(page, owner, post)
+
+      {:ok, _} = Organizations.admin_set_frozen(page, true)
+
+      # The same rule a member's repost follows: a reshare must not amplify an
+      # author (or here a resharer) the site is hiding.
+      %{entries: entries} = Posts.feed_page(follower)
+      assert Enum.filter(entries, &(&1.post.id == post.id)) == []
+    end
+  end
 end

--- a/test/vutuv_web/organization_engagement_live_test.exs
+++ b/test/vutuv_web/organization_engagement_live_test.exs
@@ -1,0 +1,87 @@
+defmodule VutuvWeb.OrganizationEngagementLiveTest do
+  @moduledoc """
+  Liking and resharing **as a page** from the feed (issue #1336).
+
+  The surface follows the composer's precedent rather than inventing one:
+  `/feed` stays the *member's* feed while they are switched into a page — it is
+  their reading surface — but what they *write* there goes out in the page's
+  name. The composer has worked that way since #1335, so the action bar does
+  too, and there is no separate place to go to react as a page.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Organizations
+  alias Vutuv.Posts
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp recycle_login(conn),
+    do: conn |> recycle() |> Map.put(:secret_key_base, conn.secret_key_base)
+
+  test "the like button acts in the page's name, not the publisher's", %{conn: conn} do
+    {conn, owner} = create_and_login_user(conn)
+    page = active_organization_for(owner)
+    {:ok, _} = Organizations.add_role(page, owner, "publisher", owner)
+
+    # Somebody the publisher follows, so their post is in the feed to react to.
+    author = insert_activated_user()
+    {:ok, _} = Vutuv.Social.follow(owner, author.id)
+    {:ok, post} = Posts.create_post(author, %{body: "Hallo Welt"})
+
+    conn = conn |> post(~p"/organizations/#{page.slug}/act_as") |> recycle_login()
+
+    {:ok, feed, _html} = live(conn, ~p"/feed")
+
+    feed
+    |> element("#post-actions-post-#{post.id}-like")
+    |> render_click()
+
+    # The row belongs to the page, with the publisher recorded internally.
+    assert [like] =
+             Vutuv.Repo.all(from(l in Vutuv.Posts.PostLike, where: l.post_id == ^post.id))
+
+    assert like.organization_id == page.id
+    assert is_nil(like.user_id)
+    assert like.acting_user_id == owner.id
+
+    # And the bar reads back the PAGE's state, so the heart is filled for the
+    # whole team rather than for whoever happened to press it.
+    assert Posts.post_engagement(post.id, page).liked?
+    refute Posts.post_engagement(post.id, owner).liked?
+  end
+
+  test "the same button is the member's own when not speaking as a page", %{conn: conn} do
+    {conn, me} = create_and_login_user(conn)
+
+    author = insert_activated_user()
+    {:ok, _} = Vutuv.Social.follow(me, author.id)
+    {:ok, post} = Posts.create_post(author, %{body: "Hallo Welt"})
+
+    {:ok, feed, _html} = live(conn, ~p"/feed")
+
+    feed
+    |> element("#post-actions-post-#{post.id}-like")
+    |> render_click()
+
+    assert [like] =
+             Vutuv.Repo.all(from(l in Vutuv.Posts.PostLike, where: l.post_id == ^post.id))
+
+    assert like.user_id == me.id
+    assert is_nil(like.organization_id)
+  end
+end


### PR DESCRIPTION
Der Rest von #1336. Seit #1407 konnte eine Seite liken, reposten und speichern — aber der Repost erreichte niemanden, und es gab nichts zu drücken.

## Der Feed

`feed_repost_items/3` und `reposter_rosters/2` jointen `users` **innen** auf den Teilenden und filterten auf Mitglieder-Follows, also existierte der Repost einer Seite als Feed-Eintrag gar nicht: die Handlung gelang und ihr ganzer Zweck fiel still aus. Beide joinen jetzt beide Seiten links und lassen auch Seiten durch, denen der Leser folgt (`followed_organizations_of/1`, das es schon gab).

### Eine neue Spielart der bekannten Falle, und diese ist gemein

```elixir
defmacro account_confirmed_row(u) do
  quote do: is_nil(unquote(u).email_confirmed?) or unquote(u).email_confirmed? == true
end
```

Auf einer per **LEFT JOIN fehlenden** Zeile ist `u.email_confirmed?` NULL, also ist dieses `is_nil` **WAHR**. Das Mitglieder-Gatter ging damit für jeden Seiten-Repost durch, und eine eingefrorene Seite wurde munter weiter verbreitet. Das Makro war für einen inneren Join geschrieben, wo die Zeile immer existiert — beim Umstellen auf LEFT JOIN wird es lautlos zu "immer erlaubt".

Jedes Gatter ist deshalb jetzt auf seine Akteursart eingegrenzt (`not is_nil(r.user_id) and …`), nie bar OR-verknüpft, und ein Test friert die Seite ein und prüft, dass der Beitrag verschwindet. Er war vorher grün, weil der Eintrag ohnehin nie ankam — kalibriert habe ich ihn erst, als der Eintrag da war.

Dazu `attach_reposters/2`, das auf `%User{}` passte und Seiten-Einträge mit leerer Liste zurückließ: das Banner nannte niemanden auf einem Beitrag, der genau deswegen im Feed stand. Sein Kommentar behauptete außerdem noch, eine Seite könne gar nicht reposten.

## Die Knöpfe

Die Aktionsleiste bekommt die handelnde Identität durchgereicht (`acting_as` → `acting_as_id`) und ruft damit die Seiten-Varianten auf. **`/feed` bleibt der eigene Lesebereich**; wer gerade als Seite schreibt, reagiert dort in deren Namen — genau der Schnitt, den der Composer seit #1335 macht, also keine neue Erfindung und kein zweiter Ort.

Auch `own?` ("am eigenen Beitrag kein Herz") fragt jetzt die handelnde Identität. Sonst bekäme eine Seite am eigenen Beitrag ein lebendes Herz und danach einen abgelehnten Klick.

Ein Test drückt den echten Knopf im gerenderten Feed und prüft die Zeile: `organization_id` gesetzt, `user_id` NULL, `acting_user_id` die Person. Ein zweiter prüft, dass derselbe Knopf ohne Seitenmodus die eigene Like bleibt.

## Offen bleibt

Nur noch die **Föderation**: ein `Announce` aus dem Actor einer Seite braucht einen eigenen Zustellungslauf. Der Repost einer Seite ist bis dahin vutuv-seitig.

`mix precommit` grün, 7383 Tests.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01MMwsQi49FP21xuSoPEkMnN
