### PR TITLE
WebFinger auf einen Seiten-Handle antwortet wieder (v7.268.1)

### DIFF
--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -415,9 +415,22 @@ defmodule Vutuv.Fediverse do
   erase members' remote presence), and every *temporary* state — frozen,
   suspended, deactivated, unconfirmed. Those keep answering `404`, because a
   three-day suspension must never tell the network to delete the account.
+
+  The **page** clause (issue #1334) reads the same three things off the page,
+  and it is not decoration: pages and members share one handle namespace, so
+  WebFinger resolves `acct:<handle>@<host>` to either kind and hands whatever it
+  found to the refusal path. Without this clause that path raised
+  `FunctionClauseError` — a **500** — for every page that had claimed a handle
+  and not switched federation on, which is the state every page starts in.
+  Production answered exactly that for `acct:vutuv@vutuv.de`.
   """
   def departed?(%User{} = user) do
     enabled?() and not user.fediverse_followers? and get_actor(user) != nil
+  end
+
+  def departed?(%Organization{} = organization) do
+    enabled?() and not organization.fediverse_followers? and
+      get_organization_actor(organization) != nil
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.268.0",
+      version: "7.268.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/organization_fediverse_actor_web_test.exs
+++ b/test/vutuv_web/organization_fediverse_actor_web_test.exs
@@ -100,6 +100,41 @@ defmodule VutuvWeb.OrganizationFediverseActorWebTest do
            |> response(404)
   end
 
+  test "a page that claimed a handle but does not federate answers 404", %{conn: conn} do
+    page =
+      active_organization_for(insert(:activated_user))
+      |> Ecto.Changeset.change(%{username: "acme"})
+      |> Repo.update!()
+
+    # The combination the test above cannot reach: the handle RESOLVES (pages
+    # and members share one namespace), so the lookup succeeds and the refusal
+    # path runs — which asked `departed?/1`, a `%User{}`-only function, and blew
+    # up with a FunctionClauseError. Every remote server that ever WebFingered a
+    # page handle got a 500 out of it; production answered exactly that for
+    # `acct:vutuv@vutuv.de`.
+    assert page.username == "acme"
+    refute Vutuv.Fediverse.federated?(page)
+
+    assert conn
+           |> get(~p"/.well-known/webfinger", resource: "acct:acme@#{VutuvWeb.Endpoint.host()}")
+           |> response(404)
+  end
+
+  test "a page that switched federation off answers 410, not 404", %{conn: conn} do
+    page = federating_page()
+    {:ok, _} = Vutuv.Fediverse.ensure_organization_actor(page)
+
+    page = page |> Ecto.Changeset.change(%{fediverse_followers?: false}) |> Repo.update!()
+
+    # The same distinction a member gets: a `410` tells a remote server that
+    # knows this actor to drop it and the copies it kept, and that is the page
+    # owner's own decision to leave. A page that never federated is a plain
+    # `404` (above) — nothing out there knows it, and there is nothing to forget.
+    assert conn
+           |> get(~p"/.well-known/webfinger", resource: "acct:acme@#{VutuvWeb.Endpoint.host()}")
+           |> response(410)
+  end
+
   test "a page without a claimed handle cannot federate", %{conn: conn} do
     page =
       active_organization_for(insert(:activated_user))


### PR DESCRIPTION
**TL;DR** `GET /.well-known/webfinger?resource=acct:vutuv@vutuv.de` antwortet in Produktion mit **500**. Ursache: `Fediverse.departed?/1` hat nur eine `%User{}`-Klausel, bekommt vom WebFinger aber auch eine Organisationsseite.

**Wo:** `Vutuv.Fediverse.departed?/1`, aufgerufen aus `VutuvWeb.FediverseController.refuse/2`.

**Jetzt:** Mitglieder und Seiten teilen sich einen Handle-Namensraum. WebFinger löst den Handle also auf beides auf, und wenn die gefundene Seite nicht föderiert, geht sie in den Ablehnungspfad — dort schlägt `departed?/1` mit einer FunctionClauseError fehl. Das trifft jede Seite mit beanspruchtem Handle und ohne Fediverse-Opt-in, also den Zustand, in dem jede Seite startet.

**Danach:** dieselbe Unterscheidung wie bei einem Mitglied. **410** für eine Seite, die Föderation wieder abgeschaltet hat (ein entfernter Server darf sie und die Kopien ihrer Beiträge vergessen), **404** für eine, die nie föderiert hat.

**Warum kein Test das gefunden hat:** die vorhandenen Fälle fragten WebFinger nach dem *Slug* der Seite, der im Handle-Namensraum nie auflöst — die Anfrage endete schon vor der kaputten Stelle mit 404. Die beiden neuen Tests treffen die Kombination, um die es geht: Handle beansprucht, Opt-in aus (404) und Opt-in nachträglich abgeschaltet (410).

Hot deploy, keine Migration. Version 7.268.1.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*