### PR TITLE
Das Profilbild von gravatar.com holen wir nur noch auf Zuruf (v7.287.0)

### DIFF
--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -344,10 +344,10 @@ vutuv runs fine without internet access:
   that could work air-gapped — the check simply fails. Turn it off so the verify
   page says so plainly instead of offering a button that can never succeed.
 - Turn off the features that call out to the internet (compile-time flags in
-  `config/config.exs`): `:fetch_gravatar` (avatar lookup at registration — when
-  a picture is found, the member gets an in-app notification naming
-  gravatar.com and pointing at `/settings/profile`, so your privacy policy
-  should describe the lookup too),
+  `config/config.exs`): `:fetch_gravatar` (the member's own "Fetch my picture
+  from gravatar.com" button on `/settings/profile` — off, the button is not
+  rendered at all; nothing contacts gravatar.com unless a member presses it,
+  and registration never does),
   `:fetch_mastodon_posts` / `:fetch_bluesky_posts` (the social-feed card on
   profiles), `:fetch_code_stats` (the profile "Code" card's GitHub/GitLab/
   Codeberg statistics — off, the accounts stay plain links), and

--- a/docs/architecture/realtime.md
+++ b/docs/architecture/realtime.md
@@ -318,23 +318,6 @@ exactly at that moment. A NULL means no note, which is what every account
 predating the feature keeps — the derived feed is otherwise retroactive, and a
 welcome years after the fact would be nonsense.
 
-### The imported-gravatar note (issue #1447)
-
-Registration fetches an avatar from gravatar.com for the address somebody
-signed up with (`Accounts.store_gravatar/1`, off when `:fetch_gravatar` is
-false). When one comes back, the member's first look at their own profile shows
-a photograph they never uploaded here, from a service they may not remember
-using. The import is fine; the silence around it was not. So an in-app note
-names the source and links to `/settings/profile`, where the picture can be
-replaced or removed — inside the sentence, like the welcome note above.
-
-Same derived shape: no notification table, no push (the fetch runs during
-registration, before the first login, so the note is already waiting) and
-**no email**. `users.gravatar_imported_at` is the gate and the timestamp,
-stamped by `store_gravatar/1` only on the branch that really stored an image —
-a 404 (gravatar's answer for "no picture for this address") or a failed fetch
-leaves it NULL, and NULL means no note.
-
 ## The dead-render → socket-mount handoff (profile + feed)
 
 Every LiveView visit computes its data twice: once for the HTML the visitor

--- a/lib/vutuv/accounts.ex
+++ b/lib/vutuv/accounts.ex
@@ -78,7 +78,10 @@ defmodule Vutuv.Accounts do
         |> Enum.each(&Vutuv.Tags.add_user_tag(user, &1))
 
         user = Repo.preload(user, user_tags: [:tag])
-        maybe_fetch_gravatar(user)
+        # Registration deliberately talks to nobody outside this server. It used
+        # to fetch a gravatar.com picture here in a background task, which told
+        # a US service that this email address had just signed up — see
+        # import_gravatar_avatar/1, which is now the member's own button.
         # The landing-page counter is bumped on confirmation, not here (issue
         # #781) — see activate_user/1. A sign-up that never confirms is swept by
         # delete_unconfirmed_registrations/1 and must not inflate the total.
@@ -160,79 +163,97 @@ defmodule Vutuv.Accounts do
     |> Ecto.Changeset.unique_constraint(:username)
   end
 
-  # Best-effort gravatar import: spawned (when enabled) under the app-wide
-  # Task.Supervisor rather than an orphaned `Task.start/3`, and disabled in
-  # tests via `:fetch_gravatar` so the SQL Sandbox connection is never used by
-  # a process that does not own it and no live HTTP request is made. A test
-  # that wants the import itself calls `store_gravatar/1` and stubs the fetch
-  # through `:gravatar_req_options` (a `plug:` responder).
-  defp maybe_fetch_gravatar(user) do
-    if Application.get_env(:vutuv, :fetch_gravatar, true) do
-      Task.Supervisor.start_child(Vutuv.TaskSupervisor, fn -> store_gravatar(user) end)
-    end
+  @doc """
+  Whether this installation offers the gravatar.com avatar import at all
+  (`:fetch_gravatar`, off on an air-gapped intranet install).
 
-    :ok
+  The settings page asks this before rendering the button, so an installation
+  that cannot reach the internet offers nothing it can never deliver.
+  """
+  def gravatar_import_available?, do: Application.get_env(:vutuv, :fetch_gravatar, true)
+
+  @doc """
+  Fetches the member's gravatar.com picture and stores it as their avatar.
+
+  **Only ever called because the member asked for it** — the button on
+  /settings/profile. Registration used to do this by itself, in a background
+  task, for every sign-up: an MD5 of the address went to gravatar.com (a US
+  service) before the member had heard of the feature, which handed a third
+  party the fact that this address had just joined vutuv, and made a liar of
+  the "no data goes to third parties" promise on the privacy page for the sake
+  of a convenience nobody had asked for. Nothing reaches gravatar.com now
+  unless somebody presses the button; that press is the consent, and it is the
+  only thing that makes the transfer honest.
+
+  Returns:
+
+    * `{:ok, user}` — a picture came back and is now the avatar
+    * `{:error, :not_found}` — gravatar.com has nothing for this address
+      (its own answer to the `d=404` parameter, and the common case)
+    * `{:error, :unavailable}` — gravatar.com could not be reached, or
+      answered with something we could not use
+    * `{:error, changeset}` — the picture arrived but would not store
+
+  The caller says which of those the member reads; each one is a different
+  sentence, because "we found nothing" and "we could not ask" are different
+  news and a single "didn't work" would leave them guessing.
+  """
+  def import_gravatar_avatar(%User{} = user) do
+    user = Repo.preload(user, :emails)
+
+    case user.emails do
+      [%{md5sum: md5} | _] when is_binary(md5) -> do_import_gravatar(user, md5)
+      _no_address -> {:error, :not_found}
+    end
   end
 
-  # Public only so a test can drive it in a process that owns the sandbox
-  # connection — `maybe_fetch_gravatar/1` is the caller, and it is off in tests.
-  @doc false
-  def store_gravatar(user) do
-    url = "https://www.gravatar.com/avatar/#{hd(user.emails).md5sum}?s=130&d=404"
+  defp do_import_gravatar(user, md5) do
+    url = "https://www.gravatar.com/avatar/#{md5}?s=130&d=404"
 
     options =
       Keyword.merge(
-        [url: url, receive_timeout: 1000, connect_options: [timeout: 1000]],
+        # A member is sitting in front of this waiting for an answer, so it
+        # stays on the request path with the short timeouts the background
+        # task used — and `retry: false`, because Req's default ladder would
+        # hold the page for several seconds before saying "not reachable".
+        [url: url, receive_timeout: 2000, connect_options: [timeout: 2000], retry: false],
         Application.get_env(:vutuv, :gravatar_req_options, [])
       )
 
     case Req.get(options) do
       {:ok, %Req.Response{status: 404}} ->
-        nil
+        {:error, :not_found}
 
-      {:ok, %Req.Response{status: 200, body: body, headers: headers}} ->
-        content_type = find_content_type(headers)
-        # Path.join, not `tmp_dir <> "/" <> name`: the leading slash used to
-        # live in `filename` itself, so the users row ended up holding
-        # "/handle.jpg" where an ordinary upload stores "handle.jpg".
-        filename = "#{user.username}.#{gravatar_extension(content_type)}"
-        path = Path.join(System.tmp_dir(), filename)
+      {:ok, %Req.Response{status: 200, body: body, headers: headers}} when is_binary(body) ->
+        store_gravatar_body(user, body, find_content_type(headers))
 
-        upload = %Plug.Upload{
-          content_type: content_type,
-          filename: filename,
-          path: path
-        }
-
-        File.write(path, body)
-
-        # Through update_user/2 so the avatar file is written only after the row
-        # commits (issue #776), the same as the edit-profile path.
-        with {:ok, imported} <- update_user(user, %{avatar: upload}) do
-          {:ok, stamp_gravatar_import(imported)}
-        end
-
-      _ ->
-        nil
+      _other ->
+        {:error, :unavailable}
     end
   rescue
     error ->
       Logger.warning("gravatar import failed for user ##{user.id}: #{inspect(error)}")
-      nil
+      {:error, :unavailable}
   end
 
-  # The member never uploaded this picture, so silence about it is what makes
-  # a stranger's face on their fresh profile unsettling (issue #1447). The
-  # stamp is set in its own write, after the avatar is safely stored, and only
-  # on that path — a 404 or a failed fetch leaves it NULL and says nothing. It
-  # both gates and dates the in-app note in `Vutuv.Activity`; there is no email
-  # beside it, the way the welcome note has none either.
-  defp stamp_gravatar_import(user) do
-    user
-    |> Ecto.Changeset.change(
-      gravatar_imported_at: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
-    )
-    |> Repo.update!()
+  defp store_gravatar_body(user, body, content_type) do
+    # Path.join, not `tmp_dir <> "/" <> name`: the leading slash used to live in
+    # `filename` itself, so the users row ended up holding "/handle.jpg" where
+    # an ordinary upload stores "handle.jpg".
+    filename = "#{user.username}.#{gravatar_extension(content_type)}"
+    path = Path.join(System.tmp_dir(), filename)
+
+    upload = %Plug.Upload{content_type: content_type, filename: filename, path: path}
+
+    with :ok <- File.write(path, body),
+         # Through update_user/2 so the avatar file is written only after the
+         # row commits (issue #776), the same as the edit-profile path.
+         {:ok, imported} <- update_user(user, %{avatar: upload}) do
+      {:ok, imported}
+    else
+      {:error, %Ecto.Changeset{} = changeset} -> {:error, changeset}
+      _write_failed -> {:error, :unavailable}
+    end
   end
 
   defp find_content_type(headers) do

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -356,12 +356,6 @@ defmodule Vutuv.Accounts.User do
     # the notifications feed; NULL = no note, which is what every account
     # predating the feature keeps.
     field(:welcome_notified_at, :naive_datetime)
-    # When registration imported this member's avatar from gravatar.com
-    # (issue #1447). Stamped by Accounts.store_gravatar/1 only once an image was
-    # really stored, never cast from params. It dates the "we found a picture
-    # for your email address" note; NULL = no import and no note, which is what
-    # every account predating the feature keeps.
-    field(:gravatar_imported_at, :naive_datetime)
     # Set programmatically by Vutuv.Activity.mark_notifications_read/1; never cast.
     field(:notifications_read_at, :naive_datetime)
     # How far the digest mail has got (`Vutuv.Activity.Digest`). The feed is

--- a/lib/vutuv/activity.ex
+++ b/lib/vutuv/activity.ex
@@ -247,16 +247,6 @@ defmodule Vutuv.Activity do
     )
   end
 
-  # The "we took your picture from gravatar.com" note (see gravatar_items/3),
-  # keyed on gravatar_imported_at; MAX skips the NULL of an account whose
-  # avatar did not come from there.
-  defp gravatar_max(user_id) do
-    from(u in User,
-      where: u.id == ^user_id,
-      select: %{ts: max(u.gravatar_imported_at)}
-    )
-  end
-
   @doc """
   Record that `user_id` has seen `post_id`, so the notifications *about* that
   post stop counting as unread (`notification_post_reads`).
@@ -780,9 +770,8 @@ defmodule Vutuv.Activity do
   #   * `cv_update` counts sittings, not rows: its read-marker filter lives
   #     inside the grouped query (`CvUpdates.count_query/2`), not in `since/2`.
   #   * The fediverse kinds key on `received_at` (a :utc_datetime), `username`
-  #     on `welcome_notified_at`, `gravatar` on `gravatar_imported_at`,
-  #     `connection` on the GREATEST of the two follow times — each per-kind
-  #     helper owns its own boundary comparison.
+  #     on `welcome_notified_at`, `connection` on the GREATEST of the two
+  #     follow times — each per-kind helper owns its own boundary comparison.
   @doc """
   Every notification kind the registry produces.
 
@@ -908,13 +897,6 @@ defmodule Vutuv.Activity do
         max_arms: [username_max(user_id)],
         items: &username_items(user_id, &1, &2),
         counts: [count_username(user_id, read_at)]
-      },
-      %{
-        kind: "gravatar",
-        email_pref: nil,
-        max_arms: [gravatar_max(user_id)],
-        items: &gravatar_items(user_id, &1, &2),
-        counts: [count_gravatar(user_id, read_at)]
       },
       %{
         kind: "reference_check",
@@ -1716,36 +1698,6 @@ defmodule Vutuv.Activity do
   defp at_or_before_welcome(query, %{at: at}),
     do: where(query, [u], u.welcome_notified_at <= ^at)
 
-  # "We found a picture for your email address at gravatar.com and used it."
-  # Registration quietly fetches an avatar from there (Accounts.store_gravatar/1),
-  # so without this note a member's first look at their own profile shows a
-  # photo they never uploaded here, from a service they may not remember using.
-  # The silence is what makes that unsettling, not the import.
-  #
-  # Same shape as the welcome note above: derived from the member's own users
-  # row, no notification table, no push (the import runs during registration,
-  # before the first login, so the note is already waiting) and deliberately
-  # **no email** — one more message on top of the PIN mail would be the wrong
-  # size for it. `gravatar_imported_at` is both the gate and the timestamp, so
-  # only an import that really happened produces a row.
-  defp gravatar_items(user_id, limit, cursor) do
-    from(u in User,
-      where: u.id == ^user_id and not is_nil(u.gravatar_imported_at),
-      limit: ^limit,
-      select: {u.id, u.gravatar_imported_at}
-    )
-    |> at_or_before_gravatar(cursor)
-    |> Repo.all()
-    |> Enum.map(fn {id, at} ->
-      %{id: "gravatar-#{id}", kind: "gravatar", at: at}
-    end)
-  end
-
-  defp at_or_before_gravatar(query, nil), do: query
-
-  defp at_or_before_gravatar(query, %{at: at}),
-    do: where(query, [u], u.gravatar_imported_at <= ^at)
-
   defp at_or_before(query, nil), do: query
   defp at_or_before(query, %{at: at}), do: where(query, [event], event.inserted_at <= ^at)
 
@@ -1970,16 +1922,6 @@ defmodule Vutuv.Activity do
       )
 
     if read_at, do: where(query, [u], u.welcome_notified_at > ^read_at), else: query
-  end
-
-  defp count_gravatar(user_id, read_at) do
-    query =
-      from(u in User,
-        where: u.id == ^user_id and not is_nil(u.gravatar_imported_at),
-        select: %{count: count()}
-      )
-
-    if read_at, do: where(query, [u], u.gravatar_imported_at > ^read_at), else: query
   end
 
   defp since(query, nil), do: query

--- a/lib/vutuv_web/controllers/user_controller.ex
+++ b/lib/vutuv_web/controllers/user_controller.ex
@@ -151,6 +151,59 @@ defmodule VutuvWeb.UserController do
     )
   end
 
+  @doc """
+  Fetches the member's picture from gravatar.com, because they asked.
+
+  A POST, never a GET: it reaches out to a third party and changes the avatar,
+  so it must not be something a prefetch, a Back button or a crawler can fire.
+  Each outcome gets its own sentence — "we found nothing for your address" and
+  "we could not reach gravatar.com" are different news, and one shared "that
+  didn't work" would leave the member guessing which.
+  """
+  def import_gravatar(conn, _params) do
+    user = conn.assigns[:user]
+
+    if Accounts.gravatar_import_available?() do
+      conn |> gravatar_flash(Accounts.import_gravatar_avatar(user), user) |> gravatar_back()
+    else
+      conn
+      |> put_flash(
+        :error,
+        gettext("The gravatar.com lookup is switched off on this installation.")
+      )
+      |> gravatar_back()
+    end
+  end
+
+  defp gravatar_flash(conn, {:ok, updated}, _user) do
+    AccountEvents.record(updated, "profile_updated",
+      conn: conn,
+      details: %{fields: ["avatar"]}
+    )
+
+    put_flash(conn, :info, gettext("We took your picture from gravatar.com."))
+  end
+
+  defp gravatar_flash(conn, {:error, :not_found}, _user) do
+    put_flash(
+      conn,
+      :error,
+      gettext("gravatar.com has no picture for your email address.")
+    )
+  end
+
+  defp gravatar_flash(conn, {:error, :unavailable}, _user) do
+    put_flash(conn, :error, gettext("gravatar.com could not be reached. Please try again later."))
+  end
+
+  defp gravatar_flash(conn, {:error, _changeset}, _user) do
+    put_flash(conn, :error, gettext("The picture from gravatar.com could not be saved."))
+  end
+
+  # Back to the form, and to the avatar block in it, so the member lands on the
+  # picture they just changed rather than at the top of a long settings page.
+  defp gravatar_back(conn), do: redirect(conn, to: ~p"/settings/profile#avatar")
+
   def update(conn, %{"user" => user_params} = params) do
     user = conn.assigns[:user]
     user_params = clear_birthdate_if_requested(user_params, params)

--- a/lib/vutuv_web/live/notification_live/index.ex
+++ b/lib/vutuv_web/live/notification_live/index.ex
@@ -86,7 +86,7 @@ defmodule VutuvWeb.NotificationLive.Index do
     "people" => ~w(follower connection endorsement),
     "other" =>
       ~w(organization_role moderation image_rejected report_protection handle_change cv_update
-         username gravatar reference_check)
+         username reference_check)
   }
 
   @doc false
@@ -468,12 +468,9 @@ defmodule VutuvWeb.NotificationLive.Index do
           <.actor_links group={@group} current_user={@current_user} />
           <% target = notification_target(@n, @current_user) %>
           <%= cond do %>
-            <%!-- The two rows that are not a single link: see username_line/1
-            and gravatar_line/1, which carry their links inside the sentence. --%>
+            <%!-- The one row that is not a single link: see username_line/1. --%>
             <% @group.kind == "username" -> %>
               <.username_line handle={@n.username} />
-            <% @group.kind == "gravatar" -> %>
-              <.gravatar_line />
             <% target -> %>
               <.link href={target} class="hover:text-brand-700 hover:underline dark:hover:text-brand-300">
                 {group_text(@group)}
@@ -868,39 +865,6 @@ defmodule VutuvWeb.NotificationLive.Index do
     """
   end
 
-  # "We found a picture for your address at gravatar.com" (issue #1447).
-  # Registration fetches an avatar from gravatar.com for the address somebody
-  # signed up with, so a member who once used that service arrives to find a
-  # photo on their profile that they never uploaded here. This row is the whole
-  # point of the note: it names where the picture came from and where to get
-  # rid of it, so nothing about their own profile is a mystery.
-  #
-  # Like username_line/1 it is not one big link — the settings URL sits inside
-  # the sentence, split out of the translation with split_marker/2 (total, so a
-  # botched .po cannot raise) — and for the same reason it must not END on that
-  # URL: a full stop flush against an address reads as part of it. Keep a space
-  # and at least one word after {url} in both languages.
-  defp gravatar_line(assigns) do
-    {before_url, tail} =
-      split_marker(
-        gettext(
-          "When you signed up we found a picture for your email address at gravatar.com and used it as your profile picture. At {url} you can replace or remove it at any time."
-        ),
-        "{url}"
-      )
-
-    assigns =
-      assign(assigns,
-        before_url: before_url,
-        tail: tail,
-        settings_url: url(~p"/settings/profile")
-      )
-
-    ~H"""
-    {@before_url}<.link href={@settings_url} class={inline_link_class()}>{@settings_url}</.link>{@tail}
-    """
-  end
-
   defp inline_link_class,
     do:
       "font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
@@ -1058,9 +1022,6 @@ defmodule VutuvWeb.NotificationLive.Index do
   defp kind_glyph("cv_update"), do: "📄"
   # The welcome note naming the member's own handle.
   defp kind_glyph("username"), do: "👋"
-  # The avatar registration brought over from gravatar.com — the note is about
-  # a picture, so the same frame the image-review note uses.
-  defp kind_glyph("gravatar"), do: "🖼"
   # The finished AI reading of an Arbeitszeugnis. The magnifier, not a robot:
   # what arrived is a close reading of wording, and the member is being told to
   # go and read it.
@@ -1085,7 +1046,6 @@ defmodule VutuvWeb.NotificationLive.Index do
   defp kind_label("handle_change"), do: gettext("Handle change")
   defp kind_label("cv_update"), do: gettext("CV update")
   defp kind_label("username"), do: gettext("Username")
-  defp kind_label("gravatar"), do: gettext("Imported profile picture")
   defp kind_label("reference_check"), do: gettext("Employment reference review")
   defp kind_label(_), do: gettext("Activity")
 
@@ -1193,10 +1153,8 @@ defmodule VutuvWeb.NotificationLive.Index do
   end
 
   # The username note carries its own two links inside the sentence
-  # (username_line/1), so the row itself must not be one. Same for the gravatar
-  # note and its settings link (gravatar_line/1).
+  # (username_line/1), so the row itself must not be one.
   defp notification_target(%{kind: "username"}, _viewer), do: nil
-  defp notification_target(%{kind: "gravatar"}, _viewer), do: nil
 
   # Straight to the report the member has been waiting for.
   defp notification_target(%{kind: "reference_check"} = n, viewer) do

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -1054,6 +1054,11 @@ defmodule VutuvWeb.Router do
     put("/profile", UserController, :update)
     patch("/profile", UserController, :update)
 
+    # The member's own gravatar.com lookup (issue #1447). A POST: it hands an
+    # MD5 of their address to a third party and replaces their avatar, so it
+    # happens only on a deliberate press, never on a GET a prefetch could fire.
+    post("/profile/gravatar", UserController, :import_gravatar)
+
     # The owner's preview of their own avatar/cover while it waits in
     # AI-moderation limbo (the quarantine tree nginx never serves) — see
     # Vutuv.Moderation.ImageScans. Everyone else sees a placeholder until

--- a/lib/vutuv_web/templates/user/edit.html.heex
+++ b/lib/vutuv_web/templates/user/edit.html.heex
@@ -15,7 +15,10 @@ lands here). --%>
         <%!-- Avatar: preview the current avatar (the real photo, or the initials
         tile visitors currently see) above the upload, so the owner sees what
         they are replacing. --%>
-        <div>
+        <%!-- id + scroll-mt: the gravatar lookup redirects to #avatar, so the
+        member lands on the picture they just changed instead of the top of a
+        long settings page; scroll-mt keeps the sticky top bar off it. --%>
+        <div id="avatar" class="scroll-mt-24">
           <%= label f, :avatar, gettext("Avatar"), class: "block text-sm font-medium text-slate-900 dark:text-white" %>
           <% avatar_pending? = @user.avatar_moderation == "pending" %>
           <div class="mt-2 flex items-center gap-3">
@@ -61,6 +64,28 @@ lands here). --%>
             class="mt-3 h-20 w-20 rounded-lg object-cover ring-1 ring-slate-200 dark:ring-slate-800"
           />
           <%= error_tag f, :avatar %>
+
+          <%!-- The gravatar.com offer, and the whole reason it is a button:
+          registration used to do this by itself for every sign-up, which told a
+          US service that this address had just joined vutuv. Nothing leaves
+          this server now until somebody presses it, so the sentence says
+          plainly what pressing it sends. Submits #gravatar-form, which is
+          rendered below the main form (a form cannot nest). --%>
+          <div :if={Vutuv.Accounts.gravatar_import_available?()} class="mt-4">
+            <button
+              type="submit"
+              form="gravatar-form"
+              id="import-gravatar"
+              class="inline-flex min-h-10 items-center rounded-lg bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+            >
+              {gettext("Fetch my picture from gravatar.com")}
+            </button>
+            <p class="mt-1 text-xs text-slate-600 dark:text-slate-400">
+              {gettext(
+                "Only when you press this: we ask gravatar.com whether there is a picture for your email address, sending a hash of the address rather than the address itself. Nothing leaves this server otherwise."
+              )}
+            </p>
+          </div>
         </div>
         <%!-- Cover photo: preview the current cover (the same object-cover crop
         as the profile banner) only when one is uploaded; the gradient default
@@ -423,6 +448,20 @@ lands here). --%>
         {gettext("Cancel")}
       </.link>
     </div>
+  </.form>
+
+  <%!-- The gravatar lookup is its own form, and it sits out here because a form
+  may not nest inside another one. The button stays up in the avatar block,
+  wired to this one by its `form=` attribute — so the control is where the
+  member is looking, and it still works with JS off. --%>
+  <.form
+    :if={Vutuv.Accounts.gravatar_import_available?()}
+    :let={_gravatar}
+    for={%{}}
+    as={:gravatar}
+    id="gravatar-form"
+    action={~p"/settings/profile/gravatar"}
+  >
   </.form>
 
   <%!-- "Are you sure?" dialog for removing the date of birth. Rendered only while

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.286.1",
+      version: "7.287.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -89,12 +89,12 @@ msgstr "Schon ein Mitglied? Einloggen."
 msgid "Are you sure?"
 msgstr "Sind Sie sicher?"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:19
+#: lib/vutuv_web/templates/user/edit.html.heex:22
 #, elixir-autogen
 msgid "Avatar"
 msgstr "Avatar"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:368
+#: lib/vutuv_web/templates/user/edit.html.heex:393
 #, elixir-autogen
 msgid "Birthdate"
 msgstr "Geburtstag"
@@ -126,10 +126,10 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:259
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:26
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
-#: lib/vutuv_web/templates/user/edit.html.heex:50
-#: lib/vutuv_web/templates/user/edit.html.heex:103
-#: lib/vutuv_web/templates/user/edit.html.heex:423
-#: lib/vutuv_web/templates/user/edit.html.heex:458
+#: lib/vutuv_web/templates/user/edit.html.heex:53
+#: lib/vutuv_web/templates/user/edit.html.heex:128
+#: lib/vutuv_web/templates/user/edit.html.heex:448
+#: lib/vutuv_web/templates/user/edit.html.heex:497
 #: lib/vutuv_web/templates/username/confirm.html.heex:222
 #, elixir-autogen
 msgid "Cancel"
@@ -306,7 +306,7 @@ msgid "Fax"
 msgstr "Fax"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:511
-#: lib/vutuv_web/templates/user/edit.html.heex:125
+#: lib/vutuv_web/templates/user/edit.html.heex:150
 #, elixir-autogen
 msgid "First Name"
 msgstr "Vorname"
@@ -315,7 +315,7 @@ msgstr "Vorname"
 #: lib/vutuv_web/agent_docs/text.ex:513
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
-#: lib/vutuv_web/live/notification_live/index.ex:1005
+#: lib/vutuv_web/live/notification_live/index.ex:969
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:40
@@ -343,7 +343,7 @@ msgstr "Folge ich"
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:195
 #: lib/vutuv_web/templates/page/index.html.heex:93
-#: lib/vutuv_web/templates/user/edit.html.heex:162
+#: lib/vutuv_web/templates/user/edit.html.heex:187
 #: lib/vutuv_web/views/account_event_text.ex:197
 #, elixir-autogen
 msgid "Gender"
@@ -384,7 +384,7 @@ msgid "Language"
 msgstr "Sprache"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:513
-#: lib/vutuv_web/templates/user/edit.html.heex:130
+#: lib/vutuv_web/templates/user/edit.html.heex:155
 #, elixir-autogen
 msgid "Last Name"
 msgstr "Nachname"
@@ -443,7 +443,7 @@ msgid "Log Out"
 msgstr "Ausloggen"
 
 #: lib/vutuv_web/live/shell_live.ex:843
-#: lib/vutuv_web/live/shell_live.ex:880
+#: lib/vutuv_web/live/shell_live.ex:889
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -451,12 +451,12 @@ msgid "Log in"
 msgstr "Einloggen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:512
-#: lib/vutuv_web/templates/user/edit.html.heex:135
+#: lib/vutuv_web/templates/user/edit.html.heex:160
 #, elixir-autogen
 msgid "Middle Name"
 msgstr "Zweiter Vorname"
 
-#: lib/vutuv_web/live/notification_live/index.ex:929
+#: lib/vutuv_web/live/notification_live/index.ex:893
 #, elixir-autogen
 msgid "More"
 msgstr "Mehr"
@@ -473,7 +473,7 @@ msgstr "Mehr"
 msgid "Name"
 msgstr "Name"
 
-#: lib/vutuv_web/live/notification_live/index.ex:650
+#: lib/vutuv_web/live/notification_live/index.ex:647
 #: lib/vutuv_web/live/organization_live/activity.ex:123
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
@@ -485,7 +485,7 @@ msgid "New"
 msgstr "Neu"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:515
-#: lib/vutuv_web/templates/user/edit.html.heex:140
+#: lib/vutuv_web/templates/user/edit.html.heex:165
 #, elixir-autogen
 msgid "Nickname"
 msgstr "Spitzname"
@@ -566,7 +566,7 @@ msgid "Phone number updated successfully."
 msgstr "Telefonnummer wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:510
-#: lib/vutuv_web/templates/user/edit.html.heex:145
+#: lib/vutuv_web/templates/user/edit.html.heex:170
 #, elixir-autogen
 msgid "Prefix"
 msgstr "Titel"
@@ -626,7 +626,7 @@ msgstr "Öffentlich"
 #: lib/vutuv_web/templates/settings/preferences.html.heex:205
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
-#: lib/vutuv_web/templates/user/edit.html.heex:418
+#: lib/vutuv_web/templates/user/edit.html.heex:443
 #: lib/vutuv_web/views/settings_html.ex:175
 #, elixir-autogen
 msgid "Save"
@@ -641,7 +641,7 @@ msgstr "Speichern"
 #: lib/vutuv_web/live/search_live.ex:54
 #: lib/vutuv_web/live/search_live.ex:613
 #: lib/vutuv_web/live/shell_live.ex:711
-#: lib/vutuv_web/live/shell_live.ex:863
+#: lib/vutuv_web/live/shell_live.ex:872
 #: lib/vutuv_web/live/tag_live/timeline.ex:237
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
@@ -749,7 +749,7 @@ msgid "Submit a bugreport or a feature request."
 msgstr "Fehler auf der Seite melden."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:514
-#: lib/vutuv_web/templates/user/edit.html.heex:150
+#: lib/vutuv_web/templates/user/edit.html.heex:175
 #, elixir-autogen
 msgid "Suffix"
 msgstr "Namenszusatz"
@@ -778,12 +778,12 @@ msgstr ""
 "Der Benutzer %{name} wurde angelegt. Eine E-Mail mit einer PIN wurde "
 "verschickt."
 
-#: lib/vutuv_web/controllers/user_controller.ex:310
+#: lib/vutuv_web/controllers/user_controller.ex:363
 #, elixir-autogen
 msgid "User deleted successfully."
 msgstr "User wurde gelöscht."
 
-#: lib/vutuv_web/controllers/user_controller.ex:229
+#: lib/vutuv_web/controllers/user_controller.ex:282
 #, elixir-autogen
 msgid "User updated successfully."
 msgstr "Profil aktualisiert."
@@ -798,7 +798,7 @@ msgstr "User wurde verifiziert."
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
-#: lib/vutuv_web/live/notification_live/index.ex:1087
+#: lib/vutuv_web/live/notification_live/index.ex:1048
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -1438,7 +1438,7 @@ msgstr "Tags"
 
 #: lib/vutuv_web/controllers/email_controller.ex:167
 #: lib/vutuv_web/controllers/session_controller.ex:461
-#: lib/vutuv_web/controllers/user_controller.ex:330
+#: lib/vutuv_web/controllers/user_controller.ex:383
 #: lib/vutuv_web/controllers/username_controller.ex:215
 #, elixir-autogen
 msgid "Too many incorrect attempts."
@@ -1626,7 +1626,7 @@ msgstr "Adressen von %{name}"
 msgid "Admin control panel"
 msgstr "Admin-Bereich"
 
-#: lib/vutuv_web/live/shell_live.ex:866
+#: lib/vutuv_web/live/shell_live.ex:875
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "Mitteilungen"
@@ -1772,7 +1772,7 @@ msgstr "Nachricht"
 #: lib/vutuv_web/live/message_live/index.ex:50
 #: lib/vutuv_web/live/message_live/index.ex:622
 #: lib/vutuv_web/live/shell_live.ex:727
-#: lib/vutuv_web/live/shell_live.ex:865
+#: lib/vutuv_web/live/shell_live.ex:874
 #: lib/vutuv_web/templates/layout/app.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Messages"
@@ -1860,8 +1860,8 @@ msgstr "Diese E-Mail-Adresse konnte nicht hinzugefügt werden."
 #: lib/vutuv_web/controllers/session_controller.ex:167
 #: lib/vutuv_web/controllers/session_controller.ex:203
 #: lib/vutuv_web/controllers/session_controller.ex:219
-#: lib/vutuv_web/controllers/user_controller.ex:266
-#: lib/vutuv_web/controllers/user_controller.ex:295
+#: lib/vutuv_web/controllers/user_controller.ex:319
+#: lib/vutuv_web/controllers/user_controller.ex:348
 #: lib/vutuv_web/controllers/username_controller.ex:191
 #: lib/vutuv_web/controllers/username_controller.ex:273
 #: lib/vutuv_web/controllers/username_controller.ex:296
@@ -1936,17 +1936,17 @@ msgstr "folgt"
 msgid "submit a bug report"
 msgstr "einen Fehlerbericht erstellen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1110
+#: lib/vutuv_web/live/notification_live/index.ex:1070
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr "hat Sie für %{tag} empfohlen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1105
+#: lib/vutuv_web/live/notification_live/index.ex:1065
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr "ist jetzt mit Ihnen vernetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1100
+#: lib/vutuv_web/live/notification_live/index.ex:1060
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr "folgt Ihnen jetzt."
@@ -2038,7 +2038,7 @@ msgstr "Titelbild ändern"
 msgid "Change cover photo"
 msgstr "Titelbild ändern"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:71
+#: lib/vutuv_web/templates/user/edit.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "Cover photo"
 msgstr "Titelbild"
@@ -2109,7 +2109,7 @@ msgid "September"
 msgstr "September"
 
 #: lib/vutuv_web/templates/education/form_content.html.heex:32
-#: lib/vutuv_web/templates/user/edit.html.heex:210
+#: lib/vutuv_web/templates/user/edit.html.heex:235
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Markdown is supported: bold, italics, links and lists."
@@ -2158,7 +2158,7 @@ msgstr "Beitrag bearbeiten"
 #: lib/vutuv_web/live/post_live/feed.ex:159
 #: lib/vutuv_web/live/post_live/feed.ex:936
 #: lib/vutuv_web/live/shell_live.ex:599
-#: lib/vutuv_web/live/shell_live.ex:861
+#: lib/vutuv_web/live/shell_live.ex:870
 #: lib/vutuv_web/templates/layout/app.html.heex:122
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2242,7 +2242,7 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/gettext_extraction_anchors.ex:83
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:382
-#: lib/vutuv_web/live/notification_live/index.ex:927
+#: lib/vutuv_web/live/notification_live/index.ex:891
 #: lib/vutuv_web/live/organization_live/show.ex:549
 #: lib/vutuv_web/live/post_live/saved.ex:495
 #: lib/vutuv_web/live/search_live.ex:309
@@ -2434,7 +2434,7 @@ msgstr "Lesezeichen"
 #: lib/vutuv_web/components/post_components.ex:1567
 #: lib/vutuv_web/components/post_components.ex:4670
 #: lib/vutuv_web/components/ui.ex:2985
-#: lib/vutuv_web/live/notification_live/index.ex:1077
+#: lib/vutuv_web/live/notification_live/index.ex:1038
 #: lib/vutuv_web/views/user_html.ex:345
 #, elixir-autogen, elixir-format
 msgid "Like"
@@ -2442,7 +2442,7 @@ msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1000
 #: lib/vutuv_web/components/post_components.ex:4679
-#: lib/vutuv_web/live/notification_live/index.ex:1007
+#: lib/vutuv_web/live/notification_live/index.ex:971
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
 #: lib/vutuv_web/live/shell_live.ex:789
@@ -2527,7 +2527,7 @@ msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
 
 #: lib/vutuv_web/components/post_components.ex:393
-#: lib/vutuv_web/live/notification_live/index.ex:1008
+#: lib/vutuv_web/live/notification_live/index.ex:972
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Antworten"
@@ -2535,7 +2535,7 @@ msgstr "Antworten"
 #: lib/vutuv_web/components/post_components.ex:1578
 #: lib/vutuv_web/components/post_components.ex:4706
 #: lib/vutuv_web/components/post_components.ex:4707
-#: lib/vutuv_web/live/notification_live/index.ex:1074
+#: lib/vutuv_web/live/notification_live/index.ex:1035
 #: lib/vutuv_web/live/post_live/reply.ex:42
 #, elixir-autogen, elixir-format
 msgid "Reply"
@@ -2557,7 +2557,7 @@ msgstr "Solange es geteilte Beiträge oder Antworten gibt, lässt sich der Empf�
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beiträge oder Antworten gibt, bleibt er öffentlich; löschen können Sie ihn weiterhin."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1300
+#: lib/vutuv_web/live/notification_live/index.ex:1258
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
@@ -2838,7 +2838,7 @@ msgstr[1] "+%{formatted} weitere Tags"
 #: lib/vutuv_web/agent_docs/markdown.ex:548
 #: lib/vutuv_web/agent_docs/text.ex:515
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:1006
+#: lib/vutuv_web/live/notification_live/index.ex:970
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
@@ -2893,23 +2893,23 @@ msgid "Open someone's profile to message them."
 msgstr "Öffnen Sie ein Profil, um jemandem zu schreiben."
 
 #: lib/vutuv_web/components/organization_components.ex:225
-#: lib/vutuv_web/live/notification_live/index.ex:1090
+#: lib/vutuv_web/live/notification_live/index.ex:1050
 #: lib/vutuv_web/live/organization_live/activity.ex:99
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr "Aktivität"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1080
+#: lib/vutuv_web/live/notification_live/index.ex:1041
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr "Vernetzung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1073
+#: lib/vutuv_web/live/notification_live/index.ex:1034
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr "Empfehlung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1072
+#: lib/vutuv_web/live/notification_live/index.ex:1033
 #: lib/vutuv_web/templates/user/show.html.heex:933
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -2922,7 +2922,7 @@ msgstr[1] "Follower"
 msgid "Welcome to vutuv, %{name}!"
 msgstr "Willkommen bei vutuv, %{name}!"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1107
+#: lib/vutuv_web/live/notification_live/index.ex:1067
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr "gefällt Ihr Beitrag."
@@ -2954,12 +2954,12 @@ msgstr "(gelöschtes Konto)"
 msgid "(no text)"
 msgstr "(kein Text)"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1336
+#: lib/vutuv_web/live/notification_live/index.ex:1294
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr "Eine Meldung zu Ihrem Inhalt wurde bestätigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1337
+#: lib/vutuv_web/live/notification_live/index.ex:1295
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr "Eine Meldung zu Ihrem Inhalt wurde verworfen; er ist wieder sichtbar."
@@ -3074,7 +3074,7 @@ msgstr "Familienfreundlich bleiben"
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:1081
+#: lib/vutuv_web/live/notification_live/index.ex:1042
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3218,7 +3218,7 @@ msgstr "Private Nachricht"
 
 #: lib/vutuv_web/components/ui.ex:3794
 #: lib/vutuv_web/live/shell_live.ex:612
-#: lib/vutuv_web/live/shell_live.ex:870
+#: lib/vutuv_web/live/shell_live.ex:879
 #: lib/vutuv_web/templates/import/new.html.heex:15
 #: lib/vutuv_web/templates/import/preview.html.heex:55
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
@@ -3534,12 +3534,12 @@ msgstr "Sie haben das bereits gemeldet. Unser Team kümmert sich darum."
 msgid "You cannot report your own content."
 msgstr "Eigene Inhalte können Sie nicht melden."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1339
+#: lib/vutuv_web/live/notification_live/index.ex:1297
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr "Sie haben gemeldeten Inhalt gelöscht; der Fall ist abgeschlossen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1338
+#: lib/vutuv_web/live/notification_live/index.ex:1296
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr "Sie haben gemeldeten Inhalt überarbeitet; der Fall ist abgeschlossen."
@@ -3549,7 +3549,7 @@ msgstr "Sie haben gemeldeten Inhalt überarbeitet; der Fall ist abgeschlossen."
 msgid "Your content was reported"
 msgstr "Ihr Inhalt wurde gemeldet"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1340
+#: lib/vutuv_web/live/notification_live/index.ex:1298
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3744,7 +3744,7 @@ msgstr "Verlauf"
 msgid "Open the profile"
 msgstr "Profil öffnen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1364
+#: lib/vutuv_web/live/notification_live/index.ex:1322
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3771,7 +3771,7 @@ msgstr "Besitzer hat den Inhalt bearbeitet"
 msgid "Report filed"
 msgstr "Meldung eingegangen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1083
+#: lib/vutuv_web/live/notification_live/index.ex:1044
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr "Schutz nach Meldung"
@@ -3853,7 +3853,7 @@ msgstr "Bestätigt"
 msgid "Waiting for the owner"
 msgstr "Wartet auf den Besitzer"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1369
+#: lib/vutuv_web/live/notification_live/index.ex:1327
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -4767,7 +4767,7 @@ msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
 #: lib/vutuv_web/agent_docs/text.ex:388
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:516
-#: lib/vutuv_web/live/notification_live/index.ex:928
+#: lib/vutuv_web/live/notification_live/index.ex:892
 #: lib/vutuv_web/live/organization_live/show.ex:632
 #: lib/vutuv_web/live/post_live/saved.ex:498
 #: lib/vutuv_web/live/search_live.ex:307
@@ -4792,7 +4792,7 @@ msgstr "Ähnliche Namen"
 #: lib/vutuv_web/components/post_components.ex:409
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
-#: lib/vutuv_web/live/notification_live/index.ex:926
+#: lib/vutuv_web/live/notification_live/index.ex:890
 #: lib/vutuv_web/live/search_live.ex:306
 #: lib/vutuv_web/views/qualification_html.ex:90
 #, elixir-autogen, elixir-format
@@ -5625,7 +5625,7 @@ msgid "Previous post in the feed"
 msgstr "Vorheriger Beitrag im Feed"
 
 #: lib/vutuv_web/live/shell_live.ex:592
-#: lib/vutuv_web/live/shell_live.ex:854
+#: lib/vutuv_web/live/shell_live.ex:863
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr "Hauptnavigation"
@@ -5638,7 +5638,7 @@ msgstr "Fußzeilen-Navigation"
 #: lib/vutuv_web/components/post_components.ex:2835
 #: lib/vutuv_web/components/post_components.ex:2887
 #: lib/vutuv_web/components/post_components.ex:3284
-#: lib/vutuv_web/live/notification_live/index.ex:694
+#: lib/vutuv_web/live/notification_live/index.ex:691
 #: lib/vutuv_web/live/post_live/feed.ex:1245
 #: lib/vutuv_web/views/user_html.ex:113
 #, elixir-autogen, elixir-format
@@ -5679,7 +5679,7 @@ msgstr "Art der E-Mail"
 msgid "Type of email address"
 msgstr "Art der E-Mail-Adresse"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:197
+#: lib/vutuv_web/templates/user/edit.html.heex:222
 #, elixir-autogen, elixir-format
 msgid "About you"
 msgstr "Über Sie"
@@ -5762,12 +5762,12 @@ msgstr "Apps von Drittanbietern, die Sie autorisiert haben."
 msgid "View"
 msgstr "Ansehen"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:122
+#: lib/vutuv_web/templates/user/edit.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "Your name"
 msgstr "Ihr Name"
 
-#: lib/vutuv_web/live/notification_live/index.ex:523
+#: lib/vutuv_web/live/notification_live/index.ex:520
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr "Ihr Beitrag"
@@ -5821,24 +5821,24 @@ msgstr ""
 "Dies stellt die Sprache der gesamten vutuv-Oberfläche ein, nicht die Ihres "
 "öffentlichen Profils."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:27
-#: lib/vutuv_web/templates/user/edit.html.heex:31
+#: lib/vutuv_web/templates/user/edit.html.heex:30
+#: lib/vutuv_web/templates/user/edit.html.heex:34
 #, elixir-autogen, elixir-format
 msgid "Current avatar"
 msgstr "Aktueller Avatar"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:80
-#: lib/vutuv_web/templates/user/edit.html.heex:84
+#: lib/vutuv_web/templates/user/edit.html.heex:105
+#: lib/vutuv_web/templates/user/edit.html.heex:109
 #, elixir-autogen, elixir-format
 msgid "Current cover photo"
 msgstr "Aktuelles Titelbild"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:146
+#: lib/vutuv_web/templates/user/edit.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "e.g. Dr. or Prof."
 msgstr "z. B. Dr. oder Prof."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:151
+#: lib/vutuv_web/templates/user/edit.html.heex:176
 #, elixir-autogen, elixir-format
 msgid "e.g. Jr. or PhD"
 msgstr "z. B. jun. oder B.Sc."
@@ -5865,7 +5865,7 @@ msgid "Apps & API"
 msgstr "Apps & API-Zugang"
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:127
-#: lib/vutuv_web/live/notification_live/index.ex:1009
+#: lib/vutuv_web/live/notification_live/index.ex:973
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:17
@@ -6296,7 +6296,7 @@ msgid "Add a tagline"
 msgstr "Kurzbeschreibung hinzufügen"
 
 #: lib/vutuv_web/live/cv_live.ex:148
-#: lib/vutuv_web/templates/user/edit.html.heex:206
+#: lib/vutuv_web/templates/user/edit.html.heex:231
 #: lib/vutuv_web/views/account_event_text.ex:190
 #, elixir-autogen, elixir-format
 msgid "Tagline"
@@ -6320,8 +6320,8 @@ msgid_plural "Posts"
 msgstr[0] "Beitrag"
 msgstr[1] "Beiträge"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:55
-#: lib/vutuv_web/templates/user/edit.html.heex:108
+#: lib/vutuv_web/templates/user/edit.html.heex:58
+#: lib/vutuv_web/templates/user/edit.html.heex:133
 #, elixir-autogen, elixir-format
 msgid "After choosing a file you can reposition and zoom it."
 msgstr "Nach der Auswahl einer Datei können Sie sie verschieben und zoomen."
@@ -6331,43 +6331,43 @@ msgstr "Nach der Auswahl einer Datei können Sie sie verschieben und zoomen."
 msgid "Also on"
 msgstr "Auch auf"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:48
-#: lib/vutuv_web/templates/user/edit.html.heex:101
+#: lib/vutuv_web/templates/user/edit.html.heex:51
+#: lib/vutuv_web/templates/user/edit.html.heex:126
 #, elixir-autogen, elixir-format
 msgid "Drag to move, use the slider to zoom. The framed area is what others see."
 msgstr ""
 "Zum Verschieben ziehen, zum Zoomen den Regler nutzen. Der umrahmte Bereich "
 "ist für andere sichtbar."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:60
+#: lib/vutuv_web/templates/user/edit.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "New avatar preview"
 msgstr "Vorschau des neuen Avatars"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:113
+#: lib/vutuv_web/templates/user/edit.html.heex:138
 #, elixir-autogen, elixir-format
 msgid "New cover photo preview"
 msgstr "Vorschau des neuen Titelbilds"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:100
+#: lib/vutuv_web/templates/user/edit.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Position your cover photo"
 msgstr "Titelbild positionieren"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:47
+#: lib/vutuv_web/templates/user/edit.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "Position your photo"
 msgstr "Foto positionieren"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:49
-#: lib/vutuv_web/templates/user/edit.html.heex:102
+#: lib/vutuv_web/templates/user/edit.html.heex:52
+#: lib/vutuv_web/templates/user/edit.html.heex:127
 #, elixir-autogen, elixir-format
 msgid "Use photo"
 msgstr "Foto verwenden"
 
 #: lib/vutuv_web/live/post_live/composer.ex:1372
-#: lib/vutuv_web/templates/user/edit.html.heex:51
-#: lib/vutuv_web/templates/user/edit.html.heex:104
+#: lib/vutuv_web/templates/user/edit.html.heex:54
+#: lib/vutuv_web/templates/user/edit.html.heex:129
 #, elixir-autogen, elixir-format
 msgid "Zoom"
 msgstr "Zoom"
@@ -6558,10 +6558,10 @@ msgid "No endorsements yet."
 msgstr "Noch keine Empfehlungen."
 
 #: lib/vutuv_web/components/ui.ex:1860
-#: lib/vutuv_web/live/notification_live/index.ex:628
-#: lib/vutuv_web/live/notification_live/index.ex:643
-#: lib/vutuv_web/live/notification_live/index.ex:781
-#: lib/vutuv_web/live/notification_live/index.ex:783
+#: lib/vutuv_web/live/notification_live/index.ex:625
+#: lib/vutuv_web/live/notification_live/index.ex:640
+#: lib/vutuv_web/live/notification_live/index.ex:778
+#: lib/vutuv_web/live/notification_live/index.ex:780
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr "und %{count} weitere"
@@ -8071,13 +8071,13 @@ msgstr "Neue Mitglieder"
 #: lib/vutuv_web/components/job_components.ex:173
 #: lib/vutuv_web/live/admin/dashboard_live.ex:287
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:457
-#: lib/vutuv_web/live/notification_live/index.ex:955
+#: lib/vutuv_web/live/notification_live/index.ex:919
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr "Heute"
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:291
-#: lib/vutuv_web/live/notification_live/index.ex:958
+#: lib/vutuv_web/live/notification_live/index.ex:922
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr "Gestern"
@@ -8321,8 +8321,8 @@ msgstr "Identität verifiziert. Das Mitglied wurde per E-Mail benachrichtigt."
 msgid "Identity-verified"
 msgstr "Identität verifiziert"
 
-#: lib/vutuv/accounts.ex:1394
-#: lib/vutuv/accounts.ex:1443
+#: lib/vutuv/accounts.ex:1418
+#: lib/vutuv/accounts.ex:1467
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -8363,7 +8363,7 @@ msgstr "Nicht bestätigt"
 msgid "Open the member browser"
 msgstr "Mitgliederübersicht öffnen"
 
-#: lib/vutuv/accounts.ex:1411
+#: lib/vutuv/accounts.ex:1435
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -8813,7 +8813,7 @@ msgstr "Basisdaten & Fotos"
 msgid "Language & display"
 msgstr "Sprache & Anzeige"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:477
+#: lib/vutuv_web/templates/user/edit.html.heex:516
 #, elixir-autogen, elixir-format
 msgid "More profile sections"
 msgstr "Weitere Profil-Bereiche"
@@ -8843,7 +8843,7 @@ msgstr ""
 "Nachrichten und Einstellungen. Sie enthält private Daten, bewahren Sie sie "
 "also sorgfältig auf."
 
-#: lib/vutuv_web/controllers/user_controller.ex:246
+#: lib/vutuv_web/controllers/user_controller.ex:299
 #, elixir-autogen, elixir-format
 msgid "Please type your username exactly as shown to confirm the deletion."
 msgstr ""
@@ -9122,7 +9122,7 @@ msgstr "Social-Media-Konten verwalten"
 msgid "Your Fediverse handle"
 msgstr "Ihr Fediverse-Handle"
 
-#: lib/vutuv/accounts.ex:1406
+#: lib/vutuv/accounts.ex:1430
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -9361,7 +9361,7 @@ msgstr ""
 "LaTeX ist der Quelltext zum Setzen, und JSON Resume ist das offene Format "
 "von %{link}."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:219
+#: lib/vutuv_web/templates/user/edit.html.heex:244
 #, elixir-autogen, elixir-format
 msgid "characters"
 msgstr "Zeichen"
@@ -9928,7 +9928,7 @@ msgstr "Yoruba"
 msgid "Employment status"
 msgstr "Beschäftigungsstatus"
 
-#: lib/vutuv/accounts/user.ex:1090
+#: lib/vutuv/accounts/user.ex:1084
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9939,13 +9939,13 @@ msgstr "Auf Jobsuche"
 msgid "Not open to work"
 msgstr "Nicht offen für Angebote"
 
-#: lib/vutuv/accounts/user.ex:1087
+#: lib/vutuv/accounts/user.ex:1081
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
 msgstr "Offen für Angebote"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:243
+#: lib/vutuv_web/templates/user/edit.html.heex:268
 #, elixir-autogen, elixir-format
 msgid "Shown as a badge next to your tagline so people can see whether you are open to opportunities."
 msgstr ""
@@ -10219,18 +10219,18 @@ msgstr "+%{code} ist die Ländervorwahl von %{region}"
 msgid "Date of birth"
 msgstr "Geburtsdatum"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:396
-#: lib/vutuv_web/templates/user/edit.html.heex:465
+#: lib/vutuv_web/templates/user/edit.html.heex:421
+#: lib/vutuv_web/templates/user/edit.html.heex:504
 #, elixir-autogen, elixir-format
 msgid "Remove date of birth"
 msgstr "Geburtsdatum entfernen"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:445
+#: lib/vutuv_web/templates/user/edit.html.heex:484
 #, elixir-autogen, elixir-format
 msgid "Remove your date of birth?"
 msgstr "Geburtsdatum entfernen?"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:448
+#: lib/vutuv_web/templates/user/edit.html.heex:487
 #, elixir-autogen, elixir-format
 msgid "Your date of birth will be removed and your age will no longer be shown on your profile. You can add it again at any time."
 msgstr ""
@@ -11409,7 +11409,7 @@ msgstr "Versuche"
 msgid "Views"
 msgstr "Ansichten"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:252
+#: lib/vutuv_web/templates/user/edit.html.heex:277
 #, elixir-autogen, elixir-format
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
@@ -11418,45 +11418,45 @@ msgstr ""
 " Konto anlegen kann. Wählen Sie „Niemand“, um den Status zu speichern, ohne "
 "ihn anzuzeigen."
 
-#: lib/vutuv/accounts/user.ex:1128
+#: lib/vutuv/accounts/user.ex:1122
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Alle, auch nicht angemeldete Besucher"
 
-#: lib/vutuv/accounts/user.ex:1133
+#: lib/vutuv/accounts/user.ex:1127
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Niemand"
 
-#: lib/vutuv/accounts/user.ex:1131
+#: lib/vutuv/accounts/user.ex:1125
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:566
 #, elixir-autogen, elixir-format
 msgid "Signed-in members only"
 msgstr "Nur angemeldete Mitglieder"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:249
+#: lib/vutuv_web/templates/user/edit.html.heex:274
 #: lib/vutuv_web/templates/welcome/show.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Who can see your availability?"
 msgstr "Wer kann Ihre Verfügbarkeit sehen?"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:274
+#: lib/vutuv_web/templates/user/edit.html.heex:299
 #: lib/vutuv_web/templates/welcome/show.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Amount"
 msgstr "Betrag"
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:464
-#: lib/vutuv_web/templates/user/edit.html.heex:282
+#: lib/vutuv_web/templates/user/edit.html.heex:307
 #: lib/vutuv_web/templates/welcome/show.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "Currency"
 msgstr "Währung"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:292
+#: lib/vutuv_web/templates/user/edit.html.heex:317
 #, elixir-autogen, elixir-format
 msgid "Hidden by default, and it still does its job while hidden. \"Signed-in members only\" adds a quiet line to your profile for members; \"Everyone\" also shows it to logged-out visitors."
 msgstr ""
@@ -11464,13 +11464,13 @@ msgstr ""
 "angemeldete Mitglieder“ ergänzt Ihr Profil um eine dezente Zeile für "
 "Mitglieder; „Alle“ zeigt sie auch nicht angemeldeten Besuchern."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:265
+#: lib/vutuv_web/templates/user/edit.html.heex:290
 #: lib/vutuv_web/templates/welcome/show.html.heex:114
 #, elixir-autogen, elixir-format
 msgid "Minimum salary expectation"
 msgstr "Mindest-Gehaltsvorstellung"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:268
+#: lib/vutuv_web/templates/user/edit.html.heex:293
 #, elixir-autogen, elixir-format
 msgid "Optional. Even when hidden, it sharpens your own job search and alerts by filtering out postings below it. Leave the amount empty to remove it."
 msgstr ""
@@ -11479,7 +11479,7 @@ msgstr ""
 "Sie den Betrag leer, um die Angabe zu entfernen."
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:471
-#: lib/vutuv_web/templates/user/edit.html.heex:278
+#: lib/vutuv_web/templates/user/edit.html.heex:303
 #: lib/vutuv_web/templates/welcome/show.html.heex:127
 #, elixir-autogen, elixir-format
 msgid "Per"
@@ -11490,7 +11490,7 @@ msgstr "Pro"
 msgid "Salary expectation from %{amount} %{currency} per %{period}"
 msgstr "Gehaltsvorstellung ab %{amount} %{currency} pro %{period}"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:289
+#: lib/vutuv_web/templates/user/edit.html.heex:314
 #, elixir-autogen, elixir-format
 msgid "Who can see your salary expectation?"
 msgstr "Wer kann Ihre Gehaltsvorstellung sehen?"
@@ -11559,7 +11559,7 @@ msgstr "Ein Mitglied ausschließen"
 msgid "Exclude an email domain"
 msgstr "Eine E-Mail-Domain ausschließen"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:345
+#: lib/vutuv_web/templates/user/edit.html.heex:370
 #, elixir-autogen, elixir-format
 msgid "Hide from specific people"
 msgstr "Vor bestimmten Personen verbergen"
@@ -11570,7 +11570,7 @@ msgstr "Vor bestimmten Personen verbergen"
 msgid "Job-search exclusion list"
 msgstr "Ausschlussliste für die Jobsuche"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:348
+#: lib/vutuv_web/templates/user/edit.html.heex:373
 #, elixir-autogen, elixir-format
 msgid "Keep your availability broadly visible while making sure your own employer never sees it. Exclude specific members or email domains, and they never see your availability or salary expectation, even at \"Everyone\"."
 msgstr ""
@@ -11579,7 +11579,7 @@ msgstr ""
 "Mitglieder oder E-Mail-Domains aus; sie sehen Ihre Verfügbarkeit und Ihre "
 "Gehaltsvorstellung dann nie, auch nicht bei „Alle“."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:356
+#: lib/vutuv_web/templates/user/edit.html.heex:381
 #, elixir-autogen, elixir-format
 msgid "Manage exclusion list (1 entry)"
 msgid_plural "Manage exclusion list (%{formatted} entries)"
@@ -12477,7 +12477,7 @@ msgstr "Organisationsseite"
 msgid "Organization pages"
 msgstr "Organisationsseiten"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1084
+#: lib/vutuv_web/live/notification_live/index.ex:1045
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr "Organisationsrolle"
@@ -12593,22 +12593,22 @@ msgstr "Ihre Organisationsseite ist verifiziert und jetzt live."
 msgid "Your organization page was updated."
 msgstr "Ihre Organisationsseite wurde aktualisiert."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1328
+#: lib/vutuv_web/live/notification_live/index.ex:1286
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr "hat Ihnen eine Rolle bei %{organization} gegeben."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1325
+#: lib/vutuv_web/live/notification_live/index.ex:1283
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr "hat Sie zum Recruiter für %{organization} gemacht."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1322
+#: lib/vutuv_web/live/notification_live/index.ex:1280
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr "hat Sie zum Administrator von %{organization} gemacht."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1319
+#: lib/vutuv_web/live/notification_live/index.ex:1277
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr "hat Sie zum Besitzer von %{organization} gemacht."
@@ -12815,7 +12815,7 @@ msgstr "Halten Sie Strg / Cmd gedrückt, um mehrere auszuwählen."
 msgid "How to apply"
 msgstr "So bewerben Sie sich"
 
-#: lib/vutuv/accounts/user.ex:1102
+#: lib/vutuv/accounts/user.ex:1096
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12935,7 +12935,7 @@ msgstr "Hier ist noch nichts. Jobs, die Ihnen gefallen, erscheinen hier."
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) für KI-Agenten anbieten."
 
-#: lib/vutuv/accounts/user.ex:1101
+#: lib/vutuv/accounts/user.ex:1095
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -13017,7 +13017,7 @@ msgstr "Anzeige nicht gefunden."
 msgid "Publish"
 msgstr "Veröffentlichen"
 
-#: lib/vutuv/accounts/user.ex:1103
+#: lib/vutuv/accounts/user.ex:1097
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:496
 #: lib/vutuv_web/agent_docs/markdown.ex:389
@@ -13997,14 +13997,14 @@ msgstr "Dieses Mitglied existiert nicht mehr."
 msgid "%{pending} image(s) in the scan queue; %{rejected} rejected in the last 7 days. A growing queue usually means Ollama is unreachable."
 msgstr "%{pending} Bild(er) in der Warteschlange; %{rejected} in den letzten 7 Tagen abgelehnt. Eine wachsende Warteschlange bedeutet meist, dass Ollama nicht erreichbar ist."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:38
-#: lib/vutuv_web/templates/user/edit.html.heex:91
+#: lib/vutuv_web/templates/user/edit.html.heex:41
+#: lib/vutuv_web/templates/user/edit.html.heex:116
 #: lib/vutuv_web/templates/user/show.html.heex:61
 #, elixir-autogen, elixir-format
 msgid "Image awaiting review, visible only to you"
 msgstr "Bild wird geprüft, nur für Sie sichtbar"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1082
+#: lib/vutuv_web/live/notification_live/index.ex:1043
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -14045,36 +14045,36 @@ msgstr "Screenshot entfernt."
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr "Dieser Screenshot wurde automatisch aus dem Link in Ihrem Beitrag erstellt. Falls er unbrauchbar ist (zum Beispiel weil ein Cookie-Banner die Seite verdeckt), können Sie ihn entfernen."
 
-#: lib/vutuv/accounts/user.ex:1146
+#: lib/vutuv/accounts/user.ex:1140
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
 msgstr "Nur das Alter, ohne das Datum"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:407
+#: lib/vutuv_web/templates/user/edit.html.heex:432
 #, elixir-autogen, elixir-format
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr "Wählen Sie, wie viel von Ihrem Geburtstag Ihr Profil zeigt. „Nur das Alter“ verbirgt das genaue Datum, „Tag und Monat“ verbirgt das Jahr (und Ihr Alter), und „Nicht anzeigen“ speichert ihn weiterhin, hält ihn aber von Ihrem Profil fern."
 
-#: lib/vutuv/accounts/user.ex:1149
+#: lib/vutuv/accounts/user.ex:1143
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Tag und Monat, ohne das Jahr"
 
-#: lib/vutuv/accounts/user.ex:1152
+#: lib/vutuv/accounts/user.ex:1146
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Geburtstag nicht anzeigen"
 
-#: lib/vutuv/accounts/user.ex:1143
+#: lib/vutuv/accounts/user.ex:1137
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
 msgstr "Vollständiges Datum und Alter"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:404
+#: lib/vutuv_web/templates/user/edit.html.heex:429
 #, elixir-autogen, elixir-format
 msgid "Show my birthday as"
 msgstr "Geburtstag anzeigen als"
@@ -14091,7 +14091,7 @@ msgstr[1] "%{formatted} Beiträge erwähnen aktuell %{handle} und werden beim Um
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr "Beim Ändern werden alle Erwähnungen Ihres alten Handles in Beiträgen automatisch auf den neuen umgeschrieben und die Verfasser dieser Beiträge benachrichtigt. Ihre alte Profiladresse funktioniert dann nicht mehr."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1085
+#: lib/vutuv_web/live/notification_live/index.ex:1046
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr "Handle-Änderung"
@@ -14103,7 +14103,7 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] "Wir haben %{formatted} Beitrag aktualisiert, der Ihren alten Handle erwähnt hat, und dessen Verfasser benachrichtigt."
 msgstr[1] "Wir haben %{formatted} Beiträge aktualisiert, die Ihren alten Handle erwähnt haben, und deren Verfasser benachrichtigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1378
+#: lib/vutuv_web/live/notification_live/index.ex:1336
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr "hat den Handle von @%{old} auf @%{new} geändert."
@@ -14317,22 +14317,22 @@ msgstr[1] "Meine %{formatted} Follower darüber informieren"
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr "Die Benachrichtigung enthält einen Link zu diesem Eintrag. Es wird keine E-Mail verschickt, und das passiert nur bei neuen Einträgen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1086
+#: lib/vutuv_web/live/notification_live/index.ex:1047
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr "Lebenslauf-Update"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1398
+#: lib/vutuv_web/live/notification_live/index.ex:1356
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr "hat eine neue Station im Lebenslauf: %{entry}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1390
+#: lib/vutuv_web/live/notification_live/index.ex:1348
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr "hat eine neue Ausbildung im Lebenslauf: %{entry}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1395
+#: lib/vutuv_web/live/notification_live/index.ex:1353
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr "hat ein neues Zertifikat im Lebenslauf: %{entry}"
@@ -14357,7 +14357,7 @@ msgstr "Über neue Lebenslauf-Einträge von Personen informieren, denen ich folg
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch immer."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1403
+#: lib/vutuv_web/live/notification_live/index.ex:1361
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
@@ -14488,14 +14488,14 @@ msgstr "Mit Qualifikation: %{name}"
 msgid "Publisher:"
 msgstr "Verlag:"
 
-#: lib/vutuv_web/live/notification_live/index.ex:947
+#: lib/vutuv_web/live/notification_live/index.ex:911
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] "%{formatted} neue Mitteilung"
 msgstr[1] "%{formatted} neue Mitteilungen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:961
+#: lib/vutuv_web/live/notification_live/index.ex:925
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr "%{day}. %{month} %{year}"
@@ -14510,23 +14510,23 @@ msgstr "Zurückfolgen"
 msgid "Last 30 days"
 msgstr "Letzte 30 Tage"
 
-#: lib/vutuv_web/live/notification_live/index.ex:913
-#: lib/vutuv_web/live/notification_live/index.ex:1166
+#: lib/vutuv_web/live/notification_live/index.ex:877
+#: lib/vutuv_web/live/notification_live/index.ex:1126
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr "und"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1103
+#: lib/vutuv_web/live/notification_live/index.ex:1063
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr "sind jetzt mit Ihnen vernetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1098
+#: lib/vutuv_web/live/notification_live/index.ex:1058
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr "folgen Ihnen jetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1113
+#: lib/vutuv_web/live/notification_live/index.ex:1073
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
@@ -14738,13 +14738,13 @@ msgstr ""
 "Optional, und niemand sonst sieht es. Die Angabe filtert Stellen darunter "
 "aus Ihrer eigenen Jobsuche."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:312
+#: lib/vutuv_web/templates/user/edit.html.heex:337
 #: lib/vutuv_web/templates/welcome/show.html.heex:143
 #, elixir-autogen, elixir-format
 msgid "How do you want to work?"
 msgstr "Wie möchten Sie arbeiten?"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:332
+#: lib/vutuv_web/templates/user/edit.html.heex:357
 #: lib/vutuv_web/templates/welcome/show.html.heex:162
 #, elixir-autogen, elixir-format
 msgid "Shown next to your availability, and used to match you with postings."
@@ -14768,7 +14768,7 @@ msgstr "Erstmal überspringen"
 msgid "Preferred workplace"
 msgstr "Bevorzugte Arbeitsform"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:240
+#: lib/vutuv_web/templates/user/edit.html.heex:265
 #: lib/vutuv_web/templates/welcome/show.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Availability"
@@ -14779,7 +14779,7 @@ msgstr "Verfügbarkeit"
 msgid "An automated check removed an image from your vutuv account"
 msgstr "Eine automatische Prüfung hat ein Bild aus Ihrem vutuv-Konto entfernt"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1352
+#: lib/vutuv_web/live/notification_live/index.ex:1310
 #, elixir-autogen, elixir-format
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
@@ -14787,12 +14787,12 @@ msgstr ""
 "familienfreundlich genug für ein Arbeitsumfeld. Sie kann sich irren, "
 "antworten Sie in dem Fall einfach auf unsere E-Mail."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1075
+#: lib/vutuv_web/live/notification_live/index.ex:1036
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr "Thread-Antwort"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1153
+#: lib/vutuv_web/live/notification_live/index.ex:1113
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -14811,12 +14811,12 @@ msgstr "Unterhaltung"
 msgid "Only part of this long conversation is shown."
 msgstr "Von dieser langen Unterhaltung wird nur ein Teil angezeigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1076
+#: lib/vutuv_web/live/notification_live/index.ex:1037
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr "Erwähnung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1302
+#: lib/vutuv_web/live/notification_live/index.ex:1260
 #, elixir-autogen, elixir-format
 msgid "mentioned you in a post."
 msgstr "hat Sie in einem Beitrag erwähnt."
@@ -15169,7 +15169,7 @@ msgstr "Diese Ausbildung wird jetzt oben in Ihrem Profil angezeigt."
 msgid "Thread replies"
 msgstr "Thread-Antworten"
 
-#: lib/vutuv_web/live/notification_live/index.ex:606
+#: lib/vutuv_web/live/notification_live/index.ex:603
 #, elixir-autogen, elixir-format
 msgid "Turn off thread notifications"
 msgstr "Thread-Benachrichtigungen abschalten"
@@ -15220,7 +15220,7 @@ msgstr "Sie haben noch nichts stummgeschaltet."
 msgid "You have reached the maximum of %{count} filters."
 msgstr "Sie haben das Maximum von %{count} Filtern erreicht."
 
-#: lib/vutuv_web/live/notification_live/index.ex:601
+#: lib/vutuv_web/live/notification_live/index.ex:598
 #, elixir-autogen, elixir-format
 msgid "You wrote in this thread."
 msgstr "Sie haben in diesem Thread geschrieben."
@@ -16208,7 +16208,7 @@ msgstr "Vom Mitglied entfernt"
 msgid "Replies from other networks"
 msgstr "Antworten aus anderen Netzwerken"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1078
+#: lib/vutuv_web/live/notification_live/index.ex:1039
 #, elixir-autogen, elixir-format
 msgid "Reply from another network"
 msgstr "Antwort aus einem anderen Netzwerk"
@@ -16229,7 +16229,7 @@ msgid "Reported as not appropriate"
 msgstr "Als unangemessen gemeldet"
 
 #: lib/vutuv_web/components/post_components.ex:1077
-#: lib/vutuv_web/live/notification_live/index.ex:548
+#: lib/vutuv_web/live/notification_live/index.ex:545
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
 msgstr "Nur an Sie gesendet, für niemanden sonst sichtbar"
@@ -16280,7 +16280,7 @@ msgstr "Was"
 msgid "You have reported a lot today. Please try again tomorrow."
 msgstr "Sie haben heute schon viel gemeldet. Bitte versuchen Sie es morgen wieder."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1305
+#: lib/vutuv_web/live/notification_live/index.ex:1263
 #, elixir-autogen, elixir-format
 msgid "replied to your post from another network."
 msgstr "hat aus einem anderen Netzwerk auf Ihren Beitrag geantwortet."
@@ -16972,19 +16972,19 @@ msgstr "angehefteter Beitrag"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:475
 #: lib/vutuv_web/agent_docs/text.ex:467
-#: lib/vutuv_web/templates/user/edit.html.heex:180
+#: lib/vutuv_web/templates/user/edit.html.heex:205
 #: lib/vutuv_web/templates/user/show.html.heex:244
 #: lib/vutuv_web/views/account_event_text.ex:191
 #, elixir-autogen, elixir-format
 msgid "Name pronunciation"
 msgstr "Aussprache des Namens"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:184
+#: lib/vutuv_web/templates/user/edit.html.heex:209
 #, elixir-autogen, elixir-format
 msgid "e.g. [SHTEH-fahn VIN-ter-my-er]"
 msgstr "z. B. [SCHTEH-fan WIN-ter-mei-er]"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:187
+#: lib/vutuv_web/templates/user/edit.html.heex:212
 #, elixir-autogen, elixir-format
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
@@ -17304,7 +17304,7 @@ msgstr "Fediverse-Reaktionen"
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1079
+#: lib/vutuv_web/live/notification_live/index.ex:1040
 #, elixir-autogen, elixir-format
 msgid "Reaction from another network"
 msgstr "Reaktion aus einem anderen Netzwerk"
@@ -17324,21 +17324,21 @@ msgstr ""
 "Mehr speichern wir über diese Menschen nicht: keinen Namen, kein Bild, "
 "keinen Text. Ausschalten löscht, was dafür gespeichert ist."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1134
+#: lib/vutuv_web/live/notification_live/index.ex:1094
 #, elixir-autogen, elixir-format
 msgid "liked your post on another network."
 msgid_plural "liked your post on another network."
 msgstr[0] "gefällt Ihr Beitrag in einem anderen Netzwerk."
 msgstr[1] "gefällt Ihr Beitrag in einem anderen Netzwerk."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1142
+#: lib/vutuv_web/live/notification_live/index.ex:1102
 #, elixir-autogen, elixir-format
 msgid "reacted to your post from another network."
 msgid_plural "reacted to your post from another network."
 msgstr[0] "hat aus einem anderen Netzwerk auf Ihren Beitrag reagiert."
 msgstr[1] "haben aus einem anderen Netzwerk auf Ihren Beitrag reagiert."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1126
+#: lib/vutuv_web/live/notification_live/index.ex:1086
 #, elixir-autogen, elixir-format
 msgid "shared your post on another network."
 msgid_plural "shared your post on another network."
@@ -18701,7 +18701,7 @@ msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
 "Noch nichts von vutuv. Folgen Sie Menschen hier, um diesen Tab zu füllen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:578
+#: lib/vutuv_web/live/notification_live/index.ex:575
 #, elixir-autogen, elixir-format
 msgid "View the conversation"
 msgstr "Unterhaltung ansehen"
@@ -19573,7 +19573,7 @@ msgstr "Arbeitszeugnis geändert"
 msgid "Employment reference deleted"
 msgstr "Arbeitszeugnis gelöscht"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1089
+#: lib/vutuv_web/live/notification_live/index.ex:1049
 #, elixir-autogen, elixir-format
 msgid "Employment reference review"
 msgstr "Zeugnisprüfung"
@@ -19598,13 +19598,13 @@ msgstr "Ausstellungsdatum"
 msgid "Reviewing your reference. This usually takes about %{duration}."
 msgstr "Ihr Zeugnis wird geprüft. Das dauert erfahrungsgemäß etwa %{duration}."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1293
+#: lib/vutuv_web/live/notification_live/index.ex:1251
 #: lib/vutuv_web/views/notification_digest_text.ex:84
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready."
 msgstr "Die Prüfung von „%{title}“ ist fertig."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1290
+#: lib/vutuv_web/live/notification_live/index.ex:1248
 #: lib/vutuv_web/views/notification_digest_text.ex:81
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready: %{grade}."
@@ -19620,7 +19620,7 @@ msgstr "Erfahrungsgemäß etwa %{duration}."
 msgid "When the review of one of your employment references is finished. It takes minutes, so you can close the page and wait for the email."
 msgstr "Wenn die Prüfung eines Ihrer Arbeitszeugnisse fertig ist. Das dauert einige Minuten, Sie können die Seite also schließen und auf die E-Mail warten."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1296
+#: lib/vutuv_web/live/notification_live/index.ex:1254
 #, elixir-autogen, elixir-format
 msgid "Your employment reference has been reviewed."
 msgstr "Ihr Arbeitszeugnis wurde geprüft."
@@ -19962,7 +19962,7 @@ msgstr "Frau"
 msgid "Salutation"
 msgstr "Anrede"
 
-#: lib/vutuv_web/controllers/user_controller.ex:222
+#: lib/vutuv_web/controllers/user_controller.ex:275
 #, elixir-autogen, elixir-format
 msgid "Your verified badge was removed because you changed your name or date of birth. We re-check identity against those details so members can trust verified profiles and nobody can set up a fake verified account. An admin can verify you again anytime."
 msgstr ""
@@ -20005,7 +20005,7 @@ msgstr ""
 msgid "Cancel registration"
 msgstr "Registrierung abbrechen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:847
+#: lib/vutuv_web/live/notification_live/index.ex:844
 #, elixir-autogen, elixir-format
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
@@ -20025,17 +20025,17 @@ msgstr ""
 "Kommt keine PIN an? Ist die E-Mail-Adresse {email} korrekt? Haben Sie einmal "
 "in Ihren Spam-Ordner geschaut?"
 
-#: lib/vutuv/accounts/user.ex:1249
+#: lib/vutuv/accounts/user.ex:1243
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/vutuv/accounts/user.ex:1247
+#: lib/vutuv/accounts/user.ex:1241
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr "Weiblich"
 
-#: lib/vutuv/accounts/user.ex:1248
+#: lib/vutuv/accounts/user.ex:1242
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Männlich"
@@ -21296,12 +21296,37 @@ msgstr "eine Adresse in einem anderen Netzwerk: vutuv bietet Ihnen an, ihr zu fo
 msgid "the address of a post out there: vutuv fetches it so you can answer it here"
 msgstr "die Adresse eines Beitrags dort draußen: vutuv holt ihn, damit Sie hier darauf antworten können"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1088
+#: lib/vutuv_web/templates/user/edit.html.heex:81
 #, elixir-autogen, elixir-format
-msgid "Imported profile picture"
-msgstr "Übernommenes Profilbild"
+msgid "Fetch my picture from gravatar.com"
+msgstr "Mein Bild von gravatar.com holen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:886
+#: lib/vutuv_web/controllers/user_controller.ex:200
 #, elixir-autogen, elixir-format
-msgid "When you signed up we found a picture for your email address at gravatar.com and used it as your profile picture. At {url} you can replace or remove it at any time."
-msgstr "Bei Ihrer Anmeldung haben wir zu Ihrer E-Mail-Adresse ein Bild bei gravatar.com gefunden und als Ihr Profilbild übernommen. Unter {url} können Sie es jederzeit austauschen oder entfernen."
+msgid "The picture from gravatar.com could not be saved."
+msgstr "Das Bild von gravatar.com konnte nicht gespeichert werden."
+
+#: lib/vutuv_web/controllers/user_controller.ex:184
+#, elixir-autogen, elixir-format
+msgid "We took your picture from gravatar.com."
+msgstr "Wir haben Ihr Bild von gravatar.com übernommen."
+
+#: lib/vutuv_web/controllers/user_controller.ex:196
+#, elixir-autogen, elixir-format
+msgid "gravatar.com could not be reached. Please try again later."
+msgstr "gravatar.com war nicht erreichbar. Bitte versuchen Sie es später noch einmal."
+
+#: lib/vutuv_web/controllers/user_controller.ex:191
+#, elixir-autogen, elixir-format
+msgid "gravatar.com has no picture for your email address."
+msgstr "gravatar.com hat kein Bild zu Ihrer E-Mail-Adresse."
+
+#: lib/vutuv_web/templates/user/edit.html.heex:84
+#, elixir-autogen, elixir-format
+msgid "Only when you press this: we ask gravatar.com whether there is a picture for your email address, sending a hash of the address rather than the address itself. Nothing leaves this server otherwise."
+msgstr "Nur wenn Sie hier klicken: Wir fragen bei gravatar.com nach, ob es zu Ihrer E-Mail-Adresse ein Bild gibt, und übermitteln dafür einen Hashwert der Adresse, nicht die Adresse selbst. Sonst verlässt nichts diesen Server."
+
+#: lib/vutuv_web/controllers/user_controller.ex:172
+#, elixir-autogen, elixir-format
+msgid "The gravatar.com lookup is switched off on this installation."
+msgstr "Die Abfrage bei gravatar.com ist auf dieser Installation abgeschaltet."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -91,12 +91,12 @@ msgstr ""
 msgid "Are you sure?"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:19
+#: lib/vutuv_web/templates/user/edit.html.heex:22
 #, elixir-autogen
 msgid "Avatar"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:368
+#: lib/vutuv_web/templates/user/edit.html.heex:393
 #, elixir-autogen
 msgid "Birthdate"
 msgstr ""
@@ -128,10 +128,10 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:259
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:26
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
-#: lib/vutuv_web/templates/user/edit.html.heex:50
-#: lib/vutuv_web/templates/user/edit.html.heex:103
-#: lib/vutuv_web/templates/user/edit.html.heex:423
-#: lib/vutuv_web/templates/user/edit.html.heex:458
+#: lib/vutuv_web/templates/user/edit.html.heex:53
+#: lib/vutuv_web/templates/user/edit.html.heex:128
+#: lib/vutuv_web/templates/user/edit.html.heex:448
+#: lib/vutuv_web/templates/user/edit.html.heex:497
 #: lib/vutuv_web/templates/username/confirm.html.heex:222
 #, elixir-autogen
 msgid "Cancel"
@@ -306,7 +306,7 @@ msgid "Fax"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:511
-#: lib/vutuv_web/templates/user/edit.html.heex:125
+#: lib/vutuv_web/templates/user/edit.html.heex:150
 #, elixir-autogen
 msgid "First Name"
 msgstr ""
@@ -315,7 +315,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:513
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
-#: lib/vutuv_web/live/notification_live/index.ex:1005
+#: lib/vutuv_web/live/notification_live/index.ex:969
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:40
@@ -343,7 +343,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:195
 #: lib/vutuv_web/templates/page/index.html.heex:93
-#: lib/vutuv_web/templates/user/edit.html.heex:162
+#: lib/vutuv_web/templates/user/edit.html.heex:187
 #: lib/vutuv_web/views/account_event_text.ex:197
 #, elixir-autogen
 msgid "Gender"
@@ -384,7 +384,7 @@ msgid "Language"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:513
-#: lib/vutuv_web/templates/user/edit.html.heex:130
+#: lib/vutuv_web/templates/user/edit.html.heex:155
 #, elixir-autogen
 msgid "Last Name"
 msgstr ""
@@ -443,7 +443,7 @@ msgid "Log Out"
 msgstr ""
 
 #: lib/vutuv_web/live/shell_live.ex:843
-#: lib/vutuv_web/live/shell_live.ex:880
+#: lib/vutuv_web/live/shell_live.ex:889
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -451,12 +451,12 @@ msgid "Log in"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:512
-#: lib/vutuv_web/templates/user/edit.html.heex:135
+#: lib/vutuv_web/templates/user/edit.html.heex:160
 #, elixir-autogen
 msgid "Middle Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:929
+#: lib/vutuv_web/live/notification_live/index.ex:893
 #, elixir-autogen
 msgid "More"
 msgstr ""
@@ -473,7 +473,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:650
+#: lib/vutuv_web/live/notification_live/index.ex:647
 #: lib/vutuv_web/live/organization_live/activity.ex:123
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
@@ -485,7 +485,7 @@ msgid "New"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:515
-#: lib/vutuv_web/templates/user/edit.html.heex:140
+#: lib/vutuv_web/templates/user/edit.html.heex:165
 #, elixir-autogen
 msgid "Nickname"
 msgstr ""
@@ -566,7 +566,7 @@ msgid "Phone number updated successfully."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:510
-#: lib/vutuv_web/templates/user/edit.html.heex:145
+#: lib/vutuv_web/templates/user/edit.html.heex:170
 #, elixir-autogen
 msgid "Prefix"
 msgstr ""
@@ -626,7 +626,7 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/preferences.html.heex:205
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
-#: lib/vutuv_web/templates/user/edit.html.heex:418
+#: lib/vutuv_web/templates/user/edit.html.heex:443
 #: lib/vutuv_web/views/settings_html.ex:175
 #, elixir-autogen
 msgid "Save"
@@ -641,7 +641,7 @@ msgstr ""
 #: lib/vutuv_web/live/search_live.ex:54
 #: lib/vutuv_web/live/search_live.ex:613
 #: lib/vutuv_web/live/shell_live.ex:711
-#: lib/vutuv_web/live/shell_live.ex:863
+#: lib/vutuv_web/live/shell_live.ex:872
 #: lib/vutuv_web/live/tag_live/timeline.ex:237
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
@@ -747,7 +747,7 @@ msgid "Submit a bugreport or a feature request."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:514
-#: lib/vutuv_web/templates/user/edit.html.heex:150
+#: lib/vutuv_web/templates/user/edit.html.heex:175
 #, elixir-autogen
 msgid "Suffix"
 msgstr ""
@@ -774,12 +774,12 @@ msgstr ""
 msgid "User %{name} created successfully. An email has been sent with your PIN."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:310
+#: lib/vutuv_web/controllers/user_controller.ex:363
 #, elixir-autogen
 msgid "User deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:229
+#: lib/vutuv_web/controllers/user_controller.ex:282
 #, elixir-autogen
 msgid "User updated successfully."
 msgstr ""
@@ -794,7 +794,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
-#: lib/vutuv_web/live/notification_live/index.ex:1087
+#: lib/vutuv_web/live/notification_live/index.ex:1048
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -1411,7 +1411,7 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/email_controller.ex:167
 #: lib/vutuv_web/controllers/session_controller.ex:461
-#: lib/vutuv_web/controllers/user_controller.ex:330
+#: lib/vutuv_web/controllers/user_controller.ex:383
 #: lib/vutuv_web/controllers/username_controller.ex:215
 #, elixir-autogen
 msgid "Too many incorrect attempts."
@@ -1594,7 +1594,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:866
+#: lib/vutuv_web/live/shell_live.ex:875
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1737,7 +1737,7 @@ msgstr ""
 #: lib/vutuv_web/live/message_live/index.ex:50
 #: lib/vutuv_web/live/message_live/index.ex:622
 #: lib/vutuv_web/live/shell_live.ex:727
-#: lib/vutuv_web/live/shell_live.ex:865
+#: lib/vutuv_web/live/shell_live.ex:874
 #: lib/vutuv_web/templates/layout/app.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Messages"
@@ -1825,8 +1825,8 @@ msgstr ""
 #: lib/vutuv_web/controllers/session_controller.ex:167
 #: lib/vutuv_web/controllers/session_controller.ex:203
 #: lib/vutuv_web/controllers/session_controller.ex:219
-#: lib/vutuv_web/controllers/user_controller.ex:266
-#: lib/vutuv_web/controllers/user_controller.ex:295
+#: lib/vutuv_web/controllers/user_controller.ex:319
+#: lib/vutuv_web/controllers/user_controller.ex:348
 #: lib/vutuv_web/controllers/username_controller.ex:191
 #: lib/vutuv_web/controllers/username_controller.ex:273
 #: lib/vutuv_web/controllers/username_controller.ex:296
@@ -1895,17 +1895,17 @@ msgstr ""
 msgid "submit a bug report"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1110
+#: lib/vutuv_web/live/notification_live/index.ex:1070
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1105
+#: lib/vutuv_web/live/notification_live/index.ex:1065
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1100
+#: lib/vutuv_web/live/notification_live/index.ex:1060
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr ""
@@ -1995,7 +1995,7 @@ msgstr ""
 msgid "Change cover photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:71
+#: lib/vutuv_web/templates/user/edit.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "Cover photo"
 msgstr ""
@@ -2066,7 +2066,7 @@ msgid "September"
 msgstr ""
 
 #: lib/vutuv_web/templates/education/form_content.html.heex:32
-#: lib/vutuv_web/templates/user/edit.html.heex:210
+#: lib/vutuv_web/templates/user/edit.html.heex:235
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Markdown is supported: bold, italics, links and lists."
@@ -2115,7 +2115,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/feed.ex:159
 #: lib/vutuv_web/live/post_live/feed.ex:936
 #: lib/vutuv_web/live/shell_live.ex:599
-#: lib/vutuv_web/live/shell_live.ex:861
+#: lib/vutuv_web/live/shell_live.ex:870
 #: lib/vutuv_web/templates/layout/app.html.heex:122
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2197,7 +2197,7 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:83
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:382
-#: lib/vutuv_web/live/notification_live/index.ex:927
+#: lib/vutuv_web/live/notification_live/index.ex:891
 #: lib/vutuv_web/live/organization_live/show.ex:549
 #: lib/vutuv_web/live/post_live/saved.ex:495
 #: lib/vutuv_web/live/search_live.ex:309
@@ -2387,7 +2387,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1567
 #: lib/vutuv_web/components/post_components.ex:4670
 #: lib/vutuv_web/components/ui.ex:2985
-#: lib/vutuv_web/live/notification_live/index.ex:1077
+#: lib/vutuv_web/live/notification_live/index.ex:1038
 #: lib/vutuv_web/views/user_html.ex:345
 #, elixir-autogen, elixir-format
 msgid "Like"
@@ -2395,7 +2395,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1000
 #: lib/vutuv_web/components/post_components.ex:4679
-#: lib/vutuv_web/live/notification_live/index.ex:1007
+#: lib/vutuv_web/live/notification_live/index.ex:971
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
 #: lib/vutuv_web/live/shell_live.ex:789
@@ -2480,7 +2480,7 @@ msgid "Only public posts can be answered."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:393
-#: lib/vutuv_web/live/notification_live/index.ex:1008
+#: lib/vutuv_web/live/notification_live/index.ex:972
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
@@ -2488,7 +2488,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1578
 #: lib/vutuv_web/components/post_components.ex:4706
 #: lib/vutuv_web/components/post_components.ex:4707
-#: lib/vutuv_web/live/notification_live/index.ex:1074
+#: lib/vutuv_web/live/notification_live/index.ex:1035
 #: lib/vutuv_web/live/post_live/reply.ex:42
 #, elixir-autogen, elixir-format
 msgid "Reply"
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1300
+#: lib/vutuv_web/live/notification_live/index.ex:1258
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr ""
@@ -2787,7 +2787,7 @@ msgstr[1] ""
 #: lib/vutuv_web/agent_docs/markdown.ex:548
 #: lib/vutuv_web/agent_docs/text.ex:515
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:1006
+#: lib/vutuv_web/live/notification_live/index.ex:970
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
@@ -2842,23 +2842,23 @@ msgid "Open someone's profile to message them."
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:225
-#: lib/vutuv_web/live/notification_live/index.ex:1090
+#: lib/vutuv_web/live/notification_live/index.ex:1050
 #: lib/vutuv_web/live/organization_live/activity.ex:99
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1080
+#: lib/vutuv_web/live/notification_live/index.ex:1041
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1073
+#: lib/vutuv_web/live/notification_live/index.ex:1034
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1072
+#: lib/vutuv_web/live/notification_live/index.ex:1033
 #: lib/vutuv_web/templates/user/show.html.heex:933
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -2871,7 +2871,7 @@ msgstr[1] ""
 msgid "Welcome to vutuv, %{name}!"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1107
+#: lib/vutuv_web/live/notification_live/index.ex:1067
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr ""
@@ -2903,12 +2903,12 @@ msgstr ""
 msgid "(no text)"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1336
+#: lib/vutuv_web/live/notification_live/index.ex:1294
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1337
+#: lib/vutuv_web/live/notification_live/index.ex:1295
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr ""
@@ -3014,7 +3014,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:1081
+#: lib/vutuv_web/live/notification_live/index.ex:1042
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3145,7 +3145,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3794
 #: lib/vutuv_web/live/shell_live.ex:612
-#: lib/vutuv_web/live/shell_live.ex:870
+#: lib/vutuv_web/live/shell_live.ex:879
 #: lib/vutuv_web/templates/import/new.html.heex:15
 #: lib/vutuv_web/templates/import/preview.html.heex:55
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
@@ -3438,12 +3438,12 @@ msgstr ""
 msgid "You cannot report your own content."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1339
+#: lib/vutuv_web/live/notification_live/index.ex:1297
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1338
+#: lib/vutuv_web/live/notification_live/index.ex:1296
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr ""
@@ -3453,7 +3453,7 @@ msgstr ""
 msgid "Your content was reported"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1340
+#: lib/vutuv_web/live/notification_live/index.ex:1298
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3637,7 +3637,7 @@ msgstr ""
 msgid "Open the profile"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1364
+#: lib/vutuv_web/live/notification_live/index.ex:1322
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3662,7 +3662,7 @@ msgstr ""
 msgid "Report filed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1083
+#: lib/vutuv_web/live/notification_live/index.ex:1044
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr ""
@@ -3737,7 +3737,7 @@ msgstr ""
 msgid "Waiting for the owner"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1369
+#: lib/vutuv_web/live/notification_live/index.ex:1327
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -4594,7 +4594,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:388
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:516
-#: lib/vutuv_web/live/notification_live/index.ex:928
+#: lib/vutuv_web/live/notification_live/index.ex:892
 #: lib/vutuv_web/live/organization_live/show.ex:632
 #: lib/vutuv_web/live/post_live/saved.ex:498
 #: lib/vutuv_web/live/search_live.ex:307
@@ -4617,7 +4617,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:409
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
-#: lib/vutuv_web/live/notification_live/index.ex:926
+#: lib/vutuv_web/live/notification_live/index.ex:890
 #: lib/vutuv_web/live/search_live.ex:306
 #: lib/vutuv_web/views/qualification_html.ex:90
 #, elixir-autogen, elixir-format
@@ -5400,7 +5400,7 @@ msgid "Previous post in the feed"
 msgstr ""
 
 #: lib/vutuv_web/live/shell_live.ex:592
-#: lib/vutuv_web/live/shell_live.ex:854
+#: lib/vutuv_web/live/shell_live.ex:863
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -5413,7 +5413,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:2835
 #: lib/vutuv_web/components/post_components.ex:2887
 #: lib/vutuv_web/components/post_components.ex:3284
-#: lib/vutuv_web/live/notification_live/index.ex:694
+#: lib/vutuv_web/live/notification_live/index.ex:691
 #: lib/vutuv_web/live/post_live/feed.ex:1245
 #: lib/vutuv_web/views/user_html.ex:113
 #, elixir-autogen, elixir-format
@@ -5454,7 +5454,7 @@ msgstr ""
 msgid "Type of email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:197
+#: lib/vutuv_web/templates/user/edit.html.heex:222
 #, elixir-autogen, elixir-format
 msgid "About you"
 msgstr ""
@@ -5536,12 +5536,12 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:122
+#: lib/vutuv_web/templates/user/edit.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "Your name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:523
+#: lib/vutuv_web/live/notification_live/index.ex:520
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr ""
@@ -5593,24 +5593,24 @@ msgstr ""
 msgid "This sets the language of the whole vutuv interface, not your public profile."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:27
-#: lib/vutuv_web/templates/user/edit.html.heex:31
+#: lib/vutuv_web/templates/user/edit.html.heex:30
+#: lib/vutuv_web/templates/user/edit.html.heex:34
 #, elixir-autogen, elixir-format
 msgid "Current avatar"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:80
-#: lib/vutuv_web/templates/user/edit.html.heex:84
+#: lib/vutuv_web/templates/user/edit.html.heex:105
+#: lib/vutuv_web/templates/user/edit.html.heex:109
 #, elixir-autogen, elixir-format
 msgid "Current cover photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:146
+#: lib/vutuv_web/templates/user/edit.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "e.g. Dr. or Prof."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:151
+#: lib/vutuv_web/templates/user/edit.html.heex:176
 #, elixir-autogen, elixir-format
 msgid "e.g. Jr. or PhD"
 msgstr ""
@@ -5637,7 +5637,7 @@ msgid "Apps & API"
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:127
-#: lib/vutuv_web/live/notification_live/index.ex:1009
+#: lib/vutuv_web/live/notification_live/index.ex:973
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:17
@@ -6052,7 +6052,7 @@ msgid "Add a tagline"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:148
-#: lib/vutuv_web/templates/user/edit.html.heex:206
+#: lib/vutuv_web/templates/user/edit.html.heex:231
 #: lib/vutuv_web/views/account_event_text.ex:190
 #, elixir-autogen, elixir-format
 msgid "Tagline"
@@ -6076,8 +6076,8 @@ msgid_plural "Posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:55
-#: lib/vutuv_web/templates/user/edit.html.heex:108
+#: lib/vutuv_web/templates/user/edit.html.heex:58
+#: lib/vutuv_web/templates/user/edit.html.heex:133
 #, elixir-autogen, elixir-format
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
@@ -6087,41 +6087,41 @@ msgstr ""
 msgid "Also on"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:48
-#: lib/vutuv_web/templates/user/edit.html.heex:101
+#: lib/vutuv_web/templates/user/edit.html.heex:51
+#: lib/vutuv_web/templates/user/edit.html.heex:126
 #, elixir-autogen, elixir-format
 msgid "Drag to move, use the slider to zoom. The framed area is what others see."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:60
+#: lib/vutuv_web/templates/user/edit.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "New avatar preview"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:113
+#: lib/vutuv_web/templates/user/edit.html.heex:138
 #, elixir-autogen, elixir-format
 msgid "New cover photo preview"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:100
+#: lib/vutuv_web/templates/user/edit.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Position your cover photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:47
+#: lib/vutuv_web/templates/user/edit.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "Position your photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:49
-#: lib/vutuv_web/templates/user/edit.html.heex:102
+#: lib/vutuv_web/templates/user/edit.html.heex:52
+#: lib/vutuv_web/templates/user/edit.html.heex:127
 #, elixir-autogen, elixir-format
 msgid "Use photo"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/composer.ex:1372
-#: lib/vutuv_web/templates/user/edit.html.heex:51
-#: lib/vutuv_web/templates/user/edit.html.heex:104
+#: lib/vutuv_web/templates/user/edit.html.heex:54
+#: lib/vutuv_web/templates/user/edit.html.heex:129
 #, elixir-autogen, elixir-format
 msgid "Zoom"
 msgstr ""
@@ -6304,10 +6304,10 @@ msgid "No endorsements yet."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:1860
-#: lib/vutuv_web/live/notification_live/index.ex:628
-#: lib/vutuv_web/live/notification_live/index.ex:643
-#: lib/vutuv_web/live/notification_live/index.ex:781
-#: lib/vutuv_web/live/notification_live/index.ex:783
+#: lib/vutuv_web/live/notification_live/index.ex:625
+#: lib/vutuv_web/live/notification_live/index.ex:640
+#: lib/vutuv_web/live/notification_live/index.ex:778
+#: lib/vutuv_web/live/notification_live/index.ex:780
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr ""
@@ -7732,13 +7732,13 @@ msgstr ""
 #: lib/vutuv_web/components/job_components.ex:173
 #: lib/vutuv_web/live/admin/dashboard_live.ex:287
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:457
-#: lib/vutuv_web/live/notification_live/index.ex:955
+#: lib/vutuv_web/live/notification_live/index.ex:919
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:291
-#: lib/vutuv_web/live/notification_live/index.ex:958
+#: lib/vutuv_web/live/notification_live/index.ex:922
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr ""
@@ -7961,8 +7961,8 @@ msgstr ""
 msgid "Identity-verified"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1394
-#: lib/vutuv/accounts.ex:1443
+#: lib/vutuv/accounts.ex:1418
+#: lib/vutuv/accounts.ex:1467
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -8001,7 +8001,7 @@ msgstr ""
 msgid "Open the member browser"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1411
+#: lib/vutuv/accounts.ex:1435
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -8411,7 +8411,7 @@ msgstr ""
 msgid "Language & display"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:477
+#: lib/vutuv_web/templates/user/edit.html.heex:516
 #, elixir-autogen, elixir-format
 msgid "More profile sections"
 msgstr ""
@@ -8438,7 +8438,7 @@ msgstr ""
 msgid "The file is in JSON format and includes your profile, posts, messages and settings. It contains private data, so store it carefully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:246
+#: lib/vutuv_web/controllers/user_controller.ex:299
 #, elixir-autogen, elixir-format
 msgid "Please type your username exactly as shown to confirm the deletion."
 msgstr ""
@@ -8690,7 +8690,7 @@ msgstr ""
 msgid "Your Fediverse handle"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1406
+#: lib/vutuv/accounts.ex:1430
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -8903,7 +8903,7 @@ msgstr ""
 msgid "For a PDF, open the print view and choose \"Save as PDF\" in your browser's print dialog. Word and OpenDocument are editable; LaTeX is the typesetting source; JSON Resume is the open %{link} format."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:219
+#: lib/vutuv_web/templates/user/edit.html.heex:244
 #, elixir-autogen, elixir-format
 msgid "characters"
 msgstr ""
@@ -9462,7 +9462,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1090
+#: lib/vutuv/accounts/user.ex:1084
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9473,13 +9473,13 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1087
+#: lib/vutuv/accounts/user.ex:1081
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:243
+#: lib/vutuv_web/templates/user/edit.html.heex:268
 #, elixir-autogen, elixir-format
 msgid "Shown as a badge next to your tagline so people can see whether you are open to opportunities."
 msgstr ""
@@ -9737,18 +9737,18 @@ msgstr ""
 msgid "Date of birth"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:396
-#: lib/vutuv_web/templates/user/edit.html.heex:465
+#: lib/vutuv_web/templates/user/edit.html.heex:421
+#: lib/vutuv_web/templates/user/edit.html.heex:504
 #, elixir-autogen, elixir-format
 msgid "Remove date of birth"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:445
+#: lib/vutuv_web/templates/user/edit.html.heex:484
 #, elixir-autogen, elixir-format
 msgid "Remove your date of birth?"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:448
+#: lib/vutuv_web/templates/user/edit.html.heex:487
 #, elixir-autogen, elixir-format
 msgid "Your date of birth will be removed and your age will no longer be shown on your profile. You can add it again at any time."
 msgstr ""
@@ -10823,67 +10823,67 @@ msgstr ""
 msgid "Views"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:252
+#: lib/vutuv_web/templates/user/edit.html.heex:277
 #, elixir-autogen, elixir-format
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1128
+#: lib/vutuv/accounts/user.ex:1122
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1133
+#: lib/vutuv/accounts/user.ex:1127
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1131
+#: lib/vutuv/accounts/user.ex:1125
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:566
 #, elixir-autogen, elixir-format
 msgid "Signed-in members only"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:249
+#: lib/vutuv_web/templates/user/edit.html.heex:274
 #: lib/vutuv_web/templates/welcome/show.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Who can see your availability?"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:274
+#: lib/vutuv_web/templates/user/edit.html.heex:299
 #: lib/vutuv_web/templates/welcome/show.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Amount"
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:464
-#: lib/vutuv_web/templates/user/edit.html.heex:282
+#: lib/vutuv_web/templates/user/edit.html.heex:307
 #: lib/vutuv_web/templates/welcome/show.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "Currency"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:292
+#: lib/vutuv_web/templates/user/edit.html.heex:317
 #, elixir-autogen, elixir-format
 msgid "Hidden by default, and it still does its job while hidden. \"Signed-in members only\" adds a quiet line to your profile for members; \"Everyone\" also shows it to logged-out visitors."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:265
+#: lib/vutuv_web/templates/user/edit.html.heex:290
 #: lib/vutuv_web/templates/welcome/show.html.heex:114
 #, elixir-autogen, elixir-format
 msgid "Minimum salary expectation"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:268
+#: lib/vutuv_web/templates/user/edit.html.heex:293
 #, elixir-autogen, elixir-format
 msgid "Optional. Even when hidden, it sharpens your own job search and alerts by filtering out postings below it. Leave the amount empty to remove it."
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:471
-#: lib/vutuv_web/templates/user/edit.html.heex:278
+#: lib/vutuv_web/templates/user/edit.html.heex:303
 #: lib/vutuv_web/templates/welcome/show.html.heex:127
 #, elixir-autogen, elixir-format
 msgid "Per"
@@ -10894,7 +10894,7 @@ msgstr ""
 msgid "Salary expectation from %{amount} %{currency} per %{period}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:289
+#: lib/vutuv_web/templates/user/edit.html.heex:314
 #, elixir-autogen, elixir-format
 msgid "Who can see your salary expectation?"
 msgstr ""
@@ -10963,7 +10963,7 @@ msgstr ""
 msgid "Exclude an email domain"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:345
+#: lib/vutuv_web/templates/user/edit.html.heex:370
 #, elixir-autogen, elixir-format
 msgid "Hide from specific people"
 msgstr ""
@@ -10974,12 +10974,12 @@ msgstr ""
 msgid "Job-search exclusion list"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:348
+#: lib/vutuv_web/templates/user/edit.html.heex:373
 #, elixir-autogen, elixir-format
 msgid "Keep your availability broadly visible while making sure your own employer never sees it. Exclude specific members or email domains, and they never see your availability or salary expectation, even at \"Everyone\"."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:356
+#: lib/vutuv_web/templates/user/edit.html.heex:381
 #, elixir-autogen, elixir-format
 msgid "Manage exclusion list (1 entry)"
 msgid_plural "Manage exclusion list (%{formatted} entries)"
@@ -11828,7 +11828,7 @@ msgstr ""
 msgid "Organization pages"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1084
+#: lib/vutuv_web/live/notification_live/index.ex:1045
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr ""
@@ -11936,22 +11936,22 @@ msgstr ""
 msgid "Your organization page was updated."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1328
+#: lib/vutuv_web/live/notification_live/index.ex:1286
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1325
+#: lib/vutuv_web/live/notification_live/index.ex:1283
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1322
+#: lib/vutuv_web/live/notification_live/index.ex:1280
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1319
+#: lib/vutuv_web/live/notification_live/index.ex:1277
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr ""
@@ -12153,7 +12153,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1102
+#: lib/vutuv/accounts/user.ex:1096
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12273,7 +12273,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1101
+#: lib/vutuv/accounts/user.ex:1095
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12355,7 +12355,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1103
+#: lib/vutuv/accounts/user.ex:1097
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:496
 #: lib/vutuv_web/agent_docs/markdown.ex:389
@@ -13321,14 +13321,14 @@ msgstr ""
 msgid "%{pending} image(s) in the scan queue; %{rejected} rejected in the last 7 days. A growing queue usually means Ollama is unreachable."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:38
-#: lib/vutuv_web/templates/user/edit.html.heex:91
+#: lib/vutuv_web/templates/user/edit.html.heex:41
+#: lib/vutuv_web/templates/user/edit.html.heex:116
 #: lib/vutuv_web/templates/user/show.html.heex:61
 #, elixir-autogen, elixir-format
 msgid "Image awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1082
+#: lib/vutuv_web/live/notification_live/index.ex:1043
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13369,36 +13369,36 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1146
+#: lib/vutuv/accounts/user.ex:1140
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:407
+#: lib/vutuv_web/templates/user/edit.html.heex:432
 #, elixir-autogen, elixir-format
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1149
+#: lib/vutuv/accounts/user.ex:1143
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1152
+#: lib/vutuv/accounts/user.ex:1146
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1143
+#: lib/vutuv/accounts/user.ex:1137
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:404
+#: lib/vutuv_web/templates/user/edit.html.heex:429
 #, elixir-autogen, elixir-format
 msgid "Show my birthday as"
 msgstr ""
@@ -13415,7 +13415,7 @@ msgstr[1] ""
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1085
+#: lib/vutuv_web/live/notification_live/index.ex:1046
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr ""
@@ -13427,7 +13427,7 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1378
+#: lib/vutuv_web/live/notification_live/index.ex:1336
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
@@ -13634,22 +13634,22 @@ msgstr[1] ""
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1086
+#: lib/vutuv_web/live/notification_live/index.ex:1047
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1398
+#: lib/vutuv_web/live/notification_live/index.ex:1356
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1390
+#: lib/vutuv_web/live/notification_live/index.ex:1348
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1395
+#: lib/vutuv_web/live/notification_live/index.ex:1353
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr ""
@@ -13674,7 +13674,7 @@ msgstr ""
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1403
+#: lib/vutuv_web/live/notification_live/index.ex:1361
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr ""
@@ -13805,14 +13805,14 @@ msgstr ""
 msgid "Publisher:"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:947
+#: lib/vutuv_web/live/notification_live/index.ex:911
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:961
+#: lib/vutuv_web/live/notification_live/index.ex:925
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr ""
@@ -13827,23 +13827,23 @@ msgstr ""
 msgid "Last 30 days"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:913
-#: lib/vutuv_web/live/notification_live/index.ex:1166
+#: lib/vutuv_web/live/notification_live/index.ex:877
+#: lib/vutuv_web/live/notification_live/index.ex:1126
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1103
+#: lib/vutuv_web/live/notification_live/index.ex:1063
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1098
+#: lib/vutuv_web/live/notification_live/index.ex:1058
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1113
+#: lib/vutuv_web/live/notification_live/index.ex:1073
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr ""
@@ -14045,13 +14045,13 @@ msgstr ""
 msgid "Optional, and nobody else sees it. It filters postings below it out of your own job search."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:312
+#: lib/vutuv_web/templates/user/edit.html.heex:337
 #: lib/vutuv_web/templates/welcome/show.html.heex:143
 #, elixir-autogen, elixir-format
 msgid "How do you want to work?"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:332
+#: lib/vutuv_web/templates/user/edit.html.heex:357
 #: lib/vutuv_web/templates/welcome/show.html.heex:162
 #, elixir-autogen, elixir-format
 msgid "Shown next to your availability, and used to match you with postings."
@@ -14073,7 +14073,7 @@ msgstr ""
 msgid "Preferred workplace"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:240
+#: lib/vutuv_web/templates/user/edit.html.heex:265
 #: lib/vutuv_web/templates/welcome/show.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Availability"
@@ -14084,17 +14084,17 @@ msgstr ""
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1352
+#: lib/vutuv_web/live/notification_live/index.ex:1310
 #, elixir-autogen, elixir-format
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1075
+#: lib/vutuv_web/live/notification_live/index.ex:1036
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1153
+#: lib/vutuv_web/live/notification_live/index.ex:1113
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -14113,12 +14113,12 @@ msgstr ""
 msgid "Only part of this long conversation is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1076
+#: lib/vutuv_web/live/notification_live/index.ex:1037
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1302
+#: lib/vutuv_web/live/notification_live/index.ex:1260
 #, elixir-autogen, elixir-format
 msgid "mentioned you in a post."
 msgstr ""
@@ -14462,7 +14462,7 @@ msgstr ""
 msgid "Thread replies"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:606
+#: lib/vutuv_web/live/notification_live/index.ex:603
 #, elixir-autogen, elixir-format
 msgid "Turn off thread notifications"
 msgstr ""
@@ -14513,7 +14513,7 @@ msgstr ""
 msgid "You have reached the maximum of %{count} filters."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:601
+#: lib/vutuv_web/live/notification_live/index.ex:598
 #, elixir-autogen, elixir-format
 msgid "You wrote in this thread."
 msgstr ""
@@ -15487,7 +15487,7 @@ msgstr ""
 msgid "Replies from other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1078
+#: lib/vutuv_web/live/notification_live/index.ex:1039
 #, elixir-autogen, elixir-format
 msgid "Reply from another network"
 msgstr ""
@@ -15508,7 +15508,7 @@ msgid "Reported as not appropriate"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1077
-#: lib/vutuv_web/live/notification_live/index.ex:548
+#: lib/vutuv_web/live/notification_live/index.ex:545
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
 msgstr ""
@@ -15559,7 +15559,7 @@ msgstr ""
 msgid "You have reported a lot today. Please try again tomorrow."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1305
+#: lib/vutuv_web/live/notification_live/index.ex:1263
 #, elixir-autogen, elixir-format
 msgid "replied to your post from another network."
 msgstr ""
@@ -16245,19 +16245,19 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:475
 #: lib/vutuv_web/agent_docs/text.ex:467
-#: lib/vutuv_web/templates/user/edit.html.heex:180
+#: lib/vutuv_web/templates/user/edit.html.heex:205
 #: lib/vutuv_web/templates/user/show.html.heex:244
 #: lib/vutuv_web/views/account_event_text.ex:191
 #, elixir-autogen, elixir-format
 msgid "Name pronunciation"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:184
+#: lib/vutuv_web/templates/user/edit.html.heex:209
 #, elixir-autogen, elixir-format
 msgid "e.g. [SHTEH-fahn VIN-ter-my-er]"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:187
+#: lib/vutuv_web/templates/user/edit.html.heex:212
 #, elixir-autogen, elixir-format
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
@@ -16573,7 +16573,7 @@ msgstr ""
 msgid "From other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1079
+#: lib/vutuv_web/live/notification_live/index.ex:1040
 #, elixir-autogen, elixir-format
 msgid "Reaction from another network"
 msgstr ""
@@ -16588,21 +16588,21 @@ msgstr ""
 msgid "Show under each of your posts who out there liked or shared it, by their account address on their own server, linked to that account. Visible to everyone who sees the post. We keep nothing else about these people: no name, no picture, no text. Switching it off deletes what is stored for it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1134
+#: lib/vutuv_web/live/notification_live/index.ex:1094
 #, elixir-autogen, elixir-format
 msgid "liked your post on another network."
 msgid_plural "liked your post on another network."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1142
+#: lib/vutuv_web/live/notification_live/index.ex:1102
 #, elixir-autogen, elixir-format
 msgid "reacted to your post from another network."
 msgid_plural "reacted to your post from another network."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1126
+#: lib/vutuv_web/live/notification_live/index.ex:1086
 #, elixir-autogen, elixir-format
 msgid "shared your post on another network."
 msgid_plural "shared your post on another network."
@@ -17945,7 +17945,7 @@ msgstr ""
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:578
+#: lib/vutuv_web/live/notification_live/index.ex:575
 #, elixir-autogen, elixir-format
 msgid "View the conversation"
 msgstr ""
@@ -18815,7 +18815,7 @@ msgstr ""
 msgid "Employment reference deleted"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1089
+#: lib/vutuv_web/live/notification_live/index.ex:1049
 #, elixir-autogen, elixir-format
 msgid "Employment reference review"
 msgstr ""
@@ -18840,13 +18840,13 @@ msgstr ""
 msgid "Reviewing your reference. This usually takes about %{duration}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1293
+#: lib/vutuv_web/live/notification_live/index.ex:1251
 #: lib/vutuv_web/views/notification_digest_text.ex:84
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1290
+#: lib/vutuv_web/live/notification_live/index.ex:1248
 #: lib/vutuv_web/views/notification_digest_text.ex:81
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready: %{grade}."
@@ -18862,7 +18862,7 @@ msgstr ""
 msgid "When the review of one of your employment references is finished. It takes minutes, so you can close the page and wait for the email."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1296
+#: lib/vutuv_web/live/notification_live/index.ex:1254
 #, elixir-autogen, elixir-format
 msgid "Your employment reference has been reviewed."
 msgstr ""
@@ -19204,7 +19204,7 @@ msgstr ""
 msgid "Salutation"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:222
+#: lib/vutuv_web/controllers/user_controller.ex:275
 #, elixir-autogen, elixir-format
 msgid "Your verified badge was removed because you changed your name or date of birth. We re-check identity against those details so members can trust verified profiles and nobody can set up a fake verified account. An admin can verify you again anytime."
 msgstr ""
@@ -19236,7 +19236,7 @@ msgstr ""
 msgid "Cancel registration"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:847
+#: lib/vutuv_web/live/notification_live/index.ex:844
 #, elixir-autogen, elixir-format
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
@@ -19251,17 +19251,17 @@ msgstr ""
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1249
+#: lib/vutuv/accounts/user.ex:1243
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1247
+#: lib/vutuv/accounts/user.ex:1241
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1248
+#: lib/vutuv/accounts/user.ex:1242
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -20513,12 +20513,37 @@ msgstr ""
 msgid "the address of a post out there: vutuv fetches it so you can answer it here"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1088
+#: lib/vutuv_web/templates/user/edit.html.heex:81
 #, elixir-autogen, elixir-format
-msgid "Imported profile picture"
+msgid "Fetch my picture from gravatar.com"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:886
+#: lib/vutuv_web/controllers/user_controller.ex:200
 #, elixir-autogen, elixir-format
-msgid "When you signed up we found a picture for your email address at gravatar.com and used it as your profile picture. At {url} you can replace or remove it at any time."
+msgid "The picture from gravatar.com could not be saved."
+msgstr ""
+
+#: lib/vutuv_web/controllers/user_controller.ex:184
+#, elixir-autogen, elixir-format
+msgid "We took your picture from gravatar.com."
+msgstr ""
+
+#: lib/vutuv_web/controllers/user_controller.ex:196
+#, elixir-autogen, elixir-format
+msgid "gravatar.com could not be reached. Please try again later."
+msgstr ""
+
+#: lib/vutuv_web/controllers/user_controller.ex:191
+#, elixir-autogen, elixir-format
+msgid "gravatar.com has no picture for your email address."
+msgstr ""
+
+#: lib/vutuv_web/templates/user/edit.html.heex:84
+#, elixir-autogen, elixir-format
+msgid "Only when you press this: we ask gravatar.com whether there is a picture for your email address, sending a hash of the address rather than the address itself. Nothing leaves this server otherwise."
+msgstr ""
+
+#: lib/vutuv_web/controllers/user_controller.ex:172
+#, elixir-autogen, elixir-format
+msgid "The gravatar.com lookup is switched off on this installation."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -89,12 +89,12 @@ msgstr ""
 msgid "Are you sure?"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:19
+#: lib/vutuv_web/templates/user/edit.html.heex:22
 #, elixir-autogen
 msgid "Avatar"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:368
+#: lib/vutuv_web/templates/user/edit.html.heex:393
 #, elixir-autogen
 msgid "Birthdate"
 msgstr ""
@@ -126,10 +126,10 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:259
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:26
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
-#: lib/vutuv_web/templates/user/edit.html.heex:50
-#: lib/vutuv_web/templates/user/edit.html.heex:103
-#: lib/vutuv_web/templates/user/edit.html.heex:423
-#: lib/vutuv_web/templates/user/edit.html.heex:458
+#: lib/vutuv_web/templates/user/edit.html.heex:53
+#: lib/vutuv_web/templates/user/edit.html.heex:128
+#: lib/vutuv_web/templates/user/edit.html.heex:448
+#: lib/vutuv_web/templates/user/edit.html.heex:497
 #: lib/vutuv_web/templates/username/confirm.html.heex:222
 #, elixir-autogen
 msgid "Cancel"
@@ -304,7 +304,7 @@ msgid "Fax"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:511
-#: lib/vutuv_web/templates/user/edit.html.heex:125
+#: lib/vutuv_web/templates/user/edit.html.heex:150
 #, elixir-autogen
 msgid "First Name"
 msgstr ""
@@ -313,7 +313,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:513
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
-#: lib/vutuv_web/live/notification_live/index.ex:1005
+#: lib/vutuv_web/live/notification_live/index.ex:969
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:40
@@ -341,7 +341,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:195
 #: lib/vutuv_web/templates/page/index.html.heex:93
-#: lib/vutuv_web/templates/user/edit.html.heex:162
+#: lib/vutuv_web/templates/user/edit.html.heex:187
 #: lib/vutuv_web/views/account_event_text.ex:197
 #, elixir-autogen
 msgid "Gender"
@@ -382,7 +382,7 @@ msgid "Language"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:513
-#: lib/vutuv_web/templates/user/edit.html.heex:130
+#: lib/vutuv_web/templates/user/edit.html.heex:155
 #, elixir-autogen
 msgid "Last Name"
 msgstr ""
@@ -441,7 +441,7 @@ msgid "Log Out"
 msgstr ""
 
 #: lib/vutuv_web/live/shell_live.ex:843
-#: lib/vutuv_web/live/shell_live.ex:880
+#: lib/vutuv_web/live/shell_live.ex:889
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -449,12 +449,12 @@ msgid "Log in"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:512
-#: lib/vutuv_web/templates/user/edit.html.heex:135
+#: lib/vutuv_web/templates/user/edit.html.heex:160
 #, elixir-autogen
 msgid "Middle Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:929
+#: lib/vutuv_web/live/notification_live/index.ex:893
 #, elixir-autogen
 msgid "More"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:650
+#: lib/vutuv_web/live/notification_live/index.ex:647
 #: lib/vutuv_web/live/organization_live/activity.ex:123
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
@@ -483,7 +483,7 @@ msgid "New"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:515
-#: lib/vutuv_web/templates/user/edit.html.heex:140
+#: lib/vutuv_web/templates/user/edit.html.heex:165
 #, elixir-autogen
 msgid "Nickname"
 msgstr ""
@@ -564,7 +564,7 @@ msgid "Phone number updated successfully."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:510
-#: lib/vutuv_web/templates/user/edit.html.heex:145
+#: lib/vutuv_web/templates/user/edit.html.heex:170
 #, elixir-autogen
 msgid "Prefix"
 msgstr ""
@@ -624,7 +624,7 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/preferences.html.heex:205
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
-#: lib/vutuv_web/templates/user/edit.html.heex:418
+#: lib/vutuv_web/templates/user/edit.html.heex:443
 #: lib/vutuv_web/views/settings_html.ex:175
 #, elixir-autogen
 msgid "Save"
@@ -639,7 +639,7 @@ msgstr ""
 #: lib/vutuv_web/live/search_live.ex:54
 #: lib/vutuv_web/live/search_live.ex:613
 #: lib/vutuv_web/live/shell_live.ex:711
-#: lib/vutuv_web/live/shell_live.ex:863
+#: lib/vutuv_web/live/shell_live.ex:872
 #: lib/vutuv_web/live/tag_live/timeline.ex:237
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
@@ -745,7 +745,7 @@ msgid "Submit a bugreport or a feature request."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:514
-#: lib/vutuv_web/templates/user/edit.html.heex:150
+#: lib/vutuv_web/templates/user/edit.html.heex:175
 #, elixir-autogen
 msgid "Suffix"
 msgstr ""
@@ -772,12 +772,12 @@ msgstr ""
 msgid "User %{name} created successfully. An email has been sent with your PIN."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:310
+#: lib/vutuv_web/controllers/user_controller.ex:363
 #, elixir-autogen
 msgid "User deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:229
+#: lib/vutuv_web/controllers/user_controller.ex:282
 #, elixir-autogen
 msgid "User updated successfully."
 msgstr ""
@@ -792,7 +792,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
-#: lib/vutuv_web/live/notification_live/index.ex:1087
+#: lib/vutuv_web/live/notification_live/index.ex:1048
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -1409,7 +1409,7 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/email_controller.ex:167
 #: lib/vutuv_web/controllers/session_controller.ex:461
-#: lib/vutuv_web/controllers/user_controller.ex:330
+#: lib/vutuv_web/controllers/user_controller.ex:383
 #: lib/vutuv_web/controllers/username_controller.ex:215
 #, elixir-autogen
 msgid "Too many incorrect attempts."
@@ -1592,7 +1592,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:866
+#: lib/vutuv_web/live/shell_live.ex:875
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1735,7 +1735,7 @@ msgstr ""
 #: lib/vutuv_web/live/message_live/index.ex:50
 #: lib/vutuv_web/live/message_live/index.ex:622
 #: lib/vutuv_web/live/shell_live.ex:727
-#: lib/vutuv_web/live/shell_live.ex:865
+#: lib/vutuv_web/live/shell_live.ex:874
 #: lib/vutuv_web/templates/layout/app.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Messages"
@@ -1823,8 +1823,8 @@ msgstr ""
 #: lib/vutuv_web/controllers/session_controller.ex:167
 #: lib/vutuv_web/controllers/session_controller.ex:203
 #: lib/vutuv_web/controllers/session_controller.ex:219
-#: lib/vutuv_web/controllers/user_controller.ex:266
-#: lib/vutuv_web/controllers/user_controller.ex:295
+#: lib/vutuv_web/controllers/user_controller.ex:319
+#: lib/vutuv_web/controllers/user_controller.ex:348
 #: lib/vutuv_web/controllers/username_controller.ex:191
 #: lib/vutuv_web/controllers/username_controller.ex:273
 #: lib/vutuv_web/controllers/username_controller.ex:296
@@ -1893,17 +1893,17 @@ msgstr ""
 msgid "submit a bug report"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1110
+#: lib/vutuv_web/live/notification_live/index.ex:1070
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1105
+#: lib/vutuv_web/live/notification_live/index.ex:1065
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1100
+#: lib/vutuv_web/live/notification_live/index.ex:1060
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr ""
@@ -1993,7 +1993,7 @@ msgstr ""
 msgid "Change cover photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:71
+#: lib/vutuv_web/templates/user/edit.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "Cover photo"
 msgstr ""
@@ -2064,7 +2064,7 @@ msgid "September"
 msgstr ""
 
 #: lib/vutuv_web/templates/education/form_content.html.heex:32
-#: lib/vutuv_web/templates/user/edit.html.heex:210
+#: lib/vutuv_web/templates/user/edit.html.heex:235
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Markdown is supported: bold, italics, links and lists."
@@ -2113,7 +2113,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/feed.ex:159
 #: lib/vutuv_web/live/post_live/feed.ex:936
 #: lib/vutuv_web/live/shell_live.ex:599
-#: lib/vutuv_web/live/shell_live.ex:861
+#: lib/vutuv_web/live/shell_live.ex:870
 #: lib/vutuv_web/templates/layout/app.html.heex:122
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2195,7 +2195,7 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:83
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:382
-#: lib/vutuv_web/live/notification_live/index.ex:927
+#: lib/vutuv_web/live/notification_live/index.ex:891
 #: lib/vutuv_web/live/organization_live/show.ex:549
 #: lib/vutuv_web/live/post_live/saved.ex:495
 #: lib/vutuv_web/live/search_live.ex:309
@@ -2385,7 +2385,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1567
 #: lib/vutuv_web/components/post_components.ex:4670
 #: lib/vutuv_web/components/ui.ex:2985
-#: lib/vutuv_web/live/notification_live/index.ex:1077
+#: lib/vutuv_web/live/notification_live/index.ex:1038
 #: lib/vutuv_web/views/user_html.ex:345
 #, elixir-autogen, elixir-format
 msgid "Like"
@@ -2393,7 +2393,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1000
 #: lib/vutuv_web/components/post_components.ex:4679
-#: lib/vutuv_web/live/notification_live/index.ex:1007
+#: lib/vutuv_web/live/notification_live/index.ex:971
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
 #: lib/vutuv_web/live/shell_live.ex:789
@@ -2478,7 +2478,7 @@ msgid "Only public posts can be answered."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:393
-#: lib/vutuv_web/live/notification_live/index.ex:1008
+#: lib/vutuv_web/live/notification_live/index.ex:972
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
@@ -2486,7 +2486,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1578
 #: lib/vutuv_web/components/post_components.ex:4706
 #: lib/vutuv_web/components/post_components.ex:4707
-#: lib/vutuv_web/live/notification_live/index.ex:1074
+#: lib/vutuv_web/live/notification_live/index.ex:1035
 #: lib/vutuv_web/live/post_live/reply.ex:42
 #, elixir-autogen, elixir-format
 msgid "Reply"
@@ -2508,7 +2508,7 @@ msgstr ""
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1300
+#: lib/vutuv_web/live/notification_live/index.ex:1258
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr ""
@@ -2785,7 +2785,7 @@ msgstr[1] ""
 #: lib/vutuv_web/agent_docs/markdown.ex:548
 #: lib/vutuv_web/agent_docs/text.ex:515
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:1006
+#: lib/vutuv_web/live/notification_live/index.ex:970
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
@@ -2840,23 +2840,23 @@ msgid "Open someone's profile to message them."
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:225
-#: lib/vutuv_web/live/notification_live/index.ex:1090
+#: lib/vutuv_web/live/notification_live/index.ex:1050
 #: lib/vutuv_web/live/organization_live/activity.ex:99
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1080
+#: lib/vutuv_web/live/notification_live/index.ex:1041
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1073
+#: lib/vutuv_web/live/notification_live/index.ex:1034
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1072
+#: lib/vutuv_web/live/notification_live/index.ex:1033
 #: lib/vutuv_web/templates/user/show.html.heex:933
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -2869,7 +2869,7 @@ msgstr[1] ""
 msgid "Welcome to vutuv, %{name}!"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1107
+#: lib/vutuv_web/live/notification_live/index.ex:1067
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr ""
@@ -2901,12 +2901,12 @@ msgstr ""
 msgid "(no text)"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1336
+#: lib/vutuv_web/live/notification_live/index.ex:1294
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1337
+#: lib/vutuv_web/live/notification_live/index.ex:1295
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr ""
@@ -3012,7 +3012,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:1081
+#: lib/vutuv_web/live/notification_live/index.ex:1042
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3143,7 +3143,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3794
 #: lib/vutuv_web/live/shell_live.ex:612
-#: lib/vutuv_web/live/shell_live.ex:870
+#: lib/vutuv_web/live/shell_live.ex:879
 #: lib/vutuv_web/templates/import/new.html.heex:15
 #: lib/vutuv_web/templates/import/preview.html.heex:55
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
@@ -3436,12 +3436,12 @@ msgstr ""
 msgid "You cannot report your own content."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1339
+#: lib/vutuv_web/live/notification_live/index.ex:1297
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1338
+#: lib/vutuv_web/live/notification_live/index.ex:1296
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr ""
@@ -3451,7 +3451,7 @@ msgstr ""
 msgid "Your content was reported"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1340
+#: lib/vutuv_web/live/notification_live/index.ex:1298
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3635,7 +3635,7 @@ msgstr ""
 msgid "Open the profile"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1364
+#: lib/vutuv_web/live/notification_live/index.ex:1322
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3660,7 +3660,7 @@ msgstr ""
 msgid "Report filed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1083
+#: lib/vutuv_web/live/notification_live/index.ex:1044
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr ""
@@ -3735,7 +3735,7 @@ msgstr ""
 msgid "Waiting for the owner"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1369
+#: lib/vutuv_web/live/notification_live/index.ex:1327
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -4592,7 +4592,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:388
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:516
-#: lib/vutuv_web/live/notification_live/index.ex:928
+#: lib/vutuv_web/live/notification_live/index.ex:892
 #: lib/vutuv_web/live/organization_live/show.ex:632
 #: lib/vutuv_web/live/post_live/saved.ex:498
 #: lib/vutuv_web/live/search_live.ex:307
@@ -4615,7 +4615,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:409
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
-#: lib/vutuv_web/live/notification_live/index.ex:926
+#: lib/vutuv_web/live/notification_live/index.ex:890
 #: lib/vutuv_web/live/search_live.ex:306
 #: lib/vutuv_web/views/qualification_html.ex:90
 #, elixir-autogen, elixir-format
@@ -5398,7 +5398,7 @@ msgid "Previous post in the feed"
 msgstr ""
 
 #: lib/vutuv_web/live/shell_live.ex:592
-#: lib/vutuv_web/live/shell_live.ex:854
+#: lib/vutuv_web/live/shell_live.ex:863
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -5411,7 +5411,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:2835
 #: lib/vutuv_web/components/post_components.ex:2887
 #: lib/vutuv_web/components/post_components.ex:3284
-#: lib/vutuv_web/live/notification_live/index.ex:694
+#: lib/vutuv_web/live/notification_live/index.ex:691
 #: lib/vutuv_web/live/post_live/feed.ex:1245
 #: lib/vutuv_web/views/user_html.ex:113
 #, elixir-autogen, elixir-format
@@ -5452,7 +5452,7 @@ msgstr ""
 msgid "Type of email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:197
+#: lib/vutuv_web/templates/user/edit.html.heex:222
 #, elixir-autogen, elixir-format
 msgid "About you"
 msgstr ""
@@ -5534,12 +5534,12 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:122
+#: lib/vutuv_web/templates/user/edit.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "Your name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:523
+#: lib/vutuv_web/live/notification_live/index.ex:520
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr ""
@@ -5591,24 +5591,24 @@ msgstr ""
 msgid "This sets the language of the whole vutuv interface, not your public profile."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:27
-#: lib/vutuv_web/templates/user/edit.html.heex:31
+#: lib/vutuv_web/templates/user/edit.html.heex:30
+#: lib/vutuv_web/templates/user/edit.html.heex:34
 #, elixir-autogen, elixir-format
 msgid "Current avatar"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:80
-#: lib/vutuv_web/templates/user/edit.html.heex:84
+#: lib/vutuv_web/templates/user/edit.html.heex:105
+#: lib/vutuv_web/templates/user/edit.html.heex:109
 #, elixir-autogen, elixir-format
 msgid "Current cover photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:146
+#: lib/vutuv_web/templates/user/edit.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "e.g. Dr. or Prof."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:151
+#: lib/vutuv_web/templates/user/edit.html.heex:176
 #, elixir-autogen, elixir-format
 msgid "e.g. Jr. or PhD"
 msgstr ""
@@ -5635,7 +5635,7 @@ msgid "Apps & API"
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:127
-#: lib/vutuv_web/live/notification_live/index.ex:1009
+#: lib/vutuv_web/live/notification_live/index.ex:973
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:17
@@ -6050,7 +6050,7 @@ msgid "Add a tagline"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:148
-#: lib/vutuv_web/templates/user/edit.html.heex:206
+#: lib/vutuv_web/templates/user/edit.html.heex:231
 #: lib/vutuv_web/views/account_event_text.ex:190
 #, elixir-autogen, elixir-format
 msgid "Tagline"
@@ -6074,8 +6074,8 @@ msgid_plural "Posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:55
-#: lib/vutuv_web/templates/user/edit.html.heex:108
+#: lib/vutuv_web/templates/user/edit.html.heex:58
+#: lib/vutuv_web/templates/user/edit.html.heex:133
 #, elixir-autogen, elixir-format
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
@@ -6085,41 +6085,41 @@ msgstr ""
 msgid "Also on"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:48
-#: lib/vutuv_web/templates/user/edit.html.heex:101
+#: lib/vutuv_web/templates/user/edit.html.heex:51
+#: lib/vutuv_web/templates/user/edit.html.heex:126
 #, elixir-autogen, elixir-format
 msgid "Drag to move, use the slider to zoom. The framed area is what others see."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:60
+#: lib/vutuv_web/templates/user/edit.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "New avatar preview"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:113
+#: lib/vutuv_web/templates/user/edit.html.heex:138
 #, elixir-autogen, elixir-format
 msgid "New cover photo preview"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:100
+#: lib/vutuv_web/templates/user/edit.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Position your cover photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:47
+#: lib/vutuv_web/templates/user/edit.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "Position your photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:49
-#: lib/vutuv_web/templates/user/edit.html.heex:102
+#: lib/vutuv_web/templates/user/edit.html.heex:52
+#: lib/vutuv_web/templates/user/edit.html.heex:127
 #, elixir-autogen, elixir-format
 msgid "Use photo"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/composer.ex:1372
-#: lib/vutuv_web/templates/user/edit.html.heex:51
-#: lib/vutuv_web/templates/user/edit.html.heex:104
+#: lib/vutuv_web/templates/user/edit.html.heex:54
+#: lib/vutuv_web/templates/user/edit.html.heex:129
 #, elixir-autogen, elixir-format
 msgid "Zoom"
 msgstr ""
@@ -6302,10 +6302,10 @@ msgid "No endorsements yet."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:1860
-#: lib/vutuv_web/live/notification_live/index.ex:628
-#: lib/vutuv_web/live/notification_live/index.ex:643
-#: lib/vutuv_web/live/notification_live/index.ex:781
-#: lib/vutuv_web/live/notification_live/index.ex:783
+#: lib/vutuv_web/live/notification_live/index.ex:625
+#: lib/vutuv_web/live/notification_live/index.ex:640
+#: lib/vutuv_web/live/notification_live/index.ex:778
+#: lib/vutuv_web/live/notification_live/index.ex:780
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr ""
@@ -7730,13 +7730,13 @@ msgstr ""
 #: lib/vutuv_web/components/job_components.ex:173
 #: lib/vutuv_web/live/admin/dashboard_live.ex:287
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:457
-#: lib/vutuv_web/live/notification_live/index.ex:955
+#: lib/vutuv_web/live/notification_live/index.ex:919
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:291
-#: lib/vutuv_web/live/notification_live/index.ex:958
+#: lib/vutuv_web/live/notification_live/index.ex:922
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr ""
@@ -7959,8 +7959,8 @@ msgstr ""
 msgid "Identity-verified"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1394
-#: lib/vutuv/accounts.ex:1443
+#: lib/vutuv/accounts.ex:1418
+#: lib/vutuv/accounts.ex:1467
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -7999,7 +7999,7 @@ msgstr ""
 msgid "Open the member browser"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1411
+#: lib/vutuv/accounts.ex:1435
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -8409,7 +8409,7 @@ msgstr ""
 msgid "Language & display"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:477
+#: lib/vutuv_web/templates/user/edit.html.heex:516
 #, elixir-autogen, elixir-format
 msgid "More profile sections"
 msgstr ""
@@ -8436,7 +8436,7 @@ msgstr ""
 msgid "The file is in JSON format and includes your profile, posts, messages and settings. It contains private data, so store it carefully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:246
+#: lib/vutuv_web/controllers/user_controller.ex:299
 #, elixir-autogen, elixir-format
 msgid "Please type your username exactly as shown to confirm the deletion."
 msgstr ""
@@ -8688,7 +8688,7 @@ msgstr ""
 msgid "Your Fediverse handle"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1406
+#: lib/vutuv/accounts.ex:1430
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -8901,7 +8901,7 @@ msgstr ""
 msgid "For a PDF, open the print view and choose \"Save as PDF\" in your browser's print dialog. Word and OpenDocument are editable; LaTeX is the typesetting source; JSON Resume is the open %{link} format."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:219
+#: lib/vutuv_web/templates/user/edit.html.heex:244
 #, elixir-autogen, elixir-format
 msgid "characters"
 msgstr ""
@@ -9460,7 +9460,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1090
+#: lib/vutuv/accounts/user.ex:1084
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9471,13 +9471,13 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1087
+#: lib/vutuv/accounts/user.ex:1081
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:243
+#: lib/vutuv_web/templates/user/edit.html.heex:268
 #, elixir-autogen, elixir-format
 msgid "Shown as a badge next to your tagline so people can see whether you are open to opportunities."
 msgstr ""
@@ -9735,18 +9735,18 @@ msgstr ""
 msgid "Date of birth"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:396
-#: lib/vutuv_web/templates/user/edit.html.heex:465
+#: lib/vutuv_web/templates/user/edit.html.heex:421
+#: lib/vutuv_web/templates/user/edit.html.heex:504
 #, elixir-autogen, elixir-format
 msgid "Remove date of birth"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:445
+#: lib/vutuv_web/templates/user/edit.html.heex:484
 #, elixir-autogen, elixir-format
 msgid "Remove your date of birth?"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:448
+#: lib/vutuv_web/templates/user/edit.html.heex:487
 #, elixir-autogen, elixir-format
 msgid "Your date of birth will be removed and your age will no longer be shown on your profile. You can add it again at any time."
 msgstr ""
@@ -10821,67 +10821,67 @@ msgstr ""
 msgid "Views"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:252
+#: lib/vutuv_web/templates/user/edit.html.heex:277
 #, elixir-autogen, elixir-format
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1128
+#: lib/vutuv/accounts/user.ex:1122
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1133
+#: lib/vutuv/accounts/user.ex:1127
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1131
+#: lib/vutuv/accounts/user.ex:1125
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:566
 #, elixir-autogen, elixir-format
 msgid "Signed-in members only"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:249
+#: lib/vutuv_web/templates/user/edit.html.heex:274
 #: lib/vutuv_web/templates/welcome/show.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Who can see your availability?"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:274
+#: lib/vutuv_web/templates/user/edit.html.heex:299
 #: lib/vutuv_web/templates/welcome/show.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Amount"
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:464
-#: lib/vutuv_web/templates/user/edit.html.heex:282
+#: lib/vutuv_web/templates/user/edit.html.heex:307
 #: lib/vutuv_web/templates/welcome/show.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "Currency"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:292
+#: lib/vutuv_web/templates/user/edit.html.heex:317
 #, elixir-autogen, elixir-format
 msgid "Hidden by default, and it still does its job while hidden. \"Signed-in members only\" adds a quiet line to your profile for members; \"Everyone\" also shows it to logged-out visitors."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:265
+#: lib/vutuv_web/templates/user/edit.html.heex:290
 #: lib/vutuv_web/templates/welcome/show.html.heex:114
 #, elixir-autogen, elixir-format
 msgid "Minimum salary expectation"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:268
+#: lib/vutuv_web/templates/user/edit.html.heex:293
 #, elixir-autogen, elixir-format
 msgid "Optional. Even when hidden, it sharpens your own job search and alerts by filtering out postings below it. Leave the amount empty to remove it."
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:471
-#: lib/vutuv_web/templates/user/edit.html.heex:278
+#: lib/vutuv_web/templates/user/edit.html.heex:303
 #: lib/vutuv_web/templates/welcome/show.html.heex:127
 #, elixir-autogen, elixir-format
 msgid "Per"
@@ -10892,7 +10892,7 @@ msgstr ""
 msgid "Salary expectation from %{amount} %{currency} per %{period}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:289
+#: lib/vutuv_web/templates/user/edit.html.heex:314
 #, elixir-autogen, elixir-format
 msgid "Who can see your salary expectation?"
 msgstr ""
@@ -10961,7 +10961,7 @@ msgstr ""
 msgid "Exclude an email domain"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:345
+#: lib/vutuv_web/templates/user/edit.html.heex:370
 #, elixir-autogen, elixir-format
 msgid "Hide from specific people"
 msgstr ""
@@ -10972,12 +10972,12 @@ msgstr ""
 msgid "Job-search exclusion list"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:348
+#: lib/vutuv_web/templates/user/edit.html.heex:373
 #, elixir-autogen, elixir-format
 msgid "Keep your availability broadly visible while making sure your own employer never sees it. Exclude specific members or email domains, and they never see your availability or salary expectation, even at \"Everyone\"."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:356
+#: lib/vutuv_web/templates/user/edit.html.heex:381
 #, elixir-autogen, elixir-format
 msgid "Manage exclusion list (1 entry)"
 msgid_plural "Manage exclusion list (%{formatted} entries)"
@@ -11826,7 +11826,7 @@ msgstr ""
 msgid "Organization pages"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1084
+#: lib/vutuv_web/live/notification_live/index.ex:1045
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr ""
@@ -11934,22 +11934,22 @@ msgstr ""
 msgid "Your organization page was updated."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1328
+#: lib/vutuv_web/live/notification_live/index.ex:1286
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1325
+#: lib/vutuv_web/live/notification_live/index.ex:1283
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1322
+#: lib/vutuv_web/live/notification_live/index.ex:1280
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1319
+#: lib/vutuv_web/live/notification_live/index.ex:1277
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr ""
@@ -12151,7 +12151,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1102
+#: lib/vutuv/accounts/user.ex:1096
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12271,7 +12271,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1101
+#: lib/vutuv/accounts/user.ex:1095
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12353,7 +12353,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1103
+#: lib/vutuv/accounts/user.ex:1097
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:496
 #: lib/vutuv_web/agent_docs/markdown.ex:389
@@ -13319,14 +13319,14 @@ msgstr ""
 msgid "%{pending} image(s) in the scan queue; %{rejected} rejected in the last 7 days. A growing queue usually means Ollama is unreachable."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:38
-#: lib/vutuv_web/templates/user/edit.html.heex:91
+#: lib/vutuv_web/templates/user/edit.html.heex:41
+#: lib/vutuv_web/templates/user/edit.html.heex:116
 #: lib/vutuv_web/templates/user/show.html.heex:61
 #, elixir-autogen, elixir-format
 msgid "Image awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1082
+#: lib/vutuv_web/live/notification_live/index.ex:1043
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13367,36 +13367,36 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1146
+#: lib/vutuv/accounts/user.ex:1140
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:407
+#: lib/vutuv_web/templates/user/edit.html.heex:432
 #, elixir-autogen, elixir-format
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1149
+#: lib/vutuv/accounts/user.ex:1143
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1152
+#: lib/vutuv/accounts/user.ex:1146
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1143
+#: lib/vutuv/accounts/user.ex:1137
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:404
+#: lib/vutuv_web/templates/user/edit.html.heex:429
 #, elixir-autogen, elixir-format
 msgid "Show my birthday as"
 msgstr ""
@@ -13413,7 +13413,7 @@ msgstr[1] ""
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1085
+#: lib/vutuv_web/live/notification_live/index.ex:1046
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr ""
@@ -13425,7 +13425,7 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1378
+#: lib/vutuv_web/live/notification_live/index.ex:1336
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
@@ -13632,22 +13632,22 @@ msgstr[1] ""
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1086
+#: lib/vutuv_web/live/notification_live/index.ex:1047
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1398
+#: lib/vutuv_web/live/notification_live/index.ex:1356
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1390
+#: lib/vutuv_web/live/notification_live/index.ex:1348
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1395
+#: lib/vutuv_web/live/notification_live/index.ex:1353
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr ""
@@ -13672,7 +13672,7 @@ msgstr ""
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1403
+#: lib/vutuv_web/live/notification_live/index.ex:1361
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr ""
@@ -13803,14 +13803,14 @@ msgstr ""
 msgid "Publisher:"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:947
+#: lib/vutuv_web/live/notification_live/index.ex:911
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:961
+#: lib/vutuv_web/live/notification_live/index.ex:925
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr ""
@@ -13825,23 +13825,23 @@ msgstr ""
 msgid "Last 30 days"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:913
-#: lib/vutuv_web/live/notification_live/index.ex:1166
+#: lib/vutuv_web/live/notification_live/index.ex:877
+#: lib/vutuv_web/live/notification_live/index.ex:1126
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1103
+#: lib/vutuv_web/live/notification_live/index.ex:1063
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1098
+#: lib/vutuv_web/live/notification_live/index.ex:1058
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1113
+#: lib/vutuv_web/live/notification_live/index.ex:1073
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr ""
@@ -14043,13 +14043,13 @@ msgstr ""
 msgid "Optional, and nobody else sees it. It filters postings below it out of your own job search."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:312
+#: lib/vutuv_web/templates/user/edit.html.heex:337
 #: lib/vutuv_web/templates/welcome/show.html.heex:143
 #, elixir-autogen, elixir-format
 msgid "How do you want to work?"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:332
+#: lib/vutuv_web/templates/user/edit.html.heex:357
 #: lib/vutuv_web/templates/welcome/show.html.heex:162
 #, elixir-autogen, elixir-format
 msgid "Shown next to your availability, and used to match you with postings."
@@ -14071,7 +14071,7 @@ msgstr ""
 msgid "Preferred workplace"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:240
+#: lib/vutuv_web/templates/user/edit.html.heex:265
 #: lib/vutuv_web/templates/welcome/show.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Availability"
@@ -14082,17 +14082,17 @@ msgstr ""
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1352
+#: lib/vutuv_web/live/notification_live/index.ex:1310
 #, elixir-autogen, elixir-format
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1075
+#: lib/vutuv_web/live/notification_live/index.ex:1036
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1153
+#: lib/vutuv_web/live/notification_live/index.ex:1113
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -14111,12 +14111,12 @@ msgstr ""
 msgid "Only part of this long conversation is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1076
+#: lib/vutuv_web/live/notification_live/index.ex:1037
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1302
+#: lib/vutuv_web/live/notification_live/index.ex:1260
 #, elixir-autogen, elixir-format
 msgid "mentioned you in a post."
 msgstr ""
@@ -14460,7 +14460,7 @@ msgstr ""
 msgid "Thread replies"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:606
+#: lib/vutuv_web/live/notification_live/index.ex:603
 #, elixir-autogen, elixir-format
 msgid "Turn off thread notifications"
 msgstr ""
@@ -14511,7 +14511,7 @@ msgstr ""
 msgid "You have reached the maximum of %{count} filters."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:601
+#: lib/vutuv_web/live/notification_live/index.ex:598
 #, elixir-autogen, elixir-format
 msgid "You wrote in this thread."
 msgstr ""
@@ -15485,7 +15485,7 @@ msgstr ""
 msgid "Replies from other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1078
+#: lib/vutuv_web/live/notification_live/index.ex:1039
 #, elixir-autogen, elixir-format
 msgid "Reply from another network"
 msgstr ""
@@ -15506,7 +15506,7 @@ msgid "Reported as not appropriate"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1077
-#: lib/vutuv_web/live/notification_live/index.ex:548
+#: lib/vutuv_web/live/notification_live/index.ex:545
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
 msgstr ""
@@ -15557,7 +15557,7 @@ msgstr ""
 msgid "You have reported a lot today. Please try again tomorrow."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1305
+#: lib/vutuv_web/live/notification_live/index.ex:1263
 #, elixir-autogen, elixir-format, fuzzy
 msgid "replied to your post from another network."
 msgstr ""
@@ -16243,19 +16243,19 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:475
 #: lib/vutuv_web/agent_docs/text.ex:467
-#: lib/vutuv_web/templates/user/edit.html.heex:180
+#: lib/vutuv_web/templates/user/edit.html.heex:205
 #: lib/vutuv_web/templates/user/show.html.heex:244
 #: lib/vutuv_web/views/account_event_text.ex:191
 #, elixir-autogen, elixir-format
 msgid "Name pronunciation"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:184
+#: lib/vutuv_web/templates/user/edit.html.heex:209
 #, elixir-autogen, elixir-format
 msgid "e.g. [SHTEH-fahn VIN-ter-my-er]"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:187
+#: lib/vutuv_web/templates/user/edit.html.heex:212
 #, elixir-autogen, elixir-format
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
@@ -16571,7 +16571,7 @@ msgstr ""
 msgid "From other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1079
+#: lib/vutuv_web/live/notification_live/index.ex:1040
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Reaction from another network"
 msgstr ""
@@ -16586,21 +16586,21 @@ msgstr ""
 msgid "Show under each of your posts who out there liked or shared it, by their account address on their own server, linked to that account. Visible to everyone who sees the post. We keep nothing else about these people: no name, no picture, no text. Switching it off deletes what is stored for it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1134
+#: lib/vutuv_web/live/notification_live/index.ex:1094
 #, elixir-autogen, elixir-format
 msgid "liked your post on another network."
 msgid_plural "liked your post on another network."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1142
+#: lib/vutuv_web/live/notification_live/index.ex:1102
 #, elixir-autogen, elixir-format, fuzzy
 msgid "reacted to your post from another network."
 msgid_plural "reacted to your post from another network."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1126
+#: lib/vutuv_web/live/notification_live/index.ex:1086
 #, elixir-autogen, elixir-format
 msgid "shared your post on another network."
 msgid_plural "shared your post on another network."
@@ -17943,7 +17943,7 @@ msgstr ""
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:578
+#: lib/vutuv_web/live/notification_live/index.ex:575
 #, elixir-autogen, elixir-format
 msgid "View the conversation"
 msgstr ""
@@ -18813,7 +18813,7 @@ msgstr ""
 msgid "Employment reference deleted"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1089
+#: lib/vutuv_web/live/notification_live/index.ex:1049
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Employment reference review"
 msgstr ""
@@ -18838,13 +18838,13 @@ msgstr ""
 msgid "Reviewing your reference. This usually takes about %{duration}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1293
+#: lib/vutuv_web/live/notification_live/index.ex:1251
 #: lib/vutuv_web/views/notification_digest_text.ex:84
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1290
+#: lib/vutuv_web/live/notification_live/index.ex:1248
 #: lib/vutuv_web/views/notification_digest_text.ex:81
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready: %{grade}."
@@ -18860,7 +18860,7 @@ msgstr ""
 msgid "When the review of one of your employment references is finished. It takes minutes, so you can close the page and wait for the email."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1296
+#: lib/vutuv_web/live/notification_live/index.ex:1254
 #, elixir-autogen, elixir-format
 msgid "Your employment reference has been reviewed."
 msgstr ""
@@ -19202,7 +19202,7 @@ msgstr ""
 msgid "Salutation"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:222
+#: lib/vutuv_web/controllers/user_controller.ex:275
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Your verified badge was removed because you changed your name or date of birth. We re-check identity against those details so members can trust verified profiles and nobody can set up a fake verified account. An admin can verify you again anytime."
 msgstr ""
@@ -19234,7 +19234,7 @@ msgstr ""
 msgid "Cancel registration"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:847
+#: lib/vutuv_web/live/notification_live/index.ex:844
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
@@ -19249,17 +19249,17 @@ msgstr ""
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1249
+#: lib/vutuv/accounts/user.ex:1243
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1247
+#: lib/vutuv/accounts/user.ex:1241
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1248
+#: lib/vutuv/accounts/user.ex:1242
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -20511,12 +20511,37 @@ msgstr ""
 msgid "the address of a post out there: vutuv fetches it so you can answer it here"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1088
+#: lib/vutuv_web/templates/user/edit.html.heex:81
 #, elixir-autogen, elixir-format
-msgid "Imported profile picture"
+msgid "Fetch my picture from gravatar.com"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:886
+#: lib/vutuv_web/controllers/user_controller.ex:200
 #, elixir-autogen, elixir-format
-msgid "When you signed up we found a picture for your email address at gravatar.com and used it as your profile picture. At {url} you can replace or remove it at any time."
+msgid "The picture from gravatar.com could not be saved."
+msgstr ""
+
+#: lib/vutuv_web/controllers/user_controller.ex:184
+#, elixir-autogen, elixir-format
+msgid "We took your picture from gravatar.com."
+msgstr ""
+
+#: lib/vutuv_web/controllers/user_controller.ex:196
+#, elixir-autogen, elixir-format
+msgid "gravatar.com could not be reached. Please try again later."
+msgstr ""
+
+#: lib/vutuv_web/controllers/user_controller.ex:191
+#, elixir-autogen, elixir-format
+msgid "gravatar.com has no picture for your email address."
+msgstr ""
+
+#: lib/vutuv_web/templates/user/edit.html.heex:84
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Only when you press this: we ask gravatar.com whether there is a picture for your email address, sending a hash of the address rather than the address itself. Nothing leaves this server otherwise."
+msgstr ""
+
+#: lib/vutuv_web/controllers/user_controller.ex:172
+#, elixir-autogen, elixir-format
+msgid "The gravatar.com lookup is switched off on this installation."
 msgstr ""

--- a/test/vutuv/accounts/gravatar_import_test.exs
+++ b/test/vutuv/accounts/gravatar_import_test.exs
@@ -1,15 +1,18 @@
 defmodule Vutuv.Accounts.GravatarImportTest do
   @moduledoc """
-  The avatar registration fetches from gravatar.com (issue #1447): that it is
-  stored, and that `gravatar_imported_at` is stamped **only** when an image
-  really arrived — the stamp is what tells the member about it, so a 404 or a
-  failed fetch must leave it NULL and say nothing.
+  The gravatar.com avatar import (issue #1447), which is now a thing a member
+  asks for and never something registration does behind their back.
+
+  Two claims are worth a test each. That the import works and stores the
+  picture, and that each failure is told apart from the others — "gravatar.com
+  has nothing for your address" and "gravatar.com did not answer" are different
+  news for the member, so the function must not collapse them into one error.
 
   Not async: sets the global `:uploads_dir_prefix` (so the avatar files land in
   a temp dir instead of the checkout) and `:gravatar_req_options` (the `plug:`
   responder standing in for gravatar.com). Nothing else in the suite reads the
-  latter; `:uploads_dir_prefix` is shared with
-  `Vutuv.UploadsIntegrationTest`, which is sync for the same reason.
+  latter; `:uploads_dir_prefix` is shared with `Vutuv.UploadsIntegrationTest`,
+  which is sync for the same reason.
   """
   use Vutuv.DataCase, async: false
 
@@ -29,45 +32,41 @@ defmodule Vutuv.Accounts.GravatarImportTest do
       restore(:gravatar_req_options, options)
     end)
 
-    user = insert(:user, emails: [build(:email)])
-    {:ok, user: user}
+    {:ok, user: insert(:user, emails: [build(:email)])}
   end
 
-  test "an imported picture becomes the avatar and stamps the import", %{user: user} do
+  test "an imported picture becomes the avatar", %{user: user} do
     stub_gravatar(200, png_bytes(), "image/png")
 
-    assert {:ok, imported} = Accounts.store_gravatar(user)
+    assert {:ok, imported} = Accounts.import_gravatar_avatar(user)
     assert imported.avatar == "#{user.username}.png"
-    assert %NaiveDateTime{} = imported.gravatar_imported_at
-
-    assert Repo.reload!(user).gravatar_imported_at == imported.gravatar_imported_at
+    assert Repo.reload!(user).avatar == imported.avatar
   end
 
   # 404 is gravatar's answer for "no picture for this address" (the `d=404`
-  # parameter asks for it), and it is the common case. Nothing was imported, so
-  # there is nothing to tell the member about.
-  test "no picture at gravatar.com leaves the stamp NULL", %{user: user} do
+  # parameter asks for it), and it is by far the common case.
+  test "no picture there is :not_found, and the avatar is untouched", %{user: user} do
     stub_gravatar(404, "", "text/plain")
 
-    assert Accounts.store_gravatar(user) == nil
-    assert Repo.reload!(user).gravatar_imported_at == nil
+    assert Accounts.import_gravatar_avatar(user) == {:error, :not_found}
+    assert Repo.reload!(user).avatar == nil
   end
 
-  test "a failed fetch leaves the stamp NULL", %{user: user} do
+  test "an unreachable gravatar.com is :unavailable, not :not_found", %{user: user} do
     stub_gravatar(500, "", "text/plain")
 
-    assert Accounts.store_gravatar(user) == nil
-    assert Repo.reload!(user).gravatar_imported_at == nil
+    assert Accounts.import_gravatar_avatar(user) == {:error, :unavailable}
+    assert Repo.reload!(user).avatar == nil
   end
 
-  # `retry: false` only so the 500 case does not sit through Req's default
-  # backoff ladder; what the stub proves is the branch taken after the last
-  # answer, which the retries do not change. The content type is real
-  # (`image/png`), because Req's decode_body step branches on it — a bare
-  # send_resp would hand the code a differently shaped body than gravatar does.
+  # A member with no address at all cannot be looked up; that must answer, not
+  # raise (the old code took `hd/1` of the list).
+  test "a member without an email address is :not_found" do
+    assert Accounts.import_gravatar_avatar(insert(:user)) == {:error, :not_found}
+  end
+
   defp stub_gravatar(status, body, content_type) do
     Application.put_env(:vutuv, :gravatar_req_options,
-      retry: false,
       plug: fn conn ->
         conn
         |> Plug.Conn.put_resp_content_type(content_type)

--- a/test/vutuv/activity_test.exs
+++ b/test/vutuv/activity_test.exs
@@ -122,26 +122,6 @@ defmodule Vutuv.ActivityTest do
       assert recent_notifications(me.id) == []
     end
 
-    test "an imported gravatar leaves a note about where the picture came from" do
-      me = insert(:user, gravatar_imported_at: ~N[2026-08-14 09:00:00])
-
-      assert [n] = recent_notifications(me.id)
-      assert n.kind == "gravatar"
-      assert n.id == "gravatar-#{me.id}"
-      assert n.at == ~N[2026-08-14 09:00:00]
-      # The installation did this, not another member: no actor at all.
-      refute Map.has_key?(n, :actor_name)
-    end
-
-    # The vast majority of sign-ups have no gravatar, and their avatar is their
-    # own upload — telling them about an import that never happened would be
-    # both wrong and alarming.
-    test "an account whose avatar did not come from gravatar gets no such note" do
-      me = insert(:user, avatar: "selfie.jpg")
-
-      assert recent_notifications(me.id) == []
-    end
-
     test "a self-endorsement produces no notification" do
       me = insert(:user)
       tag = insert(:tag)

--- a/test/vutuv_web/controllers/gravatar_button_test.exs
+++ b/test/vutuv_web/controllers/gravatar_button_test.exs
@@ -1,0 +1,181 @@
+defmodule VutuvWeb.GravatarButtonTest do
+  @moduledoc """
+  The member's own gravatar.com lookup on /settings/profile (issue #1447).
+
+  The load-bearing test here is the last one: **registration must contact
+  gravatar.com never**. That lookup used to run in a background task for every
+  sign-up, which handed a US service the fact that an address had just joined
+  vutuv — a third-party transfer nobody asked for, and one the privacy page
+  promised did not happen. So the stub records any hit and the test waits for
+  one that must not come.
+
+  Not async: flips `:fetch_gravatar` and `:gravatar_req_options`, both global
+  and not rolled back by the SQL sandbox. `:fetch_gravatar` is read by
+  `Accounts.gravatar_import_available?/1` and the profile template; it is
+  `false` for the rest of the suite (config/test.exs).
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  setup do
+    tmp = Path.join(System.tmp_dir!(), "vutuv_gravbtn_#{System.unique_integer([:positive])}")
+
+    saved =
+      for k <- [:uploads_dir_prefix, :gravatar_req_options, :fetch_gravatar],
+          do: {k, Application.fetch_env(:vutuv, k)}
+
+    Application.put_env(:vutuv, :uploads_dir_prefix, tmp)
+    Application.put_env(:vutuv, :fetch_gravatar, true)
+
+    on_exit(fn ->
+      File.rm_rf(tmp)
+
+      for {k, was} <- saved do
+        case was do
+          {:ok, value} -> Application.put_env(:vutuv, k, value)
+          :error -> Application.delete_env(:vutuv, k)
+        end
+      end
+    end)
+
+    :ok
+  end
+
+  describe "the button on /settings/profile" do
+    test "renders, and posts to the route it actually names", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+
+      body = conn |> get(~p"/settings/profile") |> html_response(200)
+
+      assert body =~ "gravatar.com"
+      assert body =~ ~s(id="import-gravatar")
+      # The button is wired to the separate form by `form=`, since a form cannot
+      # nest inside the profile form.
+      assert body =~ ~s(form="gravatar-form")
+      # Assert the form's rendered action rather than a route we know exists:
+      # a Save button pointing at a retired URL is exactly how /settings/privacy
+      # 404ed in production for eight releases.
+      assert body =~ ~s(action="/settings/profile/gravatar")
+    end
+
+    # The German render is the one real visitors get; an English-only assertion
+    # would pass even if the msgstr were empty or fuzzy-filled with nonsense.
+    test "says it in German for a German browser", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+
+      body =
+        conn
+        |> recycle()
+        |> put_req_header("accept-language", "de-DE,de")
+        |> get(~p"/settings/profile")
+        |> html_response(200)
+
+      assert body =~ "Mein Bild von gravatar.com holen"
+      # The sentence must keep saying what is sent, in German too.
+      assert body =~ "Hashwert der Adresse"
+    end
+
+    # An air-gapped intranet installation cannot reach gravatar.com, so it must
+    # not be offered a button that can only ever fail.
+    test "is absent when the installation has the lookup switched off", %{conn: conn} do
+      Application.put_env(:vutuv, :fetch_gravatar, false)
+      {conn, _user} = create_and_login_user(conn)
+
+      body = conn |> get(~p"/settings/profile") |> html_response(200)
+
+      refute body =~ ~s(id="import-gravatar")
+      refute body =~ "gravatar.com"
+    end
+  end
+
+  describe "pressing it" do
+    test "stores the picture and says so", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      stub_gravatar(200, png_bytes(), "image/png")
+
+      conn = post(conn, ~p"/settings/profile/gravatar")
+
+      assert redirected_to(conn) == "/settings/profile#avatar"
+      assert flash_text(conn, :info) =~ "gravatar.com"
+      assert Repo.reload!(user).avatar == "#{user.username}.png"
+    end
+
+    # The two failures must read differently — "there is no picture for you"
+    # is not "we could not ask".
+    test "says so when gravatar.com has nothing for the address", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      stub_gravatar(404, "", "text/plain")
+
+      conn = post(conn, ~p"/settings/profile/gravatar")
+
+      assert flash_text(conn, :error) =~ "no picture"
+      assert Repo.reload!(user).avatar == nil
+    end
+
+    test "says something different when gravatar.com cannot be reached", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      stub_gravatar(500, "", "text/plain")
+
+      conn = post(conn, ~p"/settings/profile/gravatar")
+
+      assert flash_text(conn, :error) =~ "could not be reached"
+      assert Repo.reload!(user).avatar == nil
+    end
+
+    # The settings pipeline bounces an anonymous request to the start page
+    # (RequireLogin's convention), so nothing reaches gravatar.com.
+    test "a logged-out visitor cannot fire it", %{conn: conn} do
+      test_pid = self()
+
+      Application.put_env(:vutuv, :gravatar_req_options,
+        plug: fn c ->
+          send(test_pid, :gravatar_was_called)
+          Plug.Conn.send_resp(c, 200, "")
+        end
+      )
+
+      conn = post(conn, ~p"/settings/profile/gravatar")
+
+      assert redirected_to(conn) == "/"
+      refute_receive :gravatar_was_called, 200
+    end
+  end
+
+  # The whole point of issue #1447's second round: signing up talks to nobody.
+  test "registration never contacts gravatar.com", %{conn: conn} do
+    test_pid = self()
+
+    Application.put_env(:vutuv, :gravatar_req_options,
+      plug: fn c ->
+        send(test_pid, :gravatar_was_called)
+        Plug.Conn.send_resp(c, 200, "")
+      end
+    )
+
+    {_conn, user} = create_and_login_user(conn)
+
+    # refute_receive, not a bare assertion: the old code ran the fetch in a
+    # Task.Supervisor child, so a re-added background call would arrive late
+    # and a synchronous check would miss it.
+    refute_receive :gravatar_was_called, 500
+    assert Repo.reload!(user).avatar == nil
+  end
+
+  defp stub_gravatar(status, body, content_type) do
+    Application.put_env(:vutuv, :gravatar_req_options,
+      plug: fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type(content_type)
+        |> Plug.Conn.send_resp(status, body)
+      end
+    )
+  end
+
+  defp png_bytes do
+    {:ok, img} = Image.new(120, 120, color: [10, 120, 200])
+    path = Path.join(System.tmp_dir!(), "gravbtn_#{System.unique_integer([:positive])}.png")
+    {:ok, _} = Image.write(img, path)
+    File.read!(path)
+  end
+
+  defp flash_text(conn, key), do: Phoenix.Flash.get(conn.assigns.flash, key) || ""
+end

--- a/test/vutuv_web/live/notification_live_test.exs
+++ b/test/vutuv_web/live/notification_live_test.exs
@@ -89,63 +89,6 @@ defmodule VutuvWeb.NotificationLiveTest do
       refute html =~ "/settings/username</a>."
     end
 
-    # Registration quietly fetches an avatar from gravatar.com, so a member who
-    # once used that service arrives to a photo they never uploaded here. Our
-    # silence is what made that unsettling (issue #1447).
-    test "tells a member their picture was imported from gravatar.com", %{conn: conn} do
-      {conn, user} = create_and_login_user(conn)
-      stamp_gravatar_import(user, ~N[2026-08-14 09:00:00])
-
-      {:ok, live, _html} = live(conn, ~p"/notifications")
-
-      assert has_element?(live, ~s([data-notification-row][data-kind="gravatar"]))
-      html = render(live)
-      # It names the source; a picture "we found somewhere" would be worse than
-      # saying nothing.
-      assert html =~ "gravatar.com"
-
-      # The link sits inside the sentence (the row itself is not one link) and
-      # leads where the picture can be replaced or removed.
-      settings_url = VutuvWeb.Endpoint.url() <> "/settings/profile"
-
-      assert has_element?(
-               live,
-               ~s([data-kind="gravatar"] a[href="#{settings_url}"]),
-               settings_url
-             )
-
-      # Same rule as the welcome note: never end the sentence on the URL, or the
-      # full stop reads as part of the address.
-      refute html =~ "/settings/profile</a>."
-    end
-
-    # The German render is the one real visitors get, and a fuzzy-filled msgstr
-    # would only show here (an English-only assertion passes either way).
-    test "says it in German for a German browser", %{conn: conn} do
-      {conn, user} = create_and_login_user(conn)
-      stamp_gravatar_import(user, ~N[2026-08-14 09:00:00])
-
-      body =
-        conn
-        |> recycle()
-        |> put_req_header("accept-language", "de-DE,de")
-        |> get(~p"/notifications")
-        |> html_response(200)
-
-      assert body =~ "gravatar.com gefunden"
-      assert body =~ "Profilbild"
-      refute body =~ "/settings/profile</a>."
-    end
-
-    # Nobody is told about an import that never happened.
-    test "says nothing when the avatar did not come from gravatar", %{conn: conn} do
-      {conn, _user} = create_and_login_user(conn)
-
-      {:ok, live, _html} = live(conn, ~p"/notifications")
-
-      refute has_element?(live, ~s([data-kind="gravatar"]))
-    end
-
     test "lists real events derived from the database", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
 
@@ -1323,15 +1266,6 @@ defmodule VutuvWeb.NotificationLiveTest do
     Vutuv.Repo.update_all(
       from(u in Vutuv.Accounts.User, where: u.id == ^id),
       set: [welcome_notified_at: at]
-    )
-  end
-
-  defp stamp_gravatar_import(%{id: id}, at) do
-    import Ecto.Query
-
-    Vutuv.Repo.update_all(
-      from(u in Vutuv.Accounts.User, where: u.id == ^id),
-      set: [gravatar_imported_at: at]
     )
   end
 


### PR DESCRIPTION
Reopens and re-answers #1447. v7.285.0 told the member about the silent gravatar import; this removes the silent import instead.

## Why the notification was the wrong answer

Registration sent an MD5 of every new member's email to gravatar.com. Anyone holding that address can hash it and learn that this person just joined vutuv — a transfer to a US third party that nobody asked for, against a privacy page that has always promised none. Small in effect, but the promise is the promise. Telling members after the fact does not fix a transfer that should not happen.

## What lands

- **Registration contacts nobody.** The background task is gone.
- **A button instead**, on `/settings/profile` right under the avatar: "Fetch my picture from gravatar.com", with a sentence saying what pressing it sends. The press is the consent.
- **Three distinct outcomes.** Found → it is your avatar. `{:error, :not_found}` → "gravatar.com has no picture for your email address." `{:error, :unavailable}` → "gravatar.com could not be reached." The two failures are deliberately different sentences; one shared "didn't work" would leave the member guessing which.
- **`POST`, never `GET`** — it reaches a third party and changes the avatar, so no prefetch, Back button or crawler can fire it. The button sits inside the profile form visually but is wired by `form=` to its own form below it (a form cannot nest), so it still works with JS off.
- **Off means invisible.** With `:fetch_gravatar` false the button is not rendered — an air-gapped install is not offered something that can only fail.
- **The v7.285.0 notification is removed**: the `gravatar` kind, its row, glyph, label and strings. A button you pressed yourself needs no notification saying you pressed it.

## Follow-up owed

`users.gravatar_imported_at` is untouched by this release but still known to the one now running, so per the N-1 rule it can only be dropped **next** deploy. Production has exactly one stamped row, from the three hours v7.285.0 was live; that member keeps their avatar.

## Tests

The one that matters expects nothing to happen: it registers a member with a stub that reports any hit, then waits for a hit that must not come (`refute_receive`, not a synchronous check — the old code fetched in a `Task.Supervisor` child, so a re-added background call would arrive late). **Calibrated:** re-adding the auto-fetch turns it red, verified, then reverted.

Plus: the button renders and posts to the action it actually names; the German render (`Accept-Language: de-DE,de`) says it in German; the button is absent when the flag is off; each of the three outcomes; a logged-out POST is bounced and reaches gravatar.com not at all; and unit coverage of `import_gravatar_avatar/1` including a member with no address (the old code took `hd/1` of an empty list).

`mix precommit` green (7645 tests).

## While I was in the privacy page — two unrelated gaps

I read the live text at `/admin/legal` before editing and did **not** save anything; it is still at its 2026-07-30 revision. Two findings worth their own decision:

1. **The Arbeitszeugnis feature is not in the production privacy policy at all.** v7.227.0 (2026-08-03) added that text to `priv/repo/seed_data/legal/datenschutzerklaerung.md` — a file only a one-time migration reads, and that migration had long since run. So the paragraph never reached the database copy that is actually served. Live production says nothing about a feature that stores a document containing name, birth date, employer and a performance rating, OCRs it, and runs it through a language model. **The seed file is acting as a false safety net**: it looks like the place to document new processing and reaches nobody.
2. **The cookie section is factually wrong.** It says the session cookie is deleted when you close the browser. It is `max-age=7776000` — 90 days, verified against the live `Set-Cookie` — and there is a second one (`_vutuv_login_pin`, 30 minutes, during login only), so "only one cookie" is off too.

Say the word and I will fix both, together with a short new gravatar paragraph that now reads much better than the one I drafted this morning: nothing is transferred unless the member presses a button.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_013zucWqZGcJqm1bvmEvxwf2
