### PR TITLE
Die Fediverse-Karte der Tagseite saß in der Kopfzeile (v7.280.2)

### DIFF
--- a/lib/vutuv_web/templates/tag/show.html.heex
+++ b/lib/vutuv_web/templates/tag/show.html.heex
@@ -18,20 +18,6 @@ card stretch edge to edge with a huge line length and dead space. --%>
       </p>
     </div>
     <.tag_follow_button :if={@current_user} following?={@following_tag?} tag={@tag} />
-
-  <%!-- A visitor who arrived from another server wants two things: this topic's
-  address, and to follow it where their own account lives. The follow button
-  above renders only for a signed-in member, so without this the page showed
-  such a visitor a follower count and no way in short of registering — the exact
-  friction issue #1330 removes. Same markup as the profile and the page card,
-  because the visitor is the same person asking the same thing. --%>
-  <.follow_us_from_elsewhere
-    :if={@fediverse_handle}
-    id="tag-fediverse"
-    handle={@fediverse_handle}
-    name={"#" <> @tag.slug}
-    action={~p"/tags/#{@tag.slug}/fediverse/follow"}
-  />
   </div>
   <div class="breadcrumbs">
     {gen_breadcrumbs([{gettext("Tags"), ~p"/tags"}, gettext("Show")])}
@@ -42,6 +28,30 @@ card stretch edge to edge with a huge line length and dead space. --%>
   <div class="card-list">
     <%= render "single_card.html", assigns %>
   </div>
+
+  <%!-- A visitor who arrived from another server wants two things: this topic's
+  address, and to follow it where their own account lives. The pill in the
+  header is for signed-in members only, so without this the page showed such a
+  visitor a follower count and no way in short of registering — the friction
+  issue #1330 removes. Same markup as the profile and the page card, because it
+  is the same person asking the same thing.
+
+  Below the front matter and above the timeline, and **outside** the header:
+  `.profile-header` is a flex row for the title and the pill, and a card as a
+  third child there squeezed the handle into one character per line. The topic's
+  own content stays first, the way the profile keeps its fediverse card among
+  the content rather than in the header.
+
+  The `<.card>` around it is the profile's arrangement too: the component draws
+  the address box and the form, the caller supplies the surface they sit on. --%>
+  <.card :if={@fediverse_handle} id="tag-fediverse" class="mt-6">
+    <.follow_us_from_elsewhere
+      id="tag-fediverse"
+      handle={@fediverse_handle}
+      name={"#" <> @tag.slug}
+      action={~p"/tags/#{@tag.slug}/fediverse/follow"}
+    />
+  </.card>
 
   <%!-- Everything written about this tag — vutuv posts and posts cached from
   other networks in one list — as the embedded VutuvWeb.TagLive.Timeline

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.280.1",
+      version: "7.280.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/tag_page_fediverse_test.exs
+++ b/test/vutuv_web/tag_page_fediverse_test.exs
@@ -46,6 +46,37 @@ defmodule VutuvWeb.TagPageFediverseTest do
     assert html =~ ~s(action="/tags/#{tag.slug}/fediverse/follow")
   end
 
+  test "the card sits below the header, not inside it", %{conn: conn} do
+    tag = topic()
+
+    doc = conn |> get(~p"/tags/#{tag.slug}") |> html_response(200) |> LazyHTML.from_document()
+
+    assert LazyHTML.query(doc, "#tag-fediverse") |> Enum.any?(),
+           "the fediverse card is missing"
+
+    # It shipped inside `.profile-header` once, which is a flex row for the
+    # title and the follow pill: as a third child there the card was squeezed to
+    # a column and the handle rendered one character per line. The member's own
+    # pill has to stay in that header, the card must not.
+    assert LazyHTML.query(doc, ".profile-header #tag-fediverse") |> Enum.empty?(),
+           "the fediverse card is inside the header again"
+
+    assert LazyHTML.query(doc, ".profile-header") |> Enum.any?()
+  end
+
+  test "a signed-in member still gets the plain follow pill", %{conn: conn} do
+    tag = topic()
+    {conn, _member} = create_and_login_user(conn)
+
+    html = conn |> get(~p"/tags/#{tag.slug}") |> html_response(200)
+
+    # The fediverse card is for people who are somewhere else. A member of this
+    # installation subscribes with one click (#872), and that must not be the
+    # thing that got pushed aside by it.
+    assert html =~ "/tag_follows"
+    assert html =~ ~s(id="tag-fediverse")
+  end
+
   test "the follower count sums the members and the remote accounts", %{conn: conn} do
     tag = topic()
     member = insert(:activated_user)


### PR DESCRIPTION
A defect I shipped in v7.279.0, visible on the live tag pages.

I put the card inside the `.profile-header` block, which is a flex row for the title and the follow pill. As a third child there the card was squeezed to a column: the address `@elixir@tags.vutuv.de` rendered **one character per line**, and the member's `# Folgen` pill was jammed against the title. On the production page it looked as though subscribing to a topic as a member were an appendix to the fediverse part.

The card now sits below the header, between the topic's front matter and the timeline, wrapped in a `<.card>` — the arrangement the profile already uses: the component draws the address box and the form, the calling page supplies the surface they sit on. That second half was the real reason it looked bare even apart from the squeeze; I had simply forgotten the frame.

**Two tests hold it:** that `#tag-fediverse` exists and is **not** inside `.profile-header`, and that a signed-in member still gets their ordinary follow pill. The second matters more — a card for people on other servers must not push aside the one-click subscription this installation's own members have had since #872.

`mix precommit` green (7538 tests).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*