### PR TITLE
Ein Tag fängt nie mit einem # an (v7.300.1) [cold-deploy]

### DIFF
--- a/lib/vutuv/tags/tag.ex
+++ b/lib/vutuv/tags/tag.ex
@@ -30,6 +30,15 @@ defmodule Vutuv.Tags.Tag do
   # hold only what the narrowest local part out there accepts.
   @slug_grammar_message "may contain only lowercase letters, digits and underscores"
 
+  # The `#` belongs to the hashtag *notation*, never to the tag. Every member
+  # path already strips it (`normalize_value/1`), so this only fires where a
+  # name is cast raw — the admin edit form — and it fires loudly rather than
+  # minting the `#`-prefixed twin of a tag that already exists. The catalog
+  # still holds a couple of dozen such rows from before the strip;
+  # `validate_change/3` runs only on a change, so they stay editable — the same
+  # way the punctuation rule leaves its three legacy rows alone.
+  @leading_hash_message "must not start with #"
+
   # What counts as content: anything that is not punctuation (`\p{P}`), a
   # separator/whitespace (`\p{Z}`) or an invisible control character (`\p{C}`).
   # Letters and digits, of course — and **symbols** (`\p{S}`), which is what
@@ -104,6 +113,7 @@ defmodule Vutuv.Tags.Tag do
     |> validate_format(:name, ~r/^[^\r\n\t]+$/, message: "must be a single line")
     |> validate_web_address()
     |> validate_punctuation_only()
+    |> validate_leading_hash()
     |> validate_length(:slug, max: 60)
     |> validate_length(:name, max: 255)
     |> validate_slug_grammar()
@@ -147,6 +157,14 @@ defmodule Vutuv.Tags.Tag do
   defp validate_punctuation_only(changeset) do
     validate_change(changeset, :name, fn :name, name ->
       if punctuation_only?(name), do: [name: @punctuation_message], else: []
+    end)
+  end
+
+  # Only a *leading* `#` is refused: `C#`, `F#` and `fitness#stuff` are ordinary
+  # names, and the slug grammar above already keeps a `#` out of the URL.
+  defp validate_leading_hash(changeset) do
+    validate_change(changeset, :name, fn :name, name ->
+      if String.starts_with?(name, "#"), do: [name: @leading_hash_message], else: []
     end)
   end
 
@@ -219,21 +237,26 @@ defmodule Vutuv.Tags.Tag do
     end
   end
 
-  @leading_hash ~r/^#+\s*/
+  # Every `#` the value opens with, plus the whitespace between them: the class
+  # is greedy up to the last `#` it can still reach, so `"## # Elixir"` loses
+  # all three while `"#fitness#stuff"` loses only the first (`f` ends the run).
+  @leading_hash ~r/^[\s#]*#/u
 
   @doc """
-  Normalizes a typed tag value: trims it, strips a leading `#` (the hashtag
-  form members naturally type, since posts render `#hashtag` links, so
+  Normalizes a typed tag value: trims it, strips **every** leading `#` (the
+  hashtag form members naturally type, since posts render `#hashtag` links, so
   `"#elixir"` is stored as the tag `elixir` and links to the same global tag as
-  `"elixir"` rather than a `#`-prefixed duplicate; only a *leading* run of `#`
-  and any space right after it is removed, so `"C#"` / `"F#"` keep their
-  trailing `#`), and collapses every interior run of whitespace to a single
-  space so a multi-word tag is stored cleanly (`"Ruby   on  Rails"` and a
-  pasted `"Ruby\\non Rails"` both become `"Ruby on Rails"`). A bare `"#"`
-  normalizes to `""` (dropped as blank by the tokenizer, rejected by the
-  changeset). Applied at every tag-value boundary: `Vutuv.Tags.parse_tag_names/1`,
-  `Vutuv.Posts` post tags, `create_or_link_tag/2` and `changeset/2`, so no entry
-  point can store a leading `#` or ragged whitespace.
+  `"elixir"` rather than a `#`-prefixed duplicate; `"## # Elixir"` is the same
+  tag again). Only a *leading* `#` goes, so `"C#"` / `"F#"` keep their trailing
+  one and `"fitness#stuff"` its interior one. Then every interior run of
+  whitespace collapses to a single space, so a multi-word tag is stored cleanly
+  (`"Ruby   on  Rails"` and a pasted `"Ruby\\non Rails"` both become
+  `"Ruby on Rails"`). A value that is nothing but `#` normalizes to `""`
+  (dropped as blank by the tokenizer, rejected by the changeset). Applied at
+  every tag-value boundary: `Vutuv.Tags.parse_tag_names/1`, `Vutuv.Posts` post
+  tags, `create_or_link_tag/2` and `changeset/2`; the changeset then *refuses* a
+  leading `#` outright (`@leading_hash_message`), so the raw name heads no entry
+  point normalizes — the admin edit form — cannot store one either.
   """
   def normalize_value(value) when is_binary(value) do
     value

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.300.0",
+      version: "7.300.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260816212834_fix_hashtag_prefixed_tag_names.exs
+++ b/priv/repo/migrations/20260816212834_fix_hashtag_prefixed_tag_names.exs
@@ -1,0 +1,216 @@
+defmodule Vutuv.Repo.Migrations.FixHashtagPrefixedTagNames do
+  use Ecto.Migration
+
+  @moduledoc """
+  Takes the leading `#` off the tag names that still carry one.
+
+  A `#` belongs to the hashtag *notation*, never to the tag: `#phoenix` is not a
+  second topic beside `phoenix`, it is `phoenix` stored wrong. The catalog
+  collected such rows until the tag input learned to strip the prefix (the
+  newest on vutuv.de is from 2026-07-01); this migration corrects the rows that
+  are already there, and `Vutuv.Tags.Tag` now refuses a new one.
+
+  ## Two steps, because a rename is not always enough
+
+  **1. Strip the prefix.** Generic, over whatever the installation happens to
+  hold: every name that opens with a `#` loses the whole opening run of `#` and
+  the whitespace between them, and interior whitespace collapses — the same
+  thing `Vutuv.Tags.Tag.normalize_value/1` does to a typed value, written once
+  in SQL. Slugs are left alone: the slugifier already dropped the `#` when the
+  row was minted, so `#3DPrinting` sits on `/tags/3dprinting` and no URL moves.
+  A name that is nothing *but* `#` would strip to blank and is skipped rather
+  than emptied — there is no such row on vutuv.de, and a blank name is worse
+  than a wrong one.
+
+  **2. Fold the six rows that are now a second copy of an existing tag.** Where
+  the `#` had pushed the slugifier onto a suffixed slug (`phoenix_c088bedb`,
+  because `phoenix` was taken), stripping the name leaves two rows for one
+  topic. Those are listed below by slug and folded through
+  `Vutuv.Tags.Merge.merge/3` — the same code path the admin screen uses, so the
+  members, posts, follows, job postings, cached remote posts and newsletter
+  audiences move with the endorsement rescue, and every fold lands on
+  `/admin/tag_merges` where it can be taken back one at a time.
+
+  Step 1 has to run **first**: `Merge` refuses a pair whose names differ only in
+  characters the slugifier deletes (the `c` / `c++` / `c#` guard from #1337),
+  and `#phoenix` against `phoenix` is exactly that shape until the `#` is gone.
+
+  ## Which row survives a fold
+
+  The one whose slug has no `_<sha>` suffix, because that slug is the public URL
+  and the tag's fediverse actor name. On five of the six pairs that row is also
+  the one with far more profiles, so nothing is lost. The sixth is
+  `myelixirstatus`, where the `#` row is the *older* one and holds the clean
+  slug: it survives (with its name corrected in step 1) and the suffixed row
+  folds into it, so `/tags/myelixirstatus` keeps working.
+
+  A former-slug alias is re-pointed at the survivor before the fold, so no
+  alternative name ends up pointing at another alternative name — `Tag` resolves
+  exactly one hop.
+
+  ## Elsewhere, and on the way back
+
+  Every fold names **slugs**, matched exactly, so a pair that is absent is
+  skipped and a fresh database — CI, `mix test`, another installation — folds
+  nothing. Step 1 stays generic and corrects whatever that installation has.
+
+  N-1 safe: no schema change. The deployed release reads `tags.name` and already
+  resolves an alias to its topic.
+
+  `down/0` reverts the folds it made. Two things it deliberately leaves: the
+  `#` stays off (the prefix was the bug, and which rows carried it is not
+  recoverable from the rows themselves once it is gone), and a re-pointed
+  former-slug alias keeps pointing at the survivor — which is where it belongs
+  either way, since both rows name the one topic.
+  """
+
+  # {surviving slug, absorbed slug}. Read off vutuv.de's catalog by hand; the
+  # comment is the state each pair was read in, as name (profiles carrying it).
+  @folds [
+    # phoenix (18) <- #phoenix (1)
+    {"phoenix", "phoenix_c088bedb"},
+    # haskell (13) <- #haskell (1)
+    {"haskell", "haskell_014b6157"},
+    # innovation (13) <- #Innovation (1)
+    {"innovation", "innovation_45d06e1c"},
+    # Grafana (3) <- #Grafana (0, one post)
+    {"grafana", "grafana_5dbba8ec"},
+    # Observability (3) <- #Observability (0, one post)
+    {"observability", "observability_a23c7928"},
+    # #myelixirstatus (1) <- myelixirstatus (1). The only pair where the `#` row
+    # survives: it is the older of the two and it holds the unsuffixed slug.
+    {"myelixirstatus", "myelixirstatus_5c46085c"}
+  ]
+
+  @merge_module Vutuv.Tags.Merge
+  @tag_module Vutuv.Tags.Tag
+
+  # `#`, the whitespace between a run of them, and the run itself — anchored at
+  # the start, so `C#`, `F#` and `fitness#stuff` keep the `#` they earned.
+  @strip_prefix "^[[:space:]#]*#"
+  @has_prefix "^[[:space:]]*#"
+
+  @doc """
+  The folds this migration performs, as `{surviving slug, absorbed slug}`.
+  Public so the test asserts against this list rather than a copy of it.
+  """
+  def folds, do: @folds
+
+  def up do
+    IO.puts("fix_hashtag_prefixed_tag_names: " <> strip_prefixes(repo()))
+    IO.puts("fix_hashtag_prefixed_tag_names: " <> fold_duplicates(repo()))
+  end
+
+  def down, do: IO.puts("fix_hashtag_prefixed_tag_names: " <> revert_folds(repo()))
+
+  @doc """
+  Step 1 against an explicit repo, returning the report as a line.
+
+  Public and repo-taking so the test drives **this** code rather than a copy of
+  it: `repo/0` only answers inside a running migration.
+  """
+  def strip_prefixes(repo) do
+    %{num_rows: renamed} =
+      repo.query!("""
+      update tags
+         set name = btrim(regexp_replace(regexp_replace(name, '#{@strip_prefix}', ''), '[[:space:]]+', ' ', 'g')),
+             updated_at = timezone('utc', now())
+       where name ~ '#{@has_prefix}'
+         and regexp_replace(name, '#{@strip_prefix}', '') ~ '[^[:space:]]'
+      """)
+
+    %{rows: [[left]]} =
+      repo.query!("select count(*) from tags where name ~ '#{@has_prefix}'")
+
+    "#{renamed} names corrected, #{left} left alone (nothing but hashes)"
+  end
+
+  @doc "Step 2 against an explicit repo. See `strip_prefixes/1`."
+  def fold_duplicates(repo) do
+    if available?() do
+      report = Enum.reduce(@folds, %{folded: 0, missing: 0, failed: [], repo: repo}, &fold/2)
+
+      "#{report.folded} duplicates folded" <>
+        ", #{report.missing} listed pairs not present here" <>
+        ", #{length(report.failed)} refused#{failures(report.failed)}"
+    else
+      "#{inspect(@merge_module)} is unavailable, nothing folded"
+    end
+  end
+
+  @doc """
+  Reverts every fold this migration made and nobody has undone by hand.
+
+  Recognised by having no admin behind it: a merge from the admin screen always
+  records who did it, this one cannot. A fold already reverted stays reverted.
+  """
+  def revert_folds(repo) do
+    if available?() do
+      reverted =
+        @folds
+        |> Enum.map(fn {_keeper, absorbed} -> repo.get_by(@tag_module, slug: absorbed) end)
+        |> Enum.reject(&is_nil/1)
+        |> Enum.flat_map(&merges_of(repo, &1))
+        |> Enum.count(fn merge -> match?({:ok, _}, @merge_module.revert(merge)) end)
+
+      "#{reverted} folds reverted, names left corrected"
+    else
+      "#{inspect(@merge_module)} is unavailable, nothing reverted"
+    end
+  end
+
+  defp fold({keeper_slug, absorbed_slug}, acc) do
+    keeper = acc.repo.get_by(@tag_module, slug: keeper_slug)
+    absorbed = acc.repo.get_by(@tag_module, slug: absorbed_slug)
+
+    if is_nil(keeper) or is_nil(absorbed) do
+      %{acc | missing: acc.missing + 1}
+    else
+      repoint_aliases(acc.repo, absorbed, keeper)
+
+      case @merge_module.merge(absorbed, keeper, kind: "former") do
+        {:ok, _merge} -> %{acc | folded: acc.folded + 1}
+        {:error, why} -> %{acc | failed: acc.failed ++ [{absorbed_slug, why}]}
+      end
+    end
+  end
+
+  # An alternative name filed under the row about to be absorbed — the retired
+  # dotted slug `phoenix.c088bedb`, say — has to move to the survivor first:
+  # `Vutuv.Tags.Tag.find_by_value/1` follows exactly one hop, so an alias left
+  # pointing at an alias resolves to a row no listing shows.
+  defp repoint_aliases(repo, absorbed, keeper) do
+    repo.query!(
+      "update tags set merged_into_id = $1::text::uuid where merged_into_id = $2::text::uuid",
+      [keeper.id, absorbed.id]
+    )
+  end
+
+  # The unreverted merges recorded for this absorbed tag that no admin performed.
+  defp merges_of(repo, tag) do
+    import Ecto.Query
+
+    repo.all(
+      from(m in "tag_merges",
+        where:
+          m.absorbed_tag_id == type(^tag.id, Vutuv.UUIDv7) and is_nil(m.reverted_at) and
+            is_nil(m.admin_user_id),
+        select: m.id
+      )
+    )
+    |> Enum.map(&@merge_module.get_merge(Ecto.UUID.cast!(&1)))
+    |> Enum.reject(&is_nil/1)
+  end
+
+  # A migration must stay replayable long after the code around it has moved on,
+  # so the one app module it leans on is checked rather than assumed.
+  defp available? do
+    Code.ensure_loaded?(@merge_module) and function_exported?(@merge_module, :merge, 3)
+  end
+
+  defp failures([]), do: ""
+
+  defp failures(failed) do
+    " (" <> Enum.map_join(failed, ", ", fn {slug, why} -> "#{slug}: #{why}" end) <> ")"
+  end
+end

--- a/test/vutuv/repo/fix_hashtag_prefixed_tag_names_test.exs
+++ b/test/vutuv/repo/fix_hashtag_prefixed_tag_names_test.exs
@@ -1,0 +1,204 @@
+defmodule Vutuv.Repo.FixHashtagPrefixedTagNamesTest do
+  @moduledoc """
+  Covers the one-time migration `fix_hashtag_prefixed_tag_names`.
+
+  Step 1 (stripping the `#` off a name) is generic, so it is exercised here for
+  real. Step 2 names six slugs off vutuv.de's catalog, which a fresh test
+  database does not hold — that half is a run against `vutuv1_dev` (see
+  CLAUDE.md); what this file guards is that the list is sound, that an absent
+  pair is skipped rather than fatal, and that the fold really moves a member's
+  rows and really comes back on a rollback.
+
+  It drives `strip_prefixes/1`, `fold_duplicates/1` and `revert_folds/1`, the
+  migration's own code, so the two cannot drift apart.
+
+  `async: false`: the module is loaded from `priv/repo/migrations` with
+  `Code.require_file/1`, which is global.
+  """
+  use Vutuv.DataCase, async: false
+
+  alias Vutuv.Tags.Merge
+  alias Vutuv.Tags.Tag
+  alias Vutuv.Tags.UserTag
+
+  @migration Vutuv.Repo.Migrations.FixHashtagPrefixedTagNames
+
+  setup_all do
+    unless Code.ensure_loaded?(@migration) do
+      [file] = Path.wildcard("priv/repo/migrations/*_fix_hashtag_prefixed_tag_names.exs")
+      Code.require_file(file)
+    end
+
+    :ok
+  end
+
+  defp tag(slug, name), do: insert(:tag, name: name, slug: slug)
+
+  describe "stripping the prefix" do
+    test "takes off every leading #, however many and however spaced" do
+      rows =
+        for {name, expected} <- [
+              {"#phoenix", "phoenix"},
+              {"##Elixir", "Elixir"},
+              {"## Elixir", "Elixir"},
+              {"# #Elixir", "Elixir"},
+              {"  #Elixir", "Elixir"}
+            ] do
+          {tag("fixup_#{System.unique_integer([:positive])}", name), expected}
+        end
+
+      @migration.strip_prefixes(Repo)
+
+      for {tag, expected} <- rows do
+        assert Repo.get!(Tag, tag.id).name == expected
+      end
+    end
+
+    test "leaves a # that is not leading alone" do
+      kept =
+        for name <- ["C#", "F#", "fitness#stuff", "Ruby on Rails"] do
+          tag("kept_#{System.unique_integer([:positive])}", name)
+        end
+
+      @migration.strip_prefixes(Repo)
+
+      for tag <- kept, do: assert(Repo.get!(Tag, tag.id).name == tag.name)
+    end
+
+    test "skips a name that is nothing but hashes rather than emptying it" do
+      # A blank name is worse than a wrong one: it renders as nothing and no
+      # changeset would let it back in.
+      hashes = tag("only_hashes_#{System.unique_integer([:positive])}", "## #")
+
+      report = @migration.strip_prefixes(Repo)
+
+      assert report =~ "1 left alone"
+      assert Repo.get!(Tag, hashes.id).name == "## #"
+    end
+
+    test "reports what it corrected" do
+      tag("reported_#{System.unique_integer([:positive])}", "#reported")
+
+      assert @migration.strip_prefixes(Repo) =~ "1 names corrected"
+    end
+  end
+
+  describe "the fold list itself" do
+    test "names every pair exactly once and never folds a tag into itself" do
+      folds = @migration.folds()
+      slugs = Enum.flat_map(folds, fn {keeper, absorbed} -> [keeper, absorbed] end)
+
+      assert slugs == Enum.uniq(slugs)
+      for {keeper, absorbed} <- folds, do: refute(keeper == absorbed)
+    end
+
+    test "builds no chains: a surviving tag is never absorbed elsewhere" do
+      # A chain would fail on its second step, since an alternative name may not
+      # be absorbed again.
+      folds = @migration.folds()
+      keepers = MapSet.new(folds, &elem(&1, 0))
+      absorbed = MapSet.new(folds, &elem(&1, 1))
+
+      assert MapSet.disjoint?(keepers, absorbed)
+    end
+  end
+
+  describe "folding" do
+    test "an empty catalog is a clean no-op" do
+      # The case every other installation and every CI run is in.
+      assert @migration.fold_duplicates(Repo) =~ "0 duplicates folded"
+    end
+
+    test "folds a listed pair that is present, and moves its rows" do
+      {keeper_slug, absorbed_slug} = hd(@migration.folds())
+      keeper = tag(keeper_slug, keeper_slug)
+      absorbed = tag(absorbed_slug, absorbed_slug)
+      user_tag = insert(:user_tag, user: insert(:activated_user), tag: absorbed)
+
+      report = @migration.fold_duplicates(Repo)
+
+      assert report =~ "1 duplicates folded"
+      assert Repo.get!(Tag, absorbed.id).merged_into_id == keeper.id
+      assert Repo.get!(UserTag, user_tag.id).tag_id == keeper.id
+    end
+
+    test "a pair whose surviving tag is absent is skipped whole" do
+      {_keeper_slug, absorbed_slug} = hd(@migration.folds())
+      absorbed = tag(absorbed_slug, absorbed_slug)
+
+      report = @migration.fold_duplicates(Repo)
+
+      assert report =~ "0 duplicates folded"
+      assert report =~ "6 listed pairs not present here"
+      assert is_nil(Repo.get!(Tag, absorbed.id).merged_into_id)
+    end
+
+    test "an alternative name under the absorbed row moves to the survivor" do
+      # Otherwise the retired dotted slug would point at an alias, and
+      # `Tag.find_by_value/1` follows exactly one hop.
+      {keeper_slug, absorbed_slug} = hd(@migration.folds())
+      keeper = tag(keeper_slug, keeper_slug)
+      absorbed = tag(absorbed_slug, absorbed_slug)
+      former = tag("#{absorbed_slug}_former", "#{absorbed_slug}.former")
+      {:ok, _} = Merge.merge(former, absorbed)
+
+      @migration.fold_duplicates(Repo)
+
+      assert Repo.get!(Tag, former.id).merged_into_id == keeper.id
+      assert Repo.get!(Tag, absorbed.id).merged_into_id == keeper.id
+    end
+
+    test "a tag somebody already merged by hand is refused, and the rest still runs" do
+      [{first_keeper, first_absorbed}, {second_keeper, second_absorbed} | _] = @migration.folds()
+
+      keeper = tag(first_keeper, first_keeper)
+      already = tag(first_absorbed, first_absorbed)
+      untouched_keeper = tag(second_keeper, second_keeper)
+      untouched = tag(second_absorbed, second_absorbed)
+
+      # Somebody put this one somewhere else already.
+      elsewhere = tag("elsewhere_#{System.unique_integer([:positive])}", "Elsewhere")
+      {:ok, _} = Merge.merge(already, elsewhere)
+
+      report = @migration.fold_duplicates(Repo)
+
+      assert report =~ "already_merged"
+      assert Repo.get!(Tag, already.id).merged_into_id == elsewhere.id
+      assert Repo.get!(Tag, untouched.id).merged_into_id == untouched_keeper.id
+      assert keeper.id
+    end
+  end
+
+  describe "rolling back" do
+    test "puts back what the migration folded, and leaves the name corrected" do
+      {keeper_slug, absorbed_slug} = hd(@migration.folds())
+      keeper = tag(keeper_slug, keeper_slug)
+      absorbed = tag(absorbed_slug, "##{absorbed_slug}")
+      user_tag = insert(:user_tag, user: insert(:activated_user), tag: absorbed)
+
+      @migration.strip_prefixes(Repo)
+      @migration.fold_duplicates(Repo)
+
+      assert @migration.revert_folds(Repo) =~ "1 folds reverted"
+      assert is_nil(Repo.get!(Tag, absorbed.id).merged_into_id)
+      assert Repo.get!(UserTag, user_tag.id).tag_id == absorbed.id
+      # The `#` was the bug; a rollback does not put a bug back.
+      assert Repo.get!(Tag, absorbed.id).name == absorbed_slug
+      assert keeper.id
+    end
+
+    test "leaves a merge an admin made by hand alone" do
+      # The rollback recognises its own work by there being no admin behind it.
+      # Undoing somebody's deliberate merge would be the worst thing this
+      # migration could do on the way out.
+      {keeper_slug, absorbed_slug} = hd(@migration.folds())
+      keeper = tag(keeper_slug, keeper_slug)
+      absorbed = tag(absorbed_slug, absorbed_slug)
+      admin = insert(:activated_user)
+      {:ok, _} = Merge.merge(absorbed, keeper, actor: admin)
+
+      assert @migration.revert_folds(Repo) =~ "0 folds reverted"
+      assert Repo.get!(Tag, absorbed.id).merged_into_id == keeper.id
+    end
+  end
+end

--- a/test/vutuv/tags/tag_test.exs
+++ b/test/vutuv/tags/tag_test.exs
@@ -28,6 +28,53 @@ defmodule Vutuv.Tags.TagTest do
       changeset = Tag.changeset(%Tag{}, %{"value" => "Ruby   on  Rails"})
       assert get_change(changeset, :name) == "Ruby on Rails"
     end
+
+    test "strips every leading #, however many and however spaced" do
+      for typed <- ["##Elixir", "## Elixir", "# #Elixir", "#  ## # Elixir", "  #Elixir"] do
+        assert get_change(Tag.changeset(%Tag{}, %{"value" => typed}), :name) == "Elixir",
+               "#{inspect(typed)} did not normalize to \"Elixir\""
+      end
+    end
+
+    test "a value that is nothing but hashes normalizes to blank and is refused" do
+      changeset = Tag.changeset(%Tag{}, %{"value" => "## #"})
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).name
+    end
+  end
+
+  describe "a name may not start with #" do
+    # normalize_value/1 strips the hashtag form on every member path, so this
+    # backstops the raw name/slug heads — the admin edit form casts :name
+    # straight from a text field — and makes the rule fail loudly rather than
+    # minting the `#`-prefixed duplicate of a tag that already exists.
+    import Ecto.Changeset
+
+    test "the raw name head refuses it" do
+      changeset = Tag.changeset(%Tag{}, %{"name" => "#Elixir", "slug" => "elixir"})
+      refute changeset.valid?
+      assert "must not start with #" in errors_on(changeset).name
+    end
+
+    test "the admin edit form refuses it" do
+      changeset = Tag.edit_changeset(%Tag{}, %{"name" => "#Elixir", "slug" => "elixir"})
+      refute changeset.valid?
+      assert "must not start with #" in errors_on(changeset).name
+    end
+
+    test "C# and an interior # are untouched" do
+      assert Tag.changeset(%Tag{}, %{"name" => "C#", "slug" => "c_sharp"}).valid?
+      assert Tag.changeset(%Tag{}, %{"name" => "fitness#stuff", "slug" => "fitness_stuff"}).valid?
+    end
+
+    test "a legacy #-named tag stays editable as long as the name is left alone" do
+      # validate_change/3 runs only on a *change*, so a row minted before this
+      # rule can still have its description edited — the same way the
+      # punctuation rule leaves its three legacy rows alone.
+      tag = insert(:tag, name: "#legacy_hash_tag", slug: "legacy_hash_tag")
+
+      assert Tag.edit_changeset(tag, %{"description" => "still editable"}).valid?
+    end
   end
 
   describe "related_users/2" do


### PR DESCRIPTION
**TL;DR** Ein Tag-Name darf nicht mit `#` anfangen: beim Anlegen wird jedes führende `#` abgeschnitten, der Changeset weist es zusätzlich zurück, und eine Migration räumt die 25 Altzeilen auf. **v7.300.1, cold deploy** (neue Migration).

**Warum:** Das `#` gehört der Hashtag-Schreibweise, nie dem Tag. `#phoenix` ist kein zweites Thema neben `phoenix`, sondern `phoenix` falsch gespeichert.

**Code:** `normalize_value/1` schnitt bisher nur *einen* Lauf `#` ab, `"# #Elixir"` behielt eins. Jetzt fällt jedes führende `#` samt Zwischenraum weg. Neu daneben `validate_leading_hash/1` — greift dort, wo bisher nichts normalisierte, also im Admin-Formular. `C#`, `F#` und `fitness#stuff` bleiben unangetastet.

**Migration** (`fix_hashtag_prefixed_tag_names`), zwei Schritte:

1. Generisches SQL über alle Namen mit führendem `#`. Slugs bleiben, der Slugifier hatte das `#` beim Anlegen schon geschluckt — es wandert keine URL.
2. Sechs Zeilen sind nach der Korrektur eine zweite Kopie eines vorhandenen Tags (das `#` hatte den Slugifier auf `phoenix_c088bedb` gedrängt, weil `phoenix` besetzt war). Die laufen über `Vutuv.Tags.Merge.merge/3`, also mit Ledger auf `/admin/tag_merges` und einzeln zurücknehmbar. Es überlebt die Zeile mit dem sauberen Slug — das ist die öffentliche URL und der Fediverse-Actor-Name.

Reihenfolge ist zwingend: `Merge` verweigert ein Paar, das sich nur in Zeichen unterscheidet, die der Slugifier löscht (die `c`/`c++`/`c#`-Sperre aus #1337), und `#phoenix` gegen `phoenix` ist genau diese Form, bis das `#` weg ist.

**Gegen `vutuv1_dev` gelaufen:** 25 Namen korrigiert, 6 Dubletten gefaltet, 0 verweigert, keine Zeile verloren, kein Alias zeigt auf einen Alias. Rollback ebenfalls geprüft (6 Faltungen sauber zurückgenommen), danach erneut angewandt.

**N-1:** kein DDL, reine Datenmigration. Das laufende Release liest `tags.name` und löst einen Alias bereits auf sein Thema auf.

**Fremde Installationen:** Schritt 2 matcht die sechs Slugs exakt und ist anderswo ein No-op, Schritt 1 korrigiert, was dort steht.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*
