### PR TITLE
Der Folgen-Knopf folgt der Zeile, die über ihm steht (v7.297.1)

### DIFF
--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -1011,15 +1011,8 @@ defmodule Vutuv.Fediverse do
       :remote ->
         with :ok <- check_can_follow(user),
              :ok <- check_follow_limit(user),
-             {:ok, account} <- resolve_remote_account(user, address),
-             {:ok, follow} <- insert_remote_follow(user, account) do
-          enqueue(
-            user,
-            [account.inbox_uri],
-            Docs.follow_activity(user, account.actor_uri, follow.follow_activity_id)
-          )
-
-          {:ok, %{follow | remote_account: account}}
+             {:ok, account} <- resolve_remote_account(user, address) do
+          send_follow(user, account)
         end
 
       # A vutuv follow needs no actor key and spends no outbound budget, so
@@ -1033,6 +1026,63 @@ defmodule Vutuv.Fediverse do
 
       :unknown ->
         with :ok <- check_can_resolve(), do: {:error, :local_account}
+    end
+  end
+
+  @doc """
+  A member follows an account this installation **already holds**: the account
+  page (`/system/fediverse/account/:id`) and the card a looked-up post arrives
+  with both have the row in front of them, so neither has anything to look up.
+
+  Separate from `follow_remote/2`, and that is the whole point. That one takes
+  what somebody *typed* and works out who it names — parse the address, ask
+  WebFinger for the actor id. Handing it a stored `actor_uri` instead looked
+  like the same act and was not: `parse_address/1` accepts exactly the three
+  shapes people paste (`@you@server`, `you@server`, `https://server/@you`), and
+  a real actor id is under no obligation to be one of them.
+  `https://social.isarosc.de/ap/users/116970588627792798` is an ordinary
+  Mastodon-family actor with one path segment too many and no handle in it at
+  all, so pressing "Follow" answered *"That does not look like an address on
+  another network"* about an account whose card was right above the button.
+
+  Widening the parser is not the fix: its narrowness is load-bearing, because
+  `look_up_post/2` tells an account URL from a post URL by exactly the segment
+  count it refuses (see `classify_lookup/2`). So this takes the identity we
+  hold rather than a string to re-derive it from.
+
+  The actor document is still fetched, because the inbox and the key are what
+  the `Follow` is delivered and signed against and a stored row can be old.
+  What is gone is the WebFinger hop, which had nothing left to prove — the
+  row's `actor_uri` *is* the canonical id, either resolved through WebFinger
+  once already or read off a signature-verified inbound activity. The gates and
+  the refusal vocabulary are `follow_remote/2`'s, in the same order and
+  including the hourly budget: a follow sent from a page is the same outbound
+  act as one sent from the address box, and a cap one surface does not count is
+  not a cap.
+  """
+  def follow_remote_account(%User{} = user, %RemoteAccount{} = account) do
+    with :ok <- check_can_follow(user),
+         :ok <- check_follow_limit(user),
+         :ok <- check_follow_host(account.actor_uri),
+         :ok <- claim_remote_follow_budget(user),
+         {:ok, remote} <- fetch_follow_target(account.actor_uri, user),
+         :ok <- check_follow_host(remote.id),
+         {:ok, fresh} <- upsert_remote_account(remote) do
+      send_follow(user, fresh)
+    end
+  end
+
+  # The row plus the signed request, shared by both ways in so a follow sent
+  # from a page and one sent from the address box cannot drift apart.
+  defp send_follow(%User{} = user, %RemoteAccount{} = account) do
+    with {:ok, follow} <- insert_remote_follow(user, account) do
+      enqueue(
+        user,
+        [account.inbox_uri],
+        Docs.follow_activity(user, account.actor_uri, follow.follow_activity_id)
+      )
+
+      {:ok, %{follow | remote_account: account}}
     end
   end
 

--- a/lib/vutuv_web/live/fediverse_account_live.ex
+++ b/lib/vutuv_web/live/fediverse_account_live.ex
@@ -104,7 +104,7 @@ defmodule VutuvWeb.FediverseAccountLive do
   def handle_event("follow", _params, socket) do
     account = socket.assigns.account
 
-    case Fediverse.follow_remote(socket.assigns.current_user, account.actor_uri) do
+    case Fediverse.follow_remote_account(socket.assigns.current_user, account) do
       {:ok, follow} ->
         # Only the button changes. A fresh follow is "requested", so no
         # followers-only post opens until the other server answers, and there is

--- a/lib/vutuv_web/live/fediverse_lookup_live.ex
+++ b/lib/vutuv_web/live/fediverse_lookup_live.ex
@@ -123,7 +123,7 @@ defmodule VutuvWeb.FediverseLookupLive do
   def handle_event("follow", _params, socket) do
     account = socket.assigns.post.remote_account
 
-    case Fediverse.follow_remote(socket.assigns.current_user, account.actor_uri) do
+    case Fediverse.follow_remote_account(socket.assigns.current_user, account) do
       {:ok, follow} ->
         {:noreply,
          socket

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.297.0",
+      version: "7.297.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/fediverse_remote_follows_test.exs
+++ b/test/vutuv/fediverse_remote_follows_test.exs
@@ -15,6 +15,7 @@ defmodule Vutuv.FediverseRemoteFollowsTest do
   alias Vutuv.Fediverse.Delivery
   alias Vutuv.Fediverse.Follow
   alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemoteFollow
   alias Vutuv.Social
   alias Vutuv.Social.Follow, as: SocialFollow
   alias VutuvWeb.Fediverse.Docs
@@ -318,6 +319,120 @@ defmodule Vutuv.FediverseRemoteFollowsTest do
 
       assert {:ok, _follow} = Fediverse.follow_remote(user, "@them@social.example")
       assert {:error, :follow_limit} = Fediverse.follow_remote(user, "@other@social.example")
+    end
+  end
+
+  describe "follow_remote_account/2" do
+    # An actor id is under no obligation to look like a pasted address.
+    # social.isarosc.de publishes `/ap/users/<numeric id>` — one path segment
+    # more than `parse_address/1` accepts, and no handle in it at all — so
+    # pressing "Follow" on that account's own page used to answer
+    # `:invalid_address` about an account whose card was right above the button.
+    @stored_actor "https://social.isarosc.de/ap/users/116970588627792798"
+
+    defp stored_account(actor_uri) do
+      {:ok, account} =
+        %RemoteAccount{}
+        |> RemoteAccount.changeset(%{
+          actor_uri: actor_uri,
+          host: URI.parse(actor_uri).host,
+          handle: "axel",
+          name: "Pandolin",
+          inbox_uri: actor_uri <> "/inbox"
+        })
+        |> Repo.insert()
+
+      account
+    end
+
+    # Only the actor document, and only over the id we already hold: a row we
+    # stored has nothing left for WebFinger to prove.
+    defp stub_actor(actor_uri) do
+      stub_remote(fn conn ->
+        if conn.request_path == "/.well-known/webfinger",
+          do: raise("an account we already hold needs no WebFinger lookup")
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/activity+json")
+        |> Plug.Conn.send_resp(
+          200,
+          Jason.encode!(%{
+            "id" => actor_uri,
+            "type" => "Person",
+            "preferredUsername" => "axel",
+            "name" => "Pandolin",
+            "inbox" => actor_uri <> "/inbox",
+            "publicKey" => %{"id" => actor_uri <> "#main-key", "publicKeyPem" => "PEM"}
+          })
+        )
+      end)
+    end
+
+    # The calibration for the whole describe block: the parser refuses this id
+    # and is meant to, because `look_up_post/2` tells an account URL from a post
+    # URL by exactly the segment count it refuses. Widening it is not the fix;
+    # not going through it is.
+    test "the address parser refuses that actor id, and stays that way" do
+      assert {:error, :invalid_address} = RemoteFollow.parse_address(@stored_actor)
+    end
+
+    test "follows an actor id no address parser would accept" do
+      stub_actor(@stored_actor)
+      user = federated_user()
+      account = stored_account(@stored_actor)
+
+      assert {:ok, follow} = Fediverse.follow_remote_account(user, account)
+
+      assert follow.state == "requested"
+      assert follow.remote_account_id == account.id
+      assert follow.user_id == user.id
+
+      assert [%{"type" => "Follow"} = activity] = deliveries(user)
+      assert activity["object"] == @stored_actor
+      assert [delivery] = Repo.all(Delivery)
+      assert delivery.inbox_uri == @stored_actor <> "/inbox"
+
+      # One row, refreshed rather than duplicated.
+      assert Repo.aggregate(RemoteAccount, :count) == 1
+    end
+
+    test "a second press is refused, and the gates still hold" do
+      stub_actor(@stored_actor)
+      user = federated_user()
+      account = stored_account(@stored_actor)
+
+      assert {:ok, _follow} = Fediverse.follow_remote_account(user, account)
+      assert {:error, :already_following} = Fediverse.follow_remote_account(user, account)
+
+      assert {:error, :not_federating} =
+               Fediverse.follow_remote_account(insert(:activated_user), account)
+    end
+
+    test "a server blocked since the row was stored is refused without a request" do
+      stub_remote(fn _conn -> raise "a blocked server must never be contacted" end)
+      admin = insert(:user, admin?: true)
+      {:ok, _} = Fediverse.block_instance(%{"host" => "social.isarosc.de"}, admin)
+
+      assert {:error, :instance_blocked} =
+               Fediverse.follow_remote_account(federated_user(), stored_account(@stored_actor))
+
+      assert Repo.aggregate(Follow, :count) == 0
+    end
+
+    test "the hourly budget counts these follows too" do
+      stub_actor(@stored_actor)
+      Application.put_env(:vutuv, :fediverse_remote_follow_limit, 1)
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_remote_follow_limit) end)
+
+      user = federated_user()
+
+      assert {:ok, _follow} = Fediverse.follow_remote_account(user, stored_account(@stored_actor))
+
+      assert {:error, :follow_capped} =
+               Fediverse.follow_remote_account(
+                 user,
+                 stored_account("https://social.isarosc.de/ap/users/2")
+               )
     end
   end
 

--- a/test/vutuv_web/live/fediverse_account_live_test.exs
+++ b/test/vutuv_web/live/fediverse_account_live_test.exs
@@ -126,6 +126,59 @@ defmodule VutuvWeb.FediverseAccountLiveTest do
     assert Repo.aggregate(Follow, :count) == 0
   end
 
+  # The member's report: an actor id whose path is `/ap/users/<numeric id>` —
+  # ordinary Mastodon-family, one segment more than a pasted address may have —
+  # answered the follow with "That does not look like an address on another
+  # network", about the account whose card sits above the button. The page
+  # follows the row it is drawn from now, so no address is parsed at all.
+  test "the follow works for an actor id that is not a pasted address", %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+    {:ok, user} = Vutuv.Accounts.update_user(user, %{"fediverse_followers?" => "true"})
+    {:ok, _actor} = Fediverse.ensure_actor(user)
+
+    actor = "https://social.example/ap/users/116970588627792798"
+
+    Application.put_env(:vutuv, :fediverse_req_options,
+      plug: fn conn ->
+        if conn.request_path == "/.well-known/webfinger",
+          do: raise("an account we already hold needs no WebFinger lookup")
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/activity+json")
+        |> Plug.Conn.send_resp(
+          200,
+          Jason.encode!(%{
+            "id" => actor,
+            "type" => "Person",
+            "preferredUsername" => "them",
+            "name" => "Them Themself",
+            "inbox" => actor <> "/inbox",
+            "publicKey" => %{"id" => actor <> "#main-key", "publicKeyPem" => "PEM"}
+          })
+        )
+      end
+    )
+
+    on_exit(fn -> Application.delete_env(:vutuv, :fediverse_req_options) end)
+
+    acc =
+      Repo.insert!(%RemoteAccount{
+        actor_uri: actor,
+        host: "social.example",
+        handle: "them",
+        name: "Them Themself",
+        inbox_uri: actor <> "/inbox"
+      })
+
+    {:ok, view, _html} = live(conn, ~p"/system/fediverse/account/#{acc.id}")
+
+    html = view |> element("#follow") |> render_click()
+
+    refute html =~ "does not look like an address"
+    assert has_element?(view, "[data-follow-state=requested]")
+    assert Repo.aggregate(Follow, :count) == 1
+  end
+
   test "muting is reversible, and this page is where it reverses", %{conn: conn} do
     {conn, user} = create_and_login_user(conn)
     {:ok, user} = Vutuv.Accounts.update_user(user, %{"fediverse_followers?" => "true"})


### PR DESCRIPTION
**TL;DR** "Folgen" auf der Seite eines Kontos aus einem anderen Netzwerk gab `Das sieht nicht nach einer Adresse in einem anderen Netzwerk aus` zurück, weil die gespeicherte Actor-Kennung durch den Parser für getippte Adressen lief.

**Wo:** `Vutuv.Fediverse`, `FediverseAccountLive`, `FediverseLookupLive`

**Vorher:** `follow_remote(user, account.actor_uri)` — `parse_address/1` kennt nur `@du@server`, `du@server` und `https://server/@du`. `social.isarosc.de` veröffentlicht `https://social.isarosc.de/ap/users/116970588627792798`: ein Segment zu viel, kein Handle darin, also `:invalid_address` über ein Konto, dessen Karte direkt über dem Knopf steht.

**Jetzt:** `follow_remote_account/2` folgt der Zeile, die die Seite ohnehin hält. Gleiche Schranken und gleiche Absagen wie `follow_remote/2`, Stundenbudget eingeschlossen; das Actor-Dokument wird weiter geholt (Inbox und Schlüssel tragen Zustellung und Signatur), nur der WebFinger-Schritt entfällt.

**Warum nicht den Parser weiten:** `look_up_post/2` unterscheidet Konto- von Beitrags-URL genau an der Segmentzahl, die `parse_address/1` ablehnt.

**Tests:** Kontext-Tests für die unparsebare Actor-Kennung, Sperrliste, Budget und den zweiten Druck, dazu ein LiveView-Test, der den echten `#follow`-Knopf klickt. Kalibriert: mit dem alten Aufruf wird er rot, mit genau dieser Meldung.

Hot deploy, keine Migration. `mix precommit` grün.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*

https://claude.ai/code/session_01Q8JQm6Wy6ptako9bWS8EWb