### PR TITLE
Eine Seite bekommt im Fediverse ein Gesicht (v7.273.0)

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -884,6 +884,18 @@ already general: `note/2`, `create_activity/2` and `envelope/4` read the author
 only through `actor_url/1`, so only `note_url/2` needed to learn the page's
 permalink shape.
 
+**The one field it was missing was the face.** The first cut carried no `icon`,
+so a page federated faceless however good its logo was and no upload could
+change it. It has one now, and the two halves of that are worth keeping
+together: the document names `/organizations/:slug/avatar.jpg`
+(`VutuvWeb.OrganizationAvatarController`), which derives a 512px square JPEG on
+the fly from the kept private original, because whoever fetches an avatar from
+outside does it anonymously and does not decode the AVIF versions the site
+serves itself — the member endpoint's arrangement one to one. The field is
+**absent** for a page with no logo rather than pointing at a URL that 404s, and
+the endpoint applies the page's own visibility, so a pending or frozen page
+keeps its picture private like every other byte of it.
+
 **The inbox is deliberately narrower.** A page accepts `Follow` and
 `Undo(Follow)` and acknowledges everything else with the same `202` the member
 inbox gives anything it does not handle. It holds no conversations, answers no

--- a/lib/vutuv/uploaders/organization_image_store.ex
+++ b/lib/vutuv/uploaders/organization_image_store.ex
@@ -15,10 +15,12 @@ defmodule Vutuv.OrganizationImageStore do
   is shared with `Vutuv.PostImageStore`.
   """
 
+  alias Vix.Vips.Operation
   alias Vutuv.Uploads.Originals
   alias Vutuv.Uploads.Spec
 
   @versions ~w(thumb feed large)
+  @og_size 512
 
   defdelegate extension_whitelist, to: Vutuv.PostImageStore
 
@@ -70,6 +72,45 @@ defmodule Vutuv.OrganizationImageStore do
   def accel_path(token, version) when is_binary(token) and version in @versions do
     "/internal_organization_images/#{token}/#{version}#{Spec.served_ext()}"
   end
+
+  @doc """
+  A stored image as JPEG bytes for `/organizations/:slug/avatar.jpg`
+  (`VutuvWeb.OrganizationAvatarController`): the `icon` of a page's ActivityPub
+  actor document, and whatever else fetches a picture from outside. Neither a
+  remote server nor a link-preview scraper decodes the AVIF versions served
+  above, so the JPEG is derived on the fly from the kept private original,
+  metadata-stripped, at #{@og_size}px square — `Vutuv.Avatar.og_jpeg/1` for a
+  page instead of a member.
+
+  There is no served-version fallback: unlike avatars, organization images have
+  kept an original since the day the store existed, so a token with no original
+  has nothing on disk at all. `:error` then, and for an unknown token.
+
+  Who may see it is the caller's decision (`Organizations.image_visible_to?/2`
+  and the page's own visibility); this only answers whether bytes exist.
+  """
+  def og_jpeg(token) when is_binary(token) do
+    case original_path(token) do
+      nil ->
+        :error
+
+      path ->
+        with {:ok, rotated} <- Spec.open_rotated(path),
+             {:ok, square} <-
+               Image.thumbnail(rotated, "#{@og_size}x#{@og_size}", crop: :center),
+             {:ok, data} <- Operation.jpegsave_buffer(square, keep: [], Q: 80) do
+          {:ok, data}
+        else
+          _ -> :error
+        end
+    end
+  end
+
+  def og_jpeg(_), do: :error
+
+  @doc "Absolute path of the kept private original, or `nil` when there is none."
+  def original_path(token) when is_binary(token), do: Originals.path(storage_dir(token))
+  def original_path(_), do: nil
 
   @doc "Removes every stored file of `token`. A no-op when nothing is stored."
   def delete(token) when is_binary(token) do

--- a/lib/vutuv_web/controllers/organization_avatar_controller.ex
+++ b/lib/vutuv_web/controllers/organization_avatar_controller.ex
@@ -1,0 +1,45 @@
+defmodule VutuvWeb.OrganizationAvatarController do
+  @moduledoc """
+  `GET /organizations/:slug/avatar.jpg` — a page's logo as a square JPEG, the
+  `icon` of its ActivityPub actor document.
+
+  Issue #1334 shipped the page actor with no icon at all, so a page federated
+  faceless however good its logo was, and no upload could change that. The
+  member endpoint beside this one (`VutuvWeb.AvatarController`) had already
+  answered the same question for `og:image`: whoever fetches an avatar from
+  outside does it anonymously and does not decode the AVIF versions the site
+  serves itself, so the JPEG is derived on the fly from the kept private
+  original. A page's own `og:image` still falls back to the brand card
+  (`VutuvWeb.OpenGraph` has no organization branch); when it grows one, this is
+  the URL it should name.
+
+  A page that is not public yet keeps its logo private, the same gate
+  `VutuvWeb.OrganizationImageController` puts in front of every other byte of
+  it. Served outside the browser pipeline like the feeds, with plain-text 404s:
+  an unknown slug, a page with no logo and a page nobody may see all look the
+  same from outside.
+  """
+
+  use VutuvWeb, :controller
+
+  alias Vutuv.OrganizationImageStore
+  alias Vutuv.Organizations
+  alias Vutuv.Organizations.Organization
+
+  def show(conn, %{"slug" => slug}) do
+    with %Organization{logo: logo} = organization when is_binary(logo) <-
+           Organizations.get_organization_by_slug(slug),
+         true <- Organizations.organization_visible_to?(organization, nil),
+         {:ok, jpeg} <- OrganizationImageStore.og_jpeg(logo) do
+      conn
+      |> put_resp_content_type("image/jpeg", nil)
+      |> put_resp_header("cache-control", "public, max-age=86400")
+      |> send_resp(200, jpeg)
+    else
+      _ ->
+        conn
+        |> put_resp_content_type("text/plain")
+        |> send_resp(404, "Not Found")
+    end
+  end
+end

--- a/lib/vutuv_web/fediverse/docs.ex
+++ b/lib/vutuv_web/fediverse/docs.ex
@@ -194,7 +194,7 @@ defmodule VutuvWeb.Fediverse.Docs do
       # `Fediverse.federated?/1` refuses a page that has not claimed one.
       "preferredUsername" => organization.username,
       "name" => organization.name,
-      "summary" => organization.description,
+      "summary" => organization_summary(organization),
       "url" => "#{base()}/organizations/#{organization.slug}",
       "inbox" => actor_url <> "/inbox",
       "outbox" => actor_url <> "/outbox",
@@ -208,6 +208,40 @@ defmodule VutuvWeb.Fediverse.Docs do
         "publicKeyPem" => actor.public_key_pem
       }
     }
+    |> put_organization_icon(organization)
+  end
+
+  # A page's description is Markdown, and `summary` is HTML — the first cut put
+  # the stored source straight on the wire, so a bio written with a link or a
+  # list travelled as its own markup characters, unescaped and unwrapped. It
+  # goes through the renderer the page itself uses (`<.markdown_prose>`), so
+  # what a remote server shows is what a visitor here reads, and through the
+  # same absolutizer the post bodies use, because a root-relative `/handle`
+  # means nothing on another server. The member half already did this with its
+  # headline (`summary/1`), plainer only because a headline is one line of text.
+  defp organization_summary(%Organization{description: description})
+       when description in [nil, ""],
+       do: ""
+
+  defp organization_summary(%Organization{description: description}) do
+    description
+    |> VutuvWeb.Markdown.render()
+    |> Phoenix.HTML.safe_to_string()
+    |> absolutize()
+  end
+
+  # The page's logo, which is the avatar a remote server shows beside its name.
+  # Rendered only when there is one: the document is a promise to strangers, and
+  # `/organizations/:slug/avatar.jpg` answers for a page with a logo and nothing
+  # else, so naming it unconditionally would advertise a 404.
+  defp put_organization_icon(doc, %Organization{logo: nil}), do: doc
+
+  defp put_organization_icon(doc, %Organization{} = organization) do
+    Map.put(doc, "icon", %{
+      "type" => "Image",
+      "mediaType" => "image/jpeg",
+      "url" => "#{base()}/organizations/#{organization.slug}/avatar.jpg"
+    })
   end
 
   # The accounts the member is migrating *from* (issue #986). Rendered only

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -159,6 +159,10 @@ defmodule VutuvWeb.Router do
     # member avatar as a scraper-friendly JPEG. The consumers are the
     # WhatsApp/Facebook/... scrapers, not browsers.
     get("/og-card.png", PageController, :og_card)
+    # A page's logo, same job: its own link previews and the `icon` its
+    # ActivityPub actor document points at. Before /:slug/avatar.jpg only for
+    # readability — the paths differ in length and cannot collide.
+    get("/organizations/:slug/avatar.jpg", OrganizationAvatarController, :show)
     get("/:slug/avatar.jpg", AvatarController, :show)
     # Agent-skills discovery (Cloudflare draft) + security.txt (RFC 9116).
     get("/.well-known/agent-skills/index.json", WellKnownController, :agent_skills_index)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.272.1",
+      version: "7.273.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/controllers/organization_avatar_controller_test.exs
+++ b/test/vutuv_web/controllers/organization_avatar_controller_test.exs
@@ -1,0 +1,128 @@
+defmodule VutuvWeb.OrganizationAvatarControllerTest do
+  @moduledoc """
+  `GET /organizations/:slug/avatar.jpg` — a page's logo as a square JPEG, and
+  the `icon` its ActivityPub actor document points at.
+
+  Issue #1334 shipped the page actor without an icon, so a page federated
+  faceless however good its logo was. Remote servers and link-preview scrapers
+  fetch an avatar anonymously and do not decode the AVIF versions the site
+  serves itself, which is why this derives a JPEG from the kept private
+  original — the member endpoint's arrangement one to one.
+
+  `async: false`: points the global `:uploads_dir_prefix` at a tmp dir and flips
+  `:verify_organization_domains` for the organization helpers.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vix.Vips.Image, as: VipsImage
+  alias Vutuv.Organizations
+  alias Vutuv.Repo
+
+  setup do
+    tmp = Path.join(System.tmp_dir!(), "vutuv_org_logo_#{System.unique_integer([:positive])}")
+    put_config(:uploads_dir_prefix, tmp)
+    put_config(:verify_organization_domains, true)
+
+    on_exit(fn ->
+      File.rm_rf(tmp)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  # `Application.get_env/2` cannot tell "absent" from "set to nil", so restoring
+  # with it can write a real nil over a key that only had a default. Capture with
+  # fetch_env/2 and restore the two cases apart.
+  defp put_config(key, value) do
+    original = Application.fetch_env(:vutuv, key)
+    Application.put_env(:vutuv, key, value)
+
+    on_exit(fn ->
+      case original do
+        {:ok, was} -> Application.put_env(:vutuv, key, was)
+        :error -> Application.delete_env(:vutuv, key)
+      end
+    end)
+  end
+
+  defp federating_page(handle \\ "acme") do
+    owner = insert(:activated_user)
+
+    page =
+      active_organization_for(owner)
+      |> Ecto.Changeset.change(%{fediverse_followers?: true, username: handle})
+      |> Repo.update!()
+
+    {page, owner}
+  end
+
+  defp with_logo({organization, owner}) do
+    src = Path.join(System.tmp_dir!(), "logo_#{System.unique_integer([:positive])}.jpg")
+    {:ok, img} = Image.new(600, 400, color: [10, 120, 200])
+    {:ok, _} = Image.write(img, src)
+    on_exit(fn -> File.rm(src) end)
+
+    {:ok, organization} = Organizations.store_logo(organization, owner, src, "logo.jpg")
+    assert is_binary(organization.logo), "the logo was not released"
+    organization
+  end
+
+  defp ap(conn), do: put_req_header(conn, "accept", "application/activity+json")
+
+  test "serves the logo as a square, metadata-free JPEG", %{conn: conn} do
+    page = federating_page() |> with_logo()
+
+    conn = get(conn, "/organizations/#{page.slug}/avatar.jpg")
+
+    assert conn.status == 200
+    # No charset: a binary body must not claim one (binary_content_type_test.exs).
+    assert get_resp_header(conn, "content-type") == ["image/jpeg"]
+    assert [cache] = get_resp_header(conn, "cache-control")
+    assert cache =~ "public"
+
+    {:ok, jpeg} = Image.from_binary(conn.resp_body)
+    assert {Image.width(jpeg), Image.height(jpeg)} == {512, 512}
+
+    {:ok, fields} = VipsImage.header_field_names(jpeg)
+    assert Enum.filter(fields, &String.contains?(&1, "exif")) == []
+  end
+
+  test "the actor document names that JPEG as its icon, and the URL answers", %{conn: conn} do
+    page = federating_page() |> with_logo()
+
+    json = conn |> ap() |> get(~p"/organizations/#{page.slug}/actor") |> json_response(200)
+
+    assert json["icon"]["type"] == "Image"
+    assert json["icon"]["mediaType"] == "image/jpeg"
+    assert json["icon"]["url"] =~ "/organizations/#{page.slug}/avatar.jpg"
+
+    # The document is a promise to strangers: an icon URL that 404s reads as a
+    # broken actor from outside, so walk the document rather than name the path.
+    path = URI.parse(json["icon"]["url"]).path
+    assert get(conn, path).status == 200
+  end
+
+  test "a page with no logo advertises no icon and answers 404", %{conn: conn} do
+    {page, _owner} = federating_page()
+
+    json = conn |> ap() |> get(~p"/organizations/#{page.slug}/actor") |> json_response(200)
+    refute Map.has_key?(json, "icon")
+
+    assert get(conn, "/organizations/#{page.slug}/avatar.jpg").status == 404
+    assert get(conn, "/organizations/nobody-here/avatar.jpg").status == 404
+  end
+
+  test "a frozen page keeps its logo private", %{conn: conn} do
+    page = federating_page() |> with_logo()
+    assert get(conn, "/organizations/#{page.slug}/avatar.jpg").status == 200
+
+    {:ok, page} = Organizations.admin_set_frozen(page, true)
+
+    # The same gate every other byte of the page passes: while the page itself
+    # is not public, neither is the picture on it.
+    assert get(conn, "/organizations/#{page.slug}/avatar.jpg").status == 404
+  end
+end

--- a/test/vutuv_web/organization_fediverse_actor_web_test.exs
+++ b/test/vutuv_web/organization_fediverse_actor_web_test.exs
@@ -73,6 +73,31 @@ defmodule VutuvWeb.OrganizationFediverseActorWebTest do
     refute Map.has_key?(json, "movedTo")
   end
 
+  test "the page's description travels as HTML, not as its Markdown source", %{conn: conn} do
+    page =
+      federating_page()
+      |> Ecto.Changeset.change(%{description: "**Wir** bauen vutuv. 5 < 6"})
+      |> Repo.update!()
+
+    json = conn |> ap() |> get(~p"/organizations/#{page.slug}/actor") |> json_response(200)
+
+    # `summary` is an HTML field, and a description is Markdown. Putting the
+    # stored source on the wire showed a remote reader the markup characters
+    # themselves — and shipped a bare `<` into a field the other side parses.
+    assert json["summary"] =~ "<strong>Wir</strong>"
+    refute json["summary"] =~ "**Wir**"
+    assert json["summary"] =~ "5 &lt; 6"
+    assert json["summary"] =~ "<p>"
+  end
+
+  test "a page with no description says so with an empty summary", %{conn: conn} do
+    page = federating_page()
+
+    json = conn |> ap() |> get(~p"/organizations/#{page.slug}/actor") |> json_response(200)
+
+    assert json["summary"] == ""
+  end
+
   test "the followers collection counts the remote followers", %{conn: conn} do
     page = federating_page()
 
@@ -124,7 +149,7 @@ defmodule VutuvWeb.OrganizationFediverseActorWebTest do
     page = federating_page()
     {:ok, _} = Vutuv.Fediverse.ensure_organization_actor(page)
 
-    page = page |> Ecto.Changeset.change(%{fediverse_followers?: false}) |> Repo.update!()
+    _page = page |> Ecto.Changeset.change(%{fediverse_followers?: false}) |> Repo.update!()
 
     # The same distinction a member gets: a `410` tells a remote server that
     # knows this actor to drop it and the copies it kept, and that is the page


### PR DESCRIPTION
A page's actor document carried no `icon`, so an organization federated faceless however good its logo was, and no upload could change it. It has one now.

**What is new**

- `GET /organizations/:slug/avatar.jpg` (`VutuvWeb.OrganizationAvatarController`) derives a 512px square JPEG from the kept private original. Whoever fetches an avatar from outside does it anonymously and does not decode the AVIF versions the site serves itself, which is the same reason the member endpoint beside it exists.
- `Docs.organization_actor/2` names that URL as its `icon` — and only when there is a logo, because the document is a promise to strangers and an icon that 404s reads as a broken actor.
- The endpoint applies the page's own visibility, so a pending or frozen page keeps its picture private like every other byte of it.

**A second fix in the same field, found while writing a description for one of these pages**

`summary` is an HTML field and a page's description is Markdown, but the stored source went on the wire raw and unescaped — a description with a link or a list travelled as its own markup characters. It now runs through the renderer the page itself uses (`<.markdown_prose>`) and the absolutizer the post bodies use, because a root-relative `/handle` means nothing on another server. The member half already did this with its headline.

**Tests:** `organization_avatar_controller_test.exs` (the JPEG is square and metadata-free; the actor names it and the URL answers; no logo means no `icon` and a 404; a frozen page 404s) plus two summary cases in `organization_fediverse_actor_web_test.exs`.

`mix precommit` green (7456 tests).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*
