### PR TITLE
Die Beitrags-Adresse einer Seite antwortet dem Fediverse (v7.274.1)

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -1049,8 +1049,20 @@ in the sentence has no row there at all.
 
 Pleasing symmetry, and the reason a closing line is the right shape: that is
 exactly what `Markdown.split_trailing_hashtags/1` folds back into chips when a
-remote post arrives here, so a vutuv post landing on another vutuv installation
-comes out as chips again.
+remote post arrives here (`RemoteHtml.to_text/3` turns the `</p>` into a line
+break first), so a vutuv post landing on another vutuv installation comes out as
+chips again.
+
+**A page post's permalink answers ActivityPub too.** Found while checking the
+above against production: `note_url/2` makes `/organizations/:slug/posts/:id`
+the **id** of every page post we federate, which is what a remote server fetches
+to verify the object, thread a reply under it or see whether it still exists —
+and that URL answered **500**. The action ran the accept header through
+`AgentDocs.negotiate/1`, which knows nothing about `application/activity+json`,
+while the member permalink had had its own branch from the start. It has one
+now, with the page's own gates in front of it: the page must federate, the post
+must not be held by moderation, and a page that switched federation off gets the
+same `410`/`404` refusal its actor endpoint gives.
 
 ## Deliberate v1 limits
 

--- a/lib/vutuv_web/controllers/organization_controller.ex
+++ b/lib/vutuv_web/controllers/organization_controller.ex
@@ -22,6 +22,7 @@ defmodule VutuvWeb.OrganizationController do
   alias Vutuv.Pages
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
+  alias Vutuv.Repo
   alias VutuvWeb.AgentDocs
   alias VutuvWeb.AgentDocs.OrganizationDoc
   alias VutuvWeb.AgentDocs.PostDoc
@@ -210,24 +211,61 @@ defmodule VutuvWeb.OrganizationController do
 
     with {:ok, organization} <- Organizations.fetch_visible_organization(slug, viewer),
          %Post{} = post <- Posts.get_organization_post(organization, id, viewer) do
-      case AgentDocs.negotiate(conn) do
-        :html ->
-          conn
-          |> AgentDocs.put_html_alternates()
-          |> put_layout(html: false)
-          |> live_render(VutuvWeb.OrganizationLive.Post,
-            session:
-              conn
-              |> ControllerHelpers.live_render_session()
-              |> Map.put("organization_id", organization.id)
-              |> Map.put("post_id", id)
-          )
+      cond do
+        # This URL is the **id** every page post carries into the fediverse
+        # (`Docs.note_url/2`), so it is what a remote server fetches to verify
+        # the object, thread a reply under it or check it still exists. Until
+        # this branch existed the accept header fell through to
+        # `AgentDocs.negotiate/1`, which knows nothing about
+        # `application/activity+json`, and the request 500ed — on the id of
+        # every post a page had ever federated. The member permalink
+        # (`VutuvWeb.PostController`) has answered the same request with the
+        # Note from the start; this is that arrangement for a page.
+        FediverseController.ap_request?(conn) and Fediverse.federated?(organization) and
+            not Posts.moderation_hidden?(post) ->
+          send_note(conn, organization, post)
 
-        format ->
-          send_organization_post_doc(conn, format, organization, post)
+        FediverseController.ap_request?(conn) ->
+          FediverseController.refuse(conn, organization)
+
+        true ->
+          send_post_document(conn, organization, post, id)
       end
     else
       _ -> ControllerHelpers.render_error(conn, 404)
+    end
+  end
+
+  # The ActivityPub rendering of a page's post, the twin of
+  # `VutuvWeb.PostController`'s.
+  defp send_note(conn, organization, post) do
+    note =
+      post
+      |> Repo.preload(Docs.note_preloads())
+      |> Docs.note(organization)
+      |> Map.put("@context", "https://www.w3.org/ns/activitystreams")
+
+    conn
+    |> put_resp_content_type("application/activity+json")
+    |> send_resp(200, Jason.encode!(note))
+  end
+
+  defp send_post_document(conn, organization, post, id) do
+    case AgentDocs.negotiate(conn) do
+      :html ->
+        conn
+        |> AgentDocs.put_html_alternates()
+        |> put_layout(html: false)
+        |> live_render(VutuvWeb.OrganizationLive.Post,
+          session:
+            conn
+            |> ControllerHelpers.live_render_session()
+            |> Map.put("organization_id", organization.id)
+            |> Map.put("post_id", id)
+        )
+
+      format ->
+        send_organization_post_doc(conn, format, organization, post)
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.274.0",
+      version: "7.274.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/organization_post_note_web_test.exs
+++ b/test/vutuv_web/organization_post_note_web_test.exs
@@ -1,0 +1,87 @@
+defmodule VutuvWeb.OrganizationPostNoteWebTest do
+  @moduledoc """
+  The ActivityPub rendering of a page's post permalink.
+
+  `note_url/2` builds a page post's federated id as
+  `/organizations/:slug/posts/:id`, so that URL **is** the object id every
+  remote server holding one of our page posts fetches — to verify it, to thread
+  a reply under it, to check it still exists. The member permalink beside it has
+  answered such a request with the Note since the beginning.
+
+  `async: false` because the organization helpers flip the global
+  `:verify_organization_domains` flag and the DNS-resolver stub beside it.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Organizations
+  alias Vutuv.Posts
+  alias Vutuv.Repo
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp federating_page_with_post(body \\ "Von uns.") do
+    owner = insert(:activated_user)
+
+    page =
+      active_organization_for(owner)
+      |> Ecto.Changeset.change(%{fediverse_followers?: true, username: "acme"})
+      |> Repo.update!()
+
+    {:ok, _} = Organizations.add_role(page, owner, "publisher", owner)
+    {:ok, post} = Posts.create_organization_post(page, owner, %{body: body})
+    {page, post}
+  end
+
+  defp ap(conn), do: put_req_header(conn, "accept", "application/activity+json")
+
+  test "the page post permalink answers ActivityPub with its Note", %{conn: conn} do
+    {page, post} = federating_page_with_post()
+
+    conn = conn |> ap() |> get(~p"/organizations/#{page.slug}/posts/#{post.id}")
+
+    # It answered **500** until v7.274.1: the action ran the accept header
+    # through `AgentDocs.negotiate/2`, which knows nothing about
+    # `application/activity+json`, while the member permalink had had its own
+    # branch all along. Every page post we federate names this URL as its id.
+    assert conn.status == 200
+    assert [content_type] = get_resp_header(conn, "content-type")
+    assert content_type =~ "application/activity+json"
+
+    note = Jason.decode!(conn.resp_body)
+    assert note["type"] == "Note"
+    assert note["id"] =~ "/organizations/#{page.slug}/posts/#{post.id}"
+    assert note["attributedTo"] =~ "/organizations/#{page.slug}/actor"
+    assert note["content"] =~ "Von uns."
+  end
+
+  test "a page that does not federate serves no Note", %{conn: conn} do
+    {page, post} = federating_page_with_post()
+
+    page
+    |> Ecto.Changeset.change(%{fediverse_followers?: false})
+    |> Repo.update!()
+
+    # Same rule the member permalink applies: nothing is federated for an
+    # account that does not, so the HTML page is all there is.
+    conn = conn |> ap() |> get(~p"/organizations/#{page.slug}/posts/#{post.id}")
+    refute conn.status == 200
+  end
+
+  test "the HTML permalink is untouched", %{conn: conn} do
+    {page, post} = federating_page_with_post()
+
+    assert conn |> get(~p"/organizations/#{page.slug}/posts/#{post.id}") |> html_response(200) =~
+             "Von uns."
+  end
+end


### PR DESCRIPTION
Found while checking the hashtag work (#1421) against production, and independent of it.

`Docs.note_url/2` makes `/organizations/:slug/posts/:id` the **id** of every page post we federate. That is the URL a remote server fetches to verify the object, to thread a reply under it, or to see whether it still exists. It answered **500**.

The cause is dull, the reach is not: the action ran the accept header through `AgentDocs.negotiate/1`, which knows nothing about `application/activity+json`, and the request fell into `Plug.Conn.resp/3` with no matching clause. The member permalink (`VutuvWeb.PostController`) has had its own ActivityPub branch from the start; the page one never got it. So the id of every post any page ever federated was a 500.

It answers with the Note now, behind the page's own gates: the page must federate, the post must not be held by moderation, and a page that switched federation off gets the same `410`/`404` refusal its actor endpoint gives.

**Test** in `organization_post_note_web_test.exs`, calibrated against the broken code, where it failed with `** (FunctionClauseError) no function clause matching in Plug.Conn.resp/3`.

`mix precommit` green (7468 tests).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*
