### PR TITLE
Ein Thema kann Follower von draußen haben (v7.276.3)

### DIFF
--- a/lib/vutuv/fediverse/follower.ex
+++ b/lib/vutuv/fediverse/follower.ex
@@ -36,10 +36,11 @@ defmodule Vutuv.Fediverse.Follower do
     field(:name, :string)
     field(:last_checked_at, :naive_datetime)
 
-    # A remote follower follows a member OR a page (issue #1334),
-    # CHECK-enforced to exactly one.
+    # A remote follower follows a member, a page (issue #1334) or a topic
+    # (issue #1330), CHECK-enforced to exactly one.
     belongs_to(:user, Vutuv.Accounts.User)
     belongs_to(:organization, Vutuv.Organizations.Organization)
+    belongs_to(:tag, Vutuv.Tags.Tag)
 
     timestamps()
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.276.2",
+      version: "7.276.3",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260812213019_add_tag_to_fediverse_followers.exs
+++ b/priv/repo/migrations/20260812213019_add_tag_to_fediverse_followers.exs
@@ -1,0 +1,68 @@
+defmodule Vutuv.Repo.Migrations.AddTagToFediverseFollowers do
+  @moduledoc """
+  Issue #1330: somebody on another server can follow a **topic**, so the row
+  that records a remote follower needs a third owner beside the member and the
+  page.
+
+  Same shape as the two before it: a nullable `tag_id`, the CHECK widened to
+  exactly one of three, and its own unique index — `(tag_id, actor_uri)`, so one
+  remote account follows one topic once, which is what makes an `add` idempotent
+  when a server re-delivers a `Follow`.
+
+  ## Why this can ship alone
+
+  Nothing writes it yet, and nothing outside this database can see it. The parts
+  a remote server *can* see — WebFinger on the tag host, the `Group` document,
+  the inbox that answers `Follow` with `Accept` — still have to arrive together:
+  a recorded Follow that is never answered shows on Mastodon as pending forever,
+  which is the failure the whole gate exists to prevent. So the storage goes
+  first, the way it did for the keypair in v7.276.1 and for the page in #1334.
+
+  N-1 safe: the previous release writes only member and page followers, which
+  satisfy the widened CHECK, and every query it runs scopes to `user_id` or
+  `organization_id`, so a tag row is invisible to it rather than confusing.
+  """
+  use Ecto.Migration
+
+  @check :fediverse_followers_exactly_one_target
+
+  def up do
+    alter table(:fediverse_followers) do
+      add(:tag_id, references(:tags, type: :binary_id, on_delete: :delete_all))
+    end
+
+    drop(constraint(:fediverse_followers, @check))
+
+    create(
+      constraint(:fediverse_followers, @check,
+        check: """
+        (CASE WHEN user_id IS NULL THEN 0 ELSE 1 END +
+         CASE WHEN organization_id IS NULL THEN 0 ELSE 1 END +
+         CASE WHEN tag_id IS NULL THEN 0 ELSE 1 END) = 1
+        """
+      )
+    )
+
+    create(unique_index(:fediverse_followers, [:tag_id, :actor_uri]))
+  end
+
+  def down do
+    drop(unique_index(:fediverse_followers, [:tag_id, :actor_uri]))
+    drop(constraint(:fediverse_followers, @check))
+
+    execute("DELETE FROM fediverse_followers WHERE tag_id IS NOT NULL")
+
+    create(
+      constraint(:fediverse_followers, @check,
+        check: """
+        (CASE WHEN user_id IS NULL THEN 0 ELSE 1 END +
+         CASE WHEN organization_id IS NULL THEN 0 ELSE 1 END) = 1
+        """
+      )
+    )
+
+    alter table(:fediverse_followers) do
+      remove(:tag_id)
+    end
+  end
+end

--- a/test/vutuv/fediverse_tag_follower_storage_test.exs
+++ b/test/vutuv/fediverse_tag_follower_storage_test.exs
@@ -1,0 +1,80 @@
+defmodule Vutuv.FediverseTagFollowerStorageTest do
+  @moduledoc """
+  Where a remote follower of a **topic** is recorded (issue #1330).
+
+  Storage only, like the keypair before it: nothing writes these yet and nothing
+  outside this database can see one. What a remote server *can* see — WebFinger
+  on the tag host, the `Group` document, the inbox that answers `Follow` — still
+  has to arrive together, because a recorded Follow that is never answered shows
+  as pending forever on the other side.
+  """
+  use Vutuv.DataCase, async: true
+
+  alias Vutuv.Fediverse.Follower
+  alias Vutuv.Tags.Tag
+
+  defp tag do
+    n = System.unique_integer([:positive])
+    insert(:tag, name: "topic#{n}", slug: "topic#{n}")
+  end
+
+  defp follower(attrs) do
+    Repo.insert(
+      struct(
+        %Follower{
+          actor_uri: "https://remote.example/users/frida",
+          inbox_uri: "https://remote.example/users/frida/inbox"
+        },
+        attrs
+      )
+    )
+  end
+
+  test "a topic can hold remote followers" do
+    tag = tag()
+
+    assert {:ok, row} = follower(tag_id: tag.id)
+    assert row.tag_id == tag.id
+    assert is_nil(row.user_id)
+    assert is_nil(row.organization_id)
+  end
+
+  test "one remote account follows one topic once" do
+    tag = tag()
+    assert {:ok, _} = follower(tag_id: tag.id)
+
+    # What makes re-delivering a `Follow` idempotent rather than a second row.
+    assert_raise Ecto.ConstraintError, ~r/fediverse_followers_tag_id_actor_uri_index/, fn ->
+      follower(tag_id: tag.id)
+    end
+  end
+
+  test "the same account may follow a topic and a member separately" do
+    tag = tag()
+    user = insert(:activated_user)
+
+    assert {:ok, _} = follower(tag_id: tag.id)
+    assert {:ok, _} = follower(user_id: user.id)
+  end
+
+  test "a row names exactly one owner" do
+    tag = tag()
+    user = insert(:activated_user)
+
+    error =
+      assert_raise Ecto.ConstraintError, fn ->
+        follower(tag_id: tag.id, user_id: user.id)
+      end
+
+    assert error.message =~ "fediverse_followers_exactly_one_target"
+  end
+
+  test "deleting the topic takes its followers with it" do
+    tag = tag()
+    {:ok, row} = follower(tag_id: tag.id)
+
+    Repo.delete!(Repo.get!(Tag, tag.id))
+
+    refute Repo.get(Follower, row.id)
+  end
+end


### PR DESCRIPTION
Second part of the foundation for #1330: the row that records a remote follower takes a third owner beside the member and the page.

Same shape as the two before it: a nullable `tag_id`, the CHECK widened to exactly one of three, and its own unique index on `(tag_id, actor_uri)` — one remote account follows one topic once, which is what makes a re-delivered `Follow` idempotent instead of a second row.

**This can ship alone** because nothing writes it and nothing outside the database can see it. What a remote server *can* see — WebFinger on the tag host, the `Group` document, the inbox that answers `Follow` with `Accept` — still has to arrive together: a Follow that is recorded and never answered shows as pending forever on the other side.

N-1 safe: the previous release writes only member and page followers, which satisfy the widened CHECK, and every query it runs scopes to `user_id` or `organization_id`, so a tag row is invisible to it rather than confusing.

One thing the migration had to get right and nearly did not: the existing constraint is called `fediverse_followers_exactly_one_target`, not `..._owner` like its twin on `fediverse_actors`. Caught by running it against `vutuv1_dev`.

`mix precommit` green (7502 tests).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*