### PR TITLE
Der Fediverse-Schalter einer Seite ist auffindbar und erklärt sich (v7.270.0)

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -890,6 +890,34 @@ that turns out to be local follows the page here
 (`Fediverse.follow_local_organization/2`). The doc builders carry the same fact,
 so `.md`/`.txt`/`.json`/`.xml` name the address too.
 
+**And the owner has to be able to find the switch.** It sits at
+`/organizations/:slug/fediverse`, which was linked from exactly one place: the
+manage pages' tab bar, which renders **only on the manage pages themselves**. The
+page's own owner row named Edit / Team / Domains, so the way in was to open one
+of those three and notice a tab — five of the eight areas were unreachable by
+anything but accident. The page now names Fediverse in that row, and the empty
+Fediverse card carries the app's ordinary `<.empty_add>` scaffold for its owner,
+the same way an empty profile section teaches what goes in it. Note the standing
+hazard: that owner row and the tab bar are two hand-kept lists of one map and
+they had already drifted. Rendering both from a single source is the real fix,
+and it is a nav change to agree on rather than to slip in.
+
+**And the words had to change with it**, because the owner this now reaches is
+the secretary of a Verein, not somebody who knows the protocol. Every sentence on
+the switch page was built on the verb *federate* ("Föderieren starten", "Diese
+Seite föderiert nicht"), which is not a word in ordinary German or English. The
+whole owner path now leads with what it does for the organization — *people who
+have no vutuv account can follow this page and read its posts, in networks like
+Mastodon* — and names the address by its shape (`@name@host`, "written like an
+email address") rather than by a term. The invitation on the page and the switch
+page share that first sentence as **one msgid**, so the offer and the page it
+leads to cannot describe the same thing in two ways. "Fediverse" survives as the
+heading, the tab and the section name: it is what the thing is called, and one
+place that explains it beats hiding it and meeting it again unexplained. The edit
+form's "Root handle" became "The organization's @name" for the same reason — the
+switch page sends the owner there to claim one, and a handoff that renames the
+thing mid-flow is where people give up.
+
 Two things ride along with it. The page URL now answers an **ActivityPub
 `Accept`** with the actor document (`404`/`410` when it does not federate), which
 is what Mastodon fetches when somebody pastes the URL rather than the handle —

--- a/lib/vutuv_web/live/organization_live/edit.ex
+++ b/lib/vutuv_web/live/organization_live/edit.ex
@@ -399,10 +399,14 @@ defmodule VutuvWeb.OrganizationLive.Edit do
       </.card>
 
       <.card :if={@owner? and @organization.status == "active"} class="mt-8">
-        <.section_title>{gettext("Root handle")}</.section_title>
+        <%!-- "@name", not "root handle": the Fediverse page sends its owner here
+        to claim one, and it would be a poor handoff to name the same thing twice
+        in two words, one of which ("Root-URL") describes our routing rather than
+        what the owner gets. What they get is a short address of their own. --%>
+        <.section_title>{gettext("The organization's @name")}</.section_title>
         <p class="mt-1 text-xs text-slate-600 dark:text-slate-400">
           {gettext(
-            "Claim a short @handle so this organization has its own root URL, like a member profile. Letters, numbers and underscores, %{min} to %{max} characters.",
+            "Claim a short @name so this organization has an address of its own, like a member. Letters, numbers and underscores, %{min} to %{max} characters.",
             min: Vutuv.Handles.min_length(),
             max: Vutuv.Handles.max_length()
           )}

--- a/lib/vutuv_web/live/organization_live/fediverse.ex
+++ b/lib/vutuv_web/live/organization_live/fediverse.ex
@@ -77,20 +77,34 @@ defmodule VutuvWeb.OrganizationLive.Fediverse do
       />
 
       <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100">{gettext("Fediverse")}</h1>
+      <%!-- The same sentence the page's own empty Fediverse card shows, from one
+      msgid: the owner arrives here from that card, and a page that greeted them
+      by restating the offer in different words would read as a different
+      feature. It says what this does for the organization (reach past vutuv)
+      before it names anything, because "federate" is a word almost nobody
+      outside this protocol knows, in English or in German. --%>
       <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
-        {gettext("Let people on Mastodon and other networks follow this page and receive its posts.")}
+        {gettext(
+          "People who have no vutuv account can follow this page and read its posts, in networks like Mastodon."
+        )}
       </p>
 
       <.card :if={!@enabled?} class="mt-6">
         <p class="text-sm text-slate-700 dark:text-slate-300">
-          {gettext("This installation has federation switched off, so nothing here has any effect.")}
+          {gettext("This vutuv exchanges nothing with other networks, so nothing here has any effect.")}
         </p>
       </.card>
 
       <.card :if={@enabled? and is_nil(@organization.username)} class="mt-6" id="needs-handle">
-        <.section_title>{gettext("A handle is needed first")}</.section_title>
+        <.section_title>{gettext("A short @name is needed first")}</.section_title>
+        <%!-- Showing the shape of the address teaches more than naming the
+        concept does: everybody has seen an email address, and this is written
+        the same way. --%>
         <p class="mt-2 text-sm text-slate-700 dark:text-slate-300">
-          {gettext("Out there this page is addressed by its handle, the way a member is. Claim one on the page settings, then come back.")}
+          {gettext(
+            "Other networks address this page as @name@%{host}, the way they address a member. So it needs a short @name of its own first. Claim one in the page settings, then come back.",
+            host: VutuvWeb.Endpoint.host()
+          )}
         </p>
         <.link
           navigate={~p"/organizations/#{@organization.slug}/edit"}
@@ -108,11 +122,11 @@ defmodule VutuvWeb.OrganizationLive.Fediverse do
 
         <p class="mt-4 text-sm text-slate-700 dark:text-slate-300">
           <%= if @federated? do %>
-            {gettext("This page is being federated. %{count} accounts on other networks follow it.",
+            {gettext("This page is visible on other networks. %{count} accounts there follow it.",
               count: delimited_count(@remote_followers)
             )}
           <% else %>
-            {gettext("This page is not being federated. Nothing of it is visible on other networks.")}
+            {gettext("This page is not visible on other networks. Nothing of it leaves vutuv.")}
           <% end %>
         </p>
 
@@ -131,11 +145,13 @@ defmodule VutuvWeb.OrganizationLive.Fediverse do
             if @federated?,
               do: nil,
               else:
-                gettext("Posts of this page will be sent to other servers from now on. Continue?")
+                gettext(
+                  "From now on, posts of this page also go to other networks. Continue?"
+                )
           }
           class="mt-4"
         >
-          {if @federated?, do: gettext("Stop federating"), else: gettext("Start federating")}
+          {if @federated?, do: gettext("Switch it off"), else: gettext("Switch it on")}
         </.button>
       </.card>
 
@@ -143,7 +159,7 @@ defmodule VutuvWeb.OrganizationLive.Fediverse do
         :if={@ever_federated? and not @federated?}
         class="mt-4 text-sm text-slate-600 dark:text-slate-400"
       >
-        {gettext("This page federated before. Servers that still hold copies keep them until they act on a deletion request.")}
+        {gettext("This page was visible on other networks before. Servers that still hold copies keep them until they act on a deletion request.")}
       </p>
     </div>
     """

--- a/lib/vutuv_web/live/organization_live/show.ex
+++ b/lib/vutuv_web/live/organization_live/show.ex
@@ -159,6 +159,15 @@ defmodule VutuvWeb.OrganizationLive.Show do
       :fediverse,
       if(Fediverse.federated?(organization), do: %{handle: Docs.handle(organization)})
     )
+    # Whether to offer the owner the switch instead of an address. Read off the
+    # same two facts the card needs, so the template asks no questions of its
+    # own: the installation must federate at all, and this must be the owner
+    # (federating decides how the page appears on servers we do not run, which
+    # is why the switch itself is owner-only rather than publisher-wide).
+    |> assign(
+      :fediverse_invite?,
+      Fediverse.enabled?() and Organizations.owner?(organization, viewer)
+    )
     |> assign(:engagement, Organizations.organization_engagement(organization, viewer))
     |> assign(:dns_value, primary && Organizations.dns_txt_value(primary))
     |> assign(:dns_challenge_name, primary && Organizations.dns_challenge_name(primary))
@@ -500,6 +509,21 @@ defmodule VutuvWeb.OrganizationLive.Show do
                 >
                   {gettext("Domains")}
                 </.link>
+                <%!-- This row and the manage pages' tab bar are two hand-kept
+                lists of the same map, and they had drifted: the tab bar names
+                eight areas, this row named three, and Fediverse was among the
+                five an owner could only reach by opening one of the three and
+                noticing a tab. Adding one link is the small fix; the real one is
+                to render both from a single source, which is a nav change worth
+                agreeing on first. Until then, keep them in step by hand. --%>
+                <.link
+                  :if={@owner?}
+                  id="organization-manage-fediverse"
+                  navigate={~p"/organizations/#{@organization.slug}/fediverse"}
+                  class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+                >
+                  {gettext("Fediverse")}
+                </.link>
                 <.link
                   :if={@current_user && !@can_manage?}
                   href={~p"/reports/new?#{[type: "organization", id: @organization.id, return_to: "/organizations/#{@organization.slug}"]}"}
@@ -666,14 +690,57 @@ defmodule VutuvWeb.OrganizationLive.Show do
           without scrolling past the posts; `scroll-mt-24` keeps the sticky top
           bar off the title when that shortcut (or the controller's error
           redirect) lands on the anchor. --%>
-          <.card :if={@fediverse} id="organization-fediverse" class="scroll-mt-24">
+          <%!-- Without an address the card is an EMPTY SECTION, and this app
+          teaches an empty section to its owner rather than hiding it: the same
+          dashed `<.empty_add>` scaffold every profile section shows while it has
+          nothing in it. It is needed here more than anywhere, because the switch
+          is otherwise unreachable by accident — it lives behind the manage tab
+          bar, which renders only on the manage pages themselves, so an owner had
+          to open "Edit" and notice a tab to learn that a page can federate at
+          all. Owners only, and only where the installation federates: a visitor
+          has nothing to do with it, and where the operator switched federation
+          off there is nothing to switch on. --%>
+          <.card
+            :if={@fediverse || @fediverse_invite?}
+            id="organization-fediverse"
+            class="scroll-mt-24"
+          >
             <.section_title>{gettext("Fediverse")}</.section_title>
-            <.follow_us_from_elsewhere
-              id="organization-fediverse"
-              handle={@fediverse.handle}
-              name={@organization.name}
-              action={~p"/organizations/#{@organization.slug}/fediverse/follow"}
-            />
+
+            <%= if @fediverse do %>
+              <.follow_us_from_elsewhere
+                id="organization-fediverse"
+                handle={@fediverse.handle}
+                name={@organization.name}
+                action={~p"/organizations/#{@organization.slug}/fediverse/follow"}
+              />
+            <% else %>
+              <%!-- Says what this does for the organization before it names
+              anything: reach past vutuv. "Fediverse" is the heading and the word
+              the owner will meet again on the switch page and in the tab bar, so
+              it is worth teaching once, in the one place where it is explained.
+              The first sentence is shared with that switch page (one msgid), so
+              the offer and the page it leads to cannot describe the same thing
+              in two different ways. The second is the mental model people
+              actually have for an `@name@host` address. --%>
+              <p class="mt-1 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
+                {gettext(
+                  "People who have no vutuv account can follow this page and read its posts, in networks like Mastodon."
+                )}
+              </p>
+              <p class="mt-2 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
+                {gettext(
+                  "The page gets an address of its own for that, written like an email address."
+                )}
+              </p>
+              <.empty_add
+                href={~p"/organizations/#{@organization.slug}/fediverse"}
+                id="organization-fediverse-enable"
+                class="mt-3"
+              >
+                {gettext("Set this page up for other networks")}
+              </.empty_add>
+            <% end %>
           </.card>
         </div>
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.269.0",
+      version: "7.270.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -32,8 +32,8 @@ msgstr "Eintrag hinzufügen"
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
-#: lib/vutuv_web/live/organization_live/fediverse.ex:104
-#: lib/vutuv_web/live/organization_live/show.ex:682
+#: lib/vutuv_web/live/organization_live/fediverse.ex:118
+#: lib/vutuv_web/live/organization_live/show.ex:749
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
@@ -216,7 +216,7 @@ msgstr "Download"
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
 #: lib/vutuv_web/live/job_posting_live/show.ex:178
-#: lib/vutuv_web/live/organization_live/show.ex:487
+#: lib/vutuv_web/live/organization_live/show.ex:496
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:7
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:19
@@ -333,7 +333,7 @@ msgstr "Follower"
 #: lib/vutuv_web/components/ui.ex:2014
 #: lib/vutuv_web/components/ui.ex:2072
 #: lib/vutuv_web/controllers/followee_controller.ex:29
-#: lib/vutuv_web/live/organization_live/show.ex:447
+#: lib/vutuv_web/live/organization_live/show.ex:456
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:53
 #: lib/vutuv_web/templates/user/show.html.heex:955
@@ -442,8 +442,8 @@ msgstr "Einloggen"
 msgid "Log Out"
 msgstr "Ausloggen"
 
-#: lib/vutuv_web/live/shell_live.ex:789
-#: lib/vutuv_web/live/shell_live.ex:826
+#: lib/vutuv_web/live/shell_live.ex:797
+#: lib/vutuv_web/live/shell_live.ex:834
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -640,8 +640,8 @@ msgstr "Speichern"
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:42
 #: lib/vutuv_web/live/search_live.ex:399
-#: lib/vutuv_web/live/shell_live.ex:657
-#: lib/vutuv_web/live/shell_live.ex:809
+#: lib/vutuv_web/live/shell_live.ex:665
+#: lib/vutuv_web/live/shell_live.ex:817
 #: lib/vutuv_web/live/tag_live/timeline.ex:255
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
@@ -1184,7 +1184,7 @@ msgstr "Lokalisierung hinzufügen"
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:761
+#: lib/vutuv_web/live/shell_live.ex:769
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1625,7 +1625,7 @@ msgstr "Adressen von %{name}"
 msgid "Admin control panel"
 msgstr "Admin-Bereich"
 
-#: lib/vutuv_web/live/shell_live.ex:812
+#: lib/vutuv_web/live/shell_live.ex:820
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "Mitteilungen"
@@ -1721,8 +1721,8 @@ msgstr "Empfehlen"
 #: lib/vutuv_web/live/fediverse_following_live.ex:313
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:363
 #: lib/vutuv_web/live/organization_live/following.ex:218
-#: lib/vutuv_web/live/organization_live/show.ex:416
-#: lib/vutuv_web/live/organization_live/show.ex:445
+#: lib/vutuv_web/live/organization_live/show.ex:425
+#: lib/vutuv_web/live/organization_live/show.ex:454
 #: lib/vutuv_web/templates/user/show.html.heex:1269
 #, elixir-autogen, elixir-format
 msgid "Follow"
@@ -1741,7 +1741,7 @@ msgstr ""
 " von jemandem, den Sie kennen oder interessant finden, und klicken Sie auf "
 "Folgen!"
 
-#: lib/vutuv_web/live/shell_live.ex:780
+#: lib/vutuv_web/live/shell_live.ex:788
 #: lib/vutuv_web/views/settings_html.ex:261
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1762,7 +1762,7 @@ msgstr "Ausloggen"
 msgid "Member"
 msgstr "Mitglied"
 
-#: lib/vutuv_web/live/organization_live/show.ex:466
+#: lib/vutuv_web/live/organization_live/show.ex:475
 #: lib/vutuv_web/templates/user/show.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Message"
@@ -1770,14 +1770,14 @@ msgstr "Nachricht"
 
 #: lib/vutuv_web/live/message_live/index.ex:50
 #: lib/vutuv_web/live/message_live/index.ex:622
-#: lib/vutuv_web/live/shell_live.ex:673
-#: lib/vutuv_web/live/shell_live.ex:811
+#: lib/vutuv_web/live/shell_live.ex:681
+#: lib/vutuv_web/live/shell_live.ex:819
 #: lib/vutuv_web/templates/layout/app.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr "Nachrichten"
 
-#: lib/vutuv_web/live/shell_live.ex:567
+#: lib/vutuv_web/live/shell_live.ex:575
 #, elixir-autogen, elixir-format
 msgid "Network"
 msgstr "Netzwerk"
@@ -1801,7 +1801,7 @@ msgstr "Noch nichts Neues."
 #: lib/vutuv_web/components/ui.ex:3714
 #: lib/vutuv_web/live/notification_live/index.ex:105
 #: lib/vutuv_web/live/notification_live/index.ex:329
-#: lib/vutuv_web/live/shell_live.ex:684
+#: lib/vutuv_web/live/shell_live.ex:692
 #: lib/vutuv_web/templates/layout/app.html.heex:124
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -1960,7 +1960,7 @@ msgstr "Seitennavigation"
 #: lib/vutuv_web/components/ui.ex:3461
 #: lib/vutuv_web/live/organization_live/activity.ex:146
 #: lib/vutuv_web/live/organization_live/feed.ex:101
-#: lib/vutuv_web/live/organization_live/show.ex:598
+#: lib/vutuv_web/live/organization_live/show.ex:622
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr "Mehr laden"
@@ -2156,8 +2156,8 @@ msgstr "Beitrag bearbeiten"
 #: lib/vutuv_web/live/organization_live/feed.ex:79
 #: lib/vutuv_web/live/post_live/feed.ex:158
 #: lib/vutuv_web/live/post_live/feed.ex:952
-#: lib/vutuv_web/live/shell_live.ex:547
-#: lib/vutuv_web/live/shell_live.ex:807
+#: lib/vutuv_web/live/shell_live.ex:555
+#: lib/vutuv_web/live/shell_live.ex:815
 #: lib/vutuv_web/templates/layout/app.html.heex:122
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2242,7 +2242,7 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:382
 #: lib/vutuv_web/live/notification_live/index.ex:882
-#: lib/vutuv_web/live/organization_live/show.ex:525
+#: lib/vutuv_web/live/organization_live/show.ex:549
 #: lib/vutuv_web/live/post_live/saved.ex:495
 #: lib/vutuv_web/live/search_live.ex:205
 #: lib/vutuv_web/live/search_live.ex:551
@@ -2332,7 +2332,7 @@ msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
 
 #: lib/vutuv_web/components/ui.ex:3978
-#: lib/vutuv_web/live/shell_live.ex:727
+#: lib/vutuv_web/live/shell_live.ex:735
 #: lib/vutuv_web/templates/post/index.html.heex:17
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:208
@@ -2422,8 +2422,8 @@ msgstr "Lesezeichen setzen"
 #: lib/vutuv_web/agent_docs/markdown.ex:997
 #: lib/vutuv_web/live/post_live/saved.ex:175
 #: lib/vutuv_web/live/post_live/saved.ex:488
-#: lib/vutuv_web/live/shell_live.ex:666
-#: lib/vutuv_web/live/shell_live.ex:732
+#: lib/vutuv_web/live/shell_live.ex:674
+#: lib/vutuv_web/live/shell_live.ex:740
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2444,7 +2444,7 @@ msgstr "Gefällt mir"
 #: lib/vutuv_web/live/notification_live/index.ex:962
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
-#: lib/vutuv_web/live/shell_live.ex:735
+#: lib/vutuv_web/live/shell_live.ex:743
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2507,7 +2507,7 @@ msgstr "Gefällt mir entfernen"
 #: lib/vutuv_web/components/ui.ex:2073
 #: lib/vutuv_web/live/organization_live/following.ex:197
 #: lib/vutuv_web/live/organization_live/following.ex:256
-#: lib/vutuv_web/live/organization_live/show.ex:450
+#: lib/vutuv_web/live/organization_live/show.ex:459
 #: lib/vutuv_web/live/post_live/feed.ex:1188
 #: lib/vutuv_web/templates/followee/index.html.heex:44
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
@@ -3216,8 +3216,8 @@ msgid "Private message"
 msgstr "Private Nachricht"
 
 #: lib/vutuv_web/components/ui.ex:3646
-#: lib/vutuv_web/live/shell_live.ex:560
-#: lib/vutuv_web/live/shell_live.ex:816
+#: lib/vutuv_web/live/shell_live.ex:568
+#: lib/vutuv_web/live/shell_live.ex:824
 #: lib/vutuv_web/templates/import/new.html.heex:15
 #: lib/vutuv_web/templates/import/preview.html.heex:55
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
@@ -3244,7 +3244,7 @@ msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 #: lib/vutuv_web/components/post_components.ex:1066
 #: lib/vutuv_web/components/post_components.ex:2042
 #: lib/vutuv_web/components/post_components.ex:2767
-#: lib/vutuv_web/live/organization_live/show.ex:508
+#: lib/vutuv_web/live/organization_live/show.ex:532
 #: lib/vutuv_web/templates/user/show.html.heex:219
 #, elixir-autogen, elixir-format
 msgid "Report"
@@ -4767,7 +4767,7 @@ msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:516
 #: lib/vutuv_web/live/notification_live/index.ex:883
-#: lib/vutuv_web/live/organization_live/show.ex:608
+#: lib/vutuv_web/live/organization_live/show.ex:632
 #: lib/vutuv_web/live/post_live/saved.ex:498
 #: lib/vutuv_web/live/search_live.ex:203
 #: lib/vutuv_web/live/search_live.ex:493
@@ -5528,7 +5528,7 @@ msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
 msgid "Content under review"
 msgstr "Inhalte in Prüfung"
 
-#: lib/vutuv_web/live/shell_live.ex:714
+#: lib/vutuv_web/live/shell_live.ex:722
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr "Kontomenü"
@@ -5550,7 +5550,7 @@ msgstr "Menüs und Dialoge schließen"
 msgid "General"
 msgstr "Allgemeines"
 
-#: lib/vutuv_web/live/shell_live.ex:771
+#: lib/vutuv_web/live/shell_live.ex:779
 #: lib/vutuv_web/templates/layout/app.html.heex:154
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5569,7 +5569,7 @@ msgstr "Navigation"
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:285
-#: lib/vutuv_web/live/shell_live.ex:751
+#: lib/vutuv_web/live/shell_live.ex:759
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5623,8 +5623,8 @@ msgstr "Nächster Beitrag im Feed"
 msgid "Previous post in the feed"
 msgstr "Vorheriger Beitrag im Feed"
 
-#: lib/vutuv_web/live/shell_live.ex:540
-#: lib/vutuv_web/live/shell_live.ex:800
+#: lib/vutuv_web/live/shell_live.ex:548
+#: lib/vutuv_web/live/shell_live.ex:808
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr "Hauptnavigation"
@@ -5693,7 +5693,7 @@ msgstr "Über Sie"
 msgid "Account"
 msgstr "Konto"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:443
+#: lib/vutuv_web/live/organization_live/edit.ex:447
 #, elixir-autogen, elixir-format
 msgid "Change"
 msgstr "Ändern"
@@ -9086,7 +9086,8 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/live/fediverse_followers_live.ex:169
 #: lib/vutuv_web/live/fediverse_following_live.ex:286
 #: lib/vutuv_web/live/organization_live/fediverse.ex:79
-#: lib/vutuv_web/live/organization_live/show.ex:670
+#: lib/vutuv_web/live/organization_live/show.ex:525
+#: lib/vutuv_web/live/organization_live/show.ex:708
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:341
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:5
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
@@ -10778,7 +10779,7 @@ msgid_plural "%{count} stars"
 msgstr[0] "%{count} Stern"
 msgstr[1] "%{count} Sterne"
 
-#: lib/vutuv_web/live/organization_live/show.ex:474
+#: lib/vutuv_web/live/organization_live/show.ex:483
 #: lib/vutuv_web/views/user_html.ex:536
 #: lib/vutuv_web/views/user_html.ex:715
 #, elixir-autogen, elixir-format
@@ -11659,7 +11660,7 @@ msgstr "Ihre Liste ist leer. Es ist noch niemand ausgeschlossen."
 msgid "AI agents"
 msgstr "KI-Agenten"
 
-#: lib/vutuv_web/live/organization_live/show.ex:515
+#: lib/vutuv_web/live/organization_live/show.ex:539
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "Über die Organisation"
@@ -11672,7 +11673,7 @@ msgstr "Weiter zur Verifizierung"
 #: lib/vutuv_web/live/organization_live/domains.ex:248
 #: lib/vutuv_web/live/organization_live/domains.ex:288
 #: lib/vutuv_web/live/organization_live/new.ex:146
-#: lib/vutuv_web/live/organization_live/show.ex:756
+#: lib/vutuv_web/live/organization_live/show.ex:823
 #: lib/vutuv_web/templates/url/verify.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "DNS TXT record"
@@ -11680,8 +11681,8 @@ msgstr "DNS-TXT-Eintrag"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:153
 #: lib/vutuv_web/live/organization_live/domains.ex:167
-#: lib/vutuv_web/live/organization_live/show.ex:348
-#: lib/vutuv_web/live/organization_live/show.ex:815
+#: lib/vutuv_web/live/organization_live/show.ex:357
+#: lib/vutuv_web/live/organization_live/show.ex:882
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr "Die Domain-Verifizierung ist auf dieser Installation deaktiviert."
@@ -11721,7 +11722,7 @@ msgstr ""
 msgid "Please log in first."
 msgstr "Bitte loggen Sie sich zuerst ein."
 
-#: lib/vutuv_web/live/organization_live/show.ex:729
+#: lib/vutuv_web/live/organization_live/show.ex:796
 #, elixir-autogen, elixir-format
 msgid "Prove you control %{domain} to publish this page."
 msgstr "Weisen Sie nach, dass Ihnen %{domain} gehört, um diese Seite zu veröffentlichen."
@@ -11748,7 +11749,7 @@ msgid "Select a country"
 msgstr "Land auswählen"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:307
-#: lib/vutuv_web/live/organization_live/show.ex:791
+#: lib/vutuv_web/live/organization_live/show.ex:858
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr "Stellen Sie diese Datei bereit unter:"
@@ -11759,28 +11760,28 @@ msgstr "Stellen Sie diese Datei bereit unter:"
 msgid "State / region (optional)"
 msgstr "Bundesland / Region (optional)"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:473
+#: lib/vutuv_web/live/organization_live/edit.ex:477
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr "Dieser Dateityp ist nicht erlaubt."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:471
+#: lib/vutuv_web/live/organization_live/edit.ex:475
 #, elixir-autogen, elixir-format
 msgid "The file is too large."
 msgstr "Die Datei ist zu groß."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:474
+#: lib/vutuv_web/live/organization_live/edit.ex:478
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr "Der Upload ist fehlgeschlagen."
 
 #: lib/vutuv_web/live/organization_live/new.ex:131
-#: lib/vutuv_web/live/organization_live/show.ex:744
+#: lib/vutuv_web/live/organization_live/show.ex:811
 #, elixir-autogen, elixir-format
 msgid "Verification method"
 msgstr "Verifizierungsmethode"
 
-#: lib/vutuv_web/live/organization_live/show.ex:704
+#: lib/vutuv_web/live/organization_live/show.ex:771
 #, elixir-autogen, elixir-format
 msgid "Verified domains"
 msgstr "Verifizierte Domains"
@@ -11796,19 +11797,19 @@ msgstr "Verifiziert über"
 msgid "Verified via %{domain}"
 msgstr "Verifiziert über %{domain}"
 
-#: lib/vutuv_web/live/organization_live/show.ex:726
+#: lib/vutuv_web/live/organization_live/show.ex:793
 #, elixir-autogen, elixir-format
 msgid "Verify %{name}"
 msgstr "%{name} verifizieren"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:320
-#: lib/vutuv_web/live/organization_live/show.ex:811
+#: lib/vutuv_web/live/organization_live/show.ex:878
 #, elixir-autogen, elixir-format
 msgid "Verify now"
 msgstr "Jetzt verifizieren"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:149
-#: lib/vutuv_web/live/organization_live/show.ex:343
+#: lib/vutuv_web/live/organization_live/show.ex:352
 #, elixir-autogen, elixir-format
 msgid "We could not find the record or file yet. It can take a while to propagate. Please try again."
 msgstr ""
@@ -11825,7 +11826,7 @@ msgstr "Website"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:249
 #: lib/vutuv_web/live/organization_live/domains.ex:298
-#: lib/vutuv_web/live/organization_live/show.ex:767
+#: lib/vutuv_web/live/organization_live/show.ex:834
 #: lib/vutuv_web/templates/url/verify.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Website file"
@@ -11836,7 +11837,7 @@ msgstr "Website-Datei"
 msgid "Website file (.well-known)"
 msgstr "Website-Datei (.well-known)"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:472
+#: lib/vutuv_web/live/organization_live/edit.ex:476
 #, elixir-autogen, elixir-format
 msgid "You can only upload one logo."
 msgstr "Sie können nur ein Logo hochladen."
@@ -11849,7 +11850,7 @@ msgstr ""
 "die Kontrolle über die Domain nachzuweisen."
 
 #: lib/vutuv_web/live/organization_live/domains.ex:309
-#: lib/vutuv_web/live/organization_live/show.ex:797
+#: lib/vutuv_web/live/organization_live/show.ex:864
 #: lib/vutuv_web/templates/url/verify.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
@@ -11900,7 +11901,7 @@ msgstr "Alias entfernt."
 #: lib/vutuv_web/agent_docs/markdown.ex:358
 #: lib/vutuv_web/agent_docs/text.ex:381
 #: lib/vutuv_web/live/organization_live/edit.ex:353
-#: lib/vutuv_web/live/organization_live/show.ex:692
+#: lib/vutuv_web/live/organization_live/show.ex:759
 #: lib/vutuv_web/templates/tag/single_card.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Also known as"
@@ -11970,7 +11971,7 @@ msgstr "Domain verifiziert."
 #: lib/vutuv_web/components/organization_components.ex:212
 #: lib/vutuv_web/live/admin/organization_live.ex:305
 #: lib/vutuv_web/live/organization_live/domains.ex:161
-#: lib/vutuv_web/live/organization_live/show.ex:501
+#: lib/vutuv_web/live/organization_live/show.ex:510
 #, elixir-autogen, elixir-format
 msgid "Domains"
 msgstr "Domains"
@@ -12088,7 +12089,7 @@ msgstr "Name, Alias oder Domain suchen"
 #: lib/vutuv_web/components/organization_components.ex:209
 #: lib/vutuv_web/live/admin/organization_live.ex:321
 #: lib/vutuv_web/live/organization_live/roles.ex:165
-#: lib/vutuv_web/live/organization_live/show.ex:494
+#: lib/vutuv_web/live/organization_live/show.ex:503
 #, elixir-autogen, elixir-format
 msgid "Team"
 msgstr "Team"
@@ -12144,32 +12145,27 @@ msgstr "Straße und Hausnummer (optional)"
 msgid "ZIP / postal code (optional)"
 msgstr "PLZ (optional)"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:443
+#: lib/vutuv_web/live/organization_live/edit.ex:447
 #, elixir-autogen, elixir-format
 msgid "Claim"
 msgstr "Reservieren"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:412
+#: lib/vutuv_web/live/organization_live/edit.ex:416
 #, elixir-autogen, elixir-format
 msgid "Reachable at"
 msgstr "Erreichbar unter"
-
-#: lib/vutuv_web/live/organization_live/edit.ex:402
-#, elixir-autogen, elixir-format
-msgid "Root handle"
-msgstr "Handle"
 
 #: lib/vutuv_web/live/organization_live/edit.ex:203
 #, elixir-autogen, elixir-format
 msgid "That handle is not available."
 msgstr "Dieses Handle ist nicht verfügbar."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:449
+#: lib/vutuv_web/live/organization_live/edit.ex:453
 #, elixir-autogen, elixir-format
 msgid "Danger zone"
 msgstr "Gefahrenbereich"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:460
+#: lib/vutuv_web/live/organization_live/edit.ex:464
 #, elixir-autogen, elixir-format
 msgid "Really delete %{name}? This cannot be undone."
 msgstr "%{name} wirklich löschen? Das kann nicht rückgängig gemacht werden."
@@ -12278,7 +12274,7 @@ msgstr "verifizierte Webseite"
 msgid "%{min} to %{max} characters: letters (a-z), numbers (0-9) and underscores."
 msgstr "%{min} bis %{max} Zeichen: Buchstaben (a-z), Zahlen (0-9) und Unterstriche."
 
-#: lib/vutuv_web/live/organization_live/show.ex:623
+#: lib/vutuv_web/live/organization_live/show.ex:647
 #, elixir-autogen, elixir-format
 msgid "Former"
 msgstr "Ehemalig"
@@ -12376,11 +12372,6 @@ msgstr ""
 "Domain oder einer Subdomain davon liegt, wird ausgeschlossen. So verbergen "
 "Sie es zuverlässig vor Ihrer ganzen Organisation."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:404
-#, elixir-autogen, elixir-format
-msgid "Claim a short @handle so this organization has its own root URL, like a member profile. Letters, numbers and underscores, %{min} to %{max} characters."
-msgstr "Reservieren Sie ein kurzes @handle, damit diese Organisation wie ein Mitgliedsprofil eine eigene Root-URL bekommt. Buchstaben, Zahlen und Unterstriche, %{min} bis %{max} Zeichen."
-
 #: lib/vutuv_web/live/organization_live/index.ex:70
 #: lib/vutuv_web/live/organization_live/index.ex:101
 #: lib/vutuv_web/live/organization_live/new.ex:26
@@ -12410,17 +12401,17 @@ msgstr "Vielleicht brauchen Sie Hilfe von Ihrer IT"
 msgid "The proof is a small technical change to your domain: a DNS entry or a file on your website. If you don't manage the website yourself, ask the person or team who does. That is usually your IT department or the company that runs your website. We show the exact instructions on the next step, so you can simply pass them on."
 msgstr "Der Nachweis ist eine kleine technische Änderung an Ihrer Domain: ein DNS-Eintrag oder eine Datei auf Ihrer Website. Wenn Sie die Website nicht selbst verwalten, fragen Sie die Person oder das Team, das dies tut. Das ist meist Ihre IT-Abteilung oder die Firma, die Ihre Website betreut. Die genaue Anleitung zeigen wir Ihnen im nächsten Schritt, Sie können sie einfach weitergeben."
 
-#: lib/vutuv_web/live/organization_live/show.ex:738
+#: lib/vutuv_web/live/organization_live/show.ex:805
 #, elixir-autogen, elixir-format
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr "Diese Schritte sind technisch. Wenn Sie %{domain} nicht selbst verwalten, kopieren Sie den unten gezeigten Eintrag oder die Datei und senden Sie ihn an Ihre IT-Abteilung oder die Firma, die Ihre Website betreut. Sobald sie ihn hinzugefügt hat, kommen Sie hierher zurück und klicken auf „Jetzt verifizieren“."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:464
+#: lib/vutuv_web/live/organization_live/edit.ex:468
 #, elixir-autogen, elixir-format
 msgid "Delete this organization"
 msgstr "Diese Organisation löschen"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:451
+#: lib/vutuv_web/live/organization_live/edit.ex:455
 #, elixir-autogen, elixir-format
 msgid "Deleting this organization page is permanent. Its verified domains and its @handle are freed and can be claimed again."
 msgstr "Das Löschen dieser Organisationsseite ist endgültig. Ihre verifizierten Domains und ihr @handle werden freigegeben und können erneut beansprucht werden."
@@ -12529,7 +12520,7 @@ msgstr "Organisation wieder freigegeben."
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:501
-#: lib/vutuv_web/live/shell_live.ex:742
+#: lib/vutuv_web/live/shell_live.ex:750
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:83
@@ -12581,7 +12572,7 @@ msgstr "Dieser Name ist für diese Organisation bereits eingetragen."
 msgid "The organization page was deleted."
 msgstr "Die Organisationsseite wurde gelöscht."
 
-#: lib/vutuv_web/live/organization_live/show.ex:355
+#: lib/vutuv_web/live/organization_live/show.ex:364
 #, elixir-autogen, elixir-format
 msgid "This organization page was reported and is hidden while it is reviewed. Only you and the moderators can see it."
 msgstr ""
@@ -12617,7 +12608,7 @@ msgstr "Sie dürfen diese Organisation nicht löschen."
 msgid "Your organization handle is set."
 msgstr "Ihr Organisations-Handle ist gesetzt."
 
-#: lib/vutuv_web/live/organization_live/show.ex:281
+#: lib/vutuv_web/live/organization_live/show.ex:290
 #, elixir-autogen, elixir-format
 msgid "Your organization page is verified and now live."
 msgstr "Ihre Organisationsseite ist verifiziert und jetzt live."
@@ -12647,7 +12638,7 @@ msgstr "hat Sie zum Administrator von %{organization} gemacht."
 msgid "made you an owner of %{organization}."
 msgstr "hat Sie zum Besitzer von %{organization} gemacht."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:433
+#: lib/vutuv_web/live/organization_live/edit.ex:437
 #, elixir-autogen, elixir-format
 msgid "your_organization"
 msgstr "ihre_organisation"
@@ -12875,7 +12866,7 @@ msgstr "Stellenbezeichnung"
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:504
-#: lib/vutuv_web/live/shell_live.ex:574
+#: lib/vutuv_web/live/shell_live.ex:582
 #: lib/vutuv_web/templates/layout/app.html.heex:81
 #: lib/vutuv_web/templates/qualification/show.html.heex:38
 #, elixir-autogen, elixir-format
@@ -13322,13 +13313,13 @@ msgid "Getting an error, or is %{host} a CNAME / alias to another address? A TXT
 msgstr "Bekommen Sie einen Fehler, oder ist %{host} ein CNAME / Alias auf eine andere Adresse? Ein TXT-Eintrag kann nicht denselben Namen wie ein CNAME haben. Verwenden Sie stattdessen diesen Namen, mit exakt demselben Wert wie oben:"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:305
-#: lib/vutuv_web/live/organization_live/show.ex:784
+#: lib/vutuv_web/live/organization_live/show.ex:851
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr "Ist %{domain} ein CNAME / Alias (ein TXT-Eintrag kann nicht denselben Namen wie ein CNAME haben), legen Sie den Eintrag stattdessen auf %{name} an, mit demselben Wert."
 
 #: lib/vutuv_web/live/organization_live/domains.ex:303
-#: lib/vutuv_web/live/organization_live/show.ex:775
+#: lib/vutuv_web/live/organization_live/show.ex:842
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
 msgstr "Legen Sie in Ihren DNS-Einstellungen einen TXT-Eintrag auf dem Namen %{domain} mit diesem Wert an:"
@@ -13424,7 +13415,7 @@ msgid "Minimum yearly salary"
 msgstr "Mindestgehalt pro Jahr"
 
 #: lib/vutuv_web/live/job_board_live.ex:324
-#: lib/vutuv_web/live/organization_live/show.ex:650
+#: lib/vutuv_web/live/organization_live/show.ex:674
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr "Weitere Stellen"
@@ -13453,7 +13444,7 @@ msgstr "Keine passenden Stellen. Passen Sie die Filter an."
 #: lib/vutuv_web/agent_docs/markdown.ex:436
 #: lib/vutuv_web/agent_docs/text.ex:445
 #: lib/vutuv_web/agent_docs/text.ex:457
-#: lib/vutuv_web/live/organization_live/show.ex:637
+#: lib/vutuv_web/live/organization_live/show.ex:661
 #: lib/vutuv_web/templates/tag/show.html.heex:45
 #, elixir-autogen, elixir-format
 msgid "Open positions"
@@ -20856,33 +20847,33 @@ msgstr "Schreibt Beiträge im Namen der Organisation."
 msgid "The owner gives other members their roles on the page, and can hand ownership over to someone else at any time. Someone can hold several roles, and writing in the organization's name is always granted on its own."
 msgstr "Der Besitzer vergibt die Rollen der anderen Mitglieder auf der Seite und kann den Besitz jederzeit an jemand anderen übergeben. Jemand kann mehrere Rollen haben, und das Schreiben im Namen der Organisation wird immer einzeln vergeben."
 
-#: lib/vutuv_web/live/organization_live/show.ex:593
+#: lib/vutuv_web/live/organization_live/show.ex:617
 #, elixir-autogen, elixir-format
 msgid "Nothing published yet."
 msgstr "Noch nichts veröffentlicht."
 
-#: lib/vutuv_web/live/organization_live/show.ex:575
+#: lib/vutuv_web/live/organization_live/show.ex:599
 #: lib/vutuv_web/live/post_live/composer.ex:1814
 #, elixir-autogen, elixir-format
 msgid "Post as %{name}"
 msgstr "Als %{name} veröffentlichen"
 
-#: lib/vutuv_web/live/organization_live/show.ex:211
+#: lib/vutuv_web/live/organization_live/show.ex:220
 #, elixir-autogen, elixir-format
 msgid "Published as %{name}."
 msgstr "Als %{name} veröffentlicht."
 
-#: lib/vutuv_web/live/organization_live/show.ex:223
+#: lib/vutuv_web/live/organization_live/show.ex:232
 #, elixir-autogen, elixir-format
 msgid "That post could not be published."
 msgstr "Dieser Beitrag konnte nicht veröffentlicht werden."
 
-#: lib/vutuv_web/live/organization_live/show.ex:567
+#: lib/vutuv_web/live/organization_live/show.ex:591
 #, elixir-autogen, elixir-format
 msgid "Write something as %{name}"
 msgstr "Schreiben Sie etwas als %{name}"
 
-#: lib/vutuv_web/live/organization_live/show.ex:217
+#: lib/vutuv_web/live/organization_live/show.ex:226
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr "Sie dürfen nicht mehr im Namen dieser Organisation schreiben."
@@ -20892,7 +20883,7 @@ msgstr "Sie dürfen nicht mehr im Namen dieser Organisation schreiben."
 msgid "A post in an organization's name is always public."
 msgstr "Ein Beitrag im Namen einer Organisation ist immer öffentlich."
 
-#: lib/vutuv_web/live/shell_live.ex:506
+#: lib/vutuv_web/live/shell_live.ex:514
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr "Seite öffnen"
@@ -20907,12 +20898,12 @@ msgstr "Begonnen, im Namen einer Organisation zu schreiben"
 msgid "Stopped writing as an organization"
 msgstr "Beendet, im Namen einer Organisation zu schreiben"
 
-#: lib/vutuv_web/live/organization_live/show.ex:551
+#: lib/vutuv_web/live/organization_live/show.ex:575
 #, elixir-autogen, elixir-format
 msgid "Write as %{name} for now"
 msgstr "Vorerst als %{name} schreiben"
 
-#: lib/vutuv_web/live/shell_live.ex:516
+#: lib/vutuv_web/live/shell_live.ex:524
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr "Wieder als ich selbst schreiben"
@@ -21035,70 +21026,20 @@ msgstr "Was die Mitglieder und Organisationen veröffentlicht haben, denen diese
 msgid "Follows – %{name}"
 msgstr "Folgt – %{name}"
 
-#: lib/vutuv_web/live/organization_live/fediverse.ex:91
-#, elixir-autogen, elixir-format
-msgid "A handle is needed first"
-msgstr "Zuerst wird ein Handle gebraucht"
-
 #: lib/vutuv_web/live/organization_live/fediverse.ex:33
 #, elixir-autogen, elixir-format
 msgid "Fediverse – %{name}"
 msgstr "Fediverse – %{name}"
 
-#: lib/vutuv_web/live/organization_live/fediverse.ex:81
-#, elixir-autogen, elixir-format
-msgid "Let people on Mastodon and other networks follow this page and receive its posts."
-msgstr "Lassen Sie Leute auf Mastodon und anderen Netzwerken dieser Seite folgen und ihre Beiträge empfangen."
-
-#: lib/vutuv_web/live/organization_live/fediverse.ex:93
-#, elixir-autogen, elixir-format
-msgid "Out there this page is addressed by its handle, the way a member is. Claim one on the page settings, then come back."
-msgstr "Da draußen wird diese Seite über ihr Handle angesprochen, so wie ein Mitglied auch. Beanspruchen Sie eines in den Seiteneinstellungen und kommen Sie dann zurück."
-
-#: lib/vutuv_web/live/organization_live/fediverse.ex:99
+#: lib/vutuv_web/live/organization_live/fediverse.ex:113
 #, elixir-autogen, elixir-format
 msgid "Page settings"
 msgstr "Seiteneinstellungen"
 
-#: lib/vutuv_web/live/organization_live/fediverse.ex:134
-#, elixir-autogen, elixir-format
-msgid "Posts of this page will be sent to other servers from now on. Continue?"
-msgstr "Beiträge dieser Seite gehen ab jetzt an andere Server. Fortfahren?"
-
-#: lib/vutuv_web/live/organization_live/fediverse.ex:138
-#, elixir-autogen, elixir-format
-msgid "Start federating"
-msgstr "Föderieren starten"
-
-#: lib/vutuv_web/live/organization_live/fediverse.ex:138
-#, elixir-autogen, elixir-format
-msgid "Stop federating"
-msgstr "Föderieren beenden"
-
-#: lib/vutuv_web/live/organization_live/fediverse.ex:123
+#: lib/vutuv_web/live/organization_live/fediverse.ex:137
 #, elixir-autogen, elixir-format
 msgid "Switching this off stops new posts from leaving. Copies another server already holds can only be asked to delete them, never made to."
 msgstr "Das Ausschalten hält neue Beiträge zurück. Kopien, die ein anderer Server schon hat, kann man nur um Löschung bitten, nie dazu zwingen."
-
-#: lib/vutuv_web/live/organization_live/fediverse.ex:86
-#, elixir-autogen, elixir-format
-msgid "This installation has federation switched off, so nothing here has any effect."
-msgstr "Auf dieser Installation ist das Föderieren abgeschaltet, hier hat also nichts eine Wirkung."
-
-#: lib/vutuv_web/live/organization_live/fediverse.ex:146
-#, elixir-autogen, elixir-format
-msgid "This page federated before. Servers that still hold copies keep them until they act on a deletion request."
-msgstr "Diese Seite hat früher föderiert. Server, die noch Kopien halten, behalten sie, bis sie einer Löschbitte nachkommen."
-
-#: lib/vutuv_web/live/organization_live/fediverse.ex:111
-#, elixir-autogen, elixir-format
-msgid "This page is being federated. %{count} accounts on other networks follow it."
-msgstr "Diese Seite föderiert. %{count} Konten auf anderen Netzwerken folgen ihr."
-
-#: lib/vutuv_web/live/organization_live/fediverse.ex:115
-#, elixir-autogen, elixir-format
-msgid "This page is not being federated. Nothing of it is visible on other networks."
-msgstr "Diese Seite föderiert nicht. Nichts von ihr ist auf anderen Netzwerken sichtbar."
 
 #: lib/vutuv_web/live/organization_live/following.ex:206
 #, elixir-autogen, elixir-format
@@ -21160,3 +21101,74 @@ msgstr "Diese Adresse gehört zu diesem vutuv. Melden Sie sich an, dann können 
 #, elixir-autogen, elixir-format
 msgid "This page is not on the Fediverse."
 msgstr "Diese Seite ist nicht im Fediverse."
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:99
+#, elixir-autogen, elixir-format
+msgid "A short @name is needed first"
+msgstr "Zuerst wird ein kurzer @-Name gebraucht"
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:148
+#, elixir-autogen, elixir-format
+msgid "From now on, posts of this page also go to other networks. Continue?"
+msgstr "Beiträge dieser Seite gehen ab jetzt auch an andere Netzwerke. Fortfahren?"
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:104
+#, elixir-autogen, elixir-format
+msgid "Other networks address this page as @name@%{host}, the way they address a member. So it needs a short @name of its own first. Claim one in the page settings, then come back."
+msgstr "Andere Netzwerke sprechen diese Seite als @name@%{host} an, so wie sie ein Mitglied ansprechen. Dafür braucht sie zuerst einen kurzen @-Namen. Reservieren Sie einen in den Seiteneinstellungen und kommen Sie dann zurück."
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:87
+#: lib/vutuv_web/live/organization_live/show.ex:727
+#, elixir-autogen, elixir-format
+msgid "People who have no vutuv account can follow this page and read its posts, in networks like Mastodon."
+msgstr "Auch Menschen ohne vutuv-Konto können dieser Seite folgen und ihre Beiträge lesen, in Netzwerken wie Mastodon."
+
+#: lib/vutuv_web/live/organization_live/show.ex:741
+#, elixir-autogen, elixir-format
+msgid "Set this page up for other networks"
+msgstr "Seite für andere Netzwerke einrichten"
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:154
+#, elixir-autogen, elixir-format
+msgid "Switch it off"
+msgstr "Ausschalten"
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:154
+#, elixir-autogen, elixir-format
+msgid "Switch it on"
+msgstr "Einschalten"
+
+#: lib/vutuv_web/live/organization_live/show.ex:732
+#, elixir-autogen, elixir-format
+msgid "The page gets an address of its own for that, written like an email address."
+msgstr "Die Seite bekommt dafür eine eigene Adresse, die wie eine E-Mail-Adresse aussieht."
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:129
+#, elixir-autogen, elixir-format
+msgid "This page is not visible on other networks. Nothing of it leaves vutuv."
+msgstr "Diese Seite ist auf anderen Netzwerken nicht sichtbar. Nichts von ihr verlässt vutuv."
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:125
+#, elixir-autogen, elixir-format
+msgid "This page is visible on other networks. %{count} accounts there follow it."
+msgstr "Diese Seite ist auf anderen Netzwerken sichtbar. %{count} Konten dort folgen ihr."
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:162
+#, elixir-autogen, elixir-format
+msgid "This page was visible on other networks before. Servers that still hold copies keep them until they act on a deletion request."
+msgstr "Diese Seite war früher auf anderen Netzwerken sichtbar. Server, die noch Kopien halten, behalten sie, bis sie einer Löschbitte nachkommen."
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:94
+#, elixir-autogen, elixir-format
+msgid "This vutuv exchanges nothing with other networks, so nothing here has any effect."
+msgstr "Dieses vutuv tauscht nichts mit anderen Netzwerken aus, hier hat also nichts eine Wirkung."
+
+#: lib/vutuv_web/live/organization_live/edit.ex:408
+#, elixir-autogen, elixir-format
+msgid "Claim a short @name so this organization has an address of its own, like a member. Letters, numbers and underscores, %{min} to %{max} characters."
+msgstr "Reservieren Sie einen kurzen @-Namen, damit diese Organisation eine eigene Adresse bekommt, so wie ein Mitglied. Buchstaben, Zahlen und Unterstriche, %{min} bis %{max} Zeichen."
+
+#: lib/vutuv_web/live/organization_live/edit.ex:406
+#, elixir-autogen, elixir-format
+msgid "The organization's @name"
+msgstr "Der @-Name der Organisation"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -34,8 +34,8 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
-#: lib/vutuv_web/live/organization_live/fediverse.ex:104
-#: lib/vutuv_web/live/organization_live/show.ex:682
+#: lib/vutuv_web/live/organization_live/fediverse.ex:118
+#: lib/vutuv_web/live/organization_live/show.ex:749
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
@@ -216,7 +216,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
 #: lib/vutuv_web/live/job_posting_live/show.ex:178
-#: lib/vutuv_web/live/organization_live/show.ex:487
+#: lib/vutuv_web/live/organization_live/show.ex:496
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:7
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:19
@@ -333,7 +333,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:2014
 #: lib/vutuv_web/components/ui.ex:2072
 #: lib/vutuv_web/controllers/followee_controller.ex:29
-#: lib/vutuv_web/live/organization_live/show.ex:447
+#: lib/vutuv_web/live/organization_live/show.ex:456
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:53
 #: lib/vutuv_web/templates/user/show.html.heex:955
@@ -442,8 +442,8 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:789
-#: lib/vutuv_web/live/shell_live.ex:826
+#: lib/vutuv_web/live/shell_live.ex:797
+#: lib/vutuv_web/live/shell_live.ex:834
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -640,8 +640,8 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:42
 #: lib/vutuv_web/live/search_live.ex:399
-#: lib/vutuv_web/live/shell_live.ex:657
-#: lib/vutuv_web/live/shell_live.ex:809
+#: lib/vutuv_web/live/shell_live.ex:665
+#: lib/vutuv_web/live/shell_live.ex:817
 #: lib/vutuv_web/live/tag_live/timeline.ex:255
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
@@ -1160,7 +1160,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:761
+#: lib/vutuv_web/live/shell_live.ex:769
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1593,7 +1593,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:812
+#: lib/vutuv_web/live/shell_live.ex:820
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1689,8 +1689,8 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_following_live.ex:313
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:363
 #: lib/vutuv_web/live/organization_live/following.ex:218
-#: lib/vutuv_web/live/organization_live/show.ex:416
-#: lib/vutuv_web/live/organization_live/show.ex:445
+#: lib/vutuv_web/live/organization_live/show.ex:425
+#: lib/vutuv_web/live/organization_live/show.ex:454
 #: lib/vutuv_web/templates/user/show.html.heex:1269
 #, elixir-autogen, elixir-format
 msgid "Follow"
@@ -1706,7 +1706,7 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:780
+#: lib/vutuv_web/live/shell_live.ex:788
 #: lib/vutuv_web/views/settings_html.ex:261
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1727,7 +1727,7 @@ msgstr ""
 msgid "Member"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:466
+#: lib/vutuv_web/live/organization_live/show.ex:475
 #: lib/vutuv_web/templates/user/show.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Message"
@@ -1735,14 +1735,14 @@ msgstr ""
 
 #: lib/vutuv_web/live/message_live/index.ex:50
 #: lib/vutuv_web/live/message_live/index.ex:622
-#: lib/vutuv_web/live/shell_live.ex:673
-#: lib/vutuv_web/live/shell_live.ex:811
+#: lib/vutuv_web/live/shell_live.ex:681
+#: lib/vutuv_web/live/shell_live.ex:819
 #: lib/vutuv_web/templates/layout/app.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:567
+#: lib/vutuv_web/live/shell_live.ex:575
 #, elixir-autogen, elixir-format
 msgid "Network"
 msgstr ""
@@ -1766,7 +1766,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3714
 #: lib/vutuv_web/live/notification_live/index.ex:105
 #: lib/vutuv_web/live/notification_live/index.ex:329
-#: lib/vutuv_web/live/shell_live.ex:684
+#: lib/vutuv_web/live/shell_live.ex:692
 #: lib/vutuv_web/templates/layout/app.html.heex:124
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -1919,7 +1919,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3461
 #: lib/vutuv_web/live/organization_live/activity.ex:146
 #: lib/vutuv_web/live/organization_live/feed.ex:101
-#: lib/vutuv_web/live/organization_live/show.ex:598
+#: lib/vutuv_web/live/organization_live/show.ex:622
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr ""
@@ -2113,8 +2113,8 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/feed.ex:79
 #: lib/vutuv_web/live/post_live/feed.ex:158
 #: lib/vutuv_web/live/post_live/feed.ex:952
-#: lib/vutuv_web/live/shell_live.ex:547
-#: lib/vutuv_web/live/shell_live.ex:807
+#: lib/vutuv_web/live/shell_live.ex:555
+#: lib/vutuv_web/live/shell_live.ex:815
 #: lib/vutuv_web/templates/layout/app.html.heex:122
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2197,7 +2197,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:382
 #: lib/vutuv_web/live/notification_live/index.ex:882
-#: lib/vutuv_web/live/organization_live/show.ex:525
+#: lib/vutuv_web/live/organization_live/show.ex:549
 #: lib/vutuv_web/live/post_live/saved.ex:495
 #: lib/vutuv_web/live/search_live.ex:205
 #: lib/vutuv_web/live/search_live.ex:551
@@ -2285,7 +2285,7 @@ msgid "Upload failed."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3978
-#: lib/vutuv_web/live/shell_live.ex:727
+#: lib/vutuv_web/live/shell_live.ex:735
 #: lib/vutuv_web/templates/post/index.html.heex:17
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:208
@@ -2375,8 +2375,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:997
 #: lib/vutuv_web/live/post_live/saved.ex:175
 #: lib/vutuv_web/live/post_live/saved.ex:488
-#: lib/vutuv_web/live/shell_live.ex:666
-#: lib/vutuv_web/live/shell_live.ex:732
+#: lib/vutuv_web/live/shell_live.ex:674
+#: lib/vutuv_web/live/shell_live.ex:740
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2397,7 +2397,7 @@ msgstr ""
 #: lib/vutuv_web/live/notification_live/index.ex:962
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
-#: lib/vutuv_web/live/shell_live.ex:735
+#: lib/vutuv_web/live/shell_live.ex:743
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2460,7 +2460,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:2073
 #: lib/vutuv_web/live/organization_live/following.ex:197
 #: lib/vutuv_web/live/organization_live/following.ex:256
-#: lib/vutuv_web/live/organization_live/show.ex:450
+#: lib/vutuv_web/live/organization_live/show.ex:459
 #: lib/vutuv_web/live/post_live/feed.ex:1188
 #: lib/vutuv_web/templates/followee/index.html.heex:44
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
@@ -3143,8 +3143,8 @@ msgid "Private message"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3646
-#: lib/vutuv_web/live/shell_live.ex:560
-#: lib/vutuv_web/live/shell_live.ex:816
+#: lib/vutuv_web/live/shell_live.ex:568
+#: lib/vutuv_web/live/shell_live.ex:824
 #: lib/vutuv_web/templates/import/new.html.heex:15
 #: lib/vutuv_web/templates/import/preview.html.heex:55
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
@@ -3171,7 +3171,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1066
 #: lib/vutuv_web/components/post_components.ex:2042
 #: lib/vutuv_web/components/post_components.ex:2767
-#: lib/vutuv_web/live/organization_live/show.ex:508
+#: lib/vutuv_web/live/organization_live/show.ex:532
 #: lib/vutuv_web/templates/user/show.html.heex:219
 #, elixir-autogen, elixir-format
 msgid "Report"
@@ -4594,7 +4594,7 @@ msgstr ""
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:516
 #: lib/vutuv_web/live/notification_live/index.ex:883
-#: lib/vutuv_web/live/organization_live/show.ex:608
+#: lib/vutuv_web/live/organization_live/show.ex:632
 #: lib/vutuv_web/live/post_live/saved.ex:498
 #: lib/vutuv_web/live/search_live.ex:203
 #: lib/vutuv_web/live/search_live.ex:493
@@ -5303,7 +5303,7 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:714
+#: lib/vutuv_web/live/shell_live.ex:722
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
@@ -5325,7 +5325,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:771
+#: lib/vutuv_web/live/shell_live.ex:779
 #: lib/vutuv_web/templates/layout/app.html.heex:154
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5344,7 +5344,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:285
-#: lib/vutuv_web/live/shell_live.ex:751
+#: lib/vutuv_web/live/shell_live.ex:759
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5398,8 +5398,8 @@ msgstr ""
 msgid "Previous post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:540
-#: lib/vutuv_web/live/shell_live.ex:800
+#: lib/vutuv_web/live/shell_live.ex:548
+#: lib/vutuv_web/live/shell_live.ex:808
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -5468,7 +5468,7 @@ msgstr ""
 msgid "Account"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:443
+#: lib/vutuv_web/live/organization_live/edit.ex:447
 #, elixir-autogen, elixir-format
 msgid "Change"
 msgstr ""
@@ -8655,7 +8655,8 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_followers_live.ex:169
 #: lib/vutuv_web/live/fediverse_following_live.ex:286
 #: lib/vutuv_web/live/organization_live/fediverse.ex:79
-#: lib/vutuv_web/live/organization_live/show.ex:670
+#: lib/vutuv_web/live/organization_live/show.ex:525
+#: lib/vutuv_web/live/organization_live/show.ex:708
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:341
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:5
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
@@ -10245,7 +10246,7 @@ msgid_plural "%{count} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:474
+#: lib/vutuv_web/live/organization_live/show.ex:483
 #: lib/vutuv_web/views/user_html.ex:536
 #: lib/vutuv_web/views/user_html.ex:715
 #, elixir-autogen, elixir-format
@@ -11050,7 +11051,7 @@ msgstr ""
 msgid "AI agents"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:515
+#: lib/vutuv_web/live/organization_live/show.ex:539
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
@@ -11063,7 +11064,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:248
 #: lib/vutuv_web/live/organization_live/domains.ex:288
 #: lib/vutuv_web/live/organization_live/new.ex:146
-#: lib/vutuv_web/live/organization_live/show.ex:756
+#: lib/vutuv_web/live/organization_live/show.ex:823
 #: lib/vutuv_web/templates/url/verify.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "DNS TXT record"
@@ -11071,8 +11072,8 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:153
 #: lib/vutuv_web/live/organization_live/domains.ex:167
-#: lib/vutuv_web/live/organization_live/show.ex:348
-#: lib/vutuv_web/live/organization_live/show.ex:815
+#: lib/vutuv_web/live/organization_live/show.ex:357
+#: lib/vutuv_web/live/organization_live/show.ex:882
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr ""
@@ -11109,7 +11110,7 @@ msgstr ""
 msgid "Please log in first."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:729
+#: lib/vutuv_web/live/organization_live/show.ex:796
 #, elixir-autogen, elixir-format
 msgid "Prove you control %{domain} to publish this page."
 msgstr ""
@@ -11136,7 +11137,7 @@ msgid "Select a country"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:307
-#: lib/vutuv_web/live/organization_live/show.ex:791
+#: lib/vutuv_web/live/organization_live/show.ex:858
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr ""
@@ -11147,28 +11148,28 @@ msgstr ""
 msgid "State / region (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:473
+#: lib/vutuv_web/live/organization_live/edit.ex:477
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:471
+#: lib/vutuv_web/live/organization_live/edit.ex:475
 #, elixir-autogen, elixir-format
 msgid "The file is too large."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:474
+#: lib/vutuv_web/live/organization_live/edit.ex:478
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/new.ex:131
-#: lib/vutuv_web/live/organization_live/show.ex:744
+#: lib/vutuv_web/live/organization_live/show.ex:811
 #, elixir-autogen, elixir-format
 msgid "Verification method"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:704
+#: lib/vutuv_web/live/organization_live/show.ex:771
 #, elixir-autogen, elixir-format
 msgid "Verified domains"
 msgstr ""
@@ -11184,19 +11185,19 @@ msgstr ""
 msgid "Verified via %{domain}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:726
+#: lib/vutuv_web/live/organization_live/show.ex:793
 #, elixir-autogen, elixir-format
 msgid "Verify %{name}"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:320
-#: lib/vutuv_web/live/organization_live/show.ex:811
+#: lib/vutuv_web/live/organization_live/show.ex:878
 #, elixir-autogen, elixir-format
 msgid "Verify now"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:149
-#: lib/vutuv_web/live/organization_live/show.ex:343
+#: lib/vutuv_web/live/organization_live/show.ex:352
 #, elixir-autogen, elixir-format
 msgid "We could not find the record or file yet. It can take a while to propagate. Please try again."
 msgstr ""
@@ -11211,7 +11212,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:249
 #: lib/vutuv_web/live/organization_live/domains.ex:298
-#: lib/vutuv_web/live/organization_live/show.ex:767
+#: lib/vutuv_web/live/organization_live/show.ex:834
 #: lib/vutuv_web/templates/url/verify.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Website file"
@@ -11222,7 +11223,7 @@ msgstr ""
 msgid "Website file (.well-known)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:472
+#: lib/vutuv_web/live/organization_live/edit.ex:476
 #, elixir-autogen, elixir-format
 msgid "You can only upload one logo."
 msgstr ""
@@ -11233,7 +11234,7 @@ msgid "You will publish a record or file to prove control of the domain on the n
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:309
-#: lib/vutuv_web/live/organization_live/show.ex:797
+#: lib/vutuv_web/live/organization_live/show.ex:864
 #: lib/vutuv_web/templates/url/verify.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
@@ -11284,7 +11285,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:358
 #: lib/vutuv_web/agent_docs/text.ex:381
 #: lib/vutuv_web/live/organization_live/edit.ex:353
-#: lib/vutuv_web/live/organization_live/show.ex:692
+#: lib/vutuv_web/live/organization_live/show.ex:759
 #: lib/vutuv_web/templates/tag/single_card.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Also known as"
@@ -11350,7 +11351,7 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:212
 #: lib/vutuv_web/live/admin/organization_live.ex:305
 #: lib/vutuv_web/live/organization_live/domains.ex:161
-#: lib/vutuv_web/live/organization_live/show.ex:501
+#: lib/vutuv_web/live/organization_live/show.ex:510
 #, elixir-autogen, elixir-format
 msgid "Domains"
 msgstr ""
@@ -11466,7 +11467,7 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:209
 #: lib/vutuv_web/live/admin/organization_live.ex:321
 #: lib/vutuv_web/live/organization_live/roles.ex:165
-#: lib/vutuv_web/live/organization_live/show.ex:494
+#: lib/vutuv_web/live/organization_live/show.ex:503
 #, elixir-autogen, elixir-format
 msgid "Team"
 msgstr ""
@@ -11522,19 +11523,14 @@ msgstr ""
 msgid "ZIP / postal code (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:443
+#: lib/vutuv_web/live/organization_live/edit.ex:447
 #, elixir-autogen, elixir-format
 msgid "Claim"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:412
+#: lib/vutuv_web/live/organization_live/edit.ex:416
 #, elixir-autogen, elixir-format
 msgid "Reachable at"
-msgstr ""
-
-#: lib/vutuv_web/live/organization_live/edit.ex:402
-#, elixir-autogen, elixir-format
-msgid "Root handle"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:203
@@ -11542,12 +11538,12 @@ msgstr ""
 msgid "That handle is not available."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:449
+#: lib/vutuv_web/live/organization_live/edit.ex:453
 #, elixir-autogen, elixir-format
 msgid "Danger zone"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:460
+#: lib/vutuv_web/live/organization_live/edit.ex:464
 #, elixir-autogen, elixir-format
 msgid "Really delete %{name}? This cannot be undone."
 msgstr ""
@@ -11648,7 +11644,7 @@ msgstr ""
 msgid "%{min} to %{max} characters: letters (a-z), numbers (0-9) and underscores."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:623
+#: lib/vutuv_web/live/organization_live/show.ex:647
 #, elixir-autogen, elixir-format
 msgid "Former"
 msgstr ""
@@ -11724,11 +11720,6 @@ msgstr ""
 msgid "Any signed-in member whose confirmed email is at this domain, or a subdomain of it, is excluded. This is the reliable way to hide from your whole organization."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:404
-#, elixir-autogen, elixir-format
-msgid "Claim a short @handle so this organization has its own root URL, like a member profile. Letters, numbers and underscores, %{min} to %{max} characters."
-msgstr ""
-
 #: lib/vutuv_web/live/organization_live/index.ex:70
 #: lib/vutuv_web/live/organization_live/index.ex:101
 #: lib/vutuv_web/live/organization_live/new.ex:26
@@ -11758,17 +11749,17 @@ msgstr ""
 msgid "The proof is a small technical change to your domain: a DNS entry or a file on your website. If you don't manage the website yourself, ask the person or team who does. That is usually your IT department or the company that runs your website. We show the exact instructions on the next step, so you can simply pass them on."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:738
+#: lib/vutuv_web/live/organization_live/show.ex:805
 #, elixir-autogen, elixir-format
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:464
+#: lib/vutuv_web/live/organization_live/edit.ex:468
 #, elixir-autogen, elixir-format
 msgid "Delete this organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:451
+#: lib/vutuv_web/live/organization_live/edit.ex:455
 #, elixir-autogen, elixir-format
 msgid "Deleting this organization page is permanent. Its verified domains and its @handle are freed and can be claimed again."
 msgstr ""
@@ -11876,7 +11867,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:501
-#: lib/vutuv_web/live/shell_live.ex:742
+#: lib/vutuv_web/live/shell_live.ex:750
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:83
@@ -11926,7 +11917,7 @@ msgstr ""
 msgid "The organization page was deleted."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:355
+#: lib/vutuv_web/live/organization_live/show.ex:364
 #, elixir-autogen, elixir-format
 msgid "This organization page was reported and is hidden while it is reviewed. Only you and the moderators can see it."
 msgstr ""
@@ -11956,7 +11947,7 @@ msgstr ""
 msgid "Your organization handle is set."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:281
+#: lib/vutuv_web/live/organization_live/show.ex:290
 #, elixir-autogen, elixir-format
 msgid "Your organization page is verified and now live."
 msgstr ""
@@ -11986,7 +11977,7 @@ msgstr ""
 msgid "made you an owner of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:433
+#: lib/vutuv_web/live/organization_live/edit.ex:437
 #, elixir-autogen, elixir-format
 msgid "your_organization"
 msgstr ""
@@ -12209,7 +12200,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:504
-#: lib/vutuv_web/live/shell_live.ex:574
+#: lib/vutuv_web/live/shell_live.ex:582
 #: lib/vutuv_web/templates/layout/app.html.heex:81
 #: lib/vutuv_web/templates/qualification/show.html.heex:38
 #, elixir-autogen, elixir-format
@@ -12656,13 +12647,13 @@ msgid "Getting an error, or is %{host} a CNAME / alias to another address? A TXT
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:305
-#: lib/vutuv_web/live/organization_live/show.ex:784
+#: lib/vutuv_web/live/organization_live/show.ex:851
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:303
-#: lib/vutuv_web/live/organization_live/show.ex:775
+#: lib/vutuv_web/live/organization_live/show.ex:842
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
 msgstr ""
@@ -12758,7 +12749,7 @@ msgid "Minimum yearly salary"
 msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:324
-#: lib/vutuv_web/live/organization_live/show.ex:650
+#: lib/vutuv_web/live/organization_live/show.ex:674
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr ""
@@ -12787,7 +12778,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:436
 #: lib/vutuv_web/agent_docs/text.ex:445
 #: lib/vutuv_web/agent_docs/text.ex:457
-#: lib/vutuv_web/live/organization_live/show.ex:637
+#: lib/vutuv_web/live/organization_live/show.ex:661
 #: lib/vutuv_web/templates/tag/show.html.heex:45
 #, elixir-autogen, elixir-format
 msgid "Open positions"
@@ -20072,33 +20063,33 @@ msgstr ""
 msgid "The owner gives other members their roles on the page, and can hand ownership over to someone else at any time. Someone can hold several roles, and writing in the organization's name is always granted on its own."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:593
+#: lib/vutuv_web/live/organization_live/show.ex:617
 #, elixir-autogen, elixir-format
 msgid "Nothing published yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:575
+#: lib/vutuv_web/live/organization_live/show.ex:599
 #: lib/vutuv_web/live/post_live/composer.ex:1814
 #, elixir-autogen, elixir-format
 msgid "Post as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:211
+#: lib/vutuv_web/live/organization_live/show.ex:220
 #, elixir-autogen, elixir-format
 msgid "Published as %{name}."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:223
+#: lib/vutuv_web/live/organization_live/show.ex:232
 #, elixir-autogen, elixir-format
 msgid "That post could not be published."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:567
+#: lib/vutuv_web/live/organization_live/show.ex:591
 #, elixir-autogen, elixir-format
 msgid "Write something as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:217
+#: lib/vutuv_web/live/organization_live/show.ex:226
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr ""
@@ -20108,7 +20099,7 @@ msgstr ""
 msgid "A post in an organization's name is always public."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:506
+#: lib/vutuv_web/live/shell_live.ex:514
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr ""
@@ -20123,12 +20114,12 @@ msgstr ""
 msgid "Stopped writing as an organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:551
+#: lib/vutuv_web/live/organization_live/show.ex:575
 #, elixir-autogen, elixir-format
 msgid "Write as %{name} for now"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:516
+#: lib/vutuv_web/live/shell_live.ex:524
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr ""
@@ -20251,69 +20242,19 @@ msgstr ""
 msgid "Follows – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/fediverse.ex:91
-#, elixir-autogen, elixir-format
-msgid "A handle is needed first"
-msgstr ""
-
 #: lib/vutuv_web/live/organization_live/fediverse.ex:33
 #, elixir-autogen, elixir-format
 msgid "Fediverse – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/fediverse.ex:81
-#, elixir-autogen, elixir-format
-msgid "Let people on Mastodon and other networks follow this page and receive its posts."
-msgstr ""
-
-#: lib/vutuv_web/live/organization_live/fediverse.ex:93
-#, elixir-autogen, elixir-format
-msgid "Out there this page is addressed by its handle, the way a member is. Claim one on the page settings, then come back."
-msgstr ""
-
-#: lib/vutuv_web/live/organization_live/fediverse.ex:99
+#: lib/vutuv_web/live/organization_live/fediverse.ex:113
 #, elixir-autogen, elixir-format
 msgid "Page settings"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/fediverse.ex:134
-#, elixir-autogen, elixir-format
-msgid "Posts of this page will be sent to other servers from now on. Continue?"
-msgstr ""
-
-#: lib/vutuv_web/live/organization_live/fediverse.ex:138
-#, elixir-autogen, elixir-format
-msgid "Start federating"
-msgstr ""
-
-#: lib/vutuv_web/live/organization_live/fediverse.ex:138
-#, elixir-autogen, elixir-format
-msgid "Stop federating"
-msgstr ""
-
-#: lib/vutuv_web/live/organization_live/fediverse.ex:123
+#: lib/vutuv_web/live/organization_live/fediverse.ex:137
 #, elixir-autogen, elixir-format
 msgid "Switching this off stops new posts from leaving. Copies another server already holds can only be asked to delete them, never made to."
-msgstr ""
-
-#: lib/vutuv_web/live/organization_live/fediverse.ex:86
-#, elixir-autogen, elixir-format
-msgid "This installation has federation switched off, so nothing here has any effect."
-msgstr ""
-
-#: lib/vutuv_web/live/organization_live/fediverse.ex:146
-#, elixir-autogen, elixir-format
-msgid "This page federated before. Servers that still hold copies keep them until they act on a deletion request."
-msgstr ""
-
-#: lib/vutuv_web/live/organization_live/fediverse.ex:111
-#, elixir-autogen, elixir-format
-msgid "This page is being federated. %{count} accounts on other networks follow it."
-msgstr ""
-
-#: lib/vutuv_web/live/organization_live/fediverse.ex:115
-#, elixir-autogen, elixir-format
-msgid "This page is not being federated. Nothing of it is visible on other networks."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/following.ex:206
@@ -20375,4 +20316,75 @@ msgstr ""
 #: lib/vutuv_web/controllers/remote_follow_controller.ex:161
 #, elixir-autogen, elixir-format
 msgid "This page is not on the Fediverse."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:99
+#, elixir-autogen, elixir-format
+msgid "A short @name is needed first"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:148
+#, elixir-autogen, elixir-format
+msgid "From now on, posts of this page also go to other networks. Continue?"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:104
+#, elixir-autogen, elixir-format
+msgid "Other networks address this page as @name@%{host}, the way they address a member. So it needs a short @name of its own first. Claim one in the page settings, then come back."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:87
+#: lib/vutuv_web/live/organization_live/show.ex:727
+#, elixir-autogen, elixir-format
+msgid "People who have no vutuv account can follow this page and read its posts, in networks like Mastodon."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/show.ex:741
+#, elixir-autogen, elixir-format
+msgid "Set this page up for other networks"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:154
+#, elixir-autogen, elixir-format
+msgid "Switch it off"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:154
+#, elixir-autogen, elixir-format
+msgid "Switch it on"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/show.ex:732
+#, elixir-autogen, elixir-format
+msgid "The page gets an address of its own for that, written like an email address."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:129
+#, elixir-autogen, elixir-format
+msgid "This page is not visible on other networks. Nothing of it leaves vutuv."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:125
+#, elixir-autogen, elixir-format
+msgid "This page is visible on other networks. %{count} accounts there follow it."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:162
+#, elixir-autogen, elixir-format
+msgid "This page was visible on other networks before. Servers that still hold copies keep them until they act on a deletion request."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:94
+#, elixir-autogen, elixir-format
+msgid "This vutuv exchanges nothing with other networks, so nothing here has any effect."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/edit.ex:408
+#, elixir-autogen, elixir-format
+msgid "Claim a short @name so this organization has an address of its own, like a member. Letters, numbers and underscores, %{min} to %{max} characters."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/edit.ex:406
+#, elixir-autogen, elixir-format
+msgid "The organization's @name"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -32,8 +32,8 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
-#: lib/vutuv_web/live/organization_live/fediverse.ex:104
-#: lib/vutuv_web/live/organization_live/show.ex:682
+#: lib/vutuv_web/live/organization_live/fediverse.ex:118
+#: lib/vutuv_web/live/organization_live/show.ex:749
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
@@ -214,7 +214,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
 #: lib/vutuv_web/live/job_posting_live/show.ex:178
-#: lib/vutuv_web/live/organization_live/show.ex:487
+#: lib/vutuv_web/live/organization_live/show.ex:496
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:7
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:19
@@ -331,7 +331,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:2014
 #: lib/vutuv_web/components/ui.ex:2072
 #: lib/vutuv_web/controllers/followee_controller.ex:29
-#: lib/vutuv_web/live/organization_live/show.ex:447
+#: lib/vutuv_web/live/organization_live/show.ex:456
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:53
 #: lib/vutuv_web/templates/user/show.html.heex:955
@@ -440,8 +440,8 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:789
-#: lib/vutuv_web/live/shell_live.ex:826
+#: lib/vutuv_web/live/shell_live.ex:797
+#: lib/vutuv_web/live/shell_live.ex:834
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -638,8 +638,8 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:42
 #: lib/vutuv_web/live/search_live.ex:399
-#: lib/vutuv_web/live/shell_live.ex:657
-#: lib/vutuv_web/live/shell_live.ex:809
+#: lib/vutuv_web/live/shell_live.ex:665
+#: lib/vutuv_web/live/shell_live.ex:817
 #: lib/vutuv_web/live/tag_live/timeline.ex:255
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
@@ -1158,7 +1158,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:761
+#: lib/vutuv_web/live/shell_live.ex:769
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1591,7 +1591,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:812
+#: lib/vutuv_web/live/shell_live.ex:820
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1687,8 +1687,8 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_following_live.ex:313
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:363
 #: lib/vutuv_web/live/organization_live/following.ex:218
-#: lib/vutuv_web/live/organization_live/show.ex:416
-#: lib/vutuv_web/live/organization_live/show.ex:445
+#: lib/vutuv_web/live/organization_live/show.ex:425
+#: lib/vutuv_web/live/organization_live/show.ex:454
 #: lib/vutuv_web/templates/user/show.html.heex:1269
 #, elixir-autogen, elixir-format
 msgid "Follow"
@@ -1704,7 +1704,7 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:780
+#: lib/vutuv_web/live/shell_live.ex:788
 #: lib/vutuv_web/views/settings_html.ex:261
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1725,7 +1725,7 @@ msgstr ""
 msgid "Member"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:466
+#: lib/vutuv_web/live/organization_live/show.ex:475
 #: lib/vutuv_web/templates/user/show.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Message"
@@ -1733,14 +1733,14 @@ msgstr ""
 
 #: lib/vutuv_web/live/message_live/index.ex:50
 #: lib/vutuv_web/live/message_live/index.ex:622
-#: lib/vutuv_web/live/shell_live.ex:673
-#: lib/vutuv_web/live/shell_live.ex:811
+#: lib/vutuv_web/live/shell_live.ex:681
+#: lib/vutuv_web/live/shell_live.ex:819
 #: lib/vutuv_web/templates/layout/app.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:567
+#: lib/vutuv_web/live/shell_live.ex:575
 #, elixir-autogen, elixir-format
 msgid "Network"
 msgstr ""
@@ -1764,7 +1764,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3714
 #: lib/vutuv_web/live/notification_live/index.ex:105
 #: lib/vutuv_web/live/notification_live/index.ex:329
-#: lib/vutuv_web/live/shell_live.ex:684
+#: lib/vutuv_web/live/shell_live.ex:692
 #: lib/vutuv_web/templates/layout/app.html.heex:124
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -1917,7 +1917,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3461
 #: lib/vutuv_web/live/organization_live/activity.ex:146
 #: lib/vutuv_web/live/organization_live/feed.ex:101
-#: lib/vutuv_web/live/organization_live/show.ex:598
+#: lib/vutuv_web/live/organization_live/show.ex:622
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr ""
@@ -2111,8 +2111,8 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/feed.ex:79
 #: lib/vutuv_web/live/post_live/feed.ex:158
 #: lib/vutuv_web/live/post_live/feed.ex:952
-#: lib/vutuv_web/live/shell_live.ex:547
-#: lib/vutuv_web/live/shell_live.ex:807
+#: lib/vutuv_web/live/shell_live.ex:555
+#: lib/vutuv_web/live/shell_live.ex:815
 #: lib/vutuv_web/templates/layout/app.html.heex:122
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2195,7 +2195,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:382
 #: lib/vutuv_web/live/notification_live/index.ex:882
-#: lib/vutuv_web/live/organization_live/show.ex:525
+#: lib/vutuv_web/live/organization_live/show.ex:549
 #: lib/vutuv_web/live/post_live/saved.ex:495
 #: lib/vutuv_web/live/search_live.ex:205
 #: lib/vutuv_web/live/search_live.ex:551
@@ -2283,7 +2283,7 @@ msgid "Upload failed."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3978
-#: lib/vutuv_web/live/shell_live.ex:727
+#: lib/vutuv_web/live/shell_live.ex:735
 #: lib/vutuv_web/templates/post/index.html.heex:17
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:208
@@ -2373,8 +2373,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:997
 #: lib/vutuv_web/live/post_live/saved.ex:175
 #: lib/vutuv_web/live/post_live/saved.ex:488
-#: lib/vutuv_web/live/shell_live.ex:666
-#: lib/vutuv_web/live/shell_live.ex:732
+#: lib/vutuv_web/live/shell_live.ex:674
+#: lib/vutuv_web/live/shell_live.ex:740
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2395,7 +2395,7 @@ msgstr ""
 #: lib/vutuv_web/live/notification_live/index.ex:962
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
-#: lib/vutuv_web/live/shell_live.ex:735
+#: lib/vutuv_web/live/shell_live.ex:743
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2458,7 +2458,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:2073
 #: lib/vutuv_web/live/organization_live/following.ex:197
 #: lib/vutuv_web/live/organization_live/following.ex:256
-#: lib/vutuv_web/live/organization_live/show.ex:450
+#: lib/vutuv_web/live/organization_live/show.ex:459
 #: lib/vutuv_web/live/post_live/feed.ex:1188
 #: lib/vutuv_web/templates/followee/index.html.heex:44
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
@@ -3141,8 +3141,8 @@ msgid "Private message"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3646
-#: lib/vutuv_web/live/shell_live.ex:560
-#: lib/vutuv_web/live/shell_live.ex:816
+#: lib/vutuv_web/live/shell_live.ex:568
+#: lib/vutuv_web/live/shell_live.ex:824
 #: lib/vutuv_web/templates/import/new.html.heex:15
 #: lib/vutuv_web/templates/import/preview.html.heex:55
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
@@ -3169,7 +3169,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1066
 #: lib/vutuv_web/components/post_components.ex:2042
 #: lib/vutuv_web/components/post_components.ex:2767
-#: lib/vutuv_web/live/organization_live/show.ex:508
+#: lib/vutuv_web/live/organization_live/show.ex:532
 #: lib/vutuv_web/templates/user/show.html.heex:219
 #, elixir-autogen, elixir-format
 msgid "Report"
@@ -4592,7 +4592,7 @@ msgstr ""
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:516
 #: lib/vutuv_web/live/notification_live/index.ex:883
-#: lib/vutuv_web/live/organization_live/show.ex:608
+#: lib/vutuv_web/live/organization_live/show.ex:632
 #: lib/vutuv_web/live/post_live/saved.ex:498
 #: lib/vutuv_web/live/search_live.ex:203
 #: lib/vutuv_web/live/search_live.ex:493
@@ -5301,7 +5301,7 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:714
+#: lib/vutuv_web/live/shell_live.ex:722
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
@@ -5323,7 +5323,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:771
+#: lib/vutuv_web/live/shell_live.ex:779
 #: lib/vutuv_web/templates/layout/app.html.heex:154
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5342,7 +5342,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:285
-#: lib/vutuv_web/live/shell_live.ex:751
+#: lib/vutuv_web/live/shell_live.ex:759
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5396,8 +5396,8 @@ msgstr ""
 msgid "Previous post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:540
-#: lib/vutuv_web/live/shell_live.ex:800
+#: lib/vutuv_web/live/shell_live.ex:548
+#: lib/vutuv_web/live/shell_live.ex:808
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -5466,7 +5466,7 @@ msgstr ""
 msgid "Account"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:443
+#: lib/vutuv_web/live/organization_live/edit.ex:447
 #, elixir-autogen, elixir-format
 msgid "Change"
 msgstr ""
@@ -8653,7 +8653,8 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_followers_live.ex:169
 #: lib/vutuv_web/live/fediverse_following_live.ex:286
 #: lib/vutuv_web/live/organization_live/fediverse.ex:79
-#: lib/vutuv_web/live/organization_live/show.ex:670
+#: lib/vutuv_web/live/organization_live/show.ex:525
+#: lib/vutuv_web/live/organization_live/show.ex:708
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:341
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:5
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
@@ -10243,7 +10244,7 @@ msgid_plural "%{count} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:474
+#: lib/vutuv_web/live/organization_live/show.ex:483
 #: lib/vutuv_web/views/user_html.ex:536
 #: lib/vutuv_web/views/user_html.ex:715
 #, elixir-autogen, elixir-format
@@ -11048,7 +11049,7 @@ msgstr ""
 msgid "AI agents"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:515
+#: lib/vutuv_web/live/organization_live/show.ex:539
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
@@ -11061,7 +11062,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:248
 #: lib/vutuv_web/live/organization_live/domains.ex:288
 #: lib/vutuv_web/live/organization_live/new.ex:146
-#: lib/vutuv_web/live/organization_live/show.ex:756
+#: lib/vutuv_web/live/organization_live/show.ex:823
 #: lib/vutuv_web/templates/url/verify.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "DNS TXT record"
@@ -11069,8 +11070,8 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:153
 #: lib/vutuv_web/live/organization_live/domains.ex:167
-#: lib/vutuv_web/live/organization_live/show.ex:348
-#: lib/vutuv_web/live/organization_live/show.ex:815
+#: lib/vutuv_web/live/organization_live/show.ex:357
+#: lib/vutuv_web/live/organization_live/show.ex:882
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr ""
@@ -11107,7 +11108,7 @@ msgstr ""
 msgid "Please log in first."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:729
+#: lib/vutuv_web/live/organization_live/show.ex:796
 #, elixir-autogen, elixir-format
 msgid "Prove you control %{domain} to publish this page."
 msgstr ""
@@ -11134,7 +11135,7 @@ msgid "Select a country"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:307
-#: lib/vutuv_web/live/organization_live/show.ex:791
+#: lib/vutuv_web/live/organization_live/show.ex:858
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr ""
@@ -11145,28 +11146,28 @@ msgstr ""
 msgid "State / region (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:473
+#: lib/vutuv_web/live/organization_live/edit.ex:477
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:471
+#: lib/vutuv_web/live/organization_live/edit.ex:475
 #, elixir-autogen, elixir-format
 msgid "The file is too large."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:474
+#: lib/vutuv_web/live/organization_live/edit.ex:478
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/new.ex:131
-#: lib/vutuv_web/live/organization_live/show.ex:744
+#: lib/vutuv_web/live/organization_live/show.ex:811
 #, elixir-autogen, elixir-format
 msgid "Verification method"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:704
+#: lib/vutuv_web/live/organization_live/show.ex:771
 #, elixir-autogen, elixir-format
 msgid "Verified domains"
 msgstr ""
@@ -11182,19 +11183,19 @@ msgstr ""
 msgid "Verified via %{domain}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:726
+#: lib/vutuv_web/live/organization_live/show.ex:793
 #, elixir-autogen, elixir-format
 msgid "Verify %{name}"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:320
-#: lib/vutuv_web/live/organization_live/show.ex:811
+#: lib/vutuv_web/live/organization_live/show.ex:878
 #, elixir-autogen, elixir-format
 msgid "Verify now"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:149
-#: lib/vutuv_web/live/organization_live/show.ex:343
+#: lib/vutuv_web/live/organization_live/show.ex:352
 #, elixir-autogen, elixir-format
 msgid "We could not find the record or file yet. It can take a while to propagate. Please try again."
 msgstr ""
@@ -11209,7 +11210,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:249
 #: lib/vutuv_web/live/organization_live/domains.ex:298
-#: lib/vutuv_web/live/organization_live/show.ex:767
+#: lib/vutuv_web/live/organization_live/show.ex:834
 #: lib/vutuv_web/templates/url/verify.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Website file"
@@ -11220,7 +11221,7 @@ msgstr ""
 msgid "Website file (.well-known)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:472
+#: lib/vutuv_web/live/organization_live/edit.ex:476
 #, elixir-autogen, elixir-format
 msgid "You can only upload one logo."
 msgstr ""
@@ -11231,7 +11232,7 @@ msgid "You will publish a record or file to prove control of the domain on the n
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:309
-#: lib/vutuv_web/live/organization_live/show.ex:797
+#: lib/vutuv_web/live/organization_live/show.ex:864
 #: lib/vutuv_web/templates/url/verify.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
@@ -11282,7 +11283,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:358
 #: lib/vutuv_web/agent_docs/text.ex:381
 #: lib/vutuv_web/live/organization_live/edit.ex:353
-#: lib/vutuv_web/live/organization_live/show.ex:692
+#: lib/vutuv_web/live/organization_live/show.ex:759
 #: lib/vutuv_web/templates/tag/single_card.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Also known as"
@@ -11348,7 +11349,7 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:212
 #: lib/vutuv_web/live/admin/organization_live.ex:305
 #: lib/vutuv_web/live/organization_live/domains.ex:161
-#: lib/vutuv_web/live/organization_live/show.ex:501
+#: lib/vutuv_web/live/organization_live/show.ex:510
 #, elixir-autogen, elixir-format
 msgid "Domains"
 msgstr ""
@@ -11464,7 +11465,7 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:209
 #: lib/vutuv_web/live/admin/organization_live.ex:321
 #: lib/vutuv_web/live/organization_live/roles.ex:165
-#: lib/vutuv_web/live/organization_live/show.ex:494
+#: lib/vutuv_web/live/organization_live/show.ex:503
 #, elixir-autogen, elixir-format
 msgid "Team"
 msgstr ""
@@ -11520,19 +11521,14 @@ msgstr ""
 msgid "ZIP / postal code (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:443
+#: lib/vutuv_web/live/organization_live/edit.ex:447
 #, elixir-autogen, elixir-format
 msgid "Claim"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:412
+#: lib/vutuv_web/live/organization_live/edit.ex:416
 #, elixir-autogen, elixir-format
 msgid "Reachable at"
-msgstr ""
-
-#: lib/vutuv_web/live/organization_live/edit.ex:402
-#, elixir-autogen, elixir-format
-msgid "Root handle"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:203
@@ -11540,12 +11536,12 @@ msgstr ""
 msgid "That handle is not available."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:449
+#: lib/vutuv_web/live/organization_live/edit.ex:453
 #, elixir-autogen, elixir-format
 msgid "Danger zone"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:460
+#: lib/vutuv_web/live/organization_live/edit.ex:464
 #, elixir-autogen, elixir-format
 msgid "Really delete %{name}? This cannot be undone."
 msgstr ""
@@ -11646,7 +11642,7 @@ msgstr ""
 msgid "%{min} to %{max} characters: letters (a-z), numbers (0-9) and underscores."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:623
+#: lib/vutuv_web/live/organization_live/show.ex:647
 #, elixir-autogen, elixir-format
 msgid "Former"
 msgstr ""
@@ -11722,11 +11718,6 @@ msgstr ""
 msgid "Any signed-in member whose confirmed email is at this domain, or a subdomain of it, is excluded. This is the reliable way to hide from your whole organization."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:404
-#, elixir-autogen, elixir-format
-msgid "Claim a short @handle so this organization has its own root URL, like a member profile. Letters, numbers and underscores, %{min} to %{max} characters."
-msgstr ""
-
 #: lib/vutuv_web/live/organization_live/index.ex:70
 #: lib/vutuv_web/live/organization_live/index.ex:101
 #: lib/vutuv_web/live/organization_live/new.ex:26
@@ -11756,17 +11747,17 @@ msgstr ""
 msgid "The proof is a small technical change to your domain: a DNS entry or a file on your website. If you don't manage the website yourself, ask the person or team who does. That is usually your IT department or the company that runs your website. We show the exact instructions on the next step, so you can simply pass them on."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:738
+#: lib/vutuv_web/live/organization_live/show.ex:805
 #, elixir-autogen, elixir-format
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:464
+#: lib/vutuv_web/live/organization_live/edit.ex:468
 #, elixir-autogen, elixir-format
 msgid "Delete this organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:451
+#: lib/vutuv_web/live/organization_live/edit.ex:455
 #, elixir-autogen, elixir-format
 msgid "Deleting this organization page is permanent. Its verified domains and its @handle are freed and can be claimed again."
 msgstr ""
@@ -11874,7 +11865,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:501
-#: lib/vutuv_web/live/shell_live.ex:742
+#: lib/vutuv_web/live/shell_live.ex:750
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:83
@@ -11924,7 +11915,7 @@ msgstr ""
 msgid "The organization page was deleted."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:355
+#: lib/vutuv_web/live/organization_live/show.ex:364
 #, elixir-autogen, elixir-format
 msgid "This organization page was reported and is hidden while it is reviewed. Only you and the moderators can see it."
 msgstr ""
@@ -11954,7 +11945,7 @@ msgstr ""
 msgid "Your organization handle is set."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:281
+#: lib/vutuv_web/live/organization_live/show.ex:290
 #, elixir-autogen, elixir-format
 msgid "Your organization page is verified and now live."
 msgstr ""
@@ -11984,7 +11975,7 @@ msgstr ""
 msgid "made you an owner of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:433
+#: lib/vutuv_web/live/organization_live/edit.ex:437
 #, elixir-autogen, elixir-format
 msgid "your_organization"
 msgstr ""
@@ -12207,7 +12198,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:504
-#: lib/vutuv_web/live/shell_live.ex:574
+#: lib/vutuv_web/live/shell_live.ex:582
 #: lib/vutuv_web/templates/layout/app.html.heex:81
 #: lib/vutuv_web/templates/qualification/show.html.heex:38
 #, elixir-autogen, elixir-format
@@ -12654,13 +12645,13 @@ msgid "Getting an error, or is %{host} a CNAME / alias to another address? A TXT
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:305
-#: lib/vutuv_web/live/organization_live/show.ex:784
+#: lib/vutuv_web/live/organization_live/show.ex:851
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:303
-#: lib/vutuv_web/live/organization_live/show.ex:775
+#: lib/vutuv_web/live/organization_live/show.ex:842
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
 msgstr ""
@@ -12756,7 +12747,7 @@ msgid "Minimum yearly salary"
 msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:324
-#: lib/vutuv_web/live/organization_live/show.ex:650
+#: lib/vutuv_web/live/organization_live/show.ex:674
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr ""
@@ -12785,7 +12776,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:436
 #: lib/vutuv_web/agent_docs/text.ex:445
 #: lib/vutuv_web/agent_docs/text.ex:457
-#: lib/vutuv_web/live/organization_live/show.ex:637
+#: lib/vutuv_web/live/organization_live/show.ex:661
 #: lib/vutuv_web/templates/tag/show.html.heex:45
 #, elixir-autogen, elixir-format
 msgid "Open positions"
@@ -20070,33 +20061,33 @@ msgstr ""
 msgid "The owner gives other members their roles on the page, and can hand ownership over to someone else at any time. Someone can hold several roles, and writing in the organization's name is always granted on its own."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:593
+#: lib/vutuv_web/live/organization_live/show.ex:617
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing published yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:575
+#: lib/vutuv_web/live/organization_live/show.ex:599
 #: lib/vutuv_web/live/post_live/composer.ex:1814
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:211
+#: lib/vutuv_web/live/organization_live/show.ex:220
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Published as %{name}."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:223
+#: lib/vutuv_web/live/organization_live/show.ex:232
 #, elixir-autogen, elixir-format
 msgid "That post could not be published."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:567
+#: lib/vutuv_web/live/organization_live/show.ex:591
 #, elixir-autogen, elixir-format
 msgid "Write something as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:217
+#: lib/vutuv_web/live/organization_live/show.ex:226
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr ""
@@ -20106,7 +20097,7 @@ msgstr ""
 msgid "A post in an organization's name is always public."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:506
+#: lib/vutuv_web/live/shell_live.ex:514
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Open the page"
 msgstr ""
@@ -20121,12 +20112,12 @@ msgstr ""
 msgid "Stopped writing as an organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:551
+#: lib/vutuv_web/live/organization_live/show.ex:575
 #, elixir-autogen, elixir-format
 msgid "Write as %{name} for now"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:516
+#: lib/vutuv_web/live/shell_live.ex:524
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr ""
@@ -20249,69 +20240,19 @@ msgstr ""
 msgid "Follows – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/fediverse.ex:91
-#, elixir-autogen, elixir-format
-msgid "A handle is needed first"
-msgstr ""
-
 #: lib/vutuv_web/live/organization_live/fediverse.ex:33
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Fediverse – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/fediverse.ex:81
-#, elixir-autogen, elixir-format
-msgid "Let people on Mastodon and other networks follow this page and receive its posts."
-msgstr ""
-
-#: lib/vutuv_web/live/organization_live/fediverse.ex:93
-#, elixir-autogen, elixir-format
-msgid "Out there this page is addressed by its handle, the way a member is. Claim one on the page settings, then come back."
-msgstr ""
-
-#: lib/vutuv_web/live/organization_live/fediverse.ex:99
+#: lib/vutuv_web/live/organization_live/fediverse.ex:113
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Page settings"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/fediverse.ex:134
-#, elixir-autogen, elixir-format
-msgid "Posts of this page will be sent to other servers from now on. Continue?"
-msgstr ""
-
-#: lib/vutuv_web/live/organization_live/fediverse.ex:138
-#, elixir-autogen, elixir-format
-msgid "Start federating"
-msgstr ""
-
-#: lib/vutuv_web/live/organization_live/fediverse.ex:138
-#, elixir-autogen, elixir-format
-msgid "Stop federating"
-msgstr ""
-
-#: lib/vutuv_web/live/organization_live/fediverse.ex:123
+#: lib/vutuv_web/live/organization_live/fediverse.ex:137
 #, elixir-autogen, elixir-format
 msgid "Switching this off stops new posts from leaving. Copies another server already holds can only be asked to delete them, never made to."
-msgstr ""
-
-#: lib/vutuv_web/live/organization_live/fediverse.ex:86
-#, elixir-autogen, elixir-format
-msgid "This installation has federation switched off, so nothing here has any effect."
-msgstr ""
-
-#: lib/vutuv_web/live/organization_live/fediverse.ex:146
-#, elixir-autogen, elixir-format
-msgid "This page federated before. Servers that still hold copies keep them until they act on a deletion request."
-msgstr ""
-
-#: lib/vutuv_web/live/organization_live/fediverse.ex:111
-#, elixir-autogen, elixir-format
-msgid "This page is being federated. %{count} accounts on other networks follow it."
-msgstr ""
-
-#: lib/vutuv_web/live/organization_live/fediverse.ex:115
-#, elixir-autogen, elixir-format
-msgid "This page is not being federated. Nothing of it is visible on other networks."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/following.ex:206
@@ -20373,4 +20314,75 @@ msgstr ""
 #: lib/vutuv_web/controllers/remote_follow_controller.ex:161
 #, elixir-autogen, elixir-format, fuzzy
 msgid "This page is not on the Fediverse."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:99
+#, elixir-autogen, elixir-format
+msgid "A short @name is needed first"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:148
+#, elixir-autogen, elixir-format
+msgid "From now on, posts of this page also go to other networks. Continue?"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:104
+#, elixir-autogen, elixir-format
+msgid "Other networks address this page as @name@%{host}, the way they address a member. So it needs a short @name of its own first. Claim one in the page settings, then come back."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:87
+#: lib/vutuv_web/live/organization_live/show.ex:727
+#, elixir-autogen, elixir-format
+msgid "People who have no vutuv account can follow this page and read its posts, in networks like Mastodon."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/show.ex:741
+#, elixir-autogen, elixir-format
+msgid "Set this page up for other networks"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:154
+#, elixir-autogen, elixir-format
+msgid "Switch it off"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:154
+#, elixir-autogen, elixir-format
+msgid "Switch it on"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/show.ex:732
+#, elixir-autogen, elixir-format
+msgid "The page gets an address of its own for that, written like an email address."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:129
+#, elixir-autogen, elixir-format, fuzzy
+msgid "This page is not visible on other networks. Nothing of it leaves vutuv."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:125
+#, elixir-autogen, elixir-format, fuzzy
+msgid "This page is visible on other networks. %{count} accounts there follow it."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:162
+#, elixir-autogen, elixir-format
+msgid "This page was visible on other networks before. Servers that still hold copies keep them until they act on a deletion request."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:94
+#, elixir-autogen, elixir-format
+msgid "This vutuv exchanges nothing with other networks, so nothing here has any effect."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/edit.ex:408
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Claim a short @name so this organization has an address of its own, like a member. Letters, numbers and underscores, %{min} to %{max} characters."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/edit.ex:406
+#, elixir-autogen, elixir-format
+msgid "The organization's @name"
 msgstr ""

--- a/test/vutuv_web/organization_fediverse_card_test.exs
+++ b/test/vutuv_web/organization_fediverse_card_test.exs
@@ -29,6 +29,7 @@ defmodule VutuvWeb.OrganizationFediverseCardTest do
   @handle "#organization-fediverse-handle"
   @form "#remote-follow-form"
   @shortcut "#organization-fediverse-shortcut"
+  @invite "#organization-fediverse-enable"
 
   setup do
     Application.put_env(:vutuv, :verify_organization_domains, true)
@@ -88,6 +89,60 @@ defmodule VutuvWeb.OrganizationFediverseCardTest do
 
       refute has_element?(view, @card)
       refute has_element?(view, @shortcut)
+    end
+
+    test "invites the owner of a page that does not federate, and nobody else", %{conn: conn} do
+      {conn, owner} = create_and_login_user(conn)
+      page = active_organization_for(owner)
+
+      {:ok, view, _html} = live(conn, ~p"/organizations/#{page.slug}")
+
+      # The whole feature was unreachable: the switch lives behind the manage
+      # tab bar, which only renders on the manage pages themselves, and the
+      # page's own owner row named Edit / Team / Domains and nothing else. An
+      # owner had to click "Edit" and notice a tab to learn that their page can
+      # federate at all. So the empty section teaches it, the way every other
+      # empty section on this app teaches what goes in it.
+      assert has_element?(view, "#{@card} [data-empty-add]")
+      assert has_element?(view, @invite)
+      assert view |> element(@invite) |> render() =~ "/organizations/#{page.slug}/fediverse"
+
+      # And it is scaffolding for the owner, not something a visitor reads.
+      {:ok, visitor, _html} = live(build_conn(), ~p"/organizations/#{page.slug}")
+      refute has_element?(visitor, @card)
+    end
+
+    test "no invitation while the installation switch is off", %{conn: conn} do
+      {conn, owner} = create_and_login_user(conn)
+      page = active_organization_for(owner)
+      Application.put_env(:vutuv, :fediverse_enabled, false)
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_enabled) end)
+
+      {:ok, view, _html} = live(conn, ~p"/organizations/#{page.slug}")
+
+      # There is nothing to switch on: this installation exchanges nothing with
+      # other networks, and the switch page itself says so.
+      refute has_element?(view, @card)
+    end
+
+    test "the owner row on the page names the Fediverse", %{conn: conn} do
+      {conn, owner} = create_and_login_user(conn)
+      page = active_organization_for(owner)
+
+      {:ok, view, _html} = live(conn, ~p"/organizations/#{page.slug}")
+
+      # The row beside Edit / Team / Domains, so the switch is reachable from
+      # the top of the page too, not only from the card at its foot.
+      assert has_element?(view, ~s|#organization-manage-fediverse|)
+    end
+
+    test "the owner row keeps the Fediverse to the owner", %{conn: conn} do
+      {conn, _viewer} = create_and_login_user(conn)
+      page = active_organization_for(insert(:activated_user))
+
+      {:ok, view, _html} = live(conn, ~p"/organizations/#{page.slug}")
+
+      refute has_element?(view, ~s|#organization-manage-fediverse|)
     end
 
     test "is absent for a page that never claimed a handle", %{conn: conn} do
@@ -325,6 +380,27 @@ defmodule VutuvWeb.OrganizationFediverseCardTest do
       assert html =~ "Sie sind auf Mastodon oder in einer anderen Fediverse-App?"
       assert html =~ "Folgen Sie #{page.name} von dort aus"
       assert html =~ "Von Ihrem eigenen Server aus folgen"
+    end
+
+    test "the owner's invitation reads as German", %{conn: conn} do
+      {conn, owner} = create_and_login_user(conn)
+      page = active_organization_for(owner)
+
+      html =
+        conn
+        |> Phoenix.ConnTest.recycle()
+        |> put_req_header("accept-language", "de-DE,de")
+        |> get(~p"/organizations/#{page.slug}")
+        |> html_response(200)
+
+      # The offer leads with what it does for the organization (reach past
+      # vutuv), not with the name of a protocol. "Föderieren" is the word this
+      # path used to be written in and almost nobody outside the Fediverse knows
+      # it, so it is named here to keep it out.
+      assert html =~ "Seite für andere Netzwerke einrichten"
+      assert html =~ "Auch Menschen ohne vutuv-Konto können dieser Seite folgen"
+      assert html =~ "wie eine E-Mail-Adresse aussieht"
+      refute html =~ "öderier"
     end
 
     test "the refusal for a page that does not federate is German", %{conn: conn} do

--- a/test/vutuv_web/organization_fediverse_switch_test.exs
+++ b/test/vutuv_web/organization_fediverse_switch_test.exs
@@ -125,8 +125,14 @@ defmodule VutuvWeb.OrganizationFediverseSwitchTest do
       |> get(~p"/organizations/#{page.slug}/fediverse")
       |> html_response(200)
 
-    assert html =~ "Föderieren starten"
-    assert html =~ "Diese Seite föderiert nicht."
+    # The page is written for the owner of a company or an association, not for
+    # somebody who already knows the protocol: it says what this does for the
+    # organization (reach past vutuv) and never asks them to know the verb
+    # "föderieren", which is what every sentence here used to be built on.
+    assert html =~ "Auch Menschen ohne vutuv-Konto können dieser Seite folgen"
+    assert html =~ "Einschalten"
+    assert html =~ "Diese Seite ist auf anderen Netzwerken nicht sichtbar."
+    refute html =~ "öderier"
 
     # The merge filled this one from "Einstellungen durchsuchen" (search
     # settings) and "Fediverse" without the page name; both are named here so


### PR DESCRIPTION
**TL;DR** Der Schalter war nur aus der Reiterleiste verlinkt, die es nur auf den Verwaltungsseiten gibt — und die Texte dort waren auf dem Verb „föderieren" aufgebaut. Beides behoben.

**Wo:** `VutuvWeb.OrganizationLive.Show`, `VutuvWeb.OrganizationLive.Fediverse`, `VutuvWeb.OrganizationLive.Edit`.

### Auffindbarkeit

**Jetzt:** `/organizations/:slug/fediverse` war von **genau einer** Stelle verlinkt: der Reiterleiste der Verwaltungsseiten, die nur auf diesen Seiten selbst gerendert wird. Der Einstieg von der Seite aus nannte *Bearbeiten*, *Team*, *Domains*. Also: eine dieser drei öffnen und dann einen Reiter bemerken — sonst erfährt niemand, dass eine Seite im Fediverse sein kann. Fünf von acht Bereichen waren nur zufällig erreichbar.

**Danach:** zwei Wege, beide dort, wo ohnehin jemand hinschaut.

- Die Eigentümer-Zeile auf der Seite nennt jetzt auch **Fediverse**.
- Die **leere Fediverse-Karte** trägt für ihren Eigentümer die gestrichelte `<.empty_add>`-Einladung — dasselbe Muster, mit dem jeder leere Profilabschnitt erklärt, was hineingehört. Besucher sehen unverändert nichts.

⚠️ Stehende Gefahr, bewusst nicht hier gelöst: die Eigentümer-Zeile und die Reiterleiste sind **zwei handgepflegte Listen derselben Landkarte** und waren bereits auseinandergelaufen. Beide aus einer Quelle zu rendern ist die eigentliche Lösung, aber eine Navigationsänderung, die ich lieber vorher mit dir bespreche.

### Texte

Erreicht wird damit die Schriftführerin eines Vereins, nicht jemand, der das Protokoll kennt. Die Schalterseite war durchgehend auf **„föderieren"** aufgebaut („Föderieren starten", „Diese Seite föderiert nicht") — ein Wort, das es im normalen Sprachgebrauch nicht gibt.

Der ganze Weg beginnt jetzt mit dem Nutzen für die Organisation und benennt die Adresse über ihre Form statt über einen Fachbegriff:

| vorher | jetzt |
|---|---|
| „Lassen Sie Leute auf Mastodon und anderen Netzwerken dieser Seite folgen …" | „Auch Menschen ohne vutuv-Konto können dieser Seite folgen und ihre Beiträge lesen, in Netzwerken wie Mastodon." |
| „Diese Seite föderiert nicht." | „Diese Seite ist auf anderen Netzwerken nicht sichtbar. Nichts von ihr verlässt vutuv." |
| „Föderieren starten" / „Föderieren beenden" | „Einschalten" / „Ausschalten" |
| „Zuerst wird ein Handle gebraucht" | „Zuerst wird ein kurzer @-Name gebraucht" (+ die Adresse als `@name@vutuv.de` gezeigt) |
| „Root handle" (Bearbeiten-Formular) | „Der @-Name der Organisation" |

Einladung und Schalterseite teilen sich den ersten Satz als **eine msgid**, können also nicht auseinanderlaufen. **„Fediverse" bleibt** als Überschrift, Reiter und Abschnittsname: so heisst die Sache, und eine Stelle, die sie erklärt, ist besser, als sie zu verstecken und später unerklärt wiederzutreffen. „Root handle" ist mitgewandert, weil die Schalterseite genau dorthin schickt und eine Übergabe, die die Sache unterwegs umbenennt, die Stelle ist, an der Leute aufgeben.

Alle 14 deutschen Sätze von Hand geschrieben (zwei kamen wieder fuzzy mit der alten „föderiert"-Fassung zurück). Zwei Tests lesen die Seiten mit deutschem `Accept-Language` und lehnen `öderier` ausdrücklich ab.

Hot deploy, keine Migration. Version 7.270.0.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*