### PR TITLE
Ein Ollama-Aufruf übersetzt und nennt die Quellsprache (v7.298.1)

### DIFF
--- a/lib/vutuv/translations/translator.ex
+++ b/lib/vutuv/translations/translator.ex
@@ -1,0 +1,209 @@
+defmodule Vutuv.Translations.Translator do
+  @moduledoc """
+  The Ollama client behind on-demand post translations (issue #1457): **one**
+  call per (subject, target language) that translates the text and reports
+  the source language as a byproduct — there is no separate detection step
+  anywhere, the author's declaration (issue #1489) and this report are the
+  only sources of language truth.
+
+  Local posts are Markdown and the prompt says so: code fences, URLs,
+  `@handles` and `#tags` stay untouched, and the result renders through the
+  normal `VutuvWeb.Markdown` pipeline + sanitizer, so a translation opens no
+  new XSS surface. Remote content (`Vutuv.Fediverse.RemotePost` /
+  `Vutuv.Fediverse.Note`) is already plain text (`Vutuv.RemoteHtml`): its
+  `content_text` and `summary` (content warning) translate as plain text.
+
+  Errors are two-class, and the worker treats them differently:
+
+    * `{:error, {:service, reason}}` — Ollama unreachable, HTTP failure. The
+      text is fine; the service is not. Retried patiently.
+    * `{:error, {:content, reason}}` — the model's answer failed the
+      plausibility checks (empty, absurd length ratio, altered code fence).
+      Counts toward the strike cap; at the cap the job ends `failed` and the
+      card keeps showing the original — junk is never stored.
+
+  The model comes from `:ollama_translation_model` (deliberately separate
+  from the vision model — issue #1455 picked gemma4:31b). `num_ctx` is set
+  explicitly: Ollama truncates silently otherwise, and the eval measured the
+  20,000-char body cap comfortably inside 16k tokens. Tests inject a `plug:`
+  responder via the `:translation_req_options` config key (the Req seam every
+  outbound client here uses), answering with a real
+  `content-type: application/json`.
+  """
+
+  alias Jason.OrderedObject
+  alias Vutuv.Posts.Post
+  alias Vutuv.Translations
+
+  @req_options_key :translation_req_options
+
+  # Prompt + a 20k-char body + the translated answer all fit well inside 16k
+  # tokens (the #1455 eval's 11k-char worst case used ~6.4k in total). Set
+  # explicitly — Ollama silently truncates at its default otherwise.
+  @num_ctx 16_384
+
+  # The answer must be a translation, not a summary and not an essay. Beyond
+  # these bounds the model lost the thread; strike instead of storing junk.
+  @min_length_ratio 0.3
+  @max_length_ratio 3.0
+
+  @markdown_rules """
+  The post is Markdown. Preserve the Markdown structure exactly: headings,
+  lists, blockquotes, links, emphasis. Leave code fences (``` blocks), URLs,
+  @handles and #tags completely untouched. Keep emoji where they are.
+  """
+
+  @plain_rules """
+  The post is plain text. Do not add any formatting or Markdown. Leave URLs,
+  @handles and #tags completely untouched. Keep emoji where they are.
+  """
+
+  @doc """
+  Translates `subject` (a `Vutuv.Posts.Post`, `Vutuv.Fediverse.RemotePost` or
+  `Vutuv.Fediverse.Note`) into `target_language`. Returns
+  `{:ok, %{source_language: …, body: …, summary: …, model: …}}` ready for
+  `Vutuv.Translations.store_translation/3`, or a two-class error (moduledoc).
+  """
+  def translate(subject, target_language) do
+    text = Translations.source_text(subject)
+    summary = Translations.source_summary(subject)
+
+    body = %{
+      model: model(),
+      stream: false,
+      format: schema(summary),
+      options: %{temperature: 0, num_ctx: @num_ctx},
+      messages: [%{role: "user", content: prompt(subject, text, summary, target_language)}]
+    }
+
+    case Vutuv.Ollama.post("/api/chat", body,
+           timeout: timeout(),
+           req_options_key: @req_options_key
+         ) do
+      {:ok, response} -> parse(response, text, summary)
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp prompt(subject, text, summary, target_language) do
+    """
+    You are a professional translator. Translate the following social-media
+    post into the language with BCP47 tag "#{target_language}".
+
+    Rules:
+    #{format_rules(subject)}\
+    - Translate idiomatically, never word for word, but never change the
+      meaning. Negations must stay negations.
+    - Keep the paragraph structure: same number of paragraphs.
+
+    Answer with a JSON object:
+    - "source_language": the BCP47 tag of the language the post is written in
+      ("de", "en", or another tag if it is neither)
+    - "body": the full translation
+    #{summary_instruction(summary)}
+    The post:
+
+    #{text}
+    """
+  end
+
+  defp format_rules(%Post{}), do: @markdown_rules
+  defp format_rules(_remote), do: @plain_rules
+
+  defp summary_instruction(nil), do: ""
+
+  defp summary_instruction(summary) do
+    """
+    - "summary": the translation of this content warning: #{Jason.encode!(summary)}
+    """
+  end
+
+  # Ollama structured output: the model may only answer this shape, and the
+  # property order is generation order (OrderedObject, not a map) — the
+  # source language is a one-token answer, so it comes first and cannot be
+  # biased by the translation that follows.
+  defp schema(summary) do
+    base = [
+      source_language: %{type: "string"},
+      body: %{type: "string"}
+    ]
+
+    props = if summary, do: base ++ [summary: %{type: "string"}], else: base
+
+    OrderedObject.new(
+      type: "object",
+      required: Enum.map(props, fn {key, _} -> Atom.to_string(key) end),
+      properties: OrderedObject.new(props)
+    )
+  end
+
+  # The answer arrives as a JSON string in the assistant message (the schema
+  # constrains generation, but never trust it enough to skip validation).
+  defp parse(%{"message" => %{"content" => content}}, text, summary) when is_binary(content) do
+    case Jason.decode(content) do
+      {:ok, %{"body" => body} = answer} when is_binary(body) ->
+        vet(answer, body, text, summary)
+
+      _ ->
+        {:error, {:content, :bad_answer}}
+    end
+  end
+
+  defp parse(_body, _text, _summary), do: {:error, {:content, :bad_answer}}
+
+  # The plausibility gate (issue #1457): junk is never stored. The checks are
+  # deliberately mechanical — the #1455 eval showed they catch a model that
+  # lost the thread (collapsed structure, essay-length padding, a "translated"
+  # code block) while never tripping on a faithful translation.
+  defp vet(answer, body, text, summary) do
+    cond do
+      String.trim(body) == "" ->
+        {:error, {:content, :empty}}
+
+      not plausible_length?(body, text) ->
+        {:error, {:content, :length_ratio}}
+
+      fences(body) != fences(text) ->
+        {:error, {:content, :fence_changed}}
+
+      summary != nil and String.trim(answer["summary"] || "") == "" ->
+        {:error, {:content, :empty_summary}}
+
+      true ->
+        {:ok,
+         %{
+           source_language: source_language(answer),
+           body: body,
+           summary: summary && answer["summary"],
+           model: model()
+         }}
+    end
+  end
+
+  defp plausible_length?(body, text) do
+    ratio = String.length(body) / max(String.length(text), 1)
+    ratio >= @min_length_ratio and ratio <= @max_length_ratio
+  end
+
+  # The fenced blocks, trailing whitespace ignored per block. Compared as a
+  # list: count, order and contents must all survive the translation.
+  defp fences(text) do
+    ~r/```.*?```/s
+    |> Regex.scan(text)
+    |> Enum.map(fn [block] -> String.trim_trailing(block) end)
+  end
+
+  # "und" (undetermined) when the model's tag is garbage: it is a valid ISO
+  # 639 tag for exactly this case, and the display layer knows to show no
+  # source label for it. Never nil — the row records that detection ran.
+  defp source_language(answer) do
+    Translations.normalize_language(answer["source_language"]) || "und"
+  end
+
+  defp model, do: Application.get_env(:vutuv, :ollama_translation_model, "gemma4:31b")
+
+  # Text inference on the shared box can stall for minutes under contention
+  # (`OLLAMA_NUM_PARALLEL=1`); the queue is async, so patience beats a
+  # spurious service error.
+  defp timeout, do: Application.get_env(:vutuv, :ollama_translation_timeout, 600_000)
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.298.0",
+      version: "7.298.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/translations/translator_test.exs
+++ b/test/vutuv/translations/translator_test.exs
@@ -1,0 +1,195 @@
+defmodule Vutuv.Translations.TranslatorTest do
+  @moduledoc """
+  The Ollama translation client (issue #1457): one call that translates and
+  reports the source language, the Markdown/plain-text prompt split, the
+  plausibility gate that strikes instead of storing junk, and the two error
+  classes the worker depends on. All against a `plug:` stub via
+  `:translation_req_options` (answering with a real JSON content-type) — no
+  live Ollama. `async: false`: the stub key is global application env.
+  """
+  use Vutuv.DataCase, async: false
+
+  alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.Translations.Translator
+
+  setup do
+    on_exit(fn -> Application.delete_env(:vutuv, :translation_req_options) end)
+    :ok
+  end
+
+  defp stub(fun), do: Application.put_env(:vutuv, :translation_req_options, plug: fun)
+
+  defp answer(conn, payload) do
+    body = %{"message" => %{"role" => "assistant", "content" => Jason.encode!(payload)}}
+
+    conn
+    |> Plug.Conn.put_resp_content_type("application/json")
+    |> Plug.Conn.send_resp(200, Jason.encode!(body))
+  end
+
+  defp post!(body), do: insert(:post, body: body)
+
+  defp remote!(attrs) do
+    account =
+      Repo.insert!(%Vutuv.Fediverse.RemoteAccount{
+        actor_uri: "https://social.example/users/u#{System.unique_integer([:positive])}",
+        host: "social.example",
+        handle: "them",
+        inbox_uri: "https://social.example/inbox"
+      })
+
+    now = DateTime.utc_now(:second)
+
+    Repo.insert!(
+      struct!(
+        %RemotePost{
+          remote_account_id: account.id,
+          object_uri: "https://social.example/p/#{System.unique_integer([:positive])}",
+          audience: "public",
+          kind: "note",
+          published_at: now,
+          received_at: now,
+          expires_at: DateTime.add(now, 86_400)
+        },
+        attrs
+      )
+    )
+  end
+
+  test "translates a Markdown post in one call and reports the source language" do
+    parent = self()
+
+    stub(fn conn ->
+      {:ok, raw, conn} = Plug.Conn.read_body(conn)
+      send(parent, {:request, Jason.decode!(raw)})
+      answer(conn, %{"source_language" => "de", "body" => "Good **morning** everyone."})
+    end)
+
+    post = post!("Guten **Morgen** allerseits.")
+
+    assert {:ok, result} = Translator.translate(post, "en")
+    assert result.body == "Good **morning** everyone."
+    assert result.source_language == "de"
+    assert result.summary == nil
+    assert is_binary(result.model)
+
+    assert_receive {:request, request}
+    prompt = hd(request["messages"])["content"]
+    assert prompt =~ "Markdown"
+    assert prompt =~ "Guten **Morgen** allerseits."
+    assert request["options"]["temperature"] == 0
+    assert request["options"]["num_ctx"] >= 16_384
+    # One call, no separate detection request.
+    refute_receive {:request, _}, 50
+  end
+
+  test "remote content translates as plain text, content warning included" do
+    parent = self()
+
+    stub(fn conn ->
+      {:ok, raw, conn} = Plug.Conn.read_body(conn)
+      send(parent, {:request, Jason.decode!(raw)})
+
+      answer(conn, %{
+        "source_language" => "fr",
+        "body" => "Hello everyone.",
+        "summary" => "CW: politics"
+      })
+    end)
+
+    remote = remote!(%{content_text: "Bonjour tout le monde.", summary: "CW: politique"})
+
+    assert {:ok, result} = Translator.translate(remote, "en")
+    assert result.summary == "CW: politics"
+    assert result.source_language == "fr"
+
+    assert_receive {:request, request}
+    prompt = hd(request["messages"])["content"]
+    assert prompt =~ "plain text"
+    assert prompt =~ "CW: politique"
+    assert request["format"]["required"] == ["source_language", "body", "summary"]
+  end
+
+  test "a garbage source-language tag stores as \"und\", never on the wire" do
+    stub(fn conn ->
+      answer(conn, %{"source_language" => "definitely not a tag", "body" => "Fine text here."})
+    end)
+
+    assert {:ok, %{source_language: "und"}} = Translator.translate(post!("Ein Text hier."), "en")
+  end
+
+  test "an empty answer is a content strike, not a stored translation" do
+    stub(fn conn -> answer(conn, %{"source_language" => "de", "body" => "   "}) end)
+
+    assert {:error, {:content, :empty}} = Translator.translate(post!("Guten Morgen."), "en")
+  end
+
+  test "an absurd length ratio is a content strike" do
+    stub(fn conn -> answer(conn, %{"source_language" => "de", "body" => "Hi."}) end)
+
+    long = String.duplicate("Ein ordentlich langer deutscher Satz. ", 20)
+    assert {:error, {:content, :length_ratio}} = Translator.translate(post!(long), "en")
+  end
+
+  test "a translated code fence is a content strike" do
+    source = """
+    Schau dir das an:
+
+    ```elixir
+    IO.puts("Hallo")
+    ```
+    """
+
+    translated = """
+    Look at this:
+
+    ```elixir
+    IO.puts("Hello")
+    ```
+    """
+
+    stub(fn conn -> answer(conn, %{"source_language" => "de", "body" => translated}) end)
+
+    assert {:error, {:content, :fence_changed}} = Translator.translate(post!(source), "en")
+  end
+
+  test "an intact code fence passes the gate" do
+    source = """
+    Schau dir das an:
+
+    ```elixir
+    IO.puts("Hallo")
+    ```
+    """
+
+    translated = """
+    Look at this:
+
+    ```elixir
+    IO.puts("Hallo")
+    ```
+    """
+
+    stub(fn conn -> answer(conn, %{"source_language" => "de", "body" => translated}) end)
+
+    assert {:ok, %{body: ^translated}} = Translator.translate(post!(source), "en")
+  end
+
+  test "non-JSON content in the answer is a content strike" do
+    stub(fn conn ->
+      body = %{"message" => %{"role" => "assistant", "content" => "no json at all"}}
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(200, Jason.encode!(body))
+    end)
+
+    assert {:error, {:content, :bad_answer}} = Translator.translate(post!("Guten Morgen."), "en")
+  end
+
+  test "an HTTP failure is a service error — the text is fine" do
+    stub(fn conn -> Plug.Conn.send_resp(conn, 500, "boom") end)
+
+    assert {:error, {:service, _reason}} = Translator.translate(post!("Guten Morgen."), "en")
+  end
+end


### PR DESCRIPTION
`Vutuv.Translations.Translator` (#1457): ein Call je (Subjekt, Zielsprache), das Modell übersetzt und meldet die Quellsprache als Nebenprodukt — keine separate Erkennung. Markdown-Regeln für lokale Beiträge, Klartext samt Content-Warning für Remote-Inhalte, `num_ctx` explizit 16k. Plausibilitätsgate (leer, Längenverhältnis 0,3–3,0, veränderte Code-Fence) → Content-Strike statt gespeichertem Murks; Service-Fehler sind eine eigene Klasse. Tests stubben Ollama per `plug:` mit echtem JSON-Content-Type.

Closes #1457

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*

https://claude.ai/code/session_0159WnrRezuoxqwov7gUTAmx