### PR TITLE
Die Tagseite lässt Fremde herein (v7.279.0)

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -1139,11 +1139,25 @@ own actor. An alias announces nothing — its canonical already did.
 A topic nobody follows queues nothing and does not even mint a keypair, so the
 common case costs one query.
 
-### What is not built yet
+### The tag page's own half
 
-The tag page's own half: a remote-follow entry point for a logged-out visitor
-(the button renders only for members today) and a follower count that sums the
-local `TagFollow` rows with the remote ones.
+A visitor who arrived from another server gets the two things they came for, in
+the same card the profile and the organization page use
+(`<.follow_us_from_elsewhere>`): the topic's address to copy, and a form that
+resolves **their** server's follow dialog and sends them there, so the follow is
+confirmed where their account lives. Before this the page showed such a visitor
+a follower count and no way in short of registering, since the follow button
+renders only for a signed-in member — the exact friction this issue set out to
+remove.
+
+The follower figure is **one number**: the local `TagFollow` rows plus the
+remote actors. They are the same thing — people following this topic — and
+splitting them would ask a reader to add two numbers up.
+
+One case the shared controller had to learn: an address on **our** tag host is
+us. Asking it over the network would be vutuv WebFingering itself and could only
+route the visitor back here, so a signed-in member naming it simply gets the
+plain vutuv tag follow. That is `own_host?/1` again, in its third caller.
 
 ## Deliberate v1 limits
 

--- a/lib/vutuv_web/controllers/remote_follow_controller.ex
+++ b/lib/vutuv_web/controllers/remote_follow_controller.ex
@@ -33,6 +33,8 @@ defmodule VutuvWeb.RemoteFollowController do
   alias Vutuv.Fediverse.RemoteFollow
   alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
+  alias Vutuv.Tags
+  alias Vutuv.Tags.Tag
   alias VutuvWeb.ControllerHelpers
   alias VutuvWeb.Fediverse.Docs
   alias VutuvWeb.RateLimit
@@ -53,6 +55,13 @@ defmodule VutuvWeb.RemoteFollowController do
     case Organizations.fetch_visible_organization(slug, conn.assigns[:current_user]) do
       {:error, :not_found} -> ControllerHelpers.render_error(conn, 404)
       {:ok, organization} -> follow(conn, organization, params["address"] || "")
+    end
+  end
+
+  def create_tag(conn, %{"slug" => slug} = params) do
+    case Tags.get_canonical_tag_by_slug(slug) do
+      nil -> ControllerHelpers.render_error(conn, 404)
+      tag -> follow(conn, tag, params["address"] || "")
     end
   end
 
@@ -117,6 +126,16 @@ defmodule VutuvWeb.RemoteFollowController do
     end
   end
 
+  defp flash_local_follow(conn, %Tag{} = tag, {:ok, {:local_follow, _follow}}) do
+    put_flash(
+      conn,
+      :info,
+      gettext("You are on this vutuv yourself, so you now follow #%{tag} right here.",
+        tag: tag.slug
+      )
+    )
+  end
+
   defp flash_local_follow(conn, subject, {:ok, {:local_follow, _followee}}) do
     put_flash(
       conn,
@@ -129,6 +148,10 @@ defmodule VutuvWeb.RemoteFollowController do
 
   defp flash_local_follow(conn, _subject, {:error, :own_account}) do
     put_flash(conn, :error, gettext("That is your own profile. You cannot follow yourself."))
+  end
+
+  defp flash_local_follow(conn, %Tag{} = tag, {:error, :already_following}) do
+    put_flash(conn, :info, gettext("You already follow #%{tag} here.", tag: tag.slug))
   end
 
   defp flash_local_follow(conn, subject, {:error, :already_following}) do
@@ -147,20 +170,35 @@ defmodule VutuvWeb.RemoteFollowController do
   # account away is followed at the new address, not here; a page cannot move
   # (`moved_to` is a person's decision about their own identity and pages carry
   # no such column), so its gate is the plain one.
+  defp followable?(%Tag{} = tag), do: Fediverse.federated?(tag)
   defp followable?(%Organization{} = organization), do: Fediverse.federated?(organization)
   defp followable?(user), do: Fediverse.federated?(user) and not Fediverse.moved?(user)
 
   defp local_follow(viewer, %Organization{} = organization),
     do: Fediverse.follow_local_organization(viewer, organization)
 
+  # A member whose "own server" is this one gets the plain vutuv tag follow —
+  # the same subscription the button on the page makes.
+  defp local_follow(viewer, %Tag{} = tag), do: local_tag_follow(Tags.follow_tag(viewer, tag.id))
+
   defp local_follow(viewer, user), do: Fediverse.follow_local_member(viewer, user)
+
+  defp local_tag_follow({:ok, follow}), do: {:ok, {:local_follow, follow}}
+  defp local_tag_follow(other), do: other
 
   # The two sentences that name what the visitor is looking at. Their own
   # msgids rather than an interpolated word: German inflects around it.
+  defp not_federating_message(%Tag{}),
+    do: gettext("This topic is not on the Fediverse.")
+
   defp not_federating_message(%Organization{}),
     do: gettext("This page is not on the Fediverse.")
 
   defp not_federating_message(_user), do: gettext("This profile is not on the Fediverse.")
+
+  defp sign_in_message(%Tag{}) do
+    gettext("That address is on this vutuv. Sign in and use the Follow button on this page.")
+  end
 
   defp sign_in_message(%Organization{}) do
     gettext("That address is on this vutuv. Sign in and use the Follow button on this page.")
@@ -197,6 +235,9 @@ defmodule VutuvWeb.RemoteFollowController do
       _ -> gettext("Your server")
     end
   end
+
+  defp back_to(conn, %Tag{} = tag),
+    do: redirect(conn, to: ~p"/tags/#{tag.slug}" <> "#tag-fediverse")
 
   defp back_to(conn, %Organization{} = organization) do
     redirect(conn, to: Organizations.canonical_path(organization) <> "#organization-fediverse")

--- a/lib/vutuv_web/controllers/tag_controller.ex
+++ b/lib/vutuv_web/controllers/tag_controller.ex
@@ -2,6 +2,7 @@ defmodule VutuvWeb.TagController do
   use VutuvWeb, :controller
 
   alias Vutuv.Accounts.User
+  alias Vutuv.Fediverse
   alias Vutuv.Jobs
   alias Vutuv.Organizations.Organization
   alias Vutuv.Pages
@@ -11,6 +12,7 @@ defmodule VutuvWeb.TagController do
   alias VutuvWeb.AgentDocs
   alias VutuvWeb.AgentDocs.ListDocs
   alias VutuvWeb.ContentPolicy
+  alias VutuvWeb.Fediverse.Docs
 
   # Not the shared `ResolveSlug` plug: an alternative name for a topic keeps its
   # own slug (issue #1338), and that URL must lead to the topic rather than 404
@@ -82,7 +84,11 @@ defmodule VutuvWeb.TagController do
     # member's state here would offer to unfollow something the page never
     # followed.
     following_tag? = tag_followed?(conn.assigns[:acting_as], current_user, tag)
-    tag_follower_count = Tags.tag_follower_count(tag)
+    # The public figure is everyone following this topic, wherever their account
+    # lives (issue #1330): the local `TagFollow` rows plus the remote actors.
+    # Splitting them would ask a reader to add two numbers that mean one thing.
+    tag_follower_count =
+      Tags.tag_follower_count(tag) + Fediverse.tag_remote_follower_count(tag)
 
     # A tag page below the search-engine bar (fewer than
     # Tags.min_indexable_members/0 visible members and no public post) is a
@@ -105,6 +111,9 @@ defmodule VutuvWeb.TagController do
           current_user: current_user,
           following_tag?: following_tag?,
           tag_follower_count: tag_follower_count,
+          # nil unless this installation federates, in which case the card shows
+          # the topic's address and the "follow from your own server" form.
+          fediverse_handle: tag_fediverse_handle(tag),
           open_positions: Jobs.list_tag_postings(tag, conn.assigns[:current_user]),
           # The timeline itself is the embedded VutuvWeb.TagLive.Timeline
           # LiveView; the controller only hands it the tag and the controls a
@@ -171,6 +180,12 @@ defmodule VutuvWeb.TagController do
   # Who the pill speaks for: the page being acted as, else the member, else
   # nobody. One decider, so the shown state and the toggle behind it cannot
   # disagree — the same shape `follower_of/1` has on the organization page.
+  # `@name@tags.<host>`, or nil when the installation does not federate — which
+  # is what the card renders on.
+  defp tag_fediverse_handle(tag) do
+    if Fediverse.federated?(tag), do: "@" <> Docs.acct(tag)
+  end
+
   defp tag_followed?(%Organization{} = page, _member, tag),
     do: Tags.tag_followed_by_organization?(page, tag)
 

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -331,6 +331,11 @@ defmodule VutuvWeb.Router do
     # follow dialog. No login (the whole point is that their account is
     # elsewhere); refused unless this page federates.
     post("/organizations/:slug/fediverse/follow", RemoteFollowController, :create_organization)
+    # And the topic twin (issue #1330): a visitor who arrived from another
+    # server follows `#elixir` where their own account lives, without
+    # registering here — the acquisition path a centralised network cannot
+    # offer at all.
+    post("/tags/:slug/fediverse/follow", RemoteFollowController, :create_tag)
 
     # Switching into an organization and back (issue #1335). Never GET: a
     # request that changes whose name you are speaking in must not be fired by

--- a/lib/vutuv_web/templates/tag/show.html.heex
+++ b/lib/vutuv_web/templates/tag/show.html.heex
@@ -18,6 +18,20 @@ card stretch edge to edge with a huge line length and dead space. --%>
       </p>
     </div>
     <.tag_follow_button :if={@current_user} following?={@following_tag?} tag={@tag} />
+
+  <%!-- A visitor who arrived from another server wants two things: this topic's
+  address, and to follow it where their own account lives. The follow button
+  above renders only for a signed-in member, so without this the page showed
+  such a visitor a follower count and no way in short of registering — the exact
+  friction issue #1330 removes. Same markup as the profile and the page card,
+  because the visitor is the same person asking the same thing. --%>
+  <.follow_us_from_elsewhere
+    :if={@fediverse_handle}
+    id="tag-fediverse"
+    handle={@fediverse_handle}
+    name={"#" <> @tag.slug}
+    action={~p"/tags/#{@tag.slug}/fediverse/follow"}
+  />
   </div>
   <div class="breadcrumbs">
     {gen_breadcrumbs([{gettext("Tags"), ~p"/tags"}, gettext("Show")])}

--- a/lib/vutuv_web/views/tag_html.ex
+++ b/lib/vutuv_web/views/tag_html.ex
@@ -1,6 +1,8 @@
 defmodule VutuvWeb.TagHTML do
   @moduledoc false
   use VutuvWeb, :html
+
+  import VutuvWeb.FediverseComponents, only: [follow_us_from_elsewhere: 1]
   import VutuvWeb.UserHelpers
   import VutuvWeb.JobComponents, only: [job_card: 1]
   alias Vutuv.Tags.Tag

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.278.0",
+      version: "7.279.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/tag_page_fediverse_test.exs
+++ b/test/vutuv_web/tag_page_fediverse_test.exs
@@ -1,0 +1,88 @@
+defmodule VutuvWeb.TagPageFediverseTest do
+  @moduledoc """
+  The tag page's own half of issue #1330: a visitor who arrived from another
+  server can see the topic's address and follow it where their account lives,
+  and the follower count means everyone following the topic rather than only
+  the members.
+
+  This is the friction the issue set out to remove. The follow button renders
+  only for a signed-in member, so before this a visitor from Mastodon saw a
+  count and had no way in short of registering.
+
+  `async: false`: points `:fediverse_tag_host` at a known host, which is global.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Tags
+
+  @tag_host "tags.example.test"
+
+  setup do
+    original = Application.fetch_env(:vutuv, :fediverse_tag_host)
+    Application.put_env(:vutuv, :fediverse_tag_host, @tag_host)
+
+    on_exit(fn ->
+      case original do
+        {:ok, was} -> Application.put_env(:vutuv, :fediverse_tag_host, was)
+        :error -> Application.delete_env(:vutuv, :fediverse_tag_host)
+      end
+    end)
+
+    :ok
+  end
+
+  defp topic do
+    n = System.unique_integer([:positive])
+    insert(:tag, name: "Elixir #{n}", slug: "elixir_#{n}")
+  end
+
+  test "a logged-out visitor is shown the address and a way in", %{conn: conn} do
+    tag = topic()
+
+    html = conn |> get(~p"/tags/#{tag.slug}") |> html_response(200)
+
+    assert html =~ "@#{tag.slug}@#{@tag_host}"
+    assert html =~ ~s(action="/tags/#{tag.slug}/fediverse/follow")
+  end
+
+  test "the follower count sums the members and the remote accounts", %{conn: conn} do
+    tag = topic()
+    member = insert(:activated_user)
+    {:ok, _} = Tags.follow_tag(member, tag.id)
+
+    {:ok, _} =
+      Fediverse.add_tag_follower(tag, %{
+        actor_uri: "https://remote.example/users/frida",
+        inbox_uri: "https://remote.example/users/frida/inbox"
+      })
+
+    html = conn |> get(~p"/tags/#{tag.slug}") |> html_response(200)
+
+    # One figure, because it is one thing: everyone following this topic.
+    assert html =~ "2 followers"
+  end
+
+  test "a member who names an address of ours gets a plain vutuv follow", %{conn: conn} do
+    tag = topic()
+    {conn, member} = create_and_login_user(conn)
+
+    # The tag host counts as us, which is what `own_host?/1` is for: asking it
+    # over the network would be vutuv WebFingering itself, and the answer could
+    # only ever route them back here. So they get what they actually asked for,
+    # the plain tag follow.
+    conn =
+      post(conn, ~p"/tags/#{tag.slug}/fediverse/follow",
+        address: "@#{member.username}@#{@tag_host}"
+      )
+
+    assert redirected_to(conn) =~ "/tags/#{tag.slug}"
+    assert Tags.tag_followed?(member, tag)
+  end
+
+  test "the address of an unknown topic is a 404, not a redirect", %{conn: conn} do
+    conn = post(conn, ~p"/tags/gibt_es_nicht/fediverse/follow", address: "@a@remote.example")
+
+    assert conn.status == 404
+  end
+end


### PR DESCRIPTION
Closes #1330.

The last part. A visitor who lands on a tag page from another server now gets the two things they came for: the topic's address to copy, and a form that resolves **their** server's follow dialog and sends them there, so the follow is confirmed where their account lives.

Before this, that visitor saw a follower count and no way in — the follow button renders only for a signed-in member. That is precisely the friction this issue set out to remove, and it is the acquisition path a centralised network cannot offer at all: no registration, just a follow from wherever you already are.

Same card as the profile and the organization page (`<.follow_us_from_elsewhere>`), because it is the same person asking the same thing.

**The follower figure is one number** now: the local `TagFollow` rows plus the remote actors. They are the same thing — people following this topic — and splitting them would ask a reader to add two numbers up.

**One case the shared controller had to learn:** an address on our own tag host is us. Asking it over the network would be vutuv WebFingering itself and could only route the visitor back here, so a signed-in member naming it simply gets the plain vutuv tag follow. `own_host?/1` in its third caller.

`mix precommit` green (7524 tests).

**One thing production still needs from you** before any of this is reachable from outside: `tags.vutuv.de` resolves now, but nginx has no `server_name` for it and no certificate — TLS currently answers with `CN=animina.de`, i.e. the default server.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*