### PR TITLE
Ein Screenshot, den keiner mehr aus der Quarantäne holt (v7.283.1)

### DIFF
--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -94,7 +94,7 @@ Everything else has a default (the vutuv.de production value):
 | `DB_NAME` | `vutuv3_prod` | PostgreSQL database |
 | `DB_HOST` | `127.0.0.1` | PostgreSQL host |
 | `POOL_SIZE` | `10` | DB connection pool |
-| `UPLOADS_DIR_PREFIX` | `/srv/legacy-vutuv` | **Set this.** Root directory for uploaded images (avatars, covers, screenshots, post images, private originals) |
+| `UPLOADS_DIR_PREFIX` | `/srv/legacy-vutuv` (fallback only) | **Set this.** Root directory for uploaded images (avatars, covers, screenshots, post images, private originals). The default is a historical fallback, not a recommendation: pick a directory your app user owns (vutuv.de uses `/srv/vutuv3`) |
 | `CHROMIUM_PATH` | – | Chromium binary, if not on `$PATH` |
 | `SCREENSHOT_BLOCKLIST` | – | Extra pages never to take a link-preview screenshot of, on top of the shipped `reddit.com` and `heise.de`. Comma-separated domains and/or URLs, copied into the blocklist table the first time you migrate; afterwards the live list is edited in the admin area (see "Screenshot blocklist" below) and this variable is inert. `SCREENSHOT_BLOCKED_HOSTS` is the older name and still works |
 | `SMTP_RELAY` | `127.0.0.1` | SMTP server |

--- a/docs/architecture/images.md
+++ b/docs/architecture/images.md
@@ -297,7 +297,8 @@ The moving parts (all under `Vutuv.Moderation`):
   released).
 - `ImageScanWorker` — boot-resume + poll + nudge, mirroring
   `Vutuv.Posts.ScreenshotWorker`; hourly `repair_drift/0` re-enqueues any
-  asset stranded in `pending`.
+  asset stranded in `pending`, and `ImageSubjects.settle_stranded_quarantine/0`
+  settles the **opposite** drift (below).
 
 **Limbo.** A fresh image starts `pending`: the owner sees it (avatar/cover
 through the authenticated `/settings/pending_image/...` quarantine preview,
@@ -312,6 +313,25 @@ the asset's reference and notifies the owner (in-app + email, both derived
 from the audit row). Organization logos differ deliberately: the
 `organizations.logo` pointer only ever names a released image, so the old
 logo keeps showing while the new one is scanned.
+
+**The two drifts, and why the second one hurt (issue #1443).** Approval is two
+writes in one order: `apply_approved/1` flips the row with `update_all`, then
+promotes the files. A release that dies in between — or an `update_all` that
+matches nothing and answers `:stale` — leaves the subject **no longer pending
+with its bytes still in quarantine**, and `repair_drift/0` is blind to it,
+because that query looks for rows that ARE pending. On production one profile
+link sat like that for ten hours showing a broken image, and it came back only
+because a deploy's `Vutuv.Uploads.Regenerator` rebuilt the thumb from the kept
+original by accident. Two defences now: `Vutuv.Screenshot.url/2` **fails
+closed** (a row naming a file that is not on disk renders the placeholder, not
+a URL that 404s — and `<.link_thumb>` reads its `shot`/`pending` state off that
+resolved src rather than off the column), and the hourly repair runs
+`settle_stranded_quarantine/0`, which walks the quarantine tree (the stuck
+state itself, where a query would have to test every row on disk to infer it)
+and promotes a directory whose subject left `pending` and still names that
+capture. It is fail-closed both ways: a subject still `pending` is left
+strictly alone, and bytes no row claims — or whose row now names a different
+capture — are deleted rather than published.
 
 **Fail-closed by construction.** The gallery tables default `moderation` to
 `pending` (an upload path that forgot to enqueue leaves the image invisible,

--- a/lib/vutuv/moderation/image_scan_worker.ex
+++ b/lib/vutuv/moderation/image_scan_worker.ex
@@ -8,6 +8,11 @@ defmodule Vutuv.Moderation.ImageScanWorker do
   (`repair_drift/0`), so a restart or re-deploy never leaves an image in
   limbo forever; the drift repair re-runs hourly as the standing backstop.
 
+  That hour also settles the **opposite** drift (issue #1443):
+  `ImageSubjects.settle_stranded_quarantine/0`, an asset whose row already
+  left `pending` while its bytes stayed in quarantine. `repair_drift/0` is
+  blind to it, because it looks for rows that are still pending.
+
   Gated by the `:image_scan_worker` config flag (off in tests, which call
   `ImageScans.deliver_due/1` directly with a stubbed judge); the actual
   Ollama call is additionally gated by `:moderate_images`.
@@ -18,6 +23,7 @@ defmodule Vutuv.Moderation.ImageScanWorker do
   require Logger
 
   alias Vutuv.Moderation.ImageScans
+  alias Vutuv.Moderation.ImageSubjects
 
   @default_interval :timer.seconds(15)
   # Polls between drift repairs (~hourly at the default interval).
@@ -71,6 +77,18 @@ defmodule Vutuv.Moderation.ImageScanWorker do
     case ImageScans.repair_drift() do
       0 -> :ok
       count -> Logger.info("image moderation drift repair re-enqueued #{count} scan(s)")
+    end
+
+    # The opposite drift (issue #1443): a subject that already left `pending`
+    # while its bytes stayed in quarantine, which `repair_drift/0` cannot see.
+    case ImageSubjects.settle_stranded_quarantine() do
+      %{promoted: 0, dropped: 0} ->
+        :ok
+
+      %{promoted: promoted, dropped: dropped} ->
+        Logger.info(
+          "image moderation settled stranded quarantine: #{promoted} promoted, #{dropped} dropped"
+        )
     end
   rescue
     error -> Logger.error("image moderation drift repair failed: #{inspect(error)}")

--- a/lib/vutuv/moderation/image_subjects.ex
+++ b/lib/vutuv/moderation/image_subjects.ex
@@ -677,6 +677,86 @@ defmodule Vutuv.Moderation.ImageSubjects do
   ## Drift repair source
 
   @doc """
+  Settles every screenshot left behind in the quarantine tree, and answers
+  `%{promoted: n, dropped: n}`.
+
+  The twin of `stranded_pending/0` for the opposite drift (issue #1443).
+  `apply_approved/1` flips the row and promotes the file in that order, so a
+  release that dies in between — or an `update_all` that matches nothing and
+  answers `:stale` — leaves a subject that is no longer `pending` with its
+  bytes still in quarantine. `stranded_pending/0` cannot see it (that query
+  selects rows that ARE pending), so until this existed the picture came back
+  only when the next deploy's image regeneration happened to rebuild it from
+  the kept original.
+
+  Driven off the **tree**, not the table: a stuck directory is the state
+  itself, where a query would have to test every screenshot row on disk to
+  infer it (there is normally not a single one).
+
+  Fail-closed in both directions. A subject still `pending` is left strictly
+  alone — promoting it would publish an image no verdict has cleared — and
+  bytes whose subject is gone, or whose subject now names a different capture,
+  are deleted rather than published. Idempotent, so the hourly repair can run
+  it forever.
+  """
+  def settle_stranded_quarantine do
+    Enum.reduce(Vutuv.Screenshot.quarantined_ids(), %{promoted: 0, dropped: 0}, fn id, acc ->
+      case stranded_verdict(id) do
+        {:promote, subject} ->
+          Vutuv.Screenshot.promote_from_quarantine(subject)
+          Map.update!(acc, :promoted, &(&1 + 1))
+
+        :drop ->
+          Vutuv.Screenshot.drop_quarantine(id)
+          Map.update!(acc, :dropped, &(&1 + 1))
+
+        :skip ->
+          acc
+      end
+    end)
+  end
+
+  defp stranded_verdict(id) do
+    case screenshot_subject(id) do
+      nil ->
+        :drop
+
+      subject ->
+        cond do
+          screenshot_moderation(subject) == "pending" -> :skip
+          holds_quarantined_capture?(subject, id) -> {:promote, subject}
+          true -> :drop
+        end
+    end
+  end
+
+  # A quarantine directory is named after its subject's id, and the two
+  # screenshot kinds share the tree, so the id is looked up in both tables. A
+  # directory name that is not even a UUID belongs to neither.
+  defp screenshot_subject(id) do
+    case Vutuv.UUIDv7.cast_or_nil(id) do
+      nil -> nil
+      uuid -> Repo.get(Url, uuid) || Repo.get(PostScreenshot, uuid)
+    end
+  end
+
+  defp screenshot_moderation(%Url{screenshot_moderation: state}), do: state
+  defp screenshot_moderation(%PostScreenshot{moderation: state}), do: state
+
+  # The stored value is `<hash><ext>`; the quarantined thumb carries the hash
+  # alone. Comparing them is what keeps a re-capture from publishing the
+  # picture it replaced.
+  defp holds_quarantined_capture?(subject, id) do
+    case {subject.screenshot, Vutuv.Screenshot.quarantined_hash(id)} do
+      {stored, hash} when is_binary(stored) and is_binary(hash) ->
+        stored |> Uploads.strip_query() |> Path.rootname() == hash
+
+      _ ->
+        false
+    end
+  end
+
+  @doc """
   Every asset stuck in `pending` with no open scan, as
   `{kind, subject_id, owner_user_id, fingerprint}` — what
   `Vutuv.Moderation.ImageScans.repair_drift/0` re-enqueues.

--- a/lib/vutuv/uploaders/screenshot.ex
+++ b/lib/vutuv/uploaders/screenshot.ex
@@ -127,25 +127,84 @@ defmodule Vutuv.Screenshot do
   end
 
   @doc """
+  The bundled stand-in shown wherever a screenshot cannot be served: none was
+  taken, one is still in moderation limbo, or the row names a file that is not
+  on disk.
+  """
+  def placeholder_url, do: "/images/screenshot.png"
+
+  @doc """
   Root-relative URL for the served thumb, `nil` for `:original` (the original
-  is never URL-addressable). Falls back to the bundled
-  `/images/screenshot.png` placeholder when there is no screenshot.
+  is never URL-addressable). Falls back to `placeholder_url/0` when there is no
+  screenshot.
+
+  **It also falls back when the row names a file that is not there** (issue
+  #1443). A row can outlive its bytes — a release flipped the moderation state
+  and then died before promoting the file out of quarantine, and the state is
+  invisible to the drift repair, which only looks for rows still `pending`.
+  Building the path anyway put a URL that 404s on a public profile for ten
+  hours. The `File.exists?` check below already had to run to choose between
+  the AVIF and a legacy WebP, so answering "neither" costs nothing and makes
+  every such cause degrade to "no screenshot yet" instead of a broken image.
   """
   def url(file_and_scope, version \\ :thumb)
 
-  def url({nil, _scope}, :thumb), do: "/images/screenshot.png"
+  def url({nil, _scope}, :thumb), do: placeholder_url()
   def url({_screenshot, _scope}, :original), do: nil
 
   def url({screenshot, scope}, :thumb) do
-    if held_in_limbo?(scope) do
+    cond do
       # Moderation limbo: renders exactly like "no screenshot yet".
-      "/images/screenshot.png"
-    else
-      "/"
-      |> Path.join(Path.join(storage_dir(scope), served_filename(scope, screenshot)))
-      |> URI.encode()
+      held_in_limbo?(scope) ->
+        placeholder_url()
+
+      filename = served_filename(scope, screenshot) ->
+        "/" |> Path.join(Path.join(storage_dir(scope), filename)) |> URI.encode()
+
+      true ->
+        placeholder_url()
     end
   end
+
+  @doc """
+  Every subject id whose quarantine directory still holds files. The entry
+  point of the stranded-quarantine repair (issue #1443, see
+  `Vutuv.Moderation.ImageSubjects.settle_stranded_quarantine/0`): reading the
+  tree finds the stuck state directly, where a DB query would have to test
+  every screenshot row on disk to infer it.
+  """
+  def quarantined_ids do
+    Vutuv.Uploads.quarantine_dir("screenshots")
+    |> Path.join("*/*")
+    |> Path.wildcard()
+    |> Enum.map(&(&1 |> Path.dirname() |> Path.basename()))
+    |> Enum.uniq()
+  end
+
+  @doc """
+  The content hash of the thumb waiting in `id`'s quarantine directory, or
+  `nil`. Compared against the subject's own `screenshot` before anything is
+  promoted, so bytes a row has moved on from are never published.
+  """
+  def quarantined_hash(id) do
+    id
+    |> quarantine_dir_for()
+    |> Path.join("thumb-*")
+    |> Path.wildcard()
+    |> List.first()
+    |> case do
+      nil -> nil
+      file -> file |> Path.basename() |> Path.rootname() |> String.replace_prefix("thumb-", "")
+    end
+  end
+
+  @doc "Removes `id`'s quarantine directory, bytes no row claims any more."
+  def drop_quarantine(id) do
+    File.rm_rf(quarantine_dir_for(id))
+    :ok
+  end
+
+  defp quarantine_dir_for(id), do: Vutuv.Uploads.quarantine_dir("screenshots/#{id}")
 
   @doc """
   Removes the screenshot files for `url` — the served thumb and the private
@@ -173,14 +232,15 @@ defmodule Vutuv.Screenshot do
 
   # The .avif is authoritative; until the regeneration has run, a pre-AVIF
   # `.webp` thumb keeps resolving. Transitional — remove together with
-  # `Spec.legacy_exts/0`.
+  # `Spec.legacy_exts/0`. `nil` when neither is on disk, which is what makes
+  # `url/2` fail closed (issue #1443) instead of naming a file that 404s.
   defp served_filename(scope, screenshot) do
     avif = thumb_filename(rootname(screenshot), Spec.served_ext())
 
     cond do
       File.exists?(Path.join(disk_dir(scope), avif)) -> avif
       (legacy = legacy_filename(scope, screenshot)) != nil -> legacy
-      true -> avif
+      true -> nil
     end
   end
 

--- a/lib/vutuv/uploads.ex
+++ b/lib/vutuv/uploads.ex
@@ -52,8 +52,12 @@ defmodule Vutuv.Uploads do
 
   @doc """
   The absolute storage root, configured per environment via
-  `config :vutuv, :uploads_dir_prefix`. Empty in dev/test and
-  `/srv/legacy-vutuv` in production.
+  `config :vutuv, :uploads_dir_prefix` (env var `UPLOADS_DIR_PREFIX`). Empty in
+  dev/test; every installation sets its own in production, and vutuv.de's is
+  `/srv/vutuv3`. `/srv/legacy-vutuv` is only the fallback `runtime.exs` names
+  when the env var is absent — this doc used to quote it as if it were the
+  production path, which sent an investigation looking for a member's files in
+  a directory that does not exist on the server.
   """
   def uploads_dir_prefix, do: Application.get_env(:vutuv, :uploads_dir_prefix, "")
 

--- a/lib/vutuv_web/components/ui.ex
+++ b/lib/vutuv_web/components/ui.ex
@@ -925,9 +925,16 @@ defmodule VutuvWeb.UI do
   attr(:class, :any, default: nil)
 
   def link_thumb(assigns) do
+    src = Vutuv.Screenshot.url({assigns.url.screenshot, assigns.url}, :thumb)
+
     assigns =
       assigns
-      |> assign(:src, Vutuv.Screenshot.url({assigns.url.screenshot, assigns.url}, :thumb))
+      |> assign(:src, src)
+      # A row can name a capture whose file is not on disk, and `url/2` then
+      # answers the placeholder (issue #1443) — so the state is read off the
+      # resolved src, not off the column. Calling that tile "shot" while the
+      # placeholder renders would be a state nobody could act on.
+      |> assign(:stored?, src != Vutuv.Screenshot.placeholder_url())
       |> assign(:blocklisted?, Vutuv.ScreenshotBlocklist.blocked?(assigns.url.value))
 
     ~H"""
@@ -945,7 +952,7 @@ defmodule VutuvWeb.UI do
     </div>
     <img
       :if={not (is_nil(@url.screenshot) and @blocklisted?)}
-      data-link-thumb={if @url.screenshot, do: "shot", else: "pending"}
+      data-link-thumb={if @stored?, do: "shot", else: "pending"}
       src={@src}
       alt={@url.description || VutuvWeb.UrlHTML.display_url(@url.value)}
       width="400"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.283.0",
+      version: "7.283.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/fediverse_remote_post_screenshots_test.exs
+++ b/test/vutuv/fediverse_remote_post_screenshots_test.exs
@@ -116,6 +116,14 @@ defmodule Vutuv.FediverseRemotePostScreenshotsTest do
       )
       |> Repo.update()
 
+    # The row and the disk have to agree: since issue #1443 a row naming a file
+    # that is not there renders the placeholder, not a URL that would 404.
+    dir = Path.join(Vutuv.Uploads.uploads_dir_prefix(), "screenshots/#{ready.id}")
+    File.mkdir_p!(dir)
+    {:ok, img} = Image.new(20, 20, color: [1, 2, 3])
+    {:ok, _} = Image.write(img, Path.join(dir, "thumb-0123456789ab.avif"))
+    on_exit(fn -> File.rm_rf(dir) end)
+
     ready
   end
 

--- a/test/vutuv/moderation/stranded_quarantine_test.exs
+++ b/test/vutuv/moderation/stranded_quarantine_test.exs
@@ -1,0 +1,177 @@
+defmodule Vutuv.Moderation.StrandedQuarantineTest do
+  @moduledoc """
+  Issue #1443: a screenshot whose row left `pending` while its file stayed in
+  the quarantine tree.
+
+  `ImageSubjects.apply_approved/1` flips the row with `update_all` and calls
+  `Screenshot.promote_from_quarantine/1` only afterwards, so anything ending
+  the process in between (a deploy, a crash) — or an `update_all` that matches
+  no row and answers `:stale` — leaves the subject approved with its bytes
+  still in quarantine. The drift repair cannot see that state: it selects rows
+  that are `pending`, and this one is not. On production it showed as a broken
+  image on a public profile for ten hours, until a deploy's image regeneration
+  rebuilt the thumb from the kept original by accident.
+
+  Two defences are tested here. The serving side now **fails closed** (no file
+  on disk means the placeholder, never a URL that 404s), which covers every
+  cause including ones nobody has thought of; and the hourly drift repair now
+  settles a stranded quarantine directory, which restores the picture instead
+  of waiting for the next deploy.
+
+  Not async: flips `:uploads_dir_prefix` (read by every uploader and every
+  display helper) and `:moderate_images` (read by `Vutuv.Moderation.ImageScans`
+  and, through it, by every upload path).
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Ecto.Query
+
+  alias Vutuv.Moderation.ImageSubjects
+  alias Vutuv.Profiles.Url
+  alias Vutuv.Repo
+  alias Vutuv.Screenshot
+
+  setup do
+    tmp = Path.join(System.tmp_dir!(), "vutuv_stranded_#{System.unique_integer([:positive])}")
+    prev_dir = Application.fetch_env(:vutuv, :uploads_dir_prefix)
+    Application.put_env(:vutuv, :uploads_dir_prefix, tmp)
+    Application.put_env(:vutuv, :moderate_images, true)
+
+    on_exit(fn ->
+      File.rm_rf(tmp)
+      Application.put_env(:vutuv, :moderate_images, false)
+
+      case prev_dir do
+        {:ok, was} -> Application.put_env(:vutuv, :uploads_dir_prefix, was)
+        :error -> Application.delete_env(:vutuv, :uploads_dir_prefix)
+      end
+    end)
+
+    {:ok, tmp: tmp, user: insert_activated_user()}
+  end
+
+  defp capture_link(user) do
+    src = Path.join(System.tmp_dir!(), "shot_#{System.unique_integer([:positive])}.jpg")
+    {:ok, img} = Image.new(300, 200, color: [10, 120, 200])
+    {:ok, _} = Image.write(img, src)
+    on_exit(fn -> File.rm(src) end)
+
+    {:ok, url} =
+      user
+      |> Ecto.build_assoc(:urls)
+      |> Url.changeset(%{"value" => "https://example.com"})
+      |> Repo.insert()
+
+    {:ok, url} =
+      url
+      |> Url.changeset(%{
+        screenshot: %Plug.Upload{filename: "shot.jpg", path: src, content_type: "image/jpeg"}
+      })
+      |> Repo.update()
+
+    url
+  end
+
+  # The production state: the scan cleared the image, the row says so, and the
+  # file never left quarantine.
+  defp strand(url) do
+    {1, _} =
+      Repo.update_all(from(u in Url, where: u.id == ^url.id),
+        set: [screenshot_moderation: "approved"]
+      )
+
+    Repo.get!(Url, url.id)
+  end
+
+  defp quarantined?(tmp, url), do: Path.wildcard(quarantine_glob(tmp, url)) != []
+  defp quarantine_glob(tmp, url), do: Path.join(tmp, "quarantine/screenshots/#{url.id}/*")
+  defp served?(tmp, url), do: Path.wildcard(Path.join(tmp, "screenshots/#{url.id}/*")) != []
+
+  describe "serving a screenshot whose file is not on disk" do
+    test "answers the placeholder rather than a URL that 404s", %{tmp: tmp, user: user} do
+      url = user |> capture_link() |> strand()
+
+      # Calibration: the bytes really are only in quarantine, so the served
+      # path this row names cannot resolve.
+      assert quarantined?(tmp, url)
+      refute served?(tmp, url)
+
+      assert Screenshot.url({url.screenshot, url}, :thumb) == "/images/screenshot.png"
+    end
+
+    test "the links page calls such a tile pending, not a stored capture", %{
+      conn: conn,
+      user: user
+    } do
+      url = user |> capture_link() |> strand()
+
+      html = conn |> get(~p"/#{user}/links") |> html_response(200)
+
+      assert html =~ ~s|data-link-thumb="pending"|
+      refute html =~ ~s|data-link-thumb="shot"|
+      refute html =~ "/screenshots/#{url.id}/"
+    end
+
+    test "a screenshot that is really there still serves", %{tmp: tmp, user: user} do
+      url = capture_link(user)
+      # Release it the way an approved scan does.
+      url = strand(url)
+      Screenshot.promote_from_quarantine(url)
+
+      assert served?(tmp, url)
+      assert Screenshot.url({url.screenshot, url}, :thumb) =~ "/screenshots/#{url.id}/thumb-"
+    end
+  end
+
+  describe "settle_stranded_quarantine/0" do
+    test "promotes a stranded screenshot, so the picture comes back", %{tmp: tmp, user: user} do
+      url = user |> capture_link() |> strand()
+
+      assert ImageSubjects.settle_stranded_quarantine() == %{promoted: 1, dropped: 0}
+
+      assert served?(tmp, url)
+      refute quarantined?(tmp, url)
+      assert Screenshot.url({url.screenshot, url}, :thumb) =~ "/screenshots/#{url.id}/thumb-"
+    end
+
+    test "leaves a subject that is still pending alone", %{tmp: tmp, user: user} do
+      url = capture_link(user)
+      assert url.screenshot_moderation == "pending"
+
+      assert ImageSubjects.settle_stranded_quarantine() == %{promoted: 0, dropped: 0}
+
+      # Publishing these bytes would be publishing an unreviewed image.
+      assert quarantined?(tmp, url)
+      refute served?(tmp, url)
+    end
+
+    test "drops bytes no row claims any more", %{tmp: tmp, user: user} do
+      url = capture_link(user)
+      Repo.delete_all(from(u in Url, where: u.id == ^url.id))
+
+      assert ImageSubjects.settle_stranded_quarantine() == %{promoted: 0, dropped: 1}
+
+      refute quarantined?(tmp, url)
+      refute served?(tmp, url)
+    end
+
+    test "drops bytes the row has moved on from", %{tmp: tmp, user: user} do
+      url = capture_link(user)
+
+      {1, _} =
+        Repo.update_all(from(u in Url, where: u.id == ^url.id),
+          set: [screenshot: "0123456789ab.jpg", screenshot_moderation: "approved"]
+        )
+
+      assert ImageSubjects.settle_stranded_quarantine() == %{promoted: 0, dropped: 1}
+
+      refute quarantined?(tmp, url)
+      refute served?(tmp, url)
+    end
+
+    test "is idempotent and cheap when nothing is stranded" do
+      assert ImageSubjects.settle_stranded_quarantine() == %{promoted: 0, dropped: 0}
+      assert ImageSubjects.settle_stranded_quarantine() == %{promoted: 0, dropped: 0}
+    end
+  end
+end

--- a/test/vutuv/uploaders/screenshot_test.exs
+++ b/test/vutuv/uploaders/screenshot_test.exs
@@ -31,8 +31,19 @@ defmodule Vutuv.ScreenshotTest do
     {:ok, tmp: tmp}
   end
 
+  # A URL is only ever built for a file that is really there (issue #1443), so
+  # every naming assertion below puts one on disk first.
+  defp write_thumb(tmp, filename) do
+    dir = Path.join(tmp, "screenshots/42")
+    File.mkdir_p!(dir)
+    {:ok, img} = Image.new(20, 20, color: [1, 2, 3])
+    {:ok, _} = Image.write(img, Path.join(dir, filename))
+  end
+
   describe "url/2" do
-    test "thumb filename is fingerprinted from the stored hash, served as .avif" do
+    test "thumb filename is fingerprinted from the stored hash, served as .avif", %{tmp: tmp} do
+      write_thumb(tmp, "thumb-a1b2c3d4e5f6.avif")
+
       assert Vutuv.Screenshot.url({"a1b2c3d4e5f6.webp", @url}, :thumb) ==
                "/screenshots/42/thumb-a1b2c3d4e5f6.avif"
     end
@@ -45,7 +56,17 @@ defmodule Vutuv.ScreenshotTest do
       assert Vutuv.Screenshot.url({nil, @url}, :thumb) == "/images/screenshot.png"
     end
 
-    test "tolerates a legacy '?<timestamp>' suffix in the stored value" do
+    # Issue #1443: a row can outlive its bytes (a release flipped the
+    # moderation state and died before promoting the file out of quarantine).
+    # Naming the file anyway put a URL that 404s on a public profile.
+    test "falls back to the placeholder when the named file is not on disk" do
+      assert Vutuv.Screenshot.url({"a1b2c3d4e5f6.webp", @url}, :thumb) ==
+               "/images/screenshot.png"
+    end
+
+    test "tolerates a legacy '?<timestamp>' suffix in the stored value", %{tmp: tmp} do
+      write_thumb(tmp, "thumb-shot.avif")
+
       assert Vutuv.Screenshot.url({"shot.png?63876543210", @url}, :thumb) ==
                "/screenshots/42/thumb-shot.avif"
     end

--- a/test/vutuv_web/controllers/profile_links_test.exs
+++ b/test/vutuv_web/controllers/profile_links_test.exs
@@ -11,10 +11,34 @@ defmodule VutuvWeb.ProfileLinksTest do
   test "links render their screenshot thumbnails as preview cards", %{conn: conn} do
     user = insert_activated_user()
     url = insert(:url, user: user, screenshot: "b0efec47a6e9.webp")
+    # The thumb has to be on disk: since issue #1443 a row naming a file that
+    # is not there renders the placeholder rather than a URL that would 404.
+    write_thumb(url, "thumb-b0efec47a6e9.avif")
 
     html = conn |> get(~p"/#{user}") |> html_response(200)
 
     assert html =~ ~s(src="/screenshots/#{url.id}/thumb-b0efec47a6e9.avif")
+  end
+
+  test "a link whose stored capture is missing on disk falls back too", %{conn: conn} do
+    user = insert_activated_user()
+    url = insert(:url, user: user, screenshot: "b0efec47a6e9.webp")
+
+    html = conn |> get(~p"/#{user}") |> html_response(200)
+
+    assert html =~ ~s(src="/images/screenshot.png")
+    refute html =~ "/screenshots/#{url.id}/"
+  end
+
+  # The test env's uploads prefix is the checkout itself, and `/screenshots` is
+  # gitignored; the directory is named after a fresh UUID, so no two tests can
+  # collide and this stays async.
+  defp write_thumb(url, filename) do
+    dir = Path.join(Vutuv.Uploads.uploads_dir_prefix(), "screenshots/#{url.id}")
+    File.mkdir_p!(dir)
+    {:ok, img} = Image.new(20, 20, color: [1, 2, 3])
+    {:ok, _} = Image.write(img, Path.join(dir, filename))
+    on_exit(fn -> File.rm_rf(dir) end)
   end
 
   test "links whose capture is still on its way fall back to the placeholder image", %{conn: conn} do


### PR DESCRIPTION
Closes #1443

**Chased on disk, and the mechanism is now proven rather than guessed.** The quarantined thumb carries the capture's own timestamp, there was no served file at all, and `promote_from_quarantine/1` removes the quarantine directory unconditionally — including on the branch where it finds nothing to move. So that function never ran for this row. Exactly one directory across the whole installation was in that state, and it healed by accident when the next deploy's `Vutuv.Uploads.Regenerator` rebuilt the thumb from the kept original, about ten hours after the capture.

`apply_approved/1` flips the row with `update_all` and promotes the files afterwards. A release that dies in between — or an `update_all` that matches nothing and answers `:stale` — leaves the subject no longer `pending` with its bytes in quarantine, and `repair_drift/0` is blind to it because that query selects rows that ARE pending.

**Two defences, deliberately at different levels.**

* `Vutuv.Screenshot.url/2` **fails closed**: a row naming a file that is not on disk answers the placeholder instead of a path that 404s. It costs nothing (the `File.exists?` check already ran to choose between the AVIF and a legacy WebP) and it covers every cause, including ones nobody has thought of. `<.link_thumb>` now reads its `shot`/`pending` state off the resolved src rather than off the column, so a tile cannot claim a stored capture while the placeholder renders.
* The hourly repair settles the opposite drift (`ImageSubjects.settle_stranded_quarantine/0`). It walks the **tree**, not the table: a stuck directory is the state itself, where a query would have to test every screenshot row on disk to infer it. Fail-closed both ways — a subject still `pending` is left strictly alone (promoting it would publish an unreviewed image), and bytes no row claims, or whose row now names a different capture, are deleted rather than published.

**Tests** cover both, and both halves were calibrated against the un-fixed code: reverting the serving fix turns exactly the two serving tests red, and dropping the `pending` guard turns the "leaves a pending subject alone" test red. Three existing tests were leaning on the hole — they set the column and never wrote a file, then asserted the built path. They write the file now, so they still lock the naming convention without depending on a bug.

Nothing to clean up in production: the one affected row already healed itself on yesterday's deploy.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_013zucWqZGcJqm1bvmEvxwf2
