### PR TITLE
Ein Thema wird gefunden, egal welches Trennzeichen jemand tippt (v7.275.0)

### DIFF
--- a/lib/vutuv/tags.ex
+++ b/lib/vutuv/tags.ex
@@ -16,6 +16,9 @@ defmodule Vutuv.Tags do
   alias Vutuv.Posts
   alias Vutuv.Repo
   alias Vutuv.SearchText
+  require Vutuv.Tags.MatchKey
+
+  alias Vutuv.Tags.MatchKey
   alias Vutuv.Tags.Tag
   alias Vutuv.Tags.TagFollow
   alias Vutuv.Tags.UserTag
@@ -116,7 +119,11 @@ defmodule Vutuv.Tags do
 
     names
     |> Enum.map(fn name ->
-      key = String.downcase(name)
+      # The same folded key the single lookup uses (`Vutuv.Tags.MatchKey`), or a
+      # batch goes on counting spellings where one lookup counts topics — which
+      # is what sign-up's three-tag minimum and the composer's cap of five are
+      # counting. A name with nothing to key on stands for itself.
+      key = MatchKey.normalize(name) || String.downcase(name)
       Map.get(resolved, key, {{:new, key}, name})
     end)
     |> Enum.uniq_by(&elem(&1, 0))
@@ -128,18 +135,19 @@ defmodule Vutuv.Tags do
   # `Tag.find_by_value/1` matches on). The identity is the **canonical** tag's
   # id, which is what makes two different spellings of one topic collapse.
   defp resolution_by_key(names) do
-    downcased = Enum.map(names, &String.downcase/1)
+    keys = names |> Enum.map(&MatchKey.normalize/1) |> Enum.reject(&is_nil/1)
 
     from(t in Tag,
       left_join: c in assoc(t, :merged_into),
-      where: fragment("lower(?)", t.name) in ^downcased or t.slug in ^downcased,
+      where: MatchKey.sql(t.name) in ^keys or MatchKey.sql(t.slug) in ^keys,
       select:
-        {fragment("lower(?)", t.name), t.slug, coalesce(c.id, t.id), coalesce(c.name, t.name)}
+        {MatchKey.sql(t.name), MatchKey.sql(t.slug), coalesce(c.id, t.id),
+         coalesce(c.name, t.name)}
     )
     |> Repo.all()
-    |> Enum.flat_map(fn {lower_name, slug, id, name} ->
+    |> Enum.flat_map(fn {name_key, slug_key, id, name} ->
       entry = {{:tag, id}, name}
-      [{lower_name, entry}, {slug, entry}]
+      for key <- Enum.uniq([name_key, slug_key]), is_binary(key), do: {key, entry}
     end)
     |> Map.new()
   end

--- a/lib/vutuv/tags/match_key.ex
+++ b/lib/vutuv/tags/match_key.ex
@@ -1,0 +1,93 @@
+defmodule Vutuv.Tags.MatchKey do
+  @moduledoc """
+  The one key two spellings of a topic have to agree on (issue #1332).
+
+  A tag used to be looked up by its exact lowercased name or its exact slug,
+  which let space and hyphen resolve **by accident** — the slugifier writes
+  hyphens and the slug is one of the two keys — while underscore against
+  anything did not, in either direction. Underscores are the shape the older
+  half of the catalog carries, so every such lookup missed the tag that already
+  existed and minted a second page for it: exactly the sprawl #1338's merge pass
+  had just cleaned up by hand.
+
+  The key case-folds, drops zero-width characters and collapses a run of
+  space / hyphen / underscore to a single `-`.
+
+  Four rules, each from a real row in the catalog:
+
+  - **Collapse, never delete.** `Open-Source Software` and `open source
+    software` are one topic. `e commerce` against `ecommerce` is a judgement
+    call and stays two names for a human to merge.
+  - **Strip zero-width characters** before comparing. Two names in the catalog
+    differ only by a U+200B: invisible to every reader, distinct to Postgres.
+  - **A key with nothing to key on is no key.** A value with no `[a-z0-9]` left
+    (`-`, `.`) answers `nil` and matches nothing, rather than bucketing every
+    such name into one topic.
+  - **Punctuation that carries meaning is kept.** `c++` keys as `c++`, not as
+    `c` — the distinction between C, C++ and C# is the subject of #1337 and must
+    survive the lookup, not be folded away by it.
+
+  Both sides of the comparison live here, in Elixir for the typed value and as
+  a Postgres expression for the stored column, so they cannot drift apart.
+  """
+
+  # U+200B ZERO WIDTH SPACE, U+200C ZWNJ, U+200D ZWJ, U+FEFF BOM.
+  @zero_width ~r/[\x{200B}\x{200C}\x{200D}\x{FEFF}]/u
+  @separators ~r/[\s_-]+/u
+  @keyable ~r/[a-z0-9]/u
+
+  @doc """
+  The key for a typed value, or `nil` when there is nothing to match on.
+
+      iex> Vutuv.Tags.MatchKey.normalize("Open__Source - Software")
+      "open-source-software"
+
+      iex> Vutuv.Tags.MatchKey.normalize("-")
+      nil
+  """
+  def normalize(value) when is_binary(value) do
+    key =
+      value
+      |> String.replace(@zero_width, "")
+      |> String.downcase()
+      |> String.replace(@separators, "-")
+      |> String.trim("-")
+
+    if Regex.match?(@keyable, key), do: key
+  end
+
+  def normalize(_), do: nil
+
+  @doc """
+  The same key over a stored column, as a Postgres expression.
+
+  Written as one fragment rather than composed, because Ecto needs the SQL
+  literal at the call site; both callers (`Vutuv.Tags.Tag.find_by_value/1` and
+  `Vutuv.Tags.canonical_tag_names/1`) get it from here so there is one
+  definition of the key and not three.
+
+  Verified against the real catalog rather than read off the code: it folds
+  `Open__Source - Software`, `open-source-software` and `legacy_framework_zzz`
+  onto the keys their siblings carry, strips a U+200B, answers NULL for `-`,
+  and leaves `c++` and non-ASCII names alone.
+  """
+  defmacro sql(column) do
+    quote do
+      fragment(
+        """
+        nullif(
+          btrim(
+            regexp_replace(
+              lower(regexp_replace(?, '[​‌‍﻿]', '', 'g')),
+              '[[:space:]_-]+', '-', 'g'
+            ),
+            '-'
+          ),
+          ''
+        )\
+        """,
+        unquote(column)
+      )
+    end
+  end
+end

--- a/lib/vutuv/tags/tag.ex
+++ b/lib/vutuv/tags/tag.ex
@@ -4,8 +4,11 @@ defmodule Vutuv.Tags.Tag do
   use VutuvWeb, :model
   @derive {Phoenix.Param, key: :slug}
 
+  require Vutuv.Tags.MatchKey
+
   alias Vutuv.Accounts.User
   alias Vutuv.Repo
+  alias Vutuv.Tags.MatchKey
   alias Vutuv.WebAddress
 
   # A tag names a skill, a topic or an interest. A member who pastes their
@@ -234,14 +237,36 @@ defmodule Vutuv.Tags.Tag do
   larger query rather than fetching a single row.
   """
   def find_by_value(value) when is_binary(value) do
+    case MatchKey.normalize(value) do
+      nil -> nil
+      key -> value |> by_match_key(key) |> follow_alias()
+    end
+  end
+
+  # The catalog still holds both spellings of a few topics (#1332 normalizes the
+  # column; until it has, `phoenix-framework` and `phoenix_framework` are two
+  # rows with one key), so which row a folded key finds must not depend on the
+  # planner: an exact hit on the name wins, then an exact hit on the slug, then
+  # the oldest row — ids are UUID v7, so that is the first spelling written.
+  defp by_match_key(value, key) do
     down = String.downcase(value)
 
     from(t in __MODULE__,
-      where: fragment("lower(?)", t.name) == ^down or t.slug == ^down,
+      where: MatchKey.sql(t.name) == ^key or MatchKey.sql(t.slug) == ^key,
+      order_by: [
+        asc:
+          fragment(
+            "case when lower(?) = ? then 0 when ? = ? then 1 else 2 end",
+            t.name,
+            ^down,
+            t.slug,
+            ^down
+          ),
+        asc: t.id
+      ],
       limit: 1
     )
     |> Repo.one()
-    |> follow_alias()
   end
 
   # An alias is a tag row pointing at its canonical (issue #1338), so a value

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.274.1",
+      version: "7.275.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/tags/separator_lookup_test.exs
+++ b/test/vutuv/tags/separator_lookup_test.exs
@@ -1,0 +1,124 @@
+defmodule Vutuv.Tags.SeparatorLookupTest do
+  @moduledoc """
+  One topic, however its separator is typed (issue #1332, want 1).
+
+  `Tag.find_by_value/1` used to key on the exact lowercased name or the exact
+  slug, so space against hyphen resolved by accident (the slugifier writes
+  hyphens, and the slug is one of the two keys) while **underscore against
+  anything did not** — in either direction. That is the shape the older half of
+  the catalog carries, so the lookup kept minting a second page for a topic that
+  already had one, which is the sprawl #1338's merge pass had just cleaned up.
+
+  Every tag here is minted per test with a unique name, because the tag name is
+  a shared lookup key and the slug a unique index (the async rule in
+  `.claude/rules/elixir.md`).
+  """
+  use Vutuv.DataCase, async: true
+
+  alias Vutuv.Tags
+  alias Vutuv.Tags.Tag
+
+  defp seed(name, slug) do
+    n = System.unique_integer([:positive])
+    insert(:tag, name: "#{name} #{n}", slug: "#{slug}#{n}")
+  end
+
+  describe "find_by_value/1 folds separators" do
+    test "a hyphen-slug topic is found however the separator is typed" do
+      tag = seed("Probe Framework", "probe-framework-")
+      base = tag.name
+
+      for typed <- [
+            base,
+            String.replace(base, " ", "-"),
+            String.replace(base, " ", "_"),
+            String.upcase(base),
+            String.replace(base, " ", "  "),
+            tag.slug,
+            String.replace(tag.slug, "-", "_")
+          ] do
+        assert %Tag{id: found} = Tag.find_by_value(typed), "#{typed} found nothing"
+        assert found == tag.id, "#{typed} found another tag"
+      end
+    end
+
+    test "an underscore-slug topic is found too, which is where it used to fail" do
+      tag = seed("Legacy Framework", "legacy_framework_")
+
+      for typed <- [
+            tag.name,
+            String.replace(tag.name, " ", "-"),
+            String.downcase(String.replace(tag.name, " ", "-")),
+            tag.slug,
+            String.replace(tag.slug, "_", "-")
+          ] do
+        assert %Tag{id: found} = Tag.find_by_value(typed), "#{typed} found nothing"
+        assert found == tag.id, "#{typed} found another tag"
+      end
+    end
+
+    test "a run of separators collapses to one, but a missing one is not invented" do
+      tag = seed("Open Source Software", "open-source-software-")
+
+      assert %Tag{id: id} = Tag.find_by_value(String.replace(tag.name, " ", " - _ "))
+      assert id == tag.id
+
+      # `e commerce` against `ecommerce` is a judgement call for a human, so
+      # deleting the separator is not part of this: collapse, never delete.
+      refute Tag.find_by_value(String.replace(tag.name, " ", ""))
+    end
+
+    test "a zero-width character is invisible to a reader and must be to the lookup" do
+      tag = seed("Zero Width", "zero-width-")
+
+      assert %Tag{id: id} = Tag.find_by_value(String.replace(tag.name, " ", "​ "))
+      assert id == tag.id
+    end
+
+    test "a name with nothing to key on matches nothing, rather than grouping" do
+      # These normalize to an empty key. Bucketing them would make every one of
+      # them the same topic as every other.
+      seed("Dash", "dash-")
+
+      for value <- ["-", "--", "_", " ", "."] do
+        refute Tag.find_by_value(value), "#{inspect(value)} resolved to a tag"
+      end
+    end
+
+    test "an alias still resolves to its canonical topic, whatever the spelling" do
+      canonical = seed("Canonical Topic", "canonical-topic-")
+      n = System.unique_integer([:positive])
+
+      alias_tag =
+        insert(:tag,
+          name: "Alias Topic #{n}",
+          slug: "alias-topic-#{n}",
+          merged_into_id: canonical.id
+        )
+
+      assert %Tag{id: id} = Tag.find_by_value(String.replace(alias_tag.name, " ", "_"))
+      assert id == canonical.id
+    end
+  end
+
+  describe "canonical_tag_names/1 uses the same key" do
+    test "two spellings of one topic count once" do
+      tag = seed("Batch Topic", "batch-topic-")
+      spaced = tag.name
+      underscored = String.replace(tag.name, " ", "_")
+
+      # The batch resolves what a single lookup resolves, or the sign-up
+      # three-tag minimum and the composer's cap of five count spellings
+      # instead of topics.
+      assert Tags.canonical_tag_names([spaced, underscored]) == [tag.name]
+    end
+
+    test "an unknown name is kept as typed, and two spellings of it count once" do
+      n = System.unique_integer([:positive])
+      typed = "Frisch Erfunden #{n}"
+
+      assert [kept] = Tags.canonical_tag_names([typed, String.replace(typed, " ", "-")])
+      assert kept == typed
+    end
+  end
+end


### PR DESCRIPTION
Want 1 of #1332. Want 2 (the slug grammar) stays open, blocked on #1337.

`Tag.find_by_value/1` keyed on the exact lowercased name or the exact slug. Space against hyphen resolved **by accident** — the slugifier writes hyphens and the slug is one of the two keys — while underscore against anything did not, in either direction. Underscores are the shape the older half of the catalog carries, the half #1338's merge pass had just cleaned up by hand, so every such lookup missed the tag that already existed and minted a second page for it.

`Vutuv.Tags.MatchKey` is now the one key both spellings must agree on: case-folded, zero-width characters dropped, a run of space / hyphen / underscore collapsed to a single `-`. Four rules, each from a real row in the catalog:

- **Collapse, never delete** — `e commerce` against `ecommerce` stays a human judgement call.
- **Strip zero-width first** — two names differ only by a U+200B today.
- **A key with no `[a-z0-9]` is no key** — otherwise `-`, `.` and friends all bucket into one topic.
- **Punctuation that carries meaning survives** — `c++` keys as `c++`, not as `c`. That distinction is #1337's subject and must not be folded away here.

Both sides of the comparison live in that module (Elixir for the typed value, a Postgres expression for the stored column) so they cannot drift. The SQL was verified against the real catalog rather than read off the code.

`canonical_tag_names/1` takes the same key, or a batch keeps counting spellings where a single lookup counts topics — which is what sign-up's three-tag minimum and the composer's cap of five are counting.

One subtlety worth keeping: while the catalog still holds both spellings of a topic (until #1332's want 2 normalizes the column), which row a folded key finds must not depend on the planner. Exact name hit first, then exact slug, then the oldest row.

`mix precommit` green (7476 tests). The new cases were red before the change: 7 of 8.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*