### PR TITLE
Übersetzen auf Zuruf, und der Feed kennt Ihre Sprachen (v7.299.0)

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -82,6 +82,14 @@ config :vutuv, :image_scan_worker, false
 # own sync file.
 config :vutuv, :translate_posts, true
 config :vutuv, :translation_worker, false
+# The fediverse inbound rate cap counts in a GLOBAL in-memory bucket the SQL
+# sandbox never rolls back, and ~29 test files share the literal actor
+# "https://social.example/users/alice" — so one full run draws the shipped
+# 60/hour actor budget down until whichever file the seed puts last starts
+# failing with :inbound_capped (first bitten at ~7860 tests). Effectively
+# unlimited here; the cap's own tests set tight values per test and restore
+# THIS configured value afterwards (fetch_env, not delete_env).
+config :vutuv, :fediverse_inbound_caps, {1_000_000, 1_000_000}
 # Same arrangement for the Arbeitszeugnis analysis: the queue tests drain via
 # Checks.deliver_due/1 with a stubbed analysis function, and neither the
 # polling worker nor the daily skill fetch may run from the sandbox.

--- a/docs/architecture/translations.md
+++ b/docs/architecture/translations.md
@@ -95,6 +95,27 @@ default `gemma4:31b` — issue #1455's eval: the smaller/faster models invert
 negations). On success the worker broadcasts `{:translation_ready, row}` on
 `Translations.topic(subject)` for the live swap-in (issue #1462).
 
+## The reader's controls
+
+Every card whose language differs from the UI locale (or declares none)
+carries a quiet **Translate** action on the LiveView surfaces (feed,
+permalink thread, profile — issue #1462): tap → pending line → the worker's
+broadcast swaps the translated body in, labelled "Translated from X" with
+the original one tap away. A shown translation renders through the normal
+Markdown pipeline (local posts) or as plain text (remote content), and the
+card's `lang` attribute follows what is shown. The host-side half is
+`VutuvWeb.Live.PostTranslations`; the card-side half is the `translations`
+map + `translatable?` flag on `VutuvWeb.PostComponents`.
+
+The **feed language preference** (issue #1461, on /settings/preferences)
+adds Mastodon's chosen-languages filter: `users.feed_languages` (nil = all)
+plus the `:feed_foreign_posts` pref — original (shipped default) /
+translate / hide. Hide is `Posts.language_scope/2` (`is_nil or in` — NULL
+never hides) applied inside every feed source query; translate mode
+auto-requests translations for rendered foreign cards (one batched
+`fresh_translations/2` query per page, `PostTranslations.auto_translate/3`).
+Feed only; profiles, permalinks, search and public surfaces are untouched.
+
 ## What deliberately does not exist
 
 - No backfill, no bulk pre-computation: a job exists only because a reader

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -279,6 +279,15 @@ defmodule Vutuv.Accounts.User do
     field(:map_openstreetmap?, :boolean)
     field(:map_apple?, :boolean)
     field(:default_map_service, :string)
+    # The feed language preference (issue #1461): what happens to feed posts
+    # outside `feed_languages` — "original" / "translate" / "hide"; nil
+    # inherits the installation default (a Vutuv.Prefs knob). The chips list
+    # is the member's own (nil = all languages, no installation default: "all"
+    # is the only sensible default everywhere). Read the pair through
+    # `Vutuv.Posts.feed_language_filter/1` and the translate-mode helpers,
+    # never raw.
+    field(:feed_foreign_posts, :string)
+    field(:feed_languages, {:array, :string})
     # The reader's post-display preferences (same settings page, applied to
     # every post this member reads: feed, profile Beiträge, permalink). The
     # line counts drive the CSS line-clamp on the preview body, desktop and
@@ -475,7 +484,7 @@ defmodule Vutuv.Accounts.User do
   # :email_confirmed? is NOT here either: it flips only via the login-PIN path
   # (Accounts.activate_user/1, its own narrow cast) — castable, it would let a
   # registration self-activate without ever proving control of an email.
-  @optional_fields ~w(noindex? noai? notification_emails? dm_email_each_message? dm_email_delay_minutes email_on_endorsement? email_on_follower? email_on_reference_check? newsletter_emails? saved_search_emails? cv_update_notifications? thread_notifications? show_online_status? show_mastodon_feed? show_code_stats? fediverse_followers? fediverse_reactions? fediverse_replies? also_known_as_input map_google? map_openstreetmap? map_apple? default_map_service post_lines_desktop post_lines_mobile post_hyphenate_desktop post_hyphenate_mobile notification_post_lines like_attribution? headline employment_status employment_status_visibility desired_salary_min desired_salary_currency desired_salary_period desired_salary_visibility desired_workplace_types first_name last_name middle_name nickname honorific_prefix honorific_suffix name_pronunciation gender birthdate birthdate_visibility locale tag_list auto_post_deletion? auto_post_deletion_after_days auto_post_deletion_keep_photos? auto_post_deletion_keep_answered? auto_post_deletion_keep_bookmarked? auto_post_deletion_delete_replies? auto_post_deletion_min_likes auto_post_deletion_min_bookmarks auto_post_deletion_min_reposts)a
+  @optional_fields ~w(noindex? noai? notification_emails? dm_email_each_message? dm_email_delay_minutes email_on_endorsement? email_on_follower? email_on_reference_check? newsletter_emails? saved_search_emails? cv_update_notifications? thread_notifications? show_online_status? show_mastodon_feed? show_code_stats? fediverse_followers? fediverse_reactions? fediverse_replies? also_known_as_input map_google? map_openstreetmap? map_apple? default_map_service post_lines_desktop post_lines_mobile post_hyphenate_desktop post_hyphenate_mobile notification_post_lines like_attribution? headline employment_status employment_status_visibility desired_salary_min desired_salary_currency desired_salary_period desired_salary_visibility desired_workplace_types first_name last_name middle_name nickname honorific_prefix honorific_suffix name_pronunciation gender birthdate birthdate_visibility locale tag_list auto_post_deletion? auto_post_deletion_after_days auto_post_deletion_keep_photos? auto_post_deletion_keep_answered? auto_post_deletion_keep_bookmarked? auto_post_deletion_delete_replies? auto_post_deletion_min_likes auto_post_deletion_min_bookmarks auto_post_deletion_min_reposts feed_foreign_posts feed_languages)a
 
   # The ages the automatic post deletion offers (issue #1255), in days. A fixed
   # list rather than a free number field on purpose: this setting deletes
@@ -696,6 +705,11 @@ defmodule Vutuv.Accounts.User do
     # inline (not `Maps.service_strings/0`) to avoid a compile cycle, since Maps
     # pattern-matches the `User` struct.
     |> validate_inclusion(:default_map_service, ~w(google openstreetmap apple))
+    # The feed's foreign-language mode (issue #1461); a tampered value must
+    # not fail the whole preferences form, so unknown values are refused with
+    # a field error like the map service above.
+    |> validate_inclusion(:feed_foreign_posts, ~w(original translate hide))
+    |> normalize_feed_languages()
     # Post-display line clamp: 0 means "no truncation"; anything above is a
     # line count, capped so nobody stores an absurd value (the bound comes from
     # the Vutuv.Prefs registry via post_lines_max/0). validate_number only
@@ -792,6 +806,25 @@ defmodule Vutuv.Accounts.User do
   # what a spam sign-up puts there. A tagline that *mentions* an address inside
   # a sentence ("Co-Founder of Taxdoo (www.taxdoo.com)") is ordinary and stays
   # valid — members have the Links section for the address itself.
+  # The chips list stores only known language codes, and the two spellings of
+  # "all languages" — every box ticked, or none — both store as nil, so the
+  # feed filter has exactly one representation of "nothing to hide".
+  defp normalize_feed_languages(changeset) do
+    case get_change(changeset, :feed_languages) do
+      nil ->
+        changeset
+
+      list when is_list(list) ->
+        known = Enum.filter(Enum.uniq(list), &Vutuv.Languages.known?/1)
+
+        if known == [] or length(known) >= length(Vutuv.Languages.codes()) do
+          put_change(changeset, :feed_languages, nil)
+        else
+          put_change(changeset, :feed_languages, known)
+        end
+    end
+  end
+
   defp validate_headline_not_link_only(changeset) do
     validate_change(changeset, :headline, fn :headline, headline ->
       if WebAddress.link_only?(headline),

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -2352,7 +2352,7 @@ defmodule Vutuv.Fediverse do
     end
   end
 
-  def feed_remote_posts(%User{id: viewer_id}, fetch_n, cursor) do
+  def feed_remote_posts(%User{id: viewer_id} = viewer, fetch_n, cursor) do
     if enabled?() do
       from(p in RemotePost,
         join: a in RemoteAccount,
@@ -2365,6 +2365,7 @@ defmodule Vutuv.Fediverse do
         limit: ^fetch_n,
         preload: [:screenshot, remote_account: a]
       )
+      |> Vutuv.Posts.language_scope(Vutuv.Posts.feed_language_filter(viewer))
       |> utc_at_or_before(cursor, :published_at)
       |> Repo.all()
       |> Enum.map(&remote_feed_entry/1)
@@ -2382,10 +2383,11 @@ defmodule Vutuv.Fediverse do
   to any follow of the author. Stamped with the repost time, like a local
   repost: what is new is the sharing, not the post.
   """
-  def feed_remote_reposts(%User{id: viewer_id}, fetch_n, cursor) do
+  def feed_remote_reposts(%User{id: viewer_id} = viewer, fetch_n, cursor) do
     if enabled?() do
       from(r in PostRepost,
         join: p in RemotePost,
+        as: :language_source,
         on: p.id == r.remote_post_id,
         join: a in RemoteAccount,
         on: a.id == p.remote_account_id,
@@ -2407,6 +2409,7 @@ defmodule Vutuv.Fediverse do
         limit: ^fetch_n,
         preload: [remote_post: {p, [:screenshot, remote_account: a]}, user: reposter]
       )
+      |> Vutuv.Posts.named_language_scope(Vutuv.Posts.feed_language_filter(viewer))
       |> remote_reposts_at_or_before(cursor)
       |> Repo.all()
       |> Enum.map(&remote_repost_entry/1)
@@ -2483,6 +2486,7 @@ defmodule Vutuv.Fediverse do
         join: f in Follow,
         on: f.remote_account_id == a.id,
         left_join: rp in RemotePost,
+        as: :language_source,
         on: rp.id == b.remote_post_id,
         where: f.user_id == ^viewer_id and f.muted == false and f.state == "accepted",
         where: is_nil(rp.id) or rp.remote_account_id not in subquery(muted_authors),
@@ -2499,6 +2503,7 @@ defmodule Vutuv.Fediverse do
         ]
       )
       |> boosts_of_kind(opts[:only])
+      |> Vutuv.Posts.named_language_scope(Vutuv.Posts.feed_language_filter(viewer))
       |> utc_at_or_before(cursor, :announced_at)
       |> Repo.all()
       |> Enum.map(&boost_entry/1)
@@ -2553,6 +2558,10 @@ defmodule Vutuv.Fediverse do
     local_posts = for %{post: %Post{} = post} <- entries, do: post
     visible_ids = visible_boost_post_ids(local_posts, viewer)
     blocked_author_ids = blocked_boost_author_ids(local_posts, viewer_id)
+    # The language filter's local half (issue #1461): the boost query joins
+    # only the CACHED post (scoped in-query), so a boosted vutuv post is
+    # checked here with the other in-memory gates. NULL never hides.
+    chosen = Posts.feed_language_filter(viewer)
 
     Enum.filter(entries, fn
       %{remote_post: %RemotePost{} = post} ->
@@ -2561,7 +2570,8 @@ defmodule Vutuv.Fediverse do
       %{post: %Post{} = post} ->
         (MapSet.member?(visible_ids, post.id) or
            (viewer.admin? == true and Posts.moderation_hidden?(post))) and
-          not MapSet.member?(blocked_author_ids, post.user_id)
+          not MapSet.member?(blocked_author_ids, post.user_id) and
+          (is_nil(chosen) or is_nil(post.language) or post.language in chosen)
 
       _entry ->
         false
@@ -6595,10 +6605,11 @@ defmodule Vutuv.Fediverse do
   follows nobody out there. Stamped with the reshare time: what is new is the
   sharing.
   """
-  def feed_remote_reply_reposts(%User{id: viewer_id}, fetch_n, cursor) do
+  def feed_remote_reply_reposts(%User{id: viewer_id} = viewer, fetch_n, cursor) do
     if enabled?() do
       from(r in NoteRepost,
         join: n in Note,
+        as: :language_source,
         on: n.id == r.note_id,
         join: resharer in User,
         on: resharer.id == r.user_id,
@@ -6617,6 +6628,7 @@ defmodule Vutuv.Fediverse do
         order_by: [desc: r.inserted_at, desc: r.id],
         preload: [note: n, user: resharer]
       )
+      |> Vutuv.Posts.named_language_scope(Vutuv.Posts.feed_language_filter(viewer))
       |> limit(^fetch_n)
       |> note_reposts_at_or_before(cursor)
       |> Repo.all()

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -2230,6 +2230,45 @@ defmodule Vutuv.Posts do
   end
 
   @doc """
+  The chosen-languages list the viewer's feed HIDES by (issue #1461), or nil
+  when nothing is hidden — which is almost everyone: only the "hide" mode
+  with a real language selection filters at all. The one place this pair of
+  columns is interpreted for the feed queries.
+  """
+  def feed_language_filter(%User{} = viewer) do
+    chosen = viewer.feed_languages
+
+    if Vutuv.Prefs.get(viewer, :feed_foreign_posts) == "hide" and is_list(chosen) and
+         chosen != [] do
+      chosen
+    end
+  end
+
+  @doc """
+  Narrows a feed source query to the chosen languages. nil = no filter. The
+  clause is spelled `is_nil or in` on purpose: NULL (undeclared) never hides
+  (the organization milestone's NOT-IN/NULL lesson), and the binding is the
+  query's root — every feed source roots at its language-bearing schema.
+  """
+  def language_scope(query, nil), do: query
+
+  def language_scope(query, chosen) when is_list(chosen) do
+    from(x in query, where: is_nil(x.language) or x.language in ^chosen)
+  end
+
+  @doc """
+  `language_scope/2` for a source whose language-bearing schema is a JOIN
+  rather than the root — the join carries `as: :language_source`. A left-join
+  NULL row passes (its language reads NULL), which is exactly right for the
+  boost source's local half.
+  """
+  def named_language_scope(query, nil), do: query
+
+  def named_language_scope(query, chosen) when is_list(chosen) do
+    from([language_source: x] in query, where: is_nil(x.language) or x.language in ^chosen)
+  end
+
+  @doc """
   One page of `viewer`'s newsfeed: own posts plus posts **and reposts** of
   followed (activated) authors, visibility-filtered, newest first.
 
@@ -2472,6 +2511,7 @@ defmodule Vutuv.Posts do
       limit: ^fetch_n
     )
     |> scope_visible(viewer)
+    |> language_scope(feed_language_filter(viewer))
     |> posts_at_or_before(cursor)
     |> Repo.all()
     |> Enum.map(&%{id: "post-#{&1.id}", post: &1, reposted_by: nil, at: &1.inserted_at})
@@ -2486,7 +2526,7 @@ defmodule Vutuv.Posts do
   # No `scope_visible/2`: an organization post carries no denials by
   # construction (`create_organization_post/3`), so the only thing that can hide
   # one is moderation, and that is exactly what the two guards below are.
-  defp feed_organization_post_items(%User{id: viewer_id}, fetch_n, cursor) do
+  defp feed_organization_post_items(%User{id: viewer_id} = viewer, fetch_n, cursor) do
     from(p in Post,
       join: o in Organization,
       as: :organization,
@@ -2497,6 +2537,7 @@ defmodule Vutuv.Posts do
       order_by: [desc: p.inserted_at, desc: p.id],
       limit: ^fetch_n
     )
+    |> language_scope(feed_language_filter(viewer))
     |> posts_at_or_before(cursor)
     |> Repo.all()
     |> Enum.map(&%{id: "post-#{&1.id}", post: &1, reposted_by: nil, at: &1.inserted_at})
@@ -2543,6 +2584,7 @@ defmodule Vutuv.Posts do
       select: {r.id, r.inserted_at, p, reposter, rp}
     )
     |> scope_visible(viewer)
+    |> language_scope(feed_language_filter(viewer))
     |> reposts_at_or_before(cursor)
     |> Repo.all()
     |> Enum.map(fn {id, at, post, reposter, page} ->
@@ -2610,6 +2652,7 @@ defmodule Vutuv.Posts do
           limit: ^fetch_n
         )
         |> scope_visible(viewer)
+        |> language_scope(feed_language_filter(viewer))
         |> posts_at_or_before(cursor)
         |> Repo.all()
         |> Enum.map(&%{id: "tagpost-#{&1.id}", post: &1, reposted_by: nil, at: &1.inserted_at})

--- a/lib/vutuv/prefs.ex
+++ b/lib/vutuv/prefs.ex
@@ -77,6 +77,18 @@ defmodule Vutuv.Prefs do
     # same card. An installation that wants the opposite posture flips this one
     # default at /admin/preferences and every untouched member follows.
     %Pref{key: :like_attribution?, type: :boolean, default: true, group: :privacy},
+    # What the feed does with posts outside the member's chosen languages
+    # (issue #1461): show the original (shipped default), auto-translate into
+    # the UI language, or hide them. The chosen-languages list itself is a
+    # plain member column (users.feed_languages, nil = all) — "all" is the
+    # only sensible default everywhere, so it carries no installation knob.
+    %Pref{
+      key: :feed_foreign_posts,
+      type: :select,
+      default: "original",
+      values: ~w(original translate hide),
+      group: :feed
+    },
     %Pref{key: :map_google?, type: :boolean, default: true, group: :maps},
     %Pref{key: :map_openstreetmap?, type: :boolean, default: true, group: :maps},
     %Pref{key: :map_apple?, type: :boolean, default: true, group: :maps},
@@ -126,12 +138,22 @@ defmodule Vutuv.Prefs do
   def label(:like_attribution?),
     do: Gettext.gettext(VutuvWeb.Gettext, "Show my name on posts I like")
 
+  def label(:feed_foreign_posts),
+    do: Gettext.gettext(VutuvWeb.Gettext, "Posts in other languages")
+
   def label(:map_google?), do: Gettext.gettext(VutuvWeb.Gettext, "Show Google Maps")
   def label(:map_openstreetmap?), do: Gettext.gettext(VutuvWeb.Gettext, "Show OpenStreetMap")
   def label(:map_apple?), do: Gettext.gettext(VutuvWeb.Gettext, "Show Apple Maps")
   def label(:default_map_service), do: Gettext.gettext(VutuvWeb.Gettext, "Default map")
 
   @doc "A short muted helper line under the control, or nil."
+  def hint(:feed_foreign_posts),
+    do:
+      Gettext.gettext(
+        VutuvWeb.Gettext,
+        "What your feed does with posts outside your chosen languages: show them as they are, translate them for you, or hide them. Posts that declare no language always show."
+      )
+
   def hint(key) when key in [:post_lines_desktop, :post_lines_mobile],
     do: Gettext.gettext(VutuvWeb.Gettext, "0 means posts are never shortened.")
 
@@ -165,6 +187,7 @@ defmodule Vutuv.Prefs do
 
   @doc "The human label of a pref group."
   def group_label(:post_display), do: Gettext.gettext(VutuvWeb.Gettext, "Posts")
+  def group_label(:feed), do: Gettext.gettext(VutuvWeb.Gettext, "Feed")
   def group_label(:privacy), do: Gettext.gettext(VutuvWeb.Gettext, "Privacy")
   def group_label(:maps), do: Gettext.gettext(VutuvWeb.Gettext, "Maps")
 
@@ -178,6 +201,16 @@ defmodule Vutuv.Prefs do
     do: Vutuv.Maps.label(:openstreetmap)
 
   def value_label(%Pref{key: :default_map_service}, "apple"), do: Vutuv.Maps.label(:apple)
+
+  def value_label(%Pref{key: :feed_foreign_posts}, "original"),
+    do: Gettext.gettext(VutuvWeb.Gettext, "Show the original")
+
+  def value_label(%Pref{key: :feed_foreign_posts}, "translate"),
+    do: Gettext.gettext(VutuvWeb.Gettext, "Translate into my language")
+
+  def value_label(%Pref{key: :feed_foreign_posts}, "hide"),
+    do: Gettext.gettext(VutuvWeb.Gettext, "Hide them")
+
   def value_label(%Pref{}, value), do: to_string(value)
 
   # ── Encoding ──

--- a/lib/vutuv/translations.ex
+++ b/lib/vutuv/translations.ex
@@ -129,6 +129,41 @@ defmodule Vutuv.Translations do
   end
 
   @doc """
+  `fresh_translation/2` over many subjects at once — ONE query per subject
+  kind present, never one per card (the feed's translate mode renders whole
+  pages). Returns `%{subject_key => %Translation{}}` for the fresh hits;
+  stale and missing rows are simply absent.
+  """
+  def fresh_translations([], _target_language), do: %{}
+
+  def fresh_translations(subjects, target_language) do
+    by_key =
+      subjects
+      |> Enum.group_by(fn subject -> subject_column(subject) end, fn subject -> subject.id end)
+      |> Enum.flat_map(fn {column, ids} ->
+        Repo.all(
+          from(t in Translation,
+            where: field(t, ^column) in ^ids and t.target_language == ^target_language
+          )
+        )
+      end)
+      |> Map.new(&{subject(&1), &1})
+
+    for subject <- subjects,
+        translation = by_key[subject_key(subject)],
+        translation != nil,
+        translation.source_sha256 == source_sha256(subject),
+        into: %{} do
+      {subject_key(subject), translation}
+    end
+  end
+
+  @doc ~S|The `{kind, id}` key for a SUBJECT struct — the struct-side twin of `subject/1`.|
+  def subject_key(%Post{id: id}), do: {:post, id}
+  def subject_key(%RemotePost{id: id}), do: {:remote_post, id}
+  def subject_key(%Note{id: id}), do: {:note, id}
+
+  @doc """
   Stores (or refreshes) the translation of `subject` into `target_language`.
   `result` carries what the model answered: `:body`, `:source_language`, and
   for remote content `:summary`; `:model` names who translated. Stamped with

--- a/lib/vutuv/translations/translator.ex
+++ b/lib/vutuv/translations/translator.ex
@@ -76,8 +76,13 @@ defmodule Vutuv.Translations.Translator do
       messages: [%{role: "user", content: prompt(subject, text, summary, target_language)}]
     }
 
+    # `remote_timeout:` too: the short 30s skip that suits a quick image
+    # verdict makes every real translation "fail" on a priority-list
+    # `:ollama_url` — a translation legitimately runs minutes, on whichever
+    # instance answers it.
     case Vutuv.Ollama.post("/api/chat", body,
            timeout: timeout(),
+           remote_timeout: timeout(),
            req_options_key: @req_options_key
          ) do
       {:ok, response} -> parse(response, text, summary)

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -37,6 +37,7 @@ defmodule VutuvWeb.PostComponents do
   alias Vutuv.Fediverse.RemoteImage
   alias Vutuv.Fediverse.RemotePost
   alias Vutuv.Isbn
+  alias Vutuv.Languages
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
@@ -52,6 +53,7 @@ defmodule VutuvWeb.PostComponents do
   alias Vutuv.RemoteMedia
   alias Vutuv.ReviewCover
   alias Vutuv.Tags
+  alias Vutuv.Translations.Translation
   alias VutuvWeb.FediverseComponents
   alias VutuvWeb.Markdown
   alias VutuvWeb.PostLive.RemoteActionsComponent
@@ -163,6 +165,20 @@ defmodule VutuvWeb.PostComponents do
         "the plain count"
   )
 
+  attr(:translations, :map,
+    default: %{},
+    doc:
+      "the host's translation map (issue #1462), key {:post, id} → :pending | " <>
+        "%Vutuv.Translations.Translation{} (= shown). The card looks itself up"
+  )
+
+  attr(:translatable?, :boolean,
+    default: false,
+    doc:
+      "whether this viewer gets the Translate action (VutuvWeb.Live.PostTranslations." <>
+        "available?/1 — LiveView hosts with a signed-in viewer only)"
+  )
+
   def post_card(assigns) do
     # The reader's post-display preferences (per-breakpoint line clamp +
     # hyphenation), fed onto the body as CSS custom properties below. There is
@@ -191,13 +207,22 @@ defmodule VutuvWeb.PostComponents do
     # simply stays absent for strangers while the author sees it; a preview
     # body carrying inline images switches to the height-based media clamp
     # (`inline_media?` below — a line clamp cannot hold pictures or floats).
+    # The card's translation state (issue #1462): a shown translation swaps
+    # the body source before the Markdown render, so the translated text goes
+    # through the exact pipeline + sanitizer the original does — no new XSS
+    # surface. The gallery/inline split below stays keyed on the ORIGINAL
+    # body: the translator leaves image references untouched.
+    translation = card_translation(assigns, {:post, post.id}, post.body, post.language)
+
     # A link in the body that points at a webpage this author has PROVED is
     # theirs wears the verified mark (issue #1246). The links ride in on the
     # already-preloaded author (`Vutuv.Posts.post_preloads/0`), so a feed of
     # fifty cards costs one batched query, not fifty — and a surface that
     # renders a card without that preload simply marks nothing.
     body_html =
-      Markdown.render_post(post.body, post.images, verified_links: VerifiedLinks.of(post.user))
+      Markdown.render_post(translation.body_source, post.images,
+        verified_links: VerifiedLinks.of(post.user)
+      )
 
     # Attachments the body references inline render in place; the rest form
     # the gallery (full mode) / the image tile row (preview).
@@ -229,6 +254,12 @@ defmodule VutuvWeb.PostComponents do
       # that carry the reader's preference onto the post body; nil for a default
       # / logged-out reader, so their DOM stays clean and the CSS fallbacks apply.
       |> assign(:body_style, post_body_style(prefs))
+      # The translation line's three states + the body's `lang` attribute
+      # (screen readers, hyphenation — worth having independent of any
+      # translation). A shown translation is in the reader's own language.
+      |> assign(:translation_state, translation.state)
+      |> assign(:body_lang, translation.lang)
+      |> assign(:offer_translation?, translation.offer?)
       |> assign(:restricted?, Posts.restricted?(post))
       |> assign(:permalink, Posts.path(post))
       |> assign(:gallery, gallery)
@@ -687,6 +718,9 @@ defmodule VutuvWeb.PostComponents do
         "the page (the permalink thread), so the row is just the flat card"
   )
 
+  attr(:translations, :map, default: %{})
+  attr(:translatable?, :boolean, default: false)
+
   def post_thread_entry(assigns) do
     # An explicit [] means "collapsed, no ancestors" (a root/standalone) and must
     # not fall back; only a missing (nil) list falls back to the one-level parent.
@@ -707,6 +741,8 @@ defmodule VutuvWeb.PostComponents do
         entry_id={@entry_id}
         surface={@surface}
         conn_or_socket={@conn_or_socket}
+        translations={@translations}
+        translatable?={@translatable?}
         show_reply_banner={@nest_parent}
       />
     <% else %>
@@ -720,6 +756,8 @@ defmodule VutuvWeb.PostComponents do
         viewer={@viewer}
         surface={@surface}
         conn_or_socket={@conn_or_socket}
+        translations={@translations}
+        translatable?={@translatable?}
       />
     <% end %>
     """
@@ -801,6 +839,8 @@ defmodule VutuvWeb.PostComponents do
   )
 
   attr(:acting_as, :any, default: nil)
+  attr(:translations, :map, default: %{})
+  attr(:translatable?, :boolean, default: false)
 
   defp thread_chain(assigns) do
     # `@thread_indent_cap` is a module attribute, not an assign, so resolve the
@@ -894,6 +934,8 @@ defmodule VutuvWeb.PostComponents do
             owner?={node.owner?}
             viewer={@viewer}
             marks={node.marks}
+            translations={@translations}
+            translatable?={@translatable?}
             live?
           />
         <% else %>
@@ -910,6 +952,8 @@ defmodule VutuvWeb.PostComponents do
             conn_or_socket={@conn_or_socket}
             mode={Map.get(node, :mode, :preview)}
             likers={Map.get(node, :likers)}
+            translations={@translations}
+            translatable?={@translatable?}
             show_reply_banner={reply_banner?(node, @connected?, @indent?)}
           />
         <% end %>
@@ -922,6 +966,8 @@ defmodule VutuvWeb.PostComponents do
         viewer={@viewer}
         surface={@surface}
         conn_or_socket={@conn_or_socket}
+        translations={@translations}
+        translatable?={@translatable?}
       />
     </div>
     """
@@ -997,11 +1043,23 @@ defmodule VutuvWeb.PostComponents do
       "the member whose reshare put this reply in the reader's feed (issue #1275), or nil in a conversation, where it stands under the post it answers"
   )
 
+  attr(:translations, :map,
+    default: %{},
+    doc: "the host's translation map (issue #1462), key {:note, id} — see <.post_card>"
+  )
+
+  attr(:translatable?, :boolean,
+    default: false,
+    doc: "whether this viewer gets the Translate action — see <.post_card>"
+  )
+
   def remote_reply_card(assigns) do
     note = assigns.note
+    translation = card_translation(assigns, {:note, note.id}, note.content_text, note.language)
 
     assigns =
       assigns
+      |> assign(:translation, translation)
       |> assign(:author, Note.label(note))
       |> assign(:handle, Note.display_handle(note))
       |> assign(:host, Note.host(note.actor_uri))
@@ -1077,7 +1135,18 @@ defmodule VutuvWeb.PostComponents do
             {gettext("Sent to you only, visible to nobody else")}
           </.remote_restricted_note>
 
-          <.remote_body warning={@warned? && @note.summary} text={@note.content_text} />
+          <.remote_body
+            warning={@warned? && translated_summary(@translation, @note.summary)}
+            text={@translation.body_source}
+            lang={@translation.lang}
+          />
+
+          <.translation_line
+            state={@translation.state}
+            offer?={@translation.offer?}
+            kind="note"
+            subject_id={@note.id}
+          />
 
           <%!-- The card's acts, in the open under the body where a reader
           looks for them (issues #1270, #1275, #1276). The bar owns its own
@@ -1399,6 +1468,10 @@ defmodule VutuvWeb.PostComponents do
   # sentence somebody wrote on another server. Google honors the attribute on a
   # `div`/`span`/`section` and covers its descendants, so the one wrapper takes
   # the warning, the body and the chips with it.
+  # The body's language (BCP47 primary subtag) for the `lang` attribute;
+  # nil renders no attribute.
+  attr(:lang, :string, default: nil)
+
   defp remote_body(assigns) do
     {text, hashtags} = Markdown.split_trailing_hashtags(assigns.text)
 
@@ -1424,6 +1497,7 @@ defmodule VutuvWeb.PostComponents do
           </summary>
           <div
             :if={@body?}
+            lang={@lang}
             class="markdown markdown--post mt-1.5 text-sm text-slate-700 dark:text-slate-300"
           >
             {Phoenix.HTML.raw(@html)}
@@ -1431,7 +1505,11 @@ defmodule VutuvWeb.PostComponents do
           <.remote_tags tags={@tags} />
         </details>
       <% else %>
-        <div :if={@body?} class="markdown markdown--post text-sm text-slate-700 dark:text-slate-300">
+        <div
+          :if={@body?}
+          lang={@lang}
+          class="markdown markdown--post text-sm text-slate-700 dark:text-slate-300"
+        >
           {Phoenix.HTML.raw(@html)}
         </div>
         <.remote_tags tags={@tags} />
@@ -1959,12 +2037,26 @@ defmodule VutuvWeb.PostComponents do
       "whether the ⋯ menu offers Mute. Pass false where the viewer is known not to follow the account (the lookup page, issue #1211): muting a follow that does not exist is a control that does nothing and a flash that says otherwise"
   )
 
+  attr(:translations, :map,
+    default: %{},
+    doc: "the host's translation map (issue #1462), key {:remote_post, id} — see <.post_card>"
+  )
+
+  attr(:translatable?, :boolean,
+    default: false,
+    doc: "whether this viewer gets the Translate action — see <.post_card>"
+  )
+
   def remote_post_card(assigns) do
     post = assigns.remote_post
     account = post.remote_account
 
+    translation =
+      card_translation(assigns, {:remote_post, post.id}, post.content_text, post.language)
+
     assigns =
       assigns
+      |> assign(:translation, translation)
       |> assign(:account, account)
       |> assign(:initials, name_initials(RemoteAccount.display_name(account) || account.handle))
       |> assign(:link_screenshot, remote_link_screenshot(post, assigns.images))
@@ -2065,11 +2157,20 @@ defmodule VutuvWeb.PostComponents do
             <.remote_body
               warning={
                 RemotePost.warned?(@remote_post) &&
-                  (@remote_post.summary || gettext("Marked as sensitive by its author"))
+                  (translated_summary(@translation, @remote_post.summary) ||
+                     gettext("Marked as sensitive by its author"))
               }
-              text={@remote_post.content_text}
+              text={@translation.body_source}
+              lang={@translation.lang}
             />
           </div>
+
+          <.translation_line
+            state={@translation.state}
+            offer?={@translation.offer?}
+            kind="remote_post"
+            subject_id={@remote_post.id}
+          />
 
           <.remote_post_images images={@images} />
 
@@ -2372,13 +2473,22 @@ defmodule VutuvWeb.PostComponents do
   )
 
   attr(:conn_or_socket, :any, required: true)
+  attr(:translations, :map, default: %{})
+  attr(:translatable?, :boolean, default: false)
 
   def thread_conversation(assigns) do
     top_id = with %{id: id} <- List.first(assigns.posts), do: id
     assigns = assign(assigns, :roots, conversation_nodes(assigns.posts, top_id, assigns))
 
     ~H"""
-    <.thread_chain nodes={@roots} viewer={@viewer} surface={:flat} conn_or_socket={@conn_or_socket} />
+    <.thread_chain
+      nodes={@roots}
+      viewer={@viewer}
+      surface={:flat}
+      conn_or_socket={@conn_or_socket}
+      translations={@translations}
+      translatable?={@translatable?}
+    />
     """
   end
 
@@ -2402,6 +2512,8 @@ defmodule VutuvWeb.PostComponents do
   attr(:note_marks, :any, default: nil)
   attr(:likers, :any, default: nil)
   attr(:conn_or_socket, :any, required: true)
+  attr(:translations, :map, default: %{})
+  attr(:translatable?, :boolean, default: false)
 
   def thread_window_conversation(assigns) do
     window = assigns.window
@@ -2429,6 +2541,8 @@ defmodule VutuvWeb.PostComponents do
         viewer={@viewer}
         surface={:flat}
         conn_or_socket={@conn_or_socket}
+        translations={@translations}
+        translatable?={@translatable?}
       />
       <div class="py-3 pl-1">
         <button
@@ -2451,6 +2565,8 @@ defmodule VutuvWeb.PostComponents do
       viewer={@viewer}
       surface={:flat}
       conn_or_socket={@conn_or_socket}
+      translations={@translations}
+      translatable?={@translatable?}
     />
     <div :if={@window.more > 0} class="pl-1 pt-3">
       <button
@@ -2801,6 +2917,7 @@ defmodule VutuvWeb.PostComponents do
               <div
                 :if={@mode == :full and @post.body != ""}
                 data-post-body
+                lang={@body_lang}
                 class="markdown markdown--post mt-2 text-slate-800 dark:text-slate-200"
                 {style_attrs(@body_style)}
               >
@@ -2827,6 +2944,7 @@ defmodule VutuvWeb.PostComponents do
                 body_style={@body_style}
                 class="mt-2"
                 tags={@post.tags}
+                lang={@body_lang}
                 wrap
               >
                 <:float>
@@ -2856,6 +2974,7 @@ defmodule VutuvWeb.PostComponents do
                 body_style={@body_style}
                 class="mt-2"
                 tags={@post.tags}
+                lang={@body_lang}
                 wrap
               >
                 <:float>
@@ -2874,6 +2993,7 @@ defmodule VutuvWeb.PostComponents do
                 class="mt-2"
                 media={@inline_media?}
                 tags={@post.tags}
+                lang={@body_lang}
               />
 
               <%!-- Attachments the body does NOT reference inline. A single
@@ -2973,6 +3093,17 @@ defmodule VutuvWeb.PostComponents do
           />
 
           <.liked_by :if={@likers} likers={@likers} />
+
+          <%!-- The translation line (issue #1462): the quiet Translate action
+          on a foreign-language card, the pending notice while the worker runs,
+          or — never silently — the "Translated from …" label with the original
+          one tap away. Events go to the host LiveView (no phx-target). --%>
+          <.translation_line
+            state={@translation_state}
+            offer?={@offer_translation?}
+            kind="post"
+            subject_id={@post.id}
+          />
 
           <%!-- The action bar (like / repost / bookmark + counters). On a
           LiveView host it is an in-process LiveComponent that re-renders in
@@ -3097,6 +3228,9 @@ defmodule VutuvWeb.PostComponents do
   # there is no float there, so the caller's plain row below already sits at
   # the end of the text).
   attr(:tags, :list, default: [])
+  # The body's language (BCP47 primary subtag) for the `lang` attribute —
+  # screen readers and hyphenation; nil renders no attribute.
+  attr(:lang, :string, default: nil)
   slot(:float)
 
   defp preview_body(assigns) do
@@ -3119,6 +3253,7 @@ defmodule VutuvWeb.PostComponents do
           ]}
           data-clamp-body
           data-post-body
+          lang={@lang}
           {style_attrs(@body_style)}
         >
           <%!-- The floated media is the clamp block's FIRST child so the body text
@@ -3759,6 +3894,95 @@ defmodule VutuvWeb.PostComponents do
   # Spaced rather than shingled, and `xs` rather than the `2xs` of the repost
   # banner: these are people the reader may well want to look up, so each face
   # is a finger-sized target and a picture-less member's monogram stays whole.
+  # The translation line's three states (issue #1462): the shown label ("never
+  # a silent translation"), the pending notice, or the quiet Translate action.
+  # Never more than one renders. Events carry the subject as kind + id and go
+  # to the host LiveView, which owns the translations map.
+  attr(:state, :any, doc: "nil | :pending | %Vutuv.Translations.Translation{} (= shown)")
+  attr(:offer?, :boolean, doc: "whether an untranslated card gets the Translate action")
+  attr(:kind, :string, doc: "\"post\" / \"remote_post\" / \"note\"")
+  attr(:subject_id, :any)
+
+  defp translation_line(assigns) do
+    ~H"""
+    <p
+      :if={match?(%Translation{}, @state)}
+      class="mt-2 flex flex-wrap items-center gap-x-1.5 text-xs text-slate-600 dark:text-slate-400"
+      data-translation-label
+    >
+      {translated_from_label(@state)}
+      <span aria-hidden="true">·</span>
+      <button
+        type="button"
+        phx-click="show-original"
+        phx-value-kind={@kind}
+        phx-value-id={@subject_id}
+        class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+      >
+        {gettext("Show the original")}
+      </button>
+    </p>
+    <p
+      :if={@state == :pending}
+      role="status"
+      class="mt-2 flex items-center gap-1.5 text-xs text-slate-600 dark:text-slate-400"
+      data-translation-pending
+    >
+      <.hourglass class="h-3.5 w-3.5 text-slate-400 dark:text-slate-500" />
+      {gettext("Translating…")}
+    </p>
+    <p :if={is_nil(@state) and @offer?} class="mt-2">
+      <button
+        type="button"
+        phx-click="translate"
+        phx-value-kind={@kind}
+        phx-value-id={@subject_id}
+        data-translate-button
+        class="text-xs font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+      >
+        {gettext("Translate")}
+      </button>
+    </p>
+    """
+  end
+
+  # "und" is the model's honest "could not tell" — a label naming no language
+  # beats one confidently naming the wrong one.
+  defp translated_from_label(%Translation{source_language: source}) when source in [nil, "und"],
+    do: gettext("Translated")
+
+  defp translated_from_label(%Translation{source_language: source}),
+    do: gettext("Translated from %{language}", language: Languages.name(source))
+
+  # A card whose language differs from the reader's UI locale — or declares
+  # none — gets the manual Translate action (issue #1462).
+  defp foreign_language?(language),
+    do: is_nil(language) or language != Gettext.get_locale(VutuvWeb.Gettext)
+
+  # The shown translation's content warning, else the original — a warning
+  # must never silently vanish just because its translation lacks one.
+  defp translated_summary(%{shown: %Translation{summary: summary}}, _original)
+       when is_binary(summary) and summary != "",
+       do: summary
+
+  defp translated_summary(_translation, original), do: original
+
+  # One card's translation view-state, computed in one place for all three
+  # card kinds: what the body renders from, which language it is in, and
+  # whether the Translate action shows.
+  defp card_translation(assigns, key, original_body, original_language) do
+    state = assigns.translations[key]
+    shown = if match?(%Translation{}, state), do: state
+
+    %{
+      state: state,
+      body_source: if(shown, do: shown.body, else: original_body),
+      shown: shown,
+      lang: if(shown, do: shown.target_language, else: original_language),
+      offer?: assigns.translatable? and foreign_language?(original_language)
+    }
+  end
+
   attr(:likers, :map, required: true)
 
   defp liked_by(%{likers: %{users: []}} = assigns), do: ~H""

--- a/lib/vutuv_web/components/ui.ex
+++ b/lib/vutuv_web/components/ui.ex
@@ -3932,8 +3932,11 @@ defmodule VutuvWeb.UI do
              gettext("log history audit trail security was that me who changed when protocol")
          ),
          row(:preferences, gettext("Language & display"), ~p"/settings/preferences",
-           hint: gettext("Interface language, maps, how posts are shortened"),
-           terms: gettext("german english locale translation map font length hyphenation")
+           hint: gettext("Interface language, feed languages, maps, how posts are shortened"),
+           terms:
+             gettext(
+               "german english locale translation translate map font length hyphenation feed languages hide foreign übersetzen sprache"
+             )
          ),
          row(:import, gettext("Import"), ~p"/settings/import/linkedin",
            hint: gettext("Take your data over from LinkedIn"),

--- a/lib/vutuv_web/controllers/settings_controller.ex
+++ b/lib/vutuv_web/controllers/settings_controller.ex
@@ -752,6 +752,34 @@ defmodule VutuvWeb.SettingsController do
     reset_prefs(conn, :maps, gettext("Map preferences reset to the site defaults."))
   end
 
+  # The feed language preference (issue #1461): which languages the feed
+  # shows, and what happens to the rest. A reading preference like the maps,
+  # so it lives on the same language & display page.
+  def update_feed_languages(conn, %{"user" => params}) do
+    save(
+      conn,
+      # An all-unticked checkbox set posts no "feed_languages" key at all,
+      # which cast would read as "keep the stored list" — here it means the
+      # member cleared every box, i.e. "all languages" (the changeset maps
+      # [] to nil).
+      Map.put_new(params, "feed_languages", []),
+      "preferences.html",
+      ~p"/settings/preferences",
+      gettext("Feed language settings saved.")
+    )
+  end
+
+  def reset_feed_languages(conn, _params) do
+    # The chips list is a plain member column beside the :feed pref group,
+    # so the reset clears both halves.
+    {:ok, _} =
+      conn.assigns[:user]
+      |> Ecto.Changeset.change(%{feed_languages: nil})
+      |> Repo.update()
+
+    reset_prefs(conn, :feed, gettext("Feed language settings reset to the site defaults."))
+  end
+
   # The like-attribution switch (issue #1233) lives on the visibility page
   # rather than under language & display, so its reset lands back there.
   def reset_privacy_prefs(conn, _params) do

--- a/lib/vutuv_web/gettext_extraction_anchors.ex
+++ b/lib/vutuv_web/gettext_extraction_anchors.ex
@@ -77,6 +77,14 @@ defmodule VutuvWeb.GettextExtractionAnchors do
         "When off, other members no longer see you among the likes of a post. The author of the post still does: we named you in the notification they got when you liked it. Either way the post keeps the same number of likes."
       ),
       gettext("Privacy"),
+      # Vutuv.Prefs — the feed language preference (issue #1461)
+      gettext("Posts in other languages"),
+      gettext("Translate into my language"),
+      gettext("Hide them"),
+      gettext(
+        "What your feed does with posts outside your chosen languages: show them as they are, translate them for you, or hide them. Posts that declare no language always show."
+      ),
+      gettext("Feed"),
       gettext("0 means posts are never shortened."),
       gettext("How much of a post a notification quotes before it is cut off."),
       gettext("Opens first, as the main button. The others appear as alternatives."),

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -41,6 +41,7 @@ defmodule VutuvWeb.PostLive.Feed do
   alias VutuvWeb.Live.DayClockRestream
   alias VutuvWeb.Live.InitAssigns
   alias VutuvWeb.Live.MountHandoff
+  alias VutuvWeb.Live.PostTranslations
   alias VutuvWeb.Live.RemotePostActions
   alias VutuvWeb.UserHelpers
 
@@ -154,6 +155,10 @@ defmodule VutuvWeb.PostLive.Feed do
   # connected socket would replay as an empty feed.
   defp apply_feed_payload(socket, payload) do
     socket
+    # On-demand translations (issue #1462): the per-card view state, and
+    # whether this viewer gets the controls at all.
+    |> assign(:post_translations, %{})
+    |> assign(:translatable?, PostTranslations.available?(socket.assigns.current_user))
     |> assign(:content_filters, payload.content_filters)
     |> assign(:revealed_filters, MapSet.new())
     |> assign(:page_title, gettext("Feed"))
@@ -181,6 +186,33 @@ defmodule VutuvWeb.PostLive.Feed do
     |> assign(payload.rails)
     |> stream_configure(:posts, dom_id: &"feed-#{&1.id}")
     |> stream(:posts, payload.entries)
+    |> auto_translate_entries(payload.entries)
+  end
+
+  # Translate mode (issue #1461): fold the page's foreign-language subjects
+  # into the translations map — cached rows show at once, the rest queue and
+  # swap in live. Only on the connected socket: the dead render is replaced
+  # moments later, and the jobs it would enqueue are the same deduped ones.
+  defp auto_translate_entries(socket, entries) do
+    viewer = socket.assigns.current_user
+
+    if connected?(socket) and PostTranslations.auto_translate?(viewer) do
+      subjects = Enum.flat_map(entries, &entry_subjects/1)
+      map = PostTranslations.auto_translate(socket.assigns.post_translations, subjects, viewer)
+      assign(socket, :post_translations, map)
+    else
+      socket
+    end
+  end
+
+  # What a feed entry shows that could be translated: its own post (plus the
+  # nested ancestors of a reply), a cached remote post, or a remote reply.
+  defp entry_subjects(entry) do
+    cond do
+      Posts.remote_reply_entry?(entry) -> [entry.note]
+      Posts.remote_feed_entry?(entry) -> [entry.remote_post]
+      true -> [entry.post | entry[:ancestors] || []]
+    end
   end
 
   # The desktop "Who to follow" rail: a randomized handful of the most-followed
@@ -341,6 +373,32 @@ defmodule VutuvWeb.PostLive.Feed do
     end)
   end
 
+  # A card's Translate tap (issue #1462): authorize + queue (or serve the
+  # cache), then re-render the one streamed card the state concerns.
+  @impl true
+  def handle_event("translate", %{"kind" => kind, "id" => id}, socket) do
+    case PostTranslations.request(socket.assigns.current_user, kind, id) do
+      {:ok, key, state} ->
+        {:noreply,
+         socket
+         |> update(:post_translations, &Map.put(&1, key, state))
+         |> restream_translated(key)}
+
+      :denied ->
+        {:noreply, socket}
+    end
+  end
+
+  def handle_event("show-original", %{"kind" => kind, "id" => id}, socket) do
+    case PostTranslations.show_original(socket.assigns.post_translations, kind, id) do
+      :ignore ->
+        {:noreply, socket}
+
+      {key, map} ->
+        {:noreply, socket |> assign(:post_translations, map) |> restream_translated(key)}
+    end
+  end
+
   @impl true
   def handle_event("load-more", _params, socket) do
     page =
@@ -372,7 +430,8 @@ defmodule VutuvWeb.PostLive.Feed do
      |> assign(:more?, page.more?)
      |> assign(:cursor, page.next_cursor)
      |> update(:entries, &(&1 ++ entries))
-     |> stream(:posts, entries, at: -1)}
+     |> stream(:posts, entries, at: -1)
+     |> auto_translate_entries(entries)}
   end
 
   # A source tab (All / vutuv / Fediverse). The tab decides which sources the
@@ -637,6 +696,28 @@ defmodule VutuvWeb.PostLive.Feed do
     {:noreply, refresh_shown_post(socket, post_id)}
   end
 
+  # The worker finished a translation this reader asked for (issue #1462):
+  # swap it into the one card, or clear the pending line on a failure.
+  def handle_info({:translation_ready, translation}, socket) do
+    case PostTranslations.apply_ready(socket.assigns.post_translations, translation) do
+      :ignore ->
+        {:noreply, socket}
+
+      {key, map} ->
+        {:noreply, socket |> assign(:post_translations, map) |> restream_translated(key)}
+    end
+  end
+
+  def handle_info({:translation_failed, key, target}, socket) do
+    case PostTranslations.apply_failed(socket.assigns.post_translations, key, target) do
+      :ignore ->
+        {:noreply, socket}
+
+      {key, map} ->
+        {:noreply, socket |> assign(:post_translations, map) |> restream_translated(key)}
+    end
+  end
+
   # The composer says it holds a draft, so show it (issue #1130). Two moments
   # send this: the first characters of a normal compose (the panel is already
   # open, so the assign is a no-op), and the `validate` LiveView's form recovery
@@ -861,6 +942,32 @@ defmodule VutuvWeb.PostLive.Feed do
   # `entry.post` goes through this (or `find_by_post_id/2`) first.
   defp local_entries(entries), do: Enum.reject(entries, &Posts.remote_feed_entry?/1)
 
+  # Re-render the one streamed card a translation state change concerns; a
+  # subject not on screen is a harmless no-op (update_only). A local post may
+  # sit in an entry as the leaf OR as a nested ancestor — either way the
+  # entry re-renders with the current translations map.
+  defp restream_translated(socket, key) do
+    case find_by_translation_key(socket.assigns.entries, key) do
+      nil -> socket
+      entry -> stream_insert(socket, :posts, entry, update_only: true)
+    end
+  end
+
+  defp find_by_translation_key(entries, {:post, id}) do
+    Enum.find(entries, fn entry ->
+      not Posts.remote_feed_entry?(entry) and not Posts.remote_reply_entry?(entry) and
+        (entry.post.id == id or Enum.any?(entry[:ancestors] || [], &(&1.id == id)))
+    end)
+  end
+
+  defp find_by_translation_key(entries, {:remote_post, id}) do
+    Enum.find(entries, &(Posts.remote_feed_entry?(&1) and &1.remote_post.id == id))
+  end
+
+  defp find_by_translation_key(entries, {:note, id}) do
+    Enum.find(entries, &(Posts.remote_reply_entry?(&1) and &1.note.id == id))
+  end
+
   defp find_by_post_id(entries, post_id) do
     Enum.find(entries, fn entry ->
       not Posts.remote_feed_entry?(entry) and entry.post.id == post_id
@@ -1065,6 +1172,8 @@ defmodule VutuvWeb.PostLive.Feed do
                     viewer={@current_user}
                     marks={entry[:marks]}
                     reposted_by={entry.reposted_by}
+                    translations={@post_translations}
+                    translatable?={@translatable?}
                     live?
                   />
                 <% Posts.remote_feed_entry?(entry) -> %>
@@ -1073,13 +1182,15 @@ defmodule VutuvWeb.PostLive.Feed do
                   (issue #1164; replies and boosts are #1165/#1166), and its own
                   report control. --%>
                   <.remote_post_card
-            live?
+                    live?
                     remote_post={entry.remote_post}
                     images={entry[:images] || []}
                     marks={entry[:marks]}
                     reposted_by={entry[:reposted_by]}
                     boosted_by={entry[:boosted_by]}
                     viewer={@current_user}
+                    translations={@post_translations}
+                    translatable?={@translatable?}
                   />
                 <% true -> %>
                   <%!-- A vutuv member's post that a followed account out there
@@ -1099,6 +1210,8 @@ defmodule VutuvWeb.PostLive.Feed do
                     entry_id={entry.id}
                     conn_or_socket={@socket}
                     engagement={entry.engagement}
+                    translations={@post_translations}
+                    translatable?={@translatable?}
                     surface={:flat}
                   />
               <% end %>

--- a/lib/vutuv_web/live/post_live/thread.ex
+++ b/lib/vutuv_web/live/post_live/thread.ex
@@ -52,6 +52,7 @@ defmodule VutuvWeb.PostLive.Thread do
   alias Vutuv.Social
   alias VutuvWeb.Live.InitAssigns
   alias VutuvWeb.Live.MountHandoff
+  alias VutuvWeb.Live.PostTranslations
   alias VutuvWeb.PostLive.ActionsComponent
 
   # The origin's like/repost figures on a card from another network tick
@@ -71,6 +72,9 @@ defmodule VutuvWeb.PostLive.Thread do
       |> assign(:reply_budget, defaults.replies)
       |> assign(:subscribed_ids, MapSet.new())
       |> assign(:notice, nil)
+      # On-demand translations (issue #1462): per-card view state + gate.
+      |> assign(:post_translations, %{})
+      |> assign(:translatable?, PostTranslations.available?(socket.assigns.current_user))
       |> mount_window()
 
     {:ok, socket}
@@ -157,6 +161,38 @@ defmodule VutuvWeb.PostLive.Thread do
   end
 
   @impl true
+  def handle_event("translate", %{"kind" => kind, "id" => id}, socket) do
+    case PostTranslations.request(socket.assigns.current_user, kind, id) do
+      {:ok, key, state} ->
+        {:noreply, update(socket, :post_translations, &Map.put(&1, key, state))}
+
+      :denied ->
+        {:noreply, socket}
+    end
+  end
+
+  def handle_event("show-original", %{"kind" => kind, "id" => id}, socket) do
+    case PostTranslations.show_original(socket.assigns.post_translations, kind, id) do
+      :ignore -> {:noreply, socket}
+      {_key, map} -> {:noreply, assign(socket, :post_translations, map)}
+    end
+  end
+
+  @impl true
+  def handle_info({:translation_ready, %Vutuv.Translations.Translation{} = translation}, socket) do
+    case PostTranslations.apply_ready(socket.assigns.post_translations, translation) do
+      :ignore -> {:noreply, socket}
+      {_key, map} -> {:noreply, assign(socket, :post_translations, map)}
+    end
+  end
+
+  def handle_info({:translation_failed, key, target}, socket) do
+    case PostTranslations.apply_failed(socket.assigns.post_translations, key, target) do
+      :ignore -> {:noreply, socket}
+      {_key, map} -> {:noreply, assign(socket, :post_translations, map)}
+    end
+  end
+
   def handle_info({:post_counters, %{post_id: post_id} = payload}, socket) do
     # This host holds the post-topic subscriptions for its cards; the matching
     # in-process bar applies the payload (`ActionBar.apply_counters/2`). The
@@ -365,6 +401,8 @@ defmodule VutuvWeb.PostLive.Thread do
             likers={@likers}
             mode={:full}
             conn_or_socket={@socket}
+            translations={@post_translations}
+            translatable?={@translatable?}
           />
         <% true -> %>
           <%!-- The conversation (issue #1006), rendered like a feed thread
@@ -385,6 +423,8 @@ defmodule VutuvWeb.PostLive.Thread do
                 likers={@likers}
                 auto_scroll?={@auto_scroll?}
                 conn_or_socket={@socket}
+                translations={@post_translations}
+                translatable?={@translatable?}
               />
             <% else %>
               <.thread_window_conversation
@@ -398,6 +438,8 @@ defmodule VutuvWeb.PostLive.Thread do
                 likers={@likers}
                 auto_scroll?={@auto_scroll?}
                 conn_or_socket={@socket}
+                translations={@post_translations}
+                translatable?={@translatable?}
               />
             <% end %>
           </.card>

--- a/lib/vutuv_web/live/post_translations.ex
+++ b/lib/vutuv_web/live/post_translations.ex
@@ -1,0 +1,205 @@
+defmodule VutuvWeb.Live.PostTranslations do
+  @moduledoc """
+  The shared host-side half of on-demand post translations (issue #1462),
+  used by every LiveView that renders post cards (feed, permalink thread,
+  profile). The cards themselves read a `translations` map — key
+  `{:post | :remote_post | :note, id}`, value `:pending` or a
+  `%Vutuv.Translations.Translation{}` (which means: shown) — and each host
+  keeps that map in an assign, because how a change reaches the DOM differs
+  per host (a plain re-render, or a `stream_insert` of the one affected
+  entry).
+
+  The flow: a card's "Translate" button fires `"translate"` with the subject
+  kind + id; `request/3` authorizes the subject against the viewer, asks
+  `Vutuv.Translations.request/2` (cache hit shows immediately, otherwise a
+  job queues) and subscribes the host to the subject's topic; the worker's
+  `{:translation_ready, …}` broadcast swaps the text in via `apply_ready/3`,
+  and a `{:translation_failed, …}` just clears the pending line
+  (`apply_failed/3`) — the card keeps showing the original. "Show the
+  original" removes the map entry; the cached row stays, so translating
+  again is instant.
+
+  Nothing here renders on logged-out, agent-format or ActivityPub surfaces —
+  hosts gate the whole feature with `available?/1`.
+  """
+
+  alias Vutuv.Accounts.User
+  alias Vutuv.Posts
+  alias Vutuv.Repo
+  alias Vutuv.Translations
+  alias Vutuv.Translations.Translation
+
+  @doc """
+  Whether this viewer gets translation controls at all: the installation has
+  the feature on, and somebody is signed in (public and logged-out surfaces
+  always show the original).
+  """
+  def available?(viewer), do: Translations.enabled?() and match?(%User{}, viewer)
+
+  @doc "The reader's translation target: their UI locale."
+  def target_language, do: Gettext.get_locale(VutuvWeb.Gettext)
+
+  @doc """
+  Handles a card's "Translate" click. Returns `{:ok, key, state}` with
+  `state` either `:pending` or the cached `%Translation{}` (shown at once),
+  or `:denied` for a subject this viewer may not read (a tampered id), the
+  feature being off, or an unknown kind.
+  """
+  def request(viewer, kind, id) do
+    with true <- available?(viewer),
+         {:ok, subject} <- fetch_subject(kind, id, viewer) do
+      case Translations.request(subject, target_language()) do
+        {:cached, translation} ->
+          {:ok, subject_key(subject), translation}
+
+        {:queued, _job} ->
+          Phoenix.PubSub.subscribe(Vutuv.PubSub, Translations.topic(subject))
+          {:ok, subject_key(subject), :pending}
+
+        :disabled ->
+          :denied
+      end
+    else
+      _denied -> :denied
+    end
+  end
+
+  @doc """
+  Folds a worker `{:translation_ready, translation}` broadcast into the map:
+  the entry flips from `:pending` to shown — but only if this host asked
+  (the key is pending) and the translation is into this reader's language.
+  Returns `{key, map}` or `:ignore`.
+  """
+  def apply_ready(map, %Translation{} = translation) do
+    key = Translations.subject(translation)
+
+    if map[key] == :pending and translation.target_language == target_language() do
+      {key, Map.put(map, key, translation)}
+    else
+      :ignore
+    end
+  end
+
+  @doc """
+  Folds a `{:translation_failed, subject, target}` broadcast into the map:
+  the pending line simply disappears and the card keeps the original.
+  Returns `{key, map}` or `:ignore`.
+  """
+  def apply_failed(map, subject_key, target) do
+    if map[subject_key] == :pending and target == target_language() do
+      {subject_key, Map.delete(map, subject_key)}
+    else
+      :ignore
+    end
+  end
+
+  @doc """
+  Handles a card's "Show the original" click: drops the entry (the cached
+  translation row stays, so translating again is instant). Returns
+  `{key, map}` or `:ignore` for an unknown kind.
+  """
+  def show_original(map, kind, id) do
+    case parse_key(kind, id) do
+      nil -> :ignore
+      key -> {key, Map.delete(map, key)}
+    end
+  end
+
+  @doc ~S|The `{kind, id}` map key for a card's subject struct.|
+  defdelegate subject_key(subject), to: Translations
+
+  @doc """
+  Whether this viewer's feed auto-translates (issue #1461): the feature is
+  available to them AND they chose the "translate" mode for posts outside
+  their languages.
+  """
+  def auto_translate?(viewer) do
+    available?(viewer) and Vutuv.Prefs.get(viewer, :feed_foreign_posts) == "translate"
+  end
+
+  @doc """
+  Translate mode's page hook: folds a freshly loaded page's subjects into the
+  map — cached translations show at once (ONE batched query per page, never
+  one per card), the rest queue with the pending line and the live swap-in.
+  Unknown-language subjects count as the reader's own: never auto-translated,
+  the manual button covers them. Already-decided keys are left alone, so a
+  reader's "Show the original" survives a load-more.
+  """
+  def auto_translate(map, subjects, viewer) do
+    target = target_language()
+    chosen = viewer.feed_languages || []
+
+    wanted =
+      subjects
+      |> Enum.uniq_by(&subject_key/1)
+      |> Enum.filter(&auto_translation_wanted?(map, &1, target, chosen))
+
+    cached = Translations.fresh_translations(wanted, target)
+
+    Enum.reduce(wanted, map, fn subject, acc ->
+      resolve_auto(acc, subject, cached[subject_key(subject)], target)
+    end)
+  end
+
+  defp auto_translation_wanted?(map, subject, target, chosen) do
+    language = subject_language(subject)
+
+    is_binary(language) and language != target and language not in chosen and
+      not Map.has_key?(map, subject_key(subject))
+  end
+
+  defp resolve_auto(map, subject, %Translation{} = cached, _target),
+    do: Map.put(map, subject_key(subject), cached)
+
+  defp resolve_auto(map, subject, nil, target) do
+    case Translations.request(subject, target) do
+      {:cached, translation} ->
+        Map.put(map, subject_key(subject), translation)
+
+      {:queued, _job} ->
+        Phoenix.PubSub.subscribe(Vutuv.PubSub, Translations.topic(subject))
+        Map.put(map, subject_key(subject), :pending)
+
+      :disabled ->
+        map
+    end
+  end
+
+  defp subject_language(%Posts.Post{language: language}), do: language
+  defp subject_language(%Vutuv.Fediverse.RemotePost{language: language}), do: language
+  defp subject_language(%Vutuv.Fediverse.Note{language: language}), do: language
+
+  # The subject behind a card's click, checked against the viewer: a post
+  # must be visible to them (a tampered id must not spend translation budget
+  # on somebody else's restricted post, even though the result would never
+  # render); cached remote content is what logged-in members see anyway.
+  defp fetch_subject("post", id, viewer) do
+    with %Posts.Post{} = post <- Posts.get_post(id),
+         true <- Posts.visible_to?(post, viewer) do
+      {:ok, post}
+    else
+      _hidden -> :error
+    end
+  end
+
+  defp fetch_subject("remote_post", id, _viewer) do
+    case Repo.get(Vutuv.Fediverse.RemotePost, id) do
+      %Vutuv.Fediverse.RemotePost{} = remote -> {:ok, remote}
+      nil -> :error
+    end
+  end
+
+  defp fetch_subject("note", id, _viewer) do
+    case Repo.get(Vutuv.Fediverse.Note, id) do
+      %Vutuv.Fediverse.Note{} = note -> {:ok, note}
+      nil -> :error
+    end
+  end
+
+  defp fetch_subject(_kind, _id, _viewer), do: :error
+
+  defp parse_key("post", id), do: {:post, id}
+  defp parse_key("remote_post", id), do: {:remote_post, id}
+  defp parse_key("note", id), do: {:note, id}
+  defp parse_key(_kind, _id), do: nil
+end

--- a/lib/vutuv_web/live/user_profile_live.ex
+++ b/lib/vutuv_web/live/user_profile_live.ex
@@ -52,6 +52,7 @@ defmodule VutuvWeb.UserProfileLive do
   alias VutuvWeb.Fediverse.Docs
   alias VutuvWeb.Live.InitAssigns
   alias VutuvWeb.Live.MountHandoff
+  alias VutuvWeb.Live.PostTranslations
 
   # The controller embeds this LiveView with `live_render/3` (not a `live/3`
   # router route), so `VutuvWeb.Live.InitAssigns` cannot be the on_mount: it
@@ -81,6 +82,9 @@ defmodule VutuvWeb.UserProfileLive do
       # (issue #859), one of "all" / "certification" / "license". Set once here
       # so it survives the PubSub re-renders that rebuild the profile assigns.
       |> assign(:qualifications_tab, "all")
+      # On-demand translations (issue #1462): per-card view state + gate.
+      |> assign(:post_translations, %{})
+      |> assign(:translatable?, PostTranslations.available?(socket.assigns.current_user))
       |> mount_profile()
 
     # Only a real visitor triggers the (cached, single-flight) social feed
@@ -178,6 +182,24 @@ defmodule VutuvWeb.UserProfileLive do
       {:noreply, refresh_social(socket)}
     else
       {:noreply, socket}
+    end
+  end
+
+  def handle_event("translate", %{"kind" => kind, "id" => id}, socket) do
+    case PostTranslations.request(socket.assigns.current_user, kind, id) do
+      {:ok, key, state} ->
+        translations = Map.put(socket.assigns.post_translations, key, state)
+        {:noreply, assign(socket, :post_translations, translations)}
+
+      :denied ->
+        {:noreply, socket}
+    end
+  end
+
+  def handle_event("show-original", %{"kind" => kind, "id" => id}, socket) do
+    case PostTranslations.show_original(socket.assigns.post_translations, kind, id) do
+      :ignore -> {:noreply, socket}
+      {_key, map} -> {:noreply, assign(socket, :post_translations, map)}
     end
   end
 
@@ -329,6 +351,20 @@ defmodule VutuvWeb.UserProfileLive do
   # reflects changes made on another page or by another member.
 
   @impl true
+  def handle_info({:translation_ready, %Vutuv.Translations.Translation{} = translation}, socket) do
+    case PostTranslations.apply_ready(socket.assigns.post_translations, translation) do
+      :ignore -> {:noreply, socket}
+      {_key, map} -> {:noreply, assign(socket, :post_translations, map)}
+    end
+  end
+
+  def handle_info({:translation_failed, key, target}, socket) do
+    case PostTranslations.apply_failed(socket.assigns.post_translations, key, target) do
+      :ignore -> {:noreply, socket}
+      {_key, map} -> {:noreply, assign(socket, :post_translations, map)}
+    end
+  end
+
   def handle_info({:social_graph_changed, _payload}, socket),
     do: {:noreply, refresh_social(socket)}
 

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -1158,6 +1158,9 @@ defmodule VutuvWeb.Router do
     patch("/maps", SettingsController, :update_maps)
     put("/post_display", SettingsController, :update_post_display)
     patch("/post_display", SettingsController, :update_post_display)
+    put("/feed_languages", SettingsController, :update_feed_languages)
+    patch("/feed_languages", SettingsController, :update_feed_languages)
+    post("/feed_languages/reset", SettingsController, :reset_feed_languages)
     # Clear a whole preference group back to nil = "inherit the installation
     # default" (Vutuv.Prefs) — the quiet reset links under the two cards.
     post("/post_display/reset", SettingsController, :reset_post_display)

--- a/lib/vutuv_web/templates/settings/preferences.html.heex
+++ b/lib/vutuv_web/templates/settings/preferences.html.heex
@@ -104,6 +104,89 @@ shortened and hyphenated. Each form posts its own subset and lands back here. --
       </div>
     </.card>
 
+    <%!-- Feed languages (issue #1461, Mastodon's chosen-languages filter plus
+          a translate mode): which languages the feed shows, and what happens
+          to the rest — original (shipped default), auto-translated into the
+          interface language, or hidden. All boxes ticked (or none) means "all
+          languages", stored as inheriting. Posts that declare no language
+          always show and are never auto-translated. The translate option only
+          does anything on installations with translations enabled; the select
+          still offers it so the choice survives the flag being turned on. --%>
+    <.card>
+      <.section_title>{gettext("Feed languages")}</.section_title>
+      <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+        {gettext(
+          "Pick which languages your feed shows, and what happens to posts in other languages. Posts that declare no language always show."
+        )}
+      </p>
+
+      <.form :let={f} for={@changeset} action={~p"/settings/feed_languages"} class="mt-5 space-y-5">
+        <.form_error changeset={@changeset} />
+
+        <fieldset class="space-y-3">
+          <legend class="text-sm font-medium text-slate-900 dark:text-white">
+            {gettext("Show these languages")}
+          </legend>
+          <p class="text-sm text-slate-600 dark:text-slate-400">
+            {gettext("Ticking every box (or none) means: all languages.")}
+          </p>
+
+          <div class="grid grid-cols-2 gap-x-4 gap-y-2 sm:grid-cols-3">
+            <label
+              :for={{label, code} <- Vutuv.Languages.options()}
+              class="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300"
+            >
+              <input
+                type="checkbox"
+                name="user[feed_languages][]"
+                value={code}
+                checked={
+                  Ecto.Changeset.get_field(@changeset, :feed_languages) == nil or
+                    code in (Ecto.Changeset.get_field(@changeset, :feed_languages) || [])
+                }
+                class={checkbox_class()}
+              />
+              <span>{label}</span>
+            </label>
+          </div>
+        </fieldset>
+
+        <div class="sm:max-w-xs">
+          <%= label f, :feed_foreign_posts, Vutuv.Prefs.label(:feed_foreign_posts), class: "block text-sm font-medium text-slate-900 dark:text-white" %>
+          <%= select f, :feed_foreign_posts,
+            Enum.map(Vutuv.Prefs.pref!(:feed_foreign_posts).values, fn value ->
+              {Vutuv.Prefs.value_label(Vutuv.Prefs.pref!(:feed_foreign_posts), value), value}
+            end),
+            class: input_class() %>
+          <%= error_tag f, :feed_foreign_posts %>
+          <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+            {Vutuv.Prefs.hint(:feed_foreign_posts)}
+          </p>
+        </div>
+
+        <div class="pt-1">
+          <.button type="submit">{gettext("Save")}</.button>
+        </div>
+      </.form>
+
+      <%!-- Back to inheriting the installation defaults — see the maps card. --%>
+      <div
+        :if={
+          Vutuv.Prefs.customized_in_group?(@user, :feed) or @user.feed_languages != nil
+        }
+        class="mt-5 border-t border-slate-100 pt-4 dark:border-slate-800"
+      >
+        <.link
+          href={~p"/settings/feed_languages/reset"}
+          method="post"
+          id="reset-feed-languages"
+          class="text-sm font-semibold text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200"
+        >
+          {gettext("Reset to the site defaults")}
+        </.link>
+      </div>
+    </.card>
+
     <%!-- Post display: how posts you read are shortened in the feed and on
           profiles. The line counts drive the CSS clamp on the preview body
           (desktop and mobile separately); 0 or an empty field means no

--- a/lib/vutuv_web/templates/user/show.html.heex
+++ b/lib/vutuv_web/templates/user/show.html.heex
@@ -539,6 +539,8 @@ the resulting ~200px rail width. --%>
             conn_or_socket={@socket}
             viewer={@current_user}
             engagement={entry[:engagement]}
+            translations={@post_translations}
+            translatable?={@translatable?}
             surface={:flat}
           />
         </div>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.298.3",
+      version: "7.299.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -38,7 +38,7 @@ msgstr "Eintrag hinzufügen"
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1445
+#: lib/vutuv_web/templates/user/show.html.heex:1447
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -103,7 +103,7 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/agent_docs/markdown.ex:595
 #: lib/vutuv_web/agent_docs/text.ex:555
 #: lib/vutuv_web/agent_docs/text.ex:556
-#: lib/vutuv_web/templates/user/show.html.heex:1077
+#: lib/vutuv_web/templates/user/show.html.heex:1079
 #, elixir-autogen
 msgid "Birthday"
 msgstr "Geburtstag"
@@ -152,7 +152,7 @@ msgstr "Wählen Sie einen Typ aus"
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1115
+#: lib/vutuv_web/templates/user/show.html.heex:1117
 #, elixir-autogen
 msgid "Contact"
 msgstr "Kontakt"
@@ -161,7 +161,7 @@ msgstr "Kontakt"
 msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
-#: lib/vutuv_web/components/post_components.ex:2782
+#: lib/vutuv_web/components/post_components.ex:2867
 #: lib/vutuv_web/components/ui.ex:3492
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -210,7 +210,7 @@ msgstr "Inaktivieren"
 msgid "Download"
 msgstr "Download"
 
-#: lib/vutuv_web/components/post_components.ex:2747
+#: lib/vutuv_web/components/post_components.ex:2832
 #: lib/vutuv_web/components/ui.ex:3483
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -224,7 +224,7 @@ msgstr "Download"
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:1100
+#: lib/vutuv_web/templates/user/show.html.heex:1102
 #, elixir-autogen
 msgid "Edit"
 msgstr "Ändern"
@@ -289,7 +289,7 @@ msgstr "E-Mail-Adresse eingeben"
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:609
+#: lib/vutuv_web/templates/user/show.html.heex:611
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -336,7 +336,7 @@ msgstr "Follower"
 #: lib/vutuv_web/live/organization_live/show.ex:471
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:53
-#: lib/vutuv_web/templates/user/show.html.heex:955
+#: lib/vutuv_web/templates/user/show.html.heex:957
 #, elixir-autogen
 msgid "Following"
 msgstr "Folge ich"
@@ -624,7 +624,8 @@ msgstr "Öffentlich"
 #: lib/vutuv_web/templates/settings/notifications.html.heex:79
 #: lib/vutuv_web/templates/settings/preferences.html.heex:29
 #: lib/vutuv_web/templates/settings/preferences.html.heex:85
-#: lib/vutuv_web/templates/settings/preferences.html.heex:205
+#: lib/vutuv_web/templates/settings/preferences.html.heex:168
+#: lib/vutuv_web/templates/settings/preferences.html.heex:288
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:443
@@ -652,7 +653,7 @@ msgstr "Speichern"
 msgid "Search"
 msgstr "Suche"
 
-#: lib/vutuv_web/components/post_components.ex:1450
+#: lib/vutuv_web/components/post_components.ex:1492
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -688,13 +689,13 @@ msgstr "Slug"
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1229
+#: lib/vutuv_web/templates/user/show.html.heex:1231
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr "Profile"
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1231
+#: lib/vutuv_web/templates/user/show.html.heex:1233
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr "Profil hinzufügen"
@@ -740,7 +741,7 @@ msgstr "Code & Repositorys"
 #: lib/vutuv_web/controllers/follow_controller.ex:24
 #: lib/vutuv_web/controllers/remote_follow_controller.ex:166
 #: lib/vutuv_web/controllers/user_save_controller.ex:45
-#: lib/vutuv_web/live/user_profile_live.ex:155
+#: lib/vutuv_web/live/user_profile_live.ex:159
 #, elixir-autogen
 msgid "Something went wrong"
 msgstr "Etwas ist schiefgelaufen"
@@ -852,8 +853,8 @@ msgid "vCard"
 msgstr "vCard"
 
 #: lib/vutuv_web/components/ui.ex:3553
-#: lib/vutuv_web/templates/user/show.html.heex:949
-#: lib/vutuv_web/templates/user/show.html.heex:972
+#: lib/vutuv_web/templates/user/show.html.heex:951
+#: lib/vutuv_web/templates/user/show.html.heex:974
 #, elixir-autogen
 msgid "View All"
 msgstr "Alle anzeigen"
@@ -934,7 +935,7 @@ msgid "You follow back %{name}."
 msgstr "Sie folgen %{name} jetzt zurück."
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:77
+#: lib/vutuv_web/live/post_live/feed.ex:78
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1060,7 +1061,7 @@ msgstr "Diese Seite ist für Sie gesperrt."
 msgid "An error occurred"
 msgstr "Es gab einen Fehler."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1066
+#: lib/vutuv_web/templates/user/show.html.heex:1068
 #, elixir-autogen
 msgid "General Info"
 msgstr "Allgemeines"
@@ -1229,7 +1230,7 @@ msgstr "Alle Tag-URLs"
 
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:603
+#: lib/vutuv_web/templates/user/show.html.heex:605
 #, elixir-autogen
 msgid "All tags"
 msgstr "Alle Tags"
@@ -1428,7 +1429,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:23
 #: lib/vutuv_web/templates/tag/show.html.heex:25
-#: lib/vutuv_web/templates/user/show.html.heex:573
+#: lib/vutuv_web/templates/user/show.html.heex:575
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
@@ -1647,7 +1648,7 @@ msgstr "Zur Startseite"
 msgid "Check your inbox"
 msgstr "Schauen Sie in Ihr Postfach"
 
-#: lib/vutuv_web/components/post_components.ex:3254
+#: lib/vutuv_web/components/post_components.ex:3339
 #: lib/vutuv_web/components/ui.ex:298
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
@@ -1722,11 +1723,11 @@ msgstr "Empfehlen"
 #: lib/vutuv_web/components/ui.ex:2227
 #: lib/vutuv_web/live/fediverse_account_live.ex:375
 #: lib/vutuv_web/live/fediverse_following_live.ex:331
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:293
-#: lib/vutuv_web/live/organization_live/following.ex:218
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:295
+#: lib/vutuv_web/live/organization_live/following.ex:219
 #: lib/vutuv_web/live/organization_live/show.ex:440
 #: lib/vutuv_web/live/organization_live/show.ex:469
-#: lib/vutuv_web/templates/user/show.html.heex:1269
+#: lib/vutuv_web/templates/user/show.html.heex:1271
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr "Folgen"
@@ -1902,7 +1903,7 @@ msgstr ""
 "Wir haben eine PIN an Ihre neue E-Mail-Adresse geschickt. Geben Sie sie "
 "unten ein, um die Adresse zu bestätigen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1183
+#: lib/vutuv_web/live/post_live/feed.ex:1296
 #: lib/vutuv_web/views/user_html.ex:208
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
@@ -2144,7 +2145,7 @@ msgstr "Upload abbrechen"
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
-#: lib/vutuv_web/components/post_components.ex:2779
+#: lib/vutuv_web/components/post_components.ex:2864
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2157,9 +2158,10 @@ msgid "Edit post"
 msgstr "Beitrag bearbeiten"
 
 #: lib/vutuv_web/components/organization_components.ex:255
+#: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:101
-#: lib/vutuv_web/live/post_live/feed.ex:159
-#: lib/vutuv_web/live/post_live/feed.ex:936
+#: lib/vutuv_web/live/post_live/feed.ex:164
+#: lib/vutuv_web/live/post_live/feed.ex:1043
 #: lib/vutuv_web/live/shell_live.ex:606
 #: lib/vutuv_web/live/shell_live.ex:887
 #: lib/vutuv_web/templates/layout/app.html.heex:171
@@ -2187,8 +2189,8 @@ msgstr "Vor einer bestimmten Person verbergen…"
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
 
-#: lib/vutuv_web/components/post_components.ex:2733
-#: lib/vutuv_web/components/post_components.ex:2735
+#: lib/vutuv_web/components/post_components.ex:2818
+#: lib/vutuv_web/components/post_components.ex:2820
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
@@ -2204,7 +2206,7 @@ msgstr "Nicht eingeloggte Besucher"
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1122
+#: lib/vutuv_web/live/post_live/feed.ex:1235
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2242,7 +2244,7 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/controllers/post_controller.ex:60
 #: lib/vutuv_web/controllers/post_controller.ex:69
 #: lib/vutuv_web/controllers/user_controller.ex:77
-#: lib/vutuv_web/gettext_extraction_anchors.ex:83
+#: lib/vutuv_web/gettext_extraction_anchors.ex:91
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:382
 #: lib/vutuv_web/live/notification_live/index.ex:891
@@ -2250,19 +2252,19 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/live/post_live/saved.ex:495
 #: lib/vutuv_web/live/search_live.ex:309
 #: lib/vutuv_web/live/search_live.ex:772
-#: lib/vutuv_web/templates/settings/preferences.html.heex:118
+#: lib/vutuv_web/templates/settings/preferences.html.heex:201
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:3190
-#: lib/vutuv_web/components/post_components.ex:3194
+#: lib/vutuv_web/components/post_components.ex:3275
+#: lib/vutuv_web/components/post_components.ex:3279
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:3191
+#: lib/vutuv_web/components/post_components.ex:3276
 #: lib/vutuv_web/live/fediverse_account_live.ex:320
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2270,7 +2272,7 @@ msgstr "Weniger anzeigen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:342
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:1087
+#: lib/vutuv_web/components/post_components.ex:1114
 #: lib/vutuv_web/live/admin/screenshot_live.ex:338
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:700
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
@@ -2298,7 +2300,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1030
+#: lib/vutuv_web/live/post_live/feed.ex:1137
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2335,7 +2337,7 @@ msgstr "Zu viele Dateien."
 msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
 
-#: lib/vutuv_web/components/ui.ex:4144
+#: lib/vutuv_web/components/ui.ex:4147
 #: lib/vutuv_web/live/shell_live.ex:788
 #: lib/vutuv_web/templates/post/index.html.heex:17
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2354,27 +2356,27 @@ msgstr "Was gibt's Neues?"
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
 
-#: lib/vutuv_web/components/post_components.ex:2730
+#: lib/vutuv_web/components/post_components.ex:2815
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:4479
+#: lib/vutuv_web/components/post_components.ex:4572
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:4483
+#: lib/vutuv_web/components/post_components.ex:4576
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:4481
+#: lib/vutuv_web/components/post_components.ex:4574
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:4482
+#: lib/vutuv_web/components/post_components.ex:4575
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
@@ -2405,7 +2407,7 @@ msgstr "Dateityp wird nicht unterstützt (erlaubt: %{types})."
 msgid "Posts by %{name}"
 msgstr "Beiträge von %{name}"
 
-#: lib/vutuv_web/templates/user/show.html.heex:563
+#: lib/vutuv_web/templates/user/show.html.heex:565
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr "Alle %{count} Beiträge ansehen"
@@ -2415,8 +2417,8 @@ msgstr "Alle %{count} Beiträge ansehen"
 msgid "All posts"
 msgstr "Alle Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:1634
-#: lib/vutuv_web/components/post_components.ex:4567
+#: lib/vutuv_web/components/post_components.ex:1681
+#: lib/vutuv_web/components/post_components.ex:4660
 #: lib/vutuv_web/components/ui.ex:3017
 #: lib/vutuv_web/views/user_html.ex:335
 #, elixir-autogen, elixir-format
@@ -2434,8 +2436,8 @@ msgstr "Lesezeichen setzen"
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/vutuv_web/components/post_components.ex:1598
-#: lib/vutuv_web/components/post_components.ex:4801
+#: lib/vutuv_web/components/post_components.ex:1645
+#: lib/vutuv_web/components/post_components.ex:4894
 #: lib/vutuv_web/components/ui.ex:3003
 #: lib/vutuv_web/live/notification_live/index.ex:1038
 #: lib/vutuv_web/views/user_html.ex:345
@@ -2444,7 +2446,7 @@ msgid "Like"
 msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1069
-#: lib/vutuv_web/components/post_components.ex:4810
+#: lib/vutuv_web/components/post_components.ex:4903
 #: lib/vutuv_web/live/notification_live/index.ex:971
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
@@ -2466,39 +2468,39 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:4556
+#: lib/vutuv_web/components/post_components.ex:4649
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
-#: lib/vutuv_web/components/post_components.ex:1634
-#: lib/vutuv_web/components/post_components.ex:4567
+#: lib/vutuv_web/components/post_components.ex:1681
+#: lib/vutuv_web/components/post_components.ex:4660
 #: lib/vutuv_web/live/post_live/saved.ex:775
 #: lib/vutuv_web/views/user_html.ex:335
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
-#: lib/vutuv_web/components/post_components.ex:1622
-#: lib/vutuv_web/components/post_components.ex:4553
+#: lib/vutuv_web/components/post_components.ex:1669
+#: lib/vutuv_web/components/post_components.ex:4646
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
-#: lib/vutuv_web/components/post_components.ex:1812
-#: lib/vutuv_web/components/post_components.ex:3770
+#: lib/vutuv_web/components/post_components.ex:1859
+#: lib/vutuv_web/components/post_components.ex:3855
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:1622
-#: lib/vutuv_web/components/post_components.ex:4553
+#: lib/vutuv_web/components/post_components.ex:1669
+#: lib/vutuv_web/components/post_components.ex:4646
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
-#: lib/vutuv_web/components/post_components.ex:4801
+#: lib/vutuv_web/components/post_components.ex:4894
 #: lib/vutuv_web/live/post_live/saved.ex:774
 #: lib/vutuv_web/views/user_html.ex:345
 #, elixir-autogen, elixir-format
@@ -2509,10 +2511,10 @@ msgstr "Gefällt mir entfernen"
 #: lib/vutuv_web/components/ui.ex:2057
 #: lib/vutuv_web/components/ui.ex:2057
 #: lib/vutuv_web/components/ui.ex:2194
-#: lib/vutuv_web/live/organization_live/following.ex:197
-#: lib/vutuv_web/live/organization_live/following.ex:256
+#: lib/vutuv_web/live/organization_live/following.ex:198
+#: lib/vutuv_web/live/organization_live/following.ex:258
 #: lib/vutuv_web/live/organization_live/show.ex:474
-#: lib/vutuv_web/live/post_live/feed.ex:1172
+#: lib/vutuv_web/live/post_live/feed.ex:1285
 #: lib/vutuv_web/templates/followee/index.html.heex:44
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2524,7 +2526,7 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:4854
+#: lib/vutuv_web/components/post_components.ex:4947
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
@@ -2535,16 +2537,16 @@ msgstr "Nur öffentliche Beiträge können beantwortet werden."
 msgid "Replies"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:1609
-#: lib/vutuv_web/components/post_components.ex:4837
-#: lib/vutuv_web/components/post_components.ex:4838
+#: lib/vutuv_web/components/post_components.ex:1656
+#: lib/vutuv_web/components/post_components.ex:4930
+#: lib/vutuv_web/components/post_components.ex:4931
 #: lib/vutuv_web/live/notification_live/index.ex:1035
 #: lib/vutuv_web/live/post_live/reply.ex:42
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:2697
+#: lib/vutuv_web/components/post_components.ex:2782
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
@@ -2565,7 +2567,7 @@ msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beitr
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
 
-#: lib/vutuv_web/components/post_components.ex:2248
+#: lib/vutuv_web/components/post_components.ex:2318
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:59
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:56
@@ -2573,14 +2575,14 @@ msgstr "hat auf Ihren Beitrag geantwortet."
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
 
-#: lib/vutuv_web/components/post_components.ex:2673
+#: lib/vutuv_web/components/post_components.ex:2758
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:2667
-#: lib/vutuv_web/components/post_components.ex:2689
-#: lib/vutuv_web/components/post_components.ex:2692
+#: lib/vutuv_web/components/post_components.ex:2752
+#: lib/vutuv_web/components/post_components.ex:2774
+#: lib/vutuv_web/components/post_components.ex:2777
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
@@ -2748,38 +2750,38 @@ msgstr "Andere E-Mail-Adresse verwenden"
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
 #: lib/vutuv_web/templates/url/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:885
+#: lib/vutuv_web/templates/user/show.html.heex:887
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr "Link hinzufügen"
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1189
+#: lib/vutuv_web/templates/user/show.html.heex:1191
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr "Telefonnummer hinzufügen"
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1447
+#: lib/vutuv_web/templates/user/show.html.heex:1449
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr "Adresse hinzufügen"
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1117
+#: lib/vutuv_web/templates/user/show.html.heex:1119
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr "E-Mail-Adresse hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1068
+#: lib/vutuv_web/templates/user/show.html.heex:1070
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr "Persönliche Angaben hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:612
+#: lib/vutuv_web/templates/user/show.html.heex:614
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #: lib/vutuv_web/templates/work_experience/new.html.heex:5
 #, elixir-autogen, elixir-format
@@ -2799,12 +2801,12 @@ msgstr "Ersten Beitrag schreiben"
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:216
-#: lib/vutuv_web/templates/user/show.html.heex:603
+#: lib/vutuv_web/templates/user/show.html.heex:605
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr "Verwalten"
 
-#: lib/vutuv_web/live/post_live/feed.ex:961
+#: lib/vutuv_web/live/post_live/feed.ex:1068
 #: lib/vutuv_web/templates/user/show.html.heex:474
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2879,7 +2881,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:4480
+#: lib/vutuv_web/components/post_components.ex:4573
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -2907,7 +2909,7 @@ msgid "Endorsement"
 msgstr "Empfehlung"
 
 #: lib/vutuv_web/live/notification_live/index.ex:1033
-#: lib/vutuv_web/templates/user/show.html.heex:933
+#: lib/vutuv_web/templates/user/show.html.heex:935
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -3154,13 +3156,13 @@ msgstr "Nichts zu sehen, keiner Ihrer Inhalte ist derzeit gemeldet."
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1157
-#: lib/vutuv_web/templates/user/show.html.heex:1158
+#: lib/vutuv_web/templates/user/show.html.heex:1159
+#: lib/vutuv_web/templates/user/show.html.heex:1160
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:2643
+#: lib/vutuv_web/components/post_components.ex:2728
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solange eine Meldung zu diesem Beitrag bearbeitet wird, sehen nur Sie ihn."
@@ -3240,9 +3242,9 @@ msgstr "Abgelehnt"
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 
-#: lib/vutuv_web/components/post_components.ex:1097
-#: lib/vutuv_web/components/post_components.ex:2073
-#: lib/vutuv_web/components/post_components.ex:2803
+#: lib/vutuv_web/components/post_components.ex:1124
+#: lib/vutuv_web/components/post_components.ex:2134
+#: lib/vutuv_web/components/post_components.ex:2888
 #: lib/vutuv_web/live/organization_live/show.ex:547
 #: lib/vutuv_web/templates/user/show.html.heex:219
 #, elixir-autogen, elixir-format
@@ -4701,12 +4703,12 @@ msgid "You have not blocked anyone."
 msgstr "Sie haben niemanden blockiert."
 
 #: lib/vutuv_web/controllers/block_controller.ex:89
-#: lib/vutuv_web/live/user_profile_live.ex:304
+#: lib/vutuv_web/live/user_profile_live.ex:326
 #, elixir-autogen, elixir-format
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1127
+#: lib/vutuv_web/live/post_live/feed.ex:1240
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
@@ -4717,10 +4719,10 @@ msgid "Find members"
 msgstr "Mitglieder finden"
 
 #: lib/vutuv_web/components/organization_components.ex:261
-#: lib/vutuv_web/live/organization_live/following.ex:154
+#: lib/vutuv_web/live/organization_live/following.ex:155
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:53
-#: lib/vutuv_web/templates/user/show.html.heex:955
+#: lib/vutuv_web/templates/user/show.html.heex:957
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr "Folgt"
@@ -4840,8 +4842,8 @@ msgstr "sucht nur in Vornamen (nachname: für Nachnamen)"
 
 #: lib/vutuv_web/live/job_board_live.ex:388
 #: lib/vutuv_web/live/tag_new_live.ex:48
-#: lib/vutuv_web/live/user_profile_live.ex:1295
-#: lib/vutuv_web/templates/user/show.html.heex:576
+#: lib/vutuv_web/live/user_profile_live.ex:1331
+#: lib/vutuv_web/templates/user/show.html.heex:578
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr "Tags hinzufügen"
@@ -5478,7 +5480,7 @@ msgstr "API-Token (%{date})"
 msgid "API documentation"
 msgstr "API-Dokumentation"
 
-#: lib/vutuv_web/components/ui.ex:3954
+#: lib/vutuv_web/components/ui.ex:3957
 #: lib/vutuv_web/controllers/settings_controller.ex:145
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5562,10 +5564,10 @@ msgstr "Tastaturkürzel"
 msgid "Navigation"
 msgstr "Navigation"
 
-#: lib/vutuv_web/components/ui.ex:4051
-#: lib/vutuv_web/components/ui.ex:4056
-#: lib/vutuv_web/components/ui.ex:4135
-#: lib/vutuv_web/components/ui.ex:4199
+#: lib/vutuv_web/components/ui.ex:4054
+#: lib/vutuv_web/components/ui.ex:4059
+#: lib/vutuv_web/components/ui.ex:4138
+#: lib/vutuv_web/components/ui.ex:4202
 #: lib/vutuv_web/controllers/settings_controller.ex:61
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5609,7 +5611,7 @@ msgstr "Profil vervollständigen"
 msgid "A few quick steps so people can find and recognize you."
 msgstr "Ein paar schnelle Schritte, damit andere Sie finden und erkennen."
 
-#: lib/vutuv_web/live/user_profile_live.ex:1301
+#: lib/vutuv_web/live/user_profile_live.ex:1337
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr "Profilfoto hinzufügen"
@@ -5635,11 +5637,11 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:2868
-#: lib/vutuv_web/components/post_components.ex:2922
-#: lib/vutuv_web/components/post_components.ex:3334
+#: lib/vutuv_web/components/post_components.ex:2953
+#: lib/vutuv_web/components/post_components.ex:3007
+#: lib/vutuv_web/components/post_components.ex:3419
 #: lib/vutuv_web/live/notification_live/index.ex:691
-#: lib/vutuv_web/live/post_live/feed.ex:1245
+#: lib/vutuv_web/live/post_live/feed.ex:1358
 #: lib/vutuv_web/views/user_html.ex:113
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5858,7 +5860,7 @@ msgstr "@%{slug} folgt Ihnen jetzt auf vutuv"
 msgid "Apps"
 msgstr "Apps"
 
-#: lib/vutuv_web/components/ui.ex:3950
+#: lib/vutuv_web/components/ui.ex:3953
 #: lib/vutuv_web/controllers/settings_controller.ex:165
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -6088,7 +6090,7 @@ msgid_plural "%{count} minutes ago"
 msgstr[0] "vor %{count} Minute"
 msgstr[1] "vor %{count} Minuten"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:811
+#: lib/vutuv_web/controllers/settings_controller.ex:839
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr "Alle anderen Geräte wurden abgemeldet."
@@ -6128,7 +6130,7 @@ msgstr "Neue Anmeldung bei Ihrem vutuv-Konto"
 msgid "Signed-in devices"
 msgstr "Angemeldete Geräte"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:798
+#: lib/vutuv_web/controllers/settings_controller.ex:826
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr "Dieses Gerät wurde abgemeldet."
@@ -6290,7 +6292,7 @@ msgstr "z. B. MacBook"
 msgid "or"
 msgstr "oder"
 
-#: lib/vutuv_web/live/user_profile_live.ex:1306
+#: lib/vutuv_web/live/user_profile_live.ex:1342
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr "Kurzbeschreibung hinzufügen"
@@ -6305,7 +6307,7 @@ msgstr "Kurzbeschreibung"
 #: lib/vutuv_web/components/ui.ex:314
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:883
+#: lib/vutuv_web/templates/user/show.html.heex:885
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
@@ -6326,7 +6328,7 @@ msgstr[1] "Beiträge"
 msgid "After choosing a file you can reposition and zoom it."
 msgstr "Nach der Auswahl einer Datei können Sie sie verschieben und zoomen."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1498
+#: lib/vutuv_web/templates/user/show.html.heex:1500
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr "Auch auf"
@@ -6372,8 +6374,8 @@ msgstr "Foto verwenden"
 msgid "Zoom"
 msgstr "Zoom"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1083
-#: lib/vutuv_web/templates/user/show.html.heex:1093
+#: lib/vutuv_web/templates/user/show.html.heex:1085
+#: lib/vutuv_web/templates/user/show.html.heex:1095
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6415,12 +6417,12 @@ msgstr "Tagesbericht für %{day}"
 msgid "Jump to a day"
 msgstr "Zu einem Tag springen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1205
+#: lib/vutuv_web/templates/user/show.html.heex:1207
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr "E-Mails verwalten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1216
+#: lib/vutuv_web/templates/user/show.html.heex:1218
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr "Telefon verwalten"
@@ -6463,7 +6465,7 @@ msgstr "Vorheriger Tag"
 msgid "Reposts"
 msgstr "Reposts"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1214
+#: lib/vutuv_web/templates/user/show.html.heex:1216
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr "Alle Telefonnummern anzeigen"
@@ -6513,20 +6515,20 @@ msgstr "Karteneinstellungen gespeichert."
 msgid "Map services to show"
 msgstr "Anzuzeigende Kartendienste"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:84
+#: lib/vutuv_web/gettext_extraction_anchors.ex:92
 #: lib/vutuv_web/templates/settings/preferences.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Maps"
 msgstr "Karten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1484
-#: lib/vutuv_web/templates/user/show.html.heex:1492
-#: lib/vutuv_web/templates/user/show.html.heex:1504
+#: lib/vutuv_web/templates/user/show.html.heex:1486
+#: lib/vutuv_web/templates/user/show.html.heex:1494
+#: lib/vutuv_web/templates/user/show.html.heex:1506
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr "In %{name} öffnen"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:82
+#: lib/vutuv_web/gettext_extraction_anchors.ex:90
 #: lib/vutuv_web/templates/settings/preferences.html.heex:80
 #, elixir-autogen, elixir-format
 msgid "Opens first, as the main button. The others appear as alternatives."
@@ -6886,7 +6888,7 @@ msgid "Mute"
 msgstr "Stummschalten"
 
 #: lib/vutuv_web/controllers/follow_controller.ex:49
-#: lib/vutuv_web/live/user_profile_live.ex:245
+#: lib/vutuv_web/live/user_profile_live.ex:267
 #, elixir-autogen, elixir-format
 msgid "Muted. Their posts no longer appear in your feed."
 msgstr "Stummgeschaltet. Die Beiträge erscheinen nicht mehr in Ihrem Feed."
@@ -6910,7 +6912,7 @@ msgid "Unmute"
 msgstr "Stummschaltung aufheben"
 
 #: lib/vutuv_web/controllers/follow_controller.ex:51
-#: lib/vutuv_web/live/user_profile_live.ex:247
+#: lib/vutuv_web/live/user_profile_live.ex:269
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts appear in your feed again."
 msgstr ""
@@ -6926,7 +6928,7 @@ msgstr "Folgen Sie einander, um mit %{name} vernetzt zu sein und ihn zu lesen."
 msgid "Go to profile to follow"
 msgstr "Zum Profil, um zu folgen"
 
-#: lib/vutuv_web/components/post_components.ex:2800
+#: lib/vutuv_web/components/post_components.ex:2885
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr "@%{handle} stummschalten"
@@ -6936,7 +6938,7 @@ msgstr "@%{handle} stummschalten"
 msgid "Professional"
 msgstr "Beruflich"
 
-#: lib/vutuv_web/components/post_components.ex:2799
+#: lib/vutuv_web/components/post_components.ex:2884
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr "@%{handle} nicht mehr stummschalten"
@@ -7641,7 +7643,7 @@ msgstr "Alle abwählen"
 msgid "applies to the whole list, not just this page"
 msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 
-#: lib/vutuv_web/components/post_components.ex:4712
+#: lib/vutuv_web/components/post_components.ex:4805
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8500,7 +8502,7 @@ msgstr[1] "%{count} Berufserfahrungen"
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
 #: lib/vutuv_web/templates/education/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:669
+#: lib/vutuv_web/templates/user/show.html.heex:671
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr "Ausbildung hinzufügen"
@@ -8525,7 +8527,7 @@ msgstr "Abschluss"
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
 #: lib/vutuv_web/templates/import/preview.html.heex:44
-#: lib/vutuv_web/templates/user/show.html.heex:666
+#: lib/vutuv_web/templates/user/show.html.heex:668
 #: lib/vutuv_web/views/import_html.ex:66
 #: lib/vutuv_web/views/job_reference_html.ex:265
 #, elixir-autogen, elixir-format
@@ -8573,7 +8575,7 @@ msgstr ""
 " was Sie nicht übernehmen möchten. Einträge, die bereits in Ihrem Profil "
 "stehen, sind für Sie abgewählt."
 
-#: lib/vutuv_web/components/ui.ex:3938
+#: lib/vutuv_web/components/ui.ex:3941
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Import"
@@ -8713,7 +8715,7 @@ msgid "Loading posts"
 msgstr "Beiträge werden geladen"
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:140
-#: lib/vutuv_web/templates/user/show.html.heex:1351
+#: lib/vutuv_web/templates/user/show.html.heex:1353
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr "Social-Media-Beiträge"
@@ -8820,7 +8822,7 @@ msgstr "Weitere Profil-Bereiche"
 msgid "Sign-in & security"
 msgstr "Anmeldung & Sicherheit"
 
-#: lib/vutuv_web/components/ui.ex:3942
+#: lib/vutuv_web/components/ui.ex:3945
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8847,13 +8849,13 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr "Geben Sie zur Bestätigung Ihren Benutzernamen ein:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1212
-#: lib/vutuv_web/live/post_live/feed.ex:1213
+#: lib/vutuv_web/live/post_live/feed.ex:1325
+#: lib/vutuv_web/live/post_live/feed.ex:1326
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr "Andere Beiträge anzeigen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1207
+#: lib/vutuv_web/live/post_live/feed.ex:1320
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr "Vorgeschlagene Beiträge"
@@ -9073,8 +9075,8 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:997
-#: lib/vutuv_web/templates/user/show.html.heex:1256
+#: lib/vutuv_web/templates/user/show.html.heex:999
+#: lib/vutuv_web/templates/user/show.html.heex:1258
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr "Fediverse"
@@ -9230,7 +9232,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:3773
+#: lib/vutuv_web/components/post_components.ex:3858
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9509,7 +9511,7 @@ msgstr "A2 (Grundkenntnisse)"
 
 #: lib/vutuv_web/templates/language/manage.html.heex:8
 #: lib/vutuv_web/templates/language/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:731
+#: lib/vutuv_web/templates/user/show.html.heex:733
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr "Sprache hinzufügen"
@@ -9733,7 +9735,7 @@ msgstr "Sprache erfolgreich aktualisiert."
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:4
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:728
+#: lib/vutuv_web/templates/user/show.html.heex:730
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr "Sprachen"
@@ -9920,7 +9922,7 @@ msgstr "Yoruba"
 msgid "Employment status"
 msgstr "Beschäftigungsstatus"
 
-#: lib/vutuv/accounts/user.ex:1084
+#: lib/vutuv/accounts/user.ex:1117
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9931,7 +9933,7 @@ msgstr "Auf Jobsuche"
 msgid "Not open to work"
 msgstr "Nicht offen für Angebote"
 
-#: lib/vutuv/accounts/user.ex:1081
+#: lib/vutuv/accounts/user.ex:1114
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -10024,7 +10026,7 @@ msgstr[0] "%{count} Zertifikat oder Lizenz"
 msgstr[1] "%{count} Zertifikate oder Lizenzen"
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:837
+#: lib/vutuv_web/templates/user/show.html.heex:839
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr "Zertifikat oder Lizenz hinzufügen"
@@ -10073,7 +10075,7 @@ msgstr "Zertifikate"
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:834
+#: lib/vutuv_web/templates/user/show.html.heex:836
 #: lib/vutuv_web/views/import_html.ex:67
 #: lib/vutuv_web/views/job_reference_html.ex:266
 #, elixir-autogen, elixir-format
@@ -10197,8 +10199,8 @@ msgstr "Bevorzugt"
 msgid "Preferred contact language"
 msgstr "Bevorzugte Kontaktsprache"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1179
-#: lib/vutuv_web/templates/user/show.html.heex:1180
+#: lib/vutuv_web/templates/user/show.html.heex:1181
+#: lib/vutuv_web/templates/user/show.html.heex:1182
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr "+%{code} ist die Ländervorwahl von %{region}"
@@ -10767,7 +10769,7 @@ msgstr[1] "%{formatted} Sterne"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:62
 #: lib/vutuv_web/agent_docs/text.ex:59
-#: lib/vutuv_web/templates/user/show.html.heex:1325
+#: lib/vutuv_web/templates/user/show.html.heex:1327
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr "Code"
@@ -11046,14 +11048,14 @@ msgid_plural "You have %{formatted} new messages."
 msgstr[0] "Sie haben %{formatted} neue Nachricht."
 msgstr[1] "Sie haben %{formatted} neue Nachrichten."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:189
+#: lib/vutuv_web/templates/settings/preferences.html.heex:272
 #, elixir-autogen, elixir-format
 msgid "Break long words at syllable points so the text wraps evenly. Helpful in the narrow phone column."
 msgstr ""
 "Trennt lange Wörter an Silbengrenzen, damit der Text gleichmäßig umbricht. "
 "Hilfreich in der schmalen Smartphone-Spalte."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:120
+#: lib/vutuv_web/templates/settings/preferences.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "How posts you read are shortened in your feed and on profiles. These are your own reading preferences."
 msgstr ""
@@ -11061,35 +11063,35 @@ msgstr ""
 "Das sind Ihre eigenen Anzeige-Einstellungen."
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:68
-#: lib/vutuv_web/templates/settings/preferences.html.heex:196
+#: lib/vutuv_web/templates/settings/preferences.html.heex:279
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on desktop"
 msgstr "Silbentrennung am Desktop"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:69
-#: lib/vutuv_web/templates/settings/preferences.html.heex:200
+#: lib/vutuv_web/templates/settings/preferences.html.heex:283
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on mobile"
 msgstr "Silbentrennung auf dem Smartphone"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:186
+#: lib/vutuv_web/templates/settings/preferences.html.heex:269
 #, elixir-autogen, elixir-format
 msgid "Hyphenation"
 msgstr "Silbentrennung"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:66
-#: lib/vutuv_web/templates/settings/preferences.html.heex:143
+#: lib/vutuv_web/templates/settings/preferences.html.heex:226
 #, elixir-autogen, elixir-format
 msgid "Lines on desktop"
 msgstr "Zeilen am Desktop"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:67
-#: lib/vutuv_web/templates/settings/preferences.html.heex:152
+#: lib/vutuv_web/templates/settings/preferences.html.heex:235
 #, elixir-autogen, elixir-format
 msgid "Lines on mobile"
 msgstr "Zeilen auf dem Smartphone"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:138
+#: lib/vutuv_web/templates/settings/preferences.html.heex:221
 #, elixir-autogen, elixir-format
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
@@ -11101,7 +11103,7 @@ msgstr ""
 msgid "Post display settings saved."
 msgstr "Anzeige-Einstellungen für Beiträge gespeichert."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:135
+#: lib/vutuv_web/templates/settings/preferences.html.heex:218
 #, elixir-autogen, elixir-format
 msgid "Shorten a post after"
 msgstr "Beitrag kürzen nach"
@@ -11202,7 +11204,8 @@ msgid "Preferences of %{name}"
 msgstr "Einstellungen von %{name}"
 
 #: lib/vutuv_web/templates/settings/preferences.html.heex:102
-#: lib/vutuv_web/templates/settings/preferences.html.heex:220
+#: lib/vutuv_web/templates/settings/preferences.html.heex:185
+#: lib/vutuv_web/templates/settings/preferences.html.heex:303
 #, elixir-autogen, elixir-format
 msgid "Reset to the site defaults"
 msgstr "Auf die Standardwerte zurücksetzen"
@@ -11236,17 +11239,17 @@ msgstr ""
 "wählt, und was ausgeloggte Besucher sehen. Änderungen gelten sofort; "
 "Mitglieder mit eigenem Wert sind nicht betroffen."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:80
+#: lib/vutuv_web/gettext_extraction_anchors.ex:88
 #, elixir-autogen, elixir-format
 msgid "0 means posts are never shortened."
 msgstr "0 bedeutet: Beiträge werden nie gekürzt."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:86
+#: lib/vutuv_web/gettext_extraction_anchors.ex:94
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr "Aus"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:85
+#: lib/vutuv_web/gettext_extraction_anchors.ex:93
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr "An"
@@ -11412,19 +11415,19 @@ msgstr ""
 " Konto anlegen kann. Wählen Sie „Niemand“, um den Status zu speichern, ohne "
 "ihn anzuzeigen."
 
-#: lib/vutuv/accounts/user.ex:1122
+#: lib/vutuv/accounts/user.ex:1155
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Alle, auch nicht angemeldete Besucher"
 
-#: lib/vutuv/accounts/user.ex:1127
+#: lib/vutuv/accounts/user.ex:1160
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Niemand"
 
-#: lib/vutuv/accounts/user.ex:1125
+#: lib/vutuv/accounts/user.ex:1158
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:566
 #, elixir-autogen, elixir-format
@@ -12469,7 +12472,7 @@ msgstr "Organisation wieder freigegeben."
 #: lib/vutuv_web/agent_docs/markdown.ex:418
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:388
-#: lib/vutuv_web/components/ui.ex:3946
+#: lib/vutuv_web/components/ui.ex:3949
 #: lib/vutuv_web/controllers/settings_controller.ex:179
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
@@ -12795,7 +12798,7 @@ msgstr "Halten Sie Strg / Cmd gedrückt, um mehrere auszuwählen."
 msgid "How to apply"
 msgstr "So bewerben Sie sich"
 
-#: lib/vutuv/accounts/user.ex:1096
+#: lib/vutuv/accounts/user.ex:1129
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12915,7 +12918,7 @@ msgstr "Hier ist noch nichts. Jobs, die Ihnen gefallen, erscheinen hier."
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) für KI-Agenten anbieten."
 
-#: lib/vutuv/accounts/user.ex:1095
+#: lib/vutuv/accounts/user.ex:1128
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12997,7 +13000,7 @@ msgstr "Anzeige nicht gefunden."
 msgid "Publish"
 msgstr "Veröffentlichen"
 
-#: lib/vutuv/accounts/user.ex:1097
+#: lib/vutuv/accounts/user.ex:1130
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:564
 #: lib/vutuv_web/agent_docs/markdown.ex:458
@@ -13724,12 +13727,12 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "E-Mail-Benachrichtigungen für Ihre gespeicherte Suche „%{label}“ stoppen?"
 
-#: lib/vutuv_web/components/post_components.ex:2207
+#: lib/vutuv_web/components/post_components.ex:2277
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:651
 #: lib/vutuv_web/controllers/settings_controller.ex:669
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:387
-#: lib/vutuv_web/live/organization_live/following.ex:140
+#: lib/vutuv_web/live/organization_live/following.ex:141
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr "Das hat nicht geklappt."
@@ -14025,7 +14028,7 @@ msgstr "Screenshot entfernt."
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr "Dieser Screenshot wurde automatisch aus dem Link in Ihrem Beitrag erstellt. Falls er unbrauchbar ist (zum Beispiel weil ein Cookie-Banner die Seite verdeckt), können Sie ihn entfernen."
 
-#: lib/vutuv/accounts/user.ex:1140
+#: lib/vutuv/accounts/user.ex:1173
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -14036,19 +14039,19 @@ msgstr "Nur das Alter, ohne das Datum"
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr "Wählen Sie, wie viel von Ihrem Geburtstag Ihr Profil zeigt. „Nur das Alter“ verbirgt das genaue Datum, „Tag und Monat“ verbirgt das Jahr (und Ihr Alter), und „Nicht anzeigen“ speichert ihn weiterhin, hält ihn aber von Ihrem Profil fern."
 
-#: lib/vutuv/accounts/user.ex:1143
+#: lib/vutuv/accounts/user.ex:1176
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Tag und Monat, ohne das Jahr"
 
-#: lib/vutuv/accounts/user.ex:1146
+#: lib/vutuv/accounts/user.ex:1179
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Geburtstag nicht anzeigen"
 
-#: lib/vutuv/accounts/user.ex:1137
+#: lib/vutuv/accounts/user.ex:1170
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -14177,14 +14180,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3888
 #: lib/vutuv_web/controllers/settings_controller.ex:570
-#: lib/vutuv_web/live/post_live/feed.ex:1158
+#: lib/vutuv_web/live/post_live/feed.ex:1271
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr "Tags, denen Sie folgen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1173
+#: lib/vutuv_web/live/post_live/feed.ex:1286
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr "#%{tag} entfolgen"
@@ -14228,7 +14231,7 @@ msgstr "Signal und WhatsApp akzeptieren eine Telefonnummer oder einen Benutzerna
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1291
+#: lib/vutuv_web/templates/user/show.html.heex:1293
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr "Messenger hinzufügen"
@@ -14265,7 +14268,7 @@ msgstr "Messenger wurde geändert."
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1289
+#: lib/vutuv_web/templates/user/show.html.heex:1291
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr "Messenger"
@@ -14342,34 +14345,34 @@ msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch imm
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:4342
+#: lib/vutuv_web/components/post_components.ex:4435
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1158
-#: lib/vutuv_web/components/post_components.ex:4299
+#: lib/vutuv_web/components/post_components.ex:4392
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:4343
+#: lib/vutuv_web/components/post_components.ex:4436
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:4345
+#: lib/vutuv_web/components/post_components.ex:4438
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:4341
+#: lib/vutuv_web/components/post_components.ex:4434
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1158
-#: lib/vutuv_web/components/post_components.ex:4298
+#: lib/vutuv_web/components/post_components.ex:4391
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Filmbesprechung"
@@ -14380,12 +14383,12 @@ msgstr "Filmbesprechung"
 msgid "Look up"
 msgstr "Nachschlagen"
 
-#: lib/vutuv_web/components/post_components.ex:4340
+#: lib/vutuv_web/components/post_components.ex:4433
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
 
-#: lib/vutuv_web/components/post_components.ex:4344
+#: lib/vutuv_web/components/post_components.ex:4437
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14405,7 +14408,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:4381
+#: lib/vutuv_web/components/post_components.ex:4474
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14413,27 +14416,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:4411
+#: lib/vutuv_web/components/post_components.ex:4504
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:4412
+#: lib/vutuv_web/components/post_components.ex:4505
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:4410
+#: lib/vutuv_web/components/post_components.ex:4503
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:4370
+#: lib/vutuv_web/components/post_components.ex:4463
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:4417
+#: lib/vutuv_web/components/post_components.ex:4510
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14463,7 +14466,7 @@ msgstr "Mit Qualifikation:"
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:4184
+#: lib/vutuv_web/components/post_components.ex:4277
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
@@ -14511,7 +14514,7 @@ msgstr "folgen Ihnen jetzt."
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:4175
+#: lib/vutuv_web/components/post_components.ex:4268
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
@@ -14653,22 +14656,22 @@ msgid "proof document"
 msgstr "Nachweis"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:74
-#: lib/vutuv_web/templates/settings/preferences.html.heex:174
+#: lib/vutuv_web/templates/settings/preferences.html.heex:257
 #, elixir-autogen, elixir-format
 msgid "Lines in notifications"
 msgstr "Zeilen in Benachrichtigungen"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:81
+#: lib/vutuv_web/gettext_extraction_anchors.ex:89
 #, elixir-autogen, elixir-format
 msgid "How much of a post a notification quotes before it is cut off."
 msgstr "Wie viel von einem Beitrag eine Benachrichtigung zitiert, bevor abgeschnitten wird."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:165
+#: lib/vutuv_web/templates/settings/preferences.html.heex:248
 #, elixir-autogen, elixir-format
 msgid "Quoted posts in notifications"
 msgstr "Zitierte Beiträge in Benachrichtigungen"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:168
+#: lib/vutuv_web/templates/settings/preferences.html.heex:251
 #, elixir-autogen, elixir-format
 msgid "Your notifications quote the post someone liked or replied to. Leave the field empty to follow the site default."
 msgstr ""
@@ -14883,7 +14886,7 @@ msgstr "Konto einfrieren"
 msgid "No accounts are currently frozen."
 msgstr "Zurzeit sind keine Konten eingefroren."
 
-#: lib/vutuv_web/live/post_live/thread.ex:416
+#: lib/vutuv_web/live/post_live/thread.ex:458
 #, elixir-autogen, elixir-format
 msgid "Read it from the start"
 msgstr "Von Anfang an lesen"
@@ -14903,14 +14906,14 @@ msgstr "Konto zum Einfrieren suchen"
 msgid "See all frozen accounts"
 msgstr "Alle eingefrorenen Konten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2471
+#: lib/vutuv_web/components/post_components.ex:2554
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "%{formatted} früheren Beitrag anzeigen"
 msgstr[1] "%{formatted} frühere Beiträge anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2493
+#: lib/vutuv_web/components/post_components.ex:2578
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14922,7 +14925,7 @@ msgstr[1] "%{formatted} weitere Antworten anzeigen"
 msgid "This page is no longer available."
 msgstr "Diese Seite ist nicht mehr verfügbar."
 
-#: lib/vutuv_web/live/post_live/thread.ex:408
+#: lib/vutuv_web/live/post_live/thread.ex:450
 #, elixir-autogen, elixir-format
 msgid "This post is part of a conversation with %{formatted} posts."
 msgstr "Dieser Beitrag ist Teil einer Unterhaltung mit %{formatted} Beiträgen."
@@ -14937,7 +14940,7 @@ msgstr "Dieses Profil ist zurzeit nicht verfügbar."
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das Konto zu finden, das eingefroren werden soll."
 
-#: lib/vutuv_web/components/post_components.ex:4809
+#: lib/vutuv_web/components/post_components.ex:4902
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Der eigene Beitrag lässt sich nicht mit „Gefällt mir“ markieren."
@@ -15084,7 +15087,7 @@ msgstr "Nach einem Tag filtern"
 msgid "Filter removed."
 msgstr "Filter entfernt."
 
-#: lib/vutuv_web/live/post_live/feed.ex:295
+#: lib/vutuv_web/live/post_live/feed.ex:327
 #, elixir-autogen, elixir-format
 msgid "Hidden: matches your filter"
 msgstr "Ausgeblendet: passt zu Ihrem Filter"
@@ -15119,7 +15122,7 @@ msgstr ""
 "Wählen Sie unten einen Abschluss oder eine Schule, um ihn statt eines "
 "Jobtitels oben in Ihrem Profil anzuzeigen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:304
+#: lib/vutuv_web/live/post_live/feed.ex:336
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr "Trotzdem anzeigen"
@@ -15406,7 +15409,7 @@ msgstr "Geben Sie es weiter wie eine E-Mail-Adresse. Jeder bei Mastodon und Co. 
 msgid "Nobody yet. Post your handle where people can see it, and the first follows will show up here."
 msgstr "Noch niemand. Posten Sie Ihr Handle dort, wo andere es sehen, dann tauchen die ersten Follower hier auf."
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:303
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:305
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Related"
@@ -15678,7 +15681,7 @@ msgstr "Anwendung bearbeiten"
 msgid "Book an ad"
 msgstr "Anzeige buchen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1001
+#: lib/vutuv_web/templates/user/show.html.heex:1003
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr "%{name} hat dieses Fediverse-Konto umgezogen. Folgen Sie stattdessen der neuen Adresse:"
@@ -15799,12 +15802,12 @@ msgstr "Die Themen, für die Sie bekannt sind"
 msgid "skill topic keyword expertise endorsement"
 msgstr "fähigkeit kenntnis thema stichwort schlagwort expertise empfehlung"
 
-#: lib/vutuv_web/components/ui.ex:3947
+#: lib/vutuv_web/components/ui.ex:3950
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr "Organisationsseiten, die Sie verwalten"
 
-#: lib/vutuv_web/components/ui.ex:3948
+#: lib/vutuv_web/components/ui.ex:3951
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr "firma unternehmen arbeitgeber betrieb organisation seite"
@@ -15959,52 +15962,42 @@ msgstr "Passkeys, angemeldete Geräte, Anmeldecodes"
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr "passwort kennwort anmelden abmelden login logout sitzung gerät passkey totp 2fa pin sicherheit"
 
-#: lib/vutuv_web/components/ui.ex:3935
-#, elixir-autogen, elixir-format
-msgid "Interface language, maps, how posts are shortened"
-msgstr "Sprache der Oberfläche, Karten, Kürzung von Beiträgen"
-
-#: lib/vutuv_web/components/ui.ex:3936
-#, elixir-autogen, elixir-format
-msgid "german english locale translation map font length hyphenation"
-msgstr "deutsch englisch sprache übersetzung karte schrift länge silbentrennung darstellung"
-
-#: lib/vutuv_web/components/ui.ex:3939
+#: lib/vutuv_web/components/ui.ex:3942
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr "Ihre Daten von LinkedIn übernehmen"
 
-#: lib/vutuv_web/components/ui.ex:3940
+#: lib/vutuv_web/components/ui.ex:3943
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr "linkedin hochladen zip übernehmen importieren umzug"
 
-#: lib/vutuv_web/components/ui.ex:3943
+#: lib/vutuv_web/components/ui.ex:3946
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr "Alles herunterladen, was wir über Sie speichern"
 
-#: lib/vutuv_web/components/ui.ex:3944
+#: lib/vutuv_web/components/ui.ex:3947
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr "herunterladen download dsgvo gdpr daten sicherung json lebenslauf auskunft"
 
-#: lib/vutuv_web/components/ui.ex:3951
+#: lib/vutuv_web/components/ui.ex:3954
 #, elixir-autogen, elixir-format
 msgid "Connected apps and access tokens"
 msgstr "Verbundene Apps und Zugriffstoken"
 
-#: lib/vutuv_web/components/ui.ex:3952
+#: lib/vutuv_web/components/ui.ex:3955
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party"
 msgstr "api token oauth entwickler verbunden drittanbieter schnittstelle"
 
-#: lib/vutuv_web/components/ui.ex:3955
+#: lib/vutuv_web/components/ui.ex:3958
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr "Ihr Konto und alles darauf entfernen"
 
-#: lib/vutuv_web/components/ui.ex:3956
+#: lib/vutuv_web/components/ui.ex:3959
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr "löschen entfernen schließen kündigen beenden verlassen"
@@ -16126,21 +16119,21 @@ msgstr ""
 "wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
-#: lib/vutuv_web/components/post_components.ex:4757
+#: lib/vutuv_web/components/post_components.ex:4850
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:4761
+#: lib/vutuv_web/components/post_components.ex:4854
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Like"
 msgstr[1] "%{formatted} Likes"
 
-#: lib/vutuv_web/components/post_components.ex:4765
+#: lib/vutuv_web/components/post_components.ex:4858
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -16148,7 +16141,7 @@ msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1107
-#: lib/vutuv_web/components/post_components.ex:4716
+#: lib/vutuv_web/components/post_components.ex:4809
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Bereits in den Zahlen oben enthalten."
@@ -16164,14 +16157,14 @@ msgstr "Antworten, die dort draußen geschrieben werden, erscheinen unter Ihrem 
 msgid "Content warning"
 msgstr "Inhaltswarnung"
 
-#: lib/vutuv_web/components/post_components.ex:1198
-#: lib/vutuv_web/components/post_components.ex:1754
+#: lib/vutuv_web/components/post_components.ex:1236
+#: lib/vutuv_web/components/post_components.ex:1801
 #: lib/vutuv_web/live/fediverse_account_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr "Aus einem anderen Netzwerk"
 
-#: lib/vutuv_web/components/post_components.ex:1085
+#: lib/vutuv_web/components/post_components.ex:1112
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr "Diese Antwort aus Ihrem Beitrag entfernen?"
@@ -16193,12 +16186,12 @@ msgstr "Antworten aus anderen Netzwerken"
 msgid "Reply from another network"
 msgstr "Antwort aus einem anderen Netzwerk"
 
-#: lib/vutuv_web/live/post_live/thread.ex:146
+#: lib/vutuv_web/live/post_live/thread.ex:150
 #, elixir-autogen, elixir-format
 msgid "Reply removed."
 msgstr "Antwort entfernt."
 
-#: lib/vutuv_web/components/post_components.ex:1094
+#: lib/vutuv_web/components/post_components.ex:1121
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
@@ -16208,7 +16201,7 @@ msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
 msgid "Reported as not appropriate"
 msgstr "Als unangemessen gemeldet"
 
-#: lib/vutuv_web/components/post_components.ex:1108
+#: lib/vutuv_web/components/post_components.ex:1135
 #: lib/vutuv_web/live/notification_live/index.ex:545
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -16229,20 +16222,20 @@ msgstr "Gespeicherte Antworten"
 msgid "Taken down"
 msgstr "Entfernt"
 
-#: lib/vutuv_web/live/post_live/thread.ex:155
+#: lib/vutuv_web/live/post_live/thread.ex:159
 #, elixir-autogen, elixir-format
 msgid "Thank you. The reply was deleted right away."
 msgstr "Danke. Die Antwort wurde sofort gelöscht."
 
-#: lib/vutuv_web/live/post_live/thread.ex:315
+#: lib/vutuv_web/live/post_live/thread.ex:351
 #, elixir-autogen, elixir-format
 msgid "That reply is not yours to remove."
 msgstr "Diese Antwort können Sie nicht entfernen."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1291
-#: lib/vutuv_web/components/post_components.ex:1129
-#: lib/vutuv_web/components/post_components.ex:1329
-#: lib/vutuv_web/components/post_components.ex:2127
+#: lib/vutuv_web/components/post_components.ex:1167
+#: lib/vutuv_web/components/post_components.ex:1367
+#: lib/vutuv_web/components/post_components.ex:2197
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr "Original ansehen"
@@ -16254,7 +16247,7 @@ msgstr "Original ansehen"
 msgid "What"
 msgstr "Was"
 
-#: lib/vutuv_web/live/post_live/thread.ex:311
+#: lib/vutuv_web/live/post_live/thread.ex:347
 #: lib/vutuv_web/live/remote_post_actions.ex:47
 #, elixir-autogen, elixir-format
 msgid "You have reported a lot today. Please try again tomorrow."
@@ -16908,22 +16901,22 @@ msgstr "Was sich an welchem Konto geändert hat, wann, von welchem Gerät und wi
 msgid "device or detail"
 msgstr "Gerät oder Detail"
 
-#: lib/vutuv_web/components/post_components.ex:2655
+#: lib/vutuv_web/components/post_components.ex:2740
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Angehefteter Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:2766
+#: lib/vutuv_web/components/post_components.ex:2851
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "An Profil anheften"
 
-#: lib/vutuv_web/components/post_components.ex:2774
+#: lib/vutuv_web/components/post_components.ex:2859
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Vom Profil lösen"
 
-#: lib/vutuv_web/components/post_components.ex:2760
+#: lib/vutuv_web/components/post_components.ex:2845
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr "Es lässt sich nur ein Beitrag an Ihr Profil anheften. Diesen anheften und den anderen lösen?"
@@ -17015,7 +17008,7 @@ msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1219
 #: lib/vutuv_web/agent_docs/text.ex:765
-#: lib/vutuv_web/components/post_components.ex:3257
+#: lib/vutuv_web/components/post_components.ex:3342
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr "Original herunterladen"
@@ -17045,7 +17038,7 @@ msgstr "Volle Auflösung, direkt aus dem Beitrag."
 msgid "Just the picture"
 msgstr "Nur das Bild"
 
-#: lib/vutuv_web/components/post_components.ex:3256
+#: lib/vutuv_web/components/post_components.ex:3341
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr "Nächstes Foto"
@@ -17055,29 +17048,29 @@ msgstr "Nächstes Foto"
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
 
-#: lib/vutuv_web/components/post_components.ex:3637
+#: lib/vutuv_web/components/post_components.ex:3722
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post so far."
 msgstr "Bisher sehen nur Sie diesen Beitrag."
 
-#: lib/vutuv_web/components/post_components.ex:2260
+#: lib/vutuv_web/components/post_components.ex:2330
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Fediverse-Einstellungen öffnen"
 
-#: lib/vutuv_web/components/post_components.ex:3640
+#: lib/vutuv_web/components/post_components.ex:3725
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] "Unsere KI prüft das Foto. Sobald es durch ist, geht der Beitrag von selbst online."
 msgstr[1] "Unsere KI prüft die Fotos, %{done} von %{total} sind durch. Sobald das letzte durch ist, geht der Beitrag von selbst online."
 
-#: lib/vutuv_web/components/post_components.ex:3463
+#: lib/vutuv_web/components/post_components.ex:3548
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} von %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:2979
+#: lib/vutuv_web/components/post_components.ex:3064
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
@@ -17090,12 +17083,12 @@ msgstr "Foto-Einstellungen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1252
 #: lib/vutuv_web/agent_docs/text.ex:752
-#: lib/vutuv_web/components/post_components.ex:3674
+#: lib/vutuv_web/components/post_components.ex:3759
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Fotos:"
 
-#: lib/vutuv_web/components/post_components.ex:3255
+#: lib/vutuv_web/components/post_components.ex:3340
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr "Vorheriges Foto"
@@ -17116,7 +17109,7 @@ msgstr "Dieselben Bildpunkte, sonst nichts: Ort und Seriennummern entfernt, Qual
 msgid "Show camera settings"
 msgstr "Kameradaten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2313
+#: lib/vutuv_web/components/post_components.ex:2383
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr "Dieser Server ist auf dieser Seite gesperrt, deshalb kann keine Antwort dorthin gesendet werden."
@@ -17136,7 +17129,7 @@ msgstr "Dieses Dateiformat lässt sich nur unverändert weitergeben. Entfernen S
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr "Dieses Foto enthält den Ort, an dem es aufgenommen wurde. Wer die exakte Datei herunterlädt, kann ihn auslesen."
 
-#: lib/vutuv_web/components/post_components.ex:2304
+#: lib/vutuv_web/components/post_components.ex:2374
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht öffentlich beantworten."
@@ -17146,12 +17139,12 @@ msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht �
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr "Diese Antwort wurde in einem anderen Netzwerk geschrieben. Sie zu beantworten heißt, Ihre Worte in dieses Netzwerk zu senden, und das tut vutuv nur für Mitglieder, die die Fediverse-Teilnahme eingeschaltet haben."
 
-#: lib/vutuv_web/components/post_components.ex:2322
+#: lib/vutuv_web/components/post_components.ex:2392
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Diese Seite nimmt nicht am Fediverse teil."
 
-#: lib/vutuv_web/components/post_components.ex:2256
+#: lib/vutuv_web/components/post_components.ex:2326
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Fediverse-Teilnahme einschalten, um zu antworten"
@@ -17166,7 +17159,7 @@ msgstr "Wer diese Fotos weiterverwenden darf"
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke geschickt. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:2317
+#: lib/vutuv_web/components/post_components.ex:2387
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshalb werden von hier aus keine Antworten mehr gesendet."
@@ -17176,7 +17169,7 @@ msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshal
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr "Ihre Fediverse-Einstellungen erlauben es derzeit nicht, eine Antwort zu senden."
 
-#: lib/vutuv_web/components/post_components.ex:2270
+#: lib/vutuv_web/components/post_components.ex:2340
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr "Ihre Antwort geht an %{handle} auf dem eigenen Server und an Ihre Fediverse-Follower. Auf vutuv ist sie ebenfalls ein öffentlicher Beitrag."
@@ -17197,8 +17190,8 @@ msgstr "Fotos hinzufügen"
 msgid "Licence"
 msgstr "Lizenz"
 
-#: lib/vutuv_web/live/post_live/feed.ex:970
-#: lib/vutuv_web/live/post_live/feed.ex:971
+#: lib/vutuv_web/live/post_live/feed.ex:1077
+#: lib/vutuv_web/live/post_live/feed.ex:1078
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr "Fotos posten"
@@ -17263,13 +17256,13 @@ msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exak
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1125
-#: lib/vutuv_web/components/post_components.ex:4754
+#: lib/vutuv_web/components/post_components.ex:4847
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1123
-#: lib/vutuv_web/components/post_components.ex:4751
+#: lib/vutuv_web/components/post_components.ex:4844
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} hat das geteilt"
@@ -17279,7 +17272,7 @@ msgstr "%{handle} hat das geteilt"
 msgid "Fediverse reactions"
 msgstr "Fediverse-Reaktionen"
 
-#: lib/vutuv_web/components/post_components.ex:4643
+#: lib/vutuv_web/components/post_components.ex:4736
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
@@ -17383,7 +17376,7 @@ msgstr "Fotodetails"
 #: lib/vutuv_web/live/fediverse_following_live.ex:60
 #: lib/vutuv_web/live/fediverse_following_live.ex:301
 #: lib/vutuv_web/live/fediverse_following_live.ex:314
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:312
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:314
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:159
 #, elixir-autogen, elixir-format
 msgid "Accounts you follow elsewhere"
@@ -17442,7 +17435,7 @@ msgid "Mastodon and the other networks work like email: an address is enough. Pa
 msgstr "Mastodon und die anderen Netzwerke funktionieren wie E-Mail: Eine Adresse genügt. Fügen Sie hier eine ein, und vutuv fragt den betreffenden Server, ob Sie dem Konto folgen dürfen."
 
 #: lib/vutuv_web/components/fediverse_components.ex:314
-#: lib/vutuv_web/live/organization_live/following.ex:247
+#: lib/vutuv_web/live/organization_live/following.ex:249
 #, elixir-autogen, elixir-format
 msgid "Requested"
 msgstr "Angefragt"
@@ -17626,7 +17619,7 @@ msgstr "Von hier aus wird %{follows} Konten in anderen Netzwerken gefolgt, davon
 msgid "Cached posts"
 msgstr "Zwischengespeicherte Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:2082
+#: lib/vutuv_web/components/post_components.ex:2143
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr "Nur für die Follower dieses Kontos"
@@ -17636,7 +17629,7 @@ msgstr "Nur für die Follower dieses Kontos"
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Danke. Unsere Kopie wurde sofort gelöscht."
 
-#: lib/vutuv_web/components/post_components.ex:2126
+#: lib/vutuv_web/components/post_components.ex:2196
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Beim Original abstimmen"
@@ -17656,24 +17649,24 @@ msgstr "Zwischengespeicherter Beitrag gemeldet, hier für alle entfernt"
 msgid "Content from other networks taken down by members"
 msgstr "Von Mitgliedern entfernte Inhalte aus anderen Netzwerken"
 
-#: lib/vutuv_web/components/post_components.ex:1453
+#: lib/vutuv_web/components/post_components.ex:1495
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr "Verbergen"
 
-#: lib/vutuv_web/components/post_components.ex:2099
+#: lib/vutuv_web/components/post_components.ex:2161
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Von der verfassenden Person als sensibel markiert"
 
-#: lib/vutuv_web/components/post_components.ex:2061
+#: lib/vutuv_web/components/post_components.ex:2122
 #, elixir-autogen, elixir-format
 msgid "Mute %{handle}"
 msgstr "%{handle} stummschalten"
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:225
 #: lib/vutuv_web/live/fediverse_post_live.ex:104
-#: lib/vutuv_web/live/post_live/feed.ex:436
+#: lib/vutuv_web/live/post_live/feed.ex:495
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
 msgstr "Stummgeschaltet. Sie folgen dem Konto weiterhin; die Beiträge verschwinden aus Ihrem Feed."
@@ -17683,7 +17676,7 @@ msgstr "Stummgeschaltet. Sie folgen dem Konto weiterhin; die Beiträge verschwin
 msgid "Nobody has removed or reported anything yet."
 msgstr "Bisher hat niemand etwas entfernt oder gemeldet."
 
-#: lib/vutuv_web/components/post_components.ex:2068
+#: lib/vutuv_web/components/post_components.ex:2129
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr "Diesen Beitrag als unangemessen melden? Unsere Kopie wird sofort für alle auf diesem vutuv gelöscht."
@@ -17905,27 +17898,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] "(ein Bild)"
 msgstr[1] "(%{count} Bilder)"
 
-#: lib/vutuv_web/components/post_components.ex:1857
+#: lib/vutuv_web/components/post_components.ex:1904
 #, elixir-autogen, elixir-format
 msgid "A picture is on its way."
 msgstr "Ein Bild ist unterwegs."
 
-#: lib/vutuv_web/components/post_components.ex:1886
+#: lib/vutuv_web/components/post_components.ex:1933
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr "Wieder verdecken"
 
-#: lib/vutuv_web/components/post_components.ex:1881
+#: lib/vutuv_web/components/post_components.ex:1928
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr "Heikles Motiv. Bild anzeigen."
 
-#: lib/vutuv_web/components/post_components.ex:2163
+#: lib/vutuv_web/components/post_components.ex:2233
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Das sind viele Likes in einer Stunde. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:2169
+#: lib/vutuv_web/components/post_components.ex:2239
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Diesen Beitrag gibt es hier nicht mehr."
@@ -17935,7 +17928,7 @@ msgstr "Diesen Beitrag gibt es hier nicht mehr."
 msgid "Back to the feed"
 msgstr "Zurück zum Feed"
 
-#: lib/vutuv_web/components/post_components.ex:2308
+#: lib/vutuv_web/components/post_components.ex:2378
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17986,7 +17979,7 @@ msgstr ""
 "Dieser Link zeigt auf einen einzelnen Beitrag. Von hier aus können Sie dem "
 "Konto dahinter folgen: %{account}."
 
-#: lib/vutuv_web/live/user_profile_live.ex:1341
+#: lib/vutuv_web/live/user_profile_live.ex:1377
 #, elixir-autogen, elixir-format
 msgid "You already follow one member."
 msgid_plural "You already follow %{count} members."
@@ -18248,7 +18241,7 @@ msgstr "Einen Beitrag über seine Adresse nachschlagen"
 msgid "Look up a post from another network"
 msgstr "Einen Beitrag aus einem anderen Netzwerk nachschlagen"
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:306
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "Looking for an account rather than a single post?"
 msgstr "Suchen Sie ein Konto statt eines einzelnen Beitrags?"
@@ -18273,7 +18266,7 @@ msgstr "Das sieht nicht nach dem Link zu einem Beitrag aus. Kopieren Sie die Adr
 msgid "That is a link on this vutuv, not on another network."
 msgstr "Das ist ein Link auf dieses vutuv, nicht auf ein anderes Netzwerk."
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:298
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "Their account page here"
 msgstr "Die Seite dieses Kontos hier"
@@ -18323,7 +18316,7 @@ msgstr "Sie haben in der letzten Stunde viele Beiträge nachgeschlagen. Bitte ve
 msgid "You redirected your Fediverse followers to another account, so nothing is fetched or sent from this one any more."
 msgstr "Sie haben Ihre Fediverse-Follower auf ein anderes Konto umgeleitet, deshalb wird von diesem Konto aus nichts mehr geholt und nichts mehr gesendet."
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:316
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr "Einen nachgeschlagenen Beitrag bewahrt vutuv genauso sechs Monate lang auf wie jeden anderen Beitrag aus einem anderen Netzwerk. Der Server der verfassenden Person wird sonst nichts gefragt."
@@ -18718,7 +18711,7 @@ msgstr "Auf vutuv gibt es zu diesem Tag noch keine Beiträge."
 msgid "word in a post"
 msgstr "Wort in einem Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:2166
+#: lib/vutuv_web/components/post_components.ex:2236
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr "Diese Antwort gibt es hier nicht mehr."
@@ -19021,19 +19014,19 @@ msgstr "Auf der Seite eines Beitrags stehen direkt unter der Zahl die Mitglieder
 msgid "Liked by"
 msgstr "Gefällt diesen Mitgliedern"
 
-#: lib/vutuv_web/components/post_components.ex:3921
+#: lib/vutuv_web/components/post_components.ex:4014
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Gefällt %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:3923
+#: lib/vutuv_web/components/post_components.ex:4016
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Gefällt %{name} und %{formatted} weiteren"
 msgstr[1] "Gefällt %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/components/post_components.ex:3934
+#: lib/vutuv_web/components/post_components.ex:4027
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr "Nur Sie sehen hier alle: Einige dieser Mitglieder werden anderen Lesern nicht genannt."
@@ -19053,7 +19046,7 @@ msgstr "Meinen Namen bei Beiträgen zeigen, die mir gefallen"
 msgid "When off, other members no longer see you among the likes of a post. The author of the post still does: we named you in the notification they got when you liked it. Either way the post keeps the same number of likes."
 msgstr "Wenn aus, sehen andere Mitglieder Sie nicht mehr bei den Likes eines Beitrags. Die Autorin oder der Autor des Beitrags sieht es weiterhin: In der Benachrichtigung von damals haben wir Sie namentlich genannt. Der Beitrag hat in beiden Fällen gleich viele Likes."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:761
+#: lib/vutuv_web/controllers/settings_controller.ex:789
 #, elixir-autogen, elixir-format
 msgid "Your likes follow the site default again."
 msgstr "Ihre Likes folgen wieder dem Standardwert der Website."
@@ -19095,7 +19088,7 @@ msgstr "Für dieses Zeugnis läuft bereits eine Prüfung."
 #: lib/vutuv_web/controllers/job_reference_controller.ex:144
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:18
 #: lib/vutuv_web/templates/job_reference/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:771
+#: lib/vutuv_web/templates/user/show.html.heex:773
 #, elixir-autogen, elixir-format
 msgid "Add an employment reference"
 msgstr "Arbeitszeugnis hinzufügen"
@@ -19170,7 +19163,7 @@ msgstr "Arbeitszeugnis aktualisiert."
 #: lib/vutuv_web/templates/job_reference/new.html.heex:4
 #: lib/vutuv_web/templates/job_reference/show.html.heex:12
 #: lib/vutuv_web/templates/job_reference/view.html.heex:11
-#: lib/vutuv_web/templates/user/show.html.heex:768
+#: lib/vutuv_web/templates/user/show.html.heex:770
 #, elixir-autogen, elixir-format
 msgid "Employment references"
 msgstr "Arbeitszeugnisse"
@@ -19803,7 +19796,7 @@ msgstr "Ihr vutuv-Benutzername steht fest."
 msgid "by the lawyer Tom Braegelmann"
 msgstr "von Rechtsanwalt Tom Braegelmann"
 
-#: lib/vutuv_web/templates/user/show.html.heex:812
+#: lib/vutuv_web/templates/user/show.html.heex:814
 #, elixir-autogen, elixir-format
 msgid "Documents:"
 msgstr "Belegt:"
@@ -19993,7 +19986,7 @@ msgstr ""
 "ändern, und unter {import_url} importieren Sie ein bestehendes "
 "LinkedIn-Profil."
 
-#: lib/vutuv_web/live/user_profile_live.ex:1326
+#: lib/vutuv_web/live/user_profile_live.ex:1362
 #, elixir-autogen, elixir-format
 msgid "Follow other members"
 msgstr "Anderen Mitgliedern folgen"
@@ -20005,17 +19998,17 @@ msgstr ""
 "Kommt keine PIN an? Ist die E-Mail-Adresse {email} korrekt? Haben Sie einmal "
 "in Ihren Spam-Ordner geschaut?"
 
-#: lib/vutuv/accounts/user.ex:1243
+#: lib/vutuv/accounts/user.ex:1276
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/vutuv/accounts/user.ex:1241
+#: lib/vutuv/accounts/user.ex:1274
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr "Weiblich"
 
-#: lib/vutuv/accounts/user.ex:1242
+#: lib/vutuv/accounts/user.ex:1275
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Männlich"
@@ -20703,7 +20696,7 @@ msgstr "Suchen Sie so oft Sie möchten und nehmen Sie dazu, was gehört. Abkürz
 msgid "Start over"
 msgstr "Von vorn beginnen"
 
-#: lib/vutuv_web/components/post_components.ex:2196
+#: lib/vutuv_web/components/post_components.ex:2266
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr "Ein Herz oder ein Repost geht zurück in das Netzwerk, aus dem dieser Beitrag stammt. Ihr Konto nimmt derzeit nicht am Fediverse teil. Einschalten können Sie das in den {settings}."
@@ -20891,7 +20884,7 @@ msgstr "Feed – %{name}"
 msgid "Follow as %{name}"
 msgstr "Als %{name} folgen"
 
-#: lib/vutuv_web/live/organization_live/following.ex:160
+#: lib/vutuv_web/live/organization_live/following.ex:161
 #, elixir-autogen, elixir-format
 msgid "Members and organizations"
 msgstr "Mitglieder und Organisationen"
@@ -20901,28 +20894,28 @@ msgstr "Mitglieder und Organisationen"
 msgid "Nothing here yet. This page does not follow anyone, or nobody it follows has published."
 msgstr "Noch nichts da. Diese Seite folgt niemandem, oder niemand, dem sie folgt, hat etwas veröffentlicht."
 
-#: lib/vutuv_web/live/organization_live/following.ex:156
+#: lib/vutuv_web/live/organization_live/following.ex:157
 #, elixir-autogen, elixir-format
 msgid "The members, organizations and topics this page follows. Everything here shapes its feed, and only the team can see this list."
 msgstr "Die Mitglieder, Organisationen und Themen, denen diese Seite folgt. Alles hier prägt ihren Feed, und nur das Team sieht diese Liste."
 
-#: lib/vutuv_web/live/organization_live/following.ex:266
+#: lib/vutuv_web/live/organization_live/following.ex:268
 #, elixir-autogen, elixir-format
 msgid "This page does not follow any topics yet."
 msgstr "Diese Seite folgt noch keinem Thema."
 
-#: lib/vutuv_web/live/organization_live/following.ex:163
+#: lib/vutuv_web/live/organization_live/following.ex:164
 #, elixir-autogen, elixir-format
 msgid "This page does not follow anyone yet."
 msgstr "Diese Seite folgt noch niemandem."
 
-#: lib/vutuv_web/live/organization_live/following.ex:263
+#: lib/vutuv_web/live/organization_live/following.ex:265
 #, elixir-autogen, elixir-format
 msgid "Topics"
 msgstr "Themen"
 
-#: lib/vutuv_web/live/organization_live/following.ex:276
-#: lib/vutuv_web/live/organization_live/following.ex:277
+#: lib/vutuv_web/live/organization_live/following.ex:278
+#: lib/vutuv_web/live/organization_live/following.ex:279
 #, elixir-autogen, elixir-format
 msgid "Unfollow %{tag}"
 msgstr "%{tag} entfolgen"
@@ -20932,7 +20925,7 @@ msgstr "%{tag} entfolgen"
 msgid "What the members and organizations this page follows have published. Liking or saving something here is done from your own account, not the page's."
 msgstr "Was die Mitglieder und Organisationen veröffentlicht haben, denen diese Seite folgt. Wer hier etwas mag oder speichert, tut das aus dem eigenen Konto, nicht aus dem der Seite."
 
-#: lib/vutuv_web/live/organization_live/following.ex:52
+#: lib/vutuv_web/live/organization_live/following.ex:53
 #, elixir-autogen, elixir-format
 msgid "Follows – %{name}"
 msgstr "Folgt – %{name}"
@@ -20952,42 +20945,42 @@ msgstr "Seiteneinstellungen"
 msgid "Switching this off stops new posts from leaving. Copies another server already holds can only be asked to delete them, never made to."
 msgstr "Das Ausschalten hält neue Beiträge zurück. Kopien, die ein anderer Server schon hat, kann man nur um Löschung bitten, nie dazu zwingen."
 
-#: lib/vutuv_web/live/organization_live/following.ex:206
+#: lib/vutuv_web/live/organization_live/following.ex:207
 #, elixir-autogen, elixir-format
 msgid "Accounts on other networks"
 msgstr "Konten auf anderen Netzwerken"
 
-#: lib/vutuv_web/live/organization_live/following.ex:216
+#: lib/vutuv_web/live/organization_live/following.ex:217
 #, elixir-autogen, elixir-format
 msgid "Fediverse address"
 msgstr "Fediverse-Adresse"
 
-#: lib/vutuv_web/live/organization_live/following.ex:126
+#: lib/vutuv_web/live/organization_live/following.ex:127
 #, elixir-autogen, elixir-format
 msgid "That does not look like a Fediverse address."
 msgstr "Das sieht nicht nach einer Fediverse-Adresse aus."
 
-#: lib/vutuv_web/live/organization_live/following.ex:132
+#: lib/vutuv_web/live/organization_live/following.ex:133
 #, elixir-autogen, elixir-format
 msgid "That server did not answer."
 msgstr "Dieser Server hat nicht geantwortet."
 
-#: lib/vutuv_web/live/organization_live/following.ex:138
+#: lib/vutuv_web/live/organization_live/following.ex:139
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this installation."
 msgstr "Dieser Server ist auf dieser Installation gesperrt."
 
-#: lib/vutuv_web/live/organization_live/following.ex:129
+#: lib/vutuv_web/live/organization_live/following.ex:130
 #, elixir-autogen, elixir-format
 msgid "This page already follows that account."
 msgstr "Diese Seite folgt diesem Konto bereits."
 
-#: lib/vutuv_web/live/organization_live/following.ex:226
+#: lib/vutuv_web/live/organization_live/following.ex:227
 #, elixir-autogen, elixir-format
 msgid "This page does not follow anyone on another network yet."
 msgstr "Diese Seite folgt noch niemandem auf einem anderen Netzwerk."
 
-#: lib/vutuv_web/live/organization_live/following.ex:135
+#: lib/vutuv_web/live/organization_live/following.ex:136
 #, elixir-autogen, elixir-format
 msgid "Too many attempts for now. Try again later."
 msgstr "Zu viele Versuche. Bitte versuchen Sie es später erneut."
@@ -21545,27 +21538,87 @@ msgstr "Sprache des Beitrags"
 msgid "The language this post is written in"
 msgstr "Die Sprache, in der dieser Beitrag geschrieben ist"
 
-#: lib/vutuv_web/components/post_components.ex:3837
+#: lib/vutuv_web/components/post_components.ex:3922
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Original anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:3858
+#: lib/vutuv_web/components/post_components.ex:3943
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Übersetzen"
 
-#: lib/vutuv_web/components/post_components.ex:3867
+#: lib/vutuv_web/components/post_components.ex:3952
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Übersetzt"
 
-#: lib/vutuv_web/components/post_components.ex:3870
+#: lib/vutuv_web/components/post_components.ex:3955
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Übersetzt aus %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:3847
+#: lib/vutuv_web/components/post_components.ex:3932
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Wird übersetzt …"
+
+#: lib/vutuv_web/controllers/settings_controller.ex:780
+#, elixir-autogen, elixir-format
+msgid "Feed language settings reset to the site defaults."
+msgstr "Feed-Spracheinstellungen auf die Website-Vorgaben zurückgesetzt."
+
+#: lib/vutuv_web/controllers/settings_controller.ex:768
+#, elixir-autogen, elixir-format
+msgid "Feed language settings saved."
+msgstr "Feed-Spracheinstellungen gespeichert."
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:116
+#, elixir-autogen, elixir-format
+msgid "Feed languages"
+msgstr "Feed-Sprachen"
+
+#: lib/vutuv_web/components/ui.ex:3935
+#, elixir-autogen, elixir-format
+msgid "Interface language, feed languages, maps, how posts are shortened"
+msgstr "Sprache der Oberfläche, Feed-Sprachen, Karten, Kürzung von Beiträgen"
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:118
+#, elixir-autogen, elixir-format
+msgid "Pick which languages your feed shows, and what happens to posts in other languages. Posts that declare no language always show."
+msgstr "Wählen Sie, welche Sprachen Ihr Feed zeigt und was mit Beiträgen in anderen Sprachen passiert. Beiträge ohne Sprachangabe werden immer gezeigt."
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:128
+#, elixir-autogen, elixir-format
+msgid "Show these languages"
+msgstr "Diese Sprachen zeigen"
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:131
+#, elixir-autogen, elixir-format
+msgid "Ticking every box (or none) means: all languages."
+msgstr "Alle Kästchen angehakt (oder keins) bedeutet: alle Sprachen."
+
+#: lib/vutuv_web/components/ui.ex:3937
+#, elixir-autogen, elixir-format
+msgid "german english locale translation translate map font length hyphenation feed languages hide foreign übersetzen sprache"
+msgstr "deutsch englisch locale übersetzung übersetzen karte schrift länge silbentrennung feed sprachen ausblenden fremdsprache"
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:83
+#, elixir-autogen, elixir-format
+msgid "Hide them"
+msgstr "Ausblenden"
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:81
+#, elixir-autogen, elixir-format
+msgid "Posts in other languages"
+msgstr "Beiträge in anderen Sprachen"
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:82
+#, elixir-autogen, elixir-format
+msgid "Translate into my language"
+msgstr "In meine Sprache übersetzen"
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:84
+#, elixir-autogen, elixir-format
+msgid "What your feed does with posts outside your chosen languages: show them as they are, translate them for you, or hide them. Posts that declare no language always show."
+msgstr "Was Ihr Feed mit Beiträgen außerhalb Ihrer gewählten Sprachen macht: im Original zeigen, für Sie übersetzen oder ausblenden. Beiträge ohne Sprachangabe werden immer gezeigt."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -40,7 +40,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1445
+#: lib/vutuv_web/templates/user/show.html.heex:1447
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -105,7 +105,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:595
 #: lib/vutuv_web/agent_docs/text.ex:555
 #: lib/vutuv_web/agent_docs/text.ex:556
-#: lib/vutuv_web/templates/user/show.html.heex:1077
+#: lib/vutuv_web/templates/user/show.html.heex:1079
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
@@ -152,7 +152,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1115
+#: lib/vutuv_web/templates/user/show.html.heex:1117
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -161,7 +161,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2782
+#: lib/vutuv_web/components/post_components.ex:2867
 #: lib/vutuv_web/components/ui.ex:3492
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -210,7 +210,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2747
+#: lib/vutuv_web/components/post_components.ex:2832
 #: lib/vutuv_web/components/ui.ex:3483
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -224,7 +224,7 @@ msgstr ""
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:1100
+#: lib/vutuv_web/templates/user/show.html.heex:1102
 #, elixir-autogen
 msgid "Edit"
 msgstr ""
@@ -289,7 +289,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:609
+#: lib/vutuv_web/templates/user/show.html.heex:611
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -336,7 +336,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/show.ex:471
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:53
-#: lib/vutuv_web/templates/user/show.html.heex:955
+#: lib/vutuv_web/templates/user/show.html.heex:957
 #, elixir-autogen
 msgid "Following"
 msgstr ""
@@ -624,7 +624,8 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/notifications.html.heex:79
 #: lib/vutuv_web/templates/settings/preferences.html.heex:29
 #: lib/vutuv_web/templates/settings/preferences.html.heex:85
-#: lib/vutuv_web/templates/settings/preferences.html.heex:205
+#: lib/vutuv_web/templates/settings/preferences.html.heex:168
+#: lib/vutuv_web/templates/settings/preferences.html.heex:288
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:443
@@ -652,7 +653,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1450
+#: lib/vutuv_web/components/post_components.ex:1492
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -688,13 +689,13 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1229
+#: lib/vutuv_web/templates/user/show.html.heex:1231
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1231
+#: lib/vutuv_web/templates/user/show.html.heex:1233
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -738,7 +739,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/follow_controller.ex:24
 #: lib/vutuv_web/controllers/remote_follow_controller.ex:166
 #: lib/vutuv_web/controllers/user_save_controller.ex:45
-#: lib/vutuv_web/live/user_profile_live.ex:155
+#: lib/vutuv_web/live/user_profile_live.ex:159
 #, elixir-autogen
 msgid "Something went wrong"
 msgstr ""
@@ -848,8 +849,8 @@ msgid "vCard"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3553
-#: lib/vutuv_web/templates/user/show.html.heex:949
-#: lib/vutuv_web/templates/user/show.html.heex:972
+#: lib/vutuv_web/templates/user/show.html.heex:951
+#: lib/vutuv_web/templates/user/show.html.heex:974
 #, elixir-autogen
 msgid "View All"
 msgstr ""
@@ -924,7 +925,7 @@ msgid "You follow back %{name}."
 msgstr ""
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:77
+#: lib/vutuv_web/live/post_live/feed.ex:78
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1039,7 +1040,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1066
+#: lib/vutuv_web/templates/user/show.html.heex:1068
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1205,7 +1206,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:603
+#: lib/vutuv_web/templates/user/show.html.heex:605
 #, elixir-autogen
 msgid "All tags"
 msgstr ""
@@ -1401,7 +1402,7 @@ msgstr ""
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:23
 #: lib/vutuv_web/templates/tag/show.html.heex:25
-#: lib/vutuv_web/templates/user/show.html.heex:573
+#: lib/vutuv_web/templates/user/show.html.heex:575
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
@@ -1615,7 +1616,7 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3254
+#: lib/vutuv_web/components/post_components.ex:3339
 #: lib/vutuv_web/components/ui.ex:298
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
@@ -1690,11 +1691,11 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:2227
 #: lib/vutuv_web/live/fediverse_account_live.ex:375
 #: lib/vutuv_web/live/fediverse_following_live.ex:331
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:293
-#: lib/vutuv_web/live/organization_live/following.ex:218
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:295
+#: lib/vutuv_web/live/organization_live/following.ex:219
 #: lib/vutuv_web/live/organization_live/show.ex:440
 #: lib/vutuv_web/live/organization_live/show.ex:469
-#: lib/vutuv_web/templates/user/show.html.heex:1269
+#: lib/vutuv_web/templates/user/show.html.heex:1271
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr ""
@@ -1861,7 +1862,7 @@ msgstr ""
 msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1183
+#: lib/vutuv_web/live/post_live/feed.ex:1296
 #: lib/vutuv_web/views/user_html.ex:208
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
@@ -2101,7 +2102,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2779
+#: lib/vutuv_web/components/post_components.ex:2864
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2114,9 +2115,10 @@ msgid "Edit post"
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:255
+#: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:101
-#: lib/vutuv_web/live/post_live/feed.ex:159
-#: lib/vutuv_web/live/post_live/feed.ex:936
+#: lib/vutuv_web/live/post_live/feed.ex:164
+#: lib/vutuv_web/live/post_live/feed.ex:1043
 #: lib/vutuv_web/live/shell_live.ex:606
 #: lib/vutuv_web/live/shell_live.ex:887
 #: lib/vutuv_web/templates/layout/app.html.heex:171
@@ -2144,8 +2146,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2733
-#: lib/vutuv_web/components/post_components.ex:2735
+#: lib/vutuv_web/components/post_components.ex:2818
+#: lib/vutuv_web/components/post_components.ex:2820
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2161,7 +2163,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1122
+#: lib/vutuv_web/live/post_live/feed.ex:1235
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2197,7 +2199,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/post_controller.ex:60
 #: lib/vutuv_web/controllers/post_controller.ex:69
 #: lib/vutuv_web/controllers/user_controller.ex:77
-#: lib/vutuv_web/gettext_extraction_anchors.ex:83
+#: lib/vutuv_web/gettext_extraction_anchors.ex:91
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:382
 #: lib/vutuv_web/live/notification_live/index.ex:891
@@ -2205,19 +2207,19 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:495
 #: lib/vutuv_web/live/search_live.ex:309
 #: lib/vutuv_web/live/search_live.ex:772
-#: lib/vutuv_web/templates/settings/preferences.html.heex:118
+#: lib/vutuv_web/templates/settings/preferences.html.heex:201
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3190
-#: lib/vutuv_web/components/post_components.ex:3194
+#: lib/vutuv_web/components/post_components.ex:3275
+#: lib/vutuv_web/components/post_components.ex:3279
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3191
+#: lib/vutuv_web/components/post_components.ex:3276
 #: lib/vutuv_web/live/fediverse_account_live.ex:320
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2225,7 +2227,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:342
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:1087
+#: lib/vutuv_web/components/post_components.ex:1114
 #: lib/vutuv_web/live/admin/screenshot_live.ex:338
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:700
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
@@ -2251,7 +2253,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1030
+#: lib/vutuv_web/live/post_live/feed.ex:1137
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2288,7 +2290,7 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4144
+#: lib/vutuv_web/components/ui.ex:4147
 #: lib/vutuv_web/live/shell_live.ex:788
 #: lib/vutuv_web/templates/post/index.html.heex:17
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2307,27 +2309,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2730
+#: lib/vutuv_web/components/post_components.ex:2815
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4479
+#: lib/vutuv_web/components/post_components.ex:4572
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4483
+#: lib/vutuv_web/components/post_components.ex:4576
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4481
+#: lib/vutuv_web/components/post_components.ex:4574
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4482
+#: lib/vutuv_web/components/post_components.ex:4575
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2358,7 +2360,7 @@ msgstr ""
 msgid "Posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:563
+#: lib/vutuv_web/templates/user/show.html.heex:565
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr ""
@@ -2368,8 +2370,8 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1634
-#: lib/vutuv_web/components/post_components.ex:4567
+#: lib/vutuv_web/components/post_components.ex:1681
+#: lib/vutuv_web/components/post_components.ex:4660
 #: lib/vutuv_web/components/ui.ex:3017
 #: lib/vutuv_web/views/user_html.ex:335
 #, elixir-autogen, elixir-format
@@ -2387,8 +2389,8 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1598
-#: lib/vutuv_web/components/post_components.ex:4801
+#: lib/vutuv_web/components/post_components.ex:1645
+#: lib/vutuv_web/components/post_components.ex:4894
 #: lib/vutuv_web/components/ui.ex:3003
 #: lib/vutuv_web/live/notification_live/index.ex:1038
 #: lib/vutuv_web/views/user_html.ex:345
@@ -2397,7 +2399,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1069
-#: lib/vutuv_web/components/post_components.ex:4810
+#: lib/vutuv_web/components/post_components.ex:4903
 #: lib/vutuv_web/live/notification_live/index.ex:971
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
@@ -2419,39 +2421,39 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4556
+#: lib/vutuv_web/components/post_components.ex:4649
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1634
-#: lib/vutuv_web/components/post_components.ex:4567
+#: lib/vutuv_web/components/post_components.ex:1681
+#: lib/vutuv_web/components/post_components.ex:4660
 #: lib/vutuv_web/live/post_live/saved.ex:775
 #: lib/vutuv_web/views/user_html.ex:335
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1622
-#: lib/vutuv_web/components/post_components.ex:4553
+#: lib/vutuv_web/components/post_components.ex:1669
+#: lib/vutuv_web/components/post_components.ex:4646
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1812
-#: lib/vutuv_web/components/post_components.ex:3770
+#: lib/vutuv_web/components/post_components.ex:1859
+#: lib/vutuv_web/components/post_components.ex:3855
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1622
-#: lib/vutuv_web/components/post_components.ex:4553
+#: lib/vutuv_web/components/post_components.ex:1669
+#: lib/vutuv_web/components/post_components.ex:4646
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4801
+#: lib/vutuv_web/components/post_components.ex:4894
 #: lib/vutuv_web/live/post_live/saved.ex:774
 #: lib/vutuv_web/views/user_html.ex:345
 #, elixir-autogen, elixir-format
@@ -2462,10 +2464,10 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:2057
 #: lib/vutuv_web/components/ui.ex:2057
 #: lib/vutuv_web/components/ui.ex:2194
-#: lib/vutuv_web/live/organization_live/following.ex:197
-#: lib/vutuv_web/live/organization_live/following.ex:256
+#: lib/vutuv_web/live/organization_live/following.ex:198
+#: lib/vutuv_web/live/organization_live/following.ex:258
 #: lib/vutuv_web/live/organization_live/show.ex:474
-#: lib/vutuv_web/live/post_live/feed.ex:1172
+#: lib/vutuv_web/live/post_live/feed.ex:1285
 #: lib/vutuv_web/templates/followee/index.html.heex:44
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2477,7 +2479,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4854
+#: lib/vutuv_web/components/post_components.ex:4947
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2488,16 +2490,16 @@ msgstr ""
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1609
-#: lib/vutuv_web/components/post_components.ex:4837
-#: lib/vutuv_web/components/post_components.ex:4838
+#: lib/vutuv_web/components/post_components.ex:1656
+#: lib/vutuv_web/components/post_components.ex:4930
+#: lib/vutuv_web/components/post_components.ex:4931
 #: lib/vutuv_web/live/notification_live/index.ex:1035
 #: lib/vutuv_web/live/post_live/reply.ex:42
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2697
+#: lib/vutuv_web/components/post_components.ex:2782
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2518,7 +2520,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2248
+#: lib/vutuv_web/components/post_components.ex:2318
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:59
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:56
@@ -2526,14 +2528,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2673
+#: lib/vutuv_web/components/post_components.ex:2758
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2667
-#: lib/vutuv_web/components/post_components.ex:2689
-#: lib/vutuv_web/components/post_components.ex:2692
+#: lib/vutuv_web/components/post_components.ex:2752
+#: lib/vutuv_web/components/post_components.ex:2774
+#: lib/vutuv_web/components/post_components.ex:2777
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2699,38 +2701,38 @@ msgstr ""
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
 #: lib/vutuv_web/templates/url/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:885
+#: lib/vutuv_web/templates/user/show.html.heex:887
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1189
+#: lib/vutuv_web/templates/user/show.html.heex:1191
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1447
+#: lib/vutuv_web/templates/user/show.html.heex:1449
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1117
+#: lib/vutuv_web/templates/user/show.html.heex:1119
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1068
+#: lib/vutuv_web/templates/user/show.html.heex:1070
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:612
+#: lib/vutuv_web/templates/user/show.html.heex:614
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #: lib/vutuv_web/templates/work_experience/new.html.heex:5
 #, elixir-autogen, elixir-format
@@ -2750,12 +2752,12 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:216
-#: lib/vutuv_web/templates/user/show.html.heex:603
+#: lib/vutuv_web/templates/user/show.html.heex:605
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:961
+#: lib/vutuv_web/live/post_live/feed.ex:1068
 #: lib/vutuv_web/templates/user/show.html.heex:474
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2830,7 +2832,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4480
+#: lib/vutuv_web/components/post_components.ex:4573
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2858,7 +2860,7 @@ msgid "Endorsement"
 msgstr ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:1033
-#: lib/vutuv_web/templates/user/show.html.heex:933
+#: lib/vutuv_web/templates/user/show.html.heex:935
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -3087,13 +3089,13 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1157
-#: lib/vutuv_web/templates/user/show.html.heex:1158
+#: lib/vutuv_web/templates/user/show.html.heex:1159
+#: lib/vutuv_web/templates/user/show.html.heex:1160
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2643
+#: lib/vutuv_web/components/post_components.ex:2728
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3169,9 +3171,9 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1097
-#: lib/vutuv_web/components/post_components.ex:2073
-#: lib/vutuv_web/components/post_components.ex:2803
+#: lib/vutuv_web/components/post_components.ex:1124
+#: lib/vutuv_web/components/post_components.ex:2134
+#: lib/vutuv_web/components/post_components.ex:2888
 #: lib/vutuv_web/live/organization_live/show.ex:547
 #: lib/vutuv_web/templates/user/show.html.heex:219
 #, elixir-autogen, elixir-format
@@ -4532,12 +4534,12 @@ msgid "You have not blocked anyone."
 msgstr ""
 
 #: lib/vutuv_web/controllers/block_controller.ex:89
-#: lib/vutuv_web/live/user_profile_live.ex:304
+#: lib/vutuv_web/live/user_profile_live.ex:326
 #, elixir-autogen, elixir-format
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1127
+#: lib/vutuv_web/live/post_live/feed.ex:1240
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -4548,10 +4550,10 @@ msgid "Find members"
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:261
-#: lib/vutuv_web/live/organization_live/following.ex:154
+#: lib/vutuv_web/live/organization_live/following.ex:155
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:53
-#: lib/vutuv_web/templates/user/show.html.heex:955
+#: lib/vutuv_web/templates/user/show.html.heex:957
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -4667,8 +4669,8 @@ msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:388
 #: lib/vutuv_web/live/tag_new_live.ex:48
-#: lib/vutuv_web/live/user_profile_live.ex:1295
-#: lib/vutuv_web/templates/user/show.html.heex:576
+#: lib/vutuv_web/live/user_profile_live.ex:1331
+#: lib/vutuv_web/templates/user/show.html.heex:578
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr ""
@@ -5260,7 +5262,7 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3954
+#: lib/vutuv_web/components/ui.ex:3957
 #: lib/vutuv_web/controllers/settings_controller.ex:145
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5339,10 +5341,10 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4051
-#: lib/vutuv_web/components/ui.ex:4056
-#: lib/vutuv_web/components/ui.ex:4135
-#: lib/vutuv_web/components/ui.ex:4199
+#: lib/vutuv_web/components/ui.ex:4054
+#: lib/vutuv_web/components/ui.ex:4059
+#: lib/vutuv_web/components/ui.ex:4138
+#: lib/vutuv_web/components/ui.ex:4202
 #: lib/vutuv_web/controllers/settings_controller.ex:61
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5386,7 +5388,7 @@ msgstr ""
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1301
+#: lib/vutuv_web/live/user_profile_live.ex:1337
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr ""
@@ -5412,11 +5414,11 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2868
-#: lib/vutuv_web/components/post_components.ex:2922
-#: lib/vutuv_web/components/post_components.ex:3334
+#: lib/vutuv_web/components/post_components.ex:2953
+#: lib/vutuv_web/components/post_components.ex:3007
+#: lib/vutuv_web/components/post_components.ex:3419
 #: lib/vutuv_web/live/notification_live/index.ex:691
-#: lib/vutuv_web/live/post_live/feed.ex:1245
+#: lib/vutuv_web/live/post_live/feed.ex:1358
 #: lib/vutuv_web/views/user_html.ex:113
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5632,7 +5634,7 @@ msgstr ""
 msgid "Apps"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3950
+#: lib/vutuv_web/components/ui.ex:3953
 #: lib/vutuv_web/controllers/settings_controller.ex:165
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -5858,7 +5860,7 @@ msgid_plural "%{count} minutes ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:811
+#: lib/vutuv_web/controllers/settings_controller.ex:839
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr ""
@@ -5898,7 +5900,7 @@ msgstr ""
 msgid "Signed-in devices"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:798
+#: lib/vutuv_web/controllers/settings_controller.ex:826
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr ""
@@ -6048,7 +6050,7 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1306
+#: lib/vutuv_web/live/user_profile_live.ex:1342
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr ""
@@ -6063,7 +6065,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:314
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:883
+#: lib/vutuv_web/templates/user/show.html.heex:885
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
@@ -6084,7 +6086,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1498
+#: lib/vutuv_web/templates/user/show.html.heex:1500
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6128,8 +6130,8 @@ msgstr ""
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1083
-#: lib/vutuv_web/templates/user/show.html.heex:1093
+#: lib/vutuv_web/templates/user/show.html.heex:1085
+#: lib/vutuv_web/templates/user/show.html.heex:1095
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6169,12 +6171,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1205
+#: lib/vutuv_web/templates/user/show.html.heex:1207
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1216
+#: lib/vutuv_web/templates/user/show.html.heex:1218
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6217,7 +6219,7 @@ msgstr ""
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1214
+#: lib/vutuv_web/templates/user/show.html.heex:1216
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
@@ -6265,20 +6267,20 @@ msgstr ""
 msgid "Map services to show"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:84
+#: lib/vutuv_web/gettext_extraction_anchors.ex:92
 #: lib/vutuv_web/templates/settings/preferences.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1484
-#: lib/vutuv_web/templates/user/show.html.heex:1492
-#: lib/vutuv_web/templates/user/show.html.heex:1504
+#: lib/vutuv_web/templates/user/show.html.heex:1486
+#: lib/vutuv_web/templates/user/show.html.heex:1494
+#: lib/vutuv_web/templates/user/show.html.heex:1506
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:82
+#: lib/vutuv_web/gettext_extraction_anchors.ex:90
 #: lib/vutuv_web/templates/settings/preferences.html.heex:80
 #, elixir-autogen, elixir-format
 msgid "Opens first, as the main button. The others appear as alternatives."
@@ -6609,7 +6611,7 @@ msgid "Mute"
 msgstr ""
 
 #: lib/vutuv_web/controllers/follow_controller.ex:49
-#: lib/vutuv_web/live/user_profile_live.ex:245
+#: lib/vutuv_web/live/user_profile_live.ex:267
 #, elixir-autogen, elixir-format
 msgid "Muted. Their posts no longer appear in your feed."
 msgstr ""
@@ -6633,7 +6635,7 @@ msgid "Unmute"
 msgstr ""
 
 #: lib/vutuv_web/controllers/follow_controller.ex:51
-#: lib/vutuv_web/live/user_profile_live.ex:247
+#: lib/vutuv_web/live/user_profile_live.ex:269
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts appear in your feed again."
 msgstr ""
@@ -6648,7 +6650,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2800
+#: lib/vutuv_web/components/post_components.ex:2885
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6658,7 +6660,7 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2799
+#: lib/vutuv_web/components/post_components.ex:2884
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -7339,7 +7341,7 @@ msgstr ""
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4712
+#: lib/vutuv_web/components/post_components.ex:4805
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8131,7 +8133,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
 #: lib/vutuv_web/templates/education/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:669
+#: lib/vutuv_web/templates/user/show.html.heex:671
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr ""
@@ -8156,7 +8158,7 @@ msgstr ""
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
 #: lib/vutuv_web/templates/import/preview.html.heex:44
-#: lib/vutuv_web/templates/user/show.html.heex:666
+#: lib/vutuv_web/templates/user/show.html.heex:668
 #: lib/vutuv_web/views/import_html.ex:66
 #: lib/vutuv_web/views/job_reference_html.ex:265
 #, elixir-autogen, elixir-format
@@ -8199,7 +8201,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3938
+#: lib/vutuv_web/components/ui.ex:3941
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8336,7 +8338,7 @@ msgid "Loading posts"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:140
-#: lib/vutuv_web/templates/user/show.html.heex:1351
+#: lib/vutuv_web/templates/user/show.html.heex:1353
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8424,7 +8426,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3942
+#: lib/vutuv_web/components/ui.ex:3945
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8446,13 +8448,13 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1212
-#: lib/vutuv_web/live/post_live/feed.ex:1213
+#: lib/vutuv_web/live/post_live/feed.ex:1325
+#: lib/vutuv_web/live/post_live/feed.ex:1326
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1207
+#: lib/vutuv_web/live/post_live/feed.ex:1320
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr ""
@@ -8652,8 +8654,8 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:997
-#: lib/vutuv_web/templates/user/show.html.heex:1256
+#: lib/vutuv_web/templates/user/show.html.heex:999
+#: lib/vutuv_web/templates/user/show.html.heex:1258
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr ""
@@ -8797,7 +8799,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3773
+#: lib/vutuv_web/components/post_components.ex:3858
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9049,7 +9051,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/language/manage.html.heex:8
 #: lib/vutuv_web/templates/language/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:731
+#: lib/vutuv_web/templates/user/show.html.heex:733
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr ""
@@ -9273,7 +9275,7 @@ msgstr ""
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:4
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:728
+#: lib/vutuv_web/templates/user/show.html.heex:730
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr ""
@@ -9460,7 +9462,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1084
+#: lib/vutuv/accounts/user.ex:1117
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9471,7 +9473,7 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1081
+#: lib/vutuv/accounts/user.ex:1114
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -9553,7 +9555,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:837
+#: lib/vutuv_web/templates/user/show.html.heex:839
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr ""
@@ -9602,7 +9604,7 @@ msgstr ""
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:834
+#: lib/vutuv_web/templates/user/show.html.heex:836
 #: lib/vutuv_web/views/import_html.ex:67
 #: lib/vutuv_web/views/job_reference_html.ex:266
 #, elixir-autogen, elixir-format
@@ -9721,8 +9723,8 @@ msgstr ""
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1179
-#: lib/vutuv_web/templates/user/show.html.heex:1180
+#: lib/vutuv_web/templates/user/show.html.heex:1181
+#: lib/vutuv_web/templates/user/show.html.heex:1182
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -10244,7 +10246,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:62
 #: lib/vutuv_web/agent_docs/text.ex:59
-#: lib/vutuv_web/templates/user/show.html.heex:1325
+#: lib/vutuv_web/templates/user/show.html.heex:1327
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -10502,46 +10504,46 @@ msgid_plural "You have %{formatted} new messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:189
+#: lib/vutuv_web/templates/settings/preferences.html.heex:272
 #, elixir-autogen, elixir-format
 msgid "Break long words at syllable points so the text wraps evenly. Helpful in the narrow phone column."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:120
+#: lib/vutuv_web/templates/settings/preferences.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "How posts you read are shortened in your feed and on profiles. These are your own reading preferences."
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:68
-#: lib/vutuv_web/templates/settings/preferences.html.heex:196
+#: lib/vutuv_web/templates/settings/preferences.html.heex:279
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on desktop"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:69
-#: lib/vutuv_web/templates/settings/preferences.html.heex:200
+#: lib/vutuv_web/templates/settings/preferences.html.heex:283
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on mobile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:186
+#: lib/vutuv_web/templates/settings/preferences.html.heex:269
 #, elixir-autogen, elixir-format
 msgid "Hyphenation"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:66
-#: lib/vutuv_web/templates/settings/preferences.html.heex:143
+#: lib/vutuv_web/templates/settings/preferences.html.heex:226
 #, elixir-autogen, elixir-format
 msgid "Lines on desktop"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:67
-#: lib/vutuv_web/templates/settings/preferences.html.heex:152
+#: lib/vutuv_web/templates/settings/preferences.html.heex:235
 #, elixir-autogen, elixir-format
 msgid "Lines on mobile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:138
+#: lib/vutuv_web/templates/settings/preferences.html.heex:221
 #, elixir-autogen, elixir-format
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
@@ -10551,7 +10553,7 @@ msgstr ""
 msgid "Post display settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:135
+#: lib/vutuv_web/templates/settings/preferences.html.heex:218
 #, elixir-autogen, elixir-format
 msgid "Shorten a post after"
 msgstr ""
@@ -10637,7 +10639,8 @@ msgid "Preferences of %{name}"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/preferences.html.heex:102
-#: lib/vutuv_web/templates/settings/preferences.html.heex:220
+#: lib/vutuv_web/templates/settings/preferences.html.heex:185
+#: lib/vutuv_web/templates/settings/preferences.html.heex:303
 #, elixir-autogen, elixir-format
 msgid "Reset to the site defaults"
 msgstr ""
@@ -10668,17 +10671,17 @@ msgstr ""
 msgid "What every member gets until they choose for themselves on their settings pages, and what logged-out visitors see. Changes apply immediately; members who set their own value are not affected."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:80
+#: lib/vutuv_web/gettext_extraction_anchors.ex:88
 #, elixir-autogen, elixir-format
 msgid "0 means posts are never shortened."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:86
+#: lib/vutuv_web/gettext_extraction_anchors.ex:94
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:85
+#: lib/vutuv_web/gettext_extraction_anchors.ex:93
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr ""
@@ -10828,19 +10831,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1122
+#: lib/vutuv/accounts/user.ex:1155
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1127
+#: lib/vutuv/accounts/user.ex:1160
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1125
+#: lib/vutuv/accounts/user.ex:1158
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:566
 #, elixir-autogen, elixir-format
@@ -11830,7 +11833,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:418
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:388
-#: lib/vutuv_web/components/ui.ex:3946
+#: lib/vutuv_web/components/ui.ex:3949
 #: lib/vutuv_web/controllers/settings_controller.ex:179
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
@@ -12143,7 +12146,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1096
+#: lib/vutuv/accounts/user.ex:1129
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12263,7 +12266,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1095
+#: lib/vutuv/accounts/user.ex:1128
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12345,7 +12348,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1097
+#: lib/vutuv/accounts/user.ex:1130
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:564
 #: lib/vutuv_web/agent_docs/markdown.ex:458
@@ -13066,12 +13069,12 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2207
+#: lib/vutuv_web/components/post_components.ex:2277
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:651
 #: lib/vutuv_web/controllers/settings_controller.ex:669
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:387
-#: lib/vutuv_web/live/organization_live/following.ex:140
+#: lib/vutuv_web/live/organization_live/following.ex:141
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr ""
@@ -13359,7 +13362,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1140
+#: lib/vutuv/accounts/user.ex:1173
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13370,19 +13373,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1143
+#: lib/vutuv/accounts/user.ex:1176
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1146
+#: lib/vutuv/accounts/user.ex:1179
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1137
+#: lib/vutuv/accounts/user.ex:1170
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13506,14 +13509,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3888
 #: lib/vutuv_web/controllers/settings_controller.ex:570
-#: lib/vutuv_web/live/post_live/feed.ex:1158
+#: lib/vutuv_web/live/post_live/feed.ex:1271
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1173
+#: lib/vutuv_web/live/post_live/feed.ex:1286
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr ""
@@ -13555,7 +13558,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1291
+#: lib/vutuv_web/templates/user/show.html.heex:1293
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
@@ -13592,7 +13595,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1289
+#: lib/vutuv_web/templates/user/show.html.heex:1291
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
@@ -13669,34 +13672,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4342
+#: lib/vutuv_web/components/post_components.ex:4435
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1158
-#: lib/vutuv_web/components/post_components.ex:4299
+#: lib/vutuv_web/components/post_components.ex:4392
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4343
+#: lib/vutuv_web/components/post_components.ex:4436
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4345
+#: lib/vutuv_web/components/post_components.ex:4438
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4341
+#: lib/vutuv_web/components/post_components.ex:4434
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1158
-#: lib/vutuv_web/components/post_components.ex:4298
+#: lib/vutuv_web/components/post_components.ex:4391
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13707,12 +13710,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4340
+#: lib/vutuv_web/components/post_components.ex:4433
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4344
+#: lib/vutuv_web/components/post_components.ex:4437
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13732,7 +13735,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4381
+#: lib/vutuv_web/components/post_components.ex:4474
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13740,27 +13743,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4411
+#: lib/vutuv_web/components/post_components.ex:4504
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4412
+#: lib/vutuv_web/components/post_components.ex:4505
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4410
+#: lib/vutuv_web/components/post_components.ex:4503
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4370
+#: lib/vutuv_web/components/post_components.ex:4463
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4417
+#: lib/vutuv_web/components/post_components.ex:4510
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13790,7 +13793,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4184
+#: lib/vutuv_web/components/post_components.ex:4277
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13838,7 +13841,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4175
+#: lib/vutuv_web/components/post_components.ex:4268
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -13980,22 +13983,22 @@ msgid "proof document"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:74
-#: lib/vutuv_web/templates/settings/preferences.html.heex:174
+#: lib/vutuv_web/templates/settings/preferences.html.heex:257
 #, elixir-autogen, elixir-format
 msgid "Lines in notifications"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:81
+#: lib/vutuv_web/gettext_extraction_anchors.ex:89
 #, elixir-autogen, elixir-format
 msgid "How much of a post a notification quotes before it is cut off."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:165
+#: lib/vutuv_web/templates/settings/preferences.html.heex:248
 #, elixir-autogen, elixir-format
 msgid "Quoted posts in notifications"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:168
+#: lib/vutuv_web/templates/settings/preferences.html.heex:251
 #, elixir-autogen, elixir-format
 msgid "Your notifications quote the post someone liked or replied to. Leave the field empty to follow the site default."
 msgstr ""
@@ -14188,7 +14191,7 @@ msgstr ""
 msgid "No accounts are currently frozen."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:416
+#: lib/vutuv_web/live/post_live/thread.ex:458
 #, elixir-autogen, elixir-format
 msgid "Read it from the start"
 msgstr ""
@@ -14208,14 +14211,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2471
+#: lib/vutuv_web/components/post_components.ex:2554
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2493
+#: lib/vutuv_web/components/post_components.ex:2578
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14227,7 +14230,7 @@ msgstr[1] ""
 msgid "This page is no longer available."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:408
+#: lib/vutuv_web/live/post_live/thread.ex:450
 #, elixir-autogen, elixir-format
 msgid "This post is part of a conversation with %{formatted} posts."
 msgstr ""
@@ -14242,7 +14245,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4809
+#: lib/vutuv_web/components/post_components.ex:4902
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14389,7 +14392,7 @@ msgstr ""
 msgid "Filter removed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:295
+#: lib/vutuv_web/live/post_live/feed.ex:327
 #, elixir-autogen, elixir-format
 msgid "Hidden: matches your filter"
 msgstr ""
@@ -14422,7 +14425,7 @@ msgstr ""
 msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:304
+#: lib/vutuv_web/live/post_live/feed.ex:336
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr ""
@@ -14709,7 +14712,7 @@ msgstr ""
 msgid "Nobody yet. Post your handle where people can see it, and the first follows will show up here."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:303
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:305
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Related"
@@ -14981,7 +14984,7 @@ msgstr ""
 msgid "Book an ad"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1001
+#: lib/vutuv_web/templates/user/show.html.heex:1003
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr ""
@@ -15102,12 +15105,12 @@ msgstr ""
 msgid "skill topic keyword expertise endorsement"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3947
+#: lib/vutuv_web/components/ui.ex:3950
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3948
+#: lib/vutuv_web/components/ui.ex:3951
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr ""
@@ -15262,52 +15265,42 @@ msgstr ""
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3935
-#, elixir-autogen, elixir-format
-msgid "Interface language, maps, how posts are shortened"
-msgstr ""
-
-#: lib/vutuv_web/components/ui.ex:3936
-#, elixir-autogen, elixir-format
-msgid "german english locale translation map font length hyphenation"
-msgstr ""
-
-#: lib/vutuv_web/components/ui.ex:3939
+#: lib/vutuv_web/components/ui.ex:3942
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3940
+#: lib/vutuv_web/components/ui.ex:3943
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3943
+#: lib/vutuv_web/components/ui.ex:3946
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3944
+#: lib/vutuv_web/components/ui.ex:3947
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3951
+#: lib/vutuv_web/components/ui.ex:3954
 #, elixir-autogen, elixir-format
 msgid "Connected apps and access tokens"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3952
+#: lib/vutuv_web/components/ui.ex:3955
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3955
+#: lib/vutuv_web/components/ui.ex:3958
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3956
+#: lib/vutuv_web/components/ui.ex:3959
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr ""
@@ -15415,21 +15408,21 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4757
+#: lib/vutuv_web/components/post_components.ex:4850
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4761
+#: lib/vutuv_web/components/post_components.ex:4854
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4765
+#: lib/vutuv_web/components/post_components.ex:4858
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15437,7 +15430,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1107
-#: lib/vutuv_web/components/post_components.ex:4716
+#: lib/vutuv_web/components/post_components.ex:4809
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15453,14 +15446,14 @@ msgstr ""
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1198
-#: lib/vutuv_web/components/post_components.ex:1754
+#: lib/vutuv_web/components/post_components.ex:1236
+#: lib/vutuv_web/components/post_components.ex:1801
 #: lib/vutuv_web/live/fediverse_account_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1085
+#: lib/vutuv_web/components/post_components.ex:1112
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15482,12 +15475,12 @@ msgstr ""
 msgid "Reply from another network"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:146
+#: lib/vutuv_web/live/post_live/thread.ex:150
 #, elixir-autogen, elixir-format
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1094
+#: lib/vutuv_web/components/post_components.ex:1121
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15497,7 +15490,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1108
+#: lib/vutuv_web/components/post_components.ex:1135
 #: lib/vutuv_web/live/notification_live/index.ex:545
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -15518,20 +15511,20 @@ msgstr ""
 msgid "Taken down"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:155
+#: lib/vutuv_web/live/post_live/thread.ex:159
 #, elixir-autogen, elixir-format
 msgid "Thank you. The reply was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:315
+#: lib/vutuv_web/live/post_live/thread.ex:351
 #, elixir-autogen, elixir-format
 msgid "That reply is not yours to remove."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1291
-#: lib/vutuv_web/components/post_components.ex:1129
-#: lib/vutuv_web/components/post_components.ex:1329
-#: lib/vutuv_web/components/post_components.ex:2127
+#: lib/vutuv_web/components/post_components.ex:1167
+#: lib/vutuv_web/components/post_components.ex:1367
+#: lib/vutuv_web/components/post_components.ex:2197
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -15543,7 +15536,7 @@ msgstr ""
 msgid "What"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:311
+#: lib/vutuv_web/live/post_live/thread.ex:347
 #: lib/vutuv_web/live/remote_post_actions.ex:47
 #, elixir-autogen, elixir-format
 msgid "You have reported a lot today. Please try again tomorrow."
@@ -16193,22 +16186,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2655
+#: lib/vutuv_web/components/post_components.ex:2740
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2766
+#: lib/vutuv_web/components/post_components.ex:2851
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2774
+#: lib/vutuv_web/components/post_components.ex:2859
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2760
+#: lib/vutuv_web/components/post_components.ex:2845
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16294,7 +16287,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1219
 #: lib/vutuv_web/agent_docs/text.ex:765
-#: lib/vutuv_web/components/post_components.ex:3257
+#: lib/vutuv_web/components/post_components.ex:3342
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
@@ -16324,7 +16317,7 @@ msgstr ""
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3256
+#: lib/vutuv_web/components/post_components.ex:3341
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
@@ -16334,29 +16327,29 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3637
+#: lib/vutuv_web/components/post_components.ex:3722
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post so far."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2260
+#: lib/vutuv_web/components/post_components.ex:2330
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3640
+#: lib/vutuv_web/components/post_components.ex:3725
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3463
+#: lib/vutuv_web/components/post_components.ex:3548
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2979
+#: lib/vutuv_web/components/post_components.ex:3064
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16369,12 +16362,12 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1252
 #: lib/vutuv_web/agent_docs/text.ex:752
-#: lib/vutuv_web/components/post_components.ex:3674
+#: lib/vutuv_web/components/post_components.ex:3759
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3255
+#: lib/vutuv_web/components/post_components.ex:3340
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr ""
@@ -16395,7 +16388,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2313
+#: lib/vutuv_web/components/post_components.ex:2383
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16415,7 +16408,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2304
+#: lib/vutuv_web/components/post_components.ex:2374
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16425,12 +16418,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2322
+#: lib/vutuv_web/components/post_components.ex:2392
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2256
+#: lib/vutuv_web/components/post_components.ex:2326
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16445,7 +16438,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2317
+#: lib/vutuv_web/components/post_components.ex:2387
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16455,7 +16448,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2270
+#: lib/vutuv_web/components/post_components.ex:2340
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16476,8 +16469,8 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:970
-#: lib/vutuv_web/live/post_live/feed.ex:971
+#: lib/vutuv_web/live/post_live/feed.ex:1077
+#: lib/vutuv_web/live/post_live/feed.ex:1078
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr ""
@@ -16542,13 +16535,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1125
-#: lib/vutuv_web/components/post_components.ex:4754
+#: lib/vutuv_web/components/post_components.ex:4847
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1123
-#: lib/vutuv_web/components/post_components.ex:4751
+#: lib/vutuv_web/components/post_components.ex:4844
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr ""
@@ -16558,7 +16551,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4643
+#: lib/vutuv_web/components/post_components.ex:4736
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr ""
@@ -16653,7 +16646,7 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_following_live.ex:60
 #: lib/vutuv_web/live/fediverse_following_live.ex:301
 #: lib/vutuv_web/live/fediverse_following_live.ex:314
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:312
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:314
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:159
 #, elixir-autogen, elixir-format
 msgid "Accounts you follow elsewhere"
@@ -16712,7 +16705,7 @@ msgid "Mastodon and the other networks work like email: an address is enough. Pa
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:314
-#: lib/vutuv_web/live/organization_live/following.ex:247
+#: lib/vutuv_web/live/organization_live/following.ex:249
 #, elixir-autogen, elixir-format
 msgid "Requested"
 msgstr ""
@@ -16896,7 +16889,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2082
+#: lib/vutuv_web/components/post_components.ex:2143
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
@@ -16906,7 +16899,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2126
+#: lib/vutuv_web/components/post_components.ex:2196
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16926,24 +16919,24 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1453
+#: lib/vutuv_web/components/post_components.ex:1495
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2099
+#: lib/vutuv_web/components/post_components.ex:2161
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2061
+#: lib/vutuv_web/components/post_components.ex:2122
 #, elixir-autogen, elixir-format
 msgid "Mute %{handle}"
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:225
 #: lib/vutuv_web/live/fediverse_post_live.ex:104
-#: lib/vutuv_web/live/post_live/feed.ex:436
+#: lib/vutuv_web/live/post_live/feed.ex:495
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
 msgstr ""
@@ -16953,7 +16946,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2068
+#: lib/vutuv_web/components/post_components.ex:2129
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -17175,27 +17168,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1857
+#: lib/vutuv_web/components/post_components.ex:1904
 #, elixir-autogen, elixir-format
 msgid "A picture is on its way."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1886
+#: lib/vutuv_web/components/post_components.ex:1933
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1881
+#: lib/vutuv_web/components/post_components.ex:1928
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2163
+#: lib/vutuv_web/components/post_components.ex:2233
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2169
+#: lib/vutuv_web/components/post_components.ex:2239
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr ""
@@ -17205,7 +17198,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2308
+#: lib/vutuv_web/components/post_components.ex:2378
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17245,7 +17238,7 @@ msgstr ""
 msgid "That link points at a single post. You can follow its author, %{account}, from here."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1341
+#: lib/vutuv_web/live/user_profile_live.ex:1377
 #, elixir-autogen, elixir-format
 msgid "You already follow one member."
 msgid_plural "You already follow %{count} members."
@@ -17505,7 +17498,7 @@ msgstr ""
 msgid "Look up a post from another network"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:306
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "Looking for an account rather than a single post?"
 msgstr ""
@@ -17530,7 +17523,7 @@ msgstr ""
 msgid "That is a link on this vutuv, not on another network."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:298
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "Their account page here"
 msgstr ""
@@ -17580,7 +17573,7 @@ msgstr ""
 msgid "You redirected your Fediverse followers to another account, so nothing is fetched or sent from this one any more."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:316
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr ""
@@ -17972,7 +17965,7 @@ msgstr ""
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2166
+#: lib/vutuv_web/components/post_components.ex:2236
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -18275,19 +18268,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3921
+#: lib/vutuv_web/components/post_components.ex:4014
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3923
+#: lib/vutuv_web/components/post_components.ex:4016
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3934
+#: lib/vutuv_web/components/post_components.ex:4027
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -18307,7 +18300,7 @@ msgstr ""
 msgid "When off, other members no longer see you among the likes of a post. The author of the post still does: we named you in the notification they got when you liked it. Either way the post keeps the same number of likes."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:761
+#: lib/vutuv_web/controllers/settings_controller.ex:789
 #, elixir-autogen, elixir-format
 msgid "Your likes follow the site default again."
 msgstr ""
@@ -18347,7 +18340,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/job_reference_controller.ex:144
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:18
 #: lib/vutuv_web/templates/job_reference/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:771
+#: lib/vutuv_web/templates/user/show.html.heex:773
 #, elixir-autogen, elixir-format
 msgid "Add an employment reference"
 msgstr ""
@@ -18422,7 +18415,7 @@ msgstr ""
 #: lib/vutuv_web/templates/job_reference/new.html.heex:4
 #: lib/vutuv_web/templates/job_reference/show.html.heex:12
 #: lib/vutuv_web/templates/job_reference/view.html.heex:11
-#: lib/vutuv_web/templates/user/show.html.heex:768
+#: lib/vutuv_web/templates/user/show.html.heex:770
 #, elixir-autogen, elixir-format
 msgid "Employment references"
 msgstr ""
@@ -19055,7 +19048,7 @@ msgstr ""
 msgid "by the lawyer Tom Braegelmann"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:812
+#: lib/vutuv_web/templates/user/show.html.heex:814
 #, elixir-autogen, elixir-format
 msgid "Documents:"
 msgstr ""
@@ -19231,7 +19224,7 @@ msgstr ""
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1326
+#: lib/vutuv_web/live/user_profile_live.ex:1362
 #, elixir-autogen, elixir-format
 msgid "Follow other members"
 msgstr ""
@@ -19241,17 +19234,17 @@ msgstr ""
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1243
+#: lib/vutuv/accounts/user.ex:1276
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1241
+#: lib/vutuv/accounts/user.ex:1274
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1242
+#: lib/vutuv/accounts/user.ex:1275
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -19937,7 +19930,7 @@ msgstr ""
 msgid "Start over"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2196
+#: lib/vutuv_web/components/post_components.ex:2266
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -20125,7 +20118,7 @@ msgstr ""
 msgid "Follow as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:160
+#: lib/vutuv_web/live/organization_live/following.ex:161
 #, elixir-autogen, elixir-format
 msgid "Members and organizations"
 msgstr ""
@@ -20135,28 +20128,28 @@ msgstr ""
 msgid "Nothing here yet. This page does not follow anyone, or nobody it follows has published."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:156
+#: lib/vutuv_web/live/organization_live/following.ex:157
 #, elixir-autogen, elixir-format
 msgid "The members, organizations and topics this page follows. Everything here shapes its feed, and only the team can see this list."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:266
+#: lib/vutuv_web/live/organization_live/following.ex:268
 #, elixir-autogen, elixir-format
 msgid "This page does not follow any topics yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:163
+#: lib/vutuv_web/live/organization_live/following.ex:164
 #, elixir-autogen, elixir-format
 msgid "This page does not follow anyone yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:263
+#: lib/vutuv_web/live/organization_live/following.ex:265
 #, elixir-autogen, elixir-format
 msgid "Topics"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:276
-#: lib/vutuv_web/live/organization_live/following.ex:277
+#: lib/vutuv_web/live/organization_live/following.ex:278
+#: lib/vutuv_web/live/organization_live/following.ex:279
 #, elixir-autogen, elixir-format
 msgid "Unfollow %{tag}"
 msgstr ""
@@ -20166,7 +20159,7 @@ msgstr ""
 msgid "What the members and organizations this page follows have published. Liking or saving something here is done from your own account, not the page's."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:52
+#: lib/vutuv_web/live/organization_live/following.ex:53
 #, elixir-autogen, elixir-format
 msgid "Follows – %{name}"
 msgstr ""
@@ -20186,42 +20179,42 @@ msgstr ""
 msgid "Switching this off stops new posts from leaving. Copies another server already holds can only be asked to delete them, never made to."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:206
+#: lib/vutuv_web/live/organization_live/following.ex:207
 #, elixir-autogen, elixir-format
 msgid "Accounts on other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:216
+#: lib/vutuv_web/live/organization_live/following.ex:217
 #, elixir-autogen, elixir-format
 msgid "Fediverse address"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:126
+#: lib/vutuv_web/live/organization_live/following.ex:127
 #, elixir-autogen, elixir-format
 msgid "That does not look like a Fediverse address."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:132
+#: lib/vutuv_web/live/organization_live/following.ex:133
 #, elixir-autogen, elixir-format
 msgid "That server did not answer."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:138
+#: lib/vutuv_web/live/organization_live/following.ex:139
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this installation."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:129
+#: lib/vutuv_web/live/organization_live/following.ex:130
 #, elixir-autogen, elixir-format
 msgid "This page already follows that account."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:226
+#: lib/vutuv_web/live/organization_live/following.ex:227
 #, elixir-autogen, elixir-format
 msgid "This page does not follow anyone on another network yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:135
+#: lib/vutuv_web/live/organization_live/following.ex:136
 #, elixir-autogen, elixir-format
 msgid "Too many attempts for now. Try again later."
 msgstr ""
@@ -20755,27 +20748,87 @@ msgstr ""
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3837
+#: lib/vutuv_web/components/post_components.ex:3922
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3858
+#: lib/vutuv_web/components/post_components.ex:3943
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3867
+#: lib/vutuv_web/components/post_components.ex:3952
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3870
+#: lib/vutuv_web/components/post_components.ex:3955
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3847
+#: lib/vutuv_web/components/post_components.ex:3932
 #, elixir-autogen, elixir-format
 msgid "Translating…"
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:780
+#, elixir-autogen, elixir-format
+msgid "Feed language settings reset to the site defaults."
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:768
+#, elixir-autogen, elixir-format
+msgid "Feed language settings saved."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:116
+#, elixir-autogen, elixir-format
+msgid "Feed languages"
+msgstr ""
+
+#: lib/vutuv_web/components/ui.ex:3935
+#, elixir-autogen, elixir-format
+msgid "Interface language, feed languages, maps, how posts are shortened"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:118
+#, elixir-autogen, elixir-format
+msgid "Pick which languages your feed shows, and what happens to posts in other languages. Posts that declare no language always show."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:128
+#, elixir-autogen, elixir-format
+msgid "Show these languages"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:131
+#, elixir-autogen, elixir-format
+msgid "Ticking every box (or none) means: all languages."
+msgstr ""
+
+#: lib/vutuv_web/components/ui.ex:3937
+#, elixir-autogen, elixir-format
+msgid "german english locale translation translate map font length hyphenation feed languages hide foreign übersetzen sprache"
+msgstr ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:83
+#, elixir-autogen, elixir-format
+msgid "Hide them"
+msgstr ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:81
+#, elixir-autogen, elixir-format
+msgid "Posts in other languages"
+msgstr ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:82
+#, elixir-autogen, elixir-format
+msgid "Translate into my language"
+msgstr ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:84
+#, elixir-autogen, elixir-format
+msgid "What your feed does with posts outside your chosen languages: show them as they are, translate them for you, or hide them. Posts that declare no language always show."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -38,7 +38,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1445
+#: lib/vutuv_web/templates/user/show.html.heex:1447
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -103,7 +103,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:595
 #: lib/vutuv_web/agent_docs/text.ex:555
 #: lib/vutuv_web/agent_docs/text.ex:556
-#: lib/vutuv_web/templates/user/show.html.heex:1077
+#: lib/vutuv_web/templates/user/show.html.heex:1079
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
@@ -150,7 +150,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1115
+#: lib/vutuv_web/templates/user/show.html.heex:1117
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -159,7 +159,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2782
+#: lib/vutuv_web/components/post_components.ex:2867
 #: lib/vutuv_web/components/ui.ex:3492
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -208,7 +208,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2747
+#: lib/vutuv_web/components/post_components.ex:2832
 #: lib/vutuv_web/components/ui.ex:3483
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -222,7 +222,7 @@ msgstr ""
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:1100
+#: lib/vutuv_web/templates/user/show.html.heex:1102
 #, elixir-autogen
 msgid "Edit"
 msgstr ""
@@ -287,7 +287,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:609
+#: lib/vutuv_web/templates/user/show.html.heex:611
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -334,7 +334,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/show.ex:471
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:53
-#: lib/vutuv_web/templates/user/show.html.heex:955
+#: lib/vutuv_web/templates/user/show.html.heex:957
 #, elixir-autogen
 msgid "Following"
 msgstr ""
@@ -622,7 +622,8 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/notifications.html.heex:79
 #: lib/vutuv_web/templates/settings/preferences.html.heex:29
 #: lib/vutuv_web/templates/settings/preferences.html.heex:85
-#: lib/vutuv_web/templates/settings/preferences.html.heex:205
+#: lib/vutuv_web/templates/settings/preferences.html.heex:168
+#: lib/vutuv_web/templates/settings/preferences.html.heex:288
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:443
@@ -650,7 +651,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1450
+#: lib/vutuv_web/components/post_components.ex:1492
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -686,13 +687,13 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1229
+#: lib/vutuv_web/templates/user/show.html.heex:1231
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1231
+#: lib/vutuv_web/templates/user/show.html.heex:1233
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -736,7 +737,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/follow_controller.ex:24
 #: lib/vutuv_web/controllers/remote_follow_controller.ex:166
 #: lib/vutuv_web/controllers/user_save_controller.ex:45
-#: lib/vutuv_web/live/user_profile_live.ex:155
+#: lib/vutuv_web/live/user_profile_live.ex:159
 #, elixir-autogen
 msgid "Something went wrong"
 msgstr ""
@@ -846,8 +847,8 @@ msgid "vCard"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3553
-#: lib/vutuv_web/templates/user/show.html.heex:949
-#: lib/vutuv_web/templates/user/show.html.heex:972
+#: lib/vutuv_web/templates/user/show.html.heex:951
+#: lib/vutuv_web/templates/user/show.html.heex:974
 #, elixir-autogen
 msgid "View All"
 msgstr ""
@@ -922,7 +923,7 @@ msgid "You follow back %{name}."
 msgstr ""
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:77
+#: lib/vutuv_web/live/post_live/feed.ex:78
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1037,7 +1038,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1066
+#: lib/vutuv_web/templates/user/show.html.heex:1068
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1203,7 +1204,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:603
+#: lib/vutuv_web/templates/user/show.html.heex:605
 #, elixir-autogen
 msgid "All tags"
 msgstr ""
@@ -1399,7 +1400,7 @@ msgstr ""
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:23
 #: lib/vutuv_web/templates/tag/show.html.heex:25
-#: lib/vutuv_web/templates/user/show.html.heex:573
+#: lib/vutuv_web/templates/user/show.html.heex:575
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
@@ -1613,7 +1614,7 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3254
+#: lib/vutuv_web/components/post_components.ex:3339
 #: lib/vutuv_web/components/ui.ex:298
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
@@ -1688,11 +1689,11 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:2227
 #: lib/vutuv_web/live/fediverse_account_live.ex:375
 #: lib/vutuv_web/live/fediverse_following_live.ex:331
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:293
-#: lib/vutuv_web/live/organization_live/following.ex:218
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:295
+#: lib/vutuv_web/live/organization_live/following.ex:219
 #: lib/vutuv_web/live/organization_live/show.ex:440
 #: lib/vutuv_web/live/organization_live/show.ex:469
-#: lib/vutuv_web/templates/user/show.html.heex:1269
+#: lib/vutuv_web/templates/user/show.html.heex:1271
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr ""
@@ -1859,7 +1860,7 @@ msgstr ""
 msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1183
+#: lib/vutuv_web/live/post_live/feed.ex:1296
 #: lib/vutuv_web/views/user_html.ex:208
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
@@ -2099,7 +2100,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2779
+#: lib/vutuv_web/components/post_components.ex:2864
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2112,9 +2113,10 @@ msgid "Edit post"
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:255
+#: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:101
-#: lib/vutuv_web/live/post_live/feed.ex:159
-#: lib/vutuv_web/live/post_live/feed.ex:936
+#: lib/vutuv_web/live/post_live/feed.ex:164
+#: lib/vutuv_web/live/post_live/feed.ex:1043
 #: lib/vutuv_web/live/shell_live.ex:606
 #: lib/vutuv_web/live/shell_live.ex:887
 #: lib/vutuv_web/templates/layout/app.html.heex:171
@@ -2142,8 +2144,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2733
-#: lib/vutuv_web/components/post_components.ex:2735
+#: lib/vutuv_web/components/post_components.ex:2818
+#: lib/vutuv_web/components/post_components.ex:2820
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2159,7 +2161,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1122
+#: lib/vutuv_web/live/post_live/feed.ex:1235
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2195,7 +2197,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/post_controller.ex:60
 #: lib/vutuv_web/controllers/post_controller.ex:69
 #: lib/vutuv_web/controllers/user_controller.ex:77
-#: lib/vutuv_web/gettext_extraction_anchors.ex:83
+#: lib/vutuv_web/gettext_extraction_anchors.ex:91
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:382
 #: lib/vutuv_web/live/notification_live/index.ex:891
@@ -2203,19 +2205,19 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:495
 #: lib/vutuv_web/live/search_live.ex:309
 #: lib/vutuv_web/live/search_live.ex:772
-#: lib/vutuv_web/templates/settings/preferences.html.heex:118
+#: lib/vutuv_web/templates/settings/preferences.html.heex:201
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3190
-#: lib/vutuv_web/components/post_components.ex:3194
+#: lib/vutuv_web/components/post_components.ex:3275
+#: lib/vutuv_web/components/post_components.ex:3279
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3191
+#: lib/vutuv_web/components/post_components.ex:3276
 #: lib/vutuv_web/live/fediverse_account_live.ex:320
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2223,7 +2225,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:342
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:1087
+#: lib/vutuv_web/components/post_components.ex:1114
 #: lib/vutuv_web/live/admin/screenshot_live.ex:338
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:700
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
@@ -2249,7 +2251,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1030
+#: lib/vutuv_web/live/post_live/feed.ex:1137
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2286,7 +2288,7 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4144
+#: lib/vutuv_web/components/ui.ex:4147
 #: lib/vutuv_web/live/shell_live.ex:788
 #: lib/vutuv_web/templates/post/index.html.heex:17
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2305,27 +2307,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2730
+#: lib/vutuv_web/components/post_components.ex:2815
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4479
+#: lib/vutuv_web/components/post_components.ex:4572
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4483
+#: lib/vutuv_web/components/post_components.ex:4576
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4481
+#: lib/vutuv_web/components/post_components.ex:4574
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4482
+#: lib/vutuv_web/components/post_components.ex:4575
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2356,7 +2358,7 @@ msgstr ""
 msgid "Posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:563
+#: lib/vutuv_web/templates/user/show.html.heex:565
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr ""
@@ -2366,8 +2368,8 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1634
-#: lib/vutuv_web/components/post_components.ex:4567
+#: lib/vutuv_web/components/post_components.ex:1681
+#: lib/vutuv_web/components/post_components.ex:4660
 #: lib/vutuv_web/components/ui.ex:3017
 #: lib/vutuv_web/views/user_html.ex:335
 #, elixir-autogen, elixir-format
@@ -2385,8 +2387,8 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1598
-#: lib/vutuv_web/components/post_components.ex:4801
+#: lib/vutuv_web/components/post_components.ex:1645
+#: lib/vutuv_web/components/post_components.ex:4894
 #: lib/vutuv_web/components/ui.ex:3003
 #: lib/vutuv_web/live/notification_live/index.ex:1038
 #: lib/vutuv_web/views/user_html.ex:345
@@ -2395,7 +2397,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1069
-#: lib/vutuv_web/components/post_components.ex:4810
+#: lib/vutuv_web/components/post_components.ex:4903
 #: lib/vutuv_web/live/notification_live/index.ex:971
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
@@ -2417,39 +2419,39 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4556
+#: lib/vutuv_web/components/post_components.ex:4649
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1634
-#: lib/vutuv_web/components/post_components.ex:4567
+#: lib/vutuv_web/components/post_components.ex:1681
+#: lib/vutuv_web/components/post_components.ex:4660
 #: lib/vutuv_web/live/post_live/saved.ex:775
 #: lib/vutuv_web/views/user_html.ex:335
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1622
-#: lib/vutuv_web/components/post_components.ex:4553
+#: lib/vutuv_web/components/post_components.ex:1669
+#: lib/vutuv_web/components/post_components.ex:4646
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1812
-#: lib/vutuv_web/components/post_components.ex:3770
+#: lib/vutuv_web/components/post_components.ex:1859
+#: lib/vutuv_web/components/post_components.ex:3855
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1622
-#: lib/vutuv_web/components/post_components.ex:4553
+#: lib/vutuv_web/components/post_components.ex:1669
+#: lib/vutuv_web/components/post_components.ex:4646
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4801
+#: lib/vutuv_web/components/post_components.ex:4894
 #: lib/vutuv_web/live/post_live/saved.ex:774
 #: lib/vutuv_web/views/user_html.ex:345
 #, elixir-autogen, elixir-format
@@ -2460,10 +2462,10 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:2057
 #: lib/vutuv_web/components/ui.ex:2057
 #: lib/vutuv_web/components/ui.ex:2194
-#: lib/vutuv_web/live/organization_live/following.ex:197
-#: lib/vutuv_web/live/organization_live/following.ex:256
+#: lib/vutuv_web/live/organization_live/following.ex:198
+#: lib/vutuv_web/live/organization_live/following.ex:258
 #: lib/vutuv_web/live/organization_live/show.ex:474
-#: lib/vutuv_web/live/post_live/feed.ex:1172
+#: lib/vutuv_web/live/post_live/feed.ex:1285
 #: lib/vutuv_web/templates/followee/index.html.heex:44
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2475,7 +2477,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4854
+#: lib/vutuv_web/components/post_components.ex:4947
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2486,16 +2488,16 @@ msgstr ""
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1609
-#: lib/vutuv_web/components/post_components.ex:4837
-#: lib/vutuv_web/components/post_components.ex:4838
+#: lib/vutuv_web/components/post_components.ex:1656
+#: lib/vutuv_web/components/post_components.ex:4930
+#: lib/vutuv_web/components/post_components.ex:4931
 #: lib/vutuv_web/live/notification_live/index.ex:1035
 #: lib/vutuv_web/live/post_live/reply.ex:42
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2697
+#: lib/vutuv_web/components/post_components.ex:2782
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2516,7 +2518,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2248
+#: lib/vutuv_web/components/post_components.ex:2318
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:59
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:56
@@ -2524,14 +2526,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2673
+#: lib/vutuv_web/components/post_components.ex:2758
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2667
-#: lib/vutuv_web/components/post_components.ex:2689
-#: lib/vutuv_web/components/post_components.ex:2692
+#: lib/vutuv_web/components/post_components.ex:2752
+#: lib/vutuv_web/components/post_components.ex:2774
+#: lib/vutuv_web/components/post_components.ex:2777
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2697,38 +2699,38 @@ msgstr ""
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
 #: lib/vutuv_web/templates/url/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:885
+#: lib/vutuv_web/templates/user/show.html.heex:887
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1189
+#: lib/vutuv_web/templates/user/show.html.heex:1191
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1447
+#: lib/vutuv_web/templates/user/show.html.heex:1449
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1117
+#: lib/vutuv_web/templates/user/show.html.heex:1119
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1068
+#: lib/vutuv_web/templates/user/show.html.heex:1070
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:612
+#: lib/vutuv_web/templates/user/show.html.heex:614
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #: lib/vutuv_web/templates/work_experience/new.html.heex:5
 #, elixir-autogen, elixir-format
@@ -2748,12 +2750,12 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:216
-#: lib/vutuv_web/templates/user/show.html.heex:603
+#: lib/vutuv_web/templates/user/show.html.heex:605
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:961
+#: lib/vutuv_web/live/post_live/feed.ex:1068
 #: lib/vutuv_web/templates/user/show.html.heex:474
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2828,7 +2830,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4480
+#: lib/vutuv_web/components/post_components.ex:4573
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2856,7 +2858,7 @@ msgid "Endorsement"
 msgstr ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:1033
-#: lib/vutuv_web/templates/user/show.html.heex:933
+#: lib/vutuv_web/templates/user/show.html.heex:935
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -3085,13 +3087,13 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1157
-#: lib/vutuv_web/templates/user/show.html.heex:1158
+#: lib/vutuv_web/templates/user/show.html.heex:1159
+#: lib/vutuv_web/templates/user/show.html.heex:1160
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2643
+#: lib/vutuv_web/components/post_components.ex:2728
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3167,9 +3169,9 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1097
-#: lib/vutuv_web/components/post_components.ex:2073
-#: lib/vutuv_web/components/post_components.ex:2803
+#: lib/vutuv_web/components/post_components.ex:1124
+#: lib/vutuv_web/components/post_components.ex:2134
+#: lib/vutuv_web/components/post_components.ex:2888
 #: lib/vutuv_web/live/organization_live/show.ex:547
 #: lib/vutuv_web/templates/user/show.html.heex:219
 #, elixir-autogen, elixir-format
@@ -4530,12 +4532,12 @@ msgid "You have not blocked anyone."
 msgstr ""
 
 #: lib/vutuv_web/controllers/block_controller.ex:89
-#: lib/vutuv_web/live/user_profile_live.ex:304
+#: lib/vutuv_web/live/user_profile_live.ex:326
 #, elixir-autogen, elixir-format
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1127
+#: lib/vutuv_web/live/post_live/feed.ex:1240
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -4546,10 +4548,10 @@ msgid "Find members"
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:261
-#: lib/vutuv_web/live/organization_live/following.ex:154
+#: lib/vutuv_web/live/organization_live/following.ex:155
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:53
-#: lib/vutuv_web/templates/user/show.html.heex:955
+#: lib/vutuv_web/templates/user/show.html.heex:957
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -4665,8 +4667,8 @@ msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:388
 #: lib/vutuv_web/live/tag_new_live.ex:48
-#: lib/vutuv_web/live/user_profile_live.ex:1295
-#: lib/vutuv_web/templates/user/show.html.heex:576
+#: lib/vutuv_web/live/user_profile_live.ex:1331
+#: lib/vutuv_web/templates/user/show.html.heex:578
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr ""
@@ -5258,7 +5260,7 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3954
+#: lib/vutuv_web/components/ui.ex:3957
 #: lib/vutuv_web/controllers/settings_controller.ex:145
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5337,10 +5339,10 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4051
-#: lib/vutuv_web/components/ui.ex:4056
-#: lib/vutuv_web/components/ui.ex:4135
-#: lib/vutuv_web/components/ui.ex:4199
+#: lib/vutuv_web/components/ui.ex:4054
+#: lib/vutuv_web/components/ui.ex:4059
+#: lib/vutuv_web/components/ui.ex:4138
+#: lib/vutuv_web/components/ui.ex:4202
 #: lib/vutuv_web/controllers/settings_controller.ex:61
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5384,7 +5386,7 @@ msgstr ""
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1301
+#: lib/vutuv_web/live/user_profile_live.ex:1337
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr ""
@@ -5410,11 +5412,11 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2868
-#: lib/vutuv_web/components/post_components.ex:2922
-#: lib/vutuv_web/components/post_components.ex:3334
+#: lib/vutuv_web/components/post_components.ex:2953
+#: lib/vutuv_web/components/post_components.ex:3007
+#: lib/vutuv_web/components/post_components.ex:3419
 #: lib/vutuv_web/live/notification_live/index.ex:691
-#: lib/vutuv_web/live/post_live/feed.ex:1245
+#: lib/vutuv_web/live/post_live/feed.ex:1358
 #: lib/vutuv_web/views/user_html.ex:113
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5630,7 +5632,7 @@ msgstr ""
 msgid "Apps"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3950
+#: lib/vutuv_web/components/ui.ex:3953
 #: lib/vutuv_web/controllers/settings_controller.ex:165
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -5856,7 +5858,7 @@ msgid_plural "%{count} minutes ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:811
+#: lib/vutuv_web/controllers/settings_controller.ex:839
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr ""
@@ -5896,7 +5898,7 @@ msgstr ""
 msgid "Signed-in devices"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:798
+#: lib/vutuv_web/controllers/settings_controller.ex:826
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr ""
@@ -6046,7 +6048,7 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1306
+#: lib/vutuv_web/live/user_profile_live.ex:1342
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr ""
@@ -6061,7 +6063,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:314
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:883
+#: lib/vutuv_web/templates/user/show.html.heex:885
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
@@ -6082,7 +6084,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1498
+#: lib/vutuv_web/templates/user/show.html.heex:1500
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6126,8 +6128,8 @@ msgstr ""
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1083
-#: lib/vutuv_web/templates/user/show.html.heex:1093
+#: lib/vutuv_web/templates/user/show.html.heex:1085
+#: lib/vutuv_web/templates/user/show.html.heex:1095
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6167,12 +6169,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1205
+#: lib/vutuv_web/templates/user/show.html.heex:1207
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1216
+#: lib/vutuv_web/templates/user/show.html.heex:1218
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6215,7 +6217,7 @@ msgstr ""
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1214
+#: lib/vutuv_web/templates/user/show.html.heex:1216
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
@@ -6263,20 +6265,20 @@ msgstr ""
 msgid "Map services to show"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:84
+#: lib/vutuv_web/gettext_extraction_anchors.ex:92
 #: lib/vutuv_web/templates/settings/preferences.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1484
-#: lib/vutuv_web/templates/user/show.html.heex:1492
-#: lib/vutuv_web/templates/user/show.html.heex:1504
+#: lib/vutuv_web/templates/user/show.html.heex:1486
+#: lib/vutuv_web/templates/user/show.html.heex:1494
+#: lib/vutuv_web/templates/user/show.html.heex:1506
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:82
+#: lib/vutuv_web/gettext_extraction_anchors.ex:90
 #: lib/vutuv_web/templates/settings/preferences.html.heex:80
 #, elixir-autogen, elixir-format
 msgid "Opens first, as the main button. The others appear as alternatives."
@@ -6607,7 +6609,7 @@ msgid "Mute"
 msgstr ""
 
 #: lib/vutuv_web/controllers/follow_controller.ex:49
-#: lib/vutuv_web/live/user_profile_live.ex:245
+#: lib/vutuv_web/live/user_profile_live.ex:267
 #, elixir-autogen, elixir-format
 msgid "Muted. Their posts no longer appear in your feed."
 msgstr ""
@@ -6631,7 +6633,7 @@ msgid "Unmute"
 msgstr ""
 
 #: lib/vutuv_web/controllers/follow_controller.ex:51
-#: lib/vutuv_web/live/user_profile_live.ex:247
+#: lib/vutuv_web/live/user_profile_live.ex:269
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts appear in your feed again."
 msgstr ""
@@ -6646,7 +6648,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2800
+#: lib/vutuv_web/components/post_components.ex:2885
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6656,7 +6658,7 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2799
+#: lib/vutuv_web/components/post_components.ex:2884
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -7337,7 +7339,7 @@ msgstr ""
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4712
+#: lib/vutuv_web/components/post_components.ex:4805
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8129,7 +8131,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
 #: lib/vutuv_web/templates/education/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:669
+#: lib/vutuv_web/templates/user/show.html.heex:671
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr ""
@@ -8154,7 +8156,7 @@ msgstr ""
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
 #: lib/vutuv_web/templates/import/preview.html.heex:44
-#: lib/vutuv_web/templates/user/show.html.heex:666
+#: lib/vutuv_web/templates/user/show.html.heex:668
 #: lib/vutuv_web/views/import_html.ex:66
 #: lib/vutuv_web/views/job_reference_html.ex:265
 #, elixir-autogen, elixir-format
@@ -8197,7 +8199,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3938
+#: lib/vutuv_web/components/ui.ex:3941
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8334,7 +8336,7 @@ msgid "Loading posts"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:140
-#: lib/vutuv_web/templates/user/show.html.heex:1351
+#: lib/vutuv_web/templates/user/show.html.heex:1353
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8422,7 +8424,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3942
+#: lib/vutuv_web/components/ui.ex:3945
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8444,13 +8446,13 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1212
-#: lib/vutuv_web/live/post_live/feed.ex:1213
+#: lib/vutuv_web/live/post_live/feed.ex:1325
+#: lib/vutuv_web/live/post_live/feed.ex:1326
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1207
+#: lib/vutuv_web/live/post_live/feed.ex:1320
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr ""
@@ -8650,8 +8652,8 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:997
-#: lib/vutuv_web/templates/user/show.html.heex:1256
+#: lib/vutuv_web/templates/user/show.html.heex:999
+#: lib/vutuv_web/templates/user/show.html.heex:1258
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr ""
@@ -8795,7 +8797,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3773
+#: lib/vutuv_web/components/post_components.ex:3858
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9047,7 +9049,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/language/manage.html.heex:8
 #: lib/vutuv_web/templates/language/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:731
+#: lib/vutuv_web/templates/user/show.html.heex:733
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr ""
@@ -9271,7 +9273,7 @@ msgstr ""
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:4
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:728
+#: lib/vutuv_web/templates/user/show.html.heex:730
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr ""
@@ -9458,7 +9460,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1084
+#: lib/vutuv/accounts/user.ex:1117
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9469,7 +9471,7 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1081
+#: lib/vutuv/accounts/user.ex:1114
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -9551,7 +9553,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:837
+#: lib/vutuv_web/templates/user/show.html.heex:839
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr ""
@@ -9600,7 +9602,7 @@ msgstr ""
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:834
+#: lib/vutuv_web/templates/user/show.html.heex:836
 #: lib/vutuv_web/views/import_html.ex:67
 #: lib/vutuv_web/views/job_reference_html.ex:266
 #, elixir-autogen, elixir-format
@@ -9719,8 +9721,8 @@ msgstr ""
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1179
-#: lib/vutuv_web/templates/user/show.html.heex:1180
+#: lib/vutuv_web/templates/user/show.html.heex:1181
+#: lib/vutuv_web/templates/user/show.html.heex:1182
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -10242,7 +10244,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:62
 #: lib/vutuv_web/agent_docs/text.ex:59
-#: lib/vutuv_web/templates/user/show.html.heex:1325
+#: lib/vutuv_web/templates/user/show.html.heex:1327
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -10500,46 +10502,46 @@ msgid_plural "You have %{formatted} new messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:189
+#: lib/vutuv_web/templates/settings/preferences.html.heex:272
 #, elixir-autogen, elixir-format
 msgid "Break long words at syllable points so the text wraps evenly. Helpful in the narrow phone column."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:120
+#: lib/vutuv_web/templates/settings/preferences.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "How posts you read are shortened in your feed and on profiles. These are your own reading preferences."
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:68
-#: lib/vutuv_web/templates/settings/preferences.html.heex:196
+#: lib/vutuv_web/templates/settings/preferences.html.heex:279
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on desktop"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:69
-#: lib/vutuv_web/templates/settings/preferences.html.heex:200
+#: lib/vutuv_web/templates/settings/preferences.html.heex:283
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on mobile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:186
+#: lib/vutuv_web/templates/settings/preferences.html.heex:269
 #, elixir-autogen, elixir-format
 msgid "Hyphenation"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:66
-#: lib/vutuv_web/templates/settings/preferences.html.heex:143
+#: lib/vutuv_web/templates/settings/preferences.html.heex:226
 #, elixir-autogen, elixir-format
 msgid "Lines on desktop"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:67
-#: lib/vutuv_web/templates/settings/preferences.html.heex:152
+#: lib/vutuv_web/templates/settings/preferences.html.heex:235
 #, elixir-autogen, elixir-format
 msgid "Lines on mobile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:138
+#: lib/vutuv_web/templates/settings/preferences.html.heex:221
 #, elixir-autogen, elixir-format
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
@@ -10549,7 +10551,7 @@ msgstr ""
 msgid "Post display settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:135
+#: lib/vutuv_web/templates/settings/preferences.html.heex:218
 #, elixir-autogen, elixir-format
 msgid "Shorten a post after"
 msgstr ""
@@ -10635,7 +10637,8 @@ msgid "Preferences of %{name}"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/preferences.html.heex:102
-#: lib/vutuv_web/templates/settings/preferences.html.heex:220
+#: lib/vutuv_web/templates/settings/preferences.html.heex:185
+#: lib/vutuv_web/templates/settings/preferences.html.heex:303
 #, elixir-autogen, elixir-format
 msgid "Reset to the site defaults"
 msgstr ""
@@ -10666,17 +10669,17 @@ msgstr ""
 msgid "What every member gets until they choose for themselves on their settings pages, and what logged-out visitors see. Changes apply immediately; members who set their own value are not affected."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:80
+#: lib/vutuv_web/gettext_extraction_anchors.ex:88
 #, elixir-autogen, elixir-format
 msgid "0 means posts are never shortened."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:86
+#: lib/vutuv_web/gettext_extraction_anchors.ex:94
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:85
+#: lib/vutuv_web/gettext_extraction_anchors.ex:93
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr ""
@@ -10826,19 +10829,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1122
+#: lib/vutuv/accounts/user.ex:1155
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1127
+#: lib/vutuv/accounts/user.ex:1160
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1125
+#: lib/vutuv/accounts/user.ex:1158
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:566
 #, elixir-autogen, elixir-format
@@ -11828,7 +11831,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:418
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:388
-#: lib/vutuv_web/components/ui.ex:3946
+#: lib/vutuv_web/components/ui.ex:3949
 #: lib/vutuv_web/controllers/settings_controller.ex:179
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
@@ -12141,7 +12144,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1096
+#: lib/vutuv/accounts/user.ex:1129
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12261,7 +12264,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1095
+#: lib/vutuv/accounts/user.ex:1128
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12343,7 +12346,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1097
+#: lib/vutuv/accounts/user.ex:1130
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:564
 #: lib/vutuv_web/agent_docs/markdown.ex:458
@@ -13064,12 +13067,12 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2207
+#: lib/vutuv_web/components/post_components.ex:2277
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:651
 #: lib/vutuv_web/controllers/settings_controller.ex:669
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:387
-#: lib/vutuv_web/live/organization_live/following.ex:140
+#: lib/vutuv_web/live/organization_live/following.ex:141
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr ""
@@ -13357,7 +13360,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1140
+#: lib/vutuv/accounts/user.ex:1173
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13368,19 +13371,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1143
+#: lib/vutuv/accounts/user.ex:1176
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1146
+#: lib/vutuv/accounts/user.ex:1179
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1137
+#: lib/vutuv/accounts/user.ex:1170
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13504,14 +13507,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3888
 #: lib/vutuv_web/controllers/settings_controller.ex:570
-#: lib/vutuv_web/live/post_live/feed.ex:1158
+#: lib/vutuv_web/live/post_live/feed.ex:1271
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1173
+#: lib/vutuv_web/live/post_live/feed.ex:1286
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr ""
@@ -13553,7 +13556,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1291
+#: lib/vutuv_web/templates/user/show.html.heex:1293
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
@@ -13590,7 +13593,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1289
+#: lib/vutuv_web/templates/user/show.html.heex:1291
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
@@ -13667,34 +13670,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4342
+#: lib/vutuv_web/components/post_components.ex:4435
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1158
-#: lib/vutuv_web/components/post_components.ex:4299
+#: lib/vutuv_web/components/post_components.ex:4392
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4343
+#: lib/vutuv_web/components/post_components.ex:4436
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4345
+#: lib/vutuv_web/components/post_components.ex:4438
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4341
+#: lib/vutuv_web/components/post_components.ex:4434
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1158
-#: lib/vutuv_web/components/post_components.ex:4298
+#: lib/vutuv_web/components/post_components.ex:4391
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13705,12 +13708,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4340
+#: lib/vutuv_web/components/post_components.ex:4433
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4344
+#: lib/vutuv_web/components/post_components.ex:4437
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13730,7 +13733,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4381
+#: lib/vutuv_web/components/post_components.ex:4474
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13738,27 +13741,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4411
+#: lib/vutuv_web/components/post_components.ex:4504
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4412
+#: lib/vutuv_web/components/post_components.ex:4505
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4410
+#: lib/vutuv_web/components/post_components.ex:4503
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4370
+#: lib/vutuv_web/components/post_components.ex:4463
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4417
+#: lib/vutuv_web/components/post_components.ex:4510
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13788,7 +13791,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4184
+#: lib/vutuv_web/components/post_components.ex:4277
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13836,7 +13839,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4175
+#: lib/vutuv_web/components/post_components.ex:4268
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -13978,22 +13981,22 @@ msgid "proof document"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:74
-#: lib/vutuv_web/templates/settings/preferences.html.heex:174
+#: lib/vutuv_web/templates/settings/preferences.html.heex:257
 #, elixir-autogen, elixir-format
 msgid "Lines in notifications"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:81
+#: lib/vutuv_web/gettext_extraction_anchors.ex:89
 #, elixir-autogen, elixir-format
 msgid "How much of a post a notification quotes before it is cut off."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:165
+#: lib/vutuv_web/templates/settings/preferences.html.heex:248
 #, elixir-autogen, elixir-format
 msgid "Quoted posts in notifications"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:168
+#: lib/vutuv_web/templates/settings/preferences.html.heex:251
 #, elixir-autogen, elixir-format
 msgid "Your notifications quote the post someone liked or replied to. Leave the field empty to follow the site default."
 msgstr ""
@@ -14186,7 +14189,7 @@ msgstr ""
 msgid "No accounts are currently frozen."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:416
+#: lib/vutuv_web/live/post_live/thread.ex:458
 #, elixir-autogen, elixir-format
 msgid "Read it from the start"
 msgstr ""
@@ -14206,14 +14209,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2471
+#: lib/vutuv_web/components/post_components.ex:2554
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2493
+#: lib/vutuv_web/components/post_components.ex:2578
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14225,7 +14228,7 @@ msgstr[1] ""
 msgid "This page is no longer available."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:408
+#: lib/vutuv_web/live/post_live/thread.ex:450
 #, elixir-autogen, elixir-format
 msgid "This post is part of a conversation with %{formatted} posts."
 msgstr ""
@@ -14240,7 +14243,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4809
+#: lib/vutuv_web/components/post_components.ex:4902
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14387,7 +14390,7 @@ msgstr ""
 msgid "Filter removed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:295
+#: lib/vutuv_web/live/post_live/feed.ex:327
 #, elixir-autogen, elixir-format
 msgid "Hidden: matches your filter"
 msgstr ""
@@ -14420,7 +14423,7 @@ msgstr ""
 msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:304
+#: lib/vutuv_web/live/post_live/feed.ex:336
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr ""
@@ -14707,7 +14710,7 @@ msgstr ""
 msgid "Nobody yet. Post your handle where people can see it, and the first follows will show up here."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:303
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:305
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Related"
@@ -14979,7 +14982,7 @@ msgstr ""
 msgid "Book an ad"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1001
+#: lib/vutuv_web/templates/user/show.html.heex:1003
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr ""
@@ -15100,12 +15103,12 @@ msgstr ""
 msgid "skill topic keyword expertise endorsement"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3947
+#: lib/vutuv_web/components/ui.ex:3950
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3948
+#: lib/vutuv_web/components/ui.ex:3951
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr ""
@@ -15260,52 +15263,42 @@ msgstr ""
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3935
-#, elixir-autogen, elixir-format
-msgid "Interface language, maps, how posts are shortened"
-msgstr ""
-
-#: lib/vutuv_web/components/ui.ex:3936
-#, elixir-autogen, elixir-format
-msgid "german english locale translation map font length hyphenation"
-msgstr ""
-
-#: lib/vutuv_web/components/ui.ex:3939
+#: lib/vutuv_web/components/ui.ex:3942
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3940
+#: lib/vutuv_web/components/ui.ex:3943
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3943
+#: lib/vutuv_web/components/ui.ex:3946
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3944
+#: lib/vutuv_web/components/ui.ex:3947
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3951
+#: lib/vutuv_web/components/ui.ex:3954
 #, elixir-autogen, elixir-format
 msgid "Connected apps and access tokens"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3952
+#: lib/vutuv_web/components/ui.ex:3955
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3955
+#: lib/vutuv_web/components/ui.ex:3958
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3956
+#: lib/vutuv_web/components/ui.ex:3959
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr ""
@@ -15413,21 +15406,21 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4757
+#: lib/vutuv_web/components/post_components.ex:4850
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4761
+#: lib/vutuv_web/components/post_components.ex:4854
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4765
+#: lib/vutuv_web/components/post_components.ex:4858
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15435,7 +15428,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1107
-#: lib/vutuv_web/components/post_components.ex:4716
+#: lib/vutuv_web/components/post_components.ex:4809
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15451,14 +15444,14 @@ msgstr ""
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1198
-#: lib/vutuv_web/components/post_components.ex:1754
+#: lib/vutuv_web/components/post_components.ex:1236
+#: lib/vutuv_web/components/post_components.ex:1801
 #: lib/vutuv_web/live/fediverse_account_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1085
+#: lib/vutuv_web/components/post_components.ex:1112
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15480,12 +15473,12 @@ msgstr ""
 msgid "Reply from another network"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:146
+#: lib/vutuv_web/live/post_live/thread.ex:150
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1094
+#: lib/vutuv_web/components/post_components.ex:1121
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15495,7 +15488,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1108
+#: lib/vutuv_web/components/post_components.ex:1135
 #: lib/vutuv_web/live/notification_live/index.ex:545
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -15516,20 +15509,20 @@ msgstr ""
 msgid "Taken down"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:155
+#: lib/vutuv_web/live/post_live/thread.ex:159
 #, elixir-autogen, elixir-format
 msgid "Thank you. The reply was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:315
+#: lib/vutuv_web/live/post_live/thread.ex:351
 #, elixir-autogen, elixir-format
 msgid "That reply is not yours to remove."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1291
-#: lib/vutuv_web/components/post_components.ex:1129
-#: lib/vutuv_web/components/post_components.ex:1329
-#: lib/vutuv_web/components/post_components.ex:2127
+#: lib/vutuv_web/components/post_components.ex:1167
+#: lib/vutuv_web/components/post_components.ex:1367
+#: lib/vutuv_web/components/post_components.ex:2197
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -15541,7 +15534,7 @@ msgstr ""
 msgid "What"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:311
+#: lib/vutuv_web/live/post_live/thread.ex:347
 #: lib/vutuv_web/live/remote_post_actions.ex:47
 #, elixir-autogen, elixir-format
 msgid "You have reported a lot today. Please try again tomorrow."
@@ -16191,22 +16184,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2655
+#: lib/vutuv_web/components/post_components.ex:2740
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2766
+#: lib/vutuv_web/components/post_components.ex:2851
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2774
+#: lib/vutuv_web/components/post_components.ex:2859
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2760
+#: lib/vutuv_web/components/post_components.ex:2845
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16292,7 +16285,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1219
 #: lib/vutuv_web/agent_docs/text.ex:765
-#: lib/vutuv_web/components/post_components.ex:3257
+#: lib/vutuv_web/components/post_components.ex:3342
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
@@ -16322,7 +16315,7 @@ msgstr ""
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3256
+#: lib/vutuv_web/components/post_components.ex:3341
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
@@ -16332,29 +16325,29 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3637
+#: lib/vutuv_web/components/post_components.ex:3722
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Only you can see this post so far."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2260
+#: lib/vutuv_web/components/post_components.ex:2330
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3640
+#: lib/vutuv_web/components/post_components.ex:3725
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3463
+#: lib/vutuv_web/components/post_components.ex:3548
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2979
+#: lib/vutuv_web/components/post_components.ex:3064
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16367,12 +16360,12 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1252
 #: lib/vutuv_web/agent_docs/text.ex:752
-#: lib/vutuv_web/components/post_components.ex:3674
+#: lib/vutuv_web/components/post_components.ex:3759
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3255
+#: lib/vutuv_web/components/post_components.ex:3340
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Previous photo"
 msgstr ""
@@ -16393,7 +16386,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2313
+#: lib/vutuv_web/components/post_components.ex:2383
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16413,7 +16406,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2304
+#: lib/vutuv_web/components/post_components.ex:2374
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16423,12 +16416,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2322
+#: lib/vutuv_web/components/post_components.ex:2392
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2256
+#: lib/vutuv_web/components/post_components.ex:2326
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16443,7 +16436,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2317
+#: lib/vutuv_web/components/post_components.ex:2387
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16453,7 +16446,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2270
+#: lib/vutuv_web/components/post_components.ex:2340
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16474,8 +16467,8 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:970
-#: lib/vutuv_web/live/post_live/feed.ex:971
+#: lib/vutuv_web/live/post_live/feed.ex:1077
+#: lib/vutuv_web/live/post_live/feed.ex:1078
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post photos"
 msgstr ""
@@ -16540,13 +16533,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1125
-#: lib/vutuv_web/components/post_components.ex:4754
+#: lib/vutuv_web/components/post_components.ex:4847
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1123
-#: lib/vutuv_web/components/post_components.ex:4751
+#: lib/vutuv_web/components/post_components.ex:4844
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
 msgstr ""
@@ -16556,7 +16549,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4643
+#: lib/vutuv_web/components/post_components.ex:4736
 #, elixir-autogen, elixir-format, fuzzy
 msgid "From other networks"
 msgstr ""
@@ -16651,7 +16644,7 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_following_live.ex:60
 #: lib/vutuv_web/live/fediverse_following_live.ex:301
 #: lib/vutuv_web/live/fediverse_following_live.ex:314
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:312
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:314
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:159
 #, elixir-autogen, elixir-format
 msgid "Accounts you follow elsewhere"
@@ -16710,7 +16703,7 @@ msgid "Mastodon and the other networks work like email: an address is enough. Pa
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:314
-#: lib/vutuv_web/live/organization_live/following.ex:247
+#: lib/vutuv_web/live/organization_live/following.ex:249
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Requested"
 msgstr ""
@@ -16894,7 +16887,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2082
+#: lib/vutuv_web/components/post_components.ex:2143
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
@@ -16904,7 +16897,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2126
+#: lib/vutuv_web/components/post_components.ex:2196
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16924,24 +16917,24 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1453
+#: lib/vutuv_web/components/post_components.ex:1495
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2099
+#: lib/vutuv_web/components/post_components.ex:2161
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Marked as sensitive by its author"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2061
+#: lib/vutuv_web/components/post_components.ex:2122
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Mute %{handle}"
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:225
 #: lib/vutuv_web/live/fediverse_post_live.ex:104
-#: lib/vutuv_web/live/post_live/feed.ex:436
+#: lib/vutuv_web/live/post_live/feed.ex:495
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
 msgstr ""
@@ -16951,7 +16944,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2068
+#: lib/vutuv_web/components/post_components.ex:2129
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -17173,27 +17166,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1857
+#: lib/vutuv_web/components/post_components.ex:1904
 #, elixir-autogen, elixir-format
 msgid "A picture is on its way."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1886
+#: lib/vutuv_web/components/post_components.ex:1933
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1881
+#: lib/vutuv_web/components/post_components.ex:1928
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2163
+#: lib/vutuv_web/components/post_components.ex:2233
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2169
+#: lib/vutuv_web/components/post_components.ex:2239
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That post is not here any more."
 msgstr ""
@@ -17203,7 +17196,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2308
+#: lib/vutuv_web/components/post_components.ex:2378
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17243,7 +17236,7 @@ msgstr ""
 msgid "That link points at a single post. You can follow its author, %{account}, from here."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1341
+#: lib/vutuv_web/live/user_profile_live.ex:1377
 #, elixir-autogen, elixir-format
 msgid "You already follow one member."
 msgid_plural "You already follow %{count} members."
@@ -17503,7 +17496,7 @@ msgstr ""
 msgid "Look up a post from another network"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:306
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "Looking for an account rather than a single post?"
 msgstr ""
@@ -17528,7 +17521,7 @@ msgstr ""
 msgid "That is a link on this vutuv, not on another network."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:298
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "Their account page here"
 msgstr ""
@@ -17578,7 +17571,7 @@ msgstr ""
 msgid "You redirected your Fediverse followers to another account, so nothing is fetched or sent from this one any more."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:316
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr ""
@@ -17970,7 +17963,7 @@ msgstr ""
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2166
+#: lib/vutuv_web/components/post_components.ex:2236
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -18273,19 +18266,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3921
+#: lib/vutuv_web/components/post_components.ex:4014
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3923
+#: lib/vutuv_web/components/post_components.ex:4016
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3934
+#: lib/vutuv_web/components/post_components.ex:4027
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -18305,7 +18298,7 @@ msgstr ""
 msgid "When off, other members no longer see you among the likes of a post. The author of the post still does: we named you in the notification they got when you liked it. Either way the post keeps the same number of likes."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:761
+#: lib/vutuv_web/controllers/settings_controller.ex:789
 #, elixir-autogen, elixir-format
 msgid "Your likes follow the site default again."
 msgstr ""
@@ -18345,7 +18338,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/job_reference_controller.ex:144
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:18
 #: lib/vutuv_web/templates/job_reference/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:771
+#: lib/vutuv_web/templates/user/show.html.heex:773
 #, elixir-autogen, elixir-format
 msgid "Add an employment reference"
 msgstr ""
@@ -18420,7 +18413,7 @@ msgstr ""
 #: lib/vutuv_web/templates/job_reference/new.html.heex:4
 #: lib/vutuv_web/templates/job_reference/show.html.heex:12
 #: lib/vutuv_web/templates/job_reference/view.html.heex:11
-#: lib/vutuv_web/templates/user/show.html.heex:768
+#: lib/vutuv_web/templates/user/show.html.heex:770
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Employment references"
 msgstr ""
@@ -19053,7 +19046,7 @@ msgstr ""
 msgid "by the lawyer Tom Braegelmann"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:812
+#: lib/vutuv_web/templates/user/show.html.heex:814
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Documents:"
 msgstr ""
@@ -19229,7 +19222,7 @@ msgstr ""
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1326
+#: lib/vutuv_web/live/user_profile_live.ex:1362
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follow other members"
 msgstr ""
@@ -19239,17 +19232,17 @@ msgstr ""
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1243
+#: lib/vutuv/accounts/user.ex:1276
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1241
+#: lib/vutuv/accounts/user.ex:1274
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1242
+#: lib/vutuv/accounts/user.ex:1275
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -19935,7 +19928,7 @@ msgstr ""
 msgid "Start over"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2196
+#: lib/vutuv_web/components/post_components.ex:2266
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -20123,7 +20116,7 @@ msgstr ""
 msgid "Follow as %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:160
+#: lib/vutuv_web/live/organization_live/following.ex:161
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Members and organizations"
 msgstr ""
@@ -20133,28 +20126,28 @@ msgstr ""
 msgid "Nothing here yet. This page does not follow anyone, or nobody it follows has published."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:156
+#: lib/vutuv_web/live/organization_live/following.ex:157
 #, elixir-autogen, elixir-format
 msgid "The members, organizations and topics this page follows. Everything here shapes its feed, and only the team can see this list."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:266
+#: lib/vutuv_web/live/organization_live/following.ex:268
 #, elixir-autogen, elixir-format, fuzzy
 msgid "This page does not follow any topics yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:163
+#: lib/vutuv_web/live/organization_live/following.ex:164
 #, elixir-autogen, elixir-format, fuzzy
 msgid "This page does not follow anyone yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:263
+#: lib/vutuv_web/live/organization_live/following.ex:265
 #, elixir-autogen, elixir-format
 msgid "Topics"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:276
-#: lib/vutuv_web/live/organization_live/following.ex:277
+#: lib/vutuv_web/live/organization_live/following.ex:278
+#: lib/vutuv_web/live/organization_live/following.ex:279
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Unfollow %{tag}"
 msgstr ""
@@ -20164,7 +20157,7 @@ msgstr ""
 msgid "What the members and organizations this page follows have published. Liking or saving something here is done from your own account, not the page's."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:52
+#: lib/vutuv_web/live/organization_live/following.ex:53
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follows – %{name}"
 msgstr ""
@@ -20184,42 +20177,42 @@ msgstr ""
 msgid "Switching this off stops new posts from leaving. Copies another server already holds can only be asked to delete them, never made to."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:206
+#: lib/vutuv_web/live/organization_live/following.ex:207
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Accounts on other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:216
+#: lib/vutuv_web/live/organization_live/following.ex:217
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Fediverse address"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:126
+#: lib/vutuv_web/live/organization_live/following.ex:127
 #, elixir-autogen, elixir-format
 msgid "That does not look like a Fediverse address."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:132
+#: lib/vutuv_web/live/organization_live/following.ex:133
 #, elixir-autogen, elixir-format
 msgid "That server did not answer."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:138
+#: lib/vutuv_web/live/organization_live/following.ex:139
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That server is blocked on this installation."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:129
+#: lib/vutuv_web/live/organization_live/following.ex:130
 #, elixir-autogen, elixir-format
 msgid "This page already follows that account."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:226
+#: lib/vutuv_web/live/organization_live/following.ex:227
 #, elixir-autogen, elixir-format, fuzzy
 msgid "This page does not follow anyone on another network yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/following.ex:135
+#: lib/vutuv_web/live/organization_live/following.ex:136
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Too many attempts for now. Try again later."
 msgstr ""
@@ -20753,27 +20746,87 @@ msgstr ""
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3837
+#: lib/vutuv_web/components/post_components.ex:3922
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3858
+#: lib/vutuv_web/components/post_components.ex:3943
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3867
+#: lib/vutuv_web/components/post_components.ex:3952
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3870
+#: lib/vutuv_web/components/post_components.ex:3955
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3847
+#: lib/vutuv_web/components/post_components.ex:3932
 #, elixir-autogen, elixir-format
 msgid "Translating…"
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:780
+#, elixir-autogen, elixir-format
+msgid "Feed language settings reset to the site defaults."
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:768
+#, elixir-autogen, elixir-format
+msgid "Feed language settings saved."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:116
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Feed languages"
+msgstr ""
+
+#: lib/vutuv_web/components/ui.ex:3935
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Interface language, feed languages, maps, how posts are shortened"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:118
+#, elixir-autogen, elixir-format
+msgid "Pick which languages your feed shows, and what happens to posts in other languages. Posts that declare no language always show."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:128
+#, elixir-autogen, elixir-format
+msgid "Show these languages"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:131
+#, elixir-autogen, elixir-format
+msgid "Ticking every box (or none) means: all languages."
+msgstr ""
+
+#: lib/vutuv_web/components/ui.ex:3937
+#, elixir-autogen, elixir-format
+msgid "german english locale translation translate map font length hyphenation feed languages hide foreign übersetzen sprache"
+msgstr ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:83
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Hide them"
+msgstr ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:81
+#, elixir-autogen, elixir-format
+msgid "Posts in other languages"
+msgstr ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:82
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Translate into my language"
+msgstr ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:84
+#, elixir-autogen, elixir-format
+msgid "What your feed does with posts outside your chosen languages: show them as they are, translate them for you, or hide them. Posts that declare no language always show."
 msgstr ""

--- a/priv/repo/migrations/20260816153203_add_feed_language_preference.exs
+++ b/priv/repo/migrations/20260816153203_add_feed_language_preference.exs
@@ -1,0 +1,19 @@
+defmodule Vutuv.Repo.Migrations.AddFeedLanguagePreference do
+  use Ecto.Migration
+
+  @moduledoc """
+  The feed language preference (issue #1461, Mastodon's chosen-languages
+  filter plus a translate mode): `feed_languages` is the member's "show
+  these languages" list (NULL = all — the Prefs convention that "never
+  touched" stays distinguishable), `feed_foreign_posts` says what happens to
+  the rest (original / translate / hide; NULL = inherit the installation
+  default, a `Vutuv.Prefs` knob). N-1 safe: pure nullable additions.
+  """
+
+  def change do
+    alter table(:users) do
+      add(:feed_foreign_posts, :string)
+      add(:feed_languages, {:array, :string})
+    end
+  end
+end

--- a/test/vutuv/fediverse_blocklist_test.exs
+++ b/test/vutuv/fediverse_blocklist_test.exs
@@ -182,8 +182,15 @@ defmodule Vutuv.FediverseBlocklistTest do
   describe "inbound caps" do
     test "a server over its hourly cap is throttled while other servers are unaffected" do
       # Tiny budgets so the test states the rule instead of writing 600 rows.
+      original_caps = Application.fetch_env(:vutuv, :fediverse_inbound_caps)
       Application.put_env(:vutuv, :fediverse_inbound_caps, {2, 2})
-      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_inbound_caps) end)
+
+      on_exit(fn ->
+        case original_caps do
+          {:ok, was} -> Application.put_env(:vutuv, :fediverse_inbound_caps, was)
+          :error -> Application.delete_env(:vutuv, :fediverse_inbound_caps)
+        end
+      end)
 
       member = federating_member()
 
@@ -213,8 +220,15 @@ defmodule Vutuv.FediverseBlocklistTest do
 
     test "one remote account cannot spend the whole host budget" do
       # Room for 10 rows from the host, but only 1 from any single actor.
+      original_caps = Application.fetch_env(:vutuv, :fediverse_inbound_caps)
       Application.put_env(:vutuv, :fediverse_inbound_caps, {10, 1})
-      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_inbound_caps) end)
+
+      on_exit(fn ->
+        case original_caps do
+          {:ok, was} -> Application.put_env(:vutuv, :fediverse_inbound_caps, was)
+          :error -> Application.delete_env(:vutuv, :fediverse_inbound_caps)
+        end
+      end)
 
       member = federating_member()
       other = federating_member()

--- a/test/vutuv/fediverse_notes_test.exs
+++ b/test/vutuv/fediverse_notes_test.exs
@@ -244,8 +244,15 @@ defmodule Vutuv.FediverseNotesTest do
     end
 
     test "is subject to the inbound caps (#1067)", %{user: user, note_url: note_url} do
+      original_caps = Application.fetch_env(:vutuv, :fediverse_inbound_caps)
       Application.put_env(:vutuv, :fediverse_inbound_caps, {1, 1})
-      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_inbound_caps) end)
+
+      on_exit(fn ->
+        case original_caps do
+          {:ok, was} -> Application.put_env(:vutuv, :fediverse_inbound_caps, was)
+          :error -> Application.delete_env(:vutuv, :fediverse_inbound_caps)
+        end
+      end)
 
       assert :ok = Fediverse.record_reply(user, create_activity(note_url), remote())
 

--- a/test/vutuv/feed_language_filter_test.exs
+++ b/test/vutuv/feed_language_filter_test.exs
@@ -1,0 +1,126 @@
+defmodule Vutuv.FeedLanguageFilterTest do
+  @moduledoc """
+  The feed's chosen-languages filter (issue #1461): "hide" drops posts in
+  other languages from every feed source, NULL (undeclared) never hides, and
+  the shipped default ("original") filters nothing.
+  """
+  use Vutuv.DataCase, async: true
+
+  alias Vutuv.Fediverse.Follow
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.Posts
+
+  defp reader!(attrs) do
+    :activated_user
+    |> insert()
+    |> Ecto.Changeset.change(attrs)
+    |> Repo.update!()
+  end
+
+  defp author_followed_by!(reader) do
+    author = insert(:activated_user)
+    insert(:follow, follower: reader, followee: author)
+    author
+  end
+
+  defp post!(author, body, language) do
+    {:ok, post} = Posts.create_post(author, %{body: body, language: language})
+    post
+  end
+
+  defp feed_ids(reader) do
+    Posts.feed_page(reader).entries |> Enum.map(& &1.post.id) |> MapSet.new()
+  end
+
+  test "hide drops foreign-language posts; chosen and NULL always show" do
+    reader = reader!(%{feed_foreign_posts: "hide", feed_languages: ["de"]})
+    author = author_followed_by!(reader)
+
+    german = post!(author, "Guten Morgen.", "de")
+    english = post!(author, "Good morning.", "en")
+    {:ok, undeclared} = Posts.create_post(author, %{body: "Ohne Sprache."})
+
+    ids = feed_ids(reader)
+    assert german.id in ids
+    assert undeclared.id in ids
+    refute english.id in ids
+  end
+
+  test "the shipped default filters nothing" do
+    reader = reader!(%{feed_languages: ["de"]})
+    author = author_followed_by!(reader)
+    english = post!(author, "Good morning.", "en")
+
+    assert english.id in feed_ids(reader)
+  end
+
+  test "hide with no chosen languages filters nothing" do
+    reader = reader!(%{feed_foreign_posts: "hide", feed_languages: nil})
+    author = author_followed_by!(reader)
+    english = post!(author, "Good morning.", "en")
+
+    assert english.id in feed_ids(reader)
+  end
+
+  test "hide reaches the remote-post source too" do
+    reader = reader!(%{feed_foreign_posts: "hide", feed_languages: ["de"]})
+
+    account =
+      Repo.insert!(%RemoteAccount{
+        actor_uri: "https://social.example/users/them#{System.unique_integer([:positive])}",
+        host: "social.example",
+        handle: "them",
+        inbox_uri: "https://social.example/inbox"
+      })
+
+    Repo.insert!(%Follow{
+      user_id: reader.id,
+      remote_account_id: account.id,
+      state: "accepted",
+      follow_activity_id: "https://social.example/follows/#{System.unique_integer([:positive])}"
+    })
+
+    now = DateTime.utc_now(:second)
+
+    for language <- ["en", "de", nil] do
+      Repo.insert!(%RemotePost{
+        remote_account_id: account.id,
+        object_uri: "https://social.example/p/#{System.unique_integer([:positive])}",
+        content_text: "Text #{language}",
+        language: language,
+        audience: "public",
+        kind: "note",
+        published_at: now,
+        received_at: now,
+        expires_at: DateTime.add(now, 86_400)
+      })
+    end
+
+    remote_languages =
+      Posts.feed_page(reader).entries
+      |> Enum.filter(&Posts.remote_feed_entry?/1)
+      |> Enum.map(& &1.remote_post.language)
+
+    assert "de" in remote_languages
+    assert nil in remote_languages
+    refute "en" in remote_languages
+  end
+
+  test "the changeset stores only known codes and maps all-or-none to nil" do
+    user = insert(:user)
+
+    {:ok, updated} =
+      Vutuv.Accounts.update_user(user, %{"feed_languages" => ["de", "xx", "<script>"]})
+
+    assert updated.feed_languages == ["de"]
+
+    {:ok, cleared} = Vutuv.Accounts.update_user(updated, %{"feed_languages" => []})
+    assert cleared.feed_languages == nil
+
+    {:ok, all} =
+      Vutuv.Accounts.update_user(updated, %{"feed_languages" => Vutuv.Languages.codes()})
+
+    assert all.feed_languages == nil
+  end
+end

--- a/test/vutuv_web/live/feed_translate_mode_test.exs
+++ b/test/vutuv_web/live/feed_translate_mode_test.exs
@@ -1,0 +1,114 @@
+defmodule VutuvWeb.FeedTranslateModeTest do
+  @moduledoc """
+  The feed's translate mode (issue #1461): with `feed_foreign_posts` set to
+  "translate", foreign-language cards auto-request their translation on page
+  load — cached ones show at once, the rest show the original with the
+  pending line until the worker's broadcast swaps them in. Plus the settings
+  form the pair of controls is set on.
+  """
+  use VutuvWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.Posts
+  alias Vutuv.Translations
+  alias Vutuv.Translations.TranslationJob
+
+  defp translate_mode!(user) do
+    user
+    |> Ecto.Changeset.change(%{feed_foreign_posts: "translate"})
+    |> Repo.update!()
+  end
+
+  test "a cached translation shows at once, an uncached one queues", %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+    translate_mode!(user)
+
+    {:ok, cached} = Posts.create_post(user, %{body: "Schon übersetzt.", language: "de"})
+    {:ok, fresh} = Posts.create_post(user, %{body: "Noch nicht übersetzt.", language: "de"})
+
+    {:ok, _} =
+      Translations.store_translation(cached, "en", %{
+        source_language: "de",
+        body: "Already translated.",
+        model: "stub"
+      })
+
+    {:ok, live, _html} = live(conn, ~p"/feed")
+    html = render(live)
+
+    # The cached card swapped in with its label; the other shows the original
+    # with the pending line, and exactly one job was queued for it.
+    assert html =~ "Already translated."
+    refute html =~ "Schon übersetzt."
+    assert html =~ "Translated from German"
+    assert html =~ "Noch nicht übersetzt."
+    assert has_element?(live, "[data-translation-pending]")
+
+    assert [job] = Repo.all(TranslationJob)
+    assert job.post_id == fresh.id
+
+    # The worker finishes; the second card swaps in live.
+    :ok =
+      Translations.deliver_due(
+        translate: fn _subject, _target ->
+          {:ok, %{source_language: "de", body: "Not yet translated.", summary: nil, model: "s"}}
+        end
+      )
+
+    html = render(live)
+    assert html =~ "Not yet translated."
+    refute html =~ "Noch nicht übersetzt."
+  end
+
+  test "a post in a chosen language is not auto-translated", %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+
+    user
+    |> Ecto.Changeset.change(%{feed_foreign_posts: "translate", feed_languages: ["de", "en"]})
+    |> Repo.update!()
+
+    {:ok, _} = Posts.create_post(user, %{body: "Gewählte Sprache.", language: "de"})
+
+    {:ok, live, _html} = live(conn, ~p"/feed")
+
+    assert render(live) =~ "Gewählte Sprache."
+    assert Repo.aggregate(TranslationJob, :count) == 0
+    # The manual button still offers the choice.
+    assert has_element?(live, "[data-translate-button]")
+  end
+
+  describe "the settings form" do
+    test "stores the mode and the chosen languages, and resets to inherit", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      conn =
+        put(conn, ~p"/settings/feed_languages", %{
+          "user" => %{"feed_foreign_posts" => "hide", "feed_languages" => ["de", "en"]}
+        })
+
+      assert redirected_to(conn) == ~p"/settings/preferences"
+      reloaded = Repo.reload!(user)
+      assert reloaded.feed_foreign_posts == "hide"
+      assert Enum.sort(reloaded.feed_languages) == ["de", "en"]
+
+      conn = post(conn, ~p"/settings/feed_languages/reset", %{})
+      assert redirected_to(conn) == ~p"/settings/preferences"
+      reset = Repo.reload!(user)
+      assert reset.feed_foreign_posts == nil
+      assert reset.feed_languages == nil
+    end
+
+    test "renders the card with German strings for a German member", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      user |> Ecto.Changeset.change(%{locale: "de"}) |> Repo.update!()
+
+      html = conn |> get(~p"/settings/preferences") |> html_response(200)
+
+      assert html =~ "Beiträge in anderen Sprachen"
+      assert html =~ "In meine Sprache übersetzen"
+      assert html =~ "Ausblenden"
+      assert html =~ "Diese Sprachen zeigen"
+    end
+  end
+end

--- a/test/vutuv_web/live/post_translation_display_test.exs
+++ b/test/vutuv_web/live/post_translation_display_test.exs
@@ -1,0 +1,185 @@
+defmodule VutuvWeb.PostTranslationDisplayTest do
+  @moduledoc """
+  The translate action on post cards (issue #1462): the quiet button on a
+  foreign-language card, the pending line, the live swap-in over PubSub, the
+  "never a silent translation" label with the original one tap away, and the
+  `lang` attribute. Logged-out and same-language cards get none of it.
+  """
+  use VutuvWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.Posts
+  alias Vutuv.Translations
+
+  defp german_post!(user) do
+    {:ok, post} = Posts.create_post(user, %{body: "Guten Morgen allerseits.", language: "de"})
+    post
+  end
+
+  defp translator(body) do
+    fn _subject, _target ->
+      {:ok, %{source_language: "de", body: body, summary: nil, model: "stub"}}
+    end
+  end
+
+  describe "the feed" do
+    test "translate → pending → live swap-in → back to the original", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      post = german_post!(user)
+
+      {:ok, live, _html} = live(conn, ~p"/feed")
+
+      # The viewer's locale is "en", the post declares "de": the quiet action.
+      assert has_element?(live, "[data-translate-button]")
+
+      live
+      |> element(~s(button[phx-click="translate"][phx-value-id="#{post.id}"]))
+      |> render_click()
+
+      # Queued, not cached: the pending line shows while the worker runs.
+      assert has_element?(live, "[data-translation-pending]")
+
+      :ok = Translations.deliver_due(translate: translator("Good morning everyone."))
+
+      html = render(live)
+      assert html =~ "Good morning everyone."
+      refute html =~ "Guten Morgen allerseits."
+      assert html =~ "Translated from German"
+      assert html =~ ~s(lang="en")
+
+      # The original is one tap away; the cached row stays for the next tap.
+      live
+      |> element(~s(button[phx-click="show-original"][phx-value-id="#{post.id}"]))
+      |> render_click()
+
+      html = render(live)
+      assert html =~ "Guten Morgen allerseits."
+      refute html =~ "Good morning everyone."
+    end
+
+    test "a cached translation swaps in without a job", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      post = german_post!(user)
+
+      {:ok, _} =
+        Translations.store_translation(post, "en", %{
+          source_language: "de",
+          body: "Cached morning.",
+          model: "stub"
+        })
+
+      {:ok, live, _html} = live(conn, ~p"/feed")
+
+      live
+      |> element(~s(button[phx-click="translate"][phx-value-id="#{post.id}"]))
+      |> render_click()
+
+      assert render(live) =~ "Cached morning."
+      assert Repo.aggregate(Vutuv.Translations.TranslationJob, :count) == 0
+    end
+
+    test "a card in the reader's own language offers no translate action", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      {:ok, _post} = Posts.create_post(user, %{body: "Same language.", language: "en"})
+
+      {:ok, live, _html} = live(conn, ~p"/feed")
+
+      refute has_element?(live, "[data-translate-button]")
+    end
+
+    test "a failed translation clears the pending line, the original stands", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      post = german_post!(user)
+
+      {:ok, live, _html} = live(conn, ~p"/feed")
+
+      live
+      |> element(~s(button[phx-click="translate"][phx-value-id="#{post.id}"]))
+      |> render_click()
+
+      assert has_element?(live, "[data-translation-pending]")
+
+      # Drive the job to its strike cap: the worker broadcasts the failure.
+      failing = fn _subject, _target -> {:error, {:content, :length_ratio}} end
+
+      for _round <- 1..4 do
+        Repo.update_all(Vutuv.Translations.TranslationJob, set: [next_attempt_at: nil])
+        :ok = Translations.deliver_due(translate: failing)
+      end
+
+      html = render(live)
+      refute html =~ "data-translation-pending"
+      assert html =~ "Guten Morgen allerseits."
+    end
+  end
+
+  describe "the profile" do
+    test "translating and toggling back works on the profile's posts card", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      post = german_post!(user)
+
+      {:ok, _} =
+        Translations.store_translation(post, "en", %{
+          source_language: "de",
+          body: "Profile morning.",
+          model: "stub"
+        })
+
+      {:ok, live, _html} = live(conn, ~p"/#{user.username}")
+
+      live
+      |> element(~s(button[phx-click="translate"][phx-value-id="#{post.id}"]))
+      |> render_click()
+
+      assert render(live) =~ "Profile morning."
+
+      live
+      |> element(~s(button[phx-click="show-original"][phx-value-id="#{post.id}"]))
+      |> render_click()
+
+      assert render(live) =~ "Guten Morgen allerseits."
+    end
+
+    test "a logged-out visitor sees the original and no translation controls", %{conn: conn} do
+      user = insert(:user, email_confirmed?: true)
+      _post = german_post!(user)
+
+      conn = get(conn, ~p"/#{user.username}")
+      html = html_response(conn, 200)
+
+      assert html =~ "Guten Morgen allerseits."
+      refute html =~ "data-translate-button"
+      # The lang attribute is worth having independent of any translation.
+      assert html =~ ~s(lang="de")
+    end
+  end
+
+  describe "German UI strings (by name, against fuzzy fills)" do
+    test "the whole flow reads German for a German member", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      user |> Ecto.Changeset.change(%{locale: "de"}) |> Repo.update!()
+
+      {:ok, post} = Posts.create_post(user, %{body: "English words here.", language: "en"})
+
+      {:ok, _} =
+        Translations.store_translation(post, "de", %{
+          source_language: "en",
+          body: "Deutsche Wörter hier.",
+          model: "stub"
+        })
+
+      {:ok, live, html} = live(conn, ~p"/feed")
+      assert html =~ "Übersetzen"
+
+      live
+      |> element(~s(button[phx-click="translate"][phx-value-id="#{post.id}"]))
+      |> render_click()
+
+      html = render(live)
+      assert html =~ "Deutsche Wörter hier."
+      assert html =~ "Übersetzt aus Englisch"
+      assert html =~ "Original anzeigen"
+    end
+  end
+end


### PR DESCRIPTION
Die Anzeige-Hälfte von Milestone 13 — #1461 und #1462 in einem PR, weil jede Hälfte die andere referenziert (der Übersetzen-Modus des Feeds IST die Auto-Variante des Karten-Buttons).

Fremdsprachige Karten (Feed, Permalink-Konversation, Profil) tragen eine leise Übersetzen-Aktion: Klick → Wartezeile → Live-Swap über den Worker-Broadcast. Nie still: „Übersetzt aus Englisch · Original anzeigen" auf jeder übersetzten Karte, `lang`-Attribut auf jedem Beitragstext. Der übersetzte Text läuft durch dieselbe Markdown-Pipeline wie das Original. Dazu die Feed-Sprachpräferenz: gewählte Sprachen + original/übersetzen/ausblenden (Prefs-Knopf, Admin-Default inklusive). Ausblenden filtert per `is_nil or in` in jeder Feed-Quelle — NULL versteckt nie; der Übersetzen-Modus holt Übersetzungen gebündelt je Seite. Browser-Smoketest: Button, Wartezeile und deutsche Labels live geprüft.

Nebenbei behoben: der Übersetzer bekommt auch auf einer `OLLAMA_URL`-Prioritätsliste den geduldigen Timeout (der 30-s-Skip ließ jede echte Übersetzung scheitern), und der Fediverse-Inbound-Cap zählt im Test-Env nicht mehr global gegen die ~29 Testdateien mit demselben Actor-Literal (drei Cap-Tests stellen ihre Werte jetzt per fetch_env zurück).

Closes #1461
Closes #1462

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*

https://claude.ai/code/session_0159WnrRezuoxqwov7gUTAmx