### PR TITLE
Domain-Verifizierung findet den Eintrag jetzt selbst (v7.290.0)

### DIFF
--- a/docs/architecture/organizations.md
+++ b/docs/architecture/organizations.md
@@ -110,6 +110,8 @@ that owns the organization gate and test seams:
 - **DNS** — a `vutuv-organization-verify=<token>` TXT record on the domain, or on
   the CNAME-safe `_vutuv.<domain>` alternate name for a domain that is itself a
   CNAME (see `profiles.md` and `WebVerification.dns_challenge_name/1`, issue #947).
+  The record is read from the zone's **own name servers** (`Vutuv.Dns`), not
+  through a recursive resolver — see "Why the DNS read bypasses the cache" below.
 - **Website file** — the token served at
   `https://<domain>/.well-known/vutuv-organization-verify.txt`, fetched with `Req`
   behind the SSRF guard (`Vutuv.Ssrf`), never following redirects.
@@ -149,10 +151,25 @@ domain — the domain, not the name, is what viewers trust.
   a `pending` organization plus an owner `OrganizationRole` and an unverified primary
   `OrganizationDomain` derived from the website URL.
 - The owner finishes the claim on the page's verification panel (shown to the
-  owner while the page is `pending`): publish the record/file, click **Verify
-  now**. A successful proof stamps `verified_at`, flips the page to `active`, and
-  sends an operator notice (`Emailer.organization_verified_notice/2`) so a human
-  reviews every new page while volume is low.
+  owner while the page is `pending`, at the page's own permanent URL
+  `/organizations/:slug`, and reachable from `/settings/organizations`, where a
+  pending row shows a **Finish verification** call to action instead of the
+  generic "Manage"): publish the record/file, click **Verify now**. A successful
+  proof stamps `verified_at`, flips the page to `active`, and sends an operator
+  notice (`Emailer.organization_verified_notice/2`) so a human reviews every new
+  page while volume is low.
+- **The claim also finishes on its own** (`Vutuv.Organizations.PendingDomainSweeper`,
+  issue #1466). Publishing a DNS record does not complete when the member
+  presses Save at their provider; it completes minutes or hours later, out of
+  their hands. So a pending domain is re-checked on a backoff ladder read from
+  its own age — `@pending_backoff`, every two minutes for the first quarter of
+  an hour, flattening to six-hourly and abandoned after 30 days — and on success
+  the owners get `Emailer.organization_domain_verified_email/4` and any open page
+  is told over the organization's PubSub topic, so it turns into the live page with
+  no reload. Both sweepers share the `:recheck_organization_domains` gate.
+  `check_domain/2` stamps `last_checked_at` on **every** outcome, including the
+  failures, or a domain that can never verify would hold the front of every
+  oldest-first batch for ever.
 - DNS / well-known domains are **re-checked weekly**
   (`Vutuv.Organizations.DomainRecheckSweeper`, gated by
   `:recheck_organization_domains`; the sweeper ticks hourly but only re-checks
@@ -162,6 +179,41 @@ domain — the domain, not the name, is what viewers trust.
   verified status, and if it was the organization's last verified domain the page
   falls back to `pending` and the operator is alerted
   (`Emailer.organization_unverified_notice/2`).
+
+### Why the DNS read bypasses the cache
+
+`Vutuv.Dns` finds the deepest ancestor of the queried name that has `NS`
+records, resolves those name servers and asks **them** for the TXT record,
+rather than asking the recursive resolver in `/etc/resolv.conf`. That is not an
+optimisation, it is the difference between the feature working and not:
+
+- A claim is almost always started **before** the record exists — the member has
+  to read the value off the panel to publish it. That first look primes the
+  resolver's **negative** cache for the zone's SOA negative TTL, commonly hours,
+  and a short TTL on the record published seconds later cannot shorten it. Every
+  later "Verify now" then gets the same cached "no" from a resolver that is
+  working exactly as designed (issue #1466).
+- Every authoritative server is asked, not only the first, because a zone whose
+  servers are mid-transfer answers differently depending on who you ask.
+- An answer without the `aa` bit is discarded (`Vutuv.Dns.InetRes.txt_at/2`), so
+  a referral is never read as "no record", and a bare TLD is never used as the
+  zone (`zone_candidates/1`), since its registry servers only ever refer.
+- Name-server addresses come out of DNS, which the claimed domain's owner
+  controls, so an address `Vutuv.Ssrf.internal_ip?/1` calls internal is dropped:
+  an `NS` record pointing at `127.0.0.1` or a metadata endpoint must not turn
+  this server into a probe.
+- When no zone can be found or nothing answers — split-horizon intranet
+  resolvers, a firewall allowing port 53 only to the configured resolver — the
+  plain recursive lookup still runs, so this can only make verification more
+  likely to succeed.
+
+The panel reports what the check actually read (`WebVerification.dns_check/4` /
+`well_known_check/4` → `OrganizationComponents.check_report/1`): the names
+queried, the value wanted, and every TXT record found there. A member whose SPF
+record is listed back at them can see in one line that the proof went to the
+wrong name, which "not found yet, please try again" never told them. That block
+is an assign and not a flash on purpose — an identical flash renders no diff, so
+the old toast made every attempt after the first look like a dead button.
 
 ### Who hears about a failing proof
 
@@ -180,6 +232,10 @@ in their own locale, linking to `/organizations/:slug/domains`):
   verified domains is not told it is about to go offline.
 - **Demotion** — `Emailer.organization_page_unverified_email/4`, sent alongside
   the operator notice when the last verified domain is dropped.
+- **Verified in the background** — `Emailer.organization_domain_verified_email/4`,
+  sent only from the pending pass, never from a click: somebody watching the
+  page being verified does not need a mail about it, and the whole point of this
+  one is that it reaches the member who published the record and closed the tab.
 
 Recipients are **owners only**: domains are an owner-only power
 (`can_manage_domains?/2`), so an admin or recruiter would get a call to action

--- a/lib/vutuv/application.ex
+++ b/lib/vutuv/application.ex
@@ -113,6 +113,10 @@ defmodule Vutuv.Application do
         optional_child(:sweep_unreachable_accounts, Vutuv.Deliverability.Sweeper) ++
         optional_child(:resume_stuck_broadcasts, Vutuv.Newsletters.BroadcastResumer) ++
         optional_child(:recheck_organization_domains, Vutuv.Organizations.DomainRecheckSweeper) ++
+        optional_child(
+          :recheck_organization_domains,
+          Vutuv.Organizations.PendingDomainSweeper
+        ) ++
         optional_child(:recheck_user_links, Vutuv.Profiles.LinkRecheckSweeper) ++
         optional_child(
           :recheck_social_accounts,

--- a/lib/vutuv/dns.ex
+++ b/lib/vutuv/dns.ex
@@ -1,0 +1,118 @@
+defmodule Vutuv.Dns do
+  @moduledoc """
+  Reading a TXT record from the **zone's own name servers** rather than from a
+  caching resolver (issue #1466).
+
+  Domain verification is the one DNS read where a cache is the enemy. A member
+  starts the claim, we look, the record is not there yet, and the recursive
+  resolver caches that miss for the zone's negative TTL — which the zone's SOA
+  sets, commonly hours, and which the short TTL on the record they publish
+  seconds later cannot shorten. From then on every "Verify now" gets the same
+  cached "no" until the negative TTL runs out, however correct the record is.
+  That is what #1466 reported, and it is not fixable by retrying harder.
+
+  So: find the deepest ancestor of the name that has `NS` records, resolve those
+  name servers, and put the TXT question to them directly. There is no cache in
+  front of an authoritative server, so the answer is the zone's current truth.
+  All of them are asked, not just the first, because a zone whose servers are
+  mid-transfer answers differently depending on who you ask and the member
+  should not be punished for arriving during that window.
+
+  Two guards. Name-server addresses come out of DNS, which the domain's owner
+  controls, so an address `Vutuv.Ssrf` calls internal is dropped — pointing an
+  `NS` record at `127.0.0.1` or a metadata endpoint must not turn this server
+  into a probe. And a name server that answers without the `aa` bit is not
+  believed (see `Vutuv.Dns.InetRes.txt_at/2`).
+
+  When no name server can be found or none of them answers at all — a
+  split-horizon intranet resolver, a firewall that only allows port 53 to the
+  configured resolver — the plain recursive lookup still runs, so this can only
+  make verification more likely to succeed, never less.
+  """
+
+  alias Vutuv.Dns.InetRes
+  alias Vutuv.Ssrf
+
+  # Enough to cover the usual two-to-four-server zone and to survive one being
+  # down, without turning one click into a dozen queries.
+  @max_nameservers 4
+
+  @doc """
+  TXT records for `name` in the `[[charlist]]` shape `:inet_res.lookup/4`
+  returns (one list of string chunks per record), read from the zone's
+  authoritative servers where they can be reached and from the resolver
+  otherwise.
+  """
+  def txt_records(name, backend \\ InetRes) when is_binary(name) do
+    case authoritative_txt(name, backend) do
+      {:ok, records} -> records
+      :error -> backend.lookup(name, :txt)
+    end
+  end
+
+  @doc """
+  The authoritative name servers for the zone holding `name`, as
+  `{address, 53}` pairs — internal addresses dropped, capped at a handful.
+  Empty when the zone cannot be determined.
+  """
+  def nameservers(name, backend \\ InetRes) when is_binary(name) do
+    name
+    |> zone_candidates()
+    |> Enum.find_value([], fn zone ->
+      case backend.lookup(zone, :ns) do
+        [] -> nil
+        names -> Enum.map(names, &to_string/1)
+      end
+    end)
+    |> Enum.flat_map(&addresses(&1, backend))
+    |> Enum.reject(&Ssrf.internal_ip?/1)
+    |> Enum.uniq()
+    |> Enum.take(@max_nameservers)
+    |> Enum.map(&{&1, 53})
+  end
+
+  @doc """
+  The names to try for the zone cut, deepest first: the name itself, then each
+  ancestor down to two labels.
+
+  A bare TLD is never offered. Its registry servers answer a TXT query with a
+  referral rather than an answer, and a referral read as "no record" would be a
+  confident wrong "no" — the exact failure this module exists to remove.
+  """
+  def zone_candidates(name) when is_binary(name) do
+    labels = name |> String.trim_trailing(".") |> String.split(".", trim: true)
+    deepest_drop = max(Enum.count(labels) - 2, -1)
+
+    Enum.map(0..deepest_drop//1, fn drop ->
+      labels |> Enum.drop(drop) |> Enum.join(".")
+    end)
+  end
+
+  defp authoritative_txt(name, backend) do
+    case nameservers(name, backend) do
+      [] -> :error
+      servers -> Enum.reduce_while(servers, :error, &ask(&1, name, backend, &2))
+    end
+  end
+
+  # Reduced rather than `find_value`d: a server that answers "nothing here" is
+  # still an answer we trust over the cache, so an empty result has to survive
+  # the rest of the round even while a later server is asked.
+  defp ask(server, name, backend, answered) do
+    case backend.txt_at(name, [server]) do
+      {:ok, []} -> {:cont, {:ok, []}}
+      {:ok, records} -> {:halt, {:ok, records}}
+      {:error, _reason} -> {:cont, answered}
+    end
+  end
+
+  # IPv4 first, IPv6 only where a name server offers nothing else: an install
+  # without IPv6 connectivity would otherwise spend its whole query budget on
+  # addresses it cannot reach.
+  defp addresses(nameserver, backend) do
+    case backend.lookup(nameserver, :a) do
+      [] -> backend.lookup(nameserver, :aaaa)
+      addresses -> addresses
+    end
+  end
+end

--- a/lib/vutuv/dns/backend.ex
+++ b/lib/vutuv/dns/backend.ex
@@ -1,0 +1,17 @@
+defmodule Vutuv.Dns.Backend do
+  @moduledoc """
+  The two DNS primitives `Vutuv.Dns` needs, behind a behaviour so tests can
+  answer them from their own data instead of the network.
+  """
+
+  @doc "A plain recursive lookup through the configured resolver."
+  @callback lookup(name :: String.t(), type :: :ns | :a | :aaaa | :txt) :: [term()]
+
+  @doc """
+  A TXT query sent straight to the given name servers. `{:ok, records}` only for
+  an **authoritative** answer (the `aa` bit set); anything else is an error, so
+  the caller can move on to the next server rather than trust a referral.
+  """
+  @callback txt_at(name :: String.t(), nameservers :: [{:inet.ip_address(), 1..65_535}]) ::
+              {:ok, [[charlist()]]} | {:error, term()}
+end

--- a/lib/vutuv/dns/inet_res.ex
+++ b/lib/vutuv/dns/inet_res.ex
@@ -1,0 +1,69 @@
+defmodule Vutuv.Dns.InetRes do
+  @moduledoc """
+  The production `Vutuv.Dns.Backend`, built on Erlang's own `:inet_res`. Every
+  call answers with data or an error and never raises, because a name server is
+  a third party and half of what it does is fail.
+  """
+
+  @behaviour Vutuv.Dns.Backend
+
+  require Logger
+
+  # A single query. Short on purpose: a verification click waits on this, and a
+  # name server that needs longer than two seconds is one we ask again later.
+  @timeout 2_000
+
+  @impl true
+  def lookup(name, type) do
+    :inet_res.lookup(to_charlist(name), :in, type, timeout: @timeout)
+  rescue
+    _ -> []
+  catch
+    _, _ -> []
+  end
+
+  @impl true
+  def txt_at(name, nameservers) do
+    case :inet_res.resolve(to_charlist(name), :in, :txt,
+           nameservers: nameservers,
+           timeout: @timeout
+         ) do
+      {:ok, message} ->
+        answer(message)
+
+      # The name does not exist, said by the server that owns the zone. That is
+      # a real answer, not a failure, so it must not send us back to the cache.
+      {:error, {:nxdomain, _message}} ->
+        {:ok, []}
+
+      {:error, :nxdomain} ->
+        {:ok, []}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  rescue
+    error ->
+      Logger.debug("authoritative TXT query for #{name} failed: #{inspect(error)}")
+      {:error, :exception}
+  catch
+    _, _ -> {:error, :exception}
+  end
+
+  # Only an answer carrying the `aa` bit is worth having: without it we are
+  # holding a referral or a recursive server's cached copy, which is the very
+  # thing this whole path exists to bypass.
+  defp answer(message) do
+    if message |> :inet_dns.msg(:header) |> :inet_dns.header(:aa) do
+      records =
+        message
+        |> :inet_dns.msg(:anlist)
+        |> Enum.filter(&(:inet_dns.rr(&1, :type) == :txt))
+        |> Enum.map(&:inet_dns.rr(&1, :data))
+
+      {:ok, records}
+    else
+      {:error, :not_authoritative}
+    end
+  end
+end

--- a/lib/vutuv/notifications/emailer.ex
+++ b/lib/vutuv/notifications/emailer.ex
@@ -833,6 +833,31 @@ defmodule Vutuv.Notifications.Emailer do
     do: gettext("A domain of your organization page on vutuv is about to be dropped")
 
   @doc """
+  Tells an organization owner that the background check found the proof and the
+  page is live (issue #1466).
+
+  Only the background pass sends this. Somebody who pressed "Verify now" and is
+  looking at the page being verified does not need a mail about it; the point of
+  this one is that it reaches the member who published the record, closed the
+  tab and would otherwise have to keep coming back to guess whether DNS had
+  caught up.
+  """
+  def organization_domain_verified_email(user, email, organization, domain) do
+    build_email(
+      user,
+      email,
+      "organization_domain_verified",
+      %{
+        organization_name: organization.name,
+        organization_slug: organization.slug,
+        domain: domain.domain,
+        method: domain.method
+      },
+      fn -> gettext("Your organization page on vutuv is verified") end
+    )
+  end
+
+  @doc """
   Tells an organization owner the grace window ran out on the page's last
   verified domain: it is back to "pending" and no longer publicly visible. The
   member-facing twin of `organization_unverified_notice/2`.

--- a/lib/vutuv/organizations.ex
+++ b/lib/vutuv/organizations.ex
@@ -57,6 +57,29 @@ defmodule Vutuv.Organizations do
   @recheck_interval_hours 24 * 7
   @grace_days 7
 
+  # How often a domain that is still waiting for its proof is looked at, by how
+  # long ago the claim was started: `{claim younger than, check every}` in
+  # seconds (issue #1466). Somebody who has just been shown the record is
+  # publishing it right now, so the first quarter of an hour is checked hard and
+  # the ladder then flattens out. Past the last step the claim is abandoned
+  # rather than swept for ever — the owner can still press "Verify now", which
+  # is what they will do if they ever come back to it.
+  @pending_backoff [
+    {900, 120},
+    {7_200, 600},
+    {86_400, 3_600},
+    {30 * 86_400, 6 * 3_600}
+  ]
+  # The smallest interval on the ladder and the age past its last step, both
+  # derived so the SQL prefilter and the ladder cannot drift apart.
+  @pending_min_interval @pending_backoff |> Enum.map(&elem(&1, 1)) |> Enum.min()
+  @pending_abandon_after @pending_backoff |> List.last() |> elem(0)
+  # Rows read per pass, and how many of them are actually checked. The scan is
+  # oldest-checked-first, so the rows most likely to be due come first and a
+  # pass never walks the whole table.
+  @pending_scan 200
+  @pending_batch 50
+
   @doc """
   The canonical URL path of an organization page: its opt-in root handle when claimed
   (`/:username`, issue #941), otherwise `/organizations/:slug`. The one definition
@@ -1095,6 +1118,43 @@ defmodule Vutuv.Organizations do
     end
   end
 
+  @doc """
+  Runs the domain's proof and **says what it saw** (issue #1466):
+  `{:ok, organization}` once the page is live, or `{:error, report}` with the
+  names queried, the value we wanted and the records actually found — the
+  difference between "not yet" and "you published it one label too deep".
+
+  It also stamps `last_checked_at` on a failure, which `verify_domain/2` never
+  did, so a pending domain can say when it was last looked at and the background
+  pass can back off from it.
+
+  `report.disabled?` marks the one case that is not about the domain at all:
+  domain verification is switched off on this installation.
+  """
+  def check_domain(%Organization{} = organization, %OrganizationDomain{} = domain) do
+    if verification_enabled?() do
+      domain |> run_check() |> record_check(organization, domain)
+    else
+      {:error, %{method: domain.method, disabled?: true}}
+    end
+  end
+
+  defp run_check(%OrganizationDomain{method: "dns"} = domain),
+    do: Verification.dns_check(domain.domain, domain.verification_token)
+
+  defp run_check(%OrganizationDomain{method: "well_known"} = domain),
+    do: Verification.well_known_check(domain.domain, domain.verification_token)
+
+  defp record_check({:ok, _report}, organization, domain), do: activate(organization, domain)
+
+  defp record_check({:error, report}, _organization, domain) do
+    domain
+    |> OrganizationDomain.check_changeset(%{last_checked_at: now()})
+    |> Repo.update()
+
+    {:error, Map.put(report, :disabled?, false)}
+  end
+
   # Flips a pending organization to active off a freshly verified domain, stamps
   # verified_at once, and alerts the operator on first verification.
   defp activate(%Organization{} = organization, %OrganizationDomain{} = domain) do
@@ -1128,6 +1188,101 @@ defmodule Vutuv.Organizations do
     end
 
     {:ok, organization}
+  end
+
+  # --- finishing a claim in the background (issue #1466) ----------------------
+  #
+  # Until this existed, a pending domain was checked exactly when somebody
+  # pressed the button and never otherwise: `domains_due_for_recheck/1` below
+  # only guards domains that are already verified. So a member who published the
+  # record and closed the tab was never verified, and nothing on the page told
+  # them that clicking again was the only way. These two functions are the other
+  # half of that promise, and the mail on success is what lets them close the
+  # tab at all.
+
+  @doc """
+  Pending domains that are due for a background check: never verified, the claim
+  not yet abandoned, and last looked at longer ago than the backoff step its age
+  puts it on.
+
+  The interval is applied in memory because it depends on the row's own age; the
+  query narrows to rows that could possibly be due (the shortest step) and reads
+  them oldest-checked-first, so the ones most likely due are at the front.
+  """
+  def pending_domains_due(now \\ NaiveDateTime.utc_now()) do
+    now = NaiveDateTime.truncate(now, :second)
+    abandoned_before = NaiveDateTime.add(now, -@pending_abandon_after)
+    checked_before = NaiveDateTime.add(now, -@pending_min_interval)
+
+    from(d in OrganizationDomain,
+      where:
+        d.method in ["dns", "well_known"] and is_nil(d.verified_at) and
+          d.inserted_at > ^abandoned_before and
+          (is_nil(d.last_checked_at) or d.last_checked_at < ^checked_before),
+      order_by: [asc_nulls_first: d.last_checked_at, asc: d.id],
+      limit: @pending_scan
+    )
+    |> Repo.all()
+    |> Enum.filter(&pending_due?(&1, now))
+    |> Enum.take(@pending_batch)
+  end
+
+  @doc """
+  Checks every due pending domain and returns how many pages went live this
+  pass. No-op when network verification is disabled.
+  """
+  def check_pending_domains do
+    if verification_enabled?() do
+      pending_domains_due()
+      |> Task.async_stream(&check_pending_domain/1,
+        max_concurrency: 10,
+        ordered: false,
+        timeout: :infinity
+      )
+      |> Enum.count(fn {:ok, outcome} -> outcome == :verified end)
+    else
+      0
+    end
+  end
+
+  defp check_pending_domain(%OrganizationDomain{} = domain) do
+    organization = get_organization!(domain.organization_id)
+
+    # `check_domain/2` stamps `last_checked_at` on the failing branch too, so a
+    # domain whose record is still missing leaves the due set for this step's
+    # interval instead of holding the front of every batch.
+    case check_domain(organization, domain) do
+      {:ok, organization} ->
+        notify_owners_of_verified(organization, domain)
+        broadcast_verified(organization)
+        :verified
+
+      {:error, _report} ->
+        :pending
+    end
+  end
+
+  defp pending_due?(%OrganizationDomain{} = domain, now) do
+    case pending_interval(NaiveDateTime.diff(now, domain.inserted_at)) do
+      :abandoned ->
+        false
+
+      interval ->
+        is_nil(domain.last_checked_at) or
+          NaiveDateTime.diff(now, domain.last_checked_at) >= interval
+    end
+  end
+
+  defp pending_interval(age_in_seconds) do
+    Enum.find_value(@pending_backoff, :abandoned, fn {younger_than, interval} ->
+      age_in_seconds < younger_than && interval
+    end)
+  end
+
+  defp notify_owners_of_verified(organization, domain) do
+    notify_owners(organization, fn user, address ->
+      Emailer.organization_domain_verified_email(user, address, organization, domain)
+    end)
   end
 
   # --- periodic re-check ------------------------------------------------------
@@ -1401,6 +1556,18 @@ defmodule Vutuv.Organizations do
 
   @doc "Subscribes to an organization's live counter topic."
   def subscribe(organization_id), do: Engagement.subscribe(organization_id, @engagement_cfg)
+
+  # Tells an open page that the background pass finished its claim, so somebody
+  # who published the record and left the tab sitting there watches it go live
+  # instead of reloading to find out (issue #1466). Lives here rather than with
+  # the pending pass above because `@engagement_cfg` owns the topic name.
+  defp broadcast_verified(%Organization{id: id}) do
+    Phoenix.PubSub.broadcast(
+      Vutuv.PubSub,
+      Engagement.topic(id, @engagement_cfg),
+      {:organization_verified, id}
+    )
+  end
 
   @doc """
   One page of the member's liked / bookmarked organizations for the `/bookmarks`

--- a/lib/vutuv/organizations/pending_domain_sweeper.ex
+++ b/lib/vutuv/organizations/pending_domain_sweeper.ex
@@ -1,0 +1,57 @@
+defmodule Vutuv.Organizations.PendingDomainSweeper do
+  @moduledoc """
+  Finishes a domain claim nobody is watching (`Vutuv.Organizations.check_pending_domains/0`,
+  issue #1466).
+
+  Publishing a DNS record is not an act that completes when the member presses
+  Save at their provider: it completes when the record has reached the zone's
+  name servers, minutes or hours later and entirely out of their hands. Before
+  this sweeper the only thing that ever looked again was the member pressing
+  "Verify now", so the reasonable thing to do — publish the record, close the
+  tab, get on with the day — was the one thing that never worked.
+
+  Ticks every two minutes, which is the shortest step of the backoff ladder in
+  `Vutuv.Organizations`; the ladder, not this interval, decides how often any
+  one domain is actually looked at. On success the owners get a mail and any
+  open page is told over PubSub.
+
+  Gated twice, like its `Vutuv.Organizations.DomainRecheckSweeper` sibling: the
+  child starts only when `:recheck_organization_domains` is on (off in tests, so
+  it never touches the SQL sandbox from outside), and the pass itself is a no-op
+  when `:verify_organization_domains` is off (intranet installs that must not
+  call out).
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias Vutuv.Organizations
+
+  @interval :timer.minutes(2)
+
+  def start_link(_opts), do: GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+
+  @impl true
+  def init(:ok) do
+    schedule()
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_info(:sweep, state) do
+    try do
+      case Organizations.check_pending_domains() do
+        0 -> :ok
+        count -> Logger.info("Organization domain claims finished in the background: #{count}")
+      end
+    rescue
+      error -> Logger.error("Pending organization domain check failed: #{inspect(error)}")
+    end
+
+    schedule()
+    {:noreply, state}
+  end
+
+  defp schedule, do: Process.send_after(self(), :sweep, @interval)
+end

--- a/lib/vutuv/organizations/verification.ex
+++ b/lib/vutuv/organizations/verification.ex
@@ -45,6 +45,14 @@ defmodule Vutuv.Organizations.Verification do
     WebVerification.dns_verified?(host, @dns_prefix, token, dns_resolver())
   end
 
+  @doc """
+  The `dns` check with a report of the names queried and the TXT records found
+  there — what the verification panel shows the member after a failed attempt.
+  """
+  def dns_check(host, token) when is_binary(host) and is_binary(token) do
+    WebVerification.dns_check(host, @dns_prefix, token, dns_resolver())
+  end
+
   # --- well-known file --------------------------------------------------------
 
   @doc "The URL fetched for the `well_known` method."
@@ -55,6 +63,15 @@ defmodule Vutuv.Organizations.Verification do
   """
   def well_known_verified?(host, token) when is_binary(host) and is_binary(token) do
     WebVerification.well_known_verified?(host, @well_known_path, token, req_options())
+  end
+
+  @doc """
+  The `well_known` check with a report of the URL fetched, the status it
+  answered and the first line it served — the file half of what the
+  verification panel shows after a failed attempt.
+  """
+  def well_known_check(host, token) when is_binary(host) and is_binary(token) do
+    WebVerification.well_known_check(host, @well_known_path, token, req_options())
   end
 
   defp dns_resolver do

--- a/lib/vutuv/web_verification.ex
+++ b/lib/vutuv/web_verification.ex
@@ -26,7 +26,13 @@ defmodule Vutuv.WebVerification do
 
   require Logger
 
+  alias Vutuv.Dns
   alias Vutuv.Ssrf
+
+  # How much of an unexpected answer is quoted back to the member in a check
+  # report. Enough to recognise the record or page they published by mistake,
+  # short enough that a hostile body cannot fill their screen.
+  @max_excerpt 160
 
   @max_well_known_bytes 4_096
   # rel=me links can sit anywhere in the page (a footer, an "about" sidebar), so
@@ -70,12 +76,48 @@ defmodule Vutuv.WebVerification do
   def dns_verified?(host, prefix, token, resolver)
       when is_binary(host) and is_binary(prefix) and is_binary(token) and
              is_function(resolver, 1) do
-    expected = dns_txt_value(prefix, token)
+    match?({:ok, _report}, dns_check(host, prefix, token, resolver))
+  end
 
-    # The bare host is checked first, so the common (non-CNAME) case verifies in
-    # a single lookup and only a miss pays for the second, alternate-name query.
-    [host, dns_challenge_name(host)]
-    |> Enum.any?(fn name -> Enum.any?(txt_records(name, resolver), &(&1 == expected)) end)
+  @doc """
+  The `dns` check plus a report of what was actually read: which names were
+  queried, the value we wanted, and **every** TXT record we saw there.
+
+  The report is the whole point of this function existing beside
+  `dns_verified?/4`. A bare "not found yet" leaves a member re-reading their own
+  zone file; being told that we see their SPF record and their Google
+  verification but not ours tells them in one line that they published to the
+  wrong name, or with a typo, or on a zone that is not the live one.
+  """
+  def dns_check(host, prefix, token, resolver)
+      when is_binary(host) and is_binary(prefix) and is_binary(token) and
+             is_function(resolver, 1) do
+    expected = dns_txt_value(prefix, token)
+    names = [host, dns_challenge_name(host)]
+
+    # The bare host is read first and a hit stops there, so the common
+    # (non-CNAME) case still verifies in a single lookup and only a miss pays
+    # for the second, alternate-name query — the one that then also fills the
+    # report.
+    {found, matched?} =
+      Enum.reduce_while(names, {[], false}, fn name, {seen, _matched?} ->
+        records = txt_records(name, resolver)
+
+        if expected in records do
+          {:halt, {seen ++ records, true}}
+        else
+          {:cont, {seen ++ records, false}}
+        end
+      end)
+
+    report = %{
+      method: "dns",
+      names: names,
+      expected: expected,
+      found: found |> Enum.uniq() |> Enum.map(&excerpt/1)
+    }
+
+    if matched?, do: {:ok, report}, else: {:error, report}
   end
 
   defp txt_records(host, resolver) do
@@ -86,9 +128,14 @@ defmodule Vutuv.WebVerification do
     _ -> []
   end
 
-  @doc "The default DNS TXT resolver (`:inet_res.lookup/3`)."
+  @doc """
+  The default DNS TXT resolver. Reads the record from the zone's **own** name
+  servers where it can reach them (`Vutuv.Dns`), because a recursive resolver
+  answers a freshly published record from its negative cache for the zone's
+  negative TTL — hours, in the case that produced issue #1466.
+  """
   def default_txt_lookup(host) do
-    :inet_res.lookup(to_charlist(host), :in, :txt)
+    Dns.txt_records(host)
   end
 
   # --- well-known file --------------------------------------------------------
@@ -104,9 +151,33 @@ defmodule Vutuv.WebVerification do
   """
   def well_known_verified?(host, path, token, req_options)
       when is_binary(host) and is_binary(path) and is_binary(token) do
-    case fetch(well_known_url(host, path), host, req_options, @max_well_known_bytes, "text/plain") do
-      {:ok, body} -> String.trim(body) == token
-      {:error, _} -> false
+    match?({:ok, _report}, well_known_check(host, path, token, req_options))
+  end
+
+  @doc """
+  The `well_known` check plus a report of what the fetch actually got: the URL,
+  the HTTP status, and the first line of the body when there was one.
+
+  One fetch answers both halves, so a failing check costs no more than it did
+  before it started explaining itself. `status: nil` means the request never
+  produced a response at all (DNS, TLS, connection, the SSRF guard).
+  """
+  def well_known_check(host, path, token, req_options)
+      when is_binary(host) and is_binary(path) and is_binary(token) do
+    url = well_known_url(host, path)
+
+    case fetch(url, host, req_options, @max_well_known_bytes, "text/plain") do
+      {:ok, body} ->
+        served = String.trim(body)
+        report = %{method: "well_known", url: url, status: 200, found: excerpt(served)}
+
+        if served == token, do: {:ok, report}, else: {:error, report}
+
+      {:error, {:status, status}} ->
+        {:error, %{method: "well_known", url: url, status: status, found: nil}}
+
+      {:error, _reason} ->
+        {:error, %{method: "well_known", url: url, status: nil, found: nil}}
     end
   end
 
@@ -226,6 +297,18 @@ defmodule Vutuv.WebVerification do
     error ->
       Logger.warning("web verification fetch failed for #{url}: #{inspect(error)}")
       {:error, :exception}
+  end
+
+  # One short, printable line out of whatever a third party served us. It goes
+  # straight into a page the member reads, so it is cut to a length that cannot
+  # take the layout over and stripped of the control characters an HTML escape
+  # would leave as invisible junk.
+  defp excerpt(value) do
+    value
+    |> to_string()
+    |> String.replace(~r/[[:cntrl:]]+/u, " ")
+    |> String.trim()
+    |> String.slice(0, @max_excerpt)
   end
 
   defp user_agent do

--- a/lib/vutuv_web/components/organization_components.ex
+++ b/lib/vutuv_web/components/organization_components.ex
@@ -10,7 +10,7 @@ defmodule VutuvWeb.OrganizationComponents do
   use Gettext, backend: VutuvWeb.Gettext
 
   import VutuvWeb.ErrorHelpers
-  import VutuvWeb.UI, only: [input_class: 2]
+  import VutuvWeb.UI, only: [input_class: 2, local_time: 1]
 
   alias Vutuv.Countries
   alias Vutuv.Organizations.Organization
@@ -62,6 +62,108 @@ defmodule VutuvWeb.OrganizationComponents do
       </svg>
       {gettext("Verified via %{domain}", domain: @domain)}
     </span>
+    """
+  end
+
+  attr(:report, :map, default: nil)
+  attr(:id, :string, required: true)
+
+  @doc """
+  What the last domain check actually saw (issue #1466).
+
+  A failed check used to answer with one auto-dismissing toast reading "not
+  found yet, please try again", and a second attempt with the identical message
+  produced no diff at all — so from the second click on, the button looked
+  broken. This block replaces that: it stays on the page until the next attempt
+  replaces it, and it names the value we wanted, where we looked and what was
+  there instead, which is usually the whole diagnosis (a record on the wrong
+  name, a stray quote, a zone that is not the live one).
+
+  Slate rather than red or amber: a proof that has not propagated yet is the
+  ordinary case, not a mistake the member made, and amber belongs to moderation.
+  """
+  def check_report(assigns) do
+    ~H"""
+    <div
+      :if={@report}
+      id={@id}
+      data-check-report
+      role="status"
+      class="mt-3 rounded-lg bg-white p-4 text-sm ring-1 ring-slate-200 dark:bg-slate-900 dark:ring-slate-700"
+    >
+      <p class="font-semibold text-slate-900 dark:text-slate-100">
+        {gettext("Not found yet")} &middot;
+        <.local_time at={@report.checked_at} id={"#{@id}-time"} format="%H:%M" />
+      </p>
+
+      <%= cond do %>
+        <% @report[:disabled?] -> %>
+          <p class="mt-2 text-slate-700 dark:text-slate-300">
+            {gettext("Domain verification is disabled on this installation.")}
+          </p>
+        <% @report.method == "dns" -> %>
+          <p class="mt-2 text-slate-700 dark:text-slate-300">
+            {gettext("We asked the name servers of your domain directly, for %{names}, and looked for this value:", names: Enum.join(@report.names, ", "))}
+          </p>
+          <code phx-no-curly-interpolation class={code_class()}><%= @report.expected %></code>
+          <p class="mt-3 text-slate-700 dark:text-slate-300">
+            {gettext("What is published there right now:")}
+          </p>
+          <ul :if={@report.found != []} data-check-found class="mt-1 space-y-1">
+            <li :for={record <- @report.found}>
+              <code phx-no-curly-interpolation class={code_class()}><%= record %></code>
+            </li>
+          </ul>
+          <p
+            :if={@report.found == []}
+            data-check-found
+            class="mt-1 text-slate-600 dark:text-slate-400"
+          >
+            {gettext("No TXT record at all.")}
+          </p>
+        <% true -> %>
+          <p class="mt-2 text-slate-700 dark:text-slate-300">{gettext("We fetched this address:")}</p>
+          <code phx-no-curly-interpolation class={code_class()}><%= @report.url %></code>
+          <p class="mt-3 text-slate-700 dark:text-slate-300" data-check-found>
+            {well_known_outcome(@report)}
+          </p>
+      <% end %>
+    </div>
+    """
+  end
+
+  defp code_class do
+    "mt-1 block overflow-x-auto rounded bg-slate-50 px-3 py-2 font-mono text-xs text-slate-900 dark:bg-slate-800 dark:text-slate-100"
+  end
+
+  # The one sentence saying what came back from the file fetch. `status: nil`
+  # means there was no response at all, which is a different problem from a 404
+  # and has to read as one.
+  defp well_known_outcome(%{status: nil}),
+    do: gettext("We could not reach that address at all.")
+
+  defp well_known_outcome(%{status: 200, found: found}) when is_binary(found) and found != "",
+    do: gettext("It answered, but with something else: %{found}", found: found)
+
+  defp well_known_outcome(%{status: 200}),
+    do: gettext("It answered with an empty file.")
+
+  defp well_known_outcome(%{status: status}),
+    do: gettext("It answered with HTTP status %{status}.", status: status)
+
+  attr(:domain, :string, required: true)
+
+  @doc """
+  The standing promise under a verification panel: this is not the only thing
+  that ever looks again. Without it the honest reading of the panel is that a
+  member has to sit and press the button until DNS catches up, which is what
+  issue #1466 described doing.
+  """
+  def check_reassurance(assigns) do
+    ~H"""
+    <p data-check-reassurance class="mt-3 text-xs text-slate-600 dark:text-slate-400">
+      {gettext("A new entry can take a while to reach everyone. We keep checking %{domain} by ourselves and send you an email as soon as it works, so you can close this page.", domain: @domain)}
+    </p>
     """
   end
 

--- a/lib/vutuv_web/live/organization_live/domains.ex
+++ b/lib/vutuv_web/live/organization_live/domains.ex
@@ -11,7 +11,8 @@ defmodule VutuvWeb.OrganizationLive.Domains do
 
   use VutuvWeb, :live_view
 
-  import VutuvWeb.OrganizationComponents, only: [manage_header: 1]
+  import VutuvWeb.OrganizationComponents,
+    only: [manage_header: 1, check_report: 1, check_reassurance: 1]
 
   alias Vutuv.Organizations
   alias VutuvWeb.Live.InitAssigns
@@ -27,6 +28,9 @@ defmodule VutuvWeb.OrganizationLive.Domains do
      |> assign(:page_title, gettext("Domains – %{name}", name: organization.name))
      |> assign(:new_domain, "")
      |> assign(:new_method, "dns")
+     # What the last check saw, per domain (issue #1466). Keyed by domain id
+     # because this page can have several claims running at once.
+     |> assign(:check_reports, %{})
      |> assign(:verification_enabled?, Organizations.verification_enabled?())
      |> load_domains()}
   end
@@ -78,7 +82,9 @@ defmodule VutuvWeb.OrganizationLive.Domains do
            Organizations.get_domain(socket.assigns.organization, id),
          true <- is_nil(domain.verified_at) do
       {:ok, _} = Organizations.set_domain_method(domain, method)
-      {:noreply, load_domains(socket)}
+      # The stored report was about the other method, so it would now be
+      # answering a question nobody asked.
+      {:noreply, socket |> forget_report(id) |> load_domains()}
     else
       _ -> {:noreply, socket}
     end
@@ -92,13 +98,16 @@ defmodule VutuvWeb.OrganizationLive.Domains do
         {:noreply, socket}
 
       domain ->
-        case Organizations.verify_domain(organization, domain) do
+        case Organizations.check_domain(organization, domain) do
           {:ok, _organization} ->
-            {:noreply, socket |> load_domains() |> put_flash(:info, gettext("Domain verified."))}
-
-          {:error, _} ->
             {:noreply,
-             put_flash(socket, :error, verify_error(socket.assigns.verification_enabled?))}
+             socket
+             |> forget_report(id)
+             |> load_domains()
+             |> put_flash(:info, gettext("Domain verified."))}
+
+          {:error, report} ->
+            {:noreply, put_report(socket, id, report)}
         end
     end
   end
@@ -144,13 +153,18 @@ defmodule VutuvWeb.OrganizationLive.Domains do
   @impl true
   def handle_info(_message, socket), do: {:noreply, socket}
 
-  defp verify_error(true),
-    do:
-      gettext(
-        "We could not find the record or file yet. It can take a while to propagate. Please try again."
-      )
+  # The moment the check ran, kept beside its result so each panel can say when
+  # it last looked.
+  defp put_report(socket, domain_id, report) do
+    stamped =
+      Map.put(report, :checked_at, NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second))
 
-  defp verify_error(false), do: gettext("Domain verification is disabled on this installation.")
+    assign(socket, :check_reports, Map.put(socket.assigns.check_reports, domain_id, stamped))
+  end
+
+  defp forget_report(socket, domain_id) do
+    assign(socket, :check_reports, Map.delete(socket.assigns.check_reports, domain_id))
+  end
 
   @impl true
   def render(assigns) do
@@ -310,15 +324,24 @@ defmodule VutuvWeb.OrganizationLive.Domains do
         <code phx-no-curly-interpolation class="mt-1 block overflow-x-auto rounded bg-white px-3 py-2 font-mono text-xs text-slate-900 ring-1 ring-slate-200 dark:bg-slate-900 dark:text-slate-100 dark:ring-slate-700"><%= @well_known_content %></code>
       <% end %>
 
+      <%!-- `phx-disable-with` is the whole feedback while the check runs, and it
+      is a DNS or HTTP round trip that can take seconds (issue #1466). --%>
       <button
         type="button"
         phx-click="verify"
         phx-value-id={@domain.id}
+        phx-disable-with={gettext("Checking …")}
         id={"verify-#{@domain.id}"}
-        class="mt-3 rounded-lg bg-brand-600 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-700"
+        class="mt-3 rounded-lg bg-brand-600 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-700 disabled:opacity-60"
       >
         {gettext("Verify now")}
       </button>
+
+      <.check_report id={"verify-report-#{@domain.id}"} report={@check_reports[@domain.id]} />
+      <%!-- Only a domain that was never verified is picked up by the two-minute
+      background pass. One in its grace window is on the weekly re-check, so
+      promising it a mail "as soon as it works" would be untrue. --%>
+      <.check_reassurance :if={is_nil(@domain.verified_at)} domain={@domain.domain} />
     </div>
     """
   end

--- a/lib/vutuv_web/live/organization_live/show.ex
+++ b/lib/vutuv_web/live/organization_live/show.ex
@@ -45,6 +45,11 @@ defmodule VutuvWeb.OrganizationLive.Show do
       |> assign_people(organization)
       |> assign_org_jobs(organization)
       |> assign(:post_body, "")
+      # What the last domain check saw (issue #1466). A socket assign rather
+      # than a flash: it is the answer to a question the member just asked and
+      # it has to survive on the page, where a toast auto-dismisses and a repeat
+      # of the identical toast renders no diff at all.
+      |> assign(:check_report, nil)
       |> assign_org_posts(organization)
 
     {:ok, socket}
@@ -270,8 +275,12 @@ defmodule VutuvWeb.OrganizationLive.Show do
     if socket.assigns.can_edit? and socket.assigns.pending? do
       {:ok, _domain} = Organizations.set_domain_method(socket.assigns.primary_domain, method)
 
+      # The old report was about the other method, so it would now be answering
+      # a question nobody asked.
       {:noreply,
-       assign_organization(socket, socket.assigns.organization, socket.assigns.current_user)}
+       socket
+       |> assign(:check_report, nil)
+       |> assign_organization(socket.assigns.organization, socket.assigns.current_user)}
     else
       {:noreply, socket}
     end
@@ -282,20 +291,27 @@ defmodule VutuvWeb.OrganizationLive.Show do
       organization = socket.assigns.organization
       domain = socket.assigns.primary_domain
 
-      case Organizations.verify_domain(organization, domain) do
+      case Organizations.check_domain(organization, domain) do
         {:ok, organization} ->
           {:noreply,
            socket
+           |> assign(:check_report, nil)
            |> assign_organization(organization, socket.assigns.current_user)
            |> put_flash(:info, gettext("Your organization page is verified and now live."))}
 
-        {:error, _reason} ->
-          {:noreply,
-           put_flash(socket, :error, verify_error_message(socket.assigns.verification_enabled?))}
+        {:error, report} ->
+          {:noreply, assign(socket, :check_report, stamp(report))}
       end
     else
       {:noreply, socket}
     end
+  end
+
+  # The moment the check ran, kept beside its result so the panel can say when
+  # it last looked — the pending domain's own `last_checked_at` is written by
+  # the same call, but this one belongs to the answer on screen.
+  defp stamp(report) do
+    Map.put(report, :checked_at, NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second))
   end
 
   # Who the follow belongs to: the page being acted as, else the member. A page
@@ -331,6 +347,19 @@ defmodule VutuvWeb.OrganizationLive.Show do
     {:noreply, assign(socket, :engagement, %{socket.assigns.engagement | likes: likes})}
   end
 
+  # The background pass finished the claim (issue #1466). Somebody who published
+  # the record and left this tab open watches the panel turn into their page,
+  # which is the clearest possible answer to "is it working yet".
+  def handle_info({:organization_verified, _id}, socket) do
+    organization = Organizations.get_organization!(socket.assigns.organization.id)
+
+    {:noreply,
+     socket
+     |> assign(:check_report, nil)
+     |> assign_organization(organization, socket.assigns.current_user)
+     |> put_flash(:info, gettext("Your organization page is verified and now live."))}
+  end
+
   def handle_info(_message, socket), do: {:noreply, socket}
 
   # `primary_domain` is a %OrganizationDomain{} struct here (the assign holds the row
@@ -346,15 +375,6 @@ defmodule VutuvWeb.OrganizationLive.Show do
         assign(socket, :engagement, Organizations.organization_engagement(organization, user))
     end
   end
-
-  defp verify_error_message(true),
-    do:
-      gettext(
-        "We could not find the record or file yet. It can take a while to propagate. Please try again."
-      )
-
-  defp verify_error_message(false),
-    do: gettext("Domain verification is disabled on this installation.")
 
   @impl true
   def render(assigns) do
@@ -869,14 +889,25 @@ defmodule VutuvWeb.OrganizationLive.Show do
             <% end %>
           </div>
 
+          <%!-- `phx-disable-with` is the whole feedback a member gets while the
+          check runs, and the check is a DNS or HTTP round trip that can take
+          seconds. Without it the button sits there unchanged and the click
+          reads as swallowed, which is half of what issue #1466 reported. --%>
           <button
             type="button"
             phx-click="verify"
+            phx-disable-with={gettext("Checking …")}
             id="verify-domain"
-            class="mt-6 rounded-lg bg-brand-600 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-700"
+            class="mt-6 rounded-lg bg-brand-600 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-700 disabled:opacity-60"
           >
             {gettext("Verify now")}
           </button>
+
+          <.check_report id="verify-domain-report" report={@check_report} />
+          <.check_reassurance
+            :if={is_nil(@primary_domain.verified_at)}
+            domain={@primary_domain.domain}
+          />
         <% else %>
           <p class="mt-6 rounded-lg bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:bg-amber-900/30 dark:text-amber-200">
             {gettext("Domain verification is disabled on this installation.")}

--- a/lib/vutuv_web/templates/email/organization_domain_verified_de.text.eex
+++ b/lib/vutuv_web/templates/email/organization_domain_verified_de.text.eex
@@ -1,0 +1,22 @@
+<%= email_greeting(@user) %>,
+
+der Nachweis für <%= @domain %> ist da: Ihre Organisationsseite
+"<%= @organization_name %>" ist verifiziert und ab sofort öffentlich sichtbar.
+
+Sie mussten nichts weiter tun. Wir haben nach Ihrem Eintrag von selbst weiter
+gesucht, weil ein neuer <%= if @method == "dns" do %>DNS-Eintrag<% else %>Server-Eintrag<% end %> je nach Anbieter eine Weile braucht, bis
+er überall ankommt.
+<%= if @method == "dns" do %>
+Bitte lassen Sie den TXT-Eintrag stehen. Wir prüfen ihn wöchentlich, und ohne
+ihn verliert die Seite ihre Verifizierung wieder.
+<% else %>
+Bitte lassen Sie die Prüfdatei liegen. Wir prüfen sie wöchentlich, und ohne sie
+verliert die Seite ihre Verifizierung wieder.
+<% end %>
+Hier ist Ihre Seite:
+
+<%= @url %>organizations/<%= @organization_slug %>
+
+<%= render "_signature_de.text" %>
+
+<%= render "_footer.text" %>

--- a/lib/vutuv_web/templates/email/organization_domain_verified_en.text.eex
+++ b/lib/vutuv_web/templates/email/organization_domain_verified_en.text.eex
@@ -1,0 +1,22 @@
+<%= email_greeting(@user) %>,
+
+the proof for <%= @domain %> is there: your organization page
+"<%= @organization_name %>" is verified and publicly visible from now on.
+
+You did not have to do anything else. We kept looking after you published the
+entry, because a new <%= if @method == "dns" do %>DNS record<% else %>file<% end %> can take a while to reach everyone,
+depending on your provider.
+<%= if @method == "dns" do %>
+Please leave the TXT record in place. We check it every week, and without it
+the page loses its verification again.
+<% else %>
+Please leave the proof file in place. We check it every week, and without it
+the page loses its verification again.
+<% end %>
+Here is your page:
+
+<%= @url %>organizations/<%= @organization_slug %>
+
+<%= render "_signature_en.text" %>
+
+<%= render "_footer.text" %>

--- a/lib/vutuv_web/templates/email_body/organization_domain_verified_de.html.heex
+++ b/lib/vutuv_web/templates/email_body/organization_domain_verified_de.html.heex
@@ -1,0 +1,30 @@
+<.email_layout preheader="Ihre Organisationsseite ist verifiziert" locale={@locale}>
+  <.email_p>{email_greeting(@user)},</.email_p>
+  <.email_p>
+    der Nachweis für <strong>{@domain}</strong> ist da: Ihre Organisationsseite
+    „{@organization_name}" ist verifiziert und ab sofort öffentlich sichtbar.
+  </.email_p>
+  <.email_p>
+    Sie mussten nichts weiter tun. Wir haben nach Ihrem Eintrag von selbst weiter gesucht, weil
+    ein neuer
+    <%= if @method == "dns" do %>
+      DNS-Eintrag
+    <% else %>
+      Server-Eintrag
+    <% end %>
+    je nach Anbieter eine Weile braucht, bis er überall ankommt.
+  </.email_p>
+  <.email_p>
+    <%= if @method == "dns" do %>
+      Bitte lassen Sie den TXT-Eintrag stehen. Wir prüfen ihn wöchentlich, und ohne ihn verliert
+      die Seite ihre Verifizierung wieder.
+    <% else %>
+      Bitte lassen Sie die Prüfdatei liegen. Wir prüfen sie wöchentlich, und ohne sie verliert
+      die Seite ihre Verifizierung wieder.
+    <% end %>
+  </.email_p>
+  <.email_button href={"#{@url}organizations/#{@organization_slug}"}>
+    Zur Seite
+  </.email_button>
+  <.email_signature locale={@locale} />
+</.email_layout>

--- a/lib/vutuv_web/templates/email_body/organization_domain_verified_en.html.heex
+++ b/lib/vutuv_web/templates/email_body/organization_domain_verified_en.html.heex
@@ -1,0 +1,30 @@
+<.email_layout preheader="Your organization page is verified" locale={@locale}>
+  <.email_p>{email_greeting(@user)},</.email_p>
+  <.email_p>
+    the proof for <strong>{@domain}</strong> is there: your organization page
+    "{@organization_name}" is verified and publicly visible from now on.
+  </.email_p>
+  <.email_p>
+    You did not have to do anything else. We kept looking after you published the entry, because
+    a new
+    <%= if @method == "dns" do %>
+      DNS record
+    <% else %>
+      file
+    <% end %>
+    can take a while to reach everyone, depending on your provider.
+  </.email_p>
+  <.email_p>
+    <%= if @method == "dns" do %>
+      Please leave the TXT record in place. We check it every week, and without it the page loses
+      its verification again.
+    <% else %>
+      Please leave the proof file in place. We check it every week, and without it the page loses
+      its verification again.
+    <% end %>
+  </.email_p>
+  <.email_button href={"#{@url}organizations/#{@organization_slug}"}>
+    Go to the page
+  </.email_button>
+  <.email_signature locale={@locale} />
+</.email_layout>

--- a/lib/vutuv_web/templates/settings/organizations.html.heex
+++ b/lib/vutuv_web/templates/settings/organizations.html.heex
@@ -81,8 +81,23 @@ happen on the organization's own pages. --%>
             )}
           </.link>
 
+          <%!-- A page still waiting for its domain proof needs the way back to
+          the verification panel spelled out (issue #1466): its URL is permanent
+          and it is the page itself, but nothing said so, and the reporter found
+          the panel again only by editing and saving the page. The status chip
+          alone is a label, not a way in, so the pending row swaps the generic
+          "Manage" for the one thing left to do. --%>
+          <% manages? = Enum.any?(roles, &(&1 in ["owner", "admin"])) %>
           <.link
-            :if={Enum.any?(roles, &(&1 in ["owner", "admin"]))}
+            :if={manages? and organization.status == "pending"}
+            navigate={~p"/organizations/#{organization.slug}"}
+            data-finish-verification
+            class="shrink-0 rounded-lg bg-brand-600 px-3 py-1.5 text-sm font-semibold text-white hover:bg-brand-700"
+          >
+            {gettext("Finish verification")}
+          </.link>
+          <.link
+            :if={manages? and organization.status != "pending"}
             navigate={~p"/organizations/#{organization.slug}/edit"}
             class="shrink-0 text-sm font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
           >

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.289.0",
+      version: "7.290.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -19,7 +19,7 @@ msgstr "Impressum"
 #: lib/vutuv_web/components/ui.ex:3587
 #: lib/vutuv_web/live/admin/screenshot_live.ex:266
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:718
-#: lib/vutuv_web/live/organization_live/domains.ex:255
+#: lib/vutuv_web/live/organization_live/domains.ex:269
 #: lib/vutuv_web/live/organization_live/edit.ex:396
 #: lib/vutuv_web/live/organization_live/roles.ex:210
 #, elixir-autogen
@@ -33,7 +33,7 @@ msgstr "Eintrag hinzufügen"
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
 #: lib/vutuv_web/live/organization_live/fediverse.ex:119
-#: lib/vutuv_web/live/organization_live/show.ex:749
+#: lib/vutuv_web/live/organization_live/show.ex:769
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
@@ -216,7 +216,7 @@ msgstr "Download"
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
 #: lib/vutuv_web/live/job_posting_live/show.ex:178
-#: lib/vutuv_web/live/organization_live/show.ex:496
+#: lib/vutuv_web/live/organization_live/show.ex:516
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:7
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:19
@@ -333,7 +333,7 @@ msgstr "Follower"
 #: lib/vutuv_web/components/ui.ex:2117
 #: lib/vutuv_web/components/ui.ex:2175
 #: lib/vutuv_web/controllers/followee_controller.ex:29
-#: lib/vutuv_web/live/organization_live/show.ex:456
+#: lib/vutuv_web/live/organization_live/show.ex:476
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:53
 #: lib/vutuv_web/templates/user/show.html.heex:955
@@ -1167,7 +1167,7 @@ msgstr "Wählen Sie einen Social-Media-Anbieter aus"
 msgid "Add Localization"
 msgstr "Lokalisierung hinzufügen"
 
-#: lib/vutuv_web/components/organization_components.ex:273
+#: lib/vutuv_web/components/organization_components.ex:375
 #: lib/vutuv_web/live/admin/activity_live.ex:153
 #: lib/vutuv_web/live/admin/api_app_live.ex:58
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
@@ -1722,8 +1722,8 @@ msgstr "Empfehlen"
 #: lib/vutuv_web/live/fediverse_following_live.ex:331
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:293
 #: lib/vutuv_web/live/organization_live/following.ex:218
-#: lib/vutuv_web/live/organization_live/show.ex:425
-#: lib/vutuv_web/live/organization_live/show.ex:454
+#: lib/vutuv_web/live/organization_live/show.ex:445
+#: lib/vutuv_web/live/organization_live/show.ex:474
 #: lib/vutuv_web/templates/user/show.html.heex:1269
 #, elixir-autogen, elixir-format
 msgid "Follow"
@@ -1748,7 +1748,7 @@ msgstr ""
 msgid "Log out"
 msgstr "Ausloggen"
 
-#: lib/vutuv_web/components/organization_components.ex:279
+#: lib/vutuv_web/components/organization_components.ex:381
 #: lib/vutuv_web/live/admin/activity_live.ex:143
 #: lib/vutuv_web/live/admin/activity_live.ex:175
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
@@ -1763,7 +1763,7 @@ msgstr "Ausloggen"
 msgid "Member"
 msgstr "Mitglied"
 
-#: lib/vutuv_web/live/organization_live/show.ex:475
+#: lib/vutuv_web/live/organization_live/show.ex:495
 #: lib/vutuv_web/templates/user/show.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Message"
@@ -1961,7 +1961,7 @@ msgstr "Seitennavigation"
 #: lib/vutuv_web/components/ui.ex:3609
 #: lib/vutuv_web/live/organization_live/activity.ex:146
 #: lib/vutuv_web/live/organization_live/feed.ex:101
-#: lib/vutuv_web/live/organization_live/show.ex:622
+#: lib/vutuv_web/live/organization_live/show.ex:642
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr "Mehr laden"
@@ -2153,7 +2153,7 @@ msgstr "Diesen Beitrag endgültig löschen?"
 msgid "Edit post"
 msgstr "Beitrag bearbeiten"
 
-#: lib/vutuv_web/components/organization_components.ex:231
+#: lib/vutuv_web/components/organization_components.ex:333
 #: lib/vutuv_web/live/organization_live/feed.ex:79
 #: lib/vutuv_web/live/post_live/feed.ex:159
 #: lib/vutuv_web/live/post_live/feed.ex:936
@@ -2243,7 +2243,7 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:382
 #: lib/vutuv_web/live/notification_live/index.ex:891
-#: lib/vutuv_web/live/organization_live/show.ex:549
+#: lib/vutuv_web/live/organization_live/show.ex:569
 #: lib/vutuv_web/live/post_live/saved.ex:495
 #: lib/vutuv_web/live/search_live.ex:309
 #: lib/vutuv_web/live/search_live.ex:772
@@ -2271,7 +2271,7 @@ msgstr "Weniger anzeigen"
 #: lib/vutuv_web/live/admin/screenshot_live.ex:338
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:700
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
-#: lib/vutuv_web/live/organization_live/domains.ex:229
+#: lib/vutuv_web/live/organization_live/domains.ex:243
 #: lib/vutuv_web/live/organization_live/edit.ex:373
 #: lib/vutuv_web/live/organization_live/roles.ex:243
 #: lib/vutuv_web/live/post_live/composer.ex:1886
@@ -2508,7 +2508,7 @@ msgstr "Gefällt mir entfernen"
 #: lib/vutuv_web/components/ui.ex:2176
 #: lib/vutuv_web/live/organization_live/following.ex:197
 #: lib/vutuv_web/live/organization_live/following.ex:256
-#: lib/vutuv_web/live/organization_live/show.ex:459
+#: lib/vutuv_web/live/organization_live/show.ex:479
 #: lib/vutuv_web/live/post_live/feed.ex:1172
 #: lib/vutuv_web/templates/followee/index.html.heex:44
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
@@ -2792,7 +2792,7 @@ msgstr "Ersten Beitrag schreiben"
 #: lib/vutuv_web/components/ui.ex:3537
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
-#: lib/vutuv_web/templates/settings/organizations.html.heex:89
+#: lib/vutuv_web/templates/settings/organizations.html.heex:104
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:216
@@ -2892,7 +2892,7 @@ msgstr "Personen, mit denen Sie nicht vernetzt sind"
 msgid "Open someone's profile to message them."
 msgstr "Öffnen Sie ein Profil, um jemandem zu schreiben."
 
-#: lib/vutuv_web/components/organization_components.ex:225
+#: lib/vutuv_web/components/organization_components.ex:327
 #: lib/vutuv_web/live/notification_live/index.ex:1050
 #: lib/vutuv_web/live/organization_live/activity.ex:99
 #, elixir-autogen, elixir-format
@@ -3191,7 +3191,7 @@ msgstr "Warteschlange öffnen"
 msgid "Opened"
 msgstr "Eröffnet"
 
-#: lib/vutuv_web/components/organization_components.ex:272
+#: lib/vutuv_web/components/organization_components.ex:374
 #: lib/vutuv_web/live/admin/api_app_live.ex:72
 #: lib/vutuv_web/live/admin/deliverability_live.ex:171
 #: lib/vutuv_web/live/admin/moderation_live.ex:56
@@ -3245,7 +3245,7 @@ msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 #: lib/vutuv_web/components/post_components.ex:1066
 #: lib/vutuv_web/components/post_components.ex:2042
 #: lib/vutuv_web/components/post_components.ex:2772
-#: lib/vutuv_web/live/organization_live/show.ex:532
+#: lib/vutuv_web/live/organization_live/show.ex:552
 #: lib/vutuv_web/templates/user/show.html.heex:219
 #, elixir-autogen, elixir-format
 msgid "Report"
@@ -3587,42 +3587,42 @@ msgstr ""
 msgid "yes"
 msgstr "ja"
 
-#: lib/vutuv/notifications/emailer.ex:900
+#: lib/vutuv/notifications/emailer.ex:925
 #, elixir-autogen, elixir-format
 msgid "A warning for your vutuv account"
 msgstr "Eine Verwarnung für Ihr vutuv-Konto"
 
-#: lib/vutuv/notifications/emailer.ex:984
+#: lib/vutuv/notifications/emailer.ex:1009
 #, elixir-autogen, elixir-format
 msgid "Moderation: %{count} cases are waiting"
 msgstr "Moderation: %{count} Fälle warten"
 
-#: lib/vutuv/notifications/emailer.ex:962
+#: lib/vutuv/notifications/emailer.ex:987
 #, elixir-autogen, elixir-format
 msgid "Moderation: a profile was reported"
 msgstr "Moderation: Ein Profil wurde gemeldet"
 
-#: lib/vutuv/notifications/emailer.ex:874
+#: lib/vutuv/notifications/emailer.ex:899
 #, elixir-autogen, elixir-format
 msgid "The content you reported was revised"
 msgstr "Der von Ihnen gemeldete Inhalt wurde überarbeitet"
 
-#: lib/vutuv/notifications/emailer.ex:867
+#: lib/vutuv/notifications/emailer.ex:892
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv is under review"
 msgstr "Ihr Inhalt auf vutuv wird geprüft"
 
-#: lib/vutuv/notifications/emailer.ex:860
+#: lib/vutuv/notifications/emailer.ex:885
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv was reported and is hidden"
 msgstr "Ihr Inhalt auf vutuv wurde gemeldet und ist verborgen"
 
-#: lib/vutuv/notifications/emailer.ex:914
+#: lib/vutuv/notifications/emailer.ex:939
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account has been deactivated"
 msgstr "Ihr vutuv-Konto wurde deaktiviert"
 
-#: lib/vutuv/notifications/emailer.ex:907
+#: lib/vutuv/notifications/emailer.ex:932
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account is suspended"
 msgstr "Ihr vutuv-Konto ist gesperrt"
@@ -4717,7 +4717,7 @@ msgstr "Entdecken Sie Mitglieder zum Folgen"
 msgid "Find members"
 msgstr "Mitglieder finden"
 
-#: lib/vutuv_web/components/organization_components.ex:237
+#: lib/vutuv_web/components/organization_components.ex:339
 #: lib/vutuv_web/live/organization_live/following.ex:154
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:53
@@ -4768,7 +4768,7 @@ msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:516
 #: lib/vutuv_web/live/notification_live/index.ex:892
-#: lib/vutuv_web/live/organization_live/show.ex:632
+#: lib/vutuv_web/live/organization_live/show.ex:652
 #: lib/vutuv_web/live/post_live/saved.ex:498
 #: lib/vutuv_web/live/search_live.ex:307
 #: lib/vutuv_web/live/search_live.ex:714
@@ -8426,7 +8426,7 @@ msgid "Unreachable"
 msgstr "Nicht erreichbar"
 
 #: lib/vutuv_web/live/admin/member_badges.ex:20
-#: lib/vutuv_web/live/organization_live/domains.ex:178
+#: lib/vutuv_web/live/organization_live/domains.ex:192
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:32
 #, elixir-autogen, elixir-format
 msgid "Verified"
@@ -9029,7 +9029,7 @@ msgstr ""
 msgid "Not written yet"
 msgstr "Noch nicht verfasst"
 
-#: lib/vutuv_web/components/organization_components.ex:210
+#: lib/vutuv_web/components/organization_components.ex:312
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "Page"
@@ -9066,7 +9066,7 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/agent_docs/markdown.ex:541
 #: lib/vutuv_web/agent_docs/text.ex:504
 #: lib/vutuv_web/agent_docs/text.ex:508
-#: lib/vutuv_web/components/organization_components.ex:242
+#: lib/vutuv_web/components/organization_components.ex:344
 #: lib/vutuv_web/components/ui.ex:3897
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:323
@@ -9074,8 +9074,8 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/live/fediverse_followers_live.ex:169
 #: lib/vutuv_web/live/fediverse_following_live.ex:304
 #: lib/vutuv_web/live/organization_live/fediverse.ex:80
-#: lib/vutuv_web/live/organization_live/show.ex:525
-#: lib/vutuv_web/live/organization_live/show.ex:708
+#: lib/vutuv_web/live/organization_live/show.ex:545
+#: lib/vutuv_web/live/organization_live/show.ex:728
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:341
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:5
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
@@ -10755,7 +10755,7 @@ msgid_plural "%{count} stars"
 msgstr[0] "%{count} Stern"
 msgstr[1] "%{count} Sterne"
 
-#: lib/vutuv_web/live/organization_live/show.ex:483
+#: lib/vutuv_web/live/organization_live/show.ex:503
 #: lib/vutuv_web/views/user_html.ex:536
 #: lib/vutuv_web/views/user_html.ex:715
 #, elixir-autogen, elixir-format
@@ -11351,7 +11351,7 @@ msgstr "Screenshot-Warteschlange öffnen"
 #: lib/vutuv_web/live/admin/organization_live.ex:179
 #: lib/vutuv_web/live/admin/organization_live.ex:194
 #: lib/vutuv_web/live/admin/screenshot_live.ex:535
-#: lib/vutuv_web/live/organization_live/domains.ex:184
+#: lib/vutuv_web/live/organization_live/domains.ex:198
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr "Ausstehend"
@@ -11635,7 +11635,7 @@ msgstr "Ihre Liste ist leer. Es ist noch niemand ausgeschlossen."
 msgid "AI agents"
 msgstr "KI-Agenten"
 
-#: lib/vutuv_web/live/organization_live/show.ex:539
+#: lib/vutuv_web/live/organization_live/show.ex:559
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "Über die Organisation"
@@ -11645,19 +11645,18 @@ msgstr "Über die Organisation"
 msgid "Continue to verification"
 msgstr "Weiter zur Verifizierung"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:248
-#: lib/vutuv_web/live/organization_live/domains.ex:288
+#: lib/vutuv_web/live/organization_live/domains.ex:262
+#: lib/vutuv_web/live/organization_live/domains.ex:302
 #: lib/vutuv_web/live/organization_live/new.ex:161
-#: lib/vutuv_web/live/organization_live/show.ex:823
+#: lib/vutuv_web/live/organization_live/show.ex:843
 #: lib/vutuv_web/templates/url/verify.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "DNS TXT record"
 msgstr "DNS-TXT-Eintrag"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:153
-#: lib/vutuv_web/live/organization_live/domains.ex:167
-#: lib/vutuv_web/live/organization_live/show.ex:357
-#: lib/vutuv_web/live/organization_live/show.ex:882
+#: lib/vutuv_web/components/organization_components.ex:102
+#: lib/vutuv_web/live/organization_live/domains.ex:181
+#: lib/vutuv_web/live/organization_live/show.ex:913
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr "Die Domain-Verifizierung ist auf dieser Installation deaktiviert."
@@ -11697,7 +11696,7 @@ msgstr ""
 msgid "Please log in first."
 msgstr "Bitte loggen Sie sich zuerst ein."
 
-#: lib/vutuv_web/live/organization_live/show.ex:796
+#: lib/vutuv_web/live/organization_live/show.ex:816
 #, elixir-autogen, elixir-format
 msgid "Prove you control %{domain} to publish this page."
 msgstr "Weisen Sie nach, dass Ihnen %{domain} gehört, um diese Seite zu veröffentlichen."
@@ -11718,13 +11717,13 @@ msgstr "Nach Name oder Stadt suchen"
 msgid "Search engines"
 msgstr "Suchmaschinen"
 
-#: lib/vutuv_web/components/organization_components.ex:119
+#: lib/vutuv_web/components/organization_components.ex:221
 #, elixir-autogen, elixir-format
 msgid "Select a country"
 msgstr "Land auswählen"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:307
-#: lib/vutuv_web/live/organization_live/show.ex:858
+#: lib/vutuv_web/live/organization_live/domains.ex:321
+#: lib/vutuv_web/live/organization_live/show.ex:878
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr "Stellen Sie diese Datei bereit unter:"
@@ -11751,12 +11750,12 @@ msgid "The upload failed."
 msgstr "Der Upload ist fehlgeschlagen."
 
 #: lib/vutuv_web/live/organization_live/new.ex:146
-#: lib/vutuv_web/live/organization_live/show.ex:811
+#: lib/vutuv_web/live/organization_live/show.ex:831
 #, elixir-autogen, elixir-format
 msgid "Verification method"
 msgstr "Verifizierungsmethode"
 
-#: lib/vutuv_web/live/organization_live/show.ex:771
+#: lib/vutuv_web/live/organization_live/show.ex:791
 #, elixir-autogen, elixir-format
 msgid "Verified domains"
 msgstr "Verifizierte Domains"
@@ -11772,24 +11771,16 @@ msgstr "Verifiziert über"
 msgid "Verified via %{domain}"
 msgstr "Verifiziert über %{domain}"
 
-#: lib/vutuv_web/live/organization_live/show.ex:793
+#: lib/vutuv_web/live/organization_live/show.ex:813
 #, elixir-autogen, elixir-format
 msgid "Verify %{name}"
 msgstr "%{name} verifizieren"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:320
-#: lib/vutuv_web/live/organization_live/show.ex:878
+#: lib/vutuv_web/live/organization_live/domains.ex:337
+#: lib/vutuv_web/live/organization_live/show.ex:903
 #, elixir-autogen, elixir-format
 msgid "Verify now"
 msgstr "Jetzt verifizieren"
-
-#: lib/vutuv_web/live/organization_live/domains.ex:149
-#: lib/vutuv_web/live/organization_live/show.ex:352
-#, elixir-autogen, elixir-format
-msgid "We could not find the record or file yet. It can take a while to propagate. Please try again."
-msgstr ""
-"Wir konnten den Eintrag oder die Datei noch nicht finden. Die Verbreitung "
-"kann etwas dauern. Bitte versuchen Sie es erneut."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:243
 #: lib/vutuv_web/agent_docs/text.ex:227
@@ -11799,9 +11790,9 @@ msgstr ""
 msgid "Website"
 msgstr "Website"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:249
-#: lib/vutuv_web/live/organization_live/domains.ex:298
-#: lib/vutuv_web/live/organization_live/show.ex:834
+#: lib/vutuv_web/live/organization_live/domains.ex:263
+#: lib/vutuv_web/live/organization_live/domains.ex:312
+#: lib/vutuv_web/live/organization_live/show.ex:854
 #: lib/vutuv_web/templates/url/verify.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Website file"
@@ -11824,8 +11815,8 @@ msgstr ""
 "Im nächsten Schritt veröffentlichen Sie einen Eintrag oder eine Datei, um "
 "die Kontrolle über die Domain nachzuweisen."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:309
-#: lib/vutuv_web/live/organization_live/show.ex:864
+#: lib/vutuv_web/live/organization_live/domains.ex:323
+#: lib/vutuv_web/live/organization_live/show.ex:884
 #: lib/vutuv_web/templates/url/verify.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
@@ -11836,13 +11827,13 @@ msgstr "mit genau diesem Inhalt:"
 msgid "@handle or email"
 msgstr "@handle oder E-Mail"
 
-#: lib/vutuv_web/components/organization_components.ex:291
+#: lib/vutuv_web/components/organization_components.ex:393
 #: lib/vutuv_web/live/organization_live/edit.ex:390
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
 msgstr "Abkürzung"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:236
+#: lib/vutuv_web/live/organization_live/domains.ex:250
 #, elixir-autogen, elixir-format
 msgid "Add a domain"
 msgstr "Domain hinzufügen"
@@ -11857,7 +11848,7 @@ msgstr "Mitglied hinzufügen"
 msgid "Added @%{handle} to the team."
 msgstr "@%{handle} zum Team hinzugefügt."
 
-#: lib/vutuv_web/components/organization_components.ex:292
+#: lib/vutuv_web/components/organization_components.ex:394
 #: lib/vutuv_web/live/organization_live/edit.ex:388
 #, elixir-autogen, elixir-format
 msgid "Alias"
@@ -11876,7 +11867,7 @@ msgstr "Alias entfernt."
 #: lib/vutuv_web/agent_docs/markdown.ex:358
 #: lib/vutuv_web/agent_docs/text.ex:381
 #: lib/vutuv_web/live/organization_live/edit.ex:353
-#: lib/vutuv_web/live/organization_live/show.ex:759
+#: lib/vutuv_web/live/organization_live/show.ex:779
 #: lib/vutuv_web/templates/tag/single_card.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Also known as"
@@ -11903,7 +11894,7 @@ msgstr "Diese Seite archivieren?"
 msgid "Archived"
 msgstr "Archiviert"
 
-#: lib/vutuv_web/components/organization_components.ex:290
+#: lib/vutuv_web/components/organization_components.ex:392
 #: lib/vutuv_web/live/organization_live/edit.ex:389
 #, elixir-autogen, elixir-format
 msgid "Brand"
@@ -11926,37 +11917,37 @@ msgstr ""
 "Diese Seite und alles, was dazugehört, löschen? Das kann nicht rückgängig "
 "gemacht werden."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:60
+#: lib/vutuv_web/live/organization_live/domains.ex:64
 #, elixir-autogen, elixir-format
 msgid "Domain added. Publish the record or file, then verify it."
 msgstr ""
 "Domain hinzugefügt. Veröffentlichen Sie den Eintrag oder die Datei und "
 "starten Sie dann die Verifizierung."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:129
+#: lib/vutuv_web/live/organization_live/domains.ex:138
 #, elixir-autogen, elixir-format
 msgid "Domain removed."
 msgstr "Domain entfernt."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:97
+#: lib/vutuv_web/live/organization_live/domains.ex:107
 #, elixir-autogen, elixir-format
 msgid "Domain verified."
 msgstr "Domain verifiziert."
 
-#: lib/vutuv_web/components/organization_components.ex:216
+#: lib/vutuv_web/components/organization_components.ex:318
 #: lib/vutuv_web/live/admin/organization_live.ex:305
-#: lib/vutuv_web/live/organization_live/domains.ex:161
-#: lib/vutuv_web/live/organization_live/show.ex:510
+#: lib/vutuv_web/live/organization_live/domains.ex:175
+#: lib/vutuv_web/live/organization_live/show.ex:530
 #, elixir-autogen, elixir-format
 msgid "Domains"
 msgstr "Domains"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:27
+#: lib/vutuv_web/live/organization_live/domains.ex:28
 #, elixir-autogen, elixir-format
 msgid "Domains – %{name}"
 msgstr "Domains – %{name}"
 
-#: lib/vutuv_web/components/organization_components.ex:289
+#: lib/vutuv_web/components/organization_components.ex:391
 #, elixir-autogen, elixir-format
 msgid "Former name"
 msgstr "Früherer Name"
@@ -11975,7 +11966,7 @@ msgstr ""
 "Diese Seite einfrieren? Sie verschwindet für die Öffentlichkeit, bleibt aber "
 "für den Besitzer sichtbar."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:189
+#: lib/vutuv_web/live/organization_live/domains.ex:203
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "Last checked"
@@ -11996,7 +11987,7 @@ msgstr "Verlassen"
 msgid "Live"
 msgstr "Live"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:220
+#: lib/vutuv_web/live/organization_live/domains.ex:234
 #, elixir-autogen, elixir-format
 msgid "Make primary"
 msgstr "Als primär festlegen"
@@ -12006,7 +11997,7 @@ msgstr "Als primär festlegen"
 msgid "Member removed."
 msgstr "Mitglied entfernt."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:189
+#: lib/vutuv_web/live/organization_live/domains.ex:203
 #, elixir-autogen, elixir-format
 msgid "Method"
 msgstr "Methode"
@@ -12021,27 +12012,27 @@ msgstr "Namen & Aliasse"
 msgid "No member found for “%{id}”."
 msgstr "Kein Mitglied für „%{id}“ gefunden."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:114
+#: lib/vutuv_web/live/organization_live/domains.ex:123
 #, elixir-autogen, elixir-format
 msgid "Only a verified domain can be the primary one."
 msgstr "Nur eine verifizierte Domain kann die primäre sein."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:175
+#: lib/vutuv_web/live/organization_live/domains.ex:189
 #, elixir-autogen, elixir-format
 msgid "Primary"
 msgstr "Primär"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:110
+#: lib/vutuv_web/live/organization_live/domains.ex:119
 #, elixir-autogen, elixir-format
 msgid "Primary domain updated."
 msgstr "Primäre Domain aktualisiert."
 
-#: lib/vutuv_web/components/organization_components.ex:278
+#: lib/vutuv_web/components/organization_components.ex:380
 #, elixir-autogen, elixir-format
 msgid "Recruiter"
 msgstr "Recruiter"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:226
+#: lib/vutuv_web/live/organization_live/domains.ex:240
 #, elixir-autogen, elixir-format
 msgid "Remove this domain?"
 msgstr "Diese Domain entfernen?"
@@ -12061,10 +12052,10 @@ msgstr "Diesen Namen entfernen?"
 msgid "Search name, alias or domain"
 msgstr "Name, Alias oder Domain suchen"
 
-#: lib/vutuv_web/components/organization_components.ex:213
+#: lib/vutuv_web/components/organization_components.ex:315
 #: lib/vutuv_web/live/admin/organization_live.ex:321
 #: lib/vutuv_web/live/organization_live/roles.ex:165
-#: lib/vutuv_web/live/organization_live/show.ex:503
+#: lib/vutuv_web/live/organization_live/show.ex:523
 #, elixir-autogen, elixir-format
 msgid "Team"
 msgstr "Team"
@@ -12074,7 +12065,7 @@ msgstr "Team"
 msgid "Team – %{name}"
 msgstr "Team – %{name}"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:71
+#: lib/vutuv_web/live/organization_live/domains.ex:75
 #, elixir-autogen, elixir-format
 msgid "That is not a valid domain."
 msgstr "Das ist keine gültige Domain."
@@ -12249,7 +12240,7 @@ msgstr "verifizierte Webseite"
 msgid "%{min} to %{max} characters: letters (a-z), numbers (0-9) and underscores."
 msgstr "%{min} bis %{max} Zeichen: Buchstaben (a-z), Zahlen (0-9) und Unterstriche."
 
-#: lib/vutuv_web/live/organization_live/show.ex:647
+#: lib/vutuv_web/live/organization_live/show.ex:667
 #, elixir-autogen, elixir-format
 msgid "Former"
 msgstr "Ehemalig"
@@ -12313,14 +12304,14 @@ msgstr ""
 "auffindbar ist. Bei einer Umbenennung bleibt der alte Name hier automatisch "
 "erhalten."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:163
+#: lib/vutuv_web/live/organization_live/domains.ex:177
 #, elixir-autogen, elixir-format
 msgid "An organization can prove several domains. The primary one shows in the “Verified via …” badge."
 msgstr ""
 "Eine Organisation kann mehrere Domains nachweisen. Die primäre erscheint im "
 "Abzeichen „Verifiziert über …“."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:136
+#: lib/vutuv_web/live/organization_live/domains.ex:145
 #, elixir-autogen, elixir-format
 msgid "An organization keeps at least one verified domain, so this one cannot be removed."
 msgstr ""
@@ -12351,7 +12342,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/index.ex:101
 #: lib/vutuv_web/live/organization_live/new.ex:28
 #: lib/vutuv_web/live/organization_live/new.ex:95
-#: lib/vutuv_web/templates/settings/organizations.html.heex:103
+#: lib/vutuv_web/templates/settings/organizations.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Add your organization"
 msgstr "Ihre Organisation hinzufügen"
@@ -12376,7 +12367,7 @@ msgstr "Vielleicht brauchen Sie Hilfe von Ihrer IT"
 msgid "The proof is a small technical change to your domain: a DNS entry or a file on your website. If you don't manage the website yourself, ask the person or team who does. That is usually your IT department or the company that runs your website. We show the exact instructions on the next step, so you can simply pass them on."
 msgstr "Der Nachweis ist eine kleine technische Änderung an Ihrer Domain: ein DNS-Eintrag oder eine Datei auf Ihrer Website. Wenn Sie die Website nicht selbst verwalten, fragen Sie die Person oder das Team, das dies tut. Das ist meist Ihre IT-Abteilung oder die Firma, die Ihre Website betreut. Die genaue Anleitung zeigen wir Ihnen im nächsten Schritt, Sie können sie einfach weitergeben."
 
-#: lib/vutuv_web/live/organization_live/show.ex:805
+#: lib/vutuv_web/live/organization_live/show.ex:825
 #, elixir-autogen, elixir-format
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr "Diese Schritte sind technisch. Wenn Sie %{domain} nicht selbst verwalten, kopieren Sie den unten gezeigten Eintrag oder die Datei und senden Sie ihn an Ihre IT-Abteilung oder die Firma, die Ihre Website betreut. Sobald sie ihn hinzugefügt hat, kommen Sie hierher zurück und klicken auf „Jetzt verifizieren“."
@@ -12504,7 +12495,7 @@ msgstr "Organisation wieder freigegeben."
 msgid "Organizations"
 msgstr "Organisationen"
 
-#: lib/vutuv_web/components/organization_components.ex:146
+#: lib/vutuv_web/components/organization_components.ex:248
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:90
 #, elixir-autogen, elixir-format
 msgid "Please choose"
@@ -12527,7 +12518,7 @@ msgstr "Bitte loggen Sie sich ein, um eine Organisationsseite zu beanspruchen."
 msgid "Search organizations"
 msgstr "Organisationen durchsuchen"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:67
+#: lib/vutuv_web/live/organization_live/domains.ex:71
 #, elixir-autogen, elixir-format
 msgid "That domain already belongs to an organization page."
 msgstr "Diese Domain gehört bereits zu einer anderen Organisationsseite."
@@ -12547,7 +12538,7 @@ msgstr "Dieser Name ist für diese Organisation bereits eingetragen."
 msgid "The organization page was deleted."
 msgstr "Die Organisationsseite wurde gelöscht."
 
-#: lib/vutuv_web/live/organization_live/show.ex:364
+#: lib/vutuv_web/live/organization_live/show.ex:384
 #, elixir-autogen, elixir-format
 msgid "This organization page was reported and is hidden while it is reviewed. Only you and the moderators can see it."
 msgstr ""
@@ -12583,7 +12574,8 @@ msgstr "Sie dürfen diese Organisation nicht löschen."
 msgid "Your organization handle is set."
 msgstr "Ihr Organisations-Handle ist gesetzt."
 
-#: lib/vutuv_web/live/organization_live/show.ex:290
+#: lib/vutuv_web/live/organization_live/show.ex:300
+#: lib/vutuv_web/live/organization_live/show.ex:360
 #, elixir-autogen, elixir-format
 msgid "Your organization page is verified and now live."
 msgstr "Ihre Organisationsseite ist verifiziert und jetzt live."
@@ -13154,7 +13146,7 @@ msgstr "Arbeitsort"
 msgid "You already have the maximum number of published postings."
 msgstr "Sie haben bereits die maximale Anzahl veröffentlichter Anzeigen."
 
-#: lib/vutuv/notifications/emailer.ex:930
+#: lib/vutuv/notifications/emailer.ex:955
 #, elixir-autogen, elixir-format
 msgid "Your job posting on vutuv expires soon"
 msgstr "Ihre Stellenanzeige auf vutuv läuft bald ab"
@@ -13164,17 +13156,17 @@ msgstr "Ihre Stellenanzeige auf vutuv läuft bald ab"
 msgid "A domain of your organization page on vutuv is about to be dropped"
 msgstr "Eine Domain Ihrer Organisationsseite auf vutuv entfällt bald"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:202
+#: lib/vutuv_web/live/organization_live/domains.ex:216
 #, elixir-autogen, elixir-format
 msgid "Deadline"
 msgstr "Frist"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:181
+#: lib/vutuv_web/live/organization_live/domains.ex:195
 #, elixir-autogen, elixir-format
 msgid "Proof missing"
 msgstr "Nachweis fehlt"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:201
+#: lib/vutuv_web/live/organization_live/domains.ex:215
 #, elixir-autogen, elixir-format
 msgid "We could not read this domain's proof on the last check. Restore it and check again, or the domain loses its verification."
 msgstr "Der Nachweis dieser Domain war bei der letzten Prüfung nicht abrufbar. Stellen Sie ihn wieder her und prüfen Sie erneut, sonst verliert die Domain ihre Verifizierung."
@@ -13184,7 +13176,7 @@ msgstr "Der Nachweis dieser Domain war bei der letzten Prüfung nicht abrufbar. 
 msgid "Your organization page on vutuv is about to lose its verification"
 msgstr "Ihre Organisationsseite auf vutuv verliert bald ihre Verifizierung"
 
-#: lib/vutuv/notifications/emailer.ex:851
+#: lib/vutuv/notifications/emailer.ex:876
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is no longer public"
 msgstr "Ihre Organisationsseite auf vutuv ist nicht mehr öffentlich"
@@ -13247,17 +13239,17 @@ msgid_plural "Your roles"
 msgstr[0] "Ihre Rolle"
 msgstr[1] "Ihre Rollen"
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:98
+#: lib/vutuv_web/templates/settings/organizations.html.heex:113
 #, elixir-autogen, elixir-format
 msgid "Add an organization"
 msgstr "Organisation hinzufügen"
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:100
+#: lib/vutuv_web/templates/settings/organizations.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "Represent a company, association or other group? Add its page and verify the domain to become its owner."
 msgstr "Vertreten Sie ein Unternehmen, einen Verein oder eine andere Gruppe? Fügen Sie die Seite hinzu und verifizieren Sie die Domain, um ihr Besitzer zu werden."
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:110
+#: lib/vutuv_web/templates/settings/organizations.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Browse all organizations"
 msgstr "Alle Organisationen ansehen"
@@ -13287,14 +13279,14 @@ msgstr "DNS-Änderungen brauchen manchmal etwas, bis sie überall angekommen sin
 msgid "Getting an error, or is %{host} a CNAME / alias to another address? A TXT record cannot share a name with a CNAME. Use this name instead, with the exact same value as above:"
 msgstr "Bekommen Sie einen Fehler, oder ist %{host} ein CNAME / Alias auf eine andere Adresse? Ein TXT-Eintrag kann nicht denselben Namen wie ein CNAME haben. Verwenden Sie stattdessen diesen Namen, mit exakt demselben Wert wie oben:"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:305
-#: lib/vutuv_web/live/organization_live/show.ex:851
+#: lib/vutuv_web/live/organization_live/domains.ex:319
+#: lib/vutuv_web/live/organization_live/show.ex:871
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr "Ist %{domain} ein CNAME / Alias (ein TXT-Eintrag kann nicht denselben Namen wie ein CNAME haben), legen Sie den Eintrag stattdessen auf %{name} an, mit demselben Wert."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:303
-#: lib/vutuv_web/live/organization_live/show.ex:842
+#: lib/vutuv_web/live/organization_live/domains.ex:317
+#: lib/vutuv_web/live/organization_live/show.ex:862
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
 msgstr "Legen Sie in Ihren DNS-Einstellungen einen TXT-Eintrag auf dem Namen %{domain} mit diesem Wert an:"
@@ -13390,7 +13382,7 @@ msgid "Minimum yearly salary"
 msgstr "Mindestgehalt pro Jahr"
 
 #: lib/vutuv_web/live/job_board_live.ex:324
-#: lib/vutuv_web/live/organization_live/show.ex:674
+#: lib/vutuv_web/live/organization_live/show.ex:694
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr "Weitere Stellen"
@@ -13419,7 +13411,7 @@ msgstr "Keine passenden Stellen. Passen Sie die Filter an."
 #: lib/vutuv_web/agent_docs/markdown.ex:436
 #: lib/vutuv_web/agent_docs/text.ex:445
 #: lib/vutuv_web/agent_docs/text.ex:457
-#: lib/vutuv_web/live/organization_live/show.ex:661
+#: lib/vutuv_web/live/organization_live/show.ex:681
 #: lib/vutuv_web/templates/tag/show.html.heex:69
 #, elixir-autogen, elixir-format
 msgid "Open positions"
@@ -13888,7 +13880,7 @@ msgstr "Vor bestimmten Personen verbergen (Wettbewerber, eigene Belegschaft, Ein
 msgid "Inherited from the organization"
 msgstr "Von der Organisation geerbt"
 
-#: lib/vutuv_web/components/organization_components.ex:219
+#: lib/vutuv_web/components/organization_components.ex:321
 #: lib/vutuv_web/live/organization_live/exclusions.ex:103
 #, elixir-autogen, elixir-format
 msgid "Job exclusions"
@@ -14774,7 +14766,7 @@ msgstr "Bevorzugte Arbeitsform"
 msgid "Availability"
 msgstr "Verfügbarkeit"
 
-#: lib/vutuv/notifications/emailer.ex:892
+#: lib/vutuv/notifications/emailer.ex:917
 #, elixir-autogen, elixir-format
 msgid "An automated check removed an image from your vutuv account"
 msgstr "Eine automatische Prüfung hat ein Bild aus Ihrem vutuv-Konto entfernt"
@@ -20728,12 +20720,12 @@ msgstr "Von vorn beginnen"
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr "Ein Herz oder ein Repost geht zurück in das Netzwerk, aus dem dieser Beitrag stammt. Ihr Konto nimmt derzeit nicht am Fediverse teil. Einschalten können Sie das in den {settings}."
 
-#: lib/vutuv_web/components/organization_components.ex:277
+#: lib/vutuv_web/components/organization_components.ex:379
 #, elixir-autogen, elixir-format
 msgid "Editorial"
 msgstr "Redaktion"
 
-#: lib/vutuv_web/components/organization_components.ex:283
+#: lib/vutuv_web/components/organization_components.ex:385
 #, elixir-autogen, elixir-format
 msgid "Edits the page and posts jobs."
 msgstr "Bearbeitet die Seite und schreibt Stellen aus."
@@ -20743,7 +20735,7 @@ msgstr "Bearbeitet die Seite und schreibt Stellen aus."
 msgid "Give members their roles on this page. Someone can hold several at once, and every role is granted on its own."
 msgstr "Geben Sie Mitgliedern ihre Rollen auf dieser Seite. Jemand kann mehrere gleichzeitig haben, und jede Rolle wird einzeln vergeben."
 
-#: lib/vutuv_web/components/organization_components.ex:282
+#: lib/vutuv_web/components/organization_components.ex:384
 #, elixir-autogen, elixir-format
 msgid "Manages the team and the domains, and edits the page."
 msgstr "Verwaltet Team und Domains und bearbeitet die Seite."
@@ -20753,7 +20745,7 @@ msgstr "Verwaltet Team und Domains und bearbeitet die Seite."
 msgid "Pick at least one role."
 msgstr "Wählen Sie mindestens eine Rolle."
 
-#: lib/vutuv_web/components/organization_components.ex:285
+#: lib/vutuv_web/components/organization_components.ex:387
 #, elixir-autogen, elixir-format
 msgid "Posts jobs."
 msgstr "Schreibt Stellen aus."
@@ -20768,7 +20760,7 @@ msgstr "Rollen"
 msgid "Roles updated."
 msgstr "Rollen aktualisiert."
 
-#: lib/vutuv_web/components/organization_components.ex:284
+#: lib/vutuv_web/components/organization_components.ex:386
 #, elixir-autogen, elixir-format
 msgid "Writes posts in the organization's name."
 msgstr "Schreibt Beiträge im Namen der Organisation."
@@ -20778,33 +20770,33 @@ msgstr "Schreibt Beiträge im Namen der Organisation."
 msgid "The owner gives other members their roles on the page, and can hand ownership over to someone else at any time. Someone can hold several roles, and writing in the organization's name is always granted on its own."
 msgstr "Der Besitzer vergibt die Rollen der anderen Mitglieder auf der Seite und kann den Besitz jederzeit an jemand anderen übergeben. Jemand kann mehrere Rollen haben, und das Schreiben im Namen der Organisation wird immer einzeln vergeben."
 
-#: lib/vutuv_web/live/organization_live/show.ex:617
+#: lib/vutuv_web/live/organization_live/show.ex:637
 #, elixir-autogen, elixir-format
 msgid "Nothing published yet."
 msgstr "Noch nichts veröffentlicht."
 
-#: lib/vutuv_web/live/organization_live/show.ex:599
+#: lib/vutuv_web/live/organization_live/show.ex:619
 #: lib/vutuv_web/live/post_live/composer.ex:1814
 #, elixir-autogen, elixir-format
 msgid "Post as %{name}"
 msgstr "Als %{name} veröffentlichen"
 
-#: lib/vutuv_web/live/organization_live/show.ex:220
+#: lib/vutuv_web/live/organization_live/show.ex:225
 #, elixir-autogen, elixir-format
 msgid "Published as %{name}."
 msgstr "Als %{name} veröffentlicht."
 
-#: lib/vutuv_web/live/organization_live/show.ex:232
+#: lib/vutuv_web/live/organization_live/show.ex:237
 #, elixir-autogen, elixir-format
 msgid "That post could not be published."
 msgstr "Dieser Beitrag konnte nicht veröffentlicht werden."
 
-#: lib/vutuv_web/live/organization_live/show.ex:591
+#: lib/vutuv_web/live/organization_live/show.ex:611
 #, elixir-autogen, elixir-format
 msgid "Write something as %{name}"
 msgstr "Schreiben Sie etwas als %{name}"
 
-#: lib/vutuv_web/live/organization_live/show.ex:226
+#: lib/vutuv_web/live/organization_live/show.ex:231
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr "Sie dürfen nicht mehr im Namen dieser Organisation schreiben."
@@ -20829,7 +20821,7 @@ msgstr "Begonnen, im Namen einer Organisation zu schreiben"
 msgid "Stopped writing as an organization"
 msgstr "Beendet, im Namen einer Organisation zu schreiben"
 
-#: lib/vutuv_web/live/organization_live/show.ex:575
+#: lib/vutuv_web/live/organization_live/show.ex:595
 #, elixir-autogen, elixir-format
 msgid "Write as %{name} for now"
 msgstr "Vorerst als %{name} schreiben"
@@ -21051,12 +21043,12 @@ msgstr "Andere Netzwerke sprechen diese Seite als @name@%{host} an, so wie sie e
 
 #: lib/vutuv_web/live/organization_live/fediverse.ex:88
 #: lib/vutuv_web/live/organization_live/new.ex:211
-#: lib/vutuv_web/live/organization_live/show.ex:727
+#: lib/vutuv_web/live/organization_live/show.ex:747
 #, elixir-autogen, elixir-format
 msgid "People who have no vutuv account can follow this page and read its posts, in networks like Mastodon."
 msgstr "Auch Menschen ohne vutuv-Konto können dieser Seite folgen und ihre Beiträge lesen, in Netzwerken wie Mastodon."
 
-#: lib/vutuv_web/live/organization_live/show.ex:741
+#: lib/vutuv_web/live/organization_live/show.ex:761
 #, elixir-autogen, elixir-format
 msgid "Set this page up for other networks"
 msgstr "Seite für andere Netzwerke einrichten"
@@ -21071,7 +21063,7 @@ msgstr "Ausschalten"
 msgid "Switch it on"
 msgstr "Einschalten"
 
-#: lib/vutuv_web/live/organization_live/show.ex:732
+#: lib/vutuv_web/live/organization_live/show.ex:752
 #, elixir-autogen, elixir-format
 msgid "The page gets an address of its own for that, written like an email address."
 msgstr "Die Seite bekommt dafür eine eigene Adresse, die wie eine E-Mail-Adresse aussieht."
@@ -21330,3 +21322,69 @@ msgstr "Nur wenn Sie hier klicken: Wir fragen bei gravatar.com nach, ob es zu Ih
 #, elixir-autogen, elixir-format
 msgid "The gravatar.com lookup is switched off on this installation."
 msgstr "Die Abfrage bei gravatar.com ist auf dieser Installation abgeschaltet."
+
+#: lib/vutuv_web/components/organization_components.ex:165
+#, elixir-autogen, elixir-format
+msgid "A new entry can take a while to reach everyone. We keep checking %{domain} by ourselves and send you an email as soon as it works, so you can close this page."
+msgstr "Ein neuer Eintrag braucht manchmal eine Weile, bis er überall ankommt. Wir prüfen %{domain} von selbst weiter und schicken Ihnen eine E-Mail, sobald es klappt. Sie können diese Seite also schließen."
+
+#: lib/vutuv_web/live/organization_live/domains.ex:333
+#: lib/vutuv_web/live/organization_live/show.ex:899
+#, elixir-autogen, elixir-format
+msgid "Checking …"
+msgstr "Wird geprüft …"
+
+#: lib/vutuv_web/templates/settings/organizations.html.heex:97
+#, elixir-autogen, elixir-format
+msgid "Finish verification"
+msgstr "Verifizierung abschließen"
+
+#: lib/vutuv_web/components/organization_components.ex:152
+#, elixir-autogen, elixir-format
+msgid "It answered with HTTP status %{status}."
+msgstr "Die Antwort war HTTP-Status %{status}."
+
+#: lib/vutuv_web/components/organization_components.ex:149
+#, elixir-autogen, elixir-format
+msgid "It answered with an empty file."
+msgstr "Die Antwort war eine leere Datei."
+
+#: lib/vutuv_web/components/organization_components.ex:146
+#, elixir-autogen, elixir-format
+msgid "It answered, but with something else: %{found}"
+msgstr "Es kam eine Antwort, aber mit einem anderen Inhalt: %{found}"
+
+#: lib/vutuv_web/components/organization_components.ex:122
+#, elixir-autogen, elixir-format
+msgid "No TXT record at all."
+msgstr "Dort steht überhaupt kein TXT-Eintrag."
+
+#: lib/vutuv_web/components/organization_components.ex:95
+#, elixir-autogen, elixir-format
+msgid "Not found yet"
+msgstr "Noch nicht gefunden"
+
+#: lib/vutuv_web/components/organization_components.ex:106
+#, elixir-autogen, elixir-format
+msgid "We asked the name servers of your domain directly, for %{names}, and looked for this value:"
+msgstr "Wir haben die Namensserver Ihrer Domain direkt nach %{names} gefragt und diesen Wert gesucht:"
+
+#: lib/vutuv_web/components/organization_components.ex:143
+#, elixir-autogen, elixir-format
+msgid "We could not reach that address at all."
+msgstr "Wir konnten diese Adresse gar nicht erreichen."
+
+#: lib/vutuv_web/components/organization_components.ex:125
+#, elixir-autogen, elixir-format
+msgid "We fetched this address:"
+msgstr "Wir haben diese Adresse abgerufen:"
+
+#: lib/vutuv_web/components/organization_components.ex:110
+#, elixir-autogen, elixir-format
+msgid "What is published there right now:"
+msgstr "Was dort im Moment veröffentlicht ist:"
+
+#: lib/vutuv/notifications/emailer.ex:856
+#, elixir-autogen, elixir-format
+msgid "Your organization page on vutuv is verified"
+msgstr "Ihre Organisationsseite auf vutuv ist verifiziert"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -21,7 +21,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3587
 #: lib/vutuv_web/live/admin/screenshot_live.ex:266
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:718
-#: lib/vutuv_web/live/organization_live/domains.ex:255
+#: lib/vutuv_web/live/organization_live/domains.ex:269
 #: lib/vutuv_web/live/organization_live/edit.ex:396
 #: lib/vutuv_web/live/organization_live/roles.ex:210
 #, elixir-autogen
@@ -35,7 +35,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
 #: lib/vutuv_web/live/organization_live/fediverse.ex:119
-#: lib/vutuv_web/live/organization_live/show.ex:749
+#: lib/vutuv_web/live/organization_live/show.ex:769
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
@@ -216,7 +216,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
 #: lib/vutuv_web/live/job_posting_live/show.ex:178
-#: lib/vutuv_web/live/organization_live/show.ex:496
+#: lib/vutuv_web/live/organization_live/show.ex:516
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:7
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:19
@@ -333,7 +333,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:2117
 #: lib/vutuv_web/components/ui.ex:2175
 #: lib/vutuv_web/controllers/followee_controller.ex:29
-#: lib/vutuv_web/live/organization_live/show.ex:456
+#: lib/vutuv_web/live/organization_live/show.ex:476
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:53
 #: lib/vutuv_web/templates/user/show.html.heex:955
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Add Localization"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:273
+#: lib/vutuv_web/components/organization_components.ex:375
 #: lib/vutuv_web/live/admin/activity_live.ex:153
 #: lib/vutuv_web/live/admin/api_app_live.ex:58
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
@@ -1690,8 +1690,8 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_following_live.ex:331
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:293
 #: lib/vutuv_web/live/organization_live/following.ex:218
-#: lib/vutuv_web/live/organization_live/show.ex:425
-#: lib/vutuv_web/live/organization_live/show.ex:454
+#: lib/vutuv_web/live/organization_live/show.ex:445
+#: lib/vutuv_web/live/organization_live/show.ex:474
 #: lib/vutuv_web/templates/user/show.html.heex:1269
 #, elixir-autogen, elixir-format
 msgid "Follow"
@@ -1713,7 +1713,7 @@ msgstr ""
 msgid "Log out"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:279
+#: lib/vutuv_web/components/organization_components.ex:381
 #: lib/vutuv_web/live/admin/activity_live.ex:143
 #: lib/vutuv_web/live/admin/activity_live.ex:175
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
@@ -1728,7 +1728,7 @@ msgstr ""
 msgid "Member"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:475
+#: lib/vutuv_web/live/organization_live/show.ex:495
 #: lib/vutuv_web/templates/user/show.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Message"
@@ -1920,7 +1920,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3609
 #: lib/vutuv_web/live/organization_live/activity.ex:146
 #: lib/vutuv_web/live/organization_live/feed.ex:101
-#: lib/vutuv_web/live/organization_live/show.ex:622
+#: lib/vutuv_web/live/organization_live/show.ex:642
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr ""
@@ -2110,7 +2110,7 @@ msgstr ""
 msgid "Edit post"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:231
+#: lib/vutuv_web/components/organization_components.ex:333
 #: lib/vutuv_web/live/organization_live/feed.ex:79
 #: lib/vutuv_web/live/post_live/feed.ex:159
 #: lib/vutuv_web/live/post_live/feed.ex:936
@@ -2198,7 +2198,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:382
 #: lib/vutuv_web/live/notification_live/index.ex:891
-#: lib/vutuv_web/live/organization_live/show.ex:549
+#: lib/vutuv_web/live/organization_live/show.ex:569
 #: lib/vutuv_web/live/post_live/saved.ex:495
 #: lib/vutuv_web/live/search_live.ex:309
 #: lib/vutuv_web/live/search_live.ex:772
@@ -2226,7 +2226,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/screenshot_live.ex:338
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:700
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
-#: lib/vutuv_web/live/organization_live/domains.ex:229
+#: lib/vutuv_web/live/organization_live/domains.ex:243
 #: lib/vutuv_web/live/organization_live/edit.ex:373
 #: lib/vutuv_web/live/organization_live/roles.ex:243
 #: lib/vutuv_web/live/post_live/composer.ex:1886
@@ -2461,7 +2461,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:2176
 #: lib/vutuv_web/live/organization_live/following.ex:197
 #: lib/vutuv_web/live/organization_live/following.ex:256
-#: lib/vutuv_web/live/organization_live/show.ex:459
+#: lib/vutuv_web/live/organization_live/show.ex:479
 #: lib/vutuv_web/live/post_live/feed.ex:1172
 #: lib/vutuv_web/templates/followee/index.html.heex:44
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
@@ -2743,7 +2743,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3537
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
-#: lib/vutuv_web/templates/settings/organizations.html.heex:89
+#: lib/vutuv_web/templates/settings/organizations.html.heex:104
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:216
@@ -2841,7 +2841,7 @@ msgstr ""
 msgid "Open someone's profile to message them."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:225
+#: lib/vutuv_web/components/organization_components.ex:327
 #: lib/vutuv_web/live/notification_live/index.ex:1050
 #: lib/vutuv_web/live/organization_live/activity.ex:99
 #, elixir-autogen, elixir-format
@@ -3120,7 +3120,7 @@ msgstr ""
 msgid "Opened"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:272
+#: lib/vutuv_web/components/organization_components.ex:374
 #: lib/vutuv_web/live/admin/api_app_live.ex:72
 #: lib/vutuv_web/live/admin/deliverability_live.ex:171
 #: lib/vutuv_web/live/admin/moderation_live.ex:56
@@ -3172,7 +3172,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1066
 #: lib/vutuv_web/components/post_components.ex:2042
 #: lib/vutuv_web/components/post_components.ex:2772
-#: lib/vutuv_web/live/organization_live/show.ex:532
+#: lib/vutuv_web/live/organization_live/show.ex:552
 #: lib/vutuv_web/templates/user/show.html.heex:219
 #, elixir-autogen, elixir-format
 msgid "Report"
@@ -3484,42 +3484,42 @@ msgstr ""
 msgid "yes"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:900
+#: lib/vutuv/notifications/emailer.ex:925
 #, elixir-autogen, elixir-format
 msgid "A warning for your vutuv account"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:984
+#: lib/vutuv/notifications/emailer.ex:1009
 #, elixir-autogen, elixir-format
 msgid "Moderation: %{count} cases are waiting"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:962
+#: lib/vutuv/notifications/emailer.ex:987
 #, elixir-autogen, elixir-format
 msgid "Moderation: a profile was reported"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:874
+#: lib/vutuv/notifications/emailer.ex:899
 #, elixir-autogen, elixir-format
 msgid "The content you reported was revised"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:867
+#: lib/vutuv/notifications/emailer.ex:892
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv is under review"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:860
+#: lib/vutuv/notifications/emailer.ex:885
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv was reported and is hidden"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:914
+#: lib/vutuv/notifications/emailer.ex:939
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account has been deactivated"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:907
+#: lib/vutuv/notifications/emailer.ex:932
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account is suspended"
 msgstr ""
@@ -4546,7 +4546,7 @@ msgstr ""
 msgid "Find members"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:237
+#: lib/vutuv_web/components/organization_components.ex:339
 #: lib/vutuv_web/live/organization_live/following.ex:154
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:53
@@ -4595,7 +4595,7 @@ msgstr ""
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:516
 #: lib/vutuv_web/live/notification_live/index.ex:892
-#: lib/vutuv_web/live/organization_live/show.ex:632
+#: lib/vutuv_web/live/organization_live/show.ex:652
 #: lib/vutuv_web/live/post_live/saved.ex:498
 #: lib/vutuv_web/live/search_live.ex:307
 #: lib/vutuv_web/live/search_live.ex:714
@@ -8055,7 +8055,7 @@ msgid "Unreachable"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/member_badges.ex:20
-#: lib/vutuv_web/live/organization_live/domains.ex:178
+#: lib/vutuv_web/live/organization_live/domains.ex:192
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:32
 #, elixir-autogen, elixir-format
 msgid "Verified"
@@ -8603,7 +8603,7 @@ msgstr ""
 msgid "Not written yet"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:210
+#: lib/vutuv_web/components/organization_components.ex:312
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "Page"
@@ -8639,7 +8639,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:541
 #: lib/vutuv_web/agent_docs/text.ex:504
 #: lib/vutuv_web/agent_docs/text.ex:508
-#: lib/vutuv_web/components/organization_components.ex:242
+#: lib/vutuv_web/components/organization_components.ex:344
 #: lib/vutuv_web/components/ui.ex:3897
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:323
@@ -8647,8 +8647,8 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_followers_live.ex:169
 #: lib/vutuv_web/live/fediverse_following_live.ex:304
 #: lib/vutuv_web/live/organization_live/fediverse.ex:80
-#: lib/vutuv_web/live/organization_live/show.ex:525
-#: lib/vutuv_web/live/organization_live/show.ex:708
+#: lib/vutuv_web/live/organization_live/show.ex:545
+#: lib/vutuv_web/live/organization_live/show.ex:728
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:341
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:5
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
@@ -10226,7 +10226,7 @@ msgid_plural "%{count} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:483
+#: lib/vutuv_web/live/organization_live/show.ex:503
 #: lib/vutuv_web/views/user_html.ex:536
 #: lib/vutuv_web/views/user_html.ex:715
 #, elixir-autogen, elixir-format
@@ -10765,7 +10765,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/organization_live.ex:179
 #: lib/vutuv_web/live/admin/organization_live.ex:194
 #: lib/vutuv_web/live/admin/screenshot_live.ex:535
-#: lib/vutuv_web/live/organization_live/domains.ex:184
+#: lib/vutuv_web/live/organization_live/domains.ex:198
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
@@ -11030,7 +11030,7 @@ msgstr ""
 msgid "AI agents"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:539
+#: lib/vutuv_web/live/organization_live/show.ex:559
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
@@ -11040,19 +11040,18 @@ msgstr ""
 msgid "Continue to verification"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:248
-#: lib/vutuv_web/live/organization_live/domains.ex:288
+#: lib/vutuv_web/live/organization_live/domains.ex:262
+#: lib/vutuv_web/live/organization_live/domains.ex:302
 #: lib/vutuv_web/live/organization_live/new.ex:161
-#: lib/vutuv_web/live/organization_live/show.ex:823
+#: lib/vutuv_web/live/organization_live/show.ex:843
 #: lib/vutuv_web/templates/url/verify.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "DNS TXT record"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:153
-#: lib/vutuv_web/live/organization_live/domains.ex:167
-#: lib/vutuv_web/live/organization_live/show.ex:357
-#: lib/vutuv_web/live/organization_live/show.ex:882
+#: lib/vutuv_web/components/organization_components.ex:102
+#: lib/vutuv_web/live/organization_live/domains.ex:181
+#: lib/vutuv_web/live/organization_live/show.ex:913
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr ""
@@ -11089,7 +11088,7 @@ msgstr ""
 msgid "Please log in first."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:796
+#: lib/vutuv_web/live/organization_live/show.ex:816
 #, elixir-autogen, elixir-format
 msgid "Prove you control %{domain} to publish this page."
 msgstr ""
@@ -11110,13 +11109,13 @@ msgstr ""
 msgid "Search engines"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:119
+#: lib/vutuv_web/components/organization_components.ex:221
 #, elixir-autogen, elixir-format
 msgid "Select a country"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:307
-#: lib/vutuv_web/live/organization_live/show.ex:858
+#: lib/vutuv_web/live/organization_live/domains.ex:321
+#: lib/vutuv_web/live/organization_live/show.ex:878
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr ""
@@ -11143,12 +11142,12 @@ msgid "The upload failed."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/new.ex:146
-#: lib/vutuv_web/live/organization_live/show.ex:811
+#: lib/vutuv_web/live/organization_live/show.ex:831
 #, elixir-autogen, elixir-format
 msgid "Verification method"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:771
+#: lib/vutuv_web/live/organization_live/show.ex:791
 #, elixir-autogen, elixir-format
 msgid "Verified domains"
 msgstr ""
@@ -11164,21 +11163,15 @@ msgstr ""
 msgid "Verified via %{domain}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:793
+#: lib/vutuv_web/live/organization_live/show.ex:813
 #, elixir-autogen, elixir-format
 msgid "Verify %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:320
-#: lib/vutuv_web/live/organization_live/show.ex:878
+#: lib/vutuv_web/live/organization_live/domains.ex:337
+#: lib/vutuv_web/live/organization_live/show.ex:903
 #, elixir-autogen, elixir-format
 msgid "Verify now"
-msgstr ""
-
-#: lib/vutuv_web/live/organization_live/domains.ex:149
-#: lib/vutuv_web/live/organization_live/show.ex:352
-#, elixir-autogen, elixir-format
-msgid "We could not find the record or file yet. It can take a while to propagate. Please try again."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:243
@@ -11189,9 +11182,9 @@ msgstr ""
 msgid "Website"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:249
-#: lib/vutuv_web/live/organization_live/domains.ex:298
-#: lib/vutuv_web/live/organization_live/show.ex:834
+#: lib/vutuv_web/live/organization_live/domains.ex:263
+#: lib/vutuv_web/live/organization_live/domains.ex:312
+#: lib/vutuv_web/live/organization_live/show.ex:854
 #: lib/vutuv_web/templates/url/verify.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Website file"
@@ -11212,8 +11205,8 @@ msgstr ""
 msgid "You will publish a record or file to prove control of the domain on the next step."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:309
-#: lib/vutuv_web/live/organization_live/show.ex:864
+#: lib/vutuv_web/live/organization_live/domains.ex:323
+#: lib/vutuv_web/live/organization_live/show.ex:884
 #: lib/vutuv_web/templates/url/verify.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
@@ -11224,13 +11217,13 @@ msgstr ""
 msgid "@handle or email"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:291
+#: lib/vutuv_web/components/organization_components.ex:393
 #: lib/vutuv_web/live/organization_live/edit.ex:390
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:236
+#: lib/vutuv_web/live/organization_live/domains.ex:250
 #, elixir-autogen, elixir-format
 msgid "Add a domain"
 msgstr ""
@@ -11245,7 +11238,7 @@ msgstr ""
 msgid "Added @%{handle} to the team."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:292
+#: lib/vutuv_web/components/organization_components.ex:394
 #: lib/vutuv_web/live/organization_live/edit.ex:388
 #, elixir-autogen, elixir-format
 msgid "Alias"
@@ -11264,7 +11257,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:358
 #: lib/vutuv_web/agent_docs/text.ex:381
 #: lib/vutuv_web/live/organization_live/edit.ex:353
-#: lib/vutuv_web/live/organization_live/show.ex:759
+#: lib/vutuv_web/live/organization_live/show.ex:779
 #: lib/vutuv_web/templates/tag/single_card.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Also known as"
@@ -11291,7 +11284,7 @@ msgstr ""
 msgid "Archived"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:290
+#: lib/vutuv_web/components/organization_components.ex:392
 #: lib/vutuv_web/live/organization_live/edit.ex:389
 #, elixir-autogen, elixir-format
 msgid "Brand"
@@ -11312,35 +11305,35 @@ msgstr ""
 msgid "Delete this page and everything it owns? This cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:60
+#: lib/vutuv_web/live/organization_live/domains.ex:64
 #, elixir-autogen, elixir-format
 msgid "Domain added. Publish the record or file, then verify it."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:129
+#: lib/vutuv_web/live/organization_live/domains.ex:138
 #, elixir-autogen, elixir-format
 msgid "Domain removed."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:97
+#: lib/vutuv_web/live/organization_live/domains.ex:107
 #, elixir-autogen, elixir-format
 msgid "Domain verified."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:216
+#: lib/vutuv_web/components/organization_components.ex:318
 #: lib/vutuv_web/live/admin/organization_live.ex:305
-#: lib/vutuv_web/live/organization_live/domains.ex:161
-#: lib/vutuv_web/live/organization_live/show.ex:510
+#: lib/vutuv_web/live/organization_live/domains.ex:175
+#: lib/vutuv_web/live/organization_live/show.ex:530
 #, elixir-autogen, elixir-format
 msgid "Domains"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:27
+#: lib/vutuv_web/live/organization_live/domains.ex:28
 #, elixir-autogen, elixir-format
 msgid "Domains – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:289
+#: lib/vutuv_web/components/organization_components.ex:391
 #, elixir-autogen, elixir-format
 msgid "Former name"
 msgstr ""
@@ -11357,7 +11350,7 @@ msgstr ""
 msgid "Freeze this page? It disappears for the public but stays visible to its owner."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:189
+#: lib/vutuv_web/live/organization_live/domains.ex:203
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "Last checked"
@@ -11378,7 +11371,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:220
+#: lib/vutuv_web/live/organization_live/domains.ex:234
 #, elixir-autogen, elixir-format
 msgid "Make primary"
 msgstr ""
@@ -11388,7 +11381,7 @@ msgstr ""
 msgid "Member removed."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:189
+#: lib/vutuv_web/live/organization_live/domains.ex:203
 #, elixir-autogen, elixir-format
 msgid "Method"
 msgstr ""
@@ -11403,27 +11396,27 @@ msgstr ""
 msgid "No member found for “%{id}”."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:114
+#: lib/vutuv_web/live/organization_live/domains.ex:123
 #, elixir-autogen, elixir-format
 msgid "Only a verified domain can be the primary one."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:175
+#: lib/vutuv_web/live/organization_live/domains.ex:189
 #, elixir-autogen, elixir-format
 msgid "Primary"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:110
+#: lib/vutuv_web/live/organization_live/domains.ex:119
 #, elixir-autogen, elixir-format
 msgid "Primary domain updated."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:278
+#: lib/vutuv_web/components/organization_components.ex:380
 #, elixir-autogen, elixir-format
 msgid "Recruiter"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:226
+#: lib/vutuv_web/live/organization_live/domains.ex:240
 #, elixir-autogen, elixir-format
 msgid "Remove this domain?"
 msgstr ""
@@ -11443,10 +11436,10 @@ msgstr ""
 msgid "Search name, alias or domain"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:213
+#: lib/vutuv_web/components/organization_components.ex:315
 #: lib/vutuv_web/live/admin/organization_live.ex:321
 #: lib/vutuv_web/live/organization_live/roles.ex:165
-#: lib/vutuv_web/live/organization_live/show.ex:503
+#: lib/vutuv_web/live/organization_live/show.ex:523
 #, elixir-autogen, elixir-format
 msgid "Team"
 msgstr ""
@@ -11456,7 +11449,7 @@ msgstr ""
 msgid "Team – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:71
+#: lib/vutuv_web/live/organization_live/domains.ex:75
 #, elixir-autogen, elixir-format
 msgid "That is not a valid domain."
 msgstr ""
@@ -11623,7 +11616,7 @@ msgstr ""
 msgid "%{min} to %{max} characters: letters (a-z), numbers (0-9) and underscores."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:647
+#: lib/vutuv_web/live/organization_live/show.ex:667
 #, elixir-autogen, elixir-format
 msgid "Former"
 msgstr ""
@@ -11674,12 +11667,12 @@ msgstr[1] ""
 msgid "Alternative names, brands or abbreviations this organization is findable under. A rename keeps the old name here automatically."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:163
+#: lib/vutuv_web/live/organization_live/domains.ex:177
 #, elixir-autogen, elixir-format
 msgid "An organization can prove several domains. The primary one shows in the “Verified via …” badge."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:136
+#: lib/vutuv_web/live/organization_live/domains.ex:145
 #, elixir-autogen, elixir-format
 msgid "An organization keeps at least one verified domain, so this one cannot be removed."
 msgstr ""
@@ -11703,7 +11696,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/index.ex:101
 #: lib/vutuv_web/live/organization_live/new.ex:28
 #: lib/vutuv_web/live/organization_live/new.ex:95
-#: lib/vutuv_web/templates/settings/organizations.html.heex:103
+#: lib/vutuv_web/templates/settings/organizations.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Add your organization"
 msgstr ""
@@ -11728,7 +11721,7 @@ msgstr ""
 msgid "The proof is a small technical change to your domain: a DNS entry or a file on your website. If you don't manage the website yourself, ask the person or team who does. That is usually your IT department or the company that runs your website. We show the exact instructions on the next step, so you can simply pass them on."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:805
+#: lib/vutuv_web/live/organization_live/show.ex:825
 #, elixir-autogen, elixir-format
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr ""
@@ -11855,7 +11848,7 @@ msgstr ""
 msgid "Organizations"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:146
+#: lib/vutuv_web/components/organization_components.ex:248
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:90
 #, elixir-autogen, elixir-format
 msgid "Please choose"
@@ -11876,7 +11869,7 @@ msgstr ""
 msgid "Search organizations"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:67
+#: lib/vutuv_web/live/organization_live/domains.ex:71
 #, elixir-autogen, elixir-format
 msgid "That domain already belongs to an organization page."
 msgstr ""
@@ -11896,7 +11889,7 @@ msgstr ""
 msgid "The organization page was deleted."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:364
+#: lib/vutuv_web/live/organization_live/show.ex:384
 #, elixir-autogen, elixir-format
 msgid "This organization page was reported and is hidden while it is reviewed. Only you and the moderators can see it."
 msgstr ""
@@ -11926,7 +11919,8 @@ msgstr ""
 msgid "Your organization handle is set."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:290
+#: lib/vutuv_web/live/organization_live/show.ex:300
+#: lib/vutuv_web/live/organization_live/show.ex:360
 #, elixir-autogen, elixir-format
 msgid "Your organization page is verified and now live."
 msgstr ""
@@ -12492,7 +12486,7 @@ msgstr ""
 msgid "You already have the maximum number of published postings."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:930
+#: lib/vutuv/notifications/emailer.ex:955
 #, elixir-autogen, elixir-format
 msgid "Your job posting on vutuv expires soon"
 msgstr ""
@@ -12502,17 +12496,17 @@ msgstr ""
 msgid "A domain of your organization page on vutuv is about to be dropped"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:202
+#: lib/vutuv_web/live/organization_live/domains.ex:216
 #, elixir-autogen, elixir-format
 msgid "Deadline"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:181
+#: lib/vutuv_web/live/organization_live/domains.ex:195
 #, elixir-autogen, elixir-format
 msgid "Proof missing"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:201
+#: lib/vutuv_web/live/organization_live/domains.ex:215
 #, elixir-autogen, elixir-format
 msgid "We could not read this domain's proof on the last check. Restore it and check again, or the domain loses its verification."
 msgstr ""
@@ -12522,7 +12516,7 @@ msgstr ""
 msgid "Your organization page on vutuv is about to lose its verification"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:851
+#: lib/vutuv/notifications/emailer.ex:876
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is no longer public"
 msgstr ""
@@ -12585,17 +12579,17 @@ msgid_plural "Your roles"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:98
+#: lib/vutuv_web/templates/settings/organizations.html.heex:113
 #, elixir-autogen, elixir-format
 msgid "Add an organization"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:100
+#: lib/vutuv_web/templates/settings/organizations.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "Represent a company, association or other group? Add its page and verify the domain to become its owner."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:110
+#: lib/vutuv_web/templates/settings/organizations.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Browse all organizations"
 msgstr ""
@@ -12625,14 +12619,14 @@ msgstr ""
 msgid "Getting an error, or is %{host} a CNAME / alias to another address? A TXT record cannot share a name with a CNAME. Use this name instead, with the exact same value as above:"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:305
-#: lib/vutuv_web/live/organization_live/show.ex:851
+#: lib/vutuv_web/live/organization_live/domains.ex:319
+#: lib/vutuv_web/live/organization_live/show.ex:871
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:303
-#: lib/vutuv_web/live/organization_live/show.ex:842
+#: lib/vutuv_web/live/organization_live/domains.ex:317
+#: lib/vutuv_web/live/organization_live/show.ex:862
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
 msgstr ""
@@ -12728,7 +12722,7 @@ msgid "Minimum yearly salary"
 msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:324
-#: lib/vutuv_web/live/organization_live/show.ex:674
+#: lib/vutuv_web/live/organization_live/show.ex:694
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr ""
@@ -12757,7 +12751,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:436
 #: lib/vutuv_web/agent_docs/text.ex:445
 #: lib/vutuv_web/agent_docs/text.ex:457
-#: lib/vutuv_web/live/organization_live/show.ex:661
+#: lib/vutuv_web/live/organization_live/show.ex:681
 #: lib/vutuv_web/templates/tag/show.html.heex:69
 #, elixir-autogen, elixir-format
 msgid "Open positions"
@@ -13214,7 +13208,7 @@ msgstr ""
 msgid "Inherited from the organization"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:219
+#: lib/vutuv_web/components/organization_components.ex:321
 #: lib/vutuv_web/live/organization_live/exclusions.ex:103
 #, elixir-autogen, elixir-format
 msgid "Job exclusions"
@@ -14079,7 +14073,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:892
+#: lib/vutuv/notifications/emailer.ex:917
 #, elixir-autogen, elixir-format
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
@@ -19952,12 +19946,12 @@ msgstr ""
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:277
+#: lib/vutuv_web/components/organization_components.ex:379
 #, elixir-autogen, elixir-format
 msgid "Editorial"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:283
+#: lib/vutuv_web/components/organization_components.ex:385
 #, elixir-autogen, elixir-format
 msgid "Edits the page and posts jobs."
 msgstr ""
@@ -19967,7 +19961,7 @@ msgstr ""
 msgid "Give members their roles on this page. Someone can hold several at once, and every role is granted on its own."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:282
+#: lib/vutuv_web/components/organization_components.ex:384
 #, elixir-autogen, elixir-format
 msgid "Manages the team and the domains, and edits the page."
 msgstr ""
@@ -19977,7 +19971,7 @@ msgstr ""
 msgid "Pick at least one role."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:285
+#: lib/vutuv_web/components/organization_components.ex:387
 #, elixir-autogen, elixir-format
 msgid "Posts jobs."
 msgstr ""
@@ -19992,7 +19986,7 @@ msgstr ""
 msgid "Roles updated."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:284
+#: lib/vutuv_web/components/organization_components.ex:386
 #, elixir-autogen, elixir-format
 msgid "Writes posts in the organization's name."
 msgstr ""
@@ -20002,33 +19996,33 @@ msgstr ""
 msgid "The owner gives other members their roles on the page, and can hand ownership over to someone else at any time. Someone can hold several roles, and writing in the organization's name is always granted on its own."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:617
+#: lib/vutuv_web/live/organization_live/show.ex:637
 #, elixir-autogen, elixir-format
 msgid "Nothing published yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:599
+#: lib/vutuv_web/live/organization_live/show.ex:619
 #: lib/vutuv_web/live/post_live/composer.ex:1814
 #, elixir-autogen, elixir-format
 msgid "Post as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:220
+#: lib/vutuv_web/live/organization_live/show.ex:225
 #, elixir-autogen, elixir-format
 msgid "Published as %{name}."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:232
+#: lib/vutuv_web/live/organization_live/show.ex:237
 #, elixir-autogen, elixir-format
 msgid "That post could not be published."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:591
+#: lib/vutuv_web/live/organization_live/show.ex:611
 #, elixir-autogen, elixir-format
 msgid "Write something as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:226
+#: lib/vutuv_web/live/organization_live/show.ex:231
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr ""
@@ -20053,7 +20047,7 @@ msgstr ""
 msgid "Stopped writing as an organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:575
+#: lib/vutuv_web/live/organization_live/show.ex:595
 #, elixir-autogen, elixir-format
 msgid "Write as %{name} for now"
 msgstr ""
@@ -20275,12 +20269,12 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/fediverse.ex:88
 #: lib/vutuv_web/live/organization_live/new.ex:211
-#: lib/vutuv_web/live/organization_live/show.ex:727
+#: lib/vutuv_web/live/organization_live/show.ex:747
 #, elixir-autogen, elixir-format
 msgid "People who have no vutuv account can follow this page and read its posts, in networks like Mastodon."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:741
+#: lib/vutuv_web/live/organization_live/show.ex:761
 #, elixir-autogen, elixir-format
 msgid "Set this page up for other networks"
 msgstr ""
@@ -20295,7 +20289,7 @@ msgstr ""
 msgid "Switch it on"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:732
+#: lib/vutuv_web/live/organization_live/show.ex:752
 #, elixir-autogen, elixir-format
 msgid "The page gets an address of its own for that, written like an email address."
 msgstr ""
@@ -20546,4 +20540,70 @@ msgstr ""
 #: lib/vutuv_web/controllers/user_controller.ex:172
 #, elixir-autogen, elixir-format
 msgid "The gravatar.com lookup is switched off on this installation."
+msgstr ""
+
+#: lib/vutuv_web/components/organization_components.ex:165
+#, elixir-autogen, elixir-format
+msgid "A new entry can take a while to reach everyone. We keep checking %{domain} by ourselves and send you an email as soon as it works, so you can close this page."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/domains.ex:333
+#: lib/vutuv_web/live/organization_live/show.ex:899
+#, elixir-autogen, elixir-format
+msgid "Checking …"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/organizations.html.heex:97
+#, elixir-autogen, elixir-format
+msgid "Finish verification"
+msgstr ""
+
+#: lib/vutuv_web/components/organization_components.ex:152
+#, elixir-autogen, elixir-format
+msgid "It answered with HTTP status %{status}."
+msgstr ""
+
+#: lib/vutuv_web/components/organization_components.ex:149
+#, elixir-autogen, elixir-format
+msgid "It answered with an empty file."
+msgstr ""
+
+#: lib/vutuv_web/components/organization_components.ex:146
+#, elixir-autogen, elixir-format
+msgid "It answered, but with something else: %{found}"
+msgstr ""
+
+#: lib/vutuv_web/components/organization_components.ex:122
+#, elixir-autogen, elixir-format
+msgid "No TXT record at all."
+msgstr ""
+
+#: lib/vutuv_web/components/organization_components.ex:95
+#, elixir-autogen, elixir-format
+msgid "Not found yet"
+msgstr ""
+
+#: lib/vutuv_web/components/organization_components.ex:106
+#, elixir-autogen, elixir-format
+msgid "We asked the name servers of your domain directly, for %{names}, and looked for this value:"
+msgstr ""
+
+#: lib/vutuv_web/components/organization_components.ex:143
+#, elixir-autogen, elixir-format
+msgid "We could not reach that address at all."
+msgstr ""
+
+#: lib/vutuv_web/components/organization_components.ex:125
+#, elixir-autogen, elixir-format
+msgid "We fetched this address:"
+msgstr ""
+
+#: lib/vutuv_web/components/organization_components.ex:110
+#, elixir-autogen, elixir-format
+msgid "What is published there right now:"
+msgstr ""
+
+#: lib/vutuv/notifications/emailer.ex:856
+#, elixir-autogen, elixir-format
+msgid "Your organization page on vutuv is verified"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -19,7 +19,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3587
 #: lib/vutuv_web/live/admin/screenshot_live.ex:266
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:718
-#: lib/vutuv_web/live/organization_live/domains.ex:255
+#: lib/vutuv_web/live/organization_live/domains.ex:269
 #: lib/vutuv_web/live/organization_live/edit.ex:396
 #: lib/vutuv_web/live/organization_live/roles.ex:210
 #, elixir-autogen
@@ -33,7 +33,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
 #: lib/vutuv_web/live/organization_live/fediverse.ex:119
-#: lib/vutuv_web/live/organization_live/show.ex:749
+#: lib/vutuv_web/live/organization_live/show.ex:769
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
@@ -214,7 +214,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
 #: lib/vutuv_web/live/job_posting_live/show.ex:178
-#: lib/vutuv_web/live/organization_live/show.ex:496
+#: lib/vutuv_web/live/organization_live/show.ex:516
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:7
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:19
@@ -331,7 +331,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:2117
 #: lib/vutuv_web/components/ui.ex:2175
 #: lib/vutuv_web/controllers/followee_controller.ex:29
-#: lib/vutuv_web/live/organization_live/show.ex:456
+#: lib/vutuv_web/live/organization_live/show.ex:476
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:53
 #: lib/vutuv_web/templates/user/show.html.heex:955
@@ -1141,7 +1141,7 @@ msgstr ""
 msgid "Add Localization"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:273
+#: lib/vutuv_web/components/organization_components.ex:375
 #: lib/vutuv_web/live/admin/activity_live.ex:153
 #: lib/vutuv_web/live/admin/api_app_live.ex:58
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
@@ -1688,8 +1688,8 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_following_live.ex:331
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:293
 #: lib/vutuv_web/live/organization_live/following.ex:218
-#: lib/vutuv_web/live/organization_live/show.ex:425
-#: lib/vutuv_web/live/organization_live/show.ex:454
+#: lib/vutuv_web/live/organization_live/show.ex:445
+#: lib/vutuv_web/live/organization_live/show.ex:474
 #: lib/vutuv_web/templates/user/show.html.heex:1269
 #, elixir-autogen, elixir-format
 msgid "Follow"
@@ -1711,7 +1711,7 @@ msgstr ""
 msgid "Log out"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:279
+#: lib/vutuv_web/components/organization_components.ex:381
 #: lib/vutuv_web/live/admin/activity_live.ex:143
 #: lib/vutuv_web/live/admin/activity_live.ex:175
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
@@ -1726,7 +1726,7 @@ msgstr ""
 msgid "Member"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:475
+#: lib/vutuv_web/live/organization_live/show.ex:495
 #: lib/vutuv_web/templates/user/show.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Message"
@@ -1918,7 +1918,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3609
 #: lib/vutuv_web/live/organization_live/activity.ex:146
 #: lib/vutuv_web/live/organization_live/feed.ex:101
-#: lib/vutuv_web/live/organization_live/show.ex:622
+#: lib/vutuv_web/live/organization_live/show.ex:642
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr ""
@@ -2108,7 +2108,7 @@ msgstr ""
 msgid "Edit post"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:231
+#: lib/vutuv_web/components/organization_components.ex:333
 #: lib/vutuv_web/live/organization_live/feed.ex:79
 #: lib/vutuv_web/live/post_live/feed.ex:159
 #: lib/vutuv_web/live/post_live/feed.ex:936
@@ -2196,7 +2196,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:382
 #: lib/vutuv_web/live/notification_live/index.ex:891
-#: lib/vutuv_web/live/organization_live/show.ex:549
+#: lib/vutuv_web/live/organization_live/show.ex:569
 #: lib/vutuv_web/live/post_live/saved.ex:495
 #: lib/vutuv_web/live/search_live.ex:309
 #: lib/vutuv_web/live/search_live.ex:772
@@ -2224,7 +2224,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/screenshot_live.ex:338
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:700
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
-#: lib/vutuv_web/live/organization_live/domains.ex:229
+#: lib/vutuv_web/live/organization_live/domains.ex:243
 #: lib/vutuv_web/live/organization_live/edit.ex:373
 #: lib/vutuv_web/live/organization_live/roles.ex:243
 #: lib/vutuv_web/live/post_live/composer.ex:1886
@@ -2459,7 +2459,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:2176
 #: lib/vutuv_web/live/organization_live/following.ex:197
 #: lib/vutuv_web/live/organization_live/following.ex:256
-#: lib/vutuv_web/live/organization_live/show.ex:459
+#: lib/vutuv_web/live/organization_live/show.ex:479
 #: lib/vutuv_web/live/post_live/feed.ex:1172
 #: lib/vutuv_web/templates/followee/index.html.heex:44
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
@@ -2741,7 +2741,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3537
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
-#: lib/vutuv_web/templates/settings/organizations.html.heex:89
+#: lib/vutuv_web/templates/settings/organizations.html.heex:104
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:216
@@ -2839,7 +2839,7 @@ msgstr ""
 msgid "Open someone's profile to message them."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:225
+#: lib/vutuv_web/components/organization_components.ex:327
 #: lib/vutuv_web/live/notification_live/index.ex:1050
 #: lib/vutuv_web/live/organization_live/activity.ex:99
 #, elixir-autogen, elixir-format
@@ -3118,7 +3118,7 @@ msgstr ""
 msgid "Opened"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:272
+#: lib/vutuv_web/components/organization_components.ex:374
 #: lib/vutuv_web/live/admin/api_app_live.ex:72
 #: lib/vutuv_web/live/admin/deliverability_live.ex:171
 #: lib/vutuv_web/live/admin/moderation_live.ex:56
@@ -3170,7 +3170,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1066
 #: lib/vutuv_web/components/post_components.ex:2042
 #: lib/vutuv_web/components/post_components.ex:2772
-#: lib/vutuv_web/live/organization_live/show.ex:532
+#: lib/vutuv_web/live/organization_live/show.ex:552
 #: lib/vutuv_web/templates/user/show.html.heex:219
 #, elixir-autogen, elixir-format
 msgid "Report"
@@ -3482,42 +3482,42 @@ msgstr ""
 msgid "yes"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:900
+#: lib/vutuv/notifications/emailer.ex:925
 #, elixir-autogen, elixir-format
 msgid "A warning for your vutuv account"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:984
+#: lib/vutuv/notifications/emailer.ex:1009
 #, elixir-autogen, elixir-format
 msgid "Moderation: %{count} cases are waiting"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:962
+#: lib/vutuv/notifications/emailer.ex:987
 #, elixir-autogen, elixir-format
 msgid "Moderation: a profile was reported"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:874
+#: lib/vutuv/notifications/emailer.ex:899
 #, elixir-autogen, elixir-format
 msgid "The content you reported was revised"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:867
+#: lib/vutuv/notifications/emailer.ex:892
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv is under review"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:860
+#: lib/vutuv/notifications/emailer.ex:885
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv was reported and is hidden"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:914
+#: lib/vutuv/notifications/emailer.ex:939
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account has been deactivated"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:907
+#: lib/vutuv/notifications/emailer.ex:932
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account is suspended"
 msgstr ""
@@ -4544,7 +4544,7 @@ msgstr ""
 msgid "Find members"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:237
+#: lib/vutuv_web/components/organization_components.ex:339
 #: lib/vutuv_web/live/organization_live/following.ex:154
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:53
@@ -4593,7 +4593,7 @@ msgstr ""
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:516
 #: lib/vutuv_web/live/notification_live/index.ex:892
-#: lib/vutuv_web/live/organization_live/show.ex:632
+#: lib/vutuv_web/live/organization_live/show.ex:652
 #: lib/vutuv_web/live/post_live/saved.ex:498
 #: lib/vutuv_web/live/search_live.ex:307
 #: lib/vutuv_web/live/search_live.ex:714
@@ -8053,7 +8053,7 @@ msgid "Unreachable"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/member_badges.ex:20
-#: lib/vutuv_web/live/organization_live/domains.ex:178
+#: lib/vutuv_web/live/organization_live/domains.ex:192
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:32
 #, elixir-autogen, elixir-format
 msgid "Verified"
@@ -8601,7 +8601,7 @@ msgstr ""
 msgid "Not written yet"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:210
+#: lib/vutuv_web/components/organization_components.ex:312
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "Page"
@@ -8637,7 +8637,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:541
 #: lib/vutuv_web/agent_docs/text.ex:504
 #: lib/vutuv_web/agent_docs/text.ex:508
-#: lib/vutuv_web/components/organization_components.ex:242
+#: lib/vutuv_web/components/organization_components.ex:344
 #: lib/vutuv_web/components/ui.ex:3897
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:323
@@ -8645,8 +8645,8 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_followers_live.ex:169
 #: lib/vutuv_web/live/fediverse_following_live.ex:304
 #: lib/vutuv_web/live/organization_live/fediverse.ex:80
-#: lib/vutuv_web/live/organization_live/show.ex:525
-#: lib/vutuv_web/live/organization_live/show.ex:708
+#: lib/vutuv_web/live/organization_live/show.ex:545
+#: lib/vutuv_web/live/organization_live/show.ex:728
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:341
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:5
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
@@ -10224,7 +10224,7 @@ msgid_plural "%{count} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:483
+#: lib/vutuv_web/live/organization_live/show.ex:503
 #: lib/vutuv_web/views/user_html.ex:536
 #: lib/vutuv_web/views/user_html.ex:715
 #, elixir-autogen, elixir-format
@@ -10763,7 +10763,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/organization_live.ex:179
 #: lib/vutuv_web/live/admin/organization_live.ex:194
 #: lib/vutuv_web/live/admin/screenshot_live.ex:535
-#: lib/vutuv_web/live/organization_live/domains.ex:184
+#: lib/vutuv_web/live/organization_live/domains.ex:198
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
@@ -11028,7 +11028,7 @@ msgstr ""
 msgid "AI agents"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:539
+#: lib/vutuv_web/live/organization_live/show.ex:559
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
@@ -11038,19 +11038,18 @@ msgstr ""
 msgid "Continue to verification"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:248
-#: lib/vutuv_web/live/organization_live/domains.ex:288
+#: lib/vutuv_web/live/organization_live/domains.ex:262
+#: lib/vutuv_web/live/organization_live/domains.ex:302
 #: lib/vutuv_web/live/organization_live/new.ex:161
-#: lib/vutuv_web/live/organization_live/show.ex:823
+#: lib/vutuv_web/live/organization_live/show.ex:843
 #: lib/vutuv_web/templates/url/verify.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "DNS TXT record"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:153
-#: lib/vutuv_web/live/organization_live/domains.ex:167
-#: lib/vutuv_web/live/organization_live/show.ex:357
-#: lib/vutuv_web/live/organization_live/show.ex:882
+#: lib/vutuv_web/components/organization_components.ex:102
+#: lib/vutuv_web/live/organization_live/domains.ex:181
+#: lib/vutuv_web/live/organization_live/show.ex:913
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr ""
@@ -11087,7 +11086,7 @@ msgstr ""
 msgid "Please log in first."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:796
+#: lib/vutuv_web/live/organization_live/show.ex:816
 #, elixir-autogen, elixir-format
 msgid "Prove you control %{domain} to publish this page."
 msgstr ""
@@ -11108,13 +11107,13 @@ msgstr ""
 msgid "Search engines"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:119
+#: lib/vutuv_web/components/organization_components.ex:221
 #, elixir-autogen, elixir-format
 msgid "Select a country"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:307
-#: lib/vutuv_web/live/organization_live/show.ex:858
+#: lib/vutuv_web/live/organization_live/domains.ex:321
+#: lib/vutuv_web/live/organization_live/show.ex:878
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr ""
@@ -11141,12 +11140,12 @@ msgid "The upload failed."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/new.ex:146
-#: lib/vutuv_web/live/organization_live/show.ex:811
+#: lib/vutuv_web/live/organization_live/show.ex:831
 #, elixir-autogen, elixir-format
 msgid "Verification method"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:771
+#: lib/vutuv_web/live/organization_live/show.ex:791
 #, elixir-autogen, elixir-format
 msgid "Verified domains"
 msgstr ""
@@ -11162,21 +11161,15 @@ msgstr ""
 msgid "Verified via %{domain}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:793
+#: lib/vutuv_web/live/organization_live/show.ex:813
 #, elixir-autogen, elixir-format
 msgid "Verify %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:320
-#: lib/vutuv_web/live/organization_live/show.ex:878
+#: lib/vutuv_web/live/organization_live/domains.ex:337
+#: lib/vutuv_web/live/organization_live/show.ex:903
 #, elixir-autogen, elixir-format
 msgid "Verify now"
-msgstr ""
-
-#: lib/vutuv_web/live/organization_live/domains.ex:149
-#: lib/vutuv_web/live/organization_live/show.ex:352
-#, elixir-autogen, elixir-format
-msgid "We could not find the record or file yet. It can take a while to propagate. Please try again."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:243
@@ -11187,9 +11180,9 @@ msgstr ""
 msgid "Website"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:249
-#: lib/vutuv_web/live/organization_live/domains.ex:298
-#: lib/vutuv_web/live/organization_live/show.ex:834
+#: lib/vutuv_web/live/organization_live/domains.ex:263
+#: lib/vutuv_web/live/organization_live/domains.ex:312
+#: lib/vutuv_web/live/organization_live/show.ex:854
 #: lib/vutuv_web/templates/url/verify.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Website file"
@@ -11210,8 +11203,8 @@ msgstr ""
 msgid "You will publish a record or file to prove control of the domain on the next step."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:309
-#: lib/vutuv_web/live/organization_live/show.ex:864
+#: lib/vutuv_web/live/organization_live/domains.ex:323
+#: lib/vutuv_web/live/organization_live/show.ex:884
 #: lib/vutuv_web/templates/url/verify.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
@@ -11222,13 +11215,13 @@ msgstr ""
 msgid "@handle or email"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:291
+#: lib/vutuv_web/components/organization_components.ex:393
 #: lib/vutuv_web/live/organization_live/edit.ex:390
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:236
+#: lib/vutuv_web/live/organization_live/domains.ex:250
 #, elixir-autogen, elixir-format
 msgid "Add a domain"
 msgstr ""
@@ -11243,7 +11236,7 @@ msgstr ""
 msgid "Added @%{handle} to the team."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:292
+#: lib/vutuv_web/components/organization_components.ex:394
 #: lib/vutuv_web/live/organization_live/edit.ex:388
 #, elixir-autogen, elixir-format
 msgid "Alias"
@@ -11262,7 +11255,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:358
 #: lib/vutuv_web/agent_docs/text.ex:381
 #: lib/vutuv_web/live/organization_live/edit.ex:353
-#: lib/vutuv_web/live/organization_live/show.ex:759
+#: lib/vutuv_web/live/organization_live/show.ex:779
 #: lib/vutuv_web/templates/tag/single_card.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Also known as"
@@ -11289,7 +11282,7 @@ msgstr ""
 msgid "Archived"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:290
+#: lib/vutuv_web/components/organization_components.ex:392
 #: lib/vutuv_web/live/organization_live/edit.ex:389
 #, elixir-autogen, elixir-format
 msgid "Brand"
@@ -11310,35 +11303,35 @@ msgstr ""
 msgid "Delete this page and everything it owns? This cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:60
+#: lib/vutuv_web/live/organization_live/domains.ex:64
 #, elixir-autogen, elixir-format
 msgid "Domain added. Publish the record or file, then verify it."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:129
+#: lib/vutuv_web/live/organization_live/domains.ex:138
 #, elixir-autogen, elixir-format
 msgid "Domain removed."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:97
+#: lib/vutuv_web/live/organization_live/domains.ex:107
 #, elixir-autogen, elixir-format
 msgid "Domain verified."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:216
+#: lib/vutuv_web/components/organization_components.ex:318
 #: lib/vutuv_web/live/admin/organization_live.ex:305
-#: lib/vutuv_web/live/organization_live/domains.ex:161
-#: lib/vutuv_web/live/organization_live/show.ex:510
+#: lib/vutuv_web/live/organization_live/domains.ex:175
+#: lib/vutuv_web/live/organization_live/show.ex:530
 #, elixir-autogen, elixir-format
 msgid "Domains"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:27
+#: lib/vutuv_web/live/organization_live/domains.ex:28
 #, elixir-autogen, elixir-format
 msgid "Domains – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:289
+#: lib/vutuv_web/components/organization_components.ex:391
 #, elixir-autogen, elixir-format
 msgid "Former name"
 msgstr ""
@@ -11355,7 +11348,7 @@ msgstr ""
 msgid "Freeze this page? It disappears for the public but stays visible to its owner."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:189
+#: lib/vutuv_web/live/organization_live/domains.ex:203
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "Last checked"
@@ -11376,7 +11369,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:220
+#: lib/vutuv_web/live/organization_live/domains.ex:234
 #, elixir-autogen, elixir-format
 msgid "Make primary"
 msgstr ""
@@ -11386,7 +11379,7 @@ msgstr ""
 msgid "Member removed."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:189
+#: lib/vutuv_web/live/organization_live/domains.ex:203
 #, elixir-autogen, elixir-format
 msgid "Method"
 msgstr ""
@@ -11401,27 +11394,27 @@ msgstr ""
 msgid "No member found for “%{id}”."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:114
+#: lib/vutuv_web/live/organization_live/domains.ex:123
 #, elixir-autogen, elixir-format
 msgid "Only a verified domain can be the primary one."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:175
+#: lib/vutuv_web/live/organization_live/domains.ex:189
 #, elixir-autogen, elixir-format
 msgid "Primary"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:110
+#: lib/vutuv_web/live/organization_live/domains.ex:119
 #, elixir-autogen, elixir-format
 msgid "Primary domain updated."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:278
+#: lib/vutuv_web/components/organization_components.ex:380
 #, elixir-autogen, elixir-format
 msgid "Recruiter"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:226
+#: lib/vutuv_web/live/organization_live/domains.ex:240
 #, elixir-autogen, elixir-format
 msgid "Remove this domain?"
 msgstr ""
@@ -11441,10 +11434,10 @@ msgstr ""
 msgid "Search name, alias or domain"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:213
+#: lib/vutuv_web/components/organization_components.ex:315
 #: lib/vutuv_web/live/admin/organization_live.ex:321
 #: lib/vutuv_web/live/organization_live/roles.ex:165
-#: lib/vutuv_web/live/organization_live/show.ex:503
+#: lib/vutuv_web/live/organization_live/show.ex:523
 #, elixir-autogen, elixir-format
 msgid "Team"
 msgstr ""
@@ -11454,7 +11447,7 @@ msgstr ""
 msgid "Team – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:71
+#: lib/vutuv_web/live/organization_live/domains.ex:75
 #, elixir-autogen, elixir-format
 msgid "That is not a valid domain."
 msgstr ""
@@ -11621,7 +11614,7 @@ msgstr ""
 msgid "%{min} to %{max} characters: letters (a-z), numbers (0-9) and underscores."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:647
+#: lib/vutuv_web/live/organization_live/show.ex:667
 #, elixir-autogen, elixir-format
 msgid "Former"
 msgstr ""
@@ -11672,12 +11665,12 @@ msgstr[1] ""
 msgid "Alternative names, brands or abbreviations this organization is findable under. A rename keeps the old name here automatically."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:163
+#: lib/vutuv_web/live/organization_live/domains.ex:177
 #, elixir-autogen, elixir-format
 msgid "An organization can prove several domains. The primary one shows in the “Verified via …” badge."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:136
+#: lib/vutuv_web/live/organization_live/domains.ex:145
 #, elixir-autogen, elixir-format
 msgid "An organization keeps at least one verified domain, so this one cannot be removed."
 msgstr ""
@@ -11701,7 +11694,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/index.ex:101
 #: lib/vutuv_web/live/organization_live/new.ex:28
 #: lib/vutuv_web/live/organization_live/new.ex:95
-#: lib/vutuv_web/templates/settings/organizations.html.heex:103
+#: lib/vutuv_web/templates/settings/organizations.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Add your organization"
 msgstr ""
@@ -11726,7 +11719,7 @@ msgstr ""
 msgid "The proof is a small technical change to your domain: a DNS entry or a file on your website. If you don't manage the website yourself, ask the person or team who does. That is usually your IT department or the company that runs your website. We show the exact instructions on the next step, so you can simply pass them on."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:805
+#: lib/vutuv_web/live/organization_live/show.ex:825
 #, elixir-autogen, elixir-format
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr ""
@@ -11853,7 +11846,7 @@ msgstr ""
 msgid "Organizations"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:146
+#: lib/vutuv_web/components/organization_components.ex:248
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:90
 #, elixir-autogen, elixir-format
 msgid "Please choose"
@@ -11874,7 +11867,7 @@ msgstr ""
 msgid "Search organizations"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:67
+#: lib/vutuv_web/live/organization_live/domains.ex:71
 #, elixir-autogen, elixir-format
 msgid "That domain already belongs to an organization page."
 msgstr ""
@@ -11894,7 +11887,7 @@ msgstr ""
 msgid "The organization page was deleted."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:364
+#: lib/vutuv_web/live/organization_live/show.ex:384
 #, elixir-autogen, elixir-format
 msgid "This organization page was reported and is hidden while it is reviewed. Only you and the moderators can see it."
 msgstr ""
@@ -11924,7 +11917,8 @@ msgstr ""
 msgid "Your organization handle is set."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:290
+#: lib/vutuv_web/live/organization_live/show.ex:300
+#: lib/vutuv_web/live/organization_live/show.ex:360
 #, elixir-autogen, elixir-format
 msgid "Your organization page is verified and now live."
 msgstr ""
@@ -12490,7 +12484,7 @@ msgstr ""
 msgid "You already have the maximum number of published postings."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:930
+#: lib/vutuv/notifications/emailer.ex:955
 #, elixir-autogen, elixir-format
 msgid "Your job posting on vutuv expires soon"
 msgstr ""
@@ -12500,17 +12494,17 @@ msgstr ""
 msgid "A domain of your organization page on vutuv is about to be dropped"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:202
+#: lib/vutuv_web/live/organization_live/domains.ex:216
 #, elixir-autogen, elixir-format
 msgid "Deadline"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:181
+#: lib/vutuv_web/live/organization_live/domains.ex:195
 #, elixir-autogen, elixir-format
 msgid "Proof missing"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:201
+#: lib/vutuv_web/live/organization_live/domains.ex:215
 #, elixir-autogen, elixir-format
 msgid "We could not read this domain's proof on the last check. Restore it and check again, or the domain loses its verification."
 msgstr ""
@@ -12520,7 +12514,7 @@ msgstr ""
 msgid "Your organization page on vutuv is about to lose its verification"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:851
+#: lib/vutuv/notifications/emailer.ex:876
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is no longer public"
 msgstr ""
@@ -12583,17 +12577,17 @@ msgid_plural "Your roles"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:98
+#: lib/vutuv_web/templates/settings/organizations.html.heex:113
 #, elixir-autogen, elixir-format
 msgid "Add an organization"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:100
+#: lib/vutuv_web/templates/settings/organizations.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "Represent a company, association or other group? Add its page and verify the domain to become its owner."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/organizations.html.heex:110
+#: lib/vutuv_web/templates/settings/organizations.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Browse all organizations"
 msgstr ""
@@ -12623,14 +12617,14 @@ msgstr ""
 msgid "Getting an error, or is %{host} a CNAME / alias to another address? A TXT record cannot share a name with a CNAME. Use this name instead, with the exact same value as above:"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:305
-#: lib/vutuv_web/live/organization_live/show.ex:851
+#: lib/vutuv_web/live/organization_live/domains.ex:319
+#: lib/vutuv_web/live/organization_live/show.ex:871
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:303
-#: lib/vutuv_web/live/organization_live/show.ex:842
+#: lib/vutuv_web/live/organization_live/domains.ex:317
+#: lib/vutuv_web/live/organization_live/show.ex:862
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
 msgstr ""
@@ -12726,7 +12720,7 @@ msgid "Minimum yearly salary"
 msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:324
-#: lib/vutuv_web/live/organization_live/show.ex:674
+#: lib/vutuv_web/live/organization_live/show.ex:694
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr ""
@@ -12755,7 +12749,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:436
 #: lib/vutuv_web/agent_docs/text.ex:445
 #: lib/vutuv_web/agent_docs/text.ex:457
-#: lib/vutuv_web/live/organization_live/show.ex:661
+#: lib/vutuv_web/live/organization_live/show.ex:681
 #: lib/vutuv_web/templates/tag/show.html.heex:69
 #, elixir-autogen, elixir-format
 msgid "Open positions"
@@ -13212,7 +13206,7 @@ msgstr ""
 msgid "Inherited from the organization"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:219
+#: lib/vutuv_web/components/organization_components.ex:321
 #: lib/vutuv_web/live/organization_live/exclusions.ex:103
 #, elixir-autogen, elixir-format
 msgid "Job exclusions"
@@ -14077,7 +14071,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:892
+#: lib/vutuv/notifications/emailer.ex:917
 #, elixir-autogen, elixir-format
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
@@ -19950,12 +19944,12 @@ msgstr ""
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:277
+#: lib/vutuv_web/components/organization_components.ex:379
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Editorial"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:283
+#: lib/vutuv_web/components/organization_components.ex:385
 #, elixir-autogen, elixir-format
 msgid "Edits the page and posts jobs."
 msgstr ""
@@ -19965,7 +19959,7 @@ msgstr ""
 msgid "Give members their roles on this page. Someone can hold several at once, and every role is granted on its own."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:282
+#: lib/vutuv_web/components/organization_components.ex:384
 #, elixir-autogen, elixir-format
 msgid "Manages the team and the domains, and edits the page."
 msgstr ""
@@ -19975,7 +19969,7 @@ msgstr ""
 msgid "Pick at least one role."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:285
+#: lib/vutuv_web/components/organization_components.ex:387
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Posts jobs."
 msgstr ""
@@ -19990,7 +19984,7 @@ msgstr ""
 msgid "Roles updated."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:284
+#: lib/vutuv_web/components/organization_components.ex:386
 #, elixir-autogen, elixir-format
 msgid "Writes posts in the organization's name."
 msgstr ""
@@ -20000,33 +19994,33 @@ msgstr ""
 msgid "The owner gives other members their roles on the page, and can hand ownership over to someone else at any time. Someone can hold several roles, and writing in the organization's name is always granted on its own."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:617
+#: lib/vutuv_web/live/organization_live/show.ex:637
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing published yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:599
+#: lib/vutuv_web/live/organization_live/show.ex:619
 #: lib/vutuv_web/live/post_live/composer.ex:1814
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:220
+#: lib/vutuv_web/live/organization_live/show.ex:225
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Published as %{name}."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:232
+#: lib/vutuv_web/live/organization_live/show.ex:237
 #, elixir-autogen, elixir-format
 msgid "That post could not be published."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:591
+#: lib/vutuv_web/live/organization_live/show.ex:611
 #, elixir-autogen, elixir-format
 msgid "Write something as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:226
+#: lib/vutuv_web/live/organization_live/show.ex:231
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr ""
@@ -20051,7 +20045,7 @@ msgstr ""
 msgid "Stopped writing as an organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:575
+#: lib/vutuv_web/live/organization_live/show.ex:595
 #, elixir-autogen, elixir-format
 msgid "Write as %{name} for now"
 msgstr ""
@@ -20273,12 +20267,12 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/fediverse.ex:88
 #: lib/vutuv_web/live/organization_live/new.ex:211
-#: lib/vutuv_web/live/organization_live/show.ex:727
+#: lib/vutuv_web/live/organization_live/show.ex:747
 #, elixir-autogen, elixir-format
 msgid "People who have no vutuv account can follow this page and read its posts, in networks like Mastodon."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:741
+#: lib/vutuv_web/live/organization_live/show.ex:761
 #, elixir-autogen, elixir-format
 msgid "Set this page up for other networks"
 msgstr ""
@@ -20293,7 +20287,7 @@ msgstr ""
 msgid "Switch it on"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:732
+#: lib/vutuv_web/live/organization_live/show.ex:752
 #, elixir-autogen, elixir-format
 msgid "The page gets an address of its own for that, written like an email address."
 msgstr ""
@@ -20544,4 +20538,70 @@ msgstr ""
 #: lib/vutuv_web/controllers/user_controller.ex:172
 #, elixir-autogen, elixir-format
 msgid "The gravatar.com lookup is switched off on this installation."
+msgstr ""
+
+#: lib/vutuv_web/components/organization_components.ex:165
+#, elixir-autogen, elixir-format
+msgid "A new entry can take a while to reach everyone. We keep checking %{domain} by ourselves and send you an email as soon as it works, so you can close this page."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/domains.ex:333
+#: lib/vutuv_web/live/organization_live/show.ex:899
+#, elixir-autogen, elixir-format
+msgid "Checking …"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/organizations.html.heex:97
+#, elixir-autogen, elixir-format
+msgid "Finish verification"
+msgstr ""
+
+#: lib/vutuv_web/components/organization_components.ex:152
+#, elixir-autogen, elixir-format
+msgid "It answered with HTTP status %{status}."
+msgstr ""
+
+#: lib/vutuv_web/components/organization_components.ex:149
+#, elixir-autogen, elixir-format
+msgid "It answered with an empty file."
+msgstr ""
+
+#: lib/vutuv_web/components/organization_components.ex:146
+#, elixir-autogen, elixir-format
+msgid "It answered, but with something else: %{found}"
+msgstr ""
+
+#: lib/vutuv_web/components/organization_components.ex:122
+#, elixir-autogen, elixir-format
+msgid "No TXT record at all."
+msgstr ""
+
+#: lib/vutuv_web/components/organization_components.ex:95
+#, elixir-autogen, elixir-format
+msgid "Not found yet"
+msgstr ""
+
+#: lib/vutuv_web/components/organization_components.ex:106
+#, elixir-autogen, elixir-format
+msgid "We asked the name servers of your domain directly, for %{names}, and looked for this value:"
+msgstr ""
+
+#: lib/vutuv_web/components/organization_components.ex:143
+#, elixir-autogen, elixir-format
+msgid "We could not reach that address at all."
+msgstr ""
+
+#: lib/vutuv_web/components/organization_components.ex:125
+#, elixir-autogen, elixir-format
+msgid "We fetched this address:"
+msgstr ""
+
+#: lib/vutuv_web/components/organization_components.ex:110
+#, elixir-autogen, elixir-format
+msgid "What is published there right now:"
+msgstr ""
+
+#: lib/vutuv/notifications/emailer.ex:856
+#, elixir-autogen, elixir-format
+msgid "Your organization page on vutuv is verified"
 msgstr ""

--- a/test/vutuv/dns_test.exs
+++ b/test/vutuv/dns_test.exs
@@ -1,0 +1,159 @@
+defmodule Vutuv.DnsTest do
+  @moduledoc """
+  `Vutuv.Dns` reads a TXT record from the zone's own authoritative name servers
+  instead of a caching resolver (issue #1466). Every test injects its own
+  backend module, so nothing here touches real DNS and the file stays async.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Vutuv.Dns
+
+  @token "vutuv-organization-verify=abc123"
+
+  # A backend whose answers are read from the test's own data. `ns` maps a zone
+  # name to its NS names, `a` an NS name to its addresses, and `txt` a
+  # {name, server_ip} pair to the authoritative answer.
+  defmodule Stub do
+    @behaviour Vutuv.Dns.Backend
+
+    @impl true
+    def lookup(name, :ns), do: get(:ns, name, [])
+    def lookup(name, :a), do: get(:a, name, [])
+    def lookup(name, :aaaa), do: get(:aaaa, name, [])
+    def lookup(name, :txt), do: get(:txt_resolver, name, [])
+
+    @impl true
+    def txt_at(name, [{ip, 53} | _]) do
+      record(:asked, {name, ip})
+      get(:txt, {name, ip}, {:error, :timeout})
+    end
+
+    def put(key, map), do: Process.put({__MODULE__, key}, map)
+
+    def asked, do: Process.get({__MODULE__, :asked}, []) |> Enum.reverse()
+
+    defp get(key, subject, default) do
+      Process.get({__MODULE__, key}, %{}) |> Map.get(subject, default)
+    end
+
+    defp record(key, value) do
+      Process.put({__MODULE__, key}, [value | Process.get({__MODULE__, key}, [])])
+    end
+  end
+
+  describe "zone_candidates/1" do
+    test "walks up the labels, deepest first, and never offers a bare TLD" do
+      assert Dns.zone_candidates("_vutuv.vutuv.de") == ["_vutuv.vutuv.de", "vutuv.de"]
+      assert Dns.zone_candidates("vutuv.de") == ["vutuv.de"]
+
+      assert Dns.zone_candidates("shop.eu.example.co.uk") == [
+               "shop.eu.example.co.uk",
+               "eu.example.co.uk",
+               "example.co.uk",
+               "co.uk"
+             ]
+    end
+
+    test "a single label has no zone to ask" do
+      assert Dns.zone_candidates("de") == []
+      assert Dns.zone_candidates("") == []
+    end
+  end
+
+  describe "txt_records/2 against the authoritative servers" do
+    test "asks the zone's own name servers and returns what they answer" do
+      Stub.put(:ns, %{"vutuv.de" => ["a.ns14.net"]})
+      Stub.put(:a, %{"a.ns14.net" => [{185, 132, 35, 160}]})
+      Stub.put(:txt, %{{"vutuv.de", {185, 132, 35, 160}} => {:ok, [[~c"#{@token}"]]}})
+
+      assert Dns.txt_records("vutuv.de", Stub) == [[~c"#{@token}"]]
+      assert Stub.asked() == [{"vutuv.de", {185, 132, 35, 160}}]
+    end
+
+    test "walks up to the parent zone for a name that is not delegated itself" do
+      Stub.put(:ns, %{"vutuv.de" => ["a.ns14.net"]})
+      Stub.put(:a, %{"a.ns14.net" => [{185, 132, 35, 160}]})
+      Stub.put(:txt, %{{"_vutuv.vutuv.de", {185, 132, 35, 160}} => {:ok, [[~c"#{@token}"]]}})
+
+      assert Dns.txt_records("_vutuv.vutuv.de", Stub) == [[~c"#{@token}"]]
+    end
+
+    test "keeps asking while one server is behind the others" do
+      Stub.put(:ns, %{"vutuv.de" => ["a.ns14.net", "b.ns14.net"]})
+      Stub.put(:a, %{"a.ns14.net" => [{1, 1, 1, 1}], "b.ns14.net" => [{2, 2, 2, 2}]})
+
+      Stub.put(:txt, %{
+        {"vutuv.de", {1, 1, 1, 1}} => {:ok, []},
+        {"vutuv.de", {2, 2, 2, 2}} => {:ok, [[~c"#{@token}"]]}
+      })
+
+      assert Dns.txt_records("vutuv.de", Stub) == [[~c"#{@token}"]]
+    end
+
+    test "an unreachable server does not end the round" do
+      Stub.put(:ns, %{"vutuv.de" => ["a.ns14.net", "b.ns14.net"]})
+      Stub.put(:a, %{"a.ns14.net" => [{1, 1, 1, 1}], "b.ns14.net" => [{2, 2, 2, 2}]})
+
+      Stub.put(:txt, %{
+        {"vutuv.de", {1, 1, 1, 1}} => {:error, :timeout},
+        {"vutuv.de", {2, 2, 2, 2}} => {:ok, [[~c"#{@token}"]]}
+      })
+
+      assert Dns.txt_records("vutuv.de", Stub) == [[~c"#{@token}"]]
+    end
+
+    test "an authoritative empty answer is trusted, so no cached answer creeps back in" do
+      Stub.put(:ns, %{"vutuv.de" => ["a.ns14.net"]})
+      Stub.put(:a, %{"a.ns14.net" => [{1, 1, 1, 1}]})
+      Stub.put(:txt, %{{"vutuv.de", {1, 1, 1, 1}} => {:ok, []}})
+      # A stale positive still sitting in the resolver cache must not be used.
+      Stub.put(:txt_resolver, %{"vutuv.de" => [[~c"#{@token}"]]})
+
+      assert Dns.txt_records("vutuv.de", Stub) == []
+    end
+
+    test "falls back to the resolver when no name server can be found" do
+      Stub.put(:txt_resolver, %{"vutuv.de" => [[~c"#{@token}"]]})
+
+      assert Dns.txt_records("vutuv.de", Stub) == [[~c"#{@token}"]]
+      assert Stub.asked() == []
+    end
+
+    test "falls back to the resolver when every name server is unreachable" do
+      Stub.put(:ns, %{"vutuv.de" => ["a.ns14.net"]})
+      Stub.put(:a, %{"a.ns14.net" => [{1, 1, 1, 1}]})
+      Stub.put(:txt, %{{"vutuv.de", {1, 1, 1, 1}} => {:error, :timeout}})
+      Stub.put(:txt_resolver, %{"vutuv.de" => [[~c"#{@token}"]]})
+
+      assert Dns.txt_records("vutuv.de", Stub) == [[~c"#{@token}"]]
+    end
+  end
+
+  describe "nameservers/2" do
+    test "refuses an internal address, so a hostile zone cannot point us inside" do
+      Stub.put(:ns, %{"evil.example" => ["ns.evil.example"]})
+
+      Stub.put(:a, %{
+        "ns.evil.example" => [{127, 0, 0, 1}, {10, 0, 0, 5}, {169, 254, 169, 254}, {9, 9, 9, 9}]
+      })
+
+      assert Dns.nameservers("evil.example", Stub) == [{{9, 9, 9, 9}, 53}]
+    end
+
+    test "takes IPv6 only when the name server has no IPv4 address" do
+      Stub.put(:ns, %{"example.org" => ["ns.example.org"]})
+      Stub.put(:aaaa, %{"ns.example.org" => [{0x2001, 0xDB8, 0, 0, 0, 0, 0, 1}]})
+
+      assert Dns.nameservers("example.org", Stub) == [{{0x2001, 0xDB8, 0, 0, 0, 0, 0, 1}, 53}]
+    end
+
+    test "asks at most a handful of servers, however many the zone lists" do
+      names = Enum.map(1..9, &"ns#{&1}.example.org")
+      Stub.put(:ns, %{"example.org" => names})
+      Stub.put(:a, Map.new(Enum.with_index(names, 1), fn {n, i} -> {n, [{9, 9, 9, i}]} end))
+
+      assert length(Dns.nameservers("example.org", Stub)) == 4
+    end
+  end
+end

--- a/test/vutuv/organization_pending_verification_test.exs
+++ b/test/vutuv/organization_pending_verification_test.exs
@@ -1,0 +1,146 @@
+defmodule Vutuv.OrganizationPendingVerificationTest do
+  @moduledoc """
+  Finishing a domain claim without clicking (issue #1466): the report a failed
+  check hands back, the clock every outcome stamps, and the background pass that
+  picks a pending domain up on its own.
+
+  `async: false` — the whole file holds `:verify_organization_domains` down and
+  swaps `:organizations_dns_resolver`, and both are read by every other
+  organization test in the suite.
+  """
+
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.Factory
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Organizations
+  alias Vutuv.Organizations.OrganizationDomain
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    owner = insert(:activated_user)
+
+    {:ok, %{organization: organization, domain: domain}} =
+      Organizations.create_pending_organization(owner, valid_organization_attrs(), "dns")
+
+    %{owner: owner, organization: organization, domain: domain}
+  end
+
+  # The zone answers, just not with our record — the shape that made the member
+  # in #1466 re-read a zone file that was already correct.
+  defp stub_other_records do
+    Application.put_env(:vutuv, :organizations_dns_resolver, fn _host ->
+      [[~c"v=spf1 mx -all"], [~c"google-site-verification=abc"]]
+    end)
+  end
+
+  describe "check_domain/2" do
+    test "reports every record it saw, so a wrong name is visible", ctx do
+      stub_other_records()
+
+      assert {:error, report} = Organizations.check_domain(ctx.organization, ctx.domain)
+      assert report.method == "dns"
+      assert "v=spf1 mx -all" in report.found
+      assert "google-site-verification=abc" in report.found
+      assert report.expected == Organizations.dns_txt_value(ctx.domain)
+      assert ctx.domain.domain in report.names
+      assert "_vutuv.#{ctx.domain.domain}" in report.names
+    end
+
+    test "stamps the clock on a failed check", ctx do
+      stub_other_records()
+      assert is_nil(ctx.domain.last_checked_at)
+
+      assert {:error, _report} = Organizations.check_domain(ctx.organization, ctx.domain)
+      assert Repo.get!(OrganizationDomain, ctx.domain.id).last_checked_at
+    end
+
+    test "activates the page on success", ctx do
+      stub_dns(ctx.domain.verification_token)
+
+      assert {:ok, organization} = Organizations.check_domain(ctx.organization, ctx.domain)
+      assert organization.status == "active"
+      assert Repo.get!(OrganizationDomain, ctx.domain.id).verified_at
+    end
+
+    test "is refused, and stamps nothing, while verification is off", ctx do
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      stub_dns(ctx.domain.verification_token)
+
+      assert {:error, report} = Organizations.check_domain(ctx.organization, ctx.domain)
+      assert report.disabled?
+      assert is_nil(Repo.get!(OrganizationDomain, ctx.domain.id).last_checked_at)
+    end
+  end
+
+  describe "pending_domains_due/1" do
+    test "a domain nobody has checked yet is due", ctx do
+      assert ctx.domain.id in Enum.map(Organizations.pending_domains_due(), & &1.id)
+    end
+
+    test "a domain checked a moment ago is not due again immediately", ctx do
+      stub_other_records()
+      {:error, _report} = Organizations.check_domain(ctx.organization, ctx.domain)
+
+      refute ctx.domain.id in Enum.map(Organizations.pending_domains_due(), & &1.id)
+    end
+
+    test "an old pending claim is given up on rather than checked forever", ctx do
+      long_ago =
+        NaiveDateTime.utc_now()
+        |> NaiveDateTime.truncate(:second)
+        |> NaiveDateTime.add(-400 * 86_400)
+
+      ctx.domain
+      |> Ecto.Changeset.change(inserted_at: long_ago, last_checked_at: long_ago)
+      |> Repo.update!()
+
+      refute ctx.domain.id in Enum.map(Organizations.pending_domains_due(), & &1.id)
+    end
+
+    test "an already verified domain belongs to the weekly re-check, not here", ctx do
+      stub_dns(ctx.domain.verification_token)
+      {:ok, _organization} = Organizations.check_domain(ctx.organization, ctx.domain)
+
+      refute ctx.domain.id in Enum.map(Organizations.pending_domains_due(), & &1.id)
+    end
+  end
+
+  describe "check_pending_domains/0" do
+    test "verifies the page and tells its owners", ctx do
+      stub_dns(ctx.domain.verification_token)
+      flush_emails()
+
+      assert Organizations.check_pending_domains() == 1
+      assert Organizations.get_organization!(ctx.organization.id).status == "active"
+
+      subjects = flush_emails() |> Enum.map(& &1.subject)
+      assert Enum.any?(subjects, &(&1 =~ "verifiziert" or &1 =~ "verified"))
+    end
+
+    test "a still-missing record leaves the domain out of the very next pass", ctx do
+      stub_other_records()
+
+      assert Organizations.check_pending_domains() == 0
+      # The starvation guard: an unworkable item must leave the due set, or it
+      # holds the front of every batch for ever (oldest-first ordering).
+      refute ctx.domain.id in Enum.map(Organizations.pending_domains_due(), & &1.id)
+      assert Organizations.get_organization!(ctx.organization.id).status == "pending"
+    end
+
+    test "does nothing at all while verification is off", ctx do
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      stub_dns(ctx.domain.verification_token)
+
+      assert Organizations.check_pending_domains() == 0
+      assert Organizations.get_organization!(ctx.organization.id).status == "pending"
+    end
+  end
+end

--- a/test/vutuv/web_verification_test.exs
+++ b/test/vutuv/web_verification_test.exs
@@ -112,6 +112,83 @@ defmodule Vutuv.WebVerificationTest do
     end
   end
 
+  describe "check reports (issue #1466)" do
+    test "the dns report names both queried names and every record it saw" do
+      resolver = fn _host -> [[~c"v=spf1 -all"], [~c"other=1"]] end
+
+      assert {:error, report} =
+               WebVerification.dns_check(
+                 "example.org",
+                 "vutuv-organization-verify=",
+                 "tok-123",
+                 resolver
+               )
+
+      assert report.method == "dns"
+      assert report.names == ["example.org", "_vutuv.example.org"]
+      assert report.expected == "vutuv-organization-verify=tok-123"
+      assert report.found == ["v=spf1 -all", "other=1"]
+    end
+
+    test "a hit on the bare host stops there, so the happy path stays one lookup" do
+      {:ok, agent} = Agent.start_link(fn -> [] end)
+
+      resolver = fn host ->
+        Agent.update(agent, &[host | &1])
+        [[~c"vutuv-organization-verify=tok-123"]]
+      end
+
+      assert {:ok, _report} =
+               WebVerification.dns_check(
+                 "example.org",
+                 "vutuv-organization-verify=",
+                 "tok-123",
+                 resolver
+               )
+
+      assert Agent.get(agent, & &1) == ["example.org"]
+    end
+
+    test "the well-known report separates a wrong body, a bad status and no answer at all" do
+      path = "/.well-known/vutuv-organization-verify.txt"
+
+      assert {:error, served} =
+               WebVerification.well_known_check(
+                 "example.org",
+                 path,
+                 "tok-123",
+                 adapter(200, "no")
+               )
+
+      assert served.status == 200
+      assert served.found == "no"
+      assert served.url == "https://example.org" <> path
+
+      assert {:error, missing} =
+               WebVerification.well_known_check("example.org", path, "tok-123", adapter(404, ""))
+
+      assert missing.status == 404
+
+      # No response at all — here because the SSRF guard refused to leave the
+      # machine, the same shape a DNS or TLS failure produces.
+      assert {:error, unreachable} =
+               WebVerification.well_known_check("localhost", path, "tok-123", adapter(200, "tok"))
+
+      assert is_nil(unreachable.status)
+    end
+
+    test "an answer with control characters is cut down to one printable line" do
+      path = "/.well-known/vutuv-organization-verify.txt"
+      body = "line one\nline two\r\n" <> String.duplicate("x", 400)
+
+      assert {:error, report} =
+               WebVerification.well_known_check("example.org", path, "tok", adapter(200, body))
+
+      refute report.found =~ "\n"
+      assert String.length(report.found) <= 160
+    end
+  end
+
   describe "rel_me_hrefs/1 (the parser)" do
     test "finds rel=me hrefs on <a> and <link>, any attribute order, any quotes" do
       html = """

--- a/test/vutuv_web/organization_verification_ux_test.exs
+++ b/test/vutuv_web/organization_verification_ux_test.exs
@@ -1,0 +1,181 @@
+defmodule VutuvWeb.OrganizationVerificationUxTest do
+  @moduledoc """
+  What the member sees while a domain claim is still open (issue #1466): the
+  report a failed check leaves on the page, the promise that something else is
+  looking too, and the way back to the panel from the settings hub.
+
+  `async: false` — the file holds `:verify_organization_domains` down and swaps
+  `:organizations_dns_resolver`, both read across the whole organization suite.
+  """
+
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Organizations
+  alias Vutuv.Organizations.Organization
+
+  @valid Vutuv.OrganizationsHelpers.valid_organization_attrs()
+
+  setup %{conn: conn} do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    {conn, user} = create_and_login_user(conn)
+
+    {:ok, %{organization: organization, domain: domain}} =
+      Organizations.create_pending_organization(user, @valid, "dns")
+
+    %{conn: conn, user: user, organization: organization, domain: domain}
+  end
+
+  defp stub_records(records) do
+    Application.put_env(:vutuv, :organizations_dns_resolver, fn _host -> records end)
+  end
+
+  describe "the verification panel" do
+    test "a failed check names what it looked for and what was there", ctx do
+      stub_records([[~c"v=spf1 mx -all"]])
+
+      {:ok, view, _html} = live(ctx.conn, ~p"/organizations/#{ctx.organization.slug}")
+      html = view |> element("#verify-domain") |> render_click()
+
+      assert html =~ "v=spf1 mx -all"
+      assert html =~ Organizations.dns_txt_value(ctx.domain)
+      assert has_element?(view, "#verify-domain-report")
+    end
+
+    test "an empty zone says so rather than saying nothing", ctx do
+      stub_records([])
+
+      {:ok, view, _html} = live(ctx.conn, ~p"/organizations/#{ctx.organization.slug}")
+      view |> element("#verify-domain") |> render_click()
+
+      assert view |> element("[data-check-found]") |> render() =~ "No TXT record"
+    end
+
+    # The reported bug: the first click showed a toast and every click after it
+    # looked like nothing at all, because an identical flash renders no diff.
+    # The report is an assign, so a second attempt always answers on the page.
+    test "a second attempt answers too, and answers with the new facts", ctx do
+      stub_records([[~c"v=spf1 mx -all"]])
+
+      {:ok, view, _html} = live(ctx.conn, ~p"/organizations/#{ctx.organization.slug}")
+      view |> element("#verify-domain") |> render_click()
+
+      stub_records([[~c"google-site-verification=abc"]])
+      html = view |> element("#verify-domain") |> render_click()
+
+      assert html =~ "google-site-verification=abc"
+      refute html =~ "v=spf1 mx -all"
+    end
+
+    test "the button says it is busy while the check runs", ctx do
+      {:ok, view, _html} = live(ctx.conn, ~p"/organizations/#{ctx.organization.slug}")
+
+      assert view |> element("#verify-domain") |> render() =~ "phx-disable-with"
+    end
+
+    test "the panel promises the background check, so the page can be closed", ctx do
+      {:ok, view, _html} = live(ctx.conn, ~p"/organizations/#{ctx.organization.slug}")
+
+      assert has_element?(view, "[data-check-reassurance]")
+    end
+
+    test "a successful check clears the report and publishes the page", ctx do
+      stub_dns(ctx.domain.verification_token)
+
+      {:ok, view, _html} = live(ctx.conn, ~p"/organizations/#{ctx.organization.slug}")
+      view |> element("#verify-domain") |> render_click()
+
+      refute has_element?(view, "#verify-domain-report")
+      assert Repo.get!(Organization, ctx.organization.id).status == "active"
+    end
+
+    test "an open page goes live by itself when the background pass finishes", ctx do
+      {:ok, view, _html} = live(ctx.conn, ~p"/organizations/#{ctx.organization.slug}")
+      assert has_element?(view, "#verify-domain")
+
+      stub_dns(ctx.domain.verification_token)
+      assert Organizations.check_pending_domains() == 1
+
+      # No reload, no click: the pass broadcasts on the page's own topic, and
+      # this render is the round trip that lets the view handle it.
+      assert render(view) =~ ctx.organization.name
+      refute has_element?(view, "#verify-domain")
+    end
+  end
+
+  # `mix gettext.extract --merge` fuzzy-filled three of these from unrelated
+  # strings: "Finish verification" came back as "Prüfung ausstehend" (the status
+  # label) and the mail subject "…is verified" as "…ist nicht mehr öffentlich"
+  # (is no longer public), the exact opposite of what it announces. Nothing
+  # fails the build on a fuzzy entry, so the German is asserted by name.
+  describe "the German rendering" do
+    test "the panel explains itself in German", ctx do
+      stub_records([[~c"v=spf1 mx -all"]])
+
+      {:ok, view, _html} =
+        ctx.conn
+        |> Phoenix.ConnTest.recycle()
+        |> Plug.Conn.put_req_header("accept-language", "de-DE,de")
+        |> live(~p"/organizations/#{ctx.organization.slug}")
+
+      html = view |> element("#verify-domain") |> render_click()
+
+      assert html =~ "Noch nicht gefunden"
+      assert html =~ "Was dort im Moment veröffentlicht ist:"
+      assert html =~ "Wird geprüft …"
+      assert html =~ "schicken Ihnen eine E-Mail"
+    end
+
+    test "the settings hub names the remaining step in German", ctx do
+      html =
+        ctx.conn
+        |> Phoenix.ConnTest.recycle()
+        |> Plug.Conn.put_req_header("accept-language", "de-DE,de")
+        |> get(~p"/settings/organizations")
+        |> html_response(200)
+
+      assert html =~ "Verifizierung abschließen"
+    end
+
+    test "the background pass announces a page that is live, not one that is gone", ctx do
+      # The mail follows the owner's own locale, not the request's — nobody is
+      # making a request when this one is sent.
+      ctx.user |> Ecto.Changeset.change(locale: "de") |> Repo.update!()
+      stub_dns(ctx.domain.verification_token)
+      flush_emails()
+
+      assert Organizations.check_pending_domains() == 1
+
+      assert Enum.any?(flush_emails(), fn email ->
+               email.subject == "Ihre Organisationsseite auf vutuv ist verifiziert"
+             end)
+    end
+  end
+
+  describe "finding the way back" do
+    test "the settings hub offers the pending page its one remaining step", ctx do
+      html = ctx.conn |> get(~p"/settings/organizations") |> html_response(200)
+
+      assert html =~ "data-finish-verification"
+      assert html =~ ~s(/organizations/#{ctx.organization.slug}")
+    end
+
+    test "an active page gets the plain manage link instead", ctx do
+      stub_dns(ctx.domain.verification_token)
+      {:ok, _organization} = Organizations.check_domain(ctx.organization, ctx.domain)
+
+      html = ctx.conn |> get(~p"/settings/organizations") |> html_response(200)
+
+      refute html =~ "data-finish-verification"
+      assert html =~ ~s(/organizations/#{ctx.organization.slug}/edit")
+    end
+  end
+end


### PR DESCRIPTION
Behebt #1466.

**Ursache.** Der TXT-Eintrag wurde über den Resolver gelesen. Eine Prüfung läuft aber fast immer, *bevor* der Eintrag existiert (man muss den Wert erst von der Seite abschreiben), also liegt danach das Negativ-Ergebnis für die Negative-TTL der Zone im Cache. Eine kurze TTL auf dem neuen Eintrag ändert daran nichts.

**Was jetzt anders ist:**

- `Vutuv.Dns` fragt die Namensserver der Zone direkt (tiefster Vorfahr mit NS-Records, alle Server, Antwort ohne `aa`-Bit wird verworfen, interne NS-Adressen fallen raus). Ohne Zone bleibt der Resolver als Rückfall.
- Der neue `PendingDomainSweeper` prüft eine wartende Domain auf einer Backoff-Leiter selbst nach (2 Min. in der ersten Viertelstunde, dann flacher, nach 30 Tagen aufgegeben) und mailt die Eigentümer, sobald es klappt. Eine offene Seite geht per PubSub ohne Reload live.
- Statt des Toasts, der ab dem zweiten Klick keinen Diff mehr erzeugte, steht das Ergebnis als Bericht auf der Seite: gefragte Namen, gesuchter Wert, tatsächlich gefundene Einträge. Der Knopf hat ein `phx-disable-with`.
- `/settings/organizations` zeigt für eine wartende Seite „Verifizierung abschließen" statt „Verwalten".

Gegen die echte Zone geprüft (vutuv.de, vier Namensserver) und im Browser durchgespielt.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*

https://claude.ai/code/session_01QC39HDeY942k8GxS5L4b9z