### PR TITLE
Emoji-Kürzel in fremden Namen bleiben nicht als Text stehen (v7.298.2)

### DIFF
--- a/lib/vutuv/activity.ex
+++ b/lib/vutuv/activity.ex
@@ -1718,7 +1718,7 @@ defmodule Vutuv.Activity do
   defp remote_actor_fields(%Note{} = note) do
     %{
       actor_id: nil,
-      actor_name: note.display_name || Note.display_handle(note),
+      actor_name: Note.label(note),
       actor_param: nil,
       actor_avatar: nil,
       actor_handle: Note.display_handle(note),

--- a/lib/vutuv/fediverse/follower.ex
+++ b/lib/vutuv/fediverse/follower.ex
@@ -68,6 +68,14 @@ defmodule Vutuv.Fediverse.Follower do
     do: Handle.display(follower.handle, actor_uri)
 
   @doc """
+  The follower's display name as vutuv writes it — their server's custom-emoji
+  shortcodes taken out (`Vutuv.Fediverse.Handle.display_name/1`) — or nil where
+  that leaves nothing, which the browser's Account cell renders as the handle
+  alone.
+  """
+  def display_name(%__MODULE__{name: name}), do: Handle.display_name(name)
+
+  @doc """
   The remote server this follower lives on, as the follower browser's Server
   column shows it and as its filter matches it (lowercased host of the actor
   URI, the Elixir twin of the `uri_host` SQL macro in `Vutuv.Fediverse`).

--- a/lib/vutuv/fediverse/handle.ex
+++ b/lib/vutuv/fediverse/handle.ex
@@ -5,7 +5,9 @@ defmodule Vutuv.Fediverse.Handle do
 
   One module because two different tables need the same answer — a stored reply
   (`Vutuv.Fediverse.Note`) and a stored reaction (`Vutuv.Fediverse.Reaction`) —
-  and a reader must not see the same person written two ways on one page.
+  and a reader must not see the same person written two ways on one page. The
+  same reason puts the *display name* here too (`display_name/1`): the name and
+  the handle are the two halves of one card header.
 
   The handle we store is the actor document's `preferredUsername`. When there is
   none (a row written before we kept it, or a server that omits it) the account
@@ -25,6 +27,40 @@ defmodule Vutuv.Fediverse.Handle do
   # Shaped like a name at all: one path segment, no whitespace, no separators,
   # and short enough not to be a wall of text in a chip.
   @username ~r/^[A-Za-z0-9_.-]{1,64}$/
+
+  # A custom-emoji shortcode as Mastodon spells one: `[a-zA-Z0-9_]{2,}` between
+  # colons, delimited by non-word characters. The delimiters are the whole
+  # point — they are what keeps a time ("10:30:45"), a scheme
+  # ("daniel:// stenberg://") and a doubled colon out of it.
+  @shortcode ~r/(?<=^|\W):[a-zA-Z0-9_]{2,}:(?=\W|$)/
+
+  @doc """
+  What a remote account is called on screen, from the display name its server
+  sent: the string with its custom-emoji shortcodes taken out, or nil when
+  nothing readable is left.
+
+  Those networks let an account put its **own server's** emoji in its name, and
+  send it as a shortcode (`"Droid Boy :coolified:"`) with the picture it stands
+  for in the actor document's `tag` array. That picture is that server's, and
+  vutuv shows no remote picture it has not cached and put past the AI gate
+  (`Vutuv.RemoteMedia`) — a name is not worth that pipeline. So the token has
+  nothing to render as, and left in it reads as a literal `":coolified:"` on
+  the card. Drop it; the Mastodon inline feed has made the same call since it
+  shipped, and this is the one implementation both use.
+
+  Cleaned on the way **out**, not on the way in: the stored value stays what
+  the server said, so a row written before this can never be the odd one out
+  and a later decision to render the pictures still has the name to put them
+  back into.
+  """
+  def display_name(name) when is_binary(name) do
+    name
+    |> String.replace(@shortcode, "")
+    |> String.replace(~r/\s+/u, " ")
+    |> SearchText.normalize_search()
+  end
+
+  def display_name(_name), do: nil
 
   @doc """
   `@handle@host` for a stored `handle` (may be nil) and the account's URI.

--- a/lib/vutuv/fediverse/note.ex
+++ b/lib/vutuv/fediverse/note.ex
@@ -129,6 +129,22 @@ defmodule Vutuv.Fediverse.Note do
   def display_handle(%__MODULE__{handle: handle, actor_uri: actor_uri}),
     do: Handle.display(handle, actor_uri)
 
+  @doc """
+  The author's display name as vutuv writes it — their server's custom-emoji
+  shortcodes taken out (`Vutuv.Fediverse.Handle.display_name/1`) — or nil where
+  that leaves nothing. Beside `label/1` because the avatar's initials want the
+  name alone and must not fall back to a handle.
+  """
+  def author_name(%__MODULE__{display_name: name}), do: Handle.display_name(name)
+
+  @doc """
+  What the card calls the author: the display name, else the `@handle@host`.
+  The one owner of that fallback, so a name cleaned in one place cannot arrive
+  raw in another — the card, the agent-format sibling and the notification all
+  read it from here.
+  """
+  def label(%__MODULE__{} = note), do: author_name(note) || display_handle(note)
+
   @doc "The server this note came from, for the card's footer and the ledger."
   defdelegate host(uri), to: Handle
 

--- a/lib/vutuv/fediverse/remote_account.ex
+++ b/lib/vutuv/fediverse/remote_account.ex
@@ -23,7 +23,6 @@ defmodule Vutuv.Fediverse.RemoteAccount do
   use VutuvWeb, :model
 
   alias Vutuv.Fediverse.Handle
-  alias Vutuv.SearchText
 
   # Remote URIs are unbounded in theory; cap generously (they are `text`
   # columns) so a hostile payload cannot store megabytes. actor_uri carries a
@@ -130,11 +129,19 @@ defmodule Vutuv.Fediverse.RemoteAccount do
   end
 
   @doc """
+  The account's display name as vutuv writes it — its server's custom-emoji
+  shortcodes taken out (`Vutuv.Fediverse.Handle.display_name/1`) — or nil where
+  that leaves nothing. Beside `label/1` because the avatar's initials want the
+  name alone and must not fall back to a handle.
+  """
+  def display_name(%__MODULE__{name: name}), do: Handle.display_name(name)
+
+  @doc """
   What the account is called on screen: its display name, else the handle, else
   the bare actor URI. Never nil, so a row with no display fields still reads as
   something rather than as a gap.
   """
   def label(%__MODULE__{} = account) do
-    SearchText.normalize_search(account.name) || display_handle(account) || account.actor_uri
+    display_name(account) || display_handle(account) || account.actor_uri
   end
 end

--- a/lib/vutuv/mastodon.ex
+++ b/lib/vutuv/mastodon.ex
@@ -20,6 +20,7 @@ defmodule Vutuv.Mastodon do
 
   require Logger
 
+  alias Vutuv.Fediverse.Handle
   alias Vutuv.RemoteHtml
   alias Vutuv.SocialFeed.Feed
   alias Vutuv.SocialFeed.Http
@@ -107,7 +108,7 @@ defmodule Vutuv.Mastodon do
   # avatar arrives as its still version.
   defp account_meta(account, user, instance) do
     name =
-      Post.presence(strip_custom_emoji(account["display_name"])) ||
+      Handle.display_name(account["display_name"]) ||
         Post.presence(account["username"]) || user
 
     %{
@@ -118,18 +119,6 @@ defmodule Vutuv.Mastodon do
       followers: Feed.follower_count(account["followers_count"])
     }
   end
-
-  # Display names may embed custom-emoji shortcodes (":verified:"); the
-  # images they name are per-instance, so here the tokens would render as
-  # literal ":verified:" text — drop them. Mastodon delimits shortcodes with
-  # non-word boundaries, which is what keeps a plain time ("10:30:45") intact.
-  defp strip_custom_emoji(value) when is_binary(value) do
-    value
-    |> String.replace(~r/(?<=^|\W):\w{2,}:(?=\W|$)/u, "")
-    |> String.replace(~r/\s{2,}/, " ")
-  end
-
-  defp strip_custom_emoji(value), do: value
 
   defp fetch_statuses(instance, id) do
     # The id came from the remote server's JSON; only a plain token may be

--- a/lib/vutuv_web/agent_docs/post_doc.ex
+++ b/lib/vutuv_web/agent_docs/post_doc.ex
@@ -342,7 +342,7 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
     |> Enum.map(fn note ->
       %{
         handle: Note.display_handle(note),
-        author: note.display_name || Note.display_handle(note),
+        author: Note.label(note),
         network: Note.host(note.actor_uri),
         url: Note.origin(note),
         received_at: note.received_at,

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -1002,11 +1002,11 @@ defmodule VutuvWeb.PostComponents do
 
     assigns =
       assigns
-      |> assign(:author, note.display_name || Note.display_handle(note))
+      |> assign(:author, Note.label(note))
       |> assign(:handle, Note.display_handle(note))
       |> assign(:host, Note.host(note.actor_uri))
       |> assign(:origin, Note.origin(note))
-      |> assign(:initials, name_initials(note.display_name || note.handle))
+      |> assign(:initials, name_initials(Note.author_name(note) || note.handle))
       |> assign(:public?, Note.public?(note))
       |> assign(:warned?, Note.warned?(note))
 
@@ -1966,7 +1966,7 @@ defmodule VutuvWeb.PostComponents do
     assigns =
       assigns
       |> assign(:account, account)
-      |> assign(:initials, name_initials(account.name || account.handle))
+      |> assign(:initials, name_initials(RemoteAccount.display_name(account) || account.handle))
       |> assign(:link_screenshot, remote_link_screenshot(post, assigns.images))
       |> assign(:permalink, remote_post_permalink(post, assigns.viewer))
       |> assign(:origin, RemotePost.origin(post))

--- a/lib/vutuv_web/live/fediverse_account_live.ex
+++ b/lib/vutuv_web/live/fediverse_account_live.ex
@@ -252,7 +252,7 @@ defmodule VutuvWeb.FediverseAccountLive do
       <.card>
         <div class="flex items-start gap-4">
           <.remote_avatar
-            initials={name_initials(@account.name || @account.handle)}
+            initials={name_initials(RemoteAccount.display_name(@account) || @account.handle)}
             src={RemoteAccount.avatar_url(@account)}
             size="lg"
           />

--- a/lib/vutuv_web/live/fediverse_followers_live.ex
+++ b/lib/vutuv_web/live/fediverse_followers_live.ex
@@ -221,7 +221,7 @@ defmodule VutuvWeb.FediverseFollowersLive do
                     <td>
                       <.account_link
                         uri={follower.actor_uri}
-                        name={follower.name}
+                        name={Follower.display_name(follower)}
                         handle={Follower.display_handle(follower)}
                       />
                     </td>

--- a/lib/vutuv_web/live/fediverse_following_live.ex
+++ b/lib/vutuv_web/live/fediverse_following_live.ex
@@ -401,7 +401,7 @@ defmodule VutuvWeb.FediverseFollowingLive do
                     <td>
                       <.account_link
                         uri={follow.remote_account.actor_uri}
-                        name={follow.remote_account.name}
+                        name={RemoteAccount.display_name(follow.remote_account)}
                         handle={RemoteAccount.display_handle(follow.remote_account)}
                       />
                     </td>

--- a/lib/vutuv_web/live/fediverse_lookup_live.ex
+++ b/lib/vutuv_web/live/fediverse_lookup_live.ex
@@ -265,7 +265,9 @@ defmodule VutuvWeb.FediverseLookupLive do
         <div class="mt-3 flex flex-wrap items-center gap-3">
           <.remote_avatar
             initials={
-              name_initials(@post.remote_account.name || @post.remote_account.handle)
+              name_initials(
+                RemoteAccount.display_name(@post.remote_account) || @post.remote_account.handle
+              )
             }
             src={RemoteAccount.avatar_url(@post.remote_account)}
           />

--- a/lib/vutuv_web/live/organization_live/fediverse_followers.ex
+++ b/lib/vutuv_web/live/organization_live/fediverse_followers.ex
@@ -206,7 +206,7 @@ defmodule VutuvWeb.OrganizationLive.FediverseFollowers do
                     <td>
                       <.account_link
                         uri={follower.actor_uri}
-                        name={follower.name}
+                        name={Follower.display_name(follower)}
                         handle={Follower.display_handle(follower)}
                       />
                     </td>

--- a/lib/vutuv_web/live/organization_live/following.ex
+++ b/lib/vutuv_web/live/organization_live/following.ex
@@ -34,6 +34,7 @@ defmodule VutuvWeb.OrganizationLive.Following do
 
   alias Vutuv.Accounts.User
   alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
   alias Vutuv.Social
@@ -230,7 +231,8 @@ defmodule VutuvWeb.OrganizationLive.Following do
           <li :for={follow <- @remote_follows} class="flex items-center gap-4 py-3">
             <div class="min-w-0 flex-1">
               <p class="truncate text-sm font-semibold text-slate-900 dark:text-slate-100">
-                {follow.remote_account.name || follow.remote_account.handle}
+                {RemoteAccount.display_name(follow.remote_account) ||
+                  follow.remote_account.handle}
               </p>
               <p class="truncate text-sm text-slate-600 dark:text-slate-400">
                 {follow.remote_account.handle}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.298.1",
+      version: "7.298.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/fediverse_handle_test.exs
+++ b/test/vutuv/fediverse_handle_test.exs
@@ -6,7 +6,78 @@ defmodule Vutuv.FediverseHandleTest do
   """
   use ExUnit.Case, async: true
 
+  alias Vutuv.Fediverse.Follower
   alias Vutuv.Fediverse.Handle
+  alias Vutuv.Fediverse.Note
+  alias Vutuv.Fediverse.RemoteAccount
+
+  describe "display_name/1" do
+    test "takes out the custom-emoji shortcodes a server's own emoji leave behind" do
+      # What arrives from social.cologne: the name carries `:coolified:` and the
+      # actor document's `tag` array carries the picture it stands for. We do
+      # not host that picture, so the token has nothing to render as.
+      assert Handle.display_name("Droid Boy :coolified:") == "Droid Boy"
+      assert Handle.display_name(":verified: Alice Anders") == "Alice Anders"
+      assert Handle.display_name("Ann :heart: Berg") == "Ann Berg"
+      assert Handle.display_name("Cem :blobcat::verified:") == "Cem"
+    end
+
+    test "a name that is nothing but shortcodes reads as no name at all" do
+      assert Handle.display_name(":verified:") == nil
+      assert Handle.display_name("   ") == nil
+      assert Handle.display_name(nil) == nil
+    end
+
+    test "a colon that is not a shortcode is left alone" do
+      # The boundaries must be non-word characters, which is what keeps a time,
+      # a URL scheme and a decorated name whole.
+      assert Handle.display_name("Alice (Live 10:30:45)") == "Alice (Live 10:30:45)"
+      assert Handle.display_name("daniel:// stenberg://") == "daniel:// stenberg://"
+      assert Handle.display_name("Spar|fin|dig :: Jan") == "Spar|fin|dig :: Jan"
+    end
+  end
+
+  describe "the stored rows read through it" do
+    test "a followed account, a reply and a follower all drop the shortcode" do
+      account = %RemoteAccount{
+        name: "Droid Boy :coolified:",
+        handle: "droidboy",
+        actor_uri: "https://social.cologne/users/droidboy"
+      }
+
+      assert RemoteAccount.label(account) == "Droid Boy"
+      assert RemoteAccount.display_name(account) == "Droid Boy"
+
+      note = %Note{
+        display_name: "Droid Boy :coolified:",
+        handle: "droidboy",
+        actor_uri: "https://social.cologne/users/droidboy"
+      }
+
+      assert Note.label(note) == "Droid Boy"
+
+      follower = %Follower{name: ":verified:", handle: "droidboy"}
+      assert Follower.display_name(follower) == nil
+    end
+
+    test "an account whose whole name was a shortcode falls back to its handle" do
+      account = %RemoteAccount{
+        name: ":verified:",
+        handle: "droidboy",
+        actor_uri: "https://social.cologne/users/droidboy"
+      }
+
+      assert RemoteAccount.label(account) == "@droidboy@social.cologne"
+
+      note = %Note{
+        display_name: ":verified:",
+        handle: "droidboy",
+        actor_uri: "https://social.cologne/users/droidboy"
+      }
+
+      assert Note.label(note) == "@droidboy@social.cologne"
+    end
+  end
 
   describe "display/2" do
     test "prefers the handle the remote server told us" do

--- a/test/vutuv_web/live/feed_remote_posts_test.exs
+++ b/test/vutuv_web/live/feed_remote_posts_test.exs
@@ -68,6 +68,29 @@ defmodule VutuvWeb.FeedRemotePostsTest do
     refute has_element?(view, "[data-remote-post='#{post.id}'] [data-post-actions]")
   end
 
+  test "an author's custom-emoji shortcode never reaches the card", %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+    post = cached_post(user)
+
+    # What social.cologne really sends: the emoji is a picture on *that*
+    # server, and the name only carries the token naming it. We host no such
+    # picture, so the token would sit on the card as literal text.
+    RemoteAccount
+    |> Repo.get!(post.remote_account_id)
+    |> Ecto.Changeset.change(name: "Droid Boy :coolified:")
+    |> Repo.update!()
+
+    {:ok, view, html} = live(conn, ~p"/feed")
+
+    assert html =~ "Droid Boy"
+    refute html =~ ":coolified:"
+    # The monogram reads the same cleaned name, so it stays the author's own
+    # initials rather than picking up the token's colon.
+    assert view
+           |> element("[data-remote-post='#{post.id}'] [data-remote-avatar]")
+           |> render() =~ "DB"
+  end
+
   describe "the way out to the original" do
     test "is the host chip itself, and no line under the card repeats it", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)


### PR DESCRIPTION
**TL;DR** Ein Mastodon-Anzeigename wie `Droid Boy :coolified:` stand als Text auf der Karte. Das Kürzel fällt jetzt weg.

**Warum:** Das Emoji ist ein Bild auf dem fremden Server, der Name trägt nur das Kürzel dafür. Wir zeigen kein fremdes Bild, das nicht zwischengespeichert und durch die KI-Prüfung gegangen ist, und für einen Namen ist diese Pipeline zu teuer.

**Wo:** `Vutuv.Fediverse.Handle.display_name/1`, gelesen von den drei Stellen, an denen ein fremder Name gespeichert ist: gefolgte Konten (`RemoteAccount`), Antworten von drüben (`Note`, neu mit `label/1`) und Follower. Die Initialen daneben lesen denselben gesäuberten Namen, damit `:verified: Alice` nicht mehr `:A` ergibt. `Vutuv.Mastodon` hatte dieselbe Regel schon privat und ruft jetzt die gemeinsame auf.

**Gesäubert wird beim Anzeigen, nicht beim Speichern.** Bereits gespeicherte Namen stimmen damit ohne Backfill, und der Rohwert bleibt erhalten, falls die Bilder später doch gerendert werden.

**Nicht dabei:** das Emoji-Bild selbst zeigen. Das ist ein Feature (Download, Moderation, Auslieferung), kein Bugfix.

Hot deploy, v7.298.2. Die neuen Tests sind gegen den ungefixten Stand kalibriert: ohne den Filter werden sechs rot.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*
