### PR TITLE
Die Bounce-Adresse verlässt den Briefkopf (v7.293.0)

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -88,8 +88,11 @@ if config_env() == :prod do
       _never -> :never
     end
 
+  # Vutuv.Mailer.SMTP is Swoosh's SMTP adapter with the envelope sender passed
+  # to the SMTP conversation directly, so the bounce address is never a visible
+  # `Sender:` header (issue #1472).
   config :vutuv, Vutuv.Mailer,
-    adapter: Swoosh.Adapters.SMTP,
+    adapter: Vutuv.Mailer.SMTP,
     relay: System.get_env("SMTP_RELAY") || "127.0.0.1",
     port: String.to_integer(System.get_env("SMTP_PORT") || "25"),
     username: System.get_env("SMTP_USERNAME") || "",

--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -106,7 +106,7 @@ Everything else has a default (the vutuv.de production value):
 | `NEWSLETTER_SEND_TIMEOUT_SECONDS` | `60` | Wall-clock ceiling on a single newsletter send. gen_smtp's per-response read timeout is a fixed 20 minutes, so a black-holing relay could otherwise freeze a broadcast long enough to look stuck and be double-sent; a timed-out send is logged as an error and the loop moves on. Raise it only for a legitimately slow smarthost, and keep it well under five minutes |
 | `MAILER_FROM_NAME` | `vutuv` | Display name of the From on every email |
 | `MAILER_FROM_ADDRESS` | `no-reply@vutuv.de` | **Set this.** From address on every email |
-| `BOUNCE_ADDRESS` | `bounces@vutuv.de` | **Set this**, to a mailbox that really accepts mail — bounces (DSNs) are addressed to it, and the default is *not* a live account. SMTP envelope sender; vutuv.de sets `sw@vutuv.de` |
+| `BOUNCE_ADDRESS` | `bounces@vutuv.de` | **Set this**, to a mailbox on your own domain that really accepts mail — bounces (DSNs) are addressed to it. It is the SMTP envelope sender only and never appears as a header, so it needs no display name and no human reading it; an alias or an automated handler is enough. Do not use a person's address: it is not shown to recipients, but it is what a remote postmaster replies to |
 | `OPERATOR_NAME` | `Wintermeyer Consulting` | **Set this.** Your name: site/email footer credit and operator-notice recipient name |
 | `OPERATOR_EMAIL` | `sw@wintermeyer-consulting.de` | **Set this.** Receives the daily report, ad bookings and account-deletion records; also the `security.txt` contact |
 | `OPERATOR_URL` | `https://wintermeyer-consulting.de` | **Set this.** Linked from the site/email footer |

--- a/docs/architecture/email.md
+++ b/docs/architecture/email.md
@@ -13,11 +13,51 @@ from `Vutuv.Notifications.Emailer.base_email/0` and sent through the single
 `Emailer.deliver/1` chokepoint, the only place allowed to call
 `Vutuv.Mailer.deliver/1`.
 
-`deliver/1` also stamps the bounce envelope sender: the `Sender` header (the
-`BOUNCE_ADDRESS` variable, `sw@vutuv.de` on vutuv.de) becomes the SMTP MAIL
-FROM. It doubles as the marker that tells vutuv's own mail apart from the other
-tenants' in the shared Postfix log, so it must be a mailbox that really accepts
-mail — see `docs/production-email-and-bounces.md` §1.6.
+## Envelope, headers and replies
+
+`deliver/1` also stamps the bounce envelope sender (`BOUNCE_ADDRESS`,
+`bounces@vutuv.de` on vutuv.de). It is the RFC 5321 **SMTP envelope sender**
+(`MAIL FROM`) and travels beside the message, never as a visible `Sender:`
+header: a `Sender:` is shown to the reader, and Outlook renders one as
+"`bounces@vutuv.de` on behalf of vutuv `<no-reply@vutuv.de>`" — a mail-handling
+address presented as the party that wrote the message (issue #1472).
+
+Swoosh's own SMTP adapter has no seam for that (`Helpers.sender/1` is
+`headers["Sender"] || from`), so production sends through
+**`Vutuv.Mailer.SMTP`**, which is that adapter with the envelope sender passed
+to the SMTP conversation directly. `Vutuv.Mailer.SMTPTest` proves both halves
+against a real throwaway SMTP server, because neither is visible in a
+`%Swoosh.Email{}`.
+
+The bounce address doubles as the marker that tells vutuv's own mail apart from
+the other tenants' in the shared Postfix log, so it must be a mailbox that
+really accepts mail — see `docs/production-email-and-bounces.md` §1.6.
+
+**Replies.** The From is not read, so mail is deliberately non-replyable unless
+it says otherwise. The two messages whose copy invites a reply — the strike-3
+deactivation and the AI image rejection, both appeals against an automated
+decision — carry a `Reply-To` to the configured `APPEAL_REPLY_TO` contact, so
+an appeal reaches a human. Nothing else sets one.
+
+## Mail classes
+
+Every builder declares one class (`Emailer.put_class/2`) and the chokepoint
+derives the handling from it. `Vutuv.Notifications.MailClassTest` lists every
+builder, so a new one fails the build until somebody decides its class.
+
+| Class | Bounce suppression | Unsubscribe | `Precedence: bulk` |
+|---|---|---|---|
+| `:critical` (login PINs, the new-sign-in warning, ad bookings) | exempt | never | never |
+| `:transactional` (their own account, page, content; operator notices) | applies | never | never |
+| `:notification` (activity news) | applies | required | never |
+| `:bulk` (newsletter, saved-search digest) | applies | required | yes |
+
+`:critical` is not a synonym for "important": it is the exemption from vutuv's
+*own* undeliverable mark. The way back into an account (a PIN) and the warning
+that somebody else is in it must not be withheld by a mark this installation
+set itself, possibly wrongly. The registration-attempt notice deliberately
+stays `:transactional` even though it is security mail, because a *third party*
+triggers it by typing somebody else's address into the sign-up form.
 
 ## Multipart bodies
 
@@ -34,8 +74,9 @@ fails the build.
 
 **Notification mail is opt-out**: the unread-message nudge respects
 `users.notification_emails?`, carries RFC 8058 one-click unsubscribe headers and
-a tokenized footer link (`/unsubscribe/:token`, no login needed); transactional
-mail (PINs, moderation) cannot be opted out of.
+a tokenized footer link (`/unsubscribe/:token`, no login needed); critical and
+transactional mail (PINs, security warnings, moderation) cannot be opted out of.
+The class table above is where that line is drawn and tested.
 
 ## Bounces and deliverability
 

--- a/docs/production-email-and-bounces.md
+++ b/docs/production-email-and-bounces.md
@@ -2,7 +2,7 @@
 
 **TL;DR** — vutuv sends all outbound mail through a **shared Postfix relay on the
 production host** (`bremen2`), with the SMTP envelope sender fixed to
-`sw@vutuv.de` (the `BOUNCE_ADDRESS` variable; see §1.6). When a recipient
+`bounces@vutuv.de` (the `BOUNCE_ADDRESS` variable; see §1.6). When a recipient
 address dies, the goal is to (1) **stop
 mailing it** and (2) eventually **freeze accounts that have become permanently
 unreachable**. The signal for "this address is dead" comes from Postfix's own
@@ -31,8 +31,8 @@ reachable as `wort.fb12.uni-bremen.de` on the Uni-Bremen network), Debian 13
 ### 1.1 The send path
 
 ```
-  Vutuv app (Swoosh, SMTP adapter)
-        │  MAIL FROM:<sw@vutuv.de>        (the Sender header; see Emailer.deliver/1)
+  Vutuv app (Vutuv.Mailer.SMTP)
+        │  MAIL FROM:<bounces@vutuv.de>   (envelope only, no Sender header; §1.7)
         │  submitted to 127.0.0.1:25, no TLS (loopback)
         ▼
   Postfix on bremen2  ──────────────►  recipient's MX (direct, relayhost is empty)
@@ -59,8 +59,8 @@ Key Postfix settings on bremen2 (read with `postconf`):
 bremen2 sends outbound mail for **several unrelated apps**, distinguishable only
 by their envelope sender. Seen in the logs:
 
-- `sw@vutuv.de` — **vutuv** (us); `bounces@vutuv.de` before 2026-07-22, so
-  older log excerpts in this document still show that address
+- `bounces@vutuv.de` — **vutuv** (us). It was `sw@vutuv.de` between 2026-07-22
+  and 2026-08-15 (§1.6), so log excerpts in this document show both addresses
 - `…@animina.de` — animina
 - `noreply@mehr-schulferien.de` — mehr-schulferien
 
@@ -128,9 +128,33 @@ Automated bounce handling never depended on it (that reads the log, §2), but it
 meant no DSN, and no remote postmaster's reply to it, ever reached a human. On
 **2026-07-22** production switched to `sw@vutuv.de` — a real mailbox, `250 OK`
 on the same probe — set as `BOUNCE_ADDRESS` in `/var/www/vutuv3/shared/.env`.
-Run that probe for whatever address you configure before trusting it; the
-shipped default in `config/config.exs` is unchanged and is *not* a working
-mailbox.
+
+On **2026-08-15** `bounces@vutuv.de` was created in Google Workspace and
+production switched back to it, so bounce handling no longer rides on a
+person's address (issue #1473). The same probe now answers:
+
+```
+250 2.1.5 OK … - gsmtp
+```
+
+Run it for whatever address you configure before trusting it. Note the
+**changeover window**: attribution joins a bounce to vutuv by the envelope
+sender (§3.2), so mail already queued under the previous address bounces under
+that one and is no longer recognized as ours. That lasts as long as the Postfix
+queue holds a message (minutes for most mail, up to ~5 days for deferred) and
+costs only detection, never a wrong deactivation.
+
+### 1.7 The envelope sender is not a header
+
+`BOUNCE_ADDRESS` reaches the SMTP conversation as `MAIL FROM` and appears in no
+header of the message. It used to be published as a `Sender:` header, because
+that is the only lever Swoosh's SMTP adapter offers — and Outlook renders such
+a header as "*`<bounce address>` on behalf of vutuv `<no-reply@vutuv.de>`*",
+i.e. the mail-handling address shown to the reader as the sender. Production
+therefore delivers through `Vutuv.Mailer.SMTP` (issue #1472), which passes the
+envelope sender to gen_smtp directly. The `Return-Path` the receiving server
+writes is unchanged, so bounce attribution and this document's §3 are not
+affected.
 
 ---
 
@@ -301,8 +325,10 @@ A hard bounce sets `emails.undeliverable_at`
 (`Vutuv.Deliverability.record_hard_bounce/3`). Then:
 
 - `Emailer.deliver/1` **drops automatic mail** to that address.
-- **PIN / login mail is exempt** (`put_private(:user_initiated, true)`): a
-  once-bounced mailbox must never lock its owner out.
+- **Critical mail is exempt** (`Emailer.put_class(:critical)` — the login PINs
+  and the new-sign-in warning): a once-bounced mailbox must never lock its
+  owner out, and the warning that somebody else signed in must not be withheld
+  by a mark this installation set itself.
 - A **successful login PIN clears the mark** (`Accounts.check_pin/3` →
   `Bounces.clear/1`): proof the address works again.
 - The owner sees a "mail to this address bounced" warning on their emails page.

--- a/lib/vutuv/mailer/smtp.ex
+++ b/lib/vutuv/mailer/smtp.ex
@@ -1,0 +1,63 @@
+defmodule Vutuv.Mailer.SMTP do
+  @moduledoc """
+  The SMTP adapter vutuv delivers through: `Swoosh.Adapters.SMTP` with the
+  RFC 5321 **envelope sender** passed to the SMTP conversation directly,
+  instead of smuggled in as a visible RFC 5322 `Sender:` header.
+
+  Upstream has no seam for this. `Swoosh.Adapters.SMTP.Helpers.sender/1` is
+  `email.headers["Sender"] || from`, so the only way to move `MAIL FROM` off
+  the `From` address is to publish that address as a header — which is how the
+  bounce address ended up visible in every vutuv message. Outlook then renders
+  `sw@vutuv.de on behalf of vutuv <no-reply@vutuv.de>`, i.e. a mail-handling
+  address presented to the reader as the transmitting party (issue #1472).
+
+  So this adapter owns the one call upstream makes and takes the envelope
+  sender from `email.private[:envelope_sender]`, which
+  `Vutuv.Notifications.Emailer.deliver/1` stamps on every outbound message.
+  Everything else — message rendering, DKIM signing, the gen_smtp config
+  transformations — is upstream's, unchanged.
+
+  Only production uses it (`config/runtime.exs`); dev previews mail locally and
+  the test env uses the Swoosh test adapter, so `Vutuv.Mailer.SMTPTest` drives
+  this module against a real throwaway SMTP server rather than through the
+  mailer.
+  """
+
+  use Swoosh.Adapter, required_config: [:relay], required_deps: [gen_smtp: :gen_smtp_client]
+
+  alias Swoosh.Adapters.SMTP, as: Upstream
+  alias Swoosh.Adapters.SMTP.Helpers
+
+  @impl Swoosh.Adapter
+  def deliver(%Swoosh.Email{} = email, config) do
+    envelope = {envelope_sender(email), recipients(email), Helpers.body(email, config)}
+
+    case :gen_smtp_client.send_blocking(envelope, Upstream.gen_smtp_config(config)) do
+      receipt when is_binary(receipt) -> {:ok, receipt}
+      {:error, type, message} -> {:error, {type, message}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
+  The address this message announces as `MAIL FROM`, i.e. where delivery
+  failures are returned to.
+
+  The chokepoint's stamp when there is one; otherwise upstream's answer, so a
+  message assembled outside `Vutuv.Notifications.Emailer` still goes out with a
+  sane envelope rather than none.
+  """
+  def envelope_sender(%Swoosh.Email{} = email) do
+    email.private[:envelope_sender] || Helpers.sender(email)
+  end
+
+  # Identical to upstream's private all_recipients/1: every address the message
+  # is delivered to, deduplicated. Bcc belongs here (the envelope is how a bcc
+  # recipient gets the mail at all) even though it is not rendered as a header.
+  defp recipients(email) do
+    [email.to, email.cc, email.bcc]
+    |> Enum.concat()
+    |> Enum.map(fn {_name, address} -> address end)
+    |> Enum.uniq()
+  end
+end

--- a/lib/vutuv/notifications/emailer.ex
+++ b/lib/vutuv/notifications/emailer.ex
@@ -13,6 +13,12 @@ defmodule Vutuv.Notifications.Emailer do
       headers (belt and suspenders, in case a future builder forgets the base)
       and hands the message to `Vutuv.Mailer`.
 
+  Two things travel beside the message rather than in its headers. The bounce
+  address is the **SMTP envelope sender** and no longer a visible `Sender:`
+  header (issue #1472; `Vutuv.Mailer.SMTP` puts it on the wire), and every
+  builder declares a **class** (`put_class/2`) that says whether the message
+  may be withheld, opted out of, or marked bulk.
+
   No code outside this module may call `Vutuv.Mailer.deliver/1` or Swoosh
   directly. Every builder function returns a `%Swoosh.Email{}`; `deliver/1`
   sends it.
@@ -85,12 +91,13 @@ defmodule Vutuv.Notifications.Emailer do
 
   @doc """
   The single delivery chokepoint for all outbound mail. Re-applies the robot
-  headers and the bounce envelope sender, drops automatic mail to addresses
-  a bounce marked undeliverable (`Vutuv.Notifications.Bounces`), and hands
-  everything else to `Vutuv.Mailer`. User-initiated mail (the PIN flows, ad
-  bookings — `put_private(:user_initiated, true)`) is exempt from the
-  suppression: a member whose mailbox once bounced must still be able to
-  request a login PIN, and a verified PIN clears the mark again.
+  headers, the bounce envelope sender and the message's class headers, drops
+  automatic mail to addresses a bounce marked undeliverable
+  (`Vutuv.Notifications.Bounces`), and hands everything else to `Vutuv.Mailer`.
+
+  `:critical` mail (`put_class/2`) is exempt from the suppression: a member
+  whose mailbox once bounced must still be able to request a login PIN, and a
+  verified PIN clears the mark again.
   """
   def deliver(%Swoosh.Email{} = email) do
     cond do
@@ -152,22 +159,35 @@ defmodule Vutuv.Notifications.Emailer do
     email
     |> robot_headers()
     |> envelope_sender()
+    |> class_headers()
     |> message_id()
   end
 
-  defp suppressed?(%Swoosh.Email{private: %{user_initiated: true}}), do: false
-
-  defp suppressed?(%Swoosh.Email{to: to}) when is_list(to) and to != [] do
-    Enum.all?(to, fn {_name, address} -> Bounces.suppressed?(address) end)
+  # Critical mail is exempt: the way back into an account, and the warning that
+  # somebody else is in it, must not be withheld by a mark this installation
+  # set itself. A verified login PIN clears the mark again (see Bounces).
+  defp suppressed?(%Swoosh.Email{to: to} = email) when is_list(to) and to != [] do
+    mail_class(email) != :critical and
+      Enum.all?(to, fn {_name, address} -> Bounces.suppressed?(address) end)
   end
 
   defp suppressed?(_email), do: false
 
-  # The Swoosh SMTP adapter uses the Sender header as the SMTP envelope
-  # sender (MAIL FROM), so every DSN comes back to the one bounce mailbox
-  # production Postfix pipes into POST /webhooks/bounces. The visible From
-  # stays no-reply@vutuv.de.
-  defp envelope_sender(email), do: header(email, "Sender", bounce_address())
+  # The RFC 5321 envelope sender (SMTP MAIL FROM), so every DSN comes back to
+  # the one bounce mailbox instead of to the unread From. It rides in the
+  # message's private map and `Vutuv.Mailer.SMTP` hands it to gen_smtp.
+  #
+  # It is deliberately NOT a `Sender:` header, which is what Swoosh's own SMTP
+  # adapter would require: that header is shown to the reader, and Outlook
+  # renders it as "<bounce address> on behalf of <From>", i.e. a mail-handling
+  # address presented as the party that sent the message (issue #1472). Any
+  # Sender header that did arrive is dropped, so the chokepoint alone decides
+  # what the envelope is.
+  defp envelope_sender(email) do
+    email
+    |> Map.update!(:headers, &Map.delete(&1, "Sender"))
+    |> put_private(:envelope_sender, bounce_address())
+  end
 
   defp bounce_address, do: Application.fetch_env!(:vutuv, :bounce_address)
 
@@ -186,9 +206,56 @@ defmodule Vutuv.Notifications.Emailer do
   @doc """
   Adds the bulk-only headers (`Precedence: bulk`, `List-Unsubscribe`). These are
   **not** safe for one-to-one transactional mail because `Precedence: bulk` can
-  hurt inbox placement, so they are opt-in and applied only to bulk mail.
+  hurt inbox placement, so they are applied only to `:bulk` mail — declaring
+  that class (`put_class/2`) is what pulls them in.
   """
   def bulk_headers(%Swoosh.Email{} = email), do: put_headers(email, bulk_header_list())
+
+  # --- Mail classes (issue #1474) ---------------------------------------------
+  #
+  # What a message *is* decides how it is handled, so every builder declares one
+  # class and the chokepoint derives the rest from it. Before this, whether a
+  # message survived the bounce suppression was decided by a private flag called
+  # `user_initiated` that only the PIN mails and the ad booking ever set, so the
+  # answer for everything else — including the new-sign-in warning — was an
+  # accident of which helper it happened to be built with.
+  #
+  #   :critical      Login PINs and security warnings. No opt-out, no bulk
+  #                  headers, and exempt from the bounce suppression.
+  #   :transactional About the recipient's own account, page or content. No
+  #                  opt-out, but dropped for an address a bounce proved dead.
+  #   :notification  Activity news. Gated on a per-type preference by its caller
+  #                  and carries the RFC 8058 one-click unsubscribe.
+  #   :bulk          Sent to many people at once. As :notification, plus
+  #                  `Precedence: bulk`.
+  @mail_classes [:critical, :transactional, :notification, :bulk]
+
+  @doc """
+  Declares what kind of mail this is (see the class list above). Every builder
+  sets one; `Vutuv.Notifications.MailClassTest` fails the build when a new
+  builder does not.
+  """
+  def put_class(%Swoosh.Email{} = email, class) when class in @mail_classes do
+    email
+    |> put_private(:mail_class, class)
+    |> class_headers()
+  end
+
+  @doc """
+  The class the builder declared. `:transactional` for a message assembled
+  outside this module — the conservative answer, since it opts nothing out and
+  claims no exemption.
+  """
+  def mail_class(%Swoosh.Email{private: %{mail_class: class}}), do: class
+  def mail_class(%Swoosh.Email{}), do: :transactional
+
+  # The headers a class implies. Only :bulk adds any; the one-click unsubscribe
+  # headers carry a per-recipient token, so they stay with the builder that can
+  # mint it. Idempotent and re-applied at the chokepoint, like the robot
+  # headers.
+  defp class_headers(email) do
+    if mail_class(email) == :bulk, do: bulk_headers(email), else: email
+  end
 
   def login_email(pin, email, %Vutuv.Accounts.User{email_confirmed?: false} = user) do
     gen_email(pin, email, user, "registration_email", fn ->
@@ -275,6 +342,7 @@ defmodule Vutuv.Notifications.Emailer do
     excerpt = message_excerpt(message_body)
 
     base_email()
+    |> put_class(:notification)
     |> to({VutuvWeb.UserHelpers.name_for_email_to_field(user), email})
     |> unsubscribe_headers(unsubscribe_url)
     |> subject(
@@ -427,8 +495,8 @@ defmodule Vutuv.Notifications.Emailer do
     rendered = alert_sections(sections, user, base, locale)
 
     base_email()
+    |> put_class(:bulk)
     |> to({VutuvWeb.UserHelpers.name_for_email_to_field(user), email})
-    |> bulk_headers()
     |> unsubscribe_headers(unsubscribe_url)
     |> subject(recipient_subject(locale, fn -> saved_search_subject(rendered) end))
     |> render_bodies("saved_search_alert", locale, %{
@@ -526,6 +594,7 @@ defmodule Vutuv.Notifications.Emailer do
     unsubscribe_url = VutuvWeb.UnsubscribeToken.url(user, field)
 
     base_email()
+    |> put_class(:notification)
     |> to({VutuvWeb.UserHelpers.name_for_email_to_field(user), email})
     |> unsubscribe_headers(unsubscribe_url)
     |> subject(recipient_subject(locale, subject_fun))
@@ -568,8 +637,8 @@ defmodule Vutuv.Notifications.Emailer do
         unsubscribe_url: unsubscribe_url
       }) do
     base_email()
+    |> put_class(:bulk)
     |> to({to_name, to_email})
-    |> bulk_headers()
     |> newsletter_unsubscribe(unsubscribe_url)
     |> subject(subject_line)
     |> html_body(
@@ -600,8 +669,10 @@ defmodule Vutuv.Notifications.Emailer do
   location (issue #786). Carries the device, approximate location, source IP
   and time so the owner can recognize (or not) the login, and deep-links to
   their signed-in-devices page so a "this wasn't me" is one click away (issue
-  #794). Transactional security mail, so it carries no unsubscribe and is built
-  with `build_email` (subject to bounce suppression, never user-initiated).
+  #794). Critical mail: it carries no unsubscribe, and it is the one message a
+  member must get even at an address a bounce marked dead — a mark this
+  installation set itself, and possibly wrongly, while the sign-in it reports
+  is happening now.
   """
   def security_alert_email(%Vutuv.Accounts.User{} = user, email, session, reasons) do
     locale = get_locale(user.locale)
@@ -618,6 +689,7 @@ defmodule Vutuv.Notifications.Emailer do
     build_email(user, email, "security_alert", assigns, fn ->
       gettext("New sign-in to your vutuv account")
     end)
+    |> put_class(:critical)
   end
 
   # The login time as plain UTC ("2026-06-15 05:41 UTC"). The server runs UTC and
@@ -656,8 +728,10 @@ defmodule Vutuv.Notifications.Emailer do
   """
   def ad_booking_email(%Vutuv.Ads.Ad{} = ad, booker) do
     base_email()
-    # A booking the member just made; never suppressed (see deliver/1).
-    |> put_private(:user_initiated, true)
+    # Critical for the same reason a PIN is: a booking the member just paid for
+    # has to reach the operator or nobody writes the invoice, so it must not be
+    # dropped by the bounce suppression (see deliver/1).
+    |> put_class(:critical)
     |> to(operator_recipient())
     |> subject("vutuv Anzeigenbuchung für den #{Calendar.strftime(ad.day, "%d.%m.%Y")}")
     |> render_bodies("ad_booking", "de", %{
@@ -709,6 +783,7 @@ defmodule Vutuv.Notifications.Emailer do
   """
   def daily_report_email(%DailyReport{} = report) do
     base_email()
+    |> put_class(:transactional)
     |> to(operator_recipient())
     |> subject(DailyReport.email_subject(report))
     |> render_bodies("daily_report", "de", %{report: report, url: public_url()})
@@ -726,6 +801,7 @@ defmodule Vutuv.Notifications.Emailer do
   """
   def account_deleted_notice(snapshot) do
     base_email()
+    |> put_class(:transactional)
     |> to(operator_recipient())
     |> subject("vutuv: Konto @#{snapshot.username} gelöscht")
     |> render_bodies("account_deleted_notice", "de", %{account: deletion_display(snapshot)})
@@ -784,6 +860,7 @@ defmodule Vutuv.Notifications.Emailer do
   # lands on the oversight page, not just the public page.
   defp organization_operator_notice(kind, organization, domain, subject_line) do
     base_email()
+    |> put_class(:transactional)
     |> to(operator_recipient())
     |> subject(subject_line)
     |> render_bodies("organization_operator_notice", "de", %{
@@ -1012,9 +1089,9 @@ defmodule Vutuv.Notifications.Emailer do
     end)
   end
 
-  # PIN mail is user-initiated: someone just asked for it, so it is exempt
-  # from the bounce suppression in deliver/1 (the way back into a once-
-  # bounced account must stay open).
+  # PIN mail is critical: someone just asked for it, so it is exempt from the
+  # bounce suppression in deliver/1 (the way back into a once-bounced account
+  # must stay open).
   defp gen_email(pin, email, user, template_base, subject_fun) do
     gen_email(pin, email, user, template_base, %{}, subject_fun)
   end
@@ -1023,15 +1100,17 @@ defmodule Vutuv.Notifications.Emailer do
   # handle in the username-change mail) and so needs assigns beyond the PIN.
   defp gen_email(pin, email, user, template_base, extra_assigns, subject_fun) do
     build_email(user, email, template_base, Map.put(extra_assigns, :pin, pin), subject_fun)
-    |> put_private(:user_initiated, true)
+    |> put_class(:critical)
   end
 
   # Every templated email: recipient, localized subject, and the matching
   # per-locale text template with `user` + `url` always in its assigns.
+  # Transactional unless its builder says otherwise afterwards.
   defp build_email(user, email, template_base, extra_assigns, subject_fun) do
     locale = get_locale(user.locale)
 
     base_email()
+    |> put_class(:transactional)
     |> to({VutuvWeb.UserHelpers.name_for_email_to_field(user), email})
     |> subject(recipient_subject(locale, subject_fun))
     |> render_bodies(

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.292.0",
+      version: "7.293.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/support/smtp_sink.ex
+++ b/test/support/smtp_sink.ex
@@ -1,0 +1,92 @@
+defmodule Vutuv.SMTPSink do
+  @moduledoc """
+  A throwaway SMTP server for tests: accepts one session on an ephemeral port,
+  answers the happy path of RFC 5321, and sends the transcript to the test
+  process as `{:smtp_session, %{mail_from: _, rcpt_to: [_], body: _}}`.
+
+  It exists because the thing under test is what goes **on the wire** — the
+  envelope sender in `MAIL FROM` and the absence of a `Sender:` header in the
+  message — and neither is observable from a `%Swoosh.Email{}` struct or from
+  the Swoosh test adapter. Deliberately not a mail server: it speaks just
+  enough for `:gen_smtp_client` to complete one delivery.
+  """
+
+  @doc """
+  Starts the sink and returns `{:ok, pid, port}`. The caller (the test process)
+  receives the transcript once the session's `DATA` is complete.
+  """
+  def start_link(test_pid) do
+    {:ok, listen} =
+      :gen_tcp.listen(0, [:binary, packet: :line, active: false, reuseaddr: true])
+
+    {:ok, port} = :inet.port(listen)
+    pid = spawn_link(fn -> accept(listen, test_pid) end)
+
+    {:ok, pid, port}
+  end
+
+  defp accept(listen, test_pid) do
+    {:ok, socket} = :gen_tcp.accept(listen)
+    :ok = :gen_tcp.send(socket, "220 sink ESMTP\r\n")
+    converse(socket, test_pid, %{mail_from: nil, rcpt_to: [], body: nil})
+    :gen_tcp.close(listen)
+  end
+
+  defp converse(socket, test_pid, session) do
+    case :gen_tcp.recv(socket, 0, 5_000) do
+      {:ok, line} -> handle(String.trim_trailing(line), socket, test_pid, session)
+      {:error, _closed} -> :ok
+    end
+  end
+
+  defp handle("QUIT", socket, _test_pid, _session) do
+    :gen_tcp.send(socket, "221 Bye\r\n")
+    :gen_tcp.close(socket)
+  end
+
+  defp handle("DATA", socket, test_pid, session) do
+    :gen_tcp.send(socket, "354 End data with <CR><LF>.<CR><LF>\r\n")
+    session = %{session | body: read_data(socket, [])}
+    :gen_tcp.send(socket, "250 OK: queued\r\n")
+    send(test_pid, {:smtp_session, %{session | rcpt_to: Enum.reverse(session.rcpt_to)}})
+    converse(socket, test_pid, session)
+  end
+
+  defp handle(line, socket, test_pid, session) do
+    session =
+      cond do
+        # "MAIL FROM:<bounces@vutuv.de>" — the RFC 5321 envelope sender, kept
+        # verbatim (angle brackets included) so a test can assert on the exact
+        # address the SMTP conversation announced.
+        String.starts_with?(line, "MAIL FROM:") ->
+          %{session | mail_from: envelope_arg(line, "MAIL FROM:")}
+
+        String.starts_with?(line, "RCPT TO:") ->
+          %{session | rcpt_to: [envelope_arg(line, "RCPT TO:") | session.rcpt_to]}
+
+        true ->
+          session
+      end
+
+    :gen_tcp.send(socket, "250 OK\r\n")
+    converse(socket, test_pid, session)
+  end
+
+  # The address without the command, and without any ESMTP parameters the
+  # client may append ("MAIL FROM:<a@b> SIZE=1234").
+  defp envelope_arg(line, command) do
+    line
+    |> String.replace_prefix(command, "")
+    |> String.trim()
+    |> String.split(" ", parts: 2)
+    |> List.first()
+  end
+
+  defp read_data(socket, acc) do
+    case :gen_tcp.recv(socket, 0, 5_000) do
+      {:ok, ".\r\n"} -> acc |> Enum.reverse() |> Enum.join()
+      {:ok, line} -> read_data(socket, [line | acc])
+      {:error, _closed} -> acc |> Enum.reverse() |> Enum.join()
+    end
+  end
+end

--- a/test/vutuv/mailer/smtp_test.exs
+++ b/test/vutuv/mailer/smtp_test.exs
@@ -1,0 +1,116 @@
+defmodule Vutuv.Mailer.SMTPTest do
+  @moduledoc """
+  Issue #1472: the bounce address must reach the SMTP conversation as the
+  RFC 5321 envelope sender (`MAIL FROM`) and must **not** appear as an RFC 5322
+  `Sender:` header in the message.
+
+  Both halves are only observable on the wire, so these tests deliver through a
+  real (throwaway) SMTP server and read the transcript back. `Vutuv.SMTPSink`
+  is that server.
+  """
+  use ExUnit.Case, async: true
+
+  alias Vutuv.Mailer.SMTP
+  alias Vutuv.Notifications.Emailer
+  alias Vutuv.SMTPSink
+
+  defp deliver_through(adapter) do
+    {:ok, _sink, port} = SMTPSink.start_link(self())
+
+    email =
+      Emailer.base_email()
+      |> Swoosh.Email.to({"Nobody", "nobody@example.com"})
+      |> Swoosh.Email.subject("On the wire")
+      |> Swoosh.Email.text_body("hi")
+
+    config = [
+      relay: "127.0.0.1",
+      port: port,
+      tls: :never,
+      auth: :never,
+      no_mx_lookups: true,
+      retries: 0
+    ]
+
+    assert {:ok, _receipt} = adapter.deliver(email, config)
+    assert_receive {:smtp_session, session}, 5_000
+
+    session
+  end
+
+  # The message headers, i.e. everything before the blank line that starts the
+  # body. A header assertion must not be satisfied (or defeated) by body text.
+  defp headers(session) do
+    session.body |> String.split("\r\n\r\n", parts: 2) |> List.first()
+  end
+
+  describe "vutuv's adapter" do
+    test "announces the bounce address as MAIL FROM" do
+      session = deliver_through(SMTP)
+
+      assert session.mail_from == "<bounces@vutuv.de>"
+      assert session.rcpt_to == ["<nobody@example.com>"]
+    end
+
+    test "puts no Sender header in the message" do
+      session = deliver_through(SMTP)
+
+      refute headers(session) =~ ~r/^Sender:/mi
+    end
+
+    test "leaves the visible From alone" do
+      session = deliver_through(SMTP)
+
+      assert headers(session) =~ ~r/^From: .*no-reply@vutuv\.de/mi
+    end
+  end
+
+  describe "the upstream adapter this one replaces" do
+    # Calibration, not coverage: these two assertions state exactly what
+    # `Swoosh.Adapters.SMTP` does differently, so the tests above cannot pass
+    # for the wrong reason. `Swoosh.Adapters.SMTP.Helpers.sender/1` is
+    # `headers["Sender"] || from`, so upstream can only move the envelope
+    # sender by making it a visible header. If this ever goes red because
+    # Swoosh grew real envelope-sender support, `Vutuv.Mailer.SMTP` can go.
+
+    test "can only set MAIL FROM through a visible Sender header" do
+      {:ok, _sink, port} = SMTPSink.start_link(self())
+
+      email =
+        Emailer.base_email()
+        |> Swoosh.Email.header("Sender", "bounces@vutuv.de")
+        |> Swoosh.Email.to({"Nobody", "nobody@example.com"})
+        |> Swoosh.Email.subject("Upstream")
+        |> Swoosh.Email.text_body("hi")
+
+      assert {:ok, _receipt} =
+               Swoosh.Adapters.SMTP.deliver(email,
+                 relay: "127.0.0.1",
+                 port: port,
+                 tls: :never,
+                 auth: :never,
+                 no_mx_lookups: true,
+                 retries: 0
+               )
+
+      assert_receive {:smtp_session, session}, 5_000
+
+      assert session.mail_from == "<bounces@vutuv.de>"
+      assert headers(session) =~ ~r/^Sender: bounces@vutuv\.de/mi
+    end
+  end
+
+  describe "envelope_sender/1" do
+    test "falls back to the From for a message built outside the chokepoint" do
+      email =
+        Swoosh.Email.new()
+        |> Swoosh.Email.from({"vutuv", "no-reply@vutuv.de"})
+
+      assert SMTP.envelope_sender(email) == "no-reply@vutuv.de"
+    end
+
+    test "prefers the envelope sender the chokepoint stamped" do
+      assert SMTP.envelope_sender(Emailer.base_email()) == "bounces@vutuv.de"
+    end
+  end
+end

--- a/test/vutuv/notifications/emailer_test.exs
+++ b/test/vutuv/notifications/emailer_test.exs
@@ -52,11 +52,12 @@ defmodule Vutuv.Notifications.EmailerTest do
 
   describe "deliver/1 chokepoint" do
     test "every message leaves with the bounce address as envelope sender" do
-      # The Swoosh SMTP adapter uses the Sender header as SMTP MAIL FROM, so
-      # bounces (DSNs) all come back to the one piped bounce mailbox instead
-      # of no-reply@. The From stays untouched.
+      # Bounces (DSNs) all come back to the one bounce mailbox instead of to
+      # no-reply@. It rides beside the message, never as a visible header, and
+      # the From stays untouched (issue #1472; the wire-level proof is in
+      # Vutuv.Mailer.SMTPTest).
       email = Emailer.base_email()
-      assert email.headers["Sender"] == "bounces@vutuv.de"
+      assert email.private[:envelope_sender] == "bounces@vutuv.de"
       assert email.from == {"vutuv", "no-reply@vutuv.de"}
 
       raw =
@@ -67,7 +68,29 @@ defmodule Vutuv.Notifications.EmailerTest do
         |> Swoosh.Email.text_body("hi")
 
       Emailer.deliver(raw)
-      assert_email_sent(fn sent -> assert sent.headers["Sender"] == "bounces@vutuv.de" end)
+
+      assert_email_sent(fn sent ->
+        assert sent.private[:envelope_sender] == "bounces@vutuv.de"
+      end)
+    end
+
+    test "no message carries a Sender header, even if a builder set one" do
+      # A `Sender:` is what Outlook renders as "<bounce address> on behalf of
+      # <From>", which is the whole reason the envelope moved out of the
+      # headers. The chokepoint owns the envelope, so it drops the header.
+      email =
+        Emailer.base_email()
+        |> Swoosh.Email.header("Sender", "somebody@example.com")
+        |> Swoosh.Email.to("nobody@example.com")
+        |> Swoosh.Email.subject("Has a Sender")
+        |> Swoosh.Email.text_body("hi")
+
+      Emailer.deliver(email)
+
+      assert_email_sent(fn sent ->
+        refute Map.has_key?(sent.headers, "Sender")
+        assert sent.private[:envelope_sender] == "bounces@vutuv.de"
+      end)
     end
 
     test "drops mail to an address containing whitespace instead of crashing" do

--- a/test/vutuv/notifications/mail_class_test.exs
+++ b/test/vutuv/notifications/mail_class_test.exs
@@ -1,0 +1,373 @@
+defmodule Vutuv.Notifications.MailClassTest do
+  @moduledoc """
+  Issue #1474: every outbound message declares what kind of mail it is, and the
+  chokepoint derives the handling from that class instead of from a private
+  flag only some builders happened to set.
+
+  Three things are asserted here. Every builder is listed (a new one fails the
+  build until somebody decides its class), each builder really produces the
+  class it is listed with, and each class really gets its policy — suppression,
+  unsubscribe headers, bulk headers.
+  """
+  use Vutuv.DataCase, async: false
+
+  alias Vutuv.Notifications.Bounces
+  alias Vutuv.Notifications.Emailer
+
+  @pin "123456"
+  @address "member@example.com"
+
+  # Every public builder in the Emailer, with the class it must produce. The
+  # reflection test below fails when a builder is added without a line here.
+  #
+  # Two lines are deliberate exceptions worth knowing about:
+  #
+  #   registration_attempt_email — a *third party* triggers it by typing
+  #     somebody else's address into the sign-up form, so it stays suppressible.
+  #     Making it critical would let anyone keep mailing an address vutuv has
+  #     already been told is dead.
+  #   ad_booking_email — critical although it is an operator notice: it is the
+  #     only record of a booking a member just paid for, and the invoice is
+  #     written by hand from it.
+  @builders [
+    {:login_email, :critical},
+    {:email_creation_email, :critical},
+    {:user_deletion_email, :critical},
+    {:username_change_email, :critical},
+    {:security_alert_email, :critical},
+    {:ad_booking_email, :critical},
+    {:registration_attempt_email, :transactional},
+    {:verification_notice, :transactional},
+    {:daily_report_email, :transactional},
+    {:account_deleted_notice, :transactional},
+    {:organization_verified_notice, :transactional},
+    {:organization_unverified_notice, :transactional},
+    {:organization_domain_dropped_notice, :transactional},
+    {:organization_domain_grace_email, :transactional},
+    {:organization_domain_verified_email, :transactional},
+    {:organization_page_unverified_email, :transactional},
+    {:moderation_frozen_email, :transactional},
+    {:moderation_review_email, :transactional},
+    {:moderation_revised_email, :transactional},
+    {:moderation_warning_email, :transactional},
+    {:moderation_suspension_email, :transactional},
+    {:moderation_deactivation_email, :transactional},
+    {:moderation_admin_urgent_email, :transactional},
+    {:moderation_admin_digest_email, :transactional},
+    {:image_rejected_email, :transactional},
+    {:job_posting_expiry_reminder_email, :transactional},
+    {:unread_messages_email, :notification},
+    {:new_follower_email, :notification},
+    {:endorsement_email, :notification},
+    {:notification_digest_email, :notification},
+    {:reference_check_email, :notification},
+    {:saved_search_alert_email, :bulk},
+    {:newsletter_email, :bulk}
+  ]
+
+  describe "every builder declares a class" do
+    test "the table above lists every public builder" do
+      Code.ensure_loaded!(Emailer)
+
+      exported =
+        Emailer.__info__(:functions)
+        |> Enum.map(fn {name, _arity} -> name end)
+        |> Enum.filter(&(Atom.to_string(&1) =~ ~r/_(email|notice)$/))
+        # base_email/0 is the starting point, not a message.
+        |> Enum.reject(&(&1 == :base_email))
+        |> Enum.uniq()
+
+      listed = Enum.map(@builders, fn {name, _class} -> name end)
+
+      assert Enum.sort(exported) == Enum.sort(listed),
+             """
+             Every email builder must declare a mail class (see put_class/2).
+
+             Not listed in this test: #{inspect(exported -- listed)}
+             Listed but no longer exported: #{inspect(listed -- exported)}
+             """
+    end
+
+    test "each builder produces the class it is listed with" do
+      for {name, expected} <- @builders do
+        assert Emailer.mail_class(build_mail(name)) == expected,
+               "#{name} should be #{expected}, got #{Emailer.mail_class(build_mail(name))}"
+      end
+    end
+  end
+
+  describe "the class decides whether mail may be withheld" do
+    setup do
+      user = insert(:activated_user, locale: "en")
+
+      insert(:email,
+        user: user,
+        value: "dead@example.com",
+        undeliverable_at: ~N[2026-08-01 09:00:00]
+      )
+
+      assert Bounces.suppressed?("dead@example.com")
+
+      %{user: user}
+    end
+
+    test "a dead address stops transactional mail", %{user: user} do
+      assert Emailer.moderation_warning_email(user, "dead@example.com")
+             |> Emailer.deliver() == :suppressed
+    end
+
+    test "but never the login PIN", %{user: user} do
+      assert {:ok, _} =
+               Emailer.login_email(@pin, "dead@example.com", user)
+               |> Emailer.deliver()
+    end
+
+    test "and never the new-sign-in warning", %{user: user} do
+      # The mark is one this installation set itself, possibly wrongly, while
+      # the sign-in being reported is happening now.
+      {_token, session} =
+        Vutuv.Sessions.start_session(user, Plug.Test.conn(:get, "/"), alert: false)
+
+      assert {:ok, _} =
+               Emailer.security_alert_email(user, "dead@example.com", session, [:new_device])
+               |> Emailer.deliver()
+    end
+  end
+
+  describe "the class decides the headers" do
+    test "critical and transactional mail can never be opted out of" do
+      for {name, class} <- @builders, class in [:critical, :transactional] do
+        headers = build_mail(name).headers
+
+        refute Map.has_key?(headers, "List-Unsubscribe"),
+               "#{name} is #{class} mail and must carry no unsubscribe header"
+
+        refute Map.has_key?(headers, "Precedence"),
+               "#{name} is #{class} mail and must not be marked bulk"
+      end
+    end
+
+    test "notification mail carries the one-click unsubscribe but is not bulk" do
+      for {name, :notification} <- @builders do
+        headers = build_mail(name).headers
+
+        assert headers["List-Unsubscribe-Post"] == "List-Unsubscribe=One-Click",
+               "#{name} is notification mail and must be unsubscribable"
+
+        refute Map.has_key?(headers, "Precedence"), "#{name} must not be marked bulk"
+      end
+    end
+
+    test "bulk mail is marked bulk and is unsubscribable" do
+      for {name, :bulk} <- @builders do
+        headers = build_mail(name).headers
+
+        assert headers["Precedence"] == "bulk", "#{name} is bulk mail"
+        assert headers["List-Unsubscribe"] =~ "/unsubscribe/", "#{name} must be unsubscribable"
+      end
+    end
+
+    test "declaring the bulk class is what pulls the bulk headers in" do
+      refute Map.has_key?(Emailer.base_email().headers, "Precedence")
+
+      bulk = Emailer.put_class(Emailer.base_email(), :bulk)
+
+      assert bulk.headers["Precedence"] == "bulk"
+    end
+  end
+
+  # --- builders ---------------------------------------------------------------
+  # One call per builder, with the smallest fixture that renders. Structs are
+  # built inline where no factory exists: these mails only read a handful of
+  # fields, and a real row would say nothing more about the class.
+
+  defp build_mail(:login_email),
+    do: Emailer.login_email(@pin, @address, user())
+
+  defp build_mail(:email_creation_email),
+    do: Emailer.email_creation_email(@pin, @address, user())
+
+  defp build_mail(:user_deletion_email),
+    do: Emailer.user_deletion_email(@pin, @address, user())
+
+  defp build_mail(:username_change_email),
+    do: Emailer.username_change_email(@pin, @address, user(), "a-new-handle")
+
+  defp build_mail(:registration_attempt_email),
+    do: Emailer.registration_attempt_email(user(), @address)
+
+  defp build_mail(:verification_notice) do
+    user = user()
+    # The factory sequences the address; this table builds every mail twice.
+    insert(:email, user: user)
+
+    Emailer.verification_notice(user)
+  end
+
+  defp build_mail(:security_alert_email) do
+    user = user()
+
+    {_token, session} =
+      Vutuv.Sessions.start_session(user, Plug.Test.conn(:get, "/"), alert: false)
+
+    Emailer.security_alert_email(user, @address, session, [:new_device])
+  end
+
+  defp build_mail(:unread_messages_email),
+    do:
+      Emailer.unread_messages_email(
+        @address,
+        insert(:activated_user, locale: "en"),
+        user(),
+        Vutuv.UUIDv7.generate(),
+        "Coffee this week?"
+      )
+
+  defp build_mail(:new_follower_email),
+    do: Emailer.new_follower_email(@address, insert(:activated_user, locale: "en"), user())
+
+  defp build_mail(:endorsement_email),
+    do: Emailer.endorsement_email(@address, insert(:activated_user, locale: "en"), user(), "ecto")
+
+  defp build_mail(:notification_digest_email),
+    do:
+      Emailer.notification_digest_email(
+        @address,
+        insert(:activated_user, locale: "en"),
+        [%{kind: "handle_change", old_handle: "old", new_handle: "new"}],
+        0
+      )
+
+  defp build_mail(:reference_check_email) do
+    user = insert(:activated_user, locale: "en")
+    reference = insert(:job_reference, user: user)
+
+    Emailer.reference_check_email(@address, user, reference, "2")
+  end
+
+  defp build_mail(:saved_search_alert_email) do
+    user = insert(:activated_user, locale: "en")
+    search = insert(:saved_search, user: user, kind: :people)
+
+    Emailer.saved_search_alert_email(user, @address, [{search, [insert(:user)]}])
+  end
+
+  defp build_mail(:newsletter_email),
+    do:
+      Emailer.newsletter_email(%{
+        to_name: "Member",
+        to_email: @address,
+        subject: "Rundbrief",
+        locale: "de",
+        content_html: "<p>Hallo</p>",
+        content_text: "Hallo",
+        unsubscribe_url: "https://example.com/unsubscribe/token"
+      })
+
+  # Built, not inserted: only one ad can be booked per day, and this table
+  # builds every mail several times over.
+  defp build_mail(:ad_booking_email),
+    do: Emailer.ad_booking_email(build(:ad), user())
+
+  defp build_mail(:daily_report_email),
+    do: Emailer.daily_report_email(%Vutuv.Reports.DailyReport{date: ~D[2026-08-15], posts: 3})
+
+  defp build_mail(:account_deleted_notice),
+    do:
+      Emailer.account_deleted_notice(%{
+        id: Vutuv.UUIDv7.generate(),
+        name: "Zaphod Beeblebrox",
+        username: "zaphod",
+        emails: ["z@example.com"],
+        phone_numbers: [],
+        post_count: 1,
+        joined_at: ~N[2024-01-02 10:00:00],
+        deleted_at: ~U[2026-07-01 12:34:56Z]
+      })
+
+  defp build_mail(:organization_verified_notice),
+    do: Emailer.organization_verified_notice(organization(), domain())
+
+  defp build_mail(:organization_unverified_notice),
+    do: Emailer.organization_unverified_notice(organization(), domain())
+
+  defp build_mail(:organization_domain_dropped_notice),
+    do: Emailer.organization_domain_dropped_notice(organization(), domain())
+
+  defp build_mail(:organization_domain_grace_email),
+    do: Emailer.organization_domain_grace_email(user(), @address, organization(), domain(), true)
+
+  defp build_mail(:organization_domain_verified_email),
+    do: Emailer.organization_domain_verified_email(user(), @address, organization(), domain())
+
+  defp build_mail(:organization_page_unverified_email),
+    do: Emailer.organization_page_unverified_email(user(), @address, organization(), domain())
+
+  defp build_mail(:moderation_frozen_email),
+    do: Emailer.moderation_frozen_email(user(), @address, moderation_case())
+
+  defp build_mail(:moderation_review_email),
+    do: Emailer.moderation_review_email(user(), @address, moderation_case())
+
+  defp build_mail(:moderation_revised_email),
+    do: Emailer.moderation_revised_email(user(), @address)
+
+  defp build_mail(:moderation_warning_email),
+    do: Emailer.moderation_warning_email(user(), @address)
+
+  defp build_mail(:moderation_suspension_email),
+    do: Emailer.moderation_suspension_email(user(), @address, ~N[2026-09-01 00:00:00])
+
+  defp build_mail(:moderation_deactivation_email),
+    do: Emailer.moderation_deactivation_email(user(), @address)
+
+  defp build_mail(:moderation_admin_urgent_email) do
+    owner = insert(:user)
+
+    case_record = %{
+      moderation_case()
+      | owner: owner,
+        reports: [
+          %Vutuv.Moderation.Report{
+            category: "spam",
+            note: "look at this",
+            inserted_at: ~N[2026-08-15 10:00:00]
+          }
+        ]
+    }
+
+    Emailer.moderation_admin_urgent_email(user(), @address, case_record)
+  end
+
+  defp build_mail(:moderation_admin_digest_email),
+    do: Emailer.moderation_admin_digest_email(user(), @address, 3)
+
+  defp build_mail(:image_rejected_email),
+    do:
+      Emailer.image_rejected_email(user(), @address, %Vutuv.Moderation.ImageScan{
+        kind: "avatar",
+        category: "shocking"
+      })
+
+  defp build_mail(:job_posting_expiry_reminder_email),
+    do:
+      Emailer.job_posting_expiry_reminder_email(user(), @address, %Vutuv.Jobs.JobPosting{
+        title: "Elixir Developer",
+        slug: "elixir-developer",
+        expires_on: ~D[2026-09-01]
+      })
+
+  defp user, do: insert(:user, locale: "en")
+
+  defp organization, do: insert(:organization)
+
+  defp domain do
+    %Vutuv.Organizations.OrganizationDomain{
+      domain: "acme.example",
+      method: "dns",
+      grace_deadline_at: ~N[2026-09-01 00:00:00]
+    }
+  end
+
+  defp moderation_case, do: %Vutuv.Moderation.Case{id: Vutuv.UUIDv7.generate()}
+end


### PR DESCRIPTION
Closes #1472 and #1474; the code half of #1473.

**#1472** — `Vutuv.Mailer.SMTP` is Swoosh's SMTP adapter with the envelope sender passed to the SMTP conversation directly, so the bounce address is `MAIL FROM` and no longer a visible `Sender:` header. Both halves are proved on the wire against a throwaway SMTP server, with the upstream adapter as the calibration case.

**#1473** — the bounce address is `bounces@vutuv.de` again, verified accepting (`RCPT TO` → `250 2.1.5 OK` at Google's MX). **Production still needs `BOUNCE_ADDRESS=bounces@vutuv.de` in `/var/www/vutuv3/shared/.env`**; until then it keeps sending as `sw@vutuv.de`. The reply policy is unchanged and now documented and tested: only the two appeal mails carry a `Reply-To`.

**#1474** — every builder declares a class (critical / transactional / notification / bulk) and the chokepoint derives suppression, unsubscribe and bulk headers from it. The new-sign-in warning is critical now; it used to be dropped for an address a bounce had marked dead.

Changeover cost: bounce attribution joins on the envelope sender, so mail queued under the old address is not recognised as ours while Postfix still holds it (minutes, up to ~5 days deferred). Detection only, never a wrong deactivation.

*An AI agent wrote this text in my name. I know that is problematic.*
