### PR TITLE
NodeInfo sagt jetzt, was uns unterscheidet (v7.288.0)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -659,9 +659,17 @@ config :vutuv, :operator_address, "Johannes-Müller-Str. 10 - 56068 Koblenz - Ge
 # since NodeInfo has no locale negotiation. (NODE_NAME / NODE_DESCRIPTION)
 config :vutuv, :node_name, "vutuv"
 
+# Keep it to a sentence or two: real entries run 10-20 words (mastodon.social
+# 12, chaos.social 10, norden.social 17) and directories truncate. Everything
+# claimed here is true of the SOFTWARE on every installation — MIT-licensed, one
+# first-party cookie and nothing loaded from another host — so it stays honest
+# for an operator who never edits it. Where the servers stand is deliberately
+# NOT in here: `Vutuv.NodeInfo` appends that from :data_location, which is the
+# only claim of the four that belongs to the operator rather than to vutuv.
 config :vutuv,
        :node_description,
-       "The open business network where professionals connect, share, and get found."
+       "The open-source business network: a professional profile and posts you can " <>
+         "follow from anywhere in the fediverse. No tracking, no third-party cookies."
 
 # -----------------------------------------------------------------------------
 

--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -139,7 +139,7 @@ Everything else has a default (the vutuv.de production value):
 | `FEDIVERSE_COUNTS_PER_HOST` | `10` | How many of that batch may belong to a single host, so one instance that happens to host many of the accounts your members follow is spread over several runs rather than fetched in a burst. What the cap holds back is written to the log |
 | `FEDIVERSE_IMAGE_HOLD_SECONDS` | `90` | How long a post whose picture the AI image scan has not judged yet waits before it federates **without** the picture. This is a ceiling, not the usual wait: the post goes out the moment the scan settles, normally within seconds. It only bites when the scanner is down, and then the choice is "the post without its picture" over "no post at all". Raise it if you run image moderation on slow hardware; irrelevant when `MODERATE_IMAGES` is off |
 | `NODE_NAME` | `vutuv` | What the fediverse directories call your installation. They fetch `/.well-known/nodeinfo` on their own and print this string beside the entry, so make it the name you want people to see in a list of servers — your organization, your community, your domain |
-| `NODE_DESCRIPTION` | (vutuv.de's pitch) | The one sentence those directories print under the name. Say what your installation is *for*; the default describes vutuv.de and is almost certainly not what you want on your own server. NodeInfo has no notion of language, so write it in the one your visitors read |
+| `NODE_DESCRIPTION` | (see below) | The sentence or two those directories print under the name. Keep it short — real entries run 10 to 20 words and the sites truncate — and say what your installation is *for*. The default claims only what is true of vutuv wherever it runs (open source, no tracking, no third-party cookies), so it stays honest if you never touch it, but it says nothing about *you*. **Where your servers stand is not part of this string**: vutuv appends that sentence from `DATA_LOCATION`, so clearing that one variable removes the hosting claim from your start page and from this document together. NodeInfo has no notion of language, so write it in the one your visitors read |
 | `ACCOUNT_EVENT_RETENTION_DAYS` | `365` | How long the **account-activity log** keeps an event, in days (see `docs/architecture/account-activity.md`). It records what changed on an account, when, from which coarse device (never an IP address), and how it was confirmed, so it is personal data with a clock on it: a year covers the "this happened months ago and I only noticed now" support case without becoming a permanent movement profile. The daily sweeper deletes anything older |
 | `FETCH_BOOK_METADATA` | `true` | `false` turns the catalogue lookups behind post **book reviews** off (the cover image, page count and publisher from Open Library, and an audiobook's running time). New reviews can no longer be created (the composer's review form was removed), but existing review posts keep rendering their card — with the flag off it shows no cover and none of those details. Set it on installations that must not call out (intranets) |
 | `DNB_SRU_URL` | `https://services.dnb.de/sru/dnb` | Where an **audiobook's running time** is looked up by ISBN: an SRU endpoint answering MARC21-xml (the Deutsche Nationalbibliothek by default — Open Library records no durations). Point it at another catalogue's SRU endpoint, or set it **empty** (`DNB_SRU_URL=`) to switch that one lookup off while the rest of the book metadata keeps working |
@@ -607,17 +607,33 @@ path in nginx.
 
 What the document says about you:
 
-- your name and one sentence, from `NODE_NAME` and `NODE_DESCRIPTION`;
+- your name and a sentence or two, from `NODE_NAME` and `NODE_DESCRIPTION`;
 - the software and its version, so a directory can tell vutuv from anything
-  else;
+  else, plus a link to its source;
 - how many members you have, how many of them signed in over the last 30 and
-  180 days, and how many public posts and replies they have written.
+  180 days, and how many public posts and replies they have written;
+- the languages you serve, your operator contact (the same one
+  `/.well-known/security.txt` already publishes), and links to your
+  Nutzungsbedingungen and Datenschutzerklärung — those two only once you have
+  actually written them at `/admin/legal`, since a link to a placeholder is
+  worse than no link.
 
 Everything in it is an aggregate and nobody is named. The post counts cover
 exactly what a logged-out visitor can already read — private, frozen and
 unmoderated posts are in neither — and the member figures are the same kind of
 number your top bar and your member directory already show. Check yours at
 `https://<your host>/system/nodeinfo/2.1`.
+
+**Two claims in the default description are worth understanding before you
+publish them under your own name.** "Open source" and "no tracking, no
+third-party cookies" are properties of the software: vutuv is MIT-licensed, it
+sets exactly one first-party cookie, and its pages load nothing from another
+host, so those hold on your installation too. "Hosted on our own hardware in X"
+is **not** a property of the software, so it is not in the description string at
+all — vutuv appends it from `DATA_LOCATION`, the same variable that drives the
+"Where your data lives" card on your start page. Run on rented cloud
+infrastructure and you clear that one variable, and the claim disappears from
+both places at once rather than being made in your name.
 
 ## Federation: blocking a remote server
 

--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -2060,9 +2060,58 @@ endpoints answering 404 — the same thing said twice.
 
 `software.name`, `repository` and `homepage` describe vutuv **the software** and
 are literals: every installation runs the same software, developed in the same
-repository. What names the operator — `metadata.nodeName` and `nodeDescription`
-— sits behind the Operator identity block in `config/config.exs` like every
-other such value, env-overridable as `NODE_NAME` / `NODE_DESCRIPTION`.
+repository. `homepage` is the apex `https://vutuv.de`, never the `www.` alias,
+which only 301s there. What names the operator — `metadata.nodeName` and
+`nodeDescription` — sits behind the Operator identity block in
+`config/config.exs` like every other such value, env-overridable as `NODE_NAME`
+/ `NODE_DESCRIPTION`.
+
+### What the description claims, and who may claim it
+
+A directory prints `nodeDescription` verbatim, so every word of it is a public
+claim made in the **operator's** name. That is the whole reason the string is
+split the way it is.
+
+The configured default claims only what is true of the software wherever it
+runs, so an operator who never edits it still says nothing false:
+
+- **open source** — MIT, verified against `LICENSE` and the repository metadata,
+  not merely "the code is public";
+- **no tracking, no third-party cookies** — verified against production: exactly
+  one cookie is set (`_vutuv_key`, first-party, HttpOnly, SameSite=Lax) and no
+  template loads an asset from another host.
+
+**Where the servers stand is the one claim of the three that belongs to the
+operator rather than to vutuv**, so it is deliberately not in the string:
+`node_description/0` appends it from `:data_location`, and it drops out entirely
+for an operator who cleared that variable. This is the same split
+`lib/vutuv_web/templates/page/index.html.heex` makes between its "Your data"
+cards, and `VutuvWeb.PageHTML.data_location/0` is the single place that decides
+whether the claim was made at all — the two surfaces cannot drift, and no
+installation publishes an infrastructure claim about itself that its operator
+never made. Keep it short, too: real entries run 10 to 20 words
+(mastodon.social 12, chaos.social 10, norden.social 17) and the directories
+truncate.
+
+What the description deliberately does **not** say is that we are the good ones.
+Every server in that list claims as much, so the claim carries no information,
+and in the fediverse specifically self-praise reads as a warning sign;
+mastodon.social's own line says who runs it and what for, never that it is the
+good one. The three facts above are the same statement in a form a reader can
+check.
+
+### The rest of `metadata`
+
+The schema leaves `metadata` free-form, and implementations use it (GoToSocial
+ships `maintainer`, `tosUrl`, `langs` and more). vutuv carries what a person
+reading a directory entry can act on: **`langs`** (the locales this installation
+serves, from the endpoint's `:locales`), **`maintainer`** (`:operator_recipient`
+— the same contact `/.well-known/security.txt` already publishes, so this is no
+new disclosure), and **`tosUrl`** / **`privacyPolicyUrl`**. The last two appear
+**only once that page has actually been written** (`Vutuv.Legal.get_page/1` with
+a non-blank body): the legal pages are per-installation data and a fresh
+installation renders a "not published yet" placeholder, so advertising the URL
+would point a directory at an empty page.
 
 Submitting anything anywhere is not part of this. Once the document is served,
 the directories that scan for it find the installation on their own.

--- a/lib/vutuv/node_info.ex
+++ b/lib/vutuv/node_info.ex
@@ -24,6 +24,31 @@ defmodule Vutuv.NodeInfo do
   `nodeDescription`) sits behind the Operator identity block in
   `config/config.exs` like every other such value.
 
+  ## What the description claims, and who may claim it
+
+  A directory prints `nodeDescription` verbatim beside the entry, so every word
+  of it is a public claim made in the operator's name — which is why the default
+  states only what is true of the **software** on every installation: it is
+  MIT-licensed, it sets one first-party cookie and it loads nothing from another
+  host. An operator who never edits the string still says nothing false.
+
+  Where the servers stand is the one claim of the four that is **not** a
+  property of the software, so it is not in the string: `node_description/0`
+  appends it from `:data_location`, which drops out entirely for an operator on
+  rented cloud infrastructure. That is the same split the start page's "Your
+  data" cards make, and `VutuvWeb.PageHTML.data_location/0` is the single place
+  that decides whether the claim was made at all. What this deliberately does
+  **not** say is that we are the good ones: every server in that list claims as
+  much, so the claim carries no information, and the facts above are the same
+  statement in a form a reader can check.
+
+  The rest of `metadata` is what a person reading a directory entry can act on:
+  `langs` (the locales served), `maintainer` (the operator contact
+  `/.well-known/security.txt` already publishes), and `tosUrl` /
+  `privacyPolicyUrl` — the last two only once that page has actually been
+  written, since a link to a "not published yet" placeholder is worse than no
+  link at all.
+
   The figures are the part worth being careful about:
 
     * **`usage.users.total` is the members here** (`Accounts.count_users/0`) and
@@ -66,12 +91,15 @@ defmodule Vutuv.NodeInfo do
 
   alias Vutuv.Accounts
   alias Vutuv.Accounts.User
+  alias Vutuv.Legal
+  alias Vutuv.Legal.LegalPage
   alias Vutuv.Moderation.Query, as: ModerationQuery
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias Vutuv.Repo
   alias Vutuv.Sessions.UserSession
   alias VutuvWeb.Endpoint
+  alias VutuvWeb.PageHTML
 
   require ModerationQuery
 
@@ -88,7 +116,9 @@ defmodule Vutuv.NodeInfo do
   # Properties of the software, identical on every installation.
   @software_name "vutuv"
   @repository "https://github.com/wintermeyer/vutuv"
-  @homepage "https://www.vutuv.de"
+  # The apex, not the `www.` alias: production 301s `www.` here, so the alias
+  # would send every directory through a redirect to reach the same page.
+  @homepage "https://vutuv.de"
 
   # The active-user windows the specification defines.
   @month_days 30
@@ -129,14 +159,61 @@ defmodule Vutuv.NodeInfo do
         "localPosts" => usage.local_posts,
         "localComments" => usage.local_comments
       },
-      "metadata" => %{
-        "nodeName" => Application.fetch_env!(:vutuv, :node_name),
-        "nodeDescription" => Application.fetch_env!(:vutuv, :node_description)
-      }
+      "metadata" => metadata()
     }
   end
 
   def document(_version), do: nil
+
+  # `metadata` is the schema's free-form half. Four of these are what a person
+  # reading a directory entry can act on; the two legal URLs appear only once
+  # the operator has actually written that page, because a link to a
+  # "not published yet" placeholder is worse than no link.
+  defp metadata do
+    {maintainer_name, maintainer_email} = Application.fetch_env!(:vutuv, :operator_recipient)
+
+    %{
+      "nodeName" => Application.fetch_env!(:vutuv, :node_name),
+      "nodeDescription" => node_description(),
+      "langs" => locales(),
+      "maintainer" => %{"name" => maintainer_name, "email" => maintainer_email}
+    }
+    |> put_legal_url("tosUrl", "nutzungsbedingungen")
+    |> put_legal_url("privacyPolicyUrl", "datenschutzerklaerung")
+  end
+
+  # The configured description says what is true of vutuv on **every**
+  # installation (open source, no tracking, no third-party cookies). Where the
+  # servers stand is not: it is a promise only the operator can make, so it is
+  # appended from `:data_location` and drops out entirely for an operator who
+  # cleared it — the same split the start page's "Your data" cards make, and
+  # `VutuvWeb.PageHTML.data_location/0` is the one place that decides whether
+  # the claim was made at all.
+  defp node_description do
+    description = Application.fetch_env!(:vutuv, :node_description)
+
+    case PageHTML.data_location() do
+      nil -> description
+      place -> description <> " Hosted on our own hardware in #{place}."
+    end
+  end
+
+  defp locales do
+    {:ok, config} = Application.fetch_env(:vutuv, Endpoint)
+    config[:locales]
+  end
+
+  defp put_legal_url(metadata, key, slug) do
+    case Legal.get_page(slug) do
+      %LegalPage{body: body} when is_binary(body) ->
+        if String.trim(body) == "",
+          do: metadata,
+          else: Map.put(metadata, key, Endpoint.url() <> "/" <> slug)
+
+      _unwritten ->
+        metadata
+    end
+  end
 
   @doc """
   The figures behind `usage`: `%{users: %{total:, active_month:,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.287.0",
+      version: "7.288.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/node_info_configuration_test.exs
+++ b/test/vutuv/node_info_configuration_test.exs
@@ -1,18 +1,23 @@
 defmodule Vutuv.NodeInfoConfigurationTest do
   @moduledoc """
-  How another installation names itself in NodeInfo (issue #1448).
+  How another installation names and describes itself in NodeInfo (issue #1448).
 
-  `async: false`, in a file of its own: this flips `:vutuv, :node_name` and
-  `:node_description`, and `Application.put_env/3` is global — the SQL sandbox
-  does not roll it back. `Vutuv.NodeInfo.document/1` is the only reader of
-  either key, and `VutuvWeb.WellKnownControllerTest` asserts on the configured
-  values through it, which is exactly the test that went red when this lived in
-  the async module beside it.
+  `async: false`, in a file of its own: this flips `:vutuv, :node_name`,
+  `:node_description` and `:data_location`, and `Application.put_env/3` is
+  global — the SQL sandbox does not roll it back. The first two are read only by
+  `Vutuv.NodeInfo.document/1`, but **`:data_location` is also read by
+  `VutuvWeb.PageHTML.data_location/0`**, i.e. by the start page's "Where your
+  data lives" card, so anything asserting on that card must stay sync too.
+  `VutuvWeb.WellKnownControllerTest` asserts on the configured values through
+  the document, which is exactly the test that went red when this lived in the
+  async module beside it.
   """
 
   use Vutuv.DataCase, async: false
 
   alias Vutuv.NodeInfo
+
+  defp description, do: NodeInfo.document("2.1")["metadata"]["nodeDescription"]
 
   test "nodeName and nodeDescription come from config, never from a literal" do
     put_config(:node_name, "Beispiel")
@@ -21,7 +26,35 @@ defmodule Vutuv.NodeInfoConfigurationTest do
     metadata = NodeInfo.document("2.1")["metadata"]
 
     assert metadata["nodeName"] == "Beispiel"
-    assert metadata["nodeDescription"] == "Ein Intranet."
+    assert metadata["nodeDescription"] =~ "Ein Intranet."
+  end
+
+  describe "the hosting claim" do
+    test "names the operator's own data location" do
+      put_config(:node_description, "Ein Intranet.")
+      put_config(:data_location, "Österreich")
+
+      assert description() == "Ein Intranet. Hosted on our own hardware in Österreich."
+    end
+
+    test "is dropped entirely by an operator who cleared the location" do
+      # What an operator on rented cloud infrastructure does — the start page's
+      # hosting card disappears for them too, and this claim must go the same
+      # way rather than being published in their name.
+      put_config(:node_description, "Ein Intranet.")
+      put_config(:data_location, "")
+
+      assert description() == "Ein Intranet."
+      refute description() =~ "own hardware"
+    end
+
+    test "is dropped when the key is absent altogether" do
+      put_config(:node_description, "Ein Intranet.")
+      Application.delete_env(:vutuv, :data_location)
+      on_exit(fn -> Application.put_env(:vutuv, :data_location, "Deutschland") end)
+
+      assert description() == "Ein Intranet."
+    end
   end
 
   defp put_config(key, value) do

--- a/test/vutuv/node_info_test.exs
+++ b/test/vutuv/node_info_test.exs
@@ -15,6 +15,7 @@ defmodule Vutuv.NodeInfoTest do
 
   alias Vutuv.Accounts
   alias Vutuv.Fediverse.Follower
+  alias Vutuv.Legal
   alias Vutuv.NodeInfo
   alias Vutuv.Posts
   alias Vutuv.Posts.PostDenial
@@ -44,7 +45,8 @@ defmodule Vutuv.NodeInfoTest do
       assert doc["software"]["name"] == "vutuv"
       assert doc["software"]["version"] == to_string(Application.spec(:vutuv, :vsn))
       assert doc["software"]["repository"] == "https://github.com/wintermeyer/vutuv"
-      assert doc["software"]["homepage"] == "https://www.vutuv.de"
+      # The apex, never the `www.` alias, which only 301s here.
+      assert doc["software"]["homepage"] == "https://vutuv.de"
 
       assert doc["metadata"]["nodeName"] == "vutuv"
       assert doc["metadata"]["nodeDescription"] =~ "business network"
@@ -66,6 +68,53 @@ defmodule Vutuv.NodeInfoTest do
     test "an unknown schema version has no document" do
       assert NodeInfo.document("1.0") == nil
       assert NodeInfo.document("2.2") == nil
+    end
+  end
+
+  describe "metadata" do
+    test "the description states what is true of the software everywhere" do
+      description = NodeInfo.document("2.1")["metadata"]["nodeDescription"]
+
+      assert description =~ "open-source"
+      assert description =~ "no third-party cookies"
+    end
+
+    test "the hosting claim names the operator's own data location" do
+      # The one claim in the description that is NOT a property of the
+      # software: `data_location` is the operator's own, exactly as on the
+      # start page.
+      assert NodeInfo.document("2.1")["metadata"]["nodeDescription"] =~
+               "on our own hardware in Deutschland"
+    end
+
+    test "langs lists the locales this installation serves" do
+      assert NodeInfo.document("2.1")["metadata"]["langs"] == ["en", "de"]
+    end
+
+    test "maintainer is the operator contact, the one security.txt already names" do
+      maintainer = NodeInfo.document("2.1")["metadata"]["maintainer"]
+
+      assert maintainer == %{
+               "name" => "Stefan Wintermeyer",
+               "email" => "sw@wintermeyer-consulting.de"
+             }
+    end
+
+    test "an unwritten legal page is not advertised" do
+      metadata = NodeInfo.document("2.1")["metadata"]
+
+      refute Map.has_key?(metadata, "tosUrl")
+      refute Map.has_key?(metadata, "privacyPolicyUrl")
+    end
+
+    test "a written legal page is linked absolutely" do
+      {:ok, _} = Legal.upsert_page("nutzungsbedingungen", %{"body" => "# Terms"})
+      {:ok, _} = Legal.upsert_page("datenschutzerklaerung", %{"body" => "# Privacy"})
+
+      metadata = NodeInfo.document("2.1")["metadata"]
+
+      assert metadata["tosUrl"] == "http://localhost:4001/nutzungsbedingungen"
+      assert metadata["privacyPolicyUrl"] == "http://localhost:4001/datenschutzerklaerung"
     end
   end
 


### PR DESCRIPTION
Folgt auf #1450 / #1448.

Die Beschreibung im NodeInfo-Dokument war der allgemeine Pitch der Startseite. Ein Verzeichnis druckt diesen Satz **wörtlich** neben den Eintrag, und in einer Liste von 72 Implementierungen ist das die einzige Stelle, an der wir sagen können, was vutuv von einem geschlossenen Karrierenetzwerk unterscheidet.

**Vorher**
```
"The open business network where professionals connect, share, and get found."
```

**Nachher**
```
"The open-source business network: a professional profile and posts you can
 follow from anywhere in the fediverse. No tracking, no third-party cookies.
 Hosted on our own hardware in Deutschland."
```

## Die Aufteilung ist der eigentliche Inhalt

Der konfigurierte Satz behauptet **ausschließlich, was für die Software auf jeder Installation gilt**, damit ein Betreiber, der ihn nie anfasst, trotzdem nichts Falsches sagt. Beides geprüft statt behauptet:

- *quelloffen* — MIT, gegen `LICENSE` und die Repo-Metadaten geprüft, nicht bloß „der Code ist öffentlich";
- *kein Tracking, keine Drittanbieter-Cookies* — gegen die Produktion geprüft: genau ein Cookie (`_vutuv_key`, First-Party, HttpOnly, SameSite=Lax), und kein Template lädt ein Asset von einem fremden Host.

**Wo die Server stehen, ist die eine der drei Aussagen, die dem Betreiber gehört und nicht vutuv** — und steht deshalb nicht in der Zeichenkette. `node_description/0` hängt sie aus `:data_location` an, und für einen Betreiber auf gemieteter Cloud-Infrastruktur fällt sie ersatzlos weg. Das ist dieselbe Trennung, die die Startseite zwischen ihren „Deine Daten"-Karten schon macht; `VutuvWeb.PageHTML.data_location/0` bleibt die eine Stelle, die entscheidet, ob die Behauptung überhaupt aufgestellt wurde. Ohne das hätte jede Installation, die die Variable nie anfasst, eine falsche Aussage über ihre eigene Infrastruktur veröffentlicht, im Namen ihres Betreibers.

Länge: echte Einträge laufen auf 10 bis 20 Wörter (mastodon.social 12, chaos.social 10, norden.social 17) und die Seiten kürzen, also wurde der Satz umgeschrieben und nicht verlängert.

**Was bewusst nicht drinsteht: dass wir die Guten sind.** Das behauptet jeder Server in dieser Liste, die Aussage trägt also keine Information, und im Fediverse liest sich Eigenlob als Warnzeichen (mastodon.social schreibt, *wer* sie betreibt und *wofür*, nie dass sie die Guten seien). Die drei Fakten sind dieselbe Aussage in nachprüfbarer Form.

## Dazu

- **`metadata.langs`**, **`metadata.maintainer`** (derselbe Kontakt, den `/.well-known/security.txt` längst veröffentlicht — also keine neue Preisgabe) sowie **`tosUrl`** und **`privacyPolicyUrl`**. Die letzten beiden nur, wenn die Seite unter `/admin/legal` wirklich geschrieben wurde: die Rechtstexte sind Installationsdaten, eine frische Installation zeigt einen „noch nicht veröffentlicht"-Platzhalter, und ein Link darauf ist schlechter als gar keiner.
- **`software.homepage` zeigt jetzt auf den Apex `https://vutuv.de`** statt auf den `www.`-Alias, der dorthin ohnehin nur mit 301 weiterleitet.

## Tests

Vier neue Fälle für `metadata` und drei für die Herkunftsangabe, darunter beide Seiten des Tors: gesetzt, leer und Schlüssel ganz entfernt. Die Tests, die `:data_location` kippen, liegen in der `async: false`-Datei, deren Moduldoc jetzt festhält, dass **auch die Startseite** diesen Schlüssel liest.

`mix precommit` grün (7654 Tests, credo ohne Befund).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01UFV3LLZ4KawwHs1gJAdgnF