### PR TITLE
Ein Thema trägt seine Beiträge zu seinen Followern (v7.278.0)

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -1120,13 +1120,30 @@ optional politeness — unanswered, it shows on Mastodon as pending forever — 
 the delivery queue took a third owner (`fediverse_deliveries.tag_id`) in the
 same change that gave the tag an inbox, exactly as the page's did.
 
+### Carrying the posts out
+
+A public post reaches the followers of every topic it carries, as an `Announce`
+from that topic's actor — the same activity the repost path builds, because a
+tag actor boosting a note is exactly that. Both ways a post carries a tag count:
+the composer's chips and a `#hashtag` in the body.
+
+Three gates, and each is load-bearing. **The author must federate**, which is
+the one thing standing between a member who chose not to and the open internet —
+a tag has no opt-in of its own precisely because this check exists.
+**The post must be public**: an audience its author narrowed must not widen
+because a topic was attached. And **only posts published here**: a cached post
+from another server (`RemotePostTag`) never reaches this path and must not,
+since re-announcing it would be redistributing somebody else's content from our
+own actor. An alias announces nothing — its canonical already did.
+
+A topic nobody follows queues nothing and does not even mint a keypair, so the
+common case costs one query.
+
 ### What is not built yet
 
-`Announce`: a public post carrying the tag does not yet reach the topic's
-followers, and the outbox is an empty collection. That is the next slice, and
-the gate it must respect is the one above — only posts by members who federate,
-and never a cached post from another server (`RemotePostTag`), which would be
-redistributing somebody else's content from our own actor.
+The tag page's own half: a remote-follow entry point for a logged-out visitor
+(the button renders only for members today) and a follower count that sums the
+local `TagFollow` rows with the remote ones.
 
 ## Deliberate v1 limits
 

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -7334,8 +7334,83 @@ defmodule Vutuv.Fediverse do
   ## Federating posts (called from Vutuv.Posts after commit)
 
   @doc "A freshly published post -> Create(Note) to every follower inbox."
-  def federate_new_post(%Post{} = post),
-    do: maybe_federate(post, &Docs.create_activity/2, "post_create")
+  def federate_new_post(%Post{} = post) do
+    # The author's own delivery decides what this function answers; the topics
+    # carrying the post are a second, independent audience and must not change
+    # what a caller reads about the first.
+    result = maybe_federate(post, &Docs.create_activity/2, "post_create")
+    announce_to_tag_followers(post)
+    result
+  end
+
+  @doc """
+  The topics a post carries announce it to **their** followers (issue #1330):
+  somebody who followed `@elixir@tags.<host>` from their own server gets it,
+  without an account here. A tag actor boosting a note is exactly an `Announce`,
+  so it reuses the one the repost path already builds.
+
+  Three gates, and each is load-bearing:
+
+  - **The author must federate.** A tag actor announcing indiscriminately would
+    carry out the posts of the very members who chose not to, which is why there
+    is no per-tag opt-in and why this check cannot move.
+  - **The post must be public.** `restricted?/1` is the same gate the author's
+    own delivery passes; an audience the author narrowed must not widen because
+    a topic was attached.
+  - **Only the tags of a post published here.** A cached post from another
+    server (`Vutuv.Fediverse.RemotePostTag`) never reaches this path, and must
+    not: re-announcing it would be redistributing somebody else's content from
+    our own actor.
+
+  A topic nobody follows queues nothing, so the common case costs one query and
+  no delivery.
+  """
+  def announce_to_tag_followers(%Post{} = post) do
+    with true <- enabled?(),
+         false <- Posts.restricted?(post),
+         author when not is_nil(author) <- Posts.author(post),
+         true <- federated?(author) do
+      post |> announceable_tags() |> Enum.each(&announce_to_tag(&1, post, author))
+      :ok
+    else
+      _ -> :skip
+    end
+  end
+
+  # Both ways a post carries a tag — the composer's chips and a `#hashtag` in
+  # the body — and canonical tags only: an alias is another name for a topic,
+  # never a second actor announcing the same post twice.
+  defp announceable_tags(%Post{id: post_id}) do
+    Repo.all(
+      from(t in Tag,
+        where: is_nil(t.merged_into_id),
+        where:
+          t.id in subquery(
+            from(pt in "post_tags",
+              where: pt.post_id == type(^post_id, Vutuv.UUIDv7),
+              select: pt.tag_id
+            )
+          ) or
+            t.id in subquery(
+              from(ph in "post_hashtags",
+                where: ph.post_id == type(^post_id, Vutuv.UUIDv7),
+                select: ph.tag_id
+              )
+            )
+      )
+    )
+  end
+
+  defp announce_to_tag(%Tag{} = tag, %Post{} = post, author) do
+    case tag_follower_inboxes(tag) do
+      [] ->
+        :skip
+
+      inboxes ->
+        {:ok, _actor} = ensure_tag_actor(tag)
+        enqueue(tag, inboxes, Docs.announce_activity(post, author, tag))
+    end
+  end
 
   @doc """
   An edited post -> Update(Note); one whose audience closed -> Delete, so

--- a/lib/vutuv_web/fediverse/docs.ex
+++ b/lib/vutuv_web/fediverse/docs.ex
@@ -468,7 +468,13 @@ defmodule VutuvWeb.Fediverse.Docs do
   # Stable per (reposted note, reposter), so the Undo references the same
   # Announce the repost sent.
   defp announce_id(%Post{id: post_id}, author, reposter),
-    do: note_url(author, post_id) <> "#announce-" <> reposter.username
+    do: note_url(author, post_id) <> "#announce-" <> announcer_name(reposter)
+
+  # Whoever is doing the announcing, named the way their own actor is: a member
+  # and a page by their handle, a topic by its slug (issue #1330), which is the
+  # tag actor's name.
+  defp announcer_name(%Tag{slug: slug}), do: slug
+  defp announcer_name(actor), do: actor.username
 
   @doc """
   The `featured` collection document (issue #1110): the member's pinned post

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.277.0",
+      version: "7.278.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/fediverse_tag_announce_test.exs
+++ b/test/vutuv/fediverse_tag_announce_test.exs
@@ -1,0 +1,154 @@
+defmodule Vutuv.FediverseTagAnnounceTest do
+  @moduledoc """
+  A topic carries its posts to the people who followed it (issue #1330, the
+  last slice): a public post tagged `#elixir` is `Announce`d by
+  `@elixir@tags.<host>` to everyone who subscribed to the topic from their own
+  server.
+
+  The gates are the point of this file. A tag has no opt-in of its own, so the
+  one thing standing between a member who chose not to federate and the open
+  internet is the author check here.
+
+  `async: false`: points `:fediverse_tag_host` at a known host, which is global.
+  """
+  use Vutuv.DataCase, async: false
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Delivery
+  alias Vutuv.Posts
+
+  @tag_host "tags.example.test"
+
+  setup do
+    original = Application.fetch_env(:vutuv, :fediverse_tag_host)
+    Application.put_env(:vutuv, :fediverse_tag_host, @tag_host)
+
+    on_exit(fn ->
+      case original do
+        {:ok, was} -> Application.put_env(:vutuv, :fediverse_tag_host, was)
+        :error -> Application.delete_env(:vutuv, :fediverse_tag_host)
+      end
+    end)
+
+    :ok
+  end
+
+  defp followed_topic do
+    n = System.unique_integer([:positive])
+    tag = insert(:tag, name: "Elixir #{n}", slug: "elixir_#{n}")
+
+    {:ok, _} =
+      Fediverse.add_tag_follower(tag, %{
+        actor_uri: "https://remote.example/users/frida#{n}",
+        inbox_uri: "https://remote.example/users/frida#{n}/inbox"
+      })
+
+    tag
+  end
+
+  defp federating_author, do: insert(:activated_user, fediverse_followers?: true)
+
+  defp tag_deliveries(tag),
+    do: Repo.all(from(d in Delivery, where: d.tag_id == ^tag.id))
+
+  test "a public post reaches the followers of the topic it carries" do
+    tag = followed_topic()
+    author = federating_author()
+
+    {:ok, post} = Posts.create_post(author, %{body: "Neues von hier.", tags: tag.name})
+
+    assert [delivery] = tag_deliveries(tag)
+    assert delivery.inbox_uri == "https://remote.example/users/frida#{suffix(tag)}/inbox"
+
+    announce = Jason.decode!(delivery.activity_json)
+    assert announce["type"] == "Announce"
+    # The actor is the topic, not the author: it is the topic these people
+    # subscribed to.
+    assert announce["actor"] =~ "//#{@tag_host}" and
+             String.ends_with?(announce["actor"], "/#{tag.slug}")
+
+    # The object is the note's own id, so the remote server fetches the post
+    # from the author's actor and renders it as a boost.
+    assert announce["object"] =~ "/#{author.username}/posts/#{post.id}"
+  end
+
+  test "a hashtag in the body carries the post as well as a chip does" do
+    tag = followed_topic()
+    author = federating_author()
+
+    {:ok, _post} = Posts.create_post(author, %{body: "Gebaut mit ##{tag.slug}."})
+
+    assert [_delivery] = tag_deliveries(tag)
+  end
+
+  test "an author who does not federate is never carried out by a topic" do
+    tag = followed_topic()
+    author = insert(:activated_user, fediverse_followers?: false)
+
+    {:ok, _post} = Posts.create_post(author, %{body: "Bleibt hier.", tags: tag.name})
+
+    # The whole reason a tag needs no opt-in of its own: what it may carry is
+    # decided by each author, at this moment.
+    assert tag_deliveries(tag) == []
+  end
+
+  test "a restricted post stays inside, whatever tag is on it" do
+    tag = followed_topic()
+    author = federating_author()
+    denied = insert(:activated_user)
+
+    {:ok, _post} =
+      Posts.create_post(author, %{
+        body: "Nur für einige.",
+        tags: tag.name,
+        denials: [%{"denied_user_id" => denied.id}]
+      })
+
+    # An audience the author narrowed must not widen because a topic was
+    # attached to it.
+    assert tag_deliveries(tag) == []
+  end
+
+  test "an alias never announces the post its canonical already carries" do
+    canonical = followed_topic()
+    n = System.unique_integer([:positive])
+
+    other_name =
+      insert(:tag,
+        name: "Alias #{n}",
+        slug: "alias_#{n}",
+        merged_into_id: canonical.id
+      )
+
+    author = federating_author()
+    {:ok, _post} = Posts.create_post(author, %{body: "Einmal reicht.", tags: canonical.name})
+
+    assert tag_deliveries(other_name) == []
+    assert length(tag_deliveries(canonical)) == 1
+  end
+
+  test "a topic nobody follows queues nothing" do
+    n = System.unique_integer([:positive])
+    lonely = insert(:tag, name: "Einsam #{n}", slug: "einsam_#{n}")
+    author = federating_author()
+
+    {:ok, _post} = Posts.create_post(author, %{body: "Niemand hört zu.", tags: lonely.name})
+
+    assert tag_deliveries(lonely) == []
+    # And no keypair was minted for a topic that had nothing to send.
+    refute Fediverse.get_tag_actor(lonely)
+  end
+
+  test "publishing a post does the announcing on its own" do
+    tag = followed_topic()
+    author = federating_author()
+
+    # Publishing alone has to reach it, or the feature only works in tests:
+    # nothing here calls `announce_to_tag_followers/1`.
+    {:ok, _post} = Posts.create_post(author, %{body: "Frisch.", tags: tag.name})
+
+    assert [_delivery] = tag_deliveries(tag)
+  end
+
+  defp suffix(tag), do: tag.slug |> String.split("_") |> List.last()
+end


### PR DESCRIPTION
The last slice of #1330: a public post reaches the followers of every topic it carries, as an `Announce` from that topic's actor. Somebody who subscribed to `@elixir@tags.vutuv.de` from their own server gets it, with no account here. A tag actor boosting a note is exactly an Announce, so it reuses the builder the repost path already has. Both ways a post carries a tag count: the composer's chips and a `#hashtag` in the body.

**Three gates, each load-bearing:**

- **The author must federate.** This is the only thing standing between a member who chose not to and the open internet — and the reason a tag needs no opt-in of its own and must never grow one.
- **The post must be public.** An audience its author narrowed must not widen because a topic was attached to it.
- **Only posts published here.** A cached post from another server (`RemotePostTag`) never reaches this path and must not: re-announcing it would be redistributing somebody else's content from our own actor. An alias announces nothing either — its canonical already did.

A topic nobody follows queues nothing and does not even mint a keypair.

**One subtlety two existing tests were right to catch:** `federate_new_post/1` still answers about the author's own delivery. The topics are a second, independent audience and must not change what a caller learns about the first.

Tests cover all three gates, both tag sources, the alias, the empty case, and that publishing alone reaches it — nothing calls the announce by hand.

`mix precommit` green (7520 tests).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*