### PR TITLE
Beiträge bekommen eine Sprache, Übersetzungen ein Zuhause (v7.297.1)

### DIFF
--- a/lib/vutuv/fediverse/note.ex
+++ b/lib/vutuv/fediverse/note.ex
@@ -71,6 +71,9 @@ defmodule Vutuv.Fediverse.Note do
     field(:display_name, :string)
     field(:content_text, :string)
     field(:summary, :string)
+    # The language the origin declared via AS2 contentMap (issue #1488), a
+    # lowercase primary language subtag; NULL = the object declared none.
+    field(:language, :string)
     field(:audience, :string)
     field(:received_at, :utc_datetime)
     field(:checked_at, :utc_datetime)

--- a/lib/vutuv/fediverse/remote_post.ex
+++ b/lib/vutuv/fediverse/remote_post.ex
@@ -65,6 +65,9 @@ defmodule Vutuv.Fediverse.RemotePost do
     field(:origin_url, :string)
     field(:content_text, :string)
     field(:summary, :string)
+    # The language the origin declared via AS2 contentMap (issue #1488), a
+    # lowercase primary language subtag; NULL = the object declared none.
+    field(:language, :string)
     field(:sensitive, :boolean, default: false)
     field(:audience, :string)
     field(:kind, :string, default: "note")

--- a/lib/vutuv/posts/post.ex
+++ b/lib/vutuv/posts/post.ex
@@ -13,6 +13,12 @@ defmodule Vutuv.Posts.Post do
   schema "posts" do
     field(:body, :string, default: "")
 
+    # The language the author declared in the composer (issue #1489), a
+    # lowercase primary language subtag ("de", "en"). NULL (legacy posts,
+    # undeclared) means: shown to everyone, never auto-translated, no AS2
+    # `contentMap` outbound.
+    field(:language, :string)
+
     # The bento arrangement the author picked for a multi-photo post, one of
     # the `Vutuv.Posts.GalleryLayout` names; nil = automatic (the mosaic's
     # orientation-driven choice). Presentation only — the agent formats list

--- a/lib/vutuv/translations.ex
+++ b/lib/vutuv/translations.ex
@@ -1,0 +1,206 @@
+defmodule Vutuv.Translations do
+  @moduledoc """
+  On-demand post translations (milestone 13, the Mastodon model): the author
+  declares a post's language, nothing is guessed, and a translation exists
+  only because a reader asked for it — cached per subject and target
+  language, never pre-computed, never federated.
+
+  A translation's **subject** is exactly one of a local `Vutuv.Posts.Post`, a
+  cached remote `Vutuv.Fediverse.RemotePost`, or a cached remote reply
+  (`Vutuv.Fediverse.Note`). The nullable id triple that encodes this is
+  confined to this context: outside callers hand over the subject struct and
+  read `subject/1` — no ad-hoc joins on the triple (the organization
+  milestone showed what leaked NULL pairs cost).
+
+  Caching is by content hash: `source_sha256` binds a translation to the
+  exact source text it rendered, so an edited post simply makes its cached
+  row stale and the next request re-translates. The queue rows in
+  `translation_jobs` are drained by `Vutuv.Translations.Worker` (#1458)
+  through `Vutuv.Translations.Translator` (#1457).
+  """
+
+  import Ecto.Query
+
+  alias Vutuv.Fediverse.Note
+  alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.Posts.Post
+  alias Vutuv.Repo
+  alias Vutuv.Translations.Translation
+  alias Vutuv.Translations.TranslationJob
+
+  @type subject :: %Post{} | %RemotePost{} | %Note{}
+
+  ## Language tags
+
+  @doc """
+  Normalizes a language tag to the lowercase primary subtag this system
+  stores ("de-AT" -> "de", "EN" -> "en"). Anything that does not start with
+  a 2-3 letter primary subtag — including nil — normalizes to nil, so a
+  hostile or malformed inbound tag can never reach a column.
+  """
+  def normalize_language(value) when is_binary(value) do
+    primary =
+      value
+      |> String.trim()
+      |> String.downcase()
+      |> String.split(["-", "_"], parts: 2)
+      |> hd()
+
+    if primary =~ ~r/^[a-z]{2,3}$/, do: primary
+  end
+
+  def normalize_language(_value), do: nil
+
+  ## The subject triple
+
+  @doc """
+  Which subject a translation or job row belongs to, as `{:post, id}`,
+  `{:remote_post, id}` or `{:note, id}` — matched on the id columns, never
+  on a preloaded association.
+  """
+  def subject(%{post_id: id}) when is_binary(id), do: {:post, id}
+  def subject(%{remote_post_id: id}) when is_binary(id), do: {:remote_post, id}
+  def subject(%{note_id: id}) when is_binary(id), do: {:note, id}
+
+  @doc "Loads the subject row behind a translation or job; nil when it is gone."
+  def load_subject(row) do
+    case subject(row) do
+      {:post, id} -> Repo.get(Post, id)
+      {:remote_post, id} -> Repo.get(RemotePost, id)
+      {:note, id} -> Repo.get(Note, id)
+    end
+  end
+
+  @doc """
+  The text a translation of this subject translates: a local post's Markdown
+  body, a remote subject's plain `content_text`.
+  """
+  def source_text(%Post{body: body}), do: body
+  def source_text(%RemotePost{content_text: text}), do: text || ""
+  def source_text(%Note{content_text: text}), do: text || ""
+
+  @doc "The subject's content warning, when it carries one (remote content only)."
+  def source_summary(%Post{}), do: nil
+  def source_summary(%RemotePost{summary: summary}), do: presence(summary)
+  def source_summary(%Note{summary: summary}), do: presence(summary)
+
+  @doc """
+  The cache key over everything a translation renders (body + summary), as
+  lowercase hex. Not privacy — the content is public; the hash only detects
+  that the source changed under a cached row.
+  """
+  def source_sha256(subject) do
+    :crypto.hash(:sha256, [source_text(subject), 0, source_summary(subject) || ""])
+    |> Base.encode16(case: :lower)
+  end
+
+  ## The cache
+
+  @doc """
+  The cached translation of `subject` into `target_language`, but only while
+  its hash still matches the subject's current text — an edited source makes
+  the row stale, and a stale row answers nil (the next request re-translates).
+  """
+  def fresh_translation(subject, target_language) do
+    if translation = Repo.one(translation_query(subject, target_language)) do
+      if translation.source_sha256 == source_sha256(subject), do: translation
+    end
+  end
+
+  @doc """
+  Stores (or refreshes) the translation of `subject` into `target_language`.
+  `result` carries what the model answered: `:body`, `:source_language`, and
+  for remote content `:summary`; `:model` names who translated. Stamped with
+  the subject's current hash.
+  """
+  def store_translation(subject, target_language, result) do
+    now = NaiveDateTime.utc_now(:second)
+
+    replace = [
+      source_language: Map.get(result, :source_language),
+      body: Map.fetch!(result, :body),
+      summary: Map.get(result, :summary),
+      model: Map.get(result, :model),
+      source_sha256: source_sha256(subject),
+      updated_at: now
+    ]
+
+    %Translation{target_language: target_language}
+    |> struct!(subject_attrs(subject))
+    |> struct!(replace)
+    |> Repo.insert(
+      on_conflict: [set: replace],
+      conflict_target: conflict_target(subject, "")
+    )
+  end
+
+  ## The queue
+
+  @doc """
+  What a reader's translate request comes down to: the cached row when it is
+  still fresh (`{:cached, translation}`), otherwise a queued job
+  (`{:queued, job}` — deduped, so a second click lands on the same open row).
+  """
+  def request(subject, target_language) do
+    if translation = fresh_translation(subject, target_language) do
+      {:cached, translation}
+    else
+      {:queued, open_job(subject, target_language) || insert_job!(subject, target_language)}
+    end
+  end
+
+  @doc "The open (pending or running) job for `subject` + target, if any."
+  def open_job(subject, target_language) do
+    from(j in job_query(subject, target_language),
+      where: j.status in ^TranslationJob.open_statuses()
+    )
+    |> Repo.one()
+  end
+
+  defp insert_job!(subject, target_language) do
+    %TranslationJob{target_language: target_language}
+    |> struct!(subject_attrs(subject))
+    |> Repo.insert!(
+      on_conflict: :nothing,
+      conflict_target: conflict_target(subject, " AND status IN ('pending', 'running')")
+    )
+
+    # Re-read instead of trusting the returned struct: on a lost race the
+    # insert did nothing and the struct's id names no row.
+    open_job(subject, target_language)
+  end
+
+  ## Shared subject plumbing (the triple stays in here)
+
+  defp subject_attrs(%Post{id: id}), do: [post_id: id]
+  defp subject_attrs(%RemotePost{id: id}), do: [remote_post_id: id]
+  defp subject_attrs(%Note{id: id}), do: [note_id: id]
+
+  defp subject_column(%Post{}), do: :post_id
+  defp subject_column(%RemotePost{}), do: :remote_post_id
+  defp subject_column(%Note{}), do: :note_id
+
+  defp conflict_target(subject, extra_where) do
+    column = subject_column(subject)
+    {:unsafe_fragment, "(#{column}, target_language) WHERE #{column} IS NOT NULL#{extra_where}"}
+  end
+
+  defp translation_query(subject, target_language) do
+    [{column, id}] = subject_attrs(subject)
+
+    from(t in Translation,
+      where: field(t, ^column) == ^id and t.target_language == ^target_language
+    )
+  end
+
+  defp job_query(subject, target_language) do
+    [{column, id}] = subject_attrs(subject)
+
+    from(j in TranslationJob,
+      where: field(j, ^column) == ^id and j.target_language == ^target_language
+    )
+  end
+
+  defp presence(nil), do: nil
+  defp presence(value), do: if(String.trim(value) == "", do: nil, else: value)
+end

--- a/lib/vutuv/translations/translation.ex
+++ b/lib/vutuv/translations/translation.ex
@@ -1,0 +1,32 @@
+defmodule Vutuv.Translations.Translation do
+  @moduledoc """
+  One cached translation of one subject into one target language.
+
+  The subject is exactly one of a local post, a cached remote post, or a
+  cached remote reply (CHECK-enforced nullable triple — read it through
+  `Vutuv.Translations.subject/1`, never by picking a column). `source_sha256`
+  binds the row to the exact source text it translated: when the source is
+  edited the hash no longer matches, the row counts as stale, and the next
+  request re-translates. All fields are set programmatically by
+  `Vutuv.Translations` — there is no user-facing changeset.
+  """
+
+  use VutuvWeb, :model
+
+  schema "translations" do
+    belongs_to(:post, Vutuv.Posts.Post)
+    belongs_to(:remote_post, Vutuv.Fediverse.RemotePost)
+    belongs_to(:note, Vutuv.Fediverse.Note)
+
+    field(:target_language, :string)
+    # As the model reported it ("de", "en", or "und" when it could not tell).
+    field(:source_language, :string)
+    field(:body, :string)
+    # The translated content warning; only remote content carries one.
+    field(:summary, :string)
+    field(:model, :string)
+    field(:source_sha256, :string)
+
+    timestamps()
+  end
+end

--- a/lib/vutuv/translations/translation_job.ex
+++ b/lib/vutuv/translations/translation_job.ex
@@ -1,0 +1,39 @@
+defmodule Vutuv.Translations.TranslationJob do
+  @moduledoc """
+  One on-demand translation request — both the durable queue entry and, once
+  resolved, the record of how it went (the `Vutuv.Moderation.ImageScan`
+  row-is-the-job pattern).
+
+  A `pending` row is work waiting for the worker, `running` is in flight,
+  `done` produced (or refreshed) a `Vutuv.Translations.Translation` row, and
+  `failed` means the strike cap was reached — the card keeps showing the
+  original. A job exists only because a reader asked for that translation;
+  nothing enqueues in bulk. Subject columns mirror `translations` (exactly
+  one set, CHECK-enforced). All fields are set programmatically by
+  `Vutuv.Translations` — there is no user-facing changeset.
+  """
+
+  use VutuvWeb, :model
+
+  @statuses ~w(pending running done failed)
+  @open_statuses ~w(pending running)
+
+  schema "translation_jobs" do
+    belongs_to(:post, Vutuv.Posts.Post)
+    belongs_to(:remote_post, Vutuv.Fediverse.RemotePost)
+    belongs_to(:note, Vutuv.Fediverse.Note)
+
+    field(:target_language, :string)
+    field(:status, :string, default: "pending")
+    field(:attempts, :integer, default: 0)
+    field(:next_attempt_at, :utc_datetime)
+    field(:last_error, :string)
+
+    timestamps()
+  end
+
+  def statuses, do: @statuses
+
+  @doc "The statuses that count as unfinished work (mirrors the partial unique indexes)."
+  def open_statuses, do: @open_statuses
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.297.1",
+      version: "7.297.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260816140922_add_language_to_posts_and_remote_content.exs
+++ b/priv/repo/migrations/20260816140922_add_language_to_posts_and_remote_content.exs
@@ -1,0 +1,20 @@
+defmodule Vutuv.Repo.Migrations.AddLanguageToPostsAndRemoteContent do
+  use Ecto.Migration
+
+  @moduledoc """
+  The post's language, declared by its author (issue #1489) or read from an
+  incoming object's AS2 `contentMap` (issue #1488). Stored as a lowercase
+  primary language subtag ("de", "en"); NULL means legacy/undeclared —
+  always shown, never auto-translated, no `contentMap` outbound.
+
+  N-1 safe: pure additions, nullable, no backfill by design.
+  """
+
+  def change do
+    for table <- [:posts, :fediverse_posts, :fediverse_notes] do
+      alter table(table) do
+        add(:language, :string)
+      end
+    end
+  end
+end

--- a/priv/repo/migrations/20260816140928_create_translations_and_translation_jobs.exs
+++ b/priv/repo/migrations/20260816140928_create_translations_and_translation_jobs.exs
@@ -1,0 +1,87 @@
+defmodule Vutuv.Repo.Migrations.CreateTranslationsAndTranslationJobs do
+  use Ecto.Migration
+
+  @moduledoc """
+  On-demand post translations (milestone 13): `translations` caches one
+  translated rendering per subject and target language, `translation_jobs`
+  is the durable work queue behind it (the `image_scans` row-is-the-job
+  pattern). A row's subject is exactly ONE of a local post, a cached remote
+  post, or a cached remote reply — CHECK-enforced, and the nullable triple
+  is confined to `Vutuv.Translations` (the organization milestone showed
+  what NULL pairs cost when they leak into ad-hoc joins).
+
+  No backfill and no pre-computation by design: a job exists only because a
+  reader asked for that translation. N-1 safe: pure additions.
+  """
+
+  @subject_check "num_nonnulls(post_id, remote_post_id, note_id) = 1"
+
+  def change do
+    create table(:translations) do
+      add(:post_id, references(:posts, on_delete: :delete_all))
+      add(:remote_post_id, references(:fediverse_posts, on_delete: :delete_all))
+      add(:note_id, references(:fediverse_notes, on_delete: :delete_all))
+
+      add(:target_language, :string, null: false)
+      # As the model reported it ("de", "en", or "und" when it could not tell).
+      add(:source_language, :string)
+      add(:body, :text, null: false)
+      # The translated content warning; only remote content carries one.
+      add(:summary, :text)
+      add(:model, :string)
+      # SHA-256 of the source text at translation time (cache invalidation,
+      # not privacy — the content is public). A stale hash re-translates on
+      # the next request.
+      add(:source_sha256, :string, null: false)
+
+      timestamps()
+    end
+
+    create(constraint(:translations, :translations_exactly_one_subject, check: @subject_check))
+
+    # One cached translation per subject + target. Three partial indexes
+    # because the subject is a nullable triple.
+    for column <- [:post_id, :remote_post_id, :note_id] do
+      create(
+        index(:translations, [column, :target_language],
+          unique: true,
+          where: "#{column} IS NOT NULL",
+          name: :"translations_#{column}_target_index"
+        )
+      )
+    end
+
+    create table(:translation_jobs) do
+      add(:post_id, references(:posts, on_delete: :delete_all))
+      add(:remote_post_id, references(:fediverse_posts, on_delete: :delete_all))
+      add(:note_id, references(:fediverse_notes, on_delete: :delete_all))
+
+      add(:target_language, :string, null: false)
+      add(:status, :string, null: false, default: "pending")
+      add(:attempts, :integer, null: false, default: 0)
+      add(:next_attempt_at, :utc_datetime)
+      add(:last_error, :string)
+
+      timestamps()
+    end
+
+    create(
+      constraint(:translation_jobs, :translation_jobs_exactly_one_subject, check: @subject_check)
+    )
+
+    # One OPEN job per subject + target; resolved rows stay as the audit
+    # trail of what was requested and how it went.
+    for column <- [:post_id, :remote_post_id, :note_id] do
+      create(
+        index(:translation_jobs, [column, :target_language],
+          unique: true,
+          where: "#{column} IS NOT NULL AND status IN ('pending', 'running')",
+          name: :"translation_jobs_open_#{column}_target_index"
+        )
+      )
+    end
+
+    # The worker's drain query: due pending work, oldest first.
+    create(index(:translation_jobs, [:status, :next_attempt_at]))
+  end
+end

--- a/test/vutuv/translations_test.exs
+++ b/test/vutuv/translations_test.exs
@@ -1,0 +1,227 @@
+defmodule Vutuv.TranslationsTest do
+  use Vutuv.DataCase, async: true
+
+  alias Vutuv.Fediverse.Note
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.Translations
+  alias Vutuv.Translations.Translation
+  alias Vutuv.Translations.TranslationJob
+
+  defp post!(attrs \\ []) do
+    insert(:post, Keyword.merge([body: "Guten Morgen allerseits."], attrs))
+  end
+
+  defp remote_post!(attrs \\ %{}) do
+    account =
+      Repo.insert!(%RemoteAccount{
+        actor_uri: "https://social.example/users/u#{System.unique_integer([:positive])}",
+        host: "social.example",
+        handle: "them",
+        inbox_uri: "https://social.example/inbox"
+      })
+
+    now = DateTime.utc_now(:second)
+
+    Repo.insert!(
+      struct!(
+        %RemotePost{
+          remote_account_id: account.id,
+          object_uri: "https://social.example/p/#{System.unique_integer([:positive])}",
+          content_text: "Bonjour tout le monde.",
+          audience: "public",
+          kind: "note",
+          published_at: now,
+          received_at: now,
+          expires_at: DateTime.add(now, 86_400)
+        },
+        attrs
+      )
+    )
+  end
+
+  defp note!(post, attrs \\ %{}) do
+    now = DateTime.utc_now(:second)
+
+    Repo.insert!(
+      struct!(
+        %Note{
+          post_id: post.id,
+          object_uri: "https://social.example/n/#{System.unique_integer([:positive])}",
+          actor_uri: "https://social.example/users/them",
+          handle: "them@social.example",
+          content_text: "Une réponse.",
+          audience: "public",
+          received_at: now,
+          checked_at: now,
+          expires_at: DateTime.add(now, 86_400)
+        },
+        attrs
+      )
+    )
+  end
+
+  describe "normalize_language/1" do
+    test "keeps a bare primary subtag, lowercased" do
+      assert Translations.normalize_language("de") == "de"
+      assert Translations.normalize_language("EN") == "en"
+      assert Translations.normalize_language("und") == "und"
+    end
+
+    test "reduces a full BCP47 tag to its primary subtag" do
+      assert Translations.normalize_language("de-AT") == "de"
+      assert Translations.normalize_language("pt_BR") == "pt"
+      assert Translations.normalize_language(" en-US ") == "en"
+    end
+
+    test "answers nil for garbage, so hostile inbound tags never reach a column" do
+      assert Translations.normalize_language("") == nil
+      assert Translations.normalize_language("x") == nil
+      assert Translations.normalize_language("deutsch") == nil
+      assert Translations.normalize_language("<script>") == nil
+      assert Translations.normalize_language(nil) == nil
+      assert Translations.normalize_language(%{"weird" => true}) == nil
+    end
+  end
+
+  describe "the subject triple" do
+    test "each subject kind stores in its own column and reads back via subject/1" do
+      post = post!()
+      remote = remote_post!()
+      note = note!(post)
+
+      for subject <- [post, remote, note] do
+        assert {:queued, %TranslationJob{} = job} = Translations.request(subject, "en")
+        assert Translations.subject(job) == expected_subject(subject)
+        assert Translations.load_subject(job).id == subject.id
+      end
+    end
+
+    test "the CHECK refuses a row without exactly one subject" do
+      post = post!()
+      remote = remote_post!()
+
+      assert_raise Ecto.ConstraintError, ~r/exactly_one_subject/, fn ->
+        Repo.insert!(%TranslationJob{target_language: "en"})
+      end
+
+      assert_raise Ecto.ConstraintError, ~r/exactly_one_subject/, fn ->
+        Repo.insert!(%TranslationJob{
+          post_id: post.id,
+          remote_post_id: remote.id,
+          target_language: "en"
+        })
+      end
+    end
+  end
+
+  describe "request/2 and the job queue" do
+    test "queues one job and dedupes the second request onto the same open row" do
+      post = post!()
+
+      assert {:queued, %TranslationJob{id: id, status: "pending"}} =
+               Translations.request(post, "en")
+
+      assert {:queued, %TranslationJob{id: ^id}} = Translations.request(post, "en")
+      assert Repo.aggregate(TranslationJob, :count) == 1
+    end
+
+    test "a different target language is separate work" do
+      post = post!()
+
+      assert {:queued, %TranslationJob{id: en_id}} = Translations.request(post, "en")
+      assert {:queued, %TranslationJob{id: fr_id}} = Translations.request(post, "fr")
+      assert en_id != fr_id
+    end
+
+    test "a resolved job does not block a fresh request" do
+      post = post!()
+      {:queued, job} = Translations.request(post, "en")
+      Repo.update_all(TranslationJob, set: [status: "failed"])
+
+      assert {:queued, %TranslationJob{id: new_id, status: "pending"}} =
+               Translations.request(post, "en")
+
+      assert new_id != job.id
+    end
+
+    test "jobs die with their subject" do
+      post = post!()
+      {:queued, _job} = Translations.request(post, "en")
+
+      Repo.delete!(post)
+      assert Repo.aggregate(TranslationJob, :count) == 0
+    end
+  end
+
+  describe "the translation cache" do
+    test "store_translation then request answers from the cache" do
+      post = post!()
+
+      assert {:ok, %Translation{} = stored} =
+               Translations.store_translation(post, "en", %{
+                 source_language: "de",
+                 body: "Good morning everyone.",
+                 model: "gemma4:31b"
+               })
+
+      assert {:cached, %Translation{id: id}} = Translations.request(post, "en")
+      assert id == stored.id
+      assert Repo.aggregate(TranslationJob, :count) == 0
+    end
+
+    test "an edited source makes the cached row stale and re-queues" do
+      post = post!()
+
+      {:ok, _} =
+        Translations.store_translation(post, "en", %{body: "Good morning.", model: "m"})
+
+      edited = %{post | body: "Guten Abend allerseits."}
+
+      assert Translations.fresh_translation(edited, "en") == nil
+      assert {:queued, %TranslationJob{}} = Translations.request(edited, "en")
+    end
+
+    test "re-storing after an edit replaces the row in place" do
+      post = post!()
+      {:ok, first} = Translations.store_translation(post, "en", %{body: "One.", model: "m"})
+
+      edited = %{post | body: "Zwei."}
+      {:ok, _second} = Translations.store_translation(edited, "en", %{body: "Two.", model: "m"})
+
+      assert Repo.aggregate(Translation, :count) == 1
+      assert Repo.get!(Translation, first.id).body == "Two."
+      assert Translations.fresh_translation(edited, "en").body == "Two."
+    end
+
+    test "a remote subject's summary is part of the cache key and the result" do
+      remote = remote_post!(%{summary: "CW: Politik"})
+
+      {:ok, stored} =
+        Translations.store_translation(remote, "en", %{
+          source_language: "fr",
+          body: "Hello everyone.",
+          summary: "CW: politics",
+          model: "m"
+        })
+
+      assert stored.summary == "CW: politics"
+      assert Translations.fresh_translation(remote, "en").id == stored.id
+
+      # The same body under an edited content warning is a different source.
+      assert Translations.fresh_translation(%{remote | summary: "CW: anders"}, "en") == nil
+    end
+
+    test "translations die with their subject" do
+      post = post!()
+      {:ok, _} = Translations.store_translation(post, "en", %{body: "X.", model: "m"})
+
+      Repo.delete!(post)
+      assert Repo.aggregate(Translation, :count) == 0
+    end
+  end
+
+  defp expected_subject(%Vutuv.Posts.Post{id: id}), do: {:post, id}
+  defp expected_subject(%RemotePost{id: id}), do: {:remote_post, id}
+  defp expected_subject(%Note{id: id}), do: {:note, id}
+end


### PR DESCRIPTION
Datenmodell für Milestone 13 (#1456): `language`-Spalten auf posts, fediverse_posts und fediverse_notes (NULL = unerklärt), `translations` als Cache je Subjekt + Zielsprache (invalidiert über `source_sha256`) und `translation_jobs` als durable Queue nach dem image_scans-Muster. Das nullable Subjekt-Tripel ist CHECK-erzwungen (`num_nonnulls = 1`) und bleibt im neuen `Vutuv.Translations`-Kontext. Rein additiv, N-1-sicher, kein Backfill.

Closes #1456

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*

https://claude.ai/code/session_0159WnrRezuoxqwov7gUTAmx