### PR TITLE
Der Seiten-Feed verträgt auch Beiträge von drüben (v7.295.2)

### DIFF
--- a/lib/vutuv_web/live/organization_live/feed.ex
+++ b/lib/vutuv_web/live/organization_live/feed.ex
@@ -16,6 +16,13 @@ defmodule VutuvWeb.OrganizationLive.Feed do
   the viewer never does is widen the feed: its contents come from the page's
   follow graph alone, so two publishers reading it see the same posts.
 
+  **Two card shapes, because the feed has two kinds of entry.** Three of its
+  four sources carry a vutuv post; the fourth (accounts the page follows on
+  other networks) carries a cached remote post and a `nil` post, so a page that
+  followed one address out there 500ed this whole view until the branch below
+  existed (issue #1482) — the same split `VutuvWeb.PostLive.Feed` and the tag
+  timeline make.
+
   Embedded via `live_render` from `VutuvWeb.OrganizationController`, which gates
   it before this ever mounts.
   """
@@ -23,11 +30,12 @@ defmodule VutuvWeb.OrganizationLive.Feed do
   use VutuvWeb, :live_view
 
   import VutuvWeb.OrganizationComponents, only: [manage_header: 1]
-  import VutuvWeb.PostComponents, only: [post_card: 1]
+  import VutuvWeb.PostComponents, only: [post_card: 1, remote_post_card: 1]
 
   alias Vutuv.Organizations
   alias Vutuv.Posts
   alias VutuvWeb.Live.InitAssigns
+  alias VutuvWeb.Live.RemotePostActions
 
   @impl true
   def mount(_params, session, socket) do
@@ -61,6 +69,20 @@ defmodule VutuvWeb.OrganizationLive.Feed do
   def handle_event("load-more", _params, socket),
     do: {:noreply, load_feed(socket, socket.assigns.cursor)}
 
+  # Reporting a cached post from another network is the reader's own act, like
+  # the like and the bookmark under the card: it deletes our copy for everybody
+  # here, so the row leaves in the same round trip rather than sitting there
+  # until the next load.
+  def handle_event("report-remote-post", %{"id" => id}, socket) do
+    RemotePostActions.report(socket, id, &drop_remote_entry(&1, id))
+  end
+
+  defp drop_remote_entry(socket, remote_post_id) do
+    update(socket, :entries, fn entries ->
+      Enum.reject(entries, &(&1[:remote_post] && &1.remote_post.id == remote_post_id))
+    end)
+  end
+
   @impl true
   def handle_info(_message, socket), do: {:noreply, socket}
 
@@ -86,14 +108,36 @@ defmodule VutuvWeb.OrganizationLive.Feed do
       </p>
 
       <div :if={@entries != []} class="mt-6 space-y-4">
-        <.post_card
-          :for={entry <- @entries}
-          entry_id={entry.id}
-          post={entry.post}
-          viewer={@current_user}
-          conn_or_socket={@socket}
-          mode={:preview}
-        />
+        <%= for entry <- @entries do %>
+          <%= if Posts.remote_feed_entry?(entry) do %>
+            <%!-- A post by an account the page follows out there — the fourth
+            source, and one that carries no vutuv post at all (`entry.post` is
+            nil). It wears the same remote card every other surface draws,
+            inside the card shell `<.post_card surface={:card}>` renders for
+            the local half beside it. No Mute: that lever belongs to the
+            reader's OWN follow, and this feed is built from the page's follow
+            graph alone — muting here would leave the card exactly where it is.
+            The page's subscriptions are taken back on the Follows tab. --%>
+            <.card>
+              <.remote_post_card
+                live?
+                remote_post={entry.remote_post}
+                images={entry[:images] || []}
+                marks={entry[:marks]}
+                viewer={@current_user}
+                mute?={false}
+              />
+            </.card>
+          <% else %>
+            <.post_card
+              entry_id={entry.id}
+              post={entry.post}
+              viewer={@current_user}
+              conn_or_socket={@socket}
+              mode={:preview}
+            />
+          <% end %>
+        <% end %>
       </div>
 
       <div :if={@more?} class="mt-6 text-center">

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.295.1",
+      version: "7.295.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/organization_feed_web_test.exs
+++ b/test/vutuv_web/organization_feed_web_test.exs
@@ -13,9 +13,14 @@ defmodule VutuvWeb.OrganizationFeedWebTest do
   import Phoenix.LiveViewTest
   import Vutuv.OrganizationsHelpers
 
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemotePost
   alias Vutuv.Organizations
   alias Vutuv.Posts
+  alias Vutuv.Repo
   alias Vutuv.Social
+  alias VutuvWeb.Fediverse.Docs
 
   setup do
     Application.put_env(:vutuv, :verify_organization_domains, true)
@@ -97,5 +102,64 @@ defmodule VutuvWeb.OrganizationFeedWebTest do
 
     feed = conn |> get(~p"/organizations/#{reader.slug}/feed") |> html_response(200)
     assert feed =~ "Von der Zweiten."
+  end
+
+  test "a post from an account the page follows out there renders", %{conn: conn} do
+    {conn, owner} = create_and_login_user(conn)
+
+    page =
+      owner
+      |> active_organization_for()
+      |> Ecto.Changeset.change(%{fediverse_followers?: true, username: "acme"})
+      |> Repo.update!()
+
+    {:ok, _} = Fediverse.ensure_organization_actor(page)
+    {:ok, _} = Organizations.add_role(page, owner, "publisher", owner)
+
+    account =
+      Repo.insert!(%RemoteAccount{
+        actor_uri: "https://social.example/users/alice",
+        host: "social.example",
+        inbox_uri: "https://social.example/users/alice/inbox",
+        handle: "@alice@social.example",
+        name: "Alice"
+      })
+
+    follow_id = Vutuv.UUIDv7.generate()
+
+    Repo.insert!(%Vutuv.Fediverse.Follow{
+      id: follow_id,
+      organization_id: page.id,
+      remote_account_id: account.id,
+      state: "accepted",
+      follow_activity_id: Docs.follow_activity_id(page, follow_id)
+    })
+
+    remote =
+      Repo.insert!(%RemotePost{
+        remote_account_id: account.id,
+        object_uri: "https://social.example/notes/1",
+        content_text: "Von drueben.",
+        audience: "public",
+        published_at: DateTime.utc_now(:second),
+        received_at: DateTime.utc_now(:second),
+        expires_at: DateTime.add(DateTime.utc_now(:second), 30, :day)
+      })
+
+    # Both renders: the controller's static one and the connected socket. The
+    # crash this covers (a remote entry drawn as a member's post, whose `post`
+    # is nil) happened in the render itself, so either alone would prove it.
+    html = conn |> get(~p"/organizations/#{page.slug}/feed") |> html_response(200)
+    assert html =~ "Von drueben."
+
+    {:ok, view, live_html} = live(conn, ~p"/organizations/#{page.slug}/feed")
+    assert live_html =~ "Von drueben."
+    assert live_html =~ "@alice@social.example"
+
+    # The card's own ⋯ menu fires this on the host, so the host has to answer
+    # it: an unhandled event kills the LiveView, which is a 500 by another name.
+    # A report deletes our copy for everybody here, so the card leaves at once.
+    assert view |> render_click("report-remote-post", %{"id" => remote.id}) =~
+             "Nothing here yet."
   end
 end


### PR DESCRIPTION
Behebt #1482.

**Ursache:** `Posts.organization_feed_page/2` hat vier Quellen. Drei liefern einen vutuv-Beitrag, die vierte (Konten, denen die Seite auf anderen Netzwerken folgt) liefert einen zwischengespeicherten Fremdbeitrag und `post: nil`. `OrganizationLive.Feed` hat jede Zeile als `<.post_card>` gezeichnet, also ein `BadMapError` in `split_gallery/2` und ein 500 — sobald die Seite auf dem Reiter „Folgt" eine Fediverse-Adresse abonniert hatte und deren erster Beitrag da war.

**Fix:** dieselbe Verzweigung, die `PostLive.Feed`, die Tag-Chronik, das Profil und `/:slug/posts` schon haben: `<.remote_post_card>` für die Fremdzeile, plus der `report-remote-post`-Handler, den deren ⋯-Menü auslöst. Kein Stummschalten auf dieser Karte — der Hebel gehört dem eigenen Abo des Lesers, dieser Feed kommt allein aus dem Folge-Graph der Seite.

Der neue Test schlägt ohne den Fix mit genau diesem `BadMapError` fehl.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*