### PR TITLE
Beim Anlegen einer Organisation wird nach anderen Netzwerken gefragt (v7.271.0)

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -902,6 +902,21 @@ hazard: that owner row and the tab bar are two hand-kept lists of one map and
 they had already drifted. Rendering both from a single source is the real fix,
 and it is a nav change to agree on rather than to slip in.
 
+**The question is asked in the claim wizard, pre-ticked** (`/organizations/new`),
+which is the member sign-up's shape and the same reasoning: the switch page
+exists for changing the answer, not for discovering the question, and most pages
+want the reach. It is safe to ask that early although the page cannot federate
+yet — the box only records an intention, and `federated?/1` still wants a
+verified, publicly visible page with a claimed `@name`, so nothing about a
+pending page reaches another server.
+
+That makes `Organizations.claim_handle/2` the moment the intention turns real,
+and therefore the moment the **keypair** has to exist: it mints one when the page
+federates. This is the page half of the invariant the member sign-up wrote down —
+*any path that can set the opt-in owes an answer to "where does the key come
+from"* — and the cost of missing it is silent: the delivery worker **deletes**
+the activities of a keyless actor as undeliverable for good.
+
 **And the words had to change with it**, because the owner this now reaches is
 the secretary of a Verein, not somebody who knows the protocol. Every sentence on
 the switch page was built on the verb *federate* ("Föderieren starten", "Diese

--- a/lib/vutuv/organizations.ex
+++ b/lib/vutuv/organizations.ex
@@ -21,6 +21,7 @@ defmodule Vutuv.Organizations do
   alias Vutuv.Accounts
   alias Vutuv.Accounts.User
   alias Vutuv.Engagement
+  alias Vutuv.Fediverse
   alias Vutuv.Handles
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.Notifications.Emailer
@@ -861,6 +862,16 @@ defmodule Vutuv.Organizations do
     |> Repo.transaction()
     |> case do
       {:ok, %{organization: updated}} ->
+        # The @name is the last thing a page needs to federate, so claiming one
+        # is the moment a wizard opt-in becomes real — and the moment the
+        # keypair has to exist. A federating page without one has its deliveries
+        # deleted as undeliverable, with no error anywhere (the member twin of
+        # this is `Accounts.activate_user/1`, which mints on confirmation for
+        # the same reason). Minted here rather than lazily on the first request,
+        # so a remote server that resolves the handle a second later finds a
+        # complete actor instead of waiting on an RSA keygen.
+        if Fediverse.federated?(updated), do: Fediverse.ensure_organization_actor(updated)
+
         {:ok, updated}
 
       {:error, :organization, changeset, _} ->

--- a/lib/vutuv/organizations/organization.ex
+++ b/lib/vutuv/organizations/organization.ex
@@ -147,7 +147,13 @@ defmodule Vutuv.Organizations.Organization do
       :zip_code,
       :city,
       :state,
-      :country
+      :country,
+      # Asked in the claim wizard, pre-ticked (the member sign-up's shape). It
+      # only records the intention: `Fediverse.federated?/1` still wants a
+      # verified, publicly visible page with a claimed @name, so nothing about a
+      # pending page reaches another server. `Organizations.claim_handle/2` is
+      # where that intention turns real, and where the keypair is minted.
+      :fediverse_followers?
     ])
     |> validate_required([:name, :kind, :city, :country])
     |> shared_validations()

--- a/lib/vutuv_web/live/organization_live/new.ex
+++ b/lib/vutuv_web/live/organization_live/new.ex
@@ -12,7 +12,9 @@ defmodule VutuvWeb.OrganizationLive.New do
   import VutuvWeb.OrganizationComponents
 
   alias Vutuv.Countries
+  alias Vutuv.Fediverse
   alias Vutuv.Organizations
+  alias Vutuv.Organizations.Organization
   alias VutuvWeb.Live.InitAssigns
 
   @impl true
@@ -26,7 +28,12 @@ defmodule VutuvWeb.OrganizationLive.New do
       |> assign(:page_title, gettext("Add your organization"))
       |> assign(:method, "dns")
       |> assign(:countries, Countries.select_options(locale))
-      |> assign_form(Organizations.change_new_organization())
+      # The Fediverse box starts ticked, and it starts ticked from the STRUCT
+      # rather than from a `checked` attribute in the markup: a `phx-change`
+      # re-render reads the form's own value, so a default that lives only in
+      # the template would tick itself again the moment the member unticks it
+      # and types one more character.
+      |> assign_form(fediverse_default_changeset())
 
     {:ok, socket}
   end
@@ -71,6 +78,14 @@ defmodule VutuvWeb.OrganizationLive.New do
     socket
     |> assign(:changeset, changeset)
     |> assign(:form, to_form(changeset, as: :organization))
+  end
+
+  # The empty form, with participation pre-selected where the installation
+  # federates at all (`Fediverse.enabled?()` false leaves the question out of the
+  # markup too, so the value it carries never reaches anybody).
+  defp fediverse_default_changeset do
+    %Organization{fediverse_followers?: Fediverse.enabled?()}
+    |> Organization.create_changeset(%{})
   end
 
   @impl true
@@ -157,6 +172,49 @@ defmodule VutuvWeb.OrganizationLive.New do
               /> {gettext("Website file (.well-known)")}
             </label>
           </div>
+        </fieldset>
+
+        <%!-- The Fediverse question, asked at the one moment somebody is already
+        deciding what this page is. It used to be asked nowhere: the switch sat
+        behind the manage tab bar, which only renders on the manage pages, so a
+        page owner had to go looking for something they had no reason to know
+        existed. Pre-ticked, like the member sign-up's box, because reach beyond
+        vutuv is what most pages want and the answer is reversible at any time.
+
+        It is safe to ask this early although the page cannot federate yet: the
+        box records an intention, and `Fediverse.federated?/1` still wants a
+        verified, publicly visible page with a claimed @name, so nothing about a
+        pending page reaches another server. `Organizations.claim_handle/2` is
+        where the intention turns real and the keypair is minted. Left out
+        entirely where the installation federates nothing. --%>
+        <fieldset :if={Fediverse.enabled?()}>
+          <legend class="text-sm font-semibold text-slate-700 dark:text-slate-200">
+            {gettext("Other networks")}
+          </legend>
+          <label class="mt-2 flex items-start gap-2 text-sm font-normal text-slate-700 dark:text-slate-300">
+            <input
+              type="hidden"
+              name="organization[fediverse_followers?]"
+              value="false"
+            />
+            <input
+              type="checkbox"
+              id="organization-fediverse-optin"
+              name="organization[fediverse_followers?]"
+              value="true"
+              checked={Phoenix.HTML.Form.normalize_value("checkbox", @form[:fediverse_followers?].value)}
+              class={checkbox_class()}
+            />
+            <span>
+              {gettext("Let people follow this page from other networks")}
+              <span class="mt-0.5 block text-xs text-slate-600 dark:text-slate-400">
+                {gettext(
+                  "People who have no vutuv account can follow this page and read its posts, in networks like Mastodon."
+                )}
+                {gettext("You can change this at any time on the page's Fediverse settings.")}
+              </span>
+            </span>
+          </label>
         </fieldset>
 
         <div class="flex items-center gap-3 pt-2">

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.270.0",
+      version: "7.271.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -115,7 +115,7 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
 #: lib/vutuv_web/live/job_posting_live/form.ex:605
 #: lib/vutuv_web/live/organization_live/edit.ex:347
-#: lib/vutuv_web/live/organization_live/new.ex:173
+#: lib/vutuv_web/live/organization_live/new.ex:231
 #: lib/vutuv_web/live/post_live/composer.ex:1370
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
@@ -1592,7 +1592,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:360
 #: lib/vutuv_web/live/job_posting_live/form.ex:410
 #: lib/vutuv_web/live/organization_live/edit.ex:296
-#: lib/vutuv_web/live/organization_live/new.ex:127
+#: lib/vutuv_web/live/organization_live/new.ex:142
 #: lib/vutuv_web/templates/ad/new.html.heex:114
 #: lib/vutuv_web/templates/address/country_input.html.heex:5
 #: lib/vutuv_web/templates/welcome/show.html.heex:80
@@ -4175,7 +4175,7 @@ msgstr "Für die Buchung ist ein vutuv-Login erforderlich."
 #: lib/vutuv_web/live/admin/organization_live.ex:245
 #: lib/vutuv_web/live/job_posting_live/form.ex:404
 #: lib/vutuv_web/live/organization_live/edit.ex:292
-#: lib/vutuv_web/live/organization_live/new.ex:123
+#: lib/vutuv_web/live/organization_live/new.ex:138
 #: lib/vutuv_web/templates/ad/new.html.heex:108
 #: lib/vutuv_web/templates/address/form_en.html.heex:33
 #: lib/vutuv_web/templates/address/form_generic.html.heex:38
@@ -11665,14 +11665,14 @@ msgstr "KI-Agenten"
 msgid "About"
 msgstr "Über die Organisation"
 
-#: lib/vutuv_web/live/organization_live/new.ex:167
+#: lib/vutuv_web/live/organization_live/new.ex:225
 #, elixir-autogen, elixir-format
 msgid "Continue to verification"
 msgstr "Weiter zur Verifizierung"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:248
 #: lib/vutuv_web/live/organization_live/domains.ex:288
-#: lib/vutuv_web/live/organization_live/new.ex:146
+#: lib/vutuv_web/live/organization_live/new.ex:161
 #: lib/vutuv_web/live/organization_live/show.ex:823
 #: lib/vutuv_web/templates/url/verify.html.heex:46
 #, elixir-autogen, elixir-format
@@ -11755,7 +11755,7 @@ msgid "Serve this file at:"
 msgstr "Stellen Sie diese Datei bereit unter:"
 
 #: lib/vutuv_web/live/organization_live/edit.ex:293
-#: lib/vutuv_web/live/organization_live/new.ex:124
+#: lib/vutuv_web/live/organization_live/new.ex:139
 #, elixir-autogen, elixir-format
 msgid "State / region (optional)"
 msgstr "Bundesland / Region (optional)"
@@ -11775,7 +11775,7 @@ msgstr "Die Datei ist zu groß."
 msgid "The upload failed."
 msgstr "Der Upload ist fehlgeschlagen."
 
-#: lib/vutuv_web/live/organization_live/new.ex:131
+#: lib/vutuv_web/live/organization_live/new.ex:146
 #: lib/vutuv_web/live/organization_live/show.ex:811
 #, elixir-autogen, elixir-format
 msgid "Verification method"
@@ -11819,7 +11819,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:243
 #: lib/vutuv_web/agent_docs/text.ex:227
 #: lib/vutuv_web/live/organization_live/edit.ex:287
-#: lib/vutuv_web/live/organization_live/new.ex:115
+#: lib/vutuv_web/live/organization_live/new.ex:130
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr "Website"
@@ -11832,7 +11832,7 @@ msgstr "Website"
 msgid "Website file"
 msgstr "Website-Datei"
 
-#: lib/vutuv_web/live/organization_live/new.ex:157
+#: lib/vutuv_web/live/organization_live/new.ex:172
 #, elixir-autogen, elixir-format
 msgid "Website file (.well-known)"
 msgstr "Website-Datei (.well-known)"
@@ -11842,7 +11842,7 @@ msgstr "Website-Datei (.well-known)"
 msgid "You can only upload one logo."
 msgstr "Sie können nur ein Logo hochladen."
 
-#: lib/vutuv_web/live/organization_live/new.ex:134
+#: lib/vutuv_web/live/organization_live/new.ex:149
 #, elixir-autogen, elixir-format
 msgid "You will publish a record or file to prove control of the domain on the next step."
 msgstr ""
@@ -12134,13 +12134,13 @@ msgid "verified"
 msgstr "verifiziert"
 
 #: lib/vutuv_web/live/organization_live/edit.ex:290
-#: lib/vutuv_web/live/organization_live/new.ex:121
+#: lib/vutuv_web/live/organization_live/new.ex:136
 #, elixir-autogen, elixir-format
 msgid "Street address (optional)"
 msgstr "Straße und Hausnummer (optional)"
 
 #: lib/vutuv_web/live/organization_live/edit.ex:291
-#: lib/vutuv_web/live/organization_live/new.ex:122
+#: lib/vutuv_web/live/organization_live/new.ex:137
 #, elixir-autogen, elixir-format
 msgid "ZIP / postal code (optional)"
 msgstr "PLZ (optional)"
@@ -12359,7 +12359,7 @@ msgstr ""
 "Eine Organisation muss mindestens einen Besitzer behalten, daher kann der "
 "letzte Besitzer nicht geändert werden."
 
-#: lib/vutuv_web/live/organization_live/new.ex:82
+#: lib/vutuv_web/live/organization_live/new.ex:97
 #, elixir-autogen, elixir-format
 msgid "Create a verified page for your company, association, school or public authority."
 msgstr "Erstellen Sie eine verifizierte Seite für Ihr Unternehmen, Ihren Verein, Ihre Schule oder Behörde."
@@ -12374,29 +12374,29 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/index.ex:70
 #: lib/vutuv_web/live/organization_live/index.ex:101
-#: lib/vutuv_web/live/organization_live/new.ex:26
-#: lib/vutuv_web/live/organization_live/new.ex:80
+#: lib/vutuv_web/live/organization_live/new.ex:28
+#: lib/vutuv_web/live/organization_live/new.ex:95
 #: lib/vutuv_web/templates/settings/organizations.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Add your organization"
 msgstr "Ihre Organisation hinzufügen"
 
-#: lib/vutuv_web/live/organization_live/new.ex:91
+#: lib/vutuv_web/live/organization_live/new.ex:106
 #, elixir-autogen, elixir-format
 msgid "Why we ask you to verify"
 msgstr "Warum wir eine Verifizierung verlangen"
 
-#: lib/vutuv_web/live/organization_live/new.ex:94
+#: lib/vutuv_web/live/organization_live/new.ex:109
 #, elixir-autogen, elixir-format
 msgid "So visitors can trust the page. We only publish it once you prove that you control the organization's web domain, so nobody can put up a page that pretends to be your organization."
 msgstr "Damit Besucher der Seite vertrauen können. Wir veröffentlichen sie erst, wenn Sie nachweisen, dass Ihnen die Web-Domain der Organisation gehört. So kann niemand eine Seite erstellen, die sich für Ihre Organisation ausgibt."
 
-#: lib/vutuv_web/live/organization_live/new.ex:99
+#: lib/vutuv_web/live/organization_live/new.ex:114
 #, elixir-autogen, elixir-format
 msgid "You might need help from your admin"
 msgstr "Vielleicht brauchen Sie Hilfe von Ihrer IT"
 
-#: lib/vutuv_web/live/organization_live/new.ex:102
+#: lib/vutuv_web/live/organization_live/new.ex:117
 #, elixir-autogen, elixir-format
 msgid "The proof is a small technical change to your domain: a DNS entry or a file on your website. If you don't manage the website yourself, ask the person or team who does. That is usually your IT department or the company that runs your website. We show the exact instructions on the next step, so you can simply pass them on."
 msgstr "Der Nachweis ist eine kleine technische Änderung an Ihrer Domain: ein DNS-Eintrag oder eine Datei auf Ihrer Website. Wenn Sie die Website nicht selbst verwalten, fragen Sie die Person oder das Team, das dies tut. Das ist meist Ihre IT-Abteilung oder die Firma, die Ihre Website betreut. Die genaue Anleitung zeigen wir Ihnen im nächsten Schritt, Sie können sie einfach weitergeben."
@@ -12417,7 +12417,7 @@ msgid "Deleting this organization page is permanent. Its verified domains and it
 msgstr "Das Löschen dieser Organisationsseite ist endgültig. Ihre verifizierten Domains und ihr @handle werden freigegeben und können erneut beansprucht werden."
 
 #: lib/vutuv_web/live/organization_live/edit.ex:268
-#: lib/vutuv_web/live/organization_live/new.ex:111
+#: lib/vutuv_web/live/organization_live/new.ex:126
 #, elixir-autogen, elixir-format
 msgid "Kind of organization"
 msgstr "Art der Organisation"
@@ -12484,7 +12484,7 @@ msgid "Organization frozen."
 msgstr "Organisation eingefroren."
 
 #: lib/vutuv_web/live/organization_live/edit.ex:267
-#: lib/vutuv_web/live/organization_live/new.ex:110
+#: lib/vutuv_web/live/organization_live/new.ex:125
 #, elixir-autogen, elixir-format
 msgid "Organization name"
 msgstr "Name der Organisation"
@@ -12557,7 +12557,7 @@ msgstr "Organisationen durchsuchen"
 msgid "That domain already belongs to an organization page."
 msgstr "Diese Domain gehört bereits zu einer anderen Organisationsseite."
 
-#: lib/vutuv_web/live/organization_live/new.ex:59
+#: lib/vutuv_web/live/organization_live/new.ex:66
 #, elixir-autogen, elixir-format
 msgid "That domain already belongs to another organization page."
 msgstr "Diese Domain gehört bereits zu einer anderen Organisationsseite."
@@ -18780,6 +18780,7 @@ msgstr "Dazu haben Sie nichts aus anderen Netzwerken gespeichert."
 msgid "Nothing saved from other networks yet. The bookmark on a post or reply from another network keeps it here."
 msgstr "Noch nichts aus anderen Netzwerken gespeichert. Das Lesezeichen an einem Beitrag oder einer Antwort aus einem anderen Netzwerk hebt ihn hier auf."
 
+#: lib/vutuv_web/live/organization_live/new.ex:192
 #: lib/vutuv_web/live/post_live/saved.ex:515
 #, elixir-autogen, elixir-format
 msgid "Other networks"
@@ -21118,6 +21119,7 @@ msgid "Other networks address this page as @name@%{host}, the way they address a
 msgstr "Andere Netzwerke sprechen diese Seite als @name@%{host} an, so wie sie ein Mitglied ansprechen. Dafür braucht sie zuerst einen kurzen @-Namen. Reservieren Sie einen in den Seiteneinstellungen und kommen Sie dann zurück."
 
 #: lib/vutuv_web/live/organization_live/fediverse.ex:87
+#: lib/vutuv_web/live/organization_live/new.ex:211
 #: lib/vutuv_web/live/organization_live/show.ex:727
 #, elixir-autogen, elixir-format
 msgid "People who have no vutuv account can follow this page and read its posts, in networks like Mastodon."
@@ -21172,3 +21174,13 @@ msgstr "Reservieren Sie einen kurzen @-Namen, damit diese Organisation eine eige
 #, elixir-autogen, elixir-format
 msgid "The organization's @name"
 msgstr "Der @-Name der Organisation"
+
+#: lib/vutuv_web/live/organization_live/new.ex:209
+#, elixir-autogen, elixir-format
+msgid "Let people follow this page from other networks"
+msgstr "Dieser Seite darf man aus anderen Netzwerken folgen"
+
+#: lib/vutuv_web/live/organization_live/new.ex:214
+#, elixir-autogen, elixir-format
+msgid "You can change this at any time on the page's Fediverse settings."
+msgstr "Sie können das jederzeit in den Fediverse-Einstellungen der Seite ändern."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -117,7 +117,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
 #: lib/vutuv_web/live/job_posting_live/form.ex:605
 #: lib/vutuv_web/live/organization_live/edit.ex:347
-#: lib/vutuv_web/live/organization_live/new.ex:173
+#: lib/vutuv_web/live/organization_live/new.ex:231
 #: lib/vutuv_web/live/post_live/composer.ex:1370
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
@@ -1560,7 +1560,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:360
 #: lib/vutuv_web/live/job_posting_live/form.ex:410
 #: lib/vutuv_web/live/organization_live/edit.ex:296
-#: lib/vutuv_web/live/organization_live/new.ex:127
+#: lib/vutuv_web/live/organization_live/new.ex:142
 #: lib/vutuv_web/templates/ad/new.html.heex:114
 #: lib/vutuv_web/templates/address/country_input.html.heex:5
 #: lib/vutuv_web/templates/welcome/show.html.heex:80
@@ -4045,7 +4045,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/organization_live.ex:245
 #: lib/vutuv_web/live/job_posting_live/form.ex:404
 #: lib/vutuv_web/live/organization_live/edit.ex:292
-#: lib/vutuv_web/live/organization_live/new.ex:123
+#: lib/vutuv_web/live/organization_live/new.ex:138
 #: lib/vutuv_web/templates/ad/new.html.heex:108
 #: lib/vutuv_web/templates/address/form_en.html.heex:33
 #: lib/vutuv_web/templates/address/form_generic.html.heex:38
@@ -11056,14 +11056,14 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/new.ex:167
+#: lib/vutuv_web/live/organization_live/new.ex:225
 #, elixir-autogen, elixir-format
 msgid "Continue to verification"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:248
 #: lib/vutuv_web/live/organization_live/domains.ex:288
-#: lib/vutuv_web/live/organization_live/new.ex:146
+#: lib/vutuv_web/live/organization_live/new.ex:161
 #: lib/vutuv_web/live/organization_live/show.ex:823
 #: lib/vutuv_web/templates/url/verify.html.heex:46
 #, elixir-autogen, elixir-format
@@ -11143,7 +11143,7 @@ msgid "Serve this file at:"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:293
-#: lib/vutuv_web/live/organization_live/new.ex:124
+#: lib/vutuv_web/live/organization_live/new.ex:139
 #, elixir-autogen, elixir-format
 msgid "State / region (optional)"
 msgstr ""
@@ -11163,7 +11163,7 @@ msgstr ""
 msgid "The upload failed."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/new.ex:131
+#: lib/vutuv_web/live/organization_live/new.ex:146
 #: lib/vutuv_web/live/organization_live/show.ex:811
 #, elixir-autogen, elixir-format
 msgid "Verification method"
@@ -11205,7 +11205,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:243
 #: lib/vutuv_web/agent_docs/text.ex:227
 #: lib/vutuv_web/live/organization_live/edit.ex:287
-#: lib/vutuv_web/live/organization_live/new.ex:115
+#: lib/vutuv_web/live/organization_live/new.ex:130
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr ""
@@ -11218,7 +11218,7 @@ msgstr ""
 msgid "Website file"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/new.ex:157
+#: lib/vutuv_web/live/organization_live/new.ex:172
 #, elixir-autogen, elixir-format
 msgid "Website file (.well-known)"
 msgstr ""
@@ -11228,7 +11228,7 @@ msgstr ""
 msgid "You can only upload one logo."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/new.ex:134
+#: lib/vutuv_web/live/organization_live/new.ex:149
 #, elixir-autogen, elixir-format
 msgid "You will publish a record or file to prove control of the domain on the next step."
 msgstr ""
@@ -11512,13 +11512,13 @@ msgid "verified"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:290
-#: lib/vutuv_web/live/organization_live/new.ex:121
+#: lib/vutuv_web/live/organization_live/new.ex:136
 #, elixir-autogen, elixir-format
 msgid "Street address (optional)"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:291
-#: lib/vutuv_web/live/organization_live/new.ex:122
+#: lib/vutuv_web/live/organization_live/new.ex:137
 #, elixir-autogen, elixir-format
 msgid "ZIP / postal code (optional)"
 msgstr ""
@@ -11710,7 +11710,7 @@ msgstr ""
 msgid "An organization must keep at least one owner, so the last owner cannot be changed."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/new.ex:82
+#: lib/vutuv_web/live/organization_live/new.ex:97
 #, elixir-autogen, elixir-format
 msgid "Create a verified page for your company, association, school or public authority."
 msgstr ""
@@ -11722,29 +11722,29 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/index.ex:70
 #: lib/vutuv_web/live/organization_live/index.ex:101
-#: lib/vutuv_web/live/organization_live/new.ex:26
-#: lib/vutuv_web/live/organization_live/new.ex:80
+#: lib/vutuv_web/live/organization_live/new.ex:28
+#: lib/vutuv_web/live/organization_live/new.ex:95
 #: lib/vutuv_web/templates/settings/organizations.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Add your organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/new.ex:91
+#: lib/vutuv_web/live/organization_live/new.ex:106
 #, elixir-autogen, elixir-format
 msgid "Why we ask you to verify"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/new.ex:94
+#: lib/vutuv_web/live/organization_live/new.ex:109
 #, elixir-autogen, elixir-format
 msgid "So visitors can trust the page. We only publish it once you prove that you control the organization's web domain, so nobody can put up a page that pretends to be your organization."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/new.ex:99
+#: lib/vutuv_web/live/organization_live/new.ex:114
 #, elixir-autogen, elixir-format
 msgid "You might need help from your admin"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/new.ex:102
+#: lib/vutuv_web/live/organization_live/new.ex:117
 #, elixir-autogen, elixir-format
 msgid "The proof is a small technical change to your domain: a DNS entry or a file on your website. If you don't manage the website yourself, ask the person or team who does. That is usually your IT department or the company that runs your website. We show the exact instructions on the next step, so you can simply pass them on."
 msgstr ""
@@ -11765,7 +11765,7 @@ msgid "Deleting this organization page is permanent. Its verified domains and it
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:268
-#: lib/vutuv_web/live/organization_live/new.ex:111
+#: lib/vutuv_web/live/organization_live/new.ex:126
 #, elixir-autogen, elixir-format
 msgid "Kind of organization"
 msgstr ""
@@ -11831,7 +11831,7 @@ msgid "Organization frozen."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:267
-#: lib/vutuv_web/live/organization_live/new.ex:110
+#: lib/vutuv_web/live/organization_live/new.ex:125
 #, elixir-autogen, elixir-format
 msgid "Organization name"
 msgstr ""
@@ -11902,7 +11902,7 @@ msgstr ""
 msgid "That domain already belongs to an organization page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/new.ex:59
+#: lib/vutuv_web/live/organization_live/new.ex:66
 #, elixir-autogen, elixir-format
 msgid "That domain already belongs to another organization page."
 msgstr ""
@@ -18020,6 +18020,7 @@ msgstr ""
 msgid "Nothing saved from other networks yet. The bookmark on a post or reply from another network keeps it here."
 msgstr ""
 
+#: lib/vutuv_web/live/organization_live/new.ex:192
 #: lib/vutuv_web/live/post_live/saved.ex:515
 #, elixir-autogen, elixir-format
 msgid "Other networks"
@@ -20334,6 +20335,7 @@ msgid "Other networks address this page as @name@%{host}, the way they address a
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/fediverse.ex:87
+#: lib/vutuv_web/live/organization_live/new.ex:211
 #: lib/vutuv_web/live/organization_live/show.ex:727
 #, elixir-autogen, elixir-format
 msgid "People who have no vutuv account can follow this page and read its posts, in networks like Mastodon."
@@ -20387,4 +20389,14 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/edit.ex:406
 #, elixir-autogen, elixir-format
 msgid "The organization's @name"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/new.ex:209
+#, elixir-autogen, elixir-format
+msgid "Let people follow this page from other networks"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/new.ex:214
+#, elixir-autogen, elixir-format
+msgid "You can change this at any time on the page's Fediverse settings."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -115,7 +115,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
 #: lib/vutuv_web/live/job_posting_live/form.ex:605
 #: lib/vutuv_web/live/organization_live/edit.ex:347
-#: lib/vutuv_web/live/organization_live/new.ex:173
+#: lib/vutuv_web/live/organization_live/new.ex:231
 #: lib/vutuv_web/live/post_live/composer.ex:1370
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
@@ -1558,7 +1558,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:360
 #: lib/vutuv_web/live/job_posting_live/form.ex:410
 #: lib/vutuv_web/live/organization_live/edit.ex:296
-#: lib/vutuv_web/live/organization_live/new.ex:127
+#: lib/vutuv_web/live/organization_live/new.ex:142
 #: lib/vutuv_web/templates/ad/new.html.heex:114
 #: lib/vutuv_web/templates/address/country_input.html.heex:5
 #: lib/vutuv_web/templates/welcome/show.html.heex:80
@@ -4043,7 +4043,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/organization_live.ex:245
 #: lib/vutuv_web/live/job_posting_live/form.ex:404
 #: lib/vutuv_web/live/organization_live/edit.ex:292
-#: lib/vutuv_web/live/organization_live/new.ex:123
+#: lib/vutuv_web/live/organization_live/new.ex:138
 #: lib/vutuv_web/templates/ad/new.html.heex:108
 #: lib/vutuv_web/templates/address/form_en.html.heex:33
 #: lib/vutuv_web/templates/address/form_generic.html.heex:38
@@ -11054,14 +11054,14 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/new.ex:167
+#: lib/vutuv_web/live/organization_live/new.ex:225
 #, elixir-autogen, elixir-format
 msgid "Continue to verification"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/domains.ex:248
 #: lib/vutuv_web/live/organization_live/domains.ex:288
-#: lib/vutuv_web/live/organization_live/new.ex:146
+#: lib/vutuv_web/live/organization_live/new.ex:161
 #: lib/vutuv_web/live/organization_live/show.ex:823
 #: lib/vutuv_web/templates/url/verify.html.heex:46
 #, elixir-autogen, elixir-format
@@ -11141,7 +11141,7 @@ msgid "Serve this file at:"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:293
-#: lib/vutuv_web/live/organization_live/new.ex:124
+#: lib/vutuv_web/live/organization_live/new.ex:139
 #, elixir-autogen, elixir-format
 msgid "State / region (optional)"
 msgstr ""
@@ -11161,7 +11161,7 @@ msgstr ""
 msgid "The upload failed."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/new.ex:131
+#: lib/vutuv_web/live/organization_live/new.ex:146
 #: lib/vutuv_web/live/organization_live/show.ex:811
 #, elixir-autogen, elixir-format
 msgid "Verification method"
@@ -11203,7 +11203,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:243
 #: lib/vutuv_web/agent_docs/text.ex:227
 #: lib/vutuv_web/live/organization_live/edit.ex:287
-#: lib/vutuv_web/live/organization_live/new.ex:115
+#: lib/vutuv_web/live/organization_live/new.ex:130
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr ""
@@ -11216,7 +11216,7 @@ msgstr ""
 msgid "Website file"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/new.ex:157
+#: lib/vutuv_web/live/organization_live/new.ex:172
 #, elixir-autogen, elixir-format
 msgid "Website file (.well-known)"
 msgstr ""
@@ -11226,7 +11226,7 @@ msgstr ""
 msgid "You can only upload one logo."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/new.ex:134
+#: lib/vutuv_web/live/organization_live/new.ex:149
 #, elixir-autogen, elixir-format
 msgid "You will publish a record or file to prove control of the domain on the next step."
 msgstr ""
@@ -11510,13 +11510,13 @@ msgid "verified"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:290
-#: lib/vutuv_web/live/organization_live/new.ex:121
+#: lib/vutuv_web/live/organization_live/new.ex:136
 #, elixir-autogen, elixir-format
 msgid "Street address (optional)"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:291
-#: lib/vutuv_web/live/organization_live/new.ex:122
+#: lib/vutuv_web/live/organization_live/new.ex:137
 #, elixir-autogen, elixir-format
 msgid "ZIP / postal code (optional)"
 msgstr ""
@@ -11708,7 +11708,7 @@ msgstr ""
 msgid "An organization must keep at least one owner, so the last owner cannot be changed."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/new.ex:82
+#: lib/vutuv_web/live/organization_live/new.ex:97
 #, elixir-autogen, elixir-format
 msgid "Create a verified page for your company, association, school or public authority."
 msgstr ""
@@ -11720,29 +11720,29 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/index.ex:70
 #: lib/vutuv_web/live/organization_live/index.ex:101
-#: lib/vutuv_web/live/organization_live/new.ex:26
-#: lib/vutuv_web/live/organization_live/new.ex:80
+#: lib/vutuv_web/live/organization_live/new.ex:28
+#: lib/vutuv_web/live/organization_live/new.ex:95
 #: lib/vutuv_web/templates/settings/organizations.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Add your organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/new.ex:91
+#: lib/vutuv_web/live/organization_live/new.ex:106
 #, elixir-autogen, elixir-format
 msgid "Why we ask you to verify"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/new.ex:94
+#: lib/vutuv_web/live/organization_live/new.ex:109
 #, elixir-autogen, elixir-format
 msgid "So visitors can trust the page. We only publish it once you prove that you control the organization's web domain, so nobody can put up a page that pretends to be your organization."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/new.ex:99
+#: lib/vutuv_web/live/organization_live/new.ex:114
 #, elixir-autogen, elixir-format
 msgid "You might need help from your admin"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/new.ex:102
+#: lib/vutuv_web/live/organization_live/new.ex:117
 #, elixir-autogen, elixir-format
 msgid "The proof is a small technical change to your domain: a DNS entry or a file on your website. If you don't manage the website yourself, ask the person or team who does. That is usually your IT department or the company that runs your website. We show the exact instructions on the next step, so you can simply pass them on."
 msgstr ""
@@ -11763,7 +11763,7 @@ msgid "Deleting this organization page is permanent. Its verified domains and it
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:268
-#: lib/vutuv_web/live/organization_live/new.ex:111
+#: lib/vutuv_web/live/organization_live/new.ex:126
 #, elixir-autogen, elixir-format
 msgid "Kind of organization"
 msgstr ""
@@ -11829,7 +11829,7 @@ msgid "Organization frozen."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:267
-#: lib/vutuv_web/live/organization_live/new.ex:110
+#: lib/vutuv_web/live/organization_live/new.ex:125
 #, elixir-autogen, elixir-format
 msgid "Organization name"
 msgstr ""
@@ -11900,7 +11900,7 @@ msgstr ""
 msgid "That domain already belongs to an organization page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/new.ex:59
+#: lib/vutuv_web/live/organization_live/new.ex:66
 #, elixir-autogen, elixir-format
 msgid "That domain already belongs to another organization page."
 msgstr ""
@@ -18018,6 +18018,7 @@ msgstr ""
 msgid "Nothing saved from other networks yet. The bookmark on a post or reply from another network keeps it here."
 msgstr ""
 
+#: lib/vutuv_web/live/organization_live/new.ex:192
 #: lib/vutuv_web/live/post_live/saved.ex:515
 #, elixir-autogen, elixir-format
 msgid "Other networks"
@@ -20332,6 +20333,7 @@ msgid "Other networks address this page as @name@%{host}, the way they address a
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/fediverse.ex:87
+#: lib/vutuv_web/live/organization_live/new.ex:211
 #: lib/vutuv_web/live/organization_live/show.ex:727
 #, elixir-autogen, elixir-format
 msgid "People who have no vutuv account can follow this page and read its posts, in networks like Mastodon."
@@ -20385,4 +20387,14 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/edit.ex:406
 #, elixir-autogen, elixir-format
 msgid "The organization's @name"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/new.ex:209
+#, elixir-autogen, elixir-format
+msgid "Let people follow this page from other networks"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/new.ex:214
+#, elixir-autogen, elixir-format
+msgid "You can change this at any time on the page's Fediverse settings."
 msgstr ""

--- a/test/vutuv/organizations_test.exs
+++ b/test/vutuv/organizations_test.exs
@@ -595,6 +595,10 @@ defmodule Vutuv.OrganizationsTest do
   end
 
   describe "claim_handle/2" do
+    # The two keypair tests need a real (DNS-verified) page, and the helper that
+    # builds one runs the verification the global flag gates.
+    setup [:enable_verification]
+
     test "a pending (unverified) organization cannot claim a root handle" do
       user = insert(:activated_user)
 
@@ -605,6 +609,36 @@ defmodule Vutuv.OrganizationsTest do
       # Otherwise anyone could register a pending "Lufthansa" and squat @lufthansa.
       assert {:error, :not_verified} =
                Organizations.claim_handle(pending, %{"username" => "squatco"})
+    end
+
+    test "claiming the @name mints the keypair of a page that opted in at creation" do
+      page =
+        insert(:activated_user)
+        |> Vutuv.OrganizationsHelpers.active_organization_for()
+        |> Ecto.Changeset.change(%{fediverse_followers?: true})
+        |> Repo.update!()
+
+      # The invariant every path that can set `fediverse_followers?` owes an
+      # answer to: where does the key come from. The switch page mints on the
+      # way in; the claim wizard cannot, because a page has no @name yet and
+      # `federated?/1` refuses it without one. So this is the moment the page
+      # becomes reachable, and the keypair has to exist by then — a federating
+      # page without one has its deliveries DELETED as undeliverable, silently.
+      refute Vutuv.Fediverse.federated?(page)
+      assert is_nil(Vutuv.Fediverse.get_organization_actor(page))
+
+      {:ok, page} = Organizations.claim_handle(page, %{"username" => "acme"})
+
+      assert Vutuv.Fediverse.federated?(page)
+      assert %Vutuv.Fediverse.Actor{} = Vutuv.Fediverse.get_organization_actor(page)
+    end
+
+    test "a page that did not opt in gets no keypair from claiming its @name" do
+      page = Vutuv.OrganizationsHelpers.active_organization_for(insert(:activated_user))
+
+      {:ok, page} = Organizations.claim_handle(page, %{"username" => "quietco"})
+
+      assert is_nil(Vutuv.Fediverse.get_organization_actor(page))
     end
   end
 end

--- a/test/vutuv_web/organization_test.exs
+++ b/test/vutuv_web/organization_test.exs
@@ -144,6 +144,93 @@ defmodule VutuvWeb.OrganizationTest do
       organization = Organizations.get_organization_by_slug("widgets-inc")
       assert organization.status == "pending"
       assert organization.kind == :association
+      # The Fediverse box is pre-ticked and rides along with the rest of the
+      # form, so a page created without touching it takes part.
+      assert organization.fediverse_followers?
+    end
+
+    test "the Fediverse question is asked here, pre-ticked", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+      {:ok, view, _html} = live(conn, ~p"/organizations/new")
+
+      # Asked at the one moment somebody is already deciding what this page is:
+      # the switch page exists for changing the answer, not for discovering the
+      # question. Pre-ticked because most pages want the reach, and reversible
+      # at any time (which the box's own text says).
+      assert has_element?(view, "#organization-fediverse-optin[checked]")
+    end
+
+    test "a member who unticks it gets a page that stays here", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+      {:ok, view, _html} = live(conn, ~p"/organizations/new")
+
+      view
+      |> form("#organization-form",
+        organization: %{
+          name: "Quiet Corp",
+          kind: "company",
+          website_url: "https://quiet.example",
+          city: "Köln",
+          country: "DE",
+          fediverse_followers?: "false"
+        }
+      )
+      |> render_submit()
+
+      refute Organizations.get_organization_by_slug("quiet-corp").fediverse_followers?
+    end
+
+    test "the German wizard asks it in German", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+
+      html =
+        conn
+        |> Phoenix.ConnTest.recycle()
+        |> Plug.Conn.put_req_header("accept-language", "de-DE,de")
+        |> get(~p"/organizations/new")
+        |> html_response(200)
+
+      assert html =~ "Dieser Seite darf man aus anderen Netzwerken folgen"
+      assert html =~ "Auch Menschen ohne vutuv-Konto können dieser Seite folgen"
+      refute html =~ "öderier"
+    end
+
+    test "the question is left out where the installation federates nothing", %{conn: conn} do
+      Application.put_env(:vutuv, :fediverse_enabled, false)
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_enabled) end)
+
+      {conn, _user} = create_and_login_user(conn)
+      {:ok, view, _html} = live(conn, ~p"/organizations/new")
+
+      refute has_element?(view, "#organization-fediverse-optin")
+    end
+
+    test "ticking it shows nothing outside until the page is verified and named",
+         %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+      {:ok, view, _html} = live(conn, ~p"/organizations/new")
+
+      view
+      |> form("#organization-form",
+        organization: %{
+          name: "Widgets Inc",
+          kind: "company",
+          website_url: "https://widgets.example",
+          city: "Köln",
+          country: "DE"
+        }
+      )
+      |> render_submit()
+
+      page = Organizations.get_organization_by_slug("widgets-inc")
+
+      # The box records an intention; `federated?/1` still wants a verified,
+      # publicly visible page with a claimed @name. So a pending page answers
+      # nothing outside, which is what keeps this box from being a way to
+      # publish an unverified page to other servers.
+      assert page.fediverse_followers?
+      refute Vutuv.Fediverse.federated?(page)
+      assert is_nil(Vutuv.Fediverse.get_organization_actor(page))
     end
   end
 


### PR DESCRIPTION
**TL;DR** `/organizations/new` fragt jetzt mit — eine vorausgewählte Checkbox, wie bei der Mitglieder-Registrierung.

**Wo:** `VutuvWeb.OrganizationLive.New`, `Vutuv.Organizations.Organization.create_changeset/2`, `Vutuv.Organizations.claim_handle/2`.

**Jetzt:** Die Frage wurde nirgends gestellt. Der Schalter lag hinter der Reiterleiste der Verwaltungsseiten, und wer eine Seite anlegt, hat keinen Grund zu vermuten, dass es ihn gibt.

**Danach:** ein Feld „Andere Netzwerke" im Assistenten, **vorausgewählt**, mit demselben Satz, den die Fediverse-Karte und die Schalterseite verwenden (eine msgid für alle drei). Ausgelassen, wo die Installation nichts mit anderen Netzwerken austauscht.

**Warum früh fragen unbedenklich ist:** die Checkbox hält nur die Absicht fest. `Fediverse.federated?/1` verlangt weiterhin eine verifizierte, öffentlich sichtbare Seite mit beanspruchtem @-Namen — von einer wartenden Seite erfährt kein fremder Server etwas. Ein Test hält genau das fest.

**Die Stelle, an der es hätte still schiefgehen können:** damit wird `claim_handle/2` der Moment, in dem die Absicht wahr wird, und damit der Moment, in dem das **Schlüsselpaar** existieren muss. Es wird jetzt dort angelegt. Das ist die Seiten-Hälfte der Regel, die die Mitglieder-Registrierung aufgeschrieben hat (#1193): *jeder Weg, der das Opt-in setzen kann, schuldet eine Antwort auf „woher kommt der Schlüssel"*. Ohne das verwirft der Auslieferungs-Worker die Aktivitäten eines Actors ohne Schlüssel **endgültig**, ohne Fehlermeldung.

**Detail, das eine Stunde kosten kann:** die Vorauswahl kommt aus dem Struct, nicht aus einem `checked` im Markup — ein `phx-change` liest den Formularwert, und eine Vorgabe, die nur in der Vorlage steht, würde sich beim nächsten Tastendruck selbst wieder ankreuzen.

**Eine Sache für dich:** die Datenschutzerklärung nennt die Fediverse-Wahl bei der *Registrierung* (Mitglieder). Ob dort eine Zeile über Seiten hinzu soll, ist deine Entscheidung — ich habe am Rechtstext nichts geändert.

7 neue Tests. Hot deploy, keine Migration. Version 7.271.0.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*