### PR TITLE
Ein Tag kann einen Schlüssel halten (v7.276.1)

### DIFF
--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -91,6 +91,7 @@ defmodule Vutuv.Fediverse do
   alias Vutuv.SearchText
   alias Vutuv.Social
   alias Vutuv.SocialFeed.Http
+  alias Vutuv.Tags.Tag
   alias Vutuv.UUIDv7
   alias VutuvWeb.Fediverse.Docs
 
@@ -242,6 +243,48 @@ defmodule Vutuv.Fediverse do
   @doc "The page's actor, or nil."
   def get_organization_actor(%Organization{id: id}),
     do: Repo.get_by(Actor, organization_id: id)
+
+  @doc """
+  The keypair a **tag** signs with, minted on first use (issue #1330).
+
+  A topic becomes an actor anyone on any server can follow without an account
+  here, and its actor name is the tag's slug with no mapping in between — which
+  is why this waited for the slug grammar to be settled (#1337/#1332): renaming
+  an actor other servers already follow costs a `Move` per tag.
+
+  Like the page's, the keypair can exist before anything is federated: it is
+  invisible outside this database. What a remote server sees — WebFinger on the
+  tag host, the `Group` document, the inbox that answers `Follow`, the
+  `Announce` of a tagged post — has to arrive together, because a Follow nobody
+  answers stays pending forever on the other side.
+
+  Only a **canonical** tag gets one. An alias is another name for a topic
+  (#1338), not a topic, so it must never become a second address for the same
+  posts.
+  """
+  def ensure_tag_actor(%Tag{merged_into_id: id}) when is_binary(id), do: {:error, :alias}
+
+  def ensure_tag_actor(%Tag{} = tag) do
+    case get_tag_actor(tag) do
+      nil ->
+        {private_pem, public_pem} = Keys.generate()
+
+        %Actor{
+          tag_id: tag.id,
+          private_key_pem: private_pem,
+          public_key_pem: public_pem
+        }
+        |> Repo.insert(on_conflict: :nothing, conflict_target: [:tag_id])
+
+        {:ok, get_tag_actor(tag)}
+
+      actor ->
+        {:ok, actor}
+    end
+  end
+
+  @doc "The tag's actor, or nil."
+  def get_tag_actor(%Tag{id: id}), do: Repo.get_by(Actor, tag_id: id)
 
   ## Remote followers
 

--- a/lib/vutuv/fediverse/actor.ex
+++ b/lib/vutuv/fediverse/actor.ex
@@ -4,13 +4,17 @@ defmodule Vutuv.Fediverse.Actor do
   lazily on opt-in. The private key signs outbound deliveries; the public key
   is published in the actor document.
 
-  The owner is a **member or an organization page** (issue #1334),
-  CHECK-enforced to exactly one. The page half is the foundation of that
-  issue's fediverse work and has no writer yet: a keypair is invisible outside
-  this database, so it could ship on its own, while the parts other servers can
+  The owner is a **member, an organization page (issue #1334) or a tag (issue
+  #1330)**, CHECK-enforced to exactly one. The page and tag halves are the
+  foundation of their issues' fediverse work: a keypair is invisible outside
+  this database, so it can ship on its own, while the parts other servers can
   see (WebFinger, the actor document, delivery, the inbox) have to land
   together — being findable without an inbox that answers Follow is worse than
   not being findable.
+
+  A tag's actor name is its slug with no mapping in between, which is why this
+  had to wait for the slug grammar to be settled (#1337/#1332): renaming an
+  actor other servers already follow costs a `Move` per tag.
   """
 
   use VutuvWeb, :model
@@ -21,6 +25,7 @@ defmodule Vutuv.Fediverse.Actor do
 
     belongs_to(:user, Vutuv.Accounts.User)
     belongs_to(:organization, Vutuv.Organizations.Organization)
+    belongs_to(:tag, Vutuv.Tags.Tag)
 
     timestamps()
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.276.0",
+      version: "7.276.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260812183859_add_tag_to_fediverse_actors.exs
+++ b/priv/repo/migrations/20260812183859_add_tag_to_fediverse_actors.exs
@@ -1,0 +1,74 @@
+defmodule Vutuv.Repo.Migrations.AddTagToFediverseActors do
+  @moduledoc """
+  Issue #1330, the foundation of it: a **tag** can hold a keypair, so a topic
+  can eventually be an ActivityPub `Group` actor anyone on any server can
+  follow without a vutuv account.
+
+  Third owner on this table, after the member and the page (#1334), and the
+  same shape: a nullable `tag_id` beside the other two, the CHECK widened to
+  exactly one of three, and its own unique index because neither existing one
+  can police the tag spelling.
+
+  ## Why only this much
+
+  The same reason the page half shipped its keypair alone: everything a remote
+  server can *see* — WebFinger on the tag host, the `Group` document, the inbox
+  that answers `Follow` with `Accept`, and the `Announce` of a tagged post —
+  has to land together. Being findable without an inbox that answers means
+  somebody presses Follow on Mastodon and it stays pending forever, which is
+  worse than not being findable at all. A keypair has no such problem: nothing
+  outside this database can see one.
+
+  It waits for one thing, and that is now true: a tag's slug is its actor name
+  with no mapping in between, so the column this hangs off is settled
+  (#1337/#1332, v7.276.0). Minting an actor from a slug that still had to be
+  renamed would have cost a `Move` per tag.
+
+  N-1 safe: the previous release writes only member and page actors, which
+  satisfy the widened CHECK, and reads actors only by `user_id` /
+  `organization_id`, which a tag row cannot match.
+  """
+  use Ecto.Migration
+
+  @check :fediverse_actors_exactly_one_owner
+
+  def up do
+    alter table(:fediverse_actors) do
+      add(:tag_id, references(:tags, type: :binary_id, on_delete: :delete_all))
+    end
+
+    drop(constraint(:fediverse_actors, @check))
+
+    create(
+      constraint(:fediverse_actors, @check,
+        check: """
+        (CASE WHEN user_id IS NULL THEN 0 ELSE 1 END +
+         CASE WHEN organization_id IS NULL THEN 0 ELSE 1 END +
+         CASE WHEN tag_id IS NULL THEN 0 ELSE 1 END) = 1
+        """
+      )
+    )
+
+    create(unique_index(:fediverse_actors, [:tag_id]))
+  end
+
+  def down do
+    drop(unique_index(:fediverse_actors, [:tag_id]))
+    drop(constraint(:fediverse_actors, @check))
+
+    execute("DELETE FROM fediverse_actors WHERE tag_id IS NOT NULL")
+
+    create(
+      constraint(:fediverse_actors, @check,
+        check: """
+        (CASE WHEN user_id IS NULL THEN 0 ELSE 1 END +
+         CASE WHEN organization_id IS NULL THEN 0 ELSE 1 END) = 1
+        """
+      )
+    )
+
+    alter table(:fediverse_actors) do
+      remove(:tag_id)
+    end
+  end
+end

--- a/test/vutuv/fediverse_tag_actor_test.exs
+++ b/test/vutuv/fediverse_tag_actor_test.exs
@@ -1,0 +1,73 @@
+defmodule Vutuv.FediverseTagActorTest do
+  @moduledoc """
+  The keypair behind a tag's future `Group` actor (issue #1330).
+
+  Only the keypair: what a remote server can see has to arrive together with an
+  inbox that answers `Follow`, or somebody presses Follow on Mastodon and it
+  stays pending forever. A keypair is invisible outside this database, which is
+  exactly why the page half of #1334 shipped its own the same way.
+  """
+  use Vutuv.DataCase, async: true
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Actor
+  alias Vutuv.Tags.Tag
+
+  defp tag(prefix \\ "topic") do
+    n = System.unique_integer([:positive])
+    insert(:tag, name: "#{prefix}#{n}", slug: "#{prefix}#{n}")
+  end
+
+  test "a tag gets a keypair on first use and keeps it" do
+    tag = tag()
+
+    assert {:ok, %Actor{} = actor} = Fediverse.ensure_tag_actor(tag)
+    assert actor.tag_id == tag.id
+    assert actor.private_key_pem =~ "PRIVATE KEY"
+    assert actor.public_key_pem =~ "PUBLIC KEY"
+
+    # Idempotent: a second call must not mint a second identity for one topic.
+    assert {:ok, %Actor{id: same}} = Fediverse.ensure_tag_actor(tag)
+    assert same == actor.id
+  end
+
+  test "an alias is another name for a topic, not a second address for it" do
+    topic = tag("canonical")
+    n = System.unique_integer([:positive])
+
+    other_name =
+      insert(:tag, name: "alias#{n}", slug: "alias#{n}", merged_into_id: topic.id)
+
+    assert {:error, :alias} = Fediverse.ensure_tag_actor(other_name)
+    refute Fediverse.get_tag_actor(other_name)
+  end
+
+  test "the owner column is exactly one of three" do
+    tag = tag()
+    user = insert(:activated_user)
+
+    # The CHECK the migration widened: a row naming two owners is a second
+    # identity for one thing, and the pair-shaped bugs of #1334 all began with a
+    # column that could hold both.
+    error =
+      assert_raise Ecto.ConstraintError, fn ->
+        Repo.insert!(%Actor{
+          tag_id: tag.id,
+          user_id: user.id,
+          private_key_pem: "x",
+          public_key_pem: "y"
+        })
+      end
+
+    assert error.message =~ "fediverse_actors_exactly_one_owner"
+  end
+
+  test "deleting the tag takes its keypair with it" do
+    tag = tag()
+    {:ok, _} = Fediverse.ensure_tag_actor(tag)
+
+    Repo.delete!(Repo.get!(Tag, tag.id))
+
+    refute Repo.get_by(Actor, tag_id: tag.id)
+  end
+end


### PR DESCRIPTION
The foundation of #1330: a tag can hold a keypair, so a topic can later be an ActivityPub `Group` actor anyone follows from any server without an account here.

Third owner on `fediverse_actors` after the member and the page, and the same shape: a nullable `tag_id` beside the other two, the CHECK widened to exactly one of three, its own unique index.

**Deliberately only this much.** Everything a remote server can see — WebFinger on the tag host, the `Group` document, the inbox that answers `Follow` with `Accept`, the `Announce` of a tagged post — has to land together. Findable without an answering inbox means somebody presses Follow on Mastodon and it stays pending forever. A keypair has no such problem: nothing outside this database can see one. That is exactly how #1334's page half went first.

**What it was waiting for is now true:** since v7.276.0 a tag's slug is its actor name with no mapping in between (#1337/#1332). Renaming an actor other servers already follow costs a `Move` per tag, so minting before the grammar was settled would have been the expensive mistake.

An **alias gets none**: another name for a topic is not a topic, and must never become a second address for the same posts.

N-1 safe: the previous release writes only member and page actors, which satisfy the widened CHECK, and reads actors only by `user_id` / `organization_id`.

`mix precommit` green (7494 tests). Migration run against `vutuv1_dev`.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*