### PR TITLE
Auch der Link-Nachweis sagt jetzt, was er gesehen hat (v7.291.0)

### DIFF
--- a/docs/architecture/organizations.md
+++ b/docs/architecture/organizations.md
@@ -208,12 +208,22 @@ optimisation, it is the difference between the feature working and not:
   likely to succeed.
 
 The panel reports what the check actually read (`WebVerification.dns_check/4` /
-`well_known_check/4` → `OrganizationComponents.check_report/1`): the names
+`well_known_check/4` → `VerificationComponents.check_report/1`): the names
 queried, the value wanted, and every TXT record found there. A member whose SPF
 record is listed back at them can see in one line that the proof went to the
 wrong name, which "not found yet, please try again" never told them. That block
 is an assign and not a flash on purpose — an identical flash renders no diff, so
 the old toast made every attempt after the first look like a dead button.
+
+`Organizations.check_domain/2` is the **only** way to run a domain's proof. It
+used to have a twin (`verify_domain/2` and its per-method variants) that
+answered a bare `{:error, :not_found}` and stamped nothing; two entry points for
+one question is how the next caller silently gets no report and no
+`last_checked_at`, which the background pass reads to back off. The report
+component is shared with the personal-webpage link proofs (`profiles.md`) — same
+question, same answer, one rendering — and each caller passes its own
+`disabled_text`, since "domain verification" and "link verification" are
+separate installation switches.
 
 ### Who hears about a failing proof
 

--- a/docs/architecture/profiles.md
+++ b/docs/architecture/profiles.md
@@ -873,6 +873,22 @@ Three methods, the member's choice on the owner-only page at
   (the `_dmarc` / `_acme-challenge` convention, RFC 8552, never a CNAME target)
   gives such a member a place to publish it (issue #947).
 
+`LinkVerification.check/3` is the single entry point, and like its organization
+twin it **says what it saw** when the proof is not there (issue #1466):
+`{:error, report}` naming what was queried, what was wanted and what was
+actually published, rendered by the shared `VerificationComponents.check_report/1`
+under the very button that produced it. The DNS half reads the zone's own name
+servers (`Vutuv.Dns`, so a cached negative answer cannot hold up a record that
+is already correct) — the same lookup organizations use, through the same
+resolver seam. The rel=me report lists the `rel="me"` links the page *does*
+carry, which is usually the whole diagnosis: a page that already points at a
+GitHub or Mastodon profile and simply does not name this one yet. A failed check
+therefore **renders** the verification page instead of redirecting to it (a
+flash cannot carry a report), and deliberately does not touch `last_checked_at`
+— that column drives the weekly re-check schedule, so a hand check must not be
+able to push it out. Unlike a pending organization domain there is no background
+retry for an unverified link, so the page promises none.
+
 State lives on the `urls` row (`verification_method`, `verification_token`,
 `verified_at`, `last_checked_at`, `grace_deadline_at`) — per-link and independent,
 with **no** uniqueness constraint (unlike organization domains: two members may each

--- a/lib/vutuv/organizations.ex
+++ b/lib/vutuv/organizations.ex
@@ -1083,39 +1083,10 @@ defmodule Vutuv.Organizations do
   @doc "Whether domain verification (DNS TXT + well-known) is enabled for this install."
   def verification_enabled?, do: Verification.enabled?()
 
-  @doc "Runs the domain's current verification method; on success activates the organization."
-  def verify_domain(%Organization{} = organization, %OrganizationDomain{method: "dns"} = domain),
-    do: verify_dns(organization, domain)
-
-  def verify_domain(
-        %Organization{} = organization,
-        %OrganizationDomain{method: "well_known"} = domain
-      ),
-      do: verify_well_known(organization, domain)
-
   @doc "Switches a pending domain between the DNS and well-known methods (same token)."
   def set_domain_method(%OrganizationDomain{} = domain, method)
       when method in ~w(dns well_known) do
     domain |> Ecto.Changeset.change(method: method) |> Repo.update()
-  end
-
-  @doc "Verifies a DNS domain; on success activates the organization."
-  def verify_dns(%Organization{} = organization, %OrganizationDomain{method: "dns"} = domain),
-    do: do_verify(organization, domain, &Verification.dns_verified?/2)
-
-  @doc "Verifies a well-known-file domain; on success activates the organization."
-  def verify_well_known(
-        %Organization{} = organization,
-        %OrganizationDomain{method: "well_known"} = domain
-      ),
-      do: do_verify(organization, domain, &Verification.well_known_verified?/2)
-
-  defp do_verify(%Organization{} = organization, %OrganizationDomain{} = domain, check) do
-    if verification_enabled?() and check.(domain.domain, domain.verification_token) do
-      activate(organization, domain)
-    else
-      {:error, :not_found}
-    end
   end
 
   @doc """
@@ -1124,9 +1095,11 @@ defmodule Vutuv.Organizations do
   names queried, the value we wanted and the records actually found — the
   difference between "not yet" and "you published it one label too deep".
 
-  It also stamps `last_checked_at` on a failure, which `verify_domain/2` never
-  did, so a pending domain can say when it was last looked at and the background
-  pass can back off from it.
+  This is the **only** way to run a domain's proof. It replaced a second
+  entry point (`verify_domain/2` and its per-method twins) that answered a bare
+  `{:error, :not_found}` and stamped nothing: two functions for one question is
+  how the next caller silently gets no report and no `last_checked_at`, which
+  the background pass reads to back off.
 
   `report.disabled?` marks the one case that is not about the domain at all:
   domain verification is switched off on this installation.

--- a/lib/vutuv/profiles/link_verification.ex
+++ b/lib/vutuv/profiles/link_verification.ex
@@ -84,32 +84,61 @@ defmodule Vutuv.Profiles.LinkVerification do
   def well_known_content(%Url{verification_token: token}), do: token
 
   @doc """
-  Verifies that `url` is `user`'s webpage via `method`. On success stamps the
-  method and timestamps and returns `{:ok, url}`. Returns `{:error, :not_found}`
-  when the proof is not present (yet) and `{:error, :disabled}` when link
-  verification is off on this installation.
+  Verifies that `url` is `user`'s webpage via `method` and **says what it saw**
+  (issue #1466). On success stamps the method and timestamps and returns
+  `{:ok, url}`; otherwise `{:error, report}` naming what was queried, what was
+  wanted and what was actually there.
+
+  A flat "we could not find the proof yet, please try again" leaves a member
+  re-reading their own zone file or page source with nothing to compare against,
+  which is what #1466 described doing for the organization half of this. The
+  report is the same shape the organization verification panel shows
+  (`Vutuv.Organizations.check_domain/2`), plus `disabled?` for the one case that
+  is not about the page at all: link verification is off on this installation.
+
+  It deliberately does **not** stamp `last_checked_at`. That column drives the
+  weekly re-check sweeper's schedule, so writing it here would let a member push
+  their own link's re-check out by pressing a button.
   """
-  def verify(%Url{} = url, %User{} = user, method) when method in ~w(rel_me dns well_known) do
-    cond do
-      not enabled?() -> {:error, :disabled}
-      proof_present?(url, user, method) -> mark_verified(url, method)
-      true -> {:error, :not_found}
+  def check(%Url{} = url, %User{} = user, method) when method in ~w(rel_me dns well_known) do
+    if enabled?() do
+      # Minting the token here is what keeps the report renderable: without one
+      # the two domain methods fall through to `run_check/3`'s last clause,
+      # whose report carries none of the fields the panel prints. That is a
+      # KeyError in the view rather than a message, so the shape is guaranteed
+      # at the door instead of guarded at every reader.
+      url = ensure_token(url)
+
+      case run_check(url, user, method) do
+        {:ok, _report} -> mark_verified(url, method)
+        {:error, report} -> {:error, Map.put(report, :disabled?, false)}
+      end
+    else
+      {:error, %{method: method, disabled?: true}}
     end
   end
 
-  defp proof_present?(%Url{} = url, %User{} = user, "rel_me"),
-    do: WebVerification.rel_me_verified?(url.value, profile_urls(user), req_options())
+  # The single proof dispatch: `check/3` shows the report, `recheck/1` only needs
+  # the verdict. Deriving the boolean from the report rather than calling the
+  # `*_verified?` twins keeps the two from ever disagreeing about the same page.
+  defp run_check(%Url{} = url, %User{} = user, "rel_me"),
+    do: WebVerification.rel_me_check(url.value, profile_urls(user), req_options())
 
-  defp proof_present?(%Url{verification_token: token, value: value}, _user, "dns")
+  defp run_check(%Url{verification_token: token, value: value}, _user, "dns")
        when is_binary(token),
-       do: WebVerification.dns_verified?(host(value), @dns_prefix, token, dns_resolver())
+       do: WebVerification.dns_check(host(value), @dns_prefix, token, dns_resolver())
 
-  defp proof_present?(%Url{verification_token: token, value: value}, _user, "well_known")
+  defp run_check(%Url{verification_token: token, value: value}, _user, "well_known")
        when is_binary(token),
-       do:
-         WebVerification.well_known_verified?(host(value), @well_known_path, token, req_options())
+       do: WebVerification.well_known_check(host(value), @well_known_path, token, req_options())
 
-  defp proof_present?(_url, _user, _method), do: false
+  # A link with no token yet cannot carry a DNS / well-known proof at all. Only
+  # `proof_present?/2` can reach this — `check/3` mints the token first — so the
+  # verdict is all this has to answer; it is never rendered.
+  defp run_check(_url, _user, method), do: {:error, %{method: method, found: nil}}
+
+  defp proof_present?(%Url{} = url, %User{} = user, method),
+    do: match?({:ok, _report}, run_check(url, user, method))
 
   defp mark_verified(%Url{} = url, method) do
     now = now()

--- a/lib/vutuv/web_verification.ex
+++ b/lib/vutuv/web_verification.ex
@@ -191,16 +191,47 @@ defmodule Vutuv.WebVerification do
   """
   def rel_me_verified?(url, expected_urls, req_options)
       when is_binary(url) and is_list(expected_urls) do
+    match?({:ok, _report}, rel_me_check(url, expected_urls, req_options))
+  end
+
+  @doc """
+  The `rel_me` check plus a report of what the fetch actually got: the URL, the
+  HTTP status, the back-link we wanted and **every** `rel="me"` link the page
+  carries.
+
+  Listing the links that are there is the diagnosis. `rel="me"` is a set, not a
+  single value, and the common failure is a page that already points at a
+  GitHub or Mastodon profile and simply does not name this one yet — which
+  reads as "verification is broken" until somebody says what was on the page.
+  """
+  def rel_me_check(url, expected_urls, req_options)
+      when is_binary(url) and is_list(expected_urls) do
     with %URI{host: host} when is_binary(host) <- URI.parse(url),
          {:ok, body} <- fetch(url, host, req_options, @max_html_bytes, "text/html") do
       wanted = MapSet.new(expected_urls, &normalize_url/1)
+      hrefs = rel_me_hrefs(body)
+      report = rel_me_report(url, expected_urls, 200, Enum.map(hrefs, &excerpt/1))
 
-      body
-      |> rel_me_hrefs()
-      |> Enum.any?(&MapSet.member?(wanted, normalize_url(&1)))
+      if Enum.any?(hrefs, &MapSet.member?(wanted, normalize_url(&1))),
+        do: {:ok, report},
+        else: {:error, report}
     else
-      _ -> false
+      {:error, {:status, status}} ->
+        {:error, rel_me_report(url, expected_urls, status, [])}
+
+      _ ->
+        {:error, rel_me_report(url, expected_urls, nil, [])}
     end
+  end
+
+  defp rel_me_report(url, expected_urls, status, found) do
+    %{
+      method: "rel_me",
+      url: url,
+      status: status,
+      expected: expected_urls,
+      found: Enum.uniq(found)
+    }
   end
 
   @tag_regex ~r/<(?:a|link)\b[^>]*>/i

--- a/lib/vutuv_web/components/organization_components.ex
+++ b/lib/vutuv_web/components/organization_components.ex
@@ -10,7 +10,7 @@ defmodule VutuvWeb.OrganizationComponents do
   use Gettext, backend: VutuvWeb.Gettext
 
   import VutuvWeb.ErrorHelpers
-  import VutuvWeb.UI, only: [input_class: 2, local_time: 1]
+  import VutuvWeb.UI, only: [input_class: 2]
 
   alias Vutuv.Countries
   alias Vutuv.Organizations.Organization
@@ -64,92 +64,6 @@ defmodule VutuvWeb.OrganizationComponents do
     </span>
     """
   end
-
-  attr(:report, :map, default: nil)
-  attr(:id, :string, required: true)
-
-  @doc """
-  What the last domain check actually saw (issue #1466).
-
-  A failed check used to answer with one auto-dismissing toast reading "not
-  found yet, please try again", and a second attempt with the identical message
-  produced no diff at all — so from the second click on, the button looked
-  broken. This block replaces that: it stays on the page until the next attempt
-  replaces it, and it names the value we wanted, where we looked and what was
-  there instead, which is usually the whole diagnosis (a record on the wrong
-  name, a stray quote, a zone that is not the live one).
-
-  Slate rather than red or amber: a proof that has not propagated yet is the
-  ordinary case, not a mistake the member made, and amber belongs to moderation.
-  """
-  def check_report(assigns) do
-    ~H"""
-    <div
-      :if={@report}
-      id={@id}
-      data-check-report
-      role="status"
-      class="mt-3 rounded-lg bg-white p-4 text-sm ring-1 ring-slate-200 dark:bg-slate-900 dark:ring-slate-700"
-    >
-      <p class="font-semibold text-slate-900 dark:text-slate-100">
-        {gettext("Not found yet")} &middot;
-        <.local_time at={@report.checked_at} id={"#{@id}-time"} format="%H:%M" />
-      </p>
-
-      <%= cond do %>
-        <% @report[:disabled?] -> %>
-          <p class="mt-2 text-slate-700 dark:text-slate-300">
-            {gettext("Domain verification is disabled on this installation.")}
-          </p>
-        <% @report.method == "dns" -> %>
-          <p class="mt-2 text-slate-700 dark:text-slate-300">
-            {gettext("We asked the name servers of your domain directly, for %{names}, and looked for this value:", names: Enum.join(@report.names, ", "))}
-          </p>
-          <code phx-no-curly-interpolation class={code_class()}><%= @report.expected %></code>
-          <p class="mt-3 text-slate-700 dark:text-slate-300">
-            {gettext("What is published there right now:")}
-          </p>
-          <ul :if={@report.found != []} data-check-found class="mt-1 space-y-1">
-            <li :for={record <- @report.found}>
-              <code phx-no-curly-interpolation class={code_class()}><%= record %></code>
-            </li>
-          </ul>
-          <p
-            :if={@report.found == []}
-            data-check-found
-            class="mt-1 text-slate-600 dark:text-slate-400"
-          >
-            {gettext("No TXT record at all.")}
-          </p>
-        <% true -> %>
-          <p class="mt-2 text-slate-700 dark:text-slate-300">{gettext("We fetched this address:")}</p>
-          <code phx-no-curly-interpolation class={code_class()}><%= @report.url %></code>
-          <p class="mt-3 text-slate-700 dark:text-slate-300" data-check-found>
-            {well_known_outcome(@report)}
-          </p>
-      <% end %>
-    </div>
-    """
-  end
-
-  defp code_class do
-    "mt-1 block overflow-x-auto rounded bg-slate-50 px-3 py-2 font-mono text-xs text-slate-900 dark:bg-slate-800 dark:text-slate-100"
-  end
-
-  # The one sentence saying what came back from the file fetch. `status: nil`
-  # means there was no response at all, which is a different problem from a 404
-  # and has to read as one.
-  defp well_known_outcome(%{status: nil}),
-    do: gettext("We could not reach that address at all.")
-
-  defp well_known_outcome(%{status: 200, found: found}) when is_binary(found) and found != "",
-    do: gettext("It answered, but with something else: %{found}", found: found)
-
-  defp well_known_outcome(%{status: 200}),
-    do: gettext("It answered with an empty file.")
-
-  defp well_known_outcome(%{status: status}),
-    do: gettext("It answered with HTTP status %{status}.", status: status)
 
   attr(:domain, :string, required: true)
 

--- a/lib/vutuv_web/components/verification_components.ex
+++ b/lib/vutuv_web/components/verification_components.ex
@@ -1,0 +1,157 @@
+defmodule VutuvWeb.VerificationComponents do
+  @moduledoc """
+  What a web-proof check actually saw (issue #1466), shared by the two things
+  that run one: an organization proving a domain
+  (`Vutuv.Organizations.check_domain/2`) and a member proving a profile link is
+  their own webpage (`Vutuv.Profiles.LinkVerification.check/3`).
+
+  It is one component because it is one question. A failed check used to answer
+  with a single sentence — "not found yet, please try again" — which leaves the
+  member re-reading their own zone file or page source with nothing to compare
+  against, and on the organization page, where the sentence was an
+  auto-dismissing toast, a second attempt with the identical message produced no
+  DOM diff at all, so from the second click on the button looked broken. This
+  block stays on the page until the next attempt replaces it, and it names the
+  value we wanted, where we looked and what was there instead, which is usually
+  the whole diagnosis: a record on the wrong name, a stray quote, a rel=me
+  link pointing at a different profile, a zone that is not the live one.
+
+  Slate rather than red or amber: a proof that has not propagated yet is the
+  ordinary case, not a mistake the member made, and amber belongs to moderation.
+
+  Not globally imported — `import VutuvWeb.VerificationComponents` at the call
+  site.
+  """
+
+  use Phoenix.Component
+
+  use Gettext, backend: VutuvWeb.Gettext
+
+  import VutuvWeb.UI, only: [local_time: 1]
+
+  @doc """
+  Stamps the moment a check ran onto its report, so the panel can say when it
+  last looked.
+
+  The domain's own `last_checked_at` is a different clock — it belongs to the
+  background sweeper's schedule — and a link's is not written by a hand check at
+  all, so the answer on screen carries its own.
+  """
+  def stamp(report) when is_map(report) do
+    Map.put(report, :checked_at, NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second))
+  end
+
+  attr(:report, :map, default: nil)
+  attr(:id, :string, required: true)
+
+  attr(:disabled_text, :string,
+    required: true,
+    doc: "what to say when verification is off on this installation"
+  )
+
+  @doc """
+  Renders one check report. Renders nothing without one.
+
+  `checked_at` is optional: a LiveView panel that replaces the report in place
+  needs the time to show that anything happened at all, while a page that was
+  just reloaded to show it does not.
+  """
+  def check_report(assigns) do
+    ~H"""
+    <div
+      :if={@report}
+      id={@id}
+      data-check-report
+      role="status"
+      class="mt-3 rounded-lg bg-white p-4 text-sm ring-1 ring-slate-200 dark:bg-slate-900 dark:ring-slate-700"
+    >
+      <p class="font-semibold text-slate-900 dark:text-slate-100">
+        {gettext("Not found yet")}
+        <span :if={@report[:checked_at]}>
+          &middot; <.local_time at={@report.checked_at} id={"#{@id}-time"} format="%H:%M" />
+        </span>
+      </p>
+
+      <%= cond do %>
+        <% @report[:disabled?] -> %>
+          <p class="mt-2 text-slate-700 dark:text-slate-300">{@disabled_text}</p>
+        <% @report.method == "dns" -> %>
+          <p class="mt-2 text-slate-700 dark:text-slate-300">
+            {gettext("We asked the name servers of your domain directly, for %{names}, and looked for this value:", names: Enum.join(@report.names, ", "))}
+          </p>
+          <code phx-no-curly-interpolation class={code_class()}><%= @report.expected %></code>
+          <p class="mt-3 text-slate-700 dark:text-slate-300">
+            {gettext("What is published there right now:")}
+          </p>
+          <ul :if={@report.found != []} data-check-found class="mt-1 space-y-1">
+            <li :for={record <- @report.found}>
+              <code phx-no-curly-interpolation class={code_class()}><%= record %></code>
+            </li>
+          </ul>
+          <p
+            :if={@report.found == []}
+            data-check-found
+            class="mt-1 text-slate-600 dark:text-slate-400"
+          >
+            {gettext("No TXT record at all.")}
+          </p>
+        <% @report.method == "rel_me" -> %>
+          <p class="mt-2 text-slate-700 dark:text-slate-300">
+            {gettext("We fetched your page and looked for a link back to:")}
+          </p>
+          <code phx-no-curly-interpolation class={code_class()}><%= Enum.join(@report.expected, " ") %></code>
+          <p class="mt-3 text-slate-700 dark:text-slate-300" data-check-found>
+            {rel_me_outcome(@report)}
+          </p>
+          <ul :if={@report.found != []} class="mt-1 space-y-1">
+            <li :for={href <- @report.found}>
+              <code phx-no-curly-interpolation class={code_class()}><%= href %></code>
+            </li>
+          </ul>
+        <% true -> %>
+          <p class="mt-2 text-slate-700 dark:text-slate-300">{gettext("We fetched this address:")}</p>
+          <code phx-no-curly-interpolation class={code_class()}><%= @report.url %></code>
+          <p class="mt-3 text-slate-700 dark:text-slate-300" data-check-found>
+            {well_known_outcome(@report)}
+          </p>
+      <% end %>
+    </div>
+    """
+  end
+
+  defp code_class do
+    "mt-1 block overflow-x-auto rounded bg-slate-50 px-3 py-2 font-mono text-xs text-slate-900 dark:bg-slate-800 dark:text-slate-100"
+  end
+
+  # The one sentence saying what came back from the file fetch. `status: nil`
+  # means there was no response at all, which is a different problem from a 404
+  # and has to read as one.
+  defp well_known_outcome(%{status: nil}),
+    do: gettext("We could not reach that address at all.")
+
+  defp well_known_outcome(%{status: 200, found: found}) when is_binary(found) and found != "",
+    do: gettext("It answered, but with something else: %{found}", found: found)
+
+  defp well_known_outcome(%{status: 200}),
+    do: gettext("It answered with an empty file.")
+
+  defp well_known_outcome(%{status: status}),
+    do: gettext("It answered with HTTP status %{status}.", status: status)
+
+  # The same three cases for the back-link method, plus the one that is special
+  # to it: the page answered and carries rel=me links, just not this one. Naming
+  # them is the diagnosis — a page usually already points at a GitHub or Mastodon
+  # profile, and seeing that list beside the wanted address is what tells the
+  # member their markup works and only the address is wrong.
+  defp rel_me_outcome(%{status: nil}),
+    do: gettext("We could not reach your page at all.")
+
+  defp rel_me_outcome(%{status: 200, found: []}),
+    do: gettext("Your page has no rel=\"me\" link at all yet.")
+
+  defp rel_me_outcome(%{status: 200}),
+    do: gettext("Your page does link back, but somewhere else:")
+
+  defp rel_me_outcome(%{status: status}),
+    do: gettext("Your page answered with HTTP status %{status}.", status: status)
+end

--- a/lib/vutuv_web/controllers/url_controller.ex
+++ b/lib/vutuv_web/controllers/url_controller.ex
@@ -126,21 +126,18 @@ defmodule VutuvWeb.UrlController do
       |> ControllerHelpers.get_owned!(:urls, id)
       |> LinkVerification.ensure_token()
 
-    render(conn, "verify.html",
-      url: url,
-      enabled?: LinkVerification.enabled?(),
-      profile_url: LinkVerification.profile_urls(conn.assigns[:user]) |> List.first(),
-      host: URI.parse(url.value).host,
-      dns_value: LinkVerification.dns_txt_value(url),
-      dns_challenge_name: LinkVerification.dns_challenge_name(url),
-      well_known_url: LinkVerification.well_known_url(url),
-      well_known_content: LinkVerification.well_known_content(url),
-      page_title: gettext("Verify link")
-    )
+    render_verify(conn, url)
   end
 
   def run_verify(conn, %{"id" => id} = params) do
-    url = ControllerHelpers.get_owned!(conn, :urls, id)
+    # The token is minted by the GET, but a failed check now re-renders the
+    # instructions, which quote it — so mint it here too rather than relying on
+    # whoever posted having loaded the page first.
+    url =
+      conn
+      |> ControllerHelpers.get_owned!(:urls, id)
+      |> LinkVerification.ensure_token()
+
     method = params["method"]
     user = conn.assigns[:user]
 
@@ -152,26 +149,35 @@ defmodule VutuvWeb.UrlController do
   end
 
   defp handle_verify(conn, url, user, method) do
-    case LinkVerification.verify(url, user, method) do
+    case LinkVerification.check(url, user, method) do
       {:ok, _url} ->
         conn
         |> put_flash(:info, gettext("Link verified. It now shows a verified mark."))
         |> redirect(to: ~p"/settings/links")
 
-      {:error, :disabled} ->
-        conn
-        |> put_flash(:error, gettext("Link verification is disabled on this installation."))
-        |> redirect(to: ~p"/settings/links/#{url}/verify")
-
-      {:error, :not_found} ->
-        conn
-        |> put_flash(
-          :error,
-          gettext(
-            "We could not find the proof yet. It can take a while to propagate. Please try again."
-          )
-        )
-        |> redirect(to: ~p"/settings/links/#{url}/verify")
+      # A failed check RENDERS the page rather than redirecting to it (issue
+      # #1466): the report of what we actually read is the answer, and a flash
+      # cannot carry it. The URL is the same either way, since the form posts to
+      # the page it lives on.
+      {:error, report} ->
+        render_verify(conn, url, report)
     end
+  end
+
+  # Every assign the verification page needs, in one place, so the GET and the
+  # failed POST cannot render two different pages.
+  defp render_verify(conn, url, report \\ nil) do
+    render(conn, "verify.html",
+      url: url,
+      enabled?: LinkVerification.enabled?(),
+      profile_url: LinkVerification.profile_urls(conn.assigns[:user]) |> List.first(),
+      host: URI.parse(url.value).host,
+      dns_value: LinkVerification.dns_txt_value(url),
+      dns_challenge_name: LinkVerification.dns_challenge_name(url),
+      well_known_url: LinkVerification.well_known_url(url),
+      well_known_content: LinkVerification.well_known_content(url),
+      check_report: report,
+      page_title: gettext("Verify link")
+    )
   end
 end

--- a/lib/vutuv_web/live/organization_live/domains.ex
+++ b/lib/vutuv_web/live/organization_live/domains.ex
@@ -11,11 +11,12 @@ defmodule VutuvWeb.OrganizationLive.Domains do
 
   use VutuvWeb, :live_view
 
-  import VutuvWeb.OrganizationComponents,
-    only: [manage_header: 1, check_report: 1, check_reassurance: 1]
+  import VutuvWeb.OrganizationComponents, only: [manage_header: 1, check_reassurance: 1]
+  import VutuvWeb.VerificationComponents, only: [check_report: 1]
 
   alias Vutuv.Organizations
   alias VutuvWeb.Live.InitAssigns
+  alias VutuvWeb.VerificationComponents
 
   @impl true
   def mount(_params, session, socket) do
@@ -156,9 +157,7 @@ defmodule VutuvWeb.OrganizationLive.Domains do
   # The moment the check ran, kept beside its result so each panel can say when
   # it last looked.
   defp put_report(socket, domain_id, report) do
-    stamped =
-      Map.put(report, :checked_at, NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second))
-
+    stamped = VerificationComponents.stamp(report)
     assign(socket, :check_reports, Map.put(socket.assigns.check_reports, domain_id, stamped))
   end
 
@@ -337,7 +336,11 @@ defmodule VutuvWeb.OrganizationLive.Domains do
         {gettext("Verify now")}
       </button>
 
-      <.check_report id={"verify-report-#{@domain.id}"} report={@check_reports[@domain.id]} />
+      <.check_report
+        id={"verify-report-#{@domain.id}"}
+        report={@check_reports[@domain.id]}
+        disabled_text={gettext("Domain verification is disabled on this installation.")}
+      />
       <%!-- Only a domain that was never verified is picked up by the two-minute
       background pass. One in its grace window is on the weekly re-check, so
       promising it a mail "as soon as it works" would be untrue. --%>

--- a/lib/vutuv_web/live/organization_live/show.ex
+++ b/lib/vutuv_web/live/organization_live/show.ex
@@ -15,6 +15,7 @@ defmodule VutuvWeb.OrganizationLive.Show do
   use VutuvWeb, :live_view
 
   import VutuvWeb.OrganizationComponents
+  import VutuvWeb.VerificationComponents, only: [check_report: 1]
   import VutuvWeb.FediverseComponents, only: [follow_us_from_elsewhere: 1]
   import VutuvWeb.JobComponents, only: [job_card: 1]
   import VutuvWeb.PostComponents, only: [post_card: 1]
@@ -30,6 +31,7 @@ defmodule VutuvWeb.OrganizationLive.Show do
   alias VutuvWeb.JsonLd
   alias VutuvWeb.Live.InitAssigns
   alias VutuvWeb.UserHelpers
+  alias VutuvWeb.VerificationComponents
 
   @impl true
   def mount(_params, session, socket) do
@@ -300,18 +302,11 @@ defmodule VutuvWeb.OrganizationLive.Show do
            |> put_flash(:info, gettext("Your organization page is verified and now live."))}
 
         {:error, report} ->
-          {:noreply, assign(socket, :check_report, stamp(report))}
+          {:noreply, assign(socket, :check_report, VerificationComponents.stamp(report))}
       end
     else
       {:noreply, socket}
     end
-  end
-
-  # The moment the check ran, kept beside its result so the panel can say when
-  # it last looked — the pending domain's own `last_checked_at` is written by
-  # the same call, but this one belongs to the answer on screen.
-  defp stamp(report) do
-    Map.put(report, :checked_at, NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second))
   end
 
   # Who the follow belongs to: the page being acted as, else the member. A page
@@ -903,7 +898,11 @@ defmodule VutuvWeb.OrganizationLive.Show do
             {gettext("Verify now")}
           </button>
 
-          <.check_report id="verify-domain-report" report={@check_report} />
+          <.check_report
+            id="verify-domain-report"
+            report={@check_report}
+            disabled_text={gettext("Domain verification is disabled on this installation.")}
+          />
           <.check_reassurance
             :if={is_nil(@primary_domain.verified_at)}
             domain={@primary_domain.domain}

--- a/lib/vutuv_web/templates/url/verify.html.heex
+++ b/lib/vutuv_web/templates/url/verify.html.heex
@@ -38,7 +38,7 @@ success the link earns the verified mark shown on the profile + section pages. -
     <p class="text-xs text-slate-600 dark:text-slate-400">
       {gettext("The link text can be anything. A hidden <link rel=\"me\"> in the page head works too.")}
     </p>
-    <.verify_form url={@url} method="rel_me" label={gettext("Verify via back-link")} />
+    <.verify_form url={@url} method="rel_me" label={gettext("Verify via back-link")} report={@check_report} />
   </.card>
 
   <%!-- DNS TXT record (for a member who controls the domain's DNS) --%>
@@ -91,7 +91,7 @@ success the link earns the verified mark shown on the profile + section pages. -
     <p class="text-xs text-slate-600 dark:text-slate-400">
       {gettext("DNS changes can take a while to spread. If it does not verify right away, wait a few minutes and try again.")}
     </p>
-    <.verify_form url={@url} method="dns" label={gettext("Verify via DNS")} />
+    <.verify_form url={@url} method="dns" label={gettext("Verify via DNS")} report={@check_report} />
   </.card>
 
   <%!-- Well-known file (for a member who controls the whole domain) --%>
@@ -107,7 +107,7 @@ success the link earns the verified mark shown on the profile + section pages. -
       phx-no-curly-interpolation
       class="block overflow-x-auto rounded bg-white px-3 py-2 font-mono text-xs text-slate-900 ring-1 ring-slate-200 dark:bg-slate-900 dark:text-slate-100 dark:ring-slate-700"
     ><%= @well_known_content %></code>
-    <.verify_form url={@url} method="well_known" label={gettext("Verify via file")} />
+    <.verify_form url={@url} method="well_known" label={gettext("Verify via file")} report={@check_report} />
   </.card>
 
   <div class="mt-6">

--- a/lib/vutuv_web/views/url_html.ex
+++ b/lib/vutuv_web/views/url_html.ex
@@ -2,6 +2,7 @@ defmodule VutuvWeb.UrlHTML do
   @moduledoc false
   use VutuvWeb, :html
   import VutuvWeb.UserHelpers
+  import VutuvWeb.VerificationComponents, only: [check_report: 1]
 
   # The single render chokepoint for a stored profile-link URL. Defense in
   # depth behind the changeset's scheme check: never emit a non-http(s) href
@@ -43,10 +44,15 @@ defmodule VutuvWeb.UrlHTML do
   attr(:url, :map, required: true)
   attr(:method, :string, required: true)
   attr(:label, :string, required: true)
+  attr(:report, :map, default: nil)
 
   # One proof method's "Verify now" button: a CSRF form POSTing the chosen
   # method to the verify action. Distinct submit id per method so tests and
   # the browser can target it (verify-rel_me / verify-dns / verify-well_known).
+  #
+  # A failed check's report (issue #1466) hangs under the button that produced
+  # it — the component decides its own contents, this only decides whose report
+  # it is, so the answer can never appear under a method nobody pressed.
   def verify_form(assigns) do
     ~H"""
     <.form for={%{}} action={~p"/settings/links/#{@url}/verify"} method="post">
@@ -59,6 +65,11 @@ defmodule VutuvWeb.UrlHTML do
         {@label}
       </button>
     </.form>
+    <.check_report
+      id={"verify-report-#{@method}"}
+      report={if @report[:method] == @method, do: @report}
+      disabled_text={gettext("Link verification is disabled on this installation.")}
+    />
     """
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.290.0",
+      version: "7.291.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -9,17 +9,17 @@
 msgid ""
 msgstr "Language: de\n"
 
-#: lib/vutuv_web/controllers/page_controller.ex:114
-#: lib/vutuv_web/templates/layout/app.html.heex:97
+#: lib/vutuv_web/controllers/page_controller.ex:174
+#: lib/vutuv_web/templates/layout/app.html.heex:108
 #, elixir-autogen
 msgid "About us"
 msgstr "Impressum"
 
-#: lib/vutuv_web/components/ui.ex:3582
-#: lib/vutuv_web/components/ui.ex:3587
+#: lib/vutuv_web/components/ui.ex:3600
+#: lib/vutuv_web/components/ui.ex:3605
 #: lib/vutuv_web/live/admin/screenshot_live.ex:266
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:718
-#: lib/vutuv_web/live/organization_live/domains.ex:269
+#: lib/vutuv_web/live/organization_live/domains.ex:268
 #: lib/vutuv_web/live/organization_live/edit.ex:396
 #: lib/vutuv_web/live/organization_live/roles.ex:210
 #, elixir-autogen
@@ -33,7 +33,7 @@ msgstr "Eintrag hinzufügen"
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
 #: lib/vutuv_web/live/organization_live/fediverse.ex:119
-#: lib/vutuv_web/live/organization_live/show.ex:769
+#: lib/vutuv_web/live/organization_live/show.ex:764
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
@@ -62,7 +62,7 @@ msgstr "Eine Adresse wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:67
 #: lib/vutuv_web/agent_docs/text.ex:64
-#: lib/vutuv_web/components/ui.ex:3840
+#: lib/vutuv_web/components/ui.ex:3858
 #: lib/vutuv_web/controllers/address_controller.ex:23
 #: lib/vutuv_web/controllers/address_controller.ex:38
 #: lib/vutuv_web/controllers/address_controller.ex:85
@@ -80,8 +80,8 @@ msgstr "Adressen"
 msgid "Already a member? Sign in here."
 msgstr "Schon ein Mitglied? Einloggen."
 
-#: lib/vutuv_web/components/ui.ex:3377
-#: lib/vutuv_web/components/ui.ex:3471
+#: lib/vutuv_web/components/ui.ex:3395
+#: lib/vutuv_web/components/ui.ex:3489
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:698
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:830
@@ -109,7 +109,7 @@ msgid "Birthday"
 msgstr "Geburtstag"
 
 #: lib/vutuv_web/components/saved_search_components.ex:110
-#: lib/vutuv_web/components/ui.ex:3371
+#: lib/vutuv_web/components/ui.ex:3389
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
@@ -162,7 +162,7 @@ msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
 #: lib/vutuv_web/components/post_components.ex:2751
-#: lib/vutuv_web/components/ui.ex:3474
+#: lib/vutuv_web/components/ui.ex:3492
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
@@ -211,12 +211,12 @@ msgid "Download"
 msgstr "Download"
 
 #: lib/vutuv_web/components/post_components.ex:2716
-#: lib/vutuv_web/components/ui.ex:3465
+#: lib/vutuv_web/components/ui.ex:3483
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
 #: lib/vutuv_web/live/job_posting_live/show.ex:178
-#: lib/vutuv_web/live/organization_live/show.ex:516
+#: lib/vutuv_web/live/organization_live/show.ex:511
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:7
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:19
@@ -285,7 +285,7 @@ msgstr "E-Mail-Adresse eingeben"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:37
 #: lib/vutuv_web/agent_docs/text.ex:34
-#: lib/vutuv_web/components/ui.ex:3804
+#: lib/vutuv_web/components/ui.ex:3822
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -326,14 +326,14 @@ msgstr "Follower"
 #: lib/vutuv_web/agent_docs/markdown.ex:547
 #: lib/vutuv_web/agent_docs/text.ex:514
 #: lib/vutuv_web/components/fediverse_components.ex:313
-#: lib/vutuv_web/components/ui.ex:2079
-#: lib/vutuv_web/components/ui.ex:2104
-#: lib/vutuv_web/components/ui.ex:2107
-#: lib/vutuv_web/components/ui.ex:2114
-#: lib/vutuv_web/components/ui.ex:2117
-#: lib/vutuv_web/components/ui.ex:2175
+#: lib/vutuv_web/components/ui.ex:2097
+#: lib/vutuv_web/components/ui.ex:2122
+#: lib/vutuv_web/components/ui.ex:2125
+#: lib/vutuv_web/components/ui.ex:2132
+#: lib/vutuv_web/components/ui.ex:2135
+#: lib/vutuv_web/components/ui.ex:2193
 #: lib/vutuv_web/controllers/followee_controller.ex:29
-#: lib/vutuv_web/live/organization_live/show.ex:476
+#: lib/vutuv_web/live/organization_live/show.ex:471
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:53
 #: lib/vutuv_web/templates/user/show.html.heex:955
@@ -361,7 +361,7 @@ msgstr "Ihr Gratis-Konto ist in nicht mal 30 Sekunden fertig."
 
 #: lib/vutuv_web/templates/directory/index.html.heex:3
 #: lib/vutuv_web/templates/directory/show.html.heex:4
-#: lib/vutuv_web/templates/layout/app.html.heex:121
+#: lib/vutuv_web/templates/layout/app.html.heex:132
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:2
 #, elixir-autogen
 msgid "Home"
@@ -442,8 +442,8 @@ msgstr "Einloggen"
 msgid "Log Out"
 msgstr "Ausloggen"
 
-#: lib/vutuv_web/live/shell_live.ex:843
-#: lib/vutuv_web/live/shell_live.ex:889
+#: lib/vutuv_web/live/shell_live.ex:850
+#: lib/vutuv_web/live/shell_live.ex:906
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -612,7 +612,7 @@ msgstr "Provider"
 msgid "Public"
 msgstr "Öffentlich"
 
-#: lib/vutuv_web/components/ui.ex:3370
+#: lib/vutuv_web/components/ui.ex:3388
 #: lib/vutuv_web/live/organization_live/edit.ex:341
 #: lib/vutuv_web/live/post_live/composer.ex:1813
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -640,13 +640,13 @@ msgstr "Speichern"
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:54
 #: lib/vutuv_web/live/search_live.ex:613
-#: lib/vutuv_web/live/shell_live.ex:711
-#: lib/vutuv_web/live/shell_live.ex:872
+#: lib/vutuv_web/live/shell_live.ex:718
+#: lib/vutuv_web/live/shell_live.ex:889
 #: lib/vutuv_web/live/tag_live/timeline.ex:237
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:30
-#: lib/vutuv_web/templates/layout/app.html.heex:126
+#: lib/vutuv_web/templates/layout/app.html.heex:137
 #, elixir-autogen
 msgid "Search"
 msgstr "Suche"
@@ -793,7 +793,7 @@ msgstr "Profil aktualisiert."
 msgid "User verified successfully."
 msgstr "User wurde verifiziert."
 
-#: lib/vutuv_web/components/ui.ex:3800
+#: lib/vutuv_web/components/ui.ex:3818
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
@@ -844,20 +844,20 @@ msgstr "Benutzername"
 msgid "Users"
 msgstr "Benutzer"
 
-#: lib/vutuv_web/components/ui.ex:1014
+#: lib/vutuv_web/components/ui.ex:1032
 #: lib/vutuv_web/templates/user/show.html.heex:343
 #, elixir-autogen
 msgid "vCard"
 msgstr "vCard"
 
-#: lib/vutuv_web/components/ui.ex:3535
+#: lib/vutuv_web/components/ui.ex:3553
 #: lib/vutuv_web/templates/user/show.html.heex:949
 #: lib/vutuv_web/templates/user/show.html.heex:972
 #, elixir-autogen
 msgid "View All"
 msgstr "Alle anzeigen"
 
-#: lib/vutuv_web/components/ui.ex:3881
+#: lib/vutuv_web/components/ui.ex:3899
 #: lib/vutuv_web/controllers/settings_controller.ex:159
 #: lib/vutuv_web/live/job_posting_live/form.ex:561
 #: lib/vutuv_web/live/organization_live/edit.ex:300
@@ -1095,7 +1095,7 @@ msgstr "vutuv Login-PIN"
 msgid "Listings"
 msgstr "Listen"
 
-#: lib/vutuv_web/controllers/page_controller.ex:263
+#: lib/vutuv_web/controllers/page_controller.ex:323
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:4
 #, elixir-autogen
 msgid "Most Followed Users"
@@ -1167,7 +1167,7 @@ msgstr "Wählen Sie einen Social-Media-Anbieter aus"
 msgid "Add Localization"
 msgstr "Lokalisierung hinzufügen"
 
-#: lib/vutuv_web/components/organization_components.ex:375
+#: lib/vutuv_web/components/organization_components.ex:289
 #: lib/vutuv_web/live/admin/activity_live.ex:153
 #: lib/vutuv_web/live/admin/api_app_live.ex:58
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
@@ -1185,7 +1185,7 @@ msgstr "Lokalisierung hinzufügen"
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:815
+#: lib/vutuv_web/live/shell_live.ex:822
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1400,7 +1400,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/agent_docs/text.ex:30
 #: lib/vutuv_web/agent_docs/text.ex:440
 #: lib/vutuv_web/agent_docs/text.ex:663
-#: lib/vutuv_web/components/ui.ex:3825
+#: lib/vutuv_web/components/ui.ex:3843
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
 #: lib/vutuv_web/cv/docx.ex:174
@@ -1626,7 +1626,7 @@ msgstr "Adressen von %{name}"
 msgid "Admin control panel"
 msgstr "Admin-Bereich"
 
-#: lib/vutuv_web/live/shell_live.ex:875
+#: lib/vutuv_web/live/shell_live.ex:892
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "Mitteilungen"
@@ -1646,15 +1646,15 @@ msgid "Check your inbox"
 msgstr "Schauen Sie in Ihr Postfach"
 
 #: lib/vutuv_web/components/post_components.ex:3204
-#: lib/vutuv_web/components/ui.ex:280
+#: lib/vutuv_web/components/ui.ex:298
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
 #: lib/vutuv_web/live/post_live/composer.ex:1331
 #: lib/vutuv_web/live/post_live/composer.ex:1332
 #: lib/vutuv_web/live/post_live/composer.ex:2249
-#: lib/vutuv_web/templates/layout/app.html.heex:159
-#: lib/vutuv_web/templates/layout/app.html.heex:165
+#: lib/vutuv_web/templates/layout/app.html.heex:170
+#: lib/vutuv_web/templates/layout/app.html.heex:176
 #: lib/vutuv_web/views/layout_html.ex:40
 #, elixir-autogen, elixir-format
 msgid "Close"
@@ -1672,16 +1672,16 @@ msgstr "Bestätigen"
 msgid "Confirm account deletion"
 msgstr "Kontolöschung bestätigen"
 
-#: lib/vutuv_web/controllers/page_controller.ex:118
-#: lib/vutuv_web/templates/layout/app.html.heex:93
+#: lib/vutuv_web/controllers/page_controller.ex:178
+#: lib/vutuv_web/templates/layout/app.html.heex:104
 #: lib/vutuv_web/templates/page/index.html.heex:261
 #: lib/vutuv_web/views/admin/legal_page_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Datenschutzerklärung"
 msgstr "Datenschutzerklärung"
 
-#: lib/vutuv_web/controllers/page_controller.ex:124
-#: lib/vutuv_web/templates/layout/app.html.heex:95
+#: lib/vutuv_web/controllers/page_controller.ex:184
+#: lib/vutuv_web/templates/layout/app.html.heex:106
 #: lib/vutuv_web/templates/page/index.html.heex:261
 #: lib/vutuv_web/views/admin/legal_page_html.ex:12
 #, elixir-autogen, elixir-format
@@ -1700,30 +1700,30 @@ msgstr "Mein Konto löschen"
 msgid "Edit profile"
 msgstr "Profil bearbeiten"
 
-#: lib/vutuv_web/components/ui.ex:1495
-#: lib/vutuv_web/components/ui.ex:1504
-#: lib/vutuv_web/components/ui.ex:1906
+#: lib/vutuv_web/components/ui.ex:1513
+#: lib/vutuv_web/components/ui.ex:1522
+#: lib/vutuv_web/components/ui.ex:1924
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr "Empfehlen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:199
-#: lib/vutuv_web/components/ui.ex:2044
-#: lib/vutuv_web/components/ui.ex:2044
-#: lib/vutuv_web/components/ui.ex:2061
-#: lib/vutuv_web/components/ui.ex:2070
-#: lib/vutuv_web/components/ui.ex:2086
-#: lib/vutuv_web/components/ui.ex:2123
-#: lib/vutuv_web/components/ui.ex:2126
-#: lib/vutuv_web/components/ui.ex:2133
-#: lib/vutuv_web/components/ui.ex:2136
-#: lib/vutuv_web/components/ui.ex:2209
+#: lib/vutuv_web/components/ui.ex:2062
+#: lib/vutuv_web/components/ui.ex:2062
+#: lib/vutuv_web/components/ui.ex:2079
+#: lib/vutuv_web/components/ui.ex:2088
+#: lib/vutuv_web/components/ui.ex:2104
+#: lib/vutuv_web/components/ui.ex:2141
+#: lib/vutuv_web/components/ui.ex:2144
+#: lib/vutuv_web/components/ui.ex:2151
+#: lib/vutuv_web/components/ui.ex:2154
+#: lib/vutuv_web/components/ui.ex:2227
 #: lib/vutuv_web/live/fediverse_account_live.ex:375
 #: lib/vutuv_web/live/fediverse_following_live.ex:331
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:293
 #: lib/vutuv_web/live/organization_live/following.ex:218
-#: lib/vutuv_web/live/organization_live/show.ex:445
-#: lib/vutuv_web/live/organization_live/show.ex:474
+#: lib/vutuv_web/live/organization_live/show.ex:440
+#: lib/vutuv_web/live/organization_live/show.ex:469
 #: lib/vutuv_web/templates/user/show.html.heex:1269
 #, elixir-autogen, elixir-format
 msgid "Follow"
@@ -1742,13 +1742,13 @@ msgstr ""
 " von jemandem, den Sie kennen oder interessant finden, und klicken Sie auf "
 "Folgen!"
 
-#: lib/vutuv_web/live/shell_live.ex:834
+#: lib/vutuv_web/live/shell_live.ex:841
 #: lib/vutuv_web/views/settings_html.ex:262
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr "Ausloggen"
 
-#: lib/vutuv_web/components/organization_components.ex:381
+#: lib/vutuv_web/components/organization_components.ex:295
 #: lib/vutuv_web/live/admin/activity_live.ex:143
 #: lib/vutuv_web/live/admin/activity_live.ex:175
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
@@ -1763,28 +1763,28 @@ msgstr "Ausloggen"
 msgid "Member"
 msgstr "Mitglied"
 
-#: lib/vutuv_web/live/organization_live/show.ex:495
+#: lib/vutuv_web/live/organization_live/show.ex:490
 #: lib/vutuv_web/templates/user/show.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr "Nachricht"
 
 #: lib/vutuv_web/live/message_live/index.ex:50
-#: lib/vutuv_web/live/message_live/index.ex:622
-#: lib/vutuv_web/live/shell_live.ex:727
-#: lib/vutuv_web/live/shell_live.ex:874
-#: lib/vutuv_web/templates/layout/app.html.heex:123
+#: lib/vutuv_web/live/message_live/index.ex:624
+#: lib/vutuv_web/live/shell_live.ex:734
+#: lib/vutuv_web/live/shell_live.ex:891
+#: lib/vutuv_web/templates/layout/app.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr "Nachrichten"
 
-#: lib/vutuv_web/live/shell_live.ex:619
+#: lib/vutuv_web/live/shell_live.ex:626
 #, elixir-autogen, elixir-format
 msgid "Network"
 msgstr "Netzwerk"
 
 #: lib/vutuv_web/components/post_components.ex:435
-#: lib/vutuv_web/components/ui.ex:3584
+#: lib/vutuv_web/components/ui.ex:3602
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:705
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:742
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:793
@@ -1799,11 +1799,11 @@ msgstr "Hier gibt es noch nichts."
 msgid "Nothing new yet."
 msgstr "Noch nichts Neues."
 
-#: lib/vutuv_web/components/ui.ex:3862
+#: lib/vutuv_web/components/ui.ex:3880
 #: lib/vutuv_web/live/notification_live/index.ex:114
 #: lib/vutuv_web/live/notification_live/index.ex:338
-#: lib/vutuv_web/live/shell_live.ex:738
-#: lib/vutuv_web/templates/layout/app.html.heex:124
+#: lib/vutuv_web/live/shell_live.ex:745
+#: lib/vutuv_web/templates/layout/app.html.heex:135
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Notifications"
@@ -1824,19 +1824,19 @@ msgid "Pardon us! Something went wrong."
 msgstr "Entschuldigung! Etwas ist schiefgelaufen."
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:130
-#: lib/vutuv_web/live/message_live/index.ex:869
+#: lib/vutuv_web/live/message_live/index.ex:871
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Send"
 msgstr "Senden"
 
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:35
-#: lib/vutuv_web/templates/layout/app.html.heex:87
+#: lib/vutuv_web/templates/layout/app.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "Source"
 msgstr "Quellcode"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:89
+#: lib/vutuv_web/templates/layout/app.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "Submit a bug report or feature request"
 msgstr "Fehler melden oder Feature vorschlagen"
@@ -1905,8 +1905,8 @@ msgstr ""
 msgid "Who to follow"
 msgstr "Vorgeschlagene Profile"
 
-#: lib/vutuv_web/live/message_live/index.ex:858
-#: lib/vutuv_web/live/message_live/index.ex:859
+#: lib/vutuv_web/live/message_live/index.ex:860
+#: lib/vutuv_web/live/message_live/index.ex:861
 #, elixir-autogen, elixir-format
 msgid "Write a message…"
 msgstr "Nachricht schreiben…"
@@ -1951,17 +1951,17 @@ msgstr "ist jetzt mit Ihnen vernetzt."
 msgid "started following you."
 msgstr "folgt Ihnen jetzt."
 
-#: lib/vutuv_web/components/ui.ex:2924
-#: lib/vutuv_web/components/ui.ex:3075
+#: lib/vutuv_web/components/ui.ex:2942
+#: lib/vutuv_web/components/ui.ex:3093
 #: lib/vutuv_web/live/organization_live/index.ex:122
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr "Seitennavigation"
 
-#: lib/vutuv_web/components/ui.ex:3609
+#: lib/vutuv_web/components/ui.ex:3627
 #: lib/vutuv_web/live/organization_live/activity.ex:146
 #: lib/vutuv_web/live/organization_live/feed.ex:101
-#: lib/vutuv_web/live/organization_live/show.ex:642
+#: lib/vutuv_web/live/organization_live/show.ex:637
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr "Mehr laden"
@@ -1973,13 +1973,13 @@ msgstr ""
 "Die Adresse selbst kann nicht geändert werden. Um eine andere zu verwenden, "
 "legen Sie sie als neue E-Mail-Adresse an und löschen Sie diese hier."
 
-#: lib/vutuv_web/components/ui.ex:3380
+#: lib/vutuv_web/components/ui.ex:3398
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr "Eintrag löschen"
 
-#: lib/vutuv_web/components/ui.ex:1220
-#: lib/vutuv_web/components/ui.ex:1230
+#: lib/vutuv_web/components/ui.ex:1238
+#: lib/vutuv_web/components/ui.ex:1248
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr "Optionen"
@@ -2018,12 +2018,12 @@ msgstr "Titelbild hinzufügen"
 msgid "Add cover photo"
 msgstr "Titelbild hinzufügen"
 
-#: lib/vutuv_web/components/ui.ex:2634
+#: lib/vutuv_web/components/ui.ex:2652
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr "April"
 
-#: lib/vutuv_web/components/ui.ex:2638
+#: lib/vutuv_web/components/ui.ex:2656
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr "August"
@@ -2048,37 +2048,37 @@ msgstr "Titelbild"
 msgid "Cover photo of %{name}"
 msgstr "Titelbild von %{name}"
 
-#: lib/vutuv_web/components/ui.ex:2642
+#: lib/vutuv_web/components/ui.ex:2660
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr "Dezember"
 
-#: lib/vutuv_web/components/ui.ex:2632
+#: lib/vutuv_web/components/ui.ex:2650
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr "Februar"
 
-#: lib/vutuv_web/components/ui.ex:2631
+#: lib/vutuv_web/components/ui.ex:2649
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr "Januar"
 
-#: lib/vutuv_web/components/ui.ex:2637
+#: lib/vutuv_web/components/ui.ex:2655
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr "Juli"
 
-#: lib/vutuv_web/components/ui.ex:2636
+#: lib/vutuv_web/components/ui.ex:2654
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr "Juni"
 
-#: lib/vutuv_web/components/ui.ex:2633
+#: lib/vutuv_web/components/ui.ex:2651
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr "März"
 
-#: lib/vutuv_web/components/ui.ex:2635
+#: lib/vutuv_web/components/ui.ex:2653
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr "Mai"
@@ -2093,17 +2093,17 @@ msgstr "Mitglied seit %{month} %{year}"
 msgid "Member since %{year}"
 msgstr "Mitglied seit %{year}"
 
-#: lib/vutuv_web/components/ui.ex:2641
+#: lib/vutuv_web/components/ui.ex:2659
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr "November"
 
-#: lib/vutuv_web/components/ui.ex:2640
+#: lib/vutuv_web/components/ui.ex:2658
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr "Oktober"
 
-#: lib/vutuv_web/components/ui.ex:2639
+#: lib/vutuv_web/components/ui.ex:2657
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr "September"
@@ -2153,13 +2153,13 @@ msgstr "Diesen Beitrag endgültig löschen?"
 msgid "Edit post"
 msgstr "Beitrag bearbeiten"
 
-#: lib/vutuv_web/components/organization_components.ex:333
+#: lib/vutuv_web/components/organization_components.ex:247
 #: lib/vutuv_web/live/organization_live/feed.ex:79
 #: lib/vutuv_web/live/post_live/feed.ex:159
 #: lib/vutuv_web/live/post_live/feed.ex:936
-#: lib/vutuv_web/live/shell_live.ex:599
-#: lib/vutuv_web/live/shell_live.ex:870
-#: lib/vutuv_web/templates/layout/app.html.heex:122
+#: lib/vutuv_web/live/shell_live.ex:606
+#: lib/vutuv_web/live/shell_live.ex:887
+#: lib/vutuv_web/templates/layout/app.html.heex:133
 #, elixir-autogen, elixir-format
 msgid "Feed"
 msgstr "Feed"
@@ -2243,7 +2243,7 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:382
 #: lib/vutuv_web/live/notification_live/index.ex:891
-#: lib/vutuv_web/live/organization_live/show.ex:569
+#: lib/vutuv_web/live/organization_live/show.ex:564
 #: lib/vutuv_web/live/post_live/saved.ex:495
 #: lib/vutuv_web/live/search_live.ex:309
 #: lib/vutuv_web/live/search_live.ex:772
@@ -2271,7 +2271,7 @@ msgstr "Weniger anzeigen"
 #: lib/vutuv_web/live/admin/screenshot_live.ex:338
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:700
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
-#: lib/vutuv_web/live/organization_live/domains.ex:243
+#: lib/vutuv_web/live/organization_live/domains.ex:242
 #: lib/vutuv_web/live/organization_live/edit.ex:373
 #: lib/vutuv_web/live/organization_live/roles.ex:243
 #: lib/vutuv_web/live/post_live/composer.ex:1886
@@ -2332,8 +2332,8 @@ msgstr "Zu viele Dateien."
 msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
 
-#: lib/vutuv_web/components/ui.ex:4126
-#: lib/vutuv_web/live/shell_live.ex:781
+#: lib/vutuv_web/components/ui.ex:4144
+#: lib/vutuv_web/live/shell_live.ex:788
 #: lib/vutuv_web/templates/post/index.html.heex:17
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:209
@@ -2414,7 +2414,7 @@ msgstr "Alle Beiträge"
 
 #: lib/vutuv_web/components/post_components.ex:1603
 #: lib/vutuv_web/components/post_components.ex:4436
-#: lib/vutuv_web/components/ui.ex:2999
+#: lib/vutuv_web/components/ui.ex:3017
 #: lib/vutuv_web/views/user_html.ex:335
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2423,8 +2423,8 @@ msgstr "Lesezeichen setzen"
 #: lib/vutuv_web/agent_docs/markdown.ex:1001
 #: lib/vutuv_web/live/post_live/saved.ex:175
 #: lib/vutuv_web/live/post_live/saved.ex:488
-#: lib/vutuv_web/live/shell_live.ex:720
-#: lib/vutuv_web/live/shell_live.ex:786
+#: lib/vutuv_web/live/shell_live.ex:727
+#: lib/vutuv_web/live/shell_live.ex:793
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2433,7 +2433,7 @@ msgstr "Lesezeichen"
 
 #: lib/vutuv_web/components/post_components.ex:1567
 #: lib/vutuv_web/components/post_components.ex:4670
-#: lib/vutuv_web/components/ui.ex:2985
+#: lib/vutuv_web/components/ui.ex:3003
 #: lib/vutuv_web/live/notification_live/index.ex:1038
 #: lib/vutuv_web/views/user_html.ex:345
 #, elixir-autogen, elixir-format
@@ -2445,7 +2445,7 @@ msgstr "Gefällt mir"
 #: lib/vutuv_web/live/notification_live/index.ex:971
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
-#: lib/vutuv_web/live/shell_live.ex:789
+#: lib/vutuv_web/live/shell_live.ex:796
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2503,12 +2503,12 @@ msgid "Unlike"
 msgstr "Gefällt mir entfernen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:343
-#: lib/vutuv_web/components/ui.ex:2039
-#: lib/vutuv_web/components/ui.ex:2039
-#: lib/vutuv_web/components/ui.ex:2176
+#: lib/vutuv_web/components/ui.ex:2057
+#: lib/vutuv_web/components/ui.ex:2057
+#: lib/vutuv_web/components/ui.ex:2194
 #: lib/vutuv_web/live/organization_live/following.ex:197
 #: lib/vutuv_web/live/organization_live/following.ex:256
-#: lib/vutuv_web/live/organization_live/show.ex:479
+#: lib/vutuv_web/live/organization_live/show.ex:474
 #: lib/vutuv_web/live/post_live/feed.ex:1172
 #: lib/vutuv_web/templates/followee/index.html.heex:44
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
@@ -2592,12 +2592,12 @@ msgstr "%{names} schreiben…"
 msgid "%{name} is typing…"
 msgstr "%{name} schreibt…"
 
-#: lib/vutuv_web/live/message_live/index.ex:881
+#: lib/vutuv_web/live/message_live/index.ex:883
 #, elixir-autogen, elixir-format
 msgid "@%{slug} has not accepted your message request yet."
 msgstr "@%{slug} hat Ihre Nachrichtenanfrage noch nicht angenommen."
 
-#: lib/vutuv_web/live/message_live/index.ex:835
+#: lib/vutuv_web/live/message_live/index.ex:837
 #, elixir-autogen, elixir-format
 msgid "@%{slug} wants to message you."
 msgstr "@%{slug} möchte Ihnen Nachrichten schicken."
@@ -2607,7 +2607,7 @@ msgstr "@%{slug} möchte Ihnen Nachrichten schicken."
 msgid "Accept"
 msgstr "Annehmen"
 
-#: lib/vutuv_web/live/message_live/index.ex:704
+#: lib/vutuv_web/live/message_live/index.ex:706
 #, elixir-autogen, elixir-format
 msgid "Back to conversations"
 msgstr "Zurück zu den Unterhaltungen"
@@ -2622,7 +2622,7 @@ msgstr "Ablehnen"
 msgid "Deleted account"
 msgstr "Gelöschtes Konto"
 
-#: lib/vutuv_web/live/message_live/index.ex:750
+#: lib/vutuv_web/live/message_live/index.ex:752
 #, elixir-autogen, elixir-format
 msgid "Load older messages"
 msgstr "Ältere Nachrichten laden"
@@ -2633,23 +2633,23 @@ msgstr "Ältere Nachrichten laden"
 msgid "Member not found."
 msgstr "Mitglied nicht gefunden."
 
-#: lib/vutuv_web/live/message_live/index.ex:683
+#: lib/vutuv_web/live/message_live/index.ex:685
 #, elixir-autogen, elixir-format
 msgid "No conversations yet."
 msgstr "Noch keine Unterhaltungen."
 
-#: lib/vutuv_web/components/ui.ex:2510
-#: lib/vutuv_web/live/message_live/index.ex:726
+#: lib/vutuv_web/components/ui.ex:2528
+#: lib/vutuv_web/live/message_live/index.ex:728
 #, elixir-autogen, elixir-format
 msgid "Online"
 msgstr "Online"
 
-#: lib/vutuv_web/live/message_live/index.ex:632
+#: lib/vutuv_web/live/message_live/index.ex:634
 #, elixir-autogen, elixir-format
 msgid "Requests"
 msgstr "Anfragen"
 
-#: lib/vutuv_web/live/message_live/index.ex:890
+#: lib/vutuv_web/live/message_live/index.ex:892
 #, elixir-autogen, elixir-format
 msgid "Select a conversation."
 msgstr "Wählen Sie eine Unterhaltung aus."
@@ -2727,7 +2727,7 @@ msgstr "Eine neue PIN ist unterwegs zu Ihrer E-Mail-Adresse."
 msgid "Okay, let's start over."
 msgstr "Alles klar, fangen wir neu an."
 
-#: lib/vutuv_web/components/ui.ex:675
+#: lib/vutuv_web/components/ui.ex:693
 #, elixir-autogen, elixir-format
 msgid "Resend PIN"
 msgstr "PIN erneut senden"
@@ -2738,7 +2738,7 @@ msgstr "PIN erneut senden"
 msgid "Too many PIN requests. Please try again later."
 msgstr "Zu viele PIN-Anfragen. Bitte versuchen Sie es später erneut."
 
-#: lib/vutuv_web/components/ui.ex:696
+#: lib/vutuv_web/components/ui.ex:714
 #, elixir-autogen, elixir-format
 msgid "Use a different email address"
 msgstr "Andere E-Mail-Adresse verwenden"
@@ -2788,8 +2788,8 @@ msgstr "Berufserfahrung hinzufügen"
 msgid "Write your first post"
 msgstr "Ersten Beitrag schreiben"
 
-#: lib/vutuv_web/components/ui.ex:3163
-#: lib/vutuv_web/components/ui.ex:3537
+#: lib/vutuv_web/components/ui.ex:3181
+#: lib/vutuv_web/components/ui.ex:3555
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
 #: lib/vutuv_web/templates/settings/organizations.html.heex:104
@@ -2844,7 +2844,7 @@ msgstr[1] "+%{formatted} weitere Tags"
 msgid "Connections"
 msgstr "Vernetzungen"
 
-#: lib/vutuv_web/components/ui.ex:1005
+#: lib/vutuv_web/components/ui.ex:1023
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr "Markdown"
@@ -2854,7 +2854,7 @@ msgstr "Markdown"
 msgid "No connections yet."
 msgstr "Noch keine Vernetzungen."
 
-#: lib/vutuv_web/components/ui.ex:1021
+#: lib/vutuv_web/components/ui.ex:1039
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr "Andere Formate"
@@ -2864,7 +2864,7 @@ msgstr "Andere Formate"
 msgid "People who aren't my connections"
 msgstr "Personen, mit denen ich nicht vernetzt bin"
 
-#: lib/vutuv_web/components/ui.ex:1006
+#: lib/vutuv_web/components/ui.ex:1024
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr "Nur Text"
@@ -2887,12 +2887,12 @@ msgstr[1] "Vernetzungen"
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
 
-#: lib/vutuv_web/live/message_live/index.ex:684
+#: lib/vutuv_web/live/message_live/index.ex:686
 #, elixir-autogen, elixir-format
 msgid "Open someone's profile to message them."
 msgstr "Öffnen Sie ein Profil, um jemandem zu schreiben."
 
-#: lib/vutuv_web/components/organization_components.ex:327
+#: lib/vutuv_web/components/organization_components.ex:241
 #: lib/vutuv_web/live/notification_live/index.ex:1050
 #: lib/vutuv_web/live/organization_live/activity.ex:99
 #, elixir-autogen, elixir-format
@@ -2992,7 +2992,7 @@ msgstr "Mobbing oder Belästigung"
 #: lib/vutuv_web/agent_docs/markdown.ex:324
 #: lib/vutuv_web/agent_docs/text.ex:306
 #: lib/vutuv_web/controllers/page_controller.ex:83
-#: lib/vutuv_web/templates/layout/app.html.heex:91
+#: lib/vutuv_web/templates/layout/app.html.heex:102
 #: lib/vutuv_web/templates/page/community.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Community guidelines"
@@ -3062,7 +3062,7 @@ msgstr ""
 msgid "Hidden. You can settle this yourself - see below."
 msgstr "Verborgen. Sie können das selbst klären, siehe unten."
 
-#: lib/vutuv_web/live/message_live/index.ex:779
+#: lib/vutuv_web/live/message_live/index.ex:781
 #, elixir-autogen, elixir-format
 msgid "Hidden: reported, under review"
 msgstr "Verborgen: gemeldet, wird geprüft"
@@ -3191,7 +3191,7 @@ msgstr "Warteschlange öffnen"
 msgid "Opened"
 msgstr "Eröffnet"
 
-#: lib/vutuv_web/components/organization_components.ex:374
+#: lib/vutuv_web/components/organization_components.ex:288
 #: lib/vutuv_web/live/admin/api_app_live.ex:72
 #: lib/vutuv_web/live/admin/deliverability_live.ex:171
 #: lib/vutuv_web/live/admin/moderation_live.ex:56
@@ -3216,9 +3216,9 @@ msgstr ""
 msgid "Private message"
 msgstr "Private Nachricht"
 
-#: lib/vutuv_web/components/ui.ex:3794
-#: lib/vutuv_web/live/shell_live.ex:612
-#: lib/vutuv_web/live/shell_live.ex:879
+#: lib/vutuv_web/components/ui.ex:3812
+#: lib/vutuv_web/live/shell_live.ex:619
+#: lib/vutuv_web/live/shell_live.ex:896
 #: lib/vutuv_web/templates/import/new.html.heex:15
 #: lib/vutuv_web/templates/import/preview.html.heex:55
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
@@ -3245,7 +3245,7 @@ msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 #: lib/vutuv_web/components/post_components.ex:1066
 #: lib/vutuv_web/components/post_components.ex:2042
 #: lib/vutuv_web/components/post_components.ex:2772
-#: lib/vutuv_web/live/organization_live/show.ex:552
+#: lib/vutuv_web/live/organization_live/show.ex:547
 #: lib/vutuv_web/templates/user/show.html.heex:219
 #, elixir-autogen, elixir-format
 msgid "Report"
@@ -3272,8 +3272,8 @@ msgstr "Meldung abgelehnt; der Inhalt ist wieder sichtbar."
 msgid "Report this content"
 msgstr "Diesen Inhalt melden"
 
-#: lib/vutuv_web/live/message_live/index.ex:798
-#: lib/vutuv_web/live/message_live/index.ex:799
+#: lib/vutuv_web/live/message_live/index.ex:800
+#: lib/vutuv_web/live/message_live/index.ex:801
 #, elixir-autogen, elixir-format
 msgid "Report this message"
 msgstr "Diese Nachricht melden"
@@ -3330,7 +3330,7 @@ msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 "Meldungen sind anonym; wir verraten nie, wer gemeldet hat. Unsere Regeln:"
 
-#: lib/vutuv_web/components/ui.ex:2899
+#: lib/vutuv_web/components/ui.ex:2917
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:773
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -4658,7 +4658,7 @@ msgstr ""
 "beide Richtungen unterbunden. Eine Aufhebung der Blockierung stellt das "
 "Entfernte nicht wieder her."
 
-#: lib/vutuv_web/components/ui.ex:3885
+#: lib/vutuv_web/components/ui.ex:3903
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -4712,12 +4712,12 @@ msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
 
-#: lib/vutuv_web/live/message_live/index.ex:687
+#: lib/vutuv_web/live/message_live/index.ex:689
 #, elixir-autogen, elixir-format
 msgid "Find members"
 msgstr "Mitglieder finden"
 
-#: lib/vutuv_web/components/organization_components.ex:339
+#: lib/vutuv_web/components/organization_components.ex:253
 #: lib/vutuv_web/live/organization_live/following.ex:154
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:53
@@ -4766,9 +4766,9 @@ msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
 #: lib/vutuv_web/agent_docs/markdown.ex:366
 #: lib/vutuv_web/agent_docs/text.ex:388
 #: lib/vutuv_web/components/saved_search_components.ex:57
-#: lib/vutuv_web/components/ui.ex:516
+#: lib/vutuv_web/components/ui.ex:534
 #: lib/vutuv_web/live/notification_live/index.ex:892
-#: lib/vutuv_web/live/organization_live/show.ex:652
+#: lib/vutuv_web/live/organization_live/show.ex:647
 #: lib/vutuv_web/live/post_live/saved.ex:498
 #: lib/vutuv_web/live/search_live.ex:307
 #: lib/vutuv_web/live/search_live.ex:714
@@ -5473,12 +5473,12 @@ msgstr "KI-Agenten und LLMs dürfen dieses Profil nutzen"
 msgid "API token (%{date})"
 msgstr "API-Token (%{date})"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:85
+#: lib/vutuv_web/templates/layout/app.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "API documentation"
 msgstr "API-Dokumentation"
 
-#: lib/vutuv_web/components/ui.ex:3936
+#: lib/vutuv_web/components/ui.ex:3954
 #: lib/vutuv_web/controllers/settings_controller.ex:145
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5529,48 +5529,48 @@ msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
 msgid "Content under review"
 msgstr "Inhalte in Prüfung"
 
-#: lib/vutuv_web/live/shell_live.ex:768
+#: lib/vutuv_web/live/shell_live.ex:775
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr "Kontomenü"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:321
 #: lib/vutuv_web/live/admin/screenshot_live.ex:431
-#: lib/vutuv_web/templates/layout/app.html.heex:128
+#: lib/vutuv_web/templates/layout/app.html.heex:139
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Aktionen"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:138
+#: lib/vutuv_web/templates/layout/app.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "Close menus and dialogs"
 msgstr "Menüs und Dialoge schließen"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:135
+#: lib/vutuv_web/templates/layout/app.html.heex:146
 #, elixir-autogen, elixir-format
 msgid "General"
 msgstr "Allgemeines"
 
-#: lib/vutuv_web/live/shell_live.ex:825
-#: lib/vutuv_web/templates/layout/app.html.heex:154
+#: lib/vutuv_web/live/shell_live.ex:832
+#: lib/vutuv_web/templates/layout/app.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
 msgstr "Tastaturkürzel"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:119
+#: lib/vutuv_web/templates/layout/app.html.heex:130
 #, elixir-autogen, elixir-format
 msgid "Navigation"
 msgstr "Navigation"
 
-#: lib/vutuv_web/components/ui.ex:4033
-#: lib/vutuv_web/components/ui.ex:4038
-#: lib/vutuv_web/components/ui.ex:4117
-#: lib/vutuv_web/components/ui.ex:4181
+#: lib/vutuv_web/components/ui.ex:4051
+#: lib/vutuv_web/components/ui.ex:4056
+#: lib/vutuv_web/components/ui.ex:4135
+#: lib/vutuv_web/components/ui.ex:4199
 #: lib/vutuv_web/controllers/settings_controller.ex:61
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:303
-#: lib/vutuv_web/live/shell_live.ex:805
+#: lib/vutuv_web/live/shell_live.ex:812
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5583,17 +5583,17 @@ msgstr "Navigation"
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:137
+#: lib/vutuv_web/templates/layout/app.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "Show this help"
 msgstr "Diese Hilfe anzeigen"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:130
+#: lib/vutuv_web/templates/layout/app.html.heex:141
 #, elixir-autogen, elixir-format
 msgid "Write a new post"
 msgstr "Beitrag schreiben"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:125
+#: lib/vutuv_web/templates/layout/app.html.heex:136
 #: lib/vutuv_web/views/page_html.ex:505
 #, elixir-autogen, elixir-format
 msgid "Your profile"
@@ -5614,23 +5614,23 @@ msgstr "Ein paar schnelle Schritte, damit andere Sie finden und erkennen."
 msgid "Add a profile photo"
 msgstr "Profilfoto hinzufügen"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:132
+#: lib/vutuv_web/templates/layout/app.html.heex:143
 #, elixir-autogen, elixir-format
 msgid "Next post in the feed"
 msgstr "Nächster Beitrag im Feed"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:133
+#: lib/vutuv_web/templates/layout/app.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "Previous post in the feed"
 msgstr "Vorheriger Beitrag im Feed"
 
-#: lib/vutuv_web/live/shell_live.ex:592
-#: lib/vutuv_web/live/shell_live.ex:863
+#: lib/vutuv_web/live/shell_live.ex:599
+#: lib/vutuv_web/live/shell_live.ex:878
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr "Hauptnavigation"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:78
+#: lib/vutuv_web/templates/layout/app.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
@@ -5684,7 +5684,7 @@ msgstr "Art der E-Mail-Adresse"
 msgid "About you"
 msgstr "Über Sie"
 
-#: lib/vutuv_web/components/ui.ex:3905
+#: lib/vutuv_web/components/ui.ex:3923
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:289
@@ -5706,7 +5706,7 @@ msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 "Laden Sie alles herunter, was vutuv über Sie speichert, als eine Datei."
 
-#: lib/vutuv_web/components/ui.ex:3832
+#: lib/vutuv_web/components/ui.ex:3850
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5740,7 +5740,7 @@ msgstr "Persönliche Tokens für die vutuv-API."
 msgid "Photos"
 msgstr "Fotos"
 
-#: lib/vutuv_web/components/ui.ex:3879
+#: lib/vutuv_web/components/ui.ex:3897
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/templates/page/index.html.heex:166
 #, elixir-autogen, elixir-format
@@ -5858,7 +5858,7 @@ msgstr "@%{slug} folgt Ihnen jetzt auf vutuv"
 msgid "Apps"
 msgstr "Apps"
 
-#: lib/vutuv_web/components/ui.ex:3932
+#: lib/vutuv_web/components/ui.ex:3950
 #: lib/vutuv_web/controllers/settings_controller.ex:165
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -5945,7 +5945,7 @@ msgstr "Wenn jemand beginnt, Ihnen zu folgen."
 msgid "@handle"
 msgstr "@handle"
 
-#: lib/vutuv_web/live/message_live/index.ex:742
+#: lib/vutuv_web/live/message_live/index.ex:744
 #, elixir-autogen, elixir-format
 msgid "Block @%{slug}"
 msgstr "@%{slug} blockieren"
@@ -6302,7 +6302,7 @@ msgstr "Kurzbeschreibung hinzufügen"
 msgid "Tagline"
 msgstr "Kurzbeschreibung"
 
-#: lib/vutuv_web/components/ui.ex:296
+#: lib/vutuv_web/components/ui.ex:314
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
 #: lib/vutuv_web/templates/user/show.html.heex:883
@@ -6490,9 +6490,9 @@ msgstr "Nach unten"
 msgid "Move up"
 msgstr "Nach oben"
 
-#: lib/vutuv_web/components/ui.ex:1495
-#: lib/vutuv_web/components/ui.ex:1504
-#: lib/vutuv_web/components/ui.ex:1907
+#: lib/vutuv_web/components/ui.ex:1513
+#: lib/vutuv_web/components/ui.ex:1522
+#: lib/vutuv_web/components/ui.ex:1925
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr "Empfehlung zurücknehmen"
@@ -6557,7 +6557,7 @@ msgstr "Mitglieder, die %{name} für %{tag} empfohlen haben"
 msgid "No endorsements yet."
 msgstr "Noch keine Empfehlungen."
 
-#: lib/vutuv_web/components/ui.ex:1860
+#: lib/vutuv_web/components/ui.ex:1878
 #: lib/vutuv_web/live/notification_live/index.ex:625
 #: lib/vutuv_web/live/notification_live/index.ex:640
 #: lib/vutuv_web/live/notification_live/index.ex:778
@@ -6877,7 +6877,7 @@ msgstr ""
 "Schalten Sie einen Schalter aus, geht der passende Opt-out auf den Seiten "
 "und Antworten über Sie mit. Mit beiden aus zum Beispiel:"
 
-#: lib/vutuv_web/components/ui.ex:2364
+#: lib/vutuv_web/components/ui.ex:2382
 #: lib/vutuv_web/live/fediverse_account_live.ex:369
 #: lib/vutuv_web/templates/settings/filters.html.heex:58
 #: lib/vutuv_web/templates/user/show.html.heex:212
@@ -6901,7 +6901,7 @@ msgstr "Neue Nachrichten und neue Vernetzungen"
 msgid "Remove this connection? You will stop following them."
 msgstr "Diese Vernetzung entfernen? Sie folgen der Person dann nicht mehr."
 
-#: lib/vutuv_web/components/ui.ex:2363
+#: lib/vutuv_web/components/ui.ex:2381
 #: lib/vutuv_web/live/fediverse_account_live.ex:367
 #: lib/vutuv_web/templates/settings/filters.html.heex:81
 #: lib/vutuv_web/templates/user/show.html.heex:212
@@ -6941,33 +6941,33 @@ msgstr "Beruflich"
 msgid "Unmute @%{handle}"
 msgstr "@%{handle} nicht mehr stummschalten"
 
-#: lib/vutuv_web/components/ui.ex:2334
+#: lib/vutuv_web/components/ui.ex:2352
 #, elixir-autogen, elixir-format
 msgid "Doesn't follow you"
 msgstr "Folgt Ihnen nicht"
 
-#: lib/vutuv_web/components/ui.ex:2328
+#: lib/vutuv_web/components/ui.ex:2346
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr "Folgt Ihnen"
 
-#: lib/vutuv_web/components/ui.ex:2318
+#: lib/vutuv_web/components/ui.ex:2336
 #, elixir-autogen, elixir-format
 msgid "This member doesn't follow you"
 msgstr "Dieses Mitglied folgt Ihnen nicht"
 
-#: lib/vutuv_web/components/ui.ex:2269
-#: lib/vutuv_web/components/ui.ex:2318
+#: lib/vutuv_web/components/ui.ex:2287
+#: lib/vutuv_web/components/ui.ex:2336
 #, elixir-autogen, elixir-format
 msgid "This member follows you"
 msgstr "Dieses Mitglied folgt Ihnen"
 
-#: lib/vutuv_web/components/ui.ex:2267
+#: lib/vutuv_web/components/ui.ex:2285
 #, elixir-autogen, elixir-format
 msgid "You follow each other"
 msgstr "Sie folgen einander"
 
-#: lib/vutuv_web/components/ui.ex:2268
+#: lib/vutuv_web/components/ui.ex:2286
 #, elixir-autogen, elixir-format
 msgid "You follow this member"
 msgstr "Sie folgen diesem Mitglied"
@@ -7555,13 +7555,13 @@ msgstr "Ihre Mitglieder werden zu dieser hinzugefügt (Vereinigung)."
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr "Seite %{page} von %{pages}, %{total} gesamt"
 
-#: lib/vutuv_web/components/ui.ex:2937
+#: lib/vutuv_web/components/ui.ex:2955
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Zurück"
 
-#: lib/vutuv_web/components/ui.ex:2953
+#: lib/vutuv_web/components/ui.ex:2971
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7846,12 +7846,12 @@ msgstr "%{count} Beiträge auf dieser Seite"
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr "weitere Beiträge verfügbar, ?cursor=%{cursor} anhängen"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:107
+#: lib/vutuv_web/templates/layout/app.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Deployment: %{date} at %{time}"
 msgstr "Deployment: %{date} um %{time} Uhr"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:107
+#: lib/vutuv_web/templates/layout/app.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Last deployed (Berlin time)"
 msgstr "Zuletzt bereitgestellt (Berliner Zeit)"
@@ -8374,7 +8374,7 @@ msgstr "PIN abgelaufen"
 msgid "PIN registered"
 msgstr "PIN-registriert"
 
-#: lib/vutuv_web/components/ui.ex:2940
+#: lib/vutuv_web/components/ui.ex:2958
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr "Seite %{page} von %{pages}"
@@ -8426,7 +8426,7 @@ msgid "Unreachable"
 msgstr "Nicht erreichbar"
 
 #: lib/vutuv_web/live/admin/member_badges.ex:20
-#: lib/vutuv_web/live/organization_live/domains.ex:192
+#: lib/vutuv_web/live/organization_live/domains.ex:191
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:32
 #, elixir-autogen, elixir-format
 msgid "Verified"
@@ -8513,7 +8513,7 @@ msgstr "Abschluss"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:41
 #: lib/vutuv_web/agent_docs/text.ex:38
-#: lib/vutuv_web/components/ui.ex:3808
+#: lib/vutuv_web/components/ui.ex:3826
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8573,7 +8573,7 @@ msgstr ""
 " was Sie nicht übernehmen möchten. Einträge, die bereits in Ihrem Profil "
 "stehen, sind für Sie abgewählt."
 
-#: lib/vutuv_web/components/ui.ex:3920
+#: lib/vutuv_web/components/ui.ex:3938
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Import"
@@ -8602,7 +8602,7 @@ msgstr "%{items} importiert."
 msgid "Nothing new to import."
 msgstr "Nichts Neues zu importieren."
 
-#: lib/vutuv_web/components/ui.ex:3836
+#: lib/vutuv_web/components/ui.ex:3854
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8696,7 +8696,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr "Zu viele Importe. Bitte versuchen Sie es in Kürze erneut."
 
-#: lib/vutuv_web/components/ui.ex:3209
+#: lib/vutuv_web/components/ui.ex:3227
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8800,13 +8800,13 @@ msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 "Ziehen Sie Ihre ZIP-Datei hierher oder klicken Sie, um eine auszuwählen."
 
-#: lib/vutuv_web/components/ui.ex:3796
+#: lib/vutuv_web/components/ui.ex:3814
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr "Basisdaten & Fotos"
 
-#: lib/vutuv_web/components/ui.ex:3916
+#: lib/vutuv_web/components/ui.ex:3934
 #: lib/vutuv_web/controllers/settings_controller.ex:122
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8818,7 +8818,7 @@ msgstr "Sprache & Anzeige"
 msgid "More profile sections"
 msgstr "Weitere Profil-Bereiche"
 
-#: lib/vutuv_web/components/ui.ex:3907
+#: lib/vutuv_web/components/ui.ex:3925
 #: lib/vutuv_web/controllers/settings_controller.ex:105
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8828,7 +8828,7 @@ msgstr "Weitere Profil-Bereiche"
 msgid "Sign-in & security"
 msgstr "Anmeldung & Sicherheit"
 
-#: lib/vutuv_web/components/ui.ex:3924
+#: lib/vutuv_web/components/ui.ex:3942
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8923,7 +8923,7 @@ msgstr "Ungültige Adresse (übersprungen)"
 #: lib/vutuv_web/templates/directory/index.html.heex:2
 #: lib/vutuv_web/templates/directory/index.html.heex:3
 #: lib/vutuv_web/templates/directory/show.html.heex:5
-#: lib/vutuv_web/templates/layout/app.html.heex:79
+#: lib/vutuv_web/templates/layout/app.html.heex:90
 #, elixir-autogen, elixir-format
 msgid "Member directory"
 msgstr "Mitgliederverzeichnis"
@@ -8959,7 +8959,7 @@ msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
 "Die Seite %{letter} des Mitgliederverzeichnisses, sortiert nach Nachnamen."
 
-#: lib/vutuv_web/components/ui.ex:1023
+#: lib/vutuv_web/components/ui.ex:1041
 #, elixir-autogen, elixir-format
 msgid "This profile is not offered as a Markdown, text, JSON or XML export."
 msgstr ""
@@ -9029,7 +9029,7 @@ msgstr ""
 msgid "Not written yet"
 msgstr "Noch nicht verfasst"
 
-#: lib/vutuv_web/components/organization_components.ex:312
+#: lib/vutuv_web/components/organization_components.ex:226
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "Page"
@@ -9066,16 +9066,16 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/agent_docs/markdown.ex:541
 #: lib/vutuv_web/agent_docs/text.ex:504
 #: lib/vutuv_web/agent_docs/text.ex:508
-#: lib/vutuv_web/components/organization_components.ex:344
-#: lib/vutuv_web/components/ui.ex:3897
+#: lib/vutuv_web/components/organization_components.ex:258
+#: lib/vutuv_web/components/ui.ex:3915
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:323
 #: lib/vutuv_web/controllers/settings_controller.ex:390
 #: lib/vutuv_web/live/fediverse_followers_live.ex:169
 #: lib/vutuv_web/live/fediverse_following_live.ex:304
 #: lib/vutuv_web/live/organization_live/fediverse.ex:80
-#: lib/vutuv_web/live/organization_live/show.ex:545
-#: lib/vutuv_web/live/organization_live/show.ex:728
+#: lib/vutuv_web/live/organization_live/show.ex:540
+#: lib/vutuv_web/live/organization_live/show.ex:723
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:341
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:5
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
@@ -9233,7 +9233,7 @@ msgstr ""
 "Ihres Browsers (Strg+P oder Cmd+P) und wählen Sie \"Als PDF speichern\", um "
 "eine PDF-Datei zu erhalten."
 
-#: lib/vutuv_web/components/ui.ex:1131
+#: lib/vutuv_web/components/ui.ex:1149
 #, elixir-autogen, elixir-format
 msgid "CV download"
 msgstr "Lebenslauf-Download"
@@ -9271,7 +9271,7 @@ msgstr "Jeder Download enthält genau die ausgewählten Teile."
 msgid "Header"
 msgstr "Kopfzeile"
 
-#: lib/vutuv_web/components/ui.ex:1141
+#: lib/vutuv_web/components/ui.ex:1159
 #: lib/vutuv_web/templates/export/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Open CV"
@@ -9309,7 +9309,7 @@ msgstr ""
 "Besuchers enthält nur, was er dort ohnehin sehen kann, und private E-Mail-"
 "Adressen erscheinen nur in Ihrem eigenen."
 
-#: lib/vutuv_web/components/ui.ex:1133
+#: lib/vutuv_web/components/ui.ex:1151
 #, elixir-autogen, elixir-format
 msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
@@ -9486,8 +9486,8 @@ msgstr "Dieses Tag kann nur von einem Admin entfernt werden."
 msgid "Yes"
 msgstr "Ja"
 
-#: lib/vutuv_web/components/ui.ex:1539
-#: lib/vutuv_web/components/ui.ex:1540
+#: lib/vutuv_web/components/ui.ex:1557
+#: lib/vutuv_web/components/ui.ex:1558
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:65
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -10065,7 +10065,7 @@ msgstr "Zertifikate"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:45
 #: lib/vutuv_web/agent_docs/text.ex:42
-#: lib/vutuv_web/components/ui.ex:3812
+#: lib/vutuv_web/components/ui.ex:3830
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:124
@@ -10265,13 +10265,13 @@ msgstr "Dauerhafter Profillink"
 msgid "Dismiss"
 msgstr "Schließen"
 
-#: lib/vutuv_web/components/ui.ex:2732
+#: lib/vutuv_web/components/ui.ex:2750
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr "Kopiert"
 
-#: lib/vutuv_web/components/ui.ex:2731
-#: lib/vutuv_web/components/ui.ex:2735
+#: lib/vutuv_web/components/ui.ex:2749
+#: lib/vutuv_web/components/ui.ex:2753
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr "Kopieren"
@@ -10465,12 +10465,12 @@ msgstr ""
 msgid "Authenticator app turned off."
 msgstr "Authenticator-App ausgeschaltet."
 
-#: lib/vutuv_web/components/ui.ex:290
+#: lib/vutuv_web/components/ui.ex:308
 #, elixir-autogen, elixir-format
 msgid "Bold"
 msgstr "Fett"
 
-#: lib/vutuv_web/components/ui.ex:386
+#: lib/vutuv_web/components/ui.ex:404
 #, elixir-autogen, elixir-format
 msgid "Bullet list"
 msgstr "Aufzählung"
@@ -10482,7 +10482,7 @@ msgstr ""
 "Sie können den Code nicht scannen? Geben Sie stattdessen diesen Schlüssel in"
 " Ihrer App ein:"
 
-#: lib/vutuv_web/components/ui.ex:378
+#: lib/vutuv_web/components/ui.ex:396
 #, elixir-autogen, elixir-format
 msgid "Code block"
 msgstr "Codeblock"
@@ -10498,17 +10498,17 @@ msgid "Delete your code list? All its codes stop working immediately."
 msgstr ""
 "Kennwortliste löschen? Alle Codes darauf funktionieren sofort nicht mehr."
 
-#: lib/vutuv_web/components/ui.ex:400
+#: lib/vutuv_web/components/ui.ex:418
 #, elixir-autogen, elixir-format
 msgid "Divider"
 msgstr "Trennlinie"
 
-#: lib/vutuv_web/components/ui.ex:288
+#: lib/vutuv_web/components/ui.ex:306
 #, elixir-autogen, elixir-format
 msgid "Formatting"
 msgstr "Formatierung"
 
-#: lib/vutuv_web/components/ui.ex:412
+#: lib/vutuv_web/components/ui.ex:430
 #, elixir-autogen, elixir-format
 msgid "Full screen"
 msgstr "Vollbild"
@@ -10523,32 +10523,32 @@ msgstr "Neue Liste erstellen"
 msgid "Generate code list"
 msgstr "Kennwortliste erstellen"
 
-#: lib/vutuv_web/components/ui.ex:366
+#: lib/vutuv_web/components/ui.ex:384
 #, elixir-autogen, elixir-format
 msgid "Heading 1"
 msgstr "Überschrift 1"
 
-#: lib/vutuv_web/components/ui.ex:369
+#: lib/vutuv_web/components/ui.ex:387
 #, elixir-autogen, elixir-format
 msgid "Heading 2"
 msgstr "Überschrift 2"
 
-#: lib/vutuv_web/components/ui.ex:372
+#: lib/vutuv_web/components/ui.ex:390
 #, elixir-autogen, elixir-format
 msgid "Heading 3"
 msgstr "Überschrift 3"
 
-#: lib/vutuv_web/components/ui.ex:358
+#: lib/vutuv_web/components/ui.ex:376
 #, elixir-autogen, elixir-format
 msgid "Inline code"
 msgstr "Inline-Code"
 
-#: lib/vutuv_web/components/ui.ex:293
+#: lib/vutuv_web/components/ui.ex:311
 #, elixir-autogen, elixir-format
 msgid "Italic"
 msgstr "Kursiv"
 
-#: lib/vutuv_web/components/ui.ex:277
+#: lib/vutuv_web/components/ui.ex:295
 #, elixir-autogen, elixir-format
 msgid "Link URL"
 msgstr "Link-URL"
@@ -10558,8 +10558,8 @@ msgstr "Link-URL"
 msgid "Login codes"
 msgstr "Anmelde-Codes"
 
-#: lib/vutuv_web/components/ui.ex:338
-#: lib/vutuv_web/components/ui.ex:339
+#: lib/vutuv_web/components/ui.ex:356
+#: lib/vutuv_web/components/ui.ex:357
 #, elixir-autogen, elixir-format
 msgid "More formatting"
 msgstr "Mehr Formatierung"
@@ -10570,7 +10570,7 @@ msgstr "Mehr Formatierung"
 msgid "Not set up."
 msgstr "Nicht eingerichtet."
 
-#: lib/vutuv_web/components/ui.ex:389
+#: lib/vutuv_web/components/ui.ex:407
 #, elixir-autogen, elixir-format
 msgid "Numbered list"
 msgstr "Nummerierte Liste"
@@ -10587,7 +10587,7 @@ msgstr ""
 "Drucken Sie diese Seite aus oder schreiben Sie die Codes ab. "
 "Durchgestrichene Codes wurden bereits verwendet."
 
-#: lib/vutuv_web/components/ui.ex:375
+#: lib/vutuv_web/components/ui.ex:393
 #, elixir-autogen, elixir-format
 msgid "Quote"
 msgstr "Zitat"
@@ -10612,12 +10612,12 @@ msgstr ""
 msgid "Set up"
 msgstr "Einrichten"
 
-#: lib/vutuv_web/components/ui.ex:355
+#: lib/vutuv_web/components/ui.ex:373
 #, elixir-autogen, elixir-format
 msgid "Strikethrough"
 msgstr "Durchgestrichen"
 
-#: lib/vutuv_web/components/ui.ex:397
+#: lib/vutuv_web/components/ui.ex:415
 #, elixir-autogen, elixir-format
 msgid "Table"
 msgstr "Tabelle"
@@ -10634,7 +10634,7 @@ msgstr ""
 msgid "To finish, enter the code your app shows now"
 msgstr "Geben Sie zum Abschluss den Code ein, den Ihre App jetzt anzeigt"
 
-#: lib/vutuv_web/components/ui.ex:409
+#: lib/vutuv_web/components/ui.ex:427
 #, elixir-autogen, elixir-format
 msgid "Toggle Markdown source"
 msgstr "Markdown-Quelltext umschalten"
@@ -10755,7 +10755,7 @@ msgid_plural "%{count} stars"
 msgstr[0] "%{count} Stern"
 msgstr[1] "%{count} Sterne"
 
-#: lib/vutuv_web/live/organization_live/show.ex:503
+#: lib/vutuv_web/live/organization_live/show.ex:498
 #: lib/vutuv_web/views/user_html.ex:536
 #: lib/vutuv_web/views/user_html.ex:715
 #, elixir-autogen, elixir-format
@@ -11351,7 +11351,7 @@ msgstr "Screenshot-Warteschlange öffnen"
 #: lib/vutuv_web/live/admin/organization_live.ex:179
 #: lib/vutuv_web/live/admin/organization_live.ex:194
 #: lib/vutuv_web/live/admin/screenshot_live.ex:535
-#: lib/vutuv_web/live/organization_live/domains.ex:198
+#: lib/vutuv_web/live/organization_live/domains.ex:197
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr "Ausstehend"
@@ -11635,7 +11635,7 @@ msgstr "Ihre Liste ist leer. Es ist noch niemand ausgeschlossen."
 msgid "AI agents"
 msgstr "KI-Agenten"
 
-#: lib/vutuv_web/live/organization_live/show.ex:559
+#: lib/vutuv_web/live/organization_live/show.ex:554
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "Über die Organisation"
@@ -11645,18 +11645,19 @@ msgstr "Über die Organisation"
 msgid "Continue to verification"
 msgstr "Weiter zur Verifizierung"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:262
-#: lib/vutuv_web/live/organization_live/domains.ex:302
+#: lib/vutuv_web/live/organization_live/domains.ex:261
+#: lib/vutuv_web/live/organization_live/domains.ex:301
 #: lib/vutuv_web/live/organization_live/new.ex:161
-#: lib/vutuv_web/live/organization_live/show.ex:843
+#: lib/vutuv_web/live/organization_live/show.ex:838
 #: lib/vutuv_web/templates/url/verify.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "DNS TXT record"
 msgstr "DNS-TXT-Eintrag"
 
-#: lib/vutuv_web/components/organization_components.ex:102
-#: lib/vutuv_web/live/organization_live/domains.ex:181
-#: lib/vutuv_web/live/organization_live/show.ex:913
+#: lib/vutuv_web/live/organization_live/domains.ex:180
+#: lib/vutuv_web/live/organization_live/domains.ex:342
+#: lib/vutuv_web/live/organization_live/show.ex:904
+#: lib/vutuv_web/live/organization_live/show.ex:912
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr "Die Domain-Verifizierung ist auf dieser Installation deaktiviert."
@@ -11696,7 +11697,7 @@ msgstr ""
 msgid "Please log in first."
 msgstr "Bitte loggen Sie sich zuerst ein."
 
-#: lib/vutuv_web/live/organization_live/show.ex:816
+#: lib/vutuv_web/live/organization_live/show.ex:811
 #, elixir-autogen, elixir-format
 msgid "Prove you control %{domain} to publish this page."
 msgstr "Weisen Sie nach, dass Ihnen %{domain} gehört, um diese Seite zu veröffentlichen."
@@ -11717,13 +11718,13 @@ msgstr "Nach Name oder Stadt suchen"
 msgid "Search engines"
 msgstr "Suchmaschinen"
 
-#: lib/vutuv_web/components/organization_components.ex:221
+#: lib/vutuv_web/components/organization_components.ex:135
 #, elixir-autogen, elixir-format
 msgid "Select a country"
 msgstr "Land auswählen"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:321
-#: lib/vutuv_web/live/organization_live/show.ex:878
+#: lib/vutuv_web/live/organization_live/domains.ex:320
+#: lib/vutuv_web/live/organization_live/show.ex:873
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr "Stellen Sie diese Datei bereit unter:"
@@ -11750,12 +11751,12 @@ msgid "The upload failed."
 msgstr "Der Upload ist fehlgeschlagen."
 
 #: lib/vutuv_web/live/organization_live/new.ex:146
-#: lib/vutuv_web/live/organization_live/show.ex:831
+#: lib/vutuv_web/live/organization_live/show.ex:826
 #, elixir-autogen, elixir-format
 msgid "Verification method"
 msgstr "Verifizierungsmethode"
 
-#: lib/vutuv_web/live/organization_live/show.ex:791
+#: lib/vutuv_web/live/organization_live/show.ex:786
 #, elixir-autogen, elixir-format
 msgid "Verified domains"
 msgstr "Verifizierte Domains"
@@ -11771,13 +11772,13 @@ msgstr "Verifiziert über"
 msgid "Verified via %{domain}"
 msgstr "Verifiziert über %{domain}"
 
-#: lib/vutuv_web/live/organization_live/show.ex:813
+#: lib/vutuv_web/live/organization_live/show.ex:808
 #, elixir-autogen, elixir-format
 msgid "Verify %{name}"
 msgstr "%{name} verifizieren"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:337
-#: lib/vutuv_web/live/organization_live/show.ex:903
+#: lib/vutuv_web/live/organization_live/domains.ex:336
+#: lib/vutuv_web/live/organization_live/show.ex:898
 #, elixir-autogen, elixir-format
 msgid "Verify now"
 msgstr "Jetzt verifizieren"
@@ -11790,9 +11791,9 @@ msgstr "Jetzt verifizieren"
 msgid "Website"
 msgstr "Website"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:263
-#: lib/vutuv_web/live/organization_live/domains.ex:312
-#: lib/vutuv_web/live/organization_live/show.ex:854
+#: lib/vutuv_web/live/organization_live/domains.ex:262
+#: lib/vutuv_web/live/organization_live/domains.ex:311
+#: lib/vutuv_web/live/organization_live/show.ex:849
 #: lib/vutuv_web/templates/url/verify.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Website file"
@@ -11815,8 +11816,8 @@ msgstr ""
 "Im nächsten Schritt veröffentlichen Sie einen Eintrag oder eine Datei, um "
 "die Kontrolle über die Domain nachzuweisen."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:323
-#: lib/vutuv_web/live/organization_live/show.ex:884
+#: lib/vutuv_web/live/organization_live/domains.ex:322
+#: lib/vutuv_web/live/organization_live/show.ex:879
 #: lib/vutuv_web/templates/url/verify.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
@@ -11827,13 +11828,13 @@ msgstr "mit genau diesem Inhalt:"
 msgid "@handle or email"
 msgstr "@handle oder E-Mail"
 
-#: lib/vutuv_web/components/organization_components.ex:393
+#: lib/vutuv_web/components/organization_components.ex:307
 #: lib/vutuv_web/live/organization_live/edit.ex:390
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
 msgstr "Abkürzung"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:250
+#: lib/vutuv_web/live/organization_live/domains.ex:249
 #, elixir-autogen, elixir-format
 msgid "Add a domain"
 msgstr "Domain hinzufügen"
@@ -11848,7 +11849,7 @@ msgstr "Mitglied hinzufügen"
 msgid "Added @%{handle} to the team."
 msgstr "@%{handle} zum Team hinzugefügt."
 
-#: lib/vutuv_web/components/organization_components.ex:394
+#: lib/vutuv_web/components/organization_components.ex:308
 #: lib/vutuv_web/live/organization_live/edit.ex:388
 #, elixir-autogen, elixir-format
 msgid "Alias"
@@ -11867,7 +11868,7 @@ msgstr "Alias entfernt."
 #: lib/vutuv_web/agent_docs/markdown.ex:358
 #: lib/vutuv_web/agent_docs/text.ex:381
 #: lib/vutuv_web/live/organization_live/edit.ex:353
-#: lib/vutuv_web/live/organization_live/show.ex:779
+#: lib/vutuv_web/live/organization_live/show.ex:774
 #: lib/vutuv_web/templates/tag/single_card.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Also known as"
@@ -11894,7 +11895,7 @@ msgstr "Diese Seite archivieren?"
 msgid "Archived"
 msgstr "Archiviert"
 
-#: lib/vutuv_web/components/organization_components.ex:392
+#: lib/vutuv_web/components/organization_components.ex:306
 #: lib/vutuv_web/live/organization_live/edit.ex:389
 #, elixir-autogen, elixir-format
 msgid "Brand"
@@ -11917,37 +11918,37 @@ msgstr ""
 "Diese Seite und alles, was dazugehört, löschen? Das kann nicht rückgängig "
 "gemacht werden."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:64
+#: lib/vutuv_web/live/organization_live/domains.ex:65
 #, elixir-autogen, elixir-format
 msgid "Domain added. Publish the record or file, then verify it."
 msgstr ""
 "Domain hinzugefügt. Veröffentlichen Sie den Eintrag oder die Datei und "
 "starten Sie dann die Verifizierung."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:138
+#: lib/vutuv_web/live/organization_live/domains.ex:139
 #, elixir-autogen, elixir-format
 msgid "Domain removed."
 msgstr "Domain entfernt."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:107
+#: lib/vutuv_web/live/organization_live/domains.ex:108
 #, elixir-autogen, elixir-format
 msgid "Domain verified."
 msgstr "Domain verifiziert."
 
-#: lib/vutuv_web/components/organization_components.ex:318
+#: lib/vutuv_web/components/organization_components.ex:232
 #: lib/vutuv_web/live/admin/organization_live.ex:305
-#: lib/vutuv_web/live/organization_live/domains.ex:175
-#: lib/vutuv_web/live/organization_live/show.ex:530
+#: lib/vutuv_web/live/organization_live/domains.ex:174
+#: lib/vutuv_web/live/organization_live/show.ex:525
 #, elixir-autogen, elixir-format
 msgid "Domains"
 msgstr "Domains"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:28
+#: lib/vutuv_web/live/organization_live/domains.ex:29
 #, elixir-autogen, elixir-format
 msgid "Domains – %{name}"
 msgstr "Domains – %{name}"
 
-#: lib/vutuv_web/components/organization_components.ex:391
+#: lib/vutuv_web/components/organization_components.ex:305
 #, elixir-autogen, elixir-format
 msgid "Former name"
 msgstr "Früherer Name"
@@ -11966,7 +11967,7 @@ msgstr ""
 "Diese Seite einfrieren? Sie verschwindet für die Öffentlichkeit, bleibt aber "
 "für den Besitzer sichtbar."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:203
+#: lib/vutuv_web/live/organization_live/domains.ex:202
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "Last checked"
@@ -11987,7 +11988,7 @@ msgstr "Verlassen"
 msgid "Live"
 msgstr "Live"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:234
+#: lib/vutuv_web/live/organization_live/domains.ex:233
 #, elixir-autogen, elixir-format
 msgid "Make primary"
 msgstr "Als primär festlegen"
@@ -11997,7 +11998,7 @@ msgstr "Als primär festlegen"
 msgid "Member removed."
 msgstr "Mitglied entfernt."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:203
+#: lib/vutuv_web/live/organization_live/domains.ex:202
 #, elixir-autogen, elixir-format
 msgid "Method"
 msgstr "Methode"
@@ -12012,27 +12013,27 @@ msgstr "Namen & Aliasse"
 msgid "No member found for “%{id}”."
 msgstr "Kein Mitglied für „%{id}“ gefunden."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:123
+#: lib/vutuv_web/live/organization_live/domains.ex:124
 #, elixir-autogen, elixir-format
 msgid "Only a verified domain can be the primary one."
 msgstr "Nur eine verifizierte Domain kann die primäre sein."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:189
+#: lib/vutuv_web/live/organization_live/domains.ex:188
 #, elixir-autogen, elixir-format
 msgid "Primary"
 msgstr "Primär"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:119
+#: lib/vutuv_web/live/organization_live/domains.ex:120
 #, elixir-autogen, elixir-format
 msgid "Primary domain updated."
 msgstr "Primäre Domain aktualisiert."
 
-#: lib/vutuv_web/components/organization_components.ex:380
+#: lib/vutuv_web/components/organization_components.ex:294
 #, elixir-autogen, elixir-format
 msgid "Recruiter"
 msgstr "Recruiter"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:240
+#: lib/vutuv_web/live/organization_live/domains.ex:239
 #, elixir-autogen, elixir-format
 msgid "Remove this domain?"
 msgstr "Diese Domain entfernen?"
@@ -12052,10 +12053,10 @@ msgstr "Diesen Namen entfernen?"
 msgid "Search name, alias or domain"
 msgstr "Name, Alias oder Domain suchen"
 
-#: lib/vutuv_web/components/organization_components.ex:315
+#: lib/vutuv_web/components/organization_components.ex:229
 #: lib/vutuv_web/live/admin/organization_live.ex:321
 #: lib/vutuv_web/live/organization_live/roles.ex:165
-#: lib/vutuv_web/live/organization_live/show.ex:523
+#: lib/vutuv_web/live/organization_live/show.ex:518
 #, elixir-autogen, elixir-format
 msgid "Team"
 msgstr "Team"
@@ -12065,7 +12066,7 @@ msgstr "Team"
 msgid "Team – %{name}"
 msgstr "Team – %{name}"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:75
+#: lib/vutuv_web/live/organization_live/domains.ex:76
 #, elixir-autogen, elixir-format
 msgid "That is not a valid domain."
 msgstr "Das ist keine gültige Domain."
@@ -12153,13 +12154,13 @@ msgstr "Zurück zu den Links"
 msgid "Back-link (rel=me)"
 msgstr "Rück-Link (rel=me)"
 
-#: lib/vutuv_web/controllers/url_controller.ex:163
 #: lib/vutuv_web/templates/url/verify.html.heex:25
+#: lib/vutuv_web/views/url_html.ex:71
 #, elixir-autogen, elixir-format
 msgid "Link verification is disabled on this installation."
 msgstr "Die Link-Verifizierung ist auf dieser Installation deaktiviert."
 
-#: lib/vutuv_web/controllers/url_controller.ex:158
+#: lib/vutuv_web/controllers/url_controller.ex:155
 #, elixir-autogen, elixir-format
 msgid "Link verified. It now shows a verified mark."
 msgstr "Link verifiziert. Er zeigt jetzt ein Verifizierungs-Häkchen."
@@ -12183,7 +12184,7 @@ msgstr ""
 "Der Linktext ist beliebig. Ein verstecktes <link rel=\"me\"> im Seitenkopf "
 "funktioniert ebenfalls."
 
-#: lib/vutuv_web/components/ui.ex:887
+#: lib/vutuv_web/components/ui.ex:905
 #: lib/vutuv_web/live/section_reorder_live.ex:195
 #, elixir-autogen, elixir-format
 msgid "Verified webpage"
@@ -12194,7 +12195,7 @@ msgstr "Verifizierte Webseite"
 msgid "Verified. Re-run any method below to refresh it."
 msgstr "Verifiziert. Führen Sie eine der Methoden unten erneut aus, um es zu aktualisieren."
 
-#: lib/vutuv_web/controllers/url_controller.ex:138
+#: lib/vutuv_web/controllers/url_controller.ex:180
 #: lib/vutuv_web/templates/url/verify.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Verify link"
@@ -12222,13 +12223,6 @@ msgstr "Per Rück-Link verifizieren"
 msgid "Verify via file"
 msgstr "Per Datei verifizieren"
 
-#: lib/vutuv_web/controllers/url_controller.ex:170
-#, elixir-autogen, elixir-format
-msgid "We could not find the proof yet. It can take a while to propagate. Please try again."
-msgstr ""
-"Wir konnten den Nachweis noch nicht finden. Die Verbreitung kann etwas "
-"dauern. Bitte versuchen Sie es erneut."
-
 #: lib/vutuv_web/agent_docs/markdown.ex:842
 #: lib/vutuv_web/agent_docs/text.ex:636
 #, elixir-autogen, elixir-format
@@ -12240,7 +12234,7 @@ msgstr "verifizierte Webseite"
 msgid "%{min} to %{max} characters: letters (a-z), numbers (0-9) and underscores."
 msgstr "%{min} bis %{max} Zeichen: Buchstaben (a-z), Zahlen (0-9) und Unterstriche."
 
-#: lib/vutuv_web/live/organization_live/show.ex:667
+#: lib/vutuv_web/live/organization_live/show.ex:662
 #, elixir-autogen, elixir-format
 msgid "Former"
 msgstr "Ehemalig"
@@ -12304,14 +12298,14 @@ msgstr ""
 "auffindbar ist. Bei einer Umbenennung bleibt der alte Name hier automatisch "
 "erhalten."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:177
+#: lib/vutuv_web/live/organization_live/domains.ex:176
 #, elixir-autogen, elixir-format
 msgid "An organization can prove several domains. The primary one shows in the “Verified via …” badge."
 msgstr ""
 "Eine Organisation kann mehrere Domains nachweisen. Die primäre erscheint im "
 "Abzeichen „Verifiziert über …“."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:145
+#: lib/vutuv_web/live/organization_live/domains.ex:146
 #, elixir-autogen, elixir-format
 msgid "An organization keeps at least one verified domain, so this one cannot be removed."
 msgstr ""
@@ -12367,7 +12361,7 @@ msgstr "Vielleicht brauchen Sie Hilfe von Ihrer IT"
 msgid "The proof is a small technical change to your domain: a DNS entry or a file on your website. If you don't manage the website yourself, ask the person or team who does. That is usually your IT department or the company that runs your website. We show the exact instructions on the next step, so you can simply pass them on."
 msgstr "Der Nachweis ist eine kleine technische Änderung an Ihrer Domain: ein DNS-Eintrag oder eine Datei auf Ihrer Website. Wenn Sie die Website nicht selbst verwalten, fragen Sie die Person oder das Team, das dies tut. Das ist meist Ihre IT-Abteilung oder die Firma, die Ihre Website betreut. Die genaue Anleitung zeigen wir Ihnen im nächsten Schritt, Sie können sie einfach weitergeben."
 
-#: lib/vutuv_web/live/organization_live/show.ex:825
+#: lib/vutuv_web/live/organization_live/show.ex:820
 #, elixir-autogen, elixir-format
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr "Diese Schritte sind technisch. Wenn Sie %{domain} nicht selbst verwalten, kopieren Sie den unten gezeigten Eintrag oder die Datei und senden Sie ihn an Ihre IT-Abteilung oder die Firma, die Ihre Website betreut. Sobald sie ihn hinzugefügt hat, kommen Sie hierher zurück und klicken auf „Jetzt verifizieren“."
@@ -12481,21 +12475,21 @@ msgstr "Organisation wieder freigegeben."
 #: lib/vutuv_web/agent_docs/markdown.ex:349
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:325
-#: lib/vutuv_web/components/ui.ex:3928
+#: lib/vutuv_web/components/ui.ex:3946
 #: lib/vutuv_web/controllers/settings_controller.ex:179
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:501
-#: lib/vutuv_web/live/shell_live.ex:796
+#: lib/vutuv_web/live/shell_live.ex:803
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
-#: lib/vutuv_web/templates/layout/app.html.heex:83
+#: lib/vutuv_web/templates/layout/app.html.heex:94
 #: lib/vutuv_web/templates/settings/organizations.html.heex:6
 #, elixir-autogen, elixir-format
 msgid "Organizations"
 msgstr "Organisationen"
 
-#: lib/vutuv_web/components/organization_components.ex:248
+#: lib/vutuv_web/components/organization_components.ex:162
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:90
 #, elixir-autogen, elixir-format
 msgid "Please choose"
@@ -12518,7 +12512,7 @@ msgstr "Bitte loggen Sie sich ein, um eine Organisationsseite zu beanspruchen."
 msgid "Search organizations"
 msgstr "Organisationen durchsuchen"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:71
+#: lib/vutuv_web/live/organization_live/domains.ex:72
 #, elixir-autogen, elixir-format
 msgid "That domain already belongs to an organization page."
 msgstr "Diese Domain gehört bereits zu einer anderen Organisationsseite."
@@ -12538,7 +12532,7 @@ msgstr "Dieser Name ist für diese Organisation bereits eingetragen."
 msgid "The organization page was deleted."
 msgstr "Die Organisationsseite wurde gelöscht."
 
-#: lib/vutuv_web/live/organization_live/show.ex:384
+#: lib/vutuv_web/live/organization_live/show.ex:379
 #, elixir-autogen, elixir-format
 msgid "This organization page was reported and is hidden while it is reviewed. Only you and the moderators can see it."
 msgstr ""
@@ -12574,8 +12568,8 @@ msgstr "Sie dürfen diese Organisation nicht löschen."
 msgid "Your organization handle is set."
 msgstr "Ihr Organisations-Handle ist gesetzt."
 
-#: lib/vutuv_web/live/organization_live/show.ex:300
-#: lib/vutuv_web/live/organization_live/show.ex:360
+#: lib/vutuv_web/live/organization_live/show.ex:302
+#: lib/vutuv_web/live/organization_live/show.ex:355
 #, elixir-autogen, elixir-format
 msgid "Your organization page is verified and now live."
 msgstr "Ihre Organisationsseite ist verifiziert und jetzt live."
@@ -12833,8 +12827,8 @@ msgstr "Stellenbezeichnung"
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:504
-#: lib/vutuv_web/live/shell_live.ex:626
-#: lib/vutuv_web/templates/layout/app.html.heex:81
+#: lib/vutuv_web/live/shell_live.ex:633
+#: lib/vutuv_web/templates/layout/app.html.heex:92
 #: lib/vutuv_web/templates/qualification/show.html.heex:38
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -13156,17 +13150,17 @@ msgstr "Ihre Stellenanzeige auf vutuv läuft bald ab"
 msgid "A domain of your organization page on vutuv is about to be dropped"
 msgstr "Eine Domain Ihrer Organisationsseite auf vutuv entfällt bald"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:216
+#: lib/vutuv_web/live/organization_live/domains.ex:215
 #, elixir-autogen, elixir-format
 msgid "Deadline"
 msgstr "Frist"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:195
+#: lib/vutuv_web/live/organization_live/domains.ex:194
 #, elixir-autogen, elixir-format
 msgid "Proof missing"
 msgstr "Nachweis fehlt"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:215
+#: lib/vutuv_web/live/organization_live/domains.ex:214
 #, elixir-autogen, elixir-format
 msgid "We could not read this domain's proof on the last check. Restore it and check again, or the domain loses its verification."
 msgstr "Der Nachweis dieser Domain war bei der letzten Prüfung nicht abrufbar. Stellen Sie ihn wieder her und prüfen Sie erneut, sonst verliert die Domain ihre Verifizierung."
@@ -13279,14 +13273,14 @@ msgstr "DNS-Änderungen brauchen manchmal etwas, bis sie überall angekommen sin
 msgid "Getting an error, or is %{host} a CNAME / alias to another address? A TXT record cannot share a name with a CNAME. Use this name instead, with the exact same value as above:"
 msgstr "Bekommen Sie einen Fehler, oder ist %{host} ein CNAME / Alias auf eine andere Adresse? Ein TXT-Eintrag kann nicht denselben Namen wie ein CNAME haben. Verwenden Sie stattdessen diesen Namen, mit exakt demselben Wert wie oben:"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:319
-#: lib/vutuv_web/live/organization_live/show.ex:871
+#: lib/vutuv_web/live/organization_live/domains.ex:318
+#: lib/vutuv_web/live/organization_live/show.ex:866
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr "Ist %{domain} ein CNAME / Alias (ein TXT-Eintrag kann nicht denselben Namen wie ein CNAME haben), legen Sie den Eintrag stattdessen auf %{name} an, mit demselben Wert."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:317
-#: lib/vutuv_web/live/organization_live/show.ex:862
+#: lib/vutuv_web/live/organization_live/domains.ex:316
+#: lib/vutuv_web/live/organization_live/show.ex:857
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
 msgstr "Legen Sie in Ihren DNS-Einstellungen einen TXT-Eintrag auf dem Namen %{domain} mit diesem Wert an:"
@@ -13382,7 +13376,7 @@ msgid "Minimum yearly salary"
 msgstr "Mindestgehalt pro Jahr"
 
 #: lib/vutuv_web/live/job_board_live.ex:324
-#: lib/vutuv_web/live/organization_live/show.ex:694
+#: lib/vutuv_web/live/organization_live/show.ex:689
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr "Weitere Stellen"
@@ -13411,7 +13405,7 @@ msgstr "Keine passenden Stellen. Passen Sie die Filter an."
 #: lib/vutuv_web/agent_docs/markdown.ex:436
 #: lib/vutuv_web/agent_docs/text.ex:445
 #: lib/vutuv_web/agent_docs/text.ex:457
-#: lib/vutuv_web/live/organization_live/show.ex:681
+#: lib/vutuv_web/live/organization_live/show.ex:676
 #: lib/vutuv_web/templates/tag/show.html.heex:69
 #, elixir-autogen, elixir-format
 msgid "Open positions"
@@ -13716,7 +13710,7 @@ msgstr "Suche speichern"
 msgid "Saved search deleted."
 msgstr "Gespeicherte Suche gelöscht."
 
-#: lib/vutuv_web/components/ui.ex:3874
+#: lib/vutuv_web/components/ui.ex:3892
 #: lib/vutuv_web/controllers/settings_controller.ex:556
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -13880,7 +13874,7 @@ msgstr "Vor bestimmten Personen verbergen (Wettbewerber, eigene Belegschaft, Ein
 msgid "Inherited from the organization"
 msgstr "Von der Organisation geerbt"
 
-#: lib/vutuv_web/components/organization_components.ex:321
+#: lib/vutuv_web/components/organization_components.ex:235
 #: lib/vutuv_web/live/organization_live/exclusions.ex:103
 #, elixir-autogen, elixir-format
 msgid "Job exclusions"
@@ -14100,27 +14094,27 @@ msgstr[1] "Wir haben %{formatted} Beiträge aktualisiert, die Ihren alten Handle
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr "hat den Handle von @%{old} auf @%{new} geändert."
 
-#: lib/vutuv_web/components/ui.ex:323
+#: lib/vutuv_web/components/ui.ex:341
 #, elixir-autogen, elixir-format
 msgid "Center"
 msgstr "Zentriert"
 
-#: lib/vutuv_web/components/ui.ex:320
+#: lib/vutuv_web/components/ui.ex:338
 #, elixir-autogen, elixir-format
 msgid "Float left"
 msgstr "Linksbündig (Text umfließt)"
 
-#: lib/vutuv_web/components/ui.ex:326
+#: lib/vutuv_web/components/ui.ex:344
 #, elixir-autogen, elixir-format
 msgid "Float right"
 msgstr "Rechtsbündig (Text umfließt)"
 
-#: lib/vutuv_web/components/ui.ex:317
+#: lib/vutuv_web/components/ui.ex:335
 #, elixir-autogen, elixir-format
 msgid "Full width"
 msgstr "Volle Breite"
 
-#: lib/vutuv_web/components/ui.ex:305
+#: lib/vutuv_web/components/ui.ex:323
 #, elixir-autogen, elixir-format
 msgid "Insert image"
 msgstr "Bild einfügen"
@@ -14187,7 +14181,7 @@ msgstr ""
 "Personen tauchen in Ihren Vorschlägen auf. Einem Tag folgen Sie auf seiner "
 "Seite."
 
-#: lib/vutuv_web/components/ui.ex:3870
+#: lib/vutuv_web/components/ui.ex:3888
 #: lib/vutuv_web/controllers/settings_controller.ex:570
 #: lib/vutuv_web/live/post_live/feed.ex:1158
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -14269,7 +14263,7 @@ msgstr "Messenger wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:59
 #: lib/vutuv_web/agent_docs/text.ex:56
-#: lib/vutuv_web/components/ui.ex:3855
+#: lib/vutuv_web/components/ui.ex:3873
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -14297,14 +14291,14 @@ msgstr "Messenger von %{name}"
 msgid "Select a messenger"
 msgstr "Messenger auswählen"
 
-#: lib/vutuv_web/components/ui.ex:3295
+#: lib/vutuv_web/components/ui.ex:3313
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] "Meinen Follower darüber informieren"
 msgstr[1] "Meine %{formatted} Follower darüber informieren"
 
-#: lib/vutuv_web/components/ui.ex:3305
+#: lib/vutuv_web/components/ui.ex:3323
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr "Die Benachrichtigung enthält einen Link zu diesem Eintrag. Es wird keine E-Mail verschickt, und das passiert nur bei neuen Einträgen."
@@ -14528,19 +14522,19 @@ msgstr "hat Sie für %{tags} empfohlen."
 msgid "by:"
 msgstr "von:"
 
-#: lib/vutuv_web/components/ui.ex:1673
+#: lib/vutuv_web/components/ui.ex:1691
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr "Empfohlen von %{name}"
 
-#: lib/vutuv_web/components/ui.ex:1677
+#: lib/vutuv_web/components/ui.ex:1695
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] "Empfohlen von %{name} und %{formatted} weiteren"
 msgstr[1] "Empfohlen von %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/live/shell_live.ex:434
+#: lib/vutuv_web/live/shell_live.ex:435
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -15111,7 +15105,7 @@ msgstr "Blenden Sie Beiträge aus Ihrem Feed aus, die ein Tag tragen oder ein Wo
 msgid "Match whole words only (word/phrase)"
 msgstr "Nur ganze Wörter treffen (Wort/Phrase)"
 
-#: lib/vutuv_web/components/ui.ex:3866
+#: lib/vutuv_web/components/ui.ex:3884
 #: lib/vutuv_web/controllers/settings_controller.ex:636
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -15746,277 +15740,277 @@ msgstr "Ihr Server"
 msgid "moved to %{address}"
 msgstr "umgezogen nach %{address}"
 
-#: lib/vutuv_web/components/ui.ex:3797
+#: lib/vutuv_web/components/ui.ex:3815
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr "Name, Foto, Titelbild, Kurzbeschreibung"
 
-#: lib/vutuv_web/components/ui.ex:3802
+#: lib/vutuv_web/components/ui.ex:3820
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr "handle spitzname nutzername umbenennen slug profiladresse url erwähnung"
 
-#: lib/vutuv_web/components/ui.ex:3805
+#: lib/vutuv_web/components/ui.ex:3823
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr "Die Stationen in Ihrem Lebenslauf"
 
-#: lib/vutuv_web/components/ui.ex:3806
+#: lib/vutuv_web/components/ui.ex:3824
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr "lebenslauf cv karriere beruf arbeitgeber position stelle job firma"
 
-#: lib/vutuv_web/components/ui.ex:3809
+#: lib/vutuv_web/components/ui.ex:3827
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr "Schulen, Hochschulen, Abschlüsse"
 
-#: lib/vutuv_web/components/ui.ex:3810
+#: lib/vutuv_web/components/ui.ex:3828
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr "lebenslauf studium schule universität hochschule abschluss ausbildung"
 
-#: lib/vutuv_web/components/ui.ex:3813
+#: lib/vutuv_web/components/ui.ex:3831
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr "Nachweise, mit Belegdokumenten"
 
-#: lib/vutuv_web/components/ui.ex:3814
+#: lib/vutuv_web/components/ui.ex:3832
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr "zertifikat lizenz urkunde diplom nachweis beleg auszeichnung dokument"
 
-#: lib/vutuv_web/components/ui.ex:3821
+#: lib/vutuv_web/components/ui.ex:3839
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr "Sprachkenntnisse"
 
-#: lib/vutuv_web/components/ui.ex:3822
+#: lib/vutuv_web/components/ui.ex:3840
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr "Die Sprachen, die Sie sprechen"
 
-#: lib/vutuv_web/components/ui.ex:3823
+#: lib/vutuv_web/components/ui.ex:3841
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr "sprache sprachen sprechen fließend muttersprache verhandlungssicher"
 
-#: lib/vutuv_web/components/ui.ex:3826
+#: lib/vutuv_web/components/ui.ex:3844
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr "Die Themen, für die Sie bekannt sind"
 
-#: lib/vutuv_web/components/ui.ex:3827
+#: lib/vutuv_web/components/ui.ex:3845
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr "fähigkeit kenntnis thema stichwort schlagwort expertise empfehlung"
 
-#: lib/vutuv_web/components/ui.ex:3929
+#: lib/vutuv_web/components/ui.ex:3947
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr "Organisationsseiten, die Sie verwalten"
 
-#: lib/vutuv_web/components/ui.ex:3930
+#: lib/vutuv_web/components/ui.ex:3948
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr "firma unternehmen arbeitgeber betrieb organisation seite"
 
-#: lib/vutuv_web/components/ui.ex:3830
+#: lib/vutuv_web/components/ui.ex:3848
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr "Kontaktdaten"
 
-#: lib/vutuv_web/components/ui.ex:3833
+#: lib/vutuv_web/components/ui.ex:3851
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr "Wo wir Sie erreichen, und welche Adresse öffentlich ist"
 
-#: lib/vutuv_web/components/ui.ex:3834
+#: lib/vutuv_web/components/ui.ex:3852
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr "mail e-mail email adresse hauptadresse primär"
 
-#: lib/vutuv_web/components/ui.ex:3837
+#: lib/vutuv_web/components/ui.ex:3855
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr "Festnetz, Mobil, Fax"
 
-#: lib/vutuv_web/components/ui.ex:3838
+#: lib/vutuv_web/components/ui.ex:3856
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr "telefon handy mobil festnetz fax nummer rufnummer"
 
-#: lib/vutuv_web/components/ui.ex:3841
+#: lib/vutuv_web/components/ui.ex:3859
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr "Postanschriften auf Ihrem Profil"
 
-#: lib/vutuv_web/components/ui.ex:3842
+#: lib/vutuv_web/components/ui.ex:3860
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr "straße stadt ort postleitzahl plz land anschrift karte"
 
-#: lib/vutuv_web/components/ui.ex:3844
+#: lib/vutuv_web/components/ui.ex:3862
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr "Webseiten & Links"
 
-#: lib/vutuv_web/components/ui.ex:3845
+#: lib/vutuv_web/components/ui.ex:3863
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr "Ihre Homepage und weitere Links"
 
-#: lib/vutuv_web/components/ui.ex:3846
+#: lib/vutuv_web/components/ui.ex:3864
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr "url webseite website homepage blog link verifizieren bestätigen rel=me"
 
-#: lib/vutuv_web/components/ui.ex:3848
+#: lib/vutuv_web/components/ui.ex:3866
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr "Social-Media-Profile"
 
-#: lib/vutuv_web/components/ui.ex:3849
+#: lib/vutuv_web/components/ui.ex:3867
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr "Mastodon, Bluesky, GitHub und die anderen"
 
-#: lib/vutuv_web/components/ui.ex:3851
+#: lib/vutuv_web/components/ui.ex:3869
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr "mastodon bluesky github gitlab codeberg linkedin x twitter instagram soziale netzwerke"
 
-#: lib/vutuv_web/components/ui.ex:3856
+#: lib/vutuv_web/components/ui.ex:3874
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr "Signal, Threema, Matrix und die anderen"
 
-#: lib/vutuv_web/components/ui.ex:3857
+#: lib/vutuv_web/components/ui.ex:3875
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr "signal threema matrix xmpp telegram whatsapp chat messenger nachrichten"
 
-#: lib/vutuv_web/components/ui.ex:3860
+#: lib/vutuv_web/components/ui.ex:3878
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr "Mitteilungen & Feed"
 
-#: lib/vutuv_web/components/ui.ex:3863
+#: lib/vutuv_web/components/ui.ex:3881
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr "Welche E-Mails wir schicken, und was die Glocke meldet"
 
-#: lib/vutuv_web/components/ui.ex:3864
+#: lib/vutuv_web/components/ui.ex:3882
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer"
 msgstr "e-mail email mail abbestellen abmelden newsletter glocke benachrichtigung weniger ruhe"
 
-#: lib/vutuv_web/components/ui.ex:3867
+#: lib/vutuv_web/components/ui.ex:3885
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr "Beiträge aus Ihrem Feed heraushalten"
 
-#: lib/vutuv_web/components/ui.ex:3868
+#: lib/vutuv_web/components/ui.ex:3886
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr "stummschalten ausblenden verbergen filter wort begriff tag feed blockieren"
 
-#: lib/vutuv_web/components/ui.ex:3871
+#: lib/vutuv_web/components/ui.ex:3889
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr "Themen, deren Beiträge in Ihrem Feed landen"
 
-#: lib/vutuv_web/components/ui.ex:3872
+#: lib/vutuv_web/components/ui.ex:3890
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr "tag thema abonnieren folgen feed"
 
-#: lib/vutuv_web/components/ui.ex:3875
+#: lib/vutuv_web/components/ui.ex:3893
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr "Job- und Personensuchen, die Ihnen neue Treffer mailen"
 
-#: lib/vutuv_web/components/ui.ex:3876
+#: lib/vutuv_web/components/ui.ex:3894
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr "job stelle stellenangebot suchauftrag suche alarm benachrichtigung merkliste"
 
-#: lib/vutuv_web/components/ui.ex:3882
+#: lib/vutuv_web/components/ui.ex:3900
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr "Suchmaschinen, KI, Online-Status"
 
-#: lib/vutuv_web/components/ui.ex:3883
+#: lib/vutuv_web/components/ui.ex:3901
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr "privatsphäre datenschutz google suchmaschine ki ai llm crawler noindex online punkt öffentlich sichtbar"
 
-#: lib/vutuv_web/components/ui.ex:3886
+#: lib/vutuv_web/components/ui.ex:3904
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr "Personen, die nicht mit Ihnen interagieren können"
 
-#: lib/vutuv_web/components/ui.ex:3887
+#: lib/vutuv_web/components/ui.ex:3905
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr "blockieren sperren bannen stummschalten melden missbrauch belästigung"
 
-#: lib/vutuv_web/components/ui.ex:3908
+#: lib/vutuv_web/components/ui.ex:3926
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr "Passkeys, angemeldete Geräte, Anmeldecodes"
 
-#: lib/vutuv_web/components/ui.ex:3909
+#: lib/vutuv_web/components/ui.ex:3927
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr "passwort kennwort anmelden abmelden login logout sitzung gerät passkey totp 2fa pin sicherheit"
 
-#: lib/vutuv_web/components/ui.ex:3917
+#: lib/vutuv_web/components/ui.ex:3935
 #, elixir-autogen, elixir-format
 msgid "Interface language, maps, how posts are shortened"
 msgstr "Sprache der Oberfläche, Karten, Kürzung von Beiträgen"
 
-#: lib/vutuv_web/components/ui.ex:3918
+#: lib/vutuv_web/components/ui.ex:3936
 #, elixir-autogen, elixir-format
 msgid "german english locale translation map font length hyphenation"
 msgstr "deutsch englisch sprache übersetzung karte schrift länge silbentrennung darstellung"
 
-#: lib/vutuv_web/components/ui.ex:3921
+#: lib/vutuv_web/components/ui.ex:3939
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr "Ihre Daten von LinkedIn übernehmen"
 
-#: lib/vutuv_web/components/ui.ex:3922
+#: lib/vutuv_web/components/ui.ex:3940
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr "linkedin hochladen zip übernehmen importieren umzug"
 
-#: lib/vutuv_web/components/ui.ex:3925
+#: lib/vutuv_web/components/ui.ex:3943
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr "Alles herunterladen, was wir über Sie speichern"
 
-#: lib/vutuv_web/components/ui.ex:3926
+#: lib/vutuv_web/components/ui.ex:3944
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr "herunterladen download dsgvo gdpr daten sicherung json lebenslauf auskunft"
 
-#: lib/vutuv_web/components/ui.ex:3933
+#: lib/vutuv_web/components/ui.ex:3951
 #, elixir-autogen, elixir-format
 msgid "Connected apps and access tokens"
 msgstr "Verbundene Apps und Zugriffstoken"
 
-#: lib/vutuv_web/components/ui.ex:3934
+#: lib/vutuv_web/components/ui.ex:3952
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party"
 msgstr "api token oauth entwickler verbunden drittanbieter schnittstelle"
 
-#: lib/vutuv_web/components/ui.ex:3937
+#: lib/vutuv_web/components/ui.ex:3955
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr "Ihr Konto und alles darauf entfernen"
 
-#: lib/vutuv_web/components/ui.ex:3938
+#: lib/vutuv_web/components/ui.ex:3956
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr "löschen entfernen schließen kündigen beenden verlassen"
@@ -16485,7 +16479,7 @@ msgstr "API-Token erstellt"
 msgid "Access token revoked"
 msgstr "API-Token widerrufen"
 
-#: lib/vutuv_web/components/ui.ex:3911
+#: lib/vutuv_web/components/ui.ex:3929
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -16832,7 +16826,7 @@ msgstr "Was sich an einem Konto geändert hat, wann, von wo und wie es bestätig
 msgid "What changed on your account, and exactly when."
 msgstr "Was sich an Ihrem Konto geändert hat, und wann genau."
 
-#: lib/vutuv_web/components/ui.ex:3912
+#: lib/vutuv_web/components/ui.ex:3930
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr "Was sich an Ihrem Konto geändert hat, und wann"
@@ -16868,7 +16862,7 @@ msgstr "durch den Betreiber"
 msgid "from a signed-in session"
 msgstr "aus einer angemeldeten Sitzung"
 
-#: lib/vutuv_web/components/ui.ex:3914
+#: lib/vutuv_web/components/ui.ex:3932
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr "protokoll verlauf historie chronik audit sicherheit war ich das wer hat wann geaendert geändert log"
@@ -17416,7 +17410,7 @@ msgstr "Ein Konto in einem anderen Netzwerk"
 msgid "Cancel request"
 msgstr "Anfrage zurückziehen"
 
-#: lib/vutuv_web/components/ui.ex:3898
+#: lib/vutuv_web/components/ui.ex:3916
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr "Konten auf Mastodon folgen, und von dort gefolgt werden"
@@ -17618,7 +17612,7 @@ msgstr "Sie haben Ihre Fediverse-Follower auf ein anderes Konto umgeleitet, desh
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr "Ihr Konto ist derzeit gesperrt, deshalb geht nichts von Ihnen an andere Netzwerke und Sie können dort niemandem folgen. Das endet von selbst, sobald die Sperre abläuft."
 
-#: lib/vutuv_web/components/ui.ex:3900
+#: lib/vutuv_web/components/ui.ex:3918
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr "mastodon activitypub foederation federation follower folgen folge umzug migration entferntes konto"
@@ -18012,12 +18006,12 @@ msgstr ""
 "Ihr Feed zeigt die Beiträge der Mitglieder, denen Sie folgen. Folgen Sie ein "
 "paar Mitgliedern, um ihn zu füllen."
 
-#: lib/vutuv_web/components/ui.ex:183
+#: lib/vutuv_web/components/ui.ex:201
 #, elixir-autogen, elixir-format
 msgid "Add another tag"
 msgstr "Weiteren Tag hinzufügen"
 
-#: lib/vutuv_web/components/ui.ex:206
+#: lib/vutuv_web/components/ui.ex:224
 #, elixir-autogen, elixir-format
 msgid "Remove the tag %{name}"
 msgstr "Tag %{name} entfernen"
@@ -18161,7 +18155,7 @@ msgstr "Ihr Benutzername ist hier Ihre öffentliche Identität. Er ändert sich 
 msgid "Your username is your public identity here. It changes only once you confirm with your passkey or a valid code below."
 msgstr "Ihr Benutzername ist hier Ihre öffentliche Identität. Er ändert sich erst, wenn Sie unten mit Ihrem Passkey oder einem gültigen Code bestätigen."
 
-#: lib/vutuv_web/components/ui.ex:462
+#: lib/vutuv_web/components/ui.ex:480
 #, elixir-autogen, elixir-format
 msgid "Markdown help"
 msgstr "Markdown-Hilfe"
@@ -18176,53 +18170,53 @@ msgstr "Auf dieser Seite"
 msgid "Read this page as Markdown"
 msgstr "Diese Seite als Markdown lesen"
 
-#: lib/vutuv_web/components/ui.ex:519
+#: lib/vutuv_web/components/ui.ex:537
 #, elixir-autogen, elixir-format
 msgid "Activities"
 msgstr "Aktivitäten"
 
-#: lib/vutuv_web/components/ui.ex:517
+#: lib/vutuv_web/components/ui.ex:535
 #, elixir-autogen, elixir-format
 msgid "Animals & nature"
 msgstr "Tiere & Natur"
 
-#: lib/vutuv_web/components/ui.ex:278
-#: lib/vutuv_web/components/ui.ex:302
+#: lib/vutuv_web/components/ui.ex:296
+#: lib/vutuv_web/components/ui.ex:320
 #, elixir-autogen, elixir-format
 msgid "Emoji"
 msgstr "Emoji"
 
-#: lib/vutuv_web/components/ui.ex:518
+#: lib/vutuv_web/components/ui.ex:536
 #, elixir-autogen, elixir-format
 msgid "Food & drink"
 msgstr "Essen & Trinken"
 
-#: lib/vutuv_web/components/ui.ex:281
+#: lib/vutuv_web/components/ui.ex:299
 #, elixir-autogen, elixir-format
 msgid "No emoji found."
 msgstr "Keine Emoji gefunden."
 
-#: lib/vutuv_web/components/ui.ex:521
+#: lib/vutuv_web/components/ui.ex:539
 #, elixir-autogen, elixir-format
 msgid "Objects"
 msgstr "Objekte"
 
-#: lib/vutuv_web/components/ui.ex:279
+#: lib/vutuv_web/components/ui.ex:297
 #, elixir-autogen, elixir-format
 msgid "Search emoji"
 msgstr "Emoji suchen"
 
-#: lib/vutuv_web/components/ui.ex:515
+#: lib/vutuv_web/components/ui.ex:533
 #, elixir-autogen, elixir-format
 msgid "Smileys"
 msgstr "Smileys"
 
-#: lib/vutuv_web/components/ui.ex:522
+#: lib/vutuv_web/components/ui.ex:540
 #, elixir-autogen, elixir-format
 msgid "Symbols"
 msgstr "Symbole"
 
-#: lib/vutuv_web/components/ui.ex:520
+#: lib/vutuv_web/components/ui.ex:538
 #, elixir-autogen, elixir-format
 msgid "Travel & places"
 msgstr "Reisen & Orte"
@@ -18473,12 +18467,12 @@ msgstr "Kacheln füllen"
 msgid "Whole photos"
 msgstr "Ganze Fotos"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:131
+#: lib/vutuv_web/templates/layout/app.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Send the post or message you are writing"
 msgstr "Beitrag oder Nachricht absenden, während Sie schreiben"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:192
+#: lib/vutuv_web/templates/layout/app.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "The single-key shortcuts pause while you type, and are off on phones and tablets."
 msgstr "Die Einzeltasten-Kürzel pausieren, während Sie tippen, und sind auf Telefonen und Tablets aus."
@@ -18771,8 +18765,8 @@ msgstr "Mehr von %{name}"
 msgid "This is vutuv's copy of a post published on %{host}. It is kept while somebody here follows its author."
 msgstr "Das ist die Kopie, die vutuv von einem auf %{host} veröffentlichten Beitrag hat. Sie bleibt erhalten, solange hier jemand diesem Konto folgt."
 
-#: lib/vutuv_web/components/ui.ex:1074
-#: lib/vutuv_web/components/ui.ex:1075
+#: lib/vutuv_web/components/ui.ex:1092
+#: lib/vutuv_web/components/ui.ex:1093
 #, elixir-autogen, elixir-format
 msgid "Subscribe to this feed in your RSS reader"
 msgstr "Diesen Feed in Ihrem RSS-Reader abonnieren"
@@ -19018,7 +19012,7 @@ msgstr "Ihre Daten bleiben Ihnen"
 msgid "Delete your account yourself, without writing to anybody. No questions asked, and you are welcome back any time."
 msgstr "Löschen Sie Ihr Konto selbst, ohne jemandem schreiben zu müssen. No questions asked! Und Sie können jederzeit gerne wiederkommen."
 
-#: lib/vutuv_web/components/ui.ex:212
+#: lib/vutuv_web/components/ui.ex:230
 #, elixir-autogen, elixir-format
 msgid "At most %{max} tags. Remove one to add another."
 msgstr "Höchstens %{max} Tags. Entfernen Sie eines, um ein anderes hinzuzufügen."
@@ -19172,7 +19166,7 @@ msgstr "Arbeitszeugnis gespeichert."
 msgid "Employment reference updated."
 msgstr "Arbeitszeugnis aktualisiert."
 
-#: lib/vutuv_web/components/ui.ex:3816
+#: lib/vutuv_web/components/ui.ex:3834
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -19366,7 +19360,7 @@ msgstr "In der Warteschlange, Ihres ist als Nächstes dran."
 msgid "You changed the text after this review. It describes the earlier version."
 msgstr "Sie haben den Text nach dieser Prüfung geändert. Sie beschreibt die frühere Fassung."
 
-#: lib/vutuv_web/components/ui.ex:3817
+#: lib/vutuv_web/components/ui.ex:3835
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr "Ihre Arbeitszeugnisse, privat bis Sie sie veröffentlichen"
@@ -19377,7 +19371,7 @@ msgstr "Ihre Arbeitszeugnisse, privat bis Sie sie veröffentlichen"
 msgid "Zwischenzeugnis"
 msgstr "Zwischenzeugnis"
 
-#: lib/vutuv_web/components/ui.ex:3819
+#: lib/vutuv_web/components/ui.ex:3837
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr "arbeitszeugnis zeugnis referenz beurteilung arbeitgeber bewertung prüfung"
@@ -19985,14 +19979,14 @@ msgstr "6-stellige PIN"
 msgid "Enter the PIN from the email"
 msgstr "PIN aus der E-Mail eingeben"
 
-#: lib/vutuv_web/components/ui.ex:667
+#: lib/vutuv_web/components/ui.ex:685
 #, elixir-autogen, elixir-format
 msgid "If you have added other addresses to your vutuv account, try logging in with one of those instead."
 msgstr ""
 "Wenn Sie Ihrem vutuv-Konto weitere Adressen hinzugefügt haben, melden Sie "
 "sich stattdessen mit einer davon an."
 
-#: lib/vutuv_web/components/ui.ex:695
+#: lib/vutuv_web/components/ui.ex:713
 #, elixir-autogen, elixir-format
 msgid "Cancel registration"
 msgstr "Registrierung abbrechen"
@@ -20010,7 +20004,7 @@ msgstr ""
 msgid "Follow other members"
 msgstr "Anderen Mitgliedern folgen"
 
-#: lib/vutuv_web/components/ui.ex:650
+#: lib/vutuv_web/components/ui.ex:668
 #, elixir-autogen, elixir-format
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
@@ -20039,7 +20033,7 @@ msgstr ""
 "Anteile bezogen auf die %{answered} Mitglieder mit Angabe. %{unanswered} ohne "
 "Angabe."
 
-#: lib/vutuv_web/components/ui.ex:3798
+#: lib/vutuv_web/components/ui.ex:3816
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr "avatar profilbild portrait foto bild geburtstag geburtsdatum geschlecht über mich"
@@ -20135,7 +20129,7 @@ msgstr "Ebenfalls löschen"
 msgid "Always keep"
 msgstr "Immer behalten"
 
-#: lib/vutuv_web/components/ui.ex:3891
+#: lib/vutuv_web/components/ui.ex:3909
 #: lib/vutuv_web/controllers/settings_controller.ex:213
 #: lib/vutuv_web/controllers/settings_controller.ex:292
 #: lib/vutuv_web/controllers/settings_controller.ex:304
@@ -20232,7 +20226,7 @@ msgstr "Fotobeiträge behalten"
 msgid "Keep posts that did well"
 msgstr "Beiträge behalten, die gut liefen"
 
-#: lib/vutuv_web/components/ui.ex:3893
+#: lib/vutuv_web/components/ui.ex:3911
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr "Ihre Beiträge nach einer selbst gewählten Zeit auslaufen lassen"
@@ -20341,7 +20335,7 @@ msgstr "Sie können vorher alles herunterladen, was Sie hier haben:"
 msgid "Your rule"
 msgstr "Ihre Regel"
 
-#: lib/vutuv_web/components/ui.ex:3895
+#: lib/vutuv_web/components/ui.ex:3913
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr "löschen entfernen beiträge alter alt ablaufen verfallen automatisch aufräumen aufbewahrung"
@@ -20720,12 +20714,12 @@ msgstr "Von vorn beginnen"
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr "Ein Herz oder ein Repost geht zurück in das Netzwerk, aus dem dieser Beitrag stammt. Ihr Konto nimmt derzeit nicht am Fediverse teil. Einschalten können Sie das in den {settings}."
 
-#: lib/vutuv_web/components/organization_components.ex:379
+#: lib/vutuv_web/components/organization_components.ex:293
 #, elixir-autogen, elixir-format
 msgid "Editorial"
 msgstr "Redaktion"
 
-#: lib/vutuv_web/components/organization_components.ex:385
+#: lib/vutuv_web/components/organization_components.ex:299
 #, elixir-autogen, elixir-format
 msgid "Edits the page and posts jobs."
 msgstr "Bearbeitet die Seite und schreibt Stellen aus."
@@ -20735,7 +20729,7 @@ msgstr "Bearbeitet die Seite und schreibt Stellen aus."
 msgid "Give members their roles on this page. Someone can hold several at once, and every role is granted on its own."
 msgstr "Geben Sie Mitgliedern ihre Rollen auf dieser Seite. Jemand kann mehrere gleichzeitig haben, und jede Rolle wird einzeln vergeben."
 
-#: lib/vutuv_web/components/organization_components.ex:384
+#: lib/vutuv_web/components/organization_components.ex:298
 #, elixir-autogen, elixir-format
 msgid "Manages the team and the domains, and edits the page."
 msgstr "Verwaltet Team und Domains und bearbeitet die Seite."
@@ -20745,7 +20739,7 @@ msgstr "Verwaltet Team und Domains und bearbeitet die Seite."
 msgid "Pick at least one role."
 msgstr "Wählen Sie mindestens eine Rolle."
 
-#: lib/vutuv_web/components/organization_components.ex:387
+#: lib/vutuv_web/components/organization_components.ex:301
 #, elixir-autogen, elixir-format
 msgid "Posts jobs."
 msgstr "Schreibt Stellen aus."
@@ -20760,7 +20754,7 @@ msgstr "Rollen"
 msgid "Roles updated."
 msgstr "Rollen aktualisiert."
 
-#: lib/vutuv_web/components/organization_components.ex:386
+#: lib/vutuv_web/components/organization_components.ex:300
 #, elixir-autogen, elixir-format
 msgid "Writes posts in the organization's name."
 msgstr "Schreibt Beiträge im Namen der Organisation."
@@ -20770,33 +20764,33 @@ msgstr "Schreibt Beiträge im Namen der Organisation."
 msgid "The owner gives other members their roles on the page, and can hand ownership over to someone else at any time. Someone can hold several roles, and writing in the organization's name is always granted on its own."
 msgstr "Der Besitzer vergibt die Rollen der anderen Mitglieder auf der Seite und kann den Besitz jederzeit an jemand anderen übergeben. Jemand kann mehrere Rollen haben, und das Schreiben im Namen der Organisation wird immer einzeln vergeben."
 
-#: lib/vutuv_web/live/organization_live/show.ex:637
+#: lib/vutuv_web/live/organization_live/show.ex:632
 #, elixir-autogen, elixir-format
 msgid "Nothing published yet."
 msgstr "Noch nichts veröffentlicht."
 
-#: lib/vutuv_web/live/organization_live/show.ex:619
+#: lib/vutuv_web/live/organization_live/show.ex:614
 #: lib/vutuv_web/live/post_live/composer.ex:1814
 #, elixir-autogen, elixir-format
 msgid "Post as %{name}"
 msgstr "Als %{name} veröffentlichen"
 
-#: lib/vutuv_web/live/organization_live/show.ex:225
+#: lib/vutuv_web/live/organization_live/show.ex:227
 #, elixir-autogen, elixir-format
 msgid "Published as %{name}."
 msgstr "Als %{name} veröffentlicht."
 
-#: lib/vutuv_web/live/organization_live/show.ex:237
+#: lib/vutuv_web/live/organization_live/show.ex:239
 #, elixir-autogen, elixir-format
 msgid "That post could not be published."
 msgstr "Dieser Beitrag konnte nicht veröffentlicht werden."
 
-#: lib/vutuv_web/live/organization_live/show.ex:611
+#: lib/vutuv_web/live/organization_live/show.ex:606
 #, elixir-autogen, elixir-format
 msgid "Write something as %{name}"
 msgstr "Schreiben Sie etwas als %{name}"
 
-#: lib/vutuv_web/live/organization_live/show.ex:231
+#: lib/vutuv_web/live/organization_live/show.ex:233
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr "Sie dürfen nicht mehr im Namen dieser Organisation schreiben."
@@ -20806,7 +20800,7 @@ msgstr "Sie dürfen nicht mehr im Namen dieser Organisation schreiben."
 msgid "A post in an organization's name is always public."
 msgstr "Ein Beitrag im Namen einer Organisation ist immer öffentlich."
 
-#: lib/vutuv_web/live/shell_live.ex:558
+#: lib/vutuv_web/live/shell_live.ex:562
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr "Seite öffnen"
@@ -20821,12 +20815,12 @@ msgstr "Begonnen, im Namen einer Organisation zu schreiben"
 msgid "Stopped writing as an organization"
 msgstr "Beendet, im Namen einer Organisation zu schreiben"
 
-#: lib/vutuv_web/live/organization_live/show.ex:595
+#: lib/vutuv_web/live/organization_live/show.ex:590
 #, elixir-autogen, elixir-format
 msgid "Write as %{name} for now"
 msgstr "Vorerst als %{name} schreiben"
 
-#: lib/vutuv_web/live/shell_live.ex:568
+#: lib/vutuv_web/live/shell_live.ex:572
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr "Wieder als ich selbst schreiben"
@@ -20836,7 +20830,7 @@ msgstr "Wieder als ich selbst schreiben"
 msgid "You are writing as %{name} now."
 msgstr "Sie schreiben jetzt als %{name}."
 
-#: lib/vutuv_web/live/shell_live.ex:544
+#: lib/vutuv_web/live/shell_live.ex:548
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr "Sie schreiben als %{name}."
@@ -21043,12 +21037,12 @@ msgstr "Andere Netzwerke sprechen diese Seite als @name@%{host} an, so wie sie e
 
 #: lib/vutuv_web/live/organization_live/fediverse.ex:88
 #: lib/vutuv_web/live/organization_live/new.ex:211
-#: lib/vutuv_web/live/organization_live/show.ex:747
+#: lib/vutuv_web/live/organization_live/show.ex:742
 #, elixir-autogen, elixir-format
 msgid "People who have no vutuv account can follow this page and read its posts, in networks like Mastodon."
 msgstr "Auch Menschen ohne vutuv-Konto können dieser Seite folgen und ihre Beiträge lesen, in Netzwerken wie Mastodon."
 
-#: lib/vutuv_web/live/organization_live/show.ex:761
+#: lib/vutuv_web/live/organization_live/show.ex:756
 #, elixir-autogen, elixir-format
 msgid "Set this page up for other networks"
 msgstr "Seite für andere Netzwerke einrichten"
@@ -21063,7 +21057,7 @@ msgstr "Ausschalten"
 msgid "Switch it on"
 msgstr "Einschalten"
 
-#: lib/vutuv_web/live/organization_live/show.ex:752
+#: lib/vutuv_web/live/organization_live/show.ex:747
 #, elixir-autogen, elixir-format
 msgid "The page gets an address of its own for that, written like an email address."
 msgstr "Die Seite bekommt dafür eine eigene Adresse, die wie eine E-Mail-Adresse aussieht."
@@ -21148,22 +21142,22 @@ msgstr "Neu registrieren"
 msgid "The PIN has expired."
 msgstr "Die PIN ist abgelaufen."
 
-#: lib/vutuv_web/components/ui.ex:771
+#: lib/vutuv_web/components/ui.ex:789
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more minute."
 msgstr "Die PIN ist noch eine Minute gültig."
 
-#: lib/vutuv_web/components/ui.ex:773
+#: lib/vutuv_web/components/ui.ex:791
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more second."
 msgstr "Die PIN ist noch eine Sekunde gültig."
 
-#: lib/vutuv_web/components/ui.ex:772
+#: lib/vutuv_web/components/ui.ex:790
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more minutes."
 msgstr "Die PIN ist noch {n} Minuten gültig."
 
-#: lib/vutuv_web/components/ui.ex:774
+#: lib/vutuv_web/components/ui.ex:792
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more seconds."
 msgstr "Die PIN ist noch {n} Sekunden gültig."
@@ -21200,21 +21194,21 @@ msgstr "Sie folgen #%{tag} hier bereits."
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr "Sie sind selbst auf diesem vutuv. Sie folgen #%{tag} jetzt direkt hier."
 
-#: lib/vutuv_web/live/shell_live.ex:464
+#: lib/vutuv_web/live/shell_live.ex:465
 #, elixir-autogen, elixir-format
 msgid "%{formatted} person"
 msgid_plural "%{formatted} people"
 msgstr[0] "%{formatted} Person"
 msgstr[1] "%{formatted} Personen"
 
-#: lib/vutuv_web/live/shell_live.ex:451
+#: lib/vutuv_web/live/shell_live.ex:452
 #, elixir-autogen, elixir-format
 msgid "person"
 msgid_plural "people"
 msgstr[0] "Person"
 msgstr[1] "Personen"
 
-#: lib/vutuv_web/live/shell_live.ex:486
+#: lib/vutuv_web/live/shell_live.ex:487
 #, elixir-autogen, elixir-format
 msgid "%{members} vutuv members plus %{fediverse} Fediverse account that follows them"
 msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that follow them"
@@ -21323,13 +21317,13 @@ msgstr "Nur wenn Sie hier klicken: Wir fragen bei gravatar.com nach, ob es zu Ih
 msgid "The gravatar.com lookup is switched off on this installation."
 msgstr "Die Abfrage bei gravatar.com ist auf dieser Installation abgeschaltet."
 
-#: lib/vutuv_web/components/organization_components.ex:165
+#: lib/vutuv_web/components/organization_components.ex:79
 #, elixir-autogen, elixir-format
 msgid "A new entry can take a while to reach everyone. We keep checking %{domain} by ourselves and send you an email as soon as it works, so you can close this page."
 msgstr "Ein neuer Eintrag braucht manchmal eine Weile, bis er überall ankommt. Wir prüfen %{domain} von selbst weiter und schicken Ihnen eine E-Mail, sobald es klappt. Sie können diese Seite also schließen."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:333
-#: lib/vutuv_web/live/organization_live/show.ex:899
+#: lib/vutuv_web/live/organization_live/domains.ex:332
+#: lib/vutuv_web/live/organization_live/show.ex:894
 #, elixir-autogen, elixir-format
 msgid "Checking …"
 msgstr "Wird geprüft …"
@@ -21339,47 +21333,47 @@ msgstr "Wird geprüft …"
 msgid "Finish verification"
 msgstr "Verifizierung abschließen"
 
-#: lib/vutuv_web/components/organization_components.ex:152
+#: lib/vutuv_web/components/verification_components.ex:139
 #, elixir-autogen, elixir-format
 msgid "It answered with HTTP status %{status}."
 msgstr "Die Antwort war HTTP-Status %{status}."
 
-#: lib/vutuv_web/components/organization_components.ex:149
+#: lib/vutuv_web/components/verification_components.ex:136
 #, elixir-autogen, elixir-format
 msgid "It answered with an empty file."
 msgstr "Die Antwort war eine leere Datei."
 
-#: lib/vutuv_web/components/organization_components.ex:146
+#: lib/vutuv_web/components/verification_components.ex:133
 #, elixir-autogen, elixir-format
 msgid "It answered, but with something else: %{found}"
 msgstr "Es kam eine Antwort, aber mit einem anderen Inhalt: %{found}"
 
-#: lib/vutuv_web/components/organization_components.ex:122
+#: lib/vutuv_web/components/verification_components.ex:96
 #, elixir-autogen, elixir-format
 msgid "No TXT record at all."
 msgstr "Dort steht überhaupt kein TXT-Eintrag."
 
-#: lib/vutuv_web/components/organization_components.ex:95
+#: lib/vutuv_web/components/verification_components.ex:69
 #, elixir-autogen, elixir-format
 msgid "Not found yet"
 msgstr "Noch nicht gefunden"
 
-#: lib/vutuv_web/components/organization_components.ex:106
+#: lib/vutuv_web/components/verification_components.ex:80
 #, elixir-autogen, elixir-format
 msgid "We asked the name servers of your domain directly, for %{names}, and looked for this value:"
 msgstr "Wir haben die Namensserver Ihrer Domain direkt nach %{names} gefragt und diesen Wert gesucht:"
 
-#: lib/vutuv_web/components/organization_components.ex:143
+#: lib/vutuv_web/components/verification_components.ex:130
 #, elixir-autogen, elixir-format
 msgid "We could not reach that address at all."
 msgstr "Wir konnten diese Adresse gar nicht erreichen."
 
-#: lib/vutuv_web/components/organization_components.ex:125
+#: lib/vutuv_web/components/verification_components.ex:112
 #, elixir-autogen, elixir-format
 msgid "We fetched this address:"
 msgstr "Wir haben diese Adresse abgerufen:"
 
-#: lib/vutuv_web/components/organization_components.ex:110
+#: lib/vutuv_web/components/verification_components.ex:84
 #, elixir-autogen, elixir-format
 msgid "What is published there right now:"
 msgstr "Was dort im Moment veröffentlicht ist:"
@@ -21388,3 +21382,28 @@ msgstr "Was dort im Moment veröffentlicht ist:"
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is verified"
 msgstr "Ihre Organisationsseite auf vutuv ist verifiziert"
+
+#: lib/vutuv_web/components/verification_components.ex:147
+#, elixir-autogen, elixir-format
+msgid "We could not reach your page at all."
+msgstr "Wir konnten Ihre Seite gar nicht erreichen."
+
+#: lib/vutuv_web/components/verification_components.ex:100
+#, elixir-autogen, elixir-format
+msgid "We fetched your page and looked for a link back to:"
+msgstr "Wir haben Ihre Seite geladen und dort nach einem Link auf diese Adresse gesucht:"
+
+#: lib/vutuv_web/components/verification_components.ex:156
+#, elixir-autogen, elixir-format
+msgid "Your page answered with HTTP status %{status}."
+msgstr "Ihre Seite hat mit HTTP-Status %{status} geantwortet."
+
+#: lib/vutuv_web/components/verification_components.ex:153
+#, elixir-autogen, elixir-format
+msgid "Your page does link back, but somewhere else:"
+msgstr "Ihre Seite verlinkt zurück, aber woandershin:"
+
+#: lib/vutuv_web/components/verification_components.ex:150
+#, elixir-autogen, elixir-format
+msgid "Your page has no rel=\"me\" link at all yet."
+msgstr "Ihre Seite hat noch gar keinen rel=\"me\"-Link."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -11,17 +11,17 @@ msgid ""
 msgstr ""
 "Language: INSERT LANGUAGE HERE\n"
 
-#: lib/vutuv_web/controllers/page_controller.ex:114
-#: lib/vutuv_web/templates/layout/app.html.heex:97
+#: lib/vutuv_web/controllers/page_controller.ex:174
+#: lib/vutuv_web/templates/layout/app.html.heex:108
 #, elixir-autogen
 msgid "About us"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3582
-#: lib/vutuv_web/components/ui.ex:3587
+#: lib/vutuv_web/components/ui.ex:3600
+#: lib/vutuv_web/components/ui.ex:3605
 #: lib/vutuv_web/live/admin/screenshot_live.ex:266
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:718
-#: lib/vutuv_web/live/organization_live/domains.ex:269
+#: lib/vutuv_web/live/organization_live/domains.ex:268
 #: lib/vutuv_web/live/organization_live/edit.ex:396
 #: lib/vutuv_web/live/organization_live/roles.ex:210
 #, elixir-autogen
@@ -35,7 +35,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
 #: lib/vutuv_web/live/organization_live/fediverse.ex:119
-#: lib/vutuv_web/live/organization_live/show.ex:769
+#: lib/vutuv_web/live/organization_live/show.ex:764
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
@@ -64,7 +64,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:67
 #: lib/vutuv_web/agent_docs/text.ex:64
-#: lib/vutuv_web/components/ui.ex:3840
+#: lib/vutuv_web/components/ui.ex:3858
 #: lib/vutuv_web/controllers/address_controller.ex:23
 #: lib/vutuv_web/controllers/address_controller.ex:38
 #: lib/vutuv_web/controllers/address_controller.ex:85
@@ -82,8 +82,8 @@ msgstr ""
 msgid "Already a member? Sign in here."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3377
-#: lib/vutuv_web/components/ui.ex:3471
+#: lib/vutuv_web/components/ui.ex:3395
+#: lib/vutuv_web/components/ui.ex:3489
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:698
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:830
@@ -111,7 +111,7 @@ msgid "Birthday"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:110
-#: lib/vutuv_web/components/ui.ex:3371
+#: lib/vutuv_web/components/ui.ex:3389
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
@@ -162,7 +162,7 @@ msgid "Couldn't follow back to %{name}."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2751
-#: lib/vutuv_web/components/ui.ex:3474
+#: lib/vutuv_web/components/ui.ex:3492
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
@@ -211,12 +211,12 @@ msgid "Download"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2716
-#: lib/vutuv_web/components/ui.ex:3465
+#: lib/vutuv_web/components/ui.ex:3483
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
 #: lib/vutuv_web/live/job_posting_live/show.ex:178
-#: lib/vutuv_web/live/organization_live/show.ex:516
+#: lib/vutuv_web/live/organization_live/show.ex:511
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:7
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:19
@@ -285,7 +285,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:37
 #: lib/vutuv_web/agent_docs/text.ex:34
-#: lib/vutuv_web/components/ui.ex:3804
+#: lib/vutuv_web/components/ui.ex:3822
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -326,14 +326,14 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:547
 #: lib/vutuv_web/agent_docs/text.ex:514
 #: lib/vutuv_web/components/fediverse_components.ex:313
-#: lib/vutuv_web/components/ui.ex:2079
-#: lib/vutuv_web/components/ui.ex:2104
-#: lib/vutuv_web/components/ui.ex:2107
-#: lib/vutuv_web/components/ui.ex:2114
-#: lib/vutuv_web/components/ui.ex:2117
-#: lib/vutuv_web/components/ui.ex:2175
+#: lib/vutuv_web/components/ui.ex:2097
+#: lib/vutuv_web/components/ui.ex:2122
+#: lib/vutuv_web/components/ui.ex:2125
+#: lib/vutuv_web/components/ui.ex:2132
+#: lib/vutuv_web/components/ui.ex:2135
+#: lib/vutuv_web/components/ui.ex:2193
 #: lib/vutuv_web/controllers/followee_controller.ex:29
-#: lib/vutuv_web/live/organization_live/show.ex:476
+#: lib/vutuv_web/live/organization_live/show.ex:471
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:53
 #: lib/vutuv_web/templates/user/show.html.heex:955
@@ -361,7 +361,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/directory/index.html.heex:3
 #: lib/vutuv_web/templates/directory/show.html.heex:4
-#: lib/vutuv_web/templates/layout/app.html.heex:121
+#: lib/vutuv_web/templates/layout/app.html.heex:132
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:2
 #, elixir-autogen
 msgid "Home"
@@ -442,8 +442,8 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:843
-#: lib/vutuv_web/live/shell_live.ex:889
+#: lib/vutuv_web/live/shell_live.ex:850
+#: lib/vutuv_web/live/shell_live.ex:906
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -612,7 +612,7 @@ msgstr ""
 msgid "Public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3370
+#: lib/vutuv_web/components/ui.ex:3388
 #: lib/vutuv_web/live/organization_live/edit.ex:341
 #: lib/vutuv_web/live/post_live/composer.ex:1813
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -640,13 +640,13 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:54
 #: lib/vutuv_web/live/search_live.ex:613
-#: lib/vutuv_web/live/shell_live.ex:711
-#: lib/vutuv_web/live/shell_live.ex:872
+#: lib/vutuv_web/live/shell_live.ex:718
+#: lib/vutuv_web/live/shell_live.ex:889
 #: lib/vutuv_web/live/tag_live/timeline.ex:237
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:30
-#: lib/vutuv_web/templates/layout/app.html.heex:126
+#: lib/vutuv_web/templates/layout/app.html.heex:137
 #, elixir-autogen
 msgid "Search"
 msgstr ""
@@ -789,7 +789,7 @@ msgstr ""
 msgid "User verified successfully."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3800
+#: lib/vutuv_web/components/ui.ex:3818
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
@@ -840,20 +840,20 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1014
+#: lib/vutuv_web/components/ui.ex:1032
 #: lib/vutuv_web/templates/user/show.html.heex:343
 #, elixir-autogen
 msgid "vCard"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3535
+#: lib/vutuv_web/components/ui.ex:3553
 #: lib/vutuv_web/templates/user/show.html.heex:949
 #: lib/vutuv_web/templates/user/show.html.heex:972
 #, elixir-autogen
 msgid "View All"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3881
+#: lib/vutuv_web/components/ui.ex:3899
 #: lib/vutuv_web/controllers/settings_controller.ex:159
 #: lib/vutuv_web/live/job_posting_live/form.ex:561
 #: lib/vutuv_web/live/organization_live/edit.ex:300
@@ -1074,7 +1074,7 @@ msgstr ""
 msgid "Listings"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:263
+#: lib/vutuv_web/controllers/page_controller.ex:323
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:4
 #, elixir-autogen
 msgid "Most Followed Users"
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Add Localization"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:375
+#: lib/vutuv_web/components/organization_components.ex:289
 #: lib/vutuv_web/live/admin/activity_live.ex:153
 #: lib/vutuv_web/live/admin/api_app_live.ex:58
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
@@ -1161,7 +1161,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:815
+#: lib/vutuv_web/live/shell_live.ex:822
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1373,7 +1373,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:30
 #: lib/vutuv_web/agent_docs/text.ex:440
 #: lib/vutuv_web/agent_docs/text.ex:663
-#: lib/vutuv_web/components/ui.ex:3825
+#: lib/vutuv_web/components/ui.ex:3843
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
 #: lib/vutuv_web/cv/docx.ex:174
@@ -1594,7 +1594,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:875
+#: lib/vutuv_web/live/shell_live.ex:892
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1614,15 +1614,15 @@ msgid "Check your inbox"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3204
-#: lib/vutuv_web/components/ui.ex:280
+#: lib/vutuv_web/components/ui.ex:298
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
 #: lib/vutuv_web/live/post_live/composer.ex:1331
 #: lib/vutuv_web/live/post_live/composer.ex:1332
 #: lib/vutuv_web/live/post_live/composer.ex:2249
-#: lib/vutuv_web/templates/layout/app.html.heex:159
-#: lib/vutuv_web/templates/layout/app.html.heex:165
+#: lib/vutuv_web/templates/layout/app.html.heex:170
+#: lib/vutuv_web/templates/layout/app.html.heex:176
 #: lib/vutuv_web/views/layout_html.ex:40
 #, elixir-autogen, elixir-format
 msgid "Close"
@@ -1640,16 +1640,16 @@ msgstr ""
 msgid "Confirm account deletion"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:118
-#: lib/vutuv_web/templates/layout/app.html.heex:93
+#: lib/vutuv_web/controllers/page_controller.ex:178
+#: lib/vutuv_web/templates/layout/app.html.heex:104
 #: lib/vutuv_web/templates/page/index.html.heex:261
 #: lib/vutuv_web/views/admin/legal_page_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Datenschutzerklärung"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:124
-#: lib/vutuv_web/templates/layout/app.html.heex:95
+#: lib/vutuv_web/controllers/page_controller.ex:184
+#: lib/vutuv_web/templates/layout/app.html.heex:106
 #: lib/vutuv_web/templates/page/index.html.heex:261
 #: lib/vutuv_web/views/admin/legal_page_html.ex:12
 #, elixir-autogen, elixir-format
@@ -1668,30 +1668,30 @@ msgstr ""
 msgid "Edit profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1495
-#: lib/vutuv_web/components/ui.ex:1504
-#: lib/vutuv_web/components/ui.ex:1906
+#: lib/vutuv_web/components/ui.ex:1513
+#: lib/vutuv_web/components/ui.ex:1522
+#: lib/vutuv_web/components/ui.ex:1924
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:199
-#: lib/vutuv_web/components/ui.ex:2044
-#: lib/vutuv_web/components/ui.ex:2044
-#: lib/vutuv_web/components/ui.ex:2061
-#: lib/vutuv_web/components/ui.ex:2070
-#: lib/vutuv_web/components/ui.ex:2086
-#: lib/vutuv_web/components/ui.ex:2123
-#: lib/vutuv_web/components/ui.ex:2126
-#: lib/vutuv_web/components/ui.ex:2133
-#: lib/vutuv_web/components/ui.ex:2136
-#: lib/vutuv_web/components/ui.ex:2209
+#: lib/vutuv_web/components/ui.ex:2062
+#: lib/vutuv_web/components/ui.ex:2062
+#: lib/vutuv_web/components/ui.ex:2079
+#: lib/vutuv_web/components/ui.ex:2088
+#: lib/vutuv_web/components/ui.ex:2104
+#: lib/vutuv_web/components/ui.ex:2141
+#: lib/vutuv_web/components/ui.ex:2144
+#: lib/vutuv_web/components/ui.ex:2151
+#: lib/vutuv_web/components/ui.ex:2154
+#: lib/vutuv_web/components/ui.ex:2227
 #: lib/vutuv_web/live/fediverse_account_live.ex:375
 #: lib/vutuv_web/live/fediverse_following_live.ex:331
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:293
 #: lib/vutuv_web/live/organization_live/following.ex:218
-#: lib/vutuv_web/live/organization_live/show.ex:445
-#: lib/vutuv_web/live/organization_live/show.ex:474
+#: lib/vutuv_web/live/organization_live/show.ex:440
+#: lib/vutuv_web/live/organization_live/show.ex:469
 #: lib/vutuv_web/templates/user/show.html.heex:1269
 #, elixir-autogen, elixir-format
 msgid "Follow"
@@ -1707,13 +1707,13 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:834
+#: lib/vutuv_web/live/shell_live.ex:841
 #: lib/vutuv_web/views/settings_html.ex:262
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:381
+#: lib/vutuv_web/components/organization_components.ex:295
 #: lib/vutuv_web/live/admin/activity_live.ex:143
 #: lib/vutuv_web/live/admin/activity_live.ex:175
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
@@ -1728,28 +1728,28 @@ msgstr ""
 msgid "Member"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:495
+#: lib/vutuv_web/live/organization_live/show.ex:490
 #: lib/vutuv_web/templates/user/show.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
 
 #: lib/vutuv_web/live/message_live/index.ex:50
-#: lib/vutuv_web/live/message_live/index.ex:622
-#: lib/vutuv_web/live/shell_live.ex:727
-#: lib/vutuv_web/live/shell_live.ex:874
-#: lib/vutuv_web/templates/layout/app.html.heex:123
+#: lib/vutuv_web/live/message_live/index.ex:624
+#: lib/vutuv_web/live/shell_live.ex:734
+#: lib/vutuv_web/live/shell_live.ex:891
+#: lib/vutuv_web/templates/layout/app.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:619
+#: lib/vutuv_web/live/shell_live.ex:626
 #, elixir-autogen, elixir-format
 msgid "Network"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:435
-#: lib/vutuv_web/components/ui.ex:3584
+#: lib/vutuv_web/components/ui.ex:3602
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:705
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:742
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:793
@@ -1764,11 +1764,11 @@ msgstr ""
 msgid "Nothing new yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3862
+#: lib/vutuv_web/components/ui.ex:3880
 #: lib/vutuv_web/live/notification_live/index.ex:114
 #: lib/vutuv_web/live/notification_live/index.ex:338
-#: lib/vutuv_web/live/shell_live.ex:738
-#: lib/vutuv_web/templates/layout/app.html.heex:124
+#: lib/vutuv_web/live/shell_live.ex:745
+#: lib/vutuv_web/templates/layout/app.html.heex:135
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Notifications"
@@ -1789,19 +1789,19 @@ msgid "Pardon us! Something went wrong."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:130
-#: lib/vutuv_web/live/message_live/index.ex:869
+#: lib/vutuv_web/live/message_live/index.ex:871
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Send"
 msgstr ""
 
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:35
-#: lib/vutuv_web/templates/layout/app.html.heex:87
+#: lib/vutuv_web/templates/layout/app.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "Source"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:89
+#: lib/vutuv_web/templates/layout/app.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "Submit a bug report or feature request"
 msgstr ""
@@ -1864,8 +1864,8 @@ msgstr ""
 msgid "Who to follow"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:858
-#: lib/vutuv_web/live/message_live/index.ex:859
+#: lib/vutuv_web/live/message_live/index.ex:860
+#: lib/vutuv_web/live/message_live/index.ex:861
 #, elixir-autogen, elixir-format
 msgid "Write a message…"
 msgstr ""
@@ -1910,17 +1910,17 @@ msgstr ""
 msgid "started following you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2924
-#: lib/vutuv_web/components/ui.ex:3075
+#: lib/vutuv_web/components/ui.ex:2942
+#: lib/vutuv_web/components/ui.ex:3093
 #: lib/vutuv_web/live/organization_live/index.ex:122
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3609
+#: lib/vutuv_web/components/ui.ex:3627
 #: lib/vutuv_web/live/organization_live/activity.ex:146
 #: lib/vutuv_web/live/organization_live/feed.ex:101
-#: lib/vutuv_web/live/organization_live/show.ex:642
+#: lib/vutuv_web/live/organization_live/show.ex:637
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr ""
@@ -1930,13 +1930,13 @@ msgstr ""
 msgid "The address itself cannot be changed. To use a different one, add it as a new email address and delete this one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3380
+#: lib/vutuv_web/components/ui.ex:3398
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1220
-#: lib/vutuv_web/components/ui.ex:1230
+#: lib/vutuv_web/components/ui.ex:1238
+#: lib/vutuv_web/components/ui.ex:1248
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr ""
@@ -1975,12 +1975,12 @@ msgstr ""
 msgid "Add cover photo"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2634
+#: lib/vutuv_web/components/ui.ex:2652
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2638
+#: lib/vutuv_web/components/ui.ex:2656
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr ""
@@ -2005,37 +2005,37 @@ msgstr ""
 msgid "Cover photo of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2642
+#: lib/vutuv_web/components/ui.ex:2660
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2632
+#: lib/vutuv_web/components/ui.ex:2650
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2631
+#: lib/vutuv_web/components/ui.ex:2649
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2637
+#: lib/vutuv_web/components/ui.ex:2655
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2636
+#: lib/vutuv_web/components/ui.ex:2654
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2633
+#: lib/vutuv_web/components/ui.ex:2651
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2635
+#: lib/vutuv_web/components/ui.ex:2653
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr ""
@@ -2050,17 +2050,17 @@ msgstr ""
 msgid "Member since %{year}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2641
+#: lib/vutuv_web/components/ui.ex:2659
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2640
+#: lib/vutuv_web/components/ui.ex:2658
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2639
+#: lib/vutuv_web/components/ui.ex:2657
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr ""
@@ -2110,13 +2110,13 @@ msgstr ""
 msgid "Edit post"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:333
+#: lib/vutuv_web/components/organization_components.ex:247
 #: lib/vutuv_web/live/organization_live/feed.ex:79
 #: lib/vutuv_web/live/post_live/feed.ex:159
 #: lib/vutuv_web/live/post_live/feed.ex:936
-#: lib/vutuv_web/live/shell_live.ex:599
-#: lib/vutuv_web/live/shell_live.ex:870
-#: lib/vutuv_web/templates/layout/app.html.heex:122
+#: lib/vutuv_web/live/shell_live.ex:606
+#: lib/vutuv_web/live/shell_live.ex:887
+#: lib/vutuv_web/templates/layout/app.html.heex:133
 #, elixir-autogen, elixir-format
 msgid "Feed"
 msgstr ""
@@ -2198,7 +2198,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:382
 #: lib/vutuv_web/live/notification_live/index.ex:891
-#: lib/vutuv_web/live/organization_live/show.ex:569
+#: lib/vutuv_web/live/organization_live/show.ex:564
 #: lib/vutuv_web/live/post_live/saved.ex:495
 #: lib/vutuv_web/live/search_live.ex:309
 #: lib/vutuv_web/live/search_live.ex:772
@@ -2226,7 +2226,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/screenshot_live.ex:338
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:700
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
-#: lib/vutuv_web/live/organization_live/domains.ex:243
+#: lib/vutuv_web/live/organization_live/domains.ex:242
 #: lib/vutuv_web/live/organization_live/edit.ex:373
 #: lib/vutuv_web/live/organization_live/roles.ex:243
 #: lib/vutuv_web/live/post_live/composer.ex:1886
@@ -2285,8 +2285,8 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4126
-#: lib/vutuv_web/live/shell_live.ex:781
+#: lib/vutuv_web/components/ui.ex:4144
+#: lib/vutuv_web/live/shell_live.ex:788
 #: lib/vutuv_web/templates/post/index.html.heex:17
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:209
@@ -2367,7 +2367,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1603
 #: lib/vutuv_web/components/post_components.ex:4436
-#: lib/vutuv_web/components/ui.ex:2999
+#: lib/vutuv_web/components/ui.ex:3017
 #: lib/vutuv_web/views/user_html.ex:335
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2376,8 +2376,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1001
 #: lib/vutuv_web/live/post_live/saved.ex:175
 #: lib/vutuv_web/live/post_live/saved.ex:488
-#: lib/vutuv_web/live/shell_live.ex:720
-#: lib/vutuv_web/live/shell_live.ex:786
+#: lib/vutuv_web/live/shell_live.ex:727
+#: lib/vutuv_web/live/shell_live.ex:793
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2386,7 +2386,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1567
 #: lib/vutuv_web/components/post_components.ex:4670
-#: lib/vutuv_web/components/ui.ex:2985
+#: lib/vutuv_web/components/ui.ex:3003
 #: lib/vutuv_web/live/notification_live/index.ex:1038
 #: lib/vutuv_web/views/user_html.ex:345
 #, elixir-autogen, elixir-format
@@ -2398,7 +2398,7 @@ msgstr ""
 #: lib/vutuv_web/live/notification_live/index.ex:971
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
-#: lib/vutuv_web/live/shell_live.ex:789
+#: lib/vutuv_web/live/shell_live.ex:796
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2456,12 +2456,12 @@ msgid "Unlike"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:343
-#: lib/vutuv_web/components/ui.ex:2039
-#: lib/vutuv_web/components/ui.ex:2039
-#: lib/vutuv_web/components/ui.ex:2176
+#: lib/vutuv_web/components/ui.ex:2057
+#: lib/vutuv_web/components/ui.ex:2057
+#: lib/vutuv_web/components/ui.ex:2194
 #: lib/vutuv_web/live/organization_live/following.ex:197
 #: lib/vutuv_web/live/organization_live/following.ex:256
-#: lib/vutuv_web/live/organization_live/show.ex:479
+#: lib/vutuv_web/live/organization_live/show.ex:474
 #: lib/vutuv_web/live/post_live/feed.ex:1172
 #: lib/vutuv_web/templates/followee/index.html.heex:44
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
@@ -2545,12 +2545,12 @@ msgstr ""
 msgid "%{name} is typing…"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:881
+#: lib/vutuv_web/live/message_live/index.ex:883
 #, elixir-autogen, elixir-format
 msgid "@%{slug} has not accepted your message request yet."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:835
+#: lib/vutuv_web/live/message_live/index.ex:837
 #, elixir-autogen, elixir-format
 msgid "@%{slug} wants to message you."
 msgstr ""
@@ -2560,7 +2560,7 @@ msgstr ""
 msgid "Accept"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:704
+#: lib/vutuv_web/live/message_live/index.ex:706
 #, elixir-autogen, elixir-format
 msgid "Back to conversations"
 msgstr ""
@@ -2575,7 +2575,7 @@ msgstr ""
 msgid "Deleted account"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:750
+#: lib/vutuv_web/live/message_live/index.ex:752
 #, elixir-autogen, elixir-format
 msgid "Load older messages"
 msgstr ""
@@ -2586,23 +2586,23 @@ msgstr ""
 msgid "Member not found."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:683
+#: lib/vutuv_web/live/message_live/index.ex:685
 #, elixir-autogen, elixir-format
 msgid "No conversations yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2510
-#: lib/vutuv_web/live/message_live/index.ex:726
+#: lib/vutuv_web/components/ui.ex:2528
+#: lib/vutuv_web/live/message_live/index.ex:728
 #, elixir-autogen, elixir-format
 msgid "Online"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:632
+#: lib/vutuv_web/live/message_live/index.ex:634
 #, elixir-autogen, elixir-format
 msgid "Requests"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:890
+#: lib/vutuv_web/live/message_live/index.ex:892
 #, elixir-autogen, elixir-format
 msgid "Select a conversation."
 msgstr ""
@@ -2678,7 +2678,7 @@ msgstr ""
 msgid "Okay, let's start over."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:675
+#: lib/vutuv_web/components/ui.ex:693
 #, elixir-autogen, elixir-format
 msgid "Resend PIN"
 msgstr ""
@@ -2689,7 +2689,7 @@ msgstr ""
 msgid "Too many PIN requests. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:696
+#: lib/vutuv_web/components/ui.ex:714
 #, elixir-autogen, elixir-format
 msgid "Use a different email address"
 msgstr ""
@@ -2739,8 +2739,8 @@ msgstr ""
 msgid "Write your first post"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3163
-#: lib/vutuv_web/components/ui.ex:3537
+#: lib/vutuv_web/components/ui.ex:3181
+#: lib/vutuv_web/components/ui.ex:3555
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
 #: lib/vutuv_web/templates/settings/organizations.html.heex:104
@@ -2793,7 +2793,7 @@ msgstr[1] ""
 msgid "Connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1005
+#: lib/vutuv_web/components/ui.ex:1023
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr ""
@@ -2803,7 +2803,7 @@ msgstr ""
 msgid "No connections yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1021
+#: lib/vutuv_web/components/ui.ex:1039
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr ""
@@ -2813,7 +2813,7 @@ msgstr ""
 msgid "People who aren't my connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1006
+#: lib/vutuv_web/components/ui.ex:1024
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr ""
@@ -2836,12 +2836,12 @@ msgstr[1] ""
 msgid "people who aren't your connections"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:684
+#: lib/vutuv_web/live/message_live/index.ex:686
 #, elixir-autogen, elixir-format
 msgid "Open someone's profile to message them."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:327
+#: lib/vutuv_web/components/organization_components.ex:241
 #: lib/vutuv_web/live/notification_live/index.ex:1050
 #: lib/vutuv_web/live/organization_live/activity.ex:99
 #, elixir-autogen, elixir-format
@@ -2941,7 +2941,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:324
 #: lib/vutuv_web/agent_docs/text.ex:306
 #: lib/vutuv_web/controllers/page_controller.ex:83
-#: lib/vutuv_web/templates/layout/app.html.heex:91
+#: lib/vutuv_web/templates/layout/app.html.heex:102
 #: lib/vutuv_web/templates/page/community.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Community guidelines"
@@ -3002,7 +3002,7 @@ msgstr ""
 msgid "Hidden. You can settle this yourself - see below."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:779
+#: lib/vutuv_web/live/message_live/index.ex:781
 #, elixir-autogen, elixir-format
 msgid "Hidden: reported, under review"
 msgstr ""
@@ -3120,7 +3120,7 @@ msgstr ""
 msgid "Opened"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:374
+#: lib/vutuv_web/components/organization_components.ex:288
 #: lib/vutuv_web/live/admin/api_app_live.ex:72
 #: lib/vutuv_web/live/admin/deliverability_live.ex:171
 #: lib/vutuv_web/live/admin/moderation_live.ex:56
@@ -3143,9 +3143,9 @@ msgstr ""
 msgid "Private message"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3794
-#: lib/vutuv_web/live/shell_live.ex:612
-#: lib/vutuv_web/live/shell_live.ex:879
+#: lib/vutuv_web/components/ui.ex:3812
+#: lib/vutuv_web/live/shell_live.ex:619
+#: lib/vutuv_web/live/shell_live.ex:896
 #: lib/vutuv_web/templates/import/new.html.heex:15
 #: lib/vutuv_web/templates/import/preview.html.heex:55
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
@@ -3172,7 +3172,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1066
 #: lib/vutuv_web/components/post_components.ex:2042
 #: lib/vutuv_web/components/post_components.ex:2772
-#: lib/vutuv_web/live/organization_live/show.ex:552
+#: lib/vutuv_web/live/organization_live/show.ex:547
 #: lib/vutuv_web/templates/user/show.html.heex:219
 #, elixir-autogen, elixir-format
 msgid "Report"
@@ -3199,8 +3199,8 @@ msgstr ""
 msgid "Report this content"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:798
-#: lib/vutuv_web/live/message_live/index.ex:799
+#: lib/vutuv_web/live/message_live/index.ex:800
+#: lib/vutuv_web/live/message_live/index.ex:801
 #, elixir-autogen, elixir-format
 msgid "Report this message"
 msgstr ""
@@ -3254,7 +3254,7 @@ msgstr ""
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2899
+#: lib/vutuv_web/components/ui.ex:2917
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:773
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -4494,7 +4494,7 @@ msgstr ""
 msgid "Block @%{slug}? This removes any follows and connection between you, closes your conversation, and prevents all interaction in both directions. Unblocking will not restore what was removed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3885
+#: lib/vutuv_web/components/ui.ex:3903
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -4541,12 +4541,12 @@ msgstr ""
 msgid "Discover people to follow"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:687
+#: lib/vutuv_web/live/message_live/index.ex:689
 #, elixir-autogen, elixir-format
 msgid "Find members"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:339
+#: lib/vutuv_web/components/organization_components.ex:253
 #: lib/vutuv_web/live/organization_live/following.ex:154
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:53
@@ -4593,9 +4593,9 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:366
 #: lib/vutuv_web/agent_docs/text.ex:388
 #: lib/vutuv_web/components/saved_search_components.ex:57
-#: lib/vutuv_web/components/ui.ex:516
+#: lib/vutuv_web/components/ui.ex:534
 #: lib/vutuv_web/live/notification_live/index.ex:892
-#: lib/vutuv_web/live/organization_live/show.ex:652
+#: lib/vutuv_web/live/organization_live/show.ex:647
 #: lib/vutuv_web/live/post_live/saved.ex:498
 #: lib/vutuv_web/live/search_live.ex:307
 #: lib/vutuv_web/live/search_live.ex:714
@@ -5253,12 +5253,12 @@ msgstr ""
 msgid "API token (%{date})"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:85
+#: lib/vutuv_web/templates/layout/app.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3936
+#: lib/vutuv_web/components/ui.ex:3954
 #: lib/vutuv_web/controllers/settings_controller.ex:145
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5304,48 +5304,48 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:768
+#: lib/vutuv_web/live/shell_live.ex:775
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:321
 #: lib/vutuv_web/live/admin/screenshot_live.ex:431
-#: lib/vutuv_web/templates/layout/app.html.heex:128
+#: lib/vutuv_web/templates/layout/app.html.heex:139
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:138
+#: lib/vutuv_web/templates/layout/app.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "Close menus and dialogs"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:135
+#: lib/vutuv_web/templates/layout/app.html.heex:146
 #, elixir-autogen, elixir-format
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:825
-#: lib/vutuv_web/templates/layout/app.html.heex:154
+#: lib/vutuv_web/live/shell_live.ex:832
+#: lib/vutuv_web/templates/layout/app.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:119
+#: lib/vutuv_web/templates/layout/app.html.heex:130
 #, elixir-autogen, elixir-format
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4033
-#: lib/vutuv_web/components/ui.ex:4038
-#: lib/vutuv_web/components/ui.ex:4117
-#: lib/vutuv_web/components/ui.ex:4181
+#: lib/vutuv_web/components/ui.ex:4051
+#: lib/vutuv_web/components/ui.ex:4056
+#: lib/vutuv_web/components/ui.ex:4135
+#: lib/vutuv_web/components/ui.ex:4199
 #: lib/vutuv_web/controllers/settings_controller.ex:61
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:303
-#: lib/vutuv_web/live/shell_live.ex:805
+#: lib/vutuv_web/live/shell_live.ex:812
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5358,17 +5358,17 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:137
+#: lib/vutuv_web/templates/layout/app.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "Show this help"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:130
+#: lib/vutuv_web/templates/layout/app.html.heex:141
 #, elixir-autogen, elixir-format
 msgid "Write a new post"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:125
+#: lib/vutuv_web/templates/layout/app.html.heex:136
 #: lib/vutuv_web/views/page_html.ex:505
 #, elixir-autogen, elixir-format
 msgid "Your profile"
@@ -5389,23 +5389,23 @@ msgstr ""
 msgid "Add a profile photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:132
+#: lib/vutuv_web/templates/layout/app.html.heex:143
 #, elixir-autogen, elixir-format
 msgid "Next post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:133
+#: lib/vutuv_web/templates/layout/app.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "Previous post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:592
-#: lib/vutuv_web/live/shell_live.ex:863
+#: lib/vutuv_web/live/shell_live.ex:599
+#: lib/vutuv_web/live/shell_live.ex:878
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:78
+#: lib/vutuv_web/templates/layout/app.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Footer navigation"
 msgstr ""
@@ -5459,7 +5459,7 @@ msgstr ""
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3905
+#: lib/vutuv_web/components/ui.ex:3923
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:289
@@ -5480,7 +5480,7 @@ msgstr ""
 msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3832
+#: lib/vutuv_web/components/ui.ex:3850
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5514,7 +5514,7 @@ msgstr ""
 msgid "Photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3879
+#: lib/vutuv_web/components/ui.ex:3897
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/templates/page/index.html.heex:166
 #, elixir-autogen, elixir-format
@@ -5630,7 +5630,7 @@ msgstr ""
 msgid "Apps"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3932
+#: lib/vutuv_web/components/ui.ex:3950
 #: lib/vutuv_web/controllers/settings_controller.ex:165
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -5715,7 +5715,7 @@ msgstr ""
 msgid "@handle"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:742
+#: lib/vutuv_web/live/message_live/index.ex:744
 #, elixir-autogen, elixir-format
 msgid "Block @%{slug}"
 msgstr ""
@@ -6058,7 +6058,7 @@ msgstr ""
 msgid "Tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:296
+#: lib/vutuv_web/components/ui.ex:314
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
 #: lib/vutuv_web/templates/user/show.html.heex:883
@@ -6240,9 +6240,9 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1495
-#: lib/vutuv_web/components/ui.ex:1504
-#: lib/vutuv_web/components/ui.ex:1907
+#: lib/vutuv_web/components/ui.ex:1513
+#: lib/vutuv_web/components/ui.ex:1522
+#: lib/vutuv_web/components/ui.ex:1925
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr ""
@@ -6303,7 +6303,7 @@ msgstr ""
 msgid "No endorsements yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1860
+#: lib/vutuv_web/components/ui.ex:1878
 #: lib/vutuv_web/live/notification_live/index.ex:625
 #: lib/vutuv_web/live/notification_live/index.ex:640
 #: lib/vutuv_web/live/notification_live/index.ex:778
@@ -6598,7 +6598,7 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2364
+#: lib/vutuv_web/components/ui.ex:2382
 #: lib/vutuv_web/live/fediverse_account_live.ex:369
 #: lib/vutuv_web/templates/settings/filters.html.heex:58
 #: lib/vutuv_web/templates/user/show.html.heex:212
@@ -6622,7 +6622,7 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2363
+#: lib/vutuv_web/components/ui.ex:2381
 #: lib/vutuv_web/live/fediverse_account_live.ex:367
 #: lib/vutuv_web/templates/settings/filters.html.heex:81
 #: lib/vutuv_web/templates/user/show.html.heex:212
@@ -6661,33 +6661,33 @@ msgstr ""
 msgid "Unmute @%{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2334
+#: lib/vutuv_web/components/ui.ex:2352
 #, elixir-autogen, elixir-format
 msgid "Doesn't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2328
+#: lib/vutuv_web/components/ui.ex:2346
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2318
+#: lib/vutuv_web/components/ui.ex:2336
 #, elixir-autogen, elixir-format
 msgid "This member doesn't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2269
-#: lib/vutuv_web/components/ui.ex:2318
+#: lib/vutuv_web/components/ui.ex:2287
+#: lib/vutuv_web/components/ui.ex:2336
 #, elixir-autogen, elixir-format
 msgid "This member follows you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2267
+#: lib/vutuv_web/components/ui.ex:2285
 #, elixir-autogen, elixir-format
 msgid "You follow each other"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2268
+#: lib/vutuv_web/components/ui.ex:2286
 #, elixir-autogen, elixir-format
 msgid "You follow this member"
 msgstr ""
@@ -7253,13 +7253,13 @@ msgstr ""
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2937
+#: lib/vutuv_web/components/ui.ex:2955
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2953
+#: lib/vutuv_web/components/ui.ex:2971
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7528,12 +7528,12 @@ msgstr ""
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:107
+#: lib/vutuv_web/templates/layout/app.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Deployment: %{date} at %{time}"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:107
+#: lib/vutuv_web/templates/layout/app.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Last deployed (Berlin time)"
 msgstr ""
@@ -8012,7 +8012,7 @@ msgstr ""
 msgid "PIN registered"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2940
+#: lib/vutuv_web/components/ui.ex:2958
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr ""
@@ -8055,7 +8055,7 @@ msgid "Unreachable"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/member_badges.ex:20
-#: lib/vutuv_web/live/organization_live/domains.ex:192
+#: lib/vutuv_web/live/organization_live/domains.ex:191
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:32
 #, elixir-autogen, elixir-format
 msgid "Verified"
@@ -8142,7 +8142,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:41
 #: lib/vutuv_web/agent_docs/text.ex:38
-#: lib/vutuv_web/components/ui.ex:3808
+#: lib/vutuv_web/components/ui.ex:3826
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8197,7 +8197,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3920
+#: lib/vutuv_web/components/ui.ex:3938
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8226,7 +8226,7 @@ msgstr ""
 msgid "Nothing new to import."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3836
+#: lib/vutuv_web/components/ui.ex:3854
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8317,7 +8317,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3209
+#: lib/vutuv_web/components/ui.ex:3227
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8398,13 +8398,13 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3796
+#: lib/vutuv_web/components/ui.ex:3814
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3916
+#: lib/vutuv_web/components/ui.ex:3934
 #: lib/vutuv_web/controllers/settings_controller.ex:122
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8416,7 +8416,7 @@ msgstr ""
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3907
+#: lib/vutuv_web/components/ui.ex:3925
 #: lib/vutuv_web/controllers/settings_controller.ex:105
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8426,7 +8426,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3924
+#: lib/vutuv_web/components/ui.ex:3942
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8509,7 +8509,7 @@ msgstr ""
 #: lib/vutuv_web/templates/directory/index.html.heex:2
 #: lib/vutuv_web/templates/directory/index.html.heex:3
 #: lib/vutuv_web/templates/directory/show.html.heex:5
-#: lib/vutuv_web/templates/layout/app.html.heex:79
+#: lib/vutuv_web/templates/layout/app.html.heex:90
 #, elixir-autogen, elixir-format
 msgid "Member directory"
 msgstr ""
@@ -8544,7 +8544,7 @@ msgstr[1] ""
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1023
+#: lib/vutuv_web/components/ui.ex:1041
 #, elixir-autogen, elixir-format
 msgid "This profile is not offered as a Markdown, text, JSON or XML export."
 msgstr ""
@@ -8603,7 +8603,7 @@ msgstr ""
 msgid "Not written yet"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:312
+#: lib/vutuv_web/components/organization_components.ex:226
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "Page"
@@ -8639,16 +8639,16 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:541
 #: lib/vutuv_web/agent_docs/text.ex:504
 #: lib/vutuv_web/agent_docs/text.ex:508
-#: lib/vutuv_web/components/organization_components.ex:344
-#: lib/vutuv_web/components/ui.ex:3897
+#: lib/vutuv_web/components/organization_components.ex:258
+#: lib/vutuv_web/components/ui.ex:3915
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:323
 #: lib/vutuv_web/controllers/settings_controller.ex:390
 #: lib/vutuv_web/live/fediverse_followers_live.ex:169
 #: lib/vutuv_web/live/fediverse_following_live.ex:304
 #: lib/vutuv_web/live/organization_live/fediverse.ex:80
-#: lib/vutuv_web/live/organization_live/show.ex:545
-#: lib/vutuv_web/live/organization_live/show.ex:728
+#: lib/vutuv_web/live/organization_live/show.ex:540
+#: lib/vutuv_web/live/organization_live/show.ex:723
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:341
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:5
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
@@ -8794,7 +8794,7 @@ msgstr ""
 msgid "This is the print view of this CV. Use your browser's print dialog (Ctrl+P or Cmd+P) and choose \"Save as PDF\" to get a PDF file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1131
+#: lib/vutuv_web/components/ui.ex:1149
 #, elixir-autogen, elixir-format
 msgid "CV download"
 msgstr ""
@@ -8832,7 +8832,7 @@ msgstr ""
 msgid "Header"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1141
+#: lib/vutuv_web/components/ui.ex:1159
 #: lib/vutuv_web/templates/export/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Open CV"
@@ -8864,7 +8864,7 @@ msgstr ""
 msgid "The CV is public, on your profile: a visitor's download contains only what they can see there anyway, and private email addresses appear only in your own."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1133
+#: lib/vutuv_web/components/ui.ex:1151
 #, elixir-autogen, elixir-format
 msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
@@ -9020,8 +9020,8 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1539
-#: lib/vutuv_web/components/ui.ex:1540
+#: lib/vutuv_web/components/ui.ex:1557
+#: lib/vutuv_web/components/ui.ex:1558
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:65
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9588,7 +9588,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:45
 #: lib/vutuv_web/agent_docs/text.ex:42
-#: lib/vutuv_web/components/ui.ex:3812
+#: lib/vutuv_web/components/ui.ex:3830
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:124
@@ -9781,13 +9781,13 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2732
+#: lib/vutuv_web/components/ui.ex:2750
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2731
-#: lib/vutuv_web/components/ui.ex:2735
+#: lib/vutuv_web/components/ui.ex:2749
+#: lib/vutuv_web/components/ui.ex:2753
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr ""
@@ -9961,12 +9961,12 @@ msgstr ""
 msgid "Authenticator app turned off."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:290
+#: lib/vutuv_web/components/ui.ex:308
 #, elixir-autogen, elixir-format
 msgid "Bold"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:386
+#: lib/vutuv_web/components/ui.ex:404
 #, elixir-autogen, elixir-format
 msgid "Bullet list"
 msgstr ""
@@ -9976,7 +9976,7 @@ msgstr ""
 msgid "Can't scan the code? Enter this key in your app instead:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:378
+#: lib/vutuv_web/components/ui.ex:396
 #, elixir-autogen, elixir-format
 msgid "Code block"
 msgstr ""
@@ -9991,17 +9991,17 @@ msgstr ""
 msgid "Delete your code list? All its codes stop working immediately."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:400
+#: lib/vutuv_web/components/ui.ex:418
 #, elixir-autogen, elixir-format
 msgid "Divider"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:288
+#: lib/vutuv_web/components/ui.ex:306
 #, elixir-autogen, elixir-format
 msgid "Formatting"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:412
+#: lib/vutuv_web/components/ui.ex:430
 #, elixir-autogen, elixir-format
 msgid "Full screen"
 msgstr ""
@@ -10016,32 +10016,32 @@ msgstr ""
 msgid "Generate code list"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:366
+#: lib/vutuv_web/components/ui.ex:384
 #, elixir-autogen, elixir-format
 msgid "Heading 1"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:369
+#: lib/vutuv_web/components/ui.ex:387
 #, elixir-autogen, elixir-format
 msgid "Heading 2"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:372
+#: lib/vutuv_web/components/ui.ex:390
 #, elixir-autogen, elixir-format
 msgid "Heading 3"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:358
+#: lib/vutuv_web/components/ui.ex:376
 #, elixir-autogen, elixir-format
 msgid "Inline code"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:293
+#: lib/vutuv_web/components/ui.ex:311
 #, elixir-autogen, elixir-format
 msgid "Italic"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:277
+#: lib/vutuv_web/components/ui.ex:295
 #, elixir-autogen, elixir-format
 msgid "Link URL"
 msgstr ""
@@ -10051,8 +10051,8 @@ msgstr ""
 msgid "Login codes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:338
-#: lib/vutuv_web/components/ui.ex:339
+#: lib/vutuv_web/components/ui.ex:356
+#: lib/vutuv_web/components/ui.ex:357
 #, elixir-autogen, elixir-format
 msgid "More formatting"
 msgstr ""
@@ -10063,7 +10063,7 @@ msgstr ""
 msgid "Not set up."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:389
+#: lib/vutuv_web/components/ui.ex:407
 #, elixir-autogen, elixir-format
 msgid "Numbered list"
 msgstr ""
@@ -10078,7 +10078,7 @@ msgstr ""
 msgid "Print this page or write the codes down. Crossed-out codes have been used."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:375
+#: lib/vutuv_web/components/ui.ex:393
 #, elixir-autogen, elixir-format
 msgid "Quote"
 msgstr ""
@@ -10099,12 +10099,12 @@ msgstr ""
 msgid "Set up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:355
+#: lib/vutuv_web/components/ui.ex:373
 #, elixir-autogen, elixir-format
 msgid "Strikethrough"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:397
+#: lib/vutuv_web/components/ui.ex:415
 #, elixir-autogen, elixir-format
 msgid "Table"
 msgstr ""
@@ -10119,7 +10119,7 @@ msgstr ""
 msgid "To finish, enter the code your app shows now"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:409
+#: lib/vutuv_web/components/ui.ex:427
 #, elixir-autogen, elixir-format
 msgid "Toggle Markdown source"
 msgstr ""
@@ -10226,7 +10226,7 @@ msgid_plural "%{count} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:503
+#: lib/vutuv_web/live/organization_live/show.ex:498
 #: lib/vutuv_web/views/user_html.ex:536
 #: lib/vutuv_web/views/user_html.ex:715
 #, elixir-autogen, elixir-format
@@ -10765,7 +10765,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/organization_live.ex:179
 #: lib/vutuv_web/live/admin/organization_live.ex:194
 #: lib/vutuv_web/live/admin/screenshot_live.ex:535
-#: lib/vutuv_web/live/organization_live/domains.ex:198
+#: lib/vutuv_web/live/organization_live/domains.ex:197
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
@@ -11030,7 +11030,7 @@ msgstr ""
 msgid "AI agents"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:559
+#: lib/vutuv_web/live/organization_live/show.ex:554
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
@@ -11040,18 +11040,19 @@ msgstr ""
 msgid "Continue to verification"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:262
-#: lib/vutuv_web/live/organization_live/domains.ex:302
+#: lib/vutuv_web/live/organization_live/domains.ex:261
+#: lib/vutuv_web/live/organization_live/domains.ex:301
 #: lib/vutuv_web/live/organization_live/new.ex:161
-#: lib/vutuv_web/live/organization_live/show.ex:843
+#: lib/vutuv_web/live/organization_live/show.ex:838
 #: lib/vutuv_web/templates/url/verify.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "DNS TXT record"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:102
-#: lib/vutuv_web/live/organization_live/domains.ex:181
-#: lib/vutuv_web/live/organization_live/show.ex:913
+#: lib/vutuv_web/live/organization_live/domains.ex:180
+#: lib/vutuv_web/live/organization_live/domains.ex:342
+#: lib/vutuv_web/live/organization_live/show.ex:904
+#: lib/vutuv_web/live/organization_live/show.ex:912
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr ""
@@ -11088,7 +11089,7 @@ msgstr ""
 msgid "Please log in first."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:816
+#: lib/vutuv_web/live/organization_live/show.ex:811
 #, elixir-autogen, elixir-format
 msgid "Prove you control %{domain} to publish this page."
 msgstr ""
@@ -11109,13 +11110,13 @@ msgstr ""
 msgid "Search engines"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:221
+#: lib/vutuv_web/components/organization_components.ex:135
 #, elixir-autogen, elixir-format
 msgid "Select a country"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:321
-#: lib/vutuv_web/live/organization_live/show.ex:878
+#: lib/vutuv_web/live/organization_live/domains.ex:320
+#: lib/vutuv_web/live/organization_live/show.ex:873
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr ""
@@ -11142,12 +11143,12 @@ msgid "The upload failed."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/new.ex:146
-#: lib/vutuv_web/live/organization_live/show.ex:831
+#: lib/vutuv_web/live/organization_live/show.ex:826
 #, elixir-autogen, elixir-format
 msgid "Verification method"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:791
+#: lib/vutuv_web/live/organization_live/show.ex:786
 #, elixir-autogen, elixir-format
 msgid "Verified domains"
 msgstr ""
@@ -11163,13 +11164,13 @@ msgstr ""
 msgid "Verified via %{domain}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:813
+#: lib/vutuv_web/live/organization_live/show.ex:808
 #, elixir-autogen, elixir-format
 msgid "Verify %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:337
-#: lib/vutuv_web/live/organization_live/show.ex:903
+#: lib/vutuv_web/live/organization_live/domains.ex:336
+#: lib/vutuv_web/live/organization_live/show.ex:898
 #, elixir-autogen, elixir-format
 msgid "Verify now"
 msgstr ""
@@ -11182,9 +11183,9 @@ msgstr ""
 msgid "Website"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:263
-#: lib/vutuv_web/live/organization_live/domains.ex:312
-#: lib/vutuv_web/live/organization_live/show.ex:854
+#: lib/vutuv_web/live/organization_live/domains.ex:262
+#: lib/vutuv_web/live/organization_live/domains.ex:311
+#: lib/vutuv_web/live/organization_live/show.ex:849
 #: lib/vutuv_web/templates/url/verify.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Website file"
@@ -11205,8 +11206,8 @@ msgstr ""
 msgid "You will publish a record or file to prove control of the domain on the next step."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:323
-#: lib/vutuv_web/live/organization_live/show.ex:884
+#: lib/vutuv_web/live/organization_live/domains.ex:322
+#: lib/vutuv_web/live/organization_live/show.ex:879
 #: lib/vutuv_web/templates/url/verify.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
@@ -11217,13 +11218,13 @@ msgstr ""
 msgid "@handle or email"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:393
+#: lib/vutuv_web/components/organization_components.ex:307
 #: lib/vutuv_web/live/organization_live/edit.ex:390
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:250
+#: lib/vutuv_web/live/organization_live/domains.ex:249
 #, elixir-autogen, elixir-format
 msgid "Add a domain"
 msgstr ""
@@ -11238,7 +11239,7 @@ msgstr ""
 msgid "Added @%{handle} to the team."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:394
+#: lib/vutuv_web/components/organization_components.ex:308
 #: lib/vutuv_web/live/organization_live/edit.ex:388
 #, elixir-autogen, elixir-format
 msgid "Alias"
@@ -11257,7 +11258,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:358
 #: lib/vutuv_web/agent_docs/text.ex:381
 #: lib/vutuv_web/live/organization_live/edit.ex:353
-#: lib/vutuv_web/live/organization_live/show.ex:779
+#: lib/vutuv_web/live/organization_live/show.ex:774
 #: lib/vutuv_web/templates/tag/single_card.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Also known as"
@@ -11284,7 +11285,7 @@ msgstr ""
 msgid "Archived"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:392
+#: lib/vutuv_web/components/organization_components.ex:306
 #: lib/vutuv_web/live/organization_live/edit.ex:389
 #, elixir-autogen, elixir-format
 msgid "Brand"
@@ -11305,35 +11306,35 @@ msgstr ""
 msgid "Delete this page and everything it owns? This cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:64
+#: lib/vutuv_web/live/organization_live/domains.ex:65
 #, elixir-autogen, elixir-format
 msgid "Domain added. Publish the record or file, then verify it."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:138
+#: lib/vutuv_web/live/organization_live/domains.ex:139
 #, elixir-autogen, elixir-format
 msgid "Domain removed."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:107
+#: lib/vutuv_web/live/organization_live/domains.ex:108
 #, elixir-autogen, elixir-format
 msgid "Domain verified."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:318
+#: lib/vutuv_web/components/organization_components.ex:232
 #: lib/vutuv_web/live/admin/organization_live.ex:305
-#: lib/vutuv_web/live/organization_live/domains.ex:175
-#: lib/vutuv_web/live/organization_live/show.ex:530
+#: lib/vutuv_web/live/organization_live/domains.ex:174
+#: lib/vutuv_web/live/organization_live/show.ex:525
 #, elixir-autogen, elixir-format
 msgid "Domains"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:28
+#: lib/vutuv_web/live/organization_live/domains.ex:29
 #, elixir-autogen, elixir-format
 msgid "Domains – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:391
+#: lib/vutuv_web/components/organization_components.ex:305
 #, elixir-autogen, elixir-format
 msgid "Former name"
 msgstr ""
@@ -11350,7 +11351,7 @@ msgstr ""
 msgid "Freeze this page? It disappears for the public but stays visible to its owner."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:203
+#: lib/vutuv_web/live/organization_live/domains.ex:202
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "Last checked"
@@ -11371,7 +11372,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:234
+#: lib/vutuv_web/live/organization_live/domains.ex:233
 #, elixir-autogen, elixir-format
 msgid "Make primary"
 msgstr ""
@@ -11381,7 +11382,7 @@ msgstr ""
 msgid "Member removed."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:203
+#: lib/vutuv_web/live/organization_live/domains.ex:202
 #, elixir-autogen, elixir-format
 msgid "Method"
 msgstr ""
@@ -11396,27 +11397,27 @@ msgstr ""
 msgid "No member found for “%{id}”."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:123
+#: lib/vutuv_web/live/organization_live/domains.ex:124
 #, elixir-autogen, elixir-format
 msgid "Only a verified domain can be the primary one."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:189
+#: lib/vutuv_web/live/organization_live/domains.ex:188
 #, elixir-autogen, elixir-format
 msgid "Primary"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:119
+#: lib/vutuv_web/live/organization_live/domains.ex:120
 #, elixir-autogen, elixir-format
 msgid "Primary domain updated."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:380
+#: lib/vutuv_web/components/organization_components.ex:294
 #, elixir-autogen, elixir-format
 msgid "Recruiter"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:240
+#: lib/vutuv_web/live/organization_live/domains.ex:239
 #, elixir-autogen, elixir-format
 msgid "Remove this domain?"
 msgstr ""
@@ -11436,10 +11437,10 @@ msgstr ""
 msgid "Search name, alias or domain"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:315
+#: lib/vutuv_web/components/organization_components.ex:229
 #: lib/vutuv_web/live/admin/organization_live.ex:321
 #: lib/vutuv_web/live/organization_live/roles.ex:165
-#: lib/vutuv_web/live/organization_live/show.ex:523
+#: lib/vutuv_web/live/organization_live/show.ex:518
 #, elixir-autogen, elixir-format
 msgid "Team"
 msgstr ""
@@ -11449,7 +11450,7 @@ msgstr ""
 msgid "Team – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:75
+#: lib/vutuv_web/live/organization_live/domains.ex:76
 #, elixir-autogen, elixir-format
 msgid "That is not a valid domain."
 msgstr ""
@@ -11535,13 +11536,13 @@ msgstr ""
 msgid "Back-link (rel=me)"
 msgstr ""
 
-#: lib/vutuv_web/controllers/url_controller.ex:163
 #: lib/vutuv_web/templates/url/verify.html.heex:25
+#: lib/vutuv_web/views/url_html.ex:71
 #, elixir-autogen, elixir-format
 msgid "Link verification is disabled on this installation."
 msgstr ""
 
-#: lib/vutuv_web/controllers/url_controller.ex:158
+#: lib/vutuv_web/controllers/url_controller.ex:155
 #, elixir-autogen, elixir-format
 msgid "Link verified. It now shows a verified mark."
 msgstr ""
@@ -11561,7 +11562,7 @@ msgstr ""
 msgid "The link text can be anything. A hidden <link rel=\"me\"> in the page head works too."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:887
+#: lib/vutuv_web/components/ui.ex:905
 #: lib/vutuv_web/live/section_reorder_live.ex:195
 #, elixir-autogen, elixir-format
 msgid "Verified webpage"
@@ -11572,7 +11573,7 @@ msgstr ""
 msgid "Verified. Re-run any method below to refresh it."
 msgstr ""
 
-#: lib/vutuv_web/controllers/url_controller.ex:138
+#: lib/vutuv_web/controllers/url_controller.ex:180
 #: lib/vutuv_web/templates/url/verify.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Verify link"
@@ -11600,11 +11601,6 @@ msgstr ""
 msgid "Verify via file"
 msgstr ""
 
-#: lib/vutuv_web/controllers/url_controller.ex:170
-#, elixir-autogen, elixir-format
-msgid "We could not find the proof yet. It can take a while to propagate. Please try again."
-msgstr ""
-
 #: lib/vutuv_web/agent_docs/markdown.ex:842
 #: lib/vutuv_web/agent_docs/text.ex:636
 #, elixir-autogen, elixir-format
@@ -11616,7 +11612,7 @@ msgstr ""
 msgid "%{min} to %{max} characters: letters (a-z), numbers (0-9) and underscores."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:667
+#: lib/vutuv_web/live/organization_live/show.ex:662
 #, elixir-autogen, elixir-format
 msgid "Former"
 msgstr ""
@@ -11667,12 +11663,12 @@ msgstr[1] ""
 msgid "Alternative names, brands or abbreviations this organization is findable under. A rename keeps the old name here automatically."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:177
+#: lib/vutuv_web/live/organization_live/domains.ex:176
 #, elixir-autogen, elixir-format
 msgid "An organization can prove several domains. The primary one shows in the “Verified via …” badge."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:145
+#: lib/vutuv_web/live/organization_live/domains.ex:146
 #, elixir-autogen, elixir-format
 msgid "An organization keeps at least one verified domain, so this one cannot be removed."
 msgstr ""
@@ -11721,7 +11717,7 @@ msgstr ""
 msgid "The proof is a small technical change to your domain: a DNS entry or a file on your website. If you don't manage the website yourself, ask the person or team who does. That is usually your IT department or the company that runs your website. We show the exact instructions on the next step, so you can simply pass them on."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:825
+#: lib/vutuv_web/live/organization_live/show.ex:820
 #, elixir-autogen, elixir-format
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr ""
@@ -11834,21 +11830,21 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:349
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:325
-#: lib/vutuv_web/components/ui.ex:3928
+#: lib/vutuv_web/components/ui.ex:3946
 #: lib/vutuv_web/controllers/settings_controller.ex:179
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:501
-#: lib/vutuv_web/live/shell_live.ex:796
+#: lib/vutuv_web/live/shell_live.ex:803
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
-#: lib/vutuv_web/templates/layout/app.html.heex:83
+#: lib/vutuv_web/templates/layout/app.html.heex:94
 #: lib/vutuv_web/templates/settings/organizations.html.heex:6
 #, elixir-autogen, elixir-format
 msgid "Organizations"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:248
+#: lib/vutuv_web/components/organization_components.ex:162
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:90
 #, elixir-autogen, elixir-format
 msgid "Please choose"
@@ -11869,7 +11865,7 @@ msgstr ""
 msgid "Search organizations"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:71
+#: lib/vutuv_web/live/organization_live/domains.ex:72
 #, elixir-autogen, elixir-format
 msgid "That domain already belongs to an organization page."
 msgstr ""
@@ -11889,7 +11885,7 @@ msgstr ""
 msgid "The organization page was deleted."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:384
+#: lib/vutuv_web/live/organization_live/show.ex:379
 #, elixir-autogen, elixir-format
 msgid "This organization page was reported and is hidden while it is reviewed. Only you and the moderators can see it."
 msgstr ""
@@ -11919,8 +11915,8 @@ msgstr ""
 msgid "Your organization handle is set."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:300
-#: lib/vutuv_web/live/organization_live/show.ex:360
+#: lib/vutuv_web/live/organization_live/show.ex:302
+#: lib/vutuv_web/live/organization_live/show.ex:355
 #, elixir-autogen, elixir-format
 msgid "Your organization page is verified and now live."
 msgstr ""
@@ -12173,8 +12169,8 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:504
-#: lib/vutuv_web/live/shell_live.ex:626
-#: lib/vutuv_web/templates/layout/app.html.heex:81
+#: lib/vutuv_web/live/shell_live.ex:633
+#: lib/vutuv_web/templates/layout/app.html.heex:92
 #: lib/vutuv_web/templates/qualification/show.html.heex:38
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -12496,17 +12492,17 @@ msgstr ""
 msgid "A domain of your organization page on vutuv is about to be dropped"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:216
+#: lib/vutuv_web/live/organization_live/domains.ex:215
 #, elixir-autogen, elixir-format
 msgid "Deadline"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:195
+#: lib/vutuv_web/live/organization_live/domains.ex:194
 #, elixir-autogen, elixir-format
 msgid "Proof missing"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:215
+#: lib/vutuv_web/live/organization_live/domains.ex:214
 #, elixir-autogen, elixir-format
 msgid "We could not read this domain's proof on the last check. Restore it and check again, or the domain loses its verification."
 msgstr ""
@@ -12619,14 +12615,14 @@ msgstr ""
 msgid "Getting an error, or is %{host} a CNAME / alias to another address? A TXT record cannot share a name with a CNAME. Use this name instead, with the exact same value as above:"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:319
-#: lib/vutuv_web/live/organization_live/show.ex:871
+#: lib/vutuv_web/live/organization_live/domains.ex:318
+#: lib/vutuv_web/live/organization_live/show.ex:866
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:317
-#: lib/vutuv_web/live/organization_live/show.ex:862
+#: lib/vutuv_web/live/organization_live/domains.ex:316
+#: lib/vutuv_web/live/organization_live/show.ex:857
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
 msgstr ""
@@ -12722,7 +12718,7 @@ msgid "Minimum yearly salary"
 msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:324
-#: lib/vutuv_web/live/organization_live/show.ex:694
+#: lib/vutuv_web/live/organization_live/show.ex:689
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr ""
@@ -12751,7 +12747,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:436
 #: lib/vutuv_web/agent_docs/text.ex:445
 #: lib/vutuv_web/agent_docs/text.ex:457
-#: lib/vutuv_web/live/organization_live/show.ex:681
+#: lib/vutuv_web/live/organization_live/show.ex:676
 #: lib/vutuv_web/templates/tag/show.html.heex:69
 #, elixir-autogen, elixir-format
 msgid "Open positions"
@@ -13051,7 +13047,7 @@ msgstr ""
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3874
+#: lib/vutuv_web/components/ui.ex:3892
 #: lib/vutuv_web/controllers/settings_controller.ex:556
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -13208,7 +13204,7 @@ msgstr ""
 msgid "Inherited from the organization"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:321
+#: lib/vutuv_web/components/organization_components.ex:235
 #: lib/vutuv_web/live/organization_live/exclusions.ex:103
 #, elixir-autogen, elixir-format
 msgid "Job exclusions"
@@ -13426,27 +13422,27 @@ msgstr[1] ""
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:323
+#: lib/vutuv_web/components/ui.ex:341
 #, elixir-autogen, elixir-format
 msgid "Center"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:320
+#: lib/vutuv_web/components/ui.ex:338
 #, elixir-autogen, elixir-format
 msgid "Float left"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:326
+#: lib/vutuv_web/components/ui.ex:344
 #, elixir-autogen, elixir-format
 msgid "Float right"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:317
+#: lib/vutuv_web/components/ui.ex:335
 #, elixir-autogen, elixir-format
 msgid "Full width"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:305
+#: lib/vutuv_web/components/ui.ex:323
 #, elixir-autogen, elixir-format
 msgid "Insert image"
 msgstr ""
@@ -13508,7 +13504,7 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3870
+#: lib/vutuv_web/components/ui.ex:3888
 #: lib/vutuv_web/controllers/settings_controller.ex:570
 #: lib/vutuv_web/live/post_live/feed.ex:1158
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -13588,7 +13584,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:59
 #: lib/vutuv_web/agent_docs/text.ex:56
-#: lib/vutuv_web/components/ui.ex:3855
+#: lib/vutuv_web/components/ui.ex:3873
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -13616,14 +13612,14 @@ msgstr ""
 msgid "Select a messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3295
+#: lib/vutuv_web/components/ui.ex:3313
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3305
+#: lib/vutuv_web/components/ui.ex:3323
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
@@ -13847,19 +13843,19 @@ msgstr ""
 msgid "by:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1673
+#: lib/vutuv_web/components/ui.ex:1691
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1677
+#: lib/vutuv_web/components/ui.ex:1695
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:434
+#: lib/vutuv_web/live/shell_live.ex:435
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -14408,7 +14404,7 @@ msgstr ""
 msgid "Match whole words only (word/phrase)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3866
+#: lib/vutuv_web/components/ui.ex:3884
 #: lib/vutuv_web/controllers/settings_controller.ex:636
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -15041,277 +15037,277 @@ msgstr ""
 msgid "moved to %{address}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3797
+#: lib/vutuv_web/components/ui.ex:3815
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3802
+#: lib/vutuv_web/components/ui.ex:3820
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3805
+#: lib/vutuv_web/components/ui.ex:3823
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3806
+#: lib/vutuv_web/components/ui.ex:3824
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3809
+#: lib/vutuv_web/components/ui.ex:3827
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3810
+#: lib/vutuv_web/components/ui.ex:3828
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3813
+#: lib/vutuv_web/components/ui.ex:3831
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3814
+#: lib/vutuv_web/components/ui.ex:3832
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3821
+#: lib/vutuv_web/components/ui.ex:3839
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3822
+#: lib/vutuv_web/components/ui.ex:3840
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3823
+#: lib/vutuv_web/components/ui.ex:3841
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3826
+#: lib/vutuv_web/components/ui.ex:3844
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3827
+#: lib/vutuv_web/components/ui.ex:3845
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3929
+#: lib/vutuv_web/components/ui.ex:3947
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3930
+#: lib/vutuv_web/components/ui.ex:3948
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3830
+#: lib/vutuv_web/components/ui.ex:3848
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3833
+#: lib/vutuv_web/components/ui.ex:3851
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3834
+#: lib/vutuv_web/components/ui.ex:3852
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3837
+#: lib/vutuv_web/components/ui.ex:3855
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3838
+#: lib/vutuv_web/components/ui.ex:3856
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3841
+#: lib/vutuv_web/components/ui.ex:3859
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3842
+#: lib/vutuv_web/components/ui.ex:3860
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3844
+#: lib/vutuv_web/components/ui.ex:3862
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3845
+#: lib/vutuv_web/components/ui.ex:3863
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3846
+#: lib/vutuv_web/components/ui.ex:3864
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3848
+#: lib/vutuv_web/components/ui.ex:3866
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3849
+#: lib/vutuv_web/components/ui.ex:3867
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3851
+#: lib/vutuv_web/components/ui.ex:3869
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3856
+#: lib/vutuv_web/components/ui.ex:3874
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3857
+#: lib/vutuv_web/components/ui.ex:3875
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3860
+#: lib/vutuv_web/components/ui.ex:3878
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3863
+#: lib/vutuv_web/components/ui.ex:3881
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3864
+#: lib/vutuv_web/components/ui.ex:3882
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3867
+#: lib/vutuv_web/components/ui.ex:3885
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3868
+#: lib/vutuv_web/components/ui.ex:3886
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3871
+#: lib/vutuv_web/components/ui.ex:3889
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3872
+#: lib/vutuv_web/components/ui.ex:3890
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3875
+#: lib/vutuv_web/components/ui.ex:3893
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3876
+#: lib/vutuv_web/components/ui.ex:3894
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3882
+#: lib/vutuv_web/components/ui.ex:3900
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3883
+#: lib/vutuv_web/components/ui.ex:3901
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3886
+#: lib/vutuv_web/components/ui.ex:3904
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3887
+#: lib/vutuv_web/components/ui.ex:3905
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3908
+#: lib/vutuv_web/components/ui.ex:3926
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3909
+#: lib/vutuv_web/components/ui.ex:3927
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3917
+#: lib/vutuv_web/components/ui.ex:3935
 #, elixir-autogen, elixir-format
 msgid "Interface language, maps, how posts are shortened"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3918
+#: lib/vutuv_web/components/ui.ex:3936
 #, elixir-autogen, elixir-format
 msgid "german english locale translation map font length hyphenation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3921
+#: lib/vutuv_web/components/ui.ex:3939
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3922
+#: lib/vutuv_web/components/ui.ex:3940
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3925
+#: lib/vutuv_web/components/ui.ex:3943
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3926
+#: lib/vutuv_web/components/ui.ex:3944
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3933
+#: lib/vutuv_web/components/ui.ex:3951
 #, elixir-autogen, elixir-format
 msgid "Connected apps and access tokens"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3934
+#: lib/vutuv_web/components/ui.ex:3952
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3937
+#: lib/vutuv_web/components/ui.ex:3955
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3938
+#: lib/vutuv_web/components/ui.ex:3956
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr ""
@@ -15762,7 +15758,7 @@ msgstr ""
 msgid "Access token revoked"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3911
+#: lib/vutuv_web/components/ui.ex:3929
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -16109,7 +16105,7 @@ msgstr ""
 msgid "What changed on your account, and exactly when."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3912
+#: lib/vutuv_web/components/ui.ex:3930
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr ""
@@ -16145,7 +16141,7 @@ msgstr ""
 msgid "from a signed-in session"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3914
+#: lib/vutuv_web/components/ui.ex:3932
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
@@ -16678,7 +16674,7 @@ msgstr ""
 msgid "Cancel request"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3898
+#: lib/vutuv_web/components/ui.ex:3916
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr ""
@@ -16880,7 +16876,7 @@ msgstr ""
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3900
+#: lib/vutuv_web/components/ui.ex:3918
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
@@ -17261,12 +17257,12 @@ msgstr[1] ""
 msgid "Your feed shows the posts of members you follow. Follow a few to fill it."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:183
+#: lib/vutuv_web/components/ui.ex:201
 #, elixir-autogen, elixir-format
 msgid "Add another tag"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:206
+#: lib/vutuv_web/components/ui.ex:224
 #, elixir-autogen, elixir-format
 msgid "Remove the tag %{name}"
 msgstr ""
@@ -17410,7 +17406,7 @@ msgstr ""
 msgid "Your username is your public identity here. It changes only once you confirm with your passkey or a valid code below."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:462
+#: lib/vutuv_web/components/ui.ex:480
 #, elixir-autogen, elixir-format
 msgid "Markdown help"
 msgstr ""
@@ -17425,53 +17421,53 @@ msgstr ""
 msgid "Read this page as Markdown"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:519
+#: lib/vutuv_web/components/ui.ex:537
 #, elixir-autogen, elixir-format
 msgid "Activities"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:517
+#: lib/vutuv_web/components/ui.ex:535
 #, elixir-autogen, elixir-format
 msgid "Animals & nature"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:278
-#: lib/vutuv_web/components/ui.ex:302
+#: lib/vutuv_web/components/ui.ex:296
+#: lib/vutuv_web/components/ui.ex:320
 #, elixir-autogen, elixir-format
 msgid "Emoji"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:518
+#: lib/vutuv_web/components/ui.ex:536
 #, elixir-autogen, elixir-format
 msgid "Food & drink"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:281
+#: lib/vutuv_web/components/ui.ex:299
 #, elixir-autogen, elixir-format
 msgid "No emoji found."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:521
+#: lib/vutuv_web/components/ui.ex:539
 #, elixir-autogen, elixir-format
 msgid "Objects"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:279
+#: lib/vutuv_web/components/ui.ex:297
 #, elixir-autogen, elixir-format
 msgid "Search emoji"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:515
+#: lib/vutuv_web/components/ui.ex:533
 #, elixir-autogen, elixir-format
 msgid "Smileys"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:522
+#: lib/vutuv_web/components/ui.ex:540
 #, elixir-autogen, elixir-format
 msgid "Symbols"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:520
+#: lib/vutuv_web/components/ui.ex:538
 #, elixir-autogen, elixir-format
 msgid "Travel & places"
 msgstr ""
@@ -17722,12 +17718,12 @@ msgstr ""
 msgid "Whole photos"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:131
+#: lib/vutuv_web/templates/layout/app.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Send the post or message you are writing"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:192
+#: lib/vutuv_web/templates/layout/app.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "The single-key shortcuts pause while you type, and are off on phones and tablets."
 msgstr ""
@@ -18017,8 +18013,8 @@ msgstr ""
 msgid "This is vutuv's copy of a post published on %{host}. It is kept while somebody here follows its author."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1074
-#: lib/vutuv_web/components/ui.ex:1075
+#: lib/vutuv_web/components/ui.ex:1092
+#: lib/vutuv_web/components/ui.ex:1093
 #, elixir-autogen, elixir-format
 msgid "Subscribe to this feed in your RSS reader"
 msgstr ""
@@ -18264,7 +18260,7 @@ msgstr ""
 msgid "Delete your account yourself, without writing to anybody. No questions asked, and you are welcome back any time."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:212
+#: lib/vutuv_web/components/ui.ex:230
 #, elixir-autogen, elixir-format
 msgid "At most %{max} tags. Remove one to add another."
 msgstr ""
@@ -18416,7 +18412,7 @@ msgstr ""
 msgid "Employment reference updated."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3816
+#: lib/vutuv_web/components/ui.ex:3834
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -18610,7 +18606,7 @@ msgstr ""
 msgid "You changed the text after this review. It describes the earlier version."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3817
+#: lib/vutuv_web/components/ui.ex:3835
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr ""
@@ -18621,7 +18617,7 @@ msgstr ""
 msgid "Zwischenzeugnis"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3819
+#: lib/vutuv_web/components/ui.ex:3837
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr ""
@@ -19220,12 +19216,12 @@ msgstr ""
 msgid "Enter the PIN from the email"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:667
+#: lib/vutuv_web/components/ui.ex:685
 #, elixir-autogen, elixir-format
 msgid "If you have added other addresses to your vutuv account, try logging in with one of those instead."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:695
+#: lib/vutuv_web/components/ui.ex:713
 #, elixir-autogen, elixir-format
 msgid "Cancel registration"
 msgstr ""
@@ -19240,7 +19236,7 @@ msgstr ""
 msgid "Follow other members"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:650
+#: lib/vutuv_web/components/ui.ex:668
 #, elixir-autogen, elixir-format
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
@@ -19265,7 +19261,7 @@ msgstr ""
 msgid "Shares are of the %{answered} members who answered. %{unanswered} gave no answer."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3798
+#: lib/vutuv_web/components/ui.ex:3816
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr ""
@@ -19361,7 +19357,7 @@ msgstr ""
 msgid "Always keep"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3891
+#: lib/vutuv_web/components/ui.ex:3909
 #: lib/vutuv_web/controllers/settings_controller.ex:213
 #: lib/vutuv_web/controllers/settings_controller.ex:292
 #: lib/vutuv_web/controllers/settings_controller.ex:304
@@ -19458,7 +19454,7 @@ msgstr ""
 msgid "Keep posts that did well"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3893
+#: lib/vutuv_web/components/ui.ex:3911
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr ""
@@ -19567,7 +19563,7 @@ msgstr ""
 msgid "Your rule"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3895
+#: lib/vutuv_web/components/ui.ex:3913
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
@@ -19946,12 +19942,12 @@ msgstr ""
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:379
+#: lib/vutuv_web/components/organization_components.ex:293
 #, elixir-autogen, elixir-format
 msgid "Editorial"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:385
+#: lib/vutuv_web/components/organization_components.ex:299
 #, elixir-autogen, elixir-format
 msgid "Edits the page and posts jobs."
 msgstr ""
@@ -19961,7 +19957,7 @@ msgstr ""
 msgid "Give members their roles on this page. Someone can hold several at once, and every role is granted on its own."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:384
+#: lib/vutuv_web/components/organization_components.ex:298
 #, elixir-autogen, elixir-format
 msgid "Manages the team and the domains, and edits the page."
 msgstr ""
@@ -19971,7 +19967,7 @@ msgstr ""
 msgid "Pick at least one role."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:387
+#: lib/vutuv_web/components/organization_components.ex:301
 #, elixir-autogen, elixir-format
 msgid "Posts jobs."
 msgstr ""
@@ -19986,7 +19982,7 @@ msgstr ""
 msgid "Roles updated."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:386
+#: lib/vutuv_web/components/organization_components.ex:300
 #, elixir-autogen, elixir-format
 msgid "Writes posts in the organization's name."
 msgstr ""
@@ -19996,33 +19992,33 @@ msgstr ""
 msgid "The owner gives other members their roles on the page, and can hand ownership over to someone else at any time. Someone can hold several roles, and writing in the organization's name is always granted on its own."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:637
+#: lib/vutuv_web/live/organization_live/show.ex:632
 #, elixir-autogen, elixir-format
 msgid "Nothing published yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:619
+#: lib/vutuv_web/live/organization_live/show.ex:614
 #: lib/vutuv_web/live/post_live/composer.ex:1814
 #, elixir-autogen, elixir-format
 msgid "Post as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:225
+#: lib/vutuv_web/live/organization_live/show.ex:227
 #, elixir-autogen, elixir-format
 msgid "Published as %{name}."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:237
+#: lib/vutuv_web/live/organization_live/show.ex:239
 #, elixir-autogen, elixir-format
 msgid "That post could not be published."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:611
+#: lib/vutuv_web/live/organization_live/show.ex:606
 #, elixir-autogen, elixir-format
 msgid "Write something as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:231
+#: lib/vutuv_web/live/organization_live/show.ex:233
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr ""
@@ -20032,7 +20028,7 @@ msgstr ""
 msgid "A post in an organization's name is always public."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:558
+#: lib/vutuv_web/live/shell_live.ex:562
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr ""
@@ -20047,12 +20043,12 @@ msgstr ""
 msgid "Stopped writing as an organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:595
+#: lib/vutuv_web/live/organization_live/show.ex:590
 #, elixir-autogen, elixir-format
 msgid "Write as %{name} for now"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:568
+#: lib/vutuv_web/live/shell_live.ex:572
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr ""
@@ -20062,7 +20058,7 @@ msgstr ""
 msgid "You are writing as %{name} now."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:544
+#: lib/vutuv_web/live/shell_live.ex:548
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr ""
@@ -20269,12 +20265,12 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/fediverse.ex:88
 #: lib/vutuv_web/live/organization_live/new.ex:211
-#: lib/vutuv_web/live/organization_live/show.ex:747
+#: lib/vutuv_web/live/organization_live/show.ex:742
 #, elixir-autogen, elixir-format
 msgid "People who have no vutuv account can follow this page and read its posts, in networks like Mastodon."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:761
+#: lib/vutuv_web/live/organization_live/show.ex:756
 #, elixir-autogen, elixir-format
 msgid "Set this page up for other networks"
 msgstr ""
@@ -20289,7 +20285,7 @@ msgstr ""
 msgid "Switch it on"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:752
+#: lib/vutuv_web/live/organization_live/show.ex:747
 #, elixir-autogen, elixir-format
 msgid "The page gets an address of its own for that, written like an email address."
 msgstr ""
@@ -20374,22 +20370,22 @@ msgstr ""
 msgid "The PIN has expired."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:771
+#: lib/vutuv_web/components/ui.ex:789
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more minute."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:773
+#: lib/vutuv_web/components/ui.ex:791
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more second."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:772
+#: lib/vutuv_web/components/ui.ex:790
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more minutes."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:774
+#: lib/vutuv_web/components/ui.ex:792
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more seconds."
 msgstr ""
@@ -20426,21 +20422,21 @@ msgstr ""
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:464
+#: lib/vutuv_web/live/shell_live.ex:465
 #, elixir-autogen, elixir-format
 msgid "%{formatted} person"
 msgid_plural "%{formatted} people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:451
+#: lib/vutuv_web/live/shell_live.ex:452
 #, elixir-autogen, elixir-format
 msgid "person"
 msgid_plural "people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:486
+#: lib/vutuv_web/live/shell_live.ex:487
 #, elixir-autogen, elixir-format
 msgid "%{members} vutuv members plus %{fediverse} Fediverse account that follows them"
 msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that follow them"
@@ -20542,13 +20538,13 @@ msgstr ""
 msgid "The gravatar.com lookup is switched off on this installation."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:165
+#: lib/vutuv_web/components/organization_components.ex:79
 #, elixir-autogen, elixir-format
 msgid "A new entry can take a while to reach everyone. We keep checking %{domain} by ourselves and send you an email as soon as it works, so you can close this page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:333
-#: lib/vutuv_web/live/organization_live/show.ex:899
+#: lib/vutuv_web/live/organization_live/domains.ex:332
+#: lib/vutuv_web/live/organization_live/show.ex:894
 #, elixir-autogen, elixir-format
 msgid "Checking …"
 msgstr ""
@@ -20558,47 +20554,47 @@ msgstr ""
 msgid "Finish verification"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:152
+#: lib/vutuv_web/components/verification_components.ex:139
 #, elixir-autogen, elixir-format
 msgid "It answered with HTTP status %{status}."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:149
+#: lib/vutuv_web/components/verification_components.ex:136
 #, elixir-autogen, elixir-format
 msgid "It answered with an empty file."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:146
+#: lib/vutuv_web/components/verification_components.ex:133
 #, elixir-autogen, elixir-format
 msgid "It answered, but with something else: %{found}"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:122
+#: lib/vutuv_web/components/verification_components.ex:96
 #, elixir-autogen, elixir-format
 msgid "No TXT record at all."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:95
+#: lib/vutuv_web/components/verification_components.ex:69
 #, elixir-autogen, elixir-format
 msgid "Not found yet"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:106
+#: lib/vutuv_web/components/verification_components.ex:80
 #, elixir-autogen, elixir-format
 msgid "We asked the name servers of your domain directly, for %{names}, and looked for this value:"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:143
+#: lib/vutuv_web/components/verification_components.ex:130
 #, elixir-autogen, elixir-format
 msgid "We could not reach that address at all."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:125
+#: lib/vutuv_web/components/verification_components.ex:112
 #, elixir-autogen, elixir-format
 msgid "We fetched this address:"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:110
+#: lib/vutuv_web/components/verification_components.ex:84
 #, elixir-autogen, elixir-format
 msgid "What is published there right now:"
 msgstr ""
@@ -20606,4 +20602,29 @@ msgstr ""
 #: lib/vutuv/notifications/emailer.ex:856
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is verified"
+msgstr ""
+
+#: lib/vutuv_web/components/verification_components.ex:147
+#, elixir-autogen, elixir-format
+msgid "We could not reach your page at all."
+msgstr ""
+
+#: lib/vutuv_web/components/verification_components.ex:100
+#, elixir-autogen, elixir-format
+msgid "We fetched your page and looked for a link back to:"
+msgstr ""
+
+#: lib/vutuv_web/components/verification_components.ex:156
+#, elixir-autogen, elixir-format
+msgid "Your page answered with HTTP status %{status}."
+msgstr ""
+
+#: lib/vutuv_web/components/verification_components.ex:153
+#, elixir-autogen, elixir-format
+msgid "Your page does link back, but somewhere else:"
+msgstr ""
+
+#: lib/vutuv_web/components/verification_components.ex:150
+#, elixir-autogen, elixir-format
+msgid "Your page has no rel=\"me\" link at all yet."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -9,17 +9,17 @@
 msgid ""
 msgstr "Language: en\n"
 
-#: lib/vutuv_web/controllers/page_controller.ex:114
-#: lib/vutuv_web/templates/layout/app.html.heex:97
+#: lib/vutuv_web/controllers/page_controller.ex:174
+#: lib/vutuv_web/templates/layout/app.html.heex:108
 #, elixir-autogen
 msgid "About us"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3582
-#: lib/vutuv_web/components/ui.ex:3587
+#: lib/vutuv_web/components/ui.ex:3600
+#: lib/vutuv_web/components/ui.ex:3605
 #: lib/vutuv_web/live/admin/screenshot_live.ex:266
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:718
-#: lib/vutuv_web/live/organization_live/domains.ex:269
+#: lib/vutuv_web/live/organization_live/domains.ex:268
 #: lib/vutuv_web/live/organization_live/edit.ex:396
 #: lib/vutuv_web/live/organization_live/roles.ex:210
 #, elixir-autogen
@@ -33,7 +33,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
 #: lib/vutuv_web/live/organization_live/fediverse.ex:119
-#: lib/vutuv_web/live/organization_live/show.ex:769
+#: lib/vutuv_web/live/organization_live/show.ex:764
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
@@ -62,7 +62,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:67
 #: lib/vutuv_web/agent_docs/text.ex:64
-#: lib/vutuv_web/components/ui.ex:3840
+#: lib/vutuv_web/components/ui.ex:3858
 #: lib/vutuv_web/controllers/address_controller.ex:23
 #: lib/vutuv_web/controllers/address_controller.ex:38
 #: lib/vutuv_web/controllers/address_controller.ex:85
@@ -80,8 +80,8 @@ msgstr ""
 msgid "Already a member? Sign in here."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3377
-#: lib/vutuv_web/components/ui.ex:3471
+#: lib/vutuv_web/components/ui.ex:3395
+#: lib/vutuv_web/components/ui.ex:3489
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:698
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:830
@@ -109,7 +109,7 @@ msgid "Birthday"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:110
-#: lib/vutuv_web/components/ui.ex:3371
+#: lib/vutuv_web/components/ui.ex:3389
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
@@ -160,7 +160,7 @@ msgid "Couldn't follow back to %{name}."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2751
-#: lib/vutuv_web/components/ui.ex:3474
+#: lib/vutuv_web/components/ui.ex:3492
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
@@ -209,12 +209,12 @@ msgid "Download"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2716
-#: lib/vutuv_web/components/ui.ex:3465
+#: lib/vutuv_web/components/ui.ex:3483
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
 #: lib/vutuv_web/live/job_posting_live/show.ex:178
-#: lib/vutuv_web/live/organization_live/show.ex:516
+#: lib/vutuv_web/live/organization_live/show.ex:511
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:7
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:19
@@ -283,7 +283,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:37
 #: lib/vutuv_web/agent_docs/text.ex:34
-#: lib/vutuv_web/components/ui.ex:3804
+#: lib/vutuv_web/components/ui.ex:3822
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -324,14 +324,14 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:547
 #: lib/vutuv_web/agent_docs/text.ex:514
 #: lib/vutuv_web/components/fediverse_components.ex:313
-#: lib/vutuv_web/components/ui.ex:2079
-#: lib/vutuv_web/components/ui.ex:2104
-#: lib/vutuv_web/components/ui.ex:2107
-#: lib/vutuv_web/components/ui.ex:2114
-#: lib/vutuv_web/components/ui.ex:2117
-#: lib/vutuv_web/components/ui.ex:2175
+#: lib/vutuv_web/components/ui.ex:2097
+#: lib/vutuv_web/components/ui.ex:2122
+#: lib/vutuv_web/components/ui.ex:2125
+#: lib/vutuv_web/components/ui.ex:2132
+#: lib/vutuv_web/components/ui.ex:2135
+#: lib/vutuv_web/components/ui.ex:2193
 #: lib/vutuv_web/controllers/followee_controller.ex:29
-#: lib/vutuv_web/live/organization_live/show.ex:476
+#: lib/vutuv_web/live/organization_live/show.ex:471
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:53
 #: lib/vutuv_web/templates/user/show.html.heex:955
@@ -359,7 +359,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/directory/index.html.heex:3
 #: lib/vutuv_web/templates/directory/show.html.heex:4
-#: lib/vutuv_web/templates/layout/app.html.heex:121
+#: lib/vutuv_web/templates/layout/app.html.heex:132
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:2
 #, elixir-autogen
 msgid "Home"
@@ -440,8 +440,8 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:843
-#: lib/vutuv_web/live/shell_live.ex:889
+#: lib/vutuv_web/live/shell_live.ex:850
+#: lib/vutuv_web/live/shell_live.ex:906
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -610,7 +610,7 @@ msgstr ""
 msgid "Public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3370
+#: lib/vutuv_web/components/ui.ex:3388
 #: lib/vutuv_web/live/organization_live/edit.ex:341
 #: lib/vutuv_web/live/post_live/composer.ex:1813
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -638,13 +638,13 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:54
 #: lib/vutuv_web/live/search_live.ex:613
-#: lib/vutuv_web/live/shell_live.ex:711
-#: lib/vutuv_web/live/shell_live.ex:872
+#: lib/vutuv_web/live/shell_live.ex:718
+#: lib/vutuv_web/live/shell_live.ex:889
 #: lib/vutuv_web/live/tag_live/timeline.ex:237
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:30
-#: lib/vutuv_web/templates/layout/app.html.heex:126
+#: lib/vutuv_web/templates/layout/app.html.heex:137
 #, elixir-autogen
 msgid "Search"
 msgstr ""
@@ -787,7 +787,7 @@ msgstr ""
 msgid "User verified successfully."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3800
+#: lib/vutuv_web/components/ui.ex:3818
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
@@ -838,20 +838,20 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1014
+#: lib/vutuv_web/components/ui.ex:1032
 #: lib/vutuv_web/templates/user/show.html.heex:343
 #, elixir-autogen
 msgid "vCard"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3535
+#: lib/vutuv_web/components/ui.ex:3553
 #: lib/vutuv_web/templates/user/show.html.heex:949
 #: lib/vutuv_web/templates/user/show.html.heex:972
 #, elixir-autogen
 msgid "View All"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3881
+#: lib/vutuv_web/components/ui.ex:3899
 #: lib/vutuv_web/controllers/settings_controller.ex:159
 #: lib/vutuv_web/live/job_posting_live/form.ex:561
 #: lib/vutuv_web/live/organization_live/edit.ex:300
@@ -1072,7 +1072,7 @@ msgstr ""
 msgid "Listings"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:263
+#: lib/vutuv_web/controllers/page_controller.ex:323
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:4
 #, elixir-autogen
 msgid "Most Followed Users"
@@ -1141,7 +1141,7 @@ msgstr ""
 msgid "Add Localization"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:375
+#: lib/vutuv_web/components/organization_components.ex:289
 #: lib/vutuv_web/live/admin/activity_live.ex:153
 #: lib/vutuv_web/live/admin/api_app_live.ex:58
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
@@ -1159,7 +1159,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:815
+#: lib/vutuv_web/live/shell_live.ex:822
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1371,7 +1371,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:30
 #: lib/vutuv_web/agent_docs/text.ex:440
 #: lib/vutuv_web/agent_docs/text.ex:663
-#: lib/vutuv_web/components/ui.ex:3825
+#: lib/vutuv_web/components/ui.ex:3843
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
 #: lib/vutuv_web/cv/docx.ex:174
@@ -1592,7 +1592,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:875
+#: lib/vutuv_web/live/shell_live.ex:892
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1612,15 +1612,15 @@ msgid "Check your inbox"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3204
-#: lib/vutuv_web/components/ui.ex:280
+#: lib/vutuv_web/components/ui.ex:298
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
 #: lib/vutuv_web/live/post_live/composer.ex:1331
 #: lib/vutuv_web/live/post_live/composer.ex:1332
 #: lib/vutuv_web/live/post_live/composer.ex:2249
-#: lib/vutuv_web/templates/layout/app.html.heex:159
-#: lib/vutuv_web/templates/layout/app.html.heex:165
+#: lib/vutuv_web/templates/layout/app.html.heex:170
+#: lib/vutuv_web/templates/layout/app.html.heex:176
 #: lib/vutuv_web/views/layout_html.ex:40
 #, elixir-autogen, elixir-format
 msgid "Close"
@@ -1638,16 +1638,16 @@ msgstr ""
 msgid "Confirm account deletion"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:118
-#: lib/vutuv_web/templates/layout/app.html.heex:93
+#: lib/vutuv_web/controllers/page_controller.ex:178
+#: lib/vutuv_web/templates/layout/app.html.heex:104
 #: lib/vutuv_web/templates/page/index.html.heex:261
 #: lib/vutuv_web/views/admin/legal_page_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Datenschutzerklärung"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:124
-#: lib/vutuv_web/templates/layout/app.html.heex:95
+#: lib/vutuv_web/controllers/page_controller.ex:184
+#: lib/vutuv_web/templates/layout/app.html.heex:106
 #: lib/vutuv_web/templates/page/index.html.heex:261
 #: lib/vutuv_web/views/admin/legal_page_html.ex:12
 #, elixir-autogen, elixir-format
@@ -1666,30 +1666,30 @@ msgstr ""
 msgid "Edit profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1495
-#: lib/vutuv_web/components/ui.ex:1504
-#: lib/vutuv_web/components/ui.ex:1906
+#: lib/vutuv_web/components/ui.ex:1513
+#: lib/vutuv_web/components/ui.ex:1522
+#: lib/vutuv_web/components/ui.ex:1924
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:199
-#: lib/vutuv_web/components/ui.ex:2044
-#: lib/vutuv_web/components/ui.ex:2044
-#: lib/vutuv_web/components/ui.ex:2061
-#: lib/vutuv_web/components/ui.ex:2070
-#: lib/vutuv_web/components/ui.ex:2086
-#: lib/vutuv_web/components/ui.ex:2123
-#: lib/vutuv_web/components/ui.ex:2126
-#: lib/vutuv_web/components/ui.ex:2133
-#: lib/vutuv_web/components/ui.ex:2136
-#: lib/vutuv_web/components/ui.ex:2209
+#: lib/vutuv_web/components/ui.ex:2062
+#: lib/vutuv_web/components/ui.ex:2062
+#: lib/vutuv_web/components/ui.ex:2079
+#: lib/vutuv_web/components/ui.ex:2088
+#: lib/vutuv_web/components/ui.ex:2104
+#: lib/vutuv_web/components/ui.ex:2141
+#: lib/vutuv_web/components/ui.ex:2144
+#: lib/vutuv_web/components/ui.ex:2151
+#: lib/vutuv_web/components/ui.ex:2154
+#: lib/vutuv_web/components/ui.ex:2227
 #: lib/vutuv_web/live/fediverse_account_live.ex:375
 #: lib/vutuv_web/live/fediverse_following_live.ex:331
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:293
 #: lib/vutuv_web/live/organization_live/following.ex:218
-#: lib/vutuv_web/live/organization_live/show.ex:445
-#: lib/vutuv_web/live/organization_live/show.ex:474
+#: lib/vutuv_web/live/organization_live/show.ex:440
+#: lib/vutuv_web/live/organization_live/show.ex:469
 #: lib/vutuv_web/templates/user/show.html.heex:1269
 #, elixir-autogen, elixir-format
 msgid "Follow"
@@ -1705,13 +1705,13 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:834
+#: lib/vutuv_web/live/shell_live.ex:841
 #: lib/vutuv_web/views/settings_html.ex:262
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:381
+#: lib/vutuv_web/components/organization_components.ex:295
 #: lib/vutuv_web/live/admin/activity_live.ex:143
 #: lib/vutuv_web/live/admin/activity_live.ex:175
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
@@ -1726,28 +1726,28 @@ msgstr ""
 msgid "Member"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:495
+#: lib/vutuv_web/live/organization_live/show.ex:490
 #: lib/vutuv_web/templates/user/show.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
 
 #: lib/vutuv_web/live/message_live/index.ex:50
-#: lib/vutuv_web/live/message_live/index.ex:622
-#: lib/vutuv_web/live/shell_live.ex:727
-#: lib/vutuv_web/live/shell_live.ex:874
-#: lib/vutuv_web/templates/layout/app.html.heex:123
+#: lib/vutuv_web/live/message_live/index.ex:624
+#: lib/vutuv_web/live/shell_live.ex:734
+#: lib/vutuv_web/live/shell_live.ex:891
+#: lib/vutuv_web/templates/layout/app.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:619
+#: lib/vutuv_web/live/shell_live.ex:626
 #, elixir-autogen, elixir-format
 msgid "Network"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:435
-#: lib/vutuv_web/components/ui.ex:3584
+#: lib/vutuv_web/components/ui.ex:3602
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:705
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:742
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:793
@@ -1762,11 +1762,11 @@ msgstr ""
 msgid "Nothing new yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3862
+#: lib/vutuv_web/components/ui.ex:3880
 #: lib/vutuv_web/live/notification_live/index.ex:114
 #: lib/vutuv_web/live/notification_live/index.ex:338
-#: lib/vutuv_web/live/shell_live.ex:738
-#: lib/vutuv_web/templates/layout/app.html.heex:124
+#: lib/vutuv_web/live/shell_live.ex:745
+#: lib/vutuv_web/templates/layout/app.html.heex:135
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Notifications"
@@ -1787,19 +1787,19 @@ msgid "Pardon us! Something went wrong."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:130
-#: lib/vutuv_web/live/message_live/index.ex:869
+#: lib/vutuv_web/live/message_live/index.ex:871
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Send"
 msgstr ""
 
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:35
-#: lib/vutuv_web/templates/layout/app.html.heex:87
+#: lib/vutuv_web/templates/layout/app.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "Source"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:89
+#: lib/vutuv_web/templates/layout/app.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "Submit a bug report or feature request"
 msgstr ""
@@ -1862,8 +1862,8 @@ msgstr ""
 msgid "Who to follow"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:858
-#: lib/vutuv_web/live/message_live/index.ex:859
+#: lib/vutuv_web/live/message_live/index.ex:860
+#: lib/vutuv_web/live/message_live/index.ex:861
 #, elixir-autogen, elixir-format
 msgid "Write a message…"
 msgstr ""
@@ -1908,17 +1908,17 @@ msgstr ""
 msgid "started following you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2924
-#: lib/vutuv_web/components/ui.ex:3075
+#: lib/vutuv_web/components/ui.ex:2942
+#: lib/vutuv_web/components/ui.ex:3093
 #: lib/vutuv_web/live/organization_live/index.ex:122
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3609
+#: lib/vutuv_web/components/ui.ex:3627
 #: lib/vutuv_web/live/organization_live/activity.ex:146
 #: lib/vutuv_web/live/organization_live/feed.ex:101
-#: lib/vutuv_web/live/organization_live/show.ex:642
+#: lib/vutuv_web/live/organization_live/show.ex:637
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr ""
@@ -1928,13 +1928,13 @@ msgstr ""
 msgid "The address itself cannot be changed. To use a different one, add it as a new email address and delete this one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3380
+#: lib/vutuv_web/components/ui.ex:3398
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1220
-#: lib/vutuv_web/components/ui.ex:1230
+#: lib/vutuv_web/components/ui.ex:1238
+#: lib/vutuv_web/components/ui.ex:1248
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr ""
@@ -1973,12 +1973,12 @@ msgstr ""
 msgid "Add cover photo"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2634
+#: lib/vutuv_web/components/ui.ex:2652
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2638
+#: lib/vutuv_web/components/ui.ex:2656
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr ""
@@ -2003,37 +2003,37 @@ msgstr ""
 msgid "Cover photo of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2642
+#: lib/vutuv_web/components/ui.ex:2660
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2632
+#: lib/vutuv_web/components/ui.ex:2650
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2631
+#: lib/vutuv_web/components/ui.ex:2649
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2637
+#: lib/vutuv_web/components/ui.ex:2655
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2636
+#: lib/vutuv_web/components/ui.ex:2654
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2633
+#: lib/vutuv_web/components/ui.ex:2651
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2635
+#: lib/vutuv_web/components/ui.ex:2653
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr ""
@@ -2048,17 +2048,17 @@ msgstr ""
 msgid "Member since %{year}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2641
+#: lib/vutuv_web/components/ui.ex:2659
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2640
+#: lib/vutuv_web/components/ui.ex:2658
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2639
+#: lib/vutuv_web/components/ui.ex:2657
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr ""
@@ -2108,13 +2108,13 @@ msgstr ""
 msgid "Edit post"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:333
+#: lib/vutuv_web/components/organization_components.ex:247
 #: lib/vutuv_web/live/organization_live/feed.ex:79
 #: lib/vutuv_web/live/post_live/feed.ex:159
 #: lib/vutuv_web/live/post_live/feed.ex:936
-#: lib/vutuv_web/live/shell_live.ex:599
-#: lib/vutuv_web/live/shell_live.ex:870
-#: lib/vutuv_web/templates/layout/app.html.heex:122
+#: lib/vutuv_web/live/shell_live.ex:606
+#: lib/vutuv_web/live/shell_live.ex:887
+#: lib/vutuv_web/templates/layout/app.html.heex:133
 #, elixir-autogen, elixir-format
 msgid "Feed"
 msgstr ""
@@ -2196,7 +2196,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:382
 #: lib/vutuv_web/live/notification_live/index.ex:891
-#: lib/vutuv_web/live/organization_live/show.ex:569
+#: lib/vutuv_web/live/organization_live/show.ex:564
 #: lib/vutuv_web/live/post_live/saved.ex:495
 #: lib/vutuv_web/live/search_live.ex:309
 #: lib/vutuv_web/live/search_live.ex:772
@@ -2224,7 +2224,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/screenshot_live.ex:338
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:700
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
-#: lib/vutuv_web/live/organization_live/domains.ex:243
+#: lib/vutuv_web/live/organization_live/domains.ex:242
 #: lib/vutuv_web/live/organization_live/edit.ex:373
 #: lib/vutuv_web/live/organization_live/roles.ex:243
 #: lib/vutuv_web/live/post_live/composer.ex:1886
@@ -2283,8 +2283,8 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4126
-#: lib/vutuv_web/live/shell_live.ex:781
+#: lib/vutuv_web/components/ui.ex:4144
+#: lib/vutuv_web/live/shell_live.ex:788
 #: lib/vutuv_web/templates/post/index.html.heex:17
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:209
@@ -2365,7 +2365,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1603
 #: lib/vutuv_web/components/post_components.ex:4436
-#: lib/vutuv_web/components/ui.ex:2999
+#: lib/vutuv_web/components/ui.ex:3017
 #: lib/vutuv_web/views/user_html.ex:335
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2374,8 +2374,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1001
 #: lib/vutuv_web/live/post_live/saved.ex:175
 #: lib/vutuv_web/live/post_live/saved.ex:488
-#: lib/vutuv_web/live/shell_live.ex:720
-#: lib/vutuv_web/live/shell_live.ex:786
+#: lib/vutuv_web/live/shell_live.ex:727
+#: lib/vutuv_web/live/shell_live.ex:793
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2384,7 +2384,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1567
 #: lib/vutuv_web/components/post_components.ex:4670
-#: lib/vutuv_web/components/ui.ex:2985
+#: lib/vutuv_web/components/ui.ex:3003
 #: lib/vutuv_web/live/notification_live/index.ex:1038
 #: lib/vutuv_web/views/user_html.ex:345
 #, elixir-autogen, elixir-format
@@ -2396,7 +2396,7 @@ msgstr ""
 #: lib/vutuv_web/live/notification_live/index.ex:971
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
-#: lib/vutuv_web/live/shell_live.ex:789
+#: lib/vutuv_web/live/shell_live.ex:796
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2454,12 +2454,12 @@ msgid "Unlike"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:343
-#: lib/vutuv_web/components/ui.ex:2039
-#: lib/vutuv_web/components/ui.ex:2039
-#: lib/vutuv_web/components/ui.ex:2176
+#: lib/vutuv_web/components/ui.ex:2057
+#: lib/vutuv_web/components/ui.ex:2057
+#: lib/vutuv_web/components/ui.ex:2194
 #: lib/vutuv_web/live/organization_live/following.ex:197
 #: lib/vutuv_web/live/organization_live/following.ex:256
-#: lib/vutuv_web/live/organization_live/show.ex:479
+#: lib/vutuv_web/live/organization_live/show.ex:474
 #: lib/vutuv_web/live/post_live/feed.ex:1172
 #: lib/vutuv_web/templates/followee/index.html.heex:44
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
@@ -2543,12 +2543,12 @@ msgstr ""
 msgid "%{name} is typing…"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:881
+#: lib/vutuv_web/live/message_live/index.ex:883
 #, elixir-autogen, elixir-format
 msgid "@%{slug} has not accepted your message request yet."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:835
+#: lib/vutuv_web/live/message_live/index.ex:837
 #, elixir-autogen, elixir-format
 msgid "@%{slug} wants to message you."
 msgstr ""
@@ -2558,7 +2558,7 @@ msgstr ""
 msgid "Accept"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:704
+#: lib/vutuv_web/live/message_live/index.ex:706
 #, elixir-autogen, elixir-format
 msgid "Back to conversations"
 msgstr ""
@@ -2573,7 +2573,7 @@ msgstr ""
 msgid "Deleted account"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:750
+#: lib/vutuv_web/live/message_live/index.ex:752
 #, elixir-autogen, elixir-format
 msgid "Load older messages"
 msgstr ""
@@ -2584,23 +2584,23 @@ msgstr ""
 msgid "Member not found."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:683
+#: lib/vutuv_web/live/message_live/index.ex:685
 #, elixir-autogen, elixir-format
 msgid "No conversations yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2510
-#: lib/vutuv_web/live/message_live/index.ex:726
+#: lib/vutuv_web/components/ui.ex:2528
+#: lib/vutuv_web/live/message_live/index.ex:728
 #, elixir-autogen, elixir-format
 msgid "Online"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:632
+#: lib/vutuv_web/live/message_live/index.ex:634
 #, elixir-autogen, elixir-format
 msgid "Requests"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:890
+#: lib/vutuv_web/live/message_live/index.ex:892
 #, elixir-autogen, elixir-format
 msgid "Select a conversation."
 msgstr ""
@@ -2676,7 +2676,7 @@ msgstr ""
 msgid "Okay, let's start over."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:675
+#: lib/vutuv_web/components/ui.ex:693
 #, elixir-autogen, elixir-format
 msgid "Resend PIN"
 msgstr ""
@@ -2687,7 +2687,7 @@ msgstr ""
 msgid "Too many PIN requests. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:696
+#: lib/vutuv_web/components/ui.ex:714
 #, elixir-autogen, elixir-format
 msgid "Use a different email address"
 msgstr ""
@@ -2737,8 +2737,8 @@ msgstr ""
 msgid "Write your first post"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3163
-#: lib/vutuv_web/components/ui.ex:3537
+#: lib/vutuv_web/components/ui.ex:3181
+#: lib/vutuv_web/components/ui.ex:3555
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
 #: lib/vutuv_web/templates/settings/organizations.html.heex:104
@@ -2791,7 +2791,7 @@ msgstr[1] ""
 msgid "Connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1005
+#: lib/vutuv_web/components/ui.ex:1023
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr ""
@@ -2801,7 +2801,7 @@ msgstr ""
 msgid "No connections yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1021
+#: lib/vutuv_web/components/ui.ex:1039
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr ""
@@ -2811,7 +2811,7 @@ msgstr ""
 msgid "People who aren't my connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1006
+#: lib/vutuv_web/components/ui.ex:1024
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr ""
@@ -2834,12 +2834,12 @@ msgstr[1] ""
 msgid "people who aren't your connections"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:684
+#: lib/vutuv_web/live/message_live/index.ex:686
 #, elixir-autogen, elixir-format
 msgid "Open someone's profile to message them."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:327
+#: lib/vutuv_web/components/organization_components.ex:241
 #: lib/vutuv_web/live/notification_live/index.ex:1050
 #: lib/vutuv_web/live/organization_live/activity.ex:99
 #, elixir-autogen, elixir-format
@@ -2939,7 +2939,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:324
 #: lib/vutuv_web/agent_docs/text.ex:306
 #: lib/vutuv_web/controllers/page_controller.ex:83
-#: lib/vutuv_web/templates/layout/app.html.heex:91
+#: lib/vutuv_web/templates/layout/app.html.heex:102
 #: lib/vutuv_web/templates/page/community.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Community guidelines"
@@ -3000,7 +3000,7 @@ msgstr ""
 msgid "Hidden. You can settle this yourself - see below."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:779
+#: lib/vutuv_web/live/message_live/index.ex:781
 #, elixir-autogen, elixir-format
 msgid "Hidden: reported, under review"
 msgstr ""
@@ -3118,7 +3118,7 @@ msgstr ""
 msgid "Opened"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:374
+#: lib/vutuv_web/components/organization_components.ex:288
 #: lib/vutuv_web/live/admin/api_app_live.ex:72
 #: lib/vutuv_web/live/admin/deliverability_live.ex:171
 #: lib/vutuv_web/live/admin/moderation_live.ex:56
@@ -3141,9 +3141,9 @@ msgstr ""
 msgid "Private message"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3794
-#: lib/vutuv_web/live/shell_live.ex:612
-#: lib/vutuv_web/live/shell_live.ex:879
+#: lib/vutuv_web/components/ui.ex:3812
+#: lib/vutuv_web/live/shell_live.ex:619
+#: lib/vutuv_web/live/shell_live.ex:896
 #: lib/vutuv_web/templates/import/new.html.heex:15
 #: lib/vutuv_web/templates/import/preview.html.heex:55
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
@@ -3170,7 +3170,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1066
 #: lib/vutuv_web/components/post_components.ex:2042
 #: lib/vutuv_web/components/post_components.ex:2772
-#: lib/vutuv_web/live/organization_live/show.ex:552
+#: lib/vutuv_web/live/organization_live/show.ex:547
 #: lib/vutuv_web/templates/user/show.html.heex:219
 #, elixir-autogen, elixir-format
 msgid "Report"
@@ -3197,8 +3197,8 @@ msgstr ""
 msgid "Report this content"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:798
-#: lib/vutuv_web/live/message_live/index.ex:799
+#: lib/vutuv_web/live/message_live/index.ex:800
+#: lib/vutuv_web/live/message_live/index.ex:801
 #, elixir-autogen, elixir-format
 msgid "Report this message"
 msgstr ""
@@ -3252,7 +3252,7 @@ msgstr ""
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2899
+#: lib/vutuv_web/components/ui.ex:2917
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:773
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -4492,7 +4492,7 @@ msgstr ""
 msgid "Block @%{slug}? This removes any follows and connection between you, closes your conversation, and prevents all interaction in both directions. Unblocking will not restore what was removed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3885
+#: lib/vutuv_web/components/ui.ex:3903
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -4539,12 +4539,12 @@ msgstr ""
 msgid "Discover people to follow"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:687
+#: lib/vutuv_web/live/message_live/index.ex:689
 #, elixir-autogen, elixir-format
 msgid "Find members"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:339
+#: lib/vutuv_web/components/organization_components.ex:253
 #: lib/vutuv_web/live/organization_live/following.ex:154
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:53
@@ -4591,9 +4591,9 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:366
 #: lib/vutuv_web/agent_docs/text.ex:388
 #: lib/vutuv_web/components/saved_search_components.ex:57
-#: lib/vutuv_web/components/ui.ex:516
+#: lib/vutuv_web/components/ui.ex:534
 #: lib/vutuv_web/live/notification_live/index.ex:892
-#: lib/vutuv_web/live/organization_live/show.ex:652
+#: lib/vutuv_web/live/organization_live/show.ex:647
 #: lib/vutuv_web/live/post_live/saved.ex:498
 #: lib/vutuv_web/live/search_live.ex:307
 #: lib/vutuv_web/live/search_live.ex:714
@@ -5251,12 +5251,12 @@ msgstr ""
 msgid "API token (%{date})"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:85
+#: lib/vutuv_web/templates/layout/app.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3936
+#: lib/vutuv_web/components/ui.ex:3954
 #: lib/vutuv_web/controllers/settings_controller.ex:145
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5302,48 +5302,48 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:768
+#: lib/vutuv_web/live/shell_live.ex:775
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:321
 #: lib/vutuv_web/live/admin/screenshot_live.ex:431
-#: lib/vutuv_web/templates/layout/app.html.heex:128
+#: lib/vutuv_web/templates/layout/app.html.heex:139
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:138
+#: lib/vutuv_web/templates/layout/app.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "Close menus and dialogs"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:135
+#: lib/vutuv_web/templates/layout/app.html.heex:146
 #, elixir-autogen, elixir-format
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:825
-#: lib/vutuv_web/templates/layout/app.html.heex:154
+#: lib/vutuv_web/live/shell_live.ex:832
+#: lib/vutuv_web/templates/layout/app.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:119
+#: lib/vutuv_web/templates/layout/app.html.heex:130
 #, elixir-autogen, elixir-format
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4033
-#: lib/vutuv_web/components/ui.ex:4038
-#: lib/vutuv_web/components/ui.ex:4117
-#: lib/vutuv_web/components/ui.ex:4181
+#: lib/vutuv_web/components/ui.ex:4051
+#: lib/vutuv_web/components/ui.ex:4056
+#: lib/vutuv_web/components/ui.ex:4135
+#: lib/vutuv_web/components/ui.ex:4199
 #: lib/vutuv_web/controllers/settings_controller.ex:61
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:303
-#: lib/vutuv_web/live/shell_live.ex:805
+#: lib/vutuv_web/live/shell_live.ex:812
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5356,17 +5356,17 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:137
+#: lib/vutuv_web/templates/layout/app.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "Show this help"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:130
+#: lib/vutuv_web/templates/layout/app.html.heex:141
 #, elixir-autogen, elixir-format
 msgid "Write a new post"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:125
+#: lib/vutuv_web/templates/layout/app.html.heex:136
 #: lib/vutuv_web/views/page_html.ex:505
 #, elixir-autogen, elixir-format
 msgid "Your profile"
@@ -5387,23 +5387,23 @@ msgstr ""
 msgid "Add a profile photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:132
+#: lib/vutuv_web/templates/layout/app.html.heex:143
 #, elixir-autogen, elixir-format
 msgid "Next post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:133
+#: lib/vutuv_web/templates/layout/app.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "Previous post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:592
-#: lib/vutuv_web/live/shell_live.ex:863
+#: lib/vutuv_web/live/shell_live.ex:599
+#: lib/vutuv_web/live/shell_live.ex:878
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:78
+#: lib/vutuv_web/templates/layout/app.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Footer navigation"
 msgstr ""
@@ -5457,7 +5457,7 @@ msgstr ""
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3905
+#: lib/vutuv_web/components/ui.ex:3923
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:289
@@ -5478,7 +5478,7 @@ msgstr ""
 msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3832
+#: lib/vutuv_web/components/ui.ex:3850
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5512,7 +5512,7 @@ msgstr ""
 msgid "Photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3879
+#: lib/vutuv_web/components/ui.ex:3897
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/templates/page/index.html.heex:166
 #, elixir-autogen, elixir-format
@@ -5628,7 +5628,7 @@ msgstr ""
 msgid "Apps"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3932
+#: lib/vutuv_web/components/ui.ex:3950
 #: lib/vutuv_web/controllers/settings_controller.ex:165
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -5713,7 +5713,7 @@ msgstr ""
 msgid "@handle"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:742
+#: lib/vutuv_web/live/message_live/index.ex:744
 #, elixir-autogen, elixir-format
 msgid "Block @%{slug}"
 msgstr ""
@@ -6056,7 +6056,7 @@ msgstr ""
 msgid "Tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:296
+#: lib/vutuv_web/components/ui.ex:314
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
 #: lib/vutuv_web/templates/user/show.html.heex:883
@@ -6238,9 +6238,9 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1495
-#: lib/vutuv_web/components/ui.ex:1504
-#: lib/vutuv_web/components/ui.ex:1907
+#: lib/vutuv_web/components/ui.ex:1513
+#: lib/vutuv_web/components/ui.ex:1522
+#: lib/vutuv_web/components/ui.ex:1925
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr ""
@@ -6301,7 +6301,7 @@ msgstr ""
 msgid "No endorsements yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1860
+#: lib/vutuv_web/components/ui.ex:1878
 #: lib/vutuv_web/live/notification_live/index.ex:625
 #: lib/vutuv_web/live/notification_live/index.ex:640
 #: lib/vutuv_web/live/notification_live/index.ex:778
@@ -6596,7 +6596,7 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2364
+#: lib/vutuv_web/components/ui.ex:2382
 #: lib/vutuv_web/live/fediverse_account_live.ex:369
 #: lib/vutuv_web/templates/settings/filters.html.heex:58
 #: lib/vutuv_web/templates/user/show.html.heex:212
@@ -6620,7 +6620,7 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2363
+#: lib/vutuv_web/components/ui.ex:2381
 #: lib/vutuv_web/live/fediverse_account_live.ex:367
 #: lib/vutuv_web/templates/settings/filters.html.heex:81
 #: lib/vutuv_web/templates/user/show.html.heex:212
@@ -6659,33 +6659,33 @@ msgstr ""
 msgid "Unmute @%{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2334
+#: lib/vutuv_web/components/ui.ex:2352
 #, elixir-autogen, elixir-format
 msgid "Doesn't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2328
+#: lib/vutuv_web/components/ui.ex:2346
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2318
+#: lib/vutuv_web/components/ui.ex:2336
 #, elixir-autogen, elixir-format
 msgid "This member doesn't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2269
-#: lib/vutuv_web/components/ui.ex:2318
+#: lib/vutuv_web/components/ui.ex:2287
+#: lib/vutuv_web/components/ui.ex:2336
 #, elixir-autogen, elixir-format
 msgid "This member follows you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2267
+#: lib/vutuv_web/components/ui.ex:2285
 #, elixir-autogen, elixir-format
 msgid "You follow each other"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2268
+#: lib/vutuv_web/components/ui.ex:2286
 #, elixir-autogen, elixir-format
 msgid "You follow this member"
 msgstr ""
@@ -7251,13 +7251,13 @@ msgstr ""
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2937
+#: lib/vutuv_web/components/ui.ex:2955
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2953
+#: lib/vutuv_web/components/ui.ex:2971
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7526,12 +7526,12 @@ msgstr ""
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:107
+#: lib/vutuv_web/templates/layout/app.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Deployment: %{date} at %{time}"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:107
+#: lib/vutuv_web/templates/layout/app.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Last deployed (Berlin time)"
 msgstr ""
@@ -8010,7 +8010,7 @@ msgstr ""
 msgid "PIN registered"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2940
+#: lib/vutuv_web/components/ui.ex:2958
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr ""
@@ -8053,7 +8053,7 @@ msgid "Unreachable"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/member_badges.ex:20
-#: lib/vutuv_web/live/organization_live/domains.ex:192
+#: lib/vutuv_web/live/organization_live/domains.ex:191
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:32
 #, elixir-autogen, elixir-format
 msgid "Verified"
@@ -8140,7 +8140,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:41
 #: lib/vutuv_web/agent_docs/text.ex:38
-#: lib/vutuv_web/components/ui.ex:3808
+#: lib/vutuv_web/components/ui.ex:3826
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8195,7 +8195,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3920
+#: lib/vutuv_web/components/ui.ex:3938
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8224,7 +8224,7 @@ msgstr ""
 msgid "Nothing new to import."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3836
+#: lib/vutuv_web/components/ui.ex:3854
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8315,7 +8315,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3209
+#: lib/vutuv_web/components/ui.ex:3227
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8396,13 +8396,13 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3796
+#: lib/vutuv_web/components/ui.ex:3814
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3916
+#: lib/vutuv_web/components/ui.ex:3934
 #: lib/vutuv_web/controllers/settings_controller.ex:122
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8414,7 +8414,7 @@ msgstr ""
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3907
+#: lib/vutuv_web/components/ui.ex:3925
 #: lib/vutuv_web/controllers/settings_controller.ex:105
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8424,7 +8424,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3924
+#: lib/vutuv_web/components/ui.ex:3942
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8507,7 +8507,7 @@ msgstr ""
 #: lib/vutuv_web/templates/directory/index.html.heex:2
 #: lib/vutuv_web/templates/directory/index.html.heex:3
 #: lib/vutuv_web/templates/directory/show.html.heex:5
-#: lib/vutuv_web/templates/layout/app.html.heex:79
+#: lib/vutuv_web/templates/layout/app.html.heex:90
 #, elixir-autogen, elixir-format
 msgid "Member directory"
 msgstr ""
@@ -8542,7 +8542,7 @@ msgstr[1] ""
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1023
+#: lib/vutuv_web/components/ui.ex:1041
 #, elixir-autogen, elixir-format
 msgid "This profile is not offered as a Markdown, text, JSON or XML export."
 msgstr ""
@@ -8601,7 +8601,7 @@ msgstr ""
 msgid "Not written yet"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:312
+#: lib/vutuv_web/components/organization_components.ex:226
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "Page"
@@ -8637,16 +8637,16 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:541
 #: lib/vutuv_web/agent_docs/text.ex:504
 #: lib/vutuv_web/agent_docs/text.ex:508
-#: lib/vutuv_web/components/organization_components.ex:344
-#: lib/vutuv_web/components/ui.ex:3897
+#: lib/vutuv_web/components/organization_components.ex:258
+#: lib/vutuv_web/components/ui.ex:3915
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:323
 #: lib/vutuv_web/controllers/settings_controller.ex:390
 #: lib/vutuv_web/live/fediverse_followers_live.ex:169
 #: lib/vutuv_web/live/fediverse_following_live.ex:304
 #: lib/vutuv_web/live/organization_live/fediverse.ex:80
-#: lib/vutuv_web/live/organization_live/show.ex:545
-#: lib/vutuv_web/live/organization_live/show.ex:728
+#: lib/vutuv_web/live/organization_live/show.ex:540
+#: lib/vutuv_web/live/organization_live/show.ex:723
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:341
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:5
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
@@ -8792,7 +8792,7 @@ msgstr ""
 msgid "This is the print view of this CV. Use your browser's print dialog (Ctrl+P or Cmd+P) and choose \"Save as PDF\" to get a PDF file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1131
+#: lib/vutuv_web/components/ui.ex:1149
 #, elixir-autogen, elixir-format
 msgid "CV download"
 msgstr ""
@@ -8830,7 +8830,7 @@ msgstr ""
 msgid "Header"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1141
+#: lib/vutuv_web/components/ui.ex:1159
 #: lib/vutuv_web/templates/export/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Open CV"
@@ -8862,7 +8862,7 @@ msgstr ""
 msgid "The CV is public, on your profile: a visitor's download contains only what they can see there anyway, and private email addresses appear only in your own."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1133
+#: lib/vutuv_web/components/ui.ex:1151
 #, elixir-autogen, elixir-format
 msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
@@ -9018,8 +9018,8 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1539
-#: lib/vutuv_web/components/ui.ex:1540
+#: lib/vutuv_web/components/ui.ex:1557
+#: lib/vutuv_web/components/ui.ex:1558
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:65
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9586,7 +9586,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:45
 #: lib/vutuv_web/agent_docs/text.ex:42
-#: lib/vutuv_web/components/ui.ex:3812
+#: lib/vutuv_web/components/ui.ex:3830
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:124
@@ -9779,13 +9779,13 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2732
+#: lib/vutuv_web/components/ui.ex:2750
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2731
-#: lib/vutuv_web/components/ui.ex:2735
+#: lib/vutuv_web/components/ui.ex:2749
+#: lib/vutuv_web/components/ui.ex:2753
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr ""
@@ -9959,12 +9959,12 @@ msgstr ""
 msgid "Authenticator app turned off."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:290
+#: lib/vutuv_web/components/ui.ex:308
 #, elixir-autogen, elixir-format
 msgid "Bold"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:386
+#: lib/vutuv_web/components/ui.ex:404
 #, elixir-autogen, elixir-format
 msgid "Bullet list"
 msgstr ""
@@ -9974,7 +9974,7 @@ msgstr ""
 msgid "Can't scan the code? Enter this key in your app instead:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:378
+#: lib/vutuv_web/components/ui.ex:396
 #, elixir-autogen, elixir-format
 msgid "Code block"
 msgstr ""
@@ -9989,17 +9989,17 @@ msgstr ""
 msgid "Delete your code list? All its codes stop working immediately."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:400
+#: lib/vutuv_web/components/ui.ex:418
 #, elixir-autogen, elixir-format
 msgid "Divider"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:288
+#: lib/vutuv_web/components/ui.ex:306
 #, elixir-autogen, elixir-format
 msgid "Formatting"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:412
+#: lib/vutuv_web/components/ui.ex:430
 #, elixir-autogen, elixir-format
 msgid "Full screen"
 msgstr ""
@@ -10014,32 +10014,32 @@ msgstr ""
 msgid "Generate code list"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:366
+#: lib/vutuv_web/components/ui.ex:384
 #, elixir-autogen, elixir-format
 msgid "Heading 1"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:369
+#: lib/vutuv_web/components/ui.ex:387
 #, elixir-autogen, elixir-format
 msgid "Heading 2"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:372
+#: lib/vutuv_web/components/ui.ex:390
 #, elixir-autogen, elixir-format
 msgid "Heading 3"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:358
+#: lib/vutuv_web/components/ui.ex:376
 #, elixir-autogen, elixir-format
 msgid "Inline code"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:293
+#: lib/vutuv_web/components/ui.ex:311
 #, elixir-autogen, elixir-format
 msgid "Italic"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:277
+#: lib/vutuv_web/components/ui.ex:295
 #, elixir-autogen, elixir-format
 msgid "Link URL"
 msgstr ""
@@ -10049,8 +10049,8 @@ msgstr ""
 msgid "Login codes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:338
-#: lib/vutuv_web/components/ui.ex:339
+#: lib/vutuv_web/components/ui.ex:356
+#: lib/vutuv_web/components/ui.ex:357
 #, elixir-autogen, elixir-format
 msgid "More formatting"
 msgstr ""
@@ -10061,7 +10061,7 @@ msgstr ""
 msgid "Not set up."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:389
+#: lib/vutuv_web/components/ui.ex:407
 #, elixir-autogen, elixir-format
 msgid "Numbered list"
 msgstr ""
@@ -10076,7 +10076,7 @@ msgstr ""
 msgid "Print this page or write the codes down. Crossed-out codes have been used."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:375
+#: lib/vutuv_web/components/ui.ex:393
 #, elixir-autogen, elixir-format
 msgid "Quote"
 msgstr ""
@@ -10097,12 +10097,12 @@ msgstr ""
 msgid "Set up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:355
+#: lib/vutuv_web/components/ui.ex:373
 #, elixir-autogen, elixir-format
 msgid "Strikethrough"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:397
+#: lib/vutuv_web/components/ui.ex:415
 #, elixir-autogen, elixir-format
 msgid "Table"
 msgstr ""
@@ -10117,7 +10117,7 @@ msgstr ""
 msgid "To finish, enter the code your app shows now"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:409
+#: lib/vutuv_web/components/ui.ex:427
 #, elixir-autogen, elixir-format
 msgid "Toggle Markdown source"
 msgstr ""
@@ -10224,7 +10224,7 @@ msgid_plural "%{count} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:503
+#: lib/vutuv_web/live/organization_live/show.ex:498
 #: lib/vutuv_web/views/user_html.ex:536
 #: lib/vutuv_web/views/user_html.ex:715
 #, elixir-autogen, elixir-format
@@ -10763,7 +10763,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/organization_live.ex:179
 #: lib/vutuv_web/live/admin/organization_live.ex:194
 #: lib/vutuv_web/live/admin/screenshot_live.ex:535
-#: lib/vutuv_web/live/organization_live/domains.ex:198
+#: lib/vutuv_web/live/organization_live/domains.ex:197
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
@@ -11028,7 +11028,7 @@ msgstr ""
 msgid "AI agents"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:559
+#: lib/vutuv_web/live/organization_live/show.ex:554
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
@@ -11038,18 +11038,19 @@ msgstr ""
 msgid "Continue to verification"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:262
-#: lib/vutuv_web/live/organization_live/domains.ex:302
+#: lib/vutuv_web/live/organization_live/domains.ex:261
+#: lib/vutuv_web/live/organization_live/domains.ex:301
 #: lib/vutuv_web/live/organization_live/new.ex:161
-#: lib/vutuv_web/live/organization_live/show.ex:843
+#: lib/vutuv_web/live/organization_live/show.ex:838
 #: lib/vutuv_web/templates/url/verify.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "DNS TXT record"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:102
-#: lib/vutuv_web/live/organization_live/domains.ex:181
-#: lib/vutuv_web/live/organization_live/show.ex:913
+#: lib/vutuv_web/live/organization_live/domains.ex:180
+#: lib/vutuv_web/live/organization_live/domains.ex:342
+#: lib/vutuv_web/live/organization_live/show.ex:904
+#: lib/vutuv_web/live/organization_live/show.ex:912
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr ""
@@ -11086,7 +11087,7 @@ msgstr ""
 msgid "Please log in first."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:816
+#: lib/vutuv_web/live/organization_live/show.ex:811
 #, elixir-autogen, elixir-format
 msgid "Prove you control %{domain} to publish this page."
 msgstr ""
@@ -11107,13 +11108,13 @@ msgstr ""
 msgid "Search engines"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:221
+#: lib/vutuv_web/components/organization_components.ex:135
 #, elixir-autogen, elixir-format
 msgid "Select a country"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:321
-#: lib/vutuv_web/live/organization_live/show.ex:878
+#: lib/vutuv_web/live/organization_live/domains.ex:320
+#: lib/vutuv_web/live/organization_live/show.ex:873
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr ""
@@ -11140,12 +11141,12 @@ msgid "The upload failed."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/new.ex:146
-#: lib/vutuv_web/live/organization_live/show.ex:831
+#: lib/vutuv_web/live/organization_live/show.ex:826
 #, elixir-autogen, elixir-format
 msgid "Verification method"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:791
+#: lib/vutuv_web/live/organization_live/show.ex:786
 #, elixir-autogen, elixir-format
 msgid "Verified domains"
 msgstr ""
@@ -11161,13 +11162,13 @@ msgstr ""
 msgid "Verified via %{domain}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:813
+#: lib/vutuv_web/live/organization_live/show.ex:808
 #, elixir-autogen, elixir-format
 msgid "Verify %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:337
-#: lib/vutuv_web/live/organization_live/show.ex:903
+#: lib/vutuv_web/live/organization_live/domains.ex:336
+#: lib/vutuv_web/live/organization_live/show.ex:898
 #, elixir-autogen, elixir-format
 msgid "Verify now"
 msgstr ""
@@ -11180,9 +11181,9 @@ msgstr ""
 msgid "Website"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:263
-#: lib/vutuv_web/live/organization_live/domains.ex:312
-#: lib/vutuv_web/live/organization_live/show.ex:854
+#: lib/vutuv_web/live/organization_live/domains.ex:262
+#: lib/vutuv_web/live/organization_live/domains.ex:311
+#: lib/vutuv_web/live/organization_live/show.ex:849
 #: lib/vutuv_web/templates/url/verify.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Website file"
@@ -11203,8 +11204,8 @@ msgstr ""
 msgid "You will publish a record or file to prove control of the domain on the next step."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:323
-#: lib/vutuv_web/live/organization_live/show.ex:884
+#: lib/vutuv_web/live/organization_live/domains.ex:322
+#: lib/vutuv_web/live/organization_live/show.ex:879
 #: lib/vutuv_web/templates/url/verify.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
@@ -11215,13 +11216,13 @@ msgstr ""
 msgid "@handle or email"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:393
+#: lib/vutuv_web/components/organization_components.ex:307
 #: lib/vutuv_web/live/organization_live/edit.ex:390
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:250
+#: lib/vutuv_web/live/organization_live/domains.ex:249
 #, elixir-autogen, elixir-format
 msgid "Add a domain"
 msgstr ""
@@ -11236,7 +11237,7 @@ msgstr ""
 msgid "Added @%{handle} to the team."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:394
+#: lib/vutuv_web/components/organization_components.ex:308
 #: lib/vutuv_web/live/organization_live/edit.ex:388
 #, elixir-autogen, elixir-format
 msgid "Alias"
@@ -11255,7 +11256,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:358
 #: lib/vutuv_web/agent_docs/text.ex:381
 #: lib/vutuv_web/live/organization_live/edit.ex:353
-#: lib/vutuv_web/live/organization_live/show.ex:779
+#: lib/vutuv_web/live/organization_live/show.ex:774
 #: lib/vutuv_web/templates/tag/single_card.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Also known as"
@@ -11282,7 +11283,7 @@ msgstr ""
 msgid "Archived"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:392
+#: lib/vutuv_web/components/organization_components.ex:306
 #: lib/vutuv_web/live/organization_live/edit.ex:389
 #, elixir-autogen, elixir-format
 msgid "Brand"
@@ -11303,35 +11304,35 @@ msgstr ""
 msgid "Delete this page and everything it owns? This cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:64
+#: lib/vutuv_web/live/organization_live/domains.ex:65
 #, elixir-autogen, elixir-format
 msgid "Domain added. Publish the record or file, then verify it."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:138
+#: lib/vutuv_web/live/organization_live/domains.ex:139
 #, elixir-autogen, elixir-format
 msgid "Domain removed."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:107
+#: lib/vutuv_web/live/organization_live/domains.ex:108
 #, elixir-autogen, elixir-format
 msgid "Domain verified."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:318
+#: lib/vutuv_web/components/organization_components.ex:232
 #: lib/vutuv_web/live/admin/organization_live.ex:305
-#: lib/vutuv_web/live/organization_live/domains.ex:175
-#: lib/vutuv_web/live/organization_live/show.ex:530
+#: lib/vutuv_web/live/organization_live/domains.ex:174
+#: lib/vutuv_web/live/organization_live/show.ex:525
 #, elixir-autogen, elixir-format
 msgid "Domains"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:28
+#: lib/vutuv_web/live/organization_live/domains.ex:29
 #, elixir-autogen, elixir-format
 msgid "Domains – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:391
+#: lib/vutuv_web/components/organization_components.ex:305
 #, elixir-autogen, elixir-format
 msgid "Former name"
 msgstr ""
@@ -11348,7 +11349,7 @@ msgstr ""
 msgid "Freeze this page? It disappears for the public but stays visible to its owner."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:203
+#: lib/vutuv_web/live/organization_live/domains.ex:202
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "Last checked"
@@ -11369,7 +11370,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:234
+#: lib/vutuv_web/live/organization_live/domains.ex:233
 #, elixir-autogen, elixir-format
 msgid "Make primary"
 msgstr ""
@@ -11379,7 +11380,7 @@ msgstr ""
 msgid "Member removed."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:203
+#: lib/vutuv_web/live/organization_live/domains.ex:202
 #, elixir-autogen, elixir-format
 msgid "Method"
 msgstr ""
@@ -11394,27 +11395,27 @@ msgstr ""
 msgid "No member found for “%{id}”."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:123
+#: lib/vutuv_web/live/organization_live/domains.ex:124
 #, elixir-autogen, elixir-format
 msgid "Only a verified domain can be the primary one."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:189
+#: lib/vutuv_web/live/organization_live/domains.ex:188
 #, elixir-autogen, elixir-format
 msgid "Primary"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:119
+#: lib/vutuv_web/live/organization_live/domains.ex:120
 #, elixir-autogen, elixir-format
 msgid "Primary domain updated."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:380
+#: lib/vutuv_web/components/organization_components.ex:294
 #, elixir-autogen, elixir-format
 msgid "Recruiter"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:240
+#: lib/vutuv_web/live/organization_live/domains.ex:239
 #, elixir-autogen, elixir-format
 msgid "Remove this domain?"
 msgstr ""
@@ -11434,10 +11435,10 @@ msgstr ""
 msgid "Search name, alias or domain"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:315
+#: lib/vutuv_web/components/organization_components.ex:229
 #: lib/vutuv_web/live/admin/organization_live.ex:321
 #: lib/vutuv_web/live/organization_live/roles.ex:165
-#: lib/vutuv_web/live/organization_live/show.ex:523
+#: lib/vutuv_web/live/organization_live/show.ex:518
 #, elixir-autogen, elixir-format
 msgid "Team"
 msgstr ""
@@ -11447,7 +11448,7 @@ msgstr ""
 msgid "Team – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:75
+#: lib/vutuv_web/live/organization_live/domains.ex:76
 #, elixir-autogen, elixir-format
 msgid "That is not a valid domain."
 msgstr ""
@@ -11533,13 +11534,13 @@ msgstr ""
 msgid "Back-link (rel=me)"
 msgstr ""
 
-#: lib/vutuv_web/controllers/url_controller.ex:163
 #: lib/vutuv_web/templates/url/verify.html.heex:25
+#: lib/vutuv_web/views/url_html.ex:71
 #, elixir-autogen, elixir-format
 msgid "Link verification is disabled on this installation."
 msgstr ""
 
-#: lib/vutuv_web/controllers/url_controller.ex:158
+#: lib/vutuv_web/controllers/url_controller.ex:155
 #, elixir-autogen, elixir-format
 msgid "Link verified. It now shows a verified mark."
 msgstr ""
@@ -11559,7 +11560,7 @@ msgstr ""
 msgid "The link text can be anything. A hidden <link rel=\"me\"> in the page head works too."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:887
+#: lib/vutuv_web/components/ui.ex:905
 #: lib/vutuv_web/live/section_reorder_live.ex:195
 #, elixir-autogen, elixir-format
 msgid "Verified webpage"
@@ -11570,7 +11571,7 @@ msgstr ""
 msgid "Verified. Re-run any method below to refresh it."
 msgstr ""
 
-#: lib/vutuv_web/controllers/url_controller.ex:138
+#: lib/vutuv_web/controllers/url_controller.ex:180
 #: lib/vutuv_web/templates/url/verify.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Verify link"
@@ -11598,11 +11599,6 @@ msgstr ""
 msgid "Verify via file"
 msgstr ""
 
-#: lib/vutuv_web/controllers/url_controller.ex:170
-#, elixir-autogen, elixir-format
-msgid "We could not find the proof yet. It can take a while to propagate. Please try again."
-msgstr ""
-
 #: lib/vutuv_web/agent_docs/markdown.ex:842
 #: lib/vutuv_web/agent_docs/text.ex:636
 #, elixir-autogen, elixir-format
@@ -11614,7 +11610,7 @@ msgstr ""
 msgid "%{min} to %{max} characters: letters (a-z), numbers (0-9) and underscores."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:667
+#: lib/vutuv_web/live/organization_live/show.ex:662
 #, elixir-autogen, elixir-format
 msgid "Former"
 msgstr ""
@@ -11665,12 +11661,12 @@ msgstr[1] ""
 msgid "Alternative names, brands or abbreviations this organization is findable under. A rename keeps the old name here automatically."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:177
+#: lib/vutuv_web/live/organization_live/domains.ex:176
 #, elixir-autogen, elixir-format
 msgid "An organization can prove several domains. The primary one shows in the “Verified via …” badge."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:145
+#: lib/vutuv_web/live/organization_live/domains.ex:146
 #, elixir-autogen, elixir-format
 msgid "An organization keeps at least one verified domain, so this one cannot be removed."
 msgstr ""
@@ -11719,7 +11715,7 @@ msgstr ""
 msgid "The proof is a small technical change to your domain: a DNS entry or a file on your website. If you don't manage the website yourself, ask the person or team who does. That is usually your IT department or the company that runs your website. We show the exact instructions on the next step, so you can simply pass them on."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:825
+#: lib/vutuv_web/live/organization_live/show.ex:820
 #, elixir-autogen, elixir-format
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr ""
@@ -11832,21 +11828,21 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:349
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:325
-#: lib/vutuv_web/components/ui.ex:3928
+#: lib/vutuv_web/components/ui.ex:3946
 #: lib/vutuv_web/controllers/settings_controller.ex:179
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:501
-#: lib/vutuv_web/live/shell_live.ex:796
+#: lib/vutuv_web/live/shell_live.ex:803
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
-#: lib/vutuv_web/templates/layout/app.html.heex:83
+#: lib/vutuv_web/templates/layout/app.html.heex:94
 #: lib/vutuv_web/templates/settings/organizations.html.heex:6
 #, elixir-autogen, elixir-format
 msgid "Organizations"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:248
+#: lib/vutuv_web/components/organization_components.ex:162
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:90
 #, elixir-autogen, elixir-format
 msgid "Please choose"
@@ -11867,7 +11863,7 @@ msgstr ""
 msgid "Search organizations"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:71
+#: lib/vutuv_web/live/organization_live/domains.ex:72
 #, elixir-autogen, elixir-format
 msgid "That domain already belongs to an organization page."
 msgstr ""
@@ -11887,7 +11883,7 @@ msgstr ""
 msgid "The organization page was deleted."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:384
+#: lib/vutuv_web/live/organization_live/show.ex:379
 #, elixir-autogen, elixir-format
 msgid "This organization page was reported and is hidden while it is reviewed. Only you and the moderators can see it."
 msgstr ""
@@ -11917,8 +11913,8 @@ msgstr ""
 msgid "Your organization handle is set."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:300
-#: lib/vutuv_web/live/organization_live/show.ex:360
+#: lib/vutuv_web/live/organization_live/show.ex:302
+#: lib/vutuv_web/live/organization_live/show.ex:355
 #, elixir-autogen, elixir-format
 msgid "Your organization page is verified and now live."
 msgstr ""
@@ -12171,8 +12167,8 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:504
-#: lib/vutuv_web/live/shell_live.ex:626
-#: lib/vutuv_web/templates/layout/app.html.heex:81
+#: lib/vutuv_web/live/shell_live.ex:633
+#: lib/vutuv_web/templates/layout/app.html.heex:92
 #: lib/vutuv_web/templates/qualification/show.html.heex:38
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -12494,17 +12490,17 @@ msgstr ""
 msgid "A domain of your organization page on vutuv is about to be dropped"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:216
+#: lib/vutuv_web/live/organization_live/domains.ex:215
 #, elixir-autogen, elixir-format
 msgid "Deadline"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:195
+#: lib/vutuv_web/live/organization_live/domains.ex:194
 #, elixir-autogen, elixir-format
 msgid "Proof missing"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:215
+#: lib/vutuv_web/live/organization_live/domains.ex:214
 #, elixir-autogen, elixir-format
 msgid "We could not read this domain's proof on the last check. Restore it and check again, or the domain loses its verification."
 msgstr ""
@@ -12617,14 +12613,14 @@ msgstr ""
 msgid "Getting an error, or is %{host} a CNAME / alias to another address? A TXT record cannot share a name with a CNAME. Use this name instead, with the exact same value as above:"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:319
-#: lib/vutuv_web/live/organization_live/show.ex:871
+#: lib/vutuv_web/live/organization_live/domains.ex:318
+#: lib/vutuv_web/live/organization_live/show.ex:866
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:317
-#: lib/vutuv_web/live/organization_live/show.ex:862
+#: lib/vutuv_web/live/organization_live/domains.ex:316
+#: lib/vutuv_web/live/organization_live/show.ex:857
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
 msgstr ""
@@ -12720,7 +12716,7 @@ msgid "Minimum yearly salary"
 msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:324
-#: lib/vutuv_web/live/organization_live/show.ex:694
+#: lib/vutuv_web/live/organization_live/show.ex:689
 #, elixir-autogen, elixir-format
 msgid "More jobs"
 msgstr ""
@@ -12749,7 +12745,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:436
 #: lib/vutuv_web/agent_docs/text.ex:445
 #: lib/vutuv_web/agent_docs/text.ex:457
-#: lib/vutuv_web/live/organization_live/show.ex:681
+#: lib/vutuv_web/live/organization_live/show.ex:676
 #: lib/vutuv_web/templates/tag/show.html.heex:69
 #, elixir-autogen, elixir-format
 msgid "Open positions"
@@ -13049,7 +13045,7 @@ msgstr ""
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3874
+#: lib/vutuv_web/components/ui.ex:3892
 #: lib/vutuv_web/controllers/settings_controller.ex:556
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -13206,7 +13202,7 @@ msgstr ""
 msgid "Inherited from the organization"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:321
+#: lib/vutuv_web/components/organization_components.ex:235
 #: lib/vutuv_web/live/organization_live/exclusions.ex:103
 #, elixir-autogen, elixir-format
 msgid "Job exclusions"
@@ -13424,27 +13420,27 @@ msgstr[1] ""
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:323
+#: lib/vutuv_web/components/ui.ex:341
 #, elixir-autogen, elixir-format
 msgid "Center"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:320
+#: lib/vutuv_web/components/ui.ex:338
 #, elixir-autogen, elixir-format
 msgid "Float left"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:326
+#: lib/vutuv_web/components/ui.ex:344
 #, elixir-autogen, elixir-format
 msgid "Float right"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:317
+#: lib/vutuv_web/components/ui.ex:335
 #, elixir-autogen, elixir-format
 msgid "Full width"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:305
+#: lib/vutuv_web/components/ui.ex:323
 #, elixir-autogen, elixir-format
 msgid "Insert image"
 msgstr ""
@@ -13506,7 +13502,7 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3870
+#: lib/vutuv_web/components/ui.ex:3888
 #: lib/vutuv_web/controllers/settings_controller.ex:570
 #: lib/vutuv_web/live/post_live/feed.ex:1158
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -13586,7 +13582,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:59
 #: lib/vutuv_web/agent_docs/text.ex:56
-#: lib/vutuv_web/components/ui.ex:3855
+#: lib/vutuv_web/components/ui.ex:3873
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -13614,14 +13610,14 @@ msgstr ""
 msgid "Select a messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3295
+#: lib/vutuv_web/components/ui.ex:3313
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3305
+#: lib/vutuv_web/components/ui.ex:3323
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
@@ -13845,19 +13841,19 @@ msgstr ""
 msgid "by:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1673
+#: lib/vutuv_web/components/ui.ex:1691
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1677
+#: lib/vutuv_web/components/ui.ex:1695
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:434
+#: lib/vutuv_web/live/shell_live.ex:435
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -14406,7 +14402,7 @@ msgstr ""
 msgid "Match whole words only (word/phrase)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3866
+#: lib/vutuv_web/components/ui.ex:3884
 #: lib/vutuv_web/controllers/settings_controller.ex:636
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -15039,277 +15035,277 @@ msgstr ""
 msgid "moved to %{address}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3797
+#: lib/vutuv_web/components/ui.ex:3815
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3802
+#: lib/vutuv_web/components/ui.ex:3820
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3805
+#: lib/vutuv_web/components/ui.ex:3823
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3806
+#: lib/vutuv_web/components/ui.ex:3824
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3809
+#: lib/vutuv_web/components/ui.ex:3827
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3810
+#: lib/vutuv_web/components/ui.ex:3828
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3813
+#: lib/vutuv_web/components/ui.ex:3831
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3814
+#: lib/vutuv_web/components/ui.ex:3832
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3821
+#: lib/vutuv_web/components/ui.ex:3839
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3822
+#: lib/vutuv_web/components/ui.ex:3840
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3823
+#: lib/vutuv_web/components/ui.ex:3841
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3826
+#: lib/vutuv_web/components/ui.ex:3844
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3827
+#: lib/vutuv_web/components/ui.ex:3845
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3929
+#: lib/vutuv_web/components/ui.ex:3947
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3930
+#: lib/vutuv_web/components/ui.ex:3948
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3830
+#: lib/vutuv_web/components/ui.ex:3848
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3833
+#: lib/vutuv_web/components/ui.ex:3851
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3834
+#: lib/vutuv_web/components/ui.ex:3852
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3837
+#: lib/vutuv_web/components/ui.ex:3855
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3838
+#: lib/vutuv_web/components/ui.ex:3856
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3841
+#: lib/vutuv_web/components/ui.ex:3859
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3842
+#: lib/vutuv_web/components/ui.ex:3860
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3844
+#: lib/vutuv_web/components/ui.ex:3862
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3845
+#: lib/vutuv_web/components/ui.ex:3863
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3846
+#: lib/vutuv_web/components/ui.ex:3864
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3848
+#: lib/vutuv_web/components/ui.ex:3866
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3849
+#: lib/vutuv_web/components/ui.ex:3867
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3851
+#: lib/vutuv_web/components/ui.ex:3869
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3856
+#: lib/vutuv_web/components/ui.ex:3874
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3857
+#: lib/vutuv_web/components/ui.ex:3875
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3860
+#: lib/vutuv_web/components/ui.ex:3878
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3863
+#: lib/vutuv_web/components/ui.ex:3881
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3864
+#: lib/vutuv_web/components/ui.ex:3882
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3867
+#: lib/vutuv_web/components/ui.ex:3885
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3868
+#: lib/vutuv_web/components/ui.ex:3886
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3871
+#: lib/vutuv_web/components/ui.ex:3889
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3872
+#: lib/vutuv_web/components/ui.ex:3890
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3875
+#: lib/vutuv_web/components/ui.ex:3893
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3876
+#: lib/vutuv_web/components/ui.ex:3894
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3882
+#: lib/vutuv_web/components/ui.ex:3900
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3883
+#: lib/vutuv_web/components/ui.ex:3901
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3886
+#: lib/vutuv_web/components/ui.ex:3904
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3887
+#: lib/vutuv_web/components/ui.ex:3905
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3908
+#: lib/vutuv_web/components/ui.ex:3926
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3909
+#: lib/vutuv_web/components/ui.ex:3927
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3917
+#: lib/vutuv_web/components/ui.ex:3935
 #, elixir-autogen, elixir-format
 msgid "Interface language, maps, how posts are shortened"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3918
+#: lib/vutuv_web/components/ui.ex:3936
 #, elixir-autogen, elixir-format
 msgid "german english locale translation map font length hyphenation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3921
+#: lib/vutuv_web/components/ui.ex:3939
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3922
+#: lib/vutuv_web/components/ui.ex:3940
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3925
+#: lib/vutuv_web/components/ui.ex:3943
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3926
+#: lib/vutuv_web/components/ui.ex:3944
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3933
+#: lib/vutuv_web/components/ui.ex:3951
 #, elixir-autogen, elixir-format
 msgid "Connected apps and access tokens"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3934
+#: lib/vutuv_web/components/ui.ex:3952
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3937
+#: lib/vutuv_web/components/ui.ex:3955
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3938
+#: lib/vutuv_web/components/ui.ex:3956
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr ""
@@ -15760,7 +15756,7 @@ msgstr ""
 msgid "Access token revoked"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3911
+#: lib/vutuv_web/components/ui.ex:3929
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -16107,7 +16103,7 @@ msgstr ""
 msgid "What changed on your account, and exactly when."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3912
+#: lib/vutuv_web/components/ui.ex:3930
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr ""
@@ -16143,7 +16139,7 @@ msgstr ""
 msgid "from a signed-in session"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3914
+#: lib/vutuv_web/components/ui.ex:3932
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
@@ -16676,7 +16672,7 @@ msgstr ""
 msgid "Cancel request"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3898
+#: lib/vutuv_web/components/ui.ex:3916
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr ""
@@ -16878,7 +16874,7 @@ msgstr ""
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3900
+#: lib/vutuv_web/components/ui.ex:3918
 #, elixir-autogen, elixir-format, fuzzy
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
@@ -17259,12 +17255,12 @@ msgstr[1] ""
 msgid "Your feed shows the posts of members you follow. Follow a few to fill it."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:183
+#: lib/vutuv_web/components/ui.ex:201
 #, elixir-autogen, elixir-format
 msgid "Add another tag"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:206
+#: lib/vutuv_web/components/ui.ex:224
 #, elixir-autogen, elixir-format
 msgid "Remove the tag %{name}"
 msgstr ""
@@ -17408,7 +17404,7 @@ msgstr ""
 msgid "Your username is your public identity here. It changes only once you confirm with your passkey or a valid code below."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:462
+#: lib/vutuv_web/components/ui.ex:480
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Markdown help"
 msgstr ""
@@ -17423,53 +17419,53 @@ msgstr ""
 msgid "Read this page as Markdown"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:519
+#: lib/vutuv_web/components/ui.ex:537
 #, elixir-autogen, elixir-format
 msgid "Activities"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:517
+#: lib/vutuv_web/components/ui.ex:535
 #, elixir-autogen, elixir-format
 msgid "Animals & nature"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:278
-#: lib/vutuv_web/components/ui.ex:302
+#: lib/vutuv_web/components/ui.ex:296
+#: lib/vutuv_web/components/ui.ex:320
 #, elixir-autogen, elixir-format
 msgid "Emoji"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:518
+#: lib/vutuv_web/components/ui.ex:536
 #, elixir-autogen, elixir-format
 msgid "Food & drink"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:281
+#: lib/vutuv_web/components/ui.ex:299
 #, elixir-autogen, elixir-format
 msgid "No emoji found."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:521
+#: lib/vutuv_web/components/ui.ex:539
 #, elixir-autogen, elixir-format
 msgid "Objects"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:279
+#: lib/vutuv_web/components/ui.ex:297
 #, elixir-autogen, elixir-format
 msgid "Search emoji"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:515
+#: lib/vutuv_web/components/ui.ex:533
 #, elixir-autogen, elixir-format
 msgid "Smileys"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:522
+#: lib/vutuv_web/components/ui.ex:540
 #, elixir-autogen, elixir-format
 msgid "Symbols"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:520
+#: lib/vutuv_web/components/ui.ex:538
 #, elixir-autogen, elixir-format
 msgid "Travel & places"
 msgstr ""
@@ -17720,12 +17716,12 @@ msgstr ""
 msgid "Whole photos"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:131
+#: lib/vutuv_web/templates/layout/app.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Send the post or message you are writing"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:192
+#: lib/vutuv_web/templates/layout/app.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "The single-key shortcuts pause while you type, and are off on phones and tablets."
 msgstr ""
@@ -18015,8 +18011,8 @@ msgstr ""
 msgid "This is vutuv's copy of a post published on %{host}. It is kept while somebody here follows its author."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1074
-#: lib/vutuv_web/components/ui.ex:1075
+#: lib/vutuv_web/components/ui.ex:1092
+#: lib/vutuv_web/components/ui.ex:1093
 #, elixir-autogen, elixir-format
 msgid "Subscribe to this feed in your RSS reader"
 msgstr ""
@@ -18262,7 +18258,7 @@ msgstr ""
 msgid "Delete your account yourself, without writing to anybody. No questions asked, and you are welcome back any time."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:212
+#: lib/vutuv_web/components/ui.ex:230
 #, elixir-autogen, elixir-format
 msgid "At most %{max} tags. Remove one to add another."
 msgstr ""
@@ -18414,7 +18410,7 @@ msgstr ""
 msgid "Employment reference updated."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3816
+#: lib/vutuv_web/components/ui.ex:3834
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -18608,7 +18604,7 @@ msgstr ""
 msgid "You changed the text after this review. It describes the earlier version."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3817
+#: lib/vutuv_web/components/ui.ex:3835
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr ""
@@ -18619,7 +18615,7 @@ msgstr ""
 msgid "Zwischenzeugnis"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3819
+#: lib/vutuv_web/components/ui.ex:3837
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr ""
@@ -19218,12 +19214,12 @@ msgstr ""
 msgid "Enter the PIN from the email"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:667
+#: lib/vutuv_web/components/ui.ex:685
 #, elixir-autogen, elixir-format
 msgid "If you have added other addresses to your vutuv account, try logging in with one of those instead."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:695
+#: lib/vutuv_web/components/ui.ex:713
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cancel registration"
 msgstr ""
@@ -19238,7 +19234,7 @@ msgstr ""
 msgid "Follow other members"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:650
+#: lib/vutuv_web/components/ui.ex:668
 #, elixir-autogen, elixir-format
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
@@ -19263,7 +19259,7 @@ msgstr ""
 msgid "Shares are of the %{answered} members who answered. %{unanswered} gave no answer."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3798
+#: lib/vutuv_web/components/ui.ex:3816
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr ""
@@ -19359,7 +19355,7 @@ msgstr ""
 msgid "Always keep"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3891
+#: lib/vutuv_web/components/ui.ex:3909
 #: lib/vutuv_web/controllers/settings_controller.ex:213
 #: lib/vutuv_web/controllers/settings_controller.ex:292
 #: lib/vutuv_web/controllers/settings_controller.ex:304
@@ -19456,7 +19452,7 @@ msgstr ""
 msgid "Keep posts that did well"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3893
+#: lib/vutuv_web/components/ui.ex:3911
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr ""
@@ -19565,7 +19561,7 @@ msgstr ""
 msgid "Your rule"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3895
+#: lib/vutuv_web/components/ui.ex:3913
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
@@ -19944,12 +19940,12 @@ msgstr ""
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:379
+#: lib/vutuv_web/components/organization_components.ex:293
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Editorial"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:385
+#: lib/vutuv_web/components/organization_components.ex:299
 #, elixir-autogen, elixir-format
 msgid "Edits the page and posts jobs."
 msgstr ""
@@ -19959,7 +19955,7 @@ msgstr ""
 msgid "Give members their roles on this page. Someone can hold several at once, and every role is granted on its own."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:384
+#: lib/vutuv_web/components/organization_components.ex:298
 #, elixir-autogen, elixir-format
 msgid "Manages the team and the domains, and edits the page."
 msgstr ""
@@ -19969,7 +19965,7 @@ msgstr ""
 msgid "Pick at least one role."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:387
+#: lib/vutuv_web/components/organization_components.ex:301
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Posts jobs."
 msgstr ""
@@ -19984,7 +19980,7 @@ msgstr ""
 msgid "Roles updated."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:386
+#: lib/vutuv_web/components/organization_components.ex:300
 #, elixir-autogen, elixir-format
 msgid "Writes posts in the organization's name."
 msgstr ""
@@ -19994,33 +19990,33 @@ msgstr ""
 msgid "The owner gives other members their roles on the page, and can hand ownership over to someone else at any time. Someone can hold several roles, and writing in the organization's name is always granted on its own."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:637
+#: lib/vutuv_web/live/organization_live/show.ex:632
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing published yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:619
+#: lib/vutuv_web/live/organization_live/show.ex:614
 #: lib/vutuv_web/live/post_live/composer.ex:1814
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:225
+#: lib/vutuv_web/live/organization_live/show.ex:227
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Published as %{name}."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:237
+#: lib/vutuv_web/live/organization_live/show.ex:239
 #, elixir-autogen, elixir-format
 msgid "That post could not be published."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:611
+#: lib/vutuv_web/live/organization_live/show.ex:606
 #, elixir-autogen, elixir-format
 msgid "Write something as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:231
+#: lib/vutuv_web/live/organization_live/show.ex:233
 #, elixir-autogen, elixir-format
 msgid "You may no longer write in this organization's name."
 msgstr ""
@@ -20030,7 +20026,7 @@ msgstr ""
 msgid "A post in an organization's name is always public."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:558
+#: lib/vutuv_web/live/shell_live.ex:562
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Open the page"
 msgstr ""
@@ -20045,12 +20041,12 @@ msgstr ""
 msgid "Stopped writing as an organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:595
+#: lib/vutuv_web/live/organization_live/show.ex:590
 #, elixir-autogen, elixir-format
 msgid "Write as %{name} for now"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:568
+#: lib/vutuv_web/live/shell_live.ex:572
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr ""
@@ -20060,7 +20056,7 @@ msgstr ""
 msgid "You are writing as %{name} now."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:544
+#: lib/vutuv_web/live/shell_live.ex:548
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr ""
@@ -20267,12 +20263,12 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/fediverse.ex:88
 #: lib/vutuv_web/live/organization_live/new.ex:211
-#: lib/vutuv_web/live/organization_live/show.ex:747
+#: lib/vutuv_web/live/organization_live/show.ex:742
 #, elixir-autogen, elixir-format
 msgid "People who have no vutuv account can follow this page and read its posts, in networks like Mastodon."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:761
+#: lib/vutuv_web/live/organization_live/show.ex:756
 #, elixir-autogen, elixir-format
 msgid "Set this page up for other networks"
 msgstr ""
@@ -20287,7 +20283,7 @@ msgstr ""
 msgid "Switch it on"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/show.ex:752
+#: lib/vutuv_web/live/organization_live/show.ex:747
 #, elixir-autogen, elixir-format
 msgid "The page gets an address of its own for that, written like an email address."
 msgstr ""
@@ -20372,22 +20368,22 @@ msgstr ""
 msgid "The PIN has expired."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:771
+#: lib/vutuv_web/components/ui.ex:789
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more minute."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:773
+#: lib/vutuv_web/components/ui.ex:791
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more second."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:772
+#: lib/vutuv_web/components/ui.ex:790
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more minutes."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:774
+#: lib/vutuv_web/components/ui.ex:792
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more seconds."
 msgstr ""
@@ -20424,21 +20420,21 @@ msgstr ""
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:464
+#: lib/vutuv_web/live/shell_live.ex:465
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} person"
 msgid_plural "%{formatted} people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:451
+#: lib/vutuv_web/live/shell_live.ex:452
 #, elixir-autogen, elixir-format, fuzzy
 msgid "person"
 msgid_plural "people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:486
+#: lib/vutuv_web/live/shell_live.ex:487
 #, elixir-autogen, elixir-format
 msgid "%{members} vutuv members plus %{fediverse} Fediverse account that follows them"
 msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that follow them"
@@ -20540,13 +20536,13 @@ msgstr ""
 msgid "The gravatar.com lookup is switched off on this installation."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:165
+#: lib/vutuv_web/components/organization_components.ex:79
 #, elixir-autogen, elixir-format
 msgid "A new entry can take a while to reach everyone. We keep checking %{domain} by ourselves and send you an email as soon as it works, so you can close this page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:333
-#: lib/vutuv_web/live/organization_live/show.ex:899
+#: lib/vutuv_web/live/organization_live/domains.ex:332
+#: lib/vutuv_web/live/organization_live/show.ex:894
 #, elixir-autogen, elixir-format
 msgid "Checking …"
 msgstr ""
@@ -20556,47 +20552,47 @@ msgstr ""
 msgid "Finish verification"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:152
+#: lib/vutuv_web/components/verification_components.ex:139
 #, elixir-autogen, elixir-format
 msgid "It answered with HTTP status %{status}."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:149
+#: lib/vutuv_web/components/verification_components.ex:136
 #, elixir-autogen, elixir-format
 msgid "It answered with an empty file."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:146
+#: lib/vutuv_web/components/verification_components.ex:133
 #, elixir-autogen, elixir-format
 msgid "It answered, but with something else: %{found}"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:122
+#: lib/vutuv_web/components/verification_components.ex:96
 #, elixir-autogen, elixir-format
 msgid "No TXT record at all."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:95
+#: lib/vutuv_web/components/verification_components.ex:69
 #, elixir-autogen, elixir-format
 msgid "Not found yet"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:106
+#: lib/vutuv_web/components/verification_components.ex:80
 #, elixir-autogen, elixir-format
 msgid "We asked the name servers of your domain directly, for %{names}, and looked for this value:"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:143
+#: lib/vutuv_web/components/verification_components.ex:130
 #, elixir-autogen, elixir-format
 msgid "We could not reach that address at all."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:125
+#: lib/vutuv_web/components/verification_components.ex:112
 #, elixir-autogen, elixir-format
 msgid "We fetched this address:"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:110
+#: lib/vutuv_web/components/verification_components.ex:84
 #, elixir-autogen, elixir-format
 msgid "What is published there right now:"
 msgstr ""
@@ -20604,4 +20600,29 @@ msgstr ""
 #: lib/vutuv/notifications/emailer.ex:856
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is verified"
+msgstr ""
+
+#: lib/vutuv_web/components/verification_components.ex:147
+#, elixir-autogen, elixir-format
+msgid "We could not reach your page at all."
+msgstr ""
+
+#: lib/vutuv_web/components/verification_components.ex:100
+#, elixir-autogen, elixir-format
+msgid "We fetched your page and looked for a link back to:"
+msgstr ""
+
+#: lib/vutuv_web/components/verification_components.ex:156
+#, elixir-autogen, elixir-format
+msgid "Your page answered with HTTP status %{status}."
+msgstr ""
+
+#: lib/vutuv_web/components/verification_components.ex:153
+#, elixir-autogen, elixir-format
+msgid "Your page does link back, but somewhere else:"
+msgstr ""
+
+#: lib/vutuv_web/components/verification_components.ex:150
+#, elixir-autogen, elixir-format
+msgid "Your page has no rel=\"me\" link at all yet."
 msgstr ""

--- a/test/support/organizations_helpers.ex
+++ b/test/support/organizations_helpers.ex
@@ -28,7 +28,7 @@ defmodule Vutuv.OrganizationsHelpers do
   @doc "The baseline valid organization attrs, merged with `overrides`."
   def valid_organization_attrs(overrides \\ %{}), do: Map.merge(@valid_attrs, overrides)
 
-  @doc "Points the DNS resolver stub at `token`, so `verify_dns/2` succeeds."
+  @doc "Points the DNS resolver stub at `token`, so `check_domain/2` succeeds."
   def stub_dns(token) do
     Application.put_env(:vutuv, :organizations_dns_resolver, fn _host ->
       [[~c"vutuv-organization-verify=#{token}"]]
@@ -50,7 +50,7 @@ defmodule Vutuv.OrganizationsHelpers do
       Organizations.create_pending_organization(owner, valid_organization_attrs(overrides), "dns")
 
     stub_dns(domain.verification_token)
-    {:ok, organization} = Organizations.verify_dns(organization, domain)
+    {:ok, organization} = Organizations.check_domain(organization, domain)
     organization
   end
 end

--- a/test/vutuv/organizations_management_test.exs
+++ b/test/vutuv/organizations_management_test.exs
@@ -251,7 +251,7 @@ defmodule Vutuv.OrganizationsManagementTest do
       refute second.verified_at
 
       stub_dns(second.verification_token)
-      {:ok, _organization} = Organizations.verify_domain(organization, second)
+      {:ok, _organization} = Organizations.check_domain(organization, second)
       second = Organizations.get_domain(organization, second.id)
       assert second.verified_at
 
@@ -289,7 +289,7 @@ defmodule Vutuv.OrganizationsManagementTest do
 
       {:ok, second} = Organizations.add_domain(organization, "https://acme.de", "dns")
       stub_dns(second.verification_token)
-      {:ok, _} = Organizations.verify_domain(organization, second)
+      {:ok, _} = Organizations.check_domain(organization, second)
 
       # Now the primary can go; the other verified domain becomes primary.
       {:ok, _} = Organizations.remove_domain(organization, primary)

--- a/test/vutuv/organizations_test.exs
+++ b/test/vutuv/organizations_test.exs
@@ -155,7 +155,7 @@ defmodule Vutuv.OrganizationsTest do
     end
   end
 
-  describe "verify_dns/2" do
+  describe "check_domain/2 via dns" do
     setup [:enable_verification]
 
     test "activates the organization and alerts the operator when the TXT record matches" do
@@ -166,7 +166,7 @@ defmodule Vutuv.OrganizationsTest do
 
       stub_dns(domain.verification_token)
 
-      assert {:ok, organization} = Organizations.verify_dns(organization, domain)
+      assert {:ok, organization} = Organizations.check_domain(organization, domain)
       assert organization.status == "active"
       assert organization.verified_at
 
@@ -185,12 +185,13 @@ defmodule Vutuv.OrganizationsTest do
       Application.put_env(:vutuv, :organizations_dns_resolver, fn _host -> [] end)
       on_exit(fn -> Application.delete_env(:vutuv, :organizations_dns_resolver) end)
 
-      assert {:error, :not_found} = Organizations.verify_dns(organization, domain)
+      assert {:error, report} = Organizations.check_domain(organization, domain)
+      assert report.found == []
       assert Repo.get!(Organization, organization.id).status == "pending"
     end
   end
 
-  describe "verify_well_known/2" do
+  describe "check_domain/2 via well_known" do
     setup [:enable_verification]
 
     test "activates the organization when the file serves the token" do
@@ -201,20 +202,21 @@ defmodule Vutuv.OrganizationsTest do
 
       stub_well_known(domain.verification_token <> "\n")
 
-      assert {:ok, organization} = Organizations.verify_well_known(organization, domain)
+      assert {:ok, organization} = Organizations.check_domain(organization, domain)
       assert organization.status == "active"
     end
   end
 
   describe "verification disabled" do
-    test "verify_dns is a no-op when the flag is off" do
+    test "a check is a no-op when the flag is off" do
       user = insert(:activated_user)
 
       {:ok, %{organization: organization, domain: domain}} =
         Organizations.create_pending_organization(user, @valid, "dns")
 
       # flag stays false (test default)
-      assert {:error, :not_found} = Organizations.verify_dns(organization, domain)
+      assert {:error, report} = Organizations.check_domain(organization, domain)
+      assert report.disabled?
     end
   end
 
@@ -228,7 +230,7 @@ defmodule Vutuv.OrganizationsTest do
         Organizations.create_pending_organization(user, @valid, "dns")
 
       stub_dns(domain.verification_token)
-      {:ok, _organization} = Organizations.verify_dns(organization, domain)
+      {:ok, _organization} = Organizations.check_domain(organization, domain)
       domain = Repo.get!(OrganizationDomain, domain.id)
       # Consume the "verified" operator notice so the demote assertion below
       # matches the second message, not this one.
@@ -261,7 +263,7 @@ defmodule Vutuv.OrganizationsTest do
         Organizations.create_pending_organization(user, @valid, "dns")
 
       stub_dns(primary.verification_token)
-      {:ok, _} = Organizations.verify_dns(organization, primary)
+      {:ok, _} = Organizations.check_domain(organization, primary)
       primary = Repo.get!(OrganizationDomain, primary.id)
       assert primary.primary?
 
@@ -269,7 +271,7 @@ defmodule Vutuv.OrganizationsTest do
       # primary later fails.
       {:ok, second} = Organizations.add_domain(organization, "second.example.org", "dns")
       stub_dns(second.verification_token)
-      {:ok, _} = Organizations.verify_dns(organization, second)
+      {:ok, _} = Organizations.check_domain(organization, second)
 
       # The primary's record vanishes; force past grace and re-check it.
       Application.put_env(:vutuv, :organizations_dns_resolver, fn _host -> [] end)
@@ -312,7 +314,7 @@ defmodule Vutuv.OrganizationsTest do
     # then makes the TXT record vanish so the next re-check fails.
     defp break_proof(organization, domain) do
       stub_dns(domain.verification_token)
-      {:ok, _organization} = Organizations.verify_dns(organization, domain)
+      {:ok, _organization} = Organizations.check_domain(organization, domain)
       assert_email_sent(fn email -> assert email.subject =~ "Organisationsseite verifiziert" end)
       Application.put_env(:vutuv, :organizations_dns_resolver, fn _host -> [] end)
       Repo.get!(OrganizationDomain, domain.id)
@@ -433,14 +435,14 @@ defmodule Vutuv.OrganizationsTest do
         Organizations.create_pending_organization(user, @valid, "dns")
 
       stub_dns(primary.verification_token)
-      {:ok, _} = Organizations.verify_dns(organization, primary)
+      {:ok, _} = Organizations.check_domain(organization, primary)
       assert_email_sent(fn email -> assert email.subject =~ "Organisationsseite verifiziert" end)
 
       {:ok, second} = Organizations.add_domain(organization, "second.example.org", "dns")
       stub_dns(second.verification_token)
       # Re-read the page (as the domains LiveView does) so `verified_at` is set
       # and the already-sent "verified" operator notice is not sent a second time.
-      {:ok, _} = Organizations.verify_dns(Repo.get!(Organization, organization.id), second)
+      {:ok, _} = Organizations.check_domain(Repo.get!(Organization, organization.id), second)
 
       Application.put_env(:vutuv, :organizations_dns_resolver, fn _host -> [] end)
 

--- a/test/vutuv/profiles/link_verification_test.exs
+++ b/test/vutuv/profiles/link_verification_test.exs
@@ -35,35 +35,43 @@ defmodule Vutuv.Profiles.LinkVerificationTest do
     insert(:url, Map.merge(%{user: user, value: "https://alice.example/"}, attrs))
   end
 
-  describe "verify/3 via rel_me" do
+  describe "check/3 via rel_me" do
     test "marks the link verified when the page links back to the profile" do
       user = insert(:activated_user)
       url = link(user)
       stub_body(~s(<a rel="me" href="#{VutuvWeb.Endpoint.url()}/#{user.username}">me</a>))
 
-      assert {:ok, %Url{} = url} = LinkVerification.verify(url, user, "rel_me")
+      assert {:ok, %Url{} = url} = LinkVerification.check(url, user, "rel_me")
       assert Url.verified?(url)
       assert url.verification_method == "rel_me"
       assert url.verified_at
     end
 
-    test "returns :not_found when the back-link is absent" do
+    test "reports what the page actually carries when the back-link is absent" do
       user = insert(:activated_user)
       url = link(user)
-      stub_body("<p>no back-link here</p>")
+      stub_body(~s(<a rel="me" href="https://github.com/alice">gh</a>))
 
-      assert {:error, :not_found} = LinkVerification.verify(url, user, "rel_me")
+      assert {:error, report} = LinkVerification.check(url, user, "rel_me")
       refute Url.verified?(Repo.get!(Url, url.id))
+
+      # The whole point of the report (issue #1466): not "we could not find the
+      # proof yet", but the back-link the page does have beside the one wanted.
+      assert report.method == "rel_me"
+      assert report.status == 200
+      assert report.found == ["https://github.com/alice"]
+      assert report.expected == LinkVerification.profile_urls(user)
+      refute report.disabled?
     end
   end
 
-  describe "verify/3 via dns / well_known" do
+  describe "check/3 via dns / well_known" do
     test "dns marks the link verified when the TXT record is present" do
       user = insert(:activated_user)
       url = link(user) |> LinkVerification.ensure_token()
       stub_dns(url.verification_token)
 
-      assert {:ok, url} = LinkVerification.verify(url, user, "dns")
+      assert {:ok, url} = LinkVerification.check(url, user, "dns")
       assert url.verification_method == "dns"
     end
 
@@ -84,7 +92,7 @@ defmodule Vutuv.Profiles.LinkVerificationTest do
 
       on_exit(fn -> Application.delete_env(:vutuv, :user_links_dns_resolver) end)
 
-      assert {:ok, url} = LinkVerification.verify(url, user, "dns")
+      assert {:ok, url} = LinkVerification.check(url, user, "dns")
       assert url.verification_method == "dns"
     end
 
@@ -93,18 +101,59 @@ defmodule Vutuv.Profiles.LinkVerificationTest do
       url = link(user) |> LinkVerification.ensure_token()
       stub_body(url.verification_token <> "\n")
 
-      assert {:ok, url} = LinkVerification.verify(url, user, "well_known")
+      assert {:ok, url} = LinkVerification.check(url, user, "well_known")
       assert url.verification_method == "well_known"
+    end
+
+    test "the dns report names both queried names and every TXT record it saw" do
+      user = insert(:activated_user)
+      # Deliberately NOT pre-tokened: a report for a link whose token was never
+      # minted must still carry the fields the panel prints, or the page the
+      # report exists for is a KeyError instead.
+      url = link(user)
+      Application.put_env(:vutuv, :user_links_dns_resolver, fn _host -> [[~c"v=spf1 -all"]] end)
+      on_exit(fn -> Application.delete_env(:vutuv, :user_links_dns_resolver) end)
+
+      assert {:error, report} = LinkVerification.check(url, user, "dns")
+      assert report.method == "dns"
+      assert report.names == ["alice.example", "_vutuv.alice.example"]
+      assert report.found == ["v=spf1 -all"]
+
+      # The check minted the token it needed, and the report quotes that one.
+      assert report.expected == LinkVerification.dns_txt_value(Repo.get!(Url, url.id))
+    end
+
+    test "a failed check leaves the link's own check clock alone" do
+      user = insert(:activated_user)
+      # A link that is already verified must not have its weekly re-check pushed
+      # out by a member re-running a method by hand: `last_checked_at` belongs to
+      # the recheck sweeper's schedule, and a hand check is not one of its passes.
+      url =
+        link(user)
+        |> LinkVerification.ensure_token()
+        |> Ecto.Changeset.change(%{
+          verified_at: ~N[2026-01-01 00:00:00],
+          verification_method: "dns",
+          last_checked_at: ~N[2026-01-01 00:00:00]
+        })
+        |> Repo.update!()
+
+      Application.put_env(:vutuv, :user_links_dns_resolver, fn _host -> [] end)
+      on_exit(fn -> Application.delete_env(:vutuv, :user_links_dns_resolver) end)
+
+      assert {:error, _report} = LinkVerification.check(url, user, "dns")
+      assert Repo.get!(Url, url.id).last_checked_at == ~N[2026-01-01 00:00:00]
     end
   end
 
-  describe "verify/3 when disabled" do
-    test "returns :disabled and never touches the network" do
+  describe "check/3 when disabled" do
+    test "says so in the report and never touches the network" do
       Application.put_env(:vutuv, :verify_user_links, false)
       user = insert(:activated_user)
       url = link(user)
 
-      assert {:error, :disabled} = LinkVerification.verify(url, user, "rel_me")
+      assert {:error, report} = LinkVerification.check(url, user, "rel_me")
+      assert report.disabled?
     end
   end
 

--- a/test/vutuv/web_verification_test.exs
+++ b/test/vutuv/web_verification_test.exs
@@ -187,6 +187,64 @@ defmodule Vutuv.WebVerificationTest do
       refute report.found =~ "\n"
       assert String.length(report.found) <= 160
     end
+
+    test "the rel=me report lists the back-links the page actually has" do
+      body = ~s(<a rel="me" href="https://github.com/alice">gh</a><a href="/about">about</a>)
+
+      assert {:error, report} =
+               WebVerification.rel_me_check(
+                 "https://alice.example/",
+                 ["https://vutuv.de/alice"],
+                 adapter(200, body)
+               )
+
+      assert report.method == "rel_me"
+      assert report.url == "https://alice.example/"
+      assert report.status == 200
+      assert report.expected == ["https://vutuv.de/alice"]
+      # The rel=me link it does have — the whole diagnosis when a member marked
+      # the wrong one of several profile links, or none at all.
+      assert report.found == ["https://github.com/alice"]
+    end
+
+    test "the rel=me report separates a bad status from a page with no back-link" do
+      assert {:error, missing} =
+               WebVerification.rel_me_check(
+                 "https://alice.example/",
+                 ["https://vutuv.de/alice"],
+                 adapter(404, "")
+               )
+
+      assert missing.status == 404
+      assert missing.found == []
+
+      assert {:error, unreachable} =
+               WebVerification.rel_me_check(
+                 "http://localhost/",
+                 ["https://vutuv.de/alice"],
+                 adapter(200, ~s(<a rel="me" href="https://vutuv.de/alice">x</a>))
+               )
+
+      assert is_nil(unreachable.status)
+    end
+
+    test "rel_me_verified?/3 is the same check, so the two can never disagree" do
+      body = ~s(<link rel="me" href="https://vutuv.de/alice">)
+      opts = adapter(200, body)
+
+      assert {:ok, _report} =
+               WebVerification.rel_me_check(
+                 "https://alice.example/",
+                 ["https://vutuv.de/alice"],
+                 opts
+               )
+
+      assert WebVerification.rel_me_verified?(
+               "https://alice.example/",
+               ["https://vutuv.de/alice"],
+               opts
+             )
+    end
   end
 
   describe "rel_me_hrefs/1 (the parser)" do

--- a/test/vutuv_web/controllers/url_verification_test.exs
+++ b/test/vutuv_web/controllers/url_verification_test.exs
@@ -64,15 +64,61 @@ defmodule VutuvWeb.UrlVerificationTest do
       assert Repo.get!(Url, url.id).verified_at
     end
 
-    test "redirects back with an error when the proof is missing", %{conn: conn} do
+    test "re-renders the page with a report of what it saw when the proof is missing", %{
+      conn: conn
+    } do
       {conn, user} = create_and_login_user(conn)
       url = insert(:url, user: user, value: "https://alice.example/")
-      stub_body("<p>nothing here</p>")
+      stub_body(~s(<a rel="me" href="https://github.com/alice">gh</a>))
 
-      conn = post(conn, ~p"/settings/links/#{url}/verify", %{"method" => "rel_me"})
+      html =
+        conn
+        |> post(~p"/settings/links/#{url}/verify", %{"method" => "rel_me"})
+        |> html_response(200)
 
-      assert redirected_to(conn) == ~p"/settings/links/#{url}/verify"
+      # The report replaces the old flat "could not find it yet, try again"
+      # (issue #1466), and it hangs under the button that produced it.
+      assert html =~ ~s(id="verify-report-rel_me")
+      assert html =~ "https://github.com/alice"
+      refute html =~ ~s(id="verify-report-dns")
       refute Repo.get!(Url, url.id).verified_at
+    end
+
+    test "the dns report names the queried names and the records found there", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      url = insert(:url, user: user, value: "https://alice.example/")
+
+      Application.put_env(:vutuv, :user_links_dns_resolver, fn _host -> [[~c"v=spf1 -all"]] end)
+      on_exit(fn -> Application.delete_env(:vutuv, :user_links_dns_resolver) end)
+
+      html =
+        conn
+        |> post(~p"/settings/links/#{url}/verify", %{"method" => "dns"})
+        |> html_response(200)
+
+      assert html =~ ~s(id="verify-report-dns")
+      assert html =~ "_vutuv.alice.example"
+      assert html =~ "v=spf1 -all"
+      refute html =~ ~s(id="verify-report-rel_me")
+    end
+
+    test "the report reads in German for a German visitor", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      url = insert(:url, user: user, value: "https://alice.example/")
+      stub_body("<p>nichts hier</p>")
+
+      # The new report strings came in through `gettext.extract --merge`, which
+      # fuzzy-fills a brand-new msgid with the translation of whatever it looks
+      # similar to — so assert the German by name, not just that the page renders.
+      html =
+        conn
+        |> Phoenix.ConnTest.recycle()
+        |> put_req_header("accept-language", "de-DE,de")
+        |> post(~p"/settings/links/#{url}/verify", %{"method" => "rel_me"})
+        |> html_response(200)
+
+      assert html =~ "Wir haben Ihre Seite geladen"
+      assert html =~ "Ihre Seite hat noch gar keinen rel="
     end
 
     test "cannot verify another member's link", %{conn: conn} do
@@ -115,8 +161,12 @@ defmodule VutuvWeb.UrlVerificationTest do
       html = conn |> get(~p"/settings/links/#{url}/verify") |> html_response(200)
       assert html =~ "disabled on this installation"
 
-      conn = post(conn, ~p"/settings/links/#{url}/verify", %{"method" => "rel_me"})
-      assert redirected_to(conn) == ~p"/settings/links/#{url}/verify"
+      html =
+        conn
+        |> post(~p"/settings/links/#{url}/verify", %{"method" => "rel_me"})
+        |> html_response(200)
+
+      assert html =~ "disabled on this installation"
       refute Repo.get!(Url, url.id).verified_at
     end
   end


### PR DESCRIPTION
**TL;DR** Die #1466-Reparatur lag im gemeinsamen Unterbau, der Bericht darüber nur im Organisations-Zweig. Jetzt bekommt ihn auch der Nachweis einer eigenen Webseite, und die Domain-Prüfung hat wieder genau einen Einstieg.

**Version:** 7.291.0 · **Deploy:** hot (keine Migration, kein Config- oder Supervisor-Eingriff)

### Der Bericht erreicht jetzt auch die Profil-Links

- `WebVerification.rel_me_check/3` ist neu und nennt die `rel="me"`-Links, die die Seite *hat*. Das ist meist die ganze Diagnose: eine Seite verlinkt längst ein GitHub- oder Mastodon-Profil und nennt nur dieses hier noch nicht. `rel_me_verified?/3` leitet sich daraus ab, damit Urteil und Bericht nicht auseinanderlaufen können.
- `LinkVerification.check/3` löst `verify/3` ab und liefert `{:error, report}`; `proof_present?/3` (für den Recheck-Sweeper) kommt aus derselben Verzweigung statt aus einer zweiten.
- `VutuvWeb.VerificationComponents.check_report/1` ist der aus `OrganizationComponents` herausgelöste Block, um einen `rel_me`-Zweig und ein `disabled_text` je Aufrufer ergänzt. Beide Organisations-LiveViews und die Link-Seite rendern ihn; das doppelte `stamp/1` der zwei LiveViews fällt mit weg.
- Eine gescheiterte Prüfung **rendert** `/settings/links/:id/verify`, statt dorthin umzuleiten (ein Flash kann keinen Bericht tragen), und der Block hängt unter dem Knopf, der ihn erzeugt hat.

### Ein Einstieg für die Domain-Prüfung

`verify_domain/2`, `verify_dns/2`, `verify_well_known/2` und `do_verify/3` sind weg; `check_domain/2` ist der einzige Weg. Die Zwillinge antworteten mit einem nackten `{:error, :not_found}` und stempelten kein `last_checked_at`, das der Hintergrund-Durchlauf zum Zurückstecken liest.

### Kleinigkeiten

- `check/3` prägt den Token vor der Prüfung. Ohne ihn fiel der DNS-Zweig auf eine Antwort ohne `:names` zurück, was auf der Seite ein KeyError statt einer Meldung gewesen wäre.
- `gettext.extract --merge` hat zwei der fünf neuen msgids fuzzy vorbelegt (u.a. „We could not reach your page at all." mit dem Satz über die *Adresse* der Organisation). Alle fünf von Hand geschrieben, Flags entfernt, ein Test prüft zwei davon unter `Accept-Language: de-DE,de`.

`mix precommit` grün: credo ohne Befund, 7709 Tests.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*
