### PR TITLE
Ein Beitrag darf höchstens fünf Konten erwähnen (v7.292.0)

### DIFF
--- a/docs/architecture/mentions.md
+++ b/docs/architecture/mentions.md
@@ -105,6 +105,26 @@ Only **members** are resolved. Organizations hold handles in the same namespace
 and the renderer links them, but they have no notification feed, so `@acme_gmbh`
 records nothing.
 
+## The per-post cap (anti-spam)
+
+A post may name at most **`Mentions.max_post_mentions/0`** (5) distinct local
+accounts — `Mentions.validate_mention_limit/2`, run from `Post.changeset/2`
+only. Being mentioned is a notification (below), so a post that advertises
+something and then lists twenty handles reaches all twenty whether they follow
+the author or not: spam delivered through our own notification feed. The
+changeset refuses it with a sentence naming the rule ("We allow at most 5
+accounts per post. Please remove some mentions."), which the composer surfaces
+like any other body error.
+
+- Counted **after the dedupe**, so naming one person five times is one account.
+- Fediverse `@user@host` handles and handles in code spans don't count —
+  nothing here is notified by either.
+- Like the existence check it runs only when the body **changed**, so an old
+  post is not held hostage by a cap that did not exist when it was written, and
+  a rename rewrite (which bypasses changesets) never trips it.
+- Posts only. A DM already goes to one recipient, and the other mention
+  surfaces (headline, descriptions, ads) notify nobody.
+
 ## Availability (anti-hijack)
 
 A handle is only claimable if `Mentions.mentioned_in_posts?/1` is false — it is
@@ -167,6 +187,7 @@ posts (the newest five, plus an "and N more" count).
 - `lib/vutuv_web/live/notification_live/index.ex` — the `mention` and
   `handle_change` renderings.
 - `test/vutuv/mentions_test.exs`, `mention_existence_test.exs`,
+  `mention_limit_test.exs`,
   `mention_notifications_test.exs`, `handle_availability_test.exs`,
   `accounts/handle_change_propagation_test.exs`,
   `vutuv_web/live/handle_change_notification_test.exs`.

--- a/lib/vutuv/mentions.ex
+++ b/lib/vutuv/mentions.ex
@@ -19,6 +19,10 @@ defmodule Vutuv.Mentions do
       `@wanted` into a post to *reserve* it: the availability rule below then
       treats `@wanted` as "used in content" and blocks everyone from claiming
       it. Requiring the mention target to exist closes that reservation attack.
+      A post may also name at most `max_post_mentions/0` accounts
+      (`validate_mention_limit/2`), because every one of them is a
+      notification: an advert followed by a list of handles is spam delivered
+      through our own notification feed.
     * **Propagation** — when a member renames, every stored `@old` is rewritten
       to `@new` across all mention surfaces (`rewrite_everywhere/3`), and the
       new handle is only claimable when it is used in no content
@@ -89,8 +93,19 @@ defmodule Vutuv.Mentions do
     {Ad, :content}
   ]
 
+  # How many distinct local accounts one post may name. Each mention is a
+  # notification the named member never asked for, so a post that lists dozens
+  # of handles is not a conversation, it is a broadcast — the shape spam takes
+  # here (an advert, then a column of `@handle`s). Five is enough for anyone
+  # actually talking to a group and small enough that the list is worthless as
+  # a mailing tool.
+  @max_post_mentions 5
+
   @doc "The canonical entity regex, so the renderer shares this module's grammar."
   def entity_regex, do: @entity
+
+  @doc "How many distinct local accounts one post may mention."
+  def max_post_mentions, do: @max_post_mentions
 
   @doc "The `{schema, field}` mention surfaces scanned and rewritten by this module."
   def surfaces, do: @surfaces
@@ -299,6 +314,49 @@ defmodule Vutuv.Mentions do
         changeset
     end
   end
+
+  ## Mention limit (anti-spam) ---------------------------------------------
+
+  @doc """
+  Rejects a changeset whose Markdown `field` names more than
+  `max_post_mentions/0` distinct local accounts.
+
+  Being mentioned sends a notification, so a post that advertises something and
+  then lists twenty handles reaches those members whether they follow the author
+  or not — spam carried by our own notification feed. Counted after the dedupe
+  (`local_handles/1`), so naming the same person five times is one account, and
+  runs only when `field` actually changed, like the existence check beside it:
+  editing an old body is not blocked by a cap that did not exist when it was
+  written, unless the body itself is touched.
+
+  Fediverse `@user@host` handles do not count — nobody here is notified by one —
+  and neither do handles inside code spans, for the same reason the renderer
+  does not link them.
+  """
+  def validate_mention_limit(changeset, field \\ :body) do
+    case Changeset.get_change(changeset, field) do
+      text when is_binary(text) ->
+        check_mention_limit(changeset, field, local_handles(text))
+
+      _ ->
+        changeset
+    end
+  end
+
+  defp check_mention_limit(changeset, field, handles) when length(handles) > @max_post_mentions do
+    # A self-contained sentence that states the rule and what to do about it,
+    # like its existence-check twin. Keep it byte-identical to its extraction
+    # anchor in `VutuvWeb.ErrorHelpers` — gettext cannot see a literal inside
+    # `add_error/4`, and without the anchor the German copy never ships.
+    Changeset.add_error(
+      changeset,
+      field,
+      "We allow at most %{max} accounts per post. Please remove some mentions.",
+      max: @max_post_mentions
+    )
+  end
+
+  defp check_mention_limit(changeset, _field, _handles), do: changeset
 
   @doc """
   Rejects a changeset whose handle `field` is already mentioned in a public

--- a/lib/vutuv/posts/post.ex
+++ b/lib/vutuv/posts/post.ex
@@ -124,5 +124,9 @@ defmodule Vutuv.Posts.Post do
     # A body may only mention handles that exist, so nobody can seed `@wanted`
     # into a post to reserve it (the anti-hijack partner of handle availability).
     |> Mentions.validate_mentions_exist()
+    # ... and it may only name a handful of them: every mention notifies the
+    # member it names, so a long list of handles under an advert is spam
+    # delivered through the notification feed.
+    |> Mentions.validate_mention_limit()
   end
 end

--- a/lib/vutuv_web/views/error_helpers.ex
+++ b/lib/vutuv_web/views/error_helpers.ex
@@ -119,6 +119,11 @@ defmodule VutuvWeb.ErrorHelpers do
       dgettext_noop("errors", "\"%{tag}\" is only punctuation, not a tag."),
       # Vutuv.Posts, the post tag cap (issue #1237).
       dgettext_noop("errors", "Please use at most %{max} tags."),
+      # Vutuv.Mentions, the per-post mention cap (anti-spam).
+      dgettext_noop(
+        "errors",
+        "We allow at most %{max} accounts per post. Please remove some mentions."
+      ),
       # Vutuv.Accounts.User, the Fediverse aliases (issue #986, alsoKnownAs).
       dgettext_noop("errors", "Please list at most %{max} accounts."),
       dgettext_noop("errors", "\"%{uri}\" is not a valid https account address."),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.291.0",
+      version: "7.292.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/errors.po
+++ b/priv/gettext/de/LC_MESSAGES/errors.po
@@ -227,12 +227,12 @@ msgstr "darf nicht nur aus Satzzeichen bestehen"
 msgid "\"%{tag}\" is only punctuation, not a tag."
 msgstr "„%{tag}“ besteht nur aus Satzzeichen und ist kein Tag."
 
-#: lib/vutuv_web/views/error_helpers.ex:124
+#: lib/vutuv_web/views/error_helpers.ex:129
 #, elixir-autogen, elixir-format
 msgid "\"%{uri}\" is not a valid https account address."
 msgstr "„%{uri}“ ist keine gültige https-Kontoadresse."
 
-#: lib/vutuv_web/views/error_helpers.ex:123
+#: lib/vutuv_web/views/error_helpers.ex:128
 #, elixir-autogen, elixir-format
 msgid "Please list at most %{max} accounts."
 msgstr "Bitte geben Sie höchstens %{max} Konten an."
@@ -247,7 +247,14 @@ msgstr "muss beschreiben, wie der Name klingt"
 msgid "Please use at most %{max} tags."
 msgstr "Bitte verwenden Sie höchstens %{max} Tags."
 
-#: lib/vutuv_web/views/error_helpers.ex:126
+#: lib/vutuv_web/views/error_helpers.ex:131
 #, elixir-autogen, elixir-format
 msgid "Enter your Signal link, it starts with https://signal.me/#"
 msgstr "Bitte geben Sie Ihren Signal-Link ein, er beginnt mit https://signal.me/#"
+
+#: lib/vutuv_web/views/error_helpers.ex:123
+#, elixir-autogen, elixir-format
+msgid "We allow at most %{max} accounts per post. Please remove some mentions."
+msgstr ""
+"Wir erlauben höchstens %{max} Konten pro Beitrag. Bitte entfernen Sie einige "
+"Erwähnungen."

--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -225,12 +225,12 @@ msgstr ""
 msgid "\"%{tag}\" is only punctuation, not a tag."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:124
+#: lib/vutuv_web/views/error_helpers.ex:129
 #, elixir-autogen, elixir-format
 msgid "\"%{uri}\" is not a valid https account address."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:123
+#: lib/vutuv_web/views/error_helpers.ex:128
 #, elixir-autogen, elixir-format
 msgid "Please list at most %{max} accounts."
 msgstr ""
@@ -245,7 +245,12 @@ msgstr ""
 msgid "Please use at most %{max} tags."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:126
+#: lib/vutuv_web/views/error_helpers.ex:131
 #, elixir-autogen, elixir-format
 msgid "Enter your Signal link, it starts with https://signal.me/#"
+msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:123
+#, elixir-autogen, elixir-format
+msgid "We allow at most %{max} accounts per post. Please remove some mentions."
 msgstr ""

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -228,12 +228,12 @@ msgstr ""
 msgid "\"%{tag}\" is only punctuation, not a tag."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:124
+#: lib/vutuv_web/views/error_helpers.ex:129
 #, elixir-autogen, elixir-format
 msgid "\"%{uri}\" is not a valid https account address."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:123
+#: lib/vutuv_web/views/error_helpers.ex:128
 #, elixir-autogen, elixir-format
 msgid "Please list at most %{max} accounts."
 msgstr ""
@@ -248,7 +248,12 @@ msgstr ""
 msgid "Please use at most %{max} tags."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:126
+#: lib/vutuv_web/views/error_helpers.ex:131
 #, elixir-autogen, elixir-format
 msgid "Enter your Signal link, it starts with https://signal.me/#"
+msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:123
+#, elixir-autogen, elixir-format
+msgid "We allow at most %{max} accounts per post. Please remove some mentions."
 msgstr ""

--- a/test/vutuv/mention_limit_test.exs
+++ b/test/vutuv/mention_limit_test.exs
@@ -1,0 +1,92 @@
+defmodule Vutuv.MentionLimitTest do
+  use Vutuv.DataCase, async: true
+
+  alias Vutuv.Mentions
+  alias Vutuv.Posts.Post
+  alias VutuvWeb.ErrorHelpers
+
+  # Every mention notifies the member it names, so a post that advertises
+  # something and then lists a column of handles is spam carried by our own
+  # notification feed. The cap is what stops it.
+
+  defp handles(count) do
+    Enum.map(1..count, fn _ ->
+      handle = "member#{System.unique_integer([:positive])}"
+      insert(:user, username: handle)
+      handle
+    end)
+  end
+
+  defp body(handles), do: "Buy my thing! " <> Enum.map_join(handles, " ", &("@" <> &1))
+
+  describe "Post.changeset mention cap" do
+    test "accepts a post naming exactly the cap" do
+      body = body(handles(Mentions.max_post_mentions()))
+
+      assert Post.changeset(%Post{}, %{body: body}).valid?
+    end
+
+    test "rejects a post naming one account more" do
+      body = body(handles(Mentions.max_post_mentions() + 1))
+      changeset = Post.changeset(%Post{}, %{body: body})
+
+      refute changeset.valid?
+      assert %{body: messages} = errors_on(changeset)
+      assert Enum.any?(messages, &(&1 =~ "at most 5 accounts per post"))
+    end
+
+    test "counts accounts, not mentions: naming one member many times is fine" do
+      [handle] = handles(1)
+      body = "@#{handle} " |> String.duplicate(Mentions.max_post_mentions() + 3) |> String.trim()
+
+      assert Post.changeset(%Post{}, %{body: body}).valid?
+    end
+
+    test "organization handles count too (one namespace, both get named)" do
+      members = handles(Mentions.max_post_mentions())
+      org = "acme#{System.unique_integer([:positive])}"
+      insert(:organization, username: org)
+
+      refute Post.changeset(%Post{}, %{body: body(members ++ [org])}).valid?
+    end
+
+    test "fediverse handles do not count — nobody here is notified by one" do
+      body = body(handles(Mentions.max_post_mentions())) <> " @bob@geno.social @ann@geno.social"
+
+      assert Post.changeset(%Post{}, %{body: body}).valid?
+    end
+
+    test "a handle inside a code span is sample text, not an account" do
+      body = body(handles(Mentions.max_post_mentions())) <> " type `@ghost` to mention"
+
+      assert Post.changeset(%Post{}, %{body: body}).valid?
+    end
+
+    test "an untouched body is not blocked by the cap on an unrelated edit" do
+      post = insert(:post, body: body(handles(Mentions.max_post_mentions() + 4)))
+
+      assert Post.changeset(post, %{license: "cc-by"}).valid?
+    end
+  end
+
+  describe "the message" do
+    test "names the cap and what to do, as a self-contained sentence" do
+      changeset = Post.changeset(%Post{}, %{body: body(handles(6))})
+      [message] = Enum.filter(errors_on(changeset).body, &(&1 =~ "accounts per post"))
+
+      assert message == "We allow at most 5 accounts per post. Please remove some mentions."
+    end
+
+    test "reads in German, which is the language most members see" do
+      Gettext.put_locale(VutuvWeb.Gettext, "de")
+
+      german =
+        ErrorHelpers.translate_error(
+          {"We allow at most %{max} accounts per post. Please remove some mentions.", [max: 5]}
+        )
+
+      assert german ==
+               "Wir erlauben höchstens 5 Konten pro Beitrag. Bitte entfernen Sie einige Erwähnungen."
+    end
+  end
+end


### PR DESCRIPTION
**TL;DR** Ein Post darf höchstens 5 vutuv-Konten mit `@handle` nennen; darüber weist der Changeset ihn mit einer erklärenden Meldung ab.

**Warum:** Jede Erwähnung ist eine Benachrichtigung. Werbung plus eine Spalte Handles erreicht damit alle Genannten, ob sie folgen oder nicht — Spam über unsere eigene Benachrichtigungsleiste.

**Wo:** `Vutuv.Mentions.validate_mention_limit/2`, aufgerufen aus `Post.changeset/2`.

**Meldung:** „Wir erlauben höchstens 5 Konten pro Beitrag. Bitte entfernen Sie einige Erwähnungen."

**Details:** gezählt wird nach der Dedupe (derselbe Handle fünfmal = ein Konto), Fediverse-Handles und Handles in Code-Spans zählen nicht mit, und die Regel greift nur, wenn der Text geändert wird — alte Beiträge bleiben unangetastet. Neuer Test `test/vutuv/mention_limit_test.exs` (gegen den ungefixten Stand kalibriert: 3 Tests werden rot).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*