### PR TITLE
Der Feed öffnet auf dem zuletzt gewählten Reiter (v7.300.0)

### DIFF
--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -357,10 +357,40 @@ in-memory twin `Posts.feed_filter_accepts?/2`: a followed member's post neither
 appears nor counts toward the pill while the Fediverse tab is open. The one
 exception is the **viewer's own** post, which must be visible after they press
 Post — there the feed switches back to "All" rather than swallowing it. The
-choice is socket state with no URL behind it (this LiveView is off-router and
-cannot patch), so a reload opens on "All", and the agent-format siblings
-(`/feed.md|txt|json|xml`) always serve the whole feed, exactly as the archive's
-siblings ignore `?type=`.
+choice has no URL behind it (this LiveView is off-router and cannot patch), and
+the agent-format siblings (`/feed.md|txt|json|xml`) always serve the whole feed,
+exactly as the archive's siblings ignore `?type=`.
+
+**The tab outlives the visit** (issue #1499). A click stores it on the member —
+`Posts.remember_feed_filter/2`, a narrow `update_all` on `users.feed_source`
+(NULL = All) — and `Posts.remembered_feed_filter/1` reads it back at mount off
+the struct the session already loaded, so the opening filter costs no query and
+the **dead render** already draws the right tab with the right entries. Four
+things it must get right, each of which the tests cover:
+
+* The **gate runs first**. A remembered "Fediverse" whose content has since gone
+  away shows no tab bar, and opening behind it would strand the reader on a
+  timeline with no way out — so the mount folds the filter back to `:all` while
+  leaving the stored value alone, and the tab returns with the content.
+* The write happens in the **event handler**, not in `load_source_filter/2`: the
+  same helper runs when the member's own post lands on a tab that cannot hold
+  it, and that fallback is the code's doing, not a choice to remember.
+* It goes through `update_all` rather than a changeset, because a socket's
+  `%User{}` was loaded at mount and can be hours old — writing the whole struct
+  back would undo whatever changed meanwhile, from another device or another
+  tab. Nothing asks first whether the value differs; that question cannot be
+  answered from a possibly-stale struct, and the write is one row by primary key.
+* The **`MountHandoff` subject carries the filter** (`{:feed, filter}`). The
+  stash holds one entry per member, not per socket, so with a bare `:feed` a
+  second device — or the same device after the tab changed between its HTML and
+  its socket connecting — would take a page computed for another tab. Keyed by
+  the filter a mismatch is simply a miss, and that mount loads its own page.
+
+It is deliberately **not** broadcast to the member's other devices. A live tab
+switch there would reload a timeline somebody is reading from the top, taking
+its pending batch, its loaded pages and its scroll position with it — and
+reading vutuv on the desktop while the phone sits on Fediverse is a reasonable
+thing to want. The next visit is soon enough.
 
 **The bar is shown only to a member the fediverse actually reaches** (issue
 #1267). For anyone else "Fediverse" can never fill, so "vutuv" is the same

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -288,6 +288,13 @@ defmodule Vutuv.Accounts.User do
     # translate mode both do), never raw.
     field(:feed_foreign_posts, :string)
     field(:feed_languages, {:array, :string})
+    # The feed's remembered source tab (issue #1499): "vutuv" / "fediverse",
+    # nil = All. Not a form field — `Vutuv.Posts.remember_feed_filter/2` writes
+    # it from the tab click and `remembered_feed_filter/1` reads it back at
+    # mount, so the vocabulary is closed at that chokepoint rather than in a
+    # changeset. Only the opening value: while the feed is open the LiveView's
+    # own assign is the truth.
+    field(:feed_source, :string)
     # The reader's post-display preferences (same settings page, applied to
     # every post this member reads: feed, profile Beiträge, permalink). The
     # line counts drive the CSS line-clamp on the preview body, desktop and

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -2391,6 +2391,40 @@ defmodule Vutuv.Posts do
   def normalize_feed_filter(_type), do: :all
 
   @doc """
+  The source tab `viewer` last chose on `/feed` (issue #1499) — the tab their
+  next visit opens on.
+
+  Read straight off the column the session already loaded, so the opening
+  filter costs no query and the very first (dead) render can compute the right
+  page. It is the *stored* value, not the effective one: the caller still has
+  to fold it back to `:all` when `fediverse_feed_available?/1` says the tab bar
+  has nothing to show, or a member whose fediverse content dried up would open
+  on a tab they cannot see to leave.
+  """
+  def remembered_feed_filter(%User{feed_source: source}), do: normalize_feed_filter(source)
+
+  @doc """
+  Remembers `filter` as `user`'s feed tab for the next visit.
+
+  A narrow `update_all` on the one column rather than a changeset: a socket's
+  `%User{}` was loaded at mount and can be hours old by the time a tab is
+  clicked, so writing the whole struct back would undo whatever else changed
+  meanwhile — from another device, or from a settings page in the next tab.
+  For the same reason it does not first ask whether the value differs; that
+  question cannot be answered from a struct that may be stale, and the write
+  is one row by primary key. Last click wins, which is what a "last chosen"
+  value means.
+  """
+  def remember_feed_filter(%User{} = user, filter) do
+    stored = if filter in [:vutuv, :fediverse], do: to_string(filter)
+
+    {1, nil} =
+      Repo.update_all(from(u in User, where: u.id == ^user.id), set: [feed_source: stored])
+
+    :ok
+  end
+
+  @doc """
   Whether the feed tab `filter` shows `entry` — the in-memory twin of the
   source split in `feed_sources/2`, for the entries that arrive live over
   PubSub rather than through a query.

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -12,9 +12,13 @@ defmodule VutuvWeb.PostLive.Feed do
   (`PostComponents.post_filter_tabs/1` with `feed_filter_options/0`). They
   partition the feed by what kind of post an entry carries, so the two named
   tabs together are "All"; the split itself lives in
-  `Vutuv.Posts.feed_page/2`. Like the profile's tabs the choice is socket
-  state with no URL of its own (this LiveView is off-router and cannot patch),
-  so a reload opens on "All".
+  `Vutuv.Posts.feed_page/2`. The choice has no URL of its own (this LiveView
+  is off-router and cannot patch) but it does outlive the visit: the tab is
+  remembered on the member (`Vutuv.Posts.remember_feed_filter/2`, issue
+  #1499) and read back at mount, so the next visit opens where they left off.
+  Deliberately **not** broadcast to their other devices — a live tab switch
+  would reload a timeline somebody else is reading from the top and take its
+  pending batch, its loaded pages and its scroll position with it.
 
   Real-time: `Vutuv.Posts.create_post/2` broadcasts `{:new_post, …}` and
   `Vutuv.Posts.repost_post/2` `{:new_repost, …}` to the author/reposter and
@@ -81,6 +85,13 @@ defmodule VutuvWeb.PostLive.Feed do
   end
 
   defp mount_feed(socket, user) do
+    # The tab they left on (issue #1499). It opens the page *and* keys the
+    # handoff below: the stash holds one entry per member, so two devices
+    # opening /feed within its 15s TTL would otherwise let one take a page the
+    # other computed for a different tab. Keyed by the filter, a mismatch is
+    # simply a miss and that mount loads its own page.
+    remembered = Posts.remembered_feed_filter(user)
+
     if connected?(socket) do
       Vutuv.Activity.subscribe(user.id)
       # Refresh the Berlin-day-relative post stamps ("09:50 Uhr" -> "Gestern,
@@ -92,24 +103,33 @@ defmodule VutuvWeb.PostLive.Feed do
       # The dead render stashed its computed page seconds ago
       # (VutuvWeb.Live.MountHandoff); take it and skip re-running the same
       # queries. Any miss (expired, consumed, a reconnect) recomputes.
-      case MountHandoff.take(user.id, :feed) do
+      case MountHandoff.take(user.id, {:feed, remembered}) do
         {:ok, payload} -> apply_feed_payload(socket, payload)
-        :error -> apply_feed_payload(socket, feed_payload(user))
+        :error -> apply_feed_payload(socket, feed_payload(user, remembered))
       end
     else
-      payload = feed_payload(user)
-      MountHandoff.stash(user.id, :feed, payload)
+      payload = feed_payload(user, remembered)
+      MountHandoff.stash(user.id, {:feed, remembered}, payload)
       apply_feed_payload(socket, payload)
     end
   end
 
   # Everything a feed mount computes, as data — what the dead render hands the
   # connected mount through the single-use stash.
-  defp feed_payload(user) do
+  defp feed_payload(user, remembered) do
     # The member's private content filters (issue #940): compiled once, applied
     # to every page, and the set of posts they chose to reveal anyway.
     compiled = ContentFilters.compile_for(user)
-    page = Posts.feed_page(user, limit: @page_size)
+
+    # The gate before the page, because it decides which tab this mount opens
+    # on: a remembered "Fediverse" whose content has gone away shows no tab bar
+    # at all, and stranding them on the tab behind it would leave a timeline
+    # they cannot get out of. The stored value stays untouched, so the tab
+    # comes back with the content.
+    source_tabs? = Posts.fediverse_feed_available?(user)
+    filter = if source_tabs?, do: remembered, else: :all
+
+    page = Posts.feed_page(user, limit: @page_size, filter: filter)
     entries = page.entries |> with_engagement(user) |> mark_filtered(compiled, user.id)
 
     # Read the stored draft once and hand it to the composer below, which then
@@ -122,11 +142,14 @@ defmodule VutuvWeb.PostLive.Feed do
       cursor: page.next_cursor,
       draft: draft,
       entries: entries,
+      # The tab these entries were pulled for — the remembered one, or `:all`
+      # where the bar is hidden.
+      filter: filter,
       # Whether the source tabs are worth showing this member at all (issue
       # #1267). Read once per mount and carried on the handoff like the rest;
       # it is a fact about their whole timeline, not about the open tab, so
       # switching tabs must not recompute it.
-      source_tabs?: Posts.fediverse_feed_available?(user),
+      source_tabs?: source_tabs?,
       # The desktop discovery rail renders WITH the page: it was lazy-loaded
       # for one release (v7.200.3) and the pop-in read as slowness, so it is
       # eager again — computed here once, riding the handoff to the connected
@@ -162,9 +185,9 @@ defmodule VutuvWeb.PostLive.Feed do
     |> assign(:content_filters, payload.content_filters)
     |> assign(:revealed_filters, MapSet.new())
     |> assign(:page_title, gettext("Feed"))
-    # A mount always opens on the whole feed: the source tab is socket state
-    # with no URL behind it, so there is nothing to restore it from.
-    |> assign(:feed_filter, :all)
+    # The tab this mount opened on (issue #1499) — from here on the assign is
+    # the truth, and the stored column is not read again while the page lives.
+    |> assign(:feed_filter, payload.filter)
     |> assign(:source_tabs?, payload.source_tabs?)
     |> assign(:more?, payload.more?)
     |> assign(:cursor, payload.cursor)
@@ -438,7 +461,14 @@ defmodule VutuvWeb.PostLive.Feed do
   # query pulls from, so it cannot be applied to the page already on screen —
   # the timeline reloads from the top.
   def handle_event("filter-source", %{"type" => type}, socket) do
-    {:noreply, load_source_filter(socket, Posts.normalize_feed_filter(type))}
+    filter = Posts.normalize_feed_filter(type)
+    # Remembered for the next visit (issue #1499) — here and not in
+    # `load_source_filter/2`, which the arrival of the member's own post also
+    # calls to pull the feed back to "All". That fallback is the code's doing,
+    # not theirs, and must not overwrite the tab they chose.
+    Posts.remember_feed_filter(socket.assigns.current_user, filter)
+
+    {:noreply, load_source_filter(socket, filter)}
   end
 
   def handle_event("open-composer", _params, socket) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.299.2",
+      version: "7.300.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260816211949_add_feed_source_to_users.exs
+++ b/priv/repo/migrations/20260816211949_add_feed_source_to_users.exs
@@ -1,0 +1,18 @@
+defmodule Vutuv.Repo.Migrations.AddFeedSourceToUsers do
+  use Ecto.Migration
+
+  @moduledoc """
+  The feed's remembered source tab (issue #1499): which of All / vutuv /
+  Fediverse the member last chose on `/feed`. NULL is "All" — the tab a member
+  who never touched the bar opens on, and the value a click on "All" writes
+  back. Written only by `Vutuv.Posts.remember_feed_filter/2`, which is why the
+  column carries no check constraint: the three names are a closed vocabulary
+  there, not user input. N-1 safe: a pure nullable addition.
+  """
+
+  def change do
+    alter table(:users) do
+      add(:feed_source, :string)
+    end
+  end
+end

--- a/test/vutuv_web/live/feed_source_tabs_test.exs
+++ b/test/vutuv_web/live/feed_source_tabs_test.exs
@@ -15,6 +15,7 @@ defmodule VutuvWeb.FeedSourceTabsTest do
 
   import Phoenix.LiveViewTest
 
+  alias Vutuv.Accounts.User
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.Follow
   alias Vutuv.Fediverse.PostBoost
@@ -83,6 +84,10 @@ defmodule VutuvWeb.FeedSourceTabsTest do
   defp timeline(view) do
     if has_element?(view, "#feed-posts"), do: render(element(view, "#feed-posts")), else: ""
   end
+
+  # The tab as it is stored on the member, read fresh — the socket's own
+  # `%User{}` was loaded at mount and knows nothing of what was written since.
+  defp stored_tab(user), do: Repo.get!(User, user.id).feed_source
 
   describe "the tab bar shows only where it means something (issue #1267)" do
     test "renders the three source tabs above the timeline", %{conn: conn} do
@@ -259,6 +264,99 @@ defmodule VutuvWeb.FeedSourceTabsTest do
 
       assert html =~ "Nothing from the fediverse yet"
       assert has_element?(view, "#feed-source-tabs")
+    end
+  end
+
+  describe "the tab outlives the visit (issue #1499)" do
+    test "the next visit opens where the member left off", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      {_author, _post} = followed_post(user, "written here on vutuv")
+      cached_post(remote_account(user, "them"), "written out there")
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "filter-source", %{"type" => "fediverse"})
+      assert stored_tab(user) == "fediverse"
+
+      # A second visit: a new socket, nothing carried over but the column.
+      {:ok, again, _html} = live(conn, ~p"/feed")
+
+      assert has_element?(again, "[data-post-filter-tab='fediverse'][aria-pressed='true']")
+      assert timeline(again) =~ "written out there"
+      refute timeline(again) =~ "written here on vutuv"
+    end
+
+    test "picking All again forgets the choice", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      {_author, _post} = followed_post(user, "written here on vutuv")
+      cached_post(remote_account(user, "them"), "written out there")
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "filter-source", %{"type" => "vutuv"})
+      render_click(view, "filter-source", %{"type" => "all"})
+
+      assert stored_tab(user) == nil
+
+      {:ok, again, _html} = live(conn, ~p"/feed")
+      assert has_element?(again, "[data-post-filter-tab='all'][aria-pressed='true']")
+      assert timeline(again) =~ "written out there"
+    end
+
+    test "a remembered tab whose content is gone opens on All, but is not forgotten", %{
+      conn: conn
+    } do
+      # The stranding case: the tab bar is gated on there being fediverse
+      # content at all, so opening on the remembered Fediverse tab would show
+      # an empty timeline with no way back.
+      {conn, user} = create_and_login_user(conn)
+      {_author, _post} = followed_post(user, "written here on vutuv")
+      Posts.remember_feed_filter(user, :fediverse)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      refute has_element?(view, "#feed-source-tabs")
+      assert timeline(view) =~ "written here on vutuv"
+      # Kept, so the tab comes back with the content rather than silently
+      # costing them the choice.
+      assert stored_tab(user) == "fediverse"
+    end
+
+    test "the pull back to All on the member's own post is not a choice", %{conn: conn} do
+      # `load_source_filter/2` also runs when their own post lands on a tab
+      # that cannot hold it. That is the code's doing, so it must leave the
+      # remembered tab alone.
+      {conn, user} = create_and_login_user(conn)
+      cached_post(remote_account(user, "them"), "written out there")
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "filter-source", %{"type" => "fediverse"})
+
+      {:ok, _own} = Posts.create_post(user, %{body: "my own words"})
+
+      assert has_element?(view, "[data-post-filter-tab='all'][aria-pressed='true']")
+      assert stored_tab(user) == "fediverse"
+    end
+
+    test "a page computed before the tab changed is not handed to the socket", %{conn: conn} do
+      # `MountHandoff` holds one entry per member, not per socket, so the tab
+      # has to be part of its key: this member has a second device open, and
+      # between this page's HTML and its websocket connecting they switch tabs
+      # over there. Keyed only by the member, the mount below would take the
+      # page computed for the tab they just left.
+      {conn, user} = create_and_login_user(conn)
+      {_author, _post} = followed_post(user, "written here on vutuv")
+      cached_post(remote_account(user, "them"), "written out there")
+
+      # The document renders on All and stashes what it computed…
+      conn = get(conn, ~p"/feed")
+      assert html_response(conn, 200) =~ "written here on vutuv"
+
+      # …and the tab changes before this socket connects.
+      Posts.remember_feed_filter(user, :fediverse)
+
+      {:ok, view, _html} = live(conn)
+
+      assert timeline(view) =~ "written out there"
+      refute timeline(view) =~ "written here on vutuv"
     end
   end
 


### PR DESCRIPTION
Closes #1499.

The `/feed` source tab is remembered on the member (`users.feed_source`, NULL = All) and read back at mount, so the dead render already draws the right tab with the right entries — no query, no flicker.

Four details worth reviewing:

- The `fediverse_feed_available?/1` gate runs **before** the filter, so a remembered "Fediverse" with nothing left in it opens on All instead of stranding the reader on a tab with no bar; the stored value survives, so the tab returns with the content.
- The write sits in the event handler, not in `load_source_filter/2` — that helper also runs when the member's own post lands on a tab that cannot hold it, and that fallback is not a choice.
- `update_all` on the one column, never a changeset: a socket's `%User{}` can be hours old.
- The `MountHandoff` subject carries the filter, since its stash holds one entry per member, not per socket.

No PubSub to the member's other devices, deliberately — a live tab switch there would reload a timeline somebody is reading from the top.

Smoke-tested in Chrome against the dev DB: click → column written, fresh visit opens on that tab (checked in the raw server HTML too), All writes NULL again.

*An AI agent wrote this text in my name. I know that is problematic.*
