### PR TITLE
Wer für eine Seite schreibt, darf ihren Beitrag auch liken (v7.273.1)

### DIFF
--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -735,6 +735,18 @@ Counters are counted live from the `post_likes` / `post_bookmarks` /
 `post_reposts` rows and broadcast as absolute values on the post topic
 (`"post:<id>"`).
 
+**Nobody likes their own post, and "own" is a narrower word than it looks.**
+The self-vote rule (issue #1030) asks `Posts.self_vote?/2`, which is about
+**identity**: a member and their post, a page and its post. It is deliberately
+not `Posts.author?/2`, which asks whether somebody may act *in the author's
+name* and therefore answers yes for every publisher of a page. The two are the
+same question for a member and part company on a page, and while the rule
+borrowed `author?/2` every publisher was barred from the heart on their own
+page's posts — their like, not the page's, and named under the post since
+#1233 — while a colleague without the role could press it. The action bar
+renders the heart either way and swallows the refusal, so the symptom was a
+control that did nothing rather than an error anyone could report.
+
 ### Who liked it (issue #1233)
 
 The **post permalink** — and only the permalink — names the members behind the

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -893,12 +893,35 @@ defmodule Vutuv.Posts do
   def author?(%Post{organization_id: id} = post, %User{} = viewer) when is_binary(id),
     do: organization_author?(post, viewer)
 
-  # A page asking about its OWN post (issue #1336). Without this clause the
-  # catch-all below answered false, and the self-vote rule that stops a member
-  # inflating their own like count would not have applied to a page at all.
+  # A page asking about its OWN post (issue #1336): it may edit, delete and
+  # revoke what it published, like any author.
   def author?(%Post{organization_id: id}, %Organization{id: id}) when is_binary(id), do: true
 
   def author?(%Post{}, _viewer), do: false
+
+  @doc """
+  Whether `actor` **is** the post's author, as opposed to being entitled to act
+  in the author's name.
+
+  These are two questions and a page is where they part. `author?/2` answers the
+  second one, which is right for editing, deleting and pinning: the power
+  follows the role. The self-vote rule behind `like_post/2` needs the first one,
+  and for a while it borrowed `author?/2` as well — so every publisher of every
+  page was quietly barred from liking their own page's posts, although the like
+  would have been theirs and not the page's, while a colleague without the role
+  could press the heart. The button was rendered either way and the refusal was
+  swallowed, so it read as a dead control.
+
+  A member's own post and a page's own post are both self-votes; a member and
+  the page they publish for are not the same identity.
+  """
+  def self_vote?(%Post{organization_id: nil, user_id: author_id}, %User{id: author_id})
+      when is_binary(author_id),
+      do: true
+
+  def self_vote?(%Post{organization_id: id}, %Organization{id: id}) when is_binary(id), do: true
+
+  def self_vote?(%Post{}, _actor), do: false
 
   # Whether `viewer` may currently speak for the post's organization. Takes the
   # preloaded association when there is one and falls back to a lookup when
@@ -1159,10 +1182,13 @@ defmodule Vutuv.Posts do
   A member cannot like their **own** post (`{:error, :self}`): a self-vote
   inflating your own like count is not a real endorsement (issue #1030).
   Bookmarking your own post stays fine — that is a private save.
+
+  "Own" here means `self_vote?/2`, not `author?/2`: on a page's post the author
+  is the page, so its publishers are liking somebody else's post, and may.
   """
   def like_post(%User{} = user, %Post{} = post) do
     cond do
-      author?(post, user) -> {:error, :self}
+      self_vote?(post, user) -> {:error, :self}
       blocked?(user, post) -> {:error, :blocked}
       true -> do_like_post(user, post)
     end
@@ -1179,7 +1205,7 @@ defmodule Vutuv.Posts do
   def like_post(%Organization{} = page, %User{} = acting_user, %Post{} = post) do
     cond do
       not Organizations.publisher?(page, acting_user) -> {:error, :not_allowed}
-      author?(post, page) -> {:error, :self}
+      self_vote?(post, page) -> {:error, :self}
       true -> do_page_like(page, acting_user, post)
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.273.0",
+      version: "7.273.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/organization_engagement_test.exs
+++ b/test/vutuv/organization_engagement_test.exs
@@ -81,7 +81,7 @@ defmodule Vutuv.OrganizationEngagementTest do
     assert engagement.liked?
   end
 
-  test "the page's own count is not inflated by its own like" do
+  test "the page cannot like its own post, its publishers personally can" do
     {page, owner} = page_with_publisher()
     {:ok, post} = Posts.create_organization_post(page, owner, %{body: "Unser Beitrag"})
 
@@ -89,17 +89,22 @@ defmodule Vutuv.OrganizationEngagementTest do
     # author is the page.
     assert {:error, :self} = Posts.like_post(page, owner, post)
 
-    # Its publishers are refused too, and that is the pre-existing rule rather
-    # than a new one: `author?/2` already treats anybody who may currently speak
-    # for the page as the post's author, which is what gives them edit and
-    # delete rights. A publisher liking the page's post is the same self-vote.
-    assert {:error, :self} = Posts.like_post(owner, post)
-    assert Posts.post_engagement(post.id, page).likes == 0
+    # Its publishers are **not** refused, and this reverses what this test
+    # asserted until v7.273.1. The old reading leaned on `author?/2` treating
+    # anybody who may currently speak for the page as the post's author — right
+    # for edit and delete, wrong here, because the person and the page are two
+    # identities and the like belongs to the person (named under the post since
+    # #1233). It also protected nothing: a colleague without the role could
+    # always press the heart, so the rule fell on exactly the people who work on
+    # the page. `self_vote?/2` asks the identity question now.
+    assert :ok = Posts.like_post(owner, post)
+    assert Posts.post_engagement(post.id, owner).liked?
+    assert Posts.post_engagement(post.id, page).likes == 1
 
     # Somebody outside the team is an ordinary reader.
     outsider = insert(:activated_user)
     assert :ok = Posts.like_post(outsider, post)
-    assert Posts.post_engagement(post.id, outsider).likes == 1
+    assert Posts.post_engagement(post.id, outsider).likes == 2
   end
 
   test "somebody who may not speak for the page cannot act as it" do


### PR DESCRIPTION
Reported from the new vutuv page: as `wintermeyer` the heart under `@vutuv`'s post was simply dead. No error, no message, a click with no effect.

**Two questions were sharing one function.** `Posts.author?/2` answers "may this member act in the author's name", and for a page that is every current publisher — editing, deleting and pinning follow the role rather than the person, or they would walk out of the door with them. The self-vote rule from #1030 asks something else: "is this viewer the same identity as the author". For a member the two coincide; on a page they part, and because the rule borrowed `author?/2`, every publisher of every page was locked out of the heart on their own page's posts. The like would have been theirs and not the page's, and since #1233 their name shows under the post. A colleague without the role could press it.

The action bar renders the heart either way and swallows the refusal, so the symptom was a dead control rather than an error anybody could report.

`Posts.self_vote?/2` now answers the identity question, and only the two like paths call it. The rule itself stays where it belongs: a page still cannot like its own post.

**One existing test asserted the opposite** ("Its publishers are refused too", `organization_engagement_test.exs`), so the contradiction was in the repo rather than only in the code: that test now carries the new rule, keeps the half that still holds (a page cannot like itself) and says in a comment why it was reversed. It stays the single place this rule is written down. The fix was calibrated against the old code, where the new assertion failed with `left: :ok, right: {:error, :self}`.

`mix precommit` green.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*
