### PR TITLE
Die Import-Vorschau sagt zuerst, dass noch nichts passiert ist (v7.296.0)

### DIFF
--- a/lib/vutuv/imports/linked_in.ex
+++ b/lib/vutuv/imports/linked_in.ex
@@ -850,6 +850,45 @@ defmodule Vutuv.Imports.LinkedIn do
     Enum.map(candidates, fn c -> Map.put(c, :duplicate?, MapSet.member?(seen, key_fun.(c))) end)
   end
 
+  # The sections the preview tallies, in the order it lists them. Emails are
+  # deliberately absent: they are never imported, so a row claiming "0 to
+  # import" would read as a failure rather than as the rule it is.
+  @summary_sections [
+    :positions,
+    :educations,
+    :certifications,
+    :skills,
+    :urls,
+    :social,
+    :phones,
+    :profile
+  ]
+
+  @doc """
+  The per-section tally the preview shows above the candidate lists, from the
+  `mark_duplicates/2` result: how many candidates this archive produced, how
+  many of them are already on the profile, and how many are left to import.
+
+  Counts **candidates**, not CSV rows, so the figures are exactly the rows the
+  member can see below the table. A section the archive said nothing about is a
+  row of zeros and not a "file missing" claim: an empty section and an absent
+  one look the same to a member who simply has no certificates.
+  """
+  def summary_rows(candidates) do
+    for key <- @summary_sections do
+      items = Map.fetch!(candidates, key)
+      present = Enum.count(items, &present?/1)
+
+      %{key: key, found: length(items), present: present, available: length(items) - present}
+    end
+  end
+
+  # Two shapes of "the member already has this": a duplicate candidate, and a
+  # profile scalar whose field is not blank (so the import will not touch it).
+  defp present?(%{duplicate?: true}), do: true
+  defp present?(%{fillable?: false}), do: true
+  defp present?(_candidate), do: false
+
   defp profile_candidates(user, profile) do
     for {field, label} <- @profile_fields,
         value = Map.get(profile, field),
@@ -928,7 +967,15 @@ defmodule Vutuv.Imports.LinkedIn do
   Inserts the selected candidates for `user` in one transaction, skipping
   anything the member already has (so re-import never doubles a row). `selection`
   is the parse result narrowed to the chosen candidates, plus a `:profile` map of
-  the blank fields to fill. Returns `{:ok, %{created: map, skipped: map}}`.
+  the blank fields to fill.
+
+  Returns `{:ok, %{created: map, skipped: map, blocked: map}}`. The two
+  not-created buckets are counted apart because only one of them is the
+  member's own doing: `skipped` is "you already have this", `blocked` is "this
+  could not be added at all" — a social handle another member has claimed
+  (`social_key_unless_claimed/1`), a value too long for its column, a race.
+  Reporting both as "already on your profile" told members their entry was
+  imported when it never landed.
   """
   def apply_selection(user, selection) do
     # Imported prose is arbitrary external text ("Managed the @Acme account"), so
@@ -977,29 +1024,25 @@ defmodule Vutuv.Imports.LinkedIn do
 
       profile = apply_profile(user, Map.get(selection, :profile, %{}))
 
+      tallies = %{
+        positions: positions,
+        educations: educations,
+        certifications: certifications,
+        urls: urls,
+        social: social,
+        phones: phones,
+        skills: skills
+      }
+
       %{
-        created: %{
-          positions: positions.created,
-          educations: educations.created,
-          certifications: certifications.created,
-          urls: urls.created,
-          social: social.created,
-          phones: phones.created,
-          skills: skills.created,
-          profile: profile
-        },
-        skipped: %{
-          positions: positions.skipped,
-          educations: educations.skipped,
-          certifications: certifications.skipped,
-          urls: urls.skipped,
-          social: social.skipped,
-          phones: phones.skipped,
-          skills: skills.skipped
-        }
+        created: tallies |> by_outcome(:created) |> Map.put(:profile, profile),
+        skipped: by_outcome(tallies, :skipped),
+        blocked: by_outcome(tallies, :blocked)
       }
     end)
   end
+
+  defp by_outcome(tallies, outcome), do: Map.new(tallies, fn {k, t} -> {k, t[outcome]} end)
 
   # Insert each candidate whose dedup key is not already present (in the DB or
   # earlier in this same batch), building the row off the user association.
@@ -1007,10 +1050,10 @@ defmodule Vutuv.Imports.LinkedIn do
     uid = user_id(existing)
     seen = Map.fetch!(existing, type)
 
-    {seen, created, skipped} =
-      Enum.reduce(candidates, {seen, 0, 0}, &insert_one(&1, &2, fun, uid))
+    {seen, created, skipped, blocked} =
+      Enum.reduce(candidates, {seen, 0, 0, 0}, &insert_one(&1, &2, fun, uid))
 
-    {Map.put(existing, type, seen), %{created: created, skipped: skipped}}
+    {Map.put(existing, type, seen), %{created: created, skipped: skipped, blocked: blocked}}
   end
 
   defp insert_one(candidate, acc, fun, uid) do
@@ -1018,12 +1061,14 @@ defmodule Vutuv.Imports.LinkedIn do
     do_insert(key, changeset_fun, assoc, acc, uid)
   end
 
-  defp do_insert(nil, _changeset_fun, _assoc, {seen, created, skipped}, _uid),
-    do: {seen, created, skipped + 1}
+  # A nil key means the candidate can never be inserted (today: a social handle
+  # another member has claimed), so it is blocked, not skipped.
+  defp do_insert(nil, _changeset_fun, _assoc, {seen, created, skipped, blocked}, _uid),
+    do: {seen, created, skipped, blocked + 1}
 
-  defp do_insert(key, changeset_fun, assoc, {seen, created, skipped} = acc, uid) do
+  defp do_insert(key, changeset_fun, assoc, {seen, created, skipped, blocked} = acc, uid) do
     if MapSet.member?(seen, key) do
-      {seen, created, skipped + 1}
+      {seen, created, skipped + 1, blocked}
     else
       # on_conflict: :nothing — every insert here runs inside apply_selection's
       # single transaction, and a unique-index violation (even one a changeset
@@ -1042,26 +1087,31 @@ defmodule Vutuv.Imports.LinkedIn do
 
   defp insert_skills(user, existing, candidates) do
     seen = Map.fetch!(existing, :skills)
-    {seen, created, skipped} = Enum.reduce(candidates, {seen, 0, 0}, &add_skill(&1, &2, user))
-    {Map.put(existing, :skills, seen), %{created: created, skipped: skipped}}
+
+    {seen, created, skipped, blocked} =
+      Enum.reduce(candidates, {seen, 0, 0, 0}, &add_skill(&1, &2, user))
+
+    {Map.put(existing, :skills, seen), %{created: created, skipped: skipped, blocked: blocked}}
   end
 
-  defp add_skill(candidate, {seen, created, skipped} = acc, user) do
+  defp add_skill(candidate, {seen, created, skipped, blocked} = acc, user) do
     key = String.downcase(candidate.name)
 
     if MapSet.member?(seen, key) do
-      {seen, created, skipped + 1}
+      {seen, created, skipped + 1, blocked}
     else
       user |> Tags.add_user_tag(candidate.name) |> tally(key, acc)
     end
   end
 
   # A successful insert counts as created and remembers its key; a failure (a
-  # racing duplicate, an invalid row) counts as skipped.
-  defp tally({:ok, _row}, key, {seen, created, skipped}),
-    do: {MapSet.put(seen, key), created + 1, skipped}
+  # racing duplicate, a value too long for its column) counts as blocked — the
+  # member does not have that entry and never will from this archive.
+  defp tally({:ok, _row}, key, {seen, created, skipped, blocked}),
+    do: {MapSet.put(seen, key), created + 1, skipped, blocked}
 
-  defp tally({:error, _}, _key, {seen, created, skipped}), do: {seen, created, skipped + 1}
+  defp tally({:error, _}, _key, {seen, created, skipped, blocked}),
+    do: {seen, created, skipped, blocked + 1}
 
   # Fill only the blank profile fields the member selected (name / headline).
   # Guards here too, not just in the controller, so an import can never clobber

--- a/lib/vutuv_web/controllers/import_controller.ex
+++ b/lib/vutuv_web/controllers/import_controller.ex
@@ -114,9 +114,14 @@ defmodule VutuvWeb.ImportController do
   # member had re-saved in a non-UTF-8 encoding. Whatever an archive does, the
   # member gets a flash and the form back, never the 500 page.
   defp render_preview(conn, user, parsed) do
+    candidates = LinkedIn.mark_duplicates(user, parsed)
+
     render(conn, "preview.html",
       user: user,
-      candidates: LinkedIn.mark_duplicates(user, parsed),
+      candidates: candidates,
+      # Display only, so it stays out of the hidden payload: the confirm step
+      # must not be able to read counts back from a client-controlled field.
+      summary: LinkedIn.summary_rows(candidates),
       payload: Jason.encode!(LinkedIn.payload_map(parsed)),
       page_title: gettext("Import from LinkedIn")
     )
@@ -162,15 +167,21 @@ defmodule VutuvWeb.ImportController do
     |> redirect(to: ~p"/settings/import/linkedin")
   end
 
-  # "Imported 1 work experience, 2 tags. Skipped 3 entries …". The skip reason
-  # names both cases: an entry the member already has AND one another member
-  # has claimed (the globally-unique social handles — see
-  # LinkedIn.social_key_unless_claimed/1).
+  # "Imported 1 work experience, 2 tags. Skipped 3 entries that are already on
+  # your profile. 1 social account is already claimed by another member."
+  #
+  # The two not-created reasons are told apart because they mean opposite
+  # things to the member: a skipped entry is on the profile already, a blocked
+  # one never landed. One sentence for both said "already on your profile"
+  # about entries that were not.
   defp summary_flash(summary) do
-    summary.created
-    |> imported_parts()
-    |> imported_message()
-    |> append_skipped(skipped_total(summary.skipped))
+    [
+      summary.created |> imported_parts() |> imported_message(),
+      skipped_sentence(total(summary.skipped))
+      | blocked_sentences(summary.blocked)
+    ]
+    |> Enum.filter(& &1)
+    |> Enum.join(" ")
   end
 
   defp imported_parts(created) do
@@ -200,20 +211,39 @@ defmodule VutuvWeb.ImportController do
   defp imported_message([]), do: gettext("Nothing new to import.")
   defp imported_message(parts), do: gettext("Imported %{items}.", items: Enum.join(parts, ", "))
 
-  defp skipped_total(skipped) do
-    skipped.positions + skipped.educations + skipped.certifications + skipped.skills +
-      skipped.urls + skipped.social + skipped.phones
+  defp total(tally), do: tally |> Map.values() |> Enum.sum()
+
+  defp skipped_sentence(0), do: nil
+
+  defp skipped_sentence(count) do
+    ngettext(
+      "Skipped %{count} entry that is already on your profile.",
+      "Skipped %{count} entries that are already on your profile.",
+      count
+    )
   end
 
-  defp append_skipped(message, 0), do: message
+  # A claimed social handle is the one blocked case with an explanation the
+  # member can act on (social_media_accounts has a GLOBAL unique index on
+  # provider + value), so it gets its own sentence; anything else is a value
+  # the schema refused and is reported plainly rather than guessed at.
+  defp blocked_sentences(blocked) do
+    [claimed_sentence(blocked.social), rejected_sentence(total(blocked) - blocked.social)]
+  end
 
-  defp append_skipped(message, count) do
-    message <>
-      " " <>
-      ngettext(
-        "Skipped %{count} entry that is already on your profile or taken by another member.",
-        "Skipped %{count} entries that are already on your profile or taken by another member.",
-        count
-      )
+  defp claimed_sentence(0), do: nil
+
+  defp claimed_sentence(count) do
+    ngettext(
+      "%{count} social account could not be added because another member has already claimed it.",
+      "%{count} social accounts could not be added because another member has already claimed them.",
+      count
+    )
+  end
+
+  defp rejected_sentence(0), do: nil
+
+  defp rejected_sentence(count) do
+    ngettext("%{count} entry could not be added.", "%{count} entries could not be added.", count)
   end
 end

--- a/lib/vutuv_web/templates/import/new.html.heex
+++ b/lib/vutuv_web/templates/import/new.html.heex
@@ -8,6 +8,7 @@
     <ul class="mt-3 grid list-disc gap-y-1 pl-5 text-sm text-slate-700 dark:text-slate-300 sm:grid-cols-2 sm:gap-x-8">
       <li>{gettext("Work experience")}</li>
       <li>{gettext("Education")}</li>
+      <li>{gettext("Certificates & licenses")}</li>
       <li>{gettext("Tags")}</li>
       <li>{gettext("Links")}</li>
       <li>{gettext("Social media")}</li>

--- a/lib/vutuv_web/templates/import/preview.html.heex
+++ b/lib/vutuv_web/templates/import/preview.html.heex
@@ -1,7 +1,28 @@
 <.settings_shell user={@user} active={:import} title={gettext("Import from LinkedIn")}>
 <div class="max-w-3xl">
   <.card>
-    <p class="text-sm text-slate-600 dark:text-slate-400">
+    <%!-- The first thing a member needs to know is that this page changed
+    nothing yet: they may leave it, or upload again, without wondering what
+    the last attempt did to their profile. --%>
+    <div
+      data-import-analysis
+      class="rounded-lg bg-brand-50 p-4 text-sm text-brand-900 ring-1 ring-brand-100 dark:bg-brand-900/40 dark:text-brand-100 dark:ring-brand-800"
+    >
+      <p class="font-semibold">{gettext("Analysis complete. Nothing has been imported yet.")}</p>
+      <p class="mt-1">
+        {gettext("Review the entries below and confirm your selection to add them to your profile.")}
+      </p>
+    </div>
+
+    <.analysis_summary rows={@summary} />
+
+    <p class="mt-4 text-sm text-slate-600 dark:text-slate-400">
+      {gettext(
+        "You can analyse the same or a newer LinkedIn archive again at any time. Nothing is duplicated and nothing is overwritten. Entries you already have are not updated either: they keep the description and dates they have on vutuv, even when your archive holds newer ones."
+      )}
+    </p>
+
+    <p class="mt-4 text-sm text-slate-600 dark:text-slate-400">
       {gettext(
         "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
       )}

--- a/lib/vutuv_web/views/import_html.ex
+++ b/lib/vutuv_web/views/import_html.ex
@@ -2,6 +2,75 @@ defmodule VutuvWeb.ImportHTML do
   @moduledoc false
   use VutuvWeb, :html
 
+  @doc """
+  The analysis summary above the candidate lists (issue #1477): one row per
+  supported section with what the archive held, what is already on the profile
+  and what is left to import.
+
+  Counts candidates rather than CSV rows, because a raw row count needs an
+  "ignored" column to add up, and the largest ignored group would be the
+  entries a real archive simply repeats across its files, which the importer
+  collapses on purpose: a number that reads like lost data while describing
+  the importer working correctly.
+
+  Mobile-first sizing, measured rather than guessed: the headers **wrap**, and
+  they carry no `uppercase tracking-wide` (German labels set in caps cost this
+  table ~54px, which is the difference between four columns fitting a phone and
+  the "Ready to import" figure sitting off the right edge). At 8px cell padding
+  the table's min-content is ~304px against the ~310px a 390px phone leaves
+  inside the card. The `overflow-x-auto` wrapper is the backstop for anything
+  narrower, and it is what keeps a wide table from scrolling the whole page
+  sideways.
+  """
+  attr(:rows, :list, required: true)
+
+  def analysis_summary(assigns) do
+    ~H"""
+    <div class="mt-4 overflow-x-auto">
+      <table class="w-full text-sm" data-import-summary>
+        <thead>
+          <tr class="border-b border-slate-200 text-left text-xs font-semibold text-slate-500 dark:border-slate-700 dark:text-slate-400">
+            <th scope="col" class="py-2 pr-2">{gettext("Section")}</th>
+            <th scope="col" class="px-2 py-2 text-right">{gettext("Found")}</th>
+            <th scope="col" class="px-2 py-2 text-right">{gettext("Already on your profile")}</th>
+            <th scope="col" class="py-2 pl-2 text-right">{gettext("Ready to import")}</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-100 dark:divide-slate-800">
+          <tr
+            :for={row <- @rows}
+            data-import-summary-row={row.key}
+            class={
+              if(row.found == 0,
+                do: "text-slate-500 dark:text-slate-400",
+                else: "text-slate-800 dark:text-slate-200"
+              )
+            }
+          >
+            <th scope="row" class="py-2 pr-2 text-left font-medium">{section_label(row.key)}</th>
+            <td class="px-2 py-2 text-right tabular-nums">{delimited_count(row.found)}</td>
+            <td class="px-2 py-2 text-right tabular-nums">{delimited_count(row.present)}</td>
+            <td class="py-2 pl-2 text-right font-semibold tabular-nums">
+              {delimited_count(row.available)}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    """
+  end
+
+  # The same words the candidate lists below the table are titled with, so the
+  # summary and the lists can never name a section differently.
+  defp section_label(:positions), do: gettext("Work experience")
+  defp section_label(:educations), do: gettext("Education")
+  defp section_label(:certifications), do: gettext("Certificates & licenses")
+  defp section_label(:skills), do: gettext("Tags")
+  defp section_label(:urls), do: gettext("Links")
+  defp section_label(:social), do: gettext("Social media")
+  defp section_label(:phones), do: gettext("Phone numbers")
+  defp section_label(:profile), do: gettext("Profile")
+
   @doc "One selectable candidate: a checkbox + label, greyed when it is a duplicate."
   attr(:id, :string, required: true)
   attr(:label, :string, required: true)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.295.3",
+      version: "7.296.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -9,7 +9,7 @@
 msgid ""
 msgstr "Language: de\n"
 
-#: lib/vutuv_web/controllers/page_controller.ex:174
+#: lib/vutuv_web/controllers/page_controller.ex:184
 #: lib/vutuv_web/templates/layout/app.html.heex:132
 #, elixir-autogen
 msgid "About us"
@@ -19,9 +19,9 @@ msgstr "Impressum"
 #: lib/vutuv_web/components/ui.ex:3605
 #: lib/vutuv_web/live/admin/screenshot_live.ex:266
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:718
-#: lib/vutuv_web/live/organization_live/domains.ex:268
-#: lib/vutuv_web/live/organization_live/edit.ex:396
-#: lib/vutuv_web/live/organization_live/roles.ex:210
+#: lib/vutuv_web/live/organization_live/domains.ex:274
+#: lib/vutuv_web/live/organization_live/edit.ex:402
+#: lib/vutuv_web/live/organization_live/roles.ex:216
 #, elixir-autogen
 msgid "Add"
 msgstr "Eintrag hinzufügen"
@@ -114,13 +114,13 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
 #: lib/vutuv_web/live/job_posting_live/form.ex:605
-#: lib/vutuv_web/live/organization_live/edit.ex:347
+#: lib/vutuv_web/live/organization_live/edit.ex:353
 #: lib/vutuv_web/live/organization_live/new.ex:231
 #: lib/vutuv_web/live/post_live/composer.ex:1370
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
-#: lib/vutuv_web/templates/import/preview.html.heex:86
+#: lib/vutuv_web/templates/import/preview.html.heex:107
 #: lib/vutuv_web/templates/report/new.html.heex:103
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:276
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:259
@@ -177,8 +177,8 @@ msgid "Delete"
 msgstr "Löschen"
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:481
-#: lib/vutuv_web/live/organization_live/edit.ex:272
-#: lib/vutuv_web/live/organization_live/edit.ex:281
+#: lib/vutuv_web/live/organization_live/edit.ex:278
+#: lib/vutuv_web/live/organization_live/edit.ex:287
 #: lib/vutuv_web/templates/address/card_list.html.heex:5
 #: lib/vutuv_web/templates/address/form_en.html.heex:11
 #: lib/vutuv_web/templates/address/form_generic.html.heex:13
@@ -414,13 +414,14 @@ msgstr "Link wurde geändert."
 #: lib/vutuv_web/cv/latex.ex:164
 #: lib/vutuv_web/cv/odt.ex:176
 #: lib/vutuv_web/live/cv_live.ex:336
-#: lib/vutuv_web/templates/import/new.html.heex:12
-#: lib/vutuv_web/templates/import/preview.html.heex:40
+#: lib/vutuv_web/templates/import/new.html.heex:13
+#: lib/vutuv_web/templates/import/preview.html.heex:61
 #: lib/vutuv_web/templates/url/edit.html.heex:4
 #: lib/vutuv_web/templates/url/index.html.heex:10
 #: lib/vutuv_web/templates/url/manage.html.heex:4
 #: lib/vutuv_web/templates/url/new.html.heex:4
 #: lib/vutuv_web/templates/url/show.html.heex:6
+#: lib/vutuv_web/views/import_html.ex:65
 #, elixir-autogen
 msgid "Links"
 msgstr "Links"
@@ -613,7 +614,7 @@ msgid "Public"
 msgstr "Öffentlich"
 
 #: lib/vutuv_web/components/ui.ex:3388
-#: lib/vutuv_web/live/organization_live/edit.ex:341
+#: lib/vutuv_web/live/organization_live/edit.ex:347
 #: lib/vutuv_web/live/post_live/composer.ex:1813
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
@@ -860,7 +861,7 @@ msgstr "Alle anzeigen"
 #: lib/vutuv_web/components/ui.ex:3899
 #: lib/vutuv_web/controllers/settings_controller.ex:159
 #: lib/vutuv_web/live/job_posting_live/form.ex:561
-#: lib/vutuv_web/live/organization_live/edit.ex:300
+#: lib/vutuv_web/live/organization_live/edit.ex:306
 #: lib/vutuv_web/templates/email/card_list.html.heex:7
 #: lib/vutuv_web/templates/email/show.html.heex:24
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:295
@@ -1095,7 +1096,7 @@ msgstr "vutuv Login-PIN"
 msgid "Listings"
 msgstr "Listen"
 
-#: lib/vutuv_web/controllers/page_controller.ex:323
+#: lib/vutuv_web/controllers/page_controller.ex:333
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:4
 #, elixir-autogen
 msgid "Most Followed Users"
@@ -1167,7 +1168,7 @@ msgstr "Wählen Sie einen Social-Media-Anbieter aus"
 msgid "Add Localization"
 msgstr "Lokalisierung hinzufügen"
 
-#: lib/vutuv_web/components/organization_components.ex:289
+#: lib/vutuv_web/components/organization_components.ex:297
 #: lib/vutuv_web/live/admin/activity_live.ex:153
 #: lib/vutuv_web/live/admin/api_app_live.ex:58
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
@@ -1421,8 +1422,8 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:5
 #: lib/vutuv_web/templates/admin/tag/new.html.heex:5
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:5
-#: lib/vutuv_web/templates/import/new.html.heex:11
-#: lib/vutuv_web/templates/import/preview.html.heex:36
+#: lib/vutuv_web/templates/import/new.html.heex:12
+#: lib/vutuv_web/templates/import/preview.html.heex:57
 #: lib/vutuv_web/templates/page/index.html.heex:108
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -1432,6 +1433,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
 #: lib/vutuv_web/templates/user_tag/show.html.heex:6
+#: lib/vutuv_web/views/import_html.ex:64
 #, elixir-autogen
 msgid "Tags"
 msgstr "Tags"
@@ -1592,7 +1594,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:776
 #: lib/vutuv_web/live/job_board_live.ex:360
 #: lib/vutuv_web/live/job_posting_live/form.ex:410
-#: lib/vutuv_web/live/organization_live/edit.ex:296
+#: lib/vutuv_web/live/organization_live/edit.ex:302
 #: lib/vutuv_web/live/organization_live/new.ex:142
 #: lib/vutuv_web/templates/ad/new.html.heex:114
 #: lib/vutuv_web/templates/address/country_input.html.heex:5
@@ -1672,7 +1674,7 @@ msgstr "Bestätigen"
 msgid "Confirm account deletion"
 msgstr "Kontolöschung bestätigen"
 
-#: lib/vutuv_web/controllers/page_controller.ex:178
+#: lib/vutuv_web/controllers/page_controller.ex:188
 #: lib/vutuv_web/templates/layout/app.html.heex:138
 #: lib/vutuv_web/templates/page/index.html.heex:261
 #: lib/vutuv_web/views/admin/legal_page_html.ex:11
@@ -1680,7 +1682,7 @@ msgstr "Kontolöschung bestätigen"
 msgid "Datenschutzerklärung"
 msgstr "Datenschutzerklärung"
 
-#: lib/vutuv_web/controllers/page_controller.ex:184
+#: lib/vutuv_web/controllers/page_controller.ex:194
 #: lib/vutuv_web/templates/layout/app.html.heex:139
 #: lib/vutuv_web/templates/page/index.html.heex:261
 #: lib/vutuv_web/views/admin/legal_page_html.ex:12
@@ -1748,7 +1750,7 @@ msgstr ""
 msgid "Log out"
 msgstr "Ausloggen"
 
-#: lib/vutuv_web/components/organization_components.ex:295
+#: lib/vutuv_web/components/organization_components.ex:303
 #: lib/vutuv_web/live/admin/activity_live.ex:143
 #: lib/vutuv_web/live/admin/activity_live.ex:175
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
@@ -1961,7 +1963,7 @@ msgstr "Seitennavigation"
 
 #: lib/vutuv_web/components/ui.ex:3627
 #: lib/vutuv_web/live/organization_live/activity.ex:146
-#: lib/vutuv_web/live/organization_live/feed.ex:101
+#: lib/vutuv_web/live/organization_live/feed.ex:145
 #: lib/vutuv_web/live/organization_live/show.ex:637
 #, elixir-autogen, elixir-format
 msgid "Load more"
@@ -2154,8 +2156,8 @@ msgstr "Diesen Beitrag endgültig löschen?"
 msgid "Edit post"
 msgstr "Beitrag bearbeiten"
 
-#: lib/vutuv_web/components/organization_components.ex:247
-#: lib/vutuv_web/live/organization_live/feed.ex:79
+#: lib/vutuv_web/components/organization_components.ex:255
+#: lib/vutuv_web/live/organization_live/feed.ex:101
 #: lib/vutuv_web/live/post_live/feed.ex:159
 #: lib/vutuv_web/live/post_live/feed.ex:936
 #: lib/vutuv_web/live/shell_live.ex:606
@@ -2272,9 +2274,9 @@ msgstr "Weniger anzeigen"
 #: lib/vutuv_web/live/admin/screenshot_live.ex:338
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:700
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
-#: lib/vutuv_web/live/organization_live/domains.ex:242
-#: lib/vutuv_web/live/organization_live/edit.ex:373
-#: lib/vutuv_web/live/organization_live/roles.ex:243
+#: lib/vutuv_web/live/organization_live/domains.ex:248
+#: lib/vutuv_web/live/organization_live/edit.ex:379
+#: lib/vutuv_web/live/organization_live/roles.ex:249
 #: lib/vutuv_web/live/post_live/composer.ex:1886
 #: lib/vutuv_web/live/post_live/saved.ex:619
 #: lib/vutuv_web/live/post_live/saved.ex:647
@@ -2893,7 +2895,7 @@ msgstr "Personen, mit denen Sie nicht vernetzt sind"
 msgid "Open someone's profile to message them."
 msgstr "Öffnen Sie ein Profil, um jemandem zu schreiben."
 
-#: lib/vutuv_web/components/organization_components.ex:241
+#: lib/vutuv_web/components/organization_components.ex:249
 #: lib/vutuv_web/live/notification_live/index.ex:1050
 #: lib/vutuv_web/live/organization_live/activity.ex:99
 #, elixir-autogen, elixir-format
@@ -3192,7 +3194,7 @@ msgstr "Warteschlange öffnen"
 msgid "Opened"
 msgstr "Eröffnet"
 
-#: lib/vutuv_web/components/organization_components.ex:288
+#: lib/vutuv_web/components/organization_components.ex:296
 #: lib/vutuv_web/live/admin/api_app_live.ex:72
 #: lib/vutuv_web/live/admin/deliverability_live.ex:171
 #: lib/vutuv_web/live/admin/moderation_live.ex:56
@@ -3220,9 +3222,10 @@ msgstr "Private Nachricht"
 #: lib/vutuv_web/components/ui.ex:3812
 #: lib/vutuv_web/live/shell_live.ex:619
 #: lib/vutuv_web/live/shell_live.ex:896
-#: lib/vutuv_web/templates/import/new.html.heex:15
-#: lib/vutuv_web/templates/import/preview.html.heex:55
+#: lib/vutuv_web/templates/import/new.html.heex:16
+#: lib/vutuv_web/templates/import/preview.html.heex:76
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
+#: lib/vutuv_web/views/import_html.ex:68
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr "Profil"
@@ -4177,7 +4180,7 @@ msgstr "Für die Buchung ist ein vutuv-Login erforderlich."
 
 #: lib/vutuv_web/live/admin/organization_live.ex:245
 #: lib/vutuv_web/live/job_posting_live/form.ex:404
-#: lib/vutuv_web/live/organization_live/edit.ex:292
+#: lib/vutuv_web/live/organization_live/edit.ex:298
 #: lib/vutuv_web/live/organization_live/new.ex:138
 #: lib/vutuv_web/templates/ad/new.html.heex:108
 #: lib/vutuv_web/templates/address/form_en.html.heex:33
@@ -4719,7 +4722,7 @@ msgstr "Entdecken Sie Mitglieder zum Folgen"
 msgid "Find members"
 msgstr "Mitglieder finden"
 
-#: lib/vutuv_web/components/organization_components.ex:253
+#: lib/vutuv_web/components/organization_components.ex:261
 #: lib/vutuv_web/live/organization_live/following.ex:154
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:53
@@ -5698,7 +5701,7 @@ msgstr "Über Sie"
 msgid "Account"
 msgstr "Konto"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:447
+#: lib/vutuv_web/live/organization_live/edit.ex:453
 #, elixir-autogen, elixir-format
 msgid "Change"
 msgstr "Ändern"
@@ -5717,7 +5720,7 @@ msgstr ""
 #: lib/vutuv_web/templates/email/edit.html.heex:4
 #: lib/vutuv_web/templates/email/manage.html.heex:4
 #: lib/vutuv_web/templates/email/new.html.heex:4
-#: lib/vutuv_web/templates/import/preview.html.heex:69
+#: lib/vutuv_web/templates/import/preview.html.heex:90
 #: lib/vutuv_web/templates/settings/security.html.heex:17
 #, elixir-autogen, elixir-format
 msgid "Email addresses"
@@ -7628,14 +7631,14 @@ msgid "accounts"
 msgstr "Konten"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:991
-#: lib/vutuv_web/views/import_html.ex:67
-#: lib/vutuv_web/views/import_html.ex:71
+#: lib/vutuv_web/views/import_html.ex:132
+#: lib/vutuv_web/views/import_html.ex:136
 #, elixir-autogen, elixir-format
 msgid "Select all"
 msgstr "Alle auswählen"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:994
-#: lib/vutuv_web/views/import_html.ex:68
+#: lib/vutuv_web/views/import_html.ex:133
 #, elixir-autogen, elixir-format
 msgid "Unselect all"
 msgstr "Alle abwählen"
@@ -8429,7 +8432,7 @@ msgid "Unreachable"
 msgstr "Nicht erreichbar"
 
 #: lib/vutuv_web/live/admin/member_badges.ex:20
-#: lib/vutuv_web/live/organization_live/domains.ex:191
+#: lib/vutuv_web/live/organization_live/domains.ex:197
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:32
 #, elixir-autogen, elixir-format
 msgid "Verified"
@@ -8453,49 +8456,49 @@ msgstr "Noch keine Mitglieder."
 msgid "Nobody is online right now."
 msgstr "Zurzeit ist niemand online."
 
-#: lib/vutuv_web/controllers/import_controller.ex:181
+#: lib/vutuv_web/controllers/import_controller.ex:192
 #, elixir-autogen, elixir-format
 msgid "%{count} education entry"
 msgid_plural "%{count} education entries"
 msgstr[0] "%{count} Ausbildungseintrag"
 msgstr[1] "%{count} Ausbildungseinträge"
 
-#: lib/vutuv_web/controllers/import_controller.ex:189
+#: lib/vutuv_web/controllers/import_controller.ex:200
 #, elixir-autogen, elixir-format
 msgid "%{count} link"
 msgid_plural "%{count} links"
 msgstr[0] "%{count} Link"
 msgstr[1] "%{count} Links"
 
-#: lib/vutuv_web/controllers/import_controller.ex:193
+#: lib/vutuv_web/controllers/import_controller.ex:204
 #, elixir-autogen, elixir-format
 msgid "%{count} phone number"
 msgid_plural "%{count} phone numbers"
 msgstr[0] "%{count} Telefonnummer"
 msgstr[1] "%{count} Telefonnummern"
 
-#: lib/vutuv_web/controllers/import_controller.ex:195
+#: lib/vutuv_web/controllers/import_controller.ex:206
 #, elixir-autogen, elixir-format
 msgid "%{count} profile field"
 msgid_plural "%{count} profile fields"
 msgstr[0] "%{count} Profilfeld"
 msgstr[1] "%{count} Profilfelder"
 
-#: lib/vutuv_web/controllers/import_controller.ex:191
+#: lib/vutuv_web/controllers/import_controller.ex:202
 #, elixir-autogen, elixir-format
 msgid "%{count} social account"
 msgid_plural "%{count} social accounts"
 msgstr[0] "%{count} Social-Media-Konto"
 msgstr[1] "%{count} Social-Media-Konten"
 
-#: lib/vutuv_web/controllers/import_controller.ex:188
+#: lib/vutuv_web/controllers/import_controller.ex:199
 #, elixir-autogen, elixir-format
 msgid "%{count} tag"
 msgid_plural "%{count} tags"
 msgstr[0] "%{count} Tag"
 msgstr[1] "%{count} Tags"
 
-#: lib/vutuv_web/controllers/import_controller.ex:179
+#: lib/vutuv_web/controllers/import_controller.ex:190
 #, elixir-autogen, elixir-format
 msgid "%{count} work experience"
 msgid_plural "%{count} work experiences"
@@ -8528,8 +8531,9 @@ msgstr "Abschluss"
 #: lib/vutuv_web/templates/education/new.html.heex:4
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
-#: lib/vutuv_web/templates/import/preview.html.heex:23
+#: lib/vutuv_web/templates/import/preview.html.heex:44
 #: lib/vutuv_web/templates/user/show.html.heex:666
+#: lib/vutuv_web/views/import_html.ex:62
 #: lib/vutuv_web/views/job_reference_html.ex:265
 #, elixir-autogen, elixir-format
 msgid "Education"
@@ -8555,7 +8559,7 @@ msgstr "Ausbildung von %{name}"
 msgid "Education updated successfully."
 msgstr "Ausbildung erfolgreich aktualisiert."
 
-#: lib/vutuv_web/templates/import/preview.html.heex:71
+#: lib/vutuv_web/templates/import/preview.html.heex:92
 #, elixir-autogen, elixir-format
 msgid "Email addresses are not imported automatically because each one is confirmed by PIN. Add them yourself if you like:"
 msgstr ""
@@ -8568,7 +8572,7 @@ msgstr ""
 msgid "Field of study"
 msgstr "Studienfach"
 
-#: lib/vutuv_web/templates/import/preview.html.heex:5
+#: lib/vutuv_web/templates/import/preview.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
@@ -8582,7 +8586,7 @@ msgid "Import"
 msgstr "Import"
 
 #: lib/vutuv_web/controllers/import_controller.ex:36
-#: lib/vutuv_web/controllers/import_controller.ex:121
+#: lib/vutuv_web/controllers/import_controller.ex:126
 #: lib/vutuv_web/templates/import/new.html.heex:1
 #: lib/vutuv_web/templates/import/preview.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:432
@@ -8590,17 +8594,17 @@ msgstr "Import"
 msgid "Import from LinkedIn"
 msgstr "LinkedIn-Profil importieren"
 
-#: lib/vutuv_web/templates/import/preview.html.heex:84
+#: lib/vutuv_web/templates/import/preview.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Import selected"
 msgstr "Auswahl importieren"
 
-#: lib/vutuv_web/controllers/import_controller.ex:201
+#: lib/vutuv_web/controllers/import_controller.ex:212
 #, elixir-autogen, elixir-format
 msgid "Imported %{items}."
 msgstr "%{items} importiert."
 
-#: lib/vutuv_web/controllers/import_controller.ex:200
+#: lib/vutuv_web/controllers/import_controller.ex:211
 #, elixir-autogen, elixir-format
 msgid "Nothing new to import."
 msgstr "Nichts Neues zu importieren."
@@ -8610,11 +8614,12 @@ msgstr "Nichts Neues zu importieren."
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
 #: lib/vutuv_web/controllers/phone_number_controller.ex:87
-#: lib/vutuv_web/templates/import/new.html.heex:14
-#: lib/vutuv_web/templates/import/preview.html.heex:48
+#: lib/vutuv_web/templates/import/new.html.heex:15
+#: lib/vutuv_web/templates/import/preview.html.heex:69
 #: lib/vutuv_web/templates/phone_number/edit.html.heex:4
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:4
 #: lib/vutuv_web/templates/phone_number/new.html.heex:4
+#: lib/vutuv_web/views/import_html.ex:67
 #, elixir-autogen, elixir-format
 msgid "Phone numbers"
 msgstr "Telefonnummern"
@@ -8629,23 +8634,24 @@ msgstr "Bitte wählen Sie zuerst Ihre LinkedIn-Export-ZIP-Datei."
 msgid "School"
 msgstr "Schule"
 
-#: lib/vutuv_web/templates/import/preview.html.heex:60
+#: lib/vutuv_web/templates/import/preview.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "Set %{field}:"
 msgstr "%{field} setzen:"
 
-#: lib/vutuv_web/templates/import/new.html.heex:13
-#: lib/vutuv_web/templates/import/preview.html.heex:44
+#: lib/vutuv_web/templates/import/new.html.heex:14
+#: lib/vutuv_web/templates/import/preview.html.heex:65
+#: lib/vutuv_web/views/import_html.ex:66
 #, elixir-autogen, elixir-format
 msgid "Social media"
 msgstr "Soziale Medien"
 
-#: lib/vutuv_web/templates/import/new.html.heex:25
+#: lib/vutuv_web/templates/import/new.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Step 1: Download your LinkedIn data"
 msgstr "Schritt 1: Laden Sie Ihre LinkedIn-Daten herunter"
 
-#: lib/vutuv_web/templates/import/new.html.heex:76
+#: lib/vutuv_web/templates/import/new.html.heex:77
 #, elixir-autogen, elixir-format
 msgid "Step 2: Upload the ZIP here"
 msgstr "Schritt 2: Laden Sie die ZIP-Datei hier hoch"
@@ -8655,7 +8661,7 @@ msgstr "Schritt 2: Laden Sie die ZIP-Datei hier hoch"
 msgid "That does not look like a LinkedIn data export ZIP."
 msgstr "Das sieht nicht nach einem LinkedIn-Datenexport (ZIP) aus."
 
-#: lib/vutuv_web/controllers/import_controller.ex:130
+#: lib/vutuv_web/controllers/import_controller.ex:135
 #, elixir-autogen, elixir-format
 msgid "The file could not be read. Please try again."
 msgstr "Die Datei konnte nicht gelesen werden. Bitte versuchen Sie es erneut."
@@ -8666,23 +8672,24 @@ msgid "The import could not be completed. Please try again."
 msgstr ""
 "Der Import konnte nicht abgeschlossen werden. Bitte versuchen Sie es erneut."
 
-#: lib/vutuv_web/templates/import/new.html.heex:129
+#: lib/vutuv_web/templates/import/new.html.heex:130
 #, elixir-autogen, elixir-format
 msgid "Upload and preview"
 msgstr "Hochladen und Vorschau"
 
 #: lib/vutuv_web/templates/import/new.html.heex:9
-#: lib/vutuv_web/templates/import/preview.html.heex:19
+#: lib/vutuv_web/templates/import/preview.html.heex:40
+#: lib/vutuv_web/views/import_html.ex:61
 #, elixir-autogen, elixir-format
 msgid "Work experience"
 msgstr "Berufserfahrung"
 
-#: lib/vutuv_web/templates/import/preview.html.heex:75
+#: lib/vutuv_web/templates/import/preview.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "add an email address"
 msgstr "eine E-Mail-Adresse hinzufügen"
 
-#: lib/vutuv_web/views/import_html.ex:27
+#: lib/vutuv_web/views/import_html.ex:92
 #, elixir-autogen, elixir-format
 msgid "already on your profile"
 msgstr "bereits in Ihrem Profil"
@@ -8694,7 +8701,7 @@ msgstr ""
 "Dieses Archiv ist zu groß oder enthält zu viele Dateien, um es sicher zu "
 "importieren."
 
-#: lib/vutuv_web/controllers/import_controller.ex:146
+#: lib/vutuv_web/controllers/import_controller.ex:151
 #, elixir-autogen, elixir-format
 msgid "Too many imports. Please try again in a little while."
 msgstr "Zu viele Importe. Bitte versuchen Sie es in Kürze erneut."
@@ -8707,17 +8714,6 @@ msgstr "Zu viele Importe. Bitte versuchen Sie es in Kürze erneut."
 msgid "Please check the fields marked in red."
 msgstr "Bitte prüfen Sie die rot markierten Felder."
 
-#: lib/vutuv_web/controllers/import_controller.ex:213
-#, elixir-autogen, elixir-format
-msgid "Skipped %{count} entry that is already on your profile or taken by another member."
-msgid_plural "Skipped %{count} entries that are already on your profile or taken by another member."
-msgstr[0] ""
-"%{count} Eintrag übersprungen, der schon in Ihrem Profil steht oder von "
-"einem anderen Mitglied belegt ist."
-msgstr[1] ""
-"%{count} Einträge übersprungen, die schon in Ihrem Profil stehen oder von "
-"einem anderen Mitglied belegt sind."
-
 #: lib/vutuv_web/views/user_html.ex:675
 #, elixir-autogen, elixir-format
 msgid "Loading posts"
@@ -8729,30 +8725,30 @@ msgstr "Beiträge werden geladen"
 msgid "Social media posts"
 msgstr "Social-Media-Beiträge"
 
-#: lib/vutuv_web/templates/import/new.html.heex:50
+#: lib/vutuv_web/templates/import/new.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Click \"Request archive\"."
 msgstr "Klicken Sie auf „Archiv anfordern“."
 
-#: lib/vutuv_web/templates/import/new.html.heex:62
+#: lib/vutuv_web/templates/import/new.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "LinkedIn's \"Download my data\" page with \"Download larger data archive\" selected and the \"Request archive\" button below it."
 msgstr ""
 "Die LinkedIn-Seite „Meine Daten herunterladen“ mit ausgewähltem „Größeres "
 "Datenarchiv herunterladen“ und der Schaltfläche „Archiv anfordern“ darunter."
 
-#: lib/vutuv_web/templates/import/new.html.heex:38
+#: lib/vutuv_web/templates/import/new.html.heex:39
 #, elixir-autogen, elixir-format
 msgid "Open LinkedIn's data export page"
 msgstr "LinkedIn-Datenexport-Seite öffnen"
 
-#: lib/vutuv_web/templates/import/new.html.heex:72
+#: lib/vutuv_web/templates/import/new.html.heex:73
 #, elixir-autogen, elixir-format
 msgid "Select the larger archive, then click \"Request archive\"."
 msgstr ""
 "Wählen Sie das größere Archiv und klicken Sie dann auf „Archiv anfordern“."
 
-#: lib/vutuv_web/templates/import/new.html.heex:27
+#: lib/vutuv_web/templates/import/new.html.heex:28
 #, elixir-autogen, elixir-format
 msgid "LinkedIn lets you export your own data as a ZIP archive. Open the export page, request the larger archive, and download the ZIP once LinkedIn has finished preparing it (this usually takes a few minutes)."
 msgstr ""
@@ -8761,14 +8757,14 @@ msgstr ""
 " die ZIP-Datei herunter, sobald LinkedIn sie fertig vorbereitet hat (das "
 "dauert meist nur wenige Minuten)."
 
-#: lib/vutuv_web/templates/import/new.html.heex:52
+#: lib/vutuv_web/templates/import/new.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "LinkedIn prepares your archive. When it is ready (usually after a few minutes), download the ZIP to your device."
 msgstr ""
 "LinkedIn bereitet Ihr Archiv vor. Sobald es fertig ist (meist nach wenigen "
 "Minuten), laden Sie die ZIP-Datei auf Ihr Gerät herunter."
 
-#: lib/vutuv_web/templates/import/new.html.heex:78
+#: lib/vutuv_web/templates/import/new.html.heex:79
 #, elixir-autogen, elixir-format
 msgid "Then upload the ZIP file below to see the preview and pick what to add."
 msgstr ""
@@ -8780,7 +8776,7 @@ msgstr ""
 msgid "What gets imported"
 msgstr "Was importiert wird"
 
-#: lib/vutuv_web/templates/import/new.html.heex:18
+#: lib/vutuv_web/templates/import/new.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "You decide exactly what to add. In the next step we show you everything we found and you pick it entry by entry, so you never import anything sight unseen. Nothing is added until you confirm, and your existing entries are never overwritten."
 msgstr ""
@@ -8797,7 +8793,7 @@ msgstr ""
 "Importieren Sie die Daten Ihres LinkedIn-Profils in Ihr vutuv-Profil. Aus "
 "Ihrem Export können wir übernehmen:"
 
-#: lib/vutuv_web/templates/import/new.html.heex:110
+#: lib/vutuv_web/templates/import/new.html.heex:111
 #, elixir-autogen, elixir-format
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
@@ -8899,14 +8895,14 @@ msgstr ""
 msgid "The file you sent is too large."
 msgstr "Die gesendete Datei ist zu groß."
 
-#: lib/vutuv_web/templates/import/new.html.heex:92
+#: lib/vutuv_web/templates/import/new.html.heex:93
 #, elixir-autogen, elixir-format
 msgid "This file is too large. Please choose a ZIP of at most 50 MB."
 msgstr ""
 "Diese Datei ist zu groß. Bitte wählen Sie eine ZIP-Datei mit höchstens 50 "
 "MB."
 
-#: lib/vutuv_web/templates/import/new.html.heex:115
+#: lib/vutuv_web/templates/import/new.html.heex:116
 #, elixir-autogen, elixir-format
 msgid "ZIP file, up to 50 MB."
 msgstr "ZIP-Datei, bis zu 50 MB."
@@ -9032,7 +9028,7 @@ msgstr ""
 msgid "Not written yet"
 msgstr "Noch nicht verfasst"
 
-#: lib/vutuv_web/components/organization_components.ex:226
+#: lib/vutuv_web/components/organization_components.ex:234
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "Page"
@@ -9069,7 +9065,7 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/agent_docs/markdown.ex:610
 #: lib/vutuv_web/agent_docs/text.ex:567
 #: lib/vutuv_web/agent_docs/text.ex:571
-#: lib/vutuv_web/components/organization_components.ex:258
+#: lib/vutuv_web/components/organization_components.ex:266
 #: lib/vutuv_web/components/ui.ex:3915
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:323
@@ -9163,7 +9159,7 @@ msgstr "Praktikum"
 msgid "Internships"
 msgstr "Praktika"
 
-#: lib/vutuv_web/templates/import/new.html.heex:46
+#: lib/vutuv_web/templates/import/new.html.heex:47
 #, elixir-autogen, elixir-format
 msgid "On that page, select \"Download larger data archive\" (profile, positions, volunteering, education, skills)."
 msgstr ""
@@ -10027,7 +10023,7 @@ msgstr ""
 msgid "“%{name}” is an honor tag now. Add members below."
 msgstr "„%{name}“ ist jetzt ein Ehren-Tag. Fügen Sie unten Mitglieder hinzu."
 
-#: lib/vutuv_web/controllers/import_controller.ex:183
+#: lib/vutuv_web/controllers/import_controller.ex:194
 #, elixir-autogen, elixir-format
 msgid "%{count} certificate or license"
 msgid_plural "%{count} certificates or licenses"
@@ -10077,13 +10073,15 @@ msgstr "Zertifikate"
 #: lib/vutuv_web/cv/latex.ex:140
 #: lib/vutuv_web/cv/odt.ex:154
 #: lib/vutuv_web/live/cv_live.ex:361
-#: lib/vutuv_web/templates/import/preview.html.heex:27
+#: lib/vutuv_web/templates/import/new.html.heex:11
+#: lib/vutuv_web/templates/import/preview.html.heex:48
 #: lib/vutuv_web/templates/qualification/edit.html.heex:4
 #: lib/vutuv_web/templates/qualification/index.html.heex:11
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
 #: lib/vutuv_web/templates/user/show.html.heex:834
+#: lib/vutuv_web/views/import_html.ex:63
 #: lib/vutuv_web/views/job_reference_html.ex:266
 #, elixir-autogen, elixir-format
 msgid "Certificates & licenses"
@@ -10146,7 +10144,7 @@ msgstr "Lizenz"
 msgid "Licenses"
 msgstr "Lizenzen"
 
-#: lib/vutuv_web/templates/import/preview.html.heex:29
+#: lib/vutuv_web/templates/import/preview.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "LinkedIn does not say whether an entry is a certificate or a license, so we import all of them as certificates. Please review the section afterwards and switch any that are licenses."
 msgstr ""
@@ -11354,7 +11352,7 @@ msgstr "Screenshot-Warteschlange öffnen"
 #: lib/vutuv_web/live/admin/organization_live.ex:179
 #: lib/vutuv_web/live/admin/organization_live.ex:194
 #: lib/vutuv_web/live/admin/screenshot_live.ex:535
-#: lib/vutuv_web/live/organization_live/domains.ex:197
+#: lib/vutuv_web/live/organization_live/domains.ex:203
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr "Ausstehend"
@@ -11632,7 +11630,7 @@ msgstr "Ihre Ausschlussliste ist voll (max. %{count})."
 msgid "Your list is empty. Nobody is excluded yet."
 msgstr "Ihre Liste ist leer. Es ist noch niemand ausgeschlossen."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:328
+#: lib/vutuv_web/live/organization_live/edit.ex:334
 #: lib/vutuv_web/views/account_event_text.ex:210
 #, elixir-autogen, elixir-format
 msgid "AI agents"
@@ -11648,8 +11646,8 @@ msgstr "Über die Organisation"
 msgid "Continue to verification"
 msgstr "Weiter zur Verifizierung"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:261
-#: lib/vutuv_web/live/organization_live/domains.ex:301
+#: lib/vutuv_web/live/organization_live/domains.ex:267
+#: lib/vutuv_web/live/organization_live/domains.ex:307
 #: lib/vutuv_web/live/organization_live/new.ex:161
 #: lib/vutuv_web/live/organization_live/show.ex:838
 #: lib/vutuv_web/templates/url/verify.html.heex:46
@@ -11657,37 +11655,37 @@ msgstr "Weiter zur Verifizierung"
 msgid "DNS TXT record"
 msgstr "DNS-TXT-Eintrag"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:180
-#: lib/vutuv_web/live/organization_live/domains.ex:342
+#: lib/vutuv_web/live/organization_live/domains.ex:186
+#: lib/vutuv_web/live/organization_live/domains.ex:348
 #: lib/vutuv_web/live/organization_live/show.ex:904
 #: lib/vutuv_web/live/organization_live/show.ex:912
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr "Die Domain-Verifizierung ist auf dieser Installation deaktiviert."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:31
-#: lib/vutuv_web/live/organization_live/edit.ex:240
+#: lib/vutuv_web/live/organization_live/edit.ex:32
+#: lib/vutuv_web/live/organization_live/edit.ex:246
 #, elixir-autogen, elixir-format
 msgid "Edit %{name}"
 msgstr "%{name} bearbeiten"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:314
+#: lib/vutuv_web/live/organization_live/edit.ex:320
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this page and include it in the sitemap."
 msgstr ""
 "Suchmaschinen dürfen diese Seite indexieren und in die Sitemap aufnehmen."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:247
+#: lib/vutuv_web/live/organization_live/edit.ex:253
 #, elixir-autogen, elixir-format
 msgid "Logo"
 msgstr "Logo"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:275
+#: lib/vutuv_web/live/organization_live/edit.ex:281
 #, elixir-autogen, elixir-format
 msgid "Markdown is supported"
 msgstr "Markdown wird unterstützt"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:330
+#: lib/vutuv_web/live/organization_live/edit.ex:336
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) and list them for AI agents."
 msgstr ""
@@ -11705,7 +11703,7 @@ msgstr "Bitte loggen Sie sich zuerst ein."
 msgid "Prove you control %{domain} to publish this page."
 msgstr "Weisen Sie nach, dass Ihnen %{domain} gehört, um diese Seite zu veröffentlichen."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:258
+#: lib/vutuv_web/live/organization_live/edit.ex:264
 #, elixir-autogen, elixir-format
 msgid "Remove logo"
 msgstr "Logo entfernen"
@@ -11715,7 +11713,7 @@ msgstr "Logo entfernen"
 msgid "Search by name or city"
 msgstr "Nach Name oder Stadt suchen"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:312
+#: lib/vutuv_web/live/organization_live/edit.ex:318
 #: lib/vutuv_web/views/account_event_text.ex:209
 #, elixir-autogen, elixir-format
 msgid "Search engines"
@@ -11726,29 +11724,29 @@ msgstr "Suchmaschinen"
 msgid "Select a country"
 msgstr "Land auswählen"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:320
+#: lib/vutuv_web/live/organization_live/domains.ex:326
 #: lib/vutuv_web/live/organization_live/show.ex:873
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr "Stellen Sie diese Datei bereit unter:"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:293
+#: lib/vutuv_web/live/organization_live/edit.ex:299
 #: lib/vutuv_web/live/organization_live/new.ex:139
 #, elixir-autogen, elixir-format
 msgid "State / region (optional)"
 msgstr "Bundesland / Region (optional)"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:477
+#: lib/vutuv_web/live/organization_live/edit.ex:483
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr "Dieser Dateityp ist nicht erlaubt."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:475
+#: lib/vutuv_web/live/organization_live/edit.ex:481
 #, elixir-autogen, elixir-format
 msgid "The file is too large."
 msgstr "Die Datei ist zu groß."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:478
+#: lib/vutuv_web/live/organization_live/edit.ex:484
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr "Der Upload ist fehlgeschlagen."
@@ -11780,7 +11778,7 @@ msgstr "Verifiziert über %{domain}"
 msgid "Verify %{name}"
 msgstr "%{name} verifizieren"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:336
+#: lib/vutuv_web/live/organization_live/domains.ex:342
 #: lib/vutuv_web/live/organization_live/show.ex:898
 #, elixir-autogen, elixir-format
 msgid "Verify now"
@@ -11788,14 +11786,14 @@ msgstr "Jetzt verifizieren"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:243
 #: lib/vutuv_web/agent_docs/text.ex:227
-#: lib/vutuv_web/live/organization_live/edit.ex:287
+#: lib/vutuv_web/live/organization_live/edit.ex:293
 #: lib/vutuv_web/live/organization_live/new.ex:130
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr "Website"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:262
-#: lib/vutuv_web/live/organization_live/domains.ex:311
+#: lib/vutuv_web/live/organization_live/domains.ex:268
+#: lib/vutuv_web/live/organization_live/domains.ex:317
 #: lib/vutuv_web/live/organization_live/show.ex:849
 #: lib/vutuv_web/templates/url/verify.html.heex:99
 #, elixir-autogen, elixir-format
@@ -11807,7 +11805,7 @@ msgstr "Website-Datei"
 msgid "Website file (.well-known)"
 msgstr "Website-Datei (.well-known)"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:476
+#: lib/vutuv_web/live/organization_live/edit.ex:482
 #, elixir-autogen, elixir-format
 msgid "You can only upload one logo."
 msgstr "Sie können nur ein Logo hochladen."
@@ -11819,65 +11817,65 @@ msgstr ""
 "Im nächsten Schritt veröffentlichen Sie einen Eintrag oder eine Datei, um "
 "die Kontrolle über die Domain nachzuweisen."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:322
+#: lib/vutuv_web/live/organization_live/domains.ex:328
 #: lib/vutuv_web/live/organization_live/show.ex:879
 #: lib/vutuv_web/templates/url/verify.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
 msgstr "mit genau diesem Inhalt:"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:180
+#: lib/vutuv_web/live/organization_live/roles.ex:186
 #, elixir-autogen, elixir-format
 msgid "@handle or email"
 msgstr "@handle oder E-Mail"
 
-#: lib/vutuv_web/components/organization_components.ex:307
-#: lib/vutuv_web/live/organization_live/edit.ex:390
+#: lib/vutuv_web/components/organization_components.ex:315
+#: lib/vutuv_web/live/organization_live/edit.ex:396
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
 msgstr "Abkürzung"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:249
+#: lib/vutuv_web/live/organization_live/domains.ex:255
 #, elixir-autogen, elixir-format
 msgid "Add a domain"
 msgstr "Domain hinzufügen"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:171
+#: lib/vutuv_web/live/organization_live/roles.ex:177
 #, elixir-autogen, elixir-format
 msgid "Add a member"
 msgstr "Mitglied hinzufügen"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:143
+#: lib/vutuv_web/live/organization_live/roles.ex:144
 #, elixir-autogen, elixir-format
 msgid "Added @%{handle} to the team."
 msgstr "@%{handle} zum Team hinzugefügt."
 
-#: lib/vutuv_web/components/organization_components.ex:308
-#: lib/vutuv_web/live/organization_live/edit.ex:388
+#: lib/vutuv_web/components/organization_components.ex:316
+#: lib/vutuv_web/live/organization_live/edit.ex:394
 #, elixir-autogen, elixir-format
 msgid "Alias"
 msgstr "Alias"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:99
+#: lib/vutuv_web/live/organization_live/edit.ex:100
 #, elixir-autogen, elixir-format
 msgid "Alias added."
 msgstr "Alias hinzugefügt."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:123
+#: lib/vutuv_web/live/organization_live/edit.ex:124
 #, elixir-autogen, elixir-format
 msgid "Alias removed."
 msgstr "Alias entfernt."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:427
 #: lib/vutuv_web/agent_docs/text.ex:444
-#: lib/vutuv_web/live/organization_live/edit.ex:353
+#: lib/vutuv_web/live/organization_live/edit.ex:359
 #: lib/vutuv_web/live/organization_live/show.ex:774
 #: lib/vutuv_web/templates/tag/single_card.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Also known as"
 msgstr "Auch bekannt als"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:384
+#: lib/vutuv_web/live/organization_live/edit.ex:390
 #, elixir-autogen, elixir-format
 msgid "Alternative name"
 msgstr "Alternativer Name"
@@ -11898,8 +11896,8 @@ msgstr "Diese Seite archivieren?"
 msgid "Archived"
 msgstr "Archiviert"
 
-#: lib/vutuv_web/components/organization_components.ex:306
-#: lib/vutuv_web/live/organization_live/edit.ex:389
+#: lib/vutuv_web/components/organization_components.ex:314
+#: lib/vutuv_web/live/organization_live/edit.ex:395
 #, elixir-autogen, elixir-format
 msgid "Brand"
 msgstr "Marke"
@@ -11909,7 +11907,7 @@ msgstr "Marke"
 msgid "Claimed by"
 msgstr "Beansprucht von"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:216
+#: lib/vutuv_web/live/organization_live/roles.ex:222
 #, elixir-autogen, elixir-format
 msgid "Current team"
 msgstr "Aktuelles Team"
@@ -11921,37 +11919,37 @@ msgstr ""
 "Diese Seite und alles, was dazugehört, löschen? Das kann nicht rückgängig "
 "gemacht werden."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:65
+#: lib/vutuv_web/live/organization_live/domains.ex:66
 #, elixir-autogen, elixir-format
 msgid "Domain added. Publish the record or file, then verify it."
 msgstr ""
 "Domain hinzugefügt. Veröffentlichen Sie den Eintrag oder die Datei und "
 "starten Sie dann die Verifizierung."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:139
+#: lib/vutuv_web/live/organization_live/domains.ex:140
 #, elixir-autogen, elixir-format
 msgid "Domain removed."
 msgstr "Domain entfernt."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:108
+#: lib/vutuv_web/live/organization_live/domains.ex:109
 #, elixir-autogen, elixir-format
 msgid "Domain verified."
 msgstr "Domain verifiziert."
 
-#: lib/vutuv_web/components/organization_components.ex:232
+#: lib/vutuv_web/components/organization_components.ex:240
 #: lib/vutuv_web/live/admin/organization_live.ex:305
-#: lib/vutuv_web/live/organization_live/domains.ex:174
+#: lib/vutuv_web/live/organization_live/domains.ex:180
 #: lib/vutuv_web/live/organization_live/show.ex:525
 #, elixir-autogen, elixir-format
 msgid "Domains"
 msgstr "Domains"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:29
+#: lib/vutuv_web/live/organization_live/domains.ex:30
 #, elixir-autogen, elixir-format
 msgid "Domains – %{name}"
 msgstr "Domains – %{name}"
 
-#: lib/vutuv_web/components/organization_components.ex:305
+#: lib/vutuv_web/components/organization_components.ex:313
 #, elixir-autogen, elixir-format
 msgid "Former name"
 msgstr "Früherer Name"
@@ -11970,13 +11968,13 @@ msgstr ""
 "Diese Seite einfrieren? Sie verschwindet für die Öffentlichkeit, bleibt aber "
 "für den Besitzer sichtbar."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:202
+#: lib/vutuv_web/live/organization_live/domains.ex:208
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "Last checked"
 msgstr "Zuletzt geprüft"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:243
+#: lib/vutuv_web/live/organization_live/roles.ex:249
 #, elixir-autogen, elixir-format
 msgid "Leave"
 msgstr "Verlassen"
@@ -11991,17 +11989,17 @@ msgstr "Verlassen"
 msgid "Live"
 msgstr "Live"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:233
+#: lib/vutuv_web/live/organization_live/domains.ex:239
 #, elixir-autogen, elixir-format
 msgid "Make primary"
 msgstr "Als primär festlegen"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:94
+#: lib/vutuv_web/live/organization_live/roles.ex:95
 #, elixir-autogen, elixir-format
 msgid "Member removed."
 msgstr "Mitglied entfernt."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:202
+#: lib/vutuv_web/live/organization_live/domains.ex:208
 #, elixir-autogen, elixir-format
 msgid "Method"
 msgstr "Methode"
@@ -12011,42 +12009,42 @@ msgstr "Methode"
 msgid "Names & aliases"
 msgstr "Namen & Aliasse"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:81
+#: lib/vutuv_web/live/organization_live/roles.ex:82
 #, elixir-autogen, elixir-format
 msgid "No member found for “%{id}”."
 msgstr "Kein Mitglied für „%{id}“ gefunden."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:124
+#: lib/vutuv_web/live/organization_live/domains.ex:125
 #, elixir-autogen, elixir-format
 msgid "Only a verified domain can be the primary one."
 msgstr "Nur eine verifizierte Domain kann die primäre sein."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:188
+#: lib/vutuv_web/live/organization_live/domains.ex:194
 #, elixir-autogen, elixir-format
 msgid "Primary"
 msgstr "Primär"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:120
+#: lib/vutuv_web/live/organization_live/domains.ex:121
 #, elixir-autogen, elixir-format
 msgid "Primary domain updated."
 msgstr "Primäre Domain aktualisiert."
 
-#: lib/vutuv_web/components/organization_components.ex:294
+#: lib/vutuv_web/components/organization_components.ex:302
 #, elixir-autogen, elixir-format
 msgid "Recruiter"
 msgstr "Recruiter"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:239
+#: lib/vutuv_web/live/organization_live/domains.ex:245
 #, elixir-autogen, elixir-format
 msgid "Remove this domain?"
 msgstr "Diese Domain entfernen?"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:238
+#: lib/vutuv_web/live/organization_live/roles.ex:244
 #, elixir-autogen, elixir-format
 msgid "Remove this member from the team?"
 msgstr "Dieses Mitglied aus dem Team entfernen?"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:370
+#: lib/vutuv_web/live/organization_live/edit.ex:376
 #, elixir-autogen, elixir-format
 msgid "Remove this name?"
 msgstr "Diesen Namen entfernen?"
@@ -12056,25 +12054,25 @@ msgstr "Diesen Namen entfernen?"
 msgid "Search name, alias or domain"
 msgstr "Name, Alias oder Domain suchen"
 
-#: lib/vutuv_web/components/organization_components.ex:229
+#: lib/vutuv_web/components/organization_components.ex:237
 #: lib/vutuv_web/live/admin/organization_live.ex:321
-#: lib/vutuv_web/live/organization_live/roles.ex:165
+#: lib/vutuv_web/live/organization_live/roles.ex:171
 #: lib/vutuv_web/live/organization_live/show.ex:518
 #, elixir-autogen, elixir-format
 msgid "Team"
 msgstr "Team"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:36
+#: lib/vutuv_web/live/organization_live/roles.ex:37
 #, elixir-autogen, elixir-format
 msgid "Team – %{name}"
 msgstr "Team – %{name}"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:76
+#: lib/vutuv_web/live/organization_live/domains.ex:77
 #, elixir-autogen, elixir-format
 msgid "That is not a valid domain."
 msgstr "Das ist keine gültige Domain."
 
-#: lib/vutuv_web/live/organization_live/roles.ex:146
+#: lib/vutuv_web/live/organization_live/roles.ex:147
 #, elixir-autogen, elixir-format
 msgid "That member could not be added."
 msgstr "Dieses Mitglied konnte nicht hinzugefügt werden."
@@ -12103,39 +12101,39 @@ msgstr "primär"
 msgid "verified"
 msgstr "verifiziert"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:290
+#: lib/vutuv_web/live/organization_live/edit.ex:296
 #: lib/vutuv_web/live/organization_live/new.ex:136
 #, elixir-autogen, elixir-format
 msgid "Street address (optional)"
 msgstr "Straße und Hausnummer (optional)"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:291
+#: lib/vutuv_web/live/organization_live/edit.ex:297
 #: lib/vutuv_web/live/organization_live/new.ex:137
 #, elixir-autogen, elixir-format
 msgid "ZIP / postal code (optional)"
 msgstr "PLZ (optional)"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:447
+#: lib/vutuv_web/live/organization_live/edit.ex:453
 #, elixir-autogen, elixir-format
 msgid "Claim"
 msgstr "Reservieren"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:416
+#: lib/vutuv_web/live/organization_live/edit.ex:422
 #, elixir-autogen, elixir-format
 msgid "Reachable at"
 msgstr "Erreichbar unter"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:203
+#: lib/vutuv_web/live/organization_live/edit.ex:204
 #, elixir-autogen, elixir-format
 msgid "That handle is not available."
 msgstr "Dieses Handle ist nicht verfügbar."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:453
+#: lib/vutuv_web/live/organization_live/edit.ex:459
 #, elixir-autogen, elixir-format
 msgid "Danger zone"
 msgstr "Gefahrenbereich"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:464
+#: lib/vutuv_web/live/organization_live/edit.ex:470
 #, elixir-autogen, elixir-format
 msgid "Really delete %{name}? This cannot be undone."
 msgstr "%{name} wirklich löschen? Das kann nicht rückgängig gemacht werden."
@@ -12293,7 +12291,7 @@ msgstr[1] ""
 "und wurden zur Prüfung markiert. Öffnen Sie unten eine Organisation, um sie "
 "zu sehen."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:355
+#: lib/vutuv_web/live/organization_live/edit.ex:361
 #, elixir-autogen, elixir-format
 msgid "Alternative names, brands or abbreviations this organization is findable under. A rename keeps the old name here automatically."
 msgstr ""
@@ -12301,21 +12299,21 @@ msgstr ""
 "auffindbar ist. Bei einer Umbenennung bleibt der alte Name hier automatisch "
 "erhalten."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:176
+#: lib/vutuv_web/live/organization_live/domains.ex:182
 #, elixir-autogen, elixir-format
 msgid "An organization can prove several domains. The primary one shows in the “Verified via …” badge."
 msgstr ""
 "Eine Organisation kann mehrere Domains nachweisen. Die primäre erscheint im "
 "Abzeichen „Verifiziert über …“."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:146
+#: lib/vutuv_web/live/organization_live/domains.ex:147
 #, elixir-autogen, elixir-format
 msgid "An organization keeps at least one verified domain, so this one cannot be removed."
 msgstr ""
 "Eine Organisation behält mindestens eine verifizierte Domain, daher kann diese "
 "nicht entfernt werden."
 
-#: lib/vutuv_web/live/organization_live/roles.ex:152
+#: lib/vutuv_web/live/organization_live/roles.ex:153
 #, elixir-autogen, elixir-format
 msgid "An organization must keep at least one owner, so the last owner cannot be changed."
 msgstr ""
@@ -12369,23 +12367,23 @@ msgstr "Der Nachweis ist eine kleine technische Änderung an Ihrer Domain: ein D
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr "Diese Schritte sind technisch. Wenn Sie %{domain} nicht selbst verwalten, kopieren Sie den unten gezeigten Eintrag oder die Datei und senden Sie ihn an Ihre IT-Abteilung oder die Firma, die Ihre Website betreut. Sobald sie ihn hinzugefügt hat, kommen Sie hierher zurück und klicken auf „Jetzt verifizieren“."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:468
+#: lib/vutuv_web/live/organization_live/edit.ex:474
 #, elixir-autogen, elixir-format
 msgid "Delete this organization"
 msgstr "Diese Organisation löschen"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:455
+#: lib/vutuv_web/live/organization_live/edit.ex:461
 #, elixir-autogen, elixir-format
 msgid "Deleting this organization page is permanent. Its verified domains and its @handle are freed and can be claimed again."
 msgstr "Das Löschen dieser Organisationsseite ist endgültig. Ihre verifizierten Domains und ihr @handle werden freigegeben und können erneut beansprucht werden."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:268
+#: lib/vutuv_web/live/organization_live/edit.ex:274
 #: lib/vutuv_web/live/organization_live/new.ex:126
 #, elixir-autogen, elixir-format
 msgid "Kind of organization"
 msgstr "Art der Organisation"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:237
+#: lib/vutuv_web/live/organization_live/roles.ex:243
 #, elixir-autogen, elixir-format
 msgid "Leave this organization team?"
 msgstr "Dieses Organisations-Team verlassen?"
@@ -12446,7 +12444,7 @@ msgstr "Organisation gelöscht."
 msgid "Organization frozen."
 msgstr "Organisation eingefroren."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:267
+#: lib/vutuv_web/live/organization_live/edit.ex:273
 #: lib/vutuv_web/live/organization_live/new.ex:125
 #, elixir-autogen, elixir-format
 msgid "Organization name"
@@ -12515,7 +12513,7 @@ msgstr "Bitte loggen Sie sich ein, um eine Organisationsseite zu beanspruchen."
 msgid "Search organizations"
 msgstr "Organisationen durchsuchen"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:72
+#: lib/vutuv_web/live/organization_live/domains.ex:73
 #, elixir-autogen, elixir-format
 msgid "That domain already belongs to an organization page."
 msgstr "Diese Domain gehört bereits zu einer anderen Organisationsseite."
@@ -12525,12 +12523,12 @@ msgstr "Diese Domain gehört bereits zu einer anderen Organisationsseite."
 msgid "That domain already belongs to another organization page."
 msgstr "Diese Domain gehört bereits zu einer anderen Organisationsseite."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:106
+#: lib/vutuv_web/live/organization_live/edit.ex:107
 #, elixir-autogen, elixir-format
 msgid "That name is already listed for this organization."
 msgstr "Dieser Name ist für diese Organisation bereits eingetragen."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:191
+#: lib/vutuv_web/live/organization_live/edit.ex:192
 #, elixir-autogen, elixir-format
 msgid "The organization page was deleted."
 msgstr "Die Organisationsseite wurde gelöscht."
@@ -12561,12 +12559,12 @@ msgstr ""
 "Verifizierte Organisationsseiten: Domains, Team-Rollen, Aliasse und "
 "Umbenennungsverlauf. Seite einfrieren, archivieren oder löschen."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:174
+#: lib/vutuv_web/live/organization_live/edit.ex:175
 #, elixir-autogen, elixir-format
 msgid "You are not allowed to delete this organization."
 msgstr "Sie dürfen diese Organisation nicht löschen."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:139
+#: lib/vutuv_web/live/organization_live/edit.ex:140
 #, elixir-autogen, elixir-format
 msgid "Your organization handle is set."
 msgstr "Ihr Organisations-Handle ist gesetzt."
@@ -12577,7 +12575,7 @@ msgstr "Ihr Organisations-Handle ist gesetzt."
 msgid "Your organization page is verified and now live."
 msgstr "Ihre Organisationsseite ist verifiziert und jetzt live."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:70
+#: lib/vutuv_web/live/organization_live/edit.ex:71
 #, elixir-autogen, elixir-format
 msgid "Your organization page was updated."
 msgstr "Ihre Organisationsseite wurde aktualisiert."
@@ -12602,7 +12600,7 @@ msgstr "hat Sie zum Administrator von %{organization} gemacht."
 msgid "made you an owner of %{organization}."
 msgstr "hat Sie zum Besitzer von %{organization} gemacht."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:437
+#: lib/vutuv_web/live/organization_live/edit.ex:443
 #, elixir-autogen, elixir-format
 msgid "your_organization"
 msgstr "ihre_organisation"
@@ -13153,17 +13151,17 @@ msgstr "Ihre Stellenanzeige auf vutuv läuft bald ab"
 msgid "A domain of your organization page on vutuv is about to be dropped"
 msgstr "Eine Domain Ihrer Organisationsseite auf vutuv entfällt bald"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:215
+#: lib/vutuv_web/live/organization_live/domains.ex:221
 #, elixir-autogen, elixir-format
 msgid "Deadline"
 msgstr "Frist"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:194
+#: lib/vutuv_web/live/organization_live/domains.ex:200
 #, elixir-autogen, elixir-format
 msgid "Proof missing"
 msgstr "Nachweis fehlt"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:214
+#: lib/vutuv_web/live/organization_live/domains.ex:220
 #, elixir-autogen, elixir-format
 msgid "We could not read this domain's proof on the last check. Restore it and check again, or the domain loses its verification."
 msgstr "Der Nachweis dieser Domain war bei der letzten Prüfung nicht abrufbar. Stellen Sie ihn wieder her und prüfen Sie erneut, sonst verliert die Domain ihre Verifizierung."
@@ -13276,13 +13274,13 @@ msgstr "DNS-Änderungen brauchen manchmal etwas, bis sie überall angekommen sin
 msgid "Getting an error, or is %{host} a CNAME / alias to another address? A TXT record cannot share a name with a CNAME. Use this name instead, with the exact same value as above:"
 msgstr "Bekommen Sie einen Fehler, oder ist %{host} ein CNAME / Alias auf eine andere Adresse? Ein TXT-Eintrag kann nicht denselben Namen wie ein CNAME haben. Verwenden Sie stattdessen diesen Namen, mit exakt demselben Wert wie oben:"
 
-#: lib/vutuv_web/live/organization_live/domains.ex:318
+#: lib/vutuv_web/live/organization_live/domains.ex:324
 #: lib/vutuv_web/live/organization_live/show.ex:866
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr "Ist %{domain} ein CNAME / Alias (ein TXT-Eintrag kann nicht denselben Namen wie ein CNAME haben), legen Sie den Eintrag stattdessen auf %{name} an, mit demselben Wert."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:316
+#: lib/vutuv_web/live/organization_live/domains.ex:322
 #: lib/vutuv_web/live/organization_live/show.ex:857
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
@@ -13298,7 +13296,7 @@ msgstr "Legen Sie in Ihren DNS-Einstellungen einen neuen TXT-Eintrag mit diesem 
 msgid "Name (host)"
 msgstr "Name (Host)"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:147
+#: lib/vutuv_web/live/organization_live/edit.ex:148
 #, elixir-autogen, elixir-format
 msgid "Only a verified organization page can claim a handle."
 msgstr "Nur eine verifizierte Organisationsseite kann ein Handle beanspruchen."
@@ -13846,7 +13844,7 @@ msgstr "Jedes angemeldete Mitglied mit einer bestätigten E-Mail-Adresse auf die
 msgid "Back to the posting"
 msgstr "Zurück zur Stellenanzeige"
 
-#: lib/vutuv_web/live/organization_live/exclusions.ex:106
+#: lib/vutuv_web/live/organization_live/exclusions.ex:112
 #, elixir-autogen, elixir-format
 msgid "Every posting attributed to this organization inherits this standing list, on top of its own. Use it to keep vacancies away from competitors you never advertise to."
 msgstr "Jede dieser Organisation zugeordnete Stellenanzeige erbt diese dauerhafte Liste zusätzlich zu ihrer eigenen. So halten Sie Ausschreibungen von Wettbewerbern fern, denen Sie nie Stellen anzeigen möchten."
@@ -13877,13 +13875,13 @@ msgstr "Vor bestimmten Personen verbergen (Wettbewerber, eigene Belegschaft, Ein
 msgid "Inherited from the organization"
 msgstr "Von der Organisation geerbt"
 
-#: lib/vutuv_web/components/organization_components.ex:235
-#: lib/vutuv_web/live/organization_live/exclusions.ex:103
+#: lib/vutuv_web/components/organization_components.ex:243
+#: lib/vutuv_web/live/organization_live/exclusions.ex:109
 #, elixir-autogen, elixir-format
 msgid "Job exclusions"
 msgstr "Ausschlussliste"
 
-#: lib/vutuv_web/live/organization_live/exclusions.ex:33
+#: lib/vutuv_web/live/organization_live/exclusions.ex:34
 #, elixir-autogen, elixir-format
 msgid "Job exclusions – %{name}"
 msgstr "Ausschlussliste – %{name}"
@@ -13964,7 +13962,7 @@ msgstr "Alias-Markierung entfernt."
 msgid "Reviewed, all fine: clear the flag"
 msgstr "Geprüft, alles in Ordnung: Markierung entfernen"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:181
+#: lib/vutuv_web/live/organization_live/edit.ex:182
 #, elixir-autogen, elixir-format
 msgid "This page has job postings, so it cannot be deleted. Ask an admin to archive it instead."
 msgstr ""
@@ -15194,7 +15192,7 @@ msgstr "Wort oder Phrase (ganzes Wort)"
 msgid "Word, phrase or tag to mute"
 msgstr "Wort, Phrase oder Tag zum Stummschalten"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:161
+#: lib/vutuv_web/live/organization_live/edit.ex:162
 #, elixir-autogen, elixir-format
 msgid "You are not allowed to change this organization's handle."
 msgstr "Sie dürfen den Benutzernamen dieser Organisation nicht ändern."
@@ -20717,47 +20715,47 @@ msgstr "Von vorn beginnen"
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr "Ein Herz oder ein Repost geht zurück in das Netzwerk, aus dem dieser Beitrag stammt. Ihr Konto nimmt derzeit nicht am Fediverse teil. Einschalten können Sie das in den {settings}."
 
-#: lib/vutuv_web/components/organization_components.ex:293
+#: lib/vutuv_web/components/organization_components.ex:301
 #, elixir-autogen, elixir-format
 msgid "Editorial"
 msgstr "Redaktion"
 
-#: lib/vutuv_web/components/organization_components.ex:299
+#: lib/vutuv_web/components/organization_components.ex:307
 #, elixir-autogen, elixir-format
 msgid "Edits the page and posts jobs."
 msgstr "Bearbeitet die Seite und schreibt Stellen aus."
 
-#: lib/vutuv_web/live/organization_live/roles.ex:167
+#: lib/vutuv_web/live/organization_live/roles.ex:173
 #, elixir-autogen, elixir-format
 msgid "Give members their roles on this page. Someone can hold several at once, and every role is granted on its own."
 msgstr "Geben Sie Mitgliedern ihre Rollen auf dieser Seite. Jemand kann mehrere gleichzeitig haben, und jede Rolle wird einzeln vergeben."
 
-#: lib/vutuv_web/components/organization_components.ex:298
+#: lib/vutuv_web/components/organization_components.ex:306
 #, elixir-autogen, elixir-format
 msgid "Manages the team and the domains, and edits the page."
 msgstr "Verwaltet Team und Domains und bearbeitet die Seite."
 
-#: lib/vutuv_web/live/organization_live/roles.ex:74
+#: lib/vutuv_web/live/organization_live/roles.ex:75
 #, elixir-autogen, elixir-format
 msgid "Pick at least one role."
 msgstr "Wählen Sie mindestens eine Rolle."
 
-#: lib/vutuv_web/components/organization_components.ex:301
+#: lib/vutuv_web/components/organization_components.ex:309
 #, elixir-autogen, elixir-format
 msgid "Posts jobs."
 msgstr "Schreibt Stellen aus."
 
-#: lib/vutuv_web/live/organization_live/roles.ex:270
+#: lib/vutuv_web/live/organization_live/roles.ex:276
 #, elixir-autogen, elixir-format
 msgid "Roles"
 msgstr "Rollen"
 
-#: lib/vutuv_web/live/organization_live/roles.ex:88
+#: lib/vutuv_web/live/organization_live/roles.ex:89
 #, elixir-autogen, elixir-format
 msgid "Roles updated."
 msgstr "Rollen aktualisiert."
 
-#: lib/vutuv_web/components/organization_components.ex:300
+#: lib/vutuv_web/components/organization_components.ex:308
 #, elixir-autogen, elixir-format
 msgid "Writes posts in the organization's name."
 msgstr "Schreibt Beiträge im Namen der Organisation."
@@ -20890,7 +20888,7 @@ msgstr "%{name} hat diese Seite erwähnt."
 msgid "%{name} follows"
 msgstr "%{name} folgt"
 
-#: lib/vutuv_web/live/organization_live/feed.ex:41
+#: lib/vutuv_web/live/organization_live/feed.ex:49
 #, elixir-autogen, elixir-format
 msgid "Feed – %{name}"
 msgstr "Feed – %{name}"
@@ -20905,7 +20903,7 @@ msgstr "Als %{name} folgen"
 msgid "Members and organizations"
 msgstr "Mitglieder und Organisationen"
 
-#: lib/vutuv_web/live/organization_live/feed.ex:85
+#: lib/vutuv_web/live/organization_live/feed.ex:107
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. This page does not follow anyone, or nobody it follows has published."
 msgstr "Noch nichts da. Diese Seite folgt niemandem, oder niemand, dem sie folgt, hat etwas veröffentlicht."
@@ -20936,7 +20934,7 @@ msgstr "Themen"
 msgid "Unfollow %{tag}"
 msgstr "%{tag} entfolgen"
 
-#: lib/vutuv_web/live/organization_live/feed.ex:81
+#: lib/vutuv_web/live/organization_live/feed.ex:103
 #, elixir-autogen, elixir-format
 msgid "What the members and organizations this page follows have published. Liking or saving something here is done from your own account, not the page's."
 msgstr "Was die Mitglieder und Organisationen veröffentlicht haben, denen diese Seite folgt. Wer hier etwas mag oder speichert, tut das aus dem eigenen Konto, nicht aus dem der Seite."
@@ -21085,12 +21083,12 @@ msgstr "Diese Seite war früher auf anderen Netzwerken sichtbar. Server, die noc
 msgid "This vutuv exchanges nothing with other networks, so nothing here has any effect."
 msgstr "Dieses vutuv tauscht nichts mit anderen Netzwerken aus, hier hat also nichts eine Wirkung."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:408
+#: lib/vutuv_web/live/organization_live/edit.ex:414
 #, elixir-autogen, elixir-format
 msgid "Claim a short @name so this organization has an address of its own, like a member. Letters, numbers and underscores, %{min} to %{max} characters."
 msgstr "Reservieren Sie einen kurzen @-Namen, damit diese Organisation eine eigene Adresse bekommt, so wie ein Mitglied. Buchstaben, Zahlen und Unterstriche, %{min} bis %{max} Zeichen."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:406
+#: lib/vutuv_web/live/organization_live/edit.ex:412
 #, elixir-autogen, elixir-format
 msgid "The organization's @name"
 msgstr "Der @-Name der Organisation"
@@ -21325,7 +21323,7 @@ msgstr "Die Abfrage bei gravatar.com ist auf dieser Installation abgeschaltet."
 msgid "A new entry can take a while to reach everyone. We keep checking %{domain} by ourselves and send you an email as soon as it works, so you can close this page."
 msgstr "Ein neuer Eintrag braucht manchmal eine Weile, bis er überall ankommt. Wir prüfen %{domain} von selbst weiter und schicken Ihnen eine E-Mail, sobald es klappt. Sie können diese Seite also schließen."
 
-#: lib/vutuv_web/live/organization_live/domains.ex:332
+#: lib/vutuv_web/live/organization_live/domains.ex:338
 #: lib/vutuv_web/live/organization_live/show.ex:894
 #, elixir-autogen, elixir-format
 msgid "Checking …"
@@ -21420,3 +21418,70 @@ msgstr "Unternehmen"
 #, elixir-autogen, elixir-format
 msgid "Legal"
 msgstr "Rechtliches"
+
+#: lib/vutuv_web/controllers/import_controller.ex:247
+#, elixir-autogen, elixir-format
+msgid "%{count} entry could not be added."
+msgid_plural "%{count} entries could not be added."
+msgstr[0] "%{count} Eintrag konnte nicht hinzugefügt werden."
+msgstr[1] "%{count} Einträge konnten nicht hinzugefügt werden."
+
+#: lib/vutuv_web/controllers/import_controller.ex:237
+#, elixir-autogen, elixir-format
+msgid "%{count} social account could not be added because another member has already claimed it."
+msgid_plural "%{count} social accounts could not be added because another member has already claimed them."
+msgstr[0] ""
+"%{count} Social-Media-Konto konnte nicht hinzugefügt werden, weil ein "
+"anderes Mitglied es bereits belegt."
+msgstr[1] ""
+"%{count} Social-Media-Konten konnten nicht hinzugefügt werden, weil andere "
+"Mitglieder sie bereits belegen."
+
+#: lib/vutuv_web/views/import_html.ex:31
+#, elixir-autogen, elixir-format
+msgid "Already on your profile"
+msgstr "Schon im Profil"
+
+#: lib/vutuv_web/templates/import/preview.html.heex:11
+#, elixir-autogen, elixir-format
+msgid "Analysis complete. Nothing has been imported yet."
+msgstr "Analyse abgeschlossen. Es wurde noch nichts importiert."
+
+#: lib/vutuv_web/views/import_html.ex:30
+#, elixir-autogen, elixir-format
+msgid "Found"
+msgstr "Gefunden"
+
+#: lib/vutuv_web/views/import_html.ex:32
+#, elixir-autogen, elixir-format
+msgid "Ready to import"
+msgstr "Zum Import bereit"
+
+#: lib/vutuv_web/templates/import/preview.html.heex:13
+#, elixir-autogen, elixir-format
+msgid "Review the entries below and confirm your selection to add them to your profile."
+msgstr ""
+"Prüfen Sie die Einträge unten und bestätigen Sie Ihre Auswahl, um sie in Ihr "
+"Profil zu übernehmen."
+
+#: lib/vutuv_web/views/import_html.ex:29
+#, elixir-autogen, elixir-format
+msgid "Section"
+msgstr "Bereich"
+
+#: lib/vutuv_web/controllers/import_controller.ex:219
+#, elixir-autogen, elixir-format
+msgid "Skipped %{count} entry that is already on your profile."
+msgid_plural "Skipped %{count} entries that are already on your profile."
+msgstr[0] "%{count} Eintrag übersprungen, der schon in Ihrem Profil steht."
+msgstr[1] "%{count} Einträge übersprungen, die schon in Ihrem Profil stehen."
+
+#: lib/vutuv_web/templates/import/preview.html.heex:20
+#, elixir-autogen, elixir-format
+msgid "You can analyse the same or a newer LinkedIn archive again at any time. Nothing is duplicated and nothing is overwritten. Entries you already have are not updated either: they keep the description and dates they have on vutuv, even when your archive holds newer ones."
+msgstr ""
+"Sie können dasselbe oder ein neueres LinkedIn-Archiv jederzeit erneut "
+"analysieren. Dabei wird nichts doppelt angelegt und nichts überschrieben. "
+"Vorhandene Einträge werden aber auch nicht aktualisiert: Sie behalten die "
+"Beschreibung und die Zeitangaben, die sie auf vutuv haben, auch wenn Ihr "
+"Archiv neuere enthält."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Language: INSERT LANGUAGE HERE\n"
 
-#: lib/vutuv_web/controllers/page_controller.ex:174
+#: lib/vutuv_web/controllers/page_controller.ex:184
 #: lib/vutuv_web/templates/layout/app.html.heex:132
 #, elixir-autogen
 msgid "About us"
@@ -21,9 +21,9 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3605
 #: lib/vutuv_web/live/admin/screenshot_live.ex:266
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:718
-#: lib/vutuv_web/live/organization_live/domains.ex:268
-#: lib/vutuv_web/live/organization_live/edit.ex:396
-#: lib/vutuv_web/live/organization_live/roles.ex:210
+#: lib/vutuv_web/live/organization_live/domains.ex:274
+#: lib/vutuv_web/live/organization_live/edit.ex:402
+#: lib/vutuv_web/live/organization_live/roles.ex:216
 #, elixir-autogen
 msgid "Add"
 msgstr ""
@@ -116,13 +116,13 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
 #: lib/vutuv_web/live/job_posting_live/form.ex:605
-#: lib/vutuv_web/live/organization_live/edit.ex:347
+#: lib/vutuv_web/live/organization_live/edit.ex:353
 #: lib/vutuv_web/live/organization_live/new.ex:231
 #: lib/vutuv_web/live/post_live/composer.ex:1370
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
-#: lib/vutuv_web/templates/import/preview.html.heex:86
+#: lib/vutuv_web/templates/import/preview.html.heex:107
 #: lib/vutuv_web/templates/report/new.html.heex:103
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:276
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:259
@@ -177,8 +177,8 @@ msgid "Delete"
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:481
-#: lib/vutuv_web/live/organization_live/edit.ex:272
-#: lib/vutuv_web/live/organization_live/edit.ex:281
+#: lib/vutuv_web/live/organization_live/edit.ex:278
+#: lib/vutuv_web/live/organization_live/edit.ex:287
 #: lib/vutuv_web/templates/address/card_list.html.heex:5
 #: lib/vutuv_web/templates/address/form_en.html.heex:11
 #: lib/vutuv_web/templates/address/form_generic.html.heex:13
@@ -414,13 +414,14 @@ msgstr ""
 #: lib/vutuv_web/cv/latex.ex:164
 #: lib/vutuv_web/cv/odt.ex:176
 #: lib/vutuv_web/live/cv_live.ex:336
-#: lib/vutuv_web/templates/import/new.html.heex:12
-#: lib/vutuv_web/templates/import/preview.html.heex:40
+#: lib/vutuv_web/templates/import/new.html.heex:13
+#: lib/vutuv_web/templates/import/preview.html.heex:61
 #: lib/vutuv_web/templates/url/edit.html.heex:4
 #: lib/vutuv_web/templates/url/index.html.heex:10
 #: lib/vutuv_web/templates/url/manage.html.heex:4
 #: lib/vutuv_web/templates/url/new.html.heex:4
 #: lib/vutuv_web/templates/url/show.html.heex:6
+#: lib/vutuv_web/views/import_html.ex:65
 #, elixir-autogen
 msgid "Links"
 msgstr ""
@@ -613,7 +614,7 @@ msgid "Public"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3388
-#: lib/vutuv_web/live/organization_live/edit.ex:341
+#: lib/vutuv_web/live/organization_live/edit.ex:347
 #: lib/vutuv_web/live/post_live/composer.ex:1813
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
@@ -856,7 +857,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3899
 #: lib/vutuv_web/controllers/settings_controller.ex:159
 #: lib/vutuv_web/live/job_posting_live/form.ex:561
-#: lib/vutuv_web/live/organization_live/edit.ex:300
+#: lib/vutuv_web/live/organization_live/edit.ex:306
 #: lib/vutuv_web/templates/email/card_list.html.heex:7
 #: lib/vutuv_web/templates/email/show.html.heex:24
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:295
@@ -1074,7 +1075,7 @@ msgstr ""
 msgid "Listings"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:323
+#: lib/vutuv_web/controllers/page_controller.ex:333
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:4
 #, elixir-autogen
 msgid "Most Followed Users"
@@ -1143,7 +1144,7 @@ msgstr ""
 msgid "Add Localization"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:289
+#: lib/vutuv_web/components/organization_components.ex:297
 #: lib/vutuv_web/live/admin/activity_live.ex:153
 #: lib/vutuv_web/live/admin/api_app_live.ex:58
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
@@ -1394,8 +1395,8 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:5
 #: lib/vutuv_web/templates/admin/tag/new.html.heex:5
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:5
-#: lib/vutuv_web/templates/import/new.html.heex:11
-#: lib/vutuv_web/templates/import/preview.html.heex:36
+#: lib/vutuv_web/templates/import/new.html.heex:12
+#: lib/vutuv_web/templates/import/preview.html.heex:57
 #: lib/vutuv_web/templates/page/index.html.heex:108
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -1405,6 +1406,7 @@ msgstr ""
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
 #: lib/vutuv_web/templates/user_tag/show.html.heex:6
+#: lib/vutuv_web/views/import_html.ex:64
 #, elixir-autogen
 msgid "Tags"
 msgstr ""
@@ -1560,7 +1562,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:776
 #: lib/vutuv_web/live/job_board_live.ex:360
 #: lib/vutuv_web/live/job_posting_live/form.ex:410
-#: lib/vutuv_web/live/organization_live/edit.ex:296
+#: lib/vutuv_web/live/organization_live/edit.ex:302
 #: lib/vutuv_web/live/organization_live/new.ex:142
 #: lib/vutuv_web/templates/ad/new.html.heex:114
 #: lib/vutuv_web/templates/address/country_input.html.heex:5
@@ -1640,7 +1642,7 @@ msgstr ""
 msgid "Confirm account deletion"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:178
+#: lib/vutuv_web/controllers/page_controller.ex:188
 #: lib/vutuv_web/templates/layout/app.html.heex:138
 #: lib/vutuv_web/templates/page/index.html.heex:261
 #: lib/vutuv_web/views/admin/legal_page_html.ex:11
@@ -1648,7 +1650,7 @@ msgstr ""
 msgid "Datenschutzerklärung"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:184
+#: lib/vutuv_web/controllers/page_controller.ex:194
 #: lib/vutuv_web/templates/layout/app.html.heex:139
 #: lib/vutuv_web/templates/page/index.html.heex:261
 #: lib/vutuv_web/views/admin/legal_page_html.ex:12
@@ -1713,7 +1715,7 @@ msgstr ""
 msgid "Log out"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:295
+#: lib/vutuv_web/components/organization_components.ex:303
 #: lib/vutuv_web/live/admin/activity_live.ex:143
 #: lib/vutuv_web/live/admin/activity_live.ex:175
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
@@ -1920,7 +1922,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3627
 #: lib/vutuv_web/live/organization_live/activity.ex:146
-#: lib/vutuv_web/live/organization_live/feed.ex:101
+#: lib/vutuv_web/live/organization_live/feed.ex:145
 #: lib/vutuv_web/live/organization_live/show.ex:637
 #, elixir-autogen, elixir-format
 msgid "Load more"
@@ -2111,8 +2113,8 @@ msgstr ""
 msgid "Edit post"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:247
-#: lib/vutuv_web/live/organization_live/feed.ex:79
+#: lib/vutuv_web/components/organization_components.ex:255
+#: lib/vutuv_web/live/organization_live/feed.ex:101
 #: lib/vutuv_web/live/post_live/feed.ex:159
 #: lib/vutuv_web/live/post_live/feed.ex:936
 #: lib/vutuv_web/live/shell_live.ex:606
@@ -2227,9 +2229,9 @@ msgstr ""
 #: lib/vutuv_web/live/admin/screenshot_live.ex:338
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:700
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
-#: lib/vutuv_web/live/organization_live/domains.ex:242
-#: lib/vutuv_web/live/organization_live/edit.ex:373
-#: lib/vutuv_web/live/organization_live/roles.ex:243
+#: lib/vutuv_web/live/organization_live/domains.ex:248
+#: lib/vutuv_web/live/organization_live/edit.ex:379
+#: lib/vutuv_web/live/organization_live/roles.ex:249
 #: lib/vutuv_web/live/post_live/composer.ex:1886
 #: lib/vutuv_web/live/post_live/saved.ex:619
 #: lib/vutuv_web/live/post_live/saved.ex:647
@@ -2842,7 +2844,7 @@ msgstr ""
 msgid "Open someone's profile to message them."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:241
+#: lib/vutuv_web/components/organization_components.ex:249
 #: lib/vutuv_web/live/notification_live/index.ex:1050
 #: lib/vutuv_web/live/organization_live/activity.ex:99
 #, elixir-autogen, elixir-format
@@ -3121,7 +3123,7 @@ msgstr ""
 msgid "Opened"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:288
+#: lib/vutuv_web/components/organization_components.ex:296
 #: lib/vutuv_web/live/admin/api_app_live.ex:72
 #: lib/vutuv_web/live/admin/deliverability_live.ex:171
 #: lib/vutuv_web/live/admin/moderation_live.ex:56
@@ -3147,9 +3149,10 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3812
 #: lib/vutuv_web/live/shell_live.ex:619
 #: lib/vutuv_web/live/shell_live.ex:896
-#: lib/vutuv_web/templates/import/new.html.heex:15
-#: lib/vutuv_web/templates/import/preview.html.heex:55
+#: lib/vutuv_web/templates/import/new.html.heex:16
+#: lib/vutuv_web/templates/import/preview.html.heex:76
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
+#: lib/vutuv_web/views/import_html.ex:68
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr ""
@@ -4047,7 +4050,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/organization_live.ex:245
 #: lib/vutuv_web/live/job_posting_live/form.ex:404
-#: lib/vutuv_web/live/organization_live/edit.ex:292
+#: lib/vutuv_web/live/organization_live/edit.ex:298
 #: lib/vutuv_web/live/organization_live/new.ex:138
 #: lib/vutuv_web/templates/ad/new.html.heex:108
 #: lib/vutuv_web/templates/address/form_en.html.heex:33
@@ -4548,7 +4551,7 @@ msgstr ""
 msgid "Find members"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:253
+#: lib/vutuv_web/components/organization_components.ex:261
 #: lib/vutuv_web/live/organization_live/following.ex:154
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:53
@@ -5473,7 +5476,7 @@ msgstr ""
 msgid "Account"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:447
+#: lib/vutuv_web/live/organization_live/edit.ex:453
 #, elixir-autogen, elixir-format
 msgid "Change"
 msgstr ""
@@ -5491,7 +5494,7 @@ msgstr ""
 #: lib/vutuv_web/templates/email/edit.html.heex:4
 #: lib/vutuv_web/templates/email/manage.html.heex:4
 #: lib/vutuv_web/templates/email/new.html.heex:4
-#: lib/vutuv_web/templates/import/preview.html.heex:69
+#: lib/vutuv_web/templates/import/preview.html.heex:90
 #: lib/vutuv_web/templates/settings/security.html.heex:17
 #, elixir-autogen, elixir-format
 msgid "Email addresses"
@@ -7324,14 +7327,14 @@ msgid "accounts"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:991
-#: lib/vutuv_web/views/import_html.ex:67
-#: lib/vutuv_web/views/import_html.ex:71
+#: lib/vutuv_web/views/import_html.ex:132
+#: lib/vutuv_web/views/import_html.ex:136
 #, elixir-autogen, elixir-format
 msgid "Select all"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:994
-#: lib/vutuv_web/views/import_html.ex:68
+#: lib/vutuv_web/views/import_html.ex:133
 #, elixir-autogen, elixir-format
 msgid "Unselect all"
 msgstr ""
@@ -8058,7 +8061,7 @@ msgid "Unreachable"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/member_badges.ex:20
-#: lib/vutuv_web/live/organization_live/domains.ex:191
+#: lib/vutuv_web/live/organization_live/domains.ex:197
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:32
 #, elixir-autogen, elixir-format
 msgid "Verified"
@@ -8082,49 +8085,49 @@ msgstr ""
 msgid "Nobody is online right now."
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:181
+#: lib/vutuv_web/controllers/import_controller.ex:192
 #, elixir-autogen, elixir-format
 msgid "%{count} education entry"
 msgid_plural "%{count} education entries"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:189
+#: lib/vutuv_web/controllers/import_controller.ex:200
 #, elixir-autogen, elixir-format
 msgid "%{count} link"
 msgid_plural "%{count} links"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:193
+#: lib/vutuv_web/controllers/import_controller.ex:204
 #, elixir-autogen, elixir-format
 msgid "%{count} phone number"
 msgid_plural "%{count} phone numbers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:195
+#: lib/vutuv_web/controllers/import_controller.ex:206
 #, elixir-autogen, elixir-format
 msgid "%{count} profile field"
 msgid_plural "%{count} profile fields"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:191
+#: lib/vutuv_web/controllers/import_controller.ex:202
 #, elixir-autogen, elixir-format
 msgid "%{count} social account"
 msgid_plural "%{count} social accounts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:188
+#: lib/vutuv_web/controllers/import_controller.ex:199
 #, elixir-autogen, elixir-format
 msgid "%{count} tag"
 msgid_plural "%{count} tags"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:179
+#: lib/vutuv_web/controllers/import_controller.ex:190
 #, elixir-autogen, elixir-format
 msgid "%{count} work experience"
 msgid_plural "%{count} work experiences"
@@ -8157,8 +8160,9 @@ msgstr ""
 #: lib/vutuv_web/templates/education/new.html.heex:4
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
-#: lib/vutuv_web/templates/import/preview.html.heex:23
+#: lib/vutuv_web/templates/import/preview.html.heex:44
 #: lib/vutuv_web/templates/user/show.html.heex:666
+#: lib/vutuv_web/views/import_html.ex:62
 #: lib/vutuv_web/views/job_reference_html.ex:265
 #, elixir-autogen, elixir-format
 msgid "Education"
@@ -8184,7 +8188,7 @@ msgstr ""
 msgid "Education updated successfully."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/preview.html.heex:71
+#: lib/vutuv_web/templates/import/preview.html.heex:92
 #, elixir-autogen, elixir-format
 msgid "Email addresses are not imported automatically because each one is confirmed by PIN. Add them yourself if you like:"
 msgstr ""
@@ -8195,7 +8199,7 @@ msgstr ""
 msgid "Field of study"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/preview.html.heex:5
+#: lib/vutuv_web/templates/import/preview.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
@@ -8206,7 +8210,7 @@ msgid "Import"
 msgstr ""
 
 #: lib/vutuv_web/controllers/import_controller.ex:36
-#: lib/vutuv_web/controllers/import_controller.ex:121
+#: lib/vutuv_web/controllers/import_controller.ex:126
 #: lib/vutuv_web/templates/import/new.html.heex:1
 #: lib/vutuv_web/templates/import/preview.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:432
@@ -8214,17 +8218,17 @@ msgstr ""
 msgid "Import from LinkedIn"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/preview.html.heex:84
+#: lib/vutuv_web/templates/import/preview.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Import selected"
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:201
+#: lib/vutuv_web/controllers/import_controller.ex:212
 #, elixir-autogen, elixir-format
 msgid "Imported %{items}."
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:200
+#: lib/vutuv_web/controllers/import_controller.ex:211
 #, elixir-autogen, elixir-format
 msgid "Nothing new to import."
 msgstr ""
@@ -8234,11 +8238,12 @@ msgstr ""
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
 #: lib/vutuv_web/controllers/phone_number_controller.ex:87
-#: lib/vutuv_web/templates/import/new.html.heex:14
-#: lib/vutuv_web/templates/import/preview.html.heex:48
+#: lib/vutuv_web/templates/import/new.html.heex:15
+#: lib/vutuv_web/templates/import/preview.html.heex:69
 #: lib/vutuv_web/templates/phone_number/edit.html.heex:4
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:4
 #: lib/vutuv_web/templates/phone_number/new.html.heex:4
+#: lib/vutuv_web/views/import_html.ex:67
 #, elixir-autogen, elixir-format
 msgid "Phone numbers"
 msgstr ""
@@ -8253,23 +8258,24 @@ msgstr ""
 msgid "School"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/preview.html.heex:60
+#: lib/vutuv_web/templates/import/preview.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "Set %{field}:"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:13
-#: lib/vutuv_web/templates/import/preview.html.heex:44
+#: lib/vutuv_web/templates/import/new.html.heex:14
+#: lib/vutuv_web/templates/import/preview.html.heex:65
+#: lib/vutuv_web/views/import_html.ex:66
 #, elixir-autogen, elixir-format
 msgid "Social media"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:25
+#: lib/vutuv_web/templates/import/new.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Step 1: Download your LinkedIn data"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:76
+#: lib/vutuv_web/templates/import/new.html.heex:77
 #, elixir-autogen, elixir-format
 msgid "Step 2: Upload the ZIP here"
 msgstr ""
@@ -8279,7 +8285,7 @@ msgstr ""
 msgid "That does not look like a LinkedIn data export ZIP."
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:130
+#: lib/vutuv_web/controllers/import_controller.ex:135
 #, elixir-autogen, elixir-format
 msgid "The file could not be read. Please try again."
 msgstr ""
@@ -8289,23 +8295,24 @@ msgstr ""
 msgid "The import could not be completed. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:129
+#: lib/vutuv_web/templates/import/new.html.heex:130
 #, elixir-autogen, elixir-format
 msgid "Upload and preview"
 msgstr ""
 
 #: lib/vutuv_web/templates/import/new.html.heex:9
-#: lib/vutuv_web/templates/import/preview.html.heex:19
+#: lib/vutuv_web/templates/import/preview.html.heex:40
+#: lib/vutuv_web/views/import_html.ex:61
 #, elixir-autogen, elixir-format
 msgid "Work experience"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/preview.html.heex:75
+#: lib/vutuv_web/templates/import/preview.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "add an email address"
 msgstr ""
 
-#: lib/vutuv_web/views/import_html.ex:27
+#: lib/vutuv_web/views/import_html.ex:92
 #, elixir-autogen, elixir-format
 msgid "already on your profile"
 msgstr ""
@@ -8315,7 +8322,7 @@ msgstr ""
 msgid "That archive is too large or has too many files to import safely."
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:146
+#: lib/vutuv_web/controllers/import_controller.ex:151
 #, elixir-autogen, elixir-format
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
@@ -8328,13 +8335,6 @@ msgstr ""
 msgid "Please check the fields marked in red."
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:213
-#, elixir-autogen, elixir-format
-msgid "Skipped %{count} entry that is already on your profile or taken by another member."
-msgid_plural "Skipped %{count} entries that are already on your profile or taken by another member."
-msgstr[0] ""
-msgstr[1] ""
-
 #: lib/vutuv_web/views/user_html.ex:675
 #, elixir-autogen, elixir-format
 msgid "Loading posts"
@@ -8346,37 +8346,37 @@ msgstr ""
 msgid "Social media posts"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:50
+#: lib/vutuv_web/templates/import/new.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Click \"Request archive\"."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:62
+#: lib/vutuv_web/templates/import/new.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "LinkedIn's \"Download my data\" page with \"Download larger data archive\" selected and the \"Request archive\" button below it."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:38
+#: lib/vutuv_web/templates/import/new.html.heex:39
 #, elixir-autogen, elixir-format
 msgid "Open LinkedIn's data export page"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:72
+#: lib/vutuv_web/templates/import/new.html.heex:73
 #, elixir-autogen, elixir-format
 msgid "Select the larger archive, then click \"Request archive\"."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:27
+#: lib/vutuv_web/templates/import/new.html.heex:28
 #, elixir-autogen, elixir-format
 msgid "LinkedIn lets you export your own data as a ZIP archive. Open the export page, request the larger archive, and download the ZIP once LinkedIn has finished preparing it (this usually takes a few minutes)."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:52
+#: lib/vutuv_web/templates/import/new.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "LinkedIn prepares your archive. When it is ready (usually after a few minutes), download the ZIP to your device."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:78
+#: lib/vutuv_web/templates/import/new.html.heex:79
 #, elixir-autogen, elixir-format
 msgid "Then upload the ZIP file below to see the preview and pick what to add."
 msgstr ""
@@ -8386,7 +8386,7 @@ msgstr ""
 msgid "What gets imported"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:18
+#: lib/vutuv_web/templates/import/new.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "You decide exactly what to add. In the next step we show you everything we found and you pick it entry by entry, so you never import anything sight unseen. Nothing is added until you confirm, and your existing entries are never overwritten."
 msgstr ""
@@ -8396,7 +8396,7 @@ msgstr ""
 msgid "Import your LinkedIn profile data into your vutuv profile. From your export we can fill in:"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:110
+#: lib/vutuv_web/templates/import/new.html.heex:111
 #, elixir-autogen, elixir-format
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
@@ -8487,12 +8487,12 @@ msgstr ""
 msgid "The file you sent is too large."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:92
+#: lib/vutuv_web/templates/import/new.html.heex:93
 #, elixir-autogen, elixir-format
 msgid "This file is too large. Please choose a ZIP of at most 50 MB."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:115
+#: lib/vutuv_web/templates/import/new.html.heex:116
 #, elixir-autogen, elixir-format
 msgid "ZIP file, up to 50 MB."
 msgstr ""
@@ -8606,7 +8606,7 @@ msgstr ""
 msgid "Not written yet"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:226
+#: lib/vutuv_web/components/organization_components.ex:234
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "Page"
@@ -8642,7 +8642,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:610
 #: lib/vutuv_web/agent_docs/text.ex:567
 #: lib/vutuv_web/agent_docs/text.ex:571
-#: lib/vutuv_web/components/organization_components.ex:258
+#: lib/vutuv_web/components/organization_components.ex:266
 #: lib/vutuv_web/components/ui.ex:3915
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:323
@@ -8729,7 +8729,7 @@ msgstr ""
 msgid "Internships"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:46
+#: lib/vutuv_web/templates/import/new.html.heex:47
 #, elixir-autogen, elixir-format
 msgid "On that page, select \"Download larger data archive\" (profile, positions, volunteering, education, skills)."
 msgstr ""
@@ -9550,7 +9550,7 @@ msgstr ""
 msgid "“%{name}” is an honor tag now. Add members below."
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:183
+#: lib/vutuv_web/controllers/import_controller.ex:194
 #, elixir-autogen, elixir-format
 msgid "%{count} certificate or license"
 msgid_plural "%{count} certificates or licenses"
@@ -9600,13 +9600,15 @@ msgstr ""
 #: lib/vutuv_web/cv/latex.ex:140
 #: lib/vutuv_web/cv/odt.ex:154
 #: lib/vutuv_web/live/cv_live.ex:361
-#: lib/vutuv_web/templates/import/preview.html.heex:27
+#: lib/vutuv_web/templates/import/new.html.heex:11
+#: lib/vutuv_web/templates/import/preview.html.heex:48
 #: lib/vutuv_web/templates/qualification/edit.html.heex:4
 #: lib/vutuv_web/templates/qualification/index.html.heex:11
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
 #: lib/vutuv_web/templates/user/show.html.heex:834
+#: lib/vutuv_web/views/import_html.ex:63
 #: lib/vutuv_web/views/job_reference_html.ex:266
 #, elixir-autogen, elixir-format
 msgid "Certificates & licenses"
@@ -9669,7 +9671,7 @@ msgstr ""
 msgid "Licenses"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/preview.html.heex:29
+#: lib/vutuv_web/templates/import/preview.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "LinkedIn does not say whether an entry is a certificate or a license, so we import all of them as certificates. Please review the section afterwards and switch any that are licenses."
 msgstr ""
@@ -10768,7 +10770,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/organization_live.ex:179
 #: lib/vutuv_web/live/admin/organization_live.ex:194
 #: lib/vutuv_web/live/admin/screenshot_live.ex:535
-#: lib/vutuv_web/live/organization_live/domains.ex:197
+#: lib/vutuv_web/live/organization_live/domains.ex:203
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
@@ -11027,7 +11029,7 @@ msgstr ""
 msgid "Your list is empty. Nobody is excluded yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:328
+#: lib/vutuv_web/live/organization_live/edit.ex:334
 #: lib/vutuv_web/views/account_event_text.ex:210
 #, elixir-autogen, elixir-format
 msgid "AI agents"
@@ -11043,8 +11045,8 @@ msgstr ""
 msgid "Continue to verification"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:261
-#: lib/vutuv_web/live/organization_live/domains.ex:301
+#: lib/vutuv_web/live/organization_live/domains.ex:267
+#: lib/vutuv_web/live/organization_live/domains.ex:307
 #: lib/vutuv_web/live/organization_live/new.ex:161
 #: lib/vutuv_web/live/organization_live/show.ex:838
 #: lib/vutuv_web/templates/url/verify.html.heex:46
@@ -11052,36 +11054,36 @@ msgstr ""
 msgid "DNS TXT record"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:180
-#: lib/vutuv_web/live/organization_live/domains.ex:342
+#: lib/vutuv_web/live/organization_live/domains.ex:186
+#: lib/vutuv_web/live/organization_live/domains.ex:348
 #: lib/vutuv_web/live/organization_live/show.ex:904
 #: lib/vutuv_web/live/organization_live/show.ex:912
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:31
-#: lib/vutuv_web/live/organization_live/edit.ex:240
+#: lib/vutuv_web/live/organization_live/edit.ex:32
+#: lib/vutuv_web/live/organization_live/edit.ex:246
 #, elixir-autogen, elixir-format
 msgid "Edit %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:314
+#: lib/vutuv_web/live/organization_live/edit.ex:320
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this page and include it in the sitemap."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:247
+#: lib/vutuv_web/live/organization_live/edit.ex:253
 #, elixir-autogen, elixir-format
 msgid "Logo"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:275
+#: lib/vutuv_web/live/organization_live/edit.ex:281
 #, elixir-autogen, elixir-format
 msgid "Markdown is supported"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:330
+#: lib/vutuv_web/live/organization_live/edit.ex:336
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) and list them for AI agents."
 msgstr ""
@@ -11097,7 +11099,7 @@ msgstr ""
 msgid "Prove you control %{domain} to publish this page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:258
+#: lib/vutuv_web/live/organization_live/edit.ex:264
 #, elixir-autogen, elixir-format
 msgid "Remove logo"
 msgstr ""
@@ -11107,7 +11109,7 @@ msgstr ""
 msgid "Search by name or city"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:312
+#: lib/vutuv_web/live/organization_live/edit.ex:318
 #: lib/vutuv_web/views/account_event_text.ex:209
 #, elixir-autogen, elixir-format
 msgid "Search engines"
@@ -11118,29 +11120,29 @@ msgstr ""
 msgid "Select a country"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:320
+#: lib/vutuv_web/live/organization_live/domains.ex:326
 #: lib/vutuv_web/live/organization_live/show.ex:873
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:293
+#: lib/vutuv_web/live/organization_live/edit.ex:299
 #: lib/vutuv_web/live/organization_live/new.ex:139
 #, elixir-autogen, elixir-format
 msgid "State / region (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:477
+#: lib/vutuv_web/live/organization_live/edit.ex:483
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:475
+#: lib/vutuv_web/live/organization_live/edit.ex:481
 #, elixir-autogen, elixir-format
 msgid "The file is too large."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:478
+#: lib/vutuv_web/live/organization_live/edit.ex:484
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr ""
@@ -11172,7 +11174,7 @@ msgstr ""
 msgid "Verify %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:336
+#: lib/vutuv_web/live/organization_live/domains.ex:342
 #: lib/vutuv_web/live/organization_live/show.ex:898
 #, elixir-autogen, elixir-format
 msgid "Verify now"
@@ -11180,14 +11182,14 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:243
 #: lib/vutuv_web/agent_docs/text.ex:227
-#: lib/vutuv_web/live/organization_live/edit.ex:287
+#: lib/vutuv_web/live/organization_live/edit.ex:293
 #: lib/vutuv_web/live/organization_live/new.ex:130
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:262
-#: lib/vutuv_web/live/organization_live/domains.ex:311
+#: lib/vutuv_web/live/organization_live/domains.ex:268
+#: lib/vutuv_web/live/organization_live/domains.ex:317
 #: lib/vutuv_web/live/organization_live/show.ex:849
 #: lib/vutuv_web/templates/url/verify.html.heex:99
 #, elixir-autogen, elixir-format
@@ -11199,7 +11201,7 @@ msgstr ""
 msgid "Website file (.well-known)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:476
+#: lib/vutuv_web/live/organization_live/edit.ex:482
 #, elixir-autogen, elixir-format
 msgid "You can only upload one logo."
 msgstr ""
@@ -11209,65 +11211,65 @@ msgstr ""
 msgid "You will publish a record or file to prove control of the domain on the next step."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:322
+#: lib/vutuv_web/live/organization_live/domains.ex:328
 #: lib/vutuv_web/live/organization_live/show.ex:879
 #: lib/vutuv_web/templates/url/verify.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:180
+#: lib/vutuv_web/live/organization_live/roles.ex:186
 #, elixir-autogen, elixir-format
 msgid "@handle or email"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:307
-#: lib/vutuv_web/live/organization_live/edit.ex:390
+#: lib/vutuv_web/components/organization_components.ex:315
+#: lib/vutuv_web/live/organization_live/edit.ex:396
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:249
+#: lib/vutuv_web/live/organization_live/domains.ex:255
 #, elixir-autogen, elixir-format
 msgid "Add a domain"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:171
+#: lib/vutuv_web/live/organization_live/roles.ex:177
 #, elixir-autogen, elixir-format
 msgid "Add a member"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:143
+#: lib/vutuv_web/live/organization_live/roles.ex:144
 #, elixir-autogen, elixir-format
 msgid "Added @%{handle} to the team."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:308
-#: lib/vutuv_web/live/organization_live/edit.ex:388
+#: lib/vutuv_web/components/organization_components.ex:316
+#: lib/vutuv_web/live/organization_live/edit.ex:394
 #, elixir-autogen, elixir-format
 msgid "Alias"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:99
+#: lib/vutuv_web/live/organization_live/edit.ex:100
 #, elixir-autogen, elixir-format
 msgid "Alias added."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:123
+#: lib/vutuv_web/live/organization_live/edit.ex:124
 #, elixir-autogen, elixir-format
 msgid "Alias removed."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:427
 #: lib/vutuv_web/agent_docs/text.ex:444
-#: lib/vutuv_web/live/organization_live/edit.ex:353
+#: lib/vutuv_web/live/organization_live/edit.ex:359
 #: lib/vutuv_web/live/organization_live/show.ex:774
 #: lib/vutuv_web/templates/tag/single_card.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Also known as"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:384
+#: lib/vutuv_web/live/organization_live/edit.ex:390
 #, elixir-autogen, elixir-format
 msgid "Alternative name"
 msgstr ""
@@ -11288,8 +11290,8 @@ msgstr ""
 msgid "Archived"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:306
-#: lib/vutuv_web/live/organization_live/edit.ex:389
+#: lib/vutuv_web/components/organization_components.ex:314
+#: lib/vutuv_web/live/organization_live/edit.ex:395
 #, elixir-autogen, elixir-format
 msgid "Brand"
 msgstr ""
@@ -11299,7 +11301,7 @@ msgstr ""
 msgid "Claimed by"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:216
+#: lib/vutuv_web/live/organization_live/roles.ex:222
 #, elixir-autogen, elixir-format
 msgid "Current team"
 msgstr ""
@@ -11309,35 +11311,35 @@ msgstr ""
 msgid "Delete this page and everything it owns? This cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:65
+#: lib/vutuv_web/live/organization_live/domains.ex:66
 #, elixir-autogen, elixir-format
 msgid "Domain added. Publish the record or file, then verify it."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:139
+#: lib/vutuv_web/live/organization_live/domains.ex:140
 #, elixir-autogen, elixir-format
 msgid "Domain removed."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:108
+#: lib/vutuv_web/live/organization_live/domains.ex:109
 #, elixir-autogen, elixir-format
 msgid "Domain verified."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:232
+#: lib/vutuv_web/components/organization_components.ex:240
 #: lib/vutuv_web/live/admin/organization_live.ex:305
-#: lib/vutuv_web/live/organization_live/domains.ex:174
+#: lib/vutuv_web/live/organization_live/domains.ex:180
 #: lib/vutuv_web/live/organization_live/show.ex:525
 #, elixir-autogen, elixir-format
 msgid "Domains"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:29
+#: lib/vutuv_web/live/organization_live/domains.ex:30
 #, elixir-autogen, elixir-format
 msgid "Domains – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:305
+#: lib/vutuv_web/components/organization_components.ex:313
 #, elixir-autogen, elixir-format
 msgid "Former name"
 msgstr ""
@@ -11354,13 +11356,13 @@ msgstr ""
 msgid "Freeze this page? It disappears for the public but stays visible to its owner."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:202
+#: lib/vutuv_web/live/organization_live/domains.ex:208
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "Last checked"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:243
+#: lib/vutuv_web/live/organization_live/roles.ex:249
 #, elixir-autogen, elixir-format
 msgid "Leave"
 msgstr ""
@@ -11375,17 +11377,17 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:233
+#: lib/vutuv_web/live/organization_live/domains.ex:239
 #, elixir-autogen, elixir-format
 msgid "Make primary"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:94
+#: lib/vutuv_web/live/organization_live/roles.ex:95
 #, elixir-autogen, elixir-format
 msgid "Member removed."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:202
+#: lib/vutuv_web/live/organization_live/domains.ex:208
 #, elixir-autogen, elixir-format
 msgid "Method"
 msgstr ""
@@ -11395,42 +11397,42 @@ msgstr ""
 msgid "Names & aliases"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:81
+#: lib/vutuv_web/live/organization_live/roles.ex:82
 #, elixir-autogen, elixir-format
 msgid "No member found for “%{id}”."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:124
+#: lib/vutuv_web/live/organization_live/domains.ex:125
 #, elixir-autogen, elixir-format
 msgid "Only a verified domain can be the primary one."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:188
+#: lib/vutuv_web/live/organization_live/domains.ex:194
 #, elixir-autogen, elixir-format
 msgid "Primary"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:120
+#: lib/vutuv_web/live/organization_live/domains.ex:121
 #, elixir-autogen, elixir-format
 msgid "Primary domain updated."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:294
+#: lib/vutuv_web/components/organization_components.ex:302
 #, elixir-autogen, elixir-format
 msgid "Recruiter"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:239
+#: lib/vutuv_web/live/organization_live/domains.ex:245
 #, elixir-autogen, elixir-format
 msgid "Remove this domain?"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:238
+#: lib/vutuv_web/live/organization_live/roles.ex:244
 #, elixir-autogen, elixir-format
 msgid "Remove this member from the team?"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:370
+#: lib/vutuv_web/live/organization_live/edit.ex:376
 #, elixir-autogen, elixir-format
 msgid "Remove this name?"
 msgstr ""
@@ -11440,25 +11442,25 @@ msgstr ""
 msgid "Search name, alias or domain"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:229
+#: lib/vutuv_web/components/organization_components.ex:237
 #: lib/vutuv_web/live/admin/organization_live.ex:321
-#: lib/vutuv_web/live/organization_live/roles.ex:165
+#: lib/vutuv_web/live/organization_live/roles.ex:171
 #: lib/vutuv_web/live/organization_live/show.ex:518
 #, elixir-autogen, elixir-format
 msgid "Team"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:36
+#: lib/vutuv_web/live/organization_live/roles.ex:37
 #, elixir-autogen, elixir-format
 msgid "Team – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:76
+#: lib/vutuv_web/live/organization_live/domains.ex:77
 #, elixir-autogen, elixir-format
 msgid "That is not a valid domain."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:146
+#: lib/vutuv_web/live/organization_live/roles.ex:147
 #, elixir-autogen, elixir-format
 msgid "That member could not be added."
 msgstr ""
@@ -11487,39 +11489,39 @@ msgstr ""
 msgid "verified"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:290
+#: lib/vutuv_web/live/organization_live/edit.ex:296
 #: lib/vutuv_web/live/organization_live/new.ex:136
 #, elixir-autogen, elixir-format
 msgid "Street address (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:291
+#: lib/vutuv_web/live/organization_live/edit.ex:297
 #: lib/vutuv_web/live/organization_live/new.ex:137
 #, elixir-autogen, elixir-format
 msgid "ZIP / postal code (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:447
+#: lib/vutuv_web/live/organization_live/edit.ex:453
 #, elixir-autogen, elixir-format
 msgid "Claim"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:416
+#: lib/vutuv_web/live/organization_live/edit.ex:422
 #, elixir-autogen, elixir-format
 msgid "Reachable at"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:203
+#: lib/vutuv_web/live/organization_live/edit.ex:204
 #, elixir-autogen, elixir-format
 msgid "That handle is not available."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:453
+#: lib/vutuv_web/live/organization_live/edit.ex:459
 #, elixir-autogen, elixir-format
 msgid "Danger zone"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:464
+#: lib/vutuv_web/live/organization_live/edit.ex:470
 #, elixir-autogen, elixir-format
 msgid "Really delete %{name}? This cannot be undone."
 msgstr ""
@@ -11661,22 +11663,22 @@ msgid_plural "%{count} aliases match another verified organization and are flagg
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:355
+#: lib/vutuv_web/live/organization_live/edit.ex:361
 #, elixir-autogen, elixir-format
 msgid "Alternative names, brands or abbreviations this organization is findable under. A rename keeps the old name here automatically."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:176
+#: lib/vutuv_web/live/organization_live/domains.ex:182
 #, elixir-autogen, elixir-format
 msgid "An organization can prove several domains. The primary one shows in the “Verified via …” badge."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:146
+#: lib/vutuv_web/live/organization_live/domains.ex:147
 #, elixir-autogen, elixir-format
 msgid "An organization keeps at least one verified domain, so this one cannot be removed."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:152
+#: lib/vutuv_web/live/organization_live/roles.ex:153
 #, elixir-autogen, elixir-format
 msgid "An organization must keep at least one owner, so the last owner cannot be changed."
 msgstr ""
@@ -11725,23 +11727,23 @@ msgstr ""
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:468
+#: lib/vutuv_web/live/organization_live/edit.ex:474
 #, elixir-autogen, elixir-format
 msgid "Delete this organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:455
+#: lib/vutuv_web/live/organization_live/edit.ex:461
 #, elixir-autogen, elixir-format
 msgid "Deleting this organization page is permanent. Its verified domains and its @handle are freed and can be claimed again."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:268
+#: lib/vutuv_web/live/organization_live/edit.ex:274
 #: lib/vutuv_web/live/organization_live/new.ex:126
 #, elixir-autogen, elixir-format
 msgid "Kind of organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:237
+#: lib/vutuv_web/live/organization_live/roles.ex:243
 #, elixir-autogen, elixir-format
 msgid "Leave this organization team?"
 msgstr ""
@@ -11801,7 +11803,7 @@ msgstr ""
 msgid "Organization frozen."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:267
+#: lib/vutuv_web/live/organization_live/edit.ex:273
 #: lib/vutuv_web/live/organization_live/new.ex:125
 #, elixir-autogen, elixir-format
 msgid "Organization name"
@@ -11868,7 +11870,7 @@ msgstr ""
 msgid "Search organizations"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:72
+#: lib/vutuv_web/live/organization_live/domains.ex:73
 #, elixir-autogen, elixir-format
 msgid "That domain already belongs to an organization page."
 msgstr ""
@@ -11878,12 +11880,12 @@ msgstr ""
 msgid "That domain already belongs to another organization page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:106
+#: lib/vutuv_web/live/organization_live/edit.ex:107
 #, elixir-autogen, elixir-format
 msgid "That name is already listed for this organization."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:191
+#: lib/vutuv_web/live/organization_live/edit.ex:192
 #, elixir-autogen, elixir-format
 msgid "The organization page was deleted."
 msgstr ""
@@ -11908,12 +11910,12 @@ msgstr ""
 msgid "Verified organization pages: domains, team roles, aliases and rename history. Freeze, archive or delete a page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:174
+#: lib/vutuv_web/live/organization_live/edit.ex:175
 #, elixir-autogen, elixir-format
 msgid "You are not allowed to delete this organization."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:139
+#: lib/vutuv_web/live/organization_live/edit.ex:140
 #, elixir-autogen, elixir-format
 msgid "Your organization handle is set."
 msgstr ""
@@ -11924,7 +11926,7 @@ msgstr ""
 msgid "Your organization page is verified and now live."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:70
+#: lib/vutuv_web/live/organization_live/edit.ex:71
 #, elixir-autogen, elixir-format
 msgid "Your organization page was updated."
 msgstr ""
@@ -11949,7 +11951,7 @@ msgstr ""
 msgid "made you an owner of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:437
+#: lib/vutuv_web/live/organization_live/edit.ex:443
 #, elixir-autogen, elixir-format
 msgid "your_organization"
 msgstr ""
@@ -12495,17 +12497,17 @@ msgstr ""
 msgid "A domain of your organization page on vutuv is about to be dropped"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:215
+#: lib/vutuv_web/live/organization_live/domains.ex:221
 #, elixir-autogen, elixir-format
 msgid "Deadline"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:194
+#: lib/vutuv_web/live/organization_live/domains.ex:200
 #, elixir-autogen, elixir-format
 msgid "Proof missing"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:214
+#: lib/vutuv_web/live/organization_live/domains.ex:220
 #, elixir-autogen, elixir-format
 msgid "We could not read this domain's proof on the last check. Restore it and check again, or the domain loses its verification."
 msgstr ""
@@ -12618,13 +12620,13 @@ msgstr ""
 msgid "Getting an error, or is %{host} a CNAME / alias to another address? A TXT record cannot share a name with a CNAME. Use this name instead, with the exact same value as above:"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:318
+#: lib/vutuv_web/live/organization_live/domains.ex:324
 #: lib/vutuv_web/live/organization_live/show.ex:866
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:316
+#: lib/vutuv_web/live/organization_live/domains.ex:322
 #: lib/vutuv_web/live/organization_live/show.ex:857
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
@@ -12640,7 +12642,7 @@ msgstr ""
 msgid "Name (host)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:147
+#: lib/vutuv_web/live/organization_live/edit.ex:148
 #, elixir-autogen, elixir-format
 msgid "Only a verified organization page can claim a handle."
 msgstr ""
@@ -13176,7 +13178,7 @@ msgstr ""
 msgid "Back to the posting"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/exclusions.ex:106
+#: lib/vutuv_web/live/organization_live/exclusions.ex:112
 #, elixir-autogen, elixir-format
 msgid "Every posting attributed to this organization inherits this standing list, on top of its own. Use it to keep vacancies away from competitors you never advertise to."
 msgstr ""
@@ -13207,13 +13209,13 @@ msgstr ""
 msgid "Inherited from the organization"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:235
-#: lib/vutuv_web/live/organization_live/exclusions.ex:103
+#: lib/vutuv_web/components/organization_components.ex:243
+#: lib/vutuv_web/live/organization_live/exclusions.ex:109
 #, elixir-autogen, elixir-format
 msgid "Job exclusions"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/exclusions.ex:33
+#: lib/vutuv_web/live/organization_live/exclusions.ex:34
 #, elixir-autogen, elixir-format
 msgid "Job exclusions – %{name}"
 msgstr ""
@@ -13294,7 +13296,7 @@ msgstr ""
 msgid "Reviewed, all fine: clear the flag"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:181
+#: lib/vutuv_web/live/organization_live/edit.ex:182
 #, elixir-autogen, elixir-format
 msgid "This page has job postings, so it cannot be deleted. Ask an admin to archive it instead."
 msgstr ""
@@ -14491,7 +14493,7 @@ msgstr ""
 msgid "Word, phrase or tag to mute"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:161
+#: lib/vutuv_web/live/organization_live/edit.ex:162
 #, elixir-autogen, elixir-format
 msgid "You are not allowed to change this organization's handle."
 msgstr ""
@@ -19945,47 +19947,47 @@ msgstr ""
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:293
+#: lib/vutuv_web/components/organization_components.ex:301
 #, elixir-autogen, elixir-format
 msgid "Editorial"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:299
+#: lib/vutuv_web/components/organization_components.ex:307
 #, elixir-autogen, elixir-format
 msgid "Edits the page and posts jobs."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:167
+#: lib/vutuv_web/live/organization_live/roles.ex:173
 #, elixir-autogen, elixir-format
 msgid "Give members their roles on this page. Someone can hold several at once, and every role is granted on its own."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:298
+#: lib/vutuv_web/components/organization_components.ex:306
 #, elixir-autogen, elixir-format
 msgid "Manages the team and the domains, and edits the page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:74
+#: lib/vutuv_web/live/organization_live/roles.ex:75
 #, elixir-autogen, elixir-format
 msgid "Pick at least one role."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:301
+#: lib/vutuv_web/components/organization_components.ex:309
 #, elixir-autogen, elixir-format
 msgid "Posts jobs."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:270
+#: lib/vutuv_web/live/organization_live/roles.ex:276
 #, elixir-autogen, elixir-format
 msgid "Roles"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:88
+#: lib/vutuv_web/live/organization_live/roles.ex:89
 #, elixir-autogen, elixir-format
 msgid "Roles updated."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:300
+#: lib/vutuv_web/components/organization_components.ex:308
 #, elixir-autogen, elixir-format
 msgid "Writes posts in the organization's name."
 msgstr ""
@@ -20118,7 +20120,7 @@ msgstr ""
 msgid "%{name} follows"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/feed.ex:41
+#: lib/vutuv_web/live/organization_live/feed.ex:49
 #, elixir-autogen, elixir-format
 msgid "Feed – %{name}"
 msgstr ""
@@ -20133,7 +20135,7 @@ msgstr ""
 msgid "Members and organizations"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/feed.ex:85
+#: lib/vutuv_web/live/organization_live/feed.ex:107
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. This page does not follow anyone, or nobody it follows has published."
 msgstr ""
@@ -20164,7 +20166,7 @@ msgstr ""
 msgid "Unfollow %{tag}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/feed.ex:81
+#: lib/vutuv_web/live/organization_live/feed.ex:103
 #, elixir-autogen, elixir-format
 msgid "What the members and organizations this page follows have published. Liking or saving something here is done from your own account, not the page's."
 msgstr ""
@@ -20313,12 +20315,12 @@ msgstr ""
 msgid "This vutuv exchanges nothing with other networks, so nothing here has any effect."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:408
+#: lib/vutuv_web/live/organization_live/edit.ex:414
 #, elixir-autogen, elixir-format
 msgid "Claim a short @name so this organization has an address of its own, like a member. Letters, numbers and underscores, %{min} to %{max} characters."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:406
+#: lib/vutuv_web/live/organization_live/edit.ex:412
 #, elixir-autogen, elixir-format
 msgid "The organization's @name"
 msgstr ""
@@ -20546,7 +20548,7 @@ msgstr ""
 msgid "A new entry can take a while to reach everyone. We keep checking %{domain} by ourselves and send you an email as soon as it works, so you can close this page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:332
+#: lib/vutuv_web/live/organization_live/domains.ex:338
 #: lib/vutuv_web/live/organization_live/show.ex:894
 #, elixir-autogen, elixir-format
 msgid "Checking …"
@@ -20640,4 +20642,60 @@ msgstr ""
 #: lib/vutuv_web/templates/layout/app.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Legal"
+msgstr ""
+
+#: lib/vutuv_web/controllers/import_controller.ex:247
+#, elixir-autogen, elixir-format
+msgid "%{count} entry could not be added."
+msgid_plural "%{count} entries could not be added."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/controllers/import_controller.ex:237
+#, elixir-autogen, elixir-format
+msgid "%{count} social account could not be added because another member has already claimed it."
+msgid_plural "%{count} social accounts could not be added because another member has already claimed them."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/views/import_html.ex:31
+#, elixir-autogen, elixir-format
+msgid "Already on your profile"
+msgstr ""
+
+#: lib/vutuv_web/templates/import/preview.html.heex:11
+#, elixir-autogen, elixir-format
+msgid "Analysis complete. Nothing has been imported yet."
+msgstr ""
+
+#: lib/vutuv_web/views/import_html.ex:30
+#, elixir-autogen, elixir-format
+msgid "Found"
+msgstr ""
+
+#: lib/vutuv_web/views/import_html.ex:32
+#, elixir-autogen, elixir-format
+msgid "Ready to import"
+msgstr ""
+
+#: lib/vutuv_web/templates/import/preview.html.heex:13
+#, elixir-autogen, elixir-format
+msgid "Review the entries below and confirm your selection to add them to your profile."
+msgstr ""
+
+#: lib/vutuv_web/views/import_html.ex:29
+#, elixir-autogen, elixir-format
+msgid "Section"
+msgstr ""
+
+#: lib/vutuv_web/controllers/import_controller.ex:219
+#, elixir-autogen, elixir-format
+msgid "Skipped %{count} entry that is already on your profile."
+msgid_plural "Skipped %{count} entries that are already on your profile."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/templates/import/preview.html.heex:20
+#, elixir-autogen, elixir-format
+msgid "You can analyse the same or a newer LinkedIn archive again at any time. Nothing is duplicated and nothing is overwritten. Entries you already have are not updated either: they keep the description and dates they have on vutuv, even when your archive holds newer ones."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -9,7 +9,7 @@
 msgid ""
 msgstr "Language: en\n"
 
-#: lib/vutuv_web/controllers/page_controller.ex:174
+#: lib/vutuv_web/controllers/page_controller.ex:184
 #: lib/vutuv_web/templates/layout/app.html.heex:132
 #, elixir-autogen
 msgid "About us"
@@ -19,9 +19,9 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3605
 #: lib/vutuv_web/live/admin/screenshot_live.ex:266
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:718
-#: lib/vutuv_web/live/organization_live/domains.ex:268
-#: lib/vutuv_web/live/organization_live/edit.ex:396
-#: lib/vutuv_web/live/organization_live/roles.ex:210
+#: lib/vutuv_web/live/organization_live/domains.ex:274
+#: lib/vutuv_web/live/organization_live/edit.ex:402
+#: lib/vutuv_web/live/organization_live/roles.ex:216
 #, elixir-autogen
 msgid "Add"
 msgstr ""
@@ -114,13 +114,13 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
 #: lib/vutuv_web/live/job_posting_live/form.ex:605
-#: lib/vutuv_web/live/organization_live/edit.ex:347
+#: lib/vutuv_web/live/organization_live/edit.ex:353
 #: lib/vutuv_web/live/organization_live/new.ex:231
 #: lib/vutuv_web/live/post_live/composer.ex:1370
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
-#: lib/vutuv_web/templates/import/preview.html.heex:86
+#: lib/vutuv_web/templates/import/preview.html.heex:107
 #: lib/vutuv_web/templates/report/new.html.heex:103
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:276
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:259
@@ -175,8 +175,8 @@ msgid "Delete"
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:481
-#: lib/vutuv_web/live/organization_live/edit.ex:272
-#: lib/vutuv_web/live/organization_live/edit.ex:281
+#: lib/vutuv_web/live/organization_live/edit.ex:278
+#: lib/vutuv_web/live/organization_live/edit.ex:287
 #: lib/vutuv_web/templates/address/card_list.html.heex:5
 #: lib/vutuv_web/templates/address/form_en.html.heex:11
 #: lib/vutuv_web/templates/address/form_generic.html.heex:13
@@ -412,13 +412,14 @@ msgstr ""
 #: lib/vutuv_web/cv/latex.ex:164
 #: lib/vutuv_web/cv/odt.ex:176
 #: lib/vutuv_web/live/cv_live.ex:336
-#: lib/vutuv_web/templates/import/new.html.heex:12
-#: lib/vutuv_web/templates/import/preview.html.heex:40
+#: lib/vutuv_web/templates/import/new.html.heex:13
+#: lib/vutuv_web/templates/import/preview.html.heex:61
 #: lib/vutuv_web/templates/url/edit.html.heex:4
 #: lib/vutuv_web/templates/url/index.html.heex:10
 #: lib/vutuv_web/templates/url/manage.html.heex:4
 #: lib/vutuv_web/templates/url/new.html.heex:4
 #: lib/vutuv_web/templates/url/show.html.heex:6
+#: lib/vutuv_web/views/import_html.ex:65
 #, elixir-autogen
 msgid "Links"
 msgstr ""
@@ -611,7 +612,7 @@ msgid "Public"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3388
-#: lib/vutuv_web/live/organization_live/edit.ex:341
+#: lib/vutuv_web/live/organization_live/edit.ex:347
 #: lib/vutuv_web/live/post_live/composer.ex:1813
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
@@ -854,7 +855,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3899
 #: lib/vutuv_web/controllers/settings_controller.ex:159
 #: lib/vutuv_web/live/job_posting_live/form.ex:561
-#: lib/vutuv_web/live/organization_live/edit.ex:300
+#: lib/vutuv_web/live/organization_live/edit.ex:306
 #: lib/vutuv_web/templates/email/card_list.html.heex:7
 #: lib/vutuv_web/templates/email/show.html.heex:24
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:295
@@ -1072,7 +1073,7 @@ msgstr ""
 msgid "Listings"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:323
+#: lib/vutuv_web/controllers/page_controller.ex:333
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:4
 #, elixir-autogen
 msgid "Most Followed Users"
@@ -1141,7 +1142,7 @@ msgstr ""
 msgid "Add Localization"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:289
+#: lib/vutuv_web/components/organization_components.ex:297
 #: lib/vutuv_web/live/admin/activity_live.ex:153
 #: lib/vutuv_web/live/admin/api_app_live.ex:58
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
@@ -1392,8 +1393,8 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:5
 #: lib/vutuv_web/templates/admin/tag/new.html.heex:5
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:5
-#: lib/vutuv_web/templates/import/new.html.heex:11
-#: lib/vutuv_web/templates/import/preview.html.heex:36
+#: lib/vutuv_web/templates/import/new.html.heex:12
+#: lib/vutuv_web/templates/import/preview.html.heex:57
 #: lib/vutuv_web/templates/page/index.html.heex:108
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -1403,6 +1404,7 @@ msgstr ""
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
 #: lib/vutuv_web/templates/user_tag/show.html.heex:6
+#: lib/vutuv_web/views/import_html.ex:64
 #, elixir-autogen
 msgid "Tags"
 msgstr ""
@@ -1558,7 +1560,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:776
 #: lib/vutuv_web/live/job_board_live.ex:360
 #: lib/vutuv_web/live/job_posting_live/form.ex:410
-#: lib/vutuv_web/live/organization_live/edit.ex:296
+#: lib/vutuv_web/live/organization_live/edit.ex:302
 #: lib/vutuv_web/live/organization_live/new.ex:142
 #: lib/vutuv_web/templates/ad/new.html.heex:114
 #: lib/vutuv_web/templates/address/country_input.html.heex:5
@@ -1638,7 +1640,7 @@ msgstr ""
 msgid "Confirm account deletion"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:178
+#: lib/vutuv_web/controllers/page_controller.ex:188
 #: lib/vutuv_web/templates/layout/app.html.heex:138
 #: lib/vutuv_web/templates/page/index.html.heex:261
 #: lib/vutuv_web/views/admin/legal_page_html.ex:11
@@ -1646,7 +1648,7 @@ msgstr ""
 msgid "Datenschutzerklärung"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:184
+#: lib/vutuv_web/controllers/page_controller.ex:194
 #: lib/vutuv_web/templates/layout/app.html.heex:139
 #: lib/vutuv_web/templates/page/index.html.heex:261
 #: lib/vutuv_web/views/admin/legal_page_html.ex:12
@@ -1711,7 +1713,7 @@ msgstr ""
 msgid "Log out"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:295
+#: lib/vutuv_web/components/organization_components.ex:303
 #: lib/vutuv_web/live/admin/activity_live.ex:143
 #: lib/vutuv_web/live/admin/activity_live.ex:175
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
@@ -1918,7 +1920,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3627
 #: lib/vutuv_web/live/organization_live/activity.ex:146
-#: lib/vutuv_web/live/organization_live/feed.ex:101
+#: lib/vutuv_web/live/organization_live/feed.ex:145
 #: lib/vutuv_web/live/organization_live/show.ex:637
 #, elixir-autogen, elixir-format
 msgid "Load more"
@@ -2109,8 +2111,8 @@ msgstr ""
 msgid "Edit post"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:247
-#: lib/vutuv_web/live/organization_live/feed.ex:79
+#: lib/vutuv_web/components/organization_components.ex:255
+#: lib/vutuv_web/live/organization_live/feed.ex:101
 #: lib/vutuv_web/live/post_live/feed.ex:159
 #: lib/vutuv_web/live/post_live/feed.ex:936
 #: lib/vutuv_web/live/shell_live.ex:606
@@ -2225,9 +2227,9 @@ msgstr ""
 #: lib/vutuv_web/live/admin/screenshot_live.ex:338
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:700
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
-#: lib/vutuv_web/live/organization_live/domains.ex:242
-#: lib/vutuv_web/live/organization_live/edit.ex:373
-#: lib/vutuv_web/live/organization_live/roles.ex:243
+#: lib/vutuv_web/live/organization_live/domains.ex:248
+#: lib/vutuv_web/live/organization_live/edit.ex:379
+#: lib/vutuv_web/live/organization_live/roles.ex:249
 #: lib/vutuv_web/live/post_live/composer.ex:1886
 #: lib/vutuv_web/live/post_live/saved.ex:619
 #: lib/vutuv_web/live/post_live/saved.ex:647
@@ -2840,7 +2842,7 @@ msgstr ""
 msgid "Open someone's profile to message them."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:241
+#: lib/vutuv_web/components/organization_components.ex:249
 #: lib/vutuv_web/live/notification_live/index.ex:1050
 #: lib/vutuv_web/live/organization_live/activity.ex:99
 #, elixir-autogen, elixir-format
@@ -3119,7 +3121,7 @@ msgstr ""
 msgid "Opened"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:288
+#: lib/vutuv_web/components/organization_components.ex:296
 #: lib/vutuv_web/live/admin/api_app_live.ex:72
 #: lib/vutuv_web/live/admin/deliverability_live.ex:171
 #: lib/vutuv_web/live/admin/moderation_live.ex:56
@@ -3145,9 +3147,10 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3812
 #: lib/vutuv_web/live/shell_live.ex:619
 #: lib/vutuv_web/live/shell_live.ex:896
-#: lib/vutuv_web/templates/import/new.html.heex:15
-#: lib/vutuv_web/templates/import/preview.html.heex:55
+#: lib/vutuv_web/templates/import/new.html.heex:16
+#: lib/vutuv_web/templates/import/preview.html.heex:76
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
+#: lib/vutuv_web/views/import_html.ex:68
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr ""
@@ -4045,7 +4048,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/organization_live.ex:245
 #: lib/vutuv_web/live/job_posting_live/form.ex:404
-#: lib/vutuv_web/live/organization_live/edit.ex:292
+#: lib/vutuv_web/live/organization_live/edit.ex:298
 #: lib/vutuv_web/live/organization_live/new.ex:138
 #: lib/vutuv_web/templates/ad/new.html.heex:108
 #: lib/vutuv_web/templates/address/form_en.html.heex:33
@@ -4546,7 +4549,7 @@ msgstr ""
 msgid "Find members"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:253
+#: lib/vutuv_web/components/organization_components.ex:261
 #: lib/vutuv_web/live/organization_live/following.ex:154
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:53
@@ -5471,7 +5474,7 @@ msgstr ""
 msgid "Account"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:447
+#: lib/vutuv_web/live/organization_live/edit.ex:453
 #, elixir-autogen, elixir-format
 msgid "Change"
 msgstr ""
@@ -5489,7 +5492,7 @@ msgstr ""
 #: lib/vutuv_web/templates/email/edit.html.heex:4
 #: lib/vutuv_web/templates/email/manage.html.heex:4
 #: lib/vutuv_web/templates/email/new.html.heex:4
-#: lib/vutuv_web/templates/import/preview.html.heex:69
+#: lib/vutuv_web/templates/import/preview.html.heex:90
 #: lib/vutuv_web/templates/settings/security.html.heex:17
 #, elixir-autogen, elixir-format
 msgid "Email addresses"
@@ -7322,14 +7325,14 @@ msgid "accounts"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:991
-#: lib/vutuv_web/views/import_html.ex:67
-#: lib/vutuv_web/views/import_html.ex:71
+#: lib/vutuv_web/views/import_html.ex:132
+#: lib/vutuv_web/views/import_html.ex:136
 #, elixir-autogen, elixir-format
 msgid "Select all"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:994
-#: lib/vutuv_web/views/import_html.ex:68
+#: lib/vutuv_web/views/import_html.ex:133
 #, elixir-autogen, elixir-format
 msgid "Unselect all"
 msgstr ""
@@ -8056,7 +8059,7 @@ msgid "Unreachable"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/member_badges.ex:20
-#: lib/vutuv_web/live/organization_live/domains.ex:191
+#: lib/vutuv_web/live/organization_live/domains.ex:197
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:32
 #, elixir-autogen, elixir-format
 msgid "Verified"
@@ -8080,49 +8083,49 @@ msgstr ""
 msgid "Nobody is online right now."
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:181
+#: lib/vutuv_web/controllers/import_controller.ex:192
 #, elixir-autogen, elixir-format
 msgid "%{count} education entry"
 msgid_plural "%{count} education entries"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:189
+#: lib/vutuv_web/controllers/import_controller.ex:200
 #, elixir-autogen, elixir-format
 msgid "%{count} link"
 msgid_plural "%{count} links"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:193
+#: lib/vutuv_web/controllers/import_controller.ex:204
 #, elixir-autogen, elixir-format
 msgid "%{count} phone number"
 msgid_plural "%{count} phone numbers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:195
+#: lib/vutuv_web/controllers/import_controller.ex:206
 #, elixir-autogen, elixir-format
 msgid "%{count} profile field"
 msgid_plural "%{count} profile fields"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:191
+#: lib/vutuv_web/controllers/import_controller.ex:202
 #, elixir-autogen, elixir-format
 msgid "%{count} social account"
 msgid_plural "%{count} social accounts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:188
+#: lib/vutuv_web/controllers/import_controller.ex:199
 #, elixir-autogen, elixir-format
 msgid "%{count} tag"
 msgid_plural "%{count} tags"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:179
+#: lib/vutuv_web/controllers/import_controller.ex:190
 #, elixir-autogen, elixir-format
 msgid "%{count} work experience"
 msgid_plural "%{count} work experiences"
@@ -8155,8 +8158,9 @@ msgstr ""
 #: lib/vutuv_web/templates/education/new.html.heex:4
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
-#: lib/vutuv_web/templates/import/preview.html.heex:23
+#: lib/vutuv_web/templates/import/preview.html.heex:44
 #: lib/vutuv_web/templates/user/show.html.heex:666
+#: lib/vutuv_web/views/import_html.ex:62
 #: lib/vutuv_web/views/job_reference_html.ex:265
 #, elixir-autogen, elixir-format
 msgid "Education"
@@ -8182,7 +8186,7 @@ msgstr ""
 msgid "Education updated successfully."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/preview.html.heex:71
+#: lib/vutuv_web/templates/import/preview.html.heex:92
 #, elixir-autogen, elixir-format
 msgid "Email addresses are not imported automatically because each one is confirmed by PIN. Add them yourself if you like:"
 msgstr ""
@@ -8193,7 +8197,7 @@ msgstr ""
 msgid "Field of study"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/preview.html.heex:5
+#: lib/vutuv_web/templates/import/preview.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
@@ -8204,7 +8208,7 @@ msgid "Import"
 msgstr ""
 
 #: lib/vutuv_web/controllers/import_controller.ex:36
-#: lib/vutuv_web/controllers/import_controller.ex:121
+#: lib/vutuv_web/controllers/import_controller.ex:126
 #: lib/vutuv_web/templates/import/new.html.heex:1
 #: lib/vutuv_web/templates/import/preview.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:432
@@ -8212,17 +8216,17 @@ msgstr ""
 msgid "Import from LinkedIn"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/preview.html.heex:84
+#: lib/vutuv_web/templates/import/preview.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Import selected"
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:201
+#: lib/vutuv_web/controllers/import_controller.ex:212
 #, elixir-autogen, elixir-format
 msgid "Imported %{items}."
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:200
+#: lib/vutuv_web/controllers/import_controller.ex:211
 #, elixir-autogen, elixir-format
 msgid "Nothing new to import."
 msgstr ""
@@ -8232,11 +8236,12 @@ msgstr ""
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
 #: lib/vutuv_web/controllers/phone_number_controller.ex:87
-#: lib/vutuv_web/templates/import/new.html.heex:14
-#: lib/vutuv_web/templates/import/preview.html.heex:48
+#: lib/vutuv_web/templates/import/new.html.heex:15
+#: lib/vutuv_web/templates/import/preview.html.heex:69
 #: lib/vutuv_web/templates/phone_number/edit.html.heex:4
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:4
 #: lib/vutuv_web/templates/phone_number/new.html.heex:4
+#: lib/vutuv_web/views/import_html.ex:67
 #, elixir-autogen, elixir-format
 msgid "Phone numbers"
 msgstr ""
@@ -8251,23 +8256,24 @@ msgstr ""
 msgid "School"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/preview.html.heex:60
+#: lib/vutuv_web/templates/import/preview.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "Set %{field}:"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:13
-#: lib/vutuv_web/templates/import/preview.html.heex:44
+#: lib/vutuv_web/templates/import/new.html.heex:14
+#: lib/vutuv_web/templates/import/preview.html.heex:65
+#: lib/vutuv_web/views/import_html.ex:66
 #, elixir-autogen, elixir-format
 msgid "Social media"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:25
+#: lib/vutuv_web/templates/import/new.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Step 1: Download your LinkedIn data"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:76
+#: lib/vutuv_web/templates/import/new.html.heex:77
 #, elixir-autogen, elixir-format
 msgid "Step 2: Upload the ZIP here"
 msgstr ""
@@ -8277,7 +8283,7 @@ msgstr ""
 msgid "That does not look like a LinkedIn data export ZIP."
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:130
+#: lib/vutuv_web/controllers/import_controller.ex:135
 #, elixir-autogen, elixir-format
 msgid "The file could not be read. Please try again."
 msgstr ""
@@ -8287,23 +8293,24 @@ msgstr ""
 msgid "The import could not be completed. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:129
+#: lib/vutuv_web/templates/import/new.html.heex:130
 #, elixir-autogen, elixir-format
 msgid "Upload and preview"
 msgstr ""
 
 #: lib/vutuv_web/templates/import/new.html.heex:9
-#: lib/vutuv_web/templates/import/preview.html.heex:19
+#: lib/vutuv_web/templates/import/preview.html.heex:40
+#: lib/vutuv_web/views/import_html.ex:61
 #, elixir-autogen, elixir-format
 msgid "Work experience"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/preview.html.heex:75
+#: lib/vutuv_web/templates/import/preview.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "add an email address"
 msgstr ""
 
-#: lib/vutuv_web/views/import_html.ex:27
+#: lib/vutuv_web/views/import_html.ex:92
 #, elixir-autogen, elixir-format
 msgid "already on your profile"
 msgstr ""
@@ -8313,7 +8320,7 @@ msgstr ""
 msgid "That archive is too large or has too many files to import safely."
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:146
+#: lib/vutuv_web/controllers/import_controller.ex:151
 #, elixir-autogen, elixir-format
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
@@ -8326,13 +8333,6 @@ msgstr ""
 msgid "Please check the fields marked in red."
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:213
-#, elixir-autogen, elixir-format
-msgid "Skipped %{count} entry that is already on your profile or taken by another member."
-msgid_plural "Skipped %{count} entries that are already on your profile or taken by another member."
-msgstr[0] ""
-msgstr[1] ""
-
 #: lib/vutuv_web/views/user_html.ex:675
 #, elixir-autogen, elixir-format
 msgid "Loading posts"
@@ -8344,37 +8344,37 @@ msgstr ""
 msgid "Social media posts"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:50
+#: lib/vutuv_web/templates/import/new.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Click \"Request archive\"."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:62
+#: lib/vutuv_web/templates/import/new.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "LinkedIn's \"Download my data\" page with \"Download larger data archive\" selected and the \"Request archive\" button below it."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:38
+#: lib/vutuv_web/templates/import/new.html.heex:39
 #, elixir-autogen, elixir-format
 msgid "Open LinkedIn's data export page"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:72
+#: lib/vutuv_web/templates/import/new.html.heex:73
 #, elixir-autogen, elixir-format
 msgid "Select the larger archive, then click \"Request archive\"."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:27
+#: lib/vutuv_web/templates/import/new.html.heex:28
 #, elixir-autogen, elixir-format
 msgid "LinkedIn lets you export your own data as a ZIP archive. Open the export page, request the larger archive, and download the ZIP once LinkedIn has finished preparing it (this usually takes a few minutes)."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:52
+#: lib/vutuv_web/templates/import/new.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "LinkedIn prepares your archive. When it is ready (usually after a few minutes), download the ZIP to your device."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:78
+#: lib/vutuv_web/templates/import/new.html.heex:79
 #, elixir-autogen, elixir-format
 msgid "Then upload the ZIP file below to see the preview and pick what to add."
 msgstr ""
@@ -8384,7 +8384,7 @@ msgstr ""
 msgid "What gets imported"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:18
+#: lib/vutuv_web/templates/import/new.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "You decide exactly what to add. In the next step we show you everything we found and you pick it entry by entry, so you never import anything sight unseen. Nothing is added until you confirm, and your existing entries are never overwritten."
 msgstr ""
@@ -8394,7 +8394,7 @@ msgstr ""
 msgid "Import your LinkedIn profile data into your vutuv profile. From your export we can fill in:"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:110
+#: lib/vutuv_web/templates/import/new.html.heex:111
 #, elixir-autogen, elixir-format
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
@@ -8485,12 +8485,12 @@ msgstr ""
 msgid "The file you sent is too large."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:92
+#: lib/vutuv_web/templates/import/new.html.heex:93
 #, elixir-autogen, elixir-format
 msgid "This file is too large. Please choose a ZIP of at most 50 MB."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:115
+#: lib/vutuv_web/templates/import/new.html.heex:116
 #, elixir-autogen, elixir-format
 msgid "ZIP file, up to 50 MB."
 msgstr ""
@@ -8604,7 +8604,7 @@ msgstr ""
 msgid "Not written yet"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:226
+#: lib/vutuv_web/components/organization_components.ex:234
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "Page"
@@ -8640,7 +8640,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:610
 #: lib/vutuv_web/agent_docs/text.ex:567
 #: lib/vutuv_web/agent_docs/text.ex:571
-#: lib/vutuv_web/components/organization_components.ex:258
+#: lib/vutuv_web/components/organization_components.ex:266
 #: lib/vutuv_web/components/ui.ex:3915
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:323
@@ -8727,7 +8727,7 @@ msgstr ""
 msgid "Internships"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:46
+#: lib/vutuv_web/templates/import/new.html.heex:47
 #, elixir-autogen, elixir-format
 msgid "On that page, select \"Download larger data archive\" (profile, positions, volunteering, education, skills)."
 msgstr ""
@@ -9548,7 +9548,7 @@ msgstr ""
 msgid "“%{name}” is an honor tag now. Add members below."
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:183
+#: lib/vutuv_web/controllers/import_controller.ex:194
 #, elixir-autogen, elixir-format
 msgid "%{count} certificate or license"
 msgid_plural "%{count} certificates or licenses"
@@ -9598,13 +9598,15 @@ msgstr ""
 #: lib/vutuv_web/cv/latex.ex:140
 #: lib/vutuv_web/cv/odt.ex:154
 #: lib/vutuv_web/live/cv_live.ex:361
-#: lib/vutuv_web/templates/import/preview.html.heex:27
+#: lib/vutuv_web/templates/import/new.html.heex:11
+#: lib/vutuv_web/templates/import/preview.html.heex:48
 #: lib/vutuv_web/templates/qualification/edit.html.heex:4
 #: lib/vutuv_web/templates/qualification/index.html.heex:11
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
 #: lib/vutuv_web/templates/user/show.html.heex:834
+#: lib/vutuv_web/views/import_html.ex:63
 #: lib/vutuv_web/views/job_reference_html.ex:266
 #, elixir-autogen, elixir-format
 msgid "Certificates & licenses"
@@ -9667,7 +9669,7 @@ msgstr ""
 msgid "Licenses"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/preview.html.heex:29
+#: lib/vutuv_web/templates/import/preview.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "LinkedIn does not say whether an entry is a certificate or a license, so we import all of them as certificates. Please review the section afterwards and switch any that are licenses."
 msgstr ""
@@ -10766,7 +10768,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/organization_live.ex:179
 #: lib/vutuv_web/live/admin/organization_live.ex:194
 #: lib/vutuv_web/live/admin/screenshot_live.ex:535
-#: lib/vutuv_web/live/organization_live/domains.ex:197
+#: lib/vutuv_web/live/organization_live/domains.ex:203
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
@@ -11025,7 +11027,7 @@ msgstr ""
 msgid "Your list is empty. Nobody is excluded yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:328
+#: lib/vutuv_web/live/organization_live/edit.ex:334
 #: lib/vutuv_web/views/account_event_text.ex:210
 #, elixir-autogen, elixir-format
 msgid "AI agents"
@@ -11041,8 +11043,8 @@ msgstr ""
 msgid "Continue to verification"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:261
-#: lib/vutuv_web/live/organization_live/domains.ex:301
+#: lib/vutuv_web/live/organization_live/domains.ex:267
+#: lib/vutuv_web/live/organization_live/domains.ex:307
 #: lib/vutuv_web/live/organization_live/new.ex:161
 #: lib/vutuv_web/live/organization_live/show.ex:838
 #: lib/vutuv_web/templates/url/verify.html.heex:46
@@ -11050,36 +11052,36 @@ msgstr ""
 msgid "DNS TXT record"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:180
-#: lib/vutuv_web/live/organization_live/domains.ex:342
+#: lib/vutuv_web/live/organization_live/domains.ex:186
+#: lib/vutuv_web/live/organization_live/domains.ex:348
 #: lib/vutuv_web/live/organization_live/show.ex:904
 #: lib/vutuv_web/live/organization_live/show.ex:912
 #, elixir-autogen, elixir-format
 msgid "Domain verification is disabled on this installation."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:31
-#: lib/vutuv_web/live/organization_live/edit.ex:240
+#: lib/vutuv_web/live/organization_live/edit.ex:32
+#: lib/vutuv_web/live/organization_live/edit.ex:246
 #, elixir-autogen, elixir-format
 msgid "Edit %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:314
+#: lib/vutuv_web/live/organization_live/edit.ex:320
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this page and include it in the sitemap."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:247
+#: lib/vutuv_web/live/organization_live/edit.ex:253
 #, elixir-autogen, elixir-format
 msgid "Logo"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:275
+#: lib/vutuv_web/live/organization_live/edit.ex:281
 #, elixir-autogen, elixir-format
 msgid "Markdown is supported"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:330
+#: lib/vutuv_web/live/organization_live/edit.ex:336
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) and list them for AI agents."
 msgstr ""
@@ -11095,7 +11097,7 @@ msgstr ""
 msgid "Prove you control %{domain} to publish this page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:258
+#: lib/vutuv_web/live/organization_live/edit.ex:264
 #, elixir-autogen, elixir-format
 msgid "Remove logo"
 msgstr ""
@@ -11105,7 +11107,7 @@ msgstr ""
 msgid "Search by name or city"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:312
+#: lib/vutuv_web/live/organization_live/edit.ex:318
 #: lib/vutuv_web/views/account_event_text.ex:209
 #, elixir-autogen, elixir-format
 msgid "Search engines"
@@ -11116,29 +11118,29 @@ msgstr ""
 msgid "Select a country"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:320
+#: lib/vutuv_web/live/organization_live/domains.ex:326
 #: lib/vutuv_web/live/organization_live/show.ex:873
 #, elixir-autogen, elixir-format
 msgid "Serve this file at:"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:293
+#: lib/vutuv_web/live/organization_live/edit.ex:299
 #: lib/vutuv_web/live/organization_live/new.ex:139
 #, elixir-autogen, elixir-format
 msgid "State / region (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:477
+#: lib/vutuv_web/live/organization_live/edit.ex:483
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:475
+#: lib/vutuv_web/live/organization_live/edit.ex:481
 #, elixir-autogen, elixir-format
 msgid "The file is too large."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:478
+#: lib/vutuv_web/live/organization_live/edit.ex:484
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr ""
@@ -11170,7 +11172,7 @@ msgstr ""
 msgid "Verify %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:336
+#: lib/vutuv_web/live/organization_live/domains.ex:342
 #: lib/vutuv_web/live/organization_live/show.ex:898
 #, elixir-autogen, elixir-format
 msgid "Verify now"
@@ -11178,14 +11180,14 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:243
 #: lib/vutuv_web/agent_docs/text.ex:227
-#: lib/vutuv_web/live/organization_live/edit.ex:287
+#: lib/vutuv_web/live/organization_live/edit.ex:293
 #: lib/vutuv_web/live/organization_live/new.ex:130
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:262
-#: lib/vutuv_web/live/organization_live/domains.ex:311
+#: lib/vutuv_web/live/organization_live/domains.ex:268
+#: lib/vutuv_web/live/organization_live/domains.ex:317
 #: lib/vutuv_web/live/organization_live/show.ex:849
 #: lib/vutuv_web/templates/url/verify.html.heex:99
 #, elixir-autogen, elixir-format
@@ -11197,7 +11199,7 @@ msgstr ""
 msgid "Website file (.well-known)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:476
+#: lib/vutuv_web/live/organization_live/edit.ex:482
 #, elixir-autogen, elixir-format
 msgid "You can only upload one logo."
 msgstr ""
@@ -11207,65 +11209,65 @@ msgstr ""
 msgid "You will publish a record or file to prove control of the domain on the next step."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:322
+#: lib/vutuv_web/live/organization_live/domains.ex:328
 #: lib/vutuv_web/live/organization_live/show.ex:879
 #: lib/vutuv_web/templates/url/verify.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "with this exact content:"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:180
+#: lib/vutuv_web/live/organization_live/roles.ex:186
 #, elixir-autogen, elixir-format
 msgid "@handle or email"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:307
-#: lib/vutuv_web/live/organization_live/edit.ex:390
+#: lib/vutuv_web/components/organization_components.ex:315
+#: lib/vutuv_web/live/organization_live/edit.ex:396
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:249
+#: lib/vutuv_web/live/organization_live/domains.ex:255
 #, elixir-autogen, elixir-format
 msgid "Add a domain"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:171
+#: lib/vutuv_web/live/organization_live/roles.ex:177
 #, elixir-autogen, elixir-format
 msgid "Add a member"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:143
+#: lib/vutuv_web/live/organization_live/roles.ex:144
 #, elixir-autogen, elixir-format
 msgid "Added @%{handle} to the team."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:308
-#: lib/vutuv_web/live/organization_live/edit.ex:388
+#: lib/vutuv_web/components/organization_components.ex:316
+#: lib/vutuv_web/live/organization_live/edit.ex:394
 #, elixir-autogen, elixir-format
 msgid "Alias"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:99
+#: lib/vutuv_web/live/organization_live/edit.ex:100
 #, elixir-autogen, elixir-format
 msgid "Alias added."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:123
+#: lib/vutuv_web/live/organization_live/edit.ex:124
 #, elixir-autogen, elixir-format
 msgid "Alias removed."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:427
 #: lib/vutuv_web/agent_docs/text.ex:444
-#: lib/vutuv_web/live/organization_live/edit.ex:353
+#: lib/vutuv_web/live/organization_live/edit.ex:359
 #: lib/vutuv_web/live/organization_live/show.ex:774
 #: lib/vutuv_web/templates/tag/single_card.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Also known as"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:384
+#: lib/vutuv_web/live/organization_live/edit.ex:390
 #, elixir-autogen, elixir-format
 msgid "Alternative name"
 msgstr ""
@@ -11286,8 +11288,8 @@ msgstr ""
 msgid "Archived"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:306
-#: lib/vutuv_web/live/organization_live/edit.ex:389
+#: lib/vutuv_web/components/organization_components.ex:314
+#: lib/vutuv_web/live/organization_live/edit.ex:395
 #, elixir-autogen, elixir-format
 msgid "Brand"
 msgstr ""
@@ -11297,7 +11299,7 @@ msgstr ""
 msgid "Claimed by"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:216
+#: lib/vutuv_web/live/organization_live/roles.ex:222
 #, elixir-autogen, elixir-format
 msgid "Current team"
 msgstr ""
@@ -11307,35 +11309,35 @@ msgstr ""
 msgid "Delete this page and everything it owns? This cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:65
+#: lib/vutuv_web/live/organization_live/domains.ex:66
 #, elixir-autogen, elixir-format
 msgid "Domain added. Publish the record or file, then verify it."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:139
+#: lib/vutuv_web/live/organization_live/domains.ex:140
 #, elixir-autogen, elixir-format
 msgid "Domain removed."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:108
+#: lib/vutuv_web/live/organization_live/domains.ex:109
 #, elixir-autogen, elixir-format
 msgid "Domain verified."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:232
+#: lib/vutuv_web/components/organization_components.ex:240
 #: lib/vutuv_web/live/admin/organization_live.ex:305
-#: lib/vutuv_web/live/organization_live/domains.ex:174
+#: lib/vutuv_web/live/organization_live/domains.ex:180
 #: lib/vutuv_web/live/organization_live/show.ex:525
 #, elixir-autogen, elixir-format
 msgid "Domains"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:29
+#: lib/vutuv_web/live/organization_live/domains.ex:30
 #, elixir-autogen, elixir-format
 msgid "Domains – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:305
+#: lib/vutuv_web/components/organization_components.ex:313
 #, elixir-autogen, elixir-format
 msgid "Former name"
 msgstr ""
@@ -11352,13 +11354,13 @@ msgstr ""
 msgid "Freeze this page? It disappears for the public but stays visible to its owner."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:202
+#: lib/vutuv_web/live/organization_live/domains.ex:208
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "Last checked"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:243
+#: lib/vutuv_web/live/organization_live/roles.ex:249
 #, elixir-autogen, elixir-format
 msgid "Leave"
 msgstr ""
@@ -11373,17 +11375,17 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:233
+#: lib/vutuv_web/live/organization_live/domains.ex:239
 #, elixir-autogen, elixir-format
 msgid "Make primary"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:94
+#: lib/vutuv_web/live/organization_live/roles.ex:95
 #, elixir-autogen, elixir-format
 msgid "Member removed."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:202
+#: lib/vutuv_web/live/organization_live/domains.ex:208
 #, elixir-autogen, elixir-format
 msgid "Method"
 msgstr ""
@@ -11393,42 +11395,42 @@ msgstr ""
 msgid "Names & aliases"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:81
+#: lib/vutuv_web/live/organization_live/roles.ex:82
 #, elixir-autogen, elixir-format
 msgid "No member found for “%{id}”."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:124
+#: lib/vutuv_web/live/organization_live/domains.ex:125
 #, elixir-autogen, elixir-format
 msgid "Only a verified domain can be the primary one."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:188
+#: lib/vutuv_web/live/organization_live/domains.ex:194
 #, elixir-autogen, elixir-format
 msgid "Primary"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:120
+#: lib/vutuv_web/live/organization_live/domains.ex:121
 #, elixir-autogen, elixir-format
 msgid "Primary domain updated."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:294
+#: lib/vutuv_web/components/organization_components.ex:302
 #, elixir-autogen, elixir-format
 msgid "Recruiter"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:239
+#: lib/vutuv_web/live/organization_live/domains.ex:245
 #, elixir-autogen, elixir-format
 msgid "Remove this domain?"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:238
+#: lib/vutuv_web/live/organization_live/roles.ex:244
 #, elixir-autogen, elixir-format
 msgid "Remove this member from the team?"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:370
+#: lib/vutuv_web/live/organization_live/edit.ex:376
 #, elixir-autogen, elixir-format
 msgid "Remove this name?"
 msgstr ""
@@ -11438,25 +11440,25 @@ msgstr ""
 msgid "Search name, alias or domain"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:229
+#: lib/vutuv_web/components/organization_components.ex:237
 #: lib/vutuv_web/live/admin/organization_live.ex:321
-#: lib/vutuv_web/live/organization_live/roles.ex:165
+#: lib/vutuv_web/live/organization_live/roles.ex:171
 #: lib/vutuv_web/live/organization_live/show.ex:518
 #, elixir-autogen, elixir-format
 msgid "Team"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:36
+#: lib/vutuv_web/live/organization_live/roles.ex:37
 #, elixir-autogen, elixir-format
 msgid "Team – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:76
+#: lib/vutuv_web/live/organization_live/domains.ex:77
 #, elixir-autogen, elixir-format
 msgid "That is not a valid domain."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:146
+#: lib/vutuv_web/live/organization_live/roles.ex:147
 #, elixir-autogen, elixir-format
 msgid "That member could not be added."
 msgstr ""
@@ -11485,39 +11487,39 @@ msgstr ""
 msgid "verified"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:290
+#: lib/vutuv_web/live/organization_live/edit.ex:296
 #: lib/vutuv_web/live/organization_live/new.ex:136
 #, elixir-autogen, elixir-format
 msgid "Street address (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:291
+#: lib/vutuv_web/live/organization_live/edit.ex:297
 #: lib/vutuv_web/live/organization_live/new.ex:137
 #, elixir-autogen, elixir-format
 msgid "ZIP / postal code (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:447
+#: lib/vutuv_web/live/organization_live/edit.ex:453
 #, elixir-autogen, elixir-format
 msgid "Claim"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:416
+#: lib/vutuv_web/live/organization_live/edit.ex:422
 #, elixir-autogen, elixir-format
 msgid "Reachable at"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:203
+#: lib/vutuv_web/live/organization_live/edit.ex:204
 #, elixir-autogen, elixir-format
 msgid "That handle is not available."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:453
+#: lib/vutuv_web/live/organization_live/edit.ex:459
 #, elixir-autogen, elixir-format
 msgid "Danger zone"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:464
+#: lib/vutuv_web/live/organization_live/edit.ex:470
 #, elixir-autogen, elixir-format
 msgid "Really delete %{name}? This cannot be undone."
 msgstr ""
@@ -11659,22 +11661,22 @@ msgid_plural "%{count} aliases match another verified organization and are flagg
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:355
+#: lib/vutuv_web/live/organization_live/edit.ex:361
 #, elixir-autogen, elixir-format
 msgid "Alternative names, brands or abbreviations this organization is findable under. A rename keeps the old name here automatically."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:176
+#: lib/vutuv_web/live/organization_live/domains.ex:182
 #, elixir-autogen, elixir-format
 msgid "An organization can prove several domains. The primary one shows in the “Verified via …” badge."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:146
+#: lib/vutuv_web/live/organization_live/domains.ex:147
 #, elixir-autogen, elixir-format
 msgid "An organization keeps at least one verified domain, so this one cannot be removed."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:152
+#: lib/vutuv_web/live/organization_live/roles.ex:153
 #, elixir-autogen, elixir-format
 msgid "An organization must keep at least one owner, so the last owner cannot be changed."
 msgstr ""
@@ -11723,23 +11725,23 @@ msgstr ""
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:468
+#: lib/vutuv_web/live/organization_live/edit.ex:474
 #, elixir-autogen, elixir-format
 msgid "Delete this organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:455
+#: lib/vutuv_web/live/organization_live/edit.ex:461
 #, elixir-autogen, elixir-format
 msgid "Deleting this organization page is permanent. Its verified domains and its @handle are freed and can be claimed again."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:268
+#: lib/vutuv_web/live/organization_live/edit.ex:274
 #: lib/vutuv_web/live/organization_live/new.ex:126
 #, elixir-autogen, elixir-format
 msgid "Kind of organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:237
+#: lib/vutuv_web/live/organization_live/roles.ex:243
 #, elixir-autogen, elixir-format
 msgid "Leave this organization team?"
 msgstr ""
@@ -11799,7 +11801,7 @@ msgstr ""
 msgid "Organization frozen."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:267
+#: lib/vutuv_web/live/organization_live/edit.ex:273
 #: lib/vutuv_web/live/organization_live/new.ex:125
 #, elixir-autogen, elixir-format
 msgid "Organization name"
@@ -11866,7 +11868,7 @@ msgstr ""
 msgid "Search organizations"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:72
+#: lib/vutuv_web/live/organization_live/domains.ex:73
 #, elixir-autogen, elixir-format
 msgid "That domain already belongs to an organization page."
 msgstr ""
@@ -11876,12 +11878,12 @@ msgstr ""
 msgid "That domain already belongs to another organization page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:106
+#: lib/vutuv_web/live/organization_live/edit.ex:107
 #, elixir-autogen, elixir-format
 msgid "That name is already listed for this organization."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:191
+#: lib/vutuv_web/live/organization_live/edit.ex:192
 #, elixir-autogen, elixir-format
 msgid "The organization page was deleted."
 msgstr ""
@@ -11906,12 +11908,12 @@ msgstr ""
 msgid "Verified organization pages: domains, team roles, aliases and rename history. Freeze, archive or delete a page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:174
+#: lib/vutuv_web/live/organization_live/edit.ex:175
 #, elixir-autogen, elixir-format
 msgid "You are not allowed to delete this organization."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:139
+#: lib/vutuv_web/live/organization_live/edit.ex:140
 #, elixir-autogen, elixir-format
 msgid "Your organization handle is set."
 msgstr ""
@@ -11922,7 +11924,7 @@ msgstr ""
 msgid "Your organization page is verified and now live."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:70
+#: lib/vutuv_web/live/organization_live/edit.ex:71
 #, elixir-autogen, elixir-format
 msgid "Your organization page was updated."
 msgstr ""
@@ -11947,7 +11949,7 @@ msgstr ""
 msgid "made you an owner of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:437
+#: lib/vutuv_web/live/organization_live/edit.ex:443
 #, elixir-autogen, elixir-format
 msgid "your_organization"
 msgstr ""
@@ -12493,17 +12495,17 @@ msgstr ""
 msgid "A domain of your organization page on vutuv is about to be dropped"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:215
+#: lib/vutuv_web/live/organization_live/domains.ex:221
 #, elixir-autogen, elixir-format
 msgid "Deadline"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:194
+#: lib/vutuv_web/live/organization_live/domains.ex:200
 #, elixir-autogen, elixir-format
 msgid "Proof missing"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:214
+#: lib/vutuv_web/live/organization_live/domains.ex:220
 #, elixir-autogen, elixir-format
 msgid "We could not read this domain's proof on the last check. Restore it and check again, or the domain loses its verification."
 msgstr ""
@@ -12616,13 +12618,13 @@ msgstr ""
 msgid "Getting an error, or is %{host} a CNAME / alias to another address? A TXT record cannot share a name with a CNAME. Use this name instead, with the exact same value as above:"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:318
+#: lib/vutuv_web/live/organization_live/domains.ex:324
 #: lib/vutuv_web/live/organization_live/show.ex:866
 #, elixir-autogen, elixir-format
 msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:316
+#: lib/vutuv_web/live/organization_live/domains.ex:322
 #: lib/vutuv_web/live/organization_live/show.ex:857
 #, elixir-autogen, elixir-format
 msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
@@ -12638,7 +12640,7 @@ msgstr ""
 msgid "Name (host)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:147
+#: lib/vutuv_web/live/organization_live/edit.ex:148
 #, elixir-autogen, elixir-format
 msgid "Only a verified organization page can claim a handle."
 msgstr ""
@@ -13174,7 +13176,7 @@ msgstr ""
 msgid "Back to the posting"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/exclusions.ex:106
+#: lib/vutuv_web/live/organization_live/exclusions.ex:112
 #, elixir-autogen, elixir-format
 msgid "Every posting attributed to this organization inherits this standing list, on top of its own. Use it to keep vacancies away from competitors you never advertise to."
 msgstr ""
@@ -13205,13 +13207,13 @@ msgstr ""
 msgid "Inherited from the organization"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:235
-#: lib/vutuv_web/live/organization_live/exclusions.ex:103
+#: lib/vutuv_web/components/organization_components.ex:243
+#: lib/vutuv_web/live/organization_live/exclusions.ex:109
 #, elixir-autogen, elixir-format
 msgid "Job exclusions"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/exclusions.ex:33
+#: lib/vutuv_web/live/organization_live/exclusions.ex:34
 #, elixir-autogen, elixir-format
 msgid "Job exclusions – %{name}"
 msgstr ""
@@ -13292,7 +13294,7 @@ msgstr ""
 msgid "Reviewed, all fine: clear the flag"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:181
+#: lib/vutuv_web/live/organization_live/edit.ex:182
 #, elixir-autogen, elixir-format
 msgid "This page has job postings, so it cannot be deleted. Ask an admin to archive it instead."
 msgstr ""
@@ -14489,7 +14491,7 @@ msgstr ""
 msgid "Word, phrase or tag to mute"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:161
+#: lib/vutuv_web/live/organization_live/edit.ex:162
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You are not allowed to change this organization's handle."
 msgstr ""
@@ -19943,47 +19945,47 @@ msgstr ""
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:293
+#: lib/vutuv_web/components/organization_components.ex:301
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Editorial"
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:299
+#: lib/vutuv_web/components/organization_components.ex:307
 #, elixir-autogen, elixir-format
 msgid "Edits the page and posts jobs."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:167
+#: lib/vutuv_web/live/organization_live/roles.ex:173
 #, elixir-autogen, elixir-format
 msgid "Give members their roles on this page. Someone can hold several at once, and every role is granted on its own."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:298
+#: lib/vutuv_web/components/organization_components.ex:306
 #, elixir-autogen, elixir-format
 msgid "Manages the team and the domains, and edits the page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:74
+#: lib/vutuv_web/live/organization_live/roles.ex:75
 #, elixir-autogen, elixir-format
 msgid "Pick at least one role."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:301
+#: lib/vutuv_web/components/organization_components.ex:309
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Posts jobs."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:270
+#: lib/vutuv_web/live/organization_live/roles.ex:276
 #, elixir-autogen, elixir-format
 msgid "Roles"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/roles.ex:88
+#: lib/vutuv_web/live/organization_live/roles.ex:89
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Roles updated."
 msgstr ""
 
-#: lib/vutuv_web/components/organization_components.ex:300
+#: lib/vutuv_web/components/organization_components.ex:308
 #, elixir-autogen, elixir-format
 msgid "Writes posts in the organization's name."
 msgstr ""
@@ -20116,7 +20118,7 @@ msgstr ""
 msgid "%{name} follows"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/feed.ex:41
+#: lib/vutuv_web/live/organization_live/feed.ex:49
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Feed – %{name}"
 msgstr ""
@@ -20131,7 +20133,7 @@ msgstr ""
 msgid "Members and organizations"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/feed.ex:85
+#: lib/vutuv_web/live/organization_live/feed.ex:107
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. This page does not follow anyone, or nobody it follows has published."
 msgstr ""
@@ -20162,7 +20164,7 @@ msgstr ""
 msgid "Unfollow %{tag}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/feed.ex:81
+#: lib/vutuv_web/live/organization_live/feed.ex:103
 #, elixir-autogen, elixir-format
 msgid "What the members and organizations this page follows have published. Liking or saving something here is done from your own account, not the page's."
 msgstr ""
@@ -20311,12 +20313,12 @@ msgstr ""
 msgid "This vutuv exchanges nothing with other networks, so nothing here has any effect."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:408
+#: lib/vutuv_web/live/organization_live/edit.ex:414
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Claim a short @name so this organization has an address of its own, like a member. Letters, numbers and underscores, %{min} to %{max} characters."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:406
+#: lib/vutuv_web/live/organization_live/edit.ex:412
 #, elixir-autogen, elixir-format
 msgid "The organization's @name"
 msgstr ""
@@ -20544,7 +20546,7 @@ msgstr ""
 msgid "A new entry can take a while to reach everyone. We keep checking %{domain} by ourselves and send you an email as soon as it works, so you can close this page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/domains.ex:332
+#: lib/vutuv_web/live/organization_live/domains.ex:338
 #: lib/vutuv_web/live/organization_live/show.ex:894
 #, elixir-autogen, elixir-format
 msgid "Checking …"
@@ -20638,4 +20640,60 @@ msgstr ""
 #: lib/vutuv_web/templates/layout/app.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Legal"
+msgstr ""
+
+#: lib/vutuv_web/controllers/import_controller.ex:247
+#, elixir-autogen, elixir-format
+msgid "%{count} entry could not be added."
+msgid_plural "%{count} entries could not be added."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/controllers/import_controller.ex:237
+#, elixir-autogen, elixir-format
+msgid "%{count} social account could not be added because another member has already claimed it."
+msgid_plural "%{count} social accounts could not be added because another member has already claimed them."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/views/import_html.ex:31
+#, elixir-autogen, elixir-format
+msgid "Already on your profile"
+msgstr ""
+
+#: lib/vutuv_web/templates/import/preview.html.heex:11
+#, elixir-autogen, elixir-format
+msgid "Analysis complete. Nothing has been imported yet."
+msgstr ""
+
+#: lib/vutuv_web/views/import_html.ex:30
+#, elixir-autogen, elixir-format
+msgid "Found"
+msgstr ""
+
+#: lib/vutuv_web/views/import_html.ex:32
+#, elixir-autogen, elixir-format
+msgid "Ready to import"
+msgstr ""
+
+#: lib/vutuv_web/templates/import/preview.html.heex:13
+#, elixir-autogen, elixir-format
+msgid "Review the entries below and confirm your selection to add them to your profile."
+msgstr ""
+
+#: lib/vutuv_web/views/import_html.ex:29
+#, elixir-autogen, elixir-format
+msgid "Section"
+msgstr ""
+
+#: lib/vutuv_web/controllers/import_controller.ex:219
+#, elixir-autogen, elixir-format
+msgid "Skipped %{count} entry that is already on your profile."
+msgid_plural "Skipped %{count} entries that are already on your profile."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/templates/import/preview.html.heex:20
+#, elixir-autogen, elixir-format
+msgid "You can analyse the same or a newer LinkedIn archive again at any time. Nothing is duplicated and nothing is overwritten. Entries you already have are not updated either: they keep the description and dates they have on vutuv, even when your archive holds newer ones."
 msgstr ""

--- a/test/vutuv/imports/linked_in_apply_test.exs
+++ b/test/vutuv/imports/linked_in_apply_test.exs
@@ -126,9 +126,12 @@ defmodule Vutuv.Imports.LinkedInApplyTest do
 
     {:ok, summary} = LinkedIn.apply_selection(user, parsed)
 
-    # The claimed handle is skipped; the phone AFTER it still imports.
+    # The claimed handle is BLOCKED, not skipped: the member does not have it
+    # and never will from this archive, so the flash must not tell them it is
+    # already on their profile. The phone AFTER it still imports.
     assert summary.created.social == 0
-    assert summary.skipped.social == 1
+    assert summary.blocked.social == 1
+    assert summary.skipped.social == 0
     assert summary.created.phones == 1
 
     assert Repo.aggregate(
@@ -185,7 +188,7 @@ defmodule Vutuv.Imports.LinkedInApplyTest do
     {:ok, summary} = LinkedIn.apply_selection(user, parsed)
 
     assert summary.created.positions == 1
-    assert summary.skipped.positions == 1
+    assert summary.blocked.positions == 1
     assert Repo.get_by(WorkExperience, user_id: user.id, organization: "Beta")
     refute Repo.get_by(WorkExperience, user_id: user.id, organization: "Acme")
   end
@@ -202,7 +205,7 @@ defmodule Vutuv.Imports.LinkedInApplyTest do
     {:ok, summary} = LinkedIn.apply_selection(user, parsed)
 
     assert summary.created.urls == 0
-    assert summary.skipped.urls == 1
+    assert summary.blocked.urls == 1
   end
 
   test "fills a blank headline but never overwrites an existing one" do

--- a/test/vutuv/imports/linked_in_preview_test.exs
+++ b/test/vutuv/imports/linked_in_preview_test.exs
@@ -1,0 +1,87 @@
+defmodule Vutuv.Imports.LinkedInPreviewTest do
+  @moduledoc """
+  The preview layer of the LinkedIn import: `mark_duplicates/2` decides what the
+  member already has, and `summary_rows/1` tallies that per section for the
+  analysis summary the preview leads with (issue #1477).
+  """
+  use Vutuv.DataCase, async: true
+
+  import Vutuv.Factory
+
+  alias Vutuv.Imports.LinkedIn
+
+  defp zip(files) do
+    entries = Enum.map(files, fn {name, content} -> {String.to_charlist(name), content} end)
+    {:ok, {_name, binary}} = :zip.create(~c"export.zip", entries, [:memory])
+    binary
+  end
+
+  defp positions_csv(rows) do
+    "Company Name,Title,Description,Location,Started On,Finished On\n" <> rows
+  end
+
+  defp summary_for(user, files) do
+    {:ok, parsed} = LinkedIn.parse(zip(files))
+
+    user
+    |> LinkedIn.mark_duplicates(parsed)
+    |> LinkedIn.summary_rows()
+    |> Map.new(fn row -> {row.key, row} end)
+  end
+
+  test "an entry the member already has counts as present, not as available" do
+    user = insert(:user)
+    insert(:work_experience, user: user, organization: "Acme", title: "Engineer")
+
+    summary =
+      summary_for(user, [
+        {"Positions.csv",
+         positions_csv("Acme,Engineer,,Berlin,2020,\nBeta,Developer,,Kiel,2021,\n")}
+      ])
+
+    assert summary.positions == %{key: :positions, found: 2, present: 1, available: 1}
+  end
+
+  test "a section the archive says nothing about is a row of zeros, not a missing row" do
+    user = insert(:user)
+
+    summary = summary_for(user, [{"Skills.csv", "Name\nElixir\n"}])
+
+    # Every supported section is listed, so the member can see what we looked
+    # for; the empty ones simply hold zeros rather than claiming a file is
+    # missing (an empty section and an absent one look the same from here).
+    assert summary.skills == %{key: :skills, found: 1, present: 0, available: 1}
+    assert summary.certifications == %{key: :certifications, found: 0, present: 0, available: 0}
+    assert summary.phones == %{key: :phones, found: 0, present: 0, available: 0}
+  end
+
+  # Profile scalars carry `fillable?` instead of `duplicate?`: the import only
+  # ever fills a blank field, so a name the member already has is "present".
+  test "a profile field that is already set counts as present" do
+    user = insert(:user, first_name: "Ada", last_name: nil)
+
+    profile_csv =
+      "First Name,Last Name,Maiden Name,Address,Birth Date,Headline,Summary,Industry," <>
+        "Zip Code,Geo Location,Twitter Handles,Websites,Instant Messengers\n" <>
+        "Stefan,Wintermeyer,,,,,,,,,,,\n"
+
+    summary = summary_for(user, [{"Profile.csv", profile_csv}])
+
+    assert summary.profile == %{key: :profile, found: 2, present: 1, available: 1}
+  end
+
+  test "the archive's own repeated entries are collapsed before they are counted" do
+    # A real export repeats entries across its files. They are one candidate,
+    # so the summary must not report the extra copies as anything at all - an
+    # "ignored" figure here would read as lost data.
+    user = insert(:user)
+
+    summary =
+      summary_for(user, [
+        {"Positions.csv", positions_csv("Acme,Engineer,,Berlin,2020,\n")},
+        {"positions-2.csv", positions_csv("Acme,Engineer,,Berlin,2020,\n")}
+      ])
+
+    assert summary.positions == %{key: :positions, found: 1, present: 0, available: 1}
+  end
+end

--- a/test/vutuv_web/controllers/import_controller_test.exs
+++ b/test/vutuv_web/controllers/import_controller_test.exs
@@ -67,6 +67,59 @@ defmodule VutuvWeb.ImportControllerTest do
     assert body =~ "data-select-all"
   end
 
+  # Issue #1477: a member who comes back to the importer could not tell whether
+  # the last upload had already changed their profile. The preview now says so
+  # before anything else, and tallies what the archive held per section.
+  test "the preview says nothing was imported and tallies each section", %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+    insert(:work_experience, user: user, organization: "Acme", title: "Engineer")
+
+    conn =
+      post(conn, ~p"/settings/import/linkedin", %{
+        "import" => %{"archive" => upload_zip(@sample_files)}
+      })
+
+    body = html_response(conn, 200)
+    assert body =~ "data-import-analysis"
+    assert body =~ "Nothing has been imported yet"
+    # The additive behaviour is stated on the page, because an entry the member
+    # edited on LinkedIn is NOT updated here and the unchecked row does not say so.
+    assert body =~ "not updated either"
+
+    # One position, already on the profile: found 1, present 1, nothing left.
+    assert [_, found, present, available] =
+             Regex.run(
+               ~r/data-import-summary-row="positions".*?>(\d+)<.*?>(\d+)<.*?>(\d+)</s,
+               body
+             )
+
+    assert {found, present, available} == {"1", "1", "0"}
+
+    # A section this archive said nothing about is a row of zeros, not a claim
+    # that a file is missing.
+    assert body =~ ~s(data-import-summary-row="certifications")
+  end
+
+  test "the preview renders in German", %{conn: conn} do
+    # vutuv is a German site; an English-only check would miss a missing or
+    # fuzzy-filled translation on the whole panel.
+    {conn, _user} = create_and_login_user(conn)
+
+    conn =
+      conn
+      |> recycle()
+      |> put_req_header("accept-language", "de-DE,de")
+      |> post(~p"/settings/import/linkedin", %{
+        "import" => %{"archive" => upload_zip(@sample_files)}
+      })
+
+    body = html_response(conn, 200)
+    assert body =~ "Analyse abgeschlossen"
+    assert body =~ "Es wurde noch nichts importiert"
+    assert body =~ "Schon im Profil"
+    assert body =~ "Zum Import bereit"
+  end
+
   test "the uploaded temp file is deleted after parsing", %{conn: conn} do
     {conn, _user} = create_and_login_user(conn)
     upload = upload_zip(@sample_files)
@@ -150,5 +203,58 @@ defmodule VutuvWeb.ImportControllerTest do
                where: ut.user_id == ^user.id and t.name == "Elixir"
              )
            )
+  end
+
+  # Issue #1477: "already on your profile" and "another member has claimed it"
+  # used to share one sentence, so an entry that never landed was reported as
+  # one the member already had.
+  test "the confirmation flash tells a duplicate apart from a blocked entry", %{conn: conn} do
+    {conn, _user} = create_and_login_user(conn)
+    {:ok, parsed} = LinkedIn.parse(zip_binary(@sample_files))
+    payload = Jason.encode!(LinkedIn.payload_map(parsed))
+    selected = [hd(parsed.positions).id]
+
+    apply_import = fn conn ->
+      post(conn, ~p"/settings/import/linkedin/apply", %{
+        "payload" => payload,
+        "selected" => selected
+      })
+    end
+
+    first = apply_import.(conn)
+    assert Phoenix.Flash.get(first.assigns.flash, :info) =~ "Imported 1 work experience."
+
+    second = apply_import.(conn)
+    flash = Phoenix.Flash.get(second.assigns.flash, :info)
+    assert flash =~ "Nothing new to import."
+    assert flash =~ "already on your profile"
+    refute flash =~ "could not be added"
+  end
+
+  test "a social account another member holds is named as such in the flash", %{conn: conn} do
+    # A literal of this file's own: (provider, value) is globally unique, and
+    # two async files inserting the same handle convoy on that index.
+    handle = "importclaimflash"
+    other = insert(:user)
+    insert(:social_media_account, user: other, provider: "Twitter", value: handle)
+
+    {conn, _user} = create_and_login_user(conn)
+
+    profile_csv =
+      "First Name,Last Name,Maiden Name,Address,Birth Date,Headline,Summary,Industry," <>
+        "Zip Code,Geo Location,Twitter Handles,Websites,Instant Messengers\n" <>
+        "Stefan,Wintermeyer,,,,,,,,,[#{handle}],,\n"
+
+    {:ok, parsed} = LinkedIn.parse(zip_binary([{"Profile.csv", profile_csv}]))
+
+    conn =
+      post(conn, ~p"/settings/import/linkedin/apply", %{
+        "payload" => Jason.encode!(LinkedIn.payload_map(parsed)),
+        "selected" => Enum.map(parsed.social, & &1.id)
+      })
+
+    flash = Phoenix.Flash.get(conn.assigns.flash, :info)
+    assert flash =~ "already claimed it"
+    refute flash =~ "already on your profile"
   end
 end


### PR DESCRIPTION
Schließt einen Teil von #1477.

Die Vorschau der LinkedIn-Einfuhr beginnt jetzt mit „Analyse abgeschlossen. Es wurde noch nichts importiert.", zählt pro Bereich Gefunden / Schon im Profil / Zum Import bereit auf und sagt offen, dass vorhandene Einträge nicht aktualisiert werden. Die Bestätigungsmeldung trennt „steht schon im Profil" von „konnte nicht angelegt werden".

Bewusst nicht dabei: die Spalten „Zeilen gefunden" und „Ignoriert" aus dem Issue. Gezählt werden Kandidaten, nicht CSV-Zeilen, weil die größte Gruppe „ignorierter" Zeilen die Einträge sind, die ein echtes Archiv über mehrere Dateien wiederholt. Eine Zahl dafür läse sich wie Datenverlust und beschriebe den Importer beim korrekten Arbeiten. Begründung und Einladung zu einem Folge-Issue stehen im Kommentar an #1477.

Nebenbei behoben: die Einstiegsseite listete Zertifikate & Lizenzen nicht auf, obwohl sie importiert werden.

`mix precommit` grün (7783 Tests). In Chrome auf Deutsch geprüft, Tabelle passt ohne Seitwärtsscrollen in eine 390px-Breite.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*

https://claude.ai/code/session_017RQsbtfR9gL3pWy5vRY2dU