### PR TITLE
NodeInfo: die Verzeichnisse können diese Installation jetzt sehen (v7.285.0)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -651,6 +651,18 @@ config :vutuv, :operator_recipient, {"Stefan Wintermeyer", "sw@wintermeyer-consu
 config :vutuv, :operator_name, "Wintermeyer Consulting"
 config :vutuv, :operator_url, "https://wintermeyer-consulting.de"
 config :vutuv, :operator_address, "Johannes-Müller-Str. 10 - 56068 Koblenz - Germany"
+
+# How this installation names and describes itself to the fediverse's directory
+# layer (`Vutuv.NodeInfo`, the /.well-known/nodeinfo document). FediDB,
+# the-federation.info and Fediverse Observer print these two strings beside the
+# entry, so they are the installation's own words, not vutuv's — one language,
+# since NodeInfo has no locale negotiation. (NODE_NAME / NODE_DESCRIPTION)
+config :vutuv, :node_name, "vutuv"
+
+config :vutuv,
+       :node_description,
+       "The open business network where professionals connect, share, and get found."
+
 # -----------------------------------------------------------------------------
 
 # Mail is delivered via SMTP (prod) and the Local/Test adapters elsewhere, none

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -165,6 +165,15 @@ if config_env() == :prod do
     config :vutuv, :operator_address, operator_address
   end
 
+  # How the fediverse directories name this installation (Vutuv.NodeInfo).
+  if node_name = System.get_env("NODE_NAME") do
+    config :vutuv, :node_name, node_name
+  end
+
+  if node_description = System.get_env("NODE_DESCRIPTION") do
+    config :vutuv, :node_description, node_description
+  end
+
   # Follow-only ActivityPub federation. FEDIVERSE_ENABLED=false turns every
   # Fediverse endpoint and delivery off — for installations that must not
   # call out (intranets). Per member it is opt-in either way.

--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -138,6 +138,8 @@ Everything else has a default (the vutuv.de production value):
 | `FEDIVERSE_COUNTS_BATCH` | `60` | How many cached objects one refresh run (every two minutes) may ask about. Protects your own machine as much as anybody else's: a backlog drains over several runs instead of in one spike. The run interval is deliberately well under the ladder's shortest tier: a run stamps an object a few seconds after it became due, so polling *at* the tier length would leave it a few seconds short on the next run and silently double the real interval |
 | `FEDIVERSE_COUNTS_PER_HOST` | `10` | How many of that batch may belong to a single host, so one instance that happens to host many of the accounts your members follow is spread over several runs rather than fetched in a burst. What the cap holds back is written to the log |
 | `FEDIVERSE_IMAGE_HOLD_SECONDS` | `90` | How long a post whose picture the AI image scan has not judged yet waits before it federates **without** the picture. This is a ceiling, not the usual wait: the post goes out the moment the scan settles, normally within seconds. It only bites when the scanner is down, and then the choice is "the post without its picture" over "no post at all". Raise it if you run image moderation on slow hardware; irrelevant when `MODERATE_IMAGES` is off |
+| `NODE_NAME` | `vutuv` | What the fediverse directories call your installation. They fetch `/.well-known/nodeinfo` on their own and print this string beside the entry, so make it the name you want people to see in a list of servers — your organization, your community, your domain |
+| `NODE_DESCRIPTION` | (vutuv.de's pitch) | The one sentence those directories print under the name. Say what your installation is *for*; the default describes vutuv.de and is almost certainly not what you want on your own server. NodeInfo has no notion of language, so write it in the one your visitors read |
 | `ACCOUNT_EVENT_RETENTION_DAYS` | `365` | How long the **account-activity log** keeps an event, in days (see `docs/architecture/account-activity.md`). It records what changed on an account, when, from which coarse device (never an IP address), and how it was confirmed, so it is personal data with a clock on it: a year covers the "this happened months ago and I only noticed now" support case without becoming a permanent movement profile. The daily sweeper deletes anything older |
 | `FETCH_BOOK_METADATA` | `true` | `false` turns the catalogue lookups behind post **book reviews** off (the cover image, page count and publisher from Open Library, and an audiobook's running time). New reviews can no longer be created (the composer's review form was removed), but existing review posts keep rendering their card — with the flag off it shows no cover and none of those details. Set it on installations that must not call out (intranets) |
 | `DNB_SRU_URL` | `https://services.dnb.de/sru/dnb` | Where an **audiobook's running time** is looked up by ISBN: an SRU endpoint answering MARC21-xml (the Deutsche Nationalbibliothek by default — Open Library records no durations). Point it at another catalogue's SRU endpoint, or set it **empty** (`DNB_SRU_URL=`) to switch that one lookup off while the rest of the book metadata keeps working |
@@ -313,6 +315,9 @@ those directories itself.
    responsibility.
 4. **Review the operator variables** (`OPERATOR_*`, `MAILER_FROM_ADDRESS`,
    `BOUNCE_ADDRESS`) so system mail carries your identity, not vutuv.de's.
+5. **Set `NODE_NAME` and `NODE_DESCRIPTION`** if your installation is on the
+   internet — that is how the fediverse directories will name and describe it
+   (see below). The defaults describe vutuv.de.
 
 ## Intranet installations
 
@@ -590,6 +595,29 @@ The badge shows on the member's profile (and its `.md`/`.json`/… siblings) wit
 small "honor tag" marker. Reserve honor for **new** tag names: flipping a
 tag that members already hold makes them keep it but blocks them from removing it
 themselves.
+
+## Being listed in the fediverse directories
+
+Sites like FediDB, the-federation.info and Fediverse Observer keep the public
+lists of what runs on the fediverse. They find a server by fetching
+`/.well-known/nodeinfo` from it and reading the small JSON document it points
+at, so your installation appears on those lists on its own — there is nothing to
+submit, and nothing to switch on. If you would rather not be listed, block that
+path in nginx.
+
+What the document says about you:
+
+- your name and one sentence, from `NODE_NAME` and `NODE_DESCRIPTION`;
+- the software and its version, so a directory can tell vutuv from anything
+  else;
+- how many members you have, how many of them signed in over the last 30 and
+  180 days, and how many public posts and replies they have written.
+
+Everything in it is an aggregate and nobody is named. The post counts cover
+exactly what a logged-out visitor can already read — private, frozen and
+unmoderated posts are in neither — and the member figures are the same kind of
+number your top bar and your member directory already show. Check yours at
+`https://<your host>/system/nodeinfo/2.1`.
 
 ## Federation: blocking a remote server
 

--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -1997,3 +1997,72 @@ free, since by then the post is cached.
 Deliberately **not** built: backfilling an account's outbox history. The lookup
 is one post the member named; walking somebody's archive because a member
 followed them is a different bargain.
+
+## Saying this installation exists: NodeInfo (issue #1448)
+
+Everything above is federation between servers that already know about each
+other. The fediverse also has a directory layer — FediDB, the-federation.info,
+Fediverse Observer — and it works by scanning: fetch `/.well-known/nodeinfo`
+from a host, follow the highest-version link in it, read the document. An
+installation without that document can federate perfectly, be followed from
+anywhere, and still be invisible to every list a person consults when they go
+looking for federated software. There is nothing to detect.
+
+`Vutuv.NodeInfo` owns the document, `VutuvWeb.WellKnownController` serves it:
+
+| URL | What it is |
+| --- | --- |
+| `/.well-known/nodeinfo` | the link document, one entry per served version |
+| `/system/nodeinfo/2.1` | the document, with `software.repository`/`homepage` |
+| `/system/nodeinfo/2.0` | the same document without those two fields |
+
+Both schema versions are served because they cost one route: 2.0 is what every
+consumer understands, 2.1 adds the two pointers that send a directory straight
+at the source of an open-source project. The documents live under `/system/`
+rather than at a `/nodeinfo` root word, which member handles own — the
+specification fixes no path for them, which is why Mastodon, Pleroma and Misskey
+each serve them somewhere different, and every consumer follows the link.
+
+**What the figures mean** is the part worth getting right, because a number that
+does not mean what other implementations mean by it is worse than an absent
+field:
+
+* `usage.users.total` is the **members here** (`Accounts.count_users/0`), never
+  the top bar's people total. That one adds the remote accounts following this
+  installation, and those are other servers' accounts — publishing them here
+  would double-count them across the network. The exact query is used rather
+  than the cached `Vutuv.PeopleCounter`, both because the document is fetched a
+  handful of times a day and because that cell reads 0 for the first moments
+  after a deploy, which is exactly when a polling directory would record this
+  installation as empty.
+* `activeMonth` / `activeHalfyear` are the members with a signed-in device seen
+  inside the window (`user_sessions.last_seen_at`, bumped on every request) —
+  the specification's "signed in at least once in the last 30 / 180 days". A
+  revoked session still counts: the member did sign in, and logging out
+  afterwards does not undo that. Both are drawn from the same member population
+  as `total`, so neither can exceed it.
+* `localPosts` / `localComments` count what an **anonymous** reader can see
+  (`Posts.scope_visible/2` with no viewer), split on whether the post answers
+  another one. Nothing new is disclosed — those posts are already in the sitemap
+  and the RSS feeds — and a private, frozen or still-moderated post is in
+  neither figure.
+
+`openRegistrations` is `true` and hardcoded, because it is true: vutuv has no
+registration gate, so anybody who reaches an installation can sign up. It is
+deliberately not a config flag — one that changed the advertised value while the
+sign-up form kept accepting everybody would be a worse answer than the honest
+one. The day a real gate exists, this reads it.
+
+`protocols` says `activitypub` on every installation, including one running
+`FEDIVERSE_ENABLED=false`. It names the protocol the software speaks, the schema
+requires at least one entry, and a directory that follows it finds the actor
+endpoints answering 404 — the same thing said twice.
+
+`software.name`, `repository` and `homepage` describe vutuv **the software** and
+are literals: every installation runs the same software, developed in the same
+repository. What names the operator — `metadata.nodeName` and `nodeDescription`
+— sits behind the Operator identity block in `config/config.exs` like every
+other such value, env-overridable as `NODE_NAME` / `NODE_DESCRIPTION`.
+
+Submitting anything anywhere is not part of this. Once the document is served,
+the directories that scan for it find the installation on their own.

--- a/lib/vutuv/node_info.ex
+++ b/lib/vutuv/node_info.ex
@@ -1,0 +1,212 @@
+defmodule Vutuv.NodeInfo do
+  @moduledoc """
+  NodeInfo (issue #1448): the small JSON document the fediverse's directory
+  layer reads to learn that this server exists and what it runs.
+
+  FediDB, the-federation.info and Fediverse Observer all discover a server the
+  same way: fetch `/.well-known/nodeinfo`, follow the highest-version link they
+  understand, read the document. An installation without it can federate
+  perfectly, be followed from anywhere, and still be invisible to every list a
+  person consults when they go looking for federated software — there is
+  nothing for those sites to detect.
+
+  ## What this says, and what it deliberately does not
+
+  Both schema versions are served. **2.0** is what every consumer understands;
+  **2.1** adds `software.repository` and `software.homepage`, which points a
+  directory straight at the source of an open-source project. The two are the
+  same document apart from those fields.
+
+  `software.name`, `repository` and `homepage` describe **vutuv the software**,
+  not the party running this copy of it, so they are literals here and not
+  operator config — every installation runs the same software, developed in the
+  same repository. What names the operator (`metadata.nodeName`,
+  `nodeDescription`) sits behind the Operator identity block in
+  `config/config.exs` like every other such value.
+
+  The figures are the part worth being careful about:
+
+    * **`usage.users.total` is the members here** (`Accounts.count_users/0`) and
+      never the top bar's people total (`Vutuv.PeopleCounter`). That number adds
+      the remote accounts following this installation, which are other servers'
+      accounts — publishing them here would double-count them across the
+      network. The exact query is used rather than the cached counter because
+      this document is fetched a handful of times a day, and because the cell
+      reads 0 for the first moments after a deploy, which is exactly when a
+      polling directory would record this installation as empty.
+
+    * **`activeMonth` / `activeHalfyear`** are the members with a signed-in
+      device seen inside the window (`user_sessions.last_seen_at`, bumped on
+      every request). That is what the specification means — "signed in at
+      least once in the last 30 / 180 days" — so the figure is comparable with
+      what other implementations publish. A revoked session still counts: the
+      member did sign in, and logging out afterwards does not undo that. Both
+      are drawn from the same member population as `total`, so neither can
+      exceed it.
+
+    * **`localPosts` / `localComments`** count what an **anonymous** reader can
+      see (`Posts.scope_visible/2` with no viewer), split by whether the post
+      answers another one. Nothing new is disclosed: those posts are already in
+      the sitemap and the RSS feeds. A private, frozen or still-moderated post
+      is in neither figure.
+
+  `openRegistrations` is hardcoded `true` because it is true: there is no
+  registration gate in vutuv, so anybody who reaches an installation can sign
+  up. It is deliberately *not* a config flag — a flag that changed only the
+  advertised value while the sign-up form kept accepting everybody would be a
+  worse answer than the honest one. The day a real gate exists, this reads it.
+
+  `protocols` says `activitypub` on every installation, including one running
+  `FEDIVERSE_ENABLED=false`: it names the protocol the software speaks, the
+  schema requires at least one entry, and a directory that follows it finds the
+  actor endpoints answering 404 — which is the same thing said twice.
+  """
+
+  import Ecto.Query
+
+  alias Vutuv.Accounts
+  alias Vutuv.Accounts.User
+  alias Vutuv.Moderation.Query, as: ModerationQuery
+  alias Vutuv.Posts
+  alias Vutuv.Posts.Post
+  alias Vutuv.Repo
+  alias Vutuv.Sessions.UserSession
+  alias VutuvWeb.Endpoint
+
+  require ModerationQuery
+
+  # Newest first: a consumer picks the highest version it understands.
+  @versions ["2.1", "2.0"]
+  @rel_prefix "http://nodeinfo.diaspora.software/ns/schema/"
+
+  # Under /system/ rather than at the `/nodeinfo` root word, which member
+  # handles own. The specification does not fix the path — the link document
+  # below is what says where the document lives, which is why Mastodon,
+  # Pleroma and Misskey all serve it somewhere different.
+  @path_prefix "/system/nodeinfo/"
+
+  # Properties of the software, identical on every installation.
+  @software_name "vutuv"
+  @repository "https://github.com/wintermeyer/vutuv"
+  @homepage "https://www.vutuv.de"
+
+  # The active-user windows the specification defines.
+  @month_days 30
+  @halfyear_days 180
+
+  @doc "The schema versions this installation serves, newest first."
+  def versions, do: @versions
+
+  @doc """
+  The `links` of the `/.well-known/nodeinfo` link document: one entry per
+  served schema version, each an absolute URL of this installation.
+  """
+  def links do
+    Enum.map(@versions, fn version ->
+      %{"rel" => @rel_prefix <> version, "href" => Endpoint.url() <> @path_prefix <> version}
+    end)
+  end
+
+  @doc """
+  The NodeInfo document for `version` (`"2.0"` or `"2.1"`), or `nil` for a
+  version this installation does not serve.
+  """
+  def document(version) when version in @versions do
+    usage = usage()
+
+    %{
+      "version" => version,
+      "software" => software(version),
+      "protocols" => ["activitypub"],
+      "services" => %{"inbound" => [], "outbound" => []},
+      "openRegistrations" => true,
+      "usage" => %{
+        "users" => %{
+          "total" => usage.users.total,
+          "activeMonth" => usage.users.active_month,
+          "activeHalfyear" => usage.users.active_halfyear
+        },
+        "localPosts" => usage.local_posts,
+        "localComments" => usage.local_comments
+      },
+      "metadata" => %{
+        "nodeName" => Application.fetch_env!(:vutuv, :node_name),
+        "nodeDescription" => Application.fetch_env!(:vutuv, :node_description)
+      }
+    }
+  end
+
+  def document(_version), do: nil
+
+  @doc """
+  The figures behind `usage`: `%{users: %{total:, active_month:,
+  active_halfyear:}, local_posts:, local_comments:}`. Three aggregates, all of
+  them exact — see the module doc for what each one means and why. `document/1`
+  is what renames them to the schema's spelling.
+  """
+  def usage do
+    {posts, comments} = post_counts()
+
+    %{
+      users: Map.put(active_users(), :total, Accounts.count_users()),
+      local_posts: posts,
+      local_comments: comments
+    }
+  end
+
+  # 2.1 adds the two pointers at the source; 2.0 has no place for them.
+  defp software("2.1") do
+    Map.merge(software("2.0"), %{"repository" => @repository, "homepage" => @homepage})
+  end
+
+  defp software(_version) do
+    %{"name" => @software_name, "version" => to_string(Application.spec(:vutuv, :vsn))}
+  end
+
+  # Both windows in one round trip. `count(DISTINCT user_id)` because the
+  # figure counts people, not devices: a member signed in on a phone and a
+  # laptop is one active member. Joined to `users` with the same predicate
+  # `Accounts.count_users/0` uses, so `activeMonth <= activeHalfyear <= total`
+  # holds by construction rather than by luck.
+  defp active_users do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    month = DateTime.add(now, -@month_days, :day)
+    halfyear = DateTime.add(now, -@halfyear_days, :day)
+
+    Repo.one(
+      from(s in UserSession,
+        join: u in User,
+        on: u.id == s.user_id,
+        where: ModerationQuery.account_confirmed_row(u),
+        where: s.last_seen_at > ^halfyear,
+        select: %{
+          active_halfyear: fragment("count(DISTINCT ?)", s.user_id),
+          active_month:
+            fragment("count(DISTINCT ?) FILTER (WHERE ? > ?)", s.user_id, s.last_seen_at, ^month)
+        }
+      )
+    )
+  end
+
+  # The publicly visible posts, split into originals and replies in one pass.
+  defp post_counts do
+    %{posts: posts, comments: comments} =
+      Post
+      |> Posts.scope_visible(nil)
+      |> select([p], %{
+        posts:
+          filter(
+            count(p.id),
+            fragment("NOT EXISTS (SELECT 1 FROM post_replies r WHERE r.post_id = ?)", p.id)
+          ),
+        comments:
+          filter(
+            count(p.id),
+            fragment("EXISTS (SELECT 1 FROM post_replies r WHERE r.post_id = ?)", p.id)
+          )
+      })
+      |> Repo.one()
+
+    {posts, comments}
+  end
+end

--- a/lib/vutuv_web/controllers/well_known_controller.ex
+++ b/lib/vutuv_web/controllers/well_known_controller.ex
@@ -12,10 +12,16 @@ defmodule VutuvWeb.WellKnownController do
   **security.txt** (RFC 9116): the vulnerability-report contact, served
   under /.well-known and the root alias (the latter is already whitelisted
   in `VutuvWeb.Plug.AgentFormat`).
+
+  **NodeInfo** (issue #1448): how the fediverse's directory layer discovers
+  that this installation exists. `/.well-known/nodeinfo` is the link
+  document; the documents themselves live at `/system/nodeinfo/2.1` and
+  `/system/nodeinfo/2.0`. `Vutuv.NodeInfo` decides what they say.
   """
 
   use VutuvWeb, :controller
 
+  alias Vutuv.NodeInfo
   alias VutuvWeb.AgentDocs
 
   @external_resource "priv/agent_skills/SKILL.md"
@@ -53,6 +59,42 @@ defmodule VutuvWeb.WellKnownController do
     |> well_known_headers()
     |> put_resp_content_type("text/markdown")
     |> send_resp(200, @skill_md)
+  end
+
+  @doc """
+  The NodeInfo link document (a JRD): which schema versions this installation
+  serves and where. The specification names no media type for this one, so it
+  goes out as plain JSON, which is what every implementation serves and every
+  consumer expects.
+  """
+  def nodeinfo_links(conn, _params) do
+    conn
+    |> well_known_headers()
+    |> put_resp_content_type("application/json")
+    |> send_resp(200, Jason.encode!(%{"links" => NodeInfo.links()}))
+  end
+
+  @doc """
+  One NodeInfo document. An unserved schema version 404s rather than answering
+  something the consumer would then have to guess at.
+
+  The content type is the one the specification asks for: `application/json`
+  with a `profile` parameter naming the schema, so a consumer knows which
+  document it got without parsing it.
+  """
+  def nodeinfo(conn, %{"version" => version}) do
+    case NodeInfo.document(version) do
+      nil ->
+        conn |> put_status(:not_found) |> text("Not Found")
+
+      document ->
+        profile = ~s(profile="http://nodeinfo.diaspora.software/ns/schema/#{version}#")
+
+        conn
+        |> well_known_headers()
+        |> put_resp_header("content-type", "application/json; #{profile}; charset=utf-8")
+        |> send_resp(200, Jason.encode!(document))
+    end
   end
 
   def security_txt(conn, _params) do

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -189,6 +189,14 @@ defmodule VutuvWeb.Router do
     get("/.well-known/agent-skills/vutuv/SKILL.md", WellKnownController, :agent_skill)
     get("/.well-known/security.txt", WellKnownController, :security_txt)
     get("/security.txt", WellKnownController, :security_txt)
+    # NodeInfo (issue #1448): how a fediverse directory learns this
+    # installation exists. The well-known document only carries links; the
+    # documents themselves sit under /system/ rather than at a `/nodeinfo`
+    # root word, which member handles own. The specification fixes no path
+    # for them — every consumer follows the link — which is why Mastodon,
+    # Pleroma and Misskey each serve them somewhere different.
+    get("/.well-known/nodeinfo", WellKnownController, :nodeinfo_links)
+    get("/system/nodeinfo/:version", WellKnownController, :nodeinfo)
     # ActivityPub follow-only federation (Vutuv.Fediverse): WebFinger
     # discovery plus the per-member actor endpoints. Machine-to-machine like
     # the feeds above — no session/CSRF; the inbox authenticates remote

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.285.0",
+      version: "7.286.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/node_info_configuration_test.exs
+++ b/test/vutuv/node_info_configuration_test.exs
@@ -1,0 +1,38 @@
+defmodule Vutuv.NodeInfoConfigurationTest do
+  @moduledoc """
+  How another installation names itself in NodeInfo (issue #1448).
+
+  `async: false`, in a file of its own: this flips `:vutuv, :node_name` and
+  `:node_description`, and `Application.put_env/3` is global — the SQL sandbox
+  does not roll it back. `Vutuv.NodeInfo.document/1` is the only reader of
+  either key, and `VutuvWeb.WellKnownControllerTest` asserts on the configured
+  values through it, which is exactly the test that went red when this lived in
+  the async module beside it.
+  """
+
+  use Vutuv.DataCase, async: false
+
+  alias Vutuv.NodeInfo
+
+  test "nodeName and nodeDescription come from config, never from a literal" do
+    put_config(:node_name, "Beispiel")
+    put_config(:node_description, "Ein Intranet.")
+
+    metadata = NodeInfo.document("2.1")["metadata"]
+
+    assert metadata["nodeName"] == "Beispiel"
+    assert metadata["nodeDescription"] == "Ein Intranet."
+  end
+
+  defp put_config(key, value) do
+    original = Application.fetch_env(:vutuv, key)
+    Application.put_env(:vutuv, key, value)
+
+    on_exit(fn ->
+      case original do
+        {:ok, was} -> Application.put_env(:vutuv, key, was)
+        :error -> Application.delete_env(:vutuv, key)
+      end
+    end)
+  end
+end

--- a/test/vutuv/node_info_test.exs
+++ b/test/vutuv/node_info_test.exs
@@ -1,0 +1,170 @@
+defmodule Vutuv.NodeInfoTest do
+  @moduledoc """
+  The NodeInfo document (issue #1448): what an installation tells the
+  fediverse's directory layer about itself.
+
+  The figures are the interesting part. `usage.users.total` must be the
+  **members here** and never the top bar's people total, which adds the remote
+  accounts that follow this installation — those live on other servers and
+  counting them here would double-count them across the network. The active
+  windows must come from the same population as the total, or a directory sees
+  more active members than members.
+  """
+
+  use Vutuv.DataCase, async: true
+
+  alias Vutuv.Accounts
+  alias Vutuv.Fediverse.Follower
+  alias Vutuv.NodeInfo
+  alias Vutuv.Posts
+  alias Vutuv.Posts.PostDenial
+  alias Vutuv.Sessions.UserSession
+  alias Vutuv.Token
+
+  describe "links/0" do
+    test "advertises 2.1 before 2.0, each with an absolute href" do
+      assert [twenty_one, twenty] = NodeInfo.links()
+
+      assert twenty_one["rel"] == "http://nodeinfo.diaspora.software/ns/schema/2.1"
+      assert twenty_one["href"] == "http://localhost:4001/system/nodeinfo/2.1"
+      assert twenty["rel"] == "http://nodeinfo.diaspora.software/ns/schema/2.0"
+      assert twenty["href"] == "http://localhost:4001/system/nodeinfo/2.0"
+    end
+  end
+
+  describe "document/1" do
+    test "2.1 carries the required fields plus the repository pointers" do
+      doc = NodeInfo.document("2.1")
+
+      assert doc["version"] == "2.1"
+      assert doc["protocols"] == ["activitypub"]
+      assert doc["services"] == %{"inbound" => [], "outbound" => []}
+      assert doc["openRegistrations"] == true
+
+      assert doc["software"]["name"] == "vutuv"
+      assert doc["software"]["version"] == to_string(Application.spec(:vutuv, :vsn))
+      assert doc["software"]["repository"] == "https://github.com/wintermeyer/vutuv"
+      assert doc["software"]["homepage"] == "https://www.vutuv.de"
+
+      assert doc["metadata"]["nodeName"] == "vutuv"
+      assert doc["metadata"]["nodeDescription"] =~ "business network"
+    end
+
+    test "2.0 says 2.0 and drops the 2.1-only software fields" do
+      doc = NodeInfo.document("2.0")
+
+      assert doc["version"] == "2.0"
+      assert doc["software"]["name"] == "vutuv"
+      refute Map.has_key?(doc["software"], "repository")
+      refute Map.has_key?(doc["software"], "homepage")
+    end
+
+    test "the software name matches the schema's ^[a-z0-9-]+$ pattern" do
+      assert NodeInfo.document("2.1")["software"]["name"] =~ ~r/\A[a-z0-9-]+\z/
+    end
+
+    test "an unknown schema version has no document" do
+      assert NodeInfo.document("1.0") == nil
+      assert NodeInfo.document("2.2") == nil
+    end
+  end
+
+  describe "usage/0" do
+    test "users.total counts the members here, not the top bar's people total" do
+      before = NodeInfo.usage().users.total
+
+      insert(:activated_user)
+      followed = insert(:activated_user)
+      # A remote account following a member is another server's account: the top
+      # bar adds it to the people total, and this figure must not.
+      Repo.insert!(%Follower{
+        user_id: followed.id,
+        actor_uri: "https://remote.example/users/ada",
+        inbox_uri: "https://remote.example/users/ada/inbox"
+      })
+
+      assert NodeInfo.usage().users.total == before + 2
+      assert NodeInfo.usage().users.total == Accounts.count_users()
+    end
+
+    test "an unconfirmed sign-up is not a member yet" do
+      before = NodeInfo.usage().users.total
+
+      insert(:user, email_confirmed?: false)
+
+      assert NodeInfo.usage().users.total == before
+    end
+
+    test "the active windows count members by their most recent session" do
+      base = NodeInfo.usage()
+
+      recent = insert(:activated_user)
+      older = insert(:activated_user)
+      gone = insert(:activated_user)
+
+      # Two devices for one member: the figure counts people, not sessions.
+      seen(recent, -1)
+      seen(recent, -3)
+      seen(older, -90)
+      seen(gone, -200)
+
+      usage = NodeInfo.usage()
+
+      assert usage.users.active_month == base.users.active_month + 1
+      assert usage.users.active_halfyear == base.users.active_halfyear + 2
+    end
+
+    test "a signed-out device still proves the member signed in" do
+      base = NodeInfo.usage()
+
+      member = insert(:activated_user)
+      member |> seen(-2) |> Ecto.Changeset.change(revoked_at: now()) |> Repo.update!()
+
+      assert NodeInfo.usage().users.active_month == base.users.active_month + 1
+    end
+
+    test "an active window never exceeds the member total" do
+      member = insert(:activated_user)
+      seen(member, 0)
+
+      usage = NodeInfo.usage()
+
+      assert usage.users.active_month <= usage.users.total
+      assert usage.users.active_halfyear <= usage.users.total
+    end
+
+    test "localPosts counts public posts and localComments their replies" do
+      base = NodeInfo.usage()
+
+      author = insert(:activated_user)
+      {:ok, post} = Posts.create_post(author, %{"body" => "A post"})
+      {:ok, _reply} = Posts.create_reply(author, post, %{"body" => "A reply"})
+
+      usage = NodeInfo.usage()
+
+      assert usage.local_posts == base.local_posts + 1
+      assert usage.local_comments == base.local_comments + 1
+    end
+
+    test "a post nobody may see is in neither figure" do
+      author = insert(:activated_user)
+      {:ok, post} = Posts.create_post(author, %{"body" => "Hidden"})
+      base = NodeInfo.usage()
+
+      Repo.insert!(%PostDenial{post_id: post.id, wildcard: "everyone"})
+
+      assert NodeInfo.usage().local_posts == base.local_posts - 1
+    end
+  end
+
+  # One signed-in device for `user`, last seen `days_ago` days ago.
+  defp seen(user, days_ago) do
+    Repo.insert!(%UserSession{
+      user_id: user.id,
+      token_hash: Token.random_token(),
+      last_seen_at: DateTime.add(now(), days_ago, :day)
+    })
+  end
+
+  defp now, do: DateTime.utc_now() |> DateTime.truncate(:second)
+end

--- a/test/vutuv_web/controllers/well_known_controller_test.exs
+++ b/test/vutuv_web/controllers/well_known_controller_test.exs
@@ -2,7 +2,8 @@ defmodule VutuvWeb.WellKnownControllerTest do
   @moduledoc """
   The /.well-known endpoints: agent-skills discovery (Cloudflare draft
   v0.2.0 — an index.json naming the skill files, each verified by a
-  sha256 digest over the exact served bytes) and security.txt (RFC 9116).
+  sha256 digest over the exact served bytes), security.txt (RFC 9116) and
+  NodeInfo (issue #1448).
   """
 
   use VutuvWeb.ConnCase, async: true
@@ -54,6 +55,84 @@ defmodule VutuvWeb.WellKnownControllerTest do
       # extension requests and 404 (the routes would never match).
       assert get(build_conn(), "/.well-known/agent-skills/index.json").status == 200
       assert get(build_conn(), "/.well-known/agent-skills/vutuv/SKILL.md").status == 200
+    end
+  end
+
+  describe "NodeInfo" do
+    test "the well-known document links both served schema versions" do
+      conn = get(build_conn(), "/.well-known/nodeinfo")
+
+      assert conn.status == 200
+      assert [content_type] = get_resp_header(conn, "content-type")
+      assert content_type =~ "application/json"
+      assert get_resp_header(conn, "access-control-allow-origin") == ["*"]
+      assert get_resp_header(conn, "cache-control") == ["public, max-age=3600"]
+
+      assert %{"links" => links} = Jason.decode!(conn.resp_body)
+
+      assert links == [
+               %{
+                 "rel" => "http://nodeinfo.diaspora.software/ns/schema/2.1",
+                 "href" => "http://localhost:4001/system/nodeinfo/2.1"
+               },
+               %{
+                 "rel" => "http://nodeinfo.diaspora.software/ns/schema/2.0",
+                 "href" => "http://localhost:4001/system/nodeinfo/2.0"
+               }
+             ]
+    end
+
+    test "every advertised href really answers a document of that version" do
+      %{"links" => links} = Jason.decode!(get(build_conn(), "/.well-known/nodeinfo").resp_body)
+
+      for %{"rel" => rel, "href" => href} <- links do
+        version = String.replace_prefix(rel, "http://nodeinfo.diaspora.software/ns/schema/", "")
+        conn = get(build_conn(), URI.parse(href).path)
+
+        assert conn.status == 200, "#{href} did not answer"
+        assert Jason.decode!(conn.resp_body)["version"] == version
+      end
+    end
+
+    test "the document carries the schema's required fields" do
+      conn = get(build_conn(), "/system/nodeinfo/2.1")
+
+      assert conn.status == 200
+      assert [content_type] = get_resp_header(conn, "content-type")
+
+      assert content_type ==
+               ~s(application/json; profile="http://nodeinfo.diaspora.software/ns/schema/2.1#"; charset=utf-8)
+
+      doc = Jason.decode!(conn.resp_body)
+
+      for key <- ~w(version software protocols services openRegistrations usage metadata) do
+        assert Map.has_key?(doc, key), "the 2.1 document is missing #{key}"
+      end
+
+      assert doc["software"]["name"] == "vutuv"
+      assert doc["software"]["repository"] == "https://github.com/wintermeyer/vutuv"
+      assert doc["protocols"] == ["activitypub"]
+      assert is_integer(doc["usage"]["users"]["total"])
+      assert is_integer(doc["usage"]["localPosts"])
+      assert doc["metadata"]["nodeName"] == "vutuv"
+    end
+
+    test "a schema version this installation does not serve 404s" do
+      assert get(build_conn(), "/system/nodeinfo/1.0").status == 404
+      assert get(build_conn(), "/system/nodeinfo/3.0").status == 404
+    end
+
+    test "a directory asking for JSON is not diverted into the agent formats" do
+      # /system/nodeinfo/2.0 ends in a dot-something, and every consumer sends
+      # Accept: application/json — neither may reach VutuvWeb.Plug.AgentFormat's
+      # extension stripping or its handled-document 404 guard.
+      conn =
+        build_conn()
+        |> put_req_header("accept", "application/json")
+        |> get("/system/nodeinfo/2.0")
+
+      assert conn.status == 200
+      assert Jason.decode!(conn.resp_body)["version"] == "2.0"
     end
   end
 


### PR DESCRIPTION
Closes #1448.

Wer eine vutuv-Installation im Fediverse sucht, findet sie in keiner Liste. FediDB, the-federation.info und Fediverse Observer entdecken einen Server, indem sie `/.well-known/nodeinfo` abrufen und dem Link darin folgen — ohne dieses Dokument kann eine Installation perfekt föderieren, von überall abonniert werden und bleibt trotzdem unsichtbar. Es gibt schlicht nichts zu erkennen.

## Was ausgeliefert wird

| URL | Was es ist |
| --- | --- |
| `/.well-known/nodeinfo` | das Linkdokument, ein Eintrag je Schemaversion |
| `/system/nodeinfo/2.1` | das Dokument, mit `software.repository`/`homepage` |
| `/system/nodeinfo/2.0` | dasselbe ohne diese beiden Felder |

Unter `/system/` statt auf dem Wurzelwort `nodeinfo`, das den Handles gehört: die Spezifikation legt für das Dokument selbst keinen Pfad fest (deshalb liefert Mastodon, Pleroma und Misskey es jeweils woanders aus), und jeder Konsument folgt dem Link.

## Die Entscheidungen aus dem Issue

- **Beide Schemaversionen**, weil das eine Route kostet: 2.0 versteht jeder Konsument, 2.1 trägt die zwei Zeiger auf die Quelle eines Open-Source-Projekts.
- **`usage.users.total`** sind die Mitglieder hier (`Accounts.count_users/0`), nie die Personenzahl der Kopfleiste — die zählt die fremden Konten mit, die uns folgen, und die gehören anderen Servern. Die exakte Abfrage statt des gecachten `PeopleCounter`, weil dessen Zelle in den ersten Momenten nach einem Deploy `0` liest: genau dann würde ein pollendes Verzeichnis die Installation als leer notieren.
- **`activeMonth`/`activeHalfyear` werden beantwortet**, aus `user_sessions.last_seen_at`. Das ist genau, was die Spezifikation meint ("in den letzten 30/180 Tagen mindestens einmal angemeldet"), also vergleichbar mit dem, was andere veröffentlichen; eine widerrufene Session zählt mit, denn angemeldet war das Mitglied. Aus derselben Grundgesamtheit wie `total`, damit keine der beiden Zahlen sie überschreiten kann. Ein Verzeichniseintrag ohne diese Zahlen liest sich wie ein toter Server.
- **`localPosts`/`localComments` sind dabei**, gezählt über `Posts.scope_visible/2` ohne Betrachter — also genau das, was ein abgemeldeter Leser sieht. Nichts Neues wird offengelegt: diese Beiträge stehen längst in Sitemap und RSS-Feeds.
- **`openRegistrations` ist fest `true`**, weil es wahr ist — vutuv hat keine Registrierungssperre. Bewusst kein Config-Schalter: einer, der nur die angezeigte Zahl ändert, während das Anmeldeformular weiter jeden annimmt, wäre die schlechtere Antwort als die ehrliche. Der Tag, an dem es eine echte Sperre gibt, liest sie hier aus.
- **`protocols` sagt `activitypub`** auf jeder Installation, auch mit `FEDIVERSE_ENABLED=false`: es benennt das Protokoll der Software, das Schema verlangt mindestens einen Eintrag, und ein Verzeichnis, das dem folgt, findet die Actor-Endpunkte mit 404.
- **`nodeName`/`nodeDescription`** stehen im Operator-Block (`NODE_NAME` / `NODE_DESCRIPTION`); `software.name`/`repository`/`homepage` sind Literale, weil sie die Software beschreiben und nicht den Betreiber.

## Tests

`test/vutuv/node_info_test.exs` (Zahlen), `node_info_configuration_test.exs` (`async: false`, es kippt Application-Env) und ein `NodeInfo`-Block im `well_known_controller_test.exs`, der u. a. prüft, dass jede beworbene `href` wirklich ein Dokument dieser Version beantwortet. Zwei Zusicherungen sind gegen den ungefixten Stand kalibriert: mit `count(?)` statt `count(DISTINCT ?)` und ohne `scope_visible(nil)` geht jeweils genau ein Test rot.

`mix precommit` grün (7631 Tests, credo ohne Befund).

Dokumentation: `docs/ADMINS.md` (Env-Tabelle, ein Schritt in "First steps", ein Abschnitt über die Verzeichnisse) und `docs/architecture/fediverse.md`.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01UFV3LLZ4KawwHs1gJAdgnF