### PR TITLE
Die Datenbank hält Tag-Slugs in der Actor-Grammatik (v7.276.2)

### DIFF
--- a/lib/vutuv/tags/tag.ex
+++ b/lib/vutuv/tags/tag.ex
@@ -26,6 +26,10 @@ defmodule Vutuv.Tags.Tag do
   # (see `punctuation_only?/1` and the guard in `create_or_link_tag/2`).
   @punctuation_message "must not be only punctuation"
 
+  # A live tag's slug doubles as its fediverse actor name (#1330), so it may
+  # hold only what the narrowest local part out there accepts.
+  @slug_grammar_message "may contain only lowercase letters, digits and underscores"
+
   # What counts as content: anything that is not punctuation (`\p{P}`), a
   # separator/whitespace (`\p{Z}`) or an invisible control character (`\p{C}`).
   # Letters and digits, of course — and **symbols** (`\p{S}`), which is what
@@ -102,7 +106,30 @@ defmodule Vutuv.Tags.Tag do
     |> validate_punctuation_only()
     |> validate_length(:slug, max: 60)
     |> validate_length(:name, max: 255)
+    |> validate_slug_grammar()
     |> unique_constraint(:slug)
+    |> check_constraint(:slug,
+      name: :tags_slug_actor_grammar,
+      message: @slug_grammar_message
+    )
+  end
+
+  # A live tag's slug is also the name of its fediverse actor (#1330), so it
+  # lives in the narrowest local part any server accepts — the same grammar
+  # `Vutuv.Handles` enforces for a member handle. `gen_slug/2` produces nothing
+  # else; this is here for the admin edit form, which casts `:slug` straight
+  # from a text field, and it runs only on a **change**, so an alias row keeping
+  # its retired spelling is untouched (that spelling is the whole reason the row
+  # exists).
+  #
+  # The database says the same thing (`tags_slug_actor_grammar`); the
+  # `check_constraint` above turns a race into a field error rather than a 500.
+  defp validate_slug_grammar(changeset) do
+    if get_field(changeset, :merged_into_id) do
+      changeset
+    else
+      validate_format(changeset, :slug, ~r/^[a-z0-9_]+$/, message: @slug_grammar_message)
+    end
   end
 
   # A name that is nothing but a URL, a domain or an email address is refused

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.276.1",
+      version: "7.276.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260812185551_enforce_tag_slug_actor_grammar.exs
+++ b/priv/repo/migrations/20260812185551_enforce_tag_slug_actor_grammar.exs
@@ -1,0 +1,38 @@
+defmodule Vutuv.Repo.Migrations.EnforceTagSlugActorGrammar do
+  @moduledoc """
+  The constraint that keeps tag slugs inside the actor grammar (issue #1332,
+  the last piece): a live tag's slug is `^[a-z0-9_]+$`, so it is usable as the
+  name of that tag's fediverse actor with no mapping in between (#1330).
+
+  **An alias is exempt, and that is the point of it.** A `former` row exists to
+  keep the spelling a topic used to have reachable (`/tags/<old>` answers 301),
+  so it must be allowed to hold exactly the shape this constraint forbids.
+
+  ## Why this waited for its own deploy
+
+  Deploys here are blue/green: the migration runs while the **previous** release
+  is still serving. Until v7.276.0 was live, that release's slugifier still
+  wrote hyphens, so a tag minted in the switch window would have violated this
+  constraint and 500ed. v7.276.0 reached production before this shipped, and its
+  slugifier writes nothing else, so there is no window left.
+
+  Guarded on the application side too (`Vutuv.Tags.Tag`): the changeset
+  validates the same shape and names this constraint, so an admin editing a slug
+  by hand gets a field error rather than a crash.
+  """
+  use Ecto.Migration
+
+  @check :tags_slug_actor_grammar
+
+  def up do
+    create(
+      constraint(:tags, @check,
+        check: "merged_into_id IS NOT NULL OR slug ~ '^[a-z0-9_]+$'"
+      )
+    )
+  end
+
+  def down do
+    drop(constraint(:tags, @check))
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -278,7 +278,9 @@ defmodule Vutuv.Factory do
   def tag_factory do
     %Vutuv.Tags.Tag{
       name: sequence(:tag_name, &"Tag Name #{&1}"),
-      slug: sequence(:tag_slug, &"tag-#{&1}")
+      # Underscore, because a live tag's slug is its fediverse actor name and
+      # the database now says so (`tags_slug_actor_grammar`, #1332/#1330).
+      slug: sequence(:tag_slug, &"tag_#{&1}")
     }
   end
 

--- a/test/vutuv/hashtag_filing_test.exs
+++ b/test/vutuv/hashtag_filing_test.exs
@@ -25,7 +25,7 @@ defmodule Vutuv.HashtagFilingTest do
   # the tag at — so `#berlin-7` would name the tag `berlin`, not this one.
   defp tag_named(base) do
     name = "#{base}_#{System.unique_integer([:positive])}"
-    insert(:tag, name: name, slug: String.downcase(name))
+    insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
   end
 
   defp filed_tag_ids(%Vutuv.Posts.Post{} = post) do

--- a/test/vutuv/organization_post_tags_test.exs
+++ b/test/vutuv/organization_post_tags_test.exs
@@ -36,7 +36,7 @@ defmodule Vutuv.OrganizationPostTagsTest do
   # A `#hashtag` files a post only against a tag that already exists, so each
   # test mints its own first. Hardcoded literals are safe here because the
   # module is `async: false` (see the tag-uniqueness rule in the Elixir rules).
-  defp tag!(slug), do: insert(:tag, name: slug, slug: slug)
+  defp tag!(slug), do: insert(:tag, name: slug, slug: Vutuv.SlugHelpers.tagify(slug))
 
   # Filed through the composer's tag field, which is what the tag feed reads.
   defp tagged_organization_post_with_tag(tag_name) do

--- a/test/vutuv/posts_test.exs
+++ b/test/vutuv/posts_test.exs
@@ -164,7 +164,7 @@ defmodule Vutuv.PostsTest do
 
     test "creates tags from a comma-separated list, reusing tags case-insensitively" do
       name = unique_tag_name("Elixir")
-      slug = String.downcase(name)
+      slug = Vutuv.SlugHelpers.tagify(name)
       existing = insert(:tag, name: name, slug: slug)
 
       # Only a comma splits, so "Phoenix Ecto" would be one tag; these are two.
@@ -185,7 +185,7 @@ defmodule Vutuv.PostsTest do
 
     test "strips a leading # from post tags and reuses the bare tag" do
       name = unique_tag_name("Elixir")
-      existing = insert(:tag, name: name, slug: String.downcase(name))
+      existing = insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
 
       # A member types the hashtag form in the composer; it stores the bare tags
       # and links #Elixir to the existing Elixir tag rather than a # duplicate.
@@ -245,7 +245,10 @@ defmodule Vutuv.PostsTest do
       # once and count it once, or a member is refused a sixth tag for having
       # typed a fifth one twice — under two spellings that look nothing alike.
       canonical_name = unique_tag_name("Ruby on Rails")
-      canonical = insert(:tag, name: canonical_name, slug: canonical_name)
+
+      canonical =
+        insert(:tag, name: canonical_name, slug: Vutuv.SlugHelpers.tagify(canonical_name))
+
       abbreviation = unique_tag_name("ROR")
 
       insert(:tag,
@@ -976,7 +979,7 @@ defmodule Vutuv.PostsTest do
       viewer = user()
       stranger = user()
       name = unique_tag_name("Elixir")
-      tag = insert(:tag, name: name, slug: String.downcase(name))
+      tag = insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
       Vutuv.Tags.follow_tag(viewer, tag)
 
       tagged = create_post!(stranger, %{body: "elixir news", tags: String.downcase(name)})
@@ -991,7 +994,7 @@ defmodule Vutuv.PostsTest do
       friend = user()
       follow!(viewer, friend)
       name = unique_tag_name("Elixir")
-      tag = insert(:tag, name: name, slug: String.downcase(name))
+      tag = insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
       Vutuv.Tags.follow_tag(viewer, tag)
 
       post = create_post!(friend, %{body: "elixir by a friend", tags: String.downcase(name)})
@@ -1005,7 +1008,7 @@ defmodule Vutuv.PostsTest do
       noisy = user()
       follow!(viewer, noisy)
       name = unique_tag_name("Elixir")
-      tag = insert(:tag, name: name, slug: String.downcase(name))
+      tag = insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
       Vutuv.Tags.follow_tag(viewer, tag)
 
       fid = Vutuv.Social.follow_id(viewer.id, noisy.id)
@@ -1019,7 +1022,7 @@ defmodule Vutuv.PostsTest do
       viewer = user()
       blocked = user()
       name = unique_tag_name("Elixir")
-      tag = insert(:tag, name: name, slug: String.downcase(name))
+      tag = insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
       Vutuv.Tags.follow_tag(viewer, tag)
       {:ok, _} = Vutuv.Social.block_user(viewer, blocked)
 
@@ -1031,7 +1034,7 @@ defmodule Vutuv.PostsTest do
       viewer = user()
       stranger = user()
       name = unique_tag_name("Elixir")
-      insert(:tag, name: name, slug: String.downcase(name))
+      insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
 
       tagged = create_post!(stranger, %{body: "elixir news", tags: String.downcase(name)})
 

--- a/test/vutuv/repo/merge_tag_spelling_variants_test.exs
+++ b/test/vutuv/repo/merge_tag_spelling_variants_test.exs
@@ -112,7 +112,7 @@ defmodule Vutuv.Repo.MergeTagSpellingVariantsTest do
       untouched = tag(second, second)
 
       # Somebody put this one somewhere else already.
-      elsewhere = tag("elsewhere-#{System.unique_integer([:positive])}", "Elsewhere")
+      elsewhere = tag("elsewhere_#{System.unique_integer([:positive])}", "Elsewhere")
       {:ok, _} = Merge.merge(already, elsewhere)
 
       report = @migration.apply_merges(Repo)

--- a/test/vutuv/repo/retag_slugs_to_actor_grammar_test.exs
+++ b/test/vutuv/repo/retag_slugs_to_actor_grammar_test.exs
@@ -30,6 +30,16 @@ defmodule Vutuv.Repo.RetagSlugsToActorGrammarTest do
     :ok
   end
 
+  setup do
+    # This migration predates `tags_slug_actor_grammar`, so testing it means
+    # building the world it ran in — which that constraint forbids. Dropping it
+    # here is safe and self-cleaning: the SQL sandbox wraps each test in a
+    # transaction that never commits, so the constraint is back the moment the
+    # test ends.
+    Repo.query!("ALTER TABLE tags DROP CONSTRAINT tags_slug_actor_grammar")
+    :ok
+  end
+
   defp tag(name, slug, attrs \\ []), do: insert(:tag, [name: name, slug: slug] ++ attrs)
 
   defp reload(%Tag{id: id}), do: Repo.get!(Tag, id)

--- a/test/vutuv/search_test.exs
+++ b/test/vutuv/search_test.exs
@@ -118,7 +118,7 @@ defmodule Vutuv.SearchTest do
 
     test "tags match by name or slug prefix, case-insensitively" do
       name = unique_tag_name("Elixir")
-      tag = insert(:tag, name: name, slug: String.downcase(name))
+      tag = insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
       insert(:tag)
 
       assert Enum.map(Search.instant("eLi").tags, & &1.id) == [tag.id]
@@ -126,7 +126,7 @@ defmodule Vutuv.SearchTest do
 
     test "the tag member count excludes unactivated and moderation-hidden members" do
       name = unique_tag_name("Elixir")
-      tag = insert(:tag, name: name, slug: String.downcase(name))
+      tag = insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
 
       visible = searchable_user("Vera", "Visible")
       unactivated = insert(:user, email_confirmed?: false)
@@ -263,7 +263,7 @@ defmodule Vutuv.SearchTest do
 
     test "status combines with a tag filter", ctx do
       name = unique_tag_name("Elixir")
-      tag = insert(:tag, name: name, slug: String.downcase(name))
+      tag = insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
       insert(:user_tag, tag: tag, user: ctx.looking)
       # A looking member without the tag must not match.
       insert(:activated_user,
@@ -314,7 +314,7 @@ defmodule Vutuv.SearchTest do
 
     test "tag: lists people with that tag, not the tag itself" do
       name = unique_tag_name("PHP")
-      tag = insert(:tag, name: name, slug: String.downcase(name))
+      tag = insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
       with_tag = insert(:activated_user, first_name: "Paula", last_name: "Programmer")
       insert(:user_tag, tag: tag, user: with_tag)
       insert(:activated_user, first_name: "Norbert", last_name: "NoTag")
@@ -330,7 +330,7 @@ defmodule Vutuv.SearchTest do
 
     test "a name combines with the tag filter" do
       name = unique_tag_name("PHP")
-      php_tag = insert(:tag, name: name, slug: String.downcase(name))
+      php_tag = insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
       php_mueller = searchable_user("Hans", "Müller")
       insert(:user_tag, tag: php_tag, user: php_mueller)
       searchable_user("Heike", "Müller")
@@ -342,7 +342,7 @@ defmodule Vutuv.SearchTest do
 
     test "tag: also finds posts carrying that tag, matching the tag not the body (issue #946)" do
       name = unique_tag_name("PHP")
-      tag = insert(:tag, name: name, slug: String.downcase(name))
+      tag = insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
       with_tag = insert(:activated_user)
       insert(:user_tag, tag: tag, user: with_tag)
 
@@ -362,7 +362,7 @@ defmodule Vutuv.SearchTest do
 
     test "the Posts scope with a tag: filter returns only posts" do
       name = unique_tag_name("PHP")
-      tag = insert(:tag, name: name, slug: String.downcase(name))
+      tag = insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
       with_tag = insert(:activated_user)
       insert(:user_tag, tag: tag, user: with_tag)
 
@@ -408,7 +408,7 @@ defmodule Vutuv.SearchTest do
 
     test "tags carry their member counts" do
       name = unique_tag_name("Elixir")
-      tag = insert(:tag, name: name, slug: String.downcase(name))
+      tag = insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
       insert(:user_tag, tag: tag, user: insert(:activated_user))
       insert(:user_tag, tag: tag, user: insert(:activated_user))
 
@@ -420,7 +420,7 @@ defmodule Vutuv.SearchTest do
     test "the scope filter limits what is searched" do
       searchable_user("Elia", "Tester")
       name = unique_tag_name("Elixir")
-      insert(:tag, name: name, slug: String.downcase(name))
+      insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
       author = insert(:activated_user)
       Vutuv.PostsHelpers.create_post!(author, %{body: "All about elixir and more"})
 

--- a/test/vutuv/tags/assistant_test.exs
+++ b/test/vutuv/tags/assistant_test.exs
@@ -29,7 +29,7 @@ defmodule Vutuv.Tags.AssistantTest do
   end
 
   defp tag(name) do
-    insert(:tag, name: name, slug: Vutuv.SlugHelpers.gen_slug_unique(name, Tag, :slug))
+    insert(:tag, name: name, slug: Vutuv.SlugHelpers.gen_tag_slug_unique(name, Tag, :slug))
   end
 
   defp entry(name), do: %{id: Vutuv.UUIDv7.generate(), name: name}

--- a/test/vutuv/tags/merge_test.exs
+++ b/test/vutuv/tags/merge_test.exs
@@ -17,7 +17,7 @@ defmodule Vutuv.Tags.MergeTest do
   alias Vutuv.Tags.UserTagEndorsement
 
   defp tag(name) do
-    insert(:tag, name: name, slug: Vutuv.SlugHelpers.gen_slug_unique(name, Tag, :slug))
+    insert(:tag, name: name, slug: Vutuv.SlugHelpers.gen_tag_slug_unique(name, Tag, :slug))
   end
 
   setup do

--- a/test/vutuv/tags/merged_tags_hidden_test.exs
+++ b/test/vutuv/tags/merged_tags_hidden_test.exs
@@ -33,7 +33,7 @@ defmodule Vutuv.Tags.MergedTagsHiddenTest do
     %{canonical: canonical, absorbed: absorbed}
   end
 
-  defp slugify(name), do: Vutuv.SlugHelpers.gen_slug_unique(name, Tag, :slug)
+  defp slugify(name), do: Vutuv.SlugHelpers.gen_tag_slug_unique(name, Tag, :slug)
 
   defp with_two_visible_members(tag) do
     for _ <- 1..2, do: insert(:user_tag, user: insert(:activated_user), tag: tag)

--- a/test/vutuv/tags/separator_lookup_test.exs
+++ b/test/vutuv/tags/separator_lookup_test.exs
@@ -3,11 +3,15 @@ defmodule Vutuv.Tags.SeparatorLookupTest do
   One topic, however its separator is typed (issue #1332, want 1).
 
   `Tag.find_by_value/1` used to key on the exact lowercased name or the exact
-  slug, so space against hyphen resolved by accident (the slugifier writes
-  hyphens, and the slug is one of the two keys) while **underscore against
-  anything did not** — in either direction. That is the shape the older half of
-  the catalog carries, so the lookup kept minting a second page for a topic that
+  slug, so space against hyphen resolved by accident (the slugifier wrote
+  hyphens then, and the slug is one of the two keys) while **underscore against
+  anything did not** — in either direction. That was the shape the older half of
+  the catalog carried, so the lookup kept minting a second page for a topic that
   already had one, which is the sprawl #1338's merge pass had just cleaned up.
+
+  Since v7.276.2 a live slug can only be `^[a-z0-9_]+$`, so the spellings that
+  differ now sit on the **name** (which keeps whatever its first writer typed)
+  and on the retired alias rows — and that is where this still has to hold.
 
   Every tag here is minted per test with a unique name, because the tag name is
   a shared lookup key and the slug a unique index (the async rule in
@@ -18,14 +22,17 @@ defmodule Vutuv.Tags.SeparatorLookupTest do
   alias Vutuv.Tags
   alias Vutuv.Tags.Tag
 
+  # A live tag's slug is an actor name now (`tags_slug_actor_grammar`), so the
+  # old spellings live on the **name** and on retired alias rows. That is
+  # exactly where the folding still has to work.
   defp seed(name, slug) do
     n = System.unique_integer([:positive])
     insert(:tag, name: "#{name} #{n}", slug: "#{slug}#{n}")
   end
 
   describe "find_by_value/1 folds separators" do
-    test "a hyphen-slug topic is found however the separator is typed" do
-      tag = seed("Probe Framework", "probe-framework-")
+    test "a topic is found however the separator is typed" do
+      tag = seed("Probe Framework", "probe_framework_")
       base = tag.name
 
       for typed <- [
@@ -58,7 +65,7 @@ defmodule Vutuv.Tags.SeparatorLookupTest do
     end
 
     test "a run of separators collapses to one, but a missing one is not invented" do
-      tag = seed("Open Source Software", "open-source-software-")
+      tag = seed("Open Source Software", "open_source_software_")
 
       assert %Tag{id: id} = Tag.find_by_value(String.replace(tag.name, " ", " - _ "))
       assert id == tag.id
@@ -69,7 +76,7 @@ defmodule Vutuv.Tags.SeparatorLookupTest do
     end
 
     test "a zero-width character is invisible to a reader and must be to the lookup" do
-      tag = seed("Zero Width", "zero-width-")
+      tag = seed("Zero Width", "zero_width_")
 
       assert %Tag{id: id} = Tag.find_by_value(String.replace(tag.name, " ", "​ "))
       assert id == tag.id
@@ -78,7 +85,7 @@ defmodule Vutuv.Tags.SeparatorLookupTest do
     test "a name with nothing to key on matches nothing, rather than grouping" do
       # These normalize to an empty key. Bucketing them would make every one of
       # them the same topic as every other.
-      seed("Dash", "dash-")
+      seed("Dash", "dash_")
 
       for value <- ["-", "--", "_", " ", "."] do
         refute Tag.find_by_value(value), "#{inspect(value)} resolved to a tag"
@@ -86,7 +93,7 @@ defmodule Vutuv.Tags.SeparatorLookupTest do
     end
 
     test "an alias still resolves to its canonical topic, whatever the spelling" do
-      canonical = seed("Canonical Topic", "canonical-topic-")
+      canonical = seed("Canonical Topic", "canonical_topic_")
       n = System.unique_integer([:positive])
 
       alias_tag =
@@ -103,7 +110,7 @@ defmodule Vutuv.Tags.SeparatorLookupTest do
 
   describe "canonical_tag_names/1 uses the same key" do
     test "two spellings of one topic count once" do
-      tag = seed("Batch Topic", "batch-topic-")
+      tag = seed("Batch Topic", "batch_topic_")
       spaced = tag.name
       underscored = String.replace(tag.name, " ", "_")
 

--- a/test/vutuv/tags/slug_grammar_constraint_test.exs
+++ b/test/vutuv/tags/slug_grammar_constraint_test.exs
@@ -1,0 +1,60 @@
+defmodule Vutuv.Tags.SlugGrammarConstraintTest do
+  @moduledoc """
+  What keeps tag slugs inside the actor grammar once they are there (issue
+  #1332, the last piece): the database constraint and the changeset that says
+  the same thing before it.
+
+  Both halves matter. The constraint is the guarantee #1330 mints actors on;
+  the validation is what turns an admin's hand-typed slug into a field error
+  rather than a 500.
+  """
+  use Vutuv.DataCase, async: true
+
+  alias Vutuv.Tags.Tag
+
+  defp changeset(attrs), do: Tag.edit_changeset(%Tag{}, attrs)
+
+  test "a live slug may hold only lowercase letters, digits and underscores" do
+    assert %{valid?: true} = changeset(%{"name" => "Elixir", "slug" => "elixir_lang"})
+
+    for bad <- ["elixir-lang", "Elixir", "elixir.lang", "elixir lang", "c++"] do
+      cs = changeset(%{"name" => "Elixir", "slug" => bad})
+      refute cs.valid?, "#{bad} passed"
+      assert "may contain only lowercase letters, digits and underscores" in errors_on(cs).slug
+    end
+  end
+
+  test "an alias keeps the retired spelling it exists to preserve" do
+    n = System.unique_integer([:positive])
+    topic = insert(:tag, name: "Topic #{n}", slug: "topic_#{n}")
+
+    # The row that makes `/tags/<old>` answer 301 has to be allowed to hold
+    # exactly the shape the constraint forbids everywhere else. Written the way
+    # the retag migration writes it, which is what actually files these.
+    retired =
+      Repo.insert!(%Tag{
+        name: "topic-#{n}",
+        slug: "topic-#{n}",
+        merged_into_id: topic.id,
+        alias_kind: "former"
+      })
+
+    assert retired.slug == "topic-#{n}"
+  end
+
+  test "the database refuses a live row the validation would have caught" do
+    n = System.unique_integer([:positive])
+
+    # Straight past the changeset, the way a migration or a raw statement would.
+    assert_raise Postgrex.Error, ~r/tags_slug_actor_grammar/, fn ->
+      Repo.query!(
+        "insert into tags (id, name, slug, inserted_at, updated_at) values ($1, $2, $3, now(), now())",
+        [
+          Ecto.UUID.dump!(Vutuv.UUIDv7.generate()),
+          "Bad #{n}",
+          "bad-#{n}"
+        ]
+      )
+    end
+  end
+end

--- a/test/vutuv/tags/tag_alias_input_test.exs
+++ b/test/vutuv/tags/tag_alias_input_test.exs
@@ -37,7 +37,7 @@ defmodule Vutuv.Tags.TagAliasInputTest do
     )
   end
 
-  defp slugify(name), do: Vutuv.SlugHelpers.gen_slug_unique(name, Tag, :slug)
+  defp slugify(name), do: Vutuv.SlugHelpers.gen_tag_slug_unique(name, Tag, :slug)
 
   describe "canonical_tag_names/1" do
     test "replaces an alternative name with the topic it points at", ctx do

--- a/test/vutuv/tags/tag_alias_test.exs
+++ b/test/vutuv/tags/tag_alias_test.exs
@@ -21,14 +21,14 @@ defmodule Vutuv.Tags.TagAliasTest do
     name = unique_tag_name("Ruby on Rails")
 
     canonical =
-      insert(:tag, name: name, slug: Vutuv.SlugHelpers.gen_slug_unique(name, Tag, :slug))
+      insert(:tag, name: name, slug: Vutuv.SlugHelpers.gen_tag_slug_unique(name, Tag, :slug))
 
     alias_name = unique_tag_name("ROR")
 
     tag_alias =
       insert(:tag,
         name: alias_name,
-        slug: Vutuv.SlugHelpers.gen_slug_unique(alias_name, Tag, :slug),
+        slug: Vutuv.SlugHelpers.gen_tag_slug_unique(alias_name, Tag, :slug),
         merged_into_id: canonical.id,
         alias_kind: kind
       )

--- a/test/vutuv/tags/timeline_test.exs
+++ b/test/vutuv/tags/timeline_test.exs
@@ -29,7 +29,7 @@ defmodule Vutuv.Tags.TimelineTest do
   # The module's own tag, whether a post in this test already minted it or not.
   defp elixir_tag do
     Repo.get_by(Tag, name: @elixir_tag) ||
-      insert(:tag, name: @elixir_tag, slug: @elixir_tag)
+      insert(:tag, name: @elixir_tag, slug: Vutuv.SlugHelpers.tagify(@elixir_tag))
   end
 
   defp ids(%{entries: entries}), do: Enum.map(entries, & &1.id)
@@ -128,7 +128,7 @@ defmodule Vutuv.Tags.TimelineTest do
     test "a post reaching the tag through a body hashtag is listed once" do
       a = author()
       tag = insert(:tag, name: "berlin_#{System.unique_integer([:positive])}")
-      tag = Repo.update!(Ecto.Changeset.change(tag, slug: String.downcase(tag.name)))
+      tag = Repo.update!(Ecto.Changeset.change(tag, slug: Vutuv.SlugHelpers.tagify(tag.name)))
 
       # Both filings at once: the composer's field and the body's hashtag. One
       # entry, or the tag page would print the post twice.

--- a/test/vutuv/tags_test.exs
+++ b/test/vutuv/tags_test.exs
@@ -22,7 +22,7 @@ defmodule Vutuv.TagsTest do
 
     test "links to an existing tag whose name matches case-insensitively" do
       name = unique_tag_name("Elixir")
-      tag = insert(:tag, name: name, slug: String.downcase(name))
+      tag = insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
       changeset = link(String.downcase(name))
       assert get_change(changeset, :tag_id) == tag.id
     end
@@ -72,7 +72,7 @@ defmodule Vutuv.TagsTest do
       # existing spaced tag (matched case-insensitively by name), it does not
       # mint a duplicate.
       name = unique_tag_name("Ruby on Rails")
-      slug = name |> String.downcase() |> String.replace(" ", "-")
+      slug = Vutuv.SlugHelpers.tagify(name)
       tag = insert(:tag, name: name, slug: slug)
 
       changeset = link(String.downcase(name))
@@ -135,7 +135,7 @@ defmodule Vutuv.TagsTest do
     test "the admin edit form can recapitalize a legacy lowercase name" do
       name = unique_tag_name("Elixir")
       legacy = String.downcase(name)
-      tag = insert(:tag, name: legacy, slug: legacy)
+      tag = insert(:tag, name: legacy, slug: Vutuv.SlugHelpers.tagify(legacy))
 
       assert {:ok, updated} = tag |> Tag.edit_changeset(%{"name" => name}) |> Repo.update()
       assert updated.name == name
@@ -167,7 +167,7 @@ defmodule Vutuv.TagsTest do
       # The lookup in create_or_link_tag/2 would otherwise attach one of the
       # legacy URL tags in production without ever building a changeset.
       name = "www.legacy-#{System.unique_integer([:positive])}.com"
-      legacy = insert(:tag, name: name, slug: String.replace(name, ".", "_"))
+      legacy = insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
 
       assert {:error, changeset} = Tags.add_user_tag(insert(:user), name)
       assert "must not be a web or email address" in errors_on(changeset).tag_id
@@ -206,7 +206,7 @@ defmodule Vutuv.TagsTest do
     end
 
     test "a punctuation tag minted before the rule can't be linked either" do
-      legacy = insert(:tag, name: "-", slug: "-")
+      legacy = insert(:tag, name: "-", slug: "_")
 
       assert {:error, changeset} = Tags.add_user_tag(insert(:user), "-")
       assert "must not be only punctuation" in errors_on(changeset).tag_id
@@ -368,7 +368,7 @@ defmodule Vutuv.TagsTest do
 
     test "create_or_link_tag links #Elixir to the existing Elixir tag" do
       name = unique_tag_name("Elixir")
-      tag = insert(:tag, name: name, slug: String.downcase(name))
+      tag = insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
 
       changeset =
         %UserTag{} |> change(%{}) |> Tag.create_or_link_tag(%{"value" => "#" <> name})
@@ -608,7 +608,7 @@ defmodule Vutuv.TagsTest do
     test "add_user_tag/2 refuses a reserved (honor) tag" do
       user = insert(:user)
       name = unique_tag_name("vutuv_developer")
-      insert(:tag, name: name, slug: name, honor?: true)
+      insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name), honor?: true)
 
       assert {:error, changeset} = Tags.add_user_tag(user, name)
       assert %{tag_id: [_ | _]} = errors_on(changeset)
@@ -619,7 +619,7 @@ defmodule Vutuv.TagsTest do
     test "add_user_tag/2 refuses a reserved tag matched case-insensitively" do
       user = insert(:user)
       name = unique_tag_name("vutuv_developer")
-      insert(:tag, name: name, slug: name, honor?: true)
+      insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name), honor?: true)
 
       assert {:error, _changeset} = Tags.add_user_tag(user, String.upcase(name))
       refute Repo.exists?(from(ut in UserTag, where: ut.user_id == ^user.id))
@@ -628,7 +628,7 @@ defmodule Vutuv.TagsTest do
     test "add_user_tag/2 still links a normal (not honor) existing tag" do
       user = insert(:user)
       name = unique_tag_name("Elixir")
-      tag = insert(:tag, name: name, slug: String.downcase(name))
+      tag = insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
 
       assert {:ok, user_tag} = Tags.add_user_tag(user, String.downcase(name))
       assert user_tag.tag_id == tag.id
@@ -711,7 +711,7 @@ defmodule Vutuv.TagsTest do
 
     test "declare_honor_tag/1 flips an existing holder-less tag" do
       name = unique_tag_name("mentor")
-      existing = insert(:tag, name: name, slug: name)
+      existing = insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
 
       assert {:ok, tag} = Tags.declare_honor_tag(String.capitalize(name))
       assert tag.id == existing.id
@@ -720,7 +720,7 @@ defmodule Vutuv.TagsTest do
 
     test "declare_honor_tag/1 is idempotent on an existing honor tag" do
       name = unique_tag_name("mentor")
-      existing = insert(:tag, name: name, slug: name, honor?: true)
+      existing = insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name), honor?: true)
 
       assert {:ok, tag} = Tags.declare_honor_tag(name)
       assert tag.id == existing.id
@@ -728,7 +728,7 @@ defmodule Vutuv.TagsTest do
 
     test "declare_honor_tag/1 refuses to silently flip a tag members already hold" do
       name = unique_tag_name("elixir")
-      existing = insert(:tag, name: name, slug: name)
+      existing = insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
       insert(:user_tag, user: insert(:user), tag: existing)
 
       assert {:error, :has_holders, tag} = Tags.declare_honor_tag(name)
@@ -903,7 +903,7 @@ defmodule Vutuv.TagsTest do
 
     test "leaves a clean multi-word name untouched and is idempotent" do
       name = unique_tag_name("Ruby on Rails")
-      tag = insert(:tag, name: name, slug: name |> String.downcase() |> String.replace(" ", "_"))
+      tag = insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
 
       assert {0, 0} = Tags.normalize_legacy_tag_whitespace()
       assert Repo.get(Tag, tag.id).name == name

--- a/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
+++ b/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
@@ -165,7 +165,7 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     insert(:messenger, user: user, provider: "Telegram", value: "gretachats")
 
     tag_name = unique_tag_name("Bridgebuilding")
-    tag = insert(:tag, name: tag_name, slug: String.downcase(tag_name))
+    tag = insert(:tag, name: tag_name, slug: Vutuv.SlugHelpers.tagify(tag_name))
     insert(:user_tag, user: user, tag: tag)
 
     follower = insert_activated_user(first_name: "Fanny", last_name: "Follower")
@@ -1327,14 +1327,17 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     gamma = unique_tag_name("Gamma")
 
     for name <- [beta, alpha, gamma] do
-      insert(:user_tag, user: user, tag: insert(:tag, name: name, slug: String.downcase(name)))
+      insert(:user_tag,
+        user: user,
+        tag: insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
+      )
     end
 
     [gamma_ut] =
       Repo.all(
         from(u in Vutuv.Tags.UserTag,
           join: t in assoc(u, :tag),
-          where: t.slug == ^String.downcase(gamma)
+          where: t.slug == ^Vutuv.SlugHelpers.tagify(gamma)
         )
       )
 

--- a/test/vutuv_web/agent_docs/markdown_format_test.exs
+++ b/test/vutuv_web/agent_docs/markdown_format_test.exs
@@ -138,7 +138,10 @@ defmodule VutuvWeb.AgentDocs.MarkdownFormatTest do
       beta = unique_tag_name("beta")
 
       for name <- [alpha, beta] do
-        insert(:user_tag, user: user, tag: insert(:tag, name: name, slug: name))
+        insert(:user_tag,
+          user: user,
+          tag: insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
+        )
       end
 
       body = get(build_conn(), "/#{user.username}.md").resp_body

--- a/test/vutuv_web/controllers/admin/honor_tag_controller_test.exs
+++ b/test/vutuv_web/controllers/admin/honor_tag_controller_test.exs
@@ -16,7 +16,7 @@ defmodule VutuvWeb.Admin.HonorTagControllerTest do
 
     test "index lists honor tags and links to the create form", %{conn: conn} do
       # A distinct name, not the "vutuv_developer" the intro/placeholder mention.
-      insert(:tag, name: "vutuv_council", slug: "vutuv-council", honor?: true)
+      insert(:tag, name: "vutuv_council", slug: "vutuv_council", honor?: true)
       normal_tag = insert(:tag)
 
       html = conn |> get(~p"/admin/honor_tags") |> html_response(200)
@@ -38,23 +38,23 @@ defmodule VutuvWeb.Admin.HonorTagControllerTest do
 
     test "creating flips an existing holder-less tag", %{conn: conn} do
       name = unique_tag_name("mentor")
-      tag = insert(:tag, name: name, slug: name)
+      tag = insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
 
       conn = post(conn, ~p"/admin/honor_tags", honor_tag: %{name: name})
 
-      assert redirected_to(conn) == ~p"/admin/tags/#{name}"
+      assert redirected_to(conn) == ~p"/admin/tags/#{Vutuv.SlugHelpers.tagify(name)}"
       assert Repo.reload(tag).honor?
     end
 
     test "creating a name members already hold routes to the edit warning, not a silent flip",
          %{conn: conn} do
       name = unique_tag_name("elixir")
-      tag = insert(:tag, name: name, slug: name)
+      tag = insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
       insert(:user_tag, user: insert(:user), tag: tag)
 
       conn = post(conn, ~p"/admin/honor_tags", honor_tag: %{name: name})
 
-      assert redirected_to(conn) == ~p"/admin/tags/#{name}/edit"
+      assert redirected_to(conn) == ~p"/admin/tags/#{Vutuv.SlugHelpers.tagify(name)}/edit"
       refute Repo.reload(tag).honor?
     end
 

--- a/test/vutuv_web/controllers/admin/tag_controller_test.exs
+++ b/test/vutuv_web/controllers/admin/tag_controller_test.exs
@@ -22,14 +22,14 @@ defmodule VutuvWeb.Admin.TagControllerTest do
     test "paginates: rows past the first page land on page 2", %{conn: conn} do
       # 250/page (max_page_items); the slug-ordered listing puts the marker last.
       insert_list(250, :tag)
-      insert(:tag, name: "Zzz Marker", slug: "zzz-marker")
+      insert(:tag, name: "Zzz Marker", slug: "zzz_marker")
 
       page1 = conn |> get(~p"/admin/tags") |> html_response(200)
-      refute page1 =~ "zzz-marker"
+      refute page1 =~ "zzz_marker"
       assert page1 =~ "page=2"
 
       page2 = conn |> recycle() |> get(~p"/admin/tags?page=2") |> html_response(200)
-      assert page2 =~ "zzz-marker"
+      assert page2 =~ "zzz_marker"
     end
   end
 
@@ -37,8 +37,8 @@ defmodule VutuvWeb.Admin.TagControllerTest do
     test "filters the listing by name (case-insensitive substring)", %{conn: conn} do
       elixir_name = unique_tag_name("Elixir")
       ruby_name = unique_tag_name("Ruby")
-      insert(:tag, name: elixir_name, slug: String.downcase(elixir_name))
-      insert(:tag, name: ruby_name, slug: String.downcase(ruby_name))
+      insert(:tag, name: elixir_name, slug: Vutuv.SlugHelpers.tagify(elixir_name))
+      insert(:tag, name: ruby_name, slug: Vutuv.SlugHelpers.tagify(ruby_name))
 
       html = conn |> get(~p"/admin/tags?q=eli") |> html_response(200)
       assert html =~ elixir_name
@@ -46,10 +46,10 @@ defmodule VutuvWeb.Admin.TagControllerTest do
     end
 
     test "filters the listing by slug", %{conn: conn} do
-      insert(:tag, name: "C Sharp", slug: "c-sharp")
+      insert(:tag, name: "C Sharp", slug: "c_sharp")
       insert(:tag, name: "Go", slug: "golang")
 
-      html = conn |> get(~p"/admin/tags?q=c-sharp") |> html_response(200)
+      html = conn |> get(~p"/admin/tags?q=c_sharp") |> html_response(200)
       assert html =~ "C Sharp"
       refute html =~ "golang"
     end
@@ -90,15 +90,15 @@ defmodule VutuvWeb.Admin.TagControllerTest do
 
     test "pagination keeps the search filter", %{conn: conn} do
       insert_list(250, :tag)
-      insert(:tag, name: "Tag Zzz Marker", slug: "tag-zzz-marker")
+      insert(:tag, name: "Tag Zzz Marker", slug: "tag_zzz_marker")
 
       page1 = conn |> get(~p"/admin/tags?q=tag") |> html_response(200)
-      refute page1 =~ "tag-zzz-marker"
+      refute page1 =~ "tag_zzz_marker"
       assert page1 =~ "q=tag"
       assert page1 =~ "page=2"
 
       page2 = conn |> recycle() |> get(~p"/admin/tags?q=tag&page=2") |> html_response(200)
-      assert page2 =~ "tag-zzz-marker"
+      assert page2 =~ "tag_zzz_marker"
     end
   end
 

--- a/test/vutuv_web/controllers/admin/tag_member_controller_test.exs
+++ b/test/vutuv_web/controllers/admin/tag_member_controller_test.exs
@@ -16,7 +16,7 @@ defmodule VutuvWeb.Admin.TagMemberControllerTest do
     setup %{conn: conn} do
       {conn, admin} = create_and_login_admin(conn)
       name = unique_tag_name("vutuv_developer")
-      tag = insert(:tag, name: name, slug: name, honor?: true)
+      tag = insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name), honor?: true)
       {:ok, conn: conn, admin: admin, tag: tag}
     end
 

--- a/test/vutuv_web/controllers/listing_batching_test.exs
+++ b/test/vutuv_web/controllers/listing_batching_test.exs
@@ -68,7 +68,7 @@ defmodule VutuvWeb.ListingBatchingTest do
 
       # Five more tags, so the member has six in all: four are shown, two overflow.
       for n <- 1..5 do
-        insert(:user_tag, user: star, tag: insert(:tag, name: "Extra #{n}", slug: "extra-#{n}"))
+        insert(:user_tag, user: star, tag: insert(:tag, name: "Extra #{n}", slug: "extra_#{n}"))
       end
 
       body = conn |> get(~p"/listings/most_followed_users") |> html_response(200)
@@ -168,7 +168,7 @@ defmodule VutuvWeb.ListingBatchingTest do
       for n <- 1..5 do
         insert(:user_tag,
           user: follower,
-          tag: insert(:tag, name: "Extra #{n}", slug: "f-extra-#{n}")
+          tag: insert(:tag, name: "Extra #{n}", slug: "f_extra_#{n}")
         )
       end
 
@@ -191,7 +191,7 @@ defmodule VutuvWeb.ListingBatchingTest do
       insert(:user_tag_endorsement, user_tag: popular_ut, user: owner)
 
       for n <- 1..5 do
-        insert(:user_tag, user: idol, tag: insert(:tag, name: "More #{n}", slug: "g-more-#{n}"))
+        insert(:user_tag, user: idol, tag: insert(:tag, name: "More #{n}", slug: "g_more_#{n}"))
       end
 
       body = conn |> get(~p"/#{owner}/following") |> html_response(200)

--- a/test/vutuv_web/controllers/sitemap_controller_test.exs
+++ b/test/vutuv_web/controllers/sitemap_controller_test.exs
@@ -102,14 +102,14 @@ defmodule VutuvWeb.SitemapControllerTest do
       # advertised: at least Tags.min_indexable_members/0 visible members or
       # one public post. Advertising all ~10K tags put most of them into
       # Search Console as "crawled - currently not indexed".
-      rich = insert(:tag, slug: "elixir-mapped")
+      rich = insert(:tag, slug: "elixir_mapped")
 
       for _ <- 1..Vutuv.Tags.min_indexable_members() do
         insert(:user_tag, user: insert_activated_user(), tag: rich)
       end
 
-      empty = insert(:tag, slug: unique_tag_name("unused"))
-      thin = insert(:tag, slug: unique_tag_name("thin"))
+      empty = insert(:tag, slug: Vutuv.SlugHelpers.tagify(unique_tag_name("unused")))
+      thin = insert(:tag, slug: Vutuv.SlugHelpers.tagify(unique_tag_name("thin")))
       insert(:user_tag, user: insert_activated_user(), tag: thin)
 
       author = insert_activated_user()
@@ -119,7 +119,7 @@ defmodule VutuvWeb.SitemapControllerTest do
       conn = get(build_conn(), "/sitemaps/tags-1.xml")
 
       assert conn.status == 200
-      assert conn.resp_body =~ "<loc>#{@base}/tags/elixir-mapped</loc>"
+      assert conn.resp_body =~ "<loc>#{@base}/tags/elixir_mapped</loc>"
       assert conn.resp_body =~ "<loc>#{@base}/tags/#{Vutuv.SlugHelpers.tagify(posted_name)}</loc>"
       refute conn.resp_body =~ empty.slug
       refute conn.resp_body =~ thin.slug

--- a/test/vutuv_web/fediverse/docs_test.exs
+++ b/test/vutuv_web/fediverse/docs_test.exs
@@ -195,7 +195,7 @@ defmodule VutuvWeb.Fediverse.DocsTest do
     test "a multi-word tag loses its separator instead of breaking in half" do
       author = insert(:activated_user)
       n = System.unique_integer([:positive])
-      tag = insert(:tag, name: "Machine Learning #{n}", slug: "machine-learning-#{n}")
+      tag = insert(:tag, name: "Machine Learning #{n}", slug: "machine_learning_#{n}")
 
       note = tagged_note(author, %{body: "Kurz notiert.", tags: tag.name})
 
@@ -212,7 +212,7 @@ defmodule VutuvWeb.Fediverse.DocsTest do
     test "a tag that cannot become a hashtag is left out, never sent as a bare #" do
       author = insert(:activated_user)
       n = System.unique_integer([:positive])
-      tag = insert(:tag, name: "***", slug: "sternchen-#{n}")
+      tag = insert(:tag, name: "***", slug: "sternchen_#{n}")
       {:ok, post} = Vutuv.Posts.create_post(author, %{body: "Kurz notiert."})
 
       # Filed directly: a punctuation-only name is legacy data the composer no

--- a/test/vutuv_web/json_ld_test.exs
+++ b/test/vutuv_web/json_ld_test.exs
@@ -44,7 +44,7 @@ defmodule VutuvWeb.JsonLdTest do
       )
 
       insert(:social_media_account, user: user, provider: "GitHub", value: "lara")
-      tag = insert(:tag, name: "Elixir", slug: "elixir-ld")
+      tag = insert(:tag, name: "Elixir", slug: "elixir_ld")
       insert(:user_tag, user: user, tag: tag)
 
       html = build_conn() |> get("/ld_member") |> html_response(200)

--- a/test/vutuv_web/live/admin/tag_merge_live_test.exs
+++ b/test/vutuv_web/live/admin/tag_merge_live_test.exs
@@ -15,7 +15,7 @@ defmodule VutuvWeb.Admin.TagMergeLiveTest do
   alias Vutuv.Tags.UserTag
 
   defp tag(name) do
-    insert(:tag, name: name, slug: Vutuv.SlugHelpers.gen_slug_unique(name, Tag, :slug))
+    insert(:tag, name: name, slug: Vutuv.SlugHelpers.gen_tag_slug_unique(name, Tag, :slug))
   end
 
   describe "authorization" do

--- a/test/vutuv_web/live/feed_remote_posts_test.exs
+++ b/test/vutuv_web/live/feed_remote_posts_test.exs
@@ -460,7 +460,7 @@ defmodule VutuvWeb.FeedRemotePostsTest do
     # against another async module inserting the same one.
     defp linkable_tag do
       name = "Berlin_#{System.unique_integer([:positive])}"
-      tag = insert(:tag, name: name, slug: String.downcase(name))
+      tag = insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
       insert(:user_tag, user: insert(:activated_user), tag: tag)
       tag
     end

--- a/test/vutuv_web/live/search_live_test.exs
+++ b/test/vutuv_web/live/search_live_test.exs
@@ -109,11 +109,15 @@ defmodule VutuvWeb.SearchLiveTest do
 
     test "matching tags show as chips linking to the tag page", %{conn: conn} do
       name = unique_tag_name("Elixir")
-      insert(:tag, name: name, slug: String.downcase(name))
+      insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
 
       {:ok, view, _html} = live(conn, ~p"/search?q=eli")
 
-      assert has_element?(view, ~s(#search-tags a[href="/tags/#{String.downcase(name)}"]), name)
+      assert has_element?(
+               view,
+               ~s(#search-tags a[href="/tags/#{Vutuv.SlugHelpers.tagify(name)}"]),
+               name
+             )
     end
 
     test "matching public posts show with author and permalink", %{conn: conn} do
@@ -196,7 +200,7 @@ defmodule VutuvWeb.SearchLiveTest do
 
     test "tag and post matches are marked too", %{conn: conn} do
       name = unique_tag_name("Elixir")
-      insert(:tag, name: name, slug: String.downcase(name))
+      insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
       author = insert(:activated_user)
       create_post!(author, %{body: "Quantum gardening tips for beginners"})
 
@@ -222,7 +226,7 @@ defmodule VutuvWeb.SearchLiveTest do
     test "the scope chips narrow the search and the URL carries the filter", %{conn: conn} do
       searchable_user("Elia", "Tester")
       name = unique_tag_name("Elixir")
-      insert(:tag, name: name, slug: String.downcase(name))
+      insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
 
       {:ok, view, _html} = live(conn, ~p"/search?q=eli")
       assert has_element?(view, "#search-people")
@@ -287,7 +291,7 @@ defmodule VutuvWeb.SearchLiveTest do
 
     test "tag chips carry member counts", %{conn: conn} do
       name = unique_tag_name("Elixir")
-      tag = insert(:tag, name: name, slug: String.downcase(name))
+      tag = insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
       insert(:user_tag, tag: tag, user: insert(:activated_user))
 
       {:ok, view, _html} = live(conn, ~p"/search?q=elixir")
@@ -334,7 +338,7 @@ defmodule VutuvWeb.SearchLiveTest do
 
     test "tag: lists the people with that tag, not the tag itself", %{conn: conn} do
       name = unique_tag_name("PHP")
-      tag = insert(:tag, name: name, slug: String.downcase(name))
+      tag = insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
       tagged = insert(:activated_user, first_name: "Paula", last_name: "Programmer")
       insert(:user_tag, tag: tag, user: tagged)
       insert(:activated_user, first_name: "Norbert", last_name: "NoTag")
@@ -349,7 +353,7 @@ defmodule VutuvWeb.SearchLiveTest do
     test "tag: also lists posts carrying that tag, and keeps the chips enabled (issue #946)",
          %{conn: conn} do
       name = unique_tag_name("PHP")
-      tag = insert(:tag, name: name, slug: String.downcase(name))
+      tag = insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
       tagged = insert(:activated_user, first_name: "Paula", last_name: "Programmer")
       insert(:user_tag, tag: tag, user: tagged)
       author = insert(:activated_user)
@@ -367,7 +371,7 @@ defmodule VutuvWeb.SearchLiveTest do
 
     test "a name combines with tag and city filters", %{conn: conn} do
       name = unique_tag_name("PHP")
-      tag = insert(:tag, name: name, slug: String.downcase(name))
+      tag = insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
       php_mueller = searchable_user("Hans", "Müller")
       insert(:user_tag, tag: tag, user: php_mueller)
       koblenz_mueller = searchable_user("Klara", "Müller")

--- a/test/vutuv_web/live/tag_new_live_test.exs
+++ b/test/vutuv_web/live/tag_new_live_test.exs
@@ -19,7 +19,7 @@ defmodule VutuvWeb.TagNewLiveTest do
   defp tag_count(user),
     do: Repo.aggregate(from(ut in UserTag, where: ut.user_id == ^user.id), :count)
 
-  defp slugify(name), do: Vutuv.SlugHelpers.gen_slug_unique(name, Vutuv.Tags.Tag, :slug)
+  defp slugify(name), do: Vutuv.SlugHelpers.gen_tag_slug_unique(name, Vutuv.Tags.Tag, :slug)
 
   # Type `value` into the form and return the previewed chip texts, in order.
   defp preview(live, value) do
@@ -98,7 +98,7 @@ defmodule VutuvWeb.TagNewLiveTest do
     end
 
     test "a space no longer splits, so a multi-word tag stays one chip", %{live: live} do
-      insert(:tag, name: "ruby on rails", slug: "ruby-on-rails")
+      insert(:tag, name: "ruby on rails", slug: "ruby_on_rails")
 
       assert preview(live, "Ruby on Rails") == ["ruby on rails"]
     end

--- a/test/vutuv_web/live/user_profile_live_test.exs
+++ b/test/vutuv_web/live/user_profile_live_test.exs
@@ -114,7 +114,11 @@ defmodule VutuvWeb.UserProfileLiveTest do
       # 31 tags (all zero-endorsement, so slug-alphabetical): tag01 .. tag31.
       for i <- 1..31 do
         slug = "tag" <> String.pad_leading(Integer.to_string(i), 2, "0")
-        insert(:user_tag, user: owner, tag: insert(:tag, name: slug, slug: slug))
+
+        insert(:user_tag,
+          user: owner,
+          tag: insert(:tag, name: slug, slug: Vutuv.SlugHelpers.tagify(slug))
+        )
       end
 
       {:ok, view, _html} = live(conn, ~p"/#{owner}")


### PR DESCRIPTION
Closes #1332 — its last open piece.

A CHECK constraint holds what v7.276.0 established: a live tag's slug is `^[a-z0-9_]+$`, usable as its fediverse actor name with no mapping in between (#1330).

```sql
CHECK (merged_into_id IS NOT NULL OR slug ~ '^[a-z0-9_]+$')
```

**The alias exemption is the point of it.** A `former` row exists so the spelling a topic used to have keeps resolving (`/tags/<old>` answers 301), so it must be allowed to hold exactly the shape the constraint forbids everywhere else.

**Why this needed its own deploy.** Migrations here run blue/green, while the previous release is still serving. Until v7.276.0 was live, that release's slugifier still wrote hyphens, so a tag minted in the switch window would have violated the constraint and 500ed. v7.276.0 reached production today (verified: `/tags/agentic-ai` now 301s to `/tags/agentic_ai`), so the window is closed.

The application says the same thing first: the changeset validates the shape and names the constraint, so an admin hand-editing a slug gets a field error rather than a crash. It does not apply to an alias row, whose spelling is the reason it exists.

**The tail was the test suite**, and it is worth knowing why it was long: the factory minted hyphen slugs, and about twenty places derived a slug with `String.downcase(name)`. Both now go through `SlugHelpers.tagify/1`, so no test wires a spelling in any more. The retag migration's own test drops the constraint inside its transaction — it has to build the world the migration ran in, and the SQL sandbox hands it back.

`mix precommit` green (7497 tests).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*