### PR TITLE
Der Tag-Host bittet darum, vergessen zu werden (v7.295.1)

### DIFF
--- a/docs/architecture/agents-and-seo.md
+++ b/docs/architecture/agents-and-seo.md
@@ -55,6 +55,17 @@ same reason the legacy `/users/…` URLs (which 301 to the canonical `/:slug`)
 stay crawlable: blocking a redirect strands the old URL instead of letting the
 301 consolidate it. So `robots.txt` blocks only `/admin/`.
 
+The **tag host** (`tags.<our host>`, issue #1330) is the same reasoning applied
+to a whole hostname. It carries topic actors and nothing anybody reads, so none
+of it should ever appear in a result — and the way there is not `Disallow: /`,
+which would strand whatever is already indexed, but the pair this section
+describes: every response it gives carries `X-Robots-Tag: noindex, noai,
+noimageai` (the `:tag_host_docs` pipeline, and `VutuvWeb.Plug.TagHost` for the
+redirects), and its own short robots.txt (`VutuvWeb.RobotsTxt.tag_host/0`)
+disallows nothing so that header can be read. A page asked for there is
+redirected to the same page on the apex, which is the stronger signal of the
+two: a 301 consolidates the URL rather than merely dropping it.
+
 Everything else resolves itself and is deliberately crawlable too, because any
 `Disallow` beyond `/admin/` kept re-filling that Search Console bucket (and a
 failed "validate fix" pass there emails the operator):

--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -1222,6 +1222,17 @@ only one is silent: a reader handed the actor document sees JSON and shrugs,
 while a remote server handed a redirect stops being able to follow the topic
 and nothing here would say so.
 
+The host is kept out of search the same way, and by the pair that works rather
+than the one that looks decisive. Every answer it gives carries `X-Robots-Tag:
+noindex, noai, noimageai` — the `:tag_host_docs` pipeline for the documents,
+`Plug.TagHost` for the redirects — and it serves a robots.txt of its own
+(`VutuvWeb.RobotsTxt.tag_host/0`) that **disallows nothing**. A `Disallow: /`
+is how a URL gets stuck in an index rather than kept out of one: it stops the
+fetch, so the noindex is never read and the redirect can never consolidate,
+which is precisely the mistake that put 44 apex URLs into Search Console's
+"indexed, though blocked by robots.txt" report before v7.106.3. See
+`docs/architecture/agents-and-seo.md`.
+
 ### The tag page's own half
 
 A visitor who arrived from another server gets the two things they came for, in

--- a/lib/vutuv_web/controllers/page_controller.ex
+++ b/lib/vutuv_web/controllers/page_controller.ex
@@ -94,7 +94,17 @@ defmodule VutuvWeb.PageController do
     conn
     |> discovery_cache_headers()
     |> put_resp_content_type("text/plain")
-    |> send_resp(200, VutuvWeb.RobotsTxt.render(VutuvWeb.ContentPolicy.policy()))
+    |> send_resp(200, robots_body(conn))
+  end
+
+  # The tag host answers with its own, much shorter file: it carries topic
+  # addresses and nothing anybody reads, so the document has one thing to say
+  # (see `VutuvWeb.RobotsTxt.tag_host/0`, including why it does not say
+  # `Disallow: /`).
+  defp robots_body(conn) do
+    if Fediverse.tag_host?(conn.host),
+      do: VutuvWeb.RobotsTxt.tag_host(),
+      else: VutuvWeb.RobotsTxt.render(VutuvWeb.ContentPolicy.policy())
   end
 
   @doc """

--- a/lib/vutuv_web/plugs/tag_host.ex
+++ b/lib/vutuv_web/plugs/tag_host.ex
@@ -22,9 +22,15 @@ defmodule VutuvWeb.Plug.TagHost do
   `/<tag>`, is negotiated in `VutuvWeb.FediverseController` instead — only that
   route knows the slug names a topic, and only it can send a reader to the
   topic's page rather than to the start page.
+
+  Every response from this host, redirects included, also carries
+  `X-Robots-Tag: noindex, noai, noimageai`: nothing here belongs in a search
+  index, and the host's own robots.txt disallows nothing precisely so that this
+  header can be read (`VutuvWeb.RobotsTxt.tag_host/0`).
   """
 
   alias Vutuv.Fediverse
+  alias VutuvWeb.ContentPolicy
   alias VutuvWeb.Endpoint
 
   def init(opts), do: opts
@@ -32,6 +38,12 @@ defmodule VutuvWeb.Plug.TagHost do
   def call(conn, _opts) do
     if Fediverse.tag_host?(conn.host) do
       conn
+      # Nothing on this host belongs in a search index or a training corpus,
+      # and a redirect is a response like any other: the header rides along so
+      # a crawler that has one of these URLs learns to drop it rather than
+      # keeping it as a bare link. Its robots.txt allows the fetch precisely so
+      # this can be read (`VutuvWeb.RobotsTxt.tag_host/0`).
+      |> ContentPolicy.put_robots_header(true, true)
       |> Plug.Conn.put_status(:moved_permanently)
       |> Phoenix.Controller.redirect(external: site_url() <> path_with_query(conn))
       |> Plug.Conn.halt()

--- a/lib/vutuv_web/robots_txt.ex
+++ b/lib/vutuv_web/robots_txt.ex
@@ -15,6 +15,7 @@ defmodule VutuvWeb.RobotsTxt do
   `ai-input`, `ai-train`), declared per group.
   """
 
+  alias Vutuv.Fediverse
   alias VutuvWeb.ContentPolicy
 
   # Built at call time so the comment names the installation's own host.
@@ -99,6 +100,44 @@ defmodule VutuvWeb.RobotsTxt do
       sitemap_line()
     ]
     |> IO.iodata_to_binary()
+  end
+
+  @doc """
+  The file the **tag host** answers with (issue #1330): a different document,
+  because that host is a different kind of thing.
+
+  `tags.<our host>` carries the ActivityPub address of every topic and nothing
+  anybody reads, so none of it belongs in a search index — and saying that is
+  the whole file. What it must **not** say is `Disallow: /`, which is how a URL
+  gets *stuck* in an index rather than kept out of one: a Disallow stops the
+  fetch, so the redirect can never consolidate and the `X-Robots-Tag: noindex`
+  every response here carries is never read, leaving anything already indexed
+  stranded as a bare link. That is the same mistake this project shipped on the
+  apex once (v7.106.3, 44 URLs reported by Search Console as "indexed, though
+  blocked by robots.txt"), and it is worth stating twice.
+  """
+  def tag_host do
+    """
+    # robots.txt for #{Fediverse.tag_host()}
+    #
+    # This host carries the fediverse address of every topic on #{VutuvWeb.Endpoint.host()}.
+    # Nothing on it is for reading: ask it for a page and you are redirected to
+    # #{VutuvWeb.Endpoint.url()}, ask it for a topic and you land on that topic's
+    # page there. Every answer it gives also carries the header
+    # `X-Robots-Tag: noindex, noai, noimageai`.
+    #
+    # So nothing here belongs in a search index or a training corpus, and
+    # crawling is DELIBERATELY still allowed, because a `Disallow: /` is how a
+    # URL gets stuck in an index rather than kept out of one: it stops the
+    # fetch, and a URL nobody may fetch is one whose noindex is never read and
+    # whose redirect can never consolidate. Fetch it, read the header, drop the
+    # URL. That is the fastest way for this host to disappear from your results,
+    # which is what both of us want.
+
+    User-agent: *
+    Allow: /
+    Content-Signal: #{ContentPolicy.render_signals(false, false, false)}
+    """
   end
 
   defp allowed_signals(policy),

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -74,6 +74,17 @@ defmodule VutuvWeb.Router do
     plug(:put_nosniff)
   end
 
+  # The same, plus the page-level opt-out, for the documents the **tag host**
+  # serves. Nothing on that host is for reading — a page asked for there is
+  # redirected to the site (Plugs.TagHost) — so nothing it does answer belongs
+  # in a search index or a training corpus either, actor documents included.
+  # The header is what does the work; its robots.txt deliberately blocks
+  # nothing, so that this header is seen at all.
+  pipeline :tag_host_docs do
+    plug(:put_nosniff)
+    plug(Plugs.NoIndex)
+  end
+
   defp put_nosniff(conn, _opts) do
     Plug.Conn.put_resp_header(conn, "x-content-type-options", "nosniff")
   end
@@ -155,8 +166,13 @@ defmodule VutuvWeb.Router do
   # `preferredUsername@<host of the actor id>` to confirm an account: an id on
   # the apex would canonicalise the handle back into the member namespace.
   scope "/", VutuvWeb, host: "tags." do
-    pipe_through(:machine_docs)
+    pipe_through(:tag_host_docs)
 
+    # Its own robots.txt, because this host is not the site: it says that
+    # nothing here is for reading and deliberately disallows nothing (see
+    # VutuvWeb.RobotsTxt.tag_host/0). Before `/:slug` below, which would
+    # otherwise look for a topic called "robots.txt".
+    get("/robots.txt", PageController, :robots)
     get("/.well-known/webfinger", FediverseController, :webfinger)
     get("/:slug", FediverseController, :tag_actor)
     get("/:slug/followers", FediverseController, :tag_followers)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.295.0",
+      version: "7.295.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/fediverse_tag_actor_web_test.exs
+++ b/test/vutuv_web/fediverse_tag_actor_web_test.exs
@@ -230,6 +230,48 @@ defmodule VutuvWeb.FediverseTagActorWebTest do
     end
   end
 
+  describe "staying out of the index" do
+    test "the tag host answers with a robots.txt of its own", %{conn: conn} do
+      body = conn |> on_tag_host() |> get("/robots.txt") |> response(200)
+
+      assert body =~ "robots.txt for #{@tag_host}"
+      assert body =~ "Allow: /"
+
+      # The rule this project already paid for once (v7.106.3, 44 URLs reported
+      # as "indexed, though blocked by robots.txt"): a Disallow stops the
+      # fetch, so the noindex below is never read and the redirect can never
+      # consolidate. The prose in the file explains that, hence the check for
+      # a directive line rather than for the word.
+      refute Enum.any?(String.split(body, "\n"), &String.starts_with?(&1, "Disallow"))
+    end
+
+    test "every answer this host gives carries the opt-out header", %{conn: conn} do
+      tag = topic()
+
+      answers = [
+        conn |> on_tag_host() |> in_browser() |> get("/"),
+        conn |> on_tag_host() |> in_browser() |> get("/#{tag.slug}"),
+        conn |> on_tag_host() |> ap() |> get("/#{tag.slug}"),
+        conn |> on_tag_host() |> ap() |> get("/#{tag.slug}/followers"),
+        conn |> on_tag_host() |> get("/robots.txt"),
+        conn
+        |> on_tag_host()
+        |> get(~p"/.well-known/webfinger", resource: "acct:#{tag.slug}@#{@tag_host}")
+      ]
+
+      for answer <- answers do
+        assert get_resp_header(answer, "x-robots-tag") == ["noindex, noai, noimageai"]
+      end
+    end
+
+    test "the site's own robots.txt is untouched by any of it", %{conn: conn} do
+      body = conn |> get(~p"/robots.txt") |> response(200)
+
+      assert body =~ "Disallow: /admin/"
+      refute body =~ @tag_host
+    end
+  end
+
   describe "following it" do
     test "a signed Follow is recorded and answered with an Accept", %{conn: conn} do
       tag = topic()


### PR DESCRIPTION
tags.vutuv.de trägt nur die Fediverse-Adressen der Themen, also soll von dort nichts in einer Suche auftauchen.

**Zwei Teile, die zusammen wirken:**

- Jede Antwort dieses Hosts trägt `X-Robots-Tag: noindex, noai, noimageai` — die Pipeline `:tag_host_docs` für die Dokumente (Actor, followers, outbox, WebFinger, robots.txt), `VutuvWeb.Plug.TagHost` für die Weiterleitungen.
- Der Host beantwortet `/robots.txt` mit einer eigenen kurzen Datei (`VutuvWeb.RobotsTxt.tag_host/0`), die **nichts** verbietet.

**Warum kein `Disallow: /`:** das hält eine URL nicht aus dem Index heraus, sondern darin fest. Ein Disallow stoppt nur den Abruf — der noindex-Header wird dann nie gelesen und die 301-Weiterleitung kann nie konsolidieren, also bleibt alles bereits Indexierte als nackter Link stehen. Genau diese Verwechslung hatte vor v7.106.3 44 Apex-URLs in den Search-Console-Bericht „Indexiert, obwohl durch robots.txt blockiert" gebracht. Die Datei schreibt den Grund für den nächsten Leser hinein.

Die stärkste Aussage ist ohnehin schon da: seit v7.295.0 antwortet jede Seite dieses Hosts einem Crawler mit `301` auf vutuv.de, und ein 301 führt die URL zusammen, statt sie nur fallen zu lassen.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*