### PR TITLE
Der Import verspricht nur so viele Tags, wie ins Profil passen (v7.297.0)

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1119,35 +1119,119 @@ onReady(setupDropzones)
 // adds a one-click flip over every checkbox inside the enclosing
 // [data-select-group]. The button carries both localized labels as data-* so
 // no translated text is hardcoded here.
+//
+// A group may carry a cap in data-select-limit — the tags do, because a profile
+// holds at most Vutuv.Tags.max_user_tags/0 of them. Then the toggle fills the
+// cap instead of ticking everything, a tick past it is refused with the
+// group's own notice line, and [data-select-free] counts the remaining slots
+// down. A [data-duplicate] box never counts against the cap: the member already
+// has that entry, so submitting it spends no slot. The server preselects within
+// the same cap, so none of this is what keeps the import correct — it is what
+// keeps the page from promising an import it cannot deliver (issue #1478).
+function selectLimit(group) {
+  const raw = parseInt(group.dataset.selectLimit ?? "", 10)
+  return Number.isNaN(raw) ? null : raw
+}
+
+// Boxes that spend a slot, i.e. everything the member does not already have.
+function countingBoxes(group) {
+  return [
+    ...group.querySelectorAll('input[type="checkbox"]:not([data-duplicate])'),
+  ]
+}
+
+function showSelectNotice(group, show) {
+  const notice = group.querySelector("[data-select-notice]")
+  if (notice) notice.hidden = !show
+}
+
+// The live "N of M free slots selected" line, rebuilt from the whole sentence
+// the server put on the element, so no wording lives here. It counts what is
+// SELECTED, not what is left: the page arrives with its free slots already
+// ticked, and a "you can pick N more" line would greet every member with a
+// zero.
+function syncFreeCount(group, limit) {
+  const el = group.querySelector("[data-select-free]")
+  if (!el) return
+  const chosen = countingBoxes(group).filter((b) => b.checked).length
+  const template = el.dataset.labelSelected
+  if (template) {
+    el.textContent = template
+      .replace("{n}", String(chosen))
+      .replace("{max}", String(limit))
+  }
+}
+
 function wireSelectAll(btn) {
   if (!once(btn, "selectAll")) return
   const group = btn.closest("[data-select-group]")
   if (!group) return
+  const limit = selectLimit(group)
   const boxes = () => [...group.querySelectorAll('input[type="checkbox"]')]
+
+  // A full profile has nothing to offer here: the per-box guard below still
+  // refuses every tick, but a "select" button that can never select anything
+  // is noise, so it stays hidden.
+  const wireToggle = limit !== 0
 
   const sync = () => {
     const all = boxes()
     const allChecked = all.length > 0 && all.every((b) => b.checked)
-    btn.dataset.state = allChecked ? "all" : "some"
-    btn.textContent = allChecked
-      ? btn.dataset.labelDeselect
-      : btn.dataset.labelSelect
+    // At a cap, "all" means "as many as fit" — otherwise the button would
+    // never reach its deselect state on a group it can never fill.
+    const filled =
+      limit !== null &&
+      countingBoxes(group).filter((b) => b.checked).length >= limit
+    btn.dataset.state = allChecked || filled ? "all" : "some"
+    btn.textContent =
+      btn.dataset.state === "all"
+        ? btn.dataset.labelDeselect
+        : btn.dataset.labelSelect
+    if (limit !== null) syncFreeCount(group, limit)
   }
 
   btn.addEventListener("click", () => {
     const check = btn.dataset.state !== "all"
+    let budget = limit === null ? Infinity : limit
     boxes().forEach((b) => {
-      b.checked = check
+      if (!check) {
+        b.checked = false
+        return
+      }
+      const counts = !b.hasAttribute("data-duplicate")
+      if (counts && budget <= 0) {
+        b.checked = false
+        return
+      }
+      b.checked = true
+      if (counts) budget -= 1
     })
+    showSelectNotice(group, false)
     sync()
   })
 
-  // Keep the label honest when the member toggles individual boxes by hand.
+  // Keep the label honest when the member toggles individual boxes by hand,
+  // and refuse a tick that would overrun the cap.
   group.addEventListener("change", (e) => {
-    if (e.target.matches('input[type="checkbox"]')) sync()
+    const box = e.target
+    if (!box.matches('input[type="checkbox"]')) return
+
+    if (
+      limit !== null &&
+      box.checked &&
+      !box.hasAttribute("data-duplicate") &&
+      countingBoxes(group).filter((b) => b.checked).length > limit
+    ) {
+      box.checked = false
+      showSelectNotice(group, true)
+    } else if (!box.checked) {
+      showSelectNotice(group, false)
+    }
+
+    sync()
   })
 
-  btn.classList.remove("hidden")
+  if (wireToggle) btn.classList.remove("hidden")
   sync()
 }
 

--- a/lib/vutuv/imports/linked_in.ex
+++ b/lib/vutuv/imports/linked_in.ex
@@ -825,9 +825,16 @@ defmodule Vutuv.Imports.LinkedIn do
 
   @doc """
   Marks each candidate with `duplicate?: true` when the member already has it,
-  and turns the profile scalars into display candidates (with `fillable?`, so the
-  preview can offer only the fields that are currently blank). For rendering the
-  preview only; the apply step re-checks duplicates inside its transaction.
+  `select?: true` when the preview should offer it ticked, and turns the profile
+  scalars into display candidates (with `fillable?`, so the preview can offer
+  only the fields that are currently blank). For rendering the preview only; the
+  apply step re-checks duplicates inside its transaction.
+
+  `select?` is `not duplicate?` everywhere but the tags, where it also honours
+  the profile's free slots (`Tags.free_user_tag_slots/1`): a member with 6 tags
+  and 50 skills in their archive gets the first 9 ticked, not all 50. Ticking
+  what cannot be imported is not a harmless default — it is a promise the
+  confirm step then breaks silently (issue #1478).
   """
   def mark_duplicates(user, parsed) do
     existing = existing_keys(user)
@@ -840,14 +847,33 @@ defmodule Vutuv.Imports.LinkedIn do
       urls: mark(parsed.urls, existing.urls, &downcase(&1.params["value"])),
       social: mark(parsed.social, existing.social, &social_key(&1.params)),
       phones: mark(parsed.phones, existing.phones, &digits(&1.params["value"])),
-      skills: mark(parsed.skills, existing.skills, &String.downcase(&1.name)),
+      skills:
+        parsed.skills
+        |> mark(existing.skills, &String.downcase(&1.name))
+        |> preselect_within(Tags.free_user_tag_slots(user)),
       emails: parsed.emails,
       profile: profile_candidates(user, parsed.profile)
     }
   end
 
   defp mark(candidates, seen, key_fun) do
-    Enum.map(candidates, fn c -> Map.put(c, :duplicate?, MapSet.member?(seen, key_fun.(c))) end)
+    Enum.map(candidates, fn c ->
+      duplicate? = MapSet.member?(seen, key_fun.(c))
+      Map.merge(c, %{duplicate?: duplicate?, select?: not duplicate?})
+    end)
+  end
+
+  # Keep at most `budget` candidates ticked, in the archive's own order, and
+  # untick the rest. A duplicate is already unticked and costs no slot.
+  defp preselect_within(candidates, budget) do
+    {marked, _left} =
+      Enum.map_reduce(candidates, budget, fn
+        %{select?: true} = c, 0 -> {%{c | select?: false}, 0}
+        %{select?: true} = c, left -> {c, left - 1}
+        c, left -> {c, left}
+      end)
+
+    marked
   end
 
   # The sections the preview tallies, in the order it lists them. Emails are
@@ -879,7 +905,12 @@ defmodule Vutuv.Imports.LinkedIn do
       items = Map.fetch!(candidates, key)
       present = Enum.count(items, &present?/1)
 
-      %{key: key, found: length(items), present: present, available: length(items) - present}
+      %{
+        key: key,
+        found: length(items),
+        present: present,
+        available: Enum.count(items, &importable?/1)
+      }
     end
   end
 
@@ -888,6 +919,13 @@ defmodule Vutuv.Imports.LinkedIn do
   defp present?(%{duplicate?: true}), do: true
   defp present?(%{fillable?: false}), do: true
   defp present?(_candidate), do: false
+
+  # What this import would really add — which is not simply "everything you do
+  # not have": the tag section stops at the profile's free slots (issue #1478),
+  # and the preselection already carries that answer as `select?`. A profile
+  # scalar has no `select?`, so it falls back to the plain reading.
+  defp importable?(%{select?: select?}), do: select?
+  defp importable?(candidate), do: not present?(candidate)
 
   defp profile_candidates(user, profile) do
     for {field, label} <- @profile_fields,
@@ -1037,7 +1075,11 @@ defmodule Vutuv.Imports.LinkedIn do
       %{
         created: tallies |> by_outcome(:created) |> Map.put(:profile, profile),
         skipped: by_outcome(tallies, :skipped),
-        blocked: by_outcome(tallies, :blocked)
+        # A tag refused because the profile is full never landed, so it is
+        # blocked — but it gets its own figure beside the others, because it is
+        # the one blocked case the member can clear themselves, and the shared
+        # sentence would tell them the tag is already theirs (issue #1478).
+        blocked: tallies |> by_outcome(:blocked) |> Map.put(:tag_limit, skills.tag_limit)
       }
     end)
   end
@@ -1085,25 +1127,6 @@ defmodule Vutuv.Imports.LinkedIn do
     end
   end
 
-  defp insert_skills(user, existing, candidates) do
-    seen = Map.fetch!(existing, :skills)
-
-    {seen, created, skipped, blocked} =
-      Enum.reduce(candidates, {seen, 0, 0, 0}, &add_skill(&1, &2, user))
-
-    {Map.put(existing, :skills, seen), %{created: created, skipped: skipped, blocked: blocked}}
-  end
-
-  defp add_skill(candidate, {seen, created, skipped, blocked} = acc, user) do
-    key = String.downcase(candidate.name)
-
-    if MapSet.member?(seen, key) do
-      {seen, created, skipped + 1, blocked}
-    else
-      user |> Tags.add_user_tag(candidate.name) |> tally(key, acc)
-    end
-  end
-
   # A successful insert counts as created and remembers its key; a failure (a
   # racing duplicate, a value too long for its column) counts as blocked — the
   # member does not have that entry and never will from this archive.
@@ -1112,6 +1135,48 @@ defmodule Vutuv.Imports.LinkedIn do
 
   defp tally({:error, _}, _key, {seen, created, skipped, blocked}),
     do: {seen, created, skipped, blocked + 1}
+
+  # Tags are the one selection with a ceiling on the *profile*, not just on the
+  # candidate: a member may carry `Tags.max_user_tags/0` of them. So this branch
+  # takes a budget — the free slots, read once — and spends it. Everything past
+  # it is counted apart from the ordinary skips, because "you already have this"
+  # and "your profile is full" are different news and the second one is the only
+  # one the member can act on.
+  #
+  # Reading the budget once also keeps the count out of the loop:
+  # `Tags.add_user_tag/2` re-counts the member's tags on every call, so an
+  # archive with fifty skills used to issue fifty count queries inside this
+  # transaction. The guard there still stands — it is the chokepoint every entry
+  # point shares — we simply stop walking into it.
+  defp insert_skills(user, existing, candidates) do
+    seen = Map.fetch!(existing, :skills)
+    acc = {seen, 0, 0, 0, 0, Tags.free_user_tag_slots(user)}
+
+    {seen, created, skipped, blocked, limited, _budget} =
+      Enum.reduce(candidates, acc, &add_skill(&1, &2, user))
+
+    {Map.put(existing, :skills, seen),
+     %{created: created, skipped: skipped, blocked: blocked, tag_limit: limited}}
+  end
+
+  defp add_skill(candidate, {seen, created, skipped, blocked, limited, budget} = acc, user) do
+    key = String.downcase(candidate.name)
+
+    cond do
+      MapSet.member?(seen, key) -> {seen, created, skipped + 1, blocked, limited, budget}
+      budget == 0 -> {seen, created, skipped, blocked, limited + 1, budget}
+      true -> user |> Tags.add_user_tag(candidate.name) |> tally_skill(key, acc)
+    end
+  end
+
+  # A successful add counts as created, remembers its key and spends a slot; a
+  # failure (a racing duplicate, an invalid name) is blocked like any other
+  # refused insert and spends nothing.
+  defp tally_skill({:ok, _row}, key, {seen, created, skipped, blocked, limited, budget}),
+    do: {MapSet.put(seen, key), created + 1, skipped, blocked, limited, budget - 1}
+
+  defp tally_skill({:error, _}, _key, {seen, created, skipped, blocked, limited, budget}),
+    do: {seen, created, skipped, blocked + 1, limited, budget}
 
   # Fill only the blank profile fields the member selected (name / headline).
   # Guards here too, not just in the controller, so an import can never clobber

--- a/lib/vutuv/tags.ex
+++ b/lib/vutuv/tags.ex
@@ -265,7 +265,26 @@ defmodule Vutuv.Tags do
   Whether `user` already holds the maximum number of tags, so `add_user_tag/2`
   would refuse the next one. Counts the live rows, so it reflects removals.
   """
-  def at_user_tag_limit?(%User{} = user), do: user_tag_count(user.id) >= @max_user_tags
+  def at_user_tag_limit?(%User{} = user), do: free_user_tag_slots(user) == 0
+
+  @doc "How many tags `user` currently holds. Counts the live rows."
+  def user_tag_count(%User{} = user), do: user_tag_count(user.id)
+
+  def user_tag_count(user_id) when is_binary(user_id),
+    do: Repo.aggregate(from(ut in UserTag, where: ut.user_id == ^user_id), :count)
+
+  @doc """
+  How many more tags `user` may add before `add_user_tag/2` starts refusing:
+  `max_user_tags/0` minus what they hold, never negative (a profile
+  grandfathered in above the cap has no free slots, not a negative number).
+
+  This is the number a surface offering a *batch* of tags needs — the LinkedIn
+  import preselects that many candidates and the importer spends exactly that
+  many — because `at_user_tag_limit?/1` can only say "none left", which reads
+  as "go ahead" right up to the tag that is refused.
+  """
+  def free_user_tag_slots(%User{} = user),
+    do: max(@max_user_tags - user_tag_count(user.id), 0)
 
   @doc """
   Tags `user` with `name`, creating the global tag or linking the existing
@@ -320,9 +339,6 @@ defmodule Vutuv.Tags do
     )
     |> Map.put(:action, :insert)
   end
-
-  defp user_tag_count(user_id),
-    do: Repo.aggregate(from(ut in UserTag, where: ut.user_id == ^user_id), :count)
 
   # `Tag.create_or_link_tag/2` always resolves to a `:tag_id` (it either links an
   # existing tag or mints a fresh one and links that). A member can only reach an

--- a/lib/vutuv_web/controllers/import_controller.ex
+++ b/lib/vutuv_web/controllers/import_controller.ex
@@ -21,6 +21,7 @@ defmodule VutuvWeb.ImportController do
   plug(:rate_limit when action in [:create, :confirm])
 
   alias Vutuv.Imports.LinkedIn
+  alias Vutuv.Tags
   alias VutuvWeb.RateLimit
 
   # LinkedIn's "larger data archive" runs to tens of megabytes for an active
@@ -122,6 +123,7 @@ defmodule VutuvWeb.ImportController do
       # Display only, so it stays out of the hidden payload: the confirm step
       # must not be able to read counts back from a client-controlled field.
       summary: LinkedIn.summary_rows(candidates),
+      tag_capacity: tag_capacity(user),
       payload: Jason.encode!(LinkedIn.payload_map(parsed)),
       page_title: gettext("Import from LinkedIn")
     )
@@ -133,6 +135,16 @@ defmodule VutuvWeb.ImportController do
       )
 
       redirect_with_error(conn, user, gettext("The file could not be read. Please try again."))
+  end
+
+  # What the tag section may still take on: the three figures its capacity line
+  # states and the cap the preselection and the client-side guard both spend.
+  defp tag_capacity(user) do
+    %{
+      used: Tags.user_tag_count(user),
+      max: Tags.max_user_tags(),
+      free: Tags.free_user_tag_slots(user)
+    }
   end
 
   defp parse_upload(upload) do
@@ -228,7 +240,11 @@ defmodule VutuvWeb.ImportController do
   # provider + value), so it gets its own sentence; anything else is a value
   # the schema refused and is reported plainly rather than guessed at.
   defp blocked_sentences(blocked) do
-    [claimed_sentence(blocked.social), rejected_sentence(total(blocked) - blocked.social)]
+    [
+      claimed_sentence(blocked.social),
+      tag_limit_sentence(blocked.tag_limit),
+      rejected_sentence(total(blocked) - blocked.social - blocked.tag_limit)
+    ]
   end
 
   defp claimed_sentence(0), do: nil
@@ -245,5 +261,19 @@ defmodule VutuvWeb.ImportController do
 
   defp rejected_sentence(count) do
     ngettext("%{count} entry could not be added.", "%{count} entries could not be added.", count)
+  end
+
+  # The one blocked case the member can clear themselves, so it names the
+  # ceiling and what to do about it instead of joining the generic line
+  # (issue #1478).
+  defp tag_limit_sentence(0), do: nil
+
+  defp tag_limit_sentence(count) do
+    ngettext(
+      "%{count} tag did not fit: your profile holds at most %{max}. Remove some and try again.",
+      "%{count} tags did not fit: your profile holds at most %{max}. Remove some and try again.",
+      count,
+      max: Tags.max_user_tags()
+    )
   end
 end

--- a/lib/vutuv_web/live/tag_new_live.ex
+++ b/lib/vutuv_web/live/tag_new_live.ex
@@ -134,15 +134,36 @@ defmodule VutuvWeb.TagNewLive do
         end
 
       many ->
-        results = Enum.map(many, &Tags.add_user_tag(user, &1))
-        failures = Enum.count(results, &match?({:error, _}, &1))
-        successes = length(results) - failures
+        {successes, failures, limited} = add_many(user, many)
         kind = if successes == 0, do: :error, else: :info
 
         {:noreply,
          socket
-         |> put_flash(kind, UserHelpers.tags_added_flash(successes, failures))
+         |> put_flash(kind, UserHelpers.tags_added_flash(successes, failures, limited))
          |> redirect(to: ~p"/settings/tags")}
+    end
+  end
+
+  # Spend the profile's free tag slots and stop. The guard above only catches a
+  # profile that is *already* full, so a batch of ten on a profile holding
+  # twelve tags used to attach three and report the other seven as duplicates or
+  # invalid — the one reason a member cannot act on. Counting them apart lets
+  # the flash name the ceiling. Same budget shape as the LinkedIn import's
+  # `insert_skills/3`; a failed add spends no slot.
+  defp add_many(user, names) do
+    {successes, failures, limited, _budget} =
+      Enum.reduce(names, {0, 0, 0, Tags.free_user_tag_slots(user)}, &add_one(user, &1, &2))
+
+    {successes, failures, limited}
+  end
+
+  defp add_one(_user, _name, {successes, failures, limited, 0}),
+    do: {successes, failures, limited + 1, 0}
+
+  defp add_one(user, name, {successes, failures, limited, budget}) do
+    case Tags.add_user_tag(user, name) do
+      {:ok, _user_tag} -> {successes + 1, failures, limited, budget - 1}
+      {:error, _changeset} -> {successes, failures + 1, limited, budget}
     end
   end
 

--- a/lib/vutuv_web/templates/import/preview.html.heex
+++ b/lib/vutuv_web/templates/import/preview.html.heex
@@ -38,11 +38,11 @@
       <input type="hidden" name="payload" value={@payload} />
 
       <.candidate_section title={gettext("Work experience")} items={@candidates.positions}>
-        <.candidate_row :for={c <- @candidates.positions} id={c.id} label={c.label} duplicate?={c.duplicate?} />
+        <.candidate_row :for={c <- @candidates.positions} id={c.id} label={c.label} duplicate?={c.duplicate?} select?={c.select?} />
       </.candidate_section>
 
       <.candidate_section title={gettext("Education")} items={@candidates.educations}>
-        <.candidate_row :for={c <- @candidates.educations} id={c.id} label={c.label} duplicate?={c.duplicate?} />
+        <.candidate_row :for={c <- @candidates.educations} id={c.id} label={c.label} duplicate?={c.duplicate?} select?={c.select?} />
       </.candidate_section>
 
       <.candidate_section title={gettext("Certificates & licenses")} items={@candidates.certifications}>
@@ -51,23 +51,29 @@
             "LinkedIn does not say whether an entry is a certificate or a license, so we import all of them as certificates. Please review the section afterwards and switch any that are licenses."
           )}
         </p>
-        <.candidate_row :for={c <- @candidates.certifications} id={c.id} label={c.label} duplicate?={c.duplicate?} />
+        <.candidate_row :for={c <- @candidates.certifications} id={c.id} label={c.label} duplicate?={c.duplicate?} select?={c.select?} />
       </.candidate_section>
 
-      <.candidate_section title={gettext("Tags")} items={@candidates.skills}>
-        <.candidate_row :for={c <- @candidates.skills} id={c.id} label={c.label} duplicate?={c.duplicate?} />
+      <%!-- Tags are the one capped section: a profile carries at most
+      Vutuv.Tags.max_user_tags/0 of them, so the preselection stops at the free
+      slots and the section says how many that is. --%>
+      <.candidate_section title={gettext("Tags")} items={@candidates.skills} limit={@tag_capacity.free}>
+        <:note>
+          <.tag_capacity_note used={@tag_capacity.used} max={@tag_capacity.max} free={@tag_capacity.free} />
+        </:note>
+        <.candidate_row :for={c <- @candidates.skills} id={c.id} label={c.label} duplicate?={c.duplicate?} select?={c.select?} />
       </.candidate_section>
 
       <.candidate_section title={gettext("Links")} items={@candidates.urls}>
-        <.candidate_row :for={c <- @candidates.urls} id={c.id} label={c.label} duplicate?={c.duplicate?} />
+        <.candidate_row :for={c <- @candidates.urls} id={c.id} label={c.label} duplicate?={c.duplicate?} select?={c.select?} />
       </.candidate_section>
 
       <.candidate_section title={gettext("Social media")} items={@candidates.social}>
-        <.candidate_row :for={c <- @candidates.social} id={c.id} label={c.label} duplicate?={c.duplicate?} />
+        <.candidate_row :for={c <- @candidates.social} id={c.id} label={c.label} duplicate?={c.duplicate?} select?={c.select?} />
       </.candidate_section>
 
       <.candidate_section title={gettext("Phone numbers")} items={@candidates.phones}>
-        <.candidate_row :for={c <- @candidates.phones} id={c.id} label={c.label} duplicate?={c.duplicate?} />
+        <.candidate_row :for={c <- @candidates.phones} id={c.id} label={c.label} duplicate?={c.duplicate?} select?={c.select?} />
       </.candidate_section>
 
       <%!-- Profile scalars: offered only when the field is currently blank, so an

--- a/lib/vutuv_web/views/import_html.ex
+++ b/lib/vutuv_web/views/import_html.ex
@@ -71,10 +71,19 @@ defmodule VutuvWeb.ImportHTML do
   defp section_label(:phones), do: gettext("Phone numbers")
   defp section_label(:profile), do: gettext("Profile")
 
-  @doc "One selectable candidate: a checkbox + label, greyed when it is a duplicate."
+  @doc """
+  One selectable candidate: a checkbox + label, greyed when it is a duplicate.
+
+  Whether the box arrives ticked is `select?`, decided by
+  `Vutuv.Imports.LinkedIn.mark_duplicates/2` — for most sections that is simply
+  "not a duplicate", for tags it also honours the profile's free slots. A
+  duplicate is marked `data-duplicate` so the client-side cap can ignore it:
+  submitting one costs no tag slot, the apply step skips it.
+  """
   attr(:id, :string, required: true)
   attr(:label, :string, required: true)
   attr(:duplicate?, :boolean, default: false)
+  attr(:select?, :boolean, default: true)
 
   def candidate_row(assigns) do
     ~H"""
@@ -83,7 +92,8 @@ defmodule VutuvWeb.ImportHTML do
         type="checkbox"
         name="selected[]"
         value={@id}
-        checked={not @duplicate?}
+        checked={@select?}
+        data-duplicate={@duplicate? && "true"}
         class={checkbox_class()}
         id={"cand-#{@id}"}
       />
@@ -100,20 +110,97 @@ defmodule VutuvWeb.ImportHTML do
     """
   end
 
-  @doc "A titled group of candidate rows, rendered only when the group is non-empty."
+  @doc """
+  A titled group of candidate rows, rendered only when the group is non-empty.
+
+  `limit` caps how many non-duplicate boxes may be ticked at once — only the
+  tags pass one (the profile's free slots). It rides the group as
+  `data-select-limit`, where both the "select all" toggle and the per-box guard
+  in `app.js` read it; with JS off the server's own preselection is already
+  within the cap, so nothing here is load-bearing for correctness.
+  """
   attr(:title, :string, required: true)
   attr(:items, :list, required: true)
+  attr(:limit, :integer, default: nil)
+  slot(:note)
   slot(:inner_block, required: true)
 
   def candidate_section(assigns) do
     ~H"""
-    <div :if={@items != []} class="mt-6" data-select-group>
-      <.select_group_header title={@title} />
+    <div :if={@items != []} class="mt-6" data-select-group data-select-limit={@limit}>
+      <.select_group_header title={@title} limit={@limit} />
+      {render_slot(@note)}
+      <%!-- The client-side cap's refusal line. Turned off by the `hidden`
+      attribute and carrying no display utility, so nothing can out-cascade it
+      (the issue #880 trap). --%>
+      <p
+        :if={@limit}
+        data-select-notice
+        hidden
+        role="status"
+        class="mt-1 text-xs font-medium text-red-600 dark:text-red-400"
+      >
+        {gettext("There is no room for more. Uncheck one to pick another.")}
+      </p>
       <ul class="mt-2 divide-y divide-slate-100 dark:divide-slate-800">
         {render_slot(@inner_block)}
       </ul>
     </div>
     """
+  end
+
+  @doc """
+  The tag section's capacity line: what the member holds now, and how much of
+  this import is spoken for.
+
+  Two sentences, and the split matters. The first is about the **profile** and
+  never moves. The second is about the **selection** and is live — the client
+  cap rewrites it as boxes are ticked — so it counts what is selected rather
+  than what is left: a "you can import N more" phrasing reads as `0` the moment
+  the page ticks its N preselected boxes, which is the arrival state of every
+  import that has room. It carries its whole sentence as `data-label-selected`
+  (the `{n}` marker convention `<.pin_time_left>` uses; gettext only
+  interpolates `%{…}`, so the markers pass through untouched), so the JS writes
+  no translated word of its own.
+
+  A full profile gets the way out instead of a number: the tags editor.
+  """
+  attr(:used, :integer, required: true)
+  attr(:max, :integer, required: true)
+  attr(:free, :integer, required: true)
+
+  def tag_capacity_note(assigns) do
+    ~H"""
+    <p class="mt-1 text-xs text-slate-600 dark:text-slate-400" data-tag-capacity>
+      {gettext("You have %{used} of %{max} tags.", used: @used, max: @max)}
+      <span :if={@free > 0} data-select-free data-label-selected={selected_label_template()}>
+        {selected_label(@free, @free)}
+      </span>
+      <span :if={@free == 0}>
+        {gettext("There is no room for more.")}
+        <.link
+          navigate={~p"/settings/tags"}
+          class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+        >
+          {gettext("Remove tags first")}
+        </.link>.
+      </span>
+    </p>
+    """
+  end
+
+  @doc """
+  The live selection sentence's template, `{n}` of `{max}` still to fill in.
+  Shared by the server's first render and the `app.js` rewrite, so the two can
+  never word it differently.
+  """
+  def selected_label_template, do: gettext("{n} of {max} free slots selected.")
+
+  @doc "`selected_label_template/0` with the two figures filled in."
+  def selected_label(selected, free) do
+    selected_label_template()
+    |> String.replace("{n}", Integer.to_string(selected))
+    |> String.replace("{max}", Integer.to_string(free))
   end
 
   @doc """
@@ -123,21 +210,33 @@ defmodule VutuvWeb.ImportHTML do
   inside the enclosing `[data-select-group]`), so it starts hidden and does
   nothing with JS off. It carries both labels so the JS can swap them without
   hardcoding a translated string.
+
+  A capped group (`limit`, the tags) gets its own select label: it ticks as many
+  as fit and stops, so calling that "Select all" would name something the button
+  deliberately does not do.
   """
   attr(:title, :string, required: true)
+  attr(:limit, :integer, default: nil)
 
   def select_group_header(assigns) do
+    assigns =
+      assign(
+        assigns,
+        :select_label,
+        if(assigns.limit, do: gettext("Select as many as fit"), else: gettext("Select all"))
+      )
+
     ~H"""
     <div class="flex items-center justify-between gap-3">
       <.section_title>{@title}</.section_title>
       <button
         type="button"
         data-select-all
-        data-label-select={gettext("Select all")}
+        data-label-select={@select_label}
         data-label-deselect={gettext("Unselect all")}
         class="hidden text-xs font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
       >
-        {gettext("Select all")}
+        {@select_label}
       </button>
     </div>
     """

--- a/lib/vutuv_web/views/user_helpers.ex
+++ b/lib/vutuv_web/views/user_helpers.ex
@@ -22,6 +22,7 @@ defmodule VutuvWeb.UserHelpers do
   alias Vutuv.Profiles.WorkExperience
   alias Vutuv.Repo
   alias Vutuv.Social.Follow
+  alias Vutuv.Tags
   alias Vutuv.Tags.UserTag
 
   def full_name(%User{
@@ -165,16 +166,48 @@ defmodule VutuvWeb.UserHelpers do
   @doc """
   The flash for a batch tag add, shown by `VutuvWeb.TagNewLive` (the add-tag
   form's socket save) after attaching one or more tags to the member's profile.
+
+  `limited` — tags refused because the profile is at `Tags.max_user_tags/0` —
+  is counted and named apart from the ordinary failures. It used to ride the
+  same "the rest were duplicates or invalid" clause, which is the one reading
+  that stops a member from doing the thing that would actually help (the same
+  defect the LinkedIn import had, issue #1478).
   """
-  def tags_added_flash(successes, 0) do
+  def tags_added_flash(successes, failures, limited \\ 0)
+
+  def tags_added_flash(successes, 0, 0) do
     ngettext("Added %{count} tag.", "Added %{count} tags.", successes, count: successes)
   end
 
-  def tags_added_flash(successes, failures) do
-    gettext(
-      "Added %{successes} of %{total} tags (the rest were duplicates or invalid).",
-      successes: successes,
-      total: successes + failures
+  def tags_added_flash(successes, failures, limited) do
+    [added_part(successes), rejected_part(failures), tag_limit_part(limited)]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(" ")
+  end
+
+  defp added_part(0), do: nil
+
+  defp added_part(count),
+    do: ngettext("Added %{count} tag.", "Added %{count} tags.", count, count: count)
+
+  defp rejected_part(0), do: nil
+
+  defp rejected_part(count) do
+    ngettext(
+      "Skipped %{count} tag that is a duplicate or invalid.",
+      "Skipped %{count} tags that are duplicates or invalid.",
+      count
+    )
+  end
+
+  defp tag_limit_part(0), do: nil
+
+  defp tag_limit_part(count) do
+    ngettext(
+      "%{count} tag did not fit: your profile holds at most %{max}. Remove some and try again.",
+      "%{count} tags did not fit: your profile holds at most %{max}. Remove some and try again.",
+      count,
+      max: Tags.max_user_tags()
     )
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.296.0",
+      version: "7.297.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -120,7 +120,7 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
-#: lib/vutuv_web/templates/import/preview.html.heex:107
+#: lib/vutuv_web/templates/import/preview.html.heex:113
 #: lib/vutuv_web/templates/report/new.html.heex:103
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:276
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:259
@@ -415,13 +415,13 @@ msgstr "Link wurde geändert."
 #: lib/vutuv_web/cv/odt.ex:176
 #: lib/vutuv_web/live/cv_live.ex:336
 #: lib/vutuv_web/templates/import/new.html.heex:13
-#: lib/vutuv_web/templates/import/preview.html.heex:61
+#: lib/vutuv_web/templates/import/preview.html.heex:67
 #: lib/vutuv_web/templates/url/edit.html.heex:4
 #: lib/vutuv_web/templates/url/index.html.heex:10
 #: lib/vutuv_web/templates/url/manage.html.heex:4
 #: lib/vutuv_web/templates/url/new.html.heex:4
 #: lib/vutuv_web/templates/url/show.html.heex:6
-#: lib/vutuv_web/views/import_html.ex:65
+#: lib/vutuv_web/views/import_html.ex:69
 #, elixir-autogen
 msgid "Links"
 msgstr "Links"
@@ -1423,7 +1423,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/templates/admin/tag/new.html.heex:5
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:5
 #: lib/vutuv_web/templates/import/new.html.heex:12
-#: lib/vutuv_web/templates/import/preview.html.heex:57
+#: lib/vutuv_web/templates/import/preview.html.heex:60
 #: lib/vutuv_web/templates/page/index.html.heex:108
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -1433,7 +1433,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
 #: lib/vutuv_web/templates/user_tag/show.html.heex:6
-#: lib/vutuv_web/views/import_html.ex:64
+#: lib/vutuv_web/views/import_html.ex:68
 #, elixir-autogen
 msgid "Tags"
 msgstr "Tags"
@@ -2810,19 +2810,13 @@ msgstr "Verwalten"
 msgid "Write a post"
 msgstr "Beitrag schreiben"
 
-#: lib/vutuv_web/views/user_helpers.ex:170
+#: lib/vutuv_web/views/user_helpers.ex:179
+#: lib/vutuv_web/views/user_helpers.ex:191
 #, elixir-autogen, elixir-format
 msgid "Added %{count} tag."
 msgid_plural "Added %{count} tags."
 msgstr[0] "%{count} Tag hinzugefügt."
 msgstr[1] "%{count} Tags hinzugefügt."
-
-#: lib/vutuv_web/views/user_helpers.ex:174
-#, elixir-autogen, elixir-format
-msgid "Added %{successes} of %{total} tags (the rest were duplicates or invalid)."
-msgstr ""
-"%{successes} von %{total} Tags hinzugefügt (der Rest war doppelt oder "
-"ungültig)."
 
 #: lib/vutuv_web/templates/connection/index.html.heex:13
 #, elixir-autogen, elixir-format
@@ -3223,9 +3217,9 @@ msgstr "Private Nachricht"
 #: lib/vutuv_web/live/shell_live.ex:619
 #: lib/vutuv_web/live/shell_live.ex:896
 #: lib/vutuv_web/templates/import/new.html.heex:16
-#: lib/vutuv_web/templates/import/preview.html.heex:76
+#: lib/vutuv_web/templates/import/preview.html.heex:82
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
-#: lib/vutuv_web/views/import_html.ex:68
+#: lib/vutuv_web/views/import_html.ex:72
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr "Profil"
@@ -5720,7 +5714,7 @@ msgstr ""
 #: lib/vutuv_web/templates/email/edit.html.heex:4
 #: lib/vutuv_web/templates/email/manage.html.heex:4
 #: lib/vutuv_web/templates/email/new.html.heex:4
-#: lib/vutuv_web/templates/import/preview.html.heex:90
+#: lib/vutuv_web/templates/import/preview.html.heex:96
 #: lib/vutuv_web/templates/settings/security.html.heex:17
 #, elixir-autogen, elixir-format
 msgid "Email addresses"
@@ -7631,14 +7625,13 @@ msgid "accounts"
 msgstr "Konten"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:991
-#: lib/vutuv_web/views/import_html.ex:132
-#: lib/vutuv_web/views/import_html.ex:136
+#: lib/vutuv_web/views/import_html.ex:226
 #, elixir-autogen, elixir-format
 msgid "Select all"
 msgstr "Alle auswählen"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:994
-#: lib/vutuv_web/views/import_html.ex:133
+#: lib/vutuv_web/views/import_html.ex:236
 #, elixir-autogen, elixir-format
 msgid "Unselect all"
 msgstr "Alle abwählen"
@@ -8456,49 +8449,49 @@ msgstr "Noch keine Mitglieder."
 msgid "Nobody is online right now."
 msgstr "Zurzeit ist niemand online."
 
-#: lib/vutuv_web/controllers/import_controller.ex:192
+#: lib/vutuv_web/controllers/import_controller.ex:204
 #, elixir-autogen, elixir-format
 msgid "%{count} education entry"
 msgid_plural "%{count} education entries"
 msgstr[0] "%{count} Ausbildungseintrag"
 msgstr[1] "%{count} Ausbildungseinträge"
 
-#: lib/vutuv_web/controllers/import_controller.ex:200
+#: lib/vutuv_web/controllers/import_controller.ex:212
 #, elixir-autogen, elixir-format
 msgid "%{count} link"
 msgid_plural "%{count} links"
 msgstr[0] "%{count} Link"
 msgstr[1] "%{count} Links"
 
-#: lib/vutuv_web/controllers/import_controller.ex:204
+#: lib/vutuv_web/controllers/import_controller.ex:216
 #, elixir-autogen, elixir-format
 msgid "%{count} phone number"
 msgid_plural "%{count} phone numbers"
 msgstr[0] "%{count} Telefonnummer"
 msgstr[1] "%{count} Telefonnummern"
 
-#: lib/vutuv_web/controllers/import_controller.ex:206
+#: lib/vutuv_web/controllers/import_controller.ex:218
 #, elixir-autogen, elixir-format
 msgid "%{count} profile field"
 msgid_plural "%{count} profile fields"
 msgstr[0] "%{count} Profilfeld"
 msgstr[1] "%{count} Profilfelder"
 
-#: lib/vutuv_web/controllers/import_controller.ex:202
+#: lib/vutuv_web/controllers/import_controller.ex:214
 #, elixir-autogen, elixir-format
 msgid "%{count} social account"
 msgid_plural "%{count} social accounts"
 msgstr[0] "%{count} Social-Media-Konto"
 msgstr[1] "%{count} Social-Media-Konten"
 
-#: lib/vutuv_web/controllers/import_controller.ex:199
+#: lib/vutuv_web/controllers/import_controller.ex:211
 #, elixir-autogen, elixir-format
 msgid "%{count} tag"
 msgid_plural "%{count} tags"
 msgstr[0] "%{count} Tag"
 msgstr[1] "%{count} Tags"
 
-#: lib/vutuv_web/controllers/import_controller.ex:190
+#: lib/vutuv_web/controllers/import_controller.ex:202
 #, elixir-autogen, elixir-format
 msgid "%{count} work experience"
 msgid_plural "%{count} work experiences"
@@ -8533,7 +8526,7 @@ msgstr "Abschluss"
 #: lib/vutuv_web/templates/import/new.html.heex:10
 #: lib/vutuv_web/templates/import/preview.html.heex:44
 #: lib/vutuv_web/templates/user/show.html.heex:666
-#: lib/vutuv_web/views/import_html.ex:62
+#: lib/vutuv_web/views/import_html.ex:66
 #: lib/vutuv_web/views/job_reference_html.ex:265
 #, elixir-autogen, elixir-format
 msgid "Education"
@@ -8559,7 +8552,7 @@ msgstr "Ausbildung von %{name}"
 msgid "Education updated successfully."
 msgstr "Ausbildung erfolgreich aktualisiert."
 
-#: lib/vutuv_web/templates/import/preview.html.heex:92
+#: lib/vutuv_web/templates/import/preview.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "Email addresses are not imported automatically because each one is confirmed by PIN. Add them yourself if you like:"
 msgstr ""
@@ -8585,8 +8578,8 @@ msgstr ""
 msgid "Import"
 msgstr "Import"
 
-#: lib/vutuv_web/controllers/import_controller.ex:36
-#: lib/vutuv_web/controllers/import_controller.ex:126
+#: lib/vutuv_web/controllers/import_controller.ex:37
+#: lib/vutuv_web/controllers/import_controller.ex:128
 #: lib/vutuv_web/templates/import/new.html.heex:1
 #: lib/vutuv_web/templates/import/preview.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:432
@@ -8594,17 +8587,17 @@ msgstr "Import"
 msgid "Import from LinkedIn"
 msgstr "LinkedIn-Profil importieren"
 
-#: lib/vutuv_web/templates/import/preview.html.heex:105
+#: lib/vutuv_web/templates/import/preview.html.heex:111
 #, elixir-autogen, elixir-format
 msgid "Import selected"
 msgstr "Auswahl importieren"
 
-#: lib/vutuv_web/controllers/import_controller.ex:212
+#: lib/vutuv_web/controllers/import_controller.ex:224
 #, elixir-autogen, elixir-format
 msgid "Imported %{items}."
 msgstr "%{items} importiert."
 
-#: lib/vutuv_web/controllers/import_controller.ex:211
+#: lib/vutuv_web/controllers/import_controller.ex:223
 #, elixir-autogen, elixir-format
 msgid "Nothing new to import."
 msgstr "Nichts Neues zu importieren."
@@ -8615,16 +8608,16 @@ msgstr "Nichts Neues zu importieren."
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
 #: lib/vutuv_web/controllers/phone_number_controller.ex:87
 #: lib/vutuv_web/templates/import/new.html.heex:15
-#: lib/vutuv_web/templates/import/preview.html.heex:69
+#: lib/vutuv_web/templates/import/preview.html.heex:75
 #: lib/vutuv_web/templates/phone_number/edit.html.heex:4
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:4
 #: lib/vutuv_web/templates/phone_number/new.html.heex:4
-#: lib/vutuv_web/views/import_html.ex:67
+#: lib/vutuv_web/views/import_html.ex:71
 #, elixir-autogen, elixir-format
 msgid "Phone numbers"
 msgstr "Telefonnummern"
 
-#: lib/vutuv_web/controllers/import_controller.ex:81
+#: lib/vutuv_web/controllers/import_controller.ex:82
 #, elixir-autogen, elixir-format
 msgid "Please choose your LinkedIn export ZIP first."
 msgstr "Bitte wählen Sie zuerst Ihre LinkedIn-Export-ZIP-Datei."
@@ -8634,14 +8627,14 @@ msgstr "Bitte wählen Sie zuerst Ihre LinkedIn-Export-ZIP-Datei."
 msgid "School"
 msgstr "Schule"
 
-#: lib/vutuv_web/templates/import/preview.html.heex:81
+#: lib/vutuv_web/templates/import/preview.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "Set %{field}:"
 msgstr "%{field} setzen:"
 
 #: lib/vutuv_web/templates/import/new.html.heex:14
-#: lib/vutuv_web/templates/import/preview.html.heex:65
-#: lib/vutuv_web/views/import_html.ex:66
+#: lib/vutuv_web/templates/import/preview.html.heex:71
+#: lib/vutuv_web/views/import_html.ex:70
 #, elixir-autogen, elixir-format
 msgid "Social media"
 msgstr "Soziale Medien"
@@ -8656,17 +8649,17 @@ msgstr "Schritt 1: Laden Sie Ihre LinkedIn-Daten herunter"
 msgid "Step 2: Upload the ZIP here"
 msgstr "Schritt 2: Laden Sie die ZIP-Datei hier hoch"
 
-#: lib/vutuv_web/controllers/import_controller.ex:74
+#: lib/vutuv_web/controllers/import_controller.ex:75
 #, elixir-autogen, elixir-format
 msgid "That does not look like a LinkedIn data export ZIP."
 msgstr "Das sieht nicht nach einem LinkedIn-Datenexport (ZIP) aus."
 
-#: lib/vutuv_web/controllers/import_controller.ex:135
+#: lib/vutuv_web/controllers/import_controller.ex:137
 #, elixir-autogen, elixir-format
 msgid "The file could not be read. Please try again."
 msgstr "Die Datei konnte nicht gelesen werden. Bitte versuchen Sie es erneut."
 
-#: lib/vutuv_web/controllers/import_controller.ex:106
+#: lib/vutuv_web/controllers/import_controller.ex:107
 #, elixir-autogen, elixir-format
 msgid "The import could not be completed. Please try again."
 msgstr ""
@@ -8679,29 +8672,29 @@ msgstr "Hochladen und Vorschau"
 
 #: lib/vutuv_web/templates/import/new.html.heex:9
 #: lib/vutuv_web/templates/import/preview.html.heex:40
-#: lib/vutuv_web/views/import_html.ex:61
+#: lib/vutuv_web/views/import_html.ex:65
 #, elixir-autogen, elixir-format
 msgid "Work experience"
 msgstr "Berufserfahrung"
 
-#: lib/vutuv_web/templates/import/preview.html.heex:96
+#: lib/vutuv_web/templates/import/preview.html.heex:102
 #, elixir-autogen, elixir-format
 msgid "add an email address"
 msgstr "eine E-Mail-Adresse hinzufügen"
 
-#: lib/vutuv_web/views/import_html.ex:92
+#: lib/vutuv_web/views/import_html.ex:106
 #, elixir-autogen, elixir-format
 msgid "already on your profile"
 msgstr "bereits in Ihrem Profil"
 
-#: lib/vutuv_web/controllers/import_controller.ex:67
+#: lib/vutuv_web/controllers/import_controller.ex:68
 #, elixir-autogen, elixir-format
 msgid "That archive is too large or has too many files to import safely."
 msgstr ""
 "Dieses Archiv ist zu groß oder enthält zu viele Dateien, um es sicher zu "
 "importieren."
 
-#: lib/vutuv_web/controllers/import_controller.ex:151
+#: lib/vutuv_web/controllers/import_controller.ex:163
 #, elixir-autogen, elixir-format
 msgid "Too many imports. Please try again in a little while."
 msgstr "Zu viele Importe. Bitte versuchen Sie es in Kürze erneut."
@@ -8883,7 +8876,7 @@ msgid "When off, the Social Media card lists your accounts without any posts."
 msgstr ""
 "Wenn deaktiviert, zeigt die Social-Media-Karte Ihre Konten ohne Beiträge."
 
-#: lib/vutuv_web/controllers/import_controller.ex:60
+#: lib/vutuv_web/controllers/import_controller.ex:61
 #, elixir-autogen, elixir-format
 msgid "That file is too large. Please upload a ZIP of at most 50 MB."
 msgstr ""
@@ -9377,12 +9370,12 @@ msgstr "%{job} wird oben in Ihrem Profil angezeigt."
 msgid "Choose automatically instead"
 msgstr "Stattdessen automatisch wählen"
 
-#: lib/vutuv_web/views/user_helpers.ex:423
+#: lib/vutuv_web/views/user_helpers.ex:456
 #, elixir-autogen, elixir-format
 msgid "Show at top of profile"
 msgstr "Oben im Profil anzeigen"
 
-#: lib/vutuv_web/views/user_helpers.ex:414
+#: lib/vutuv_web/views/user_helpers.ex:447
 #, elixir-autogen, elixir-format
 msgid "Shown at the top of your profile"
 msgstr "Wird oben in Ihrem Profil angezeigt"
@@ -9933,7 +9926,7 @@ msgstr "Beschäftigungsstatus"
 msgid "Looking for a job"
 msgstr "Auf Jobsuche"
 
-#: lib/vutuv_web/views/user_helpers.ex:72
+#: lib/vutuv_web/views/user_helpers.ex:73
 #, elixir-autogen, elixir-format
 msgid "Not open to work"
 msgstr "Nicht offen für Angebote"
@@ -10023,7 +10016,7 @@ msgstr ""
 msgid "“%{name}” is an honor tag now. Add members below."
 msgstr "„%{name}“ ist jetzt ein Ehren-Tag. Fügen Sie unten Mitglieder hinzu."
 
-#: lib/vutuv_web/controllers/import_controller.ex:194
+#: lib/vutuv_web/controllers/import_controller.ex:206
 #, elixir-autogen, elixir-format
 msgid "%{count} certificate or license"
 msgid_plural "%{count} certificates or licenses"
@@ -10081,7 +10074,7 @@ msgstr "Zertifikate"
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
 #: lib/vutuv_web/templates/user/show.html.heex:834
-#: lib/vutuv_web/views/import_html.ex:63
+#: lib/vutuv_web/views/import_html.ex:67
 #: lib/vutuv_web/views/job_reference_html.ex:266
 #, elixir-autogen, elixir-format
 msgid "Certificates & licenses"
@@ -10250,7 +10243,7 @@ msgstr "Vorname"
 msgid "Last name"
 msgstr "Nachname"
 
-#: lib/vutuv_web/views/user_helpers.ex:95
+#: lib/vutuv_web/views/user_helpers.ex:96
 #, elixir-autogen, elixir-format
 msgid "Prefer not to say"
 msgstr "Keine Angabe"
@@ -21419,14 +21412,14 @@ msgstr "Unternehmen"
 msgid "Legal"
 msgstr "Rechtliches"
 
-#: lib/vutuv_web/controllers/import_controller.ex:247
+#: lib/vutuv_web/controllers/import_controller.ex:263
 #, elixir-autogen, elixir-format
 msgid "%{count} entry could not be added."
 msgid_plural "%{count} entries could not be added."
 msgstr[0] "%{count} Eintrag konnte nicht hinzugefügt werden."
 msgstr[1] "%{count} Einträge konnten nicht hinzugefügt werden."
 
-#: lib/vutuv_web/controllers/import_controller.ex:237
+#: lib/vutuv_web/controllers/import_controller.ex:253
 #, elixir-autogen, elixir-format
 msgid "%{count} social account could not be added because another member has already claimed it."
 msgid_plural "%{count} social accounts could not be added because another member has already claimed them."
@@ -21437,7 +21430,7 @@ msgstr[1] ""
 "%{count} Social-Media-Konten konnten nicht hinzugefügt werden, weil andere "
 "Mitglieder sie bereits belegen."
 
-#: lib/vutuv_web/views/import_html.ex:31
+#: lib/vutuv_web/views/import_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Already on your profile"
 msgstr "Schon im Profil"
@@ -21447,12 +21440,12 @@ msgstr "Schon im Profil"
 msgid "Analysis complete. Nothing has been imported yet."
 msgstr "Analyse abgeschlossen. Es wurde noch nichts importiert."
 
-#: lib/vutuv_web/views/import_html.ex:30
+#: lib/vutuv_web/views/import_html.ex:34
 #, elixir-autogen, elixir-format
 msgid "Found"
 msgstr "Gefunden"
 
-#: lib/vutuv_web/views/import_html.ex:32
+#: lib/vutuv_web/views/import_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Ready to import"
 msgstr "Zum Import bereit"
@@ -21464,12 +21457,12 @@ msgstr ""
 "Prüfen Sie die Einträge unten und bestätigen Sie Ihre Auswahl, um sie in Ihr "
 "Profil zu übernehmen."
 
-#: lib/vutuv_web/views/import_html.ex:29
+#: lib/vutuv_web/views/import_html.ex:33
 #, elixir-autogen, elixir-format
 msgid "Section"
 msgstr "Bereich"
 
-#: lib/vutuv_web/controllers/import_controller.ex:219
+#: lib/vutuv_web/controllers/import_controller.ex:231
 #, elixir-autogen, elixir-format
 msgid "Skipped %{count} entry that is already on your profile."
 msgid_plural "Skipped %{count} entries that are already on your profile."
@@ -21485,3 +21478,54 @@ msgstr ""
 "Vorhandene Einträge werden aber auch nicht aktualisiert: Sie behalten die "
 "Beschreibung und die Zeitangaben, die sie auf vutuv haben, auch wenn Ihr "
 "Archiv neuere enthält."
+
+#: lib/vutuv_web/controllers/import_controller.ex:272
+#: lib/vutuv_web/views/user_helpers.ex:206
+#, elixir-autogen, elixir-format
+msgid "%{count} tag did not fit: your profile holds at most %{max}. Remove some and try again."
+msgid_plural "%{count} tags did not fit: your profile holds at most %{max}. Remove some and try again."
+msgstr[0] ""
+"Für %{count} Tag war kein Platz mehr: Ihr Profil fasst höchstens %{max}. "
+"Entfernen Sie einige und versuchen Sie es noch einmal."
+msgstr[1] ""
+"Für %{count} Tags war kein Platz mehr: Ihr Profil fasst höchstens %{max}. "
+"Entfernen Sie einige und versuchen Sie es noch einmal."
+
+#: lib/vutuv_web/views/import_html.ex:185
+#, elixir-autogen, elixir-format
+msgid "Remove tags first"
+msgstr "Zuerst Tags entfernen"
+
+#: lib/vutuv_web/views/import_html.ex:226
+#, elixir-autogen, elixir-format
+msgid "Select as many as fit"
+msgstr "So viele wie möglich auswählen"
+
+#: lib/vutuv_web/views/user_helpers.ex:196
+#, elixir-autogen, elixir-format
+msgid "Skipped %{count} tag that is a duplicate or invalid."
+msgid_plural "Skipped %{count} tags that are duplicates or invalid."
+msgstr[0] "%{count} Tag übersprungen, das doppelt oder ungültig ist."
+msgstr[1] "%{count} Tags übersprungen, die doppelt oder ungültig sind."
+
+#: lib/vutuv_web/views/import_html.ex:180
+#, elixir-autogen, elixir-format
+msgid "There is no room for more."
+msgstr "Es ist kein Platz mehr frei."
+
+#: lib/vutuv_web/views/import_html.ex:143
+#, elixir-autogen, elixir-format
+msgid "There is no room for more. Uncheck one to pick another."
+msgstr ""
+"Es ist kein Platz mehr frei. Nehmen Sie einen Haken weg, um ein anderes Tag "
+"zu wählen."
+
+#: lib/vutuv_web/views/import_html.ex:175
+#, elixir-autogen, elixir-format
+msgid "You have %{used} of %{max} tags."
+msgstr "Sie haben %{used} von %{max} Tags."
+
+#: lib/vutuv_web/views/import_html.ex:197
+#, elixir-autogen, elixir-format
+msgid "{n} of {max} free slots selected."
+msgstr "{n} von {max} freien Plätzen ausgewählt."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -122,7 +122,7 @@ msgstr ""
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
-#: lib/vutuv_web/templates/import/preview.html.heex:107
+#: lib/vutuv_web/templates/import/preview.html.heex:113
 #: lib/vutuv_web/templates/report/new.html.heex:103
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:276
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:259
@@ -415,13 +415,13 @@ msgstr ""
 #: lib/vutuv_web/cv/odt.ex:176
 #: lib/vutuv_web/live/cv_live.ex:336
 #: lib/vutuv_web/templates/import/new.html.heex:13
-#: lib/vutuv_web/templates/import/preview.html.heex:61
+#: lib/vutuv_web/templates/import/preview.html.heex:67
 #: lib/vutuv_web/templates/url/edit.html.heex:4
 #: lib/vutuv_web/templates/url/index.html.heex:10
 #: lib/vutuv_web/templates/url/manage.html.heex:4
 #: lib/vutuv_web/templates/url/new.html.heex:4
 #: lib/vutuv_web/templates/url/show.html.heex:6
-#: lib/vutuv_web/views/import_html.ex:65
+#: lib/vutuv_web/views/import_html.ex:69
 #, elixir-autogen
 msgid "Links"
 msgstr ""
@@ -1396,7 +1396,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/tag/new.html.heex:5
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:5
 #: lib/vutuv_web/templates/import/new.html.heex:12
-#: lib/vutuv_web/templates/import/preview.html.heex:57
+#: lib/vutuv_web/templates/import/preview.html.heex:60
 #: lib/vutuv_web/templates/page/index.html.heex:108
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -1406,7 +1406,7 @@ msgstr ""
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
 #: lib/vutuv_web/templates/user_tag/show.html.heex:6
-#: lib/vutuv_web/views/import_html.ex:64
+#: lib/vutuv_web/views/import_html.ex:68
 #, elixir-autogen
 msgid "Tags"
 msgstr ""
@@ -2761,17 +2761,13 @@ msgstr ""
 msgid "Write a post"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:170
+#: lib/vutuv_web/views/user_helpers.ex:179
+#: lib/vutuv_web/views/user_helpers.ex:191
 #, elixir-autogen, elixir-format
 msgid "Added %{count} tag."
 msgid_plural "Added %{count} tags."
 msgstr[0] ""
 msgstr[1] ""
-
-#: lib/vutuv_web/views/user_helpers.ex:174
-#, elixir-autogen, elixir-format
-msgid "Added %{successes} of %{total} tags (the rest were duplicates or invalid)."
-msgstr ""
 
 #: lib/vutuv_web/templates/connection/index.html.heex:13
 #, elixir-autogen, elixir-format
@@ -3150,9 +3146,9 @@ msgstr ""
 #: lib/vutuv_web/live/shell_live.ex:619
 #: lib/vutuv_web/live/shell_live.ex:896
 #: lib/vutuv_web/templates/import/new.html.heex:16
-#: lib/vutuv_web/templates/import/preview.html.heex:76
+#: lib/vutuv_web/templates/import/preview.html.heex:82
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
-#: lib/vutuv_web/views/import_html.ex:68
+#: lib/vutuv_web/views/import_html.ex:72
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr ""
@@ -5494,7 +5490,7 @@ msgstr ""
 #: lib/vutuv_web/templates/email/edit.html.heex:4
 #: lib/vutuv_web/templates/email/manage.html.heex:4
 #: lib/vutuv_web/templates/email/new.html.heex:4
-#: lib/vutuv_web/templates/import/preview.html.heex:90
+#: lib/vutuv_web/templates/import/preview.html.heex:96
 #: lib/vutuv_web/templates/settings/security.html.heex:17
 #, elixir-autogen, elixir-format
 msgid "Email addresses"
@@ -7327,14 +7323,13 @@ msgid "accounts"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:991
-#: lib/vutuv_web/views/import_html.ex:132
-#: lib/vutuv_web/views/import_html.ex:136
+#: lib/vutuv_web/views/import_html.ex:226
 #, elixir-autogen, elixir-format
 msgid "Select all"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:994
-#: lib/vutuv_web/views/import_html.ex:133
+#: lib/vutuv_web/views/import_html.ex:236
 #, elixir-autogen, elixir-format
 msgid "Unselect all"
 msgstr ""
@@ -8085,49 +8080,49 @@ msgstr ""
 msgid "Nobody is online right now."
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:192
+#: lib/vutuv_web/controllers/import_controller.ex:204
 #, elixir-autogen, elixir-format
 msgid "%{count} education entry"
 msgid_plural "%{count} education entries"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:200
+#: lib/vutuv_web/controllers/import_controller.ex:212
 #, elixir-autogen, elixir-format
 msgid "%{count} link"
 msgid_plural "%{count} links"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:204
+#: lib/vutuv_web/controllers/import_controller.ex:216
 #, elixir-autogen, elixir-format
 msgid "%{count} phone number"
 msgid_plural "%{count} phone numbers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:206
+#: lib/vutuv_web/controllers/import_controller.ex:218
 #, elixir-autogen, elixir-format
 msgid "%{count} profile field"
 msgid_plural "%{count} profile fields"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:202
+#: lib/vutuv_web/controllers/import_controller.ex:214
 #, elixir-autogen, elixir-format
 msgid "%{count} social account"
 msgid_plural "%{count} social accounts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:199
+#: lib/vutuv_web/controllers/import_controller.ex:211
 #, elixir-autogen, elixir-format
 msgid "%{count} tag"
 msgid_plural "%{count} tags"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:190
+#: lib/vutuv_web/controllers/import_controller.ex:202
 #, elixir-autogen, elixir-format
 msgid "%{count} work experience"
 msgid_plural "%{count} work experiences"
@@ -8162,7 +8157,7 @@ msgstr ""
 #: lib/vutuv_web/templates/import/new.html.heex:10
 #: lib/vutuv_web/templates/import/preview.html.heex:44
 #: lib/vutuv_web/templates/user/show.html.heex:666
-#: lib/vutuv_web/views/import_html.ex:62
+#: lib/vutuv_web/views/import_html.ex:66
 #: lib/vutuv_web/views/job_reference_html.ex:265
 #, elixir-autogen, elixir-format
 msgid "Education"
@@ -8188,7 +8183,7 @@ msgstr ""
 msgid "Education updated successfully."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/preview.html.heex:92
+#: lib/vutuv_web/templates/import/preview.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "Email addresses are not imported automatically because each one is confirmed by PIN. Add them yourself if you like:"
 msgstr ""
@@ -8209,8 +8204,8 @@ msgstr ""
 msgid "Import"
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:36
-#: lib/vutuv_web/controllers/import_controller.ex:126
+#: lib/vutuv_web/controllers/import_controller.ex:37
+#: lib/vutuv_web/controllers/import_controller.ex:128
 #: lib/vutuv_web/templates/import/new.html.heex:1
 #: lib/vutuv_web/templates/import/preview.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:432
@@ -8218,17 +8213,17 @@ msgstr ""
 msgid "Import from LinkedIn"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/preview.html.heex:105
+#: lib/vutuv_web/templates/import/preview.html.heex:111
 #, elixir-autogen, elixir-format
 msgid "Import selected"
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:212
+#: lib/vutuv_web/controllers/import_controller.ex:224
 #, elixir-autogen, elixir-format
 msgid "Imported %{items}."
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:211
+#: lib/vutuv_web/controllers/import_controller.ex:223
 #, elixir-autogen, elixir-format
 msgid "Nothing new to import."
 msgstr ""
@@ -8239,16 +8234,16 @@ msgstr ""
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
 #: lib/vutuv_web/controllers/phone_number_controller.ex:87
 #: lib/vutuv_web/templates/import/new.html.heex:15
-#: lib/vutuv_web/templates/import/preview.html.heex:69
+#: lib/vutuv_web/templates/import/preview.html.heex:75
 #: lib/vutuv_web/templates/phone_number/edit.html.heex:4
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:4
 #: lib/vutuv_web/templates/phone_number/new.html.heex:4
-#: lib/vutuv_web/views/import_html.ex:67
+#: lib/vutuv_web/views/import_html.ex:71
 #, elixir-autogen, elixir-format
 msgid "Phone numbers"
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:81
+#: lib/vutuv_web/controllers/import_controller.ex:82
 #, elixir-autogen, elixir-format
 msgid "Please choose your LinkedIn export ZIP first."
 msgstr ""
@@ -8258,14 +8253,14 @@ msgstr ""
 msgid "School"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/preview.html.heex:81
+#: lib/vutuv_web/templates/import/preview.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "Set %{field}:"
 msgstr ""
 
 #: lib/vutuv_web/templates/import/new.html.heex:14
-#: lib/vutuv_web/templates/import/preview.html.heex:65
-#: lib/vutuv_web/views/import_html.ex:66
+#: lib/vutuv_web/templates/import/preview.html.heex:71
+#: lib/vutuv_web/views/import_html.ex:70
 #, elixir-autogen, elixir-format
 msgid "Social media"
 msgstr ""
@@ -8280,17 +8275,17 @@ msgstr ""
 msgid "Step 2: Upload the ZIP here"
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:74
+#: lib/vutuv_web/controllers/import_controller.ex:75
 #, elixir-autogen, elixir-format
 msgid "That does not look like a LinkedIn data export ZIP."
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:135
+#: lib/vutuv_web/controllers/import_controller.ex:137
 #, elixir-autogen, elixir-format
 msgid "The file could not be read. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:106
+#: lib/vutuv_web/controllers/import_controller.ex:107
 #, elixir-autogen, elixir-format
 msgid "The import could not be completed. Please try again."
 msgstr ""
@@ -8302,27 +8297,27 @@ msgstr ""
 
 #: lib/vutuv_web/templates/import/new.html.heex:9
 #: lib/vutuv_web/templates/import/preview.html.heex:40
-#: lib/vutuv_web/views/import_html.ex:61
+#: lib/vutuv_web/views/import_html.ex:65
 #, elixir-autogen, elixir-format
 msgid "Work experience"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/preview.html.heex:96
+#: lib/vutuv_web/templates/import/preview.html.heex:102
 #, elixir-autogen, elixir-format
 msgid "add an email address"
 msgstr ""
 
-#: lib/vutuv_web/views/import_html.ex:92
+#: lib/vutuv_web/views/import_html.ex:106
 #, elixir-autogen, elixir-format
 msgid "already on your profile"
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:67
+#: lib/vutuv_web/controllers/import_controller.ex:68
 #, elixir-autogen, elixir-format
 msgid "That archive is too large or has too many files to import safely."
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:151
+#: lib/vutuv_web/controllers/import_controller.ex:163
 #, elixir-autogen, elixir-format
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
@@ -8477,7 +8472,7 @@ msgstr ""
 msgid "When off, the Social Media card lists your accounts without any posts."
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:60
+#: lib/vutuv_web/controllers/import_controller.ex:61
 #, elixir-autogen, elixir-format
 msgid "That file is too large. Please upload a ZIP of at most 50 MB."
 msgstr ""
@@ -8923,12 +8918,12 @@ msgstr ""
 msgid "Choose automatically instead"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:423
+#: lib/vutuv_web/views/user_helpers.ex:456
 #, elixir-autogen, elixir-format
 msgid "Show at top of profile"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:414
+#: lib/vutuv_web/views/user_helpers.ex:447
 #, elixir-autogen, elixir-format
 msgid "Shown at the top of your profile"
 msgstr ""
@@ -9471,7 +9466,7 @@ msgstr ""
 msgid "Looking for a job"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:72
+#: lib/vutuv_web/views/user_helpers.ex:73
 #, elixir-autogen, elixir-format
 msgid "Not open to work"
 msgstr ""
@@ -9550,7 +9545,7 @@ msgstr ""
 msgid "“%{name}” is an honor tag now. Add members below."
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:194
+#: lib/vutuv_web/controllers/import_controller.ex:206
 #, elixir-autogen, elixir-format
 msgid "%{count} certificate or license"
 msgid_plural "%{count} certificates or licenses"
@@ -9608,7 +9603,7 @@ msgstr ""
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
 #: lib/vutuv_web/templates/user/show.html.heex:834
-#: lib/vutuv_web/views/import_html.ex:63
+#: lib/vutuv_web/views/import_html.ex:67
 #: lib/vutuv_web/views/job_reference_html.ex:266
 #, elixir-autogen, elixir-format
 msgid "Certificates & licenses"
@@ -9770,7 +9765,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:95
+#: lib/vutuv_web/views/user_helpers.ex:96
 #, elixir-autogen, elixir-format
 msgid "Prefer not to say"
 msgstr ""
@@ -20644,21 +20639,21 @@ msgstr ""
 msgid "Legal"
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:247
+#: lib/vutuv_web/controllers/import_controller.ex:263
 #, elixir-autogen, elixir-format
 msgid "%{count} entry could not be added."
 msgid_plural "%{count} entries could not be added."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:237
+#: lib/vutuv_web/controllers/import_controller.ex:253
 #, elixir-autogen, elixir-format
 msgid "%{count} social account could not be added because another member has already claimed it."
 msgid_plural "%{count} social accounts could not be added because another member has already claimed them."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/import_html.ex:31
+#: lib/vutuv_web/views/import_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Already on your profile"
 msgstr ""
@@ -20668,12 +20663,12 @@ msgstr ""
 msgid "Analysis complete. Nothing has been imported yet."
 msgstr ""
 
-#: lib/vutuv_web/views/import_html.ex:30
+#: lib/vutuv_web/views/import_html.ex:34
 #, elixir-autogen, elixir-format
 msgid "Found"
 msgstr ""
 
-#: lib/vutuv_web/views/import_html.ex:32
+#: lib/vutuv_web/views/import_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Ready to import"
 msgstr ""
@@ -20683,12 +20678,12 @@ msgstr ""
 msgid "Review the entries below and confirm your selection to add them to your profile."
 msgstr ""
 
-#: lib/vutuv_web/views/import_html.ex:29
+#: lib/vutuv_web/views/import_html.ex:33
 #, elixir-autogen, elixir-format
 msgid "Section"
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:219
+#: lib/vutuv_web/controllers/import_controller.ex:231
 #, elixir-autogen, elixir-format
 msgid "Skipped %{count} entry that is already on your profile."
 msgid_plural "Skipped %{count} entries that are already on your profile."
@@ -20698,4 +20693,49 @@ msgstr[1] ""
 #: lib/vutuv_web/templates/import/preview.html.heex:20
 #, elixir-autogen, elixir-format
 msgid "You can analyse the same or a newer LinkedIn archive again at any time. Nothing is duplicated and nothing is overwritten. Entries you already have are not updated either: they keep the description and dates they have on vutuv, even when your archive holds newer ones."
+msgstr ""
+
+#: lib/vutuv_web/controllers/import_controller.ex:272
+#: lib/vutuv_web/views/user_helpers.ex:206
+#, elixir-autogen, elixir-format
+msgid "%{count} tag did not fit: your profile holds at most %{max}. Remove some and try again."
+msgid_plural "%{count} tags did not fit: your profile holds at most %{max}. Remove some and try again."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/views/import_html.ex:185
+#, elixir-autogen, elixir-format
+msgid "Remove tags first"
+msgstr ""
+
+#: lib/vutuv_web/views/import_html.ex:226
+#, elixir-autogen, elixir-format
+msgid "Select as many as fit"
+msgstr ""
+
+#: lib/vutuv_web/views/user_helpers.ex:196
+#, elixir-autogen, elixir-format
+msgid "Skipped %{count} tag that is a duplicate or invalid."
+msgid_plural "Skipped %{count} tags that are duplicates or invalid."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/views/import_html.ex:180
+#, elixir-autogen, elixir-format
+msgid "There is no room for more."
+msgstr ""
+
+#: lib/vutuv_web/views/import_html.ex:143
+#, elixir-autogen, elixir-format
+msgid "There is no room for more. Uncheck one to pick another."
+msgstr ""
+
+#: lib/vutuv_web/views/import_html.ex:175
+#, elixir-autogen, elixir-format
+msgid "You have %{used} of %{max} tags."
+msgstr ""
+
+#: lib/vutuv_web/views/import_html.ex:197
+#, elixir-autogen, elixir-format
+msgid "{n} of {max} free slots selected."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -120,7 +120,7 @@ msgstr ""
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
-#: lib/vutuv_web/templates/import/preview.html.heex:107
+#: lib/vutuv_web/templates/import/preview.html.heex:113
 #: lib/vutuv_web/templates/report/new.html.heex:103
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:276
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:259
@@ -413,13 +413,13 @@ msgstr ""
 #: lib/vutuv_web/cv/odt.ex:176
 #: lib/vutuv_web/live/cv_live.ex:336
 #: lib/vutuv_web/templates/import/new.html.heex:13
-#: lib/vutuv_web/templates/import/preview.html.heex:61
+#: lib/vutuv_web/templates/import/preview.html.heex:67
 #: lib/vutuv_web/templates/url/edit.html.heex:4
 #: lib/vutuv_web/templates/url/index.html.heex:10
 #: lib/vutuv_web/templates/url/manage.html.heex:4
 #: lib/vutuv_web/templates/url/new.html.heex:4
 #: lib/vutuv_web/templates/url/show.html.heex:6
-#: lib/vutuv_web/views/import_html.ex:65
+#: lib/vutuv_web/views/import_html.ex:69
 #, elixir-autogen
 msgid "Links"
 msgstr ""
@@ -1394,7 +1394,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/tag/new.html.heex:5
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:5
 #: lib/vutuv_web/templates/import/new.html.heex:12
-#: lib/vutuv_web/templates/import/preview.html.heex:57
+#: lib/vutuv_web/templates/import/preview.html.heex:60
 #: lib/vutuv_web/templates/page/index.html.heex:108
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -1404,7 +1404,7 @@ msgstr ""
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
 #: lib/vutuv_web/templates/user_tag/show.html.heex:6
-#: lib/vutuv_web/views/import_html.ex:64
+#: lib/vutuv_web/views/import_html.ex:68
 #, elixir-autogen
 msgid "Tags"
 msgstr ""
@@ -2759,17 +2759,13 @@ msgstr ""
 msgid "Write a post"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:170
+#: lib/vutuv_web/views/user_helpers.ex:179
+#: lib/vutuv_web/views/user_helpers.ex:191
 #, elixir-autogen, elixir-format
 msgid "Added %{count} tag."
 msgid_plural "Added %{count} tags."
 msgstr[0] ""
 msgstr[1] ""
-
-#: lib/vutuv_web/views/user_helpers.ex:174
-#, elixir-autogen, elixir-format
-msgid "Added %{successes} of %{total} tags (the rest were duplicates or invalid)."
-msgstr ""
 
 #: lib/vutuv_web/templates/connection/index.html.heex:13
 #, elixir-autogen, elixir-format
@@ -3148,9 +3144,9 @@ msgstr ""
 #: lib/vutuv_web/live/shell_live.ex:619
 #: lib/vutuv_web/live/shell_live.ex:896
 #: lib/vutuv_web/templates/import/new.html.heex:16
-#: lib/vutuv_web/templates/import/preview.html.heex:76
+#: lib/vutuv_web/templates/import/preview.html.heex:82
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
-#: lib/vutuv_web/views/import_html.ex:68
+#: lib/vutuv_web/views/import_html.ex:72
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr ""
@@ -5492,7 +5488,7 @@ msgstr ""
 #: lib/vutuv_web/templates/email/edit.html.heex:4
 #: lib/vutuv_web/templates/email/manage.html.heex:4
 #: lib/vutuv_web/templates/email/new.html.heex:4
-#: lib/vutuv_web/templates/import/preview.html.heex:90
+#: lib/vutuv_web/templates/import/preview.html.heex:96
 #: lib/vutuv_web/templates/settings/security.html.heex:17
 #, elixir-autogen, elixir-format
 msgid "Email addresses"
@@ -7325,14 +7321,13 @@ msgid "accounts"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:991
-#: lib/vutuv_web/views/import_html.ex:132
-#: lib/vutuv_web/views/import_html.ex:136
+#: lib/vutuv_web/views/import_html.ex:226
 #, elixir-autogen, elixir-format
 msgid "Select all"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:994
-#: lib/vutuv_web/views/import_html.ex:133
+#: lib/vutuv_web/views/import_html.ex:236
 #, elixir-autogen, elixir-format
 msgid "Unselect all"
 msgstr ""
@@ -8083,49 +8078,49 @@ msgstr ""
 msgid "Nobody is online right now."
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:192
+#: lib/vutuv_web/controllers/import_controller.ex:204
 #, elixir-autogen, elixir-format
 msgid "%{count} education entry"
 msgid_plural "%{count} education entries"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:200
+#: lib/vutuv_web/controllers/import_controller.ex:212
 #, elixir-autogen, elixir-format
 msgid "%{count} link"
 msgid_plural "%{count} links"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:204
+#: lib/vutuv_web/controllers/import_controller.ex:216
 #, elixir-autogen, elixir-format
 msgid "%{count} phone number"
 msgid_plural "%{count} phone numbers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:206
+#: lib/vutuv_web/controllers/import_controller.ex:218
 #, elixir-autogen, elixir-format
 msgid "%{count} profile field"
 msgid_plural "%{count} profile fields"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:202
+#: lib/vutuv_web/controllers/import_controller.ex:214
 #, elixir-autogen, elixir-format
 msgid "%{count} social account"
 msgid_plural "%{count} social accounts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:199
+#: lib/vutuv_web/controllers/import_controller.ex:211
 #, elixir-autogen, elixir-format
 msgid "%{count} tag"
 msgid_plural "%{count} tags"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:190
+#: lib/vutuv_web/controllers/import_controller.ex:202
 #, elixir-autogen, elixir-format
 msgid "%{count} work experience"
 msgid_plural "%{count} work experiences"
@@ -8160,7 +8155,7 @@ msgstr ""
 #: lib/vutuv_web/templates/import/new.html.heex:10
 #: lib/vutuv_web/templates/import/preview.html.heex:44
 #: lib/vutuv_web/templates/user/show.html.heex:666
-#: lib/vutuv_web/views/import_html.ex:62
+#: lib/vutuv_web/views/import_html.ex:66
 #: lib/vutuv_web/views/job_reference_html.ex:265
 #, elixir-autogen, elixir-format
 msgid "Education"
@@ -8186,7 +8181,7 @@ msgstr ""
 msgid "Education updated successfully."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/preview.html.heex:92
+#: lib/vutuv_web/templates/import/preview.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "Email addresses are not imported automatically because each one is confirmed by PIN. Add them yourself if you like:"
 msgstr ""
@@ -8207,8 +8202,8 @@ msgstr ""
 msgid "Import"
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:36
-#: lib/vutuv_web/controllers/import_controller.ex:126
+#: lib/vutuv_web/controllers/import_controller.ex:37
+#: lib/vutuv_web/controllers/import_controller.ex:128
 #: lib/vutuv_web/templates/import/new.html.heex:1
 #: lib/vutuv_web/templates/import/preview.html.heex:1
 #: lib/vutuv_web/templates/user/show.html.heex:432
@@ -8216,17 +8211,17 @@ msgstr ""
 msgid "Import from LinkedIn"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/preview.html.heex:105
+#: lib/vutuv_web/templates/import/preview.html.heex:111
 #, elixir-autogen, elixir-format
 msgid "Import selected"
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:212
+#: lib/vutuv_web/controllers/import_controller.ex:224
 #, elixir-autogen, elixir-format
 msgid "Imported %{items}."
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:211
+#: lib/vutuv_web/controllers/import_controller.ex:223
 #, elixir-autogen, elixir-format
 msgid "Nothing new to import."
 msgstr ""
@@ -8237,16 +8232,16 @@ msgstr ""
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
 #: lib/vutuv_web/controllers/phone_number_controller.ex:87
 #: lib/vutuv_web/templates/import/new.html.heex:15
-#: lib/vutuv_web/templates/import/preview.html.heex:69
+#: lib/vutuv_web/templates/import/preview.html.heex:75
 #: lib/vutuv_web/templates/phone_number/edit.html.heex:4
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:4
 #: lib/vutuv_web/templates/phone_number/new.html.heex:4
-#: lib/vutuv_web/views/import_html.ex:67
+#: lib/vutuv_web/views/import_html.ex:71
 #, elixir-autogen, elixir-format
 msgid "Phone numbers"
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:81
+#: lib/vutuv_web/controllers/import_controller.ex:82
 #, elixir-autogen, elixir-format
 msgid "Please choose your LinkedIn export ZIP first."
 msgstr ""
@@ -8256,14 +8251,14 @@ msgstr ""
 msgid "School"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/preview.html.heex:81
+#: lib/vutuv_web/templates/import/preview.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "Set %{field}:"
 msgstr ""
 
 #: lib/vutuv_web/templates/import/new.html.heex:14
-#: lib/vutuv_web/templates/import/preview.html.heex:65
-#: lib/vutuv_web/views/import_html.ex:66
+#: lib/vutuv_web/templates/import/preview.html.heex:71
+#: lib/vutuv_web/views/import_html.ex:70
 #, elixir-autogen, elixir-format
 msgid "Social media"
 msgstr ""
@@ -8278,17 +8273,17 @@ msgstr ""
 msgid "Step 2: Upload the ZIP here"
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:74
+#: lib/vutuv_web/controllers/import_controller.ex:75
 #, elixir-autogen, elixir-format
 msgid "That does not look like a LinkedIn data export ZIP."
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:135
+#: lib/vutuv_web/controllers/import_controller.ex:137
 #, elixir-autogen, elixir-format
 msgid "The file could not be read. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:106
+#: lib/vutuv_web/controllers/import_controller.ex:107
 #, elixir-autogen, elixir-format
 msgid "The import could not be completed. Please try again."
 msgstr ""
@@ -8300,27 +8295,27 @@ msgstr ""
 
 #: lib/vutuv_web/templates/import/new.html.heex:9
 #: lib/vutuv_web/templates/import/preview.html.heex:40
-#: lib/vutuv_web/views/import_html.ex:61
+#: lib/vutuv_web/views/import_html.ex:65
 #, elixir-autogen, elixir-format
 msgid "Work experience"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/preview.html.heex:96
+#: lib/vutuv_web/templates/import/preview.html.heex:102
 #, elixir-autogen, elixir-format
 msgid "add an email address"
 msgstr ""
 
-#: lib/vutuv_web/views/import_html.ex:92
+#: lib/vutuv_web/views/import_html.ex:106
 #, elixir-autogen, elixir-format
 msgid "already on your profile"
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:67
+#: lib/vutuv_web/controllers/import_controller.ex:68
 #, elixir-autogen, elixir-format
 msgid "That archive is too large or has too many files to import safely."
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:151
+#: lib/vutuv_web/controllers/import_controller.ex:163
 #, elixir-autogen, elixir-format
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
@@ -8475,7 +8470,7 @@ msgstr ""
 msgid "When off, the Social Media card lists your accounts without any posts."
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:60
+#: lib/vutuv_web/controllers/import_controller.ex:61
 #, elixir-autogen, elixir-format
 msgid "That file is too large. Please upload a ZIP of at most 50 MB."
 msgstr ""
@@ -8921,12 +8916,12 @@ msgstr ""
 msgid "Choose automatically instead"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:423
+#: lib/vutuv_web/views/user_helpers.ex:456
 #, elixir-autogen, elixir-format
 msgid "Show at top of profile"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:414
+#: lib/vutuv_web/views/user_helpers.ex:447
 #, elixir-autogen, elixir-format
 msgid "Shown at the top of your profile"
 msgstr ""
@@ -9469,7 +9464,7 @@ msgstr ""
 msgid "Looking for a job"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:72
+#: lib/vutuv_web/views/user_helpers.ex:73
 #, elixir-autogen, elixir-format
 msgid "Not open to work"
 msgstr ""
@@ -9548,7 +9543,7 @@ msgstr ""
 msgid "“%{name}” is an honor tag now. Add members below."
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:194
+#: lib/vutuv_web/controllers/import_controller.ex:206
 #, elixir-autogen, elixir-format
 msgid "%{count} certificate or license"
 msgid_plural "%{count} certificates or licenses"
@@ -9606,7 +9601,7 @@ msgstr ""
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
 #: lib/vutuv_web/templates/user/show.html.heex:834
-#: lib/vutuv_web/views/import_html.ex:63
+#: lib/vutuv_web/views/import_html.ex:67
 #: lib/vutuv_web/views/job_reference_html.ex:266
 #, elixir-autogen, elixir-format
 msgid "Certificates & licenses"
@@ -9768,7 +9763,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:95
+#: lib/vutuv_web/views/user_helpers.ex:96
 #, elixir-autogen, elixir-format
 msgid "Prefer not to say"
 msgstr ""
@@ -20642,21 +20637,21 @@ msgstr ""
 msgid "Legal"
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:247
+#: lib/vutuv_web/controllers/import_controller.ex:263
 #, elixir-autogen, elixir-format
 msgid "%{count} entry could not be added."
 msgid_plural "%{count} entries could not be added."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:237
+#: lib/vutuv_web/controllers/import_controller.ex:253
 #, elixir-autogen, elixir-format
 msgid "%{count} social account could not be added because another member has already claimed it."
 msgid_plural "%{count} social accounts could not be added because another member has already claimed them."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/import_html.ex:31
+#: lib/vutuv_web/views/import_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Already on your profile"
 msgstr ""
@@ -20666,12 +20661,12 @@ msgstr ""
 msgid "Analysis complete. Nothing has been imported yet."
 msgstr ""
 
-#: lib/vutuv_web/views/import_html.ex:30
+#: lib/vutuv_web/views/import_html.ex:34
 #, elixir-autogen, elixir-format
 msgid "Found"
 msgstr ""
 
-#: lib/vutuv_web/views/import_html.ex:32
+#: lib/vutuv_web/views/import_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Ready to import"
 msgstr ""
@@ -20681,12 +20676,12 @@ msgstr ""
 msgid "Review the entries below and confirm your selection to add them to your profile."
 msgstr ""
 
-#: lib/vutuv_web/views/import_html.ex:29
+#: lib/vutuv_web/views/import_html.ex:33
 #, elixir-autogen, elixir-format
 msgid "Section"
 msgstr ""
 
-#: lib/vutuv_web/controllers/import_controller.ex:219
+#: lib/vutuv_web/controllers/import_controller.ex:231
 #, elixir-autogen, elixir-format
 msgid "Skipped %{count} entry that is already on your profile."
 msgid_plural "Skipped %{count} entries that are already on your profile."
@@ -20696,4 +20691,49 @@ msgstr[1] ""
 #: lib/vutuv_web/templates/import/preview.html.heex:20
 #, elixir-autogen, elixir-format
 msgid "You can analyse the same or a newer LinkedIn archive again at any time. Nothing is duplicated and nothing is overwritten. Entries you already have are not updated either: they keep the description and dates they have on vutuv, even when your archive holds newer ones."
+msgstr ""
+
+#: lib/vutuv_web/controllers/import_controller.ex:272
+#: lib/vutuv_web/views/user_helpers.ex:206
+#, elixir-autogen, elixir-format
+msgid "%{count} tag did not fit: your profile holds at most %{max}. Remove some and try again."
+msgid_plural "%{count} tags did not fit: your profile holds at most %{max}. Remove some and try again."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/views/import_html.ex:185
+#, elixir-autogen, elixir-format
+msgid "Remove tags first"
+msgstr ""
+
+#: lib/vutuv_web/views/import_html.ex:226
+#, elixir-autogen, elixir-format
+msgid "Select as many as fit"
+msgstr ""
+
+#: lib/vutuv_web/views/user_helpers.ex:196
+#, elixir-autogen, elixir-format
+msgid "Skipped %{count} tag that is a duplicate or invalid."
+msgid_plural "Skipped %{count} tags that are duplicates or invalid."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/views/import_html.ex:180
+#, elixir-autogen, elixir-format
+msgid "There is no room for more."
+msgstr ""
+
+#: lib/vutuv_web/views/import_html.ex:143
+#, elixir-autogen, elixir-format
+msgid "There is no room for more. Uncheck one to pick another."
+msgstr ""
+
+#: lib/vutuv_web/views/import_html.ex:175
+#, elixir-autogen, elixir-format
+msgid "You have %{used} of %{max} tags."
+msgstr ""
+
+#: lib/vutuv_web/views/import_html.ex:197
+#, elixir-autogen, elixir-format
+msgid "{n} of {max} free slots selected."
 msgstr ""

--- a/test/vutuv/imports/linked_in_apply_test.exs
+++ b/test/vutuv/imports/linked_in_apply_test.exs
@@ -12,6 +12,7 @@ defmodule Vutuv.Imports.LinkedInApplyTest do
   alias Vutuv.Profiles.Education
   alias Vutuv.Profiles.Qualification
   alias Vutuv.Profiles.WorkExperience
+  alias Vutuv.Tags
   alias Vutuv.Tags.UserTag
 
   defp zip(files) do
@@ -52,6 +53,98 @@ defmodule Vutuv.Imports.LinkedInApplyTest do
     assert cert.awarded_year == 2023
 
     assert Repo.aggregate(from(ut in UserTag, where: ut.user_id == ^user.id), :count) == 2
+  end
+
+  describe "the profile's tag ceiling (issue #1478)" do
+    # A profile carries at most Vutuv.Tags.max_user_tags/0 tags, so an archive
+    # can offer more skills than there is room for. Those must be counted as
+    # what they are — refused for want of room — and not folded into the
+    # ordinary skips, whose flash tells the member the entries are already
+    # theirs or claimed by somebody else.
+    defp skills_archive(names),
+      do: zip([{"Skills.csv", "Name\n" <> Enum.join(names, "\n") <> "\n"}])
+
+    defp fill_tags(user, count) do
+      for _ <- 1..count, do: insert(:user_tag, user: user, tag: build(:tag))
+      user
+    end
+
+    test "imports only as many tags as fit and counts the rest apart" do
+      max = Tags.max_user_tags()
+      user = insert(:user) |> fill_tags(max - 3)
+      names = for _ <- 1..10, do: unique_tag_name("li-skill")
+
+      {:ok, parsed} = LinkedIn.parse(skills_archive(names))
+      {:ok, summary} = LinkedIn.apply_selection(user, parsed)
+
+      assert summary.created.skills == 3
+      assert summary.blocked.tag_limit == 7
+      # Not one of them is a duplicate or an invalid name.
+      assert summary.skipped.skills == 0
+      assert Tags.user_tag_count(user) == max
+    end
+
+    test "a full profile imports no tag at all and says so" do
+      user = insert(:user) |> fill_tags(Tags.max_user_tags())
+      names = for _ <- 1..4, do: unique_tag_name("li-skill")
+
+      {:ok, parsed} = LinkedIn.parse(skills_archive(names))
+      {:ok, summary} = LinkedIn.apply_selection(user, parsed)
+
+      assert summary.created.skills == 0
+      assert summary.blocked.tag_limit == 4
+      assert Tags.user_tag_count(user) == Tags.max_user_tags()
+    end
+
+    test "a tag the member already has costs no slot" do
+      max = Tags.max_user_tags()
+      user = insert(:user) |> fill_tags(max - 3)
+      held = unique_tag_name("li-skill")
+      {:ok, _} = Tags.add_user_tag(user, held)
+      fresh = for _ <- 1..3, do: unique_tag_name("li-skill")
+
+      {:ok, parsed} = LinkedIn.parse(skills_archive([held | fresh]))
+      {:ok, summary} = LinkedIn.apply_selection(user, parsed)
+
+      assert summary.created.skills == 2
+      assert summary.skipped.skills == 1
+      assert summary.blocked.tag_limit == 1
+    end
+
+    test "the preview preselects no more skills than fit" do
+      max = Tags.max_user_tags()
+      user = insert(:user) |> fill_tags(max - 4)
+      names = for _ <- 1..9, do: unique_tag_name("li-skill")
+
+      {:ok, parsed} = LinkedIn.parse(skills_archive(names))
+      candidates = LinkedIn.mark_duplicates(user, parsed)
+
+      assert length(candidates.skills) == 9
+      assert Enum.count(candidates.skills, & &1.select?) == 4
+      # The archive's own order decides which four are offered.
+      assert candidates.skills |> Enum.take(4) |> Enum.all?(& &1.select?)
+    end
+
+    test "a full profile preselects nothing" do
+      user = insert(:user) |> fill_tags(Tags.max_user_tags())
+      names = for _ <- 1..3, do: unique_tag_name("li-skill")
+
+      {:ok, parsed} = LinkedIn.parse(skills_archive(names))
+      candidates = LinkedIn.mark_duplicates(user, parsed)
+
+      refute Enum.any?(candidates.skills, & &1.select?)
+    end
+
+    test "every other section still preselects everything that is not a duplicate" do
+      user = insert(:user)
+      {:ok, parsed} = LinkedIn.parse(sample_archive())
+
+      candidates = LinkedIn.mark_duplicates(user, parsed)
+
+      assert Enum.all?(candidates.positions, & &1.select?)
+      assert Enum.all?(candidates.educations, & &1.select?)
+      assert Enum.all?(candidates.certifications, & &1.select?)
+    end
   end
 
   test "a re-import does not double a certification (issue #859)" do

--- a/test/vutuv_web/controllers/import_controller_test.exs
+++ b/test/vutuv_web/controllers/import_controller_test.exs
@@ -257,4 +257,98 @@ defmodule VutuvWeb.ImportControllerTest do
     assert flash =~ "already claimed it"
     refute flash =~ "already on your profile"
   end
+
+  # A profile carries at most Vutuv.Tags.max_user_tags/0 tags, and an archive
+  # cheerfully offers fifty skills. The preview used to tick every one of them
+  # and the confirm step then dropped the overflow with a message blaming
+  # duplicates (issue #1478).
+  describe "the tag section's ceiling (issue #1478)" do
+    defp skill_files(names), do: [{"Skills.csv", "Name\n" <> Enum.join(names, "\n") <> "\n"}]
+
+    defp fill_tags(user, count) do
+      for _ <- 1..count, do: insert(:user_tag, user: user, tag: build(:tag))
+      user
+    end
+
+    defp preview(conn, files) do
+      conn
+      |> post(~p"/settings/import/linkedin", %{"import" => %{"archive" => upload_zip(files)}})
+      |> html_response(200)
+    end
+
+    defp checked_skill_boxes(body) do
+      body
+      |> LazyHTML.from_document()
+      |> LazyHTML.query(~s([data-select-limit] input[type="checkbox"][checked]))
+      |> Enum.count()
+    end
+
+    test "the preview ticks no more skills than the profile has room for", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      # The account signs up with three tags, so eleven of the fifteen are left
+      # once one more is attached.
+      fill_tags(user, 1)
+      names = for i <- 1..30, do: "Ceiling Skill #{i}"
+
+      body = preview(conn, skill_files(names))
+
+      assert body =~ ~s(data-select-limit="11")
+      assert checked_skill_boxes(body) == 11
+      assert body =~ "You have 4 of 15 tags."
+      # The live half counts what is selected, so the sentence is true on
+      # arrival — with the free slots already ticked, "11 more can be picked"
+      # would read as a zero.
+      assert body =~ "11 of 11 free slots selected."
+    end
+
+    test "a full profile ticks nothing and points at the tags editor", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      fill_tags(user, Vutuv.Tags.max_user_tags() - 3)
+
+      body = preview(conn, skill_files(["Ceiling Skill A", "Ceiling Skill B"]))
+
+      assert body =~ ~s(data-select-limit="0")
+      assert checked_skill_boxes(body) == 0
+      assert body =~ "There is no room for more."
+      assert body =~ ~s(href="/settings/tags")
+    end
+
+    test "the German preview names the ceiling in German", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      fill_tags(user, 1)
+
+      body =
+        conn
+        |> recycle()
+        |> put_req_header("accept-language", "de-DE,de")
+        |> preview(skill_files(["Ceiling Skill C"]))
+
+      assert body =~ "Sie haben 4 von 15 Tags."
+      assert body =~ "1 von 11 freien Plätzen ausgewählt."
+      # The msgid this one is closest to is "Remove date of birth", which is
+      # what --merge fuzzy-filled it with (the .po trap in CLAUDE.md).
+      refute body =~ "Geburtsdatum entfernen"
+    end
+
+    test "confirm reports the tags that did not fit as such", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      fill_tags(user, Vutuv.Tags.max_user_tags() - 3 - 1)
+      names = for i <- 1..5, do: "Ceiling Skill F#{i}"
+      {:ok, parsed} = LinkedIn.parse(zip_binary(skill_files(names)))
+
+      conn =
+        post(conn, ~p"/settings/import/linkedin/apply", %{
+          "payload" => Jason.encode!(LinkedIn.payload_map(parsed)),
+          "selected" => Enum.map(parsed.skills, & &1.id)
+        })
+
+      assert redirected_to(conn) == ~p"/#{user}"
+      flash = Phoenix.Flash.get(conn.assigns.flash, :info)
+      assert flash =~ "Imported 1 tag."
+      assert flash =~ "4 tags did not fit: your profile holds at most 15."
+      # The old sentence claimed those four were already on the profile.
+      refute flash =~ "already on your profile"
+      refute flash =~ "could not be added"
+    end
+  end
 end

--- a/test/vutuv_web/live/tag_new_live_test.exs
+++ b/test/vutuv_web/live/tag_new_live_test.exs
@@ -202,7 +202,9 @@ defmodule VutuvWeb.TagNewLiveTest do
       live |> form("#tag-form", tag_param: %{value: "Elixir, Phoenix"}) |> render_submit()
 
       flash = assert_redirect(live, ~p"/settings/tags")
-      assert flash["info"] == "Added 1 of 2 tags (the rest were duplicates or invalid)."
+      # Duplicates and invalid names keep their own sentence; the ceiling has
+      # one of its own (issue #1478), so neither reason speaks for the other.
+      assert flash["info"] == "Added 1 tag. Skipped 1 tag that is a duplicate or invalid."
       assert tag_count(user) == base + 2
     end
 
@@ -283,6 +285,32 @@ defmodule VutuvWeb.TagNewLiveTest do
       assert html =~ "at most"
       assert tag_count(user) == full
       refute Repo.exists?(from(t in Vutuv.Tags.Tag, where: t.name == "OneMore"))
+    end
+
+    # The guard above only catches a profile that is ALREADY full. A batch that
+    # runs into the ceiling half way through used to attach what fit and report
+    # the rest as duplicates or invalid — the one reason a member cannot act on
+    # (the same defect the LinkedIn import had, issue #1478).
+    test "a batch that overruns the ceiling names the ceiling, not duplicates", %{
+      live: live,
+      user: user
+    } do
+      # Three registration tags plus these leaves room for exactly two more.
+      for _ <- 1..(Vutuv.Tags.max_user_tags() - 3 - 2),
+          do: insert(:user_tag, user: user, tag: build(:tag))
+
+      names = for _ <- 1..5, do: unique_tag_name("Batch")
+
+      live |> form("#tag-form", tag_param: %{value: Enum.join(names, ", ")}) |> render_submit()
+
+      flash = assert_redirect(live, ~p"/settings/tags")
+
+      assert flash["info"] ==
+               "Added 2 tags. 3 tags did not fit: your profile holds at most 15. " <>
+                 "Remove some and try again."
+
+      refute flash["info"] =~ "duplicate"
+      assert tag_count(user) == Vutuv.Tags.max_user_tags()
     end
   end
 end


### PR DESCRIPTION
**TL;DR** Die Import-Vorschau hakt nur noch so viele Tags an, wie ins Profil passen, und abgelehnte Tags werden als solche gemeldet.

**Vorher:** `checked={not @duplicate?}` wählte jeden neuen Skill vor, `Tags.add_user_tag/2` lehnte alles über 15 ab, und die Absage landete im selben Topf wie ein Duplikat: „schon in Ihrem Profil oder von einem anderen Mitglied belegt".

**Jetzt:**
- `Tags.free_user_tag_slots/1` und `user_tag_count/1` sind die eine Quelle für den Spielraum.
- Die Vorschau wählt nur die freien Plätze vor und nennt Stand und Spielraum („Sie haben 11 von 15 Tags. 4 von 4 freien Plätzen ausgewählt."). Ohne JavaScript stimmt das schon.
- Der Client deckelt die Auswahl, „So viele wie möglich auswählen" füllt bis zur Grenze, ein Haken darüber wird abgelehnt statt später verschluckt.
- `insert_skills/3` bekommt ein Budget, zählt Limit-Absagen als `skipped.tag_limit` und spart nebenbei N-1 Zählabfragen in der Import-Transaktion.
- Derselbe Fehler im Tag-Editor ist mit repariert: die Vorab-Prüfung fing nur ein bereits volles Profil ab, eine Zehnerliste auf zwölf Tags meldete sieben Absagen als Duplikate.

**Geprüft:** `mix precommit` grün (7786 Tests), neue Tests einmal gegen den ungefixten Stand kalibriert (5 rot). Im Browser durchgespielt, deutsch: Vorauswahl, Deckel, Zähler, Ablehnungshinweis, Umschalter.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*

Closes #1478
