### PR TITLE
Signal nimmt jetzt auch den Kontakt-Link (v7.283.0)

### DIFF
--- a/docs/architecture/profiles.md
+++ b/docs/architecture/profiles.md
@@ -660,10 +660,36 @@ never wrongly rejected as "not a phone number". A phone value gets the
 resolver, so it shows the bare handle (copyable), the same as Session. The other
 providers carry a service-specific id/username with its own format check.
 
+**Signal takes a third shape, its contact link** (`https://signal.me/#eu/…`,
+issue #1442): the one Signal address that names neither the phone number nor the
+username, and one the member can reset inside the app at any time. Until it was
+accepted here, a pasted link was refused (it carries letters, so the username
+branch took it and choked on `:` and `/`), and members filed it under their
+webpage links instead, where it sat in the wrong card and collected a screenshot
+of a page that says nothing about them. `Messenger.kind/1` is the single
+discriminator between the three shapes — `:link`, `:phone`, `:username` — and
+`label/1` is what a link to the contact says: a contact link has no address to
+show, so it reads as "Open chat" rather than as its 64-character token. The
+validation is deliberately lenient (the provider's host plus a non-empty
+fragment, no token grammar): the link format has changed five times since 2022,
+so a strict pattern would only be the next thing to break. Storage is canonical
+(`https://<host>/#<fragment>`, host lowercased, fragment byte for byte, anything
+before the fragment dropped — the fragment *is* the address, which is why it
+never reaches Signal's server). WhatsApp's `wa.me/qr/…` short link is
+deliberately **not** in `@link_hosts`: WhatsApp shows the number in the chat
+regardless, so storing it as a link would promise a privacy it does not deliver.
+
+`Messenger.from_url/1` reads the messenger address out of a pasted URL
+(`signal.me`, `t.me`, `threema.id`, `matrix.to`) and drives the links editor's
+quiet "Add this under Messengers" offer, which seeds `/settings/messengers/new`
+from the member's own stored link (`?from_link=<url id>`, never an address in
+the query). It is an offer: moving the entry stays the member's decision.
+
 Like the other sections it has a Messengers card on the profile, owner CRUD on
 `/settings/messengers` (public showcase at `/:slug/messengers`), an ordered
 `position` (see below), agent-format siblings (`SectionDocs.messenger_entry/1`,
-kept in sync by the agent-docs drift test) carrying the deep link, `IMPP` lines
+kept in sync by the agent-docs drift test) carrying the deep link and a `kind`
+saying which of the three shapes the contact is, `IMPP` lines
 on the vCard (RFC 4770), and an `/api/2.0` read+write section.
 
 ## Tags and their endorsements (issue #895)

--- a/lib/vutuv/profiles/messenger.ex
+++ b/lib/vutuv/profiles/messenger.ex
@@ -16,9 +16,21 @@ defmodule Vutuv.Profiles.Messenger do
   section uses, while a username is kept as typed — so a valid handle is never
   rejected as "not a phone number". The other providers carry a service-specific
   id or username.
+
+  Signal takes a **third** shape, its contact link (issue #1442): it is the only
+  Signal address that names neither the phone number nor the username (the
+  fragment carries an encrypted handle), and it can be reset inside the app at
+  any time, so it is what a member reaches for who wants to be reachable without
+  disclosing an identifier. `kind/1` is the single discriminator between the
+  three shapes, and `label/1` is what a link to the contact says: a contact link
+  has no address to show, so it reads as an action.
   """
 
   use VutuvWeb, :model
+
+  # The `gettext/1` macro (not available in the shared `:model` block) so the
+  # contact-link label is picked up by `mix gettext.extract`.
+  use Gettext, backend: VutuvWeb.Gettext
 
   alias PhoenixHTMLHelpers.Link, as: HTMLLink
   alias Vutuv.Phone
@@ -45,6 +57,26 @@ defmodule Vutuv.Profiles.Messenger do
   # WhatsApp both offer usernames now). A phone-shaped value is validated and
   # canonicalised through the phone validator; a username is kept as typed.
   @dual_providers ~w(Signal WhatsApp)
+
+  # Providers whose contact may ALSO be given as a link, and the host that link
+  # has to carry. Only Signal: its link is the one Signal address that discloses
+  # neither the number nor the username. WhatsApp's `wa.me/qr/…` short link is
+  # deliberately absent — WhatsApp shows the number in the chat regardless, so
+  # storing it as a link would promise a privacy it does not deliver.
+  @link_hosts %{"Signal" => "signal.me"}
+
+  # Where a messenger address can hide inside a URL a member pasted into their
+  # links, for `from_url/1`. Wider than @link_hosts, because most of these are
+  # not stored as a link: a `t.me` address is the username inside it. `:link`
+  # keeps the whole (canonicalised) URL, `:path` takes the first path segment,
+  # `:fragment` the first fragment segment. Each is then handed to `changeset/2`,
+  # which is what actually decides whether it is a valid address.
+  @url_providers %{
+    "signal.me" => {"Signal", :link},
+    "t.me" => {"Telegram", :path},
+    "threema.id" => {"Threema", :path},
+    "matrix.to" => {"Matrix", :fragment}
+  }
 
   @doc """
   The providers `changeset/2` accepts, in the order the form's dropdown lists
@@ -78,18 +110,75 @@ defmodule Vutuv.Profiles.Messenger do
   # Reduce whatever the member typed down to the stored form, and reject
   # anything that is not a valid address for the chosen provider. Runs on the
   # trimmed change, so nothing to do when the value was not changed.
+  #
+  # A link is recognised FIRST: a pasted `https://signal.me/#eu/…` carries
+  # letters, so the username branch below would take it and reject it on `:` and
+  # `/`, which is exactly how members ended up filing it under their webpage
+  # links instead (issue #1442).
   defp normalize_value(changeset) do
     provider = get_field(changeset, :provider)
 
     case get_change(changeset, :value) do
       value when is_binary(value) ->
-        if provider in @dual_providers,
-          do: normalize_dual(changeset, value),
-          else: normalize_handle(changeset, provider, value)
+        cond do
+          link_shaped?(provider, value) -> normalize_link(changeset, provider, value)
+          provider in @dual_providers -> normalize_dual(changeset, value)
+          true -> normalize_handle(changeset, provider, value)
+        end
 
       _ ->
         changeset
     end
+  end
+
+  # Is the member trying to give a link at all? Only then does a failure deserve
+  # the link error rather than "enter a phone number or a username". An explicit
+  # scheme, or the provider's own host up front — a bare "signal.me" is none of
+  # those and stays a (perfectly valid) username.
+  defp link_shaped?(provider, value) do
+    case Map.fetch(@link_hosts, provider) do
+      {:ok, host} ->
+        String.contains?(value, "://") or
+          String.starts_with?(String.downcase(value), [
+            host <> "/",
+            host <> "#",
+            "www." <> host <> "/",
+            "www." <> host <> "#"
+          ])
+
+      :error ->
+        false
+    end
+  end
+
+  defp normalize_link(changeset, provider, value) do
+    case canonical_link(provider, value) do
+      {:ok, link} -> put_change(changeset, :value, link)
+      :error -> add_error(changeset, :value, link_error(provider))
+    end
+  end
+
+  defp link_error("Signal"), do: "Enter your Signal link, it starts with https://signal.me/#"
+
+  # The stored form of a contact link: the provider's canonical host over https
+  # plus the fragment, byte for byte. Everything else is dropped, because the
+  # fragment IS the address (that is why it never reaches Signal's server) and a
+  # query a share sheet appended is not part of it. Deliberately lenient about
+  # what the fragment contains: the format has changed five times since 2022, so
+  # a token grammar would only be the next thing to break.
+  defp canonical_link(provider, value) do
+    with {:ok, host} <- Map.fetch(@link_hosts, provider),
+         %URI{host: given, fragment: fragment} <- URI.parse(with_scheme(String.trim(value))),
+         true <- is_binary(given) and String.downcase(given) in [host, "www." <> host],
+         true <- is_binary(fragment) and fragment != "" do
+      {:ok, "https://" <> host <> "/#" <> fragment}
+    else
+      _ -> :error
+    end
+  end
+
+  defp with_scheme(value) do
+    if String.contains?(value, "://"), do: value, else: "https://" <> value
   end
 
   # Signal / WhatsApp accept a phone number OR a username. Only a phone-shaped
@@ -171,6 +260,68 @@ defmodule Vutuv.Profiles.Messenger do
   defp phone_number_value?(value), do: not Regex.match?(~r/[A-Za-z]/, value)
 
   @doc """
+  Which of its provider's address shapes a stored value is:
+
+    * `:link` — a contact link (`https://signal.me/#eu/…`), naming neither the
+      member's phone number nor their username;
+    * `:phone` — a phone number, canonicalised by `Vutuv.Phone`;
+    * `:username` — a handle or a service-specific id.
+
+  The single discriminator `url/1`, `display/1` and `label/1` branch on, so the
+  three can never disagree about what they are looking at.
+  """
+  def kind(%__MODULE__{provider: provider, value: value}) do
+    cond do
+      contact_link?(provider, value) -> :link
+      provider in @dual_providers and phone_number_value?(value) -> :phone
+      true -> :username
+    end
+  end
+
+  defp contact_link?(provider, value) when is_binary(value) do
+    match?({:ok, _link}, canonical_link(provider, value))
+  end
+
+  defp contact_link?(_provider, _value), do: false
+
+  @doc """
+  The messenger a pasted URL is an address for, as `{provider, value}` ready for
+  `changeset/2`, or `nil` when the URL is an ordinary webpage.
+
+  Behind the links editor's "this belongs under Messengers" suggestion: a member
+  whose messenger address was refused here files it as a webpage link instead
+  (issue #1442), where it is neither in the right card nor a page worth
+  screenshotting.
+  """
+  def from_url(url) when is_binary(url) do
+    uri = URI.parse(with_scheme(String.trim(url)))
+    host = uri.host |> to_string() |> String.downcase() |> String.replace_prefix("www.", "")
+
+    case Map.fetch(@url_providers, host) do
+      {:ok, {provider, source}} -> address_in(provider, source, uri)
+      :error -> nil
+    end
+  end
+
+  def from_url(_url), do: nil
+
+  defp address_in(provider, :link, uri) do
+    case canonical_link(provider, URI.to_string(uri)) do
+      {:ok, link} -> {provider, link}
+      :error -> nil
+    end
+  end
+
+  defp address_in(provider, source, uri) do
+    part = if source == :path, do: uri.path, else: uri.fragment
+
+    case part |> to_string() |> String.split("/", trim: true) do
+      [segment | _rest] -> {provider, segment}
+      [] -> nil
+    end
+  end
+
+  @doc """
   The deep link that opens the messenger straight at this contact, as a plain
   string — for the agent documents (`VutuvWeb.AgentDocs`) and the vCard `IMPP`
   lines, which need a string, not a rendered link. Yields `""` when there is no
@@ -178,43 +329,59 @@ defmodule Vutuv.Profiles.Messenger do
   services have no public username resolver), and the bare contact is shown
   instead, like Snapchat in the social media section.
   """
+  def url(%__MODULE__{provider: provider, value: value} = messenger) do
+    # A contact link IS the link; there is nothing to construct.
+    if kind(messenger) == :link, do: value, else: provider_url(provider, value)
+  end
+
+  def url(_), do: ""
+
   # WhatsApp click-to-chat wants bare E.164 digits, no "+"; only a phone number
   # has a link (a username has no public wa.me resolver).
-  def url(%__MODULE__{provider: "WhatsApp", value: value}) do
+  defp provider_url("WhatsApp", value) do
     if phone_number_value?(value),
       do: "https://wa.me/" <> String.replace(Phone.tel(value), "+", ""),
       else: ""
   end
 
   # Signal's phone deep link keeps the leading "+"; a username has no public link.
-  def url(%__MODULE__{provider: "Signal", value: value}) do
+  defp provider_url("Signal", value) do
     if phone_number_value?(value), do: "https://signal.me/#p/" <> Phone.tel(value), else: ""
   end
 
-  def url(%__MODULE__{provider: "Telegram", value: value}), do: "https://t.me/" <> value
-  def url(%__MODULE__{provider: "Threema", value: value}), do: "https://threema.id/" <> value
-  def url(%__MODULE__{provider: "Matrix", value: value}), do: "https://matrix.to/#/" <> value
-  def url(%__MODULE__{provider: "Session"}), do: ""
-  def url(_), do: ""
+  defp provider_url("Telegram", value), do: "https://t.me/" <> value
+  defp provider_url("Threema", value), do: "https://threema.id/" <> value
+  defp provider_url("Matrix", value), do: "https://matrix.to/#/" <> value
+  defp provider_url(_provider, _value), do: ""
 
   @doc """
-  The value as shown to a viewer: a phone number spaced for reading
-  (`Phone.display/1`), otherwise the stored handle/id unchanged.
+  The address itself, as a viewer would read it: a phone number spaced for
+  reading (`Phone.display/1`), otherwise the stored handle, id or link
+  unchanged. This is what the agent documents and the vCard carry, so it stays
+  the address and never a caption — for the caption see `label/1`.
   """
-  def display(%__MODULE__{provider: provider, value: value}) do
-    if provider in @dual_providers and phone_number_value?(value),
-      do: Phone.display(value),
-      else: value
+  def display(%__MODULE__{value: value} = messenger) do
+    if kind(messenger) == :phone, do: Phone.display(value), else: value
   end
 
   @doc """
-  The rendered profile link: the displayed value linked to `url/1`, or the bare
-  displayed value when the provider has no deep link (Session).
+  What a link to this contact says. A contact link has no address to show — its
+  whole point is that it names neither the number nor the username, and its
+  64-character token means nothing to a reader — so it reads as an action.
+  Every other shape shows the address itself.
+  """
+  def label(%__MODULE__{} = messenger) do
+    if kind(messenger) == :link, do: gettext("Open chat"), else: display(messenger)
+  end
+
+  @doc """
+  The rendered profile link: `label/1` linked to `url/1`, or the bare label when
+  the provider has no deep link (Session).
   """
   def messenger_link(%__MODULE__{} = messenger) do
     case url(messenger) do
-      "" -> display(messenger)
-      link -> HTMLLink.link(display(messenger), to: link, rel: "noopener noreferrer")
+      "" -> label(messenger)
+      link -> HTMLLink.link(label(messenger), to: link, rel: "noopener noreferrer")
     end
   end
 end

--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -858,7 +858,11 @@ defmodule VutuvWeb.AgentDocs.Markdown do
 
   # A messenger: the provider, its contact (a phone number or handle), and the
   # deep link that opens the app at that contact. Session has no web link, so it
-  # shows the bare contact.
+  # shows the bare contact. A contact link IS its own address, so it is printed
+  # once rather than as a link labelled with itself.
+  defp messenger_line(%{provider: provider, kind: "link", url: "http" <> _ = url}),
+    do: "- #{provider}: <#{md_url(url)}>"
+
   defp messenger_line(%{provider: provider, contact: contact, url: "http" <> _ = url}),
     do: "- #{provider}: [#{contact}](#{md_url(url)})"
 

--- a/lib/vutuv_web/agent_docs/section_docs.ex
+++ b/lib/vutuv_web/agent_docs/section_docs.ex
@@ -412,13 +412,17 @@ defmodule VutuvWeb.AgentDocs.SectionDocs do
   end
 
   @doc false
-  # `contact` is the human-readable address (a spaced phone number or the bare
-  # handle); `url` is the deep link that opens the messenger at that contact, or
-  # "" for a provider without a public web resolver (Session).
+  # `contact` is the human-readable address (a spaced phone number, a bare
+  # handle, or a contact link); `url` is the deep link that opens the messenger
+  # at that contact, or "" for a provider without a public web resolver
+  # (Session). `kind` says which of the three shapes `contact` is, so a reader
+  # need not guess — and so the renderers below can print a contact link once
+  # instead of twice, `contact` and `url` being the same string for it.
   def messenger_entry(messenger) do
     %{
       id: messenger.id,
       provider: messenger.provider,
+      kind: to_string(Messenger.kind(messenger)),
       contact: Messenger.display(messenger),
       url: Messenger.url(messenger)
     }

--- a/lib/vutuv_web/agent_docs/text.ex
+++ b/lib/vutuv_web/agent_docs/text.ex
@@ -553,7 +553,11 @@ defmodule VutuvWeb.AgentDocs.Text do
   defp social_line(account), do: "* #{account.provider}: #{account.url}"
 
   # A messenger: provider, contact (phone number or handle), and its deep link
-  # in parentheses (absent for Session, which has no web link).
+  # in parentheses (absent for Session, which has no web link). A contact link
+  # IS its own address, so it is printed once instead of twice over.
+  defp messenger_line(%{provider: provider, kind: "link", url: url}),
+    do: "* #{provider}: #{url}"
+
   defp messenger_line(%{provider: provider, contact: contact, url: ""}),
     do: "* #{provider}: #{contact}"
 

--- a/lib/vutuv_web/controllers/messenger_controller.ex
+++ b/lib/vutuv_web/controllers/messenger_controller.ex
@@ -37,8 +37,14 @@ defmodule VutuvWeb.MessengerController do
     )
   end
 
-  def new(conn, _params) do
-    changeset = Messenger.changeset(%Messenger{})
+  # `from_link` arrives from the links editor's "this belongs under Messengers"
+  # suggestion (issue #1442) and carries the id of one of the member's OWN
+  # links, never an address: the form is seeded from what `Messenger.from_url/1`
+  # reads out of that stored URL, so nothing a visitor typed into the query is
+  # reflected back into the form. Seeded on the struct rather than as params, so
+  # a prefilled form opens clean instead of pre-scolding.
+  def new(conn, params) do
+    changeset = Messenger.changeset(seed(conn, params["from_link"]))
     render(conn, "new.html", changeset: changeset)
   end
 
@@ -103,6 +109,17 @@ defmodule VutuvWeb.MessengerController do
       redirect_to: ~p"/settings/messengers"
     )
   end
+
+  defp seed(conn, id) when is_binary(id) do
+    url = ControllerHelpers.get_owned!(conn, :urls, id)
+
+    case Messenger.from_url(url.value) do
+      {provider, value} -> %Messenger{provider: provider, value: value}
+      nil -> %Messenger{}
+    end
+  end
+
+  defp seed(_conn, _id), do: %Messenger{}
 
   defp user_with_messengers(conn),
     do: Repo.preload(conn.assigns[:user], messengers: Messenger.ordered())

--- a/lib/vutuv_web/live/section_reorder_live.ex
+++ b/lib/vutuv_web/live/section_reorder_live.ex
@@ -202,6 +202,19 @@ defmodule VutuvWeb.SectionReorderLive do
           {gettext("Verify this is your page")} →
         </.link>
       </div>
+      <%!-- A messenger address filed as a webpage link (issue #1442). Signal
+      refused its own contact link until then, so members put it here, where it
+      is in the wrong card and gets a screenshot of a page that says nothing
+      about them. Only an offer: moving it is theirs to decide. --%>
+      <div :if={Messenger.from_url(@entry.value)} class="reorder__sub">
+        <.link
+          navigate={~p"/settings/messengers/new?#{[from_link: @entry.id]}"}
+          data-messenger-suggestion
+          class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+        >
+          {gettext("Add this under Messengers")} →
+        </.link>
+      </div>
     </div>
     """
   end

--- a/lib/vutuv_web/templates/messenger/form_content.html.heex
+++ b/lib/vutuv_web/templates/messenger/form_content.html.heex
@@ -14,6 +14,9 @@
     <p class="editform__hint">
       {gettext("Signal and WhatsApp accept a phone number or a username; the other messengers use their own id or handle (e.g. an 8-character Threema ID or a Matrix @you:matrix.org).")}
     </p>
+    <p class="editform__hint">
+      {gettext("Signal also takes its contact link (https://signal.me/#…). It names neither your phone number nor your username, and you can reset it in Signal at any time.")}
+    </p>
     <%= error_tag f, :value %>
   </.editform_field>
 

--- a/lib/vutuv_web/templates/messenger/show.html.heex
+++ b/lib/vutuv_web/templates/messenger/show.html.heex
@@ -1,5 +1,5 @@
 <.page_header
-  title={"#{@messenger.provider}: #{Vutuv.Profiles.Messenger.display(@messenger)}"}
+  title={"#{@messenger.provider}: #{Vutuv.Profiles.Messenger.label(@messenger)}"}
   crumbs={[
     gettext("Users"),
     {full_name(@user), ~p"/#{@user}"},

--- a/lib/vutuv_web/views/error_helpers.ex
+++ b/lib/vutuv_web/views/error_helpers.ex
@@ -121,7 +121,9 @@ defmodule VutuvWeb.ErrorHelpers do
       dgettext_noop("errors", "Please use at most %{max} tags."),
       # Vutuv.Accounts.User, the Fediverse aliases (issue #986, alsoKnownAs).
       dgettext_noop("errors", "Please list at most %{max} accounts."),
-      dgettext_noop("errors", "\"%{uri}\" is not a valid https account address.")
+      dgettext_noop("errors", "\"%{uri}\" is not a valid https account address."),
+      # Vutuv.Profiles.Messenger, the Signal contact link (issue #1442).
+      dgettext_noop("errors", "Enter your Signal link, it starts with https://signal.me/#")
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.282.1",
+      version: "7.283.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -575,7 +575,7 @@ msgstr "Titel"
 msgid "Privacy Policy"
 msgstr "Datenschutzerklärung"
 
-#: lib/vutuv_web/live/section_reorder_live.ex:259
+#: lib/vutuv_web/live/section_reorder_live.ex:272
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:88
@@ -603,7 +603,7 @@ msgid "Provider"
 msgstr "Provider"
 
 #: lib/vutuv_web/live/post_live/composer.ex:1798
-#: lib/vutuv_web/live/section_reorder_live.ex:258
+#: lib/vutuv_web/live/section_reorder_live.ex:271
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:82
@@ -1396,10 +1396,10 @@ msgstr "Tag-URLs"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:33
 #: lib/vutuv_web/agent_docs/markdown.ex:418
-#: lib/vutuv_web/agent_docs/markdown.ex:959
+#: lib/vutuv_web/agent_docs/markdown.ex:963
 #: lib/vutuv_web/agent_docs/text.ex:30
 #: lib/vutuv_web/agent_docs/text.ex:440
-#: lib/vutuv_web/agent_docs/text.ex:659
+#: lib/vutuv_web/agent_docs/text.ex:663
 #: lib/vutuv_web/components/ui.ex:3818
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -2420,7 +2420,7 @@ msgstr "Alle Beiträge"
 msgid "Bookmark"
 msgstr "Lesezeichen setzen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:997
+#: lib/vutuv_web/agent_docs/markdown.ex:1001
 #: lib/vutuv_web/live/post_live/saved.ex:175
 #: lib/vutuv_web/live/post_live/saved.ex:488
 #: lib/vutuv_web/live/shell_live.ex:720
@@ -2440,7 +2440,7 @@ msgstr "Lesezeichen"
 msgid "Like"
 msgstr "Gefällt mir"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:996
+#: lib/vutuv_web/agent_docs/markdown.ex:1000
 #: lib/vutuv_web/components/post_components.ex:4679
 #: lib/vutuv_web/live/notification_live/index.ex:971
 #: lib/vutuv_web/live/post_live/saved.ex:174
@@ -3955,7 +3955,7 @@ msgstr "Im Rahmen scrollen oder klicken, um das ganze Bild zu öffnen."
 msgid "%{count} endorsements"
 msgstr "%{count} Empfehlungen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1118
+#: lib/vutuv_web/agent_docs/markdown.ex:1122
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr "%{count} auf dieser Seite, weitere mit ?page=N"
@@ -3969,11 +3969,11 @@ msgstr "%{count} Beiträge von %{name}"
 #: lib/vutuv_web/agent_docs/markdown.ex:82
 #: lib/vutuv_web/agent_docs/markdown.ex:183
 #: lib/vutuv_web/agent_docs/markdown.ex:197
-#: lib/vutuv_web/agent_docs/markdown.ex:959
+#: lib/vutuv_web/agent_docs/markdown.ex:963
 #: lib/vutuv_web/agent_docs/text.ex:79
 #: lib/vutuv_web/agent_docs/text.ex:167
 #: lib/vutuv_web/agent_docs/text.ex:181
-#: lib/vutuv_web/agent_docs/text.ex:659
+#: lib/vutuv_web/agent_docs/text.ex:663
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr "%{count} insgesamt"
@@ -3992,22 +3992,22 @@ msgstr "Follower von %{name}"
 msgid "Images"
 msgstr "Bilder"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:977
-#: lib/vutuv_web/agent_docs/text.ex:670
+#: lib/vutuv_web/agent_docs/markdown.ex:981
+#: lib/vutuv_web/agent_docs/text.ex:674
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr "Antwort auf einen gelöschten Beitrag von %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:974
-#: lib/vutuv_web/agent_docs/text.ex:667
+#: lib/vutuv_web/agent_docs/markdown.ex:978
+#: lib/vutuv_web/agent_docs/text.ex:671
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr "Antwort auf einen gelöschten Beitrag."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:981
-#: lib/vutuv_web/agent_docs/markdown.ex:1195
-#: lib/vutuv_web/agent_docs/text.ex:673
-#: lib/vutuv_web/agent_docs/text.ex:717
+#: lib/vutuv_web/agent_docs/markdown.ex:985
+#: lib/vutuv_web/agent_docs/markdown.ex:1199
+#: lib/vutuv_web/agent_docs/text.ex:677
+#: lib/vutuv_web/agent_docs/text.ex:721
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr "Antwort auf einen Beitrag von %{name}."
@@ -4062,7 +4062,7 @@ msgstr "Beiträge (insgesamt %{count})"
 msgid "Verified profile: yes"
 msgstr "Verifiziertes Profil: ja"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:928
+#: lib/vutuv_web/agent_docs/markdown.ex:932
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr "repostet von %{name}"
@@ -4607,7 +4607,7 @@ msgstr "Werbung für heute ausblenden"
 msgid "Login PINs and other essential emails are not affected."
 msgstr "Login-PINs und andere notwendige E-Mails sind davon nicht betroffen."
 
-#: lib/vutuv_web/live/section_reorder_live.ex:253
+#: lib/vutuv_web/live/section_reorder_live.ex:266
 #: lib/vutuv_web/templates/email/card_list.html.heex:21
 #, elixir-autogen, elixir-format
 msgid "Mail to this address bounced. Logging in with a PIN sent to it will clear this warning."
@@ -4615,7 +4615,7 @@ msgstr ""
 "E-Mails an diese Adresse kamen als unzustellbar zurück. Ein Login mit einer "
 "an diese Adresse geschickten PIN entfernt diese Warnung."
 
-#: lib/vutuv_web/live/section_reorder_live.ex:254
+#: lib/vutuv_web/live/section_reorder_live.ex:267
 #: lib/vutuv_web/templates/email/card_list.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "Undeliverable"
@@ -6455,7 +6455,7 @@ msgstr "Tagesbericht öffnen"
 msgid "Previous day"
 msgstr "Vorheriger Tag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:996
+#: lib/vutuv_web/agent_docs/markdown.ex:1000
 #: lib/vutuv_web/components/post_components.ex:392
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
@@ -6566,7 +6566,7 @@ msgstr "Noch keine Empfehlungen."
 msgid "and %{count} more"
 msgstr "und %{count} weitere"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:972
+#: lib/vutuv_web/agent_docs/markdown.ex:976
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr "empfohlen am %{date}"
@@ -7831,17 +7831,17 @@ msgstr "Feed von %{name}"
 msgid "The vutuv newsfeed of %{name}"
 msgstr "Der vutuv-Newsfeed von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1123
+#: lib/vutuv_web/agent_docs/markdown.ex:1127
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr "Ihr Feed ist leer."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1126
+#: lib/vutuv_web/agent_docs/markdown.ex:1130
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr "%{count} Beiträge auf dieser Seite"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1133
+#: lib/vutuv_web/agent_docs/markdown.ex:1137
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr "weitere Beiträge verfügbar, ?cursor=%{cursor} anhängen"
@@ -9245,7 +9245,7 @@ msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] "Repostet von %{name} und %{formatted} weiteren"
 msgstr[1] "Repostet von %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:931
+#: lib/vutuv_web/agent_docs/markdown.ex:935
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr "repostet von %{name} und %{count} weiteren"
@@ -10197,7 +10197,7 @@ msgid "Preferred"
 msgstr "Bevorzugt"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:657
-#: lib/vutuv_web/live/section_reorder_live.ex:280
+#: lib/vutuv_web/live/section_reorder_live.ex:293
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
 msgid "Preferred contact language"
@@ -12239,7 +12239,7 @@ msgstr ""
 "dauern. Bitte versuchen Sie es erneut."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:842
-#: lib/vutuv_web/agent_docs/text.ex:632
+#: lib/vutuv_web/agent_docs/text.ex:636
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr "verifizierte Webseite"
@@ -14260,17 +14260,17 @@ msgstr "Messenger hinzufügen"
 msgid "Messenger"
 msgstr "Messenger"
 
-#: lib/vutuv_web/controllers/messenger_controller.ex:58
+#: lib/vutuv_web/controllers/messenger_controller.ex:64
 #, elixir-autogen, elixir-format
 msgid "Messenger created successfully."
 msgstr "Messenger wurde erstellt."
 
-#: lib/vutuv_web/controllers/messenger_controller.ex:102
+#: lib/vutuv_web/controllers/messenger_controller.ex:108
 #, elixir-autogen, elixir-format
 msgid "Messenger deleted successfully."
 msgstr "Messenger wurde gelöscht."
 
-#: lib/vutuv_web/controllers/messenger_controller.ex:91
+#: lib/vutuv_web/controllers/messenger_controller.ex:97
 #, elixir-autogen, elixir-format
 msgid "Messenger updated successfully."
 msgstr "Messenger wurde geändert."
@@ -14367,7 +14367,7 @@ msgstr "hat %{count} neue Einträge im Lebenslauf:"
 msgid "Audiobook"
 msgstr "Hörbuch"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1085
+#: lib/vutuv_web/agent_docs/markdown.ex:1089
 #: lib/vutuv_web/components/post_components.ex:4168
 #, elixir-autogen, elixir-format
 msgid "Book review"
@@ -14388,7 +14388,7 @@ msgstr "DVD/Blu-ray"
 msgid "E-book"
 msgstr "E-Book"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1085
+#: lib/vutuv_web/agent_docs/markdown.ex:1089
 #: lib/vutuv_web/components/post_components.ex:4167
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -14667,7 +14667,7 @@ msgid "View the uploaded proof (%{label})"
 msgstr "Hochgeladenen Nachweis ansehen (%{label})"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:779
-#: lib/vutuv_web/agent_docs/text.ex:624
+#: lib/vutuv_web/agent_docs/text.ex:628
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr "Nachweis"
@@ -15364,7 +15364,7 @@ msgstr "%{blocked} Server blockiert, am aktivsten eingehend: %{host}."
 msgid "none yet"
 msgstr "noch keiner"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1032
+#: lib/vutuv_web/agent_docs/markdown.ex:1036
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr "Reaktionen aus anderen Netzwerken"
@@ -16167,7 +16167,7 @@ msgid_plural "%{formatted} reposts"
 msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1034
+#: lib/vutuv_web/agent_docs/markdown.ex:1038
 #: lib/vutuv_web/components/post_components.ex:4585
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
@@ -16178,8 +16178,8 @@ msgstr "Bereits in den Zahlen oben enthalten."
 msgid "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
 msgstr "Antworten, die dort draußen geschrieben werden, erscheinen unter Ihrem Beitrag, gekennzeichnet als aus einem anderen Netzwerk. Wir speichern eine Kopie für bis zu sechs Monate und prüfen ab und zu, ob sie dort noch veröffentlicht ist; löscht sie die Autorin oder der Autor, verschwindet auch unsere. Sie können jede einzelne Antwort entfernen, und wenn Sie das hier ausschalten, werden alle gelöscht."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1216
-#: lib/vutuv_web/agent_docs/text.ex:731
+#: lib/vutuv_web/agent_docs/markdown.ex:1220
+#: lib/vutuv_web/agent_docs/text.ex:735
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr "Inhaltswarnung"
@@ -16202,7 +16202,7 @@ msgid "Removed by the member"
 msgstr "Vom Mitglied entfernt"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:125
-#: lib/vutuv_web/agent_docs/markdown.ex:1033
+#: lib/vutuv_web/agent_docs/markdown.ex:1037
 #: lib/vutuv_web/agent_docs/text.ex:116
 #, elixir-autogen, elixir-format
 msgid "Replies from other networks"
@@ -16259,7 +16259,7 @@ msgstr "Danke. Die Antwort wurde sofort gelöscht."
 msgid "That reply is not yours to remove."
 msgstr "Diese Antwort können Sie nicht entfernen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1218
+#: lib/vutuv_web/agent_docs/markdown.ex:1222
 #: lib/vutuv_web/components/post_components.ex:1098
 #: lib/vutuv_web/components/post_components.ex:1298
 #: lib/vutuv_web/components/post_components.ex:2096
@@ -16965,7 +16965,7 @@ msgstr ""
 msgid "Unpinned. The post is a normal post again."
 msgstr "Nicht mehr angeheftet. Der Beitrag ist wieder ein normaler Beitrag."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:914
+#: lib/vutuv_web/agent_docs/markdown.ex:918
 #, elixir-autogen, elixir-format
 msgid "pinned post"
 msgstr "angehefteter Beitrag"
@@ -17033,8 +17033,8 @@ msgstr "Titelbild"
 msgid "Describe the photo for people who can't see it"
 msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1146
-#: lib/vutuv_web/agent_docs/text.ex:698
+#: lib/vutuv_web/agent_docs/markdown.ex:1150
+#: lib/vutuv_web/agent_docs/text.ex:702
 #: lib/vutuv_web/components/post_components.ex:3207
 #, elixir-autogen, elixir-format
 msgid "Download the original"
@@ -17108,8 +17108,8 @@ msgstr "Foto wird geprüft"
 msgid "Photo options"
 msgstr "Foto-Einstellungen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1179
-#: lib/vutuv_web/agent_docs/text.ex:685
+#: lib/vutuv_web/agent_docs/markdown.ex:1183
+#: lib/vutuv_web/agent_docs/text.ex:689
 #: lib/vutuv_web/components/post_components.ex:3624
 #, elixir-autogen, elixir-format
 msgid "Photos:"
@@ -17282,13 +17282,13 @@ msgid_plural "Some of these photos carry the location they were taken at, and th
 msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exakte Datei gibt ihn weiter."
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1052
+#: lib/vutuv_web/agent_docs/markdown.ex:1056
 #: lib/vutuv_web/components/post_components.ex:4623
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1050
+#: lib/vutuv_web/agent_docs/markdown.ex:1054
 #: lib/vutuv_web/components/post_components.ex:4620
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
@@ -17918,7 +17918,7 @@ msgstr "Variante"
 msgid "What is being measured"
 msgstr "Was gemessen wird"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:909
+#: lib/vutuv_web/agent_docs/markdown.ex:913
 #, elixir-autogen, elixir-format
 msgid "(a picture)"
 msgid_plural "(%{count} pictures)"
@@ -19036,7 +19036,7 @@ msgstr "Höchstens %{max} Tags. Entfernen Sie eines, um ein anderes hinzuzufüge
 msgid "A post's page shows the members who liked it, right under the count. This is whether you are one of the faces."
 msgstr "Auf der Seite eines Beitrags stehen direkt unter der Zahl die Mitglieder, denen er gefällt. Hier legen Sie fest, ob Sie zu diesen Gesichtern gehören."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1020
+#: lib/vutuv_web/agent_docs/markdown.ex:1024
 #, elixir-autogen, elixir-format
 msgid "Liked by"
 msgstr "Gefällt diesen Mitgliedern"
@@ -19078,12 +19078,12 @@ msgstr "Wenn aus, sehen andere Mitglieder Sie nicht mehr bei den Likes eines Bei
 msgid "Your likes follow the site default again."
 msgstr "Ihre Likes folgen wieder dem Standardwert der Website."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1075
+#: lib/vutuv_web/agent_docs/markdown.ex:1079
 #, elixir-autogen, elixir-format
 msgid "%{address} (this page only)"
 msgstr "%{address} (nur diese Seite)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1072
+#: lib/vutuv_web/agent_docs/markdown.ex:1076
 #, elixir-autogen, elixir-format
 msgid "%{address} (whole website)"
 msgstr "%{address} (ganze Website)"
@@ -19093,7 +19093,7 @@ msgstr "%{address} (ganze Website)"
 msgid "Verified webpage of the author (%{address})"
 msgstr "Verifizierte Webseite der Autorin oder des Autors (%{address})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1064
+#: lib/vutuv_web/agent_docs/markdown.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Verified webpages of the author linked here: %{addresses}"
 msgstr ""
@@ -21245,3 +21245,18 @@ msgstr ""
 "Hier sind %{listed} vutuv Mitglieder aufgeführt, gruppiert nach dem "
 "Anfangsbuchstaben des Nachnamens; wer sein Profil nicht für Suchmaschinen "
 "freigibt, ist nicht dabei."
+
+#: lib/vutuv_web/live/section_reorder_live.ex:215
+#, elixir-autogen, elixir-format
+msgid "Add this under Messengers"
+msgstr "Unter Messenger eintragen"
+
+#: lib/vutuv/profiles/messenger.ex:374
+#, elixir-autogen, elixir-format
+msgid "Open chat"
+msgstr "Chat öffnen"
+
+#: lib/vutuv_web/templates/messenger/form_content.html.heex:18
+#, elixir-autogen, elixir-format
+msgid "Signal also takes its contact link (https://signal.me/#…). It names neither your phone number nor your username, and you can reset it in Signal at any time."
+msgstr "Für Signal können Sie auch Ihren Kontakt-Link angeben (https://signal.me/#…). Er nennt weder Ihre Rufnummer noch Ihren Benutzernamen, und Sie können ihn in Signal jederzeit zurücksetzen."

--- a/priv/gettext/de/LC_MESSAGES/errors.po
+++ b/priv/gettext/de/LC_MESSAGES/errors.po
@@ -246,3 +246,8 @@ msgstr "muss beschreiben, wie der Name klingt"
 #, elixir-autogen, elixir-format
 msgid "Please use at most %{max} tags."
 msgstr "Bitte verwenden Sie höchstens %{max} Tags."
+
+#: lib/vutuv_web/views/error_helpers.ex:126
+#, elixir-autogen, elixir-format
+msgid "Enter your Signal link, it starts with https://signal.me/#"
+msgstr "Bitte geben Sie Ihren Signal-Link ein, er beginnt mit https://signal.me/#"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -575,7 +575,7 @@ msgstr ""
 msgid "Privacy Policy"
 msgstr ""
 
-#: lib/vutuv_web/live/section_reorder_live.ex:259
+#: lib/vutuv_web/live/section_reorder_live.ex:272
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:88
@@ -603,7 +603,7 @@ msgid "Provider"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/composer.ex:1798
-#: lib/vutuv_web/live/section_reorder_live.ex:258
+#: lib/vutuv_web/live/section_reorder_live.ex:271
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:82
@@ -1369,10 +1369,10 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:33
 #: lib/vutuv_web/agent_docs/markdown.ex:418
-#: lib/vutuv_web/agent_docs/markdown.ex:959
+#: lib/vutuv_web/agent_docs/markdown.ex:963
 #: lib/vutuv_web/agent_docs/text.ex:30
 #: lib/vutuv_web/agent_docs/text.ex:440
-#: lib/vutuv_web/agent_docs/text.ex:659
+#: lib/vutuv_web/agent_docs/text.ex:663
 #: lib/vutuv_web/components/ui.ex:3818
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -2373,7 +2373,7 @@ msgstr ""
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:997
+#: lib/vutuv_web/agent_docs/markdown.ex:1001
 #: lib/vutuv_web/live/post_live/saved.ex:175
 #: lib/vutuv_web/live/post_live/saved.ex:488
 #: lib/vutuv_web/live/shell_live.ex:720
@@ -2393,7 +2393,7 @@ msgstr ""
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:996
+#: lib/vutuv_web/agent_docs/markdown.ex:1000
 #: lib/vutuv_web/components/post_components.ex:4679
 #: lib/vutuv_web/live/notification_live/index.ex:971
 #: lib/vutuv_web/live/post_live/saved.ex:174
@@ -3827,7 +3827,7 @@ msgstr ""
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1118
+#: lib/vutuv_web/agent_docs/markdown.ex:1122
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
@@ -3841,11 +3841,11 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:82
 #: lib/vutuv_web/agent_docs/markdown.ex:183
 #: lib/vutuv_web/agent_docs/markdown.ex:197
-#: lib/vutuv_web/agent_docs/markdown.ex:959
+#: lib/vutuv_web/agent_docs/markdown.ex:963
 #: lib/vutuv_web/agent_docs/text.ex:79
 #: lib/vutuv_web/agent_docs/text.ex:167
 #: lib/vutuv_web/agent_docs/text.ex:181
-#: lib/vutuv_web/agent_docs/text.ex:659
+#: lib/vutuv_web/agent_docs/text.ex:663
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr ""
@@ -3864,22 +3864,22 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:977
-#: lib/vutuv_web/agent_docs/text.ex:670
+#: lib/vutuv_web/agent_docs/markdown.ex:981
+#: lib/vutuv_web/agent_docs/text.ex:674
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:974
-#: lib/vutuv_web/agent_docs/text.ex:667
+#: lib/vutuv_web/agent_docs/markdown.ex:978
+#: lib/vutuv_web/agent_docs/text.ex:671
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:981
-#: lib/vutuv_web/agent_docs/markdown.ex:1195
-#: lib/vutuv_web/agent_docs/text.ex:673
-#: lib/vutuv_web/agent_docs/text.ex:717
+#: lib/vutuv_web/agent_docs/markdown.ex:985
+#: lib/vutuv_web/agent_docs/markdown.ex:1199
+#: lib/vutuv_web/agent_docs/text.ex:677
+#: lib/vutuv_web/agent_docs/text.ex:721
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
@@ -3934,7 +3934,7 @@ msgstr ""
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:928
+#: lib/vutuv_web/agent_docs/markdown.ex:932
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
@@ -4451,13 +4451,13 @@ msgstr ""
 msgid "Login PINs and other essential emails are not affected."
 msgstr ""
 
-#: lib/vutuv_web/live/section_reorder_live.ex:253
+#: lib/vutuv_web/live/section_reorder_live.ex:266
 #: lib/vutuv_web/templates/email/card_list.html.heex:21
 #, elixir-autogen, elixir-format
 msgid "Mail to this address bounced. Logging in with a PIN sent to it will clear this warning."
 msgstr ""
 
-#: lib/vutuv_web/live/section_reorder_live.ex:254
+#: lib/vutuv_web/live/section_reorder_live.ex:267
 #: lib/vutuv_web/templates/email/card_list.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "Undeliverable"
@@ -6207,7 +6207,7 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:996
+#: lib/vutuv_web/agent_docs/markdown.ex:1000
 #: lib/vutuv_web/components/post_components.ex:392
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
@@ -6312,7 +6312,7 @@ msgstr ""
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:972
+#: lib/vutuv_web/agent_docs/markdown.ex:976
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -7513,17 +7513,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1123
+#: lib/vutuv_web/agent_docs/markdown.ex:1127
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1126
+#: lib/vutuv_web/agent_docs/markdown.ex:1130
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1133
+#: lib/vutuv_web/agent_docs/markdown.ex:1137
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -8806,7 +8806,7 @@ msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:931
+#: lib/vutuv_web/agent_docs/markdown.ex:935
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -9715,7 +9715,7 @@ msgid "Preferred"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:657
-#: lib/vutuv_web/live/section_reorder_live.ex:280
+#: lib/vutuv_web/live/section_reorder_live.ex:293
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
 msgid "Preferred contact language"
@@ -11613,7 +11613,7 @@ msgid "We could not find the proof yet. It can take a while to propagate. Please
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:842
-#: lib/vutuv_web/agent_docs/text.ex:632
+#: lib/vutuv_web/agent_docs/text.ex:636
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr ""
@@ -13577,17 +13577,17 @@ msgstr ""
 msgid "Messenger"
 msgstr ""
 
-#: lib/vutuv_web/controllers/messenger_controller.ex:58
+#: lib/vutuv_web/controllers/messenger_controller.ex:64
 #, elixir-autogen, elixir-format
 msgid "Messenger created successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/messenger_controller.ex:102
+#: lib/vutuv_web/controllers/messenger_controller.ex:108
 #, elixir-autogen, elixir-format
 msgid "Messenger deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/messenger_controller.ex:91
+#: lib/vutuv_web/controllers/messenger_controller.ex:97
 #, elixir-autogen, elixir-format
 msgid "Messenger updated successfully."
 msgstr ""
@@ -13684,7 +13684,7 @@ msgstr ""
 msgid "Audiobook"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1085
+#: lib/vutuv_web/agent_docs/markdown.ex:1089
 #: lib/vutuv_web/components/post_components.ex:4168
 #, elixir-autogen, elixir-format
 msgid "Book review"
@@ -13705,7 +13705,7 @@ msgstr ""
 msgid "E-book"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1085
+#: lib/vutuv_web/agent_docs/markdown.ex:1089
 #: lib/vutuv_web/components/post_components.ex:4167
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -13984,7 +13984,7 @@ msgid "View the uploaded proof (%{label})"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:779
-#: lib/vutuv_web/agent_docs/text.ex:624
+#: lib/vutuv_web/agent_docs/text.ex:628
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr ""
@@ -14657,7 +14657,7 @@ msgstr ""
 msgid "none yet"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1032
+#: lib/vutuv_web/agent_docs/markdown.ex:1036
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr ""
@@ -15446,7 +15446,7 @@ msgid_plural "%{formatted} reposts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1034
+#: lib/vutuv_web/agent_docs/markdown.ex:1038
 #: lib/vutuv_web/components/post_components.ex:4585
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
@@ -15457,8 +15457,8 @@ msgstr ""
 msgid "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1216
-#: lib/vutuv_web/agent_docs/text.ex:731
+#: lib/vutuv_web/agent_docs/markdown.ex:1220
+#: lib/vutuv_web/agent_docs/text.ex:735
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr ""
@@ -15481,7 +15481,7 @@ msgid "Removed by the member"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:125
-#: lib/vutuv_web/agent_docs/markdown.ex:1033
+#: lib/vutuv_web/agent_docs/markdown.ex:1037
 #: lib/vutuv_web/agent_docs/text.ex:116
 #, elixir-autogen, elixir-format
 msgid "Replies from other networks"
@@ -15538,7 +15538,7 @@ msgstr ""
 msgid "That reply is not yours to remove."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1218
+#: lib/vutuv_web/agent_docs/markdown.ex:1222
 #: lib/vutuv_web/components/post_components.ex:1098
 #: lib/vutuv_web/components/post_components.ex:1298
 #: lib/vutuv_web/components/post_components.ex:2096
@@ -16238,7 +16238,7 @@ msgstr ""
 msgid "Unpinned. The post is a normal post again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:914
+#: lib/vutuv_web/agent_docs/markdown.ex:918
 #, elixir-autogen, elixir-format
 msgid "pinned post"
 msgstr ""
@@ -16302,8 +16302,8 @@ msgstr ""
 msgid "Describe the photo for people who can't see it"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1146
-#: lib/vutuv_web/agent_docs/text.ex:698
+#: lib/vutuv_web/agent_docs/markdown.ex:1150
+#: lib/vutuv_web/agent_docs/text.ex:702
 #: lib/vutuv_web/components/post_components.ex:3207
 #, elixir-autogen, elixir-format
 msgid "Download the original"
@@ -16377,8 +16377,8 @@ msgstr ""
 msgid "Photo options"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1179
-#: lib/vutuv_web/agent_docs/text.ex:685
+#: lib/vutuv_web/agent_docs/markdown.ex:1183
+#: lib/vutuv_web/agent_docs/text.ex:689
 #: lib/vutuv_web/components/post_components.ex:3624
 #, elixir-autogen, elixir-format
 msgid "Photos:"
@@ -16551,13 +16551,13 @@ msgid_plural "Some of these photos carry the location they were taken at, and th
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1052
+#: lib/vutuv_web/agent_docs/markdown.ex:1056
 #: lib/vutuv_web/components/post_components.ex:4623
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1050
+#: lib/vutuv_web/agent_docs/markdown.ex:1054
 #: lib/vutuv_web/components/post_components.ex:4620
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
@@ -17178,7 +17178,7 @@ msgstr ""
 msgid "What is being measured"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:909
+#: lib/vutuv_web/agent_docs/markdown.ex:913
 #, elixir-autogen, elixir-format
 msgid "(a picture)"
 msgid_plural "(%{count} pictures)"
@@ -18280,7 +18280,7 @@ msgstr ""
 msgid "A post's page shows the members who liked it, right under the count. This is whether you are one of the faces."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1020
+#: lib/vutuv_web/agent_docs/markdown.ex:1024
 #, elixir-autogen, elixir-format
 msgid "Liked by"
 msgstr ""
@@ -18322,12 +18322,12 @@ msgstr ""
 msgid "Your likes follow the site default again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1075
+#: lib/vutuv_web/agent_docs/markdown.ex:1079
 #, elixir-autogen, elixir-format
 msgid "%{address} (this page only)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1072
+#: lib/vutuv_web/agent_docs/markdown.ex:1076
 #, elixir-autogen, elixir-format
 msgid "%{address} (whole website)"
 msgstr ""
@@ -18337,7 +18337,7 @@ msgstr ""
 msgid "Verified webpage of the author (%{address})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1064
+#: lib/vutuv_web/agent_docs/markdown.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Verified webpages of the author linked here: %{addresses}"
 msgstr ""
@@ -20461,4 +20461,19 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/list_docs.ex:210
 #, elixir-autogen, elixir-format
 msgid "%{listed} vutuv members are listed here, grouped by the first letter of their last name; anyone who does not open their profile to search engines is not among them."
+msgstr ""
+
+#: lib/vutuv_web/live/section_reorder_live.ex:215
+#, elixir-autogen, elixir-format
+msgid "Add this under Messengers"
+msgstr ""
+
+#: lib/vutuv/profiles/messenger.ex:374
+#, elixir-autogen, elixir-format
+msgid "Open chat"
+msgstr ""
+
+#: lib/vutuv_web/templates/messenger/form_content.html.heex:18
+#, elixir-autogen, elixir-format
+msgid "Signal also takes its contact link (https://signal.me/#…). It names neither your phone number nor your username, and you can reset it in Signal at any time."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -573,7 +573,7 @@ msgstr ""
 msgid "Privacy Policy"
 msgstr ""
 
-#: lib/vutuv_web/live/section_reorder_live.ex:259
+#: lib/vutuv_web/live/section_reorder_live.ex:272
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:88
@@ -601,7 +601,7 @@ msgid "Provider"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/composer.ex:1798
-#: lib/vutuv_web/live/section_reorder_live.ex:258
+#: lib/vutuv_web/live/section_reorder_live.ex:271
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:82
@@ -1367,10 +1367,10 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:33
 #: lib/vutuv_web/agent_docs/markdown.ex:418
-#: lib/vutuv_web/agent_docs/markdown.ex:959
+#: lib/vutuv_web/agent_docs/markdown.ex:963
 #: lib/vutuv_web/agent_docs/text.ex:30
 #: lib/vutuv_web/agent_docs/text.ex:440
-#: lib/vutuv_web/agent_docs/text.ex:659
+#: lib/vutuv_web/agent_docs/text.ex:663
 #: lib/vutuv_web/components/ui.ex:3818
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -2371,7 +2371,7 @@ msgstr ""
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:997
+#: lib/vutuv_web/agent_docs/markdown.ex:1001
 #: lib/vutuv_web/live/post_live/saved.ex:175
 #: lib/vutuv_web/live/post_live/saved.ex:488
 #: lib/vutuv_web/live/shell_live.ex:720
@@ -2391,7 +2391,7 @@ msgstr ""
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:996
+#: lib/vutuv_web/agent_docs/markdown.ex:1000
 #: lib/vutuv_web/components/post_components.ex:4679
 #: lib/vutuv_web/live/notification_live/index.ex:971
 #: lib/vutuv_web/live/post_live/saved.ex:174
@@ -3825,7 +3825,7 @@ msgstr ""
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1118
+#: lib/vutuv_web/agent_docs/markdown.ex:1122
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
@@ -3839,11 +3839,11 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:82
 #: lib/vutuv_web/agent_docs/markdown.ex:183
 #: lib/vutuv_web/agent_docs/markdown.ex:197
-#: lib/vutuv_web/agent_docs/markdown.ex:959
+#: lib/vutuv_web/agent_docs/markdown.ex:963
 #: lib/vutuv_web/agent_docs/text.ex:79
 #: lib/vutuv_web/agent_docs/text.ex:167
 #: lib/vutuv_web/agent_docs/text.ex:181
-#: lib/vutuv_web/agent_docs/text.ex:659
+#: lib/vutuv_web/agent_docs/text.ex:663
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr ""
@@ -3862,22 +3862,22 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:977
-#: lib/vutuv_web/agent_docs/text.ex:670
+#: lib/vutuv_web/agent_docs/markdown.ex:981
+#: lib/vutuv_web/agent_docs/text.ex:674
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:974
-#: lib/vutuv_web/agent_docs/text.ex:667
+#: lib/vutuv_web/agent_docs/markdown.ex:978
+#: lib/vutuv_web/agent_docs/text.ex:671
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:981
-#: lib/vutuv_web/agent_docs/markdown.ex:1195
-#: lib/vutuv_web/agent_docs/text.ex:673
-#: lib/vutuv_web/agent_docs/text.ex:717
+#: lib/vutuv_web/agent_docs/markdown.ex:985
+#: lib/vutuv_web/agent_docs/markdown.ex:1199
+#: lib/vutuv_web/agent_docs/text.ex:677
+#: lib/vutuv_web/agent_docs/text.ex:721
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
@@ -3932,7 +3932,7 @@ msgstr ""
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:928
+#: lib/vutuv_web/agent_docs/markdown.ex:932
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
@@ -4449,13 +4449,13 @@ msgstr ""
 msgid "Login PINs and other essential emails are not affected."
 msgstr ""
 
-#: lib/vutuv_web/live/section_reorder_live.ex:253
+#: lib/vutuv_web/live/section_reorder_live.ex:266
 #: lib/vutuv_web/templates/email/card_list.html.heex:21
 #, elixir-autogen, elixir-format
 msgid "Mail to this address bounced. Logging in with a PIN sent to it will clear this warning."
 msgstr ""
 
-#: lib/vutuv_web/live/section_reorder_live.ex:254
+#: lib/vutuv_web/live/section_reorder_live.ex:267
 #: lib/vutuv_web/templates/email/card_list.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "Undeliverable"
@@ -6205,7 +6205,7 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:996
+#: lib/vutuv_web/agent_docs/markdown.ex:1000
 #: lib/vutuv_web/components/post_components.ex:392
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
@@ -6310,7 +6310,7 @@ msgstr ""
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:972
+#: lib/vutuv_web/agent_docs/markdown.ex:976
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -7511,17 +7511,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1123
+#: lib/vutuv_web/agent_docs/markdown.ex:1127
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1126
+#: lib/vutuv_web/agent_docs/markdown.ex:1130
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1133
+#: lib/vutuv_web/agent_docs/markdown.ex:1137
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -8804,7 +8804,7 @@ msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:931
+#: lib/vutuv_web/agent_docs/markdown.ex:935
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -9713,7 +9713,7 @@ msgid "Preferred"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:657
-#: lib/vutuv_web/live/section_reorder_live.ex:280
+#: lib/vutuv_web/live/section_reorder_live.ex:293
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
 msgid "Preferred contact language"
@@ -11611,7 +11611,7 @@ msgid "We could not find the proof yet. It can take a while to propagate. Please
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:842
-#: lib/vutuv_web/agent_docs/text.ex:632
+#: lib/vutuv_web/agent_docs/text.ex:636
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr ""
@@ -13575,17 +13575,17 @@ msgstr ""
 msgid "Messenger"
 msgstr ""
 
-#: lib/vutuv_web/controllers/messenger_controller.ex:58
+#: lib/vutuv_web/controllers/messenger_controller.ex:64
 #, elixir-autogen, elixir-format
 msgid "Messenger created successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/messenger_controller.ex:102
+#: lib/vutuv_web/controllers/messenger_controller.ex:108
 #, elixir-autogen, elixir-format
 msgid "Messenger deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/messenger_controller.ex:91
+#: lib/vutuv_web/controllers/messenger_controller.ex:97
 #, elixir-autogen, elixir-format
 msgid "Messenger updated successfully."
 msgstr ""
@@ -13682,7 +13682,7 @@ msgstr ""
 msgid "Audiobook"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1085
+#: lib/vutuv_web/agent_docs/markdown.ex:1089
 #: lib/vutuv_web/components/post_components.ex:4168
 #, elixir-autogen, elixir-format
 msgid "Book review"
@@ -13703,7 +13703,7 @@ msgstr ""
 msgid "E-book"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1085
+#: lib/vutuv_web/agent_docs/markdown.ex:1089
 #: lib/vutuv_web/components/post_components.ex:4167
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -13982,7 +13982,7 @@ msgid "View the uploaded proof (%{label})"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:779
-#: lib/vutuv_web/agent_docs/text.ex:624
+#: lib/vutuv_web/agent_docs/text.ex:628
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr ""
@@ -14655,7 +14655,7 @@ msgstr ""
 msgid "none yet"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1032
+#: lib/vutuv_web/agent_docs/markdown.ex:1036
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr ""
@@ -15444,7 +15444,7 @@ msgid_plural "%{formatted} reposts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1034
+#: lib/vutuv_web/agent_docs/markdown.ex:1038
 #: lib/vutuv_web/components/post_components.ex:4585
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
@@ -15455,8 +15455,8 @@ msgstr ""
 msgid "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1216
-#: lib/vutuv_web/agent_docs/text.ex:731
+#: lib/vutuv_web/agent_docs/markdown.ex:1220
+#: lib/vutuv_web/agent_docs/text.ex:735
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Content warning"
 msgstr ""
@@ -15479,7 +15479,7 @@ msgid "Removed by the member"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:125
-#: lib/vutuv_web/agent_docs/markdown.ex:1033
+#: lib/vutuv_web/agent_docs/markdown.ex:1037
 #: lib/vutuv_web/agent_docs/text.ex:116
 #, elixir-autogen, elixir-format
 msgid "Replies from other networks"
@@ -15536,7 +15536,7 @@ msgstr ""
 msgid "That reply is not yours to remove."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1218
+#: lib/vutuv_web/agent_docs/markdown.ex:1222
 #: lib/vutuv_web/components/post_components.ex:1098
 #: lib/vutuv_web/components/post_components.ex:1298
 #: lib/vutuv_web/components/post_components.ex:2096
@@ -16236,7 +16236,7 @@ msgstr ""
 msgid "Unpinned. The post is a normal post again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:914
+#: lib/vutuv_web/agent_docs/markdown.ex:918
 #, elixir-autogen, elixir-format
 msgid "pinned post"
 msgstr ""
@@ -16300,8 +16300,8 @@ msgstr ""
 msgid "Describe the photo for people who can't see it"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1146
-#: lib/vutuv_web/agent_docs/text.ex:698
+#: lib/vutuv_web/agent_docs/markdown.ex:1150
+#: lib/vutuv_web/agent_docs/text.ex:702
 #: lib/vutuv_web/components/post_components.ex:3207
 #, elixir-autogen, elixir-format
 msgid "Download the original"
@@ -16375,8 +16375,8 @@ msgstr ""
 msgid "Photo options"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1179
-#: lib/vutuv_web/agent_docs/text.ex:685
+#: lib/vutuv_web/agent_docs/markdown.ex:1183
+#: lib/vutuv_web/agent_docs/text.ex:689
 #: lib/vutuv_web/components/post_components.ex:3624
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
@@ -16549,13 +16549,13 @@ msgid_plural "Some of these photos carry the location they were taken at, and th
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1052
+#: lib/vutuv_web/agent_docs/markdown.ex:1056
 #: lib/vutuv_web/components/post_components.ex:4623
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1050
+#: lib/vutuv_web/agent_docs/markdown.ex:1054
 #: lib/vutuv_web/components/post_components.ex:4620
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
@@ -17176,7 +17176,7 @@ msgstr ""
 msgid "What is being measured"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:909
+#: lib/vutuv_web/agent_docs/markdown.ex:913
 #, elixir-autogen, elixir-format
 msgid "(a picture)"
 msgid_plural "(%{count} pictures)"
@@ -18278,7 +18278,7 @@ msgstr ""
 msgid "A post's page shows the members who liked it, right under the count. This is whether you are one of the faces."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1020
+#: lib/vutuv_web/agent_docs/markdown.ex:1024
 #, elixir-autogen, elixir-format
 msgid "Liked by"
 msgstr ""
@@ -18320,12 +18320,12 @@ msgstr ""
 msgid "Your likes follow the site default again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1075
+#: lib/vutuv_web/agent_docs/markdown.ex:1079
 #, elixir-autogen, elixir-format
 msgid "%{address} (this page only)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1072
+#: lib/vutuv_web/agent_docs/markdown.ex:1076
 #, elixir-autogen, elixir-format
 msgid "%{address} (whole website)"
 msgstr ""
@@ -18335,7 +18335,7 @@ msgstr ""
 msgid "Verified webpage of the author (%{address})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1064
+#: lib/vutuv_web/agent_docs/markdown.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Verified webpages of the author linked here: %{addresses}"
 msgstr ""
@@ -20459,4 +20459,19 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/list_docs.ex:210
 #, elixir-autogen, elixir-format
 msgid "%{listed} vutuv members are listed here, grouped by the first letter of their last name; anyone who does not open their profile to search engines is not among them."
+msgstr ""
+
+#: lib/vutuv_web/live/section_reorder_live.ex:215
+#, elixir-autogen, elixir-format
+msgid "Add this under Messengers"
+msgstr ""
+
+#: lib/vutuv/profiles/messenger.ex:374
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Open chat"
+msgstr ""
+
+#: lib/vutuv_web/templates/messenger/form_content.html.heex:18
+#, elixir-autogen, elixir-format
+msgid "Signal also takes its contact link (https://signal.me/#…). It names neither your phone number nor your username, and you can reset it in Signal at any time."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -244,3 +244,8 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Please use at most %{max} tags."
 msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:126
+#, elixir-autogen, elixir-format
+msgid "Enter your Signal link, it starts with https://signal.me/#"
+msgstr ""

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -247,3 +247,8 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Please use at most %{max} tags."
 msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:126
+#, elixir-autogen, elixir-format
+msgid "Enter your Signal link, it starts with https://signal.me/#"
+msgstr ""

--- a/test/vutuv/profiles/messenger_test.exs
+++ b/test/vutuv/profiles/messenger_test.exs
@@ -45,6 +45,125 @@ defmodule Vutuv.Profiles.MessengerTest do
     end
   end
 
+  describe "Signal also accepts its contact link" do
+    @long_link "https://signal.me/#eu/" <> String.duplicate("aB3-_", 12)
+
+    test "a signal.me link is stored as given" do
+      cs = changeset(%{"provider" => "Signal", "value" => @long_link})
+      assert cs.valid?
+      assert get_change(cs, :value) == @long_link
+    end
+
+    test "the host is compared and stored case-insensitively, the token verbatim" do
+      cs = changeset(%{"provider" => "Signal", "value" => "https://Signal.me/#eu/aB3-_xY"})
+      assert cs.valid?
+      assert get_change(cs, :value) == "https://signal.me/#eu/aB3-_xY"
+    end
+
+    test "the app scheme, a missing scheme and a www host all canonicalise to https" do
+      for typed <- [
+            "sgnl://signal.me/#eu/aB3",
+            "signal.me/#eu/aB3",
+            "https://www.signal.me/#eu/aB3",
+            "  https://signal.me/#eu/aB3  "
+          ] do
+        cs = changeset(%{"provider" => "Signal", "value" => typed})
+        assert cs.valid?, "expected #{typed} to be accepted"
+        assert get_change(cs, :value) == "https://signal.me/#eu/aB3"
+      end
+    end
+
+    test "anything before the fragment is dropped, since the fragment is the whole address" do
+      cs =
+        changeset(%{"provider" => "Signal", "value" => "https://signal.me/?utm_source=x#eu/aB3"})
+
+      assert cs.valid?
+      assert get_change(cs, :value) == "https://signal.me/#eu/aB3"
+    end
+
+    test "a link to another host, or one with no fragment, is rejected as a link" do
+      for typed <- ["https://example.com/#eu/aB3", "https://signal.me/", "signal.me/#"] do
+        cs = changeset(%{"provider" => "Signal", "value" => typed})
+        refute cs.valid?, "expected #{typed} to be rejected"
+
+        assert %{value: ["Enter your Signal link, it starts with https://signal.me/#"]} =
+                 errors_on(cs)
+      end
+    end
+
+    test "a provider without a contact link keeps rejecting a pasted URL" do
+      cs = changeset(%{"provider" => "Telegram", "value" => "https://t.me/ada"})
+      refute cs.valid?
+      assert %{value: [_]} = errors_on(cs)
+    end
+
+    test "a username that merely looks host-like is still a username" do
+      cs = changeset(%{"provider" => "Signal", "value" => "signal.me"})
+      assert cs.valid?
+      assert get_change(cs, :value) == "signal.me"
+    end
+  end
+
+  describe "kind/1 tells the three address shapes apart" do
+    test "link, phone and username" do
+      assert Messenger.kind(%Messenger{provider: "Signal", value: "https://signal.me/#eu/aB3"}) ==
+               :link
+
+      assert Messenger.kind(%Messenger{provider: "Signal", value: "+49261123456"}) == :phone
+      assert Messenger.kind(%Messenger{provider: "Signal", value: "ada.99"}) == :username
+      assert Messenger.kind(%Messenger{provider: "Threema", value: "ABCD1234"}) == :username
+    end
+  end
+
+  describe "a contact link reads as an action, never as its token" do
+    @signal_link "https://signal.me/#eu/aB3"
+
+    test "url/1 is the link itself" do
+      assert Messenger.url(%Messenger{provider: "Signal", value: @signal_link}) == @signal_link
+    end
+
+    test "label/1 says what the link does, since it names no address" do
+      assert Messenger.label(%Messenger{provider: "Signal", value: @signal_link}) == "Open chat"
+    end
+
+    test "label/1 shows the address for every other shape" do
+      assert Messenger.label(%Messenger{provider: "Signal", value: "ada.99"}) == "ada.99"
+
+      assert Messenger.label(%Messenger{provider: "Signal", value: "+49261123456"}) ==
+               "+49 261 123456"
+    end
+
+    test "display/1 keeps the address itself, so agents and the vCard get the link" do
+      assert Messenger.display(%Messenger{provider: "Signal", value: @signal_link}) ==
+               @signal_link
+    end
+  end
+
+  describe "from_url/1 recognises a messenger address pasted as a link" do
+    test "signal.me yields the canonical link, the others the address inside the URL" do
+      assert Messenger.from_url("https://signal.me/#eu/aB3") ==
+               {"Signal", "https://signal.me/#eu/aB3"}
+
+      assert Messenger.from_url("https://t.me/ada_lovelace") == {"Telegram", "ada_lovelace"}
+      assert Messenger.from_url("https://threema.id/ABCD1234") == {"Threema", "ABCD1234"}
+
+      assert Messenger.from_url("https://matrix.to/#/@you:matrix.org") ==
+               {"Matrix", "@you:matrix.org"}
+    end
+
+    test "an ordinary webpage, a bare host and junk yield nothing" do
+      assert Messenger.from_url("https://example.com/contact") == nil
+      assert Messenger.from_url("https://signal.me/") == nil
+      assert Messenger.from_url("https://t.me/") == nil
+      assert Messenger.from_url(nil) == nil
+    end
+
+    test "what it returns is accepted by the changeset" do
+      {provider, value} = Messenger.from_url("https://Signal.me/#eu/aB3")
+      assert changeset(%{"provider" => provider, "value" => value}).valid?
+    end
+  end
+
   describe "handle-based providers" do
     test "Telegram stores the username without a leading @" do
       cs = changeset(%{"provider" => "Telegram", "value" => "@ada_lovelace"})

--- a/test/vutuv_web/controllers/messenger_controller_test.exs
+++ b/test/vutuv_web/controllers/messenger_controller_test.exs
@@ -51,6 +51,20 @@ defmodule VutuvWeb.MessengerControllerTest do
       assert all_for(user) == []
     end
 
+    test "saves a Signal contact link, the address that discloses nothing", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      conn =
+        post(conn, ~p"/settings/messengers", %{
+          "messenger" => %{"provider" => "Signal", "value" => "https://Signal.me/#eu/aB3-_xY"}
+        })
+
+      assert redirected_to(conn) == ~p"/settings/messengers"
+
+      assert [%Messenger{provider: "Signal", value: "https://signal.me/#eu/aB3-_xY"}] =
+               all_for(user)
+    end
+
     test "saves a Threema handle", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
 
@@ -86,10 +100,80 @@ defmodule VutuvWeb.MessengerControllerTest do
     end
   end
 
+  describe "a Signal contact link (issue #1442)" do
+    @link "https://signal.me/#eu/aB3-_xY"
+
+    test "reads as an action, never as its token", %{conn: conn} do
+      owner = insert_activated_user()
+      insert(:messenger, user: owner, provider: "Signal", value: @link)
+
+      html = conn |> get(~p"/#{owner}/messengers") |> html_response(200)
+
+      # The href is the link; the words the reader sees are not its 64 characters.
+      assert html =~ ~s|href="https://signal.me/#eu/aB3-_xY"|
+      assert html =~ "Open chat"
+      refute html =~ ">https://signal.me"
+    end
+
+    test "the plain-text sibling prints the link once, not as its own label", %{conn: conn} do
+      owner = insert_activated_user()
+      insert(:messenger, user: owner, provider: "Signal", value: @link)
+
+      body = get(conn, "/#{owner.username}/messengers.txt").resp_body
+
+      assert body =~ "* Signal: #{@link}\n"
+      refute body =~ "(#{@link})"
+    end
+
+    test "the JSON sibling says which address shape it is", %{conn: conn} do
+      owner = insert_activated_user()
+      insert(:messenger, user: owner, provider: "Signal", value: @link)
+
+      body = get(conn, "/#{owner.username}/messengers.json").resp_body
+
+      assert %{"entries" => [%{"kind" => "link", "url" => @link}]} = Jason.decode!(body)
+    end
+  end
+
   describe "the owner's editor" do
     test "GET /settings/messengers renders the manage page", %{conn: conn} do
       {conn, _user} = create_and_login_user(conn)
       assert conn |> get(~p"/settings/messengers") |> html_response(200) =~ "Add a messenger"
+    end
+
+    test "a link filed under Links is offered a move, an ordinary page is not", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      messenger_link = insert(:url, user: user, value: "https://signal.me/#eu/aB3")
+      webpage = insert(:url, user: user, value: "https://example.org/")
+
+      html = conn |> get(~p"/settings/links") |> html_response(200)
+
+      assert html =~ ~p"/settings/messengers/new?#{[from_link: messenger_link.id]}"
+      refute html =~ ~p"/settings/messengers/new?#{[from_link: webpage.id]}"
+    end
+
+    test "the offered form is seeded from the member's own stored link", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      url = insert(:url, user: user, value: "https://Signal.me/#eu/aB3")
+
+      html =
+        conn
+        |> get(~p"/settings/messengers/new?#{[from_link: url.id]}")
+        |> html_response(200)
+
+      assert html =~ ~s|value="https://signal.me/#eu/aB3"|
+      # A prefilled form opens clean, it does not open scolding.
+      refute html =~ "fields marked in red"
+    end
+
+    test "a link belonging to somebody else cannot seed the form", %{conn: conn} do
+      stranger = insert_activated_user()
+      url = insert(:url, user: stranger, value: "https://signal.me/#eu/aB3")
+      {conn, _user} = create_and_login_user(conn)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        get(conn, ~p"/settings/messengers/new?#{[from_link: url.id]}")
+      end
     end
   end
 
@@ -117,6 +201,20 @@ defmodule VutuvWeb.MessengerControllerTest do
 
       assert Gettext.gettext(@backend, "Messenger created successfully.") ==
                "Messenger wurde erstellt."
+    end
+
+    test "the contact-link wording is German too (issue #1442)" do
+      Gettext.put_locale(@backend, "de")
+
+      assert Gettext.gettext(@backend, "Open chat") == "Chat öffnen"
+
+      assert Gettext.gettext(@backend, "Add this under Messengers") ==
+               "Unter Messenger eintragen"
+
+      refute Gettext.gettext(
+               @backend,
+               "Signal also takes its contact link (https://signal.me/#…). It names neither your phone number nor your username, and you can reset it in Signal at any time."
+             ) =~ "Signal also takes"
     end
   end
 end


### PR DESCRIPTION
Closes #1442

Signal is the only messenger here whose address necessarily discloses something: the phone number or the username. The `signal.me` link is the third shape and the only one that names neither, and it can be reset inside Signal at any time. The field refused it until now (a value carrying letters went into the username branch, whose regex chokes on `:` and `/`), so members filed it under Links: the wrong card, and a screenshot of a page that says nothing about them.

**What changed**

* `Messenger.kind/1` is the single discriminator between `:link` / `:phone` / `:username`, instead of `url/1`, `display/1` and `label/1` each working it out again.
* A link is recognised **before** the username branch and stored canonically: host lowercased, fragment byte for byte, everything before the fragment dropped (the fragment *is* the address, which is why it never reaches Signal's server).
* Validation stays deliberately lenient, host plus a non-empty fragment and no token grammar: the link format has changed five times since 2022, so a strict pattern would only be the next thing to break.
* `Messenger.label/1` is what a link to a contact says, so the profile reads "Chat öffnen" rather than a 64-character token. `display/1` still carries the address itself, so the agent formats and the vCard `IMPP` line are unchanged in kind.
* The agent formats gain `kind`, and the Markdown and plain-text renderers print a contact link once instead of twice (`contact` and `url` are the same string for it).
* The links editor offers a quiet "Add this under Messengers" for an address filed as a webpage. The form is seeded from the member's **own stored link** (`?from_link=<url id>`, never an address out of the query), and moving the entry stays the member's decision.

WhatsApp's `wa.me/qr/…` is deliberately absent: WhatsApp shows the number in the chat regardless, so storing it as a link would promise a privacy it does not deliver.

**Tests** cover the new shapes and their calibration: host casing, the `sgnl://` and scheme-less forms, a query before the fragment, a foreign host and a fragment-less link (both rejected with the link message rather than the username one), a value that merely looks host-like staying a username, the three `kind/1` answers, the plain-text and JSON siblings, the links-editor offer appearing only for a messenger address, the seeded form opening clean, and a stranger's link being unable to seed it. The German wording is asserted by name, including the one string `gettext.extract --merge` fuzzy-filled as "Fall öffnen".

Reported by a member here: https://vutuv.de/jantietje/posts/019ffd21-ce0d-7ee9-bcf2-bfe49e0852a9

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_013zucWqZGcJqm1bvmEvxwf2
