### PR TITLE
Die Verwaltungsreiter hängen an der Rolle, nicht an der Seite (v7.295.3)

### DIFF
--- a/lib/vutuv_web/components/organization_components.ex
+++ b/lib/vutuv_web/components/organization_components.ex
@@ -197,8 +197,8 @@ defmodule VutuvWeb.OrganizationComponents do
 
   attr(:organization, :map, required: true)
   attr(:active, :atom, required: true)
-  attr(:owner?, :boolean, default: false)
-  attr(:publisher?, :boolean, default: false)
+  attr(:owner?, :boolean, required: true)
+  attr(:publisher?, :boolean, required: true)
 
   @doc """
   The header + tab bar shared by the organization management pages (issue #930): a
@@ -211,6 +211,14 @@ defmodule VutuvWeb.OrganizationComponents do
   which is why those two tabs are unconditional here: the `manage?` attribute
   they used to be guarded by was passed `true` by all nine call sites, so it was
   a knob that only ever read one way.
+
+  **Both role attributes are required, and that is the fix for issue #1484.** A
+  tab bar shared by nine pages must answer to the viewer's roles alone; with
+  `publisher?` defaulting to `false`, the four pages that never passed it dropped
+  the Feed and Follows tabs, so a publisher found their page's own reading list
+  only by standing on Activity or Fediverse first. A default is the wrong shape
+  here — the safe-looking value is the one that silently hides a tab — so a
+  missing attribute now fails `compile --warnings-as-errors` instead.
   """
   def manage_header(assigns) do
     ~H"""

--- a/lib/vutuv_web/live/organization_live/domains.ex
+++ b/lib/vutuv_web/live/organization_live/domains.ex
@@ -26,6 +26,7 @@ defmodule VutuvWeb.OrganizationLive.Domains do
     {:ok,
      socket
      |> assign(:organization, organization)
+     |> assign(:publisher?, Organizations.publisher?(organization, socket.assigns.current_user))
      |> assign(:page_title, gettext("Domains – %{name}", name: organization.name))
      |> assign(:new_domain, "")
      |> assign(:new_method, "dns")
@@ -169,7 +170,12 @@ defmodule VutuvWeb.OrganizationLive.Domains do
   def render(assigns) do
     ~H"""
     <div class="mx-auto max-w-2xl py-6">
-      <.manage_header organization={@organization} active={:domains} owner?={true} />
+      <.manage_header
+        organization={@organization}
+        active={:domains}
+        owner?={true}
+        publisher?={@publisher?}
+      />
 
       <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100">{gettext("Domains")}</h1>
       <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">

--- a/lib/vutuv_web/live/organization_live/edit.ex
+++ b/lib/vutuv_web/live/organization_live/edit.ex
@@ -28,6 +28,7 @@ defmodule VutuvWeb.OrganizationLive.Edit do
       |> assign(:locale, locale)
       |> assign(:organization, organization)
       |> assign(:owner?, Organizations.owner?(organization, current_user))
+      |> assign(:publisher?, Organizations.publisher?(organization, current_user))
       |> assign(:page_title, gettext("Edit %{name}", name: organization.name))
       |> assign(:countries, Countries.select_options(locale))
       |> assign(:aliases, Organizations.list_aliases(organization))
@@ -234,7 +235,12 @@ defmodule VutuvWeb.OrganizationLive.Edit do
   def render(assigns) do
     ~H"""
     <div class="mx-auto max-w-2xl py-6">
-      <.manage_header organization={@organization} active={:edit} owner?={@owner?} />
+      <.manage_header
+        organization={@organization}
+        active={:edit}
+        owner?={@owner?}
+        publisher?={@publisher?}
+      />
 
       <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100">
         {gettext("Edit %{name}", name: @organization.name)}

--- a/lib/vutuv_web/live/organization_live/exclusions.ex
+++ b/lib/vutuv_web/live/organization_live/exclusions.ex
@@ -30,6 +30,7 @@ defmodule VutuvWeb.OrganizationLive.Exclusions do
      socket
      |> assign(:organization, organization)
      |> assign(:owner?, Organizations.owner?(organization, current_user))
+     |> assign(:publisher?, Organizations.publisher?(organization, current_user))
      |> assign(:page_title, gettext("Job exclusions – %{name}", name: organization.name))
      |> assign(:member_error, nil)
      |> assign(:org_error, nil)
@@ -97,7 +98,12 @@ defmodule VutuvWeb.OrganizationLive.Exclusions do
   def render(assigns) do
     ~H"""
     <div class="mx-auto max-w-2xl py-6">
-      <.manage_header organization={@organization} active={:exclusions} owner?={@owner?} />
+      <.manage_header
+        organization={@organization}
+        active={:exclusions}
+        owner?={@owner?}
+        publisher?={@publisher?}
+      />
 
       <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100">
         {gettext("Job exclusions")}

--- a/lib/vutuv_web/live/organization_live/roles.ex
+++ b/lib/vutuv_web/live/organization_live/roles.ex
@@ -33,6 +33,7 @@ defmodule VutuvWeb.OrganizationLive.Roles do
     {:ok,
      socket
      |> assign(:organization, organization)
+     |> assign(:publisher?, Organizations.publisher?(organization, socket.assigns.current_user))
      |> assign(:page_title, gettext("Team – %{name}", name: organization.name))
      |> assign(:identifier, "")
      # Nothing pre-ticked: with four roles a guessed default is wrong more often
@@ -160,7 +161,12 @@ defmodule VutuvWeb.OrganizationLive.Roles do
   def render(assigns) do
     ~H"""
     <div class="mx-auto max-w-2xl py-6">
-      <.manage_header organization={@organization} active={:roles} owner?={true} />
+      <.manage_header
+        organization={@organization}
+        active={:roles}
+        owner?={true}
+        publisher?={@publisher?}
+      />
 
       <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100">{gettext("Team")}</h1>
       <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.295.2",
+      version: "7.295.3",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/organization_manage_tabs_test.exs
+++ b/test/vutuv_web/organization_manage_tabs_test.exs
@@ -1,0 +1,74 @@
+defmodule VutuvWeb.OrganizationManageTabsTest do
+  @moduledoc """
+  The tab bar every organization management page shares (issue #1484).
+
+  All nine pages render `VutuvWeb.OrganizationComponents.manage_header/1`, so the
+  tab set has to follow the viewer's roles alone — never which page they happen
+  to be standing on. It did not: `publisher?` was an optional attribute
+  defaulting to `false`, and the four pages that forgot to pass it dropped the
+  Feed and Follows tabs, so the page's own reading list was reachable from two
+  pages out of six. `async: false` because the organization helpers flip the
+  global `:verify_organization_domains` flag.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  alias Vutuv.Organizations
+
+  import Vutuv.OrganizationsHelpers
+
+  # Every management page an owner reaches without holding `publisher`.
+  @owner_pages ~w(edit roles domains exclusions activity fediverse)
+  # … and the two the role itself unlocks.
+  @publisher_pages ~w(feed following)
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  test "a publisher reaches the Feed and Follows tabs from every management page",
+       %{conn: conn} do
+    {conn, owner} = create_and_login_user(conn)
+    organization = active_organization_for(owner)
+    {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+
+    for page <- @owner_pages ++ @publisher_pages do
+      html = manage_page(conn, organization, page)
+
+      assert html =~ tab_href(organization, "feed"),
+             "the Feed tab is missing on /organizations/:slug/#{page}"
+
+      assert html =~ tab_href(organization, "following"),
+             "the Follows tab is missing on /organizations/:slug/#{page}"
+    end
+  end
+
+  test "an owner who is not a publisher gets neither tab on any page", %{conn: conn} do
+    {conn, owner} = create_and_login_user(conn)
+    organization = active_organization_for(owner)
+
+    for page <- @owner_pages do
+      html = manage_page(conn, organization, page)
+
+      refute html =~ tab_href(organization, "feed"),
+             "/organizations/:slug/#{page} offers a Feed tab the viewer may not open"
+
+      refute html =~ tab_href(organization, "following"),
+             "/organizations/:slug/#{page} offers a Follows tab the viewer may not open"
+    end
+  end
+
+  defp manage_page(conn, organization, page) do
+    conn
+    |> get("/organizations/#{organization.slug}/#{page}")
+    |> html_response(200)
+  end
+
+  defp tab_href(organization, page), do: ~s|href="/organizations/#{organization.slug}/#{page}"|
+end


### PR DESCRIPTION
Behebt #1484: Die Reiter **Feed** und **Folgt** waren nur auf `/organizations/*/activity` und `/fediverse` zu sehen, nicht auf `/edit`, `/roles`, `/domains` und `/exclusions`.

**Ursache:** Alle neun Verwaltungsseiten rendern dieselbe Reiterleiste (`OrganizationComponents.manage_header/1`). Deren Attribut `publisher?` war optional mit der Vorgabe `false`, und genau diese vier Seiten haben es nie übergeben. Die Komponente bekam also gesagt, der Betrachter sei kein Publisher, und hat beide Reiter versteckt.

**Änderung:** Beide Rollen-Attribute sind jetzt Pflicht, damit eine vergessene Angabe an `compile --warnings-as-errors` scheitert statt still einen Reiter zu verstecken. Eine Vorgabe ist hier die falsche Form: der harmlos aussehende Wert ist der, der etwas verschwinden lässt. Die vier Seiten setzen `publisher?` jetzt aus `Organizations.publisher?/2`.

**Test:** `test/vutuv_web/organization_manage_tabs_test.exs` prüft die beiden Reiter-Adressen auf allen acht Seiten, die ein Publisher erreicht, und den Gegenfall (ein Owner ohne die Rolle bekommt weiterhin keinen der beiden Reiter). Gegen den ungefixten Stand kalibriert: er fiel auf `/edit` durch.

Version 7.295.3, **hot deploy** (keine Migration, keine Supervision-Tree- oder Config-Änderung).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*