### PR TITLE
Eine Seite bekommt Hand über ihre Antworten und ihre Follower (v7.272.0)

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -326,17 +326,25 @@ every activity of a member it finds no key for, silently.
     we can make, which the checker would read as "deleted upstream" and act on,
     and asking would tell the origin we hold it. They live by the ceiling and an
     upstream `Delete` alone.
-  - **Takedown, with no workflow.** The member removes a reply from their own
-    post; anyone who can see it reports it, which **deletes it immediately** —
-    no case, no freezer, because unlike a member's own post this is a cache of
-    something that still exists at its origin. Both write one
-    `Vutuv.Fediverse.NoteEvent` row, which keeps **no content and no URIs**
-    (following `FollowerPrune`, #1072): action, host, a keyed HMAC of the actor
-    URI, who acted, when. That is enough for the only decision it serves — one
-    troll or the whole server — without holding an identifier of somebody whose
-    words we just deleted. Reports are rate limited per reporter. Automatic
-    deletions are **not** logged per row (an expiry run would drown it); they go
-    to the log in aggregate.
+  - **Takedown, with no workflow.** Whoever may act as the post's author removes
+    a reply from it; anyone who can see it reports it, which **deletes it
+    immediately** — no case, no freezer, because unlike a member's own post this
+    is a cache of something that still exists at its origin. "May act as the
+    author" is `Vutuv.Posts.author?/2`, so for an **organization** post that is
+    every current publisher of the page. It has to be: a page has no replies
+    switch of its own (see below), so the single reply is the team's whole lever
+    — and until this the gate compared `posts.user_id`, which an organization
+    post leaves NULL, leaving them with nothing but "Report", which also
+    accuses the author to their own server. The `Flag` that report files is
+    signed by the post's author too (`Posts.author/1`), a member or a page.
+    Both write one `Vutuv.Fediverse.NoteEvent` row, which keeps **no content and
+    no URIs** (following `FollowerPrune`, #1072): action, host, a keyed HMAC of
+    the actor URI, whose page it sat on (`user_id` *or* `organization_id`), who
+    acted, when. That is enough for the only decision it serves — one troll or
+    the whole server — without holding an identifier of somebody whose words we
+    just deleted. Reports are rate limited per reporter. Automatic deletions are
+    **not** logged per row (an expiry run would drown it); they go to the log in
+    aggregate.
   - Everything else that deletes: the post, the account (both by FK cascade),
     `purge_instance/1` when the server is blocked, and switching the opt-in off
     (`drop_notes/1`) — the switch is a delete lever, not a display toggle.
@@ -614,6 +622,18 @@ every activity of a member it finds no key for, silently.
   followers collection stays
   count-only, so the list lives in the private settings area, never under
   `/:slug`.
+- **A page has the same list**, at `/organizations/:slug/fediverse/followers`
+  (`VutuvWeb.OrganizationLive.FediverseFollowers`), reached from the Fediverse
+  card once somebody follows: the card knew the number and not one name. Same
+  `BrowseTable` components, same queries (`count_followers/2`,
+  `list_followers_page/4` and `follower_hosts/2` take a member *or* a page and
+  scope through one private `follower_scope/1`, the nullable pair again), and
+  **owner-only** like the switch it hangs off. One structural difference: every
+  organization manage page is embedded by its controller through `live_render`,
+  so it is not mounted at the router and `push_patch/2` is unavailable — the
+  view lives in the socket and pages with `<.admin_pager>` instead of in the
+  URL, which costs a shareable filtered link. Nothing broadcasts a page's new
+  follower either, so the list is as fresh as the last load.
 - **The operator** sees federation health on `/admin`: `Fediverse.stats/0`
   reports federating members (the SQL mirror of `federated?/1`), total remote
   followers, delivery-queue depth, how many rows are stuck (carry a
@@ -849,7 +869,9 @@ beside `follows` and `tag_follows` from #1336. Each carries a CHECK for exactly
 one owner — except `fediverse_post_deliveries`, where the pair is a **writer**
 invariant rather than a schema one, because those rows deliberately outlive the
 post and its author and a foreign key would delete what a revocation still
-needs.
+needs. `fediverse_note_events` (the takedown ledger) carries the pair too and
+deliberately has **neither** column set for a cached post, which sits on nobody's
+page — so a NULL `user_id` there does not mean "nobody's".
 
 **The documents differ where a page differs.** `Docs.organization_actor/2` is
 its own builder, not a widened `actor/2`: AP type `Organization` (which is what
@@ -958,9 +980,17 @@ off a member, so `Posts.shown_counts/1` folds them in by itself.
 
 **Replies** from other networks arrive too, under the same retention model as a
 member's (issues #1069/#1071): the text expires unless its origin keeps
-confirming it, and the takedown ledger reaches it. They render read-only on the
-page's permalink — removing, reporting and the heart all belong to a person, and
-a page has nobody behind those buttons.
+confirming it, and the takedown ledger reaches it. The heart is still a person's
+(a page has nobody behind that button), but **removing one is the team's**:
+`Posts.author?/2` gates it, so every current publisher gets it. That is not
+symmetry for its own sake — a page is the one author with **no replies switch**
+(`users.fediverse_replies?` has no page twin, because a page that deliberately
+publishes outward has no comparable reason to want the reach and not the
+answers), so if the single reply cannot be taken down the team has no lever at
+all. It shipped without one: the gate compared `posts.user_id`, NULL on an
+organization post, which left "Report" as the only control — and Report deletes
+the reply *and* files a `Flag` with its author's server, so taking something off
+your own page meant accusing somebody.
 
 I had this written up here as its own feature and it was not. `fediverse_notes`
 hangs off the **post**, not off a member, and the audience a note records is

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -513,19 +513,22 @@ defmodule Vutuv.Fediverse do
   def browse_default_dir(@browse_default_sort), do: "desc"
   def browse_default_dir(_text_column), do: "asc"
 
-  @doc "How many of the member's remote followers match `filters` (for the pager)."
-  def count_followers(%User{id: user_id}, filters \\ %{}) do
-    user_id |> followers_base(filters) |> Repo.aggregate(:count)
+  @doc """
+  How many of `owner`'s remote followers match `filters` (for the pager).
+  `owner` is a member or a page (issue #1334).
+  """
+  def count_followers(owner, filters \\ %{}) do
+    owner |> followers_base(filters) |> Repo.aggregate(:count)
   end
 
   @doc """
-  One page of the member's follower browser: filtered, searched, sorted and
+  One page of `owner`'s follower browser: filtered, searched, sorted and
   paginated. `opts` may carry `:total` (skip the recount) and `:per_page`
   (default `browse_per_page/0`).
   """
-  def list_followers_page(%User{id: user_id}, filters, params \\ %{}, opts \\ []) do
+  def list_followers_page(owner, filters, params \\ %{}, opts \\ []) do
     per_page = Keyword.get(opts, :per_page, @browse_per_page)
-    base = followers_base(user_id, filters)
+    base = followers_base(owner, filters)
     total = Keyword.get(opts, :total) || Repo.aggregate(base, :count)
 
     base
@@ -535,20 +538,18 @@ defmodule Vutuv.Fediverse do
   end
 
   @doc """
-  The servers this member's remote followers live on, biggest first - the
+  The servers `owner`'s remote followers live on, biggest first - the
   follower browser's server filter, and the answer to "where are they coming
   from". Capped at `limit` hosts.
   """
-  def follower_hosts(%User{id: user_id}, limit \\ @browse_host_choices) do
-    Repo.all(
-      from(f in Follower,
-        where: f.user_id == ^user_id,
-        group_by: uri_host(f.actor_uri),
-        order_by: [desc: count(f.id), asc: uri_host(f.actor_uri)],
-        limit: ^limit,
-        select: %{host: uri_host(f.actor_uri), count: count(f.id)}
-      )
-    )
+  def follower_hosts(owner, limit \\ @browse_host_choices) do
+    owner
+    |> follower_scope()
+    |> group_by([f], uri_host(f.actor_uri))
+    |> order_by([f], desc: count(f.id), asc: uri_host(f.actor_uri))
+    |> limit(^limit)
+    |> select([f], %{host: uri_host(f.actor_uri), count: count(f.id)})
+    |> Repo.all()
   end
 
   defp validated_browse_sort(sort) when sort in @browse_sort_columns, do: sort
@@ -560,8 +561,18 @@ defmodule Vutuv.Fediverse do
   defp normalize_browse_server(nil), do: nil
   defp normalize_browse_server(host), do: String.downcase(host)
 
-  defp followers_base(user_id, filters) do
-    from(f in Follower, where: f.user_id == ^user_id)
+  # The one place a follower query names its owner's column. A member's
+  # followers hang off `user_id` and a page's off `organization_id` — the
+  # nullable pair again — so every browser query goes through here rather than
+  # writing the `where` itself.
+  defp follower_scope(%User{id: id}), do: from(f in Follower, where: f.user_id == ^id)
+
+  defp follower_scope(%Organization{id: id}),
+    do: from(f in Follower, where: f.organization_id == ^id)
+
+  defp followers_base(owner, filters) do
+    owner
+    |> follower_scope()
     |> filter_follower_server(Map.get(filters, :server))
     |> search_followers(Map.get(filters, :q))
   end
@@ -3894,15 +3905,20 @@ defmodule Vutuv.Fediverse do
   end
 
   @doc """
-  The member takes a reply off their own post. Deletes it at once and records
-  the takedown in `Vutuv.Fediverse.NoteEvent`.
+  Whoever may act as the post's author takes a reply off it. Deletes it at once
+  and records the takedown in `Vutuv.Fediverse.NoteEvent`.
+
+  For an **organization** post that is every current publisher of the page, the
+  same rule `Posts.author?/2` applies to editing it — and for a page this is the
+  *only* lever there is, since a page has no replies switch to turn the whole
+  stream off the way a member does (`users.fediverse_replies?`).
 
   Nothing leaves the building: removing a reply from your own post is a decision
   about *your* page, not an accusation, so the origin server is not told. Saying
   "this is not appropriate" is `report_note/2`, which does tell them.
   """
   def remove_note(note_id, %User{} = actor) do
-    with {:ok, _note, _author_id} <-
+    with {:ok, _note, _post} <-
            take_down_note(note_id, actor, "removed_by_member", &note_owner?/3),
          do: :ok
   end
@@ -3931,9 +3947,9 @@ defmodule Vutuv.Fediverse do
            :timer.hours(24)
          ) do
       :ok ->
-        with {:ok, note, author_id} <-
+        with {:ok, note, post} <-
                take_down_note(note_id, reporter, "reported", &note_visible?/3) do
-          flag_note(note, author_id, reporter)
+          flag_note(note, post, reporter)
           :ok
         end
 
@@ -3944,26 +3960,32 @@ defmodule Vutuv.Fediverse do
 
   # Files the report with the server the reply came from (issue #1102).
   #
-  # Signed by the member whose post the reply sat under, never by the reporter.
-  # A `Flag` is a signed statement, so it has to come from an actor we serve a
-  # key for, and vutuv has no installation-wide actor to file from (Mastodon uses
-  # its instance actor for exactly this). The thread's owner is the party that
-  # server already knows in this conversation, and using them keeps a bystander
-  # reporter out of a message that travels to strangers: nothing in the `Flag`
-  # names who reported it, and no content rides along — the reported object's own
-  # id is the whole reference.
+  # Signed by the **author of the post the reply sat under** — a member or a
+  # page — never by the reporter. A `Flag` is a signed statement, so it has to
+  # come from an actor we serve a key for, and vutuv has no installation-wide
+  # actor to file from (Mastodon uses its instance actor for exactly this). The
+  # thread's owner is the party that server already knows in this conversation,
+  # and using them keeps a bystander reporter out of a message that travels to
+  # strangers: nothing in the `Flag` names who reported it, and no content rides
+  # along — the reported object's own id is the whole reference.
+  #
+  # `Posts.author/1` is what makes the page case work at all. Reading the signer
+  # off `posts.user_id` handed `Repo.get(User, nil)` a NULL for an organization
+  # post, which RAISES rather than answering nothing: a 500 on the report button
+  # under every page post, and behind a gate (the note needs an inbox) that no
+  # member-side test could reach.
   #
   # Skipped when the note carried no answerable inbox (`own_inbox/1` refuses an
   # inbox on a host the actor does not control), when the post's author never
   # federated (no key to sign with), or when the operator has blocked that server
   # — a block is both ears and mouth shut.
-  defp flag_note(%Note{} = note, author_id, %User{} = reporter) do
+  defp flag_note(%Note{} = note, %Post{} = post, %User{} = reporter) do
     with inbox when is_binary(inbox) <- note.inbox_uri,
-         %User{} = author <- Repo.get(User, author_id),
+         author when not is_nil(author) <- Posts.author(post),
          true <- ever_federated?(author),
          false <- instance_blocked?(note.actor_uri) do
       enqueue(author, [inbox], Docs.flag_activity(author, note.object_uri, note.actor_uri))
-      log_note_event(note, author_id, reporter, "flagged")
+      log_note_event(note, post, reporter, "flagged")
       :ok
     else
       _ -> :skip
@@ -4250,14 +4272,18 @@ defmodule Vutuv.Fediverse do
   defp note_viewer_id(id) when is_binary(id), do: id
   defp note_viewer_id(_), do: "00000000-0000-0000-0000-000000000000"
 
-  # Only the member whose post it sits under (or an admin) may remove a reply.
-  defp note_owner?(_note, author_id, %User{} = actor),
-    do: actor.id == author_id or actor.admin? == true
+  # Whoever may act as the post's author may take a reply off it (or an admin).
+  # `Posts.author?/2` is the one predicate for that, which is what widens this
+  # to a page's publishers: an organization post leaves `posts.user_id` NULL, so
+  # comparing ids here used to answer false for everybody but an admin, and a
+  # page's team had no lever at all over what strangers wrote under its posts.
+  defp note_owner?(_note, %Post{} = post, %User{} = actor),
+    do: Posts.author?(post, actor) or actor.admin? == true
 
   # Anyone who can see it may report it, which for a private reply is its
   # addressee alone.
-  defp note_visible?(note, author_id, %User{} = actor),
-    do: Note.public?(note) or note_owner?(note, author_id, actor)
+  defp note_visible?(note, %Post{} = post, %User{} = actor),
+    do: Note.public?(note) or note_owner?(note, post, actor)
 
   defp take_down_note(note_id, %User{} = actor, action, authorized?) do
     query =
@@ -4265,19 +4291,20 @@ defmodule Vutuv.Fediverse do
         join: p in Post,
         on: p.id == n.post_id,
         where: n.id == ^to_string(note_id),
-        select: {n, p.user_id}
+        select: {n, p}
       )
 
     case UUIDv7.with_cast(note_id, fn _ -> Repo.one(query) end) do
-      {%Note{} = note, author_id} ->
-        if authorized?.(note, author_id, actor) do
+      {%Note{} = note, %Post{} = post} ->
+        if authorized?.(note, post, actor) do
           Repo.delete(note)
-          log_note_event(note, author_id, actor, action)
+          log_note_event(note, post, actor, action)
           Posts.broadcast_post_counters(note.post_id)
           # The deleted row is handed back so the caller can still address the
           # origin server (`flag_note/3`) — after this it is the only copy of
-          # that address left.
-          {:ok, note, author_id}
+          # that address left. The post rides along because the `Flag` has to be
+          # signed by its author, whichever kind of author that is.
+          {:ok, note, post}
         else
           {:error, :not_allowed}
         end
@@ -4287,21 +4314,23 @@ defmodule Vutuv.Fediverse do
     end
   end
 
-  defp log_note_event(%Note{} = note, author_id, %User{} = actor, action) do
+  defp log_note_event(%Note{} = note, %Post{} = post, %User{} = actor, action) do
     log_takedown(%{
       action: action,
       host: Note.host(note.actor_uri) || "unknown",
       actor_uri: note.actor_uri,
       audience: note.audience,
-      user_id: author_id,
+      user_id: post.user_id,
+      organization_id: post.organization_id,
       actor_id: actor.id
     })
   end
 
   # The one writer of the content-free takedown ledger, so its field set — and
   # the keyed digest that stands in for the actor — has a single definition
-  # whatever kind of cached content was taken down. `user_id` is the member
-  # whose page it sat on, and is absent for content that sat on nobody's (a
+  # whatever kind of cached content was taken down. `user_id` /
+  # `organization_id` is whose page it sat on — exactly one of them for a reply
+  # under a post — and both are absent for content that sat on nobody's (a
   # cached post from a followed account, issue #1161).
   defp log_takedown(attrs) do
     Repo.insert!(%NoteEvent{
@@ -4310,6 +4339,7 @@ defmodule Vutuv.Fediverse do
       actor_digest: note_actor_digest(attrs.actor_uri),
       audience: attrs.audience,
       user_id: attrs[:user_id],
+      organization_id: attrs[:organization_id],
       actor_id: attrs.actor_id
     })
   end

--- a/lib/vutuv/fediverse/note_event.ex
+++ b/lib/vutuv/fediverse/note_event.ex
@@ -22,10 +22,13 @@ defmodule Vutuv.Fediverse.NoteEvent do
   `secret_key_base`, per the project rule that a bare hash of a guessable value
   is not privacy), which groups repeat offenders without holding the identifier.
 
-  `user_id` (whose post it sat under) and `actor_id` (who acted) are plain
-  values, not associations, like the deliverability and admin-action ledgers:
-  an audit row must stay readable after the rows it references are gone. Rows
-  are written by `Vutuv.Fediverse` only, never built from user params.
+  `user_id` / `organization_id` (whose post it sat under) and `actor_id` (who
+  acted) are plain values, not associations, like the deliverability and
+  admin-action ledgers: an audit row must stay readable after the rows it
+  references are gone. Rows are written by `Vutuv.Fediverse` only, never built
+  from user params. Exactly one of the two owner columns is set for a reply
+  under a post, and **neither** for a cached post, which sits on nobody's page
+  (issue #1161) — so a NULL `user_id` alone does not mean "nobody's".
 
   Automatic deletions are deliberately **not** recorded here. An expiry sweep, a
   server block or an upstream `Delete` can remove thousands of rows at once and
@@ -52,6 +55,7 @@ defmodule Vutuv.Fediverse.NoteEvent do
     field(:actor_digest, :string)
     field(:audience, :string)
     field(:user_id, :binary_id)
+    field(:organization_id, :binary_id)
     field(:actor_id, :binary_id)
 
     timestamps(updated_at: false)

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -2529,7 +2529,12 @@ defmodule VutuvWeb.PostComponents do
   defp merge_remote_nodes(children, [], _post, _viewer, _marks), do: children
 
   defp merge_remote_nodes(children, notes, post, viewer, marks) do
-    owner? = match?(%User{}, viewer) and viewer.id == post.user_id
+    # Who gets the "Remove" item — `Posts.author?/2`, the same predicate that
+    # gates Edit and Delete, so a page's publishers get it too. Comparing
+    # `post.user_id` here left an organization post's team with only "Report",
+    # which deletes the reply AND files an accusation with the origin server:
+    # there was no way to quietly take something off your own page.
+    owner? = match?(%User{}, viewer) and Posts.author?(post, viewer)
 
     # An answer to one of these notes (issue #1070) is, underneath, an ordinary
     # reply to the same vutuv post — so `thread_forest/1` made it a *sibling* of

--- a/lib/vutuv_web/controllers/organization_controller.ex
+++ b/lib/vutuv_web/controllers/organization_controller.ex
@@ -167,6 +167,20 @@ defmodule VutuvWeb.OrganizationController do
   def fediverse(conn, %{"slug" => slug}),
     do: manage(conn, slug, VutuvWeb.OrganizationLive.Fediverse, &Organizations.owner?/2)
 
+  @doc """
+  Who follows the page from other networks. Owner-only like the switch it hangs
+  off: these are names of people who never signed up here, and the page itself
+  publishes only the count.
+  """
+  def fediverse_followers(conn, %{"slug" => slug}),
+    do:
+      manage(
+        conn,
+        slug,
+        VutuvWeb.OrganizationLive.FediverseFollowers,
+        &Organizations.owner?/2
+      )
+
   def exclusions(conn, %{"slug" => slug}),
     do: manage(conn, slug, VutuvWeb.OrganizationLive.Exclusions, &Organizations.can_manage?/2)
 

--- a/lib/vutuv_web/live/organization_live/fediverse.ex
+++ b/lib/vutuv_web/live/organization_live/fediverse.ex
@@ -130,6 +130,19 @@ defmodule VutuvWeb.OrganizationLive.Fediverse do
           <% end %>
         </p>
 
+        <%!-- The number is not the interesting half once it moves: who these
+        accounts are is, and until this link the page had no way to ask. Shown
+        only once there is somebody to look at, so an empty list is never
+        offered as a destination. --%>
+        <.link
+          :if={@remote_followers > 0}
+          navigate={~p"/organizations/#{@organization.slug}/fediverse/followers"}
+          id="all-followers-link"
+          class="mt-1 inline-block text-sm font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+        >
+          {gettext("Who follows this page")}
+        </.link>
+
         <%!-- The thing people are surprised by afterwards, so it is said before
         rather than after: switching off stops new posts leaving, but a copy
         another server already keeps can only be ASKED to go. --%>

--- a/lib/vutuv_web/live/organization_live/fediverse_followers.ex
+++ b/lib/vutuv_web/live/organization_live/fediverse_followers.ex
@@ -1,0 +1,256 @@
+defmodule VutuvWeb.OrganizationLive.FediverseFollowers do
+  @moduledoc """
+  Who follows a page from other networks
+  (`/organizations/:slug/fediverse/followers`).
+
+  The Fediverse card beside it knew the number and not one name — "0 accounts
+  there follow it" was everything a team could learn about the reach it had just
+  switched on. `Fediverse.list_organization_followers/2` had been sitting there
+  unread since #1334; this is the page that reads it.
+
+  **Owner-only, like the Fediverse tab it hangs off.** These are names of people
+  who never signed up here, and the page's own followers collection publishes
+  the count and never the names, so the list stays with the member who decided
+  to federate in the first place. Widening it to the whole team later is one
+  line; taking it back would not be.
+
+  It reuses `VutuvWeb.BrowseTable` — the same search, server filter and sortable
+  columns the member's `/settings/fediverse/followers` wears — with **one
+  difference that is structural, not a choice**: this LiveView is embedded by
+  `VutuvWeb.OrganizationController` through `live_render`, like every other
+  organization manage page, and an embedded LiveView is not mounted at the
+  router, so `push_patch/2` and `handle_params/3` are not available to it. The
+  member's page keeps its view in the URL; this one keeps it in the socket and
+  pages with `<.admin_pager>` (`phx-click`), the way the admin oversight tables
+  do. So a filtered view here is not a shareable link, and that is the whole
+  cost.
+
+  No live updates either: a follow from another network arrives at the page's
+  inbox and nothing broadcasts it, so the list is as fresh as the last load —
+  which is why nothing on it promises otherwise.
+  """
+
+  use VutuvWeb, :live_view
+
+  import VutuvWeb.BrowseTable
+  import VutuvWeb.OrganizationComponents, only: [manage_header: 1]
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Follower
+  alias Vutuv.Organizations
+  alias VutuvWeb.Live.InitAssigns
+
+  @impl true
+  def mount(_params, session, socket) do
+    socket = InitAssigns.assign_embedded(socket, session)
+    organization = Organizations.get_organization!(session["organization_id"])
+
+    {:ok,
+     socket
+     |> assign(:page_title, gettext("Followers – %{name}", name: organization.name))
+     |> assign(:organization, organization)
+     |> assign(:owner?, true)
+     |> assign(:publisher?, Organizations.publisher?(organization, socket.assigns.current_user))
+     |> assign(:filters, Fediverse.browse_filters(%{}))
+     |> assign(:page, 1)
+     |> assign_totals()
+     |> load_page()}
+  end
+
+  # The headline count and the server dropdown describe the whole list, whatever
+  # the current view filters out of it, so they are read once per mount.
+  defp assign_totals(socket) do
+    organization = socket.assigns.organization
+
+    socket
+    |> assign(:total_followers, Fediverse.organization_remote_follower_count(organization))
+    |> assign(:hosts, Fediverse.follower_hosts(organization))
+  end
+
+  defp load_page(socket) do
+    organization = socket.assigns.organization
+    filters = socket.assigns.filters
+    per_page = Fediverse.browse_per_page()
+    total = Fediverse.count_followers(organization, filters)
+    pages = max(div(total + per_page - 1, per_page), 1)
+    page = socket.assigns.page |> min(pages) |> max(1)
+
+    followers =
+      Fediverse.list_followers_page(organization, filters, %{"page" => page},
+        total: total,
+        per_page: per_page
+      )
+
+    socket
+    |> assign(:total, total)
+    |> assign(:page, page)
+    |> assign(:pages, pages)
+    |> assign(:followers, followers)
+  end
+
+  # Every filter change goes back through `Fediverse.browse_filters/1`, the same
+  # validation the URL-driven page uses, so a bad value cannot reach the query
+  # from here either.
+  defp apply_filters(socket, overrides) do
+    current = socket.assigns.filters
+
+    params = %{
+      "q" => Map.get(overrides, "q", current.q),
+      "server" => Map.get(overrides, "server", current.server),
+      "sort" => Map.get(overrides, "sort", current.sort),
+      "dir" => Map.get(overrides, "dir", current.dir)
+    }
+
+    socket
+    |> assign(:filters, Fediverse.browse_filters(params))
+    |> assign(:page, 1)
+    |> load_page()
+  end
+
+  @impl true
+  def handle_event("filter", params, socket) do
+    {:noreply, apply_filters(socket, %{"q" => params["q"], "server" => params["server"]})}
+  end
+
+  def handle_event("filter_server", %{"host" => host}, socket) do
+    {:noreply, apply_filters(socket, %{"server" => host})}
+  end
+
+  def handle_event("sort", %{"col" => col}, socket) do
+    dir = next_dir(socket.assigns.filters, fediverse_config(), col)
+
+    {:noreply, apply_filters(socket, %{"sort" => col, "dir" => dir})}
+  end
+
+  def handle_event("clear", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:filters, Fediverse.browse_filters(%{}))
+     |> assign(:page, 1)
+     |> load_page()}
+  end
+
+  def handle_event("page", %{"page" => page}, socket) do
+    {:noreply, socket |> assign(:page, String.to_integer(page)) |> load_page()}
+  end
+
+  @impl true
+  def handle_info(_message, socket), do: {:noreply, socket}
+
+  # The Server column folds away below `sm`, so the two facts a phone reader
+  # came for — who, and since when — both fit without a sideways scroll.
+  defp columns do
+    [
+      {"account", gettext("Account"), nil},
+      {"server", gettext("Server"), phone_hidden_class()},
+      {"followed", gettext("Following since"), nil}
+    ]
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="mx-auto max-w-2xl py-6">
+      <.manage_header
+        organization={@organization}
+        active={:fediverse}
+        owner?={true}
+        manage?={true}
+        publisher?={@publisher?}
+      />
+
+      <div class="space-y-6">
+        <.card>
+          <div class="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+            <.section_title>{gettext("Followers from other networks")}</.section_title>
+            <.count_pill id="follower-total" count={@total_followers} />
+          </div>
+          <p class="mt-1 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
+            {gettext(
+              "Everyone on another network who follows this page. Only you see this list: what the page publishes out there is the number, never the names."
+            )}
+          </p>
+
+          <%= if @total_followers == 0 do %>
+            <p class="mt-4 text-sm text-slate-600 dark:text-slate-400" id="no-followers">
+              {gettext(
+                "Nobody yet. Post the page's address where people can see it, and the first follows will show up here."
+              )}
+            </p>
+          <% else %>
+            <.filter_form id="follower-filter" filters={@filters} hosts={@hosts} class="mt-4" />
+
+            <p
+              :if={@followers == []}
+              class="mt-4 text-sm text-slate-600 dark:text-slate-400"
+              id="no-matches"
+            >
+              {gettext("No follower matches that. Try a shorter search, or clear the filters.")}
+            </p>
+
+            <div :if={@followers != []} class="card__tablewrap mt-4">
+              <table class="pure-table">
+                <thead>
+                  <tr>
+                    <.sort_header
+                      :for={{col, label, class} <- columns()}
+                      col={col}
+                      label={label}
+                      class={class}
+                      filters={@filters}
+                    />
+                  </tr>
+                </thead>
+                <tbody id="followers">
+                  <tr :for={follower <- @followers} id={"follower-#{follower.id}"}>
+                    <td>
+                      <.account_link
+                        uri={follower.actor_uri}
+                        name={follower.name}
+                        handle={Follower.display_handle(follower)}
+                      />
+                    </td>
+                    <td class={phone_hidden_class()}>
+                      <.server_filter
+                        host={Follower.host(follower)}
+                        title={gettext("Show only followers from this server")}
+                      />
+                    </td>
+                    <td class="whitespace-nowrap text-slate-600 dark:text-slate-400">
+                      <.local_time
+                        at={follower.inserted_at}
+                        id={"followed-#{follower.id}"}
+                        format="%Y-%m-%d"
+                      />
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <.admin_pager
+              :if={@followers != []}
+              page={@page}
+              pages={@pages}
+              prev_id="prev-page"
+              next_id="next-page"
+            />
+          <% end %>
+        </.card>
+
+        <.card>
+          <.section_title>{gettext("How this list keeps itself honest")}</.section_title>
+          <p class="mt-1 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
+            {gettext(
+              "Accounts that no longer exist on their own server drop off this list by themselves. Names and handles are the ones their server last told us."
+            )}
+          </p>
+          <.card_footer_link href={~p"/organizations/#{@organization.slug}/fediverse"}>
+            {gettext("Back to the Fediverse page")}
+          </.card_footer_link>
+        </.card>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -285,6 +285,13 @@ defmodule VutuvWeb.Router do
     get("/organizations/:slug/activity", OrganizationController, :activity)
     get("/organizations/:slug/feed", OrganizationController, :feed)
     get("/organizations/:slug/following", OrganizationController, :following)
+    # Before the bare /fediverse page, so the longer path is matched first.
+    get(
+      "/organizations/:slug/fediverse/followers",
+      OrganizationController,
+      :fediverse_followers
+    )
+
     get("/organizations/:slug/fediverse", OrganizationController, :fediverse)
     # The permalink of a post published in the organization's name (issue #1334).
     # Deliberately under the slug and not under the organization's opt-in root

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.271.0",
+      version: "7.272.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -161,7 +161,7 @@ msgstr "Kontakt"
 msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
-#: lib/vutuv_web/components/post_components.ex:2746
+#: lib/vutuv_web/components/post_components.ex:2751
 #: lib/vutuv_web/components/ui.ex:3326
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -210,7 +210,7 @@ msgstr "Inaktivieren"
 msgid "Download"
 msgstr "Download"
 
-#: lib/vutuv_web/components/post_components.ex:2711
+#: lib/vutuv_web/components/post_components.ex:2716
 #: lib/vutuv_web/components/ui.ex:3317
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -1644,7 +1644,7 @@ msgstr "Zur Startseite"
 msgid "Check your inbox"
 msgstr "Schauen Sie in Ihr Postfach"
 
-#: lib/vutuv_web/components/post_components.ex:3195
+#: lib/vutuv_web/components/post_components.ex:3200
 #: lib/vutuv_web/components/ui.ex:280
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
@@ -2140,7 +2140,7 @@ msgstr "Upload abbrechen"
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
-#: lib/vutuv_web/components/post_components.ex:2743
+#: lib/vutuv_web/components/post_components.ex:2748
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2183,8 +2183,8 @@ msgstr "Vor einer bestimmten Person verbergen…"
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
 
-#: lib/vutuv_web/components/post_components.ex:2697
-#: lib/vutuv_web/components/post_components.ex:2699
+#: lib/vutuv_web/components/post_components.ex:2702
+#: lib/vutuv_web/components/post_components.ex:2704
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
@@ -2252,13 +2252,13 @@ msgstr "Beitrag erfolgreich gelöscht."
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:3131
-#: lib/vutuv_web/components/post_components.ex:3135
+#: lib/vutuv_web/components/post_components.ex:3136
+#: lib/vutuv_web/components/post_components.ex:3140
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:3132
+#: lib/vutuv_web/components/post_components.ex:3137
 #: lib/vutuv_web/live/fediverse_account_live.ex:320
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2350,27 +2350,27 @@ msgstr "Was gibt's Neues?"
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
 
-#: lib/vutuv_web/components/post_components.ex:2694
+#: lib/vutuv_web/components/post_components.ex:2699
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:4339
+#: lib/vutuv_web/components/post_components.ex:4344
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:4343
+#: lib/vutuv_web/components/post_components.ex:4348
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:4341
+#: lib/vutuv_web/components/post_components.ex:4346
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:4342
+#: lib/vutuv_web/components/post_components.ex:4347
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
@@ -2412,7 +2412,7 @@ msgid "All posts"
 msgstr "Alle Beiträge"
 
 #: lib/vutuv_web/components/post_components.ex:1603
-#: lib/vutuv_web/components/post_components.ex:4427
+#: lib/vutuv_web/components/post_components.ex:4432
 #: lib/vutuv_web/components/ui.ex:2851
 #: lib/vutuv_web/views/user_html.ex:335
 #, elixir-autogen, elixir-format
@@ -2431,7 +2431,7 @@ msgid "Bookmarks"
 msgstr "Lesezeichen"
 
 #: lib/vutuv_web/components/post_components.ex:1567
-#: lib/vutuv_web/components/post_components.ex:4661
+#: lib/vutuv_web/components/post_components.ex:4666
 #: lib/vutuv_web/components/ui.ex:2837
 #: lib/vutuv_web/live/notification_live/index.ex:1029
 #: lib/vutuv_web/views/user_html.ex:345
@@ -2440,7 +2440,7 @@ msgid "Like"
 msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:996
-#: lib/vutuv_web/components/post_components.ex:4670
+#: lib/vutuv_web/components/post_components.ex:4675
 #: lib/vutuv_web/live/notification_live/index.ex:962
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
@@ -2462,13 +2462,13 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:4416
+#: lib/vutuv_web/components/post_components.ex:4421
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
 #: lib/vutuv_web/components/post_components.ex:1603
-#: lib/vutuv_web/components/post_components.ex:4427
+#: lib/vutuv_web/components/post_components.ex:4432
 #: lib/vutuv_web/live/post_live/saved.ex:775
 #: lib/vutuv_web/views/user_html.ex:335
 #, elixir-autogen, elixir-format
@@ -2476,25 +2476,25 @@ msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
 #: lib/vutuv_web/components/post_components.ex:1591
-#: lib/vutuv_web/components/post_components.ex:4413
+#: lib/vutuv_web/components/post_components.ex:4418
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
 #: lib/vutuv_web/components/post_components.ex:1781
-#: lib/vutuv_web/components/post_components.ex:3711
+#: lib/vutuv_web/components/post_components.ex:3716
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
 #: lib/vutuv_web/components/post_components.ex:1591
-#: lib/vutuv_web/components/post_components.ex:4413
+#: lib/vutuv_web/components/post_components.ex:4418
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
-#: lib/vutuv_web/components/post_components.ex:4661
+#: lib/vutuv_web/components/post_components.ex:4666
 #: lib/vutuv_web/live/post_live/saved.ex:774
 #: lib/vutuv_web/views/user_html.ex:345
 #, elixir-autogen, elixir-format
@@ -2520,7 +2520,7 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:4714
+#: lib/vutuv_web/components/post_components.ex:4719
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
@@ -2532,15 +2532,15 @@ msgid "Replies"
 msgstr "Antworten"
 
 #: lib/vutuv_web/components/post_components.ex:1578
-#: lib/vutuv_web/components/post_components.ex:4697
-#: lib/vutuv_web/components/post_components.ex:4698
+#: lib/vutuv_web/components/post_components.ex:4702
+#: lib/vutuv_web/components/post_components.ex:4703
 #: lib/vutuv_web/live/notification_live/index.ex:1026
 #: lib/vutuv_web/live/post_live/reply.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:2661
+#: lib/vutuv_web/components/post_components.ex:2666
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
@@ -2569,14 +2569,14 @@ msgstr "hat auf Ihren Beitrag geantwortet."
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
 
-#: lib/vutuv_web/components/post_components.ex:2637
+#: lib/vutuv_web/components/post_components.ex:2642
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:2631
-#: lib/vutuv_web/components/post_components.ex:2653
-#: lib/vutuv_web/components/post_components.ex:2656
+#: lib/vutuv_web/components/post_components.ex:2636
+#: lib/vutuv_web/components/post_components.ex:2658
+#: lib/vutuv_web/components/post_components.ex:2661
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
@@ -2881,7 +2881,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:4340
+#: lib/vutuv_web/components/post_components.ex:4345
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -3162,7 +3162,7 @@ msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:2607
+#: lib/vutuv_web/components/post_components.ex:2612
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solange eine Meldung zu diesem Beitrag bearbeitet wird, sehen nur Sie ihn."
@@ -3243,7 +3243,7 @@ msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 
 #: lib/vutuv_web/components/post_components.ex:1066
 #: lib/vutuv_web/components/post_components.ex:2042
-#: lib/vutuv_web/components/post_components.ex:2767
+#: lib/vutuv_web/components/post_components.ex:2772
 #: lib/vutuv_web/live/organization_live/show.ex:532
 #: lib/vutuv_web/templates/user/show.html.heex:219
 #, elixir-autogen, elixir-format
@@ -5634,9 +5634,9 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:2830
-#: lib/vutuv_web/components/post_components.ex:2882
-#: lib/vutuv_web/components/post_components.ex:3275
+#: lib/vutuv_web/components/post_components.ex:2835
+#: lib/vutuv_web/components/post_components.ex:2887
+#: lib/vutuv_web/components/post_components.ex:3280
 #: lib/vutuv_web/live/notification_live/index.ex:682
 #: lib/vutuv_web/live/post_live/feed.ex:1261
 #: lib/vutuv_web/views/user_html.ex:113
@@ -5687,6 +5687,7 @@ msgstr "Über Sie"
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:271
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:144
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:192
 #: lib/vutuv_web/templates/social_media_account/form_content.html.heex:12
 #, elixir-autogen, elixir-format
@@ -6924,7 +6925,7 @@ msgstr "Folgen Sie einander, um mit %{name} vernetzt zu sein und ihn zu lesen."
 msgid "Go to profile to follow"
 msgstr "Zum Profil, um zu folgen"
 
-#: lib/vutuv_web/components/post_components.ex:2764
+#: lib/vutuv_web/components/post_components.ex:2769
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr "@%{handle} stummschalten"
@@ -6934,7 +6935,7 @@ msgstr "@%{handle} stummschalten"
 msgid "Professional"
 msgstr "Beruflich"
 
-#: lib/vutuv_web/components/post_components.ex:2763
+#: lib/vutuv_web/components/post_components.ex:2768
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr "@%{handle} nicht mehr stummschalten"
@@ -7640,7 +7641,7 @@ msgstr "Alle abwählen"
 msgid "applies to the whole list, not just this page"
 msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 
-#: lib/vutuv_web/components/post_components.ex:4572
+#: lib/vutuv_web/components/post_components.ex:4577
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -9250,7 +9251,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:3714
+#: lib/vutuv_web/components/post_components.ex:3719
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -11716,7 +11717,7 @@ msgstr ""
 "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) anbieten und für KI-"
 "Agenten auflisten."
 
-#: lib/vutuv_web/controllers/organization_controller.ex:241
+#: lib/vutuv_web/controllers/organization_controller.ex:255
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:31
 #, elixir-autogen, elixir-format
 msgid "Please log in first."
@@ -14387,34 +14388,34 @@ msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch imm
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:4202
+#: lib/vutuv_web/components/post_components.ex:4207
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1085
-#: lib/vutuv_web/components/post_components.ex:4159
+#: lib/vutuv_web/components/post_components.ex:4164
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:4203
+#: lib/vutuv_web/components/post_components.ex:4208
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:4205
+#: lib/vutuv_web/components/post_components.ex:4210
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:4201
+#: lib/vutuv_web/components/post_components.ex:4206
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1085
-#: lib/vutuv_web/components/post_components.ex:4158
+#: lib/vutuv_web/components/post_components.ex:4163
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Filmbesprechung"
@@ -14425,12 +14426,12 @@ msgstr "Filmbesprechung"
 msgid "Look up"
 msgstr "Nachschlagen"
 
-#: lib/vutuv_web/components/post_components.ex:4200
+#: lib/vutuv_web/components/post_components.ex:4205
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
 
-#: lib/vutuv_web/components/post_components.ex:4204
+#: lib/vutuv_web/components/post_components.ex:4209
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14450,7 +14451,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:4241
+#: lib/vutuv_web/components/post_components.ex:4246
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14458,27 +14459,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:4271
+#: lib/vutuv_web/components/post_components.ex:4276
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:4272
+#: lib/vutuv_web/components/post_components.ex:4277
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:4270
+#: lib/vutuv_web/components/post_components.ex:4275
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:4230
+#: lib/vutuv_web/components/post_components.ex:4235
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:4277
+#: lib/vutuv_web/components/post_components.ex:4282
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14508,7 +14509,7 @@ msgstr "Mit Qualifikation:"
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:4044
+#: lib/vutuv_web/components/post_components.ex:4049
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
@@ -14556,7 +14557,7 @@ msgstr "folgen Ihnen jetzt."
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:4035
+#: lib/vutuv_web/components/post_components.ex:4040
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
@@ -14982,7 +14983,7 @@ msgstr "Dieses Profil ist zurzeit nicht verfügbar."
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das Konto zu finden, das eingefroren werden soll."
 
-#: lib/vutuv_web/components/post_components.ex:4669
+#: lib/vutuv_web/components/post_components.ex:4674
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Der eigene Beitrag lässt sich nicht mit „Gefällt mir“ markieren."
@@ -15333,6 +15334,7 @@ msgstr "Kein Server ist blockiert."
 #: lib/vutuv_web/components/browse_table.ex:364
 #: lib/vutuv_web/live/fediverse_followers_live.ex:155
 #: lib/vutuv_web/live/fediverse_following_live.ex:272
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:145
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:96
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:147
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:191
@@ -15396,6 +15398,7 @@ msgstr "Reaktionen aus anderen Netzwerken"
 #: lib/vutuv_web/live/fediverse_followers_live.ex:60
 #: lib/vutuv_web/live/fediverse_followers_live.ex:166
 #: lib/vutuv_web/live/fediverse_followers_live.ex:176
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:165
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:15
 #, elixir-autogen, elixir-format
 msgid "Followers from other networks"
@@ -16169,21 +16172,21 @@ msgstr ""
 "wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
-#: lib/vutuv_web/components/post_components.ex:4617
+#: lib/vutuv_web/components/post_components.ex:4622
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:4621
+#: lib/vutuv_web/components/post_components.ex:4626
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Like"
 msgstr[1] "%{formatted} Likes"
 
-#: lib/vutuv_web/components/post_components.ex:4625
+#: lib/vutuv_web/components/post_components.ex:4630
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -16191,7 +16194,7 @@ msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1034
-#: lib/vutuv_web/components/post_components.ex:4576
+#: lib/vutuv_web/components/post_components.ex:4581
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Bereits in den Zahlen oben enthalten."
@@ -16323,11 +16326,13 @@ msgid "All servers"
 msgstr "Alle Server"
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:156
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:146
 #, elixir-autogen, elixir-format
 msgid "Following since"
 msgstr "Folgt seit"
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:258
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:242
 #, elixir-autogen, elixir-format
 msgid "How this list keeps itself honest"
 msgstr "Wie diese Liste aktuell bleibt"
@@ -16338,11 +16343,13 @@ msgid "name, handle or server"
 msgstr "Name, Handle oder Server"
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:199
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:188
 #, elixir-autogen, elixir-format
 msgid "No follower matches that. Try a shorter search, or clear the filters."
 msgstr "Dazu passt kein Follower. Versuchen Sie eine kürzere Suche, oder setzen Sie die Filter zurück."
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:231
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:216
 #, elixir-autogen, elixir-format
 msgid "Show only followers from this server"
 msgstr "Nur Follower von diesem Server zeigen"
@@ -16951,22 +16958,22 @@ msgstr "Was sich an welchem Konto geändert hat, wann, von welchem Gerät und wi
 msgid "device or detail"
 msgstr "Gerät oder Detail"
 
-#: lib/vutuv_web/components/post_components.ex:2619
+#: lib/vutuv_web/components/post_components.ex:2624
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Angehefteter Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:2730
+#: lib/vutuv_web/components/post_components.ex:2735
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "An Profil anheften"
 
-#: lib/vutuv_web/components/post_components.ex:2738
+#: lib/vutuv_web/components/post_components.ex:2743
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Vom Profil lösen"
 
-#: lib/vutuv_web/components/post_components.ex:2724
+#: lib/vutuv_web/components/post_components.ex:2729
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr "Es lässt sich nur ein Beitrag an Ihr Profil anheften. Diesen anheften und den anderen lösen?"
@@ -17058,7 +17065,7 @@ msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1146
 #: lib/vutuv_web/agent_docs/text.ex:698
-#: lib/vutuv_web/components/post_components.ex:3198
+#: lib/vutuv_web/components/post_components.ex:3203
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr "Original herunterladen"
@@ -17088,7 +17095,7 @@ msgstr "Volle Auflösung, direkt aus dem Beitrag."
 msgid "Just the picture"
 msgstr "Nur das Bild"
 
-#: lib/vutuv_web/components/post_components.ex:3197
+#: lib/vutuv_web/components/post_components.ex:3202
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr "Nächstes Foto"
@@ -17098,7 +17105,7 @@ msgstr "Nächstes Foto"
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
 
-#: lib/vutuv_web/components/post_components.ex:3578
+#: lib/vutuv_web/components/post_components.ex:3583
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post so far."
 msgstr "Bisher sehen nur Sie diesen Beitrag."
@@ -17108,19 +17115,19 @@ msgstr "Bisher sehen nur Sie diesen Beitrag."
 msgid "Open Fediverse settings"
 msgstr "Fediverse-Einstellungen öffnen"
 
-#: lib/vutuv_web/components/post_components.ex:3581
+#: lib/vutuv_web/components/post_components.ex:3586
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] "Unsere KI prüft das Foto. Sobald es durch ist, geht der Beitrag von selbst online."
 msgstr[1] "Unsere KI prüft die Fotos, %{done} von %{total} sind durch. Sobald das letzte durch ist, geht der Beitrag von selbst online."
 
-#: lib/vutuv_web/components/post_components.ex:3404
+#: lib/vutuv_web/components/post_components.ex:3409
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} von %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:2939
+#: lib/vutuv_web/components/post_components.ex:2944
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
@@ -17133,12 +17140,12 @@ msgstr "Foto-Einstellungen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1179
 #: lib/vutuv_web/agent_docs/text.ex:685
-#: lib/vutuv_web/components/post_components.ex:3615
+#: lib/vutuv_web/components/post_components.ex:3620
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Fotos:"
 
-#: lib/vutuv_web/components/post_components.ex:3196
+#: lib/vutuv_web/components/post_components.ex:3201
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr "Vorheriges Foto"
@@ -17306,13 +17313,13 @@ msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exak
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1052
-#: lib/vutuv_web/components/post_components.ex:4614
+#: lib/vutuv_web/components/post_components.ex:4619
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1050
-#: lib/vutuv_web/components/post_components.ex:4611
+#: lib/vutuv_web/components/post_components.ex:4616
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} hat das geteilt"
@@ -17322,7 +17329,7 @@ msgstr "%{handle} hat das geteilt"
 msgid "Fediverse reactions"
 msgstr "Fediverse-Reaktionen"
 
-#: lib/vutuv_web/components/post_components.ex:4503
+#: lib/vutuv_web/components/post_components.ex:4508
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
@@ -19082,19 +19089,19 @@ msgstr "Auf der Seite eines Beitrags stehen direkt unter der Zahl die Mitglieder
 msgid "Liked by"
 msgstr "Gefällt diesen Mitgliedern"
 
-#: lib/vutuv_web/components/post_components.ex:3781
+#: lib/vutuv_web/components/post_components.ex:3786
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Gefällt %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:3783
+#: lib/vutuv_web/components/post_components.ex:3788
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Gefällt %{name} und %{formatted} weiteren"
 msgstr[1] "Gefällt %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/components/post_components.ex:3794
+#: lib/vutuv_web/components/post_components.ex:3799
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr "Nur Sie sehen hier alle: Einige dieser Mitglieder werden anderen Lesern nicht genannt."
@@ -21037,7 +21044,7 @@ msgstr "Fediverse – %{name}"
 msgid "Page settings"
 msgstr "Seiteneinstellungen"
 
-#: lib/vutuv_web/live/organization_live/fediverse.ex:137
+#: lib/vutuv_web/live/organization_live/fediverse.ex:150
 #, elixir-autogen, elixir-format
 msgid "Switching this off stops new posts from leaving. Copies another server already holds can only be asked to delete them, never made to."
 msgstr "Das Ausschalten hält neue Beiträge zurück. Kopien, die ein anderer Server schon hat, kann man nur um Löschung bitten, nie dazu zwingen."
@@ -21108,7 +21115,7 @@ msgstr "Diese Seite ist nicht im Fediverse."
 msgid "A short @name is needed first"
 msgstr "Zuerst wird ein kurzer @-Name gebraucht"
 
-#: lib/vutuv_web/live/organization_live/fediverse.ex:148
+#: lib/vutuv_web/live/organization_live/fediverse.ex:161
 #, elixir-autogen, elixir-format
 msgid "From now on, posts of this page also go to other networks. Continue?"
 msgstr "Beiträge dieser Seite gehen ab jetzt auch an andere Netzwerke. Fortfahren?"
@@ -21130,12 +21137,12 @@ msgstr "Auch Menschen ohne vutuv-Konto können dieser Seite folgen und ihre Beit
 msgid "Set this page up for other networks"
 msgstr "Seite für andere Netzwerke einrichten"
 
-#: lib/vutuv_web/live/organization_live/fediverse.ex:154
+#: lib/vutuv_web/live/organization_live/fediverse.ex:167
 #, elixir-autogen, elixir-format
 msgid "Switch it off"
 msgstr "Ausschalten"
 
-#: lib/vutuv_web/live/organization_live/fediverse.ex:154
+#: lib/vutuv_web/live/organization_live/fediverse.ex:167
 #, elixir-autogen, elixir-format
 msgid "Switch it on"
 msgstr "Einschalten"
@@ -21155,7 +21162,7 @@ msgstr "Diese Seite ist auf anderen Netzwerken nicht sichtbar. Nichts von ihr ve
 msgid "This page is visible on other networks. %{count} accounts there follow it."
 msgstr "Diese Seite ist auf anderen Netzwerken sichtbar. %{count} Konten dort folgen ihr."
 
-#: lib/vutuv_web/live/organization_live/fediverse.ex:162
+#: lib/vutuv_web/live/organization_live/fediverse.ex:175
 #, elixir-autogen, elixir-format
 msgid "This page was visible on other networks before. Servers that still hold copies keep them until they act on a deletion request."
 msgstr "Diese Seite war früher auf anderen Netzwerken sichtbar. Server, die noch Kopien halten, behalten sie, bis sie einer Löschbitte nachkommen."
@@ -21184,3 +21191,33 @@ msgstr "Dieser Seite darf man aus anderen Netzwerken folgen"
 #, elixir-autogen, elixir-format
 msgid "You can change this at any time on the page's Fediverse settings."
 msgstr "Sie können das jederzeit in den Fediverse-Einstellungen der Seite ändern."
+
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:244
+#, elixir-autogen, elixir-format
+msgid "Accounts that no longer exist on their own server drop off this list by themselves. Names and handles are the ones their server last told us."
+msgstr "Konten, die es auf ihrem eigenen Server nicht mehr gibt, verschwinden von selbst aus dieser Liste. Namen und Handles sind die, die uns der jeweilige Server zuletzt gemeldet hat."
+
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:249
+#, elixir-autogen, elixir-format
+msgid "Back to the Fediverse page"
+msgstr "Zurück zur Fediverse-Seite"
+
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:169
+#, elixir-autogen, elixir-format
+msgid "Everyone on another network who follows this page. Only you see this list: what the page publishes out there is the number, never the names."
+msgstr "Alle, die dieser Seite aus einem anderen Netzwerk folgen. Diese Liste sehen nur Sie: Nach außen veröffentlicht die Seite die Anzahl, nie die Namen."
+
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:50
+#, elixir-autogen, elixir-format
+msgid "Followers – %{name}"
+msgstr "Follower – %{name}"
+
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:176
+#, elixir-autogen, elixir-format
+msgid "Nobody yet. Post the page's address where people can see it, and the first follows will show up here."
+msgstr "Noch niemand. Posten Sie die Adresse der Seite dort, wo andere sie sehen, dann tauchen die ersten Follower hier auf."
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:143
+#, elixir-autogen, elixir-format
+msgid "Who follows this page"
+msgstr "Wer dieser Seite folgt"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -161,7 +161,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2746
+#: lib/vutuv_web/components/post_components.ex:2751
 #: lib/vutuv_web/components/ui.ex:3326
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -210,7 +210,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2711
+#: lib/vutuv_web/components/post_components.ex:2716
 #: lib/vutuv_web/components/ui.ex:3317
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -1612,7 +1612,7 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3195
+#: lib/vutuv_web/components/post_components.ex:3200
 #: lib/vutuv_web/components/ui.ex:280
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
@@ -2097,7 +2097,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2743
+#: lib/vutuv_web/components/post_components.ex:2748
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2140,8 +2140,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2697
-#: lib/vutuv_web/components/post_components.ex:2699
+#: lib/vutuv_web/components/post_components.ex:2702
+#: lib/vutuv_web/components/post_components.ex:2704
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2207,13 +2207,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3131
-#: lib/vutuv_web/components/post_components.ex:3135
+#: lib/vutuv_web/components/post_components.ex:3136
+#: lib/vutuv_web/components/post_components.ex:3140
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3132
+#: lib/vutuv_web/components/post_components.ex:3137
 #: lib/vutuv_web/live/fediverse_account_live.ex:320
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2303,27 +2303,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2694
+#: lib/vutuv_web/components/post_components.ex:2699
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4339
+#: lib/vutuv_web/components/post_components.ex:4344
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4343
+#: lib/vutuv_web/components/post_components.ex:4348
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4341
+#: lib/vutuv_web/components/post_components.ex:4346
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4342
+#: lib/vutuv_web/components/post_components.ex:4347
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2365,7 +2365,7 @@ msgid "All posts"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1603
-#: lib/vutuv_web/components/post_components.ex:4427
+#: lib/vutuv_web/components/post_components.ex:4432
 #: lib/vutuv_web/components/ui.ex:2851
 #: lib/vutuv_web/views/user_html.ex:335
 #, elixir-autogen, elixir-format
@@ -2384,7 +2384,7 @@ msgid "Bookmarks"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1567
-#: lib/vutuv_web/components/post_components.ex:4661
+#: lib/vutuv_web/components/post_components.ex:4666
 #: lib/vutuv_web/components/ui.ex:2837
 #: lib/vutuv_web/live/notification_live/index.ex:1029
 #: lib/vutuv_web/views/user_html.ex:345
@@ -2393,7 +2393,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:996
-#: lib/vutuv_web/components/post_components.ex:4670
+#: lib/vutuv_web/components/post_components.ex:4675
 #: lib/vutuv_web/live/notification_live/index.ex:962
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
@@ -2415,13 +2415,13 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4416
+#: lib/vutuv_web/components/post_components.ex:4421
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1603
-#: lib/vutuv_web/components/post_components.ex:4427
+#: lib/vutuv_web/components/post_components.ex:4432
 #: lib/vutuv_web/live/post_live/saved.ex:775
 #: lib/vutuv_web/views/user_html.ex:335
 #, elixir-autogen, elixir-format
@@ -2429,25 +2429,25 @@ msgid "Remove bookmark"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1591
-#: lib/vutuv_web/components/post_components.ex:4413
+#: lib/vutuv_web/components/post_components.ex:4418
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1781
-#: lib/vutuv_web/components/post_components.ex:3711
+#: lib/vutuv_web/components/post_components.ex:3716
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1591
-#: lib/vutuv_web/components/post_components.ex:4413
+#: lib/vutuv_web/components/post_components.ex:4418
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4661
+#: lib/vutuv_web/components/post_components.ex:4666
 #: lib/vutuv_web/live/post_live/saved.ex:774
 #: lib/vutuv_web/views/user_html.ex:345
 #, elixir-autogen, elixir-format
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4714
+#: lib/vutuv_web/components/post_components.ex:4719
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2485,15 +2485,15 @@ msgid "Replies"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1578
-#: lib/vutuv_web/components/post_components.ex:4697
-#: lib/vutuv_web/components/post_components.ex:4698
+#: lib/vutuv_web/components/post_components.ex:4702
+#: lib/vutuv_web/components/post_components.ex:4703
 #: lib/vutuv_web/live/notification_live/index.ex:1026
 #: lib/vutuv_web/live/post_live/reply.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2661
+#: lib/vutuv_web/components/post_components.ex:2666
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2522,14 +2522,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2637
+#: lib/vutuv_web/components/post_components.ex:2642
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2631
-#: lib/vutuv_web/components/post_components.ex:2653
-#: lib/vutuv_web/components/post_components.ex:2656
+#: lib/vutuv_web/components/post_components.ex:2636
+#: lib/vutuv_web/components/post_components.ex:2658
+#: lib/vutuv_web/components/post_components.ex:2661
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2830,7 +2830,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4340
+#: lib/vutuv_web/components/post_components.ex:4345
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3093,7 +3093,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2607
+#: lib/vutuv_web/components/post_components.ex:2612
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3170,7 +3170,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1066
 #: lib/vutuv_web/components/post_components.ex:2042
-#: lib/vutuv_web/components/post_components.ex:2767
+#: lib/vutuv_web/components/post_components.ex:2772
 #: lib/vutuv_web/live/organization_live/show.ex:532
 #: lib/vutuv_web/templates/user/show.html.heex:219
 #, elixir-autogen, elixir-format
@@ -5409,9 +5409,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2830
-#: lib/vutuv_web/components/post_components.ex:2882
-#: lib/vutuv_web/components/post_components.ex:3275
+#: lib/vutuv_web/components/post_components.ex:2835
+#: lib/vutuv_web/components/post_components.ex:2887
+#: lib/vutuv_web/components/post_components.ex:3280
 #: lib/vutuv_web/live/notification_live/index.ex:682
 #: lib/vutuv_web/live/post_live/feed.ex:1261
 #: lib/vutuv_web/views/user_html.ex:113
@@ -5462,6 +5462,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:271
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:144
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:192
 #: lib/vutuv_web/templates/social_media_account/form_content.html.heex:12
 #, elixir-autogen, elixir-format
@@ -6644,7 +6645,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2764
+#: lib/vutuv_web/components/post_components.ex:2769
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6654,7 +6655,7 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2763
+#: lib/vutuv_web/components/post_components.ex:2768
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -7336,7 +7337,7 @@ msgstr ""
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4572
+#: lib/vutuv_web/components/post_components.ex:4577
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8807,7 +8808,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3714
+#: lib/vutuv_web/components/post_components.ex:3719
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -11104,7 +11105,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) and list them for AI agents."
 msgstr ""
 
-#: lib/vutuv_web/controllers/organization_controller.ex:241
+#: lib/vutuv_web/controllers/organization_controller.ex:255
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:31
 #, elixir-autogen, elixir-format
 msgid "Please log in first."
@@ -13700,34 +13701,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4202
+#: lib/vutuv_web/components/post_components.ex:4207
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1085
-#: lib/vutuv_web/components/post_components.ex:4159
+#: lib/vutuv_web/components/post_components.ex:4164
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4203
+#: lib/vutuv_web/components/post_components.ex:4208
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4205
+#: lib/vutuv_web/components/post_components.ex:4210
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4201
+#: lib/vutuv_web/components/post_components.ex:4206
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1085
-#: lib/vutuv_web/components/post_components.ex:4158
+#: lib/vutuv_web/components/post_components.ex:4163
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13738,12 +13739,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4200
+#: lib/vutuv_web/components/post_components.ex:4205
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4204
+#: lib/vutuv_web/components/post_components.ex:4209
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13763,7 +13764,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4241
+#: lib/vutuv_web/components/post_components.ex:4246
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13771,27 +13772,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4271
+#: lib/vutuv_web/components/post_components.ex:4276
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4272
+#: lib/vutuv_web/components/post_components.ex:4277
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4270
+#: lib/vutuv_web/components/post_components.ex:4275
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4230
+#: lib/vutuv_web/components/post_components.ex:4235
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4277
+#: lib/vutuv_web/components/post_components.ex:4282
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13821,7 +13822,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4044
+#: lib/vutuv_web/components/post_components.ex:4049
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13869,7 +13870,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4035
+#: lib/vutuv_web/components/post_components.ex:4040
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14273,7 +14274,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4669
+#: lib/vutuv_web/components/post_components.ex:4674
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14622,6 +14623,7 @@ msgstr ""
 #: lib/vutuv_web/components/browse_table.ex:364
 #: lib/vutuv_web/live/fediverse_followers_live.ex:155
 #: lib/vutuv_web/live/fediverse_following_live.ex:272
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:145
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:96
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:147
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:191
@@ -14685,6 +14687,7 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_followers_live.ex:60
 #: lib/vutuv_web/live/fediverse_followers_live.ex:166
 #: lib/vutuv_web/live/fediverse_followers_live.ex:176
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:165
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:15
 #, elixir-autogen, elixir-format
 msgid "Followers from other networks"
@@ -15444,21 +15447,21 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4617
+#: lib/vutuv_web/components/post_components.ex:4622
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4621
+#: lib/vutuv_web/components/post_components.ex:4626
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4625
+#: lib/vutuv_web/components/post_components.ex:4630
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15466,7 +15469,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1034
-#: lib/vutuv_web/components/post_components.ex:4576
+#: lib/vutuv_web/components/post_components.ex:4581
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15598,11 +15601,13 @@ msgid "All servers"
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:156
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:146
 #, elixir-autogen, elixir-format
 msgid "Following since"
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:258
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:242
 #, elixir-autogen, elixir-format
 msgid "How this list keeps itself honest"
 msgstr ""
@@ -15613,11 +15618,13 @@ msgid "name, handle or server"
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:199
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:188
 #, elixir-autogen, elixir-format
 msgid "No follower matches that. Try a shorter search, or clear the filters."
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:231
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:216
 #, elixir-autogen, elixir-format
 msgid "Show only followers from this server"
 msgstr ""
@@ -16222,22 +16229,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2619
+#: lib/vutuv_web/components/post_components.ex:2624
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2730
+#: lib/vutuv_web/components/post_components.ex:2735
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2738
+#: lib/vutuv_web/components/post_components.ex:2743
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2724
+#: lib/vutuv_web/components/post_components.ex:2729
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16323,7 +16330,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1146
 #: lib/vutuv_web/agent_docs/text.ex:698
-#: lib/vutuv_web/components/post_components.ex:3198
+#: lib/vutuv_web/components/post_components.ex:3203
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
@@ -16353,7 +16360,7 @@ msgstr ""
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3197
+#: lib/vutuv_web/components/post_components.ex:3202
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
@@ -16363,7 +16370,7 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3578
+#: lib/vutuv_web/components/post_components.ex:3583
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post so far."
 msgstr ""
@@ -16373,19 +16380,19 @@ msgstr ""
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3581
+#: lib/vutuv_web/components/post_components.ex:3586
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3404
+#: lib/vutuv_web/components/post_components.ex:3409
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2939
+#: lib/vutuv_web/components/post_components.ex:2944
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16398,12 +16405,12 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1179
 #: lib/vutuv_web/agent_docs/text.ex:685
-#: lib/vutuv_web/components/post_components.ex:3615
+#: lib/vutuv_web/components/post_components.ex:3620
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3196
+#: lib/vutuv_web/components/post_components.ex:3201
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr ""
@@ -16571,13 +16578,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1052
-#: lib/vutuv_web/components/post_components.ex:4614
+#: lib/vutuv_web/components/post_components.ex:4619
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1050
-#: lib/vutuv_web/components/post_components.ex:4611
+#: lib/vutuv_web/components/post_components.ex:4616
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr ""
@@ -16587,7 +16594,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4503
+#: lib/vutuv_web/components/post_components.ex:4508
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr ""
@@ -18322,19 +18329,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3781
+#: lib/vutuv_web/components/post_components.ex:3786
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3783
+#: lib/vutuv_web/components/post_components.ex:3788
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3794
+#: lib/vutuv_web/components/post_components.ex:3799
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -20253,7 +20260,7 @@ msgstr ""
 msgid "Page settings"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/fediverse.ex:137
+#: lib/vutuv_web/live/organization_live/fediverse.ex:150
 #, elixir-autogen, elixir-format
 msgid "Switching this off stops new posts from leaving. Copies another server already holds can only be asked to delete them, never made to."
 msgstr ""
@@ -20324,7 +20331,7 @@ msgstr ""
 msgid "A short @name is needed first"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/fediverse.ex:148
+#: lib/vutuv_web/live/organization_live/fediverse.ex:161
 #, elixir-autogen, elixir-format
 msgid "From now on, posts of this page also go to other networks. Continue?"
 msgstr ""
@@ -20346,12 +20353,12 @@ msgstr ""
 msgid "Set this page up for other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/fediverse.ex:154
+#: lib/vutuv_web/live/organization_live/fediverse.ex:167
 #, elixir-autogen, elixir-format
 msgid "Switch it off"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/fediverse.ex:154
+#: lib/vutuv_web/live/organization_live/fediverse.ex:167
 #, elixir-autogen, elixir-format
 msgid "Switch it on"
 msgstr ""
@@ -20371,7 +20378,7 @@ msgstr ""
 msgid "This page is visible on other networks. %{count} accounts there follow it."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/fediverse.ex:162
+#: lib/vutuv_web/live/organization_live/fediverse.ex:175
 #, elixir-autogen, elixir-format
 msgid "This page was visible on other networks before. Servers that still hold copies keep them until they act on a deletion request."
 msgstr ""
@@ -20399,4 +20406,34 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/new.ex:214
 #, elixir-autogen, elixir-format
 msgid "You can change this at any time on the page's Fediverse settings."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:244
+#, elixir-autogen, elixir-format
+msgid "Accounts that no longer exist on their own server drop off this list by themselves. Names and handles are the ones their server last told us."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:249
+#, elixir-autogen, elixir-format
+msgid "Back to the Fediverse page"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:169
+#, elixir-autogen, elixir-format
+msgid "Everyone on another network who follows this page. Only you see this list: what the page publishes out there is the number, never the names."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:50
+#, elixir-autogen, elixir-format
+msgid "Followers – %{name}"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:176
+#, elixir-autogen, elixir-format
+msgid "Nobody yet. Post the page's address where people can see it, and the first follows will show up here."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:143
+#, elixir-autogen, elixir-format
+msgid "Who follows this page"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -159,7 +159,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2746
+#: lib/vutuv_web/components/post_components.ex:2751
 #: lib/vutuv_web/components/ui.ex:3326
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -208,7 +208,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2711
+#: lib/vutuv_web/components/post_components.ex:2716
 #: lib/vutuv_web/components/ui.ex:3317
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -1610,7 +1610,7 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3195
+#: lib/vutuv_web/components/post_components.ex:3200
 #: lib/vutuv_web/components/ui.ex:280
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
@@ -2095,7 +2095,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2743
+#: lib/vutuv_web/components/post_components.ex:2748
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2138,8 +2138,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2697
-#: lib/vutuv_web/components/post_components.ex:2699
+#: lib/vutuv_web/components/post_components.ex:2702
+#: lib/vutuv_web/components/post_components.ex:2704
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2205,13 +2205,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3131
-#: lib/vutuv_web/components/post_components.ex:3135
+#: lib/vutuv_web/components/post_components.ex:3136
+#: lib/vutuv_web/components/post_components.ex:3140
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3132
+#: lib/vutuv_web/components/post_components.ex:3137
 #: lib/vutuv_web/live/fediverse_account_live.ex:320
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2301,27 +2301,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2694
+#: lib/vutuv_web/components/post_components.ex:2699
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4339
+#: lib/vutuv_web/components/post_components.ex:4344
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4343
+#: lib/vutuv_web/components/post_components.ex:4348
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4341
+#: lib/vutuv_web/components/post_components.ex:4346
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4342
+#: lib/vutuv_web/components/post_components.ex:4347
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2363,7 +2363,7 @@ msgid "All posts"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1603
-#: lib/vutuv_web/components/post_components.ex:4427
+#: lib/vutuv_web/components/post_components.ex:4432
 #: lib/vutuv_web/components/ui.ex:2851
 #: lib/vutuv_web/views/user_html.ex:335
 #, elixir-autogen, elixir-format
@@ -2382,7 +2382,7 @@ msgid "Bookmarks"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1567
-#: lib/vutuv_web/components/post_components.ex:4661
+#: lib/vutuv_web/components/post_components.ex:4666
 #: lib/vutuv_web/components/ui.ex:2837
 #: lib/vutuv_web/live/notification_live/index.ex:1029
 #: lib/vutuv_web/views/user_html.ex:345
@@ -2391,7 +2391,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:996
-#: lib/vutuv_web/components/post_components.ex:4670
+#: lib/vutuv_web/components/post_components.ex:4675
 #: lib/vutuv_web/live/notification_live/index.ex:962
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
@@ -2413,13 +2413,13 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4416
+#: lib/vutuv_web/components/post_components.ex:4421
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1603
-#: lib/vutuv_web/components/post_components.ex:4427
+#: lib/vutuv_web/components/post_components.ex:4432
 #: lib/vutuv_web/live/post_live/saved.ex:775
 #: lib/vutuv_web/views/user_html.ex:335
 #, elixir-autogen, elixir-format
@@ -2427,25 +2427,25 @@ msgid "Remove bookmark"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1591
-#: lib/vutuv_web/components/post_components.ex:4413
+#: lib/vutuv_web/components/post_components.ex:4418
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1781
-#: lib/vutuv_web/components/post_components.ex:3711
+#: lib/vutuv_web/components/post_components.ex:3716
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1591
-#: lib/vutuv_web/components/post_components.ex:4413
+#: lib/vutuv_web/components/post_components.ex:4418
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4661
+#: lib/vutuv_web/components/post_components.ex:4666
 #: lib/vutuv_web/live/post_live/saved.ex:774
 #: lib/vutuv_web/views/user_html.ex:345
 #, elixir-autogen, elixir-format
@@ -2471,7 +2471,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4714
+#: lib/vutuv_web/components/post_components.ex:4719
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2483,15 +2483,15 @@ msgid "Replies"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1578
-#: lib/vutuv_web/components/post_components.ex:4697
-#: lib/vutuv_web/components/post_components.ex:4698
+#: lib/vutuv_web/components/post_components.ex:4702
+#: lib/vutuv_web/components/post_components.ex:4703
 #: lib/vutuv_web/live/notification_live/index.ex:1026
 #: lib/vutuv_web/live/post_live/reply.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2661
+#: lib/vutuv_web/components/post_components.ex:2666
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2520,14 +2520,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2637
+#: lib/vutuv_web/components/post_components.ex:2642
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2631
-#: lib/vutuv_web/components/post_components.ex:2653
-#: lib/vutuv_web/components/post_components.ex:2656
+#: lib/vutuv_web/components/post_components.ex:2636
+#: lib/vutuv_web/components/post_components.ex:2658
+#: lib/vutuv_web/components/post_components.ex:2661
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2828,7 +2828,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4340
+#: lib/vutuv_web/components/post_components.ex:4345
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3091,7 +3091,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2607
+#: lib/vutuv_web/components/post_components.ex:2612
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3168,7 +3168,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1066
 #: lib/vutuv_web/components/post_components.ex:2042
-#: lib/vutuv_web/components/post_components.ex:2767
+#: lib/vutuv_web/components/post_components.ex:2772
 #: lib/vutuv_web/live/organization_live/show.ex:532
 #: lib/vutuv_web/templates/user/show.html.heex:219
 #, elixir-autogen, elixir-format
@@ -5407,9 +5407,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2830
-#: lib/vutuv_web/components/post_components.ex:2882
-#: lib/vutuv_web/components/post_components.ex:3275
+#: lib/vutuv_web/components/post_components.ex:2835
+#: lib/vutuv_web/components/post_components.ex:2887
+#: lib/vutuv_web/components/post_components.ex:3280
 #: lib/vutuv_web/live/notification_live/index.ex:682
 #: lib/vutuv_web/live/post_live/feed.ex:1261
 #: lib/vutuv_web/views/user_html.ex:113
@@ -5460,6 +5460,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:271
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:144
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:192
 #: lib/vutuv_web/templates/social_media_account/form_content.html.heex:12
 #, elixir-autogen, elixir-format
@@ -6642,7 +6643,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2764
+#: lib/vutuv_web/components/post_components.ex:2769
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6652,7 +6653,7 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2763
+#: lib/vutuv_web/components/post_components.ex:2768
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -7334,7 +7335,7 @@ msgstr ""
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4572
+#: lib/vutuv_web/components/post_components.ex:4577
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8805,7 +8806,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3714
+#: lib/vutuv_web/components/post_components.ex:3719
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -11102,7 +11103,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) and list them for AI agents."
 msgstr ""
 
-#: lib/vutuv_web/controllers/organization_controller.ex:241
+#: lib/vutuv_web/controllers/organization_controller.ex:255
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:31
 #, elixir-autogen, elixir-format
 msgid "Please log in first."
@@ -13698,34 +13699,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4202
+#: lib/vutuv_web/components/post_components.ex:4207
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1085
-#: lib/vutuv_web/components/post_components.ex:4159
+#: lib/vutuv_web/components/post_components.ex:4164
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4203
+#: lib/vutuv_web/components/post_components.ex:4208
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4205
+#: lib/vutuv_web/components/post_components.ex:4210
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4201
+#: lib/vutuv_web/components/post_components.ex:4206
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1085
-#: lib/vutuv_web/components/post_components.ex:4158
+#: lib/vutuv_web/components/post_components.ex:4163
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13736,12 +13737,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4200
+#: lib/vutuv_web/components/post_components.ex:4205
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4204
+#: lib/vutuv_web/components/post_components.ex:4209
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13761,7 +13762,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4241
+#: lib/vutuv_web/components/post_components.ex:4246
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13769,27 +13770,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4271
+#: lib/vutuv_web/components/post_components.ex:4276
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4272
+#: lib/vutuv_web/components/post_components.ex:4277
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4270
+#: lib/vutuv_web/components/post_components.ex:4275
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4230
+#: lib/vutuv_web/components/post_components.ex:4235
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4277
+#: lib/vutuv_web/components/post_components.ex:4282
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13819,7 +13820,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4044
+#: lib/vutuv_web/components/post_components.ex:4049
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13867,7 +13868,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4035
+#: lib/vutuv_web/components/post_components.ex:4040
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14271,7 +14272,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4669
+#: lib/vutuv_web/components/post_components.ex:4674
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14620,6 +14621,7 @@ msgstr ""
 #: lib/vutuv_web/components/browse_table.ex:364
 #: lib/vutuv_web/live/fediverse_followers_live.ex:155
 #: lib/vutuv_web/live/fediverse_following_live.ex:272
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:145
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:96
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:147
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:191
@@ -14683,6 +14685,7 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_followers_live.ex:60
 #: lib/vutuv_web/live/fediverse_followers_live.ex:166
 #: lib/vutuv_web/live/fediverse_followers_live.ex:176
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:165
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:15
 #, elixir-autogen, elixir-format
 msgid "Followers from other networks"
@@ -15442,21 +15445,21 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4617
+#: lib/vutuv_web/components/post_components.ex:4622
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4621
+#: lib/vutuv_web/components/post_components.ex:4626
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4625
+#: lib/vutuv_web/components/post_components.ex:4630
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15464,7 +15467,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1034
-#: lib/vutuv_web/components/post_components.ex:4576
+#: lib/vutuv_web/components/post_components.ex:4581
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15596,11 +15599,13 @@ msgid "All servers"
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:156
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:146
 #, elixir-autogen, elixir-format
 msgid "Following since"
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:258
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:242
 #, elixir-autogen, elixir-format
 msgid "How this list keeps itself honest"
 msgstr ""
@@ -15611,11 +15616,13 @@ msgid "name, handle or server"
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:199
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:188
 #, elixir-autogen, elixir-format
 msgid "No follower matches that. Try a shorter search, or clear the filters."
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:231
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:216
 #, elixir-autogen, elixir-format
 msgid "Show only followers from this server"
 msgstr ""
@@ -16220,22 +16227,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2619
+#: lib/vutuv_web/components/post_components.ex:2624
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2730
+#: lib/vutuv_web/components/post_components.ex:2735
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2738
+#: lib/vutuv_web/components/post_components.ex:2743
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2724
+#: lib/vutuv_web/components/post_components.ex:2729
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16321,7 +16328,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1146
 #: lib/vutuv_web/agent_docs/text.ex:698
-#: lib/vutuv_web/components/post_components.ex:3198
+#: lib/vutuv_web/components/post_components.ex:3203
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
@@ -16351,7 +16358,7 @@ msgstr ""
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3197
+#: lib/vutuv_web/components/post_components.ex:3202
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
@@ -16361,7 +16368,7 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3578
+#: lib/vutuv_web/components/post_components.ex:3583
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Only you can see this post so far."
 msgstr ""
@@ -16371,19 +16378,19 @@ msgstr ""
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3581
+#: lib/vutuv_web/components/post_components.ex:3586
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3404
+#: lib/vutuv_web/components/post_components.ex:3409
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2939
+#: lib/vutuv_web/components/post_components.ex:2944
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16396,12 +16403,12 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1179
 #: lib/vutuv_web/agent_docs/text.ex:685
-#: lib/vutuv_web/components/post_components.ex:3615
+#: lib/vutuv_web/components/post_components.ex:3620
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3196
+#: lib/vutuv_web/components/post_components.ex:3201
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Previous photo"
 msgstr ""
@@ -16569,13 +16576,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1052
-#: lib/vutuv_web/components/post_components.ex:4614
+#: lib/vutuv_web/components/post_components.ex:4619
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1050
-#: lib/vutuv_web/components/post_components.ex:4611
+#: lib/vutuv_web/components/post_components.ex:4616
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
 msgstr ""
@@ -16585,7 +16592,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4503
+#: lib/vutuv_web/components/post_components.ex:4508
 #, elixir-autogen, elixir-format, fuzzy
 msgid "From other networks"
 msgstr ""
@@ -18320,19 +18327,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3781
+#: lib/vutuv_web/components/post_components.ex:3786
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3783
+#: lib/vutuv_web/components/post_components.ex:3788
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3794
+#: lib/vutuv_web/components/post_components.ex:3799
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -20251,7 +20258,7 @@ msgstr ""
 msgid "Page settings"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/fediverse.ex:137
+#: lib/vutuv_web/live/organization_live/fediverse.ex:150
 #, elixir-autogen, elixir-format
 msgid "Switching this off stops new posts from leaving. Copies another server already holds can only be asked to delete them, never made to."
 msgstr ""
@@ -20322,7 +20329,7 @@ msgstr ""
 msgid "A short @name is needed first"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/fediverse.ex:148
+#: lib/vutuv_web/live/organization_live/fediverse.ex:161
 #, elixir-autogen, elixir-format
 msgid "From now on, posts of this page also go to other networks. Continue?"
 msgstr ""
@@ -20344,12 +20351,12 @@ msgstr ""
 msgid "Set this page up for other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/fediverse.ex:154
+#: lib/vutuv_web/live/organization_live/fediverse.ex:167
 #, elixir-autogen, elixir-format
 msgid "Switch it off"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/fediverse.ex:154
+#: lib/vutuv_web/live/organization_live/fediverse.ex:167
 #, elixir-autogen, elixir-format
 msgid "Switch it on"
 msgstr ""
@@ -20369,7 +20376,7 @@ msgstr ""
 msgid "This page is visible on other networks. %{count} accounts there follow it."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/fediverse.ex:162
+#: lib/vutuv_web/live/organization_live/fediverse.ex:175
 #, elixir-autogen, elixir-format
 msgid "This page was visible on other networks before. Servers that still hold copies keep them until they act on a deletion request."
 msgstr ""
@@ -20397,4 +20404,34 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/new.ex:214
 #, elixir-autogen, elixir-format
 msgid "You can change this at any time on the page's Fediverse settings."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:244
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Accounts that no longer exist on their own server drop off this list by themselves. Names and handles are the ones their server last told us."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:249
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Back to the Fediverse page"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:169
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Everyone on another network who follows this page. Only you see this list: what the page publishes out there is the number, never the names."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:50
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Followers – %{name}"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse_followers.ex:176
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Nobody yet. Post the page's address where people can see it, and the first follows will show up here."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/fediverse.ex:143
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Who follows this page"
 msgstr ""

--- a/priv/repo/migrations/20260812091425_add_organization_id_to_fediverse_note_events.exs
+++ b/priv/repo/migrations/20260812091425_add_organization_id_to_fediverse_note_events.exs
@@ -1,0 +1,16 @@
+defmodule Vutuv.Repo.Migrations.AddOrganizationIdToFediverseNoteEvents do
+  use Ecto.Migration
+
+  # The takedown ledger recorded `user_id` = whose page the removed reply sat
+  # on, and NULL for content that sat on nobody's (a cached post). An
+  # organization post is a third case: it sits on a page, and reading a NULL
+  # there as "nobody's" would be untrue.
+  #
+  # A plain nullable column, so the release still serving traffic during the
+  # deploy keeps working (it simply never writes it).
+  def change do
+    alter table(:fediverse_note_events) do
+      add(:organization_id, :binary_id)
+    end
+  end
+end

--- a/test/vutuv/organization_fediverse_followers_test.exs
+++ b/test/vutuv/organization_fediverse_followers_test.exs
@@ -134,4 +134,77 @@ defmodule Vutuv.OrganizationFediverseFollowersTest do
 
     assert Fediverse.organization_remote_follower_count(organization) == 0
   end
+
+  describe "browsing them" do
+    setup do
+      organization = page()
+      member = insert(:activated_user)
+
+      # One follower of a MEMBER on the same server, to prove the scoping: the
+      # browser reads one shared table where a page's rows hang off
+      # `organization_id` and a member's off `user_id`.
+      {:ok, _} = Fediverse.add_follower(member, attrs())
+
+      {:ok, _} =
+        Fediverse.add_organization_follower(
+          organization,
+          attrs(%{
+            actor_uri: "https://remote.example/users/hans",
+            handle: "@hans@remote.example",
+            name: "Hans"
+          })
+        )
+
+      {:ok, _} =
+        Fediverse.add_organization_follower(
+          organization,
+          attrs(%{
+            actor_uri: "https://andere.example/users/ida",
+            inbox_uri: "https://andere.example/users/ida/inbox",
+            handle: "@ida@andere.example",
+            name: "Ida"
+          })
+        )
+
+      {:ok, organization: organization, member: member}
+    end
+
+    test "the page's own rows, and nobody else's", %{organization: organization, member: member} do
+      filters = Fediverse.browse_filters(%{})
+
+      assert Fediverse.count_followers(organization, filters) == 2
+      assert Fediverse.count_followers(member, filters) == 1
+
+      names =
+        organization
+        |> Fediverse.list_followers_page(filters)
+        |> Enum.map(& &1.name)
+        |> Enum.sort()
+
+      assert names == ["Hans", "Ida"]
+    end
+
+    test "searching and filtering by server work on a page too", %{organization: organization} do
+      assert [%Follower{name: "Ida"}] =
+               Fediverse.list_followers_page(
+                 organization,
+                 Fediverse.browse_filters(%{"q" => "ida"})
+               )
+
+      assert [%Follower{name: "Hans"}] =
+               Fediverse.list_followers_page(
+                 organization,
+                 Fediverse.browse_filters(%{"server" => "remote.example"})
+               )
+    end
+
+    test "the server list counts only the page's followers", %{organization: organization} do
+      hosts = Fediverse.follower_hosts(organization)
+
+      assert Enum.sort_by(hosts, & &1.host) == [
+               %{host: "andere.example", count: 1},
+               %{host: "remote.example", count: 1}
+             ]
+    end
+  end
 end

--- a/test/vutuv/organization_fediverse_replies_test.exs
+++ b/test/vutuv/organization_fediverse_replies_test.exs
@@ -17,7 +17,11 @@ defmodule Vutuv.OrganizationFediverseRepliesTest do
   import Vutuv.OrganizationsHelpers
 
   alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Delivery
+  alias Vutuv.Fediverse.Note
+  alias Vutuv.Fediverse.NoteEvent
   alias Vutuv.Organizations
+  alias Vutuv.Organizations.OrganizationRole
   alias Vutuv.Posts
   alias Vutuv.Repo
   alias VutuvWeb.Fediverse.Docs
@@ -36,6 +40,11 @@ defmodule Vutuv.OrganizationFediverseRepliesTest do
   end
 
   defp published_post(opts \\ []) do
+    {page, post, _owner} = published_post_with_owner(opts)
+    {page, post}
+  end
+
+  defp published_post_with_owner(opts) do
     owner = insert(:activated_user)
     page = active_organization_for(owner)
     {:ok, _} = Organizations.add_role(page, owner, "publisher", owner)
@@ -47,7 +56,7 @@ defmodule Vutuv.OrganizationFediverseRepliesTest do
 
     if page.fediverse_followers?, do: {:ok, _} = Fediverse.ensure_organization_actor(page)
     {:ok, post} = Posts.create_organization_post(page, owner, %{body: "Nach draußen."})
-    {page, post}
+    {page, post, owner}
   end
 
   defp actor,
@@ -133,5 +142,74 @@ defmodule Vutuv.OrganizationFediverseRepliesTest do
     # note carries nothing to show.
     assert :skip = Fediverse.record_organization_reply(page, activity, actor())
     assert Fediverse.list_notes([post.id], nil) == %{}
+  end
+
+  describe "taking a reply down" do
+    setup do
+      {page, post, owner} = published_post_with_owner([])
+      :ok = Fediverse.record_organization_reply(page, reply_activity(page, post), actor())
+
+      {:ok, page: page, post: post, owner: owner, note: Repo.one!(Note)}
+    end
+
+    test "a publisher takes a reply off the page's post", %{owner: owner, note: note} do
+      # The page has no replies switch, so the single reply IS the team's only
+      # lever over what strangers write under its posts. Until this it had none:
+      # the ownership check read `posts.user_id`, which an organization post
+      # leaves NULL, so nobody but an admin passed it.
+      assert :ok = Fediverse.remove_note(note.id, owner)
+
+      assert Repo.aggregate(Note, :count) == 0
+      assert [%NoteEvent{action: "removed_by_member"} = event] = Repo.all(NoteEvent)
+      assert event.actor_id == owner.id
+      assert event.host == "social.example"
+    end
+
+    test "the role carries the power, not the person", %{page: page, owner: owner, note: note} do
+      # Withdrawn publisher, and the lever goes with the role rather than
+      # staying with whoever happened to press publish — the same rule
+      # `Posts.author?/2` applies to editing the page's posts.
+      Repo.delete_all(
+        from(r in OrganizationRole,
+          where:
+            r.organization_id == ^page.id and r.user_id == ^owner.id and r.role == "publisher"
+        )
+      )
+
+      assert {:error, :not_allowed} = Fediverse.remove_note(note.id, owner)
+      assert Repo.aggregate(Note, :count) == 1
+    end
+
+    test "somebody who does not speak for the page cannot remove it", %{note: note} do
+      assert {:error, :not_allowed} = Fediverse.remove_note(note.id, insert(:activated_user))
+      assert Repo.aggregate(Note, :count) == 1
+    end
+
+    test "a report deletes it and files the Flag in the page's name", %{
+      page: page,
+      note: note
+    } do
+      # The Flag has to be signed by an actor the origin server can verify, and
+      # for a page's post that is the page. Reading the signer off
+      # `posts.user_id` handed `Repo.get(User, nil)` a NULL, which RAISES: a
+      # 500 on the report button of every page post.
+      assert :ok = Fediverse.report_note(note.id, insert(:activated_user))
+
+      assert Repo.aggregate(Note, :count) == 0
+
+      delivery = Repo.one!(from(d in Delivery, where: d.organization_id == ^page.id))
+      activity = Jason.decode!(delivery.activity_json)
+      assert activity["type"] == "Flag"
+      assert activity["actor"] == Docs.actor_url(page)
+      assert delivery.user_id == nil
+    end
+
+    test "the ledger names the page the reply sat on", %{page: page, owner: owner, note: note} do
+      :ok = Fediverse.remove_note(note.id, owner)
+
+      assert [%NoteEvent{} = event] = Repo.all(NoteEvent)
+      assert event.organization_id == page.id
+      assert event.user_id == nil
+    end
   end
 end

--- a/test/vutuv_web/live/post_thread_remote_replies_test.exs
+++ b/test/vutuv_web/live/post_thread_remote_replies_test.exs
@@ -10,10 +10,12 @@ defmodule VutuvWeb.PostThreadRemoteRepliesTest do
   use VutuvWeb.ConnCase, async: false
 
   import Phoenix.LiveViewTest
+  import Vutuv.OrganizationsHelpers
   import Vutuv.PostsHelpers
 
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.Note
+  alias Vutuv.Organizations
   alias Vutuv.Posts
 
   @actor "https://social.example/users/alice"
@@ -70,6 +72,25 @@ defmodule VutuvWeb.PostThreadRemoteRepliesTest do
       build_conn() |> Plug.Test.init_test_session(%{}) |> create_and_login_user()
 
     {user, Plug.Conn.get_session(conn)}
+  end
+
+  # A federating page with a post of its own, plus the cookie session of a
+  # member who may speak for it. Returns `{page, post, publisher_session}`.
+  defp page_post do
+    {conn, owner} =
+      build_conn() |> Plug.Test.init_test_session(%{}) |> create_and_login_user()
+
+    page = active_organization_for(owner)
+    {:ok, _} = Organizations.add_role(page, owner, "publisher", owner)
+
+    page =
+      page
+      |> Ecto.Changeset.change(%{fediverse_followers?: true, username: "acme"})
+      |> Repo.update!()
+
+    {:ok, post} = Posts.create_organization_post(page, owner, %{body: "Nach draußen."})
+
+    {page, post, Plug.Conn.get_session(conn)}
   end
 
   describe "a public reply" do
@@ -306,6 +327,74 @@ defmodule VutuvWeb.PostThreadRemoteRepliesTest do
       encoded = inspect(Map.from_struct(event))
       refute encoded =~ "Sturdier than they look."
       refute encoded =~ @actor
+    end
+  end
+
+  describe "takedown under a page's post" do
+    setup do
+      Application.put_env(:vutuv, :verify_organization_domains, true)
+
+      on_exit(fn ->
+        Application.put_env(:vutuv, :verify_organization_domains, false)
+        Application.delete_env(:vutuv, :organizations_dns_resolver)
+      end)
+
+      :ok
+    end
+
+    test "a publisher removes it, quietly" do
+      # A page has no replies switch, so this single control is its team's whole
+      # say over what strangers write under its posts. It used to be missing:
+      # the gate compared `posts.user_id`, which an organization post leaves
+      # NULL, leaving the team only "Report" — which deletes the reply AND
+      # accuses its author to their own server.
+      {_page, post, publisher} = page_post()
+      note = note!(post)
+
+      {:ok, view, html} = thread_view(post, publisher)
+      assert html =~ "Sturdier than they look."
+
+      html =
+        view
+        |> element(~s([phx-click="remove-remote-reply"][phx-value-id="#{note.id}"]))
+        |> render_click()
+
+      refute html =~ "Sturdier than they look."
+      refute Repo.get(Note, note.id)
+    end
+
+    test "a member who does not speak for the page has no Remove" do
+      # The bystander is logged in first on purpose: `sent_pin/0` reads the
+      # OLDEST mail in this process's mailbox, and creating a page mails its
+      # owner, so a login after that would read the page notice and find no PIN.
+      {_other, cookie} = other_member()
+      {_page, post, _publisher} = page_post()
+      note!(post)
+
+      {:ok, _view, html} = thread_view(post, cookie)
+
+      assert html =~ ~s(phx-click="report-remote-reply")
+      refute html =~ ~s(phx-click="remove-remote-reply")
+    end
+
+    test "reporting one signs the Flag in the page's name" do
+      {_other, cookie} = other_member()
+      {page, post, _publisher} = page_post()
+      note = note!(post)
+
+      {:ok, _} = Fediverse.ensure_organization_actor(page)
+      {:ok, view, _html} = thread_view(post, cookie)
+
+      view
+      |> element(~s([phx-click="report-remote-reply"][phx-value-id="#{note.id}"]))
+      |> render_click()
+
+      refute Repo.get(Note, note.id)
+
+      delivery =
+        Repo.one!(from(d in Vutuv.Fediverse.Delivery, where: d.organization_id == ^page.id))
+
+      assert Jason.decode!(delivery.activity_json)["type"] == "Flag"
     end
   end
 

--- a/test/vutuv_web/organization_fediverse_followers_web_test.exs
+++ b/test/vutuv_web/organization_fediverse_followers_web_test.exs
@@ -1,0 +1,154 @@
+defmodule VutuvWeb.OrganizationFediverseFollowersWebTest do
+  @moduledoc """
+  Who follows a page from other networks
+  (`/organizations/:slug/fediverse/followers`).
+
+  The Fediverse card knew the number and not one name, so a team could see the
+  reach it had switched on and never who it reached. `list_organization_followers/2`
+  had been there since #1334 with no page reading it.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag and the DNS-resolver stub beside it.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Organizations
+  alias Vutuv.Repo
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp federating_page(conn) do
+    {conn, owner} = create_and_login_user(conn)
+
+    page =
+      active_organization_for(owner)
+      |> Ecto.Changeset.change(%{username: "acme", fediverse_followers?: true})
+      |> Repo.update!()
+
+    {:ok, _} = Fediverse.ensure_organization_actor(page)
+
+    {conn, page, owner}
+  end
+
+  defp follower!(page, overrides) do
+    {:ok, follower} =
+      Fediverse.add_organization_follower(
+        page,
+        Map.merge(
+          %{
+            actor_uri: "https://remote.example/users/frida",
+            inbox_uri: "https://remote.example/users/frida/inbox",
+            handle: "@frida@remote.example",
+            name: "Frida Fern"
+          },
+          overrides
+        )
+      )
+
+    follower
+  end
+
+  test "the owner reads who follows the page, and where from", %{conn: conn} do
+    {conn, page, _owner} = federating_page(conn)
+    follower!(page, %{})
+
+    {:ok, _view, html} = live(conn, ~p"/organizations/#{page.slug}/fediverse/followers")
+
+    assert html =~ "Frida Fern"
+    assert html =~ "@frida@remote.example"
+    assert html =~ "remote.example"
+    # The link out goes to the account on its own server, never to a vutuv page.
+    assert html =~ ~s(href="https://remote.example/users/frida")
+  end
+
+  test "the Fediverse card offers the way in once somebody follows", %{conn: conn} do
+    {conn, page, _owner} = federating_page(conn)
+
+    # Nobody yet: an empty list is never offered as a destination.
+    {:ok, view, _html} = live(conn, ~p"/organizations/#{page.slug}/fediverse")
+    refute has_element?(view, "#all-followers-link")
+
+    follower!(page, %{})
+
+    {:ok, view, _html} = live(conn, ~p"/organizations/#{page.slug}/fediverse")
+    assert has_element?(view, "#all-followers-link")
+  end
+
+  test "searching and the server filter narrow the list", %{conn: conn} do
+    {conn, page, _owner} = federating_page(conn)
+    follower!(page, %{})
+
+    follower!(page, %{
+      actor_uri: "https://andere.example/users/hans",
+      inbox_uri: "https://andere.example/users/hans/inbox",
+      handle: "@hans@andere.example",
+      name: "Hans Hummel"
+    })
+
+    {:ok, view, html} = live(conn, ~p"/organizations/#{page.slug}/fediverse/followers")
+    assert html =~ "Frida Fern"
+    assert html =~ "Hans Hummel"
+
+    html = render_change(element(view, "#follower-filter"), %{"q" => "hans", "server" => ""})
+    assert html =~ "Hans Hummel"
+    refute html =~ "Frida Fern"
+
+    # The view lives in the socket, not in the URL: this page is embedded by the
+    # controller through `live_render`, so it is not mounted at the router and
+    # cannot patch. Clearing has to put the whole list back.
+    html = render_click(element(view, "#clear-filters"))
+    assert html =~ "Frida Fern"
+
+    html = render_click(view, "filter_server", %{"host" => "andere.example"})
+    assert html =~ "Hans Hummel"
+    refute html =~ "Frida Fern"
+  end
+
+  test "a page's list never shows a member's followers", %{conn: conn} do
+    {conn, page, _owner} = federating_page(conn)
+    member = insert(:activated_user)
+
+    {:ok, _} =
+      Fediverse.add_follower(member, %{
+        actor_uri: "https://remote.example/users/mine",
+        inbox_uri: "https://remote.example/users/mine/inbox",
+        handle: "@mine@remote.example",
+        name: "Nur Meiner"
+      })
+
+    {:ok, _view, html} = live(conn, ~p"/organizations/#{page.slug}/fediverse/followers")
+
+    refute html =~ "Nur Meiner"
+    assert html =~ "Nobody yet"
+  end
+
+  test "a role holder who is not the owner gets a 404", %{conn: conn} do
+    # Logged in FIRST on purpose: `sent_pin/0` reads the oldest mail in this
+    # process's mailbox, and creating a page mails its owner, so a login after
+    # that would read a page notice and find no PIN in it.
+    {other_conn, other} =
+      build_conn() |> Plug.Test.init_test_session(%{}) |> create_and_login_user()
+
+    {_conn, page, _owner} = federating_page(conn)
+    follower!(page, %{})
+
+    {:ok, _} = Organizations.add_role(page, other, "publisher", other)
+
+    assert other_conn
+           |> get(~p"/organizations/#{page.slug}/fediverse/followers")
+           |> response(404)
+  end
+end

--- a/test/vutuv_web/organization_pages_german_test.exs
+++ b/test/vutuv_web/organization_pages_german_test.exs
@@ -76,6 +76,67 @@ defmodule VutuvWeb.OrganizationPagesGermanTest do
     assert html =~ "aus dem eigenen Konto"
   end
 
+  test "the remote-follower list reads as German", %{conn: conn} do
+    {conn, owner} = create_and_login_user(conn)
+
+    organization =
+      owner
+      |> active_organization_for()
+      |> Ecto.Changeset.change(%{username: "acme", fediverse_followers?: true})
+      |> Repo.update!()
+
+    {:ok, _} =
+      Vutuv.Fediverse.add_organization_follower(organization, %{
+        actor_uri: "https://remote.example/users/frida",
+        inbox_uri: "https://remote.example/users/frida/inbox",
+        handle: "@frida@remote.example",
+        name: "Frida Fern"
+      })
+
+    html =
+      conn
+      |> german()
+      |> get(~p"/organizations/#{organization.slug}/fediverse/followers")
+      |> html_response(200)
+
+    assert html =~ "Follower aus anderen Netzwerken"
+    assert html =~ "Zurück zur Fediverse-Seite"
+    assert html =~ "Nach außen veröffentlicht die Seite die Anzahl, nie die Namen."
+
+    # What the merge filled these two with: a link back to the start page, and a
+    # sentence about the READER's own vutuv posts on a page's list.
+    refute html =~ "Zur Startseite"
+    refute html =~ "Ihren vutuv-Beiträgen"
+  end
+
+  test "the Fediverse card offers the list in German", %{conn: conn} do
+    {conn, owner} = create_and_login_user(conn)
+
+    organization =
+      owner
+      |> active_organization_for()
+      |> Ecto.Changeset.change(%{username: "acme", fediverse_followers?: true})
+      |> Repo.update!()
+
+    {:ok, _} =
+      Vutuv.Fediverse.add_organization_follower(organization, %{
+        actor_uri: "https://remote.example/users/frida",
+        inbox_uri: "https://remote.example/users/frida/inbox",
+        handle: "@frida@remote.example",
+        name: "Frida Fern"
+      })
+
+    html =
+      conn
+      |> german()
+      |> get(~p"/organizations/#{organization.slug}/fediverse")
+      |> html_response(200)
+
+    assert html =~ "Wer dieser Seite folgt"
+    # The merge made this link a sentence about somebody following the page.
+    refute html =~ "folgt dieser Seite."
+  end
+
   test "the follow-as-page pill names the page in German", %{conn: conn} do
     {conn, owner} = create_and_login_user(conn)
     organization = active_organization_for(owner)


### PR DESCRIPTION
**TL;DR** Das Team einer Seite kann eine Fediverse-Antwort jetzt still entfernen (bisher ging nur "Melden", was den Autor bei seinem Server anzeigt), und die Fediverse-Karte einer Seite führt zur Liste ihrer Follower aus anderen Netzwerken.

Beides kommt aus einem Vergleich der Fediverse-Konfiguration von Personen und Seiten. Eine Seite hat absichtlich weniger Schalter als ein Mitglied, und an zwei Stellen fehlte deshalb etwas.

## 1. Antworten entfernen (und ein Produktions-500er)

**Now:** Ein Mitglied kann eingehende Antworten aus anderen Netzwerken ganz abschalten (`users.fediverse_replies?`). Eine Seite kann das nicht, absichtlich: wer bewusst nach draußen veröffentlicht, hat keinen vergleichbaren Grund, die Reichweite zu wollen und die Antworten nicht. Damit ist die einzelne Antwort der einzige Hebel des Teams, und der fehlte: die Prüfung verglich `posts.user_id`, bei einem Seiten-Beitrag NULL, also sah niemand außer einem Admin "Entfernen". Übrig blieb "Melden", das die Antwort löscht **und** eine `Flag`-Beschwerde an den Ursprungsserver schickt.

**Want:** `Posts.author?/2` entscheidet, also jeder aktuelle Publisher der Seite. Die Rolle trägt das Recht, nicht die Person.

**Dazu ein echter Fehler auf demselben Pfad:** der `Flag` muss von einem prüfbaren Actor signiert werden, und der wurde über `posts.user_id` gesucht. `Repo.get(User, nil)` wirft, statt nichts zu liefern, also war der Melden-Knopf unter **jedem** Seiten-Beitrag ein 500er. Sichtbar wurde das nie, weil er hinter einem Gate liegt (die Antwort braucht eine gespeicherte Inbox), das kein Test auf der Mitglieder-Seite erreicht. Signiert wird jetzt über `Posts.author/1`, Mitglied oder Seite.

Das Takedown-Register bekommt eine `organization_id`, damit ein NULL in `user_id` nicht länger zwei Dinge heißt ("Seite" und "gehörte niemandem").

## 2. Follower-Liste einer Seite

**Where:** `/organizations/:slug/fediverse/followers`, verlinkt von der Fediverse-Karte, sobald jemand folgt.
**Now:** Die Karte kennt die Zahl und keinen einzigen Namen; `list_organization_followers/2` lag seit #1334 ungelesen da.
**Want:** Dieselbe Tabelle wie beim Mitglied (`BrowseTable`: Suche, Server-Filter, sortierbare Spalten), dieselben Queries (`count_followers/2`, `list_followers_page/4`, `follower_hosts/2` nehmen jetzt Mitglied *oder* Seite über ein privates `follower_scope/1`).

Ein struktureller Unterschied: jede Verwaltungsseite einer Organisation wird vom Controller per `live_render` eingebettet, ist also nicht am Router montiert, weshalb `push_patch/2` nicht verfügbar ist. Der Zustand lebt im Socket statt in der URL, geblättert wird mit `<.admin_pager>`. Kosten: ein gefilterter Blick ist kein teilbarer Link.

Sichtbar nur für den Eigentümer, wie der Schalter, an dem die Seite hängt.

## Tests

- Die Berechtigungs-Tests wurden gegen den unreparierten Code kalibriert: Publisher-Entfernen war `{:error, :not_allowed}`, das Melden warf `ArgumentError ... value is nil`.
- Deutsche Renderings mit `Accept-Language: de-DE,de` abgesichert. `gettext.extract --merge` hatte wieder fuzzy-gefüllt, unter anderem "Back to the Fediverse page" → **"Zur Startseite"** und "Who follows this page" → **"%{name} folgt dieser Seite."**; beide sind jetzt übersetzt und im Test namentlich ausgeschlossen.
- `mix precommit` grün (7440 Tests).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_017kQaCdWvWSSmsxrwx3q2LR
