### PR TITLE
Nachtrag: die Version für die Tagseite (v7.280.0)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.279.0",
+      version: "7.280.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
A version collision, and the shape of it is worth naming because it leaves no trace on its own.

While #1435 sat in CI, #1434 from another session merged and took **7.279.0** — the number #1435 had already bumped to. Both sides read the same value, so there was no merge conflict and no warning: the squash landed the tag page without moving the version, and one number would have stood for two unrelated changes.

This adds the bump that is owed. The work it belongs to is #1330's last part, in a7074a8a.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*