### PR TITLE
Der Repost einer Seite föderiert (v7.268.0)

### DIFF
--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -7473,26 +7473,38 @@ defmodule Vutuv.Fediverse do
   id, which a non-federating author does not serve). Best effort like every
   other outbound activity.
   """
-  def federate_repost(%Post{} = post, %User{} = reposter),
+  def federate_repost(%Post{} = post, reposter),
     do: maybe_federate_repost(post, reposter, &Docs.announce_activity/3)
 
-  @doc "The member un-reposts -> `Undo(Announce)` with the matching id."
-  def federate_unrepost(%Post{} = post, %User{} = reposter),
+  @doc "The resharer takes it back -> `Undo(Announce)` with the matching id."
+  def federate_unrepost(%Post{} = post, reposter),
     do: maybe_federate_repost(post, reposter, &Docs.undo_announce_activity/3)
 
-  defp maybe_federate_repost(%Post{} = post, %User{} = reposter, builder) do
+  defp maybe_federate_repost(%Post{} = post, reposter, builder) do
     with true <- enabled?(),
          true <- federated?(reposter),
-         false <- moved?(reposter),
+         false <- resharer_moved?(reposter),
          false <- Posts.restricted?(post),
-         %User{} = author <- Repo.get(User, post.user_id),
+         # `Posts.author/1`, never `Repo.get(User, post.user_id)`: that column is
+         # NULL on a page's post and `Repo.get/2` RAISES on nil rather than
+         # answering nothing. It only fired for a federated member resharing a
+         # page's post, so it sat here unnoticed from the day pages could
+         # publish (issue #1334).
+         author when not is_nil(author) <- Posts.author(post),
          true <- federated?(author),
-         [_ | _] = inboxes <- delivery_inboxes(reposter) do
+         [_ | _] = inboxes <- repost_inboxes(reposter) do
       enqueue(reposter, inboxes, builder.(post, author, reposter))
     else
       _ -> :skip
     end
   end
+
+  # Only a member can have moved to another server; a page has no `moved_to`.
+  defp resharer_moved?(%User{} = user), do: moved?(user)
+  defp resharer_moved?(%Organization{}), do: false
+
+  defp repost_inboxes(%User{} = user), do: delivery_inboxes(user)
+  defp repost_inboxes(%Organization{} = page), do: organization_delivery_inboxes(page)
 
   ## The pinned post as the `featured` collection (issue #1110)
 

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -1268,11 +1268,9 @@ defmodule Vutuv.Posts do
   The same, as a **page** (issue #1336) — a company amplifying a member's post
   to its own followers.
 
-  It deliberately does **not** federate. A member's repost sends an `Announce`
-  from their actor; the page equivalent needs the page's actor and its own
-  delivery run, which is its own piece of work. Until that exists a page's
-  repost is a vutuv-side reshare, which is the honest subset rather than a
-  half-built one.
+  It federates like a member's does when the page has opted in and claimed a
+  handle: an `Announce` from the page's own actor to the page's own remote
+  followers.
   """
   def repost_post(%Organization{} = page, %User{} = acting_user, %Post{} = post) do
     cond do
@@ -1284,15 +1282,31 @@ defmodule Vutuv.Posts do
 
   defp do_page_repost(%Organization{} = page, %User{} = acting_user, %Post{} = post) do
     case engage(PostRepost, :repost, page, post, acting_user) do
-      {:ok, %PostRepost{} = repost} -> broadcast_new_repost(repost)
-      {:ok, :noop} -> :ok
-      {:error, _} = error -> error
+      {:ok, %PostRepost{} = repost} ->
+        Vutuv.Fediverse.federate_repost(post, page)
+        broadcast_new_repost(repost)
+
+      {:ok, :noop} ->
+        :ok
+
+      {:error, _} = error ->
+        error
     end
   end
 
   @doc "Removes the actor's repost (idempotent). The last one lifts the audience lock."
-  def unrepost_post(%Organization{} = page, %Post{} = post),
-    do: disengage(PostRepost, :repost, page, post)
+  def unrepost_post(%Organization{} = page, %Post{} = post) do
+    # Only federate the Undo when there really was a reshare to undo, so an
+    # idempotent unrepost of a post the page never boosted stays silent.
+    reposted? =
+      Repo.exists?(
+        from(r in PostRepost, where: r.post_id == ^post.id and r.organization_id == ^page.id)
+      )
+
+    :ok = disengage(PostRepost, :repost, page, post)
+    if reposted?, do: Vutuv.Fediverse.federate_unrepost(post, page)
+    :ok
+  end
 
   def unrepost_post(%User{} = user, %Post{} = post) do
     # Only federate the Undo when there really was a repost to undo, so an

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.267.0",
+      version: "7.268.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/organization_fediverse_publish_test.exs
+++ b/test/vutuv/organization_fediverse_publish_test.exs
@@ -125,4 +125,84 @@ defmodule Vutuv.OrganizationFediversePublishTest do
     delivery = Repo.one!(from(d in Delivery, where: d.user_id == ^author.id))
     assert is_nil(delivery.organization_id)
   end
+
+  describe "a page reshares" do
+    test "the Announce goes out from the page's actor" do
+      {page, owner} = publishing_page()
+      remote_follower(page)
+
+      author = insert(:activated_user, fediverse_followers?: true)
+      {:ok, _} = Fediverse.ensure_actor(author)
+      {:ok, post} = Posts.create_post(author, %{body: "Ein Beitrag."})
+
+      assert :ok = Posts.repost_post(page, owner, post)
+
+      delivery =
+        Repo.one!(
+          from(d in Delivery,
+            where: d.organization_id == ^page.id,
+            where: like(d.activity_json, "%Announce%")
+          )
+        )
+
+      assert is_nil(delivery.user_id)
+
+      activity = Jason.decode!(delivery.activity_json)
+      assert activity["type"] == "Announce"
+      # The boost is the PAGE's, so the actor is the page's actor and not the
+      # publisher who pressed the button.
+      assert activity["actor"] == Docs.actor_url(page)
+    end
+
+    test "taking it back sends the Undo with the same id" do
+      {page, owner} = publishing_page()
+      remote_follower(page)
+
+      author = insert(:activated_user, fediverse_followers?: true)
+      {:ok, _} = Fediverse.ensure_actor(author)
+      {:ok, post} = Posts.create_post(author, %{body: "Ein Beitrag."})
+
+      assert :ok = Posts.repost_post(page, owner, post)
+      :ok = Posts.unrepost_post(page, post)
+
+      undo =
+        Repo.one!(
+          from(d in Delivery,
+            where: d.organization_id == ^page.id,
+            where: like(d.activity_json, "%Undo%")
+          )
+        )
+
+      activity = Jason.decode!(undo.activity_json)
+      assert activity["type"] == "Undo"
+      assert activity["object"]["type"] == "Announce"
+    end
+
+    test "a page that never opted in sends nothing" do
+      {page, owner} = publishing_page(fediverse_followers?: false)
+
+      author = insert(:activated_user, fediverse_followers?: true)
+      {:ok, _} = Fediverse.ensure_actor(author)
+      {:ok, post} = Posts.create_post(author, %{body: "Ein Beitrag."})
+
+      assert :ok = Posts.repost_post(page, owner, post)
+
+      assert Repo.aggregate(from(d in Delivery, where: d.organization_id == ^page.id), :count) ==
+               0
+    end
+  end
+
+  test "a federated member resharing a PAGE's post does not crash" do
+    {page, owner} = publishing_page()
+    {:ok, post} = Posts.create_organization_post(page, owner, %{body: "Unser Beitrag."})
+
+    member = insert(:activated_user, fediverse_followers?: true)
+    {:ok, _} = Fediverse.ensure_actor(member)
+
+    # The repost path looked the author up with `Repo.get(User, post.user_id)`,
+    # and that column is NULL on a page's post - so this RAISED rather than
+    # answering nothing. It only ever fired for a federated member resharing a
+    # page's post, which is why no test had met it.
+    assert :ok = Posts.repost_post(member, post)
+  end
 end


### PR DESCRIPTION
Der letzte offene Punkt aus #1336.

Teilt eine Seite einen Beitrag, geht jetzt ein `Announce` aus **ihrem eigenen Actor** an **ihre eigenen** entfernten Follower, und das Zurücknehmen schickt das passende `Undo`. Alles hinter dem Schalter, der ohnehin gilt: die Seite muss föderieren wollen (`fediverse_followers?`, ab Werk aus) und ein Handle geholt haben.

## Wenig zu bauen, weil #1334 die Teile schon gelegt hat

`federated?/1`, `organization_delivery_inboxes/1`, `Docs.actor_url/1` und `note_url/2` kennen eine Seite längst, und `insert_deliveries/3` schreibt die Absenderspalte ohnehin je nach Art (`sender_column/2`). Zu tun war im Wesentlichen, `maybe_federate_repost/3` nicht mehr auf `%User{}` festzunageln — plus zwei kleine Verzweigungen: eine Seite kann nicht umgezogen sein (`moved_to` gibt es dort nicht) und holt ihre Inboxen aus ihrer eigenen Followerliste.

## Ein Absturz, der seit #1334 dort lag

```elixir
%User{} = author <- Repo.get(User, post.user_id),
```

Beim Beitrag einer **Seite** ist diese Spalte NULL, und `Repo.get/2` **fliegt** bei `nil`, statt nichts zu antworten. Ausgelöst hätte das nur ein **föderierendes Mitglied**, das den Beitrag einer **Seite** teilt — beides zusammen ist selten, und ab Werk föderiert niemand, weshalb der `with`-Ausdruck vorher fast immer schon an `federated?(reposter)` ausgestiegen ist. Deshalb ist es niemandem begegnet und in keinem Test aufgeschlagen.

Die Suche geht jetzt über `Posts.author/1`, den einen Accessor, den dieser Meilenstein genau dafür hat. Ein Test deckt den Fall ab und war vorher rot mit `cannot perform Ecto.Repo.get/2 because the given value is nil`.

## Nicht gemacht, mit Grund

Die Like einer Seite bekommt in der **"Liked by"-Reihe** immer noch kein Gesicht. Der saubere Weg dahin verlangt, `organization_logo/1` aus den `OrganizationComponents` ins `UI`-Kit zu heben — das Kit kann die Komponenten nicht importieren, die es selbst importieren, und `stack_faces/1` baut Bild, Name und Pfad heute rein mitgliedsspezifisch (`~p"/#{user}"`, `full_name/1`, `<.avatar user=…>`). Das ist ein Umbau an gemeinsam genutzten Komponenten mit mehreren Aufrufstellen und gehört nicht ans Ende einer langen Sitzung.

Der Zähler stimmt weiterhin; die Seite fällt in das `+N`, genau wie jemand, der die Namensnennung abgeschaltet hat. Das ist der dokumentierte Vertrag dieser Reihe, also unvollständig statt falsch.

`mix precommit` grün, 7387 Tests.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01MMwsQi49FP21xuSoPEkMnN
