### PR TITLE
Die Sprache eines Beitrags reist im Protokoll mit (v7.299.1)

### DIFF
--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -3132,10 +3132,39 @@ defmodule Vutuv.Fediverse do
     %{
       content_text: text,
       summary: remote_text(object["summary"], RemotePost.max_summary()),
+      language: as2_language(object),
       sensitive: object["sensitive"] == true,
       audience: audience
     }
   end
+
+  @doc """
+  The language an AS2 object declares (issue #1488): the first key of
+  `contentMap`, else `nameMap`, else `summaryMap`, else the `@context`'s
+  `@language` — normalized to the primary subtag this system stores, nil for
+  anything absent or malformed. Mastodon's own parser takes the first
+  `contentMap` key the same way; genuinely multilingual maps are read by
+  nobody. ONE named function instead of a copy per `object["content"]` read
+  site.
+  """
+  def as2_language(object) when is_map(object) do
+    raw =
+      first_language_key(object["contentMap"]) ||
+        first_language_key(object["nameMap"]) ||
+        first_language_key(object["summaryMap"]) ||
+        context_language(object["@context"])
+
+    Vutuv.Translations.normalize_language(raw)
+  end
+
+  def as2_language(_object), do: nil
+
+  defp first_language_key(map) when is_map(map), do: map |> Map.keys() |> List.first()
+  defp first_language_key(_other), do: nil
+
+  defp context_language(list) when is_list(list), do: Enum.find_value(list, &context_language/1)
+  defp context_language(%{"@language" => language}), do: language
+  defp context_language(_other), do: nil
 
   defp remote_post_kind(%{"type" => "Question"}), do: "question"
   defp remote_post_kind(_object), do: "note"
@@ -4150,6 +4179,7 @@ defmodule Vutuv.Fediverse do
       |> Note.changeset(%{
         content_text: text,
         summary: remote_text(object["summary"], Note.max_summary()),
+        language: as2_language(object),
         audience: audience(user, activity, object),
         checked_at: DateTime.utc_now(:second)
       })
@@ -4544,6 +4574,7 @@ defmodule Vutuv.Fediverse do
           display_name: actor.name,
           content_text: text,
           summary: remote_text(object["summary"], Note.max_summary()),
+          language: as2_language(object),
           audience: audience(user, activity, object),
           received_at: received,
           # It was demonstrably published the moment it was delivered, so the

--- a/lib/vutuv/fediverse/note.ex
+++ b/lib/vutuv/fediverse/note.ex
@@ -164,6 +164,7 @@ defmodule Vutuv.Fediverse.Note do
       :display_name,
       :content_text,
       :summary,
+      :language,
       :audience,
       :received_at,
       :checked_at,

--- a/lib/vutuv/fediverse/remote_post.ex
+++ b/lib/vutuv/fediverse/remote_post.ex
@@ -157,6 +157,7 @@ defmodule Vutuv.Fediverse.RemotePost do
       :in_reply_to_uri,
       :origin_url,
       :summary,
+      :language,
       :sensitive,
       :audience,
       :kind,

--- a/lib/vutuv/translations/translator.ex
+++ b/lib/vutuv/translations/translator.ex
@@ -190,12 +190,22 @@ defmodule Vutuv.Translations.Translator do
     ratio >= @min_length_ratio and ratio <= @max_length_ratio
   end
 
-  # The fenced blocks, trailing whitespace ignored per block. Compared as a
-  # list: count, order and contents must all survive the translation.
+  # The fenced blocks, compared as a list: count, order and contents must all
+  # survive the translation. Whitespace-normalized per block (trailing spaces
+  # and blank lines dropped) — the #1455 eval showed the recommended model
+  # faithfully keeps fence CONTENT but sometimes drops a trailing blank line
+  # inside one, and a whitespace-only difference must not cost the reader the
+  # whole translation.
   defp fences(text) do
     ~r/```.*?```/s
     |> Regex.scan(text)
-    |> Enum.map(fn [block] -> String.trim_trailing(block) end)
+    |> Enum.map(fn [block] ->
+      block
+      |> String.split("\n")
+      |> Enum.map(&String.trim_trailing/1)
+      |> Enum.reject(&(&1 == ""))
+      |> Enum.join("\n")
+    end)
   end
 
   # "und" (undetermined) when the model's tag is garbage: it is a valid ISO

--- a/lib/vutuv_web/fediverse/docs.ex
+++ b/lib/vutuv_web/fediverse/docs.ex
@@ -730,10 +730,21 @@ defmodule VutuvWeb.Fediverse.Docs do
       "cc" => cc(user, remote),
       "url" => note_url(user, post.id)
     }
+    |> put_content_map(post)
     |> put_in_reply_to(post, remote)
     |> put_tag(remote, hashtags)
     |> put_attachments(post)
   end
+
+  # The author's declared language federates as AS2 `contentMap` (issue
+  # #1488) — the field Mastodon reads a Note's language from, and without
+  # which the post is DROPPED from the public timelines of every reader with
+  # a language filter set. NULL (legacy/undeclared) emits no key at all:
+  # never a fabricated tag.
+  defp put_content_map(note, %Post{language: language}) when is_binary(language),
+    do: Map.put(note, "contentMap", %{language => note["content"]})
+
+  defp put_content_map(note, _post), do: note
 
   # The reply from another network this post answers, when it answers one
   # (issue #1070). An un-preloaded association is a truthy `NotLoaded`, so it is

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.299.0",
+      version: "7.299.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/fediverse_language_test.exs
+++ b/test/vutuv/fediverse_language_test.exs
@@ -1,0 +1,131 @@
+defmodule Vutuv.FediverseLanguageTest do
+  @moduledoc """
+  The post language on the wire (issue #1488): outbound as AS2 `contentMap`
+  keyed by the author's declaration (a NULL-language post emits NO key —
+  never a fabricated tag), inbound read through the one `as2_language/1`
+  (contentMap → nameMap → summaryMap → @context @language) and stored on the
+  cached rows. `async: false` — the inbound caps live in the shared
+  `Vutuv.RateLimiter` ETS table.
+  """
+  use Vutuv.DataCase, async: false
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Follow
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.Posts
+  alias VutuvWeb.Fediverse.Docs
+
+  @actor "https://social.example/users/them"
+  @public "https://www.w3.org/ns/activitystreams#Public"
+
+  setup do
+    Vutuv.RateLimiter.reset()
+    :ok
+  end
+
+  describe "outbound: Docs.note/2" do
+    test "a declared language federates as contentMap" do
+      user = insert(:activated_user)
+      {:ok, post} = Posts.create_post(user, %{body: "Guten Morgen.", language: "de"})
+      post = Posts.get_post(post.id)
+
+      note = Docs.note(post, user)
+
+      assert %{"de" => html} = note["contentMap"]
+      assert html == note["content"]
+    end
+
+    test "a NULL-language post yields a Note without a contentMap key" do
+      user = insert(:activated_user)
+      {:ok, post} = Posts.create_post(user, %{body: "Ohne Sprache."})
+      post = Posts.get_post(post.id)
+
+      note = Docs.note(post, user)
+
+      refute Map.has_key?(note, "contentMap")
+    end
+  end
+
+  describe "as2_language/1" do
+    test "reads the maps in Mastodon's order and normalizes the tag" do
+      assert Fediverse.as2_language(%{"contentMap" => %{"en-US" => "x"}}) == "en"
+      assert Fediverse.as2_language(%{"nameMap" => %{"fr" => "x"}}) == "fr"
+      assert Fediverse.as2_language(%{"summaryMap" => %{"DE" => "x"}}) == "de"
+
+      assert Fediverse.as2_language(%{
+               "@context" => ["https://www.w3.org/ns/activitystreams", %{"@language" => "es"}]
+             }) == "es"
+
+      # contentMap wins over the fallbacks.
+      assert Fediverse.as2_language(%{
+               "contentMap" => %{"de" => "x"},
+               "nameMap" => %{"en" => "y"}
+             }) == "de"
+    end
+
+    test "absent or hostile declarations store nothing" do
+      assert Fediverse.as2_language(%{}) == nil
+      assert Fediverse.as2_language(%{"contentMap" => %{}}) == nil
+      assert Fediverse.as2_language(%{"contentMap" => %{"<script>" => "x"}}) == nil
+      assert Fediverse.as2_language(nil) == nil
+    end
+  end
+
+  describe "inbound storage" do
+    defp followed_account do
+      account =
+        Repo.insert!(%RemoteAccount{
+          actor_uri: @actor,
+          host: "social.example",
+          handle: "them",
+          inbox_uri: @actor <> "/inbox"
+        })
+
+      user = insert(:activated_user, fediverse_followers?: true)
+
+      Repo.insert!(%Follow{
+        user_id: user.id,
+        remote_account_id: account.id,
+        state: "accepted",
+        follow_activity_id: "https://vutuv.test/follows/#{account.id}"
+      })
+
+      {user, account}
+    end
+
+    defp create_activity(object_overrides) do
+      object =
+        Map.merge(
+          %{
+            "id" => "https://social.example/posts/#{System.unique_integer([:positive])}",
+            "type" => "Note",
+            "attributedTo" => @actor,
+            "content" => "<p>Hello.</p>",
+            "to" => [@public],
+            "cc" => []
+          },
+          object_overrides
+        )
+
+      %{"type" => "Create", "actor" => @actor, "object" => object}
+    end
+
+    test "a cached remote post keeps the language its origin declared" do
+      {_user, _account} = followed_account()
+
+      activity = create_activity(%{"contentMap" => %{"en" => "<p>Hello.</p>"}})
+      assert :ok = Fediverse.record_remote_post(activity, @actor)
+
+      assert [%RemotePost{language: "en"}] = Repo.all(RemotePost)
+    end
+
+    test "a post that declares nothing stores NULL" do
+      {_user, _account} = followed_account()
+
+      assert :ok = Fediverse.record_remote_post(create_activity(%{}), @actor)
+
+      assert [%RemotePost{language: nil}] = Repo.all(RemotePost)
+    end
+  end
+end


### PR DESCRIPTION
Föderation der Sprachangabe (#1488): ausgehend trägt jede Note die deklarierte Sprache als AS2 `contentMap` (das Feld, aus dem Mastodon die Sprache liest — ohne sie fällt ein Beitrag aus den öffentlichen Timelines jedes Lesers mit Sprachfilter); NULL erzeugt keinen Key. Eingehend liest EIN benanntes `as2_language/1` (contentMap → nameMap → summaryMap → `@context` `@language`, normalisiert auf den Primär-Subtag) und füllt die `language`-Spalten an allen Ingest-Stellen. Nur Originale föderieren; Übersetzungen verlassen nie das Haus. Nebenbei ignoriert der Fence-Vergleich des Übersetzers jetzt reine Leerraum-Unterschiede (Eval-Befund).

Closes #1488

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*

https://claude.ai/code/session_0159WnrRezuoxqwov7gUTAmx