### PR TITLE
Aufräum-Pass über den Übersetzungs-Milestone (v7.299.2)

### DIFF
--- a/docs/architecture/translations.md
+++ b/docs/architecture/translations.md
@@ -104,8 +104,9 @@ broadcast swaps the translated body in, labelled "Translated from X" with
 the original one tap away. A shown translation renders through the normal
 Markdown pipeline (local posts) or as plain text (remote content), and the
 card's `lang` attribute follows what is shown. The host-side half is
-`VutuvWeb.Live.PostTranslations`; the card-side half is the `translations`
-map + `translatable?` flag on `VutuvWeb.PostComponents`.
+`VutuvWeb.Live.PostTranslations`; the card-side half is the single
+`translations` attr on `VutuvWeb.PostComponents` — a map means the viewer
+gets the controls, nil (every non-LiveView surface) means they do not.
 
 The **feed language preference** (issue #1461, on /settings/preferences)
 adds Mastodon's chosen-languages filter: `users.feed_languages` (nil = all)

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -283,9 +283,9 @@ defmodule Vutuv.Accounts.User do
     # outside `feed_languages` — "original" / "translate" / "hide"; nil
     # inherits the installation default (a Vutuv.Prefs knob). The chips list
     # is the member's own (nil = all languages, no installation default: "all"
-    # is the only sensible default everywhere). Read the pair through
-    # `Vutuv.Posts.feed_language_filter/1` and the translate-mode helpers,
-    # never raw.
+    # is the only sensible default everywhere). Read the chips through
+    # `Vutuv.Posts.chosen_feed_languages/1` (the hide filter and the
+    # translate mode both do), never raw.
     field(:feed_foreign_posts, :string)
     field(:feed_languages, {:array, :string})
     # The reader's post-display preferences (same settings page, applied to
@@ -708,7 +708,9 @@ defmodule Vutuv.Accounts.User do
     # The feed's foreign-language mode (issue #1461); a tampered value must
     # not fail the whole preferences form, so unknown values are refused with
     # a field error like the map service above.
-    |> validate_inclusion(:feed_foreign_posts, ~w(original translate hide))
+    # The closed value set has one owner: the Vutuv.Prefs registry entry that
+    # also drives the settings page's select.
+    |> validate_inclusion(:feed_foreign_posts, Prefs.pref!(:feed_foreign_posts).values)
     |> normalize_feed_languages()
     # Post-display line clamp: 0 means "no truncation"; anything above is a
     # line count, capped so nobody stores an absurd value (the bound comes from

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -2571,7 +2571,7 @@ defmodule Vutuv.Fediverse do
         (MapSet.member?(visible_ids, post.id) or
            (viewer.admin? == true and Posts.moderation_hidden?(post))) and
           not MapSet.member?(blocked_author_ids, post.user_id) and
-          (is_nil(chosen) or is_nil(post.language) or post.language in chosen)
+          Posts.language_visible?(post.language, chosen)
 
       _entry ->
         false

--- a/lib/vutuv/languages.ex
+++ b/lib/vutuv/languages.ex
@@ -95,6 +95,18 @@ defmodule Vutuv.Languages do
   @doc "Every known language code (ISO 639-1)."
   def codes, do: @codes
 
+  @doc """
+  The locales this installation serves its UI in — the Endpoint's `:locales`
+  config, the same list `VutuvWeb.Plug.Locale` negotiates against. The one
+  public reader, so the composer's language select and the popular-posts
+  pools cannot each grow their own copy of where that list lives.
+  """
+  def site_locales do
+    :vutuv
+    |> Application.get_env(VutuvWeb.Endpoint, [])
+    |> Keyword.get(:locales, ["en"])
+  end
+
   @doc "Whether `code` is one of the curated languages."
   def known?(code) when is_binary(code), do: MapSet.member?(@code_set, code)
   def known?(_code), do: false

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -2230,16 +2230,27 @@ defmodule Vutuv.Posts do
   end
 
   @doc """
+  The languages the member marked as their own (the chips on
+  /settings/preferences), normalized for reading: `[]` when they never chose
+  any. The one raw read of the `feed_languages` column — its two consumers,
+  the hide filter below and the translate mode's "is this post foreign?"
+  test (`VutuvWeb.Live.PostTranslations`), interpret an empty choice
+  differently BY DESIGN: hide mode with no chips hides nothing
+  (`feed_language_filter/1` answers nil), while translate mode with no
+  chips treats only the UI locale as the member's own.
+  """
+  def chosen_feed_languages(%User{feed_languages: chosen}), do: chosen || []
+
+  @doc """
   The chosen-languages list the viewer's feed HIDES by (issue #1461), or nil
   when nothing is hidden — which is almost everyone: only the "hide" mode
   with a real language selection filters at all. The one place this pair of
   columns is interpreted for the feed queries.
   """
   def feed_language_filter(%User{} = viewer) do
-    chosen = viewer.feed_languages
+    chosen = chosen_feed_languages(viewer)
 
-    if Vutuv.Prefs.get(viewer, :feed_foreign_posts) == "hide" and is_list(chosen) and
-         chosen != [] do
+    if Vutuv.Prefs.get(viewer, :feed_foreign_posts) == "hide" and chosen != [] do
       chosen
     end
   end
@@ -2267,6 +2278,16 @@ defmodule Vutuv.Posts do
   def named_language_scope(query, chosen) when is_list(chosen) do
     from([language_source: x] in query, where: is_nil(x.language) or x.language in ^chosen)
   end
+
+  @doc """
+  The in-memory twin of `language_scope/2`, for rows a query already fetched
+  (the boost source's local half lives outside its query). Same rule, one
+  owner: NULL — the filter's or the row's — never hides.
+  """
+  def language_visible?(_language, nil), do: true
+
+  def language_visible?(language, chosen) when is_list(chosen),
+    do: is_nil(language) or language in chosen
 
   @doc """
   One page of `viewer`'s newsfeed: own posts plus posts **and reposts** of

--- a/lib/vutuv/posts/popular_posts.ex
+++ b/lib/vutuv/posts/popular_posts.ex
@@ -113,17 +113,9 @@ defmodule Vutuv.Posts.PopularPosts do
   # One ranking query per configured locale, for the whole installation,
   # however many people are reading.
   defp snapshot(table) do
-    for locale <- locales() do
+    for locale <- Vutuv.Languages.site_locales() do
       :ets.insert(table, {{:pool, locale}, Vutuv.Posts.compute_discover_pool(locale, @pool_size)})
     end
-  end
-
-  # The installation's configured locales, the same list the locale plug reads
-  # (it lives under the Endpoint's config, not at the top level).
-  defp locales do
-    :vutuv
-    |> Application.get_env(VutuvWeb.Endpoint, [])
-    |> Keyword.get(:locales, ["en"])
   end
 
   defp schedule(interval), do: Process.send_after(self(), :refresh, interval)

--- a/lib/vutuv/translations.ex
+++ b/lib/vutuv/translations.ex
@@ -123,7 +123,7 @@ defmodule Vutuv.Translations do
   the row stale, and a stale row answers nil (the next request re-translates).
   """
   def fresh_translation(subject, target_language) do
-    if translation = Repo.one(translation_query(subject, target_language)) do
+    if translation = Repo.one(subject_query(Translation, subject, target_language)) do
       if translation.source_sha256 == source_sha256(subject), do: translation
     end
   end
@@ -216,7 +216,7 @@ defmodule Vutuv.Translations do
 
   @doc "The open (pending or running) job for `subject` + target, if any."
   def open_job(subject, target_language) do
-    from(j in job_query(subject, target_language),
+    from(j in subject_query(TranslationJob, subject, target_language),
       where: j.status in ^TranslationJob.open_statuses()
     )
     |> Repo.one()
@@ -385,14 +385,12 @@ defmodule Vutuv.Translations do
   `{:translation_failed, subject_key, target_language}` (the key as
   `subject/1` returns it).
   """
-  def topic(%Post{id: id}), do: "translation:post:#{id}"
-  def topic(%RemotePost{id: id}), do: "translation:remote_post:#{id}"
-  def topic(%Note{id: id}), do: "translation:note:#{id}"
+  def topic(%schema{} = subject) when schema in [Post, RemotePost, Note],
+    do: key_topic(subject_key(subject))
 
-  def topic(row) do
-    {kind, id} = subject(row)
-    "translation:#{kind}:#{id}"
-  end
+  def topic(row), do: key_topic(subject(row))
+
+  defp key_topic({kind, id}), do: "translation:#{kind}:#{id}"
 
   defp broadcast(row, message) do
     Phoenix.PubSub.broadcast(Vutuv.PubSub, topic(row), message)
@@ -413,19 +411,11 @@ defmodule Vutuv.Translations do
     {:unsafe_fragment, "(#{column}, target_language) WHERE #{column} IS NOT NULL#{extra_where}"}
   end
 
-  defp translation_query(subject, target_language) do
+  defp subject_query(schema, subject, target_language) do
     [{column, id}] = subject_attrs(subject)
 
-    from(t in Translation,
+    from(t in schema,
       where: field(t, ^column) == ^id and t.target_language == ^target_language
-    )
-  end
-
-  defp job_query(subject, target_language) do
-    [{column, id}] = subject_attrs(subject)
-
-    from(j in TranslationJob,
-      where: field(j, ^column) == ^id and j.target_language == ^target_language
     )
   end
 

--- a/lib/vutuv/translations/translation_job.ex
+++ b/lib/vutuv/translations/translation_job.ex
@@ -15,7 +15,6 @@ defmodule Vutuv.Translations.TranslationJob do
 
   use VutuvWeb, :model
 
-  @statuses ~w(pending running done failed)
   @open_statuses ~w(pending running)
 
   schema "translation_jobs" do
@@ -31,8 +30,6 @@ defmodule Vutuv.Translations.TranslationJob do
 
     timestamps()
   end
-
-  def statuses, do: @statuses
 
   @doc "The statuses that count as unfinished work (mirrors the partial unique indexes)."
   def open_statuses, do: @open_statuses

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -55,6 +55,7 @@ defmodule VutuvWeb.PostComponents do
   alias Vutuv.Tags
   alias Vutuv.Translations.Translation
   alias VutuvWeb.FediverseComponents
+  alias VutuvWeb.Live.PostTranslations
   alias VutuvWeb.Markdown
   alias VutuvWeb.PostLive.RemoteActionsComponent
 
@@ -166,17 +167,13 @@ defmodule VutuvWeb.PostComponents do
   )
 
   attr(:translations, :map,
-    default: %{},
+    default: nil,
     doc:
       "the host's translation map (issue #1462), key {:post, id} → :pending | " <>
-        "%Vutuv.Translations.Translation{} (= shown). The card looks itself up"
-  )
-
-  attr(:translatable?, :boolean,
-    default: false,
-    doc:
-      "whether this viewer gets the Translate action (VutuvWeb.Live.PostTranslations." <>
-        "available?/1 — LiveView hosts with a signed-in viewer only)"
+        "%Vutuv.Translations.Translation{} (= shown). The card looks itself up. " <>
+        "nil (every non-LiveView surface) means this viewer gets no translation " <>
+        "controls; hosts pass a map exactly when VutuvWeb.Live.PostTranslations." <>
+        "available?/1 says yes"
   )
 
   def post_card(assigns) do
@@ -254,12 +251,11 @@ defmodule VutuvWeb.PostComponents do
       # that carry the reader's preference onto the post body; nil for a default
       # / logged-out reader, so their DOM stays clean and the CSS fallbacks apply.
       |> assign(:body_style, post_body_style(prefs))
-      # The translation line's three states + the body's `lang` attribute
-      # (screen readers, hyphenation — worth having independent of any
-      # translation). A shown translation is in the reader's own language.
-      |> assign(:translation_state, translation.state)
-      |> assign(:body_lang, translation.lang)
-      |> assign(:offer_translation?, translation.offer?)
+      # The card's translation view-state (the same map the remote cards
+      # keep): the line's three states + the body's `lang` attribute (screen
+      # readers, hyphenation — worth having independent of any translation).
+      # A shown translation is in the reader's own language.
+      |> assign(:translation, translation)
       |> assign(:restricted?, Posts.restricted?(post))
       |> assign(:permalink, Posts.path(post))
       |> assign(:gallery, gallery)
@@ -718,8 +714,7 @@ defmodule VutuvWeb.PostComponents do
         "the page (the permalink thread), so the row is just the flat card"
   )
 
-  attr(:translations, :map, default: %{})
-  attr(:translatable?, :boolean, default: false)
+  attr(:translations, :map, default: nil)
 
   def post_thread_entry(assigns) do
     # An explicit [] means "collapsed, no ancestors" (a root/standalone) and must
@@ -742,7 +737,6 @@ defmodule VutuvWeb.PostComponents do
         surface={@surface}
         conn_or_socket={@conn_or_socket}
         translations={@translations}
-        translatable?={@translatable?}
         show_reply_banner={@nest_parent}
       />
     <% else %>
@@ -757,7 +751,6 @@ defmodule VutuvWeb.PostComponents do
         surface={@surface}
         conn_or_socket={@conn_or_socket}
         translations={@translations}
-        translatable?={@translatable?}
       />
     <% end %>
     """
@@ -839,8 +832,7 @@ defmodule VutuvWeb.PostComponents do
   )
 
   attr(:acting_as, :any, default: nil)
-  attr(:translations, :map, default: %{})
-  attr(:translatable?, :boolean, default: false)
+  attr(:translations, :map, default: nil)
 
   defp thread_chain(assigns) do
     # `@thread_indent_cap` is a module attribute, not an assign, so resolve the
@@ -935,7 +927,6 @@ defmodule VutuvWeb.PostComponents do
             viewer={@viewer}
             marks={node.marks}
             translations={@translations}
-            translatable?={@translatable?}
             live?
           />
         <% else %>
@@ -953,7 +944,6 @@ defmodule VutuvWeb.PostComponents do
             mode={Map.get(node, :mode, :preview)}
             likers={Map.get(node, :likers)}
             translations={@translations}
-            translatable?={@translatable?}
             show_reply_banner={reply_banner?(node, @connected?, @indent?)}
           />
         <% end %>
@@ -967,7 +957,6 @@ defmodule VutuvWeb.PostComponents do
         surface={@surface}
         conn_or_socket={@conn_or_socket}
         translations={@translations}
-        translatable?={@translatable?}
       />
     </div>
     """
@@ -1044,13 +1033,8 @@ defmodule VutuvWeb.PostComponents do
   )
 
   attr(:translations, :map,
-    default: %{},
+    default: nil,
     doc: "the host's translation map (issue #1462), key {:note, id} — see <.post_card>"
-  )
-
-  attr(:translatable?, :boolean,
-    default: false,
-    doc: "whether this viewer gets the Translate action — see <.post_card>"
   )
 
   def remote_reply_card(assigns) do
@@ -2038,13 +2022,8 @@ defmodule VutuvWeb.PostComponents do
   )
 
   attr(:translations, :map,
-    default: %{},
+    default: nil,
     doc: "the host's translation map (issue #1462), key {:remote_post, id} — see <.post_card>"
-  )
-
-  attr(:translatable?, :boolean,
-    default: false,
-    doc: "whether this viewer gets the Translate action — see <.post_card>"
   )
 
   def remote_post_card(assigns) do
@@ -2473,8 +2452,7 @@ defmodule VutuvWeb.PostComponents do
   )
 
   attr(:conn_or_socket, :any, required: true)
-  attr(:translations, :map, default: %{})
-  attr(:translatable?, :boolean, default: false)
+  attr(:translations, :map, default: nil)
 
   def thread_conversation(assigns) do
     top_id = with %{id: id} <- List.first(assigns.posts), do: id
@@ -2487,7 +2465,6 @@ defmodule VutuvWeb.PostComponents do
       surface={:flat}
       conn_or_socket={@conn_or_socket}
       translations={@translations}
-      translatable?={@translatable?}
     />
     """
   end
@@ -2512,8 +2489,7 @@ defmodule VutuvWeb.PostComponents do
   attr(:note_marks, :any, default: nil)
   attr(:likers, :any, default: nil)
   attr(:conn_or_socket, :any, required: true)
-  attr(:translations, :map, default: %{})
-  attr(:translatable?, :boolean, default: false)
+  attr(:translations, :map, default: nil)
 
   def thread_window_conversation(assigns) do
     window = assigns.window
@@ -2542,7 +2518,6 @@ defmodule VutuvWeb.PostComponents do
         surface={:flat}
         conn_or_socket={@conn_or_socket}
         translations={@translations}
-        translatable?={@translatable?}
       />
       <div class="py-3 pl-1">
         <button
@@ -2566,7 +2541,6 @@ defmodule VutuvWeb.PostComponents do
       surface={:flat}
       conn_or_socket={@conn_or_socket}
       translations={@translations}
-      translatable?={@translatable?}
     />
     <div :if={@window.more > 0} class="pl-1 pt-3">
       <button
@@ -2917,7 +2891,7 @@ defmodule VutuvWeb.PostComponents do
               <div
                 :if={@mode == :full and @post.body != ""}
                 data-post-body
-                lang={@body_lang}
+                lang={@translation.lang}
                 class="markdown markdown--post mt-2 text-slate-800 dark:text-slate-200"
                 {style_attrs(@body_style)}
               >
@@ -2944,7 +2918,7 @@ defmodule VutuvWeb.PostComponents do
                 body_style={@body_style}
                 class="mt-2"
                 tags={@post.tags}
-                lang={@body_lang}
+                lang={@translation.lang}
                 wrap
               >
                 <:float>
@@ -2974,7 +2948,7 @@ defmodule VutuvWeb.PostComponents do
                 body_style={@body_style}
                 class="mt-2"
                 tags={@post.tags}
-                lang={@body_lang}
+                lang={@translation.lang}
                 wrap
               >
                 <:float>
@@ -2993,7 +2967,7 @@ defmodule VutuvWeb.PostComponents do
                 class="mt-2"
                 media={@inline_media?}
                 tags={@post.tags}
-                lang={@body_lang}
+                lang={@translation.lang}
               />
 
               <%!-- Attachments the body does NOT reference inline. A single
@@ -3099,8 +3073,8 @@ defmodule VutuvWeb.PostComponents do
           or — never silently — the "Translated from …" label with the original
           one tap away. Events go to the host LiveView (no phx-target). --%>
           <.translation_line
-            state={@translation_state}
-            offer?={@offer_translation?}
+            state={@translation.state}
+            offer?={@translation.offer?}
             kind="post"
             subject_id={@post.id}
           />
@@ -3954,14 +3928,15 @@ defmodule VutuvWeb.PostComponents do
   defp translated_from_label(%Translation{source_language: source}),
     do: gettext("Translated from %{language}", language: Languages.name(source))
 
-  # A card whose language differs from the reader's UI locale — or declares
-  # none — gets the manual Translate action (issue #1462).
+  # A card whose language differs from the reader's translation target — or
+  # declares none — gets the manual Translate action (issue #1462). The
+  # target has one owner, the same the "translate" event resolves against.
   defp foreign_language?(language),
-    do: is_nil(language) or language != Gettext.get_locale(VutuvWeb.Gettext)
+    do: is_nil(language) or language != PostTranslations.target_language()
 
   # The shown translation's content warning, else the original — a warning
   # must never silently vanish just because its translation lacks one.
-  defp translated_summary(%{shown: %Translation{summary: summary}}, _original)
+  defp translated_summary(%{state: %Translation{summary: summary}}, _original)
        when is_binary(summary) and summary != "",
        do: summary
 
@@ -3969,7 +3944,8 @@ defmodule VutuvWeb.PostComponents do
 
   # One card's translation view-state, computed in one place for all three
   # card kinds: what the body renders from, which language it is in, and
-  # whether the Translate action shows.
+  # whether the Translate action shows. A nil translations map means this
+  # viewer gets no controls at all (every non-LiveView surface).
   defp card_translation(assigns, key, original_body, original_language) do
     state = assigns.translations[key]
     shown = if match?(%Translation{}, state), do: state
@@ -3977,9 +3953,8 @@ defmodule VutuvWeb.PostComponents do
     %{
       state: state,
       body_source: if(shown, do: shown.body, else: original_body),
-      shown: shown,
       lang: if(shown, do: shown.target_language, else: original_language),
-      offer?: assigns.translatable? and foreign_language?(original_language)
+      offer?: is_map(assigns.translations) and foreign_language?(original_language)
     }
   end
 

--- a/lib/vutuv_web/controllers/settings_controller.ex
+++ b/lib/vutuv_web/controllers/settings_controller.ex
@@ -770,12 +770,10 @@ defmodule VutuvWeb.SettingsController do
   end
 
   def reset_feed_languages(conn, _params) do
-    # The chips list is a plain member column beside the :feed pref group,
-    # so the reset clears both halves.
-    {:ok, _} =
-      conn.assigns[:user]
-      |> Ecto.Changeset.change(%{feed_languages: nil})
-      |> Repo.update()
+    # The chips list is a plain member column beside the :feed pref group, so
+    # the reset clears both halves — through the user-update chokepoint like
+    # every other settings write (the changeset maps [] to nil).
+    {:ok, _} = Accounts.update_user(conn.assigns[:user], %{"feed_languages" => []})
 
     reset_prefs(conn, :feed, gettext("Feed language settings reset to the site defaults."))
   end

--- a/lib/vutuv_web/live/post_live/composer.ex
+++ b/lib/vutuv_web/live/post_live/composer.ex
@@ -348,16 +348,8 @@ defmodule VutuvWeb.PostLive.Composer do
   defp initial_language(%Post{language: language}) when is_binary(language), do: language
   defp initial_language(_post), do: Gettext.get_locale(VutuvWeb.Gettext)
 
-  # The installation's locales, from the Endpoint's config like the locale
-  # plug reads them.
-  defp site_locales do
-    :vutuv
-    |> Application.get_env(VutuvWeb.Endpoint, [])
-    |> Keyword.get(:locales, ["en"])
-  end
-
   defp other_language_options do
-    site = site_locales()
+    site = Languages.site_locales()
     Enum.reject(Languages.options(), fn {_label, code} -> code in site end)
   end
 
@@ -1820,7 +1812,7 @@ defmodule VutuvWeb.PostLive.Composer do
                 title={gettext("The language this post is written in")}
                 class={[input_class(), "h-9 w-auto py-0 text-sm"]}
               >
-                <option :for={code <- site_locales()} value={code} selected={@language == code}>
+                <option :for={code <- Languages.site_locales()} value={code} selected={@language == code}>
                   {String.upcase(code)}
                 </option>
                 <optgroup label={gettext("More languages")}>

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -155,10 +155,10 @@ defmodule VutuvWeb.PostLive.Feed do
   # connected socket would replay as an empty feed.
   defp apply_feed_payload(socket, payload) do
     socket
-    # On-demand translations (issue #1462): the per-card view state, and
-    # whether this viewer gets the controls at all.
-    |> assign(:post_translations, %{})
-    |> assign(:translatable?, PostTranslations.available?(socket.assigns.current_user))
+    # On-demand translations (issue #1462): the per-card view state. A map
+    # means this viewer gets the controls, nil means they do not — the cards
+    # read that straight off the one assign.
+    |> assign(:post_translations, PostTranslations.initial_map(socket.assigns.current_user))
     |> assign(:content_filters, payload.content_filters)
     |> assign(:revealed_filters, MapSet.new())
     |> assign(:page_title, gettext("Feed"))
@@ -953,19 +953,12 @@ defmodule VutuvWeb.PostLive.Feed do
     end
   end
 
-  defp find_by_translation_key(entries, {:post, id}) do
+  defp find_by_translation_key(entries, key) do
+    # Reuses entry_subjects/1, so "what can this entry translate" is spelled
+    # once — the reverse lookup cannot drift from the auto-translate sweep.
     Enum.find(entries, fn entry ->
-      not Posts.remote_feed_entry?(entry) and not Posts.remote_reply_entry?(entry) and
-        (entry.post.id == id or Enum.any?(entry[:ancestors] || [], &(&1.id == id)))
+      Enum.any?(entry_subjects(entry), &(PostTranslations.subject_key(&1) == key))
     end)
-  end
-
-  defp find_by_translation_key(entries, {:remote_post, id}) do
-    Enum.find(entries, &(Posts.remote_feed_entry?(&1) and &1.remote_post.id == id))
-  end
-
-  defp find_by_translation_key(entries, {:note, id}) do
-    Enum.find(entries, &(Posts.remote_reply_entry?(&1) and &1.note.id == id))
   end
 
   defp find_by_post_id(entries, post_id) do
@@ -1173,7 +1166,6 @@ defmodule VutuvWeb.PostLive.Feed do
                     marks={entry[:marks]}
                     reposted_by={entry.reposted_by}
                     translations={@post_translations}
-                    translatable?={@translatable?}
                     live?
                   />
                 <% Posts.remote_feed_entry?(entry) -> %>
@@ -1190,7 +1182,6 @@ defmodule VutuvWeb.PostLive.Feed do
                     boosted_by={entry[:boosted_by]}
                     viewer={@current_user}
                     translations={@post_translations}
-                    translatable?={@translatable?}
                   />
                 <% true -> %>
                   <%!-- A vutuv member's post that a followed account out there
@@ -1211,7 +1202,6 @@ defmodule VutuvWeb.PostLive.Feed do
                     conn_or_socket={@socket}
                     engagement={entry.engagement}
                     translations={@post_translations}
-                    translatable?={@translatable?}
                     surface={:flat}
                   />
               <% end %>

--- a/lib/vutuv_web/live/post_live/thread.ex
+++ b/lib/vutuv_web/live/post_live/thread.ex
@@ -72,9 +72,9 @@ defmodule VutuvWeb.PostLive.Thread do
       |> assign(:reply_budget, defaults.replies)
       |> assign(:subscribed_ids, MapSet.new())
       |> assign(:notice, nil)
-      # On-demand translations (issue #1462): per-card view state + gate.
-      |> assign(:post_translations, %{})
-      |> assign(:translatable?, PostTranslations.available?(socket.assigns.current_user))
+      # On-demand translations (issue #1462): per-card view state; a map
+      # means this viewer gets the controls, nil means they do not.
+      |> assign(:post_translations, PostTranslations.initial_map(socket.assigns.current_user))
       |> mount_window()
 
     {:ok, socket}
@@ -402,7 +402,6 @@ defmodule VutuvWeb.PostLive.Thread do
             mode={:full}
             conn_or_socket={@socket}
             translations={@post_translations}
-            translatable?={@translatable?}
           />
         <% true -> %>
           <%!-- The conversation (issue #1006), rendered like a feed thread
@@ -424,7 +423,6 @@ defmodule VutuvWeb.PostLive.Thread do
                 auto_scroll?={@auto_scroll?}
                 conn_or_socket={@socket}
                 translations={@post_translations}
-                translatable?={@translatable?}
               />
             <% else %>
               <.thread_window_conversation
@@ -439,7 +437,6 @@ defmodule VutuvWeb.PostLive.Thread do
                 auto_scroll?={@auto_scroll?}
                 conn_or_socket={@socket}
                 translations={@post_translations}
-                translatable?={@translatable?}
               />
             <% end %>
           </.card>

--- a/lib/vutuv_web/live/post_translations.ex
+++ b/lib/vutuv_web/live/post_translations.ex
@@ -24,8 +24,8 @@ defmodule VutuvWeb.Live.PostTranslations do
   """
 
   alias Vutuv.Accounts.User
+  alias Vutuv.Fediverse
   alias Vutuv.Posts
-  alias Vutuv.Repo
   alias Vutuv.Translations
   alias Vutuv.Translations.Translation
 
@@ -40,6 +40,13 @@ defmodule VutuvWeb.Live.PostTranslations do
   def target_language, do: Gettext.get_locale(VutuvWeb.Gettext)
 
   @doc """
+  The translations map a host mounts with: an empty map when this viewer gets
+  the controls (`available?/1`), nil when they do not. The cards read that
+  difference straight off the one assign, so no second gate travels with it.
+  """
+  def initial_map(viewer), do: if(available?(viewer), do: %{})
+
+  @doc """
   Handles a card's "Translate" click. Returns `{:ok, key, state}` with
   `state` either `:pending` or the cached `%Translation{}` (shown at once),
   or `:denied` for a subject this viewer may not read (a tampered id), the
@@ -47,20 +54,28 @@ defmodule VutuvWeb.Live.PostTranslations do
   """
   def request(viewer, kind, id) do
     with true <- available?(viewer),
-         {:ok, subject} <- fetch_subject(kind, id, viewer) do
-      case Translations.request(subject, target_language()) do
-        {:cached, translation} ->
-          {:ok, subject_key(subject), translation}
-
-        {:queued, _job} ->
-          Phoenix.PubSub.subscribe(Vutuv.PubSub, Translations.topic(subject))
-          {:ok, subject_key(subject), :pending}
-
-        :disabled ->
-          :denied
-      end
+         {:ok, subject} <- fetch_subject(kind, id, viewer),
+         {:ok, state} <- track(subject) do
+      {:ok, subject_key(subject), state}
     else
       _denied -> :denied
+    end
+  end
+
+  # The one mapping from `Translations.request/2` to a card's state — a cache
+  # hit shows at once, a queued job subscribes this host for the swap-in.
+  # Shared by the click path above and the translate mode below.
+  defp track(subject) do
+    case Translations.request(subject, target_language()) do
+      {:cached, translation} ->
+        {:ok, translation}
+
+      {:queued, _job} ->
+        Phoenix.PubSub.subscribe(Vutuv.PubSub, Translations.topic(subject))
+        {:ok, :pending}
+
+      :disabled ->
+        :denied
     end
   end
 
@@ -98,12 +113,16 @@ defmodule VutuvWeb.Live.PostTranslations do
   translation row stays, so translating again is instant). Returns
   `{key, map}` or `:ignore` for an unknown kind.
   """
-  def show_original(map, kind, id) do
+  def show_original(map, kind, id) when is_map(map) do
     case parse_key(kind, id) do
       nil -> :ignore
       key -> {key, Map.delete(map, key)}
     end
   end
+
+  # A viewer without the controls (nil map) has nothing to show or hide — a
+  # hand-crafted event must not crash the host.
+  def show_original(nil, _kind, _id), do: :ignore
 
   @doc ~S|The `{kind, id}` map key for a card's subject struct.|
   defdelegate subject_key(subject), to: Translations
@@ -127,7 +146,7 @@ defmodule VutuvWeb.Live.PostTranslations do
   """
   def auto_translate(map, subjects, viewer) do
     target = target_language()
-    chosen = viewer.feed_languages || []
+    chosen = Posts.chosen_feed_languages(viewer)
 
     wanted =
       subjects
@@ -137,37 +156,24 @@ defmodule VutuvWeb.Live.PostTranslations do
     cached = Translations.fresh_translations(wanted, target)
 
     Enum.reduce(wanted, map, fn subject, acc ->
-      resolve_auto(acc, subject, cached[subject_key(subject)], target)
+      resolve_auto(acc, subject, cached[subject_key(subject)])
     end)
   end
 
-  defp auto_translation_wanted?(map, subject, target, chosen) do
-    language = subject_language(subject)
-
+  defp auto_translation_wanted?(map, %{language: language} = subject, target, chosen) do
     is_binary(language) and language != target and language not in chosen and
       not Map.has_key?(map, subject_key(subject))
   end
 
-  defp resolve_auto(map, subject, %Translation{} = cached, _target),
+  defp resolve_auto(map, subject, %Translation{} = cached),
     do: Map.put(map, subject_key(subject), cached)
 
-  defp resolve_auto(map, subject, nil, target) do
-    case Translations.request(subject, target) do
-      {:cached, translation} ->
-        Map.put(map, subject_key(subject), translation)
-
-      {:queued, _job} ->
-        Phoenix.PubSub.subscribe(Vutuv.PubSub, Translations.topic(subject))
-        Map.put(map, subject_key(subject), :pending)
-
-      :disabled ->
-        map
+  defp resolve_auto(map, subject, nil) do
+    case track(subject) do
+      {:ok, state} -> Map.put(map, subject_key(subject), state)
+      :denied -> map
     end
   end
-
-  defp subject_language(%Posts.Post{language: language}), do: language
-  defp subject_language(%Vutuv.Fediverse.RemotePost{language: language}), do: language
-  defp subject_language(%Vutuv.Fediverse.Note{language: language}), do: language
 
   # The subject behind a card's click, checked against the viewer: a post
   # must be visible to them (a tampered id must not spend translation budget
@@ -183,15 +189,15 @@ defmodule VutuvWeb.Live.PostTranslations do
   end
 
   defp fetch_subject("remote_post", id, _viewer) do
-    case Repo.get(Vutuv.Fediverse.RemotePost, id) do
-      %Vutuv.Fediverse.RemotePost{} = remote -> {:ok, remote}
+    case Fediverse.get_remote_post(id) do
+      %Fediverse.RemotePost{} = remote -> {:ok, remote}
       nil -> :error
     end
   end
 
   defp fetch_subject("note", id, _viewer) do
-    case Repo.get(Vutuv.Fediverse.Note, id) do
-      %Vutuv.Fediverse.Note{} = note -> {:ok, note}
+    case Fediverse.get_note(id) do
+      %Fediverse.Note{} = note -> {:ok, note}
       nil -> :error
     end
   end

--- a/lib/vutuv_web/live/user_profile_live.ex
+++ b/lib/vutuv_web/live/user_profile_live.ex
@@ -82,9 +82,9 @@ defmodule VutuvWeb.UserProfileLive do
       # (issue #859), one of "all" / "certification" / "license". Set once here
       # so it survives the PubSub re-renders that rebuild the profile assigns.
       |> assign(:qualifications_tab, "all")
-      # On-demand translations (issue #1462): per-card view state + gate.
-      |> assign(:post_translations, %{})
-      |> assign(:translatable?, PostTranslations.available?(socket.assigns.current_user))
+      # On-demand translations (issue #1462): per-card view state; a map
+      # means this viewer gets the controls, nil means they do not.
+      |> assign(:post_translations, PostTranslations.initial_map(socket.assigns.current_user))
       |> mount_profile()
 
     # Only a real visitor triggers the (cached, single-flight) social feed

--- a/lib/vutuv_web/templates/user/show.html.heex
+++ b/lib/vutuv_web/templates/user/show.html.heex
@@ -540,7 +540,6 @@ the resulting ~200px rail width. --%>
             viewer={@current_user}
             engagement={entry[:engagement]}
             translations={@post_translations}
-            translatable?={@translatable?}
             surface={:flat}
           />
         </div>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.299.1",
+      version: "7.299.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Ein /simplify-Pass über den frisch gelandeten Übersetzungs-Milestone (v7.297.2–v7.299.1), vier Review-Blickwinkel, Funde direkt eingearbeitet:

- Die Karten lesen die Übersetzungs-Controls aus **einem** `translations`-Attr (nil = keine Controls) statt aus einem Zwillings-Flag, das durch sieben Komponenten gereicht wurde.
- `Posts.chosen_feed_languages/1` ist die eine Lesestelle der Sprach-Chips; `Posts.language_visible?/2` teilt die NULL-versteckt-nie-Regel zwischen Queries und Boost-Pfad.
- Der Klick-Pfad lädt Remote-Subjekte über die UUID-castenden Fediverse-Getter (nackte `Repo.get` crashten auf manipulierte `phx-value-id`).
- Feed-Sprachen-Reset über `Accounts.update_user/2`, `Languages.site_locales/0` als einziger Locales-Leser, Topic-Format/Query-Helfer einmal statt mehrfach, toter Code raus.

Netto 28 Zeilen weniger, Verhalten unverändert, `mix precommit` grün (7.868 Tests).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*

https://claude.ai/code/session_0159WnrRezuoxqwov7gUTAmx
