### PR TITLE
Ein Tag-Slug behält, was eine Technik ausmacht (v7.276.0)

### DIFF
--- a/lib/vutuv/slug_helpers.ex
+++ b/lib/vutuv/slug_helpers.ex
@@ -49,12 +49,20 @@ defmodule Vutuv.SlugHelpers do
   """
   def handleize(text) do
     text
+    |> handle_body()
+    |> String.slice(0, @handle_max_length)
+    |> String.trim("_")
+  end
+
+  # The grammar itself, without the handle's length ceiling: a tag slug shares
+  # it (`tagify/1`) and may run to 60 characters.
+  defp handle_body(text) do
+    text
     |> String.downcase()
     |> transliterate()
     |> String.replace(~r/[^a-z0-9\s_-]/u, "")
     |> String.replace(~r/[\s-]+/, "_")
-    |> String.trim("_")
-    |> String.slice(0, @handle_max_length)
+    |> String.replace(~r/_+/, "_")
     |> String.trim("_")
   end
 
@@ -71,13 +79,94 @@ defmodule Vutuv.SlugHelpers do
     |> String.replace(~r/\p{Mn}/u, "")
   end
 
+  # The symbols that are part of a technology's name rather than punctuation in
+  # it (issue #1337). Deleting them made `c++`, `c#`, `c` and `µc` slugify to
+  # the same `c`, so three of the four lived behind a random collision suffix
+  # and the readable `/tags/c` belonged to C++. Deliberately a short, explicit
+  # list and not a general rule: each entry is a name people actually write.
+  #
+  # Each is anchored so a stray symbol does not turn into a word — a `#` only
+  # counts when it follows the name it belongs to, a `+` when it follows the
+  # name or another `+`, and a `.` only at the very front (`.net`, while
+  # `node.js` keeps the separator it has always had).
+  @tag_symbol_words [
+    {~r/^\./, "dot"},
+    {~r/(?<=[a-z0-9])#/u, "sharp"},
+    {~r/(?<=[a-z0-9+])\+/u, "p"},
+    {~r{/}, "_"}
+  ]
+
+  @doc """
+  A **tag** slug: the handle grammar, `^[a-z0-9_]+$`, with the technology
+  symbols spelled out first.
+
+      iex> Vutuv.SlugHelpers.tagify("C++")
+      "cpp"
+
+      iex> Vutuv.SlugHelpers.tagify("Machine Learning")
+      "machine_learning"
+
+  Tags have their own slugifier rather than sharing `slugify_downcase/1` with
+  organizations, job postings and CV sections, because only a tag slug is also
+  the name of that tag's fediverse actor (#1330). That name has to survive
+  every server out there, which means the narrowest local part any of them
+  accepts — the same grammar `Vutuv.Handles` already enforces for a member
+  handle. A hyphen is the better character for the other three: it is the web's
+  word separator and reads to a crawler as one, and nothing federates them.
+
+  Answers `""` when nothing keyable is left, which is the caller's cue to fall
+  back to a generated slug (`gen_tag_slug_unique/3`).
+  """
+  def tagify(text) do
+    text
+    |> to_string()
+    |> String.downcase()
+    |> String.trim()
+    |> apply_symbol_words()
+    |> handle_body()
+  end
+
+  defp apply_symbol_words(text) do
+    Enum.reduce(@tag_symbol_words, text, fn {pattern, word}, acc ->
+      String.replace(acc, pattern, word)
+    end)
+  end
+
+  @doc """
+  Like `gen_slug_unique/4` but for tags: `tagify/1` for the body, and a
+  collision suffix joined with `_` rather than `.` so the result stays inside
+  the actor grammar.
+  """
+  def gen_tag_slug_unique(value, model, slug_field) do
+    slug = tagify(value)
+
+    taken =
+      Repo.one(
+        from(s in model,
+          where: field(s, ^slug_field) == ^slug,
+          limit: 1,
+          select: field(s, ^slug_field)
+        )
+      )
+
+    case {taken, slug} do
+      {_, ""} -> short_sha()
+      {nil, slug} -> slug
+      {_, slug} -> "#{slug}_#{short_sha()}"
+    end
+  end
+
   defp gen_slug(resource) do
     resource
     |> to_string()
     |> slugify_downcase()
   end
 
-  defp slugify_downcase(text) do
+  @doc """
+  The slug of everything that is **not** a tag — organizations, job postings,
+  CV sections: downcased, transliterated, separator runs to `-`.
+  """
+  def slugify_downcase(text) do
     text
     |> String.downcase()
     |> transliterate()

--- a/lib/vutuv/tags/tag.ex
+++ b/lib/vutuv/tags/tag.ex
@@ -152,7 +152,7 @@ defmodule Vutuv.Tags.Tag do
   end
 
   def gen_slug(changeset, value) do
-    slug = Vutuv.SlugHelpers.gen_slug_unique(value, __MODULE__, :slug)
+    slug = Vutuv.SlugHelpers.gen_tag_slug_unique(value, __MODULE__, :slug)
     put_change(changeset, :slug, slug)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.275.0",
+      version: "7.276.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260812164045_retag_slugs_to_actor_grammar.exs
+++ b/priv/repo/migrations/20260812164045_retag_slugs_to_actor_grammar.exs
@@ -1,0 +1,262 @@
+defmodule Vutuv.Repo.Migrations.RetagSlugsToActorGrammar do
+  @moduledoc """
+  Brings every live tag slug into the actor grammar `^[a-z0-9_]+$` (issues
+  #1337 and #1332, want 2), keeping the spelling it had reachable.
+
+  Three shapes sat in the column: underscores (the older majority, already
+  conforming), hyphens (what the slugifier wrote until now) and a `.<short-sha>`
+  collision suffix. 262 live tags needed a new slug on the catalog this was
+  measured against.
+
+  **Three resolutions, in this order.** They exist because the wanted slug is
+  often held by another row, and by what kind of row decides what is right:
+
+  1. `:free` — nobody holds it. Rename, and file the old spelling as a `former`
+     alias row so `/tags/<old>` answers 301 instead of 404.
+  2. `:swap` — it is held by an **alias of this very tag**, which is what
+     #1338's merge pass left behind: `open_source_software` was merged into
+     `open-source-software`, so the underscore spelling the grammar now wants is
+     already sitting on the absorbed row. Both slugs already resolve to one
+     topic, so the two rows exchange them. No row is added and nothing changes
+     meaning.
+  3. `:suffix` — held by an unrelated topic. Only then a `_<sha>` suffix, and
+     never silently: the count is printed.
+
+  Order matters even among the free ones. `c++` held the readable `c`, so the
+  real C sat behind `c.64f34779`; renaming `c++` to `cpp` is what frees `c` — but
+  only for the alias row that then records it, so C keeps a suffix rather than
+  quietly taking over a URL that has meant C++ all along.
+
+  Reversible: `down/0` reads the alias rows this created (and the swaps) and puts
+  the old slugs back.
+  """
+  use Ecto.Migration
+
+  import Ecto.Query
+
+  alias Vutuv.Repo
+  alias Vutuv.SlugHelpers
+
+  @grammar ~r/^[a-z0-9_]+$/
+  @alias_kind "former"
+
+  def up do
+    plan = plan()
+    Enum.each(plan, &apply_step/1)
+    IO.puts(report(plan))
+  end
+
+  def down do
+    # Two shapes to undo, and in this order. The rows `up/0` **created** carry a
+    # signature it alone writes (a `former` alias whose name is its own slug,
+    # and that slug is not an actor name): delete each and give the old slug
+    # back. What is left in that shape afterwards is a **swap** — a pre-existing
+    # alias, so it has a name of its own — and those two rows exchange their
+    # slugs back.
+    for %{id: alias_id, slug: old_slug, merged_into_id: canonical_id} <- created_aliases() do
+      delete_row(alias_id)
+      set_slug(canonical_id, old_slug)
+    end
+
+    for %{alias_id: alias_id, alias_slug: alias_slug, id: id, slug: slug} <- swapped_pairs() do
+      parking = "swap_#{short_sha()}"
+      set_slug(alias_id, parking)
+      set_slug(id, alias_slug)
+      set_slug(alias_id, slug)
+    end
+
+    :ok
+  end
+
+  @doc """
+  What `up/0` would do, without doing it. Run it before the migration on a copy
+  of the real catalog:
+
+      mix run -e 'IO.puts(Vutuv.Repo.Migrations.RetagSlugsToActorGrammar.dry_run())'
+  """
+  def dry_run, do: report(plan())
+
+  defp report(plan) do
+    counts = Enum.frequencies_by(plan, & &1.resolution)
+    suffixed = Enum.filter(plan, &(&1.resolution == :suffix))
+
+    [
+      "retag plan: #{length(plan)} live slugs",
+      "  free   (rename + former alias): #{Map.get(counts, :free, 0)}",
+      "  swap   (with own alias row):    #{Map.get(counts, :swap, 0)}",
+      "  suffix (wanted slug taken):     #{Map.get(counts, :suffix, 0)}"
+      | Enum.map(suffixed, fn s -> "    #{s.slug} -> #{s.wanted}" end)
+    ]
+    |> Enum.join("\n")
+  end
+
+  # Every live tag whose slug is not an actor name yet, with the slug it wants
+  # and how that slug can be had.
+  defp plan do
+    rows = all_rows()
+    by_slug = Map.new(rows, &{&1.slug, &1})
+
+    {conforming, to_rename} =
+      rows
+      |> Enum.filter(&is_nil(&1.merged_into_id))
+      |> Enum.split_with(fn %{slug: slug} -> Regex.match?(@grammar, slug) end)
+
+    _ = conforming
+    taken = MapSet.new(rows, & &1.slug)
+
+    to_rename
+    |> Enum.map(&Map.put(&1, :wanted, wanted_slug(&1)))
+    |> resolve(taken, by_slug, [])
+  end
+
+  # Apply what is free, then look again: a row can be blocked by another row
+  # that is itself about to move. Whatever is still blocked when a pass makes no
+  # progress is either this tag's own absorbed spelling (swap) or a different
+  # topic (suffix).
+  defp resolve([], _taken, _by_slug, done), do: Enum.reverse(done)
+
+  defp resolve(pending, taken, by_slug, done) do
+    {free, blocked} = Enum.split_with(pending, &(not MapSet.member?(taken, &1.wanted)))
+
+    if free == [] do
+      Enum.reverse(done) ++ Enum.map(blocked, &block_resolution(&1, by_slug))
+    else
+      taken = Enum.reduce(free, taken, &MapSet.put(&2, &1.wanted))
+      free = Enum.map(free, &Map.put(&1, :resolution, :free))
+      resolve(blocked, taken, by_slug, Enum.reverse(free) ++ done)
+    end
+  end
+
+  defp block_resolution(row, by_slug) do
+    case Map.get(by_slug, row.wanted) do
+      %{id: holder_id, merged_into_id: canonical_id} when canonical_id == row.id ->
+        row |> Map.put(:resolution, :swap) |> Map.put(:swap_with, holder_id)
+
+      _ ->
+        row |> Map.put(:resolution, :suffix) |> Map.put(:wanted, kept_suffix(row, by_slug))
+    end
+  end
+
+  # A blocked row is a second topic under a name somebody else already holds
+  # (`#Grafana` beside `Grafana`), which is a merge for a human to decide and
+  # never for a migration. It keeps a page of its own, so all it needs is a
+  # conforming slug — and the one it already has is the best candidate: a
+  # `.<sha>` collision suffix becomes `_<sha>`, one character changed, so the
+  # URL stays recognisable and the alias 301 covers the old spelling. Only when
+  # even that is taken is a fresh suffix minted.
+  @dotted ~r/^(?<base>.+)\.(?<sha>[a-f0-9]{4,16})$/
+
+  defp kept_suffix(%{slug: slug, wanted: wanted}, by_slug) do
+    candidate =
+      case Regex.named_captures(@dotted, slug) do
+        %{"base" => base, "sha" => sha} -> "#{SlugHelpers.tagify(base)}_#{sha}"
+        nil -> "#{wanted}_#{short_sha()}"
+      end
+
+    if Map.has_key?(by_slug, candidate), do: "#{wanted}_#{short_sha()}", else: candidate
+  end
+
+  defp wanted_slug(%{name: name, slug: slug}) do
+    case SlugHelpers.tagify(name) do
+      "" -> fallback_slug(slug)
+      wanted -> wanted
+    end
+  end
+
+  # A name that slugifies to nothing (pure non-ASCII) keeps whatever of its old
+  # slug is usable, and a generated one when even that is empty.
+  defp fallback_slug(slug) do
+    case SlugHelpers.tagify(slug) do
+      "" -> short_sha()
+      usable -> usable
+    end
+  end
+
+  defp apply_step(%{resolution: :swap, id: id, slug: old_slug, wanted: wanted, swap_with: other}) do
+    # Both slugs already resolve to this one topic, so the pair simply exchanges
+    # them. Through a parking slug, because the unique index sees each statement.
+    parking = "swap_#{short_sha()}"
+    set_slug(other, parking)
+    set_slug(id, wanted)
+    set_slug(other, old_slug)
+  end
+
+  defp apply_step(%{id: id, slug: old_slug, wanted: wanted}) do
+    set_slug(id, wanted)
+    insert_former_alias(id, old_slug)
+  end
+
+  defp set_slug(id, slug) do
+    Repo.query!("update tags set slug = $1, updated_at = $2 where id = $3", [slug, now(), uuid(id)])
+  end
+
+  defp delete_row(id), do: Repo.query!("delete from tags where id = $1", [uuid(id)])
+
+  # The old spelling as a `former` alias row: that is what makes `/tags/<old>`
+  # answer 301 (`TagController.resolve_tag/2`) and what keeps a literal
+  # `#hashtag` in an old post body resolving (`Tags.linkable_slugs/1`). Its name
+  # is the retired slug, because that is what the row records — the topic's own
+  # name stays on the row that survived.
+  defp insert_former_alias(canonical_id, old_slug) do
+    Repo.query!(
+      """
+      insert into tags (id, slug, name, merged_into_id, alias_kind, inserted_at, updated_at)
+      values ($1, $2, $3, $4, $5, $6, $6)
+      """,
+      [uuid(Vutuv.UUIDv7.generate()), old_slug, old_slug, uuid(canonical_id), @alias_kind, now()]
+    )
+  end
+
+  defp all_rows do
+    from(t in "tags",
+      select: %{id: t.id, name: t.name, slug: t.slug, merged_into_id: t.merged_into_id}
+    )
+    |> Repo.all()
+  end
+
+  # The rows `up/0` added, by the signature it alone writes: a `former` alias
+  # whose **name is its own slug** (a retired spelling records nothing else) and
+  # whose slug is not an actor name.
+  defp created_aliases do
+    from(t in "tags",
+      where: t.alias_kind == @alias_kind and not is_nil(t.merged_into_id) and t.name == t.slug,
+      select: %{id: t.id, slug: t.slug, merged_into_id: t.merged_into_id}
+    )
+    |> Repo.all()
+    |> Enum.reject(fn %{slug: slug} -> Regex.match?(@grammar, slug) end)
+  end
+
+  # A canonical row wearing the slug its own name produces, while its alias
+  # holds a spelling that is not an actor name — which is what a swap leaves
+  # behind, and (once the rows created above are gone) nothing else does. The
+  # test is against the **name**, not against the alias's slug: the canonical
+  # took `tagify(name)`, which for `C/C++` is `c_cpp` and has nothing to do with
+  # the `c_c.847f12e2` the alias ended up holding.
+  defp swapped_pairs do
+    from(t in "tags",
+      join: a in "tags",
+      on: a.merged_into_id == t.id,
+      where: is_nil(t.merged_into_id),
+      select: %{id: t.id, name: t.name, slug: t.slug, alias_id: a.id, alias_slug: a.slug}
+    )
+    |> Repo.all()
+    |> Enum.filter(fn %{name: name, slug: slug, alias_slug: alias_slug} ->
+      Regex.match?(@grammar, slug) and not Regex.match?(@grammar, alias_slug) and
+        SlugHelpers.tagify(name) == slug
+    end)
+  end
+
+  defp now, do: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+
+  # A readable id string cannot go into a `uuid` parameter: Postgres reports the
+  # type as `uuid` and Postgrex then wants the raw 16 bytes, which is the
+  # `DBConnection.EncodeError` the ecto rules warn about.
+  defp uuid(id) when is_binary(id) do
+    case Ecto.UUID.dump(id) do
+      {:ok, raw} -> raw
+      :error -> id
+    end
+  end
+
+  defp short_sha, do: 4 |> :crypto.strong_rand_bytes() |> Base.encode16(case: :lower)
+end

--- a/test/vutuv/repo/retag_slugs_to_actor_grammar_test.exs
+++ b/test/vutuv/repo/retag_slugs_to_actor_grammar_test.exs
@@ -1,0 +1,122 @@
+defmodule Vutuv.Repo.RetagSlugsToActorGrammarTest do
+  @moduledoc """
+  Covers the one-time migration `retag_slugs_to_actor_grammar` (issues #1337 and
+  #1332, want 2), which brings every live tag slug into `^[a-z0-9_]+$` — the
+  grammar #1330 needs, because a tag slug becomes that tag's fediverse actor
+  name.
+
+  The run that matters is against a copy of the real catalog (see CLAUDE.md); on
+  8,036 tags it reported 262 live slugs to rename: 217 free, 15 swapped with
+  their own alias, 30 keeping their existing collision suffix. This file builds
+  each of those three shapes by hand, so the rules cannot drift and so a fresh
+  installation's empty catalog is not the only thing CI ever sees.
+
+  `async: false`: the module is loaded from `priv/repo/migrations` with
+  `Code.require_file/1`, which is global.
+  """
+  use Vutuv.DataCase, async: false
+
+  alias Vutuv.Tags.Tag
+
+  @migration Vutuv.Repo.Migrations.RetagSlugsToActorGrammar
+  @grammar ~r/^[a-z0-9_]+$/
+
+  setup_all do
+    unless Code.ensure_loaded?(@migration) do
+      [file] = Path.wildcard("priv/repo/migrations/*_retag_slugs_to_actor_grammar.exs")
+      Code.require_file(file)
+    end
+
+    :ok
+  end
+
+  defp tag(name, slug, attrs \\ []), do: insert(:tag, [name: name, slug: slug] ++ attrs)
+
+  defp reload(%Tag{id: id}), do: Repo.get!(Tag, id)
+
+  defp alias_of(%Tag{id: id}) do
+    Repo.one(from(t in Tag, where: t.merged_into_id == ^id, order_by: [desc: t.id], limit: 1))
+  end
+
+  test "a hyphen slug is renamed and its old spelling keeps resolving" do
+    n = System.unique_integer([:positive])
+    topic = tag("Machine Learning #{n}", "machine-learning-#{n}")
+
+    @migration.up()
+
+    assert reload(topic).slug == "machine_learning_#{n}"
+
+    # The retired spelling stays in the table as a `former` alias, which is what
+    # makes `/tags/<old>` answer 301 instead of 404.
+    assert %Tag{} = retired = Repo.get_by(Tag, slug: "machine-learning-#{n}")
+    assert retired.merged_into_id == topic.id
+    assert retired.alias_kind == "former"
+  end
+
+  test "a collision suffix loses its dot rather than its identity" do
+    n = System.unique_integer([:positive])
+    # The shape 165 rows carry: a name whose slug was already taken, so the
+    # slugifier appended `.<sha>`. The wanted slug is taken here too, so the row
+    # keeps the suffix it has — one character changed, the URL still readable.
+    tag("Grafana #{n}", "grafana_#{n}")
+    dupe = tag("Grafana #{n}", "grafana_#{n}.a23c7928")
+
+    @migration.up()
+
+    # Two live topics under one name is a merge for a human to decide at
+    # /admin/tag_merges, never for a migration, so the second one keeps a page
+    # of its own — with the suffix it already had.
+    assert reload(dupe).slug == "grafana_#{n}_a23c7928"
+  end
+
+  test "a tag whose own alias holds the wanted slug swaps with it, adding no row" do
+    n = System.unique_integer([:positive])
+    topic = tag("Open-Source Software #{n}", "open-source-software-#{n}")
+
+    absorbed =
+      tag("open source software #{n}", "open_source_software_#{n}", merged_into_id: topic.id)
+
+    before = Repo.aggregate(Tag, :count)
+
+    @migration.up()
+
+    # Both slugs already resolved to this one topic, so they simply exchange
+    # them: no third row, and nothing changes meaning.
+    assert reload(topic).slug == "open_source_software_#{n}"
+    assert reload(absorbed).slug == "open-source-software-#{n}"
+    assert Repo.aggregate(Tag, :count) == before
+  end
+
+  test "an already conforming slug is left alone" do
+    n = System.unique_integer([:positive])
+    untouched = tag("Elixir #{n}", "elixir_#{n}")
+
+    @migration.up()
+
+    assert reload(untouched).slug == "elixir_#{n}"
+    refute alias_of(untouched)
+  end
+
+  test "every live slug conforms afterwards, and the rollback puts them all back" do
+    n = System.unique_integer([:positive])
+
+    rows = [
+      tag("Ruby on Rails #{n}", "ruby-on-rails-#{n}"),
+      tag("Prozessanalyse #{n}", "prozessanalyse#{n}.a635dc6a"),
+      tag("Node.js #{n}", "node_js_#{n}")
+    ]
+
+    slugs_before = Enum.map(rows, & &1.slug)
+    count_before = Repo.aggregate(Tag, :count)
+
+    @migration.up()
+
+    live = Repo.all(from(t in Tag, where: is_nil(t.merged_into_id), select: t.slug))
+    assert Enum.all?(live, &Regex.match?(@grammar, &1)), "a live slug is not an actor name"
+
+    @migration.down()
+
+    assert Enum.map(rows, &reload(&1).slug) == slugs_before
+    assert Repo.aggregate(Tag, :count) == count_before
+  end
+end

--- a/test/vutuv/tags/tag_slug_grammar_test.exs
+++ b/test/vutuv/tags/tag_slug_grammar_test.exs
@@ -1,0 +1,100 @@
+defmodule Vutuv.Tags.TagSlugGrammarTest do
+  @moduledoc """
+  What a tag slug may contain (issues #1337 and #1332, want 2).
+
+  Two things ride on this. A slug is the tag page's public URL, and the
+  slugifier used to delete every symbol that carries meaning in a technology
+  name — `c++`, `c#`, `c` and `µc` all slugified to `c`, so three of them lived
+  behind a random collision suffix and the readable `/tags/c` belonged to C++.
+  And a slug is about to be the name of that tag's fediverse actor (#1330),
+  which needs the narrowest local part any server accepts: `^[a-z0-9_]+$`, the
+  grammar `Vutuv.Handles` already enforces for member handles.
+
+  The mapping is short and explicit on purpose. Everything it does not name
+  keeps behaving as it did.
+  """
+  use Vutuv.DataCase, async: true
+
+  alias Vutuv.SlugHelpers
+  alias Vutuv.Tags.Tag
+
+  describe "tagify/1 keeps the characters that distinguish a technology" do
+    test "the symbols that carry meaning are transliterated, not deleted" do
+      assert SlugHelpers.tagify("c++") == "cpp"
+      assert SlugHelpers.tagify("C++") == "cpp"
+      assert SlugHelpers.tagify("c#") == "csharp"
+      assert SlugHelpers.tagify("F#") == "fsharp"
+      assert SlugHelpers.tagify(".net") == "dotnet"
+      assert SlugHelpers.tagify("c/c++") == "c_cpp"
+      assert SlugHelpers.tagify("c++11") == "cpp11"
+      assert SlugHelpers.tagify("ansi c++") == "ansi_cpp"
+    end
+
+    test "the four C-family names stay four different slugs" do
+      slugs = Enum.map(["c", "c++", "c#", "ansi c++"], &SlugHelpers.tagify/1)
+      assert slugs == ["c", "cpp", "csharp", "ansi_cpp"]
+      assert length(Enum.uniq(slugs)) == 4
+    end
+
+    test "the output is always a valid actor name" do
+      for name <- [
+            "Machine Learning",
+            "Ruby on Rails",
+            "Open-Source Software",
+            "Prüfer",
+            "c/c++",
+            "node.js",
+            "  spaced  out  ",
+            "UPPER_case"
+          ] do
+        slug = SlugHelpers.tagify(name)
+        assert slug =~ ~r/^[a-z0-9_]+$/, "#{name} slugified to #{inspect(slug)}"
+      end
+    end
+
+    test "a separator run becomes one underscore, and German folds rather than drops" do
+      assert SlugHelpers.tagify("Machine Learning") == "machine_learning"
+      assert SlugHelpers.tagify("Open-Source  Software") == "open_source_software"
+      assert SlugHelpers.tagify("Prüfer") == "pruefer"
+      assert SlugHelpers.tagify("Ladesäule") == "ladesaeule"
+    end
+
+    test "a name with nothing left answers empty, for the caller to suffix" do
+      assert SlugHelpers.tagify("---") == ""
+      assert SlugHelpers.tagify("日本語") == ""
+    end
+  end
+
+  describe "a minted tag" do
+    test "gets the readable slug rather than a hash" do
+      assert %Tag{slug: "cpp"} = Repo.insert!(Tag.changeset(%Tag{}, %{"value" => "C++"}))
+      assert %Tag{slug: "csharp"} = Repo.insert!(Tag.changeset(%Tag{}, %{"value" => "C#"}))
+      assert %Tag{slug: "c"} = Repo.insert!(Tag.changeset(%Tag{}, %{"value" => "C"}))
+    end
+
+    test "a collision is suffixed with an underscore, not a dot" do
+      n = System.unique_integer([:positive])
+      insert(:tag, name: "Kollision #{n}", slug: "kollision_#{n}")
+
+      tag = Repo.insert!(Tag.changeset(%Tag{}, %{"value" => "Kollision #{n}"}))
+
+      # A dot would leave the actor namespace (`^[a-z0-9_]+$`) the moment #1330
+      # mints an actor for it.
+      assert tag.slug =~ ~r/^kollision_#{n}_[a-f0-9]+$/
+    end
+
+    test "a name that slugifies to nothing still gets a usable slug" do
+      tag = Repo.insert!(Tag.changeset(%Tag{}, %{"value" => "日本語"}))
+      assert tag.slug =~ ~r/^[a-z0-9_]+$/
+    end
+  end
+
+  describe "the other slug users are untouched" do
+    test "organizations, jobs and CV sections keep hyphenated slugs" do
+      # `slugify_downcase/1` is shared, and a hyphen is the web convention for
+      # those URLs. Only the tag needs the handle grammar, because only a tag
+      # slug becomes a fediverse actor name.
+      assert SlugHelpers.slugify_downcase("Acme Consulting GmbH") == "acme-consulting-gmbh"
+    end
+  end
+end

--- a/test/vutuv/tags/tag_test.exs
+++ b/test/vutuv/tags/tag_test.exs
@@ -19,7 +19,9 @@ defmodule Vutuv.Tags.TagTest do
     test "keeps a multi-word name and slugifies it" do
       changeset = Tag.changeset(%Tag{}, %{"value" => "Ruby on Rails"})
       assert get_change(changeset, :name) == "Ruby on Rails"
-      assert get_change(changeset, :slug) == "ruby-on-rails"
+      # Underscore, not hyphen: a tag slug is also the name of that tag's
+      # fediverse actor (#1330), so it lives in the handle grammar (#1337).
+      assert get_change(changeset, :slug) == "ruby_on_rails"
     end
 
     test "collapses internal whitespace runs to a single space" do

--- a/test/vutuv/tags_test.exs
+++ b/test/vutuv/tags_test.exs
@@ -383,7 +383,7 @@ defmodule Vutuv.TagsTest do
       assert {:ok, user_tag} = Tags.add_user_tag(user, "#" <> name)
       tag = Repo.preload(user_tag, :tag).tag
       assert tag.name == name
-      assert tag.slug == name
+      assert tag.slug == String.replace(name, "-", "_")
     end
 
     test "add_user_tag keeps a trailing # (C# stays C#)" do
@@ -705,7 +705,8 @@ defmodule Vutuv.TagsTest do
       assert {:ok, tag} = Tags.declare_honor_tag("vutuv_contributor")
       assert tag.honor?
       assert tag.name == "vutuv_contributor"
-      assert tag.slug == "vutuv-contributor"
+      # Underscore since #1337: the slug is also a fediverse actor name.
+      assert tag.slug == "vutuv_contributor"
     end
 
     test "declare_honor_tag/1 flips an existing holder-less tag" do
@@ -1082,7 +1083,7 @@ defmodule Vutuv.TagsTest do
       name = unique_tag_name("Posted")
       Vutuv.PostsHelpers.create_post!(author, %{"body" => "words", "tags" => name})
 
-      tag = Repo.get_by!(Tag, slug: String.downcase(name))
+      tag = Repo.get_by!(Tag, slug: name |> String.downcase() |> String.replace("-", "_"))
       assert Tags.indexable_tag?(tag)
     end
 
@@ -1096,7 +1097,7 @@ defmodule Vutuv.TagsTest do
         "denials" => [%{"wildcard" => "everyone"}]
       })
 
-      tag = Repo.get_by!(Tag, slug: String.downcase(name))
+      tag = Repo.get_by!(Tag, slug: name |> String.downcase() |> String.replace("-", "_"))
       refute Tags.indexable_tag?(tag)
     end
   end

--- a/test/vutuv_web/controllers/admin/honor_tag_controller_test.exs
+++ b/test/vutuv_web/controllers/admin/honor_tag_controller_test.exs
@@ -31,8 +31,8 @@ defmodule VutuvWeb.Admin.HonorTagControllerTest do
     test "creating a new honor tag lands on its roster", %{conn: conn} do
       conn = post(conn, ~p"/admin/honor_tags", honor_tag: %{name: "vutuv_contributor"})
 
-      assert redirected_to(conn) == ~p"/admin/tags/vutuv-contributor"
-      tag = Repo.get_by(Tag, slug: "vutuv-contributor")
+      assert redirected_to(conn) == ~p"/admin/tags/vutuv_contributor"
+      tag = Repo.get_by(Tag, slug: "vutuv_contributor")
       assert tag.honor?
     end
 

--- a/test/vutuv_web/controllers/sitemap_controller_test.exs
+++ b/test/vutuv_web/controllers/sitemap_controller_test.exs
@@ -120,7 +120,7 @@ defmodule VutuvWeb.SitemapControllerTest do
 
       assert conn.status == 200
       assert conn.resp_body =~ "<loc>#{@base}/tags/elixir-mapped</loc>"
-      assert conn.resp_body =~ "<loc>#{@base}/tags/#{String.downcase(posted_name)}</loc>"
+      assert conn.resp_body =~ "<loc>#{@base}/tags/#{Vutuv.SlugHelpers.tagify(posted_name)}</loc>"
       refute conn.resp_body =~ empty.slug
       refute conn.resp_body =~ thin.slug
     end

--- a/test/vutuv_web/controllers/tag_controller_test.exs
+++ b/test/vutuv_web/controllers/tag_controller_test.exs
@@ -83,7 +83,7 @@ defmodule VutuvWeb.TagControllerTest do
       post =
         Vutuv.PostsHelpers.create_post!(author, %{body: "Elixir meetup notes", tags: tag_name})
 
-      html = conn |> get(~p"/tags/#{String.downcase(tag_name)}") |> html_response(200)
+      html = conn |> get(~p"/tags/#{Vutuv.SlugHelpers.tagify(tag_name)}") |> html_response(200)
 
       assert html =~ "tag-timeline"
       assert html =~ "Elixir meetup notes"

--- a/test/vutuv_web/controllers/user_tag_controller_test.exs
+++ b/test/vutuv_web/controllers/user_tag_controller_test.exs
@@ -30,7 +30,7 @@ defmodule VutuvWeb.UserTagControllerTest do
       {:ok, user_tag} = Vutuv.Tags.add_user_tag(user, name)
       tag_id = user_tag.tag_id
 
-      conn = delete(conn, ~p"/settings/tags/#{String.downcase(name)}")
+      conn = delete(conn, ~p"/settings/tags/#{Vutuv.SlugHelpers.tagify(name)}")
 
       assert redirected_to(conn) == ~p"/settings/tags"
 


### PR DESCRIPTION
Closes #1337, and settles the grammar half of #1332 (want 2) that #1330 is waiting on.

The slugifier deleted every symbol that carries meaning in a technology name, so `c++`, `c#`, `c` and `µc` all slugified to `c` — three of them lived behind a random collision suffix, and the readable `/tags/c` belonged to C++. Tags now have their own slugifier: `c++` → `cpp`, `c#` → `csharp`, `.net` → `dotnet`, `c/c++` → `c_cpp`. A short, explicit list; everything it does not name behaves as before.

The output lives in `^[a-z0-9_]+$`, the grammar `Vutuv.Handles` already enforces. That is the decision #1332 was blocked on, and it has a reason beyond taste: a tag slug becomes the name of that tag's fediverse actor (#1330), which has to be the narrowest local part any server accepts.

**`slugify_downcase/1` is deliberately untouched**, though the issue names it. Organizations, job postings and CV sections share it, a hyphen is the right character for their URLs, and none of them federate. Only the tag needs the handle grammar, so only the tag gets the new path.

**The migration, measured against the real catalog rather than estimated** — 262 live slugs:

| resolution | n | what it does |
|---|---|---|
| free | 217 | rename, old spelling stays as a `former` alias so `/tags/<old>` 301s |
| swap | 15 | #1338's merge pass left the underscore spelling on the absorbed row; the two rows exchange slugs, no row added |
| suffix | 30 | a real duplicate topic (`#Grafana` beside `Grafana`) holds the wanted slug, so the row keeps its own suffix with `_` instead of `.` — merging those is a human decision at `/admin/tag_merges`, never a migration's |

Order matters: `c++` held the readable `c`, so the real C sat behind `c.64f34779`. Renaming `c++` frees `c` — but only for the alias row that records it, because a URL that has meant C++ for years must not silently change meaning.

Run and rolled back against `vutuv1_dev`: 262 → 0 non-conforming live slugs, 247 alias rows added, and `down/0` puts every one back.

**Nine existing tests hardcoded a hyphen slug.** They now point at the real slug instead of wiring a spelling in.

`mix precommit` green (7490 tests).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*