### PR TITLE
Wir sagen jetzt, woher das Profilbild kommt (v7.285.0)

### DIFF
--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -339,7 +339,10 @@ vutuv runs fine without internet access:
   that could work air-gapped — the check simply fails. Turn it off so the verify
   page says so plainly instead of offering a button that can never succeed.
 - Turn off the features that call out to the internet (compile-time flags in
-  `config/config.exs`): `:fetch_gravatar` (avatar lookup at registration),
+  `config/config.exs`): `:fetch_gravatar` (avatar lookup at registration — when
+  a picture is found, the member gets an in-app notification naming
+  gravatar.com and pointing at `/settings/profile`, so your privacy policy
+  should describe the lookup too),
   `:fetch_mastodon_posts` / `:fetch_bluesky_posts` (the social-feed card on
   profiles), `:fetch_code_stats` (the profile "Code" card's GitHub/GitLab/
   Codeberg statistics — off, the accounts stay plain links), and

--- a/docs/architecture/realtime.md
+++ b/docs/architecture/realtime.md
@@ -302,8 +302,11 @@ instead of stacking another one.
 The very first thing a confirmed account finds in its feed is not about someone
 else: **"Ihr vutuv-Username ist @egon_mueller."** vutuv *generates* the handle
 from the member's name (`Vutuv.Handles`), so nothing in sign-up ever told them
-what it is — this row does, and it opens `/settings/security`, where they can
-change it.
+what it is — this row does. Its links sit inside the sentence rather than
+wrapping the whole row: the handle goes to the member's own profile,
+`/settings/username` changes it, and `/settings/import/linkedin` rides along
+because this is the one moment somebody arriving from LinkedIn still has that
+profile in mind.
 
 It is derived like every other kind, straight from the member's own `users`
 row: no notification table, no live push and, deliberately, **no email** — the
@@ -314,6 +317,23 @@ stamped once, by the same `Accounts.activate_user/1` branch that flips
 exactly at that moment. A NULL means no note, which is what every account
 predating the feature keeps — the derived feed is otherwise retroactive, and a
 welcome years after the fact would be nonsense.
+
+### The imported-gravatar note (issue #1447)
+
+Registration fetches an avatar from gravatar.com for the address somebody
+signed up with (`Accounts.store_gravatar/1`, off when `:fetch_gravatar` is
+false). When one comes back, the member's first look at their own profile shows
+a photograph they never uploaded here, from a service they may not remember
+using. The import is fine; the silence around it was not. So an in-app note
+names the source and links to `/settings/profile`, where the picture can be
+replaced or removed — inside the sentence, like the welcome note above.
+
+Same derived shape: no notification table, no push (the fetch runs during
+registration, before the first login, so the note is already waiting) and
+**no email**. `users.gravatar_imported_at` is the gate and the timestamp,
+stamped by `store_gravatar/1` only on the branch that really stored an image —
+a 404 (gravatar's answer for "no picture for this address") or a failed fetch
+leaves it NULL, and NULL means no note.
 
 ## The dead-render → socket-mount handoff (profile + feed)
 

--- a/lib/vutuv/accounts.ex
+++ b/lib/vutuv/accounts.ex
@@ -163,7 +163,9 @@ defmodule Vutuv.Accounts do
   # Best-effort gravatar import: spawned (when enabled) under the app-wide
   # Task.Supervisor rather than an orphaned `Task.start/3`, and disabled in
   # tests via `:fetch_gravatar` so the SQL Sandbox connection is never used by
-  # a process that does not own it and no live HTTP request is made.
+  # a process that does not own it and no live HTTP request is made. A test
+  # that wants the import itself calls `store_gravatar/1` and stubs the fetch
+  # through `:gravatar_req_options` (a `plug:` responder).
   defp maybe_fetch_gravatar(user) do
     if Application.get_env(:vutuv, :fetch_gravatar, true) do
       Task.Supervisor.start_child(Vutuv.TaskSupervisor, fn -> store_gravatar(user) end)
@@ -172,29 +174,43 @@ defmodule Vutuv.Accounts do
     :ok
   end
 
-  defp store_gravatar(user) do
+  # Public only so a test can drive it in a process that owns the sandbox
+  # connection — `maybe_fetch_gravatar/1` is the caller, and it is off in tests.
+  @doc false
+  def store_gravatar(user) do
     url = "https://www.gravatar.com/avatar/#{hd(user.emails).md5sum}?s=130&d=404"
 
-    case Req.get(url, receive_timeout: 1000, connect_options: [timeout: 1000]) do
+    options =
+      Keyword.merge(
+        [url: url, receive_timeout: 1000, connect_options: [timeout: 1000]],
+        Application.get_env(:vutuv, :gravatar_req_options, [])
+      )
+
+    case Req.get(options) do
       {:ok, %Req.Response{status: 404}} ->
         nil
 
       {:ok, %Req.Response{status: 200, body: body, headers: headers}} ->
         content_type = find_content_type(headers)
-        filename = "/#{user.username}.#{gravatar_extension(content_type)}"
-        path = System.tmp_dir()
+        # Path.join, not `tmp_dir <> "/" <> name`: the leading slash used to
+        # live in `filename` itself, so the users row ended up holding
+        # "/handle.jpg" where an ordinary upload stores "handle.jpg".
+        filename = "#{user.username}.#{gravatar_extension(content_type)}"
+        path = Path.join(System.tmp_dir(), filename)
 
         upload = %Plug.Upload{
           content_type: content_type,
           filename: filename,
-          path: path <> filename
+          path: path
         }
 
-        File.write(path <> filename, body)
+        File.write(path, body)
 
         # Through update_user/2 so the avatar file is written only after the row
         # commits (issue #776), the same as the edit-profile path.
-        update_user(user, %{avatar: upload})
+        with {:ok, imported} <- update_user(user, %{avatar: upload}) do
+          {:ok, stamp_gravatar_import(imported)}
+        end
 
       _ ->
         nil
@@ -203,6 +219,20 @@ defmodule Vutuv.Accounts do
     error ->
       Logger.warning("gravatar import failed for user ##{user.id}: #{inspect(error)}")
       nil
+  end
+
+  # The member never uploaded this picture, so silence about it is what makes
+  # a stranger's face on their fresh profile unsettling (issue #1447). The
+  # stamp is set in its own write, after the avatar is safely stored, and only
+  # on that path — a 404 or a failed fetch leaves it NULL and says nothing. It
+  # both gates and dates the in-app note in `Vutuv.Activity`; there is no email
+  # beside it, the way the welcome note has none either.
+  defp stamp_gravatar_import(user) do
+    user
+    |> Ecto.Changeset.change(
+      gravatar_imported_at: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+    )
+    |> Repo.update!()
   end
 
   defp find_content_type(headers) do

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -356,6 +356,12 @@ defmodule Vutuv.Accounts.User do
     # the notifications feed; NULL = no note, which is what every account
     # predating the feature keeps.
     field(:welcome_notified_at, :naive_datetime)
+    # When registration imported this member's avatar from gravatar.com
+    # (issue #1447). Stamped by Accounts.store_gravatar/1 only once an image was
+    # really stored, never cast from params. It dates the "we found a picture
+    # for your email address" note; NULL = no import and no note, which is what
+    # every account predating the feature keeps.
+    field(:gravatar_imported_at, :naive_datetime)
     # Set programmatically by Vutuv.Activity.mark_notifications_read/1; never cast.
     field(:notifications_read_at, :naive_datetime)
     # How far the digest mail has got (`Vutuv.Activity.Digest`). The feed is

--- a/lib/vutuv/activity.ex
+++ b/lib/vutuv/activity.ex
@@ -247,6 +247,16 @@ defmodule Vutuv.Activity do
     )
   end
 
+  # The "we took your picture from gravatar.com" note (see gravatar_items/3),
+  # keyed on gravatar_imported_at; MAX skips the NULL of an account whose
+  # avatar did not come from there.
+  defp gravatar_max(user_id) do
+    from(u in User,
+      where: u.id == ^user_id,
+      select: %{ts: max(u.gravatar_imported_at)}
+    )
+  end
+
   @doc """
   Record that `user_id` has seen `post_id`, so the notifications *about* that
   post stop counting as unread (`notification_post_reads`).
@@ -770,8 +780,9 @@ defmodule Vutuv.Activity do
   #   * `cv_update` counts sittings, not rows: its read-marker filter lives
   #     inside the grouped query (`CvUpdates.count_query/2`), not in `since/2`.
   #   * The fediverse kinds key on `received_at` (a :utc_datetime), `username`
-  #     on `welcome_notified_at`, `connection` on the GREATEST of the two
-  #     follow times — each per-kind helper owns its own boundary comparison.
+  #     on `welcome_notified_at`, `gravatar` on `gravatar_imported_at`,
+  #     `connection` on the GREATEST of the two follow times — each per-kind
+  #     helper owns its own boundary comparison.
   @doc """
   Every notification kind the registry produces.
 
@@ -897,6 +908,13 @@ defmodule Vutuv.Activity do
         max_arms: [username_max(user_id)],
         items: &username_items(user_id, &1, &2),
         counts: [count_username(user_id, read_at)]
+      },
+      %{
+        kind: "gravatar",
+        email_pref: nil,
+        max_arms: [gravatar_max(user_id)],
+        items: &gravatar_items(user_id, &1, &2),
+        counts: [count_gravatar(user_id, read_at)]
       },
       %{
         kind: "reference_check",
@@ -1698,6 +1716,36 @@ defmodule Vutuv.Activity do
   defp at_or_before_welcome(query, %{at: at}),
     do: where(query, [u], u.welcome_notified_at <= ^at)
 
+  # "We found a picture for your email address at gravatar.com and used it."
+  # Registration quietly fetches an avatar from there (Accounts.store_gravatar/1),
+  # so without this note a member's first look at their own profile shows a
+  # photo they never uploaded here, from a service they may not remember using.
+  # The silence is what makes that unsettling, not the import.
+  #
+  # Same shape as the welcome note above: derived from the member's own users
+  # row, no notification table, no push (the import runs during registration,
+  # before the first login, so the note is already waiting) and deliberately
+  # **no email** — one more message on top of the PIN mail would be the wrong
+  # size for it. `gravatar_imported_at` is both the gate and the timestamp, so
+  # only an import that really happened produces a row.
+  defp gravatar_items(user_id, limit, cursor) do
+    from(u in User,
+      where: u.id == ^user_id and not is_nil(u.gravatar_imported_at),
+      limit: ^limit,
+      select: {u.id, u.gravatar_imported_at}
+    )
+    |> at_or_before_gravatar(cursor)
+    |> Repo.all()
+    |> Enum.map(fn {id, at} ->
+      %{id: "gravatar-#{id}", kind: "gravatar", at: at}
+    end)
+  end
+
+  defp at_or_before_gravatar(query, nil), do: query
+
+  defp at_or_before_gravatar(query, %{at: at}),
+    do: where(query, [u], u.gravatar_imported_at <= ^at)
+
   defp at_or_before(query, nil), do: query
   defp at_or_before(query, %{at: at}), do: where(query, [event], event.inserted_at <= ^at)
 
@@ -1922,6 +1970,16 @@ defmodule Vutuv.Activity do
       )
 
     if read_at, do: where(query, [u], u.welcome_notified_at > ^read_at), else: query
+  end
+
+  defp count_gravatar(user_id, read_at) do
+    query =
+      from(u in User,
+        where: u.id == ^user_id and not is_nil(u.gravatar_imported_at),
+        select: %{count: count()}
+      )
+
+    if read_at, do: where(query, [u], u.gravatar_imported_at > ^read_at), else: query
   end
 
   defp since(query, nil), do: query

--- a/lib/vutuv_web/live/notification_live/index.ex
+++ b/lib/vutuv_web/live/notification_live/index.ex
@@ -86,7 +86,7 @@ defmodule VutuvWeb.NotificationLive.Index do
     "people" => ~w(follower connection endorsement),
     "other" =>
       ~w(organization_role moderation image_rejected report_protection handle_change cv_update
-         username reference_check)
+         username gravatar reference_check)
   }
 
   @doc false
@@ -468,9 +468,12 @@ defmodule VutuvWeb.NotificationLive.Index do
           <.actor_links group={@group} current_user={@current_user} />
           <% target = notification_target(@n, @current_user) %>
           <%= cond do %>
-            <%!-- The one row that is not a single link: see username_line/1. --%>
+            <%!-- The two rows that are not a single link: see username_line/1
+            and gravatar_line/1, which carry their links inside the sentence. --%>
             <% @group.kind == "username" -> %>
               <.username_line handle={@n.username} />
+            <% @group.kind == "gravatar" -> %>
+              <.gravatar_line />
             <% target -> %>
               <.link href={target} class="hover:text-brand-700 hover:underline dark:hover:text-brand-300">
                 {group_text(@group)}
@@ -865,6 +868,39 @@ defmodule VutuvWeb.NotificationLive.Index do
     """
   end
 
+  # "We found a picture for your address at gravatar.com" (issue #1447).
+  # Registration fetches an avatar from gravatar.com for the address somebody
+  # signed up with, so a member who once used that service arrives to find a
+  # photo on their profile that they never uploaded here. This row is the whole
+  # point of the note: it names where the picture came from and where to get
+  # rid of it, so nothing about their own profile is a mystery.
+  #
+  # Like username_line/1 it is not one big link — the settings URL sits inside
+  # the sentence, split out of the translation with split_marker/2 (total, so a
+  # botched .po cannot raise) — and for the same reason it must not END on that
+  # URL: a full stop flush against an address reads as part of it. Keep a space
+  # and at least one word after {url} in both languages.
+  defp gravatar_line(assigns) do
+    {before_url, tail} =
+      split_marker(
+        gettext(
+          "When you signed up we found a picture for your email address at gravatar.com and used it as your profile picture. At {url} you can replace or remove it at any time."
+        ),
+        "{url}"
+      )
+
+    assigns =
+      assign(assigns,
+        before_url: before_url,
+        tail: tail,
+        settings_url: url(~p"/settings/profile")
+      )
+
+    ~H"""
+    {@before_url}<.link href={@settings_url} class={inline_link_class()}>{@settings_url}</.link>{@tail}
+    """
+  end
+
   defp inline_link_class,
     do:
       "font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
@@ -1022,6 +1058,9 @@ defmodule VutuvWeb.NotificationLive.Index do
   defp kind_glyph("cv_update"), do: "📄"
   # The welcome note naming the member's own handle.
   defp kind_glyph("username"), do: "👋"
+  # The avatar registration brought over from gravatar.com — the note is about
+  # a picture, so the same frame the image-review note uses.
+  defp kind_glyph("gravatar"), do: "🖼"
   # The finished AI reading of an Arbeitszeugnis. The magnifier, not a robot:
   # what arrived is a close reading of wording, and the member is being told to
   # go and read it.
@@ -1046,6 +1085,7 @@ defmodule VutuvWeb.NotificationLive.Index do
   defp kind_label("handle_change"), do: gettext("Handle change")
   defp kind_label("cv_update"), do: gettext("CV update")
   defp kind_label("username"), do: gettext("Username")
+  defp kind_label("gravatar"), do: gettext("Imported profile picture")
   defp kind_label("reference_check"), do: gettext("Employment reference review")
   defp kind_label(_), do: gettext("Activity")
 
@@ -1153,8 +1193,10 @@ defmodule VutuvWeb.NotificationLive.Index do
   end
 
   # The username note carries its own two links inside the sentence
-  # (username_line/1), so the row itself must not be one.
+  # (username_line/1), so the row itself must not be one. Same for the gravatar
+  # note and its settings link (gravatar_line/1).
   defp notification_target(%{kind: "username"}, _viewer), do: nil
+  defp notification_target(%{kind: "gravatar"}, _viewer), do: nil
 
   # Straight to the report the member has been waiting for.
   defp notification_target(%{kind: "reference_check"} = n, viewer) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.284.0",
+      version: "7.285.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -15,8 +15,8 @@ msgstr "Language: de\n"
 msgid "About us"
 msgstr "Impressum"
 
-#: lib/vutuv_web/components/ui.ex:3575
-#: lib/vutuv_web/components/ui.ex:3580
+#: lib/vutuv_web/components/ui.ex:3582
+#: lib/vutuv_web/components/ui.ex:3587
 #: lib/vutuv_web/live/admin/screenshot_live.ex:266
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:718
 #: lib/vutuv_web/live/organization_live/domains.ex:255
@@ -62,7 +62,7 @@ msgstr "Eine Adresse wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:67
 #: lib/vutuv_web/agent_docs/text.ex:64
-#: lib/vutuv_web/components/ui.ex:3833
+#: lib/vutuv_web/components/ui.ex:3840
 #: lib/vutuv_web/controllers/address_controller.ex:23
 #: lib/vutuv_web/controllers/address_controller.ex:38
 #: lib/vutuv_web/controllers/address_controller.ex:85
@@ -80,8 +80,8 @@ msgstr "Adressen"
 msgid "Already a member? Sign in here."
 msgstr "Schon ein Mitglied? Einloggen."
 
-#: lib/vutuv_web/components/ui.ex:3370
-#: lib/vutuv_web/components/ui.ex:3464
+#: lib/vutuv_web/components/ui.ex:3377
+#: lib/vutuv_web/components/ui.ex:3471
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:698
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:830
@@ -109,7 +109,7 @@ msgid "Birthday"
 msgstr "Geburtstag"
 
 #: lib/vutuv_web/components/saved_search_components.ex:110
-#: lib/vutuv_web/components/ui.ex:3364
+#: lib/vutuv_web/components/ui.ex:3371
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
@@ -162,7 +162,7 @@ msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
 #: lib/vutuv_web/components/post_components.ex:2751
-#: lib/vutuv_web/components/ui.ex:3467
+#: lib/vutuv_web/components/ui.ex:3474
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
@@ -211,7 +211,7 @@ msgid "Download"
 msgstr "Download"
 
 #: lib/vutuv_web/components/post_components.ex:2716
-#: lib/vutuv_web/components/ui.ex:3458
+#: lib/vutuv_web/components/ui.ex:3465
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
@@ -285,7 +285,7 @@ msgstr "E-Mail-Adresse eingeben"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:37
 #: lib/vutuv_web/agent_docs/text.ex:34
-#: lib/vutuv_web/components/ui.ex:3797
+#: lib/vutuv_web/components/ui.ex:3804
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -315,7 +315,7 @@ msgstr "Vorname"
 #: lib/vutuv_web/agent_docs/text.ex:513
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
-#: lib/vutuv_web/live/notification_live/index.ex:969
+#: lib/vutuv_web/live/notification_live/index.ex:1005
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:40
@@ -326,12 +326,12 @@ msgstr "Follower"
 #: lib/vutuv_web/agent_docs/markdown.ex:547
 #: lib/vutuv_web/agent_docs/text.ex:514
 #: lib/vutuv_web/components/fediverse_components.ex:313
-#: lib/vutuv_web/components/ui.ex:2072
-#: lib/vutuv_web/components/ui.ex:2097
-#: lib/vutuv_web/components/ui.ex:2100
+#: lib/vutuv_web/components/ui.ex:2079
+#: lib/vutuv_web/components/ui.ex:2104
 #: lib/vutuv_web/components/ui.ex:2107
-#: lib/vutuv_web/components/ui.ex:2110
-#: lib/vutuv_web/components/ui.ex:2168
+#: lib/vutuv_web/components/ui.ex:2114
+#: lib/vutuv_web/components/ui.ex:2117
+#: lib/vutuv_web/components/ui.ex:2175
 #: lib/vutuv_web/controllers/followee_controller.ex:29
 #: lib/vutuv_web/live/organization_live/show.ex:456
 #: lib/vutuv_web/templates/followee/index.html.heex:4
@@ -456,7 +456,7 @@ msgstr "Einloggen"
 msgid "Middle Name"
 msgstr "Zweiter Vorname"
 
-#: lib/vutuv_web/live/notification_live/index.ex:893
+#: lib/vutuv_web/live/notification_live/index.ex:929
 #, elixir-autogen
 msgid "More"
 msgstr "Mehr"
@@ -473,7 +473,7 @@ msgstr "Mehr"
 msgid "Name"
 msgstr "Name"
 
-#: lib/vutuv_web/live/notification_live/index.ex:647
+#: lib/vutuv_web/live/notification_live/index.ex:650
 #: lib/vutuv_web/live/organization_live/activity.ex:123
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
@@ -612,7 +612,7 @@ msgstr "Provider"
 msgid "Public"
 msgstr "Öffentlich"
 
-#: lib/vutuv_web/components/ui.ex:3363
+#: lib/vutuv_web/components/ui.ex:3370
 #: lib/vutuv_web/live/organization_live/edit.ex:341
 #: lib/vutuv_web/live/post_live/composer.ex:1813
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -639,7 +639,7 @@ msgstr "Speichern"
 #: lib/vutuv_web/live/admin/user_live.ex:219
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:54
-#: lib/vutuv_web/live/search_live.ex:603
+#: lib/vutuv_web/live/search_live.ex:613
 #: lib/vutuv_web/live/shell_live.ex:711
 #: lib/vutuv_web/live/shell_live.ex:863
 #: lib/vutuv_web/live/tag_live/timeline.ex:237
@@ -793,12 +793,12 @@ msgstr "Profil aktualisiert."
 msgid "User verified successfully."
 msgstr "User wurde verifiziert."
 
-#: lib/vutuv_web/components/ui.ex:3793
+#: lib/vutuv_web/components/ui.ex:3800
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
-#: lib/vutuv_web/live/notification_live/index.ex:1048
+#: lib/vutuv_web/live/notification_live/index.ex:1087
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -844,20 +844,20 @@ msgstr "Benutzername"
 msgid "Users"
 msgstr "Benutzer"
 
-#: lib/vutuv_web/components/ui.ex:1007
+#: lib/vutuv_web/components/ui.ex:1014
 #: lib/vutuv_web/templates/user/show.html.heex:343
 #, elixir-autogen
 msgid "vCard"
 msgstr "vCard"
 
-#: lib/vutuv_web/components/ui.ex:3528
+#: lib/vutuv_web/components/ui.ex:3535
 #: lib/vutuv_web/templates/user/show.html.heex:949
 #: lib/vutuv_web/templates/user/show.html.heex:972
 #, elixir-autogen
 msgid "View All"
 msgstr "Alle anzeigen"
 
-#: lib/vutuv_web/components/ui.ex:3874
+#: lib/vutuv_web/components/ui.ex:3881
 #: lib/vutuv_web/controllers/settings_controller.ex:159
 #: lib/vutuv_web/live/job_posting_live/form.ex:561
 #: lib/vutuv_web/live/organization_live/edit.ex:300
@@ -1146,13 +1146,13 @@ msgstr "Die URL ist ungültig"
 msgid "Can't find URL"
 msgstr "Die URL kann nicht gefunden werden"
 
-#: lib/vutuv_web/live/search_live.ex:327
+#: lib/vutuv_web/live/search_live.ex:329
 #, elixir-autogen
 msgid "Our search will try to match similar names to your search, so don't worry about spelling."
 msgstr "Die Suche nach Vor- und Nachnamen ist fuzzy (unscharf)."
 
-#: lib/vutuv_web/live/search_live.ex:663
-#: lib/vutuv_web/live/search_live.ex:688
+#: lib/vutuv_web/live/search_live.ex:673
+#: lib/vutuv_web/live/search_live.ex:698
 #, elixir-autogen
 msgid "Search Tips"
 msgstr "Hilfe bei der Suche"
@@ -1400,7 +1400,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/agent_docs/text.ex:30
 #: lib/vutuv_web/agent_docs/text.ex:440
 #: lib/vutuv_web/agent_docs/text.ex:663
-#: lib/vutuv_web/components/ui.ex:3818
+#: lib/vutuv_web/components/ui.ex:3825
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
 #: lib/vutuv_web/cv/docx.ex:174
@@ -1411,8 +1411,8 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/live/cv_live.ex:315
 #: lib/vutuv_web/live/job_board_live.ex:277
 #: lib/vutuv_web/live/job_posting_live/form.ex:510
-#: lib/vutuv_web/live/search_live.ex:306
-#: lib/vutuv_web/live/search_live.ex:748
+#: lib/vutuv_web/live/search_live.ex:308
+#: lib/vutuv_web/live/search_live.ex:758
 #: lib/vutuv_web/live/tag_new_live.ex:36
 #: lib/vutuv_web/live/tag_new_live.ex:47
 #: lib/vutuv_web/live/tag_new_live.ex:54
@@ -1700,24 +1700,24 @@ msgstr "Mein Konto löschen"
 msgid "Edit profile"
 msgstr "Profil bearbeiten"
 
-#: lib/vutuv_web/components/ui.ex:1488
-#: lib/vutuv_web/components/ui.ex:1497
-#: lib/vutuv_web/components/ui.ex:1899
+#: lib/vutuv_web/components/ui.ex:1495
+#: lib/vutuv_web/components/ui.ex:1504
+#: lib/vutuv_web/components/ui.ex:1906
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr "Empfehlen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:199
-#: lib/vutuv_web/components/ui.ex:2037
-#: lib/vutuv_web/components/ui.ex:2037
-#: lib/vutuv_web/components/ui.ex:2054
-#: lib/vutuv_web/components/ui.ex:2063
-#: lib/vutuv_web/components/ui.ex:2079
-#: lib/vutuv_web/components/ui.ex:2116
-#: lib/vutuv_web/components/ui.ex:2119
+#: lib/vutuv_web/components/ui.ex:2044
+#: lib/vutuv_web/components/ui.ex:2044
+#: lib/vutuv_web/components/ui.ex:2061
+#: lib/vutuv_web/components/ui.ex:2070
+#: lib/vutuv_web/components/ui.ex:2086
+#: lib/vutuv_web/components/ui.ex:2123
 #: lib/vutuv_web/components/ui.ex:2126
-#: lib/vutuv_web/components/ui.ex:2129
-#: lib/vutuv_web/components/ui.ex:2202
+#: lib/vutuv_web/components/ui.ex:2133
+#: lib/vutuv_web/components/ui.ex:2136
+#: lib/vutuv_web/components/ui.ex:2209
 #: lib/vutuv_web/live/fediverse_account_live.ex:375
 #: lib/vutuv_web/live/fediverse_following_live.ex:331
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:293
@@ -1784,7 +1784,7 @@ msgid "Network"
 msgstr "Netzwerk"
 
 #: lib/vutuv_web/components/post_components.ex:435
-#: lib/vutuv_web/components/ui.ex:3577
+#: lib/vutuv_web/components/ui.ex:3584
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:705
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:742
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:793
@@ -1799,7 +1799,7 @@ msgstr "Hier gibt es noch nichts."
 msgid "Nothing new yet."
 msgstr "Noch nichts Neues."
 
-#: lib/vutuv_web/components/ui.ex:3855
+#: lib/vutuv_web/components/ui.ex:3862
 #: lib/vutuv_web/live/notification_live/index.ex:114
 #: lib/vutuv_web/live/notification_live/index.ex:338
 #: lib/vutuv_web/live/shell_live.ex:738
@@ -1936,29 +1936,29 @@ msgstr "folgt"
 msgid "submit a bug report"
 msgstr "einen Fehlerbericht erstellen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1070
+#: lib/vutuv_web/live/notification_live/index.ex:1110
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr "hat Sie für %{tag} empfohlen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1065
+#: lib/vutuv_web/live/notification_live/index.ex:1105
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr "ist jetzt mit Ihnen vernetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1060
+#: lib/vutuv_web/live/notification_live/index.ex:1100
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr "folgt Ihnen jetzt."
 
-#: lib/vutuv_web/components/ui.ex:2917
-#: lib/vutuv_web/components/ui.ex:3068
+#: lib/vutuv_web/components/ui.ex:2924
+#: lib/vutuv_web/components/ui.ex:3075
 #: lib/vutuv_web/live/organization_live/index.ex:122
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr "Seitennavigation"
 
-#: lib/vutuv_web/components/ui.ex:3602
+#: lib/vutuv_web/components/ui.ex:3609
 #: lib/vutuv_web/live/organization_live/activity.ex:146
 #: lib/vutuv_web/live/organization_live/feed.ex:101
 #: lib/vutuv_web/live/organization_live/show.ex:622
@@ -1973,13 +1973,13 @@ msgstr ""
 "Die Adresse selbst kann nicht geändert werden. Um eine andere zu verwenden, "
 "legen Sie sie als neue E-Mail-Adresse an und löschen Sie diese hier."
 
-#: lib/vutuv_web/components/ui.ex:3373
+#: lib/vutuv_web/components/ui.ex:3380
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr "Eintrag löschen"
 
-#: lib/vutuv_web/components/ui.ex:1213
-#: lib/vutuv_web/components/ui.ex:1223
+#: lib/vutuv_web/components/ui.ex:1220
+#: lib/vutuv_web/components/ui.ex:1230
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr "Optionen"
@@ -2018,12 +2018,12 @@ msgstr "Titelbild hinzufügen"
 msgid "Add cover photo"
 msgstr "Titelbild hinzufügen"
 
-#: lib/vutuv_web/components/ui.ex:2627
+#: lib/vutuv_web/components/ui.ex:2634
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr "April"
 
-#: lib/vutuv_web/components/ui.ex:2631
+#: lib/vutuv_web/components/ui.ex:2638
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr "August"
@@ -2048,37 +2048,37 @@ msgstr "Titelbild"
 msgid "Cover photo of %{name}"
 msgstr "Titelbild von %{name}"
 
-#: lib/vutuv_web/components/ui.ex:2635
+#: lib/vutuv_web/components/ui.ex:2642
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr "Dezember"
 
-#: lib/vutuv_web/components/ui.ex:2625
+#: lib/vutuv_web/components/ui.ex:2632
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr "Februar"
 
-#: lib/vutuv_web/components/ui.ex:2624
+#: lib/vutuv_web/components/ui.ex:2631
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr "Januar"
 
-#: lib/vutuv_web/components/ui.ex:2630
+#: lib/vutuv_web/components/ui.ex:2637
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr "Juli"
 
-#: lib/vutuv_web/components/ui.ex:2629
+#: lib/vutuv_web/components/ui.ex:2636
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr "Juni"
 
-#: lib/vutuv_web/components/ui.ex:2626
+#: lib/vutuv_web/components/ui.ex:2633
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr "März"
 
-#: lib/vutuv_web/components/ui.ex:2628
+#: lib/vutuv_web/components/ui.ex:2635
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr "Mai"
@@ -2093,17 +2093,17 @@ msgstr "Mitglied seit %{month} %{year}"
 msgid "Member since %{year}"
 msgstr "Mitglied seit %{year}"
 
-#: lib/vutuv_web/components/ui.ex:2634
+#: lib/vutuv_web/components/ui.ex:2641
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr "November"
 
-#: lib/vutuv_web/components/ui.ex:2633
+#: lib/vutuv_web/components/ui.ex:2640
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr "Oktober"
 
-#: lib/vutuv_web/components/ui.ex:2632
+#: lib/vutuv_web/components/ui.ex:2639
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr "September"
@@ -2242,11 +2242,11 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/gettext_extraction_anchors.ex:83
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:382
-#: lib/vutuv_web/live/notification_live/index.ex:891
+#: lib/vutuv_web/live/notification_live/index.ex:927
 #: lib/vutuv_web/live/organization_live/show.ex:549
 #: lib/vutuv_web/live/post_live/saved.ex:495
-#: lib/vutuv_web/live/search_live.ex:307
-#: lib/vutuv_web/live/search_live.ex:762
+#: lib/vutuv_web/live/search_live.ex:309
+#: lib/vutuv_web/live/search_live.ex:772
 #: lib/vutuv_web/templates/settings/preferences.html.heex:118
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
@@ -2332,7 +2332,7 @@ msgstr "Zu viele Dateien."
 msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
 
-#: lib/vutuv_web/components/ui.ex:4119
+#: lib/vutuv_web/components/ui.ex:4126
 #: lib/vutuv_web/live/shell_live.ex:781
 #: lib/vutuv_web/templates/post/index.html.heex:17
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2414,7 +2414,7 @@ msgstr "Alle Beiträge"
 
 #: lib/vutuv_web/components/post_components.ex:1603
 #: lib/vutuv_web/components/post_components.ex:4436
-#: lib/vutuv_web/components/ui.ex:2992
+#: lib/vutuv_web/components/ui.ex:2999
 #: lib/vutuv_web/views/user_html.ex:335
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2433,8 +2433,8 @@ msgstr "Lesezeichen"
 
 #: lib/vutuv_web/components/post_components.ex:1567
 #: lib/vutuv_web/components/post_components.ex:4670
-#: lib/vutuv_web/components/ui.ex:2978
-#: lib/vutuv_web/live/notification_live/index.ex:1038
+#: lib/vutuv_web/components/ui.ex:2985
+#: lib/vutuv_web/live/notification_live/index.ex:1077
 #: lib/vutuv_web/views/user_html.ex:345
 #, elixir-autogen, elixir-format
 msgid "Like"
@@ -2442,7 +2442,7 @@ msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1000
 #: lib/vutuv_web/components/post_components.ex:4679
-#: lib/vutuv_web/live/notification_live/index.ex:971
+#: lib/vutuv_web/live/notification_live/index.ex:1007
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
 #: lib/vutuv_web/live/shell_live.ex:789
@@ -2503,9 +2503,9 @@ msgid "Unlike"
 msgstr "Gefällt mir entfernen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:343
-#: lib/vutuv_web/components/ui.ex:2032
-#: lib/vutuv_web/components/ui.ex:2032
-#: lib/vutuv_web/components/ui.ex:2169
+#: lib/vutuv_web/components/ui.ex:2039
+#: lib/vutuv_web/components/ui.ex:2039
+#: lib/vutuv_web/components/ui.ex:2176
 #: lib/vutuv_web/live/organization_live/following.ex:197
 #: lib/vutuv_web/live/organization_live/following.ex:256
 #: lib/vutuv_web/live/organization_live/show.ex:459
@@ -2527,7 +2527,7 @@ msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
 
 #: lib/vutuv_web/components/post_components.ex:393
-#: lib/vutuv_web/live/notification_live/index.ex:972
+#: lib/vutuv_web/live/notification_live/index.ex:1008
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Antworten"
@@ -2535,7 +2535,7 @@ msgstr "Antworten"
 #: lib/vutuv_web/components/post_components.ex:1578
 #: lib/vutuv_web/components/post_components.ex:4706
 #: lib/vutuv_web/components/post_components.ex:4707
-#: lib/vutuv_web/live/notification_live/index.ex:1035
+#: lib/vutuv_web/live/notification_live/index.ex:1074
 #: lib/vutuv_web/live/post_live/reply.ex:42
 #, elixir-autogen, elixir-format
 msgid "Reply"
@@ -2557,7 +2557,7 @@ msgstr "Solange es geteilte Beiträge oder Antworten gibt, lässt sich der Empf�
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beiträge oder Antworten gibt, bleibt er öffentlich; löschen können Sie ihn weiterhin."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1258
+#: lib/vutuv_web/live/notification_live/index.ex:1300
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
@@ -2638,7 +2638,7 @@ msgstr "Mitglied nicht gefunden."
 msgid "No conversations yet."
 msgstr "Noch keine Unterhaltungen."
 
-#: lib/vutuv_web/components/ui.ex:2503
+#: lib/vutuv_web/components/ui.ex:2510
 #: lib/vutuv_web/live/message_live/index.ex:726
 #, elixir-autogen, elixir-format
 msgid "Online"
@@ -2788,8 +2788,8 @@ msgstr "Berufserfahrung hinzufügen"
 msgid "Write your first post"
 msgstr "Ersten Beitrag schreiben"
 
-#: lib/vutuv_web/components/ui.ex:3156
-#: lib/vutuv_web/components/ui.ex:3530
+#: lib/vutuv_web/components/ui.ex:3163
+#: lib/vutuv_web/components/ui.ex:3537
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
 #: lib/vutuv_web/templates/settings/organizations.html.heex:89
@@ -2838,13 +2838,13 @@ msgstr[1] "+%{formatted} weitere Tags"
 #: lib/vutuv_web/agent_docs/markdown.ex:548
 #: lib/vutuv_web/agent_docs/text.ex:515
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:970
+#: lib/vutuv_web/live/notification_live/index.ex:1006
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
 msgstr "Vernetzungen"
 
-#: lib/vutuv_web/components/ui.ex:998
+#: lib/vutuv_web/components/ui.ex:1005
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr "Markdown"
@@ -2854,7 +2854,7 @@ msgstr "Markdown"
 msgid "No connections yet."
 msgstr "Noch keine Vernetzungen."
 
-#: lib/vutuv_web/components/ui.ex:1014
+#: lib/vutuv_web/components/ui.ex:1021
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr "Andere Formate"
@@ -2864,7 +2864,7 @@ msgstr "Andere Formate"
 msgid "People who aren't my connections"
 msgstr "Personen, mit denen ich nicht vernetzt bin"
 
-#: lib/vutuv_web/components/ui.ex:999
+#: lib/vutuv_web/components/ui.ex:1006
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr "Nur Text"
@@ -2893,23 +2893,23 @@ msgid "Open someone's profile to message them."
 msgstr "Öffnen Sie ein Profil, um jemandem zu schreiben."
 
 #: lib/vutuv_web/components/organization_components.ex:225
-#: lib/vutuv_web/live/notification_live/index.ex:1050
+#: lib/vutuv_web/live/notification_live/index.ex:1090
 #: lib/vutuv_web/live/organization_live/activity.ex:99
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr "Aktivität"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1041
+#: lib/vutuv_web/live/notification_live/index.ex:1080
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr "Vernetzung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1034
+#: lib/vutuv_web/live/notification_live/index.ex:1073
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr "Empfehlung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1033
+#: lib/vutuv_web/live/notification_live/index.ex:1072
 #: lib/vutuv_web/templates/user/show.html.heex:933
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -2922,7 +2922,7 @@ msgstr[1] "Follower"
 msgid "Welcome to vutuv, %{name}!"
 msgstr "Willkommen bei vutuv, %{name}!"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1067
+#: lib/vutuv_web/live/notification_live/index.ex:1107
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr "gefällt Ihr Beitrag."
@@ -2954,12 +2954,12 @@ msgstr "(gelöschtes Konto)"
 msgid "(no text)"
 msgstr "(kein Text)"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1294
+#: lib/vutuv_web/live/notification_live/index.ex:1336
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr "Eine Meldung zu Ihrem Inhalt wurde bestätigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1295
+#: lib/vutuv_web/live/notification_live/index.ex:1337
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr "Eine Meldung zu Ihrem Inhalt wurde verworfen; er ist wieder sichtbar."
@@ -3074,7 +3074,7 @@ msgstr "Familienfreundlich bleiben"
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:1042
+#: lib/vutuv_web/live/notification_live/index.ex:1081
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3216,7 +3216,7 @@ msgstr ""
 msgid "Private message"
 msgstr "Private Nachricht"
 
-#: lib/vutuv_web/components/ui.ex:3787
+#: lib/vutuv_web/components/ui.ex:3794
 #: lib/vutuv_web/live/shell_live.ex:612
 #: lib/vutuv_web/live/shell_live.ex:870
 #: lib/vutuv_web/templates/import/new.html.heex:15
@@ -3330,7 +3330,7 @@ msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 "Meldungen sind anonym; wir verraten nie, wer gemeldet hat. Unsere Regeln:"
 
-#: lib/vutuv_web/components/ui.ex:2892
+#: lib/vutuv_web/components/ui.ex:2899
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:773
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -3534,12 +3534,12 @@ msgstr "Sie haben das bereits gemeldet. Unser Team kümmert sich darum."
 msgid "You cannot report your own content."
 msgstr "Eigene Inhalte können Sie nicht melden."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1297
+#: lib/vutuv_web/live/notification_live/index.ex:1339
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr "Sie haben gemeldeten Inhalt gelöscht; der Fall ist abgeschlossen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1296
+#: lib/vutuv_web/live/notification_live/index.ex:1338
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr "Sie haben gemeldeten Inhalt überarbeitet; der Fall ist abgeschlossen."
@@ -3549,7 +3549,7 @@ msgstr "Sie haben gemeldeten Inhalt überarbeitet; der Fall ist abgeschlossen."
 msgid "Your content was reported"
 msgstr "Ihr Inhalt wurde gemeldet"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1298
+#: lib/vutuv_web/live/notification_live/index.ex:1340
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3744,7 +3744,7 @@ msgstr "Verlauf"
 msgid "Open the profile"
 msgstr "Profil öffnen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1322
+#: lib/vutuv_web/live/notification_live/index.ex:1364
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3771,7 +3771,7 @@ msgstr "Besitzer hat den Inhalt bearbeitet"
 msgid "Report filed"
 msgstr "Meldung eingegangen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1044
+#: lib/vutuv_web/live/notification_live/index.ex:1083
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr "Schutz nach Meldung"
@@ -3853,7 +3853,7 @@ msgstr "Bestätigt"
 msgid "Waiting for the owner"
 msgstr "Wartet auf den Besitzer"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1327
+#: lib/vutuv_web/live/notification_live/index.ex:1369
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -4621,24 +4621,24 @@ msgstr ""
 msgid "Undeliverable"
 msgstr "Unzustellbar"
 
-#: lib/vutuv_web/live/search_live.ex:423
+#: lib/vutuv_web/live/search_live.ex:425
 #, elixir-autogen, elixir-format
 msgid "You can search for a name, email, or tag, or for words in public posts."
 msgstr ""
 "Sie können nach Namen (Vor- und Nachname), E-Mail-Adressen, Tags oder nach "
 "Wörtern in öffentlichen Beiträgen suchen."
 
-#: lib/vutuv_web/live/search_live.ex:418
+#: lib/vutuv_web/live/search_live.ex:420
 #, elixir-autogen, elixir-format
 msgid "Search for people by name, email, or username."
 msgstr "Suchen Sie Personen nach Name, E-Mail-Adresse oder Benutzername."
 
-#: lib/vutuv_web/live/search_live.ex:419
+#: lib/vutuv_web/live/search_live.ex:421
 #, elixir-autogen, elixir-format
 msgid "Search for tags by name."
 msgstr "Suchen Sie Tags nach ihrem Namen."
 
-#: lib/vutuv_web/live/search_live.ex:420
+#: lib/vutuv_web/live/search_live.ex:422
 #, elixir-autogen, elixir-format
 msgid "Search for words in public posts."
 msgstr "Suchen Sie nach Wörtern in öffentlichen Beiträgen."
@@ -4658,7 +4658,7 @@ msgstr ""
 "beide Richtungen unterbunden. Eine Aufhebung der Blockierung stellt das "
 "Entfernte nicht wieder her."
 
-#: lib/vutuv_web/components/ui.ex:3878
+#: lib/vutuv_web/components/ui.ex:3885
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -4753,12 +4753,12 @@ msgstr "Folgt noch niemandem."
 msgid "This area is reserved for administrators."
 msgstr "Dieser Bereich ist Administratoren vorbehalten."
 
-#: lib/vutuv_web/live/search_live.ex:810
+#: lib/vutuv_web/live/search_live.ex:820
 #, elixir-autogen, elixir-format
 msgid "No results for \"%{query}\""
 msgstr "Keine Ergebnisse für \"%{query}\""
 
-#: lib/vutuv_web/live/search_live.ex:731
+#: lib/vutuv_web/live/search_live.ex:741
 #, elixir-autogen, elixir-format
 msgid "Not an exact match, but sounds like your search."
 msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
@@ -4767,23 +4767,23 @@ msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
 #: lib/vutuv_web/agent_docs/text.ex:388
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:516
-#: lib/vutuv_web/live/notification_live/index.ex:892
+#: lib/vutuv_web/live/notification_live/index.ex:928
 #: lib/vutuv_web/live/organization_live/show.ex:632
 #: lib/vutuv_web/live/post_live/saved.ex:498
-#: lib/vutuv_web/live/search_live.ex:305
-#: lib/vutuv_web/live/search_live.ex:704
+#: lib/vutuv_web/live/search_live.ex:307
+#: lib/vutuv_web/live/search_live.ex:714
 #, elixir-autogen, elixir-format
 msgid "People"
 msgstr "Personen"
 
-#: lib/vutuv_web/live/search_live.ex:650
+#: lib/vutuv_web/live/search_live.ex:660
 #, elixir-autogen, elixir-format
 msgid "Results appear once you have typed at least three letters."
 msgstr ""
 "Ergebnisse erscheinen, sobald Sie mindestens drei Buchstaben eingegeben "
 "haben."
 
-#: lib/vutuv_web/live/search_live.ex:728
+#: lib/vutuv_web/live/search_live.ex:738
 #, elixir-autogen, elixir-format
 msgid "Similar names"
 msgstr "Ähnliche Namen"
@@ -4792,49 +4792,49 @@ msgstr "Ähnliche Namen"
 #: lib/vutuv_web/components/post_components.ex:409
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
-#: lib/vutuv_web/live/notification_live/index.ex:890
-#: lib/vutuv_web/live/search_live.ex:304
+#: lib/vutuv_web/live/notification_live/index.ex:926
+#: lib/vutuv_web/live/search_live.ex:306
 #: lib/vutuv_web/views/qualification_html.ex:90
 #, elixir-autogen, elixir-format
 msgid "All"
 msgstr "Alle"
 
-#: lib/vutuv_web/live/search_live.ex:633
+#: lib/vutuv_web/live/search_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "Exact matches only"
 msgstr "Nur exakte Treffer"
 
-#: lib/vutuv_web/live/search_live.ex:376
+#: lib/vutuv_web/live/search_live.ex:378
 #, elixir-autogen, elixir-format
 msgid "in quotes: exact matches only, no similar names"
 msgstr "in Anführungszeichen: nur exakte Treffer, keine ähnlichen Namen"
 
-#: lib/vutuv_web/live/search_live.ex:373
+#: lib/vutuv_web/live/search_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "searches usernames"
 msgstr "sucht Benutzernamen"
 
-#: lib/vutuv_web/live/search_live.ex:365
+#: lib/vutuv_web/live/search_live.ex:367
 #, elixir-autogen, elixir-format
 msgid "only people with an address in this city"
 msgstr "nur Personen mit einer Adresse in diesem Ort (auch stadt: / city:)"
 
-#: lib/vutuv_web/live/search_live.ex:364
+#: lib/vutuv_web/live/search_live.ex:366
 #, elixir-autogen, elixir-format
 msgid "city:koblenz"
 msgstr "ort:koblenz"
 
-#: lib/vutuv_web/live/search_live.ex:354
+#: lib/vutuv_web/live/search_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "first:stefan"
 msgstr "vorname:stefan"
 
-#: lib/vutuv_web/live/search_live.ex:375
+#: lib/vutuv_web/live/search_live.ex:377
 #, elixir-autogen, elixir-format
 msgid "miller"
 msgstr "müller"
 
-#: lib/vutuv_web/live/search_live.ex:355
+#: lib/vutuv_web/live/search_live.ex:357
 #, elixir-autogen, elixir-format
 msgid "searches first names only (last: for last names)"
 msgstr "sucht nur in Vornamen (nachname: für Nachnamen)"
@@ -4847,7 +4847,7 @@ msgstr "sucht nur in Vornamen (nachname: für Nachnamen)"
 msgid "Add a tag"
 msgstr "Tags hinzufügen"
 
-#: lib/vutuv_web/live/search_live.ex:412
+#: lib/vutuv_web/live/search_live.ex:414
 #, elixir-autogen, elixir-format
 msgid "Search for people, tags, or posts"
 msgstr "Nach Personen, Tags oder Beiträgen suchen"
@@ -5478,7 +5478,7 @@ msgstr "API-Token (%{date})"
 msgid "API documentation"
 msgstr "API-Dokumentation"
 
-#: lib/vutuv_web/components/ui.ex:3929
+#: lib/vutuv_web/components/ui.ex:3936
 #: lib/vutuv_web/controllers/settings_controller.ex:145
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5562,10 +5562,10 @@ msgstr "Tastaturkürzel"
 msgid "Navigation"
 msgstr "Navigation"
 
-#: lib/vutuv_web/components/ui.ex:4026
-#: lib/vutuv_web/components/ui.ex:4031
-#: lib/vutuv_web/components/ui.ex:4110
-#: lib/vutuv_web/components/ui.ex:4174
+#: lib/vutuv_web/components/ui.ex:4033
+#: lib/vutuv_web/components/ui.ex:4038
+#: lib/vutuv_web/components/ui.ex:4117
+#: lib/vutuv_web/components/ui.ex:4181
 #: lib/vutuv_web/controllers/settings_controller.ex:61
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5638,7 +5638,7 @@ msgstr "Fußzeilen-Navigation"
 #: lib/vutuv_web/components/post_components.ex:2835
 #: lib/vutuv_web/components/post_components.ex:2887
 #: lib/vutuv_web/components/post_components.ex:3284
-#: lib/vutuv_web/live/notification_live/index.ex:691
+#: lib/vutuv_web/live/notification_live/index.ex:694
 #: lib/vutuv_web/live/post_live/feed.ex:1245
 #: lib/vutuv_web/views/user_html.ex:113
 #, elixir-autogen, elixir-format
@@ -5684,7 +5684,7 @@ msgstr "Art der E-Mail-Adresse"
 msgid "About you"
 msgstr "Über Sie"
 
-#: lib/vutuv_web/components/ui.ex:3898
+#: lib/vutuv_web/components/ui.ex:3905
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:289
@@ -5706,7 +5706,7 @@ msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 "Laden Sie alles herunter, was vutuv über Sie speichert, als eine Datei."
 
-#: lib/vutuv_web/components/ui.ex:3825
+#: lib/vutuv_web/components/ui.ex:3832
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5740,7 +5740,7 @@ msgstr "Persönliche Tokens für die vutuv-API."
 msgid "Photos"
 msgstr "Fotos"
 
-#: lib/vutuv_web/components/ui.ex:3872
+#: lib/vutuv_web/components/ui.ex:3879
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/templates/page/index.html.heex:166
 #, elixir-autogen, elixir-format
@@ -5767,7 +5767,7 @@ msgstr "Ansehen"
 msgid "Your name"
 msgstr "Ihr Name"
 
-#: lib/vutuv_web/live/notification_live/index.ex:520
+#: lib/vutuv_web/live/notification_live/index.ex:523
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr "Ihr Beitrag"
@@ -5858,14 +5858,14 @@ msgstr "@%{slug} folgt Ihnen jetzt auf vutuv"
 msgid "Apps"
 msgstr "Apps"
 
-#: lib/vutuv_web/components/ui.ex:3925
+#: lib/vutuv_web/components/ui.ex:3932
 #: lib/vutuv_web/controllers/settings_controller.ex:165
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
 msgstr "Apps & API-Zugang"
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:127
-#: lib/vutuv_web/live/notification_live/index.ex:973
+#: lib/vutuv_web/live/notification_live/index.ex:1009
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:17
@@ -6490,9 +6490,9 @@ msgstr "Nach unten"
 msgid "Move up"
 msgstr "Nach oben"
 
-#: lib/vutuv_web/components/ui.ex:1488
-#: lib/vutuv_web/components/ui.ex:1497
-#: lib/vutuv_web/components/ui.ex:1900
+#: lib/vutuv_web/components/ui.ex:1495
+#: lib/vutuv_web/components/ui.ex:1504
+#: lib/vutuv_web/components/ui.ex:1907
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr "Empfehlung zurücknehmen"
@@ -6557,11 +6557,11 @@ msgstr "Mitglieder, die %{name} für %{tag} empfohlen haben"
 msgid "No endorsements yet."
 msgstr "Noch keine Empfehlungen."
 
-#: lib/vutuv_web/components/ui.ex:1853
-#: lib/vutuv_web/live/notification_live/index.ex:625
-#: lib/vutuv_web/live/notification_live/index.ex:640
-#: lib/vutuv_web/live/notification_live/index.ex:778
-#: lib/vutuv_web/live/notification_live/index.ex:780
+#: lib/vutuv_web/components/ui.ex:1860
+#: lib/vutuv_web/live/notification_live/index.ex:628
+#: lib/vutuv_web/live/notification_live/index.ex:643
+#: lib/vutuv_web/live/notification_live/index.ex:781
+#: lib/vutuv_web/live/notification_live/index.ex:783
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr "und %{count} weitere"
@@ -6877,7 +6877,7 @@ msgstr ""
 "Schalten Sie einen Schalter aus, geht der passende Opt-out auf den Seiten "
 "und Antworten über Sie mit. Mit beiden aus zum Beispiel:"
 
-#: lib/vutuv_web/components/ui.ex:2357
+#: lib/vutuv_web/components/ui.ex:2364
 #: lib/vutuv_web/live/fediverse_account_live.ex:369
 #: lib/vutuv_web/templates/settings/filters.html.heex:58
 #: lib/vutuv_web/templates/user/show.html.heex:212
@@ -6901,7 +6901,7 @@ msgstr "Neue Nachrichten und neue Vernetzungen"
 msgid "Remove this connection? You will stop following them."
 msgstr "Diese Vernetzung entfernen? Sie folgen der Person dann nicht mehr."
 
-#: lib/vutuv_web/components/ui.ex:2356
+#: lib/vutuv_web/components/ui.ex:2363
 #: lib/vutuv_web/live/fediverse_account_live.ex:367
 #: lib/vutuv_web/templates/settings/filters.html.heex:81
 #: lib/vutuv_web/templates/user/show.html.heex:212
@@ -6941,33 +6941,33 @@ msgstr "Beruflich"
 msgid "Unmute @%{handle}"
 msgstr "@%{handle} nicht mehr stummschalten"
 
-#: lib/vutuv_web/components/ui.ex:2327
+#: lib/vutuv_web/components/ui.ex:2334
 #, elixir-autogen, elixir-format
 msgid "Doesn't follow you"
 msgstr "Folgt Ihnen nicht"
 
-#: lib/vutuv_web/components/ui.ex:2321
+#: lib/vutuv_web/components/ui.ex:2328
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr "Folgt Ihnen"
 
-#: lib/vutuv_web/components/ui.ex:2311
+#: lib/vutuv_web/components/ui.ex:2318
 #, elixir-autogen, elixir-format
 msgid "This member doesn't follow you"
 msgstr "Dieses Mitglied folgt Ihnen nicht"
 
-#: lib/vutuv_web/components/ui.ex:2262
-#: lib/vutuv_web/components/ui.ex:2311
+#: lib/vutuv_web/components/ui.ex:2269
+#: lib/vutuv_web/components/ui.ex:2318
 #, elixir-autogen, elixir-format
 msgid "This member follows you"
 msgstr "Dieses Mitglied folgt Ihnen"
 
-#: lib/vutuv_web/components/ui.ex:2260
+#: lib/vutuv_web/components/ui.ex:2267
 #, elixir-autogen, elixir-format
 msgid "You follow each other"
 msgstr "Sie folgen einander"
 
-#: lib/vutuv_web/components/ui.ex:2261
+#: lib/vutuv_web/components/ui.ex:2268
 #, elixir-autogen, elixir-format
 msgid "You follow this member"
 msgstr "Sie folgen diesem Mitglied"
@@ -7555,13 +7555,13 @@ msgstr "Ihre Mitglieder werden zu dieser hinzugefügt (Vereinigung)."
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr "Seite %{page} von %{pages}, %{total} gesamt"
 
-#: lib/vutuv_web/components/ui.ex:2930
+#: lib/vutuv_web/components/ui.ex:2937
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Zurück"
 
-#: lib/vutuv_web/components/ui.ex:2946
+#: lib/vutuv_web/components/ui.ex:2953
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -8071,13 +8071,13 @@ msgstr "Neue Mitglieder"
 #: lib/vutuv_web/components/job_components.ex:173
 #: lib/vutuv_web/live/admin/dashboard_live.ex:287
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:457
-#: lib/vutuv_web/live/notification_live/index.ex:919
+#: lib/vutuv_web/live/notification_live/index.ex:955
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr "Heute"
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:291
-#: lib/vutuv_web/live/notification_live/index.ex:922
+#: lib/vutuv_web/live/notification_live/index.ex:958
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr "Gestern"
@@ -8321,8 +8321,8 @@ msgstr "Identität verifiziert. Das Mitglied wurde per E-Mail benachrichtigt."
 msgid "Identity-verified"
 msgstr "Identität verifiziert"
 
-#: lib/vutuv/accounts.ex:1367
-#: lib/vutuv/accounts.ex:1416
+#: lib/vutuv/accounts.ex:1394
+#: lib/vutuv/accounts.ex:1443
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -8363,7 +8363,7 @@ msgstr "Nicht bestätigt"
 msgid "Open the member browser"
 msgstr "Mitgliederübersicht öffnen"
 
-#: lib/vutuv/accounts.ex:1384
+#: lib/vutuv/accounts.ex:1411
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -8374,7 +8374,7 @@ msgstr "PIN abgelaufen"
 msgid "PIN registered"
 msgstr "PIN-registriert"
 
-#: lib/vutuv_web/components/ui.ex:2933
+#: lib/vutuv_web/components/ui.ex:2940
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr "Seite %{page} von %{pages}"
@@ -8513,7 +8513,7 @@ msgstr "Abschluss"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:41
 #: lib/vutuv_web/agent_docs/text.ex:38
-#: lib/vutuv_web/components/ui.ex:3801
+#: lib/vutuv_web/components/ui.ex:3808
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8573,7 +8573,7 @@ msgstr ""
 " was Sie nicht übernehmen möchten. Einträge, die bereits in Ihrem Profil "
 "stehen, sind für Sie abgewählt."
 
-#: lib/vutuv_web/components/ui.ex:3913
+#: lib/vutuv_web/components/ui.ex:3920
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Import"
@@ -8602,7 +8602,7 @@ msgstr "%{items} importiert."
 msgid "Nothing new to import."
 msgstr "Nichts Neues zu importieren."
 
-#: lib/vutuv_web/components/ui.ex:3829
+#: lib/vutuv_web/components/ui.ex:3836
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8696,7 +8696,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr "Zu viele Importe. Bitte versuchen Sie es in Kürze erneut."
 
-#: lib/vutuv_web/components/ui.ex:3202
+#: lib/vutuv_web/components/ui.ex:3209
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8800,13 +8800,13 @@ msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 "Ziehen Sie Ihre ZIP-Datei hierher oder klicken Sie, um eine auszuwählen."
 
-#: lib/vutuv_web/components/ui.ex:3789
+#: lib/vutuv_web/components/ui.ex:3796
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr "Basisdaten & Fotos"
 
-#: lib/vutuv_web/components/ui.ex:3909
+#: lib/vutuv_web/components/ui.ex:3916
 #: lib/vutuv_web/controllers/settings_controller.ex:122
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8818,7 +8818,7 @@ msgstr "Sprache & Anzeige"
 msgid "More profile sections"
 msgstr "Weitere Profil-Bereiche"
 
-#: lib/vutuv_web/components/ui.ex:3900
+#: lib/vutuv_web/components/ui.ex:3907
 #: lib/vutuv_web/controllers/settings_controller.ex:105
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8828,7 +8828,7 @@ msgstr "Weitere Profil-Bereiche"
 msgid "Sign-in & security"
 msgstr "Anmeldung & Sicherheit"
 
-#: lib/vutuv_web/components/ui.ex:3917
+#: lib/vutuv_web/components/ui.ex:3924
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8959,7 +8959,7 @@ msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
 "Die Seite %{letter} des Mitgliederverzeichnisses, sortiert nach Nachnamen."
 
-#: lib/vutuv_web/components/ui.ex:1016
+#: lib/vutuv_web/components/ui.ex:1023
 #, elixir-autogen, elixir-format
 msgid "This profile is not offered as a Markdown, text, JSON or XML export."
 msgstr ""
@@ -9067,7 +9067,7 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/agent_docs/text.ex:504
 #: lib/vutuv_web/agent_docs/text.ex:508
 #: lib/vutuv_web/components/organization_components.ex:242
-#: lib/vutuv_web/components/ui.ex:3890
+#: lib/vutuv_web/components/ui.ex:3897
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:323
 #: lib/vutuv_web/controllers/settings_controller.ex:390
@@ -9122,7 +9122,7 @@ msgstr "Social-Media-Konten verwalten"
 msgid "Your Fediverse handle"
 msgstr "Ihr Fediverse-Handle"
 
-#: lib/vutuv/accounts.ex:1379
+#: lib/vutuv/accounts.ex:1406
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -9179,7 +9179,7 @@ msgstr "Berufserfahrung"
 msgid "Volunteering & hobbies"
 msgstr "Ehrenamt, Hobby & Freiwilligenarbeit"
 
-#: lib/vutuv_web/live/search_live.ex:625
+#: lib/vutuv_web/live/search_live.ex:635
 #, elixir-autogen, elixir-format
 msgid "Not available while the search uses a people filter."
 msgstr "Nicht verfügbar, solange die Suche einen Personen-Filter verwendet."
@@ -9233,7 +9233,7 @@ msgstr ""
 "Ihres Browsers (Strg+P oder Cmd+P) und wählen Sie \"Als PDF speichern\", um "
 "eine PDF-Datei zu erhalten."
 
-#: lib/vutuv_web/components/ui.ex:1124
+#: lib/vutuv_web/components/ui.ex:1131
 #, elixir-autogen, elixir-format
 msgid "CV download"
 msgstr "Lebenslauf-Download"
@@ -9271,7 +9271,7 @@ msgstr "Jeder Download enthält genau die ausgewählten Teile."
 msgid "Header"
 msgstr "Kopfzeile"
 
-#: lib/vutuv_web/components/ui.ex:1134
+#: lib/vutuv_web/components/ui.ex:1141
 #: lib/vutuv_web/templates/export/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Open CV"
@@ -9309,7 +9309,7 @@ msgstr ""
 "Besuchers enthält nur, was er dort ohnehin sehen kann, und private E-Mail-"
 "Adressen erscheinen nur in Ihrem eigenen."
 
-#: lib/vutuv_web/components/ui.ex:1126
+#: lib/vutuv_web/components/ui.ex:1133
 #, elixir-autogen, elixir-format
 msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
@@ -9486,8 +9486,8 @@ msgstr "Dieses Tag kann nur von einem Admin entfernt werden."
 msgid "Yes"
 msgstr "Ja"
 
-#: lib/vutuv_web/components/ui.ex:1532
-#: lib/vutuv_web/components/ui.ex:1533
+#: lib/vutuv_web/components/ui.ex:1539
+#: lib/vutuv_web/components/ui.ex:1540
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:65
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9928,7 +9928,7 @@ msgstr "Yoruba"
 msgid "Employment status"
 msgstr "Beschäftigungsstatus"
 
-#: lib/vutuv/accounts/user.ex:1084
+#: lib/vutuv/accounts/user.ex:1090
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9939,7 +9939,7 @@ msgstr "Auf Jobsuche"
 msgid "Not open to work"
 msgstr "Nicht offen für Angebote"
 
-#: lib/vutuv/accounts/user.ex:1081
+#: lib/vutuv/accounts/user.ex:1087
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -10065,7 +10065,7 @@ msgstr "Zertifikate"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:45
 #: lib/vutuv_web/agent_docs/text.ex:42
-#: lib/vutuv_web/components/ui.ex:3805
+#: lib/vutuv_web/components/ui.ex:3812
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:124
@@ -10265,13 +10265,13 @@ msgstr "Dauerhafter Profillink"
 msgid "Dismiss"
 msgstr "Schließen"
 
-#: lib/vutuv_web/components/ui.ex:2725
+#: lib/vutuv_web/components/ui.ex:2732
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr "Kopiert"
 
-#: lib/vutuv_web/components/ui.ex:2724
-#: lib/vutuv_web/components/ui.ex:2728
+#: lib/vutuv_web/components/ui.ex:2731
+#: lib/vutuv_web/components/ui.ex:2735
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr "Kopieren"
@@ -11418,19 +11418,19 @@ msgstr ""
 " Konto anlegen kann. Wählen Sie „Niemand“, um den Status zu speichern, ohne "
 "ihn anzuzeigen."
 
-#: lib/vutuv/accounts/user.ex:1122
+#: lib/vutuv/accounts/user.ex:1128
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Alle, auch nicht angemeldete Besucher"
 
-#: lib/vutuv/accounts/user.ex:1127
+#: lib/vutuv/accounts/user.ex:1133
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Niemand"
 
-#: lib/vutuv/accounts/user.ex:1125
+#: lib/vutuv/accounts/user.ex:1131
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:566
 #, elixir-autogen, elixir-format
@@ -12477,7 +12477,7 @@ msgstr "Organisationsseite"
 msgid "Organization pages"
 msgstr "Organisationsseiten"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1045
+#: lib/vutuv_web/live/notification_live/index.ex:1084
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr "Organisationsrolle"
@@ -12490,7 +12490,7 @@ msgstr "Organisation wieder freigegeben."
 #: lib/vutuv_web/agent_docs/markdown.ex:349
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:325
-#: lib/vutuv_web/components/ui.ex:3921
+#: lib/vutuv_web/components/ui.ex:3928
 #: lib/vutuv_web/controllers/settings_controller.ex:179
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
@@ -12593,22 +12593,22 @@ msgstr "Ihre Organisationsseite ist verifiziert und jetzt live."
 msgid "Your organization page was updated."
 msgstr "Ihre Organisationsseite wurde aktualisiert."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1286
+#: lib/vutuv_web/live/notification_live/index.ex:1328
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr "hat Ihnen eine Rolle bei %{organization} gegeben."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1283
+#: lib/vutuv_web/live/notification_live/index.ex:1325
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr "hat Sie zum Recruiter für %{organization} gemacht."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1280
+#: lib/vutuv_web/live/notification_live/index.ex:1322
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr "hat Sie zum Administrator von %{organization} gemacht."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1277
+#: lib/vutuv_web/live/notification_live/index.ex:1319
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr "hat Sie zum Besitzer von %{organization} gemacht."
@@ -12815,7 +12815,7 @@ msgstr "Halten Sie Strg / Cmd gedrückt, um mehrere auszuwählen."
 msgid "How to apply"
 msgstr "So bewerben Sie sich"
 
-#: lib/vutuv/accounts/user.ex:1096
+#: lib/vutuv/accounts/user.ex:1102
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12935,7 +12935,7 @@ msgstr "Hier ist noch nichts. Jobs, die Ihnen gefallen, erscheinen hier."
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) für KI-Agenten anbieten."
 
-#: lib/vutuv/accounts/user.ex:1095
+#: lib/vutuv/accounts/user.ex:1101
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -13017,7 +13017,7 @@ msgstr "Anzeige nicht gefunden."
 msgid "Publish"
 msgstr "Veröffentlichen"
 
-#: lib/vutuv/accounts/user.ex:1097
+#: lib/vutuv/accounts/user.ex:1103
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:496
 #: lib/vutuv_web/agent_docs/markdown.ex:389
@@ -13724,7 +13724,7 @@ msgstr "Suche speichern"
 msgid "Saved search deleted."
 msgstr "Gespeicherte Suche gelöscht."
 
-#: lib/vutuv_web/components/ui.ex:3867
+#: lib/vutuv_web/components/ui.ex:3874
 #: lib/vutuv_web/controllers/settings_controller.ex:556
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -13799,7 +13799,7 @@ msgstr "Stellenbörse"
 msgid "job search"
 msgstr "Jobsuche"
 
-#: lib/vutuv_web/live/search_live.ex:370
+#: lib/vutuv_web/live/search_live.ex:372
 #, elixir-autogen, elixir-format
 msgid "only people open to offers (status:open) or looking (status:looking)"
 msgstr "nur Personen, die offen für Angebote (status:open) oder auf Jobsuche (status:looking) sind"
@@ -14004,7 +14004,7 @@ msgstr "%{pending} Bild(er) in der Warteschlange; %{rejected} in den letzten 7 T
 msgid "Image awaiting review, visible only to you"
 msgstr "Bild wird geprüft, nur für Sie sichtbar"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1043
+#: lib/vutuv_web/live/notification_live/index.ex:1082
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -14045,7 +14045,7 @@ msgstr "Screenshot entfernt."
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr "Dieser Screenshot wurde automatisch aus dem Link in Ihrem Beitrag erstellt. Falls er unbrauchbar ist (zum Beispiel weil ein Cookie-Banner die Seite verdeckt), können Sie ihn entfernen."
 
-#: lib/vutuv/accounts/user.ex:1140
+#: lib/vutuv/accounts/user.ex:1146
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -14056,19 +14056,19 @@ msgstr "Nur das Alter, ohne das Datum"
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr "Wählen Sie, wie viel von Ihrem Geburtstag Ihr Profil zeigt. „Nur das Alter“ verbirgt das genaue Datum, „Tag und Monat“ verbirgt das Jahr (und Ihr Alter), und „Nicht anzeigen“ speichert ihn weiterhin, hält ihn aber von Ihrem Profil fern."
 
-#: lib/vutuv/accounts/user.ex:1143
+#: lib/vutuv/accounts/user.ex:1149
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Tag und Monat, ohne das Jahr"
 
-#: lib/vutuv/accounts/user.ex:1146
+#: lib/vutuv/accounts/user.ex:1152
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Geburtstag nicht anzeigen"
 
-#: lib/vutuv/accounts/user.ex:1137
+#: lib/vutuv/accounts/user.ex:1143
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -14091,7 +14091,7 @@ msgstr[1] "%{formatted} Beiträge erwähnen aktuell %{handle} und werden beim Um
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr "Beim Ändern werden alle Erwähnungen Ihres alten Handles in Beiträgen automatisch auf den neuen umgeschrieben und die Verfasser dieser Beiträge benachrichtigt. Ihre alte Profiladresse funktioniert dann nicht mehr."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1046
+#: lib/vutuv_web/live/notification_live/index.ex:1085
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr "Handle-Änderung"
@@ -14103,7 +14103,7 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] "Wir haben %{formatted} Beitrag aktualisiert, der Ihren alten Handle erwähnt hat, und dessen Verfasser benachrichtigt."
 msgstr[1] "Wir haben %{formatted} Beiträge aktualisiert, die Ihren alten Handle erwähnt haben, und deren Verfasser benachrichtigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1336
+#: lib/vutuv_web/live/notification_live/index.ex:1378
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr "hat den Handle von @%{old} auf @%{new} geändert."
@@ -14145,14 +14145,14 @@ msgstr "In den Text einfügen"
 msgid "Posts with this tag"
 msgstr "Beiträge mit diesem Tag"
 
-#: lib/vutuv_web/live/search_live.ex:642
+#: lib/vutuv_web/live/search_live.ex:652
 #, elixir-autogen, elixir-format
 msgid "Your search uses a people-only filter such as city: or status:, so it only finds people."
 msgstr ""
 "Diese Suche nutzt einen reinen Personenfilter wie city: oder status: und "
 "findet daher nur Personen."
 
-#: lib/vutuv_web/live/search_live.ex:360
+#: lib/vutuv_web/live/search_live.ex:362
 #, elixir-autogen, elixir-format
 msgid "people and posts with this tag, combinable: miller tag:php"
 msgstr "Personen und Beiträge mit diesem Tag, kombinierbar: müller tag:php"
@@ -14195,7 +14195,7 @@ msgstr ""
 "Personen tauchen in Ihren Vorschlägen auf. Einem Tag folgen Sie auf seiner "
 "Seite."
 
-#: lib/vutuv_web/components/ui.ex:3863
+#: lib/vutuv_web/components/ui.ex:3870
 #: lib/vutuv_web/controllers/settings_controller.ex:570
 #: lib/vutuv_web/live/post_live/feed.ex:1158
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -14277,7 +14277,7 @@ msgstr "Messenger wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:59
 #: lib/vutuv_web/agent_docs/text.ex:56
-#: lib/vutuv_web/components/ui.ex:3848
+#: lib/vutuv_web/components/ui.ex:3855
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -14305,34 +14305,34 @@ msgstr "Messenger von %{name}"
 msgid "Select a messenger"
 msgstr "Messenger auswählen"
 
-#: lib/vutuv_web/components/ui.ex:3288
+#: lib/vutuv_web/components/ui.ex:3295
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] "Meinen Follower darüber informieren"
 msgstr[1] "Meine %{formatted} Follower darüber informieren"
 
-#: lib/vutuv_web/components/ui.ex:3298
+#: lib/vutuv_web/components/ui.ex:3305
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr "Die Benachrichtigung enthält einen Link zu diesem Eintrag. Es wird keine E-Mail verschickt, und das passiert nur bei neuen Einträgen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1047
+#: lib/vutuv_web/live/notification_live/index.ex:1086
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr "Lebenslauf-Update"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1356
+#: lib/vutuv_web/live/notification_live/index.ex:1398
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr "hat eine neue Station im Lebenslauf: %{entry}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1348
+#: lib/vutuv_web/live/notification_live/index.ex:1390
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr "hat eine neue Ausbildung im Lebenslauf: %{entry}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1353
+#: lib/vutuv_web/live/notification_live/index.ex:1395
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr "hat ein neues Zertifikat im Lebenslauf: %{entry}"
@@ -14357,7 +14357,7 @@ msgstr "Über neue Lebenslauf-Einträge von Personen informieren, denen ich folg
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch immer."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1361
+#: lib/vutuv_web/live/notification_live/index.ex:1403
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
@@ -14488,14 +14488,14 @@ msgstr "Mit Qualifikation: %{name}"
 msgid "Publisher:"
 msgstr "Verlag:"
 
-#: lib/vutuv_web/live/notification_live/index.ex:911
+#: lib/vutuv_web/live/notification_live/index.ex:947
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] "%{formatted} neue Mitteilung"
 msgstr[1] "%{formatted} neue Mitteilungen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:925
+#: lib/vutuv_web/live/notification_live/index.ex:961
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr "%{day}. %{month} %{year}"
@@ -14510,23 +14510,23 @@ msgstr "Zurückfolgen"
 msgid "Last 30 days"
 msgstr "Letzte 30 Tage"
 
-#: lib/vutuv_web/live/notification_live/index.ex:877
-#: lib/vutuv_web/live/notification_live/index.ex:1126
+#: lib/vutuv_web/live/notification_live/index.ex:913
+#: lib/vutuv_web/live/notification_live/index.ex:1166
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr "und"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1063
+#: lib/vutuv_web/live/notification_live/index.ex:1103
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr "sind jetzt mit Ihnen vernetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1058
+#: lib/vutuv_web/live/notification_live/index.ex:1098
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr "folgen Ihnen jetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1073
+#: lib/vutuv_web/live/notification_live/index.ex:1113
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
@@ -14536,12 +14536,12 @@ msgstr "hat Sie für %{tags} empfohlen."
 msgid "by:"
 msgstr "von:"
 
-#: lib/vutuv_web/components/ui.ex:1666
+#: lib/vutuv_web/components/ui.ex:1673
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr "Empfohlen von %{name}"
 
-#: lib/vutuv_web/components/ui.ex:1670
+#: lib/vutuv_web/components/ui.ex:1677
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
@@ -14779,7 +14779,7 @@ msgstr "Verfügbarkeit"
 msgid "An automated check removed an image from your vutuv account"
 msgstr "Eine automatische Prüfung hat ein Bild aus Ihrem vutuv-Konto entfernt"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1310
+#: lib/vutuv_web/live/notification_live/index.ex:1352
 #, elixir-autogen, elixir-format
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
@@ -14787,12 +14787,12 @@ msgstr ""
 "familienfreundlich genug für ein Arbeitsumfeld. Sie kann sich irren, "
 "antworten Sie in dem Fall einfach auf unsere E-Mail."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1036
+#: lib/vutuv_web/live/notification_live/index.ex:1075
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr "Thread-Antwort"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1113
+#: lib/vutuv_web/live/notification_live/index.ex:1153
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -14811,12 +14811,12 @@ msgstr "Unterhaltung"
 msgid "Only part of this long conversation is shown."
 msgstr "Von dieser langen Unterhaltung wird nur ein Teil angezeigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1037
+#: lib/vutuv_web/live/notification_live/index.ex:1076
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr "Erwähnung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1260
+#: lib/vutuv_web/live/notification_live/index.ex:1302
 #, elixir-autogen, elixir-format
 msgid "mentioned you in a post."
 msgstr "hat Sie in einem Beitrag erwähnt."
@@ -15119,7 +15119,7 @@ msgstr "Blenden Sie Beiträge aus Ihrem Feed aus, die ein Tag tragen oder ein Wo
 msgid "Match whole words only (word/phrase)"
 msgstr "Nur ganze Wörter treffen (Wort/Phrase)"
 
-#: lib/vutuv_web/components/ui.ex:3859
+#: lib/vutuv_web/components/ui.ex:3866
 #: lib/vutuv_web/controllers/settings_controller.ex:636
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -15169,7 +15169,7 @@ msgstr "Diese Ausbildung wird jetzt oben in Ihrem Profil angezeigt."
 msgid "Thread replies"
 msgstr "Thread-Antworten"
 
-#: lib/vutuv_web/live/notification_live/index.ex:603
+#: lib/vutuv_web/live/notification_live/index.ex:606
 #, elixir-autogen, elixir-format
 msgid "Turn off thread notifications"
 msgstr "Thread-Benachrichtigungen abschalten"
@@ -15220,7 +15220,7 @@ msgstr "Sie haben noch nichts stummgeschaltet."
 msgid "You have reached the maximum of %{count} filters."
 msgstr "Sie haben das Maximum von %{count} Filtern erreicht."
 
-#: lib/vutuv_web/live/notification_live/index.ex:598
+#: lib/vutuv_web/live/notification_live/index.ex:601
 #, elixir-autogen, elixir-format
 msgid "You wrote in this thread."
 msgstr "Sie haben in diesem Thread geschrieben."
@@ -15754,277 +15754,277 @@ msgstr "Ihr Server"
 msgid "moved to %{address}"
 msgstr "umgezogen nach %{address}"
 
-#: lib/vutuv_web/components/ui.ex:3790
+#: lib/vutuv_web/components/ui.ex:3797
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr "Name, Foto, Titelbild, Kurzbeschreibung"
 
-#: lib/vutuv_web/components/ui.ex:3795
+#: lib/vutuv_web/components/ui.ex:3802
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr "handle spitzname nutzername umbenennen slug profiladresse url erwähnung"
 
-#: lib/vutuv_web/components/ui.ex:3798
+#: lib/vutuv_web/components/ui.ex:3805
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr "Die Stationen in Ihrem Lebenslauf"
 
-#: lib/vutuv_web/components/ui.ex:3799
+#: lib/vutuv_web/components/ui.ex:3806
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr "lebenslauf cv karriere beruf arbeitgeber position stelle job firma"
 
-#: lib/vutuv_web/components/ui.ex:3802
+#: lib/vutuv_web/components/ui.ex:3809
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr "Schulen, Hochschulen, Abschlüsse"
 
-#: lib/vutuv_web/components/ui.ex:3803
+#: lib/vutuv_web/components/ui.ex:3810
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr "lebenslauf studium schule universität hochschule abschluss ausbildung"
 
-#: lib/vutuv_web/components/ui.ex:3806
+#: lib/vutuv_web/components/ui.ex:3813
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr "Nachweise, mit Belegdokumenten"
 
-#: lib/vutuv_web/components/ui.ex:3807
+#: lib/vutuv_web/components/ui.ex:3814
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr "zertifikat lizenz urkunde diplom nachweis beleg auszeichnung dokument"
 
-#: lib/vutuv_web/components/ui.ex:3814
+#: lib/vutuv_web/components/ui.ex:3821
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr "Sprachkenntnisse"
 
-#: lib/vutuv_web/components/ui.ex:3815
+#: lib/vutuv_web/components/ui.ex:3822
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr "Die Sprachen, die Sie sprechen"
 
-#: lib/vutuv_web/components/ui.ex:3816
+#: lib/vutuv_web/components/ui.ex:3823
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr "sprache sprachen sprechen fließend muttersprache verhandlungssicher"
 
-#: lib/vutuv_web/components/ui.ex:3819
+#: lib/vutuv_web/components/ui.ex:3826
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr "Die Themen, für die Sie bekannt sind"
 
-#: lib/vutuv_web/components/ui.ex:3820
+#: lib/vutuv_web/components/ui.ex:3827
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr "fähigkeit kenntnis thema stichwort schlagwort expertise empfehlung"
 
-#: lib/vutuv_web/components/ui.ex:3922
+#: lib/vutuv_web/components/ui.ex:3929
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr "Organisationsseiten, die Sie verwalten"
 
-#: lib/vutuv_web/components/ui.ex:3923
+#: lib/vutuv_web/components/ui.ex:3930
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr "firma unternehmen arbeitgeber betrieb organisation seite"
 
-#: lib/vutuv_web/components/ui.ex:3823
+#: lib/vutuv_web/components/ui.ex:3830
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr "Kontaktdaten"
 
-#: lib/vutuv_web/components/ui.ex:3826
+#: lib/vutuv_web/components/ui.ex:3833
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr "Wo wir Sie erreichen, und welche Adresse öffentlich ist"
 
-#: lib/vutuv_web/components/ui.ex:3827
+#: lib/vutuv_web/components/ui.ex:3834
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr "mail e-mail email adresse hauptadresse primär"
 
-#: lib/vutuv_web/components/ui.ex:3830
+#: lib/vutuv_web/components/ui.ex:3837
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr "Festnetz, Mobil, Fax"
 
-#: lib/vutuv_web/components/ui.ex:3831
+#: lib/vutuv_web/components/ui.ex:3838
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr "telefon handy mobil festnetz fax nummer rufnummer"
 
-#: lib/vutuv_web/components/ui.ex:3834
+#: lib/vutuv_web/components/ui.ex:3841
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr "Postanschriften auf Ihrem Profil"
 
-#: lib/vutuv_web/components/ui.ex:3835
+#: lib/vutuv_web/components/ui.ex:3842
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr "straße stadt ort postleitzahl plz land anschrift karte"
 
-#: lib/vutuv_web/components/ui.ex:3837
+#: lib/vutuv_web/components/ui.ex:3844
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr "Webseiten & Links"
 
-#: lib/vutuv_web/components/ui.ex:3838
+#: lib/vutuv_web/components/ui.ex:3845
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr "Ihre Homepage und weitere Links"
 
-#: lib/vutuv_web/components/ui.ex:3839
+#: lib/vutuv_web/components/ui.ex:3846
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr "url webseite website homepage blog link verifizieren bestätigen rel=me"
 
-#: lib/vutuv_web/components/ui.ex:3841
+#: lib/vutuv_web/components/ui.ex:3848
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr "Social-Media-Profile"
 
-#: lib/vutuv_web/components/ui.ex:3842
+#: lib/vutuv_web/components/ui.ex:3849
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr "Mastodon, Bluesky, GitHub und die anderen"
 
-#: lib/vutuv_web/components/ui.ex:3844
+#: lib/vutuv_web/components/ui.ex:3851
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr "mastodon bluesky github gitlab codeberg linkedin x twitter instagram soziale netzwerke"
 
-#: lib/vutuv_web/components/ui.ex:3849
+#: lib/vutuv_web/components/ui.ex:3856
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr "Signal, Threema, Matrix und die anderen"
 
-#: lib/vutuv_web/components/ui.ex:3850
+#: lib/vutuv_web/components/ui.ex:3857
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr "signal threema matrix xmpp telegram whatsapp chat messenger nachrichten"
 
-#: lib/vutuv_web/components/ui.ex:3853
+#: lib/vutuv_web/components/ui.ex:3860
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr "Mitteilungen & Feed"
 
-#: lib/vutuv_web/components/ui.ex:3856
+#: lib/vutuv_web/components/ui.ex:3863
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr "Welche E-Mails wir schicken, und was die Glocke meldet"
 
-#: lib/vutuv_web/components/ui.ex:3857
+#: lib/vutuv_web/components/ui.ex:3864
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer"
 msgstr "e-mail email mail abbestellen abmelden newsletter glocke benachrichtigung weniger ruhe"
 
-#: lib/vutuv_web/components/ui.ex:3860
+#: lib/vutuv_web/components/ui.ex:3867
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr "Beiträge aus Ihrem Feed heraushalten"
 
-#: lib/vutuv_web/components/ui.ex:3861
+#: lib/vutuv_web/components/ui.ex:3868
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr "stummschalten ausblenden verbergen filter wort begriff tag feed blockieren"
 
-#: lib/vutuv_web/components/ui.ex:3864
+#: lib/vutuv_web/components/ui.ex:3871
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr "Themen, deren Beiträge in Ihrem Feed landen"
 
-#: lib/vutuv_web/components/ui.ex:3865
+#: lib/vutuv_web/components/ui.ex:3872
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr "tag thema abonnieren folgen feed"
 
-#: lib/vutuv_web/components/ui.ex:3868
+#: lib/vutuv_web/components/ui.ex:3875
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr "Job- und Personensuchen, die Ihnen neue Treffer mailen"
 
-#: lib/vutuv_web/components/ui.ex:3869
+#: lib/vutuv_web/components/ui.ex:3876
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr "job stelle stellenangebot suchauftrag suche alarm benachrichtigung merkliste"
 
-#: lib/vutuv_web/components/ui.ex:3875
+#: lib/vutuv_web/components/ui.ex:3882
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr "Suchmaschinen, KI, Online-Status"
 
-#: lib/vutuv_web/components/ui.ex:3876
+#: lib/vutuv_web/components/ui.ex:3883
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr "privatsphäre datenschutz google suchmaschine ki ai llm crawler noindex online punkt öffentlich sichtbar"
 
-#: lib/vutuv_web/components/ui.ex:3879
+#: lib/vutuv_web/components/ui.ex:3886
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr "Personen, die nicht mit Ihnen interagieren können"
 
-#: lib/vutuv_web/components/ui.ex:3880
+#: lib/vutuv_web/components/ui.ex:3887
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr "blockieren sperren bannen stummschalten melden missbrauch belästigung"
 
-#: lib/vutuv_web/components/ui.ex:3901
+#: lib/vutuv_web/components/ui.ex:3908
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr "Passkeys, angemeldete Geräte, Anmeldecodes"
 
-#: lib/vutuv_web/components/ui.ex:3902
+#: lib/vutuv_web/components/ui.ex:3909
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr "passwort kennwort anmelden abmelden login logout sitzung gerät passkey totp 2fa pin sicherheit"
 
-#: lib/vutuv_web/components/ui.ex:3910
+#: lib/vutuv_web/components/ui.ex:3917
 #, elixir-autogen, elixir-format
 msgid "Interface language, maps, how posts are shortened"
 msgstr "Sprache der Oberfläche, Karten, Kürzung von Beiträgen"
 
-#: lib/vutuv_web/components/ui.ex:3911
+#: lib/vutuv_web/components/ui.ex:3918
 #, elixir-autogen, elixir-format
 msgid "german english locale translation map font length hyphenation"
 msgstr "deutsch englisch sprache übersetzung karte schrift länge silbentrennung darstellung"
 
-#: lib/vutuv_web/components/ui.ex:3914
+#: lib/vutuv_web/components/ui.ex:3921
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr "Ihre Daten von LinkedIn übernehmen"
 
-#: lib/vutuv_web/components/ui.ex:3915
+#: lib/vutuv_web/components/ui.ex:3922
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr "linkedin hochladen zip übernehmen importieren umzug"
 
-#: lib/vutuv_web/components/ui.ex:3918
+#: lib/vutuv_web/components/ui.ex:3925
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr "Alles herunterladen, was wir über Sie speichern"
 
-#: lib/vutuv_web/components/ui.ex:3919
+#: lib/vutuv_web/components/ui.ex:3926
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr "herunterladen download dsgvo gdpr daten sicherung json lebenslauf auskunft"
 
-#: lib/vutuv_web/components/ui.ex:3926
+#: lib/vutuv_web/components/ui.ex:3933
 #, elixir-autogen, elixir-format
 msgid "Connected apps and access tokens"
 msgstr "Verbundene Apps und Zugriffstoken"
 
-#: lib/vutuv_web/components/ui.ex:3927
+#: lib/vutuv_web/components/ui.ex:3934
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party"
 msgstr "api token oauth entwickler verbunden drittanbieter schnittstelle"
 
-#: lib/vutuv_web/components/ui.ex:3930
+#: lib/vutuv_web/components/ui.ex:3937
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr "Ihr Konto und alles darauf entfernen"
 
-#: lib/vutuv_web/components/ui.ex:3931
+#: lib/vutuv_web/components/ui.ex:3938
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr "löschen entfernen schließen kündigen beenden verlassen"
@@ -16208,7 +16208,7 @@ msgstr "Vom Mitglied entfernt"
 msgid "Replies from other networks"
 msgstr "Antworten aus anderen Netzwerken"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1039
+#: lib/vutuv_web/live/notification_live/index.ex:1078
 #, elixir-autogen, elixir-format
 msgid "Reply from another network"
 msgstr "Antwort aus einem anderen Netzwerk"
@@ -16229,7 +16229,7 @@ msgid "Reported as not appropriate"
 msgstr "Als unangemessen gemeldet"
 
 #: lib/vutuv_web/components/post_components.ex:1077
-#: lib/vutuv_web/live/notification_live/index.ex:545
+#: lib/vutuv_web/live/notification_live/index.ex:548
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
 msgstr "Nur an Sie gesendet, für niemanden sonst sichtbar"
@@ -16280,7 +16280,7 @@ msgstr "Was"
 msgid "You have reported a lot today. Please try again tomorrow."
 msgstr "Sie haben heute schon viel gemeldet. Bitte versuchen Sie es morgen wieder."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1263
+#: lib/vutuv_web/live/notification_live/index.ex:1305
 #, elixir-autogen, elixir-format
 msgid "replied to your post from another network."
 msgstr "hat aus einem anderen Netzwerk auf Ihren Beitrag geantwortet."
@@ -16493,7 +16493,7 @@ msgstr "API-Token erstellt"
 msgid "Access token revoked"
 msgstr "API-Token widerrufen"
 
-#: lib/vutuv_web/components/ui.ex:3904
+#: lib/vutuv_web/components/ui.ex:3911
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -16840,7 +16840,7 @@ msgstr "Was sich an einem Konto geändert hat, wann, von wo und wie es bestätig
 msgid "What changed on your account, and exactly when."
 msgstr "Was sich an Ihrem Konto geändert hat, und wann genau."
 
-#: lib/vutuv_web/components/ui.ex:3905
+#: lib/vutuv_web/components/ui.ex:3912
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr "Was sich an Ihrem Konto geändert hat, und wann"
@@ -16876,7 +16876,7 @@ msgstr "durch den Betreiber"
 msgid "from a signed-in session"
 msgstr "aus einer angemeldeten Sitzung"
 
-#: lib/vutuv_web/components/ui.ex:3907
+#: lib/vutuv_web/components/ui.ex:3914
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr "protokoll verlauf historie chronik audit sicherheit war ich das wer hat wann geaendert geändert log"
@@ -17304,7 +17304,7 @@ msgstr "Fediverse-Reaktionen"
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1040
+#: lib/vutuv_web/live/notification_live/index.ex:1079
 #, elixir-autogen, elixir-format
 msgid "Reaction from another network"
 msgstr "Reaktion aus einem anderen Netzwerk"
@@ -17324,21 +17324,21 @@ msgstr ""
 "Mehr speichern wir über diese Menschen nicht: keinen Namen, kein Bild, "
 "keinen Text. Ausschalten löscht, was dafür gespeichert ist."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1094
+#: lib/vutuv_web/live/notification_live/index.ex:1134
 #, elixir-autogen, elixir-format
 msgid "liked your post on another network."
 msgid_plural "liked your post on another network."
 msgstr[0] "gefällt Ihr Beitrag in einem anderen Netzwerk."
 msgstr[1] "gefällt Ihr Beitrag in einem anderen Netzwerk."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1102
+#: lib/vutuv_web/live/notification_live/index.ex:1142
 #, elixir-autogen, elixir-format
 msgid "reacted to your post from another network."
 msgid_plural "reacted to your post from another network."
 msgstr[0] "hat aus einem anderen Netzwerk auf Ihren Beitrag reagiert."
 msgstr[1] "haben aus einem anderen Netzwerk auf Ihren Beitrag reagiert."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1086
+#: lib/vutuv_web/live/notification_live/index.ex:1126
 #, elixir-autogen, elixir-format
 msgid "shared your post on another network."
 msgid_plural "shared your post on another network."
@@ -17414,7 +17414,7 @@ msgstr "Konten, denen Sie anderswo folgen"
 msgid "Address of the account"
 msgstr "Adresse des Kontos"
 
-#: lib/vutuv_web/live/search_live.ex:481
+#: lib/vutuv_web/live/search_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "An account on another network"
 msgstr "Ein Konto in einem anderen Netzwerk"
@@ -17424,7 +17424,7 @@ msgstr "Ein Konto in einem anderen Netzwerk"
 msgid "Cancel request"
 msgstr "Anfrage zurückziehen"
 
-#: lib/vutuv_web/components/ui.ex:3891
+#: lib/vutuv_web/components/ui.ex:3898
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr "Konten auf Mastodon folgen, und von dort gefolgt werden"
@@ -17441,7 +17441,7 @@ msgstr "Follower-Anfrage an %{account} gesendet."
 msgid "Follow somebody out there"
 msgstr "Jemandem dort draußen folgen"
 
-#: lib/vutuv_web/live/search_live.ex:497
+#: lib/vutuv_web/live/search_live.ex:499
 #, elixir-autogen, elixir-format
 msgid "Follow this account"
 msgstr "Diesem Konto folgen"
@@ -17482,7 +17482,7 @@ msgstr "Hier nach dieser Person suchen"
 msgid "Show only accounts on this server"
 msgstr "Nur Konten auf diesem Server anzeigen"
 
-#: lib/vutuv_web/live/search_live.ex:505
+#: lib/vutuv_web/live/search_live.ex:507
 #, elixir-autogen, elixir-format
 msgid "Sign in to follow this account"
 msgstr "Anmelden, um diesem Konto zu folgen"
@@ -17512,7 +17512,7 @@ msgstr "Das hat nicht geklappt. Prüfen Sie die Adresse und versuchen Sie es ern
 msgid "That does not look like an address on another network. They look like @name@server."
 msgstr "Das sieht nicht nach einer Adresse in einem anderen Netzwerk aus. Solche Adressen sehen aus wie @name@server."
 
-#: lib/vutuv_web/live/search_live.ex:486
+#: lib/vutuv_web/live/search_live.ex:488
 #, elixir-autogen, elixir-format
 msgid "That is an address on Mastodon or one of the other networks, so nobody here carries it. You can follow it from vutuv."
 msgstr "Das ist eine Adresse bei Mastodon oder einem der anderen Netzwerke, deshalb trägt sie hier niemand. Sie können ihr von vutuv aus folgen."
@@ -17626,7 +17626,7 @@ msgstr "Sie haben Ihre Fediverse-Follower auf ein anderes Konto umgeleitet, desh
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr "Ihr Konto ist derzeit gesperrt, deshalb geht nichts von Ihnen an andere Netzwerke und Sie können dort niemandem folgen. Das endet von selbst, sobald die Sperre abläuft."
 
-#: lib/vutuv_web/components/ui.ex:3893
+#: lib/vutuv_web/components/ui.ex:3900
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr "mastodon activitypub foederation federation follower folgen folge umzug migration entferntes konto"
@@ -17784,7 +17784,7 @@ msgid "You redirected your Fediverse followers to another account, so this one n
 msgstr "Sie haben Ihre Fediverse-Follower auf ein anderes Konto umgeleitet, deshalb folgt dieses Konto dort draußen niemandem mehr."
 
 #: lib/vutuv_web/components/fediverse_components.ex:273
-#: lib/vutuv_web/components/fediverse_components.ex:501
+#: lib/vutuv_web/components/fediverse_components.ex:502
 #, elixir-autogen, elixir-format
 msgid "Your account move"
 msgstr "Ihr Kontoumzug"
@@ -18701,7 +18701,7 @@ msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
 "Noch nichts von vutuv. Folgen Sie Menschen hier, um diesen Tab zu füllen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:575
+#: lib/vutuv_web/live/notification_live/index.ex:578
 #, elixir-autogen, elixir-format
 msgid "View the conversation"
 msgstr "Unterhaltung ansehen"
@@ -18779,8 +18779,8 @@ msgstr "Mehr von %{name}"
 msgid "This is vutuv's copy of a post published on %{host}. It is kept while somebody here follows its author."
 msgstr "Das ist die Kopie, die vutuv von einem auf %{host} veröffentlichten Beitrag hat. Sie bleibt erhalten, solange hier jemand diesem Konto folgt."
 
-#: lib/vutuv_web/components/ui.ex:1067
-#: lib/vutuv_web/components/ui.ex:1068
+#: lib/vutuv_web/components/ui.ex:1074
+#: lib/vutuv_web/components/ui.ex:1075
 #, elixir-autogen, elixir-format
 msgid "Subscribe to this feed in your RSS reader"
 msgstr "Diesen Feed in Ihrem RSS-Reader abonnieren"
@@ -19180,7 +19180,7 @@ msgstr "Arbeitszeugnis gespeichert."
 msgid "Employment reference updated."
 msgstr "Arbeitszeugnis aktualisiert."
 
-#: lib/vutuv_web/components/ui.ex:3809
+#: lib/vutuv_web/components/ui.ex:3816
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -19374,7 +19374,7 @@ msgstr "In der Warteschlange, Ihres ist als Nächstes dran."
 msgid "You changed the text after this review. It describes the earlier version."
 msgstr "Sie haben den Text nach dieser Prüfung geändert. Sie beschreibt die frühere Fassung."
 
-#: lib/vutuv_web/components/ui.ex:3810
+#: lib/vutuv_web/components/ui.ex:3817
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr "Ihre Arbeitszeugnisse, privat bis Sie sie veröffentlichen"
@@ -19385,7 +19385,7 @@ msgstr "Ihre Arbeitszeugnisse, privat bis Sie sie veröffentlichen"
 msgid "Zwischenzeugnis"
 msgstr "Zwischenzeugnis"
 
-#: lib/vutuv_web/components/ui.ex:3812
+#: lib/vutuv_web/components/ui.ex:3819
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr "arbeitszeugnis zeugnis referenz beurteilung arbeitgeber bewertung prüfung"
@@ -19573,7 +19573,7 @@ msgstr "Arbeitszeugnis geändert"
 msgid "Employment reference deleted"
 msgstr "Arbeitszeugnis gelöscht"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1049
+#: lib/vutuv_web/live/notification_live/index.ex:1089
 #, elixir-autogen, elixir-format
 msgid "Employment reference review"
 msgstr "Zeugnisprüfung"
@@ -19598,13 +19598,13 @@ msgstr "Ausstellungsdatum"
 msgid "Reviewing your reference. This usually takes about %{duration}."
 msgstr "Ihr Zeugnis wird geprüft. Das dauert erfahrungsgemäß etwa %{duration}."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1251
+#: lib/vutuv_web/live/notification_live/index.ex:1293
 #: lib/vutuv_web/views/notification_digest_text.ex:84
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready."
 msgstr "Die Prüfung von „%{title}“ ist fertig."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1248
+#: lib/vutuv_web/live/notification_live/index.ex:1290
 #: lib/vutuv_web/views/notification_digest_text.ex:81
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready: %{grade}."
@@ -19620,7 +19620,7 @@ msgstr "Erfahrungsgemäß etwa %{duration}."
 msgid "When the review of one of your employment references is finished. It takes minutes, so you can close the page and wait for the email."
 msgstr "Wenn die Prüfung eines Ihrer Arbeitszeugnisse fertig ist. Das dauert einige Minuten, Sie können die Seite also schließen und auf die E-Mail warten."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1254
+#: lib/vutuv_web/live/notification_live/index.ex:1296
 #, elixir-autogen, elixir-format
 msgid "Your employment reference has been reviewed."
 msgstr "Ihr Arbeitszeugnis wurde geprüft."
@@ -20005,7 +20005,7 @@ msgstr ""
 msgid "Cancel registration"
 msgstr "Registrierung abbrechen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:844
+#: lib/vutuv_web/live/notification_live/index.ex:847
 #, elixir-autogen, elixir-format
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
@@ -20025,17 +20025,17 @@ msgstr ""
 "Kommt keine PIN an? Ist die E-Mail-Adresse {email} korrekt? Haben Sie einmal "
 "in Ihren Spam-Ordner geschaut?"
 
-#: lib/vutuv/accounts/user.ex:1243
+#: lib/vutuv/accounts/user.ex:1249
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/vutuv/accounts/user.ex:1241
+#: lib/vutuv/accounts/user.ex:1247
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr "Weiblich"
 
-#: lib/vutuv/accounts/user.ex:1242
+#: lib/vutuv/accounts/user.ex:1248
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Männlich"
@@ -20047,7 +20047,7 @@ msgstr ""
 "Anteile bezogen auf die %{answered} Mitglieder mit Angabe. %{unanswered} ohne "
 "Angabe."
 
-#: lib/vutuv_web/components/ui.ex:3791
+#: lib/vutuv_web/components/ui.ex:3798
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr "avatar profilbild portrait foto bild geburtstag geburtsdatum geschlecht über mich"
@@ -20143,7 +20143,7 @@ msgstr "Ebenfalls löschen"
 msgid "Always keep"
 msgstr "Immer behalten"
 
-#: lib/vutuv_web/components/ui.ex:3884
+#: lib/vutuv_web/components/ui.ex:3891
 #: lib/vutuv_web/controllers/settings_controller.ex:213
 #: lib/vutuv_web/controllers/settings_controller.ex:292
 #: lib/vutuv_web/controllers/settings_controller.ex:304
@@ -20240,7 +20240,7 @@ msgstr "Fotobeiträge behalten"
 msgid "Keep posts that did well"
 msgstr "Beiträge behalten, die gut liefen"
 
-#: lib/vutuv_web/components/ui.ex:3886
+#: lib/vutuv_web/components/ui.ex:3893
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr "Ihre Beiträge nach einer selbst gewählten Zeit auslaufen lassen"
@@ -20349,7 +20349,7 @@ msgstr "Sie können vorher alles herunterladen, was Sie hier haben:"
 msgid "Your rule"
 msgstr "Ihre Regel"
 
-#: lib/vutuv_web/components/ui.ex:3888
+#: lib/vutuv_web/components/ui.ex:3895
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr "löschen entfernen beiträge alter alt ablaufen verfallen automatisch aufräumen aufbewahrung"
@@ -21261,37 +21261,47 @@ msgstr "Chat öffnen"
 msgid "Signal also takes its contact link (https://signal.me/#…). It names neither your phone number nor your username, and you can reset it in Signal at any time."
 msgstr "Für Signal können Sie auch Ihren Kontakt-Link angeben (https://signal.me/#…). Er nennt weder Ihre Rufnummer noch Ihren Benutzernamen, und Sie können ihn in Signal jederzeit zurücksetzen."
 
-#: lib/vutuv_web/live/search_live.ex:533
+#: lib/vutuv_web/live/search_live.ex:535
 #, elixir-autogen, elixir-format
 msgid "A post on another network"
 msgstr "Ein Beitrag aus einem anderen Netzwerk"
 
-#: lib/vutuv_web/live/search_live.ex:549
+#: lib/vutuv_web/live/search_live.ex:559
 #, elixir-autogen, elixir-format
 msgid "Fetch this post"
 msgstr "Diesen Beitrag holen"
 
-#: lib/vutuv_web/live/search_live.ex:411
+#: lib/vutuv_web/live/search_live.ex:413
 #, elixir-autogen, elixir-format
 msgid "Search for people, tags, posts, or paste a Fediverse address"
 msgstr "Personen, Tags, Beiträge oder eine Fediverse-Adresse"
 
-#: lib/vutuv_web/live/search_live.ex:565
+#: lib/vutuv_web/live/search_live.ex:575
 #, elixir-autogen, elixir-format
 msgid "Sign in to fetch this post"
 msgstr "Anmelden, um diesen Beitrag zu holen"
 
-#: lib/vutuv_web/live/search_live.ex:538
+#: lib/vutuv_web/live/search_live.ex:540
 #, elixir-autogen, elixir-format
 msgid "That is a link to somewhere else, not something anybody here wrote. vutuv can fetch the post behind it so you can read it, answer it, like it or repost it from here."
 msgstr "Das ist ein Link woandershin, nichts, was hier jemand geschrieben hat. vutuv kann den Beitrag dahinter holen, damit Sie ihn hier lesen, darauf antworten, ihn mögen oder teilen können."
 
-#: lib/vutuv_web/live/search_live.ex:391
+#: lib/vutuv_web/live/search_live.ex:393
 #, elixir-autogen, elixir-format
 msgid "an address on another network: vutuv offers you the follow"
 msgstr "eine Adresse in einem anderen Netzwerk: vutuv bietet Ihnen an, ihr zu folgen"
 
-#: lib/vutuv_web/live/search_live.ex:397
+#: lib/vutuv_web/live/search_live.ex:399
 #, elixir-autogen, elixir-format
 msgid "the address of a post out there: vutuv fetches it so you can answer it here"
 msgstr "die Adresse eines Beitrags dort draußen: vutuv holt ihn, damit Sie hier darauf antworten können"
+
+#: lib/vutuv_web/live/notification_live/index.ex:1088
+#, elixir-autogen, elixir-format
+msgid "Imported profile picture"
+msgstr "Übernommenes Profilbild"
+
+#: lib/vutuv_web/live/notification_live/index.ex:886
+#, elixir-autogen, elixir-format
+msgid "When you signed up we found a picture for your email address at gravatar.com and used it as your profile picture. At {url} you can replace or remove it at any time."
+msgstr "Bei Ihrer Anmeldung haben wir zu Ihrer E-Mail-Adresse ein Bild bei gravatar.com gefunden und als Ihr Profilbild übernommen. Unter {url} können Sie es jederzeit austauschen oder entfernen."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -17,8 +17,8 @@ msgstr ""
 msgid "About us"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3575
-#: lib/vutuv_web/components/ui.ex:3580
+#: lib/vutuv_web/components/ui.ex:3582
+#: lib/vutuv_web/components/ui.ex:3587
 #: lib/vutuv_web/live/admin/screenshot_live.ex:266
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:718
 #: lib/vutuv_web/live/organization_live/domains.ex:255
@@ -64,7 +64,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:67
 #: lib/vutuv_web/agent_docs/text.ex:64
-#: lib/vutuv_web/components/ui.ex:3833
+#: lib/vutuv_web/components/ui.ex:3840
 #: lib/vutuv_web/controllers/address_controller.ex:23
 #: lib/vutuv_web/controllers/address_controller.ex:38
 #: lib/vutuv_web/controllers/address_controller.ex:85
@@ -82,8 +82,8 @@ msgstr ""
 msgid "Already a member? Sign in here."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3370
-#: lib/vutuv_web/components/ui.ex:3464
+#: lib/vutuv_web/components/ui.ex:3377
+#: lib/vutuv_web/components/ui.ex:3471
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:698
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:830
@@ -111,7 +111,7 @@ msgid "Birthday"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:110
-#: lib/vutuv_web/components/ui.ex:3364
+#: lib/vutuv_web/components/ui.ex:3371
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
@@ -162,7 +162,7 @@ msgid "Couldn't follow back to %{name}."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2751
-#: lib/vutuv_web/components/ui.ex:3467
+#: lib/vutuv_web/components/ui.ex:3474
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
@@ -211,7 +211,7 @@ msgid "Download"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2716
-#: lib/vutuv_web/components/ui.ex:3458
+#: lib/vutuv_web/components/ui.ex:3465
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
@@ -285,7 +285,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:37
 #: lib/vutuv_web/agent_docs/text.ex:34
-#: lib/vutuv_web/components/ui.ex:3797
+#: lib/vutuv_web/components/ui.ex:3804
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -315,7 +315,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:513
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
-#: lib/vutuv_web/live/notification_live/index.ex:969
+#: lib/vutuv_web/live/notification_live/index.ex:1005
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:40
@@ -326,12 +326,12 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:547
 #: lib/vutuv_web/agent_docs/text.ex:514
 #: lib/vutuv_web/components/fediverse_components.ex:313
-#: lib/vutuv_web/components/ui.ex:2072
-#: lib/vutuv_web/components/ui.ex:2097
-#: lib/vutuv_web/components/ui.ex:2100
+#: lib/vutuv_web/components/ui.ex:2079
+#: lib/vutuv_web/components/ui.ex:2104
 #: lib/vutuv_web/components/ui.ex:2107
-#: lib/vutuv_web/components/ui.ex:2110
-#: lib/vutuv_web/components/ui.ex:2168
+#: lib/vutuv_web/components/ui.ex:2114
+#: lib/vutuv_web/components/ui.ex:2117
+#: lib/vutuv_web/components/ui.ex:2175
 #: lib/vutuv_web/controllers/followee_controller.ex:29
 #: lib/vutuv_web/live/organization_live/show.ex:456
 #: lib/vutuv_web/templates/followee/index.html.heex:4
@@ -456,7 +456,7 @@ msgstr ""
 msgid "Middle Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:893
+#: lib/vutuv_web/live/notification_live/index.ex:929
 #, elixir-autogen
 msgid "More"
 msgstr ""
@@ -473,7 +473,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:647
+#: lib/vutuv_web/live/notification_live/index.ex:650
 #: lib/vutuv_web/live/organization_live/activity.ex:123
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
@@ -612,7 +612,7 @@ msgstr ""
 msgid "Public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3363
+#: lib/vutuv_web/components/ui.ex:3370
 #: lib/vutuv_web/live/organization_live/edit.ex:341
 #: lib/vutuv_web/live/post_live/composer.ex:1813
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -639,7 +639,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_live.ex:219
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:54
-#: lib/vutuv_web/live/search_live.ex:603
+#: lib/vutuv_web/live/search_live.ex:613
 #: lib/vutuv_web/live/shell_live.ex:711
 #: lib/vutuv_web/live/shell_live.ex:863
 #: lib/vutuv_web/live/tag_live/timeline.ex:237
@@ -789,12 +789,12 @@ msgstr ""
 msgid "User verified successfully."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3793
+#: lib/vutuv_web/components/ui.ex:3800
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
-#: lib/vutuv_web/live/notification_live/index.ex:1048
+#: lib/vutuv_web/live/notification_live/index.ex:1087
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -840,20 +840,20 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1007
+#: lib/vutuv_web/components/ui.ex:1014
 #: lib/vutuv_web/templates/user/show.html.heex:343
 #, elixir-autogen
 msgid "vCard"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3528
+#: lib/vutuv_web/components/ui.ex:3535
 #: lib/vutuv_web/templates/user/show.html.heex:949
 #: lib/vutuv_web/templates/user/show.html.heex:972
 #, elixir-autogen
 msgid "View All"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3874
+#: lib/vutuv_web/components/ui.ex:3881
 #: lib/vutuv_web/controllers/settings_controller.ex:159
 #: lib/vutuv_web/live/job_posting_live/form.ex:561
 #: lib/vutuv_web/live/organization_live/edit.ex:300
@@ -1122,13 +1122,13 @@ msgstr ""
 msgid "Can't find URL"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:327
+#: lib/vutuv_web/live/search_live.ex:329
 #, elixir-autogen
 msgid "Our search will try to match similar names to your search, so don't worry about spelling."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:663
-#: lib/vutuv_web/live/search_live.ex:688
+#: lib/vutuv_web/live/search_live.ex:673
+#: lib/vutuv_web/live/search_live.ex:698
 #, elixir-autogen
 msgid "Search Tips"
 msgstr ""
@@ -1373,7 +1373,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:30
 #: lib/vutuv_web/agent_docs/text.ex:440
 #: lib/vutuv_web/agent_docs/text.ex:663
-#: lib/vutuv_web/components/ui.ex:3818
+#: lib/vutuv_web/components/ui.ex:3825
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
 #: lib/vutuv_web/cv/docx.ex:174
@@ -1384,8 +1384,8 @@ msgstr ""
 #: lib/vutuv_web/live/cv_live.ex:315
 #: lib/vutuv_web/live/job_board_live.ex:277
 #: lib/vutuv_web/live/job_posting_live/form.ex:510
-#: lib/vutuv_web/live/search_live.ex:306
-#: lib/vutuv_web/live/search_live.ex:748
+#: lib/vutuv_web/live/search_live.ex:308
+#: lib/vutuv_web/live/search_live.ex:758
 #: lib/vutuv_web/live/tag_new_live.ex:36
 #: lib/vutuv_web/live/tag_new_live.ex:47
 #: lib/vutuv_web/live/tag_new_live.ex:54
@@ -1668,24 +1668,24 @@ msgstr ""
 msgid "Edit profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1488
-#: lib/vutuv_web/components/ui.ex:1497
-#: lib/vutuv_web/components/ui.ex:1899
+#: lib/vutuv_web/components/ui.ex:1495
+#: lib/vutuv_web/components/ui.ex:1504
+#: lib/vutuv_web/components/ui.ex:1906
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:199
-#: lib/vutuv_web/components/ui.ex:2037
-#: lib/vutuv_web/components/ui.ex:2037
-#: lib/vutuv_web/components/ui.ex:2054
-#: lib/vutuv_web/components/ui.ex:2063
-#: lib/vutuv_web/components/ui.ex:2079
-#: lib/vutuv_web/components/ui.ex:2116
-#: lib/vutuv_web/components/ui.ex:2119
+#: lib/vutuv_web/components/ui.ex:2044
+#: lib/vutuv_web/components/ui.ex:2044
+#: lib/vutuv_web/components/ui.ex:2061
+#: lib/vutuv_web/components/ui.ex:2070
+#: lib/vutuv_web/components/ui.ex:2086
+#: lib/vutuv_web/components/ui.ex:2123
 #: lib/vutuv_web/components/ui.ex:2126
-#: lib/vutuv_web/components/ui.ex:2129
-#: lib/vutuv_web/components/ui.ex:2202
+#: lib/vutuv_web/components/ui.ex:2133
+#: lib/vutuv_web/components/ui.ex:2136
+#: lib/vutuv_web/components/ui.ex:2209
 #: lib/vutuv_web/live/fediverse_account_live.ex:375
 #: lib/vutuv_web/live/fediverse_following_live.ex:331
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:293
@@ -1749,7 +1749,7 @@ msgid "Network"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:435
-#: lib/vutuv_web/components/ui.ex:3577
+#: lib/vutuv_web/components/ui.ex:3584
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:705
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:742
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:793
@@ -1764,7 +1764,7 @@ msgstr ""
 msgid "Nothing new yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3855
+#: lib/vutuv_web/components/ui.ex:3862
 #: lib/vutuv_web/live/notification_live/index.ex:114
 #: lib/vutuv_web/live/notification_live/index.ex:338
 #: lib/vutuv_web/live/shell_live.ex:738
@@ -1895,29 +1895,29 @@ msgstr ""
 msgid "submit a bug report"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1070
+#: lib/vutuv_web/live/notification_live/index.ex:1110
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1065
+#: lib/vutuv_web/live/notification_live/index.ex:1105
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1060
+#: lib/vutuv_web/live/notification_live/index.ex:1100
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2917
-#: lib/vutuv_web/components/ui.ex:3068
+#: lib/vutuv_web/components/ui.ex:2924
+#: lib/vutuv_web/components/ui.ex:3075
 #: lib/vutuv_web/live/organization_live/index.ex:122
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3602
+#: lib/vutuv_web/components/ui.ex:3609
 #: lib/vutuv_web/live/organization_live/activity.ex:146
 #: lib/vutuv_web/live/organization_live/feed.ex:101
 #: lib/vutuv_web/live/organization_live/show.ex:622
@@ -1930,13 +1930,13 @@ msgstr ""
 msgid "The address itself cannot be changed. To use a different one, add it as a new email address and delete this one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3373
+#: lib/vutuv_web/components/ui.ex:3380
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1213
-#: lib/vutuv_web/components/ui.ex:1223
+#: lib/vutuv_web/components/ui.ex:1220
+#: lib/vutuv_web/components/ui.ex:1230
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr ""
@@ -1975,12 +1975,12 @@ msgstr ""
 msgid "Add cover photo"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2627
+#: lib/vutuv_web/components/ui.ex:2634
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2631
+#: lib/vutuv_web/components/ui.ex:2638
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr ""
@@ -2005,37 +2005,37 @@ msgstr ""
 msgid "Cover photo of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2635
+#: lib/vutuv_web/components/ui.ex:2642
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2625
+#: lib/vutuv_web/components/ui.ex:2632
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2624
+#: lib/vutuv_web/components/ui.ex:2631
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2630
+#: lib/vutuv_web/components/ui.ex:2637
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2629
+#: lib/vutuv_web/components/ui.ex:2636
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2626
+#: lib/vutuv_web/components/ui.ex:2633
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2628
+#: lib/vutuv_web/components/ui.ex:2635
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr ""
@@ -2050,17 +2050,17 @@ msgstr ""
 msgid "Member since %{year}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2634
+#: lib/vutuv_web/components/ui.ex:2641
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2633
+#: lib/vutuv_web/components/ui.ex:2640
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2632
+#: lib/vutuv_web/components/ui.ex:2639
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr ""
@@ -2197,11 +2197,11 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:83
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:382
-#: lib/vutuv_web/live/notification_live/index.ex:891
+#: lib/vutuv_web/live/notification_live/index.ex:927
 #: lib/vutuv_web/live/organization_live/show.ex:549
 #: lib/vutuv_web/live/post_live/saved.ex:495
-#: lib/vutuv_web/live/search_live.ex:307
-#: lib/vutuv_web/live/search_live.ex:762
+#: lib/vutuv_web/live/search_live.ex:309
+#: lib/vutuv_web/live/search_live.ex:772
 #: lib/vutuv_web/templates/settings/preferences.html.heex:118
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
@@ -2285,7 +2285,7 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4119
+#: lib/vutuv_web/components/ui.ex:4126
 #: lib/vutuv_web/live/shell_live.ex:781
 #: lib/vutuv_web/templates/post/index.html.heex:17
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2367,7 +2367,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1603
 #: lib/vutuv_web/components/post_components.ex:4436
-#: lib/vutuv_web/components/ui.ex:2992
+#: lib/vutuv_web/components/ui.ex:2999
 #: lib/vutuv_web/views/user_html.ex:335
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2386,8 +2386,8 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1567
 #: lib/vutuv_web/components/post_components.ex:4670
-#: lib/vutuv_web/components/ui.ex:2978
-#: lib/vutuv_web/live/notification_live/index.ex:1038
+#: lib/vutuv_web/components/ui.ex:2985
+#: lib/vutuv_web/live/notification_live/index.ex:1077
 #: lib/vutuv_web/views/user_html.ex:345
 #, elixir-autogen, elixir-format
 msgid "Like"
@@ -2395,7 +2395,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1000
 #: lib/vutuv_web/components/post_components.ex:4679
-#: lib/vutuv_web/live/notification_live/index.ex:971
+#: lib/vutuv_web/live/notification_live/index.ex:1007
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
 #: lib/vutuv_web/live/shell_live.ex:789
@@ -2456,9 +2456,9 @@ msgid "Unlike"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:343
-#: lib/vutuv_web/components/ui.ex:2032
-#: lib/vutuv_web/components/ui.ex:2032
-#: lib/vutuv_web/components/ui.ex:2169
+#: lib/vutuv_web/components/ui.ex:2039
+#: lib/vutuv_web/components/ui.ex:2039
+#: lib/vutuv_web/components/ui.ex:2176
 #: lib/vutuv_web/live/organization_live/following.ex:197
 #: lib/vutuv_web/live/organization_live/following.ex:256
 #: lib/vutuv_web/live/organization_live/show.ex:459
@@ -2480,7 +2480,7 @@ msgid "Only public posts can be answered."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:393
-#: lib/vutuv_web/live/notification_live/index.ex:972
+#: lib/vutuv_web/live/notification_live/index.ex:1008
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
@@ -2488,7 +2488,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1578
 #: lib/vutuv_web/components/post_components.ex:4706
 #: lib/vutuv_web/components/post_components.ex:4707
-#: lib/vutuv_web/live/notification_live/index.ex:1035
+#: lib/vutuv_web/live/notification_live/index.ex:1074
 #: lib/vutuv_web/live/post_live/reply.ex:42
 #, elixir-autogen, elixir-format
 msgid "Reply"
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1258
+#: lib/vutuv_web/live/notification_live/index.ex:1300
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr ""
@@ -2591,7 +2591,7 @@ msgstr ""
 msgid "No conversations yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2503
+#: lib/vutuv_web/components/ui.ex:2510
 #: lib/vutuv_web/live/message_live/index.ex:726
 #, elixir-autogen, elixir-format
 msgid "Online"
@@ -2739,8 +2739,8 @@ msgstr ""
 msgid "Write your first post"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3156
-#: lib/vutuv_web/components/ui.ex:3530
+#: lib/vutuv_web/components/ui.ex:3163
+#: lib/vutuv_web/components/ui.ex:3537
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
 #: lib/vutuv_web/templates/settings/organizations.html.heex:89
@@ -2787,13 +2787,13 @@ msgstr[1] ""
 #: lib/vutuv_web/agent_docs/markdown.ex:548
 #: lib/vutuv_web/agent_docs/text.ex:515
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:970
+#: lib/vutuv_web/live/notification_live/index.ex:1006
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:998
+#: lib/vutuv_web/components/ui.ex:1005
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr ""
@@ -2803,7 +2803,7 @@ msgstr ""
 msgid "No connections yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1014
+#: lib/vutuv_web/components/ui.ex:1021
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr ""
@@ -2813,7 +2813,7 @@ msgstr ""
 msgid "People who aren't my connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:999
+#: lib/vutuv_web/components/ui.ex:1006
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr ""
@@ -2842,23 +2842,23 @@ msgid "Open someone's profile to message them."
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:225
-#: lib/vutuv_web/live/notification_live/index.ex:1050
+#: lib/vutuv_web/live/notification_live/index.ex:1090
 #: lib/vutuv_web/live/organization_live/activity.ex:99
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1041
+#: lib/vutuv_web/live/notification_live/index.ex:1080
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1034
+#: lib/vutuv_web/live/notification_live/index.ex:1073
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1033
+#: lib/vutuv_web/live/notification_live/index.ex:1072
 #: lib/vutuv_web/templates/user/show.html.heex:933
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -2871,7 +2871,7 @@ msgstr[1] ""
 msgid "Welcome to vutuv, %{name}!"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1067
+#: lib/vutuv_web/live/notification_live/index.ex:1107
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr ""
@@ -2903,12 +2903,12 @@ msgstr ""
 msgid "(no text)"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1294
+#: lib/vutuv_web/live/notification_live/index.ex:1336
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1295
+#: lib/vutuv_web/live/notification_live/index.ex:1337
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr ""
@@ -3014,7 +3014,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:1042
+#: lib/vutuv_web/live/notification_live/index.ex:1081
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3143,7 +3143,7 @@ msgstr ""
 msgid "Private message"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3787
+#: lib/vutuv_web/components/ui.ex:3794
 #: lib/vutuv_web/live/shell_live.ex:612
 #: lib/vutuv_web/live/shell_live.ex:870
 #: lib/vutuv_web/templates/import/new.html.heex:15
@@ -3254,7 +3254,7 @@ msgstr ""
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2892
+#: lib/vutuv_web/components/ui.ex:2899
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:773
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -3438,12 +3438,12 @@ msgstr ""
 msgid "You cannot report your own content."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1297
+#: lib/vutuv_web/live/notification_live/index.ex:1339
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1296
+#: lib/vutuv_web/live/notification_live/index.ex:1338
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr ""
@@ -3453,7 +3453,7 @@ msgstr ""
 msgid "Your content was reported"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1298
+#: lib/vutuv_web/live/notification_live/index.ex:1340
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3637,7 +3637,7 @@ msgstr ""
 msgid "Open the profile"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1322
+#: lib/vutuv_web/live/notification_live/index.ex:1364
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3662,7 +3662,7 @@ msgstr ""
 msgid "Report filed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1044
+#: lib/vutuv_web/live/notification_live/index.ex:1083
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr ""
@@ -3737,7 +3737,7 @@ msgstr ""
 msgid "Waiting for the owner"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1327
+#: lib/vutuv_web/live/notification_live/index.ex:1369
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -4463,22 +4463,22 @@ msgstr ""
 msgid "Undeliverable"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:423
+#: lib/vutuv_web/live/search_live.ex:425
 #, elixir-autogen, elixir-format
 msgid "You can search for a name, email, or tag, or for words in public posts."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:418
+#: lib/vutuv_web/live/search_live.ex:420
 #, elixir-autogen, elixir-format
 msgid "Search for people by name, email, or username."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:419
+#: lib/vutuv_web/live/search_live.ex:421
 #, elixir-autogen, elixir-format
 msgid "Search for tags by name."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:420
+#: lib/vutuv_web/live/search_live.ex:422
 #, elixir-autogen, elixir-format
 msgid "Search for words in public posts."
 msgstr ""
@@ -4494,7 +4494,7 @@ msgstr ""
 msgid "Block @%{slug}? This removes any follows and connection between you, closes your conversation, and prevents all interaction in both directions. Unblocking will not restore what was removed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3878
+#: lib/vutuv_web/components/ui.ex:3885
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -4580,12 +4580,12 @@ msgstr ""
 msgid "This area is reserved for administrators."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:810
+#: lib/vutuv_web/live/search_live.ex:820
 #, elixir-autogen, elixir-format
 msgid "No results for \"%{query}\""
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:731
+#: lib/vutuv_web/live/search_live.ex:741
 #, elixir-autogen, elixir-format
 msgid "Not an exact match, but sounds like your search."
 msgstr ""
@@ -4594,21 +4594,21 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:388
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:516
-#: lib/vutuv_web/live/notification_live/index.ex:892
+#: lib/vutuv_web/live/notification_live/index.ex:928
 #: lib/vutuv_web/live/organization_live/show.ex:632
 #: lib/vutuv_web/live/post_live/saved.ex:498
-#: lib/vutuv_web/live/search_live.ex:305
-#: lib/vutuv_web/live/search_live.ex:704
+#: lib/vutuv_web/live/search_live.ex:307
+#: lib/vutuv_web/live/search_live.ex:714
 #, elixir-autogen, elixir-format
 msgid "People"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:650
+#: lib/vutuv_web/live/search_live.ex:660
 #, elixir-autogen, elixir-format
 msgid "Results appear once you have typed at least three letters."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:728
+#: lib/vutuv_web/live/search_live.ex:738
 #, elixir-autogen, elixir-format
 msgid "Similar names"
 msgstr ""
@@ -4617,49 +4617,49 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:409
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
-#: lib/vutuv_web/live/notification_live/index.ex:890
-#: lib/vutuv_web/live/search_live.ex:304
+#: lib/vutuv_web/live/notification_live/index.ex:926
+#: lib/vutuv_web/live/search_live.ex:306
 #: lib/vutuv_web/views/qualification_html.ex:90
 #, elixir-autogen, elixir-format
 msgid "All"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:633
+#: lib/vutuv_web/live/search_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "Exact matches only"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:376
+#: lib/vutuv_web/live/search_live.ex:378
 #, elixir-autogen, elixir-format
 msgid "in quotes: exact matches only, no similar names"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:373
+#: lib/vutuv_web/live/search_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "searches usernames"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:365
+#: lib/vutuv_web/live/search_live.ex:367
 #, elixir-autogen, elixir-format
 msgid "only people with an address in this city"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:364
+#: lib/vutuv_web/live/search_live.ex:366
 #, elixir-autogen, elixir-format
 msgid "city:koblenz"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:354
+#: lib/vutuv_web/live/search_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "first:stefan"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:375
+#: lib/vutuv_web/live/search_live.ex:377
 #, elixir-autogen, elixir-format
 msgid "miller"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:355
+#: lib/vutuv_web/live/search_live.ex:357
 #, elixir-autogen, elixir-format
 msgid "searches first names only (last: for last names)"
 msgstr ""
@@ -4672,7 +4672,7 @@ msgstr ""
 msgid "Add a tag"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:412
+#: lib/vutuv_web/live/search_live.ex:414
 #, elixir-autogen, elixir-format
 msgid "Search for people, tags, or posts"
 msgstr ""
@@ -5258,7 +5258,7 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3929
+#: lib/vutuv_web/components/ui.ex:3936
 #: lib/vutuv_web/controllers/settings_controller.ex:145
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5337,10 +5337,10 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4026
-#: lib/vutuv_web/components/ui.ex:4031
-#: lib/vutuv_web/components/ui.ex:4110
-#: lib/vutuv_web/components/ui.ex:4174
+#: lib/vutuv_web/components/ui.ex:4033
+#: lib/vutuv_web/components/ui.ex:4038
+#: lib/vutuv_web/components/ui.ex:4117
+#: lib/vutuv_web/components/ui.ex:4181
 #: lib/vutuv_web/controllers/settings_controller.ex:61
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5413,7 +5413,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:2835
 #: lib/vutuv_web/components/post_components.ex:2887
 #: lib/vutuv_web/components/post_components.ex:3284
-#: lib/vutuv_web/live/notification_live/index.ex:691
+#: lib/vutuv_web/live/notification_live/index.ex:694
 #: lib/vutuv_web/live/post_live/feed.ex:1245
 #: lib/vutuv_web/views/user_html.ex:113
 #, elixir-autogen, elixir-format
@@ -5459,7 +5459,7 @@ msgstr ""
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3898
+#: lib/vutuv_web/components/ui.ex:3905
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:289
@@ -5480,7 +5480,7 @@ msgstr ""
 msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3825
+#: lib/vutuv_web/components/ui.ex:3832
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5514,7 +5514,7 @@ msgstr ""
 msgid "Photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3872
+#: lib/vutuv_web/components/ui.ex:3879
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/templates/page/index.html.heex:166
 #, elixir-autogen, elixir-format
@@ -5541,7 +5541,7 @@ msgstr ""
 msgid "Your name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:520
+#: lib/vutuv_web/live/notification_live/index.ex:523
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr ""
@@ -5630,14 +5630,14 @@ msgstr ""
 msgid "Apps"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3925
+#: lib/vutuv_web/components/ui.ex:3932
 #: lib/vutuv_web/controllers/settings_controller.ex:165
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:127
-#: lib/vutuv_web/live/notification_live/index.ex:973
+#: lib/vutuv_web/live/notification_live/index.ex:1009
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:17
@@ -6240,9 +6240,9 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1488
-#: lib/vutuv_web/components/ui.ex:1497
-#: lib/vutuv_web/components/ui.ex:1900
+#: lib/vutuv_web/components/ui.ex:1495
+#: lib/vutuv_web/components/ui.ex:1504
+#: lib/vutuv_web/components/ui.ex:1907
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr ""
@@ -6303,11 +6303,11 @@ msgstr ""
 msgid "No endorsements yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1853
-#: lib/vutuv_web/live/notification_live/index.ex:625
-#: lib/vutuv_web/live/notification_live/index.ex:640
-#: lib/vutuv_web/live/notification_live/index.ex:778
-#: lib/vutuv_web/live/notification_live/index.ex:780
+#: lib/vutuv_web/components/ui.ex:1860
+#: lib/vutuv_web/live/notification_live/index.ex:628
+#: lib/vutuv_web/live/notification_live/index.ex:643
+#: lib/vutuv_web/live/notification_live/index.ex:781
+#: lib/vutuv_web/live/notification_live/index.ex:783
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr ""
@@ -6598,7 +6598,7 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2357
+#: lib/vutuv_web/components/ui.ex:2364
 #: lib/vutuv_web/live/fediverse_account_live.ex:369
 #: lib/vutuv_web/templates/settings/filters.html.heex:58
 #: lib/vutuv_web/templates/user/show.html.heex:212
@@ -6622,7 +6622,7 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2356
+#: lib/vutuv_web/components/ui.ex:2363
 #: lib/vutuv_web/live/fediverse_account_live.ex:367
 #: lib/vutuv_web/templates/settings/filters.html.heex:81
 #: lib/vutuv_web/templates/user/show.html.heex:212
@@ -6661,33 +6661,33 @@ msgstr ""
 msgid "Unmute @%{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2327
+#: lib/vutuv_web/components/ui.ex:2334
 #, elixir-autogen, elixir-format
 msgid "Doesn't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2321
+#: lib/vutuv_web/components/ui.ex:2328
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2311
+#: lib/vutuv_web/components/ui.ex:2318
 #, elixir-autogen, elixir-format
 msgid "This member doesn't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2262
-#: lib/vutuv_web/components/ui.ex:2311
+#: lib/vutuv_web/components/ui.ex:2269
+#: lib/vutuv_web/components/ui.ex:2318
 #, elixir-autogen, elixir-format
 msgid "This member follows you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2260
+#: lib/vutuv_web/components/ui.ex:2267
 #, elixir-autogen, elixir-format
 msgid "You follow each other"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2261
+#: lib/vutuv_web/components/ui.ex:2268
 #, elixir-autogen, elixir-format
 msgid "You follow this member"
 msgstr ""
@@ -7253,13 +7253,13 @@ msgstr ""
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2930
+#: lib/vutuv_web/components/ui.ex:2937
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2946
+#: lib/vutuv_web/components/ui.ex:2953
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7732,13 +7732,13 @@ msgstr ""
 #: lib/vutuv_web/components/job_components.ex:173
 #: lib/vutuv_web/live/admin/dashboard_live.ex:287
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:457
-#: lib/vutuv_web/live/notification_live/index.ex:919
+#: lib/vutuv_web/live/notification_live/index.ex:955
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:291
-#: lib/vutuv_web/live/notification_live/index.ex:922
+#: lib/vutuv_web/live/notification_live/index.ex:958
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr ""
@@ -7961,8 +7961,8 @@ msgstr ""
 msgid "Identity-verified"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1367
-#: lib/vutuv/accounts.ex:1416
+#: lib/vutuv/accounts.ex:1394
+#: lib/vutuv/accounts.ex:1443
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -8001,7 +8001,7 @@ msgstr ""
 msgid "Open the member browser"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1384
+#: lib/vutuv/accounts.ex:1411
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -8012,7 +8012,7 @@ msgstr ""
 msgid "PIN registered"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2933
+#: lib/vutuv_web/components/ui.ex:2940
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr ""
@@ -8142,7 +8142,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:41
 #: lib/vutuv_web/agent_docs/text.ex:38
-#: lib/vutuv_web/components/ui.ex:3801
+#: lib/vutuv_web/components/ui.ex:3808
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8197,7 +8197,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3913
+#: lib/vutuv_web/components/ui.ex:3920
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8226,7 +8226,7 @@ msgstr ""
 msgid "Nothing new to import."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3829
+#: lib/vutuv_web/components/ui.ex:3836
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8317,7 +8317,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3202
+#: lib/vutuv_web/components/ui.ex:3209
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8398,13 +8398,13 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3789
+#: lib/vutuv_web/components/ui.ex:3796
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3909
+#: lib/vutuv_web/components/ui.ex:3916
 #: lib/vutuv_web/controllers/settings_controller.ex:122
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8416,7 +8416,7 @@ msgstr ""
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3900
+#: lib/vutuv_web/components/ui.ex:3907
 #: lib/vutuv_web/controllers/settings_controller.ex:105
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8426,7 +8426,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3917
+#: lib/vutuv_web/components/ui.ex:3924
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8544,7 +8544,7 @@ msgstr[1] ""
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1016
+#: lib/vutuv_web/components/ui.ex:1023
 #, elixir-autogen, elixir-format
 msgid "This profile is not offered as a Markdown, text, JSON or XML export."
 msgstr ""
@@ -8640,7 +8640,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:504
 #: lib/vutuv_web/agent_docs/text.ex:508
 #: lib/vutuv_web/components/organization_components.ex:242
-#: lib/vutuv_web/components/ui.ex:3890
+#: lib/vutuv_web/components/ui.ex:3897
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:323
 #: lib/vutuv_web/controllers/settings_controller.ex:390
@@ -8690,7 +8690,7 @@ msgstr ""
 msgid "Your Fediverse handle"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1379
+#: lib/vutuv/accounts.ex:1406
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -8743,7 +8743,7 @@ msgstr ""
 msgid "Volunteering & hobbies"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:625
+#: lib/vutuv_web/live/search_live.ex:635
 #, elixir-autogen, elixir-format
 msgid "Not available while the search uses a people filter."
 msgstr ""
@@ -8794,7 +8794,7 @@ msgstr ""
 msgid "This is the print view of this CV. Use your browser's print dialog (Ctrl+P or Cmd+P) and choose \"Save as PDF\" to get a PDF file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1124
+#: lib/vutuv_web/components/ui.ex:1131
 #, elixir-autogen, elixir-format
 msgid "CV download"
 msgstr ""
@@ -8832,7 +8832,7 @@ msgstr ""
 msgid "Header"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1134
+#: lib/vutuv_web/components/ui.ex:1141
 #: lib/vutuv_web/templates/export/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Open CV"
@@ -8864,7 +8864,7 @@ msgstr ""
 msgid "The CV is public, on your profile: a visitor's download contains only what they can see there anyway, and private email addresses appear only in your own."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1126
+#: lib/vutuv_web/components/ui.ex:1133
 #, elixir-autogen, elixir-format
 msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
@@ -9020,8 +9020,8 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1532
-#: lib/vutuv_web/components/ui.ex:1533
+#: lib/vutuv_web/components/ui.ex:1539
+#: lib/vutuv_web/components/ui.ex:1540
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:65
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9462,7 +9462,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1084
+#: lib/vutuv/accounts/user.ex:1090
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9473,7 +9473,7 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1081
+#: lib/vutuv/accounts/user.ex:1087
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -9588,7 +9588,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:45
 #: lib/vutuv_web/agent_docs/text.ex:42
-#: lib/vutuv_web/components/ui.ex:3805
+#: lib/vutuv_web/components/ui.ex:3812
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:124
@@ -9781,13 +9781,13 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2725
+#: lib/vutuv_web/components/ui.ex:2732
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2724
-#: lib/vutuv_web/components/ui.ex:2728
+#: lib/vutuv_web/components/ui.ex:2731
+#: lib/vutuv_web/components/ui.ex:2735
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr ""
@@ -10828,19 +10828,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1122
+#: lib/vutuv/accounts/user.ex:1128
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1127
+#: lib/vutuv/accounts/user.ex:1133
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1125
+#: lib/vutuv/accounts/user.ex:1131
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:566
 #, elixir-autogen, elixir-format
@@ -11828,7 +11828,7 @@ msgstr ""
 msgid "Organization pages"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1045
+#: lib/vutuv_web/live/notification_live/index.ex:1084
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr ""
@@ -11841,7 +11841,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:349
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:325
-#: lib/vutuv_web/components/ui.ex:3921
+#: lib/vutuv_web/components/ui.ex:3928
 #: lib/vutuv_web/controllers/settings_controller.ex:179
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
@@ -11936,22 +11936,22 @@ msgstr ""
 msgid "Your organization page was updated."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1286
+#: lib/vutuv_web/live/notification_live/index.ex:1328
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1283
+#: lib/vutuv_web/live/notification_live/index.ex:1325
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1280
+#: lib/vutuv_web/live/notification_live/index.ex:1322
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1277
+#: lib/vutuv_web/live/notification_live/index.ex:1319
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr ""
@@ -12153,7 +12153,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1096
+#: lib/vutuv/accounts/user.ex:1102
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12273,7 +12273,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1095
+#: lib/vutuv/accounts/user.ex:1101
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12355,7 +12355,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1097
+#: lib/vutuv/accounts/user.ex:1103
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:496
 #: lib/vutuv_web/agent_docs/markdown.ex:389
@@ -13057,7 +13057,7 @@ msgstr ""
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3867
+#: lib/vutuv_web/components/ui.ex:3874
 #: lib/vutuv_web/controllers/settings_controller.ex:556
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -13127,7 +13127,7 @@ msgstr ""
 msgid "job search"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:370
+#: lib/vutuv_web/live/search_live.ex:372
 #, elixir-autogen, elixir-format
 msgid "only people open to offers (status:open) or looking (status:looking)"
 msgstr ""
@@ -13328,7 +13328,7 @@ msgstr ""
 msgid "Image awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1043
+#: lib/vutuv_web/live/notification_live/index.ex:1082
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13369,7 +13369,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1140
+#: lib/vutuv/accounts/user.ex:1146
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13380,19 +13380,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1143
+#: lib/vutuv/accounts/user.ex:1149
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1146
+#: lib/vutuv/accounts/user.ex:1152
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1137
+#: lib/vutuv/accounts/user.ex:1143
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13415,7 +13415,7 @@ msgstr[1] ""
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1046
+#: lib/vutuv_web/live/notification_live/index.ex:1085
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr ""
@@ -13427,7 +13427,7 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1336
+#: lib/vutuv_web/live/notification_live/index.ex:1378
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
@@ -13469,12 +13469,12 @@ msgstr ""
 msgid "Posts with this tag"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:642
+#: lib/vutuv_web/live/search_live.ex:652
 #, elixir-autogen, elixir-format
 msgid "Your search uses a people-only filter such as city: or status:, so it only finds people."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:360
+#: lib/vutuv_web/live/search_live.ex:362
 #, elixir-autogen, elixir-format
 msgid "people and posts with this tag, combinable: miller tag:php"
 msgstr ""
@@ -13514,7 +13514,7 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3863
+#: lib/vutuv_web/components/ui.ex:3870
 #: lib/vutuv_web/controllers/settings_controller.ex:570
 #: lib/vutuv_web/live/post_live/feed.ex:1158
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -13594,7 +13594,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:59
 #: lib/vutuv_web/agent_docs/text.ex:56
-#: lib/vutuv_web/components/ui.ex:3848
+#: lib/vutuv_web/components/ui.ex:3855
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -13622,34 +13622,34 @@ msgstr ""
 msgid "Select a messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3288
+#: lib/vutuv_web/components/ui.ex:3295
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3298
+#: lib/vutuv_web/components/ui.ex:3305
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1047
+#: lib/vutuv_web/live/notification_live/index.ex:1086
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1356
+#: lib/vutuv_web/live/notification_live/index.ex:1398
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1348
+#: lib/vutuv_web/live/notification_live/index.ex:1390
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1353
+#: lib/vutuv_web/live/notification_live/index.ex:1395
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr ""
@@ -13674,7 +13674,7 @@ msgstr ""
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1361
+#: lib/vutuv_web/live/notification_live/index.ex:1403
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr ""
@@ -13805,14 +13805,14 @@ msgstr ""
 msgid "Publisher:"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:911
+#: lib/vutuv_web/live/notification_live/index.ex:947
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:925
+#: lib/vutuv_web/live/notification_live/index.ex:961
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr ""
@@ -13827,23 +13827,23 @@ msgstr ""
 msgid "Last 30 days"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:877
-#: lib/vutuv_web/live/notification_live/index.ex:1126
+#: lib/vutuv_web/live/notification_live/index.ex:913
+#: lib/vutuv_web/live/notification_live/index.ex:1166
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1063
+#: lib/vutuv_web/live/notification_live/index.ex:1103
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1058
+#: lib/vutuv_web/live/notification_live/index.ex:1098
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1073
+#: lib/vutuv_web/live/notification_live/index.ex:1113
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr ""
@@ -13853,12 +13853,12 @@ msgstr ""
 msgid "by:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1666
+#: lib/vutuv_web/components/ui.ex:1673
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1670
+#: lib/vutuv_web/components/ui.ex:1677
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
@@ -14084,17 +14084,17 @@ msgstr ""
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1310
+#: lib/vutuv_web/live/notification_live/index.ex:1352
 #, elixir-autogen, elixir-format
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1036
+#: lib/vutuv_web/live/notification_live/index.ex:1075
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1113
+#: lib/vutuv_web/live/notification_live/index.ex:1153
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -14113,12 +14113,12 @@ msgstr ""
 msgid "Only part of this long conversation is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1037
+#: lib/vutuv_web/live/notification_live/index.ex:1076
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1260
+#: lib/vutuv_web/live/notification_live/index.ex:1302
 #, elixir-autogen, elixir-format
 msgid "mentioned you in a post."
 msgstr ""
@@ -14414,7 +14414,7 @@ msgstr ""
 msgid "Match whole words only (word/phrase)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3859
+#: lib/vutuv_web/components/ui.ex:3866
 #: lib/vutuv_web/controllers/settings_controller.ex:636
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -14462,7 +14462,7 @@ msgstr ""
 msgid "Thread replies"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:603
+#: lib/vutuv_web/live/notification_live/index.ex:606
 #, elixir-autogen, elixir-format
 msgid "Turn off thread notifications"
 msgstr ""
@@ -14513,7 +14513,7 @@ msgstr ""
 msgid "You have reached the maximum of %{count} filters."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:598
+#: lib/vutuv_web/live/notification_live/index.ex:601
 #, elixir-autogen, elixir-format
 msgid "You wrote in this thread."
 msgstr ""
@@ -15047,277 +15047,277 @@ msgstr ""
 msgid "moved to %{address}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3790
+#: lib/vutuv_web/components/ui.ex:3797
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3795
+#: lib/vutuv_web/components/ui.ex:3802
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3798
+#: lib/vutuv_web/components/ui.ex:3805
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3799
+#: lib/vutuv_web/components/ui.ex:3806
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3802
+#: lib/vutuv_web/components/ui.ex:3809
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3803
+#: lib/vutuv_web/components/ui.ex:3810
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3806
+#: lib/vutuv_web/components/ui.ex:3813
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3807
+#: lib/vutuv_web/components/ui.ex:3814
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3814
+#: lib/vutuv_web/components/ui.ex:3821
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3815
+#: lib/vutuv_web/components/ui.ex:3822
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3816
+#: lib/vutuv_web/components/ui.ex:3823
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3819
+#: lib/vutuv_web/components/ui.ex:3826
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3820
+#: lib/vutuv_web/components/ui.ex:3827
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3922
+#: lib/vutuv_web/components/ui.ex:3929
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3923
+#: lib/vutuv_web/components/ui.ex:3930
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3823
+#: lib/vutuv_web/components/ui.ex:3830
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3826
+#: lib/vutuv_web/components/ui.ex:3833
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3827
+#: lib/vutuv_web/components/ui.ex:3834
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3830
+#: lib/vutuv_web/components/ui.ex:3837
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3831
+#: lib/vutuv_web/components/ui.ex:3838
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3834
+#: lib/vutuv_web/components/ui.ex:3841
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3835
+#: lib/vutuv_web/components/ui.ex:3842
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3837
+#: lib/vutuv_web/components/ui.ex:3844
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3838
+#: lib/vutuv_web/components/ui.ex:3845
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3839
+#: lib/vutuv_web/components/ui.ex:3846
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3841
+#: lib/vutuv_web/components/ui.ex:3848
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3842
+#: lib/vutuv_web/components/ui.ex:3849
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3844
+#: lib/vutuv_web/components/ui.ex:3851
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3849
+#: lib/vutuv_web/components/ui.ex:3856
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3850
+#: lib/vutuv_web/components/ui.ex:3857
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3853
+#: lib/vutuv_web/components/ui.ex:3860
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3856
+#: lib/vutuv_web/components/ui.ex:3863
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3857
+#: lib/vutuv_web/components/ui.ex:3864
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3860
+#: lib/vutuv_web/components/ui.ex:3867
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3861
+#: lib/vutuv_web/components/ui.ex:3868
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3864
+#: lib/vutuv_web/components/ui.ex:3871
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3865
+#: lib/vutuv_web/components/ui.ex:3872
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3868
+#: lib/vutuv_web/components/ui.ex:3875
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3869
+#: lib/vutuv_web/components/ui.ex:3876
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3875
+#: lib/vutuv_web/components/ui.ex:3882
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3876
+#: lib/vutuv_web/components/ui.ex:3883
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3879
+#: lib/vutuv_web/components/ui.ex:3886
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3880
+#: lib/vutuv_web/components/ui.ex:3887
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3901
+#: lib/vutuv_web/components/ui.ex:3908
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3902
+#: lib/vutuv_web/components/ui.ex:3909
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3910
+#: lib/vutuv_web/components/ui.ex:3917
 #, elixir-autogen, elixir-format
 msgid "Interface language, maps, how posts are shortened"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3911
+#: lib/vutuv_web/components/ui.ex:3918
 #, elixir-autogen, elixir-format
 msgid "german english locale translation map font length hyphenation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3914
+#: lib/vutuv_web/components/ui.ex:3921
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3915
+#: lib/vutuv_web/components/ui.ex:3922
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3918
+#: lib/vutuv_web/components/ui.ex:3925
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3919
+#: lib/vutuv_web/components/ui.ex:3926
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3926
+#: lib/vutuv_web/components/ui.ex:3933
 #, elixir-autogen, elixir-format
 msgid "Connected apps and access tokens"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3927
+#: lib/vutuv_web/components/ui.ex:3934
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3930
+#: lib/vutuv_web/components/ui.ex:3937
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3931
+#: lib/vutuv_web/components/ui.ex:3938
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr ""
@@ -15487,7 +15487,7 @@ msgstr ""
 msgid "Replies from other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1039
+#: lib/vutuv_web/live/notification_live/index.ex:1078
 #, elixir-autogen, elixir-format
 msgid "Reply from another network"
 msgstr ""
@@ -15508,7 +15508,7 @@ msgid "Reported as not appropriate"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1077
-#: lib/vutuv_web/live/notification_live/index.ex:545
+#: lib/vutuv_web/live/notification_live/index.ex:548
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
 msgstr ""
@@ -15559,7 +15559,7 @@ msgstr ""
 msgid "You have reported a lot today. Please try again tomorrow."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1263
+#: lib/vutuv_web/live/notification_live/index.ex:1305
 #, elixir-autogen, elixir-format
 msgid "replied to your post from another network."
 msgstr ""
@@ -15768,7 +15768,7 @@ msgstr ""
 msgid "Access token revoked"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3904
+#: lib/vutuv_web/components/ui.ex:3911
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -16115,7 +16115,7 @@ msgstr ""
 msgid "What changed on your account, and exactly when."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3905
+#: lib/vutuv_web/components/ui.ex:3912
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr ""
@@ -16151,7 +16151,7 @@ msgstr ""
 msgid "from a signed-in session"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3907
+#: lib/vutuv_web/components/ui.ex:3914
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
@@ -16573,7 +16573,7 @@ msgstr ""
 msgid "From other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1040
+#: lib/vutuv_web/live/notification_live/index.ex:1079
 #, elixir-autogen, elixir-format
 msgid "Reaction from another network"
 msgstr ""
@@ -16588,21 +16588,21 @@ msgstr ""
 msgid "Show under each of your posts who out there liked or shared it, by their account address on their own server, linked to that account. Visible to everyone who sees the post. We keep nothing else about these people: no name, no picture, no text. Switching it off deletes what is stored for it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1094
+#: lib/vutuv_web/live/notification_live/index.ex:1134
 #, elixir-autogen, elixir-format
 msgid "liked your post on another network."
 msgid_plural "liked your post on another network."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1102
+#: lib/vutuv_web/live/notification_live/index.ex:1142
 #, elixir-autogen, elixir-format
 msgid "reacted to your post from another network."
 msgid_plural "reacted to your post from another network."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1086
+#: lib/vutuv_web/live/notification_live/index.ex:1126
 #, elixir-autogen, elixir-format
 msgid "shared your post on another network."
 msgid_plural "shared your post on another network."
@@ -16674,7 +16674,7 @@ msgstr ""
 msgid "Address of the account"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:481
+#: lib/vutuv_web/live/search_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "An account on another network"
 msgstr ""
@@ -16684,7 +16684,7 @@ msgstr ""
 msgid "Cancel request"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3891
+#: lib/vutuv_web/components/ui.ex:3898
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr ""
@@ -16701,7 +16701,7 @@ msgstr ""
 msgid "Follow somebody out there"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:497
+#: lib/vutuv_web/live/search_live.ex:499
 #, elixir-autogen, elixir-format
 msgid "Follow this account"
 msgstr ""
@@ -16742,7 +16742,7 @@ msgstr ""
 msgid "Show only accounts on this server"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:505
+#: lib/vutuv_web/live/search_live.ex:507
 #, elixir-autogen, elixir-format
 msgid "Sign in to follow this account"
 msgstr ""
@@ -16772,7 +16772,7 @@ msgstr ""
 msgid "That does not look like an address on another network. They look like @name@server."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:486
+#: lib/vutuv_web/live/search_live.ex:488
 #, elixir-autogen, elixir-format
 msgid "That is an address on Mastodon or one of the other networks, so nobody here carries it. You can follow it from vutuv."
 msgstr ""
@@ -16886,7 +16886,7 @@ msgstr ""
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3893
+#: lib/vutuv_web/components/ui.ex:3900
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
@@ -17044,7 +17044,7 @@ msgid "You redirected your Fediverse followers to another account, so this one n
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:273
-#: lib/vutuv_web/components/fediverse_components.ex:501
+#: lib/vutuv_web/components/fediverse_components.ex:502
 #, elixir-autogen, elixir-format
 msgid "Your account move"
 msgstr ""
@@ -17945,7 +17945,7 @@ msgstr ""
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:575
+#: lib/vutuv_web/live/notification_live/index.ex:578
 #, elixir-autogen, elixir-format
 msgid "View the conversation"
 msgstr ""
@@ -18023,8 +18023,8 @@ msgstr ""
 msgid "This is vutuv's copy of a post published on %{host}. It is kept while somebody here follows its author."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1067
-#: lib/vutuv_web/components/ui.ex:1068
+#: lib/vutuv_web/components/ui.ex:1074
+#: lib/vutuv_web/components/ui.ex:1075
 #, elixir-autogen, elixir-format
 msgid "Subscribe to this feed in your RSS reader"
 msgstr ""
@@ -18422,7 +18422,7 @@ msgstr ""
 msgid "Employment reference updated."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3809
+#: lib/vutuv_web/components/ui.ex:3816
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -18616,7 +18616,7 @@ msgstr ""
 msgid "You changed the text after this review. It describes the earlier version."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3810
+#: lib/vutuv_web/components/ui.ex:3817
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr ""
@@ -18627,7 +18627,7 @@ msgstr ""
 msgid "Zwischenzeugnis"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3812
+#: lib/vutuv_web/components/ui.ex:3819
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr ""
@@ -18815,7 +18815,7 @@ msgstr ""
 msgid "Employment reference deleted"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1049
+#: lib/vutuv_web/live/notification_live/index.ex:1089
 #, elixir-autogen, elixir-format
 msgid "Employment reference review"
 msgstr ""
@@ -18840,13 +18840,13 @@ msgstr ""
 msgid "Reviewing your reference. This usually takes about %{duration}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1251
+#: lib/vutuv_web/live/notification_live/index.ex:1293
 #: lib/vutuv_web/views/notification_digest_text.ex:84
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1248
+#: lib/vutuv_web/live/notification_live/index.ex:1290
 #: lib/vutuv_web/views/notification_digest_text.ex:81
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready: %{grade}."
@@ -18862,7 +18862,7 @@ msgstr ""
 msgid "When the review of one of your employment references is finished. It takes minutes, so you can close the page and wait for the email."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1254
+#: lib/vutuv_web/live/notification_live/index.ex:1296
 #, elixir-autogen, elixir-format
 msgid "Your employment reference has been reviewed."
 msgstr ""
@@ -19236,7 +19236,7 @@ msgstr ""
 msgid "Cancel registration"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:844
+#: lib/vutuv_web/live/notification_live/index.ex:847
 #, elixir-autogen, elixir-format
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
@@ -19251,17 +19251,17 @@ msgstr ""
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1243
+#: lib/vutuv/accounts/user.ex:1249
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1241
+#: lib/vutuv/accounts/user.ex:1247
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1242
+#: lib/vutuv/accounts/user.ex:1248
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -19271,7 +19271,7 @@ msgstr ""
 msgid "Shares are of the %{answered} members who answered. %{unanswered} gave no answer."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3791
+#: lib/vutuv_web/components/ui.ex:3798
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr ""
@@ -19367,7 +19367,7 @@ msgstr ""
 msgid "Always keep"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3884
+#: lib/vutuv_web/components/ui.ex:3891
 #: lib/vutuv_web/controllers/settings_controller.ex:213
 #: lib/vutuv_web/controllers/settings_controller.ex:292
 #: lib/vutuv_web/controllers/settings_controller.ex:304
@@ -19464,7 +19464,7 @@ msgstr ""
 msgid "Keep posts that did well"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3886
+#: lib/vutuv_web/components/ui.ex:3893
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr ""
@@ -19573,7 +19573,7 @@ msgstr ""
 msgid "Your rule"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3888
+#: lib/vutuv_web/components/ui.ex:3895
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
@@ -20478,37 +20478,47 @@ msgstr ""
 msgid "Signal also takes its contact link (https://signal.me/#…). It names neither your phone number nor your username, and you can reset it in Signal at any time."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:533
+#: lib/vutuv_web/live/search_live.ex:535
 #, elixir-autogen, elixir-format
 msgid "A post on another network"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:549
+#: lib/vutuv_web/live/search_live.ex:559
 #, elixir-autogen, elixir-format
 msgid "Fetch this post"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:411
+#: lib/vutuv_web/live/search_live.ex:413
 #, elixir-autogen, elixir-format
 msgid "Search for people, tags, posts, or paste a Fediverse address"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:565
+#: lib/vutuv_web/live/search_live.ex:575
 #, elixir-autogen, elixir-format
 msgid "Sign in to fetch this post"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:538
+#: lib/vutuv_web/live/search_live.ex:540
 #, elixir-autogen, elixir-format
 msgid "That is a link to somewhere else, not something anybody here wrote. vutuv can fetch the post behind it so you can read it, answer it, like it or repost it from here."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:391
+#: lib/vutuv_web/live/search_live.ex:393
 #, elixir-autogen, elixir-format
 msgid "an address on another network: vutuv offers you the follow"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:397
+#: lib/vutuv_web/live/search_live.ex:399
 #, elixir-autogen, elixir-format
 msgid "the address of a post out there: vutuv fetches it so you can answer it here"
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1088
+#, elixir-autogen, elixir-format
+msgid "Imported profile picture"
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:886
+#, elixir-autogen, elixir-format
+msgid "When you signed up we found a picture for your email address at gravatar.com and used it as your profile picture. At {url} you can replace or remove it at any time."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -15,8 +15,8 @@ msgstr "Language: en\n"
 msgid "About us"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3575
-#: lib/vutuv_web/components/ui.ex:3580
+#: lib/vutuv_web/components/ui.ex:3582
+#: lib/vutuv_web/components/ui.ex:3587
 #: lib/vutuv_web/live/admin/screenshot_live.ex:266
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:718
 #: lib/vutuv_web/live/organization_live/domains.ex:255
@@ -62,7 +62,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:67
 #: lib/vutuv_web/agent_docs/text.ex:64
-#: lib/vutuv_web/components/ui.ex:3833
+#: lib/vutuv_web/components/ui.ex:3840
 #: lib/vutuv_web/controllers/address_controller.ex:23
 #: lib/vutuv_web/controllers/address_controller.ex:38
 #: lib/vutuv_web/controllers/address_controller.ex:85
@@ -80,8 +80,8 @@ msgstr ""
 msgid "Already a member? Sign in here."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3370
-#: lib/vutuv_web/components/ui.ex:3464
+#: lib/vutuv_web/components/ui.ex:3377
+#: lib/vutuv_web/components/ui.ex:3471
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:698
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:830
@@ -109,7 +109,7 @@ msgid "Birthday"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:110
-#: lib/vutuv_web/components/ui.ex:3364
+#: lib/vutuv_web/components/ui.ex:3371
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
@@ -160,7 +160,7 @@ msgid "Couldn't follow back to %{name}."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2751
-#: lib/vutuv_web/components/ui.ex:3467
+#: lib/vutuv_web/components/ui.ex:3474
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
@@ -209,7 +209,7 @@ msgid "Download"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2716
-#: lib/vutuv_web/components/ui.ex:3458
+#: lib/vutuv_web/components/ui.ex:3465
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
@@ -283,7 +283,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:37
 #: lib/vutuv_web/agent_docs/text.ex:34
-#: lib/vutuv_web/components/ui.ex:3797
+#: lib/vutuv_web/components/ui.ex:3804
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -313,7 +313,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:513
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
-#: lib/vutuv_web/live/notification_live/index.ex:969
+#: lib/vutuv_web/live/notification_live/index.ex:1005
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:40
@@ -324,12 +324,12 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:547
 #: lib/vutuv_web/agent_docs/text.ex:514
 #: lib/vutuv_web/components/fediverse_components.ex:313
-#: lib/vutuv_web/components/ui.ex:2072
-#: lib/vutuv_web/components/ui.ex:2097
-#: lib/vutuv_web/components/ui.ex:2100
+#: lib/vutuv_web/components/ui.ex:2079
+#: lib/vutuv_web/components/ui.ex:2104
 #: lib/vutuv_web/components/ui.ex:2107
-#: lib/vutuv_web/components/ui.ex:2110
-#: lib/vutuv_web/components/ui.ex:2168
+#: lib/vutuv_web/components/ui.ex:2114
+#: lib/vutuv_web/components/ui.ex:2117
+#: lib/vutuv_web/components/ui.ex:2175
 #: lib/vutuv_web/controllers/followee_controller.ex:29
 #: lib/vutuv_web/live/organization_live/show.ex:456
 #: lib/vutuv_web/templates/followee/index.html.heex:4
@@ -454,7 +454,7 @@ msgstr ""
 msgid "Middle Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:893
+#: lib/vutuv_web/live/notification_live/index.ex:929
 #, elixir-autogen
 msgid "More"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:647
+#: lib/vutuv_web/live/notification_live/index.ex:650
 #: lib/vutuv_web/live/organization_live/activity.ex:123
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
@@ -610,7 +610,7 @@ msgstr ""
 msgid "Public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3363
+#: lib/vutuv_web/components/ui.ex:3370
 #: lib/vutuv_web/live/organization_live/edit.ex:341
 #: lib/vutuv_web/live/post_live/composer.ex:1813
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -637,7 +637,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_live.ex:219
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:54
-#: lib/vutuv_web/live/search_live.ex:603
+#: lib/vutuv_web/live/search_live.ex:613
 #: lib/vutuv_web/live/shell_live.ex:711
 #: lib/vutuv_web/live/shell_live.ex:863
 #: lib/vutuv_web/live/tag_live/timeline.ex:237
@@ -787,12 +787,12 @@ msgstr ""
 msgid "User verified successfully."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3793
+#: lib/vutuv_web/components/ui.ex:3800
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
-#: lib/vutuv_web/live/notification_live/index.ex:1048
+#: lib/vutuv_web/live/notification_live/index.ex:1087
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -838,20 +838,20 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1007
+#: lib/vutuv_web/components/ui.ex:1014
 #: lib/vutuv_web/templates/user/show.html.heex:343
 #, elixir-autogen
 msgid "vCard"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3528
+#: lib/vutuv_web/components/ui.ex:3535
 #: lib/vutuv_web/templates/user/show.html.heex:949
 #: lib/vutuv_web/templates/user/show.html.heex:972
 #, elixir-autogen
 msgid "View All"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3874
+#: lib/vutuv_web/components/ui.ex:3881
 #: lib/vutuv_web/controllers/settings_controller.ex:159
 #: lib/vutuv_web/live/job_posting_live/form.ex:561
 #: lib/vutuv_web/live/organization_live/edit.ex:300
@@ -1120,13 +1120,13 @@ msgstr ""
 msgid "Can't find URL"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:327
+#: lib/vutuv_web/live/search_live.ex:329
 #, elixir-autogen
 msgid "Our search will try to match similar names to your search, so don't worry about spelling."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:663
-#: lib/vutuv_web/live/search_live.ex:688
+#: lib/vutuv_web/live/search_live.ex:673
+#: lib/vutuv_web/live/search_live.ex:698
 #, elixir-autogen
 msgid "Search Tips"
 msgstr ""
@@ -1371,7 +1371,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:30
 #: lib/vutuv_web/agent_docs/text.ex:440
 #: lib/vutuv_web/agent_docs/text.ex:663
-#: lib/vutuv_web/components/ui.ex:3818
+#: lib/vutuv_web/components/ui.ex:3825
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
 #: lib/vutuv_web/cv/docx.ex:174
@@ -1382,8 +1382,8 @@ msgstr ""
 #: lib/vutuv_web/live/cv_live.ex:315
 #: lib/vutuv_web/live/job_board_live.ex:277
 #: lib/vutuv_web/live/job_posting_live/form.ex:510
-#: lib/vutuv_web/live/search_live.ex:306
-#: lib/vutuv_web/live/search_live.ex:748
+#: lib/vutuv_web/live/search_live.ex:308
+#: lib/vutuv_web/live/search_live.ex:758
 #: lib/vutuv_web/live/tag_new_live.ex:36
 #: lib/vutuv_web/live/tag_new_live.ex:47
 #: lib/vutuv_web/live/tag_new_live.ex:54
@@ -1666,24 +1666,24 @@ msgstr ""
 msgid "Edit profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1488
-#: lib/vutuv_web/components/ui.ex:1497
-#: lib/vutuv_web/components/ui.ex:1899
+#: lib/vutuv_web/components/ui.ex:1495
+#: lib/vutuv_web/components/ui.ex:1504
+#: lib/vutuv_web/components/ui.ex:1906
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:199
-#: lib/vutuv_web/components/ui.ex:2037
-#: lib/vutuv_web/components/ui.ex:2037
-#: lib/vutuv_web/components/ui.ex:2054
-#: lib/vutuv_web/components/ui.ex:2063
-#: lib/vutuv_web/components/ui.ex:2079
-#: lib/vutuv_web/components/ui.ex:2116
-#: lib/vutuv_web/components/ui.ex:2119
+#: lib/vutuv_web/components/ui.ex:2044
+#: lib/vutuv_web/components/ui.ex:2044
+#: lib/vutuv_web/components/ui.ex:2061
+#: lib/vutuv_web/components/ui.ex:2070
+#: lib/vutuv_web/components/ui.ex:2086
+#: lib/vutuv_web/components/ui.ex:2123
 #: lib/vutuv_web/components/ui.ex:2126
-#: lib/vutuv_web/components/ui.ex:2129
-#: lib/vutuv_web/components/ui.ex:2202
+#: lib/vutuv_web/components/ui.ex:2133
+#: lib/vutuv_web/components/ui.ex:2136
+#: lib/vutuv_web/components/ui.ex:2209
 #: lib/vutuv_web/live/fediverse_account_live.ex:375
 #: lib/vutuv_web/live/fediverse_following_live.ex:331
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:293
@@ -1747,7 +1747,7 @@ msgid "Network"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:435
-#: lib/vutuv_web/components/ui.ex:3577
+#: lib/vutuv_web/components/ui.ex:3584
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:705
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:742
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:793
@@ -1762,7 +1762,7 @@ msgstr ""
 msgid "Nothing new yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3855
+#: lib/vutuv_web/components/ui.ex:3862
 #: lib/vutuv_web/live/notification_live/index.ex:114
 #: lib/vutuv_web/live/notification_live/index.ex:338
 #: lib/vutuv_web/live/shell_live.ex:738
@@ -1893,29 +1893,29 @@ msgstr ""
 msgid "submit a bug report"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1070
+#: lib/vutuv_web/live/notification_live/index.ex:1110
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1065
+#: lib/vutuv_web/live/notification_live/index.ex:1105
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1060
+#: lib/vutuv_web/live/notification_live/index.ex:1100
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2917
-#: lib/vutuv_web/components/ui.ex:3068
+#: lib/vutuv_web/components/ui.ex:2924
+#: lib/vutuv_web/components/ui.ex:3075
 #: lib/vutuv_web/live/organization_live/index.ex:122
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3602
+#: lib/vutuv_web/components/ui.ex:3609
 #: lib/vutuv_web/live/organization_live/activity.ex:146
 #: lib/vutuv_web/live/organization_live/feed.ex:101
 #: lib/vutuv_web/live/organization_live/show.ex:622
@@ -1928,13 +1928,13 @@ msgstr ""
 msgid "The address itself cannot be changed. To use a different one, add it as a new email address and delete this one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3373
+#: lib/vutuv_web/components/ui.ex:3380
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1213
-#: lib/vutuv_web/components/ui.ex:1223
+#: lib/vutuv_web/components/ui.ex:1220
+#: lib/vutuv_web/components/ui.ex:1230
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr ""
@@ -1973,12 +1973,12 @@ msgstr ""
 msgid "Add cover photo"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2627
+#: lib/vutuv_web/components/ui.ex:2634
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2631
+#: lib/vutuv_web/components/ui.ex:2638
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr ""
@@ -2003,37 +2003,37 @@ msgstr ""
 msgid "Cover photo of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2635
+#: lib/vutuv_web/components/ui.ex:2642
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2625
+#: lib/vutuv_web/components/ui.ex:2632
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2624
+#: lib/vutuv_web/components/ui.ex:2631
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2630
+#: lib/vutuv_web/components/ui.ex:2637
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2629
+#: lib/vutuv_web/components/ui.ex:2636
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2626
+#: lib/vutuv_web/components/ui.ex:2633
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2628
+#: lib/vutuv_web/components/ui.ex:2635
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr ""
@@ -2048,17 +2048,17 @@ msgstr ""
 msgid "Member since %{year}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2634
+#: lib/vutuv_web/components/ui.ex:2641
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2633
+#: lib/vutuv_web/components/ui.ex:2640
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2632
+#: lib/vutuv_web/components/ui.ex:2639
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr ""
@@ -2195,11 +2195,11 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:83
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:382
-#: lib/vutuv_web/live/notification_live/index.ex:891
+#: lib/vutuv_web/live/notification_live/index.ex:927
 #: lib/vutuv_web/live/organization_live/show.ex:549
 #: lib/vutuv_web/live/post_live/saved.ex:495
-#: lib/vutuv_web/live/search_live.ex:307
-#: lib/vutuv_web/live/search_live.ex:762
+#: lib/vutuv_web/live/search_live.ex:309
+#: lib/vutuv_web/live/search_live.ex:772
 #: lib/vutuv_web/templates/settings/preferences.html.heex:118
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4119
+#: lib/vutuv_web/components/ui.ex:4126
 #: lib/vutuv_web/live/shell_live.ex:781
 #: lib/vutuv_web/templates/post/index.html.heex:17
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2365,7 +2365,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1603
 #: lib/vutuv_web/components/post_components.ex:4436
-#: lib/vutuv_web/components/ui.ex:2992
+#: lib/vutuv_web/components/ui.ex:2999
 #: lib/vutuv_web/views/user_html.ex:335
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2384,8 +2384,8 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1567
 #: lib/vutuv_web/components/post_components.ex:4670
-#: lib/vutuv_web/components/ui.ex:2978
-#: lib/vutuv_web/live/notification_live/index.ex:1038
+#: lib/vutuv_web/components/ui.ex:2985
+#: lib/vutuv_web/live/notification_live/index.ex:1077
 #: lib/vutuv_web/views/user_html.ex:345
 #, elixir-autogen, elixir-format
 msgid "Like"
@@ -2393,7 +2393,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1000
 #: lib/vutuv_web/components/post_components.ex:4679
-#: lib/vutuv_web/live/notification_live/index.ex:971
+#: lib/vutuv_web/live/notification_live/index.ex:1007
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
 #: lib/vutuv_web/live/shell_live.ex:789
@@ -2454,9 +2454,9 @@ msgid "Unlike"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:343
-#: lib/vutuv_web/components/ui.ex:2032
-#: lib/vutuv_web/components/ui.ex:2032
-#: lib/vutuv_web/components/ui.ex:2169
+#: lib/vutuv_web/components/ui.ex:2039
+#: lib/vutuv_web/components/ui.ex:2039
+#: lib/vutuv_web/components/ui.ex:2176
 #: lib/vutuv_web/live/organization_live/following.ex:197
 #: lib/vutuv_web/live/organization_live/following.ex:256
 #: lib/vutuv_web/live/organization_live/show.ex:459
@@ -2478,7 +2478,7 @@ msgid "Only public posts can be answered."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:393
-#: lib/vutuv_web/live/notification_live/index.ex:972
+#: lib/vutuv_web/live/notification_live/index.ex:1008
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
@@ -2486,7 +2486,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1578
 #: lib/vutuv_web/components/post_components.ex:4706
 #: lib/vutuv_web/components/post_components.ex:4707
-#: lib/vutuv_web/live/notification_live/index.ex:1035
+#: lib/vutuv_web/live/notification_live/index.ex:1074
 #: lib/vutuv_web/live/post_live/reply.ex:42
 #, elixir-autogen, elixir-format
 msgid "Reply"
@@ -2508,7 +2508,7 @@ msgstr ""
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1258
+#: lib/vutuv_web/live/notification_live/index.ex:1300
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr ""
@@ -2589,7 +2589,7 @@ msgstr ""
 msgid "No conversations yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2503
+#: lib/vutuv_web/components/ui.ex:2510
 #: lib/vutuv_web/live/message_live/index.ex:726
 #, elixir-autogen, elixir-format
 msgid "Online"
@@ -2737,8 +2737,8 @@ msgstr ""
 msgid "Write your first post"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3156
-#: lib/vutuv_web/components/ui.ex:3530
+#: lib/vutuv_web/components/ui.ex:3163
+#: lib/vutuv_web/components/ui.ex:3537
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
 #: lib/vutuv_web/templates/settings/organizations.html.heex:89
@@ -2785,13 +2785,13 @@ msgstr[1] ""
 #: lib/vutuv_web/agent_docs/markdown.ex:548
 #: lib/vutuv_web/agent_docs/text.ex:515
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:970
+#: lib/vutuv_web/live/notification_live/index.ex:1006
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:998
+#: lib/vutuv_web/components/ui.ex:1005
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr ""
@@ -2801,7 +2801,7 @@ msgstr ""
 msgid "No connections yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1014
+#: lib/vutuv_web/components/ui.ex:1021
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr ""
@@ -2811,7 +2811,7 @@ msgstr ""
 msgid "People who aren't my connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:999
+#: lib/vutuv_web/components/ui.ex:1006
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr ""
@@ -2840,23 +2840,23 @@ msgid "Open someone's profile to message them."
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:225
-#: lib/vutuv_web/live/notification_live/index.ex:1050
+#: lib/vutuv_web/live/notification_live/index.ex:1090
 #: lib/vutuv_web/live/organization_live/activity.ex:99
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1041
+#: lib/vutuv_web/live/notification_live/index.ex:1080
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1034
+#: lib/vutuv_web/live/notification_live/index.ex:1073
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1033
+#: lib/vutuv_web/live/notification_live/index.ex:1072
 #: lib/vutuv_web/templates/user/show.html.heex:933
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -2869,7 +2869,7 @@ msgstr[1] ""
 msgid "Welcome to vutuv, %{name}!"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1067
+#: lib/vutuv_web/live/notification_live/index.ex:1107
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr ""
@@ -2901,12 +2901,12 @@ msgstr ""
 msgid "(no text)"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1294
+#: lib/vutuv_web/live/notification_live/index.ex:1336
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1295
+#: lib/vutuv_web/live/notification_live/index.ex:1337
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr ""
@@ -3012,7 +3012,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:1042
+#: lib/vutuv_web/live/notification_live/index.ex:1081
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3141,7 +3141,7 @@ msgstr ""
 msgid "Private message"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3787
+#: lib/vutuv_web/components/ui.ex:3794
 #: lib/vutuv_web/live/shell_live.ex:612
 #: lib/vutuv_web/live/shell_live.ex:870
 #: lib/vutuv_web/templates/import/new.html.heex:15
@@ -3252,7 +3252,7 @@ msgstr ""
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2892
+#: lib/vutuv_web/components/ui.ex:2899
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:773
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -3436,12 +3436,12 @@ msgstr ""
 msgid "You cannot report your own content."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1297
+#: lib/vutuv_web/live/notification_live/index.ex:1339
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1296
+#: lib/vutuv_web/live/notification_live/index.ex:1338
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr ""
@@ -3451,7 +3451,7 @@ msgstr ""
 msgid "Your content was reported"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1298
+#: lib/vutuv_web/live/notification_live/index.ex:1340
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3635,7 +3635,7 @@ msgstr ""
 msgid "Open the profile"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1322
+#: lib/vutuv_web/live/notification_live/index.ex:1364
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3660,7 +3660,7 @@ msgstr ""
 msgid "Report filed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1044
+#: lib/vutuv_web/live/notification_live/index.ex:1083
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr ""
@@ -3735,7 +3735,7 @@ msgstr ""
 msgid "Waiting for the owner"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1327
+#: lib/vutuv_web/live/notification_live/index.ex:1369
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -4461,22 +4461,22 @@ msgstr ""
 msgid "Undeliverable"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:423
+#: lib/vutuv_web/live/search_live.ex:425
 #, elixir-autogen, elixir-format
 msgid "You can search for a name, email, or tag, or for words in public posts."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:418
+#: lib/vutuv_web/live/search_live.ex:420
 #, elixir-autogen, elixir-format
 msgid "Search for people by name, email, or username."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:419
+#: lib/vutuv_web/live/search_live.ex:421
 #, elixir-autogen, elixir-format
 msgid "Search for tags by name."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:420
+#: lib/vutuv_web/live/search_live.ex:422
 #, elixir-autogen, elixir-format
 msgid "Search for words in public posts."
 msgstr ""
@@ -4492,7 +4492,7 @@ msgstr ""
 msgid "Block @%{slug}? This removes any follows and connection between you, closes your conversation, and prevents all interaction in both directions. Unblocking will not restore what was removed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3878
+#: lib/vutuv_web/components/ui.ex:3885
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -4578,12 +4578,12 @@ msgstr ""
 msgid "This area is reserved for administrators."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:810
+#: lib/vutuv_web/live/search_live.ex:820
 #, elixir-autogen, elixir-format
 msgid "No results for \"%{query}\""
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:731
+#: lib/vutuv_web/live/search_live.ex:741
 #, elixir-autogen, elixir-format
 msgid "Not an exact match, but sounds like your search."
 msgstr ""
@@ -4592,21 +4592,21 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:388
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:516
-#: lib/vutuv_web/live/notification_live/index.ex:892
+#: lib/vutuv_web/live/notification_live/index.ex:928
 #: lib/vutuv_web/live/organization_live/show.ex:632
 #: lib/vutuv_web/live/post_live/saved.ex:498
-#: lib/vutuv_web/live/search_live.ex:305
-#: lib/vutuv_web/live/search_live.ex:704
+#: lib/vutuv_web/live/search_live.ex:307
+#: lib/vutuv_web/live/search_live.ex:714
 #, elixir-autogen, elixir-format
 msgid "People"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:650
+#: lib/vutuv_web/live/search_live.ex:660
 #, elixir-autogen, elixir-format
 msgid "Results appear once you have typed at least three letters."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:728
+#: lib/vutuv_web/live/search_live.ex:738
 #, elixir-autogen, elixir-format
 msgid "Similar names"
 msgstr ""
@@ -4615,49 +4615,49 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:409
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
-#: lib/vutuv_web/live/notification_live/index.ex:890
-#: lib/vutuv_web/live/search_live.ex:304
+#: lib/vutuv_web/live/notification_live/index.ex:926
+#: lib/vutuv_web/live/search_live.ex:306
 #: lib/vutuv_web/views/qualification_html.ex:90
 #, elixir-autogen, elixir-format
 msgid "All"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:633
+#: lib/vutuv_web/live/search_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "Exact matches only"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:376
+#: lib/vutuv_web/live/search_live.ex:378
 #, elixir-autogen, elixir-format
 msgid "in quotes: exact matches only, no similar names"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:373
+#: lib/vutuv_web/live/search_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "searches usernames"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:365
+#: lib/vutuv_web/live/search_live.ex:367
 #, elixir-autogen, elixir-format
 msgid "only people with an address in this city"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:364
+#: lib/vutuv_web/live/search_live.ex:366
 #, elixir-autogen, elixir-format
 msgid "city:koblenz"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:354
+#: lib/vutuv_web/live/search_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "first:stefan"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:375
+#: lib/vutuv_web/live/search_live.ex:377
 #, elixir-autogen, elixir-format
 msgid "miller"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:355
+#: lib/vutuv_web/live/search_live.ex:357
 #, elixir-autogen, elixir-format
 msgid "searches first names only (last: for last names)"
 msgstr ""
@@ -4670,7 +4670,7 @@ msgstr ""
 msgid "Add a tag"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:412
+#: lib/vutuv_web/live/search_live.ex:414
 #, elixir-autogen, elixir-format
 msgid "Search for people, tags, or posts"
 msgstr ""
@@ -5256,7 +5256,7 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3929
+#: lib/vutuv_web/components/ui.ex:3936
 #: lib/vutuv_web/controllers/settings_controller.ex:145
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5335,10 +5335,10 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4026
-#: lib/vutuv_web/components/ui.ex:4031
-#: lib/vutuv_web/components/ui.ex:4110
-#: lib/vutuv_web/components/ui.ex:4174
+#: lib/vutuv_web/components/ui.ex:4033
+#: lib/vutuv_web/components/ui.ex:4038
+#: lib/vutuv_web/components/ui.ex:4117
+#: lib/vutuv_web/components/ui.ex:4181
 #: lib/vutuv_web/controllers/settings_controller.ex:61
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5411,7 +5411,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:2835
 #: lib/vutuv_web/components/post_components.ex:2887
 #: lib/vutuv_web/components/post_components.ex:3284
-#: lib/vutuv_web/live/notification_live/index.ex:691
+#: lib/vutuv_web/live/notification_live/index.ex:694
 #: lib/vutuv_web/live/post_live/feed.ex:1245
 #: lib/vutuv_web/views/user_html.ex:113
 #, elixir-autogen, elixir-format
@@ -5457,7 +5457,7 @@ msgstr ""
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3898
+#: lib/vutuv_web/components/ui.ex:3905
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:289
@@ -5478,7 +5478,7 @@ msgstr ""
 msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3825
+#: lib/vutuv_web/components/ui.ex:3832
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5512,7 +5512,7 @@ msgstr ""
 msgid "Photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3872
+#: lib/vutuv_web/components/ui.ex:3879
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/templates/page/index.html.heex:166
 #, elixir-autogen, elixir-format
@@ -5539,7 +5539,7 @@ msgstr ""
 msgid "Your name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:520
+#: lib/vutuv_web/live/notification_live/index.ex:523
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr ""
@@ -5628,14 +5628,14 @@ msgstr ""
 msgid "Apps"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3925
+#: lib/vutuv_web/components/ui.ex:3932
 #: lib/vutuv_web/controllers/settings_controller.ex:165
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:127
-#: lib/vutuv_web/live/notification_live/index.ex:973
+#: lib/vutuv_web/live/notification_live/index.ex:1009
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:17
@@ -6238,9 +6238,9 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1488
-#: lib/vutuv_web/components/ui.ex:1497
-#: lib/vutuv_web/components/ui.ex:1900
+#: lib/vutuv_web/components/ui.ex:1495
+#: lib/vutuv_web/components/ui.ex:1504
+#: lib/vutuv_web/components/ui.ex:1907
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr ""
@@ -6301,11 +6301,11 @@ msgstr ""
 msgid "No endorsements yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1853
-#: lib/vutuv_web/live/notification_live/index.ex:625
-#: lib/vutuv_web/live/notification_live/index.ex:640
-#: lib/vutuv_web/live/notification_live/index.ex:778
-#: lib/vutuv_web/live/notification_live/index.ex:780
+#: lib/vutuv_web/components/ui.ex:1860
+#: lib/vutuv_web/live/notification_live/index.ex:628
+#: lib/vutuv_web/live/notification_live/index.ex:643
+#: lib/vutuv_web/live/notification_live/index.ex:781
+#: lib/vutuv_web/live/notification_live/index.ex:783
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr ""
@@ -6596,7 +6596,7 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2357
+#: lib/vutuv_web/components/ui.ex:2364
 #: lib/vutuv_web/live/fediverse_account_live.ex:369
 #: lib/vutuv_web/templates/settings/filters.html.heex:58
 #: lib/vutuv_web/templates/user/show.html.heex:212
@@ -6620,7 +6620,7 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2356
+#: lib/vutuv_web/components/ui.ex:2363
 #: lib/vutuv_web/live/fediverse_account_live.ex:367
 #: lib/vutuv_web/templates/settings/filters.html.heex:81
 #: lib/vutuv_web/templates/user/show.html.heex:212
@@ -6659,33 +6659,33 @@ msgstr ""
 msgid "Unmute @%{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2327
+#: lib/vutuv_web/components/ui.ex:2334
 #, elixir-autogen, elixir-format
 msgid "Doesn't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2321
+#: lib/vutuv_web/components/ui.ex:2328
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2311
+#: lib/vutuv_web/components/ui.ex:2318
 #, elixir-autogen, elixir-format
 msgid "This member doesn't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2262
-#: lib/vutuv_web/components/ui.ex:2311
+#: lib/vutuv_web/components/ui.ex:2269
+#: lib/vutuv_web/components/ui.ex:2318
 #, elixir-autogen, elixir-format
 msgid "This member follows you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2260
+#: lib/vutuv_web/components/ui.ex:2267
 #, elixir-autogen, elixir-format
 msgid "You follow each other"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2261
+#: lib/vutuv_web/components/ui.ex:2268
 #, elixir-autogen, elixir-format
 msgid "You follow this member"
 msgstr ""
@@ -7251,13 +7251,13 @@ msgstr ""
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2930
+#: lib/vutuv_web/components/ui.ex:2937
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2946
+#: lib/vutuv_web/components/ui.ex:2953
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7730,13 +7730,13 @@ msgstr ""
 #: lib/vutuv_web/components/job_components.ex:173
 #: lib/vutuv_web/live/admin/dashboard_live.ex:287
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:457
-#: lib/vutuv_web/live/notification_live/index.ex:919
+#: lib/vutuv_web/live/notification_live/index.ex:955
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:291
-#: lib/vutuv_web/live/notification_live/index.ex:922
+#: lib/vutuv_web/live/notification_live/index.ex:958
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr ""
@@ -7959,8 +7959,8 @@ msgstr ""
 msgid "Identity-verified"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1367
-#: lib/vutuv/accounts.ex:1416
+#: lib/vutuv/accounts.ex:1394
+#: lib/vutuv/accounts.ex:1443
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -7999,7 +7999,7 @@ msgstr ""
 msgid "Open the member browser"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1384
+#: lib/vutuv/accounts.ex:1411
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -8010,7 +8010,7 @@ msgstr ""
 msgid "PIN registered"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2933
+#: lib/vutuv_web/components/ui.ex:2940
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr ""
@@ -8140,7 +8140,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:41
 #: lib/vutuv_web/agent_docs/text.ex:38
-#: lib/vutuv_web/components/ui.ex:3801
+#: lib/vutuv_web/components/ui.ex:3808
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8195,7 +8195,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3913
+#: lib/vutuv_web/components/ui.ex:3920
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8224,7 +8224,7 @@ msgstr ""
 msgid "Nothing new to import."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3829
+#: lib/vutuv_web/components/ui.ex:3836
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8315,7 +8315,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3202
+#: lib/vutuv_web/components/ui.ex:3209
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8396,13 +8396,13 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3789
+#: lib/vutuv_web/components/ui.ex:3796
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3909
+#: lib/vutuv_web/components/ui.ex:3916
 #: lib/vutuv_web/controllers/settings_controller.ex:122
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8414,7 +8414,7 @@ msgstr ""
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3900
+#: lib/vutuv_web/components/ui.ex:3907
 #: lib/vutuv_web/controllers/settings_controller.ex:105
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8424,7 +8424,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3917
+#: lib/vutuv_web/components/ui.ex:3924
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8542,7 +8542,7 @@ msgstr[1] ""
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1016
+#: lib/vutuv_web/components/ui.ex:1023
 #, elixir-autogen, elixir-format
 msgid "This profile is not offered as a Markdown, text, JSON or XML export."
 msgstr ""
@@ -8638,7 +8638,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:504
 #: lib/vutuv_web/agent_docs/text.ex:508
 #: lib/vutuv_web/components/organization_components.ex:242
-#: lib/vutuv_web/components/ui.ex:3890
+#: lib/vutuv_web/components/ui.ex:3897
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:323
 #: lib/vutuv_web/controllers/settings_controller.ex:390
@@ -8688,7 +8688,7 @@ msgstr ""
 msgid "Your Fediverse handle"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1379
+#: lib/vutuv/accounts.ex:1406
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -8741,7 +8741,7 @@ msgstr ""
 msgid "Volunteering & hobbies"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:625
+#: lib/vutuv_web/live/search_live.ex:635
 #, elixir-autogen, elixir-format
 msgid "Not available while the search uses a people filter."
 msgstr ""
@@ -8792,7 +8792,7 @@ msgstr ""
 msgid "This is the print view of this CV. Use your browser's print dialog (Ctrl+P or Cmd+P) and choose \"Save as PDF\" to get a PDF file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1124
+#: lib/vutuv_web/components/ui.ex:1131
 #, elixir-autogen, elixir-format
 msgid "CV download"
 msgstr ""
@@ -8830,7 +8830,7 @@ msgstr ""
 msgid "Header"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1134
+#: lib/vutuv_web/components/ui.ex:1141
 #: lib/vutuv_web/templates/export/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Open CV"
@@ -8862,7 +8862,7 @@ msgstr ""
 msgid "The CV is public, on your profile: a visitor's download contains only what they can see there anyway, and private email addresses appear only in your own."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1126
+#: lib/vutuv_web/components/ui.ex:1133
 #, elixir-autogen, elixir-format
 msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
@@ -9018,8 +9018,8 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1532
-#: lib/vutuv_web/components/ui.ex:1533
+#: lib/vutuv_web/components/ui.ex:1539
+#: lib/vutuv_web/components/ui.ex:1540
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:65
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9460,7 +9460,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1084
+#: lib/vutuv/accounts/user.ex:1090
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9471,7 +9471,7 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1081
+#: lib/vutuv/accounts/user.ex:1087
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -9586,7 +9586,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:45
 #: lib/vutuv_web/agent_docs/text.ex:42
-#: lib/vutuv_web/components/ui.ex:3805
+#: lib/vutuv_web/components/ui.ex:3812
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:124
@@ -9779,13 +9779,13 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2725
+#: lib/vutuv_web/components/ui.ex:2732
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2724
-#: lib/vutuv_web/components/ui.ex:2728
+#: lib/vutuv_web/components/ui.ex:2731
+#: lib/vutuv_web/components/ui.ex:2735
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr ""
@@ -10826,19 +10826,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1122
+#: lib/vutuv/accounts/user.ex:1128
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1127
+#: lib/vutuv/accounts/user.ex:1133
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1125
+#: lib/vutuv/accounts/user.ex:1131
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:566
 #, elixir-autogen, elixir-format
@@ -11826,7 +11826,7 @@ msgstr ""
 msgid "Organization pages"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1045
+#: lib/vutuv_web/live/notification_live/index.ex:1084
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr ""
@@ -11839,7 +11839,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:349
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:325
-#: lib/vutuv_web/components/ui.ex:3921
+#: lib/vutuv_web/components/ui.ex:3928
 #: lib/vutuv_web/controllers/settings_controller.ex:179
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
@@ -11934,22 +11934,22 @@ msgstr ""
 msgid "Your organization page was updated."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1286
+#: lib/vutuv_web/live/notification_live/index.ex:1328
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1283
+#: lib/vutuv_web/live/notification_live/index.ex:1325
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1280
+#: lib/vutuv_web/live/notification_live/index.ex:1322
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1277
+#: lib/vutuv_web/live/notification_live/index.ex:1319
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr ""
@@ -12151,7 +12151,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1096
+#: lib/vutuv/accounts/user.ex:1102
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12271,7 +12271,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1095
+#: lib/vutuv/accounts/user.ex:1101
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12353,7 +12353,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1097
+#: lib/vutuv/accounts/user.ex:1103
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:496
 #: lib/vutuv_web/agent_docs/markdown.ex:389
@@ -13055,7 +13055,7 @@ msgstr ""
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3867
+#: lib/vutuv_web/components/ui.ex:3874
 #: lib/vutuv_web/controllers/settings_controller.ex:556
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -13125,7 +13125,7 @@ msgstr ""
 msgid "job search"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:370
+#: lib/vutuv_web/live/search_live.ex:372
 #, elixir-autogen, elixir-format
 msgid "only people open to offers (status:open) or looking (status:looking)"
 msgstr ""
@@ -13326,7 +13326,7 @@ msgstr ""
 msgid "Image awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1043
+#: lib/vutuv_web/live/notification_live/index.ex:1082
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13367,7 +13367,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1140
+#: lib/vutuv/accounts/user.ex:1146
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13378,19 +13378,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1143
+#: lib/vutuv/accounts/user.ex:1149
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1146
+#: lib/vutuv/accounts/user.ex:1152
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1137
+#: lib/vutuv/accounts/user.ex:1143
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13413,7 +13413,7 @@ msgstr[1] ""
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1046
+#: lib/vutuv_web/live/notification_live/index.ex:1085
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr ""
@@ -13425,7 +13425,7 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1336
+#: lib/vutuv_web/live/notification_live/index.ex:1378
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
@@ -13467,12 +13467,12 @@ msgstr ""
 msgid "Posts with this tag"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:642
+#: lib/vutuv_web/live/search_live.ex:652
 #, elixir-autogen, elixir-format
 msgid "Your search uses a people-only filter such as city: or status:, so it only finds people."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:360
+#: lib/vutuv_web/live/search_live.ex:362
 #, elixir-autogen, elixir-format
 msgid "people and posts with this tag, combinable: miller tag:php"
 msgstr ""
@@ -13512,7 +13512,7 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3863
+#: lib/vutuv_web/components/ui.ex:3870
 #: lib/vutuv_web/controllers/settings_controller.ex:570
 #: lib/vutuv_web/live/post_live/feed.ex:1158
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -13592,7 +13592,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:59
 #: lib/vutuv_web/agent_docs/text.ex:56
-#: lib/vutuv_web/components/ui.ex:3848
+#: lib/vutuv_web/components/ui.ex:3855
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -13620,34 +13620,34 @@ msgstr ""
 msgid "Select a messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3288
+#: lib/vutuv_web/components/ui.ex:3295
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3298
+#: lib/vutuv_web/components/ui.ex:3305
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1047
+#: lib/vutuv_web/live/notification_live/index.ex:1086
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1356
+#: lib/vutuv_web/live/notification_live/index.ex:1398
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1348
+#: lib/vutuv_web/live/notification_live/index.ex:1390
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1353
+#: lib/vutuv_web/live/notification_live/index.ex:1395
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr ""
@@ -13672,7 +13672,7 @@ msgstr ""
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1361
+#: lib/vutuv_web/live/notification_live/index.ex:1403
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr ""
@@ -13803,14 +13803,14 @@ msgstr ""
 msgid "Publisher:"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:911
+#: lib/vutuv_web/live/notification_live/index.ex:947
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:925
+#: lib/vutuv_web/live/notification_live/index.ex:961
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr ""
@@ -13825,23 +13825,23 @@ msgstr ""
 msgid "Last 30 days"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:877
-#: lib/vutuv_web/live/notification_live/index.ex:1126
+#: lib/vutuv_web/live/notification_live/index.ex:913
+#: lib/vutuv_web/live/notification_live/index.ex:1166
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1063
+#: lib/vutuv_web/live/notification_live/index.ex:1103
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1058
+#: lib/vutuv_web/live/notification_live/index.ex:1098
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1073
+#: lib/vutuv_web/live/notification_live/index.ex:1113
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr ""
@@ -13851,12 +13851,12 @@ msgstr ""
 msgid "by:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1666
+#: lib/vutuv_web/components/ui.ex:1673
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1670
+#: lib/vutuv_web/components/ui.ex:1677
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
@@ -14082,17 +14082,17 @@ msgstr ""
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1310
+#: lib/vutuv_web/live/notification_live/index.ex:1352
 #, elixir-autogen, elixir-format
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1036
+#: lib/vutuv_web/live/notification_live/index.ex:1075
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1113
+#: lib/vutuv_web/live/notification_live/index.ex:1153
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -14111,12 +14111,12 @@ msgstr ""
 msgid "Only part of this long conversation is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1037
+#: lib/vutuv_web/live/notification_live/index.ex:1076
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1260
+#: lib/vutuv_web/live/notification_live/index.ex:1302
 #, elixir-autogen, elixir-format
 msgid "mentioned you in a post."
 msgstr ""
@@ -14412,7 +14412,7 @@ msgstr ""
 msgid "Match whole words only (word/phrase)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3859
+#: lib/vutuv_web/components/ui.ex:3866
 #: lib/vutuv_web/controllers/settings_controller.ex:636
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -14460,7 +14460,7 @@ msgstr ""
 msgid "Thread replies"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:603
+#: lib/vutuv_web/live/notification_live/index.ex:606
 #, elixir-autogen, elixir-format
 msgid "Turn off thread notifications"
 msgstr ""
@@ -14511,7 +14511,7 @@ msgstr ""
 msgid "You have reached the maximum of %{count} filters."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:598
+#: lib/vutuv_web/live/notification_live/index.ex:601
 #, elixir-autogen, elixir-format
 msgid "You wrote in this thread."
 msgstr ""
@@ -15045,277 +15045,277 @@ msgstr ""
 msgid "moved to %{address}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3790
+#: lib/vutuv_web/components/ui.ex:3797
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3795
+#: lib/vutuv_web/components/ui.ex:3802
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3798
+#: lib/vutuv_web/components/ui.ex:3805
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3799
+#: lib/vutuv_web/components/ui.ex:3806
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3802
+#: lib/vutuv_web/components/ui.ex:3809
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3803
+#: lib/vutuv_web/components/ui.ex:3810
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3806
+#: lib/vutuv_web/components/ui.ex:3813
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3807
+#: lib/vutuv_web/components/ui.ex:3814
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3814
+#: lib/vutuv_web/components/ui.ex:3821
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3815
+#: lib/vutuv_web/components/ui.ex:3822
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3816
+#: lib/vutuv_web/components/ui.ex:3823
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3819
+#: lib/vutuv_web/components/ui.ex:3826
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3820
+#: lib/vutuv_web/components/ui.ex:3827
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3922
+#: lib/vutuv_web/components/ui.ex:3929
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3923
+#: lib/vutuv_web/components/ui.ex:3930
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3823
+#: lib/vutuv_web/components/ui.ex:3830
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3826
+#: lib/vutuv_web/components/ui.ex:3833
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3827
+#: lib/vutuv_web/components/ui.ex:3834
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3830
+#: lib/vutuv_web/components/ui.ex:3837
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3831
+#: lib/vutuv_web/components/ui.ex:3838
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3834
+#: lib/vutuv_web/components/ui.ex:3841
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3835
+#: lib/vutuv_web/components/ui.ex:3842
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3837
+#: lib/vutuv_web/components/ui.ex:3844
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3838
+#: lib/vutuv_web/components/ui.ex:3845
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3839
+#: lib/vutuv_web/components/ui.ex:3846
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3841
+#: lib/vutuv_web/components/ui.ex:3848
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3842
+#: lib/vutuv_web/components/ui.ex:3849
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3844
+#: lib/vutuv_web/components/ui.ex:3851
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3849
+#: lib/vutuv_web/components/ui.ex:3856
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3850
+#: lib/vutuv_web/components/ui.ex:3857
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3853
+#: lib/vutuv_web/components/ui.ex:3860
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3856
+#: lib/vutuv_web/components/ui.ex:3863
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3857
+#: lib/vutuv_web/components/ui.ex:3864
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3860
+#: lib/vutuv_web/components/ui.ex:3867
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3861
+#: lib/vutuv_web/components/ui.ex:3868
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3864
+#: lib/vutuv_web/components/ui.ex:3871
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3865
+#: lib/vutuv_web/components/ui.ex:3872
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3868
+#: lib/vutuv_web/components/ui.ex:3875
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3869
+#: lib/vutuv_web/components/ui.ex:3876
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3875
+#: lib/vutuv_web/components/ui.ex:3882
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3876
+#: lib/vutuv_web/components/ui.ex:3883
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3879
+#: lib/vutuv_web/components/ui.ex:3886
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3880
+#: lib/vutuv_web/components/ui.ex:3887
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3901
+#: lib/vutuv_web/components/ui.ex:3908
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3902
+#: lib/vutuv_web/components/ui.ex:3909
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3910
+#: lib/vutuv_web/components/ui.ex:3917
 #, elixir-autogen, elixir-format
 msgid "Interface language, maps, how posts are shortened"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3911
+#: lib/vutuv_web/components/ui.ex:3918
 #, elixir-autogen, elixir-format
 msgid "german english locale translation map font length hyphenation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3914
+#: lib/vutuv_web/components/ui.ex:3921
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3915
+#: lib/vutuv_web/components/ui.ex:3922
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3918
+#: lib/vutuv_web/components/ui.ex:3925
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3919
+#: lib/vutuv_web/components/ui.ex:3926
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3926
+#: lib/vutuv_web/components/ui.ex:3933
 #, elixir-autogen, elixir-format
 msgid "Connected apps and access tokens"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3927
+#: lib/vutuv_web/components/ui.ex:3934
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3930
+#: lib/vutuv_web/components/ui.ex:3937
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3931
+#: lib/vutuv_web/components/ui.ex:3938
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr ""
@@ -15485,7 +15485,7 @@ msgstr ""
 msgid "Replies from other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1039
+#: lib/vutuv_web/live/notification_live/index.ex:1078
 #, elixir-autogen, elixir-format
 msgid "Reply from another network"
 msgstr ""
@@ -15506,7 +15506,7 @@ msgid "Reported as not appropriate"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1077
-#: lib/vutuv_web/live/notification_live/index.ex:545
+#: lib/vutuv_web/live/notification_live/index.ex:548
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
 msgstr ""
@@ -15557,7 +15557,7 @@ msgstr ""
 msgid "You have reported a lot today. Please try again tomorrow."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1263
+#: lib/vutuv_web/live/notification_live/index.ex:1305
 #, elixir-autogen, elixir-format, fuzzy
 msgid "replied to your post from another network."
 msgstr ""
@@ -15766,7 +15766,7 @@ msgstr ""
 msgid "Access token revoked"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3904
+#: lib/vutuv_web/components/ui.ex:3911
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -16113,7 +16113,7 @@ msgstr ""
 msgid "What changed on your account, and exactly when."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3905
+#: lib/vutuv_web/components/ui.ex:3912
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr ""
@@ -16149,7 +16149,7 @@ msgstr ""
 msgid "from a signed-in session"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3907
+#: lib/vutuv_web/components/ui.ex:3914
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
@@ -16571,7 +16571,7 @@ msgstr ""
 msgid "From other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1040
+#: lib/vutuv_web/live/notification_live/index.ex:1079
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Reaction from another network"
 msgstr ""
@@ -16586,21 +16586,21 @@ msgstr ""
 msgid "Show under each of your posts who out there liked or shared it, by their account address on their own server, linked to that account. Visible to everyone who sees the post. We keep nothing else about these people: no name, no picture, no text. Switching it off deletes what is stored for it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1094
+#: lib/vutuv_web/live/notification_live/index.ex:1134
 #, elixir-autogen, elixir-format
 msgid "liked your post on another network."
 msgid_plural "liked your post on another network."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1102
+#: lib/vutuv_web/live/notification_live/index.ex:1142
 #, elixir-autogen, elixir-format, fuzzy
 msgid "reacted to your post from another network."
 msgid_plural "reacted to your post from another network."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1086
+#: lib/vutuv_web/live/notification_live/index.ex:1126
 #, elixir-autogen, elixir-format
 msgid "shared your post on another network."
 msgid_plural "shared your post on another network."
@@ -16672,7 +16672,7 @@ msgstr ""
 msgid "Address of the account"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:481
+#: lib/vutuv_web/live/search_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "An account on another network"
 msgstr ""
@@ -16682,7 +16682,7 @@ msgstr ""
 msgid "Cancel request"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3891
+#: lib/vutuv_web/components/ui.ex:3898
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr ""
@@ -16699,7 +16699,7 @@ msgstr ""
 msgid "Follow somebody out there"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:497
+#: lib/vutuv_web/live/search_live.ex:499
 #, elixir-autogen, elixir-format
 msgid "Follow this account"
 msgstr ""
@@ -16740,7 +16740,7 @@ msgstr ""
 msgid "Show only accounts on this server"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:505
+#: lib/vutuv_web/live/search_live.ex:507
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sign in to follow this account"
 msgstr ""
@@ -16770,7 +16770,7 @@ msgstr ""
 msgid "That does not look like an address on another network. They look like @name@server."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:486
+#: lib/vutuv_web/live/search_live.ex:488
 #, elixir-autogen, elixir-format
 msgid "That is an address on Mastodon or one of the other networks, so nobody here carries it. You can follow it from vutuv."
 msgstr ""
@@ -16884,7 +16884,7 @@ msgstr ""
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3893
+#: lib/vutuv_web/components/ui.ex:3900
 #, elixir-autogen, elixir-format, fuzzy
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
@@ -17042,7 +17042,7 @@ msgid "You redirected your Fediverse followers to another account, so this one n
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:273
-#: lib/vutuv_web/components/fediverse_components.ex:501
+#: lib/vutuv_web/components/fediverse_components.ex:502
 #, elixir-autogen, elixir-format
 msgid "Your account move"
 msgstr ""
@@ -17943,7 +17943,7 @@ msgstr ""
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:575
+#: lib/vutuv_web/live/notification_live/index.ex:578
 #, elixir-autogen, elixir-format
 msgid "View the conversation"
 msgstr ""
@@ -18021,8 +18021,8 @@ msgstr ""
 msgid "This is vutuv's copy of a post published on %{host}. It is kept while somebody here follows its author."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1067
-#: lib/vutuv_web/components/ui.ex:1068
+#: lib/vutuv_web/components/ui.ex:1074
+#: lib/vutuv_web/components/ui.ex:1075
 #, elixir-autogen, elixir-format
 msgid "Subscribe to this feed in your RSS reader"
 msgstr ""
@@ -18420,7 +18420,7 @@ msgstr ""
 msgid "Employment reference updated."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3809
+#: lib/vutuv_web/components/ui.ex:3816
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -18614,7 +18614,7 @@ msgstr ""
 msgid "You changed the text after this review. It describes the earlier version."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3810
+#: lib/vutuv_web/components/ui.ex:3817
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr ""
@@ -18625,7 +18625,7 @@ msgstr ""
 msgid "Zwischenzeugnis"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3812
+#: lib/vutuv_web/components/ui.ex:3819
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr ""
@@ -18813,7 +18813,7 @@ msgstr ""
 msgid "Employment reference deleted"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1049
+#: lib/vutuv_web/live/notification_live/index.ex:1089
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Employment reference review"
 msgstr ""
@@ -18838,13 +18838,13 @@ msgstr ""
 msgid "Reviewing your reference. This usually takes about %{duration}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1251
+#: lib/vutuv_web/live/notification_live/index.ex:1293
 #: lib/vutuv_web/views/notification_digest_text.ex:84
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1248
+#: lib/vutuv_web/live/notification_live/index.ex:1290
 #: lib/vutuv_web/views/notification_digest_text.ex:81
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready: %{grade}."
@@ -18860,7 +18860,7 @@ msgstr ""
 msgid "When the review of one of your employment references is finished. It takes minutes, so you can close the page and wait for the email."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1254
+#: lib/vutuv_web/live/notification_live/index.ex:1296
 #, elixir-autogen, elixir-format
 msgid "Your employment reference has been reviewed."
 msgstr ""
@@ -19234,7 +19234,7 @@ msgstr ""
 msgid "Cancel registration"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:844
+#: lib/vutuv_web/live/notification_live/index.ex:847
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
@@ -19249,17 +19249,17 @@ msgstr ""
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1243
+#: lib/vutuv/accounts/user.ex:1249
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1241
+#: lib/vutuv/accounts/user.ex:1247
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1242
+#: lib/vutuv/accounts/user.ex:1248
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -19269,7 +19269,7 @@ msgstr ""
 msgid "Shares are of the %{answered} members who answered. %{unanswered} gave no answer."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3791
+#: lib/vutuv_web/components/ui.ex:3798
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr ""
@@ -19365,7 +19365,7 @@ msgstr ""
 msgid "Always keep"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3884
+#: lib/vutuv_web/components/ui.ex:3891
 #: lib/vutuv_web/controllers/settings_controller.ex:213
 #: lib/vutuv_web/controllers/settings_controller.ex:292
 #: lib/vutuv_web/controllers/settings_controller.ex:304
@@ -19462,7 +19462,7 @@ msgstr ""
 msgid "Keep posts that did well"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3886
+#: lib/vutuv_web/components/ui.ex:3893
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr ""
@@ -19571,7 +19571,7 @@ msgstr ""
 msgid "Your rule"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3888
+#: lib/vutuv_web/components/ui.ex:3895
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
@@ -20476,37 +20476,47 @@ msgstr ""
 msgid "Signal also takes its contact link (https://signal.me/#…). It names neither your phone number nor your username, and you can reset it in Signal at any time."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:533
+#: lib/vutuv_web/live/search_live.ex:535
 #, elixir-autogen, elixir-format, fuzzy
 msgid "A post on another network"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:549
+#: lib/vutuv_web/live/search_live.ex:559
 #, elixir-autogen, elixir-format
 msgid "Fetch this post"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:411
+#: lib/vutuv_web/live/search_live.ex:413
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Search for people, tags, posts, or paste a Fediverse address"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:565
+#: lib/vutuv_web/live/search_live.ex:575
 #, elixir-autogen, elixir-format
 msgid "Sign in to fetch this post"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:538
+#: lib/vutuv_web/live/search_live.ex:540
 #, elixir-autogen, elixir-format
 msgid "That is a link to somewhere else, not something anybody here wrote. vutuv can fetch the post behind it so you can read it, answer it, like it or repost it from here."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:391
+#: lib/vutuv_web/live/search_live.ex:393
 #, elixir-autogen, elixir-format
 msgid "an address on another network: vutuv offers you the follow"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:397
+#: lib/vutuv_web/live/search_live.ex:399
 #, elixir-autogen, elixir-format
 msgid "the address of a post out there: vutuv fetches it so you can answer it here"
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1088
+#, elixir-autogen, elixir-format
+msgid "Imported profile picture"
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:886
+#, elixir-autogen, elixir-format
+msgid "When you signed up we found a picture for your email address at gravatar.com and used it as your profile picture. At {url} you can replace or remove it at any time."
 msgstr ""

--- a/priv/repo/migrations/20260814081712_add_gravatar_imported_at_to_users.exs
+++ b/priv/repo/migrations/20260814081712_add_gravatar_imported_at_to_users.exs
@@ -1,0 +1,19 @@
+defmodule Vutuv.Repo.Migrations.AddGravatarImportedAtToUsers do
+  use Ecto.Migration
+
+  # When registration actually imported an avatar from gravatar.com for this
+  # member (issue #1447) — stamped by `Vutuv.Accounts.store_gravatar/1` only on
+  # the path where an image was stored, never on the 404/error paths. It is the
+  # timestamp of the "we found a picture for your address" note in the
+  # notifications feed (`Vutuv.Activity`), and NULL means "no such note": every
+  # account whose avatar arrived that way before this feature keeps a clean
+  # feed rather than being told about an import from years ago.
+  #
+  # A plain nullable addition, so the currently deployed release keeps working
+  # unchanged (N-1).
+  def change do
+    alter table(:users) do
+      add(:gravatar_imported_at, :naive_datetime)
+    end
+  end
+end

--- a/test/vutuv/accounts/gravatar_import_test.exs
+++ b/test/vutuv/accounts/gravatar_import_test.exs
@@ -1,0 +1,88 @@
+defmodule Vutuv.Accounts.GravatarImportTest do
+  @moduledoc """
+  The avatar registration fetches from gravatar.com (issue #1447): that it is
+  stored, and that `gravatar_imported_at` is stamped **only** when an image
+  really arrived — the stamp is what tells the member about it, so a 404 or a
+  failed fetch must leave it NULL and say nothing.
+
+  Not async: sets the global `:uploads_dir_prefix` (so the avatar files land in
+  a temp dir instead of the checkout) and `:gravatar_req_options` (the `plug:`
+  responder standing in for gravatar.com). Nothing else in the suite reads the
+  latter; `:uploads_dir_prefix` is shared with
+  `Vutuv.UploadsIntegrationTest`, which is sync for the same reason.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.Factory
+
+  alias Vutuv.Accounts
+
+  setup do
+    tmp = Path.join(System.tmp_dir!(), "vutuv_gravatar_#{System.unique_integer([:positive])}")
+    prefix = Application.fetch_env(:vutuv, :uploads_dir_prefix)
+    options = Application.fetch_env(:vutuv, :gravatar_req_options)
+    Application.put_env(:vutuv, :uploads_dir_prefix, tmp)
+
+    on_exit(fn ->
+      File.rm_rf(tmp)
+      restore(:uploads_dir_prefix, prefix)
+      restore(:gravatar_req_options, options)
+    end)
+
+    user = insert(:user, emails: [build(:email)])
+    {:ok, user: user}
+  end
+
+  test "an imported picture becomes the avatar and stamps the import", %{user: user} do
+    stub_gravatar(200, png_bytes(), "image/png")
+
+    assert {:ok, imported} = Accounts.store_gravatar(user)
+    assert imported.avatar == "#{user.username}.png"
+    assert %NaiveDateTime{} = imported.gravatar_imported_at
+
+    assert Repo.reload!(user).gravatar_imported_at == imported.gravatar_imported_at
+  end
+
+  # 404 is gravatar's answer for "no picture for this address" (the `d=404`
+  # parameter asks for it), and it is the common case. Nothing was imported, so
+  # there is nothing to tell the member about.
+  test "no picture at gravatar.com leaves the stamp NULL", %{user: user} do
+    stub_gravatar(404, "", "text/plain")
+
+    assert Accounts.store_gravatar(user) == nil
+    assert Repo.reload!(user).gravatar_imported_at == nil
+  end
+
+  test "a failed fetch leaves the stamp NULL", %{user: user} do
+    stub_gravatar(500, "", "text/plain")
+
+    assert Accounts.store_gravatar(user) == nil
+    assert Repo.reload!(user).gravatar_imported_at == nil
+  end
+
+  # `retry: false` only so the 500 case does not sit through Req's default
+  # backoff ladder; what the stub proves is the branch taken after the last
+  # answer, which the retries do not change. The content type is real
+  # (`image/png`), because Req's decode_body step branches on it — a bare
+  # send_resp would hand the code a differently shaped body than gravatar does.
+  defp stub_gravatar(status, body, content_type) do
+    Application.put_env(:vutuv, :gravatar_req_options,
+      retry: false,
+      plug: fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type(content_type)
+        |> Plug.Conn.send_resp(status, body)
+      end
+    )
+  end
+
+  defp png_bytes do
+    {:ok, img} = Image.new(120, 120, color: [10, 120, 200])
+    path = Path.join(System.tmp_dir!(), "gravatar_#{System.unique_integer([:positive])}.png")
+    {:ok, _} = Image.write(img, path)
+    File.read!(path)
+  end
+
+  defp restore(key, {:ok, was}), do: Application.put_env(:vutuv, key, was)
+  defp restore(key, :error), do: Application.delete_env(:vutuv, key)
+end

--- a/test/vutuv/activity_test.exs
+++ b/test/vutuv/activity_test.exs
@@ -122,6 +122,26 @@ defmodule Vutuv.ActivityTest do
       assert recent_notifications(me.id) == []
     end
 
+    test "an imported gravatar leaves a note about where the picture came from" do
+      me = insert(:user, gravatar_imported_at: ~N[2026-08-14 09:00:00])
+
+      assert [n] = recent_notifications(me.id)
+      assert n.kind == "gravatar"
+      assert n.id == "gravatar-#{me.id}"
+      assert n.at == ~N[2026-08-14 09:00:00]
+      # The installation did this, not another member: no actor at all.
+      refute Map.has_key?(n, :actor_name)
+    end
+
+    # The vast majority of sign-ups have no gravatar, and their avatar is their
+    # own upload — telling them about an import that never happened would be
+    # both wrong and alarming.
+    test "an account whose avatar did not come from gravatar gets no such note" do
+      me = insert(:user, avatar: "selfie.jpg")
+
+      assert recent_notifications(me.id) == []
+    end
+
     test "a self-endorsement produces no notification" do
       me = insert(:user)
       tag = insert(:tag)

--- a/test/vutuv_web/live/notification_live_test.exs
+++ b/test/vutuv_web/live/notification_live_test.exs
@@ -89,6 +89,63 @@ defmodule VutuvWeb.NotificationLiveTest do
       refute html =~ "/settings/username</a>."
     end
 
+    # Registration quietly fetches an avatar from gravatar.com, so a member who
+    # once used that service arrives to a photo they never uploaded here. Our
+    # silence is what made that unsettling (issue #1447).
+    test "tells a member their picture was imported from gravatar.com", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      stamp_gravatar_import(user, ~N[2026-08-14 09:00:00])
+
+      {:ok, live, _html} = live(conn, ~p"/notifications")
+
+      assert has_element?(live, ~s([data-notification-row][data-kind="gravatar"]))
+      html = render(live)
+      # It names the source; a picture "we found somewhere" would be worse than
+      # saying nothing.
+      assert html =~ "gravatar.com"
+
+      # The link sits inside the sentence (the row itself is not one link) and
+      # leads where the picture can be replaced or removed.
+      settings_url = VutuvWeb.Endpoint.url() <> "/settings/profile"
+
+      assert has_element?(
+               live,
+               ~s([data-kind="gravatar"] a[href="#{settings_url}"]),
+               settings_url
+             )
+
+      # Same rule as the welcome note: never end the sentence on the URL, or the
+      # full stop reads as part of the address.
+      refute html =~ "/settings/profile</a>."
+    end
+
+    # The German render is the one real visitors get, and a fuzzy-filled msgstr
+    # would only show here (an English-only assertion passes either way).
+    test "says it in German for a German browser", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      stamp_gravatar_import(user, ~N[2026-08-14 09:00:00])
+
+      body =
+        conn
+        |> recycle()
+        |> put_req_header("accept-language", "de-DE,de")
+        |> get(~p"/notifications")
+        |> html_response(200)
+
+      assert body =~ "gravatar.com gefunden"
+      assert body =~ "Profilbild"
+      refute body =~ "/settings/profile</a>."
+    end
+
+    # Nobody is told about an import that never happened.
+    test "says nothing when the avatar did not come from gravatar", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+
+      {:ok, live, _html} = live(conn, ~p"/notifications")
+
+      refute has_element?(live, ~s([data-kind="gravatar"]))
+    end
+
     test "lists real events derived from the database", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
 
@@ -1266,6 +1323,15 @@ defmodule VutuvWeb.NotificationLiveTest do
     Vutuv.Repo.update_all(
       from(u in Vutuv.Accounts.User, where: u.id == ^id),
       set: [welcome_notified_at: at]
+    )
+  end
+
+  defp stamp_gravatar_import(%{id: id}, at) do
+    import Ecto.Query
+
+    Vutuv.Repo.update_all(
+      from(u in Vutuv.Accounts.User, where: u.id == ^id),
+      set: [gravatar_imported_at: at]
     )
   end
 


### PR DESCRIPTION
Closes #1447

Sign-up quietly pulls an avatar from gravatar.com. Now the member is told: an in-app notification that names the source and links to where the picture can be replaced or removed.

## What lands

- **`users.gravatar_imported_at`** (nullable, plain addition, N-1 safe). Stamped by `Accounts.store_gravatar/1` **only** on the branch that really stored an image; a 404 (gravatar's own "no picture for this address") or a failed fetch leaves it NULL.
- **A `gravatar` kind in `Vutuv.Activity`** with `email_pref: nil` — items, count and cursor arm keyed on that column, exactly like the `username` welcome note. Derived from the member's own users row: no notification table, no push (the import runs during registration, before the first login, so the note is already waiting), **no email**.
- **Its row on /notifications** — 🖼 glyph, label, and its own sentence. The row is not one big link; the `/settings/profile` URL sits inside the sentence, like `username_line/1`, and the sentence deliberately does not end on it.
- **German and English strings.** German: „Bei Ihrer Anmeldung haben wir zu Ihrer E-Mail-Adresse ein Bild bei gravatar.com gefunden und als Ihr Profilbild übernommen. Unter {url} können Sie es jederzeit austauschen oder entfernen."
- **Docs**: a section in `docs/architecture/realtime.md` beside the welcome note, plus a line under `:fetch_gravatar` in `docs/ADMINS.md` telling other operators their own privacy policy should describe the lookup. While in there I corrected the welcome note's stale `/settings/security` to `/settings/username`.

## A bug picked up on the way

The imported file's name carried a leading slash, because the same string was reused to build the tmp path: the users row ended up with `"/handle.jpg"` where an ordinary upload stores `"handle.jpg"`. Harmless as long as a fingerprint exists (the stored name is then only a has-an-avatar flag), but wrong. Now built with `Path.join/2`.

## Tests

`store_gravatar/1` is `@doc false` public so a test can drive it in a process that owns the sandbox connection, and the fetch is stubbed through a new `:gravatar_req_options` (`plug:`) seam — the same shape `:book_metadata_req_options` and friends already use, with the real `content-type` on the stub so Req's decode step behaves as it does against gravatar.

- `test/vutuv/accounts/gravatar_import_test.exs`: the picture becomes the avatar and the stamp is set; 404 and 500 leave it NULL.
- `activity_test.exs`: the note is derived from the stamp, and an avatar that did not come from gravatar produces none.
- `notification_live_test.exs`: the row renders, names gravatar.com, carries the settings link inside the sentence, does not end on the URL, is absent without an import — and says it in German for an `Accept-Language: de-DE,de` request.

`mix precommit` green (7621 tests).

## One thing left for you: the Datenschutzerklärung

The issue also asks for the note in the privacy page's description of the gravatar fetch. That page is **database content** (`/admin/legal`) — the file in `priv/repo/seed_data/legal/` is the frozen snapshot its one-time migration shipped with, so editing it would change nothing for anyone and would make the "frozen" claim untrue. Worth knowing: the current text does not describe the gravatar lookup **at all**, so this is a new paragraph rather than an amendment.

Here it is, ready to paste after „Ihr öffentliches Profil":

```markdown
#### Profilbild von gravatar.com

Bei der Registrierung prüfen wir einmalig, ob zu Ihrer E-Mail-Adresse beim Dienst gravatar.com (Automattic Inc., USA) ein Profilbild hinterlegt ist. Dazu übermitteln wir an diesen Dienst einen Hashwert Ihrer E-Mail-Adresse, nicht die Adresse selbst; aus dem Hashwert kann gravatar.com allerdings ein dort bereits bekanntes Konto wiedererkennen. Finden wir ein Bild, übernehmen wir es als Ihr Profilbild und teilen Ihnen das in einer Mitteilung in vutuv mit, damit Sie wissen, woher das Bild stammt. Sie können es jederzeit in Ihren Einstellungen austauschen oder entfernen. Finden wir kein Bild, wird nichts gespeichert. Rechtsgrundlage ist unser berechtigtes Interesse daran, neuen Mitgliedern ein vollständiges Profil zu erleichtern (Art. 6 Abs. 1 lit. f DSGVO).
```

Two things I did **not** decide for you, because they are yours: whether Art. 6 Abs. 1 lit. f is the basis you want (an alternative is to describe it as consent given by signing up), and whether to bump „Stand: Juni 2026" to August 2026.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_013zucWqZGcJqm1bvmEvxwf2
