### PR TITLE
Whole-app simplify sweep: one owner per rule (v7.272.1)

### DIFF
--- a/lib/vutuv/activity.ex
+++ b/lib/vutuv/activity.ex
@@ -41,6 +41,7 @@ defmodule Vutuv.Activity do
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.Organizations.Organization
   alias Vutuv.Organizations.OrganizationRole
+  alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostLike
   alias Vutuv.Posts.PostMention
@@ -771,6 +772,18 @@ defmodule Vutuv.Activity do
   #   * The fediverse kinds key on `received_at` (a :utc_datetime), `username`
   #     on `welcome_notified_at`, `connection` on the GREATEST of the two
   #     follow times — each per-kind helper owns its own boundary comparison.
+  @doc """
+  Every notification kind the registry produces.
+
+  Derived from `kind_specs/3` itself, so a presentation surface can check its
+  own coverage instead of keeping a second hand-maintained list — which had
+  already drifted: `reference_check` was in the registry and in none of the
+  notification page's filter tabs, so a live-pushed one was dropped for any
+  reader not sitting on "All". The ids here only shape queries that are never
+  run; the vocabulary is what is being asked for.
+  """
+  def kinds, do: Vutuv.UUIDv7.generate() |> kind_specs() |> Enum.map(& &1.kind)
+
   defp kind_specs(user_id, read_at \\ nil, unread? \\ false) do
     [
       %{
@@ -1149,6 +1162,10 @@ defmodule Vutuv.Activity do
       # The thread (grouping key) and the reply itself (the quote + link).
       |> Map.put(:root_post_id, root_post_id)
       |> Map.put(:reply_post_id, reply_post_id)
+      # A replier is always a member today (a page's post cannot be answered),
+      # so this matches what the view built by hand — it just stops being a
+      # second place that has to be remembered if that ever widens.
+      |> Map.put(:post_path, post_path(replier, reply_post_id))
     end)
   end
 
@@ -1175,12 +1192,23 @@ defmodule Vutuv.Activity do
     |> at_or_before(cursor)
     |> Repo.all()
     |> Enum.map(fn {id, at, author, organization, post_id} ->
+      actor = mention_actor(author, organization)
+
       "mention-#{id}"
-      |> actor_item("mention", at, mention_actor(author, organization))
+      |> actor_item("mention", at, actor)
       # The post that named them — the author's, not the recipient's.
       |> Map.put(:post_id, post_id)
+      |> Map.put(:post_path, post_path(actor, post_id))
     end)
   end
+
+  # The row carries its own link, because the view cannot build one: it holds
+  # `actor_param`, which for a page is the slug, and the deeper post path is
+  # member-only — so a mention written by a page linked into the member
+  # namespace and 404ed. `Posts.path/2` owns both shapes; here is the one place
+  # that has the actor struct to hand it.
+  defp post_path(actor, post_id) when is_binary(post_id), do: Posts.path(actor, post_id)
+  defp post_path(_actor, _post_id), do: nil
 
   # A missed LEFT join still yields a `%User{}` with every field nil rather than
   # nil itself, so the id is what says which side actually matched.

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -4497,16 +4497,21 @@ defmodule Vutuv.Fediverse do
 
   @doc "One reposted cached post, verified against its origin. See `refresh_reposted_posts/1`."
   def refresh_reposted_post(%RemotePost{} = post) do
-    with true <- enabled?(),
-         %User{} = reposter <- any_reposter(post),
-         # An unsigned GET is not a question this can act on: an
-         # authorized-fetch server answers it 403, which `fetch_remote_note/2`
-         # reads as "gone" — and that would delete a perfectly live public post
-         # plus everybody's reshares of it, on nothing but our own missing key.
-         signer when not is_nil(signer) <- signer(reposter) do
-      apply_repost_refresh(post, fetch_remote_note(post.object_uri, signer))
+    if enabled?() do
+      with %User{} = reposter <- any_reposter(post),
+           # An unsigned GET is not a question this can act on: an
+           # authorized-fetch server answers it 403, which `fetch_remote_note/2`
+           # reads as "gone" — and that would delete a perfectly live public post
+           # plus everybody's reshares of it, on nothing but our own missing key.
+           signer when not is_nil(signer) <- signer(reposter) do
+        apply_repost_refresh(post, fetch_remote_note(post.object_uri, signer))
+      else
+        _ ->
+          stamp_repost_check(post)
+          :skip
+      end
     else
-      _ -> :skip
+      :skip
     end
   end
 
@@ -4589,7 +4594,24 @@ defmodule Vutuv.Fediverse do
     :deleted
   end
 
-  defp apply_repost_refresh(%RemotePost{}, _other), do: :skip
+  defp apply_repost_refresh(%RemotePost{} = post, _other) do
+    stamp_repost_check(post)
+    :skip
+  end
+
+  # The scheduler's clock, not a claim that the origin was reached. Without it a
+  # copy nobody can sign for — or whose server is down — stays due on every run,
+  # and since `due_reposted_posts/1` serves the least recently checked first it
+  # holds the front of every batch from then on, spending the cap on work that
+  # cannot complete while genuinely due copies behind it are never re-verified.
+  # No strike: the origin did nothing wrong, and a signer can appear the moment
+  # somebody who federates reshares the same post. See `refresh_counts/1`, which
+  # carries the long version of this lesson.
+  defp stamp_repost_check(%RemotePost{id: id}) do
+    Repo.update_all(from(p in RemotePost, where: p.id == ^id),
+      set: [checked_at: DateTime.utc_now(:second)]
+    )
+  end
 
   defp picture_only_doc?(doc),
     do: doc["attachment"] |> List.wrap() |> Enum.any?(&Media.image_attachment?/1)

--- a/lib/vutuv/fediverse/note.ex
+++ b/lib/vutuv/fediverse/note.ex
@@ -48,9 +48,6 @@ defmodule Vutuv.Fediverse.Note do
   # A content warning is a headline, not a second post.
   @max_summary 500
 
-  @doc "The audience values a delivered note is classified into."
-  def audiences, do: @audiences
-
   @doc "The longest remote text a note may carry."
   def max_content, do: @max_content
 

--- a/lib/vutuv/fediverse/note_event.ex
+++ b/lib/vutuv/fediverse/note_event.ex
@@ -38,16 +38,18 @@ defmodule Vutuv.Fediverse.NoteEvent do
 
   use VutuvWeb, :model
 
+  # `action` is one of `reported`, `reported_post`, `removed_by_member` or
+  # `flagged`. Rows are written by direct insert, so that set is a convention
+  # rather than a validation — `VutuvWeb.Admin.FediverseHTML.note_event_label/1`
+  # is what has to know it, and it renders an unknown value rather than leaking
+  # a raw string at the operator.
+  #
   # `reported_post` is its own value rather than a second `reported` (issue
   # #1161): a reply sat under one member's post and only that member's page
   # changed, while a cached post is shared by everybody who follows its author,
   # so one report takes it out of every one of their feeds. An operator reading
   # this ledger has to be able to tell those two apart at a glance, and the
   # heading above the table cannot name both if the rows do not distinguish them.
-  @actions ~w(reported reported_post removed_by_member flagged)
-
-  @doc "The closed set of `action` values this ledger records."
-  def actions, do: @actions
 
   schema "fediverse_note_events" do
     field(:action, :string)

--- a/lib/vutuv/fediverse/remote_post.ex
+++ b/lib/vutuv/fediverse/remote_post.ex
@@ -104,12 +104,6 @@ defmodule Vutuv.Fediverse.RemotePost do
     has_one(:screenshot, Vutuv.Posts.PostScreenshot, foreign_key: :remote_post_id)
   end
 
-  @doc "The audiences a stored post can have."
-  def audiences, do: @audiences
-
-  @doc "The object types a stored post can have."
-  def kinds, do: @kinds
-
   @doc "The longest remote text a post may carry."
   def max_content, do: @max_content
 

--- a/lib/vutuv/jobs.ex
+++ b/lib/vutuv/jobs.ex
@@ -645,14 +645,8 @@ defmodule Vutuv.Jobs do
 
   def image_visible_to?(%JobPostingImage{job_posting: posting} = image, viewer) do
     visible_to?(posting, viewer) and
-      (ImageScans.released?(image.moderation) or privileged_image_viewer?(image, viewer))
+      (ImageScans.released?(image.moderation) or ImageScans.privileged_viewer?(image, viewer))
   end
-
-  defp privileged_image_viewer?(%JobPostingImage{user_id: uploader_id}, %User{id: uploader_id}),
-    do: true
-
-  defp privileged_image_viewer?(_image, %User{admin?: true}), do: true
-  defp privileged_image_viewer?(_image, _viewer), do: false
 
   # Attach the chosen pending images to the posting; delete + purge those the
   # editor removed.

--- a/lib/vutuv/moderation/image_scans.ex
+++ b/lib/vutuv/moderation/image_scans.ex
@@ -32,6 +32,7 @@ defmodule Vutuv.Moderation.ImageScans do
 
   require Logger
 
+  alias Vutuv.Accounts.User
   alias Vutuv.Moderation.ImageScan
   alias Vutuv.Moderation.ImageScanWorker
   alias Vutuv.Moderation.ImageSubjects
@@ -75,6 +76,19 @@ defmodule Vutuv.Moderation.ImageScans do
   def released?(nil), do: true
   def released?("approved"), do: true
   def released?(_state), do: false
+
+  @doc """
+  Who may see an image the scan has **not** released: the member who uploaded
+  it, and an admin. Everyone else waits for the verdict.
+
+  Matched on the `user_id` key rather than a struct type, so the one rule serves
+  post images, organization images and job-posting images — it was written out
+  once per image kind, which is three places for a moderation-visibility answer
+  to be changed in.
+  """
+  def privileged_viewer?(%{user_id: uploader_id}, %User{id: uploader_id}), do: true
+  def privileged_viewer?(_image, %User{admin?: true}), do: true
+  def privileged_viewer?(_image, _viewer), do: false
 
   @doc """
   Queues (or re-queues) the scan for one asset. `fingerprint` binds the

--- a/lib/vutuv/newsletters.ex
+++ b/lib/vutuv/newsletters.ex
@@ -270,26 +270,29 @@ defmodule Vutuv.Newsletters do
     end
   end
 
-  @doc "Finds a tag by exact (case-insensitive) name, or nil."
-  def find_tag(name) when is_binary(name) do
-    case String.trim(name) do
-      "" ->
-        nil
+  @doc """
+  Finds a tag by what an admin typed — its name or its slug, case-insensitively
+  — following an alternative name to the topic it stands for. Nil for no match.
 
-      trimmed ->
-        # An audience named by an alternative name is the topic's audience
-        # (issue #1338): the members are on the canonical tag, so a group built
-        # on "ROR" must resolve to Ruby on Rails or it would mail nobody.
-        from(t in Tag, where: fragment("lower(?) = lower(?)", t.name, ^trimmed), limit: 1)
-        |> Repo.one()
-        |> case do
-          nil -> nil
-          tag -> Tag.canonical(tag)
-        end
+  An audience named by an alternative name is the topic's audience (issue
+  #1338): the members are on the canonical tag, so a group built on "ROR" must
+  resolve to Ruby on Rails or it would mail nobody.
+
+  `Tag.find_by_value/1` is that lookup everywhere else in the app. This kept its
+  own copy that matched the name alone, so the slug spelling an admin sees on
+  every tag page was rejected here as "no tag with that name"; its copy also
+  resolved an alias with `Tag.canonical/1`, which answers nil when the canonical
+  row is gone, where `find_by_value/1` falls back to the alias itself.
+  """
+  def find_tag(value) when is_binary(value) do
+    case String.trim(value) do
+      "" -> nil
+      trimmed -> Tag.find_by_value(trimmed)
     end
   end
 
-  def find_tag(_name), do: nil
+  # The admin group form reaches here with no tag named at all.
+  def find_tag(_value), do: nil
 
   @doc "The distinct, non-blank country values present on member addresses, sorted."
   def country_options do

--- a/lib/vutuv/organizations.ex
+++ b/lib/vutuv/organizations.ex
@@ -239,6 +239,34 @@ defmodule Vutuv.Organizations do
   def publisher?(_, _), do: false
 
   @doc """
+  Every permission answer for one `(organization, viewer)` pair, from a single
+  read of the role table.
+
+  The four predicates above each run their own query, which is right for a
+  caller with one question and wrong for a page that asks them all: the
+  organization page asked five times (`owner?/2` twice), so one row set cost
+  five round trips. They stay the public API; this is for the caller that wants
+  the whole answer.
+
+  `can_manage?` keeps its `created_by_user_id` leg — the member who claimed the
+  page can always reach its settings, role row or not.
+  """
+  def role_powers(%Organization{} = organization, %User{} = user) do
+    roles = roles_of(organization, user)
+
+    %{
+      roles: roles,
+      owner?: "owner" in roles,
+      can_edit?: Enum.any?(roles, &(&1 in ["owner", "admin"])),
+      publisher?: "publisher" in roles,
+      can_manage?: organization.created_by_user_id == user.id or roles != []
+    }
+  end
+
+  def role_powers(_, _),
+    do: %{roles: [], owner?: false, can_edit?: false, publisher?: false, can_manage?: false}
+
+  @doc """
   The organization `user` is currently acting as, given the id their session
   carries — or `nil` (issue #1335).
 
@@ -575,16 +603,6 @@ defmodule Vutuv.Organizations do
         )
       )
     end
-  end
-
-  @doc "Fetches one role row scoped to an organization (owner-management actions)."
-  def get_role(%Organization{id: id}, role_id) do
-    Repo.one(
-      from(r in OrganizationRole,
-        where: r.organization_id == ^id and r.id == ^role_id,
-        preload: [:user]
-      )
-    )
   end
 
   @doc """
@@ -1518,17 +1536,6 @@ defmodule Vutuv.Organizations do
     Repo.aggregate(from(n in OrganizationName, where: not is_nil(n.flagged_at)), :count, :id)
   end
 
-  @doc "All flagged aliases (newest first), each with its organization, for the admin queue."
-  def list_flagged_aliases do
-    Repo.all(
-      from(n in OrganizationName,
-        where: not is_nil(n.flagged_at),
-        order_by: [desc: n.flagged_at],
-        preload: [:organization]
-      )
-    )
-  end
-
   @doc "Fetches one alias row by id for the admin queue, or nil."
   def get_alias(id), do: Vutuv.UUIDv7.with_cast(id, &Repo.get(OrganizationName, &1))
 
@@ -1582,9 +1589,6 @@ defmodule Vutuv.Organizations do
       )
     end
   end
-
-  @doc "The organization page's per-page size for its People section."
-  def people_per_page, do: @people_per_page
 
   @doc """
   The number of members whose linked work experience is at `organization` and who are

--- a/lib/vutuv/organizations.ex
+++ b/lib/vutuv/organizations.ex
@@ -1987,17 +1987,9 @@ defmodule Vutuv.Organizations do
       organization ->
         # AI-moderation limbo: until released, the bytes are uploader/admin-only.
         organization_visible_to?(organization, viewer) and
-          (ImageScans.released?(image.moderation) or privileged_image_viewer?(image, viewer))
+          (ImageScans.released?(image.moderation) or ImageScans.privileged_viewer?(image, viewer))
     end
   end
-
-  defp privileged_image_viewer?(%OrganizationImage{user_id: uploader_id}, %User{
-         id: uploader_id
-       }),
-       do: true
-
-  defp privileged_image_viewer?(_image, %User{admin?: true}), do: true
-  defp privileged_image_viewer?(_image, _viewer), do: false
 
   # --- deletion ---------------------------------------------------------------
 

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -352,6 +352,19 @@ defmodule Vutuv.Posts do
     end
   end
 
+  @doc """
+  Whether this post is a kind of post that accepts replies at all — the half of
+  the reply rule that depends on the post alone, with nobody asking yet.
+
+  Public because the reply **page** must ask it too. That page cannot run the
+  whole of `check_reply_allowed/2` (a quiet block has to let the blocked member
+  reach the composer and be refused on submit, or the block leaks), so without a
+  named predicate it kept its own weaker copy of the rule — and offered a
+  composer for a page's post, whose heading then dereferenced the member author
+  that a page's post does not have.
+  """
+  def replyable?(%Post{} = post), do: not organization_post?(post)
+
   defp check_reply_allowed(%User{} = author, %Post{} = parent) do
     cond do
       # An organization post cannot be answered yet (issue #1334). Everything
@@ -360,7 +373,7 @@ defmodule Vutuv.Posts do
       # @handle" line — and an organization has no inbox to be told about it
       # until issue #1336 gives it a reading side. Refusing outright beats a
       # reply that quietly reaches nobody.
-      organization_post?(parent) -> {:error, :restricted}
+      not replyable?(parent) -> {:error, :restricted}
       not visible_to?(parent, author) -> {:error, :not_visible}
       # Query restriction fresh from the DB, not the (possibly stale) preloaded
       # denials: the reply LiveView holds the parent struct from mount, and the
@@ -3630,7 +3643,7 @@ defmodule Vutuv.Posts do
       |> limit(^(limit + 1))
       |> offset(^offset)
       |> Repo.all()
-      |> Enum.map(&preload_post/1)
+      |> preload_posts()
 
     {shown, rest} = Enum.split(entries, limit)
 
@@ -4400,6 +4413,13 @@ defmodule Vutuv.Posts do
   defp preload_post(nil), do: nil
   defp preload_post(%Post{} = post), do: Repo.preload(post, post_preloads(), force: true)
 
+  # The whole page in one set of preload queries. `post_preloads/0` expands to
+  # roughly twenty associations, so preloading post by post costs that many
+  # queries per row — 50 rows of an organization's agent-format page came to a
+  # four-figure query count for one request.
+  defp preload_posts(posts) when is_list(posts),
+    do: Repo.preload(posts, post_preloads(), force: true)
+
   defp post_preloads do
     # denials with group/denied_user: the author-facing audience display
     # names them (never shown to other viewers). The parent carries :images +
@@ -4485,16 +4505,19 @@ defmodule Vutuv.Posts do
   is identified by and what somebody pastes a year later. One shape that always
   works beats two that depend on whether a handle was claimed.
   """
-  def path(%Post{organization_id: organization_id, id: id} = post)
-      when is_binary(organization_id) do
-    %Organization{slug: slug} = author(post)
-    "/organizations/#{slug}/posts/#{id}"
-  end
+  def path(%Post{id: id} = post), do: path(author(post), id)
 
-  def path(%Post{id: id} = post) do
-    %User{username: username} = author(post)
-    "/#{username}/posts/#{id}"
-  end
+  @doc """
+  The same permalink, for a caller that holds the **author and the id** but no
+  `%Post{}` — a notification row selected straight out of the database, or a
+  federated Note whose `id` is its permanent identity.
+
+  Those callers used to spell one of the two shapes out themselves, which is how
+  a mention written by a page came to link into the member namespace
+  (`/acme/posts/…`, a 404) on the reader's own notifications page.
+  """
+  def path(%Organization{slug: slug}, post_id), do: "/organizations/#{slug}/posts/#{post_id}"
+  def path(%User{username: username}, post_id), do: "/#{username}/posts/#{post_id}"
 
   ## Images
 

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -4794,14 +4794,8 @@ defmodule Vutuv.Posts do
     # AI-moderation limbo: until released, the bytes are owner/admin-only
     # (everyone else gets the gallery placecard, and this proxy 404s).
     visible_to?(post, viewer) and
-      (ImageScans.released?(image.moderation) or privileged_image_viewer?(image, viewer))
+      (ImageScans.released?(image.moderation) or ImageScans.privileged_viewer?(image, viewer))
   end
-
-  defp privileged_image_viewer?(%PostImage{user_id: uploader_id}, %User{id: uploader_id}),
-    do: true
-
-  defp privileged_image_viewer?(_image, %User{admin?: true}), do: true
-  defp privileged_image_viewer?(_image, _viewer), do: false
 
   @doc """
   Removes pending images older than a day (abandoned composer sessions),

--- a/lib/vutuv/profiles/social_account_verification.ex
+++ b/lib/vutuv/profiles/social_account_verification.ex
@@ -158,7 +158,8 @@ defmodule Vutuv.Profiles.SocialAccountVerification do
   @doc """
   Re-checks one verified account. A proof still in place refreshes
   `last_checked_at` and clears any grace window; a vanished one starts the
-  window, waits it out, then drops the mark. A network failure changes nothing.
+  window, waits it out, then drops the mark. A network failure leaves the mark
+  and the window alone, and only advances the clock.
 
   Returns `:ok`, `:grace_started`, `:in_grace`, `:demoted` or `:unreachable`.
   """
@@ -179,9 +180,18 @@ defmodule Vutuv.Profiles.SocialAccountVerification do
       {:ok, false} ->
         handle_recheck_failure(account, now)
 
-      # We learned nothing about the bio, so we hold the mark and try again on
-      # the next sweep — an AppView outage must not un-verify the whole network.
+      # We learned nothing about the bio, so we hold the mark and the grace
+      # window — an AppView outage must not un-verify the whole network. The
+      # clock is still stamped: it is the scheduler's, not a claim that anything
+      # was verified, and without it the row stays due on every hourly sweep
+      # while the interval is a week, so one erroring provider is re-fetched
+      # 168x more often than intended, forever. Nothing degrades meanwhile —
+      # the mark keeps standing until a check actually reads the bio.
       {:error, _reason} ->
+        account
+        |> SocialMediaAccount.verification_changeset(%{last_checked_at: now})
+        |> Repo.update()
+
         :unreachable
     end
   end

--- a/lib/vutuv_web/components/fediverse_components.ex
+++ b/lib/vutuv_web/components/fediverse_components.ex
@@ -169,22 +169,7 @@ defmodule VutuvWeb.FediverseComponents do
       )}
     </p>
 
-    <div class="mt-3 flex items-start gap-2 rounded-lg bg-slate-50 px-3 py-2 ring-1 ring-slate-200 dark:bg-slate-800/50 dark:ring-slate-700">
-      <code
-        id={"#{@id}-handle"}
-        class="min-w-0 flex-1 select-all break-all text-sm text-slate-800 dark:text-slate-100"
-      >{@handle}</code>
-      <button
-        type="button"
-        data-copy
-        data-copy-target={"#{@id}-handle"}
-        data-label-copy={gettext("Copy")}
-        data-label-copied={gettext("Copied")}
-        class="shrink-0 rounded-md bg-white px-2 py-1 text-xs font-semibold text-slate-700 ring-1 ring-slate-200 hover:bg-slate-100 dark:bg-slate-800 dark:text-slate-200 dark:ring-slate-700 dark:hover:bg-slate-700"
-      >
-        {gettext("Copy")}
-      </button>
-    </div>
+    <.copy_field id={"#{@id}-handle"}>{@handle}</.copy_field>
 
     <.form for={%{}} action={@action} id="remote-follow-form" class="mt-4">
       <label

--- a/lib/vutuv_web/components/organization_components.ex
+++ b/lib/vutuv_web/components/organization_components.ex
@@ -182,15 +182,19 @@ defmodule VutuvWeb.OrganizationComponents do
   attr(:organization, :map, required: true)
   attr(:active, :atom, required: true)
   attr(:owner?, :boolean, default: false)
-  attr(:manage?, :boolean, default: false)
   attr(:publisher?, :boolean, default: false)
 
   @doc """
   The header + tab bar shared by the organization management pages (issue #930): a
   back link to the public page and tabs for Page (edit), Team (roles), Domains and
   Job exclusions. Team/Domains show only for an owner (admins may edit the page
-  only); Job exclusions (issue #939) shows for any role holder (`manage?`), since
+  only); Job exclusions (issue #939) and Activity show for any role holder, since
   the standing default governs the postings they can already manage.
+
+  Every page that renders this header is already behind a `can_manage?/2` gate,
+  which is why those two tabs are unconditional here: the `manage?` attribute
+  they used to be guarded by was passed `true` by all nine call sites, so it was
+  a knob that only ever read one way.
   """
   def manage_header(assigns) do
     ~H"""
@@ -211,13 +215,13 @@ defmodule VutuvWeb.OrganizationComponents do
         <.manage_tab :if={@owner?} active={@active == :domains} navigate={"/organizations/#{@organization.slug}/domains"}>
           {gettext("Domains")}
         </.manage_tab>
-        <.manage_tab :if={@manage?} active={@active == :exclusions} navigate={"/organizations/#{@organization.slug}/exclusions"}>
+        <.manage_tab active={@active == :exclusions} navigate={"/organizations/#{@organization.slug}/exclusions"}>
           {gettext("Job exclusions")}
         </.manage_tab>
         <%!-- What happened to the page (issue #1336). Open to the whole team,
         not only its publishers: this is news ABOUT the page rather than
         speaking FOR it. --%>
-        <.manage_tab :if={@manage?} active={@active == :activity} navigate={"/organizations/#{@organization.slug}/activity"}>
+        <.manage_tab active={@active == :activity} navigate={"/organizations/#{@organization.slug}/activity"}>
           {gettext("Activity")}
         </.manage_tab>
         <%!-- What the page reads (issue #1336). Publishers only, unlike

--- a/lib/vutuv_web/components/ui.ex
+++ b/lib/vutuv_web/components/ui.ex
@@ -2591,6 +2591,51 @@ defmodule VutuvWeb.UI do
   end
 
   @doc """
+  A value the member is meant to hand out — a profile address, a Fediverse
+  handle, an authenticator key — in a tinted box beside a Copy button.
+
+  The button is the `data-copy` enhancement in `app.js`, which swaps its label
+  to "Copied" for a moment; with JavaScript off the `<code>` is still
+  `select-all`, so the value is one click and a keystroke away either way. Pass
+  `copy_text` when what belongs in the clipboard differs from what is shown (the
+  TOTP key is displayed in groups of four and copied without the spaces).
+
+  Distinct from `secret_once/1`, which is the brand-tinted one-shot reveal of a
+  credential that will never be shown again; this box is for a value the member
+  can come back and read any time.
+  """
+  attr(:id, :string, required: true)
+  attr(:class, :any, default: "mt-3 items-start")
+  attr(:code_class, :any, default: "text-sm")
+  attr(:copy_text, :string, default: nil)
+  slot(:inner_block, required: true)
+
+  def copy_field(assigns) do
+    ~H"""
+    <div class={[
+      "flex gap-2 rounded-lg bg-slate-50 px-3 py-2 ring-1 ring-slate-200 dark:bg-slate-800/50 dark:ring-slate-700",
+      @class
+    ]}>
+      <code
+        id={@id}
+        class={["min-w-0 flex-1 select-all break-all text-slate-800 dark:text-slate-100", @code_class]}
+      >{render_slot(@inner_block)}</code>
+      <button
+        type="button"
+        data-copy
+        data-copy-target={@id}
+        data-copy-text={@copy_text}
+        data-label-copy={gettext("Copy")}
+        data-label-copied={gettext("Copied")}
+        class="shrink-0 rounded-md bg-white px-2 py-1 text-xs font-semibold text-slate-700 ring-1 ring-slate-200 hover:bg-slate-100 dark:bg-slate-800 dark:text-slate-200 dark:ring-slate-700 dark:hover:bg-slate-700"
+      >
+        {gettext("Copy")}
+      </button>
+    </div>
+    """
+  end
+
+  @doc """
   The single rendering of a viewer-localized timestamp — the `<time>` element
   the `LocalTime` pass rewrites into the viewer's timezone (the LiveView hook on
   live pages, the `time[data-localtime]` DOMContentLoaded sweep on classic ones;

--- a/lib/vutuv_web/controllers/fediverse_controller.ex
+++ b/lib/vutuv_web/controllers/fediverse_controller.ex
@@ -767,11 +767,15 @@ defmodule VutuvWeb.FediverseController do
   # `subscribe` template, because that is where a *member* confirms a follow
   # they started elsewhere, and a page starts none.
   defp jrd(%Organization{} = organization) do
+    # `canonical_path/1`, not the slug shape spelled out: a page that claimed a
+    # root handle is served at that handle everywhere else, and this document is
+    # what remote servers are told to show a human.
     page_url =
-      "#{String.trim_trailing(VutuvWeb.Endpoint.url(), "/")}/organizations/#{organization.slug}"
+      String.trim_trailing(VutuvWeb.Endpoint.url(), "/") <>
+        Organizations.canonical_path(organization)
 
     %{
-      "subject" => "acct:#{organization.username}@#{VutuvWeb.Endpoint.host()}",
+      "subject" => "acct:" <> Docs.acct(organization),
       "aliases" => [page_url, Docs.actor_url(organization)],
       "links" => [
         %{"rel" => "self", "type" => @activity_json, "href" => Docs.actor_url(organization)},
@@ -789,7 +793,7 @@ defmodule VutuvWeb.FediverseController do
     profile_url = "#{base}/#{user.username}"
 
     %{
-      "subject" => "acct:#{user.username}@#{VutuvWeb.Endpoint.host()}",
+      "subject" => "acct:" <> Docs.acct(user),
       "aliases" => [profile_url, Docs.actor_url(user)],
       "links" => [
         %{"rel" => "self", "type" => @activity_json, "href" => Docs.actor_url(user)},

--- a/lib/vutuv_web/controllers/sitemap_controller.ex
+++ b/lib/vutuv_web/controllers/sitemap_controller.ex
@@ -45,18 +45,22 @@ defmodule VutuvWeb.SitemapController do
     send_xml(conn, urlset(Enum.map(Sitemap.static_paths(), &{&1, nil})))
   end
 
+  # The type is matched loosely and then looked up in `@entry_funs`, rather than
+  # spelled out a second time in the pattern: the alternation had never learned
+  # about `organization_posts`, so `index/2` advertised that child (it builds
+  # its list from `Sitemap.chunk_counts/0`) and this action answered it 404.
+  # One list decides what exists.
   def show(conn, %{"name" => name}) do
     with %{"type" => type, "chunk" => chunk} <-
-           Regex.named_captures(
-             ~r/^(?<type>users|posts|tags|organizations|jobs)-(?<chunk>[1-9]\d*)\.xml$/,
-             name
-           ),
-         [_ | _] = entries <- Map.fetch!(@entry_funs, type).(String.to_integer(chunk)) do
+           Regex.named_captures(~r/^(?<type>[a-z_]+)-(?<chunk>[1-9]\d*)\.xml$/, name),
+         {:ok, entries_fun} <- Map.fetch(@entry_funs, type),
+         [_ | _] = entries <- entries_fun.(String.to_integer(chunk)) do
       send_xml(conn, urlset(entries))
     else
-      # nil (bad name) or [] (chunk beyond the data) — nothing to serve. A
-      # plain 404, not the HTML error page: the consumer is a crawler, and
-      # outside the browser pipeline there is no flash for the app layout.
+      # nil (bad name), :error (unknown type) or [] (chunk beyond the data) —
+      # nothing to serve. A plain 404, not the HTML error page: the consumer is
+      # a crawler, and outside the browser pipeline there is no flash for the
+      # app layout.
       _ ->
         conn
         |> put_resp_content_type("text/plain")

--- a/lib/vutuv_web/live/account_activity_live.ex
+++ b/lib/vutuv_web/live/account_activity_live.ex
@@ -26,7 +26,7 @@ defmodule VutuvWeb.AccountActivityLive do
   on_mount({VutuvWeb.Live.InitAssigns, :require_login})
 
   import VutuvWeb.AccountEventText,
-    only: [event_label: 1, detail: 1, factor_label: 1, by_someone_else?: 1]
+    only: [event_label: 1, detail: 1, factor_label: 1, by_someone_else?: 1, by_other_badge: 1]
 
   import VutuvWeb.BrowseTable
 
@@ -246,13 +246,9 @@ defmodule VutuvWeb.AccountActivityLive do
                       </span>
                       <%!-- The one line on this page that has to shout: somebody
                       other than the member made this change. --%>
-                      <span
-                        :if={by_someone_else?(event)}
-                        data-event-by-other
-                        class="mt-1 inline-flex items-center rounded-full bg-amber-50 px-2 py-0.5 text-xs font-semibold text-amber-800 dark:bg-amber-900/30 dark:text-amber-200"
-                      >
+                      <.by_other_badge :if={by_someone_else?(event)}>
                         {gettext("Not by you")}
-                      </span>
+                      </.by_other_badge>
                       <%!-- On a phone the "Device" column is folded away, so its
                       content rides here instead of being lost. --%>
                       <span

--- a/lib/vutuv_web/live/admin/activity_live.ex
+++ b/lib/vutuv_web/live/admin/activity_live.ex
@@ -27,7 +27,7 @@ defmodule VutuvWeb.Admin.ActivityLive do
   use VutuvWeb, :live_view
 
   import VutuvWeb.AccountEventText,
-    only: [event_label: 1, detail: 1, factor_label: 1, by_someone_else?: 1]
+    only: [event_label: 1, detail: 1, factor_label: 1, by_someone_else?: 1, by_other_badge: 1]
 
   import VutuvWeb.BrowseTable
   import VutuvWeb.UserHelpers, only: [member_name: 1]
@@ -294,13 +294,9 @@ defmodule VutuvWeb.Admin.ActivityLive do
                   >
                     {gettext("Confirmed")} {factor_label(event)}
                   </span>
-                  <span
-                    :if={by_someone_else?(event)}
-                    data-event-by-other
-                    class="mt-1 inline-flex items-center rounded-full bg-amber-50 px-2 py-0.5 text-xs font-semibold text-amber-800 dark:bg-amber-900/30 dark:text-amber-200"
-                  >
+                  <.by_other_badge :if={by_someone_else?(event)}>
                     {gettext("By %{name}", name: "@#{actor_handle(event)}")}
-                  </span>
+                  </.by_other_badge>
                 </td>
                 <td class="align-top text-slate-600 dark:text-slate-400">
                   {event.device}

--- a/lib/vutuv_web/live/admin/job_live.ex
+++ b/lib/vutuv_web/live/admin/job_live.ex
@@ -334,9 +334,9 @@ defmodule VutuvWeb.Admin.JobLive do
               <.link navigate={~p"/#{@detail.posting.user.username}"} class="text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300">
                 @{@detail.posting.user.username}
               </.link>
-              <span class="text-slate-500">{member_name(@detail.posting.user)}</span>
+              <span class="text-slate-600 dark:text-slate-400">{member_name(@detail.posting.user)}</span>
             </p>
-            <p :if={is_nil(@detail.posting.user)} class="text-slate-500">{gettext("(deleted account)")}</p>
+            <p :if={is_nil(@detail.posting.user)} class="text-slate-600 dark:text-slate-400">{gettext("(deleted account)")}</p>
           </dd>
         </div>
 
@@ -356,7 +356,7 @@ defmodule VutuvWeb.Admin.JobLive do
             </p>
             <p :if={is_nil(@detail.posting.organization)}>
               {employer(@detail.posting)}
-              <span class="ml-1 text-xs text-slate-500">{gettext("(free text, unverified)")}</span>
+              <span class="ml-1 text-xs text-slate-600 dark:text-slate-400">{gettext("(free text, unverified)")}</span>
             </p>
           </dd>
         </div>
@@ -385,7 +385,7 @@ defmodule VutuvWeb.Admin.JobLive do
             <span :if={@detail.posting.first_published_at}>
               <.local_time at={@detail.posting.first_published_at} id="job-published" format="%Y-%m-%d" />
             </span>
-            <span :if={is_nil(@detail.posting.first_published_at)} class="text-slate-500">{gettext("never")}</span>
+            <span :if={is_nil(@detail.posting.first_published_at)} class="text-slate-600 dark:text-slate-400">{gettext("never")}</span>
           </dd>
         </div>
 
@@ -403,19 +403,19 @@ defmodule VutuvWeb.Admin.JobLive do
         <p class="card__label">{gettext("Poster footprint")}</p>
         <dl class="mt-2 grid grid-cols-2 gap-x-4 gap-y-2 text-sm sm:grid-cols-4">
           <div>
-            <dt class="text-xs text-slate-500">{gettext("Live postings")}</dt>
+            <dt class="text-xs text-slate-600 dark:text-slate-400">{gettext("Live postings")}</dt>
             <dd class="font-semibold tabular-nums">{delimited_count(@detail.footprint.active)}</dd>
           </div>
           <div>
-            <dt class="text-xs text-slate-500">{gettext("Total postings")}</dt>
+            <dt class="text-xs text-slate-600 dark:text-slate-400">{gettext("Total postings")}</dt>
             <dd class="font-semibold tabular-nums">{delimited_count(@detail.footprint.total)}</dd>
           </div>
           <div>
-            <dt class="text-xs text-slate-500">{gettext("Open job cases")}</dt>
+            <dt class="text-xs text-slate-600 dark:text-slate-400">{gettext("Open job cases")}</dt>
             <dd class="font-semibold tabular-nums">{delimited_count(@detail.footprint.open_cases)}</dd>
           </div>
           <div>
-            <dt class="text-xs text-slate-500">{gettext("Cold outreach")}</dt>
+            <dt class="text-xs text-slate-600 dark:text-slate-400">{gettext("Cold outreach")}</dt>
             <dd class={[
               "font-semibold tabular-nums",
               @detail.footprint.cold_outreach >= Vutuv.Chat.new_conversation_limit() &&
@@ -436,10 +436,10 @@ defmodule VutuvWeb.Admin.JobLive do
           >
             <span>
               <span class="font-semibold">{status_badge(mod_case)}</span>
-              <span class="ml-2 text-slate-500">
+              <span class="ml-2 text-slate-600 dark:text-slate-400">
                 {ngettext("%{count} report", "%{count} reports", length(mod_case.reports))}
               </span>
-              <span class="ml-2 text-slate-500">
+              <span class="ml-2 text-slate-600 dark:text-slate-400">
                 <.local_time at={mod_case.inserted_at} id={"case-#{mod_case.id}-at"} format="%Y-%m-%d" />
               </span>
             </span>

--- a/lib/vutuv_web/live/admin/organization_live.ex
+++ b/lib/vutuv_web/live/admin/organization_live.ex
@@ -310,7 +310,7 @@ defmodule VutuvWeb.Admin.OrganizationLive do
               <span class={["text-xs font-semibold", if(domain.verified_at, do: "text-emerald-600 dark:text-emerald-300", else: "text-slate-500")]}>
                 {if domain.verified_at, do: gettext("verified"), else: gettext("pending")}
               </span>
-              <span :if={domain.last_checked_at} class="text-xs text-slate-500">
+              <span :if={domain.last_checked_at} class="text-xs text-slate-600 dark:text-slate-400">
                 <.local_time at={domain.last_checked_at} id={"detail-checked-#{domain.id}"} format="%Y-%m-%d" />
               </span>
             </p>
@@ -322,9 +322,9 @@ defmodule VutuvWeb.Admin.OrganizationLive do
           <dd class="mt-1 space-y-1 text-sm text-slate-700 dark:text-slate-300">
             <p :for={role <- @detail.roles}>
               <.link navigate={"/#{role.user.username}"} class="text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300">@{role.user.username}</.link>
-              <span class="text-xs text-slate-500">{role_label(role.role)}</span>
+              <span class="text-xs text-slate-600 dark:text-slate-400">{role_label(role.role)}</span>
             </p>
-            <p :if={@detail.claimed_by} class="text-xs text-slate-500">
+            <p :if={@detail.claimed_by} class="text-xs text-slate-600 dark:text-slate-400">
               {gettext("Claimed by")}: {member_name(@detail.claimed_by)}
             </p>
           </dd>

--- a/lib/vutuv_web/live/admin/user_detail_live.ex
+++ b/lib/vutuv_web/live/admin/user_detail_live.ex
@@ -126,25 +126,25 @@ defmodule VutuvWeb.Admin.UserDetailLive do
           <p class="card__label">{gettext("Jobs footprint")}</p>
           <dl class="mt-2 grid grid-cols-2 gap-x-4 gap-y-2 text-sm sm:grid-cols-4">
             <div>
-              <dt class="text-xs text-slate-500">{gettext("Live postings")}</dt>
+              <dt class="text-xs text-slate-600 dark:text-slate-400">{gettext("Live postings")}</dt>
               <dd id="footprint-active" class="font-semibold tabular-nums">
                 {delimited_count(@footprint.active)}
               </dd>
             </div>
             <div>
-              <dt class="text-xs text-slate-500">{gettext("Total postings")}</dt>
+              <dt class="text-xs text-slate-600 dark:text-slate-400">{gettext("Total postings")}</dt>
               <dd id="footprint-total" class="font-semibold tabular-nums">
                 {delimited_count(@footprint.total)}
               </dd>
             </div>
             <div>
-              <dt class="text-xs text-slate-500">{gettext("Open job cases")}</dt>
+              <dt class="text-xs text-slate-600 dark:text-slate-400">{gettext("Open job cases")}</dt>
               <dd id="footprint-cases" class="font-semibold tabular-nums">
                 {delimited_count(@footprint.open_cases)}
               </dd>
             </div>
             <div>
-              <dt class="text-xs text-slate-500">{gettext("Cold outreach")}</dt>
+              <dt class="text-xs text-slate-600 dark:text-slate-400">{gettext("Cold outreach")}</dt>
               <dd
                 id="footprint-cold"
                 class={[

--- a/lib/vutuv_web/live/fediverse_account_live.ex
+++ b/lib/vutuv_web/live/fediverse_account_live.ex
@@ -47,6 +47,7 @@ defmodule VutuvWeb.FediverseAccountLive do
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.RemoteAccount
   alias VutuvWeb.Live.InitAssigns
+  alias VutuvWeb.Live.RemotePostActions
 
   # The origin's like/repost figures on a card from another network tick
   # while this page is open (issue #1283). One line, no handler.
@@ -156,24 +157,7 @@ defmodule VutuvWeb.FediverseAccountLive do
   # are cached because somebody else does), so it is the only place those will
   # ever be seen — and a card nobody can report is not a card, it is a display.
   def handle_event("report-remote-post", %{"id" => id}, socket) do
-    case Fediverse.report_remote_post(id, socket.assigns.current_user) do
-      :ok ->
-        {:noreply,
-         socket
-         |> put_flash(:info, gettext("Thank you. Our copy was deleted right away."))
-         |> load_posts()}
-
-      {:error, :rate_limited} ->
-        {:noreply,
-         put_flash(
-           socket,
-           :error,
-           gettext("You have reported a lot today. Please try again tomorrow.")
-         )}
-
-      {:error, :not_found} ->
-        {:noreply, load_posts(socket)}
-    end
+    RemotePostActions.report(socket, id, &load_posts/1)
   end
 
   # The heart (issue #1164): the local marker plus a signed `Like` to this

--- a/lib/vutuv_web/live/fediverse_lookup_live.ex
+++ b/lib/vutuv_web/live/fediverse_lookup_live.ex
@@ -46,6 +46,7 @@ defmodule VutuvWeb.FediverseLookupLive do
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Posts
+  alias VutuvWeb.Live.RemotePostActions
 
   # The origin's like/repost figures on a card from another network tick
   # while this page is open (issue #1283). One line, no handler.
@@ -107,24 +108,7 @@ defmodule VutuvWeb.FediverseLookupLive do
   end
 
   def handle_event("report-remote-post", _params, socket) do
-    case Fediverse.report_remote_post(socket.assigns.post.id, socket.assigns.current_user) do
-      :ok ->
-        {:noreply,
-         socket
-         |> put_flash(:info, gettext("Thank you. Our copy was deleted right away."))
-         |> clear_result()}
-
-      {:error, :rate_limited} ->
-        {:noreply,
-         put_flash(
-           socket,
-           :error,
-           gettext("You have reported a lot today. Please try again tomorrow.")
-         )}
-
-      {:error, :not_found} ->
-        {:noreply, clear_result(socket)}
-    end
+    RemotePostActions.report(socket, socket.assigns.post.id, &clear_result/1)
   end
 
   def handle_event("follow", _params, %{assigns: %{post: nil}} = socket), do: {:noreply, socket}

--- a/lib/vutuv_web/live/fediverse_lookup_live.ex
+++ b/lib/vutuv_web/live/fediverse_lookup_live.ex
@@ -157,14 +157,13 @@ defmodule VutuvWeb.FediverseLookupLive do
     viewer = socket.assigns.current_user
     ids = [post.id]
 
+    # No like/repost marks are read here: the card embeds `RemoteActionsComponent`,
+    # which loads its own. Assigning them cost two queries per lookup for values
+    # nothing rendered — and `clear_result/1` never set them, so no template
+    # could have read them without crashing on the empty state.
     socket
     |> assign(:post, post)
     |> assign(:images, Map.get(Fediverse.list_remote_images(ids), post.id, []))
-    |> assign(:liked?, MapSet.member?(Fediverse.liked_remote_post_ids(viewer, ids), post.id))
-    |> assign(
-      :reposted?,
-      MapSet.member?(Fediverse.reposted_remote_post_ids(viewer, ids), post.id)
-    )
     |> assign(:follow, Fediverse.remote_follow_for(viewer, post.remote_account))
   end
 

--- a/lib/vutuv_web/live/fediverse_post_live.ex
+++ b/lib/vutuv_web/live/fediverse_post_live.ex
@@ -46,6 +46,7 @@ defmodule VutuvWeb.FediversePostLive do
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Fediverse.RemotePost
   alias VutuvWeb.Live.InitAssigns
+  alias VutuvWeb.Live.RemotePostActions
 
   # The origin's like/repost figures on a card from another network tick
   # while this page is open (issue #1283). One line, no handler.
@@ -86,26 +87,13 @@ defmodule VutuvWeb.FediversePostLive do
 
   @impl true
   def handle_event("report-remote-post", _params, socket) do
-    case Fediverse.report_remote_post(socket.assigns.remote_post.id, socket.assigns.current_user) do
-      :ok ->
-        # The copy this page is about is gone, so there is no page left to stay
-        # on. The feed is where the card was met.
-        {:noreply,
-         socket
-         |> put_flash(:info, gettext("Thank you. Our copy was deleted right away."))
-         |> push_navigate(to: ~p"/feed")}
-
-      {:error, :rate_limited} ->
-        {:noreply,
-         put_flash(
-           socket,
-           :error,
-           gettext("You have reported a lot today. Please try again tomorrow.")
-         )}
-
-      {:error, :not_found} ->
-        {:noreply, push_navigate(socket, to: ~p"/feed")}
-    end
+    # The copy this page is about is gone, so there is no page left to stay on.
+    # The feed is where the card was met.
+    RemotePostActions.report(
+      socket,
+      socket.assigns.remote_post.id,
+      &push_navigate(&1, to: ~p"/feed")
+    )
   end
 
   def handle_event("mute-remote-account", %{"id" => account_id}, socket) do

--- a/lib/vutuv_web/live/notification_live/index.ex
+++ b/lib/vutuv_web/live/notification_live/index.ex
@@ -74,14 +74,23 @@ defmodule VutuvWeb.NotificationLive.Index do
 
   # The filter tabs: each maps to the event kinds `notifications_page`'s
   # `kinds:` option keeps. "all" passes nil (every source).
+  #
+  # Every kind in `Vutuv.Activity.kinds/0` must appear under exactly one tab, or
+  # it is unreachable from the tabs AND `filtered_out?/2` drops it from the live
+  # push for any reader not on "All" — which is what happened to
+  # `reference_check`. `notification_filter_coverage_test.exs` fails the build
+  # when the two lists drift apart again.
   @filters %{
     "all" => nil,
     "posts" => ~w(reply thread mention like fediverse_reply fediverse_reaction),
     "people" => ~w(follower connection endorsement),
     "other" =>
       ~w(organization_role moderation image_rejected report_protection handle_change cv_update
-         username)
+         username reference_check)
   }
+
+  @doc false
+  def filters, do: @filters
 
   @impl true
   def mount(_params, _session, socket) do
@@ -1163,25 +1172,13 @@ defmodule VutuvWeb.NotificationLive.Index do
     end
   end
 
-  # A mention opens the post that named the reader. That post belongs to the
-  # *actor*, not to the reader, so the permalink is built under the actor's
-  # handle — unlike reply/like, which point at the reader's own post.
-  defp notification_target(%{kind: "mention"} = n, _viewer) do
-    if is_binary(n[:post_id]) and is_binary(n[:actor_param]) do
-      ~p"/#{n.actor_param}/posts/#{n.post_id}"
-    else
-      actor_target(n)
-    end
-  end
-
-  # A thread event opens the new reply itself (on the replier's profile) —
-  # the thing the recipient has not read yet.
-  defp notification_target(%{kind: "thread"} = n, _viewer) do
-    if is_binary(n[:reply_post_id]) and is_binary(n[:actor_param]) do
-      ~p"/#{n.actor_param}/posts/#{n.reply_post_id}"
-    else
-      actor_target(n)
-    end
+  # A mention opens the post that named the reader, and a thread event the new
+  # reply — both belong to the *actor*, not to the reader, unlike reply/like
+  # below. The row carries that permalink ready-made (`Vutuv.Activity`, built
+  # through `Posts.path/2`): assembling it here from `actor_param` linked a
+  # page's mention into the member namespace, where nothing answers.
+  defp notification_target(%{kind: kind} = n, _viewer) when kind in ["mention", "thread"] do
+    n[:post_path] || actor_target(n)
   end
 
   defp notification_target(n, viewer) do

--- a/lib/vutuv_web/live/organization_live/activity.ex
+++ b/lib/vutuv_web/live/organization_live/activity.ex
@@ -92,7 +92,7 @@ defmodule VutuvWeb.OrganizationLive.Activity do
         organization={@organization}
         active={:activity}
         owner?={@owner?}
-        manage?={true}
+       
         publisher?={@publisher?}
       />
 

--- a/lib/vutuv_web/live/organization_live/domains.ex
+++ b/lib/vutuv_web/live/organization_live/domains.ex
@@ -156,7 +156,7 @@ defmodule VutuvWeb.OrganizationLive.Domains do
   def render(assigns) do
     ~H"""
     <div class="mx-auto max-w-2xl py-6">
-      <.manage_header organization={@organization} active={:domains} owner?={true} manage?={true} />
+      <.manage_header organization={@organization} active={:domains} owner?={true} />
 
       <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100">{gettext("Domains")}</h1>
       <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">

--- a/lib/vutuv_web/live/organization_live/edit.ex
+++ b/lib/vutuv_web/live/organization_live/edit.ex
@@ -234,7 +234,7 @@ defmodule VutuvWeb.OrganizationLive.Edit do
   def render(assigns) do
     ~H"""
     <div class="mx-auto max-w-2xl py-6">
-      <.manage_header organization={@organization} active={:edit} owner?={@owner?} manage?={true} />
+      <.manage_header organization={@organization} active={:edit} owner?={@owner?} />
 
       <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100">
         {gettext("Edit %{name}", name: @organization.name)}

--- a/lib/vutuv_web/live/organization_live/exclusions.ex
+++ b/lib/vutuv_web/live/organization_live/exclusions.ex
@@ -97,7 +97,7 @@ defmodule VutuvWeb.OrganizationLive.Exclusions do
   def render(assigns) do
     ~H"""
     <div class="mx-auto max-w-2xl py-6">
-      <.manage_header organization={@organization} active={:exclusions} owner?={@owner?} manage?={true} />
+      <.manage_header organization={@organization} active={:exclusions} owner?={@owner?} />
 
       <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100">
         {gettext("Job exclusions")}

--- a/lib/vutuv_web/live/organization_live/fediverse.ex
+++ b/lib/vutuv_web/live/organization_live/fediverse.ex
@@ -21,6 +21,7 @@ defmodule VutuvWeb.OrganizationLive.Fediverse do
 
   alias Vutuv.Fediverse
   alias Vutuv.Organizations
+  alias VutuvWeb.Fediverse.Docs
   alias VutuvWeb.Live.InitAssigns
 
   @impl true
@@ -117,7 +118,7 @@ defmodule VutuvWeb.OrganizationLive.Fediverse do
       <.card :if={@enabled? and not is_nil(@organization.username)} class="mt-6">
         <.section_title>{gettext("Address")}</.section_title>
         <p class="mt-2 font-mono text-sm text-slate-800 dark:text-slate-200" id="fediverse-handle">
-          @{@organization.username}@{VutuvWeb.Endpoint.host()}
+          {Docs.handle(@organization)}
         </p>
 
         <p class="mt-4 text-sm text-slate-700 dark:text-slate-300">

--- a/lib/vutuv_web/live/organization_live/fediverse.ex
+++ b/lib/vutuv_web/live/organization_live/fediverse.ex
@@ -72,7 +72,7 @@ defmodule VutuvWeb.OrganizationLive.Fediverse do
         organization={@organization}
         active={:fediverse}
         owner?={true}
-        manage?={true}
+       
         publisher?={@publisher?}
       />
 

--- a/lib/vutuv_web/live/organization_live/fediverse_followers.ex
+++ b/lib/vutuv_web/live/organization_live/fediverse_followers.ex
@@ -155,7 +155,7 @@ defmodule VutuvWeb.OrganizationLive.FediverseFollowers do
         organization={@organization}
         active={:fediverse}
         owner?={true}
-        manage?={true}
+       
         publisher?={@publisher?}
       />
 

--- a/lib/vutuv_web/live/organization_live/feed.ex
+++ b/lib/vutuv_web/live/organization_live/feed.ex
@@ -72,7 +72,7 @@ defmodule VutuvWeb.OrganizationLive.Feed do
         organization={@organization}
         active={:feed}
         owner?={@owner?}
-        manage?={true}
+       
         publisher?={true}
       />
 

--- a/lib/vutuv_web/live/organization_live/following.ex
+++ b/lib/vutuv_web/live/organization_live/following.ex
@@ -147,7 +147,7 @@ defmodule VutuvWeb.OrganizationLive.Following do
         organization={@organization}
         active={:following}
         owner?={@owner?}
-        manage?={true}
+       
         publisher?={true}
       />
 

--- a/lib/vutuv_web/live/organization_live/roles.ex
+++ b/lib/vutuv_web/live/organization_live/roles.ex
@@ -160,7 +160,7 @@ defmodule VutuvWeb.OrganizationLive.Roles do
   def render(assigns) do
     ~H"""
     <div class="mx-auto max-w-2xl py-6">
-      <.manage_header organization={@organization} active={:roles} owner?={true} manage?={true} />
+      <.manage_header organization={@organization} active={:roles} owner?={true} />
 
       <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100">{gettext("Team")}</h1>
       <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">

--- a/lib/vutuv_web/live/organization_live/show.ex
+++ b/lib/vutuv_web/live/organization_live/show.ex
@@ -113,6 +113,9 @@ defmodule VutuvWeb.OrganizationLive.Show do
     # One query for every domain, partitioned in memory (an organization has few).
     domains = Organizations.list_domains(organization)
     primary = Enum.find(domains, & &1.primary?)
+    # …and one for every permission answer this page needs. Asked separately
+    # these were five reads of the same single row set.
+    powers = Organizations.role_powers(organization, viewer)
 
     socket
     |> assign(:organization, organization)
@@ -121,13 +124,13 @@ defmodule VutuvWeb.OrganizationLive.Show do
     |> assign(:primary_domain, primary)
     |> assign(:aliases, Organizations.list_aliases(organization))
     |> assign(:country_name, Countries.name(organization.country))
-    |> assign(:can_manage?, Organizations.can_manage?(organization, viewer))
-    |> assign(:can_edit?, Organizations.can_edit_page?(organization, viewer))
-    |> assign(:owner?, Organizations.owner?(organization, viewer))
+    |> assign(:can_manage?, powers.can_manage?)
+    |> assign(:can_edit?, powers.can_edit?)
+    |> assign(:owner?, powers.owner?)
     # Never implied by owner or admin (issue #1333): speaking for the page is
-    # its own grant, so this is asked on its own rather than derived from the
-    # two above.
-    |> assign(:publisher?, Organizations.publisher?(organization, viewer))
+    # its own grant, so `role_powers/2` reads it from the role list on its own
+    # rather than deriving it from the two above.
+    |> assign(:publisher?, powers.publisher?)
     # Following a page (issue #1336): a private subscription that pulls its
     # posts into your feed. No approval and no notification — a page has no
     # inbox to be told, the same way following a member needs no permission.
@@ -164,10 +167,7 @@ defmodule VutuvWeb.OrganizationLive.Show do
     # own: the installation must federate at all, and this must be the owner
     # (federating decides how the page appears on servers we do not run, which
     # is why the switch itself is owner-only rather than publisher-wide).
-    |> assign(
-      :fediverse_invite?,
-      Fediverse.enabled?() and Organizations.owner?(organization, viewer)
-    )
+    |> assign(:fediverse_invite?, Fediverse.enabled?() and powers.owner?)
     |> assign(:engagement, Organizations.organization_engagement(organization, viewer))
     |> assign(:dns_value, primary && Organizations.dns_txt_value(primary))
     |> assign(:dns_challenge_name, primary && Organizations.dns_challenge_name(primary))

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -41,6 +41,7 @@ defmodule VutuvWeb.PostLive.Feed do
   alias VutuvWeb.Live.DayClockRestream
   alias VutuvWeb.Live.InitAssigns
   alias VutuvWeb.Live.MountHandoff
+  alias VutuvWeb.Live.RemotePostActions
   alias VutuvWeb.UserHelpers
 
   # The origin's like/repost figures on a card from another network tick
@@ -415,24 +416,7 @@ defmodule VutuvWeb.PostLive.Feed do
   # still exists at its origin, so there is no case and no freezer — and the
   # row leaves the feed in the same round trip.
   def handle_event("report-remote-post", %{"id" => id}, socket) do
-    case Fediverse.report_remote_post(id, socket.assigns.current_user) do
-      :ok ->
-        {:noreply,
-         socket
-         |> put_flash(:info, gettext("Thank you. Our copy was deleted right away."))
-         |> drop_remote_entry(id)}
-
-      {:error, :rate_limited} ->
-        {:noreply,
-         put_flash(
-           socket,
-           :error,
-           gettext("You have reported a lot today. Please try again tomorrow.")
-         )}
-
-      {:error, :not_found} ->
-        {:noreply, drop_remote_entry(socket, id)}
-    end
+    RemotePostActions.report(socket, id, &drop_remote_entry(&1, id))
   end
 
   # "Not this account today": the private, reversible lever beside Report. The

--- a/lib/vutuv_web/live/post_live/reply.ex
+++ b/lib/vutuv_web/live/post_live/reply.ex
@@ -1,9 +1,14 @@
 defmodule VutuvWeb.PostLive.Reply do
   @moduledoc """
   Reply page — the parent post (read-only preview) above the same composer
-  as the feed. Only visible, **public** parents can be answered
-  (`Vutuv.Posts.create_reply/3` enforces the same rule); everything else is
-  sent away with the unknown-id flash, so existence never leaks.
+  as the feed. Only visible, **public**, `Vutuv.Posts.replyable?/1` parents can
+  be answered; everything else is sent away with the unknown-id flash, so
+  existence never leaks. `replyable?/1` is shared with `create_reply/3`'s own
+  gate, which is what keeps a page's post (issue #1334) off this page — the
+  heading below names the parent's **member** author, which such a post has not
+  got. A block is deliberately *not* part of the gate: quiet blocking has to let
+  the blocked member reach the composer and be refused on submit, or the block
+  leaks.
 
   **Quoting a passage** (issue #1114): a reader who marks part of a post before
   pressing Reply arrives here with that text in the `quote` parameter, and the
@@ -30,7 +35,8 @@ defmodule VutuvWeb.PostLive.Reply do
     user = socket.assigns.current_user
     parent = Posts.get_post(id)
 
-    if parent && Posts.visible_to?(parent, user) && not Posts.restricted?(parent) do
+    if parent && Posts.replyable?(parent) && Posts.visible_to?(parent, user) &&
+         not Posts.restricted?(parent) do
       {:ok,
        socket
        |> assign(:page_title, gettext("Reply"))

--- a/lib/vutuv_web/live/remote_post_actions.ex
+++ b/lib/vutuv_web/live/remote_post_actions.ex
@@ -1,0 +1,54 @@
+defmodule VutuvWeb.Live.RemotePostActions do
+  @moduledoc """
+  Reporting a cached post from another network, once, for the six surfaces that
+  offer it (the feed, the tag timeline, an account's page, the URL lookup, the
+  post's own page — and any card that follows them).
+
+  A report deletes our copy immediately (`Vutuv.Fediverse.report_remote_post/2`)
+  — this is a cache of something that still exists at its origin, so there is no
+  case and no freezer — and the member is told so in the same round trip. What
+  differs per page is only what to do with the space the card leaves behind:
+  drop the row, reload the list, clear the result, or navigate away. That is the
+  `on_removed` function; everything else was copied five times, including both
+  member-facing sentences, which is five chances for one of them to drift into a
+  second wording for the same act.
+
+  The `:not_found` arm runs `on_removed` too and says nothing: the copy is
+  already gone, which is exactly what the member asked for, so reporting an
+  error would be a lie about a request that succeeded.
+  """
+
+  use Gettext, backend: VutuvWeb.Gettext
+
+  import Phoenix.LiveView, only: [put_flash: 3]
+
+  alias Vutuv.Fediverse
+
+  @doc """
+  Handles a `"report-remote-post"` event for the cached post `id`, returning the
+  `{:noreply, socket}` its `handle_event/3` clause can return directly.
+
+  `on_removed` takes the socket and returns it, and runs wherever the card has
+  to leave the page.
+  """
+  def report(socket, id, on_removed) when is_function(on_removed, 1) do
+    case Fediverse.report_remote_post(id, socket.assigns.current_user) do
+      :ok ->
+        {:noreply,
+         socket
+         |> put_flash(:info, gettext("Thank you. Our copy was deleted right away."))
+         |> on_removed.()}
+
+      {:error, :rate_limited} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           gettext("You have reported a lot today. Please try again tomorrow.")
+         )}
+
+      {:error, :not_found} ->
+        {:noreply, on_removed.(socket)}
+    end
+  end
+end

--- a/lib/vutuv_web/live/tag_live/timeline.ex
+++ b/lib/vutuv_web/live/tag_live/timeline.ex
@@ -47,6 +47,7 @@ defmodule VutuvWeb.TagLive.Timeline do
   alias Vutuv.Tags.Tag
   alias Vutuv.Tags.Timeline
   alias VutuvWeb.Live.InitAssigns
+  alias VutuvWeb.Live.RemotePostActions
 
   # The origin's like/repost figures on a card from another network tick
   # while this page is open (issue #1283). One line, no handler.
@@ -112,26 +113,7 @@ defmodule VutuvWeb.TagLive.Timeline do
   # A report deletes our copy for everybody here, so the row leaves in the same
   # round trip rather than sitting there until the next load.
   def handle_event("report-remote-post", %{"id" => id}, socket) do
-    # The same three answers, in the same words, as the feed's report control:
-    # one act, described once, wherever a member meets a cached post.
-    case Fediverse.report_remote_post(id, socket.assigns.current_user) do
-      :ok ->
-        {:noreply,
-         socket
-         |> put_flash(:info, gettext("Thank you. Our copy was deleted right away."))
-         |> drop_remote_entry(id)}
-
-      {:error, :rate_limited} ->
-        {:noreply,
-         put_flash(
-           socket,
-           :error,
-           gettext("You have reported a lot today. Please try again tomorrow.")
-         )}
-
-      {:error, :not_found} ->
-        {:noreply, drop_remote_entry(socket, id)}
-    end
+    RemotePostActions.report(socket, id, &drop_remote_entry(&1, id))
   end
 
   # ── Loading ───────────────────────────────────────────────────────────────

--- a/lib/vutuv_web/report_details.ex
+++ b/lib/vutuv_web/report_details.ex
@@ -136,10 +136,18 @@ defmodule VutuvWeb.ReportDetails do
   # liker / bookmarker) is the muted suffix. A text-less (photo-only) post has no
   # first line, so the actor's handle becomes the link text instead of a blank
   # line.
+  #
+  # The permalink is asked of `Vutuv.Posts.path/1` rather than built here: this
+  # spelled `"/posts/" <> id`, which is a route only `/api/2.0` serves, so every
+  # post line in the daily report page and its email led nowhere. The actor
+  # above is the reposter or liker, not necessarily the author, so the path has
+  # to come from the post.
   defp post_entry(post, actor) do
+    path = Vutuv.Posts.path(post)
+
     case AgentDocs.excerpt(post.body) do
-      "" -> %{primary: actor_label(actor), secondary: nil, path: "/posts/" <> post.id}
-      line -> %{primary: line, secondary: actor_label(actor), path: "/posts/" <> post.id}
+      "" -> %{primary: actor_label(actor), secondary: nil, path: path}
+      line -> %{primary: line, secondary: actor_label(actor), path: path}
     end
   end
 

--- a/lib/vutuv_web/templates/settings/fediverse.html.heex
+++ b/lib/vutuv_web/templates/settings/fediverse.html.heex
@@ -118,22 +118,7 @@ subpage now (/settings/fediverse/move), linked from the footer below. --%>
           "Give this out the way you give out an email address. Anyone on Mastodon and friends can paste it into their search and follow you from there."
         )}
       </p>
-      <div class="mt-3 flex items-start gap-2 rounded-lg bg-slate-50 px-3 py-2 ring-1 ring-slate-200 dark:bg-slate-800/50 dark:ring-slate-700">
-        <code
-          id="fediverse-handle"
-          class="min-w-0 flex-1 select-all break-all text-sm text-slate-800 dark:text-slate-100"
-        >{VutuvWeb.Fediverse.Docs.handle(@user)}</code>
-        <button
-          type="button"
-          data-copy
-          data-copy-target="fediverse-handle"
-          data-label-copy={gettext("Copy")}
-          data-label-copied={gettext("Copied")}
-          class="shrink-0 rounded-md bg-white px-2 py-1 text-xs font-semibold text-slate-700 ring-1 ring-slate-200 hover:bg-slate-100 dark:bg-slate-800 dark:text-slate-200 dark:ring-slate-700 dark:hover:bg-slate-700"
-        >
-          {gettext("Copy")}
-        </button>
-      </div>
+      <.copy_field id="fediverse-handle">{VutuvWeb.Fediverse.Docs.handle(@user)}</.copy_field>
 
       <h3 class="mt-6 text-sm font-semibold text-slate-900 dark:text-white">
         {ngettext(

--- a/lib/vutuv_web/templates/settings/security.html.heex
+++ b/lib/vutuv_web/templates/settings/security.html.heex
@@ -47,12 +47,9 @@ who still looks here first. --%>
         <li :for={event <- @recent_activity} id={"recent-event-#{event.id}"} class="py-2">
           <span class="block text-sm font-medium text-slate-800 dark:text-slate-100">
             {event_label(event)}
-            <span
-              :if={by_someone_else?(event)}
-              class="ml-1 inline-flex items-center rounded-full bg-amber-50 px-2 py-0.5 text-xs font-semibold text-amber-800 dark:bg-amber-900/30 dark:text-amber-200"
-            >
+            <.by_other_badge :if={by_someone_else?(event)} class="ml-1">
               {gettext("Not by you")}
-            </span>
+            </.by_other_badge>
           </span>
           <span class="block text-xs text-slate-600 dark:text-slate-400">
             <.local_time at={event.inserted_at} precision="second" format="%Y-%m-%d %H:%M:%S" />

--- a/lib/vutuv_web/templates/totp/new.html.heex
+++ b/lib/vutuv_web/templates/totp/new.html.heex
@@ -44,23 +44,11 @@
           data-copy enhancement). data-copy-text carries the key without the
           display grouping spaces, so what lands in the clipboard is the clean
           Base32 every authenticator app accepts. --%>
-    <div class="mt-1 flex max-w-md items-center gap-2 rounded-lg bg-slate-50 px-3 py-2 ring-1 ring-slate-200 dark:bg-slate-800/50 dark:ring-slate-700">
-      <code
-        id="totp-manual-key"
-        class="min-w-0 flex-1 select-all break-all text-sm text-slate-800 dark:text-slate-100"
-      >{@manual_secret}</code>
-      <button
-        type="button"
-        data-copy
-        data-copy-target="totp-manual-key"
-        data-copy-text={String.replace(@manual_secret, " ", "")}
-        data-label-copy={gettext("Copy")}
-        data-label-copied={gettext("Copied")}
-        class="shrink-0 rounded-md bg-white px-2 py-1 text-xs font-semibold text-slate-700 ring-1 ring-slate-200 hover:bg-slate-100 dark:bg-slate-800 dark:text-slate-200 dark:ring-slate-700 dark:hover:bg-slate-700"
-      >
-        {gettext("Copy")}
-      </button>
-    </div>
+    <.copy_field
+      id="totp-manual-key"
+      class="mt-1 max-w-md items-center"
+      copy_text={String.replace(@manual_secret, " ", "")}
+    >{@manual_secret}</.copy_field>
 
     <.form
       :let={f}

--- a/lib/vutuv_web/templates/username/new.html.heex
+++ b/lib/vutuv_web/templates/username/new.html.heex
@@ -14,22 +14,7 @@ Profile now. --%>
     you copy it by hand. --%>
     <.card>
       <.section_title>{gettext("Your profile address")}</.section_title>
-      <div class="mt-3 flex items-start gap-2 rounded-lg bg-slate-50 px-3 py-2 ring-1 ring-slate-200 dark:bg-slate-800/50 dark:ring-slate-700">
-        <code
-          id="profile-url"
-          class="min-w-0 flex-1 select-all break-all text-sm text-slate-800 dark:text-slate-100"
-        >{url(~p"/#{@user}")}</code>
-        <button
-          type="button"
-          data-copy
-          data-copy-target="profile-url"
-          data-label-copy={gettext("Copy")}
-          data-label-copied={gettext("Copied")}
-          class="shrink-0 rounded-md bg-white px-2 py-1 text-xs font-semibold text-slate-700 ring-1 ring-slate-200 hover:bg-slate-100 dark:bg-slate-800 dark:text-slate-200 dark:ring-slate-700 dark:hover:bg-slate-700"
-        >
-          {gettext("Copy")}
-        </button>
-      </div>
+      <.copy_field id="profile-url">{url(~p"/#{@user}")}</.copy_field>
       <p class="mt-3 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
         {gettext("Other members mention you as %{handle}.", handle: "@#{@user.username}")}
       </p>
@@ -101,22 +86,9 @@ Profile now. --%>
           "This link always opens your profile, even after you change your username. It is built from a fixed id, so it never breaks on a rename. For everyday sharing the short address above is friendlier."
         )}
       </p>
-      <div class="mt-3 flex items-start gap-2 rounded-lg bg-slate-50 px-3 py-2 ring-1 ring-slate-200 dark:bg-slate-800/50 dark:ring-slate-700">
-        <code
-          id="permalink-url"
-          class="min-w-0 flex-1 select-all break-all text-xs text-slate-800 dark:text-slate-100"
-        >{url(~p"/system/permalinks/users/#{@user.id}")}</code>
-        <button
-          type="button"
-          data-copy
-          data-copy-target="permalink-url"
-          data-label-copy={gettext("Copy")}
-          data-label-copied={gettext("Copied")}
-          class="shrink-0 rounded-md bg-white px-2 py-1 text-xs font-semibold text-slate-700 ring-1 ring-slate-200 hover:bg-slate-100 dark:bg-slate-800 dark:text-slate-200 dark:ring-slate-700 dark:hover:bg-slate-700"
-        >
-          {gettext("Copy")}
-        </button>
-      </div>
+      <.copy_field id="permalink-url" code_class="text-xs">
+        {url(~p"/system/permalinks/users/#{@user.id}")}
+      </.copy_field>
     </.card>
   </div>
 </.settings_shell>

--- a/lib/vutuv_web/views/account_event_text.ex
+++ b/lib/vutuv_web/views/account_event_text.ex
@@ -18,6 +18,7 @@ defmodule VutuvWeb.AccountEventText do
   context decided not to keep.
   """
 
+  use Phoenix.Component
   use Gettext, backend: VutuvWeb.Gettext
 
   alias Vutuv.AccountEvents.AccountEvent
@@ -254,4 +255,33 @@ defmodule VutuvWeb.AccountEventText do
   def by_someone_else?(%AccountEvent{actor_user_id: nil}), do: false
   def by_someone_else?(%AccountEvent{user_id: id, actor_user_id: id}), do: false
   def by_someone_else?(%AccountEvent{}), do: true
+
+  attr(:class, :any, default: "mt-1")
+  slot(:inner_block, required: true)
+
+  @doc """
+  The amber marker on a row somebody else caused — the one line on those pages
+  that has to shout.
+
+  The wording differs by page (the member is told it was not them, the admin is
+  told who it was), which is the slot; everything else is the same badge, and
+  keeping it in one place is what puts `data-event-by-other` on all three. The
+  `/settings/security` copy was written without that attribute, so the test
+  asserting the marker exists never covered that page at all.
+
+  Guard the call site with `:if={by_someone_else?(event)}` as before.
+  """
+  def by_other_badge(assigns) do
+    ~H"""
+    <span
+      data-event-by-other
+      class={[
+        "inline-flex items-center rounded-full bg-amber-50 px-2 py-0.5 text-xs font-semibold text-amber-800 dark:bg-amber-900/30 dark:text-amber-200",
+        @class
+      ]}
+    >
+      {render_slot(@inner_block)}
+    </span>
+    """
+  end
 end

--- a/lib/vutuv_web/views/admin/fediverse_html.ex
+++ b/lib/vutuv_web/views/admin/fediverse_html.ex
@@ -8,7 +8,7 @@ defmodule VutuvWeb.Admin.FediverseHTML do
 
   @doc """
   What a takedown row means, in words. The stored `action` values are the closed
-  set `Vutuv.Fediverse.NoteEvent.actions/0` holds; an unknown one still renders
+  set `Vutuv.Fediverse.NoteEvent` documents; an unknown one still renders
   something rather than leaking a raw string at the operator.
   """
   def note_event_label(%{action: "reported"}), do: gettext("Reported as not appropriate")

--- a/lib/vutuv_web/views/error_html.ex
+++ b/lib/vutuv_web/views/error_html.ex
@@ -23,6 +23,8 @@ defmodule VutuvWeb.ErrorHTML do
   use Phoenix.Component
   use Gettext, backend: VutuvWeb.Gettext
 
+  alias VutuvWeb.PageHTML
+
   # A request the server could not read (issue #1227): a mangled multipart
   # body raises in the endpoint (invalid UTF-8 in a text part, or all fields
   # dropped over a defective Content-Disposition) before any controller runs,
@@ -155,7 +157,8 @@ defmodule VutuvWeb.ErrorHTML do
   # example. The prominent note owns up to a newsletter that once shipped this
   # exact broken link. Rendered with a 404 status by VutuvWeb.PageController.
   def render("username_placeholder.html", assigns) do
-    assigns = Map.new(assigns)
+    assigns =
+      assigns |> Map.new() |> Map.put(:example_profile_url, PageHTML.example_profile_url())
 
     ~H"""
     <div class="error-page">
@@ -172,12 +175,16 @@ defmodule VutuvWeb.ErrorHTML do
           "in this address is only a placeholder. Replace it with the actual username of the person whose profile you want to visit."
         )}
       </p>
-      <%!-- The example must exist on every installation, so it points at the
-            founder's profile on vutuv.de absolutely instead of assuming this
-            host has a member called wintermeyer. --%>
-      <p class="error-page__hint">
+      <%!-- The example must exist on every installation, so it is an absolute
+            URL rather than an assumption that this host has a member called
+            wintermeyer. Which profile it is belongs to the operator
+            (`:landing_example_profile_url`, LANDING_EXAMPLE_PROFILE_URL): the
+            vutuv.de founder profile is only its default, and an installation
+            that cleared the key gets no line at all rather than a link into
+            somebody else's site. --%>
+      <p :if={@example_profile_url} class="error-page__hint">
         {gettext("For example, this profile really exists:")}
-        <a href="https://vutuv.de/wintermeyer">vutuv.de/wintermeyer</a>
+        <a href={@example_profile_url}>{PageHTML.example_profile_label(@example_profile_url)}</a>
       </p>
       <p class="error-page__hint">
         {gettext("Do not know the username? Try the")}

--- a/lib/vutuv_web/views/job_reference_html.ex
+++ b/lib/vutuv_web/views/job_reference_html.ex
@@ -268,9 +268,6 @@ defmodule VutuvWeb.JobReferenceHTML do
   @doc "The form value for one CV entry, as the controller parses it back."
   def link_value(kind, entry), do: "#{kind}:#{entry.id}"
 
-  @doc "Whether the AI check applies to this entry's country."
-  def check_supported?(reference), do: References.check_supported?(reference)
-
   @doc "Whether this installation offers the check at all."
   def checks_enabled?, do: Checks.enabled?()
 
@@ -413,19 +410,6 @@ defmodule VutuvWeb.JobReferenceHTML do
   defp hours_phrase(count),
     do: ngettext("%{formatted} hour", "%{formatted} hours", count, formatted: count)
 
-  @doc "The queue position of a waiting check, or nil."
-  def queue_position(%Check{} = check), do: Checks.queue_position(check)
-  def queue_position(_none), do: nil
-
-  @doc """
-  Whether a finished check still describes the entry's current text.
-
-  A stale result is shown, not hidden: the earlier reading is still worth
-  having, it simply no longer matches what is on screen.
-  """
-  def current_result?(%Check{} = check, reference), do: Check.current_for?(check, reference)
-  def current_result?(_none, _reference), do: false
-
   @doc """
   The one-line fact strip under a Zeugnis title: kind · employer · issue date.
 
@@ -523,12 +507,4 @@ defmodule VutuvWeb.JobReferenceHTML do
   defp grade_tint(_neutral),
     do:
       "bg-slate-100 text-slate-800 ring-1 ring-slate-200 dark:bg-slate-800 dark:text-slate-100 dark:ring-slate-700"
-
-  @doc "A short state label for the check badge on a card."
-  def check_state_label(nil), do: nil
-  def check_state_label(%Check{status: "pending"}), do: gettext("Queued")
-  def check_state_label(%Check{status: "running"}), do: gettext("Reviewing")
-  def check_state_label(%Check{status: "done"}), do: gettext("Reviewed")
-  def check_state_label(%Check{status: "failed"}), do: gettext("Review failed")
-  def check_state_label(%Check{}), do: nil
 end

--- a/lib/vutuv_web/views/settings_html.ex
+++ b/lib/vutuv_web/views/settings_html.ex
@@ -15,7 +15,8 @@ defmodule VutuvWeb.SettingsHTML do
 
   # The account-activity wording (issue #1087), so the recap on the security
   # page reads exactly like the full log at /settings/activity.
-  import VutuvWeb.AccountEventText, only: [event_label: 1, detail: 1, by_someone_else?: 1]
+  import VutuvWeb.AccountEventText,
+    only: [event_label: 1, detail: 1, by_someone_else?: 1, by_other_badge: 1]
 
   # A `<label for=…>` has to name the id the form really generated, and that is
   # not `user_<field>`: a `<.form id=…>` prefixes every input id with its own

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.272.0",
+      version: "7.272.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/fediverse_post_reposts_test.exs
+++ b/test/vutuv/fediverse_post_reposts_test.exs
@@ -386,4 +386,46 @@ defmodule Vutuv.FediversePostRepostsTest do
       assert Repo.get(RemotePost, ctx.post.id)
     end
   end
+
+  describe "the re-verification queue" do
+    # A skip that stamps no clock holds the front of every later batch: the due
+    # query serves the least recently checked first, and nothing about an
+    # unworkable copy changes between two runs. The cap is then spent on work
+    # that can never complete, while the copies somebody is actually reading sit
+    # behind it and are never reached. `refresh_counts/1` in the same module
+    # carries a long note about having shipped exactly this once; these two arms
+    # are the same shape, so they get the same guard.
+
+    test "an origin that does not answer does not hold the front of it" do
+      user = federating_member()
+      post = cached_post(account())
+      {:ok, :reposted} = Fediverse.repost_remote_post(user, post)
+
+      Application.put_env(:vutuv, :fediverse_req_options,
+        plug: fn conn -> Plug.Conn.send_resp(conn, 500, "") end
+      )
+
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_req_options) end)
+
+      assert %{skipped: 1} = Fediverse.refresh_reposted_posts()
+
+      # Stamped, so it rejoins the rotation at its own pace instead of being due
+      # again immediately. The copy stays: an outage is not a takedown.
+      assert %{skipped: 0} = Fediverse.refresh_reposted_posts()
+      assert Repo.get(RemotePost, post.id)
+    end
+
+    test "and neither does a copy nobody here can sign for" do
+      post = cached_post(account())
+      user = insert(:activated_user)
+
+      # No keypair, so there is no actor to sign the fetch as — the copy can
+      # never be verified until somebody who federates reshares it too.
+      Repo.insert!(%PostRepost{user_id: user.id, remote_post_id: post.id})
+
+      assert :skip = Fediverse.refresh_reposted_post(post)
+      assert %{skipped: 0} = Fediverse.refresh_reposted_posts()
+      assert Repo.get(RemotePost, post.id)
+    end
+  end
 end

--- a/test/vutuv/newsletter_groups_test.exs
+++ b/test/vutuv/newsletter_groups_test.exs
@@ -105,6 +105,12 @@ defmodule Vutuv.NewsletterGroupsTest do
 
       assert Newsletters.audience_count(%{tag_id: tag.id}) == 1
       assert Newsletters.find_tag("elixir").id == tag.id
+
+      # The slug spelling names the same topic everywhere else in the app
+      # (`Tag.find_by_value/1` is what the tag pages, the composer and the
+      # search box all use), so an admin who types it here must not be told the
+      # tag does not exist.
+      assert Newsletters.find_tag(tag.slug).id == tag.id
     end
 
     test "only counts emailable, subscribed members" do

--- a/test/vutuv/profiles/social_account_verification_test.exs
+++ b/test/vutuv/profiles/social_account_verification_test.exs
@@ -202,6 +202,21 @@ defmodule Vutuv.Profiles.SocialAccountVerificationTest do
       assert reloaded.verified_at
       refute reloaded.grace_deadline_at
     end
+
+    test "an unreachable provider still leaves the rotation", ctx do
+      serve_status(500)
+
+      assert :unreachable = Verification.recheck(ctx.account)
+
+      # The sweeper runs hourly but the interval is a week, so a row that keeps
+      # its old clock is re-fetched every single hour, forever, against a third
+      # party that is telling us it has nothing to say. Stamping the scheduler's
+      # clock is not a claim that we verified anything (the mark and the grace
+      # window are deliberately untouched above) — it only puts the account back
+      # into the normal rotation.
+      due = Verification.accounts_due_for_recheck() |> Enum.map(& &1.id)
+      refute ctx.account.id in due
+    end
   end
 
   describe "accounts_due_for_recheck/1" do

--- a/test/vutuv_web/controllers/sitemap_controller_test.exs
+++ b/test/vutuv_web/controllers/sitemap_controller_test.exs
@@ -126,6 +126,26 @@ defmodule VutuvWeb.SitemapControllerTest do
     end
   end
 
+  describe "GET /sitemaps/organization_posts-N.xml" do
+    test "serves the chunk the index advertises" do
+      organization = insert(:organization)
+      insert(:post, user: nil, organization: organization, body: "Wir stellen ein.")
+
+      index = get(build_conn(), "/sitemap.xml").resp_body
+      assert index =~ "#{@base}/sitemaps/organization_posts-1.xml"
+
+      # The index published this child from `Sitemap.chunk_counts/0` while the
+      # controller matched the name against a second, hand-written list that
+      # never learned about organization posts — so every page's post was
+      # offered to crawlers and then answered 404.
+      conn = get(build_conn(), "/sitemaps/organization_posts-1.xml")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "<urlset"
+      assert conn.resp_body =~ "/organizations/#{organization.slug}/posts/"
+    end
+  end
+
   describe "GET /sitemaps/static.xml" do
     test "lists the public static pages" do
       conn = get(build_conn(), "/sitemaps/static.xml")

--- a/test/vutuv_web/landing_configuration_test.exs
+++ b/test/vutuv_web/landing_configuration_test.exs
@@ -125,6 +125,29 @@ defmodule VutuvWeb.LandingConfigurationTest do
       assert html =~ ~s(href="/llms.txt")
     end
 
+    # The /username helper page offers the same example and had spelled the
+    # vutuv.de founder profile out in its markup, so an installation that
+    # configured its own — or cleared it — still sent people to vutuv.de.
+    test "the /username helper page offers the configured example too", %{conn: conn} do
+      example("https://vutuv.example/ada")
+
+      html = conn |> get(~p"/username") |> response(404)
+
+      assert html =~ "https://vutuv.example/ada"
+      assert html =~ "vutuv.example/ada"
+      refute html =~ "vutuv.de/wintermeyer"
+    end
+
+    test "and drops the example line where the installation cleared the URL", %{conn: conn} do
+      example("")
+
+      html = conn |> get(~p"/username") |> response(404)
+
+      refute html =~ "really exists"
+      # The rest of the explanation stays — that is the point of the page.
+      assert html =~ "only a placeholder"
+    end
+
     # An intranet installation federates nothing: every endpoint behind that
     # section 404s there, so promising Mastodon on the operator's front page
     # would be a straight lie. The sign-up form already gates its Fediverse

--- a/test/vutuv_web/live/account_activity_live_test.exs
+++ b/test/vutuv_web/live/account_activity_live_test.exs
@@ -142,5 +142,10 @@ defmodule VutuvWeb.AccountActivityLiveTest do
     {:ok, live, _html} = live(conn, ~p"/settings/activity")
 
     assert has_element?(live, "[data-event-by-other]")
+
+    # …and on the security page's short recap of the same events, which wrote
+    # its own copy of the badge without the marker, so this assertion silently
+    # did not cover it. Both render `<.by_other_badge>` now.
+    assert conn |> get(~p"/settings/security") |> html_response(200) =~ "data-event-by-other"
   end
 end

--- a/test/vutuv_web/live/notification_filter_coverage_test.exs
+++ b/test/vutuv_web/live/notification_filter_coverage_test.exs
@@ -1,0 +1,45 @@
+defmodule VutuvWeb.NotificationFilterCoverageTest do
+  @moduledoc """
+  The notifications page's filter tabs against the notification registry.
+
+  `Vutuv.Activity.kind_specs/3` is the one place a notification kind is
+  declared, but the page keeps its own map of which tab shows which kinds. A
+  kind missing from that map is not merely absent from a tab: `filtered_out?/2`
+  runs on the live-push branch too, so it is **dropped** for any reader who is
+  not sitting on "All" — silently, and only for the readers who filter.
+
+  That had already happened. `reference_check` shipped in v7.227.0 and was in
+  none of the three tabs.
+  """
+  use ExUnit.Case, async: true
+
+  alias Vutuv.Activity
+  alias VutuvWeb.NotificationLive.Index
+
+  test "every registry kind is shown by exactly one tab" do
+    tabs = Map.delete(Index.filters(), "all")
+    covered = tabs |> Map.values() |> List.flatten()
+
+    for kind <- Activity.kinds() do
+      assert kind in covered,
+             """
+             The notification kind #{inspect(kind)} is in Vutuv.Activity's registry but in no \
+             filter tab, so the page can never show it and a live-pushed one is dropped for \
+             every reader not on "All". Add it to a tab in VutuvWeb.NotificationLive.Index.\
+             """
+    end
+
+    # Twice would put one row under two tabs and double it in "all"'s siblings.
+    duplicates = covered -- Enum.uniq(covered)
+    assert duplicates == [], "kinds listed under more than one tab: #{inspect(duplicates)}"
+  end
+
+  test "no tab lists a kind the registry does not produce" do
+    kinds = Activity.kinds()
+
+    for {tab, listed} <- Map.delete(Index.filters(), "all"), kind <- listed do
+      assert kind in kinds,
+             "tab #{inspect(tab)} lists #{inspect(kind)}, which no longer exists in the registry"
+    end
+  end
+end

--- a/test/vutuv_web/organization_mention_notification_test.exs
+++ b/test/vutuv_web/organization_mention_notification_test.exs
@@ -52,5 +52,11 @@ defmodule VutuvWeb.OrganizationMentionNotificationTest do
     refute html =~ owner.username
     # …and the quote links to the post under the organization's own permalink.
     assert html =~ Posts.path(post)
+
+    # The row's own sentence must land there too. It built its link from the
+    # actor's param, which for a page is the slug, so it pointed at
+    # `/acme/posts/<id>` — the member namespace, where nothing answers. Two
+    # links in one row, one of them dead.
+    refute html =~ ~s|"/#{organization.slug}/posts/#{post.id}"|
   end
 end

--- a/test/vutuv_web/organization_posts_web_test.exs
+++ b/test/vutuv_web/organization_posts_web_test.exs
@@ -261,5 +261,19 @@ defmodule VutuvWeb.OrganizationPostsWebTest do
       # motion is member-shaped, and an organization has no inbox until #1336.
       assert {:error, :restricted} = Posts.create_reply(reader, post, %{body: "Antwort"})
     end
+
+    test "and the reply page turns that refusal away instead of crashing", %{conn: conn} do
+      {conn, _reader} = create_and_login_user(conn)
+      owner = insert(:activated_user)
+      organization = active_organization_for(owner)
+      {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+      {:ok, post} = Posts.create_organization_post(organization, owner, %{body: "Hallo."})
+
+      # `Posts.restricted?/1` only knows about denial rows, so the page's own
+      # gate lets a page's post through and the composer would then be offered
+      # for something `create_reply/3` refuses one submit later. Reaching it by
+      # URL must land somewhere sensible, not on a crash.
+      assert {:error, {:redirect, %{to: "/"}}} = live(conn, ~p"/posts/#{post.id}/reply")
+    end
   end
 end

--- a/test/vutuv_web/report_details_test.exs
+++ b/test/vutuv_web/report_details_test.exs
@@ -5,6 +5,7 @@ defmodule VutuvWeb.ReportDetailsTest do
   """
   use Vutuv.DataCase, async: false
 
+  alias Vutuv.Posts
   alias Vutuv.Reports
   alias Vutuv.Reports.DailyReport
   alias VutuvWeb.ReportDetails
@@ -40,9 +41,14 @@ defmodule VutuvWeb.ReportDetailsTest do
       author = insert(:user, username: "bob")
       post = insert(:post, [user: author, body: "First line\nSecond line"] ++ at(@on_day))
 
+      # Asserted against `Posts.path/1`, not a hand-written path: this line used
+      # to read `/posts/<id>`, which only `/api/2.0` serves, so the report and
+      # its email linked nowhere — and the test agreed with the bug.
       assert section(Reports.daily(@date), :posts).entries == [
-               %{primary: "First line", secondary: "@bob", path: "/posts/#{post.id}"}
+               %{primary: "First line", secondary: "@bob", path: Posts.path(post)}
              ]
+
+      assert Posts.path(post) == "/bob/posts/#{post.id}"
     end
 
     test "a text-less (photo-only) post falls back to the author handle as the line" do
@@ -50,7 +56,20 @@ defmodule VutuvWeb.ReportDetailsTest do
       post = insert(:post, [user: author, body: ""] ++ at(@on_day))
 
       assert section(Reports.daily(@date), :posts).entries == [
-               %{primary: "@carol", secondary: nil, path: "/posts/#{post.id}"}
+               %{primary: "@carol", secondary: nil, path: Posts.path(post)}
+             ]
+    end
+
+    test "a page's post links under the organization permalink shape" do
+      organization = insert(:organization)
+      post = insert(:post, [user: nil, organization: organization, body: "Neu."] ++ at(@on_day))
+
+      assert section(Reports.daily(@date), :posts).entries == [
+               %{
+                 primary: "Neu.",
+                 secondary: organization.name,
+                 path: "/organizations/#{organization.slug}/posts/#{post.id}"
+               }
              ]
     end
 


### PR DESCRIPTION
**TL;DR** A `/simplify` pass over the whole app: 20 findings applied, 5 of them real defects (a reachable 500, three dead-link classes, two self-starving sweeper queues). Nothing changes what a page says.

Five review agents (reuse, simplification, efficiency, altitude, component extraction) read `lib/` in parallel, weighted toward the 260 files changed since the last sweep (`5bb3a6e4`, v7.203.1). Each finding below was re-verified by hand before it was applied; every bugfix started with a test that goes red against the unfixed code.

## Defects found on the way

- **A reachable 500.** The reply page kept its own weaker copy of "can this be answered", so it offered a composer for a page's post — which `create_reply/3` refuses one submit later, except it never got that far, because the heading dereferenced the member author a page's post does not have. Any logged-in member could hit it by URL. `Posts.replyable?/1` now names the post-shaped half of the rule for both sides. A block deliberately stays out of the page's gate: quiet blocking has to let the blocked member reach the composer, or the block leaks.
- **A mention by a page 404ed on the reader's own notifications page** — the row built its permalink from the actor's param, which for a page is the slug. The row carries the path now, built through the new `Posts.path/2`. (The quote link one line below was already correct, so the row had two links to the same post and one was dead.)
- **`organization_posts-N.xml` was advertised by the sitemap index and answered 404** — the index builds its list from `Sitemap.chunk_counts/0`, the action matched the name against a second hand-written list that never learned about it.
- **The admin daily report and its email linked every post to `/posts/<id>`**, a route only `/api/2.0` serves.
- **Two sweepers stamped no clock on the branch where they could do no work.** Their due queries serve the least recently checked first, so such a row holds the front of every later batch forever. The social-account re-check ran hourly against a weekly interval, so one erroring provider was re-fetched 168x more often than intended, forever.
- **`reference_check` was in the notification registry and in none of the page's filter tabs**, so `filtered_out?/2` dropped a live-pushed one for every reader not on "All".

## New shared seams (reuse these)

`Posts.path/2` · `Posts.replyable?/1` · `Activity.kinds/0` · `Organizations.role_powers/2` · `ImageScans.privileged_viewer?/2` · `VutuvWeb.Live.RemotePostActions.report/3` · `<.copy_field>` · `<.by_other_badge>`

## Quieter

- The organization page asked the role table five times per load for one row set; `role_powers/2` answers all of it from one read.
- `organization_posts_page/3` preloaded post by post — ~20 association queries per row, so 50 rows of an agent-format page came to a four-figure query count for one request. One line.
- Two assigns in the Fediverse lookup cost a query each for values no template read.

## Deleted

Eleven public functions with no callers (one held four msgids for a badge that does not exist), `manage_header`'s `manage?` attribute (all nine call sites passed `true`), and three schema accessors. Every claim was checked with a repo-wide grep including `.heex`/`.eex`/`config`/`priv`.

## Deliberately not done

- `Organizations.image_tokens_for_user/1` — its doc names a caller in `Accounts.delete_user/1` that does not exist. Either orphaned files on member deletion or a wrong doc; that needs deciding, not deleting.
- The landing hero's founder signature stays hardcoded. The link, the name and the quote are one attribution; making a third of it configurable is worse than leaving it.
- 29 hand-rolled buttons vs `<.button>` — the component adds four layout classes, so it moves pixels. Worth its own pass with a browser check.

## Checks

`mix precommit` green: compile `--warnings-as-errors`, `credo --strict` (no issues, 13,841 mods/funs), format, **7,450 tests** (baseline 7,440; 10 net new). Version bumped from the current `origin/main` (7.272.0 → 7.272.1).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01C7fTurAGHf5cJyY3qJ5qF1