### PR TITLE
users.gravatar_imported_at fällt wieder weg (v7.288.1)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.288.0",
+      version: "7.288.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260814123834_drop_gravatar_imported_at_from_users.exs
+++ b/priv/repo/migrations/20260814123834_drop_gravatar_imported_at_from_users.exs
@@ -1,0 +1,29 @@
+defmodule Vutuv.Repo.Migrations.DropGravatarImportedAtFromUsers do
+  use Ecto.Migration
+
+  @moduledoc """
+  Drops `users.gravatar_imported_at`, the contract half of the expand/contract
+  begun in v7.287.0.
+
+  The column existed for one day. It was added in v7.285.0 to date an in-app
+  note telling members that registration had quietly fetched their picture from
+  gravatar.com; v7.287.0 removed that fetch entirely in favour of a button the
+  member presses (issue #1447), which made the note — and so the column —
+  pointless. Nothing has read or written it since that release, which is the
+  one currently serving traffic, so dropping it now is N-1 compatible.
+
+  It held exactly one value in production: a single sign-up caught in the three
+  hours v7.285.0 was live. That one timestamp is not worth keeping — it records
+  the reach of nothing, since the fetch itself ran silently for years before
+  this column existed and left no marker anywhere. The member's avatar is
+  untouched; only the timestamp goes.
+
+  `remove/3` names the old type, so the migration rolls back cleanly (the value
+  does not come back, which is fine — nothing reads it).
+  """
+  def change do
+    alter table(:users) do
+      remove(:gravatar_imported_at, :naive_datetime)
+    end
+  end
+end


### PR DESCRIPTION
The contract half of the expand/contract started in v7.287.0 (#1452).

`users.gravatar_imported_at` lived for one day. v7.285.0 added it to date an in-app note about the silent gravatar.com fetch at registration; v7.287.0 removed that fetch in favour of a button the member presses, which made the note and the column pointless.

**N-1 is satisfied**: nothing has read or written the column since v7.287.0, and that is the release currently serving traffic — the only remaining mention anywhere in the tree was the migration that created it. So this drop cannot break the running slot during the switch window.

Production held exactly one value, from the three hours v7.285.0 was live. It is not worth keeping: the fetch it recorded had been running silently for years before the column existed and left no marker, so the timestamp documents the reach of nothing. The member's avatar is untouched — only the timestamp goes.

`remove/3` names the old type, so the migration rolls back cleanly. Exercised against `vutuv1_dev` in both directions (migrate → rollback → migrate).

`mix precommit` green (7654 tests).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_013zucWqZGcJqm1bvmEvxwf2
