### PR TITLE
Aufräum-Pass Nr. 4, erste Hälfte: Tempo und geteilte Nähte (v7.300.2)

### DIFF
--- a/lib/vutuv/dns.ex
+++ b/lib/vutuv/dns.ex
@@ -64,9 +64,13 @@ defmodule Vutuv.Dns do
         names -> Enum.map(names, &to_string/1)
       end
     end)
-    |> Enum.flat_map(&addresses(&1, backend))
-    |> Enum.reject(&Ssrf.internal_ip?/1)
-    |> Enum.uniq()
+    # Streamed, so a zone that lists a dozen name servers costs the address
+    # lookups for the handful actually used and not for all twelve: `Enum.take/2`
+    # stops the pipeline as soon as it has enough, and reject/uniq/take are all
+    # prefix-stable, so the answer is the one the eager version gave.
+    |> Stream.flat_map(&addresses(&1, backend))
+    |> Stream.reject(&Ssrf.internal_ip?/1)
+    |> Stream.uniq()
     |> Enum.take(@max_nameservers)
     |> Enum.map(&{&1, 53})
   end

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -782,14 +782,7 @@ defmodule Vutuv.Fediverse do
   """
   def distinct_follower_count do
     if enabled?() do
-      Repo.one(
-        from(f in Follower,
-          # coalesce, because `NULL not in (…)` is NULL and would silently drop
-          # every row whose actor URI has no parseable host.
-          where: fragment("coalesce(?, '')", uri_host(f.actor_uri)) not in ^own_hosts(),
-          select: count(f.actor_uri, :distinct)
-        )
-      ) || 0
+      Repo.one(from(f in foreign_followers(), select: count(f.actor_uri, :distinct))) || 0
     else
       0
     end
@@ -805,15 +798,40 @@ defmodule Vutuv.Fediverse do
   """
   def follower_host_count do
     if enabled?() do
-      Repo.one(
-        from(f in Follower,
-          where: fragment("coalesce(?, '')", uri_host(f.actor_uri)) not in ^own_hosts(),
-          select: count(uri_host(f.actor_uri), :distinct)
-        )
-      ) || 0
+      Repo.one(from(f in foreign_followers(), select: count(uri_host(f.actor_uri), :distinct))) ||
+        0
     else
       0
     end
+  end
+
+  @doc """
+  Both reach figures from one pass over the followers, for the page that states
+  them together (`VutuvWeb.AgentDocs.InvestorsDoc`). Same gates as the two
+  functions above; `%{accounts: 0, hosts: 0}` while the fediverse is off.
+  """
+  def follower_reach do
+    if enabled?() do
+      Repo.one(
+        from(f in foreign_followers(),
+          select: %{
+            accounts: count(f.actor_uri, :distinct),
+            hosts: count(uri_host(f.actor_uri), :distinct)
+          }
+        )
+      ) || %{accounts: 0, hosts: 0}
+    else
+      %{accounts: 0, hosts: 0}
+    end
+  end
+
+  # Follows from actors that are not us. The `coalesce` is load-bearing:
+  # `NULL not in (…)` is NULL, so without it every row whose actor URI has no
+  # parseable host would be dropped from every one of these counts.
+  defp foreign_followers do
+    from(f in Follower,
+      where: fragment("coalesce(?, '')", uri_host(f.actor_uri)) not in ^own_hosts()
+    )
   end
 
   @doc """

--- a/lib/vutuv/jobs.ex
+++ b/lib/vutuv/jobs.ex
@@ -1578,5 +1578,5 @@ defmodule Vutuv.Jobs do
 
   # --- misc -----------------------------------------------------------------
 
-  defp now, do: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+  defp now, do: NaiveDateTime.utc_now(:second)
 end

--- a/lib/vutuv/node_info.ex
+++ b/lib/vutuv/node_info.ex
@@ -266,22 +266,18 @@ defmodule Vutuv.NodeInfo do
   end
 
   # The publicly visible posts, split into originals and replies in one pass.
+  #
+  # Joined rather than asked with two `EXISTS` subqueries in the SELECT list:
+  # a predicate inside `filter(count(...), …)` cannot be turned into a semi-join,
+  # so Postgres ran both subplans once per visible post. `post_replies` has a
+  # unique index on `post_id`, so the left join answers at most one row per post
+  # and `count(r.post_id)` is the reply tally exactly.
   defp post_counts do
     %{posts: posts, comments: comments} =
       Post
       |> Posts.scope_visible(nil)
-      |> select([p], %{
-        posts:
-          filter(
-            count(p.id),
-            fragment("NOT EXISTS (SELECT 1 FROM post_replies r WHERE r.post_id = ?)", p.id)
-          ),
-        comments:
-          filter(
-            count(p.id),
-            fragment("EXISTS (SELECT 1 FROM post_replies r WHERE r.post_id = ?)", p.id)
-          )
-      })
+      |> join(:left, [p], r in "post_replies", on: r.post_id == p.id)
+      |> select([p, r], %{posts: count(p.id) - count(r.post_id), comments: count(r.post_id)})
       |> Repo.one()
 
     {posts, comments}

--- a/lib/vutuv/organizations.ex
+++ b/lib/vutuv/organizations.ex
@@ -1193,7 +1193,8 @@ defmodule Vutuv.Organizations do
           d.inserted_at > ^abandoned_before and
           (is_nil(d.last_checked_at) or d.last_checked_at < ^checked_before),
       order_by: [asc_nulls_first: d.last_checked_at, asc: d.id],
-      limit: @pending_scan
+      limit: @pending_scan,
+      preload: [:organization]
     )
     |> Repo.all()
     |> Enum.filter(&pending_due?(&1, now))
@@ -1219,7 +1220,7 @@ defmodule Vutuv.Organizations do
   end
 
   defp check_pending_domain(%OrganizationDomain{} = domain) do
-    organization = get_organization!(domain.organization_id)
+    organization = organization_of(domain)
 
     # `check_domain/2` stamps `last_checked_at` on the failing branch too, so a
     # domain whose record is still missing leaves the due set for this step's
@@ -1234,6 +1235,14 @@ defmodule Vutuv.Organizations do
         :pending
     end
   end
+
+  # `pending_domains_due/0` preloads the organization, so a full batch of 50
+  # costs one query and not fifty; the lookup stays as the answer for a domain
+  # that reached here another way.
+  defp organization_of(%OrganizationDomain{organization: %Organization{} = organization}),
+    do: organization
+
+  defp organization_of(%OrganizationDomain{organization_id: id}), do: get_organization!(id)
 
   defp pending_due?(%OrganizationDomain{} = domain, now) do
     case pending_interval(NaiveDateTime.diff(now, domain.inserted_at)) do

--- a/lib/vutuv/organizations.ex
+++ b/lib/vutuv/organizations.ex
@@ -2171,5 +2171,5 @@ defmodule Vutuv.Organizations do
     )
   end
 
-  defp now, do: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+  defp now, do: NaiveDateTime.utc_now(:second)
 end

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -4644,6 +4644,23 @@ defmodule Vutuv.Posts do
   def path(%Organization{slug: slug}, post_id), do: "/organizations/#{slug}/posts/#{post_id}"
   def path(%User{username: username}, post_id), do: "/#{username}/posts/#{post_id}"
 
+  @doc """
+  Where a post's author link goes: a member's profile at their handle, an
+  organization's page at `Organizations.canonical_path/1`, which prefers its
+  opt-in root handle over `/organizations/:slug`.
+
+  The same rule `path/1` follows for the post itself, and for the same reason —
+  it was written out at every surface that renders a post header, so the next
+  kind of author would have to be remembered in each of them. It dispatches on
+  what `author/1` hands back rather than on a pattern over the preloaded
+  association: the association-shaped clause reads as a type check but behaves
+  as a preload check, so a bare `%Post{}` out of a query drew a page's post as a
+  nil member's.
+  """
+  def author_path(%Post{} = post), do: author_path(author(post))
+  def author_path(%Organization{} = organization), do: Organizations.canonical_path(organization)
+  def author_path(%User{username: username}), do: "/" <> username
+
   ## Images
 
   @doc """

--- a/lib/vutuv/profiles/link_verification.ex
+++ b/lib/vutuv/profiles/link_verification.ex
@@ -247,5 +247,5 @@ defmodule Vutuv.Profiles.LinkVerification do
     Application.get_env(:vutuv, :user_links_req_options, [])
   end
 
-  defp now, do: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+  defp now, do: NaiveDateTime.utc_now(:second)
 end

--- a/lib/vutuv/profiles/social_account_verification.ex
+++ b/lib/vutuv/profiles/social_account_verification.ex
@@ -231,5 +231,5 @@ defmodule Vutuv.Profiles.SocialAccountVerification do
     end
   end
 
-  defp now, do: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+  defp now, do: NaiveDateTime.utc_now(:second)
 end

--- a/lib/vutuv/saved_searches.ex
+++ b/lib/vutuv/saved_searches.ex
@@ -278,5 +278,5 @@ defmodule Vutuv.SavedSearches do
     end
   end
 
-  defp now, do: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+  defp now, do: NaiveDateTime.utc_now(:second)
 end

--- a/lib/vutuv/social_feed/http.ex
+++ b/lib/vutuv/social_feed/http.ex
@@ -31,6 +31,24 @@ defmodule Vutuv.SocialFeed.Http do
   tests always intercept.
   """
   def get(url, options_key, extra \\ []) do
+    url
+    |> base_options()
+    |> Keyword.merge(extra)
+    |> Keyword.merge(Application.get_env(:vutuv, options_key, []))
+    |> Req.get()
+  end
+
+  @doc """
+  The guard rails themselves, for a caller that resolves its own env seam and
+  needs its own body cap and `accept` (`Vutuv.WebVerification`, which reads a
+  member's own web page rather than an API).
+
+  Split out because that caller had grown its own copy of this list, down to
+  the comment on `decode_body:` — and the two copies had already drifted on the
+  one line that must not, the `User-Agent`, so one installation named itself
+  two ways depending on which of its own requests you looked at.
+  """
+  def base_options(url, max_bytes \\ @max_body_bytes, accept \\ "application/json") do
     [
       url: url,
       receive_timeout: 4_000,
@@ -45,12 +63,9 @@ defmodule Vutuv.SocialFeed.Http do
       # Stream with a hard ceiling so a hostile large body is dropped during
       # receipt; the per-use post-checks (decode/1, fetch_avatar/2) still enforce
       # their exact JSON / avatar limits.
-      into: Vutuv.Http.capped_collector(@max_body_bytes),
-      headers: [{"user-agent", user_agent()}, {"accept", "application/json"}]
+      into: Vutuv.Http.capped_collector(max_bytes),
+      headers: [{"user-agent", user_agent()}, {"accept", accept}]
     ]
-    |> Keyword.merge(extra)
-    |> Keyword.merge(Application.get_env(:vutuv, options_key, []))
-    |> Req.get()
   end
 
   @doc "Decodes a JSON body, refusing oversized answers unparsed."

--- a/lib/vutuv/tags/match_key.ex
+++ b/lib/vutuv/tags/match_key.ex
@@ -66,6 +66,12 @@ defmodule Vutuv.Tags.MatchKey do
   `Vutuv.Tags.canonical_tag_names/1`) get it from here so there is one
   definition of the key and not three.
 
+  `tags_name_match_key_index` and `tags_slug_match_key_index` index exactly this
+  expression, so a lookup is a bitmap index scan rather than a walk of the
+  catalog. Postgres matches an expression index by the parsed expression: change
+  a character here and every tag lookup quietly goes back to a sequential scan,
+  which is what `test/vutuv/tags/match_key_index_test.exs` watches for.
+
   Verified against the real catalog rather than read off the code: it folds
   `Open__Source - Software`, `open-source-software` and `legacy_framework_zzz`
   onto the keys their siblings carry, strips a U+200B, answers NULL for `-`,

--- a/lib/vutuv/tags/merge.ex
+++ b/lib/vutuv/tags/merge.ex
@@ -588,5 +588,5 @@ defmodule Vutuv.Tags.Merge do
     )
   end
 
-  defp now, do: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+  defp now, do: NaiveDateTime.utc_now(:second)
 end

--- a/lib/vutuv/translations.ex
+++ b/lib/vutuv/translations.ex
@@ -208,9 +208,25 @@ defmodule Vutuv.Translations do
         {:cached, translation}
 
       true ->
-        job = open_job(subject, target_language) || insert_job!(subject, target_language)
+        {:queued, job} = queue(subject, target_language)
         Worker.nudge()
         {:queued, job}
+    end
+  end
+
+  @doc """
+  Queues `subject` **without asking the cache first**, for a caller that has
+  already resolved a whole page's cached translations in one query
+  (`fresh_translations/2`) and knows this one missed — `request/2` would repeat
+  that lookup per card. It also leaves the worker alone: a page's worth of
+  subjects wants one `Worker.nudge/0` at the end, not one per card, since every
+  nudge costs the worker a full drain round.
+  """
+  def queue(subject, target_language) do
+    if enabled?() do
+      {:queued, open_job(subject, target_language) || insert_job!(subject, target_language)}
+    else
+      :disabled
     end
   end
 

--- a/lib/vutuv/uploaders/avatar.ex
+++ b/lib/vutuv/uploaders/avatar.ex
@@ -35,7 +35,6 @@ defmodule Vutuv.Avatar do
   the vCard export and `user_url/2`.
   """
 
-  alias Vix.Vips.Operation
   alias Vutuv.Uploads
   alias Vutuv.Uploads.Crop
   alias Vutuv.Uploads.Originals
@@ -175,10 +174,9 @@ defmodule Vutuv.Avatar do
   def og_jpeg(%{avatar_moderation: "pending"}), do: :error
   def og_jpeg(user), do: derive_jpeg(user, @og_size, @og_size, :center)
 
-  # JPEG from the best available source: decode + EXIF-autorotate, apply the
-  # user's crop, crop-resize, save **stripped** (`keep: []`). The original's
-  # metadata (camera, GPS) must never leak into a served or exported
-  # derivative — the same rule the AVIF pipeline enforces in Vutuv.Uploads.Spec.
+  # JPEG from the best available source, through the shared `Spec.og_jpeg/2`
+  # (which owns the decode, the EXIF autorotation and the stripped save); the
+  # shape here is the member's own crop plus the crop-resize.
   #
   # The crop is applied only when deriving from the **original**; a served
   # version fallback (legacy uploads with no kept original) is already cropped,
@@ -191,14 +189,13 @@ defmodule Vutuv.Avatar do
       {origin, path} ->
         crop = if origin == :original, do: Crop.parse(Map.get(user, :avatar_crop))
 
-        with {:ok, rotated} <- Spec.open_rotated(path),
-             {:ok, cropped} <- Crop.apply_to(rotated, crop),
-             {:ok, small} <- Image.thumbnail(cropped, "#{width}x#{height}", crop: gravity),
-             {:ok, data} <- Operation.jpegsave_buffer(small, keep: [], Q: 80) do
-          {:ok, data}
-        else
-          _ -> :error
-        end
+        Spec.og_jpeg(path, &crop_and_resize(&1, crop, width, height, gravity))
+    end
+  end
+
+  defp crop_and_resize(rotated, crop, width, height, gravity) do
+    with {:ok, cropped} <- Crop.apply_to(rotated, crop) do
+      Image.thumbnail(cropped, "#{width}x#{height}", crop: gravity)
     end
   end
 

--- a/lib/vutuv/uploaders/organization_image_store.ex
+++ b/lib/vutuv/uploaders/organization_image_store.ex
@@ -15,7 +15,6 @@ defmodule Vutuv.OrganizationImageStore do
   is shared with `Vutuv.PostImageStore`.
   """
 
-  alias Vix.Vips.Operation
   alias Vutuv.Uploads.Originals
   alias Vutuv.Uploads.Spec
 
@@ -95,14 +94,7 @@ defmodule Vutuv.OrganizationImageStore do
         :error
 
       path ->
-        with {:ok, rotated} <- Spec.open_rotated(path),
-             {:ok, square} <-
-               Image.thumbnail(rotated, "#{@og_size}x#{@og_size}", crop: :center),
-             {:ok, data} <- Operation.jpegsave_buffer(square, keep: [], Q: 80) do
-          {:ok, data}
-        else
-          _ -> :error
-        end
+        Spec.og_jpeg(path, &Image.thumbnail(&1, "#{@og_size}x#{@og_size}", crop: :center))
     end
   end
 

--- a/lib/vutuv/uploaders/post_image_store.ex
+++ b/lib/vutuv/uploaders/post_image_store.ex
@@ -238,14 +238,15 @@ defmodule Vutuv.PostImageStore do
   enforces too). `:error` when nothing usable is on disk.
   """
   def og_jpeg(%PostImage{token: token} = image) do
-    with {kind, path} <- og_source(image, token),
-         {:ok, rotated} <- Spec.open_rotated(path),
-         {:ok, framed} <- og_frame(kind, image, rotated),
-         {:ok, capped} <- Image.thumbnail(framed, "#{@og_width}", resize: :down),
-         {:ok, data} <- Operation.jpegsave_buffer(capped, keep: [], Q: 80) do
-      {:ok, data}
-    else
+    case og_source(image, token) do
+      {kind, path} -> Spec.og_jpeg(path, &frame_and_cap(&1, kind, image))
       _ -> :error
+    end
+  end
+
+  defp frame_and_cap(rotated, kind, image) do
+    with {:ok, framed} <- og_frame(kind, image, rotated) do
+      Image.thumbnail(framed, "#{@og_width}", resize: :down)
     end
   end
 

--- a/lib/vutuv/uploads/spec.ex
+++ b/lib/vutuv/uploads/spec.ex
@@ -155,6 +155,31 @@ defmodule Vutuv.Uploads.Spec do
   end
 
   @doc """
+  A **link-preview JPEG** derived from the file at `path`: decode and
+  EXIF-autorotate, hand the image to `shape` (the per-store geometry — a square
+  crop, the member's own crop, a width cap), then save it stripped.
+  `:error` when anything on the way fails.
+
+  Open Graph scrapers do not decode the AVIF versions we serve, so every store
+  that has a preview endpoint derives one of these. What must not be per-store
+  is the last step: `keep: []` is a privacy rule, not a setting — the original's
+  camera and GPS metadata may never leave in a served derivative — and it was
+  written out in three uploaders, each free to forget it.
+
+  `shape` is a `image -> {:ok, image} | any` fun; anything but `{:ok, _}` ends
+  as `:error`.
+  """
+  def og_jpeg(path, shape) when is_binary(path) and is_function(shape, 1) do
+    with {:ok, rotated} <- open_rotated(path),
+         {:ok, shaped} <- shape.(rotated),
+         {:ok, data} <- Operation.jpegsave_buffer(shaped, keep: [], Q: 80) do
+      {:ok, data}
+    else
+      _ -> :error
+    end
+  end
+
+  @doc """
   `open_rotated/1` for image bytes already in memory — same pixel budget and
   EXIF autorotation, but keyed on the **content**, not a filename.
 

--- a/lib/vutuv/web_verification.ex
+++ b/lib/vutuv/web_verification.ex
@@ -27,6 +27,7 @@ defmodule Vutuv.WebVerification do
   require Logger
 
   alias Vutuv.Dns
+  alias Vutuv.SocialFeed.Http
   alias Vutuv.Ssrf
 
   # How much of an unexpected answer is quoted back to the member in a check
@@ -293,25 +294,14 @@ defmodule Vutuv.WebVerification do
     end
   end
 
+  # The guard rails (timeouts, no retry, no redirect, `decode_body: false`, the
+  # capped collector, the installation's User-Agent) come from `Http` — they are
+  # the same rails every outbound fetch runs on, and this module used to keep
+  # its own copy of them.
   defp request(url, req_options, max_bytes, accept) do
     options =
-      [
-        url: url,
-        receive_timeout: 4_000,
-        connect_options: [timeout: 2_000],
-        retry: false,
-        redirect: false,
-        # The callers read the body as a binary (`is_binary` guards), so Req's
-        # own decode step must stay off — `into:` does NOT imply that, and a
-        # member's server may well mark a well-known answer `application/json`,
-        # which Req would decode into a map.
-        decode_body: false,
-        # Stream with a hard byte ceiling so a hostile large body is dropped
-        # during receipt instead of being buffered whole and truncated after the
-        # fact (the @max_*_bytes cap then bounds memory for real).
-        into: Vutuv.Http.capped_collector(max_bytes),
-        headers: [{"user-agent", user_agent()}, {"accept", accept}]
-      ]
+      url
+      |> Http.base_options(max_bytes, accept)
       |> Keyword.merge(req_options)
 
     case Req.get(options) do
@@ -340,10 +330,5 @@ defmodule Vutuv.WebVerification do
     |> String.replace(~r/[[:cntrl:]]+/u, " ")
     |> String.trim()
     |> String.slice(0, @max_excerpt)
-  end
-
-  defp user_agent do
-    vsn = Application.spec(:vutuv, :vsn) || ~c"0"
-    "vutuv/#{vsn} (+#{VutuvWeb.Endpoint.url()})"
   end
 end

--- a/lib/vutuv_web/agent_docs/investors_doc.ex
+++ b/lib/vutuv_web/agent_docs/investors_doc.ex
@@ -22,6 +22,7 @@ defmodule VutuvWeb.AgentDocs.InvestorsDoc do
   @doc "The public figures the investor page quotes, read live."
   def facts do
     usage = NodeInfo.usage()
+    reach = Fediverse.follower_reach()
 
     %{
       members: usage.users.total,
@@ -29,9 +30,27 @@ defmodule VutuvWeb.AgentDocs.InvestorsDoc do
       active_halfyear: usage.users.active_halfyear,
       posts: usage.local_posts,
       replies: usage.local_comments,
-      fediverse_accounts: Fediverse.distinct_follower_count(),
-      fediverse_servers: Fediverse.follower_host_count()
+      fediverse_accounts: reach.accounts,
+      fediverse_servers: reach.hosts
     }
+  end
+
+  @doc """
+  The figures as an ordered `{label, value}` list, so the `.md` and `.txt`
+  renderings name them identically. The HTML tiles are deliberately their own
+  arrangement (six tiles, the server count folded into a note on the seventh
+  figure), not a third copy of this list.
+  """
+  def figure_rows(facts) do
+    [
+      {"Members", facts.members},
+      {"Active this month", facts.active_month},
+      {"Active this half year", facts.active_halfyear},
+      {"Posts", facts.posts},
+      {"Replies", facts.replies},
+      {"Fediverse accounts", facts.fediverse_accounts},
+      {"Fediverse servers", facts.fediverse_servers}
+    ]
   end
 
   @doc """

--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -16,6 +16,7 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   alias Vutuv.Accounts.User
   alias Vutuv.CodeStats
   alias Vutuv.Isbn
+  alias VutuvWeb.AgentDocs.InvestorsDoc
   alias VutuvWeb.PostComponents
 
   # The per-user people lists (followers/following/connections) share one
@@ -355,19 +356,9 @@ defmodule VutuvWeb.AgentDocs.Markdown do
       |> Enum.filter(&is_binary/1)
       |> Enum.join("\n\n"),
       "## Figures",
-      Enum.map_join(
-        [
-          {"Members", doc.figures.members},
-          {"Active this month", doc.figures.active_month},
-          {"Active this half year", doc.figures.active_halfyear},
-          {"Posts", doc.figures.posts},
-          {"Replies", doc.figures.replies},
-          {"Fediverse accounts", doc.figures.fediverse_accounts},
-          {"Fediverse servers", doc.figures.fediverse_servers}
-        ],
-        "\n",
-        fn {label, value} -> "- #{label}: #{value}" end
-      ),
+      Enum.map_join(InvestorsDoc.figure_rows(doc.figures), "\n", fn {label, value} ->
+        "- #{label}: #{value}"
+      end),
       "Press material: #{doc.media_kit_url}"
     ]
     |> join_blocks()

--- a/lib/vutuv_web/agent_docs/post_doc.ex
+++ b/lib/vutuv_web/agent_docs/post_doc.ex
@@ -174,13 +174,6 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
     })
   end
 
-  # The name a timeline entry is signed with. A page is named by its own name;
-  # the member who published for it stays internal, exactly as on the HTML card.
-  defp timeline_author(%Post{} = post), do: author_label(Posts.author(post))
-
-  defp author_label(%Organization{name: name}), do: name
-  defp author_label(author), do: UserHelpers.full_name(author)
-
   # The organization's own reference, the counterpart of `AgentDocs.person_ref/1`.
   # `canonical_path/1` prefers the page's opt-in root handle, so the URL here is
   # the one the page answers to rather than the slug form the post lives under.
@@ -287,7 +280,9 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       url: AgentDocs.abs_url(Posts.path(post)),
       # Whichever kind of author the post has (issue #1334) — the reposters
       # below stay members, since only a member can repost.
-      author: timeline_author(post),
+      # The name the entry is signed with: a page by its own name, the member
+      # who published for it stays internal, exactly as on the HTML card.
+      author: UserHelpers.author_name(post),
       published_on: post.published_on,
       excerpt: AgentDocs.excerpt(post.body),
       reposted_by: entry[:reposted_by] && UserHelpers.full_name(entry[:reposted_by]),

--- a/lib/vutuv_web/agent_docs/text.ex
+++ b/lib/vutuv_web/agent_docs/text.ex
@@ -12,6 +12,7 @@ defmodule VutuvWeb.AgentDocs.Text do
   use Gettext, backend: VutuvWeb.Gettext
 
   alias Vutuv.Accounts.User
+  alias VutuvWeb.AgentDocs.InvestorsDoc
   alias VutuvWeb.AgentDocs.Markdown
 
   @width 80
@@ -330,15 +331,9 @@ defmodule VutuvWeb.AgentDocs.Text do
       ]
       |> Enum.filter(&is_binary/1),
       "Figures",
-      [
-        "- Members: #{doc.figures.members}",
-        "- Active this month: #{doc.figures.active_month}",
-        "- Active this half year: #{doc.figures.active_halfyear}",
-        "- Posts: #{doc.figures.posts}",
-        "- Replies: #{doc.figures.replies}",
-        "- Fediverse accounts: #{doc.figures.fediverse_accounts}",
-        "- Fediverse servers: #{doc.figures.fediverse_servers}"
-      ],
+      Enum.map(InvestorsDoc.figure_rows(doc.figures), fn {label, value} ->
+        "- #{label}: #{value}"
+      end),
       "Press material: #{doc.media_kit_url}",
       footer(doc)
     ]

--- a/lib/vutuv_web/components/organization_components.ex
+++ b/lib/vutuv_web/components/organization_components.ex
@@ -13,6 +13,7 @@ defmodule VutuvWeb.OrganizationComponents do
   import VutuvWeb.UI, only: [input_class: 2]
 
   alias Vutuv.Countries
+  alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
   alias Vutuv.Organizations.OrganizationImage
 
@@ -197,8 +198,7 @@ defmodule VutuvWeb.OrganizationComponents do
 
   attr(:organization, :map, required: true)
   attr(:active, :atom, required: true)
-  attr(:owner?, :boolean, required: true)
-  attr(:publisher?, :boolean, required: true)
+  attr(:viewer, :map, required: true)
 
   @doc """
   The header + tab bar shared by the organization management pages (issue #930): a
@@ -212,15 +212,19 @@ defmodule VutuvWeb.OrganizationComponents do
   they used to be guarded by was passed `true` by all nine call sites, so it was
   a knob that only ever read one way.
 
-  **Both role attributes are required, and that is the fix for issue #1484.** A
-  tab bar shared by nine pages must answer to the viewer's roles alone; with
-  `publisher?` defaulting to `false`, the four pages that never passed it dropped
-  the Feed and Follows tabs, so a publisher found their page's own reading list
-  only by standing on Activity or Fediverse first. A default is the wrong shape
-  here — the safe-looking value is the one that silently hides a tab — so a
-  missing attribute now fails `compile --warnings-as-errors` instead.
+  **It reads the roles itself, and that is the fix for issue #1484 carried one
+  step further.** The two booleans used to be required attributes, threaded from
+  nine call sites — five of which passed a literal `true` read off the route
+  rather than off the viewer, which is a hidden tab waiting to happen exactly as
+  `publisher?` defaulting to `false` already was. One `Organizations.role_powers/2`
+  here answers both from one query, and "a page forgot to compute a role" stops
+  being expressible. The pages are already behind their own `can_manage?/2` gate;
+  this only decides which tabs show.
   """
   def manage_header(assigns) do
+    assigns =
+      assign(assigns, :powers, Organizations.role_powers(assigns.organization, assigns.viewer))
+
     ~H"""
     <div class="mb-6">
       <.link
@@ -233,10 +237,10 @@ defmodule VutuvWeb.OrganizationComponents do
         <.manage_tab active={@active == :edit} navigate={"/organizations/#{@organization.slug}/edit"}>
           {gettext("Page")}
         </.manage_tab>
-        <.manage_tab :if={@owner?} active={@active == :roles} navigate={"/organizations/#{@organization.slug}/roles"}>
+        <.manage_tab :if={@powers.owner?} active={@active == :roles} navigate={"/organizations/#{@organization.slug}/roles"}>
           {gettext("Team")}
         </.manage_tab>
-        <.manage_tab :if={@owner?} active={@active == :domains} navigate={"/organizations/#{@organization.slug}/domains"}>
+        <.manage_tab :if={@powers.owner?} active={@active == :domains} navigate={"/organizations/#{@organization.slug}/domains"}>
           {gettext("Domains")}
         </.manage_tab>
         <.manage_tab active={@active == :exclusions} navigate={"/organizations/#{@organization.slug}/exclusions"}>
@@ -251,18 +255,18 @@ defmodule VutuvWeb.OrganizationComponents do
         <%!-- What the page reads (issue #1336). Publishers only, unlike
         Activity beside it: this is the page's own reading, part of speaking
         for it, not news about it. --%>
-        <.manage_tab :if={@publisher?} active={@active == :feed} navigate={"/organizations/#{@organization.slug}/feed"}>
+        <.manage_tab :if={@powers.publisher?} active={@active == :feed} navigate={"/organizations/#{@organization.slug}/feed"}>
           {gettext("Feed")}
         </.manage_tab>
         <%!-- "Follows", not "Following": the member-voiced msgid translates to
         "Folge ich" (I follow), which is the wrong voice under a page's nav —
         this list is what the PAGE follows, not what the reader does. --%>
-        <.manage_tab :if={@publisher?} active={@active == :following} navigate={"/organizations/#{@organization.slug}/following"}>
+        <.manage_tab :if={@powers.publisher?} active={@active == :following} navigate={"/organizations/#{@organization.slug}/following"}>
           {gettext("Follows")}
         </.manage_tab>
         <%!-- Owner-only (issue #1334): federating decides how the page appears
         on servers we do not run, and cannot be fully taken back. --%>
-        <.manage_tab :if={@owner?} active={@active == :fediverse} navigate={"/organizations/#{@organization.slug}/fediverse"}>
+        <.manage_tab :if={@powers.owner?} active={@active == :fediverse} navigate={"/organizations/#{@organization.slug}/fediverse"}>
           {gettext("Fediverse")}
         </.manage_tab>
       </nav>

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -39,12 +39,9 @@ defmodule VutuvWeb.PostComponents do
   alias Vutuv.Isbn
   alias Vutuv.Languages
   alias Vutuv.Moderation.ImageScans
-  alias Vutuv.Organizations
-  alias Vutuv.Organizations.Organization
   alias Vutuv.Posts
   alias Vutuv.Posts.GalleryLayout
   alias Vutuv.Posts.PhotoLicense
-  alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostImage
   alias Vutuv.Posts.PostRemoteReply
   alias Vutuv.Posts.PostReview
@@ -58,6 +55,7 @@ defmodule VutuvWeb.PostComponents do
   alias VutuvWeb.Live.PostTranslations
   alias VutuvWeb.Markdown
   alias VutuvWeb.PostLive.RemoteActionsComponent
+  alias VutuvWeb.UserHelpers
 
   # How many reposter faces the "Reposted by" avatar stack shows before the
   # rest collapse into a `+N` chip. Five keeps the strip to one tidy line even
@@ -306,8 +304,8 @@ defmodule VutuvWeb.PostComponents do
       # about which of the two author columns speaks.
       |> assign(:author, Posts.author(post))
       |> assign(:organization_author?, Posts.organization_post?(post))
-      |> assign(:author_path, author_path(post))
-      |> assign(:author_name, author_name(post))
+      |> assign(:author_path, Posts.author_path(post))
+      |> assign(:author_name, UserHelpers.author_name(post))
       # Whether this post is the one its author pinned to their profile (issue
       # #1110) — read off the already-preloaded author, so it costs no query.
       # Drives the menu's Pin / Unpin label and its "replaces the other one"
@@ -342,24 +340,6 @@ defmodule VutuvWeb.PostComponents do
     </div>
     """
   end
-
-  # Where the author's name and avatar link to. A member's profile lives at
-  # their handle; an organization's page at `Organizations.canonical_path/1`,
-  # which prefers its opt-in root handle over `/organizations/:slug`.
-  # Both dispatch on what `Posts.author/1` hands back rather than on a pattern
-  # over the preloaded association: the association-shaped clause reads as a
-  # type check but behaves as a preload check, so a bare %Post{} from a query
-  # drew a page's post as a nil member's.
-  defp author_path(%Post{} = post), do: author_path(Posts.author(post))
-  defp author_path(%Organization{} = organization), do: Organizations.canonical_path(organization)
-  defp author_path(%User{} = user), do: "/#{user.username}"
-
-  # The visible author name. An organization is named by its own name and has no
-  # `@handle` line beside it: a page's identity is the name, and the handle is
-  # an optional address it may never have claimed.
-  defp author_name(%Post{} = post), do: author_name(Posts.author(post))
-  defp author_name(%Organization{name: name}), do: name
-  defp author_name(%User{} = user), do: full_name(user)
 
   @doc """
   The shared shell for a threaded post list: a `divide-y` column of

--- a/lib/vutuv_web/controllers/avatar_controller.ex
+++ b/lib/vutuv_web/controllers/avatar_controller.ex
@@ -15,20 +15,17 @@ defmodule VutuvWeb.AvatarController do
   use VutuvWeb, :controller
 
   alias Vutuv.Accounts.User
+  alias Vutuv.Avatar
+  alias Vutuv.Repo
+  alias VutuvWeb.ControllerHelpers
 
   def show(conn, %{"slug" => slug}) do
-    with %User{email_confirmed?: true, avatar: avatar} = user when not is_nil(avatar) <-
-           Vutuv.Repo.get_by(User, username: slug),
-         {:ok, jpeg} <- Vutuv.Avatar.og_jpeg(user) do
-      conn
-      |> put_resp_content_type("image/jpeg", nil)
-      |> put_resp_header("cache-control", "public, max-age=86400")
-      |> send_resp(200, jpeg)
-    else
-      _ ->
-        conn
-        |> put_resp_content_type("text/plain")
-        |> send_resp(404, "Not Found")
-    end
+    bytes =
+      with %User{email_confirmed?: true, avatar: avatar} = user when not is_nil(avatar) <-
+             Repo.get_by(User, username: slug) do
+        Avatar.og_jpeg(user)
+      end
+
+    ControllerHelpers.send_og_jpeg(conn, bytes)
   end
 end

--- a/lib/vutuv_web/controllers/controller_helpers.ex
+++ b/lib/vutuv_web/controllers/controller_helpers.ex
@@ -144,6 +144,38 @@ defmodule VutuvWeb.ControllerHelpers do
   end
 
   @doc """
+  `path` with `query` appended, and no stray `?` when there is no query — the
+  join three plugs each wrote out for themselves while redirecting somewhere
+  that must keep the request's parameters.
+  """
+  def with_query(path, ""), do: path
+  def with_query(path, query) when is_binary(query), do: path <> "?" <> query
+
+  @doc """
+  Answers an `avatar.jpg` request with the derived bytes, or with the plain
+  404 every failure shares.
+
+  The two endpoints (`/:slug/avatar.jpg` for a member, `/organizations/:slug/avatar.jpg`
+  for a page) differ only in the lookup and its visibility gate; the answer is
+  the same both ways, and both halves of it are decisions rather than details:
+  the cache lifetime keeps repeat scraper traffic off libvips, and the
+  featureless plain-text 404 is what makes an unknown slug, a missing picture
+  and a page nobody may see indistinguishable from outside.
+  """
+  def send_og_jpeg(%Conn{} = conn, {:ok, jpeg}) do
+    conn
+    |> Conn.put_resp_content_type("image/jpeg", nil)
+    |> Conn.put_resp_header("cache-control", "public, max-age=86400")
+    |> Conn.send_resp(200, jpeg)
+  end
+
+  def send_og_jpeg(%Conn{} = conn, _missing) do
+    conn
+    |> Conn.put_resp_content_type("text/plain")
+    |> Conn.send_resp(404, "Not Found")
+  end
+
+  @doc """
   Renders the bare `VutuvWeb.ErrorHTML` 403/404 page and halts: the one shape
   every auth/resolve plug and the controller-side guards use to refuse a
   request.

--- a/lib/vutuv_web/controllers/organization_avatar_controller.ex
+++ b/lib/vutuv_web/controllers/organization_avatar_controller.ex
@@ -25,21 +25,16 @@ defmodule VutuvWeb.OrganizationAvatarController do
   alias Vutuv.OrganizationImageStore
   alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
+  alias VutuvWeb.ControllerHelpers
 
   def show(conn, %{"slug" => slug}) do
-    with %Organization{logo: logo} = organization when is_binary(logo) <-
-           Organizations.get_organization_by_slug(slug),
-         true <- Organizations.organization_visible_to?(organization, nil),
-         {:ok, jpeg} <- OrganizationImageStore.og_jpeg(logo) do
-      conn
-      |> put_resp_content_type("image/jpeg", nil)
-      |> put_resp_header("cache-control", "public, max-age=86400")
-      |> send_resp(200, jpeg)
-    else
-      _ ->
-        conn
-        |> put_resp_content_type("text/plain")
-        |> send_resp(404, "Not Found")
-    end
+    bytes =
+      with %Organization{logo: logo} = organization when is_binary(logo) <-
+             Organizations.get_organization_by_slug(slug),
+           true <- Organizations.organization_visible_to?(organization, nil) do
+        OrganizationImageStore.og_jpeg(logo)
+      end
+
+    ControllerHelpers.send_og_jpeg(conn, bytes)
   end
 end

--- a/lib/vutuv_web/feeds.ex
+++ b/lib/vutuv_web/feeds.ex
@@ -11,7 +11,6 @@ defmodule VutuvWeb.Feeds do
   """
 
   alias Vutuv.Organizations
-  alias Vutuv.Organizations.Organization
   alias Vutuv.Posts
   alias VutuvWeb.AgentDocs
   alias VutuvWeb.PostComponents
@@ -107,7 +106,7 @@ defmodule VutuvWeb.Feeds do
 
   defp item(post) do
     permalink = AgentDocs.abs_url(Posts.path(post))
-    author = author_name(post)
+    author = UserHelpers.author_name(post)
     title = "#{author} · #{Date.to_iso8601(post.published_on)}"
 
     [
@@ -122,16 +121,6 @@ defmodule VutuvWeb.Feeds do
       "    <content:encoded><![CDATA[#{cdata_safe(rendered_body(post))}]]></content:encoded>\n",
       "  </item>\n"
     ]
-  end
-
-  # Whichever kind of author the post has (issue #1334). A reader sees the name
-  # the post is signed with; the member who pressed publish for an organization
-  # is internal and never appears in a feed.
-  defp author_name(post) do
-    case Posts.author(post) do
-      %Organization{name: name} -> name
-      author -> UserHelpers.full_name(author)
-    end
   end
 
   defp rendered_body(post) do

--- a/lib/vutuv_web/live/admin/screenshot_live.ex
+++ b/lib/vutuv_web/live/admin/screenshot_live.ex
@@ -24,7 +24,6 @@ defmodule VutuvWeb.Admin.ScreenshotLive do
   use VutuvWeb, :live_view
 
   import VutuvWeb.ErrorHelpers, only: [error_tag: 2]
-  import VutuvWeb.UserHelpers, only: [full_name: 1]
 
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Fediverse.RemotePost
@@ -34,6 +33,7 @@ defmodule VutuvWeb.Admin.ScreenshotLive do
   alias Vutuv.Posts.Screenshots
   alias Vutuv.Posts.ScreenshotWorker
   alias Vutuv.ScreenshotBlocklist
+  alias VutuvWeb.UserHelpers
 
   @impl true
   def mount(_params, _session, socket) do
@@ -163,17 +163,6 @@ defmodule VutuvWeb.Admin.ScreenshotLive do
     |> assign(:total, total)
     |> assign(:counts, Screenshots.counts())
     |> load_blocklist()
-  end
-
-  # Whichever kind of author the post has (issue #1334). A post published in an
-  # organization's name has no member behind it here — `post.user` is nil — and
-  # a link screenshot is taken for it exactly as it is for a member's post, so
-  # both rows on this page meet one.
-  defp author_name(post) do
-    case Posts.author(post) do
-      %Organization{name: name} -> name
-      author -> full_name(author)
-    end
   end
 
   # The compact queue-table form: a member is named by handle, a page by name
@@ -388,7 +377,7 @@ defmodule VutuvWeb.Admin.ScreenshotLive do
                   navigate={Posts.path(ps.post)}
                   class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
                 >
-                  {gettext("Post by %{name}", name: author_name(ps.post))}
+                  {gettext("Post by %{name}", name: UserHelpers.author_name(ps.post))}
                 </.link>
                 <a
                   :if={ps.remote_post}

--- a/lib/vutuv_web/live/organization_live/activity.ex
+++ b/lib/vutuv_web/live/organization_live/activity.ex
@@ -42,8 +42,6 @@ defmodule VutuvWeb.OrganizationLive.Activity do
     {:ok,
      socket
      |> assign(:organization, organization)
-     |> assign(:owner?, Organizations.owner?(organization, socket.assigns.current_user))
-     |> assign(:publisher?, Organizations.publisher?(organization, socket.assigns.current_user))
      |> assign(:marker, marker)
      |> assign(:page_title, gettext("Activity – %{name}", name: organization.name))
      |> load_activity(0)}
@@ -91,9 +89,7 @@ defmodule VutuvWeb.OrganizationLive.Activity do
       <.manage_header
         organization={@organization}
         active={:activity}
-        owner?={@owner?}
-       
-        publisher?={@publisher?}
+        viewer={@current_user}
       />
 
       <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100">{gettext("Activity")}</h1>

--- a/lib/vutuv_web/live/organization_live/domains.ex
+++ b/lib/vutuv_web/live/organization_live/domains.ex
@@ -26,7 +26,6 @@ defmodule VutuvWeb.OrganizationLive.Domains do
     {:ok,
      socket
      |> assign(:organization, organization)
-     |> assign(:publisher?, Organizations.publisher?(organization, socket.assigns.current_user))
      |> assign(:page_title, gettext("Domains – %{name}", name: organization.name))
      |> assign(:new_domain, "")
      |> assign(:new_method, "dns")
@@ -173,8 +172,7 @@ defmodule VutuvWeb.OrganizationLive.Domains do
       <.manage_header
         organization={@organization}
         active={:domains}
-        owner?={true}
-        publisher?={@publisher?}
+        viewer={@current_user}
       />
 
       <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100">{gettext("Domains")}</h1>

--- a/lib/vutuv_web/live/organization_live/edit.ex
+++ b/lib/vutuv_web/live/organization_live/edit.ex
@@ -28,7 +28,6 @@ defmodule VutuvWeb.OrganizationLive.Edit do
       |> assign(:locale, locale)
       |> assign(:organization, organization)
       |> assign(:owner?, Organizations.owner?(organization, current_user))
-      |> assign(:publisher?, Organizations.publisher?(organization, current_user))
       |> assign(:page_title, gettext("Edit %{name}", name: organization.name))
       |> assign(:countries, Countries.select_options(locale))
       |> assign(:aliases, Organizations.list_aliases(organization))
@@ -238,8 +237,7 @@ defmodule VutuvWeb.OrganizationLive.Edit do
       <.manage_header
         organization={@organization}
         active={:edit}
-        owner?={@owner?}
-        publisher?={@publisher?}
+        viewer={@current_user}
       />
 
       <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100">

--- a/lib/vutuv_web/live/organization_live/exclusions.ex
+++ b/lib/vutuv_web/live/organization_live/exclusions.ex
@@ -23,14 +23,11 @@ defmodule VutuvWeb.OrganizationLive.Exclusions do
   @impl true
   def mount(_params, session, socket) do
     socket = InitAssigns.assign_embedded(socket, session)
-    current_user = socket.assigns.current_user
     organization = Organizations.get_organization!(session["organization_id"])
 
     {:ok,
      socket
      |> assign(:organization, organization)
-     |> assign(:owner?, Organizations.owner?(organization, current_user))
-     |> assign(:publisher?, Organizations.publisher?(organization, current_user))
      |> assign(:page_title, gettext("Job exclusions – %{name}", name: organization.name))
      |> assign(:member_error, nil)
      |> assign(:org_error, nil)
@@ -101,8 +98,7 @@ defmodule VutuvWeb.OrganizationLive.Exclusions do
       <.manage_header
         organization={@organization}
         active={:exclusions}
-        owner?={@owner?}
-        publisher?={@publisher?}
+        viewer={@current_user}
       />
 
       <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100">

--- a/lib/vutuv_web/live/organization_live/fediverse.ex
+++ b/lib/vutuv_web/live/organization_live/fediverse.ex
@@ -38,8 +38,6 @@ defmodule VutuvWeb.OrganizationLive.Fediverse do
   defp assign_state(socket, organization) do
     socket
     |> assign(:organization, organization)
-    |> assign(:owner?, true)
-    |> assign(:publisher?, Organizations.publisher?(organization, socket.assigns.current_user))
     |> assign(:federated?, Fediverse.federated?(organization))
     |> assign(:ever_federated?, Fediverse.ever_federated?(organization))
     |> assign(:enabled?, Fediverse.enabled?())
@@ -72,9 +70,7 @@ defmodule VutuvWeb.OrganizationLive.Fediverse do
       <.manage_header
         organization={@organization}
         active={:fediverse}
-        owner?={true}
-       
-        publisher?={@publisher?}
+        viewer={@current_user}
       />
 
       <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100">{gettext("Fediverse")}</h1>

--- a/lib/vutuv_web/live/organization_live/fediverse_followers.ex
+++ b/lib/vutuv_web/live/organization_live/fediverse_followers.ex
@@ -49,8 +49,6 @@ defmodule VutuvWeb.OrganizationLive.FediverseFollowers do
      socket
      |> assign(:page_title, gettext("Followers – %{name}", name: organization.name))
      |> assign(:organization, organization)
-     |> assign(:owner?, true)
-     |> assign(:publisher?, Organizations.publisher?(organization, socket.assigns.current_user))
      |> assign(:filters, Fediverse.browse_filters(%{}))
      |> assign(:page, 1)
      |> assign_totals()
@@ -154,9 +152,7 @@ defmodule VutuvWeb.OrganizationLive.FediverseFollowers do
       <.manage_header
         organization={@organization}
         active={:fediverse}
-        owner?={true}
-       
-        publisher?={@publisher?}
+        viewer={@current_user}
       />
 
       <div class="space-y-6">

--- a/lib/vutuv_web/live/organization_live/feed.ex
+++ b/lib/vutuv_web/live/organization_live/feed.ex
@@ -45,7 +45,6 @@ defmodule VutuvWeb.OrganizationLive.Feed do
     {:ok,
      socket
      |> assign(:organization, organization)
-     |> assign(:owner?, Organizations.owner?(organization, socket.assigns.current_user))
      |> assign(:page_title, gettext("Feed – %{name}", name: organization.name))
      |> load_feed(nil)}
   end
@@ -93,9 +92,7 @@ defmodule VutuvWeb.OrganizationLive.Feed do
       <.manage_header
         organization={@organization}
         active={:feed}
-        owner?={@owner?}
-       
-        publisher?={true}
+        viewer={@current_user}
       />
 
       <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100">{gettext("Feed")}</h1>

--- a/lib/vutuv_web/live/organization_live/following.ex
+++ b/lib/vutuv_web/live/organization_live/following.ex
@@ -49,7 +49,6 @@ defmodule VutuvWeb.OrganizationLive.Following do
     {:ok,
      socket
      |> assign(:organization, organization)
-     |> assign(:owner?, Organizations.owner?(organization, socket.assigns.current_user))
      |> assign(:page_title, gettext("Follows – %{name}", name: organization.name))
      |> assign(:address, "")
      |> assign(:follow_error, nil)
@@ -147,9 +146,7 @@ defmodule VutuvWeb.OrganizationLive.Following do
       <.manage_header
         organization={@organization}
         active={:following}
-        owner?={@owner?}
-       
-        publisher?={true}
+        viewer={@current_user}
       />
 
       <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100">{gettext("Follows")}</h1>

--- a/lib/vutuv_web/live/organization_live/roles.ex
+++ b/lib/vutuv_web/live/organization_live/roles.ex
@@ -33,7 +33,6 @@ defmodule VutuvWeb.OrganizationLive.Roles do
     {:ok,
      socket
      |> assign(:organization, organization)
-     |> assign(:publisher?, Organizations.publisher?(organization, socket.assigns.current_user))
      |> assign(:page_title, gettext("Team – %{name}", name: organization.name))
      |> assign(:identifier, "")
      # Nothing pre-ticked: with four roles a guessed default is wrong more often
@@ -164,8 +163,7 @@ defmodule VutuvWeb.OrganizationLive.Roles do
       <.manage_header
         organization={@organization}
         active={:roles}
-        owner?={true}
-        publisher?={@publisher?}
+        viewer={@current_user}
       />
 
       <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100">{gettext("Team")}</h1>

--- a/lib/vutuv_web/live/post_translations.ex
+++ b/lib/vutuv_web/live/post_translations.ex
@@ -28,6 +28,7 @@ defmodule VutuvWeb.Live.PostTranslations do
   alias Vutuv.Posts
   alias Vutuv.Translations
   alias Vutuv.Translations.Translation
+  alias Vutuv.Translations.Worker
 
   @doc """
   Whether this viewer gets translation controls at all: the installation has
@@ -155,9 +156,19 @@ defmodule VutuvWeb.Live.PostTranslations do
 
     cached = Translations.fresh_translations(wanted, target)
 
-    Enum.reduce(wanted, map, fn subject, acc ->
-      resolve_auto(acc, subject, cached[subject_key(subject)])
-    end)
+    {map, queued?} =
+      Enum.reduce(wanted, {map, false}, fn subject, {acc, queued?} ->
+        case resolve_auto(acc, subject, cached[subject_key(subject)]) do
+          {acc, true} -> {acc, true}
+          {acc, false} -> {acc, queued?}
+        end
+      end)
+
+    # One nudge for the page, not one per card: each costs the worker a full
+    # drain round (a resume_stuck UPDATE plus the due SELECT).
+    if queued?, do: Worker.nudge()
+
+    map
   end
 
   defp auto_translation_wanted?(map, %{language: language} = subject, target, chosen) do
@@ -165,13 +176,21 @@ defmodule VutuvWeb.Live.PostTranslations do
       not Map.has_key?(map, subject_key(subject))
   end
 
+  # `{map, queued_a_job?}` — the caller nudges the worker once for the page.
   defp resolve_auto(map, subject, %Translation{} = cached),
-    do: Map.put(map, subject_key(subject), cached)
+    do: {Map.put(map, subject_key(subject), cached), false}
 
+  # `queue/2` rather than `Translations.request/2`: the batch above already
+  # answered "is there a fresh translation for this subject", and `request/2`
+  # would ask again, once per card.
   defp resolve_auto(map, subject, nil) do
-    case track(subject) do
-      {:ok, state} -> Map.put(map, subject_key(subject), state)
-      :denied -> map
+    case Translations.queue(subject, target_language()) do
+      {:queued, _job} ->
+        Phoenix.PubSub.subscribe(Vutuv.PubSub, Translations.topic(subject))
+        {Map.put(map, subject_key(subject), :pending), true}
+
+      :disabled ->
+        {map, false}
     end
   end
 

--- a/lib/vutuv_web/live/search_live.ex
+++ b/lib/vutuv_web/live/search_live.ex
@@ -36,8 +36,6 @@ defmodule VutuvWeb.SearchLive do
 
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.RemoteFollow
-  alias Vutuv.Organizations
-  alias Vutuv.Organizations.Organization
   alias Vutuv.Posts
   alias Vutuv.Search
   alias VutuvWeb.UserHelpers
@@ -588,22 +586,6 @@ defmodule VutuvWeb.SearchLive do
     """
   end
 
-  # Where a result's author link goes and what it reads, for whichever kind of
-  # author the post has (issue #1334).
-  defp author_path(post) do
-    case Posts.author(post) do
-      %Organization{} = organization -> Organizations.canonical_path(organization)
-      author -> "/" <> author.username
-    end
-  end
-
-  defp author_name(post) do
-    case Posts.author(post) do
-      %Organization{name: name} -> name
-      author -> UserHelpers.full_name(author)
-    end
-  end
-
   @impl true
   def render(assigns) do
     ~H"""
@@ -791,10 +773,10 @@ defmodule VutuvWeb.SearchLive do
               <div class="min-w-0">
                 <p class="mb-0 text-sm">
                   <.link
-                    href={author_path(post)}
+                    href={Posts.author_path(post)}
                     class="font-medium text-slate-800 hover:text-brand-700 dark:text-slate-100"
                   >
-                    {author_name(post)}
+                    {UserHelpers.author_name(post)}
                   </.link>
                   <span :if={!Posts.organization_post?(post)} class="text-slate-600 dark:text-slate-400">
                     @{post.user.username}

--- a/lib/vutuv_web/plugs/newsletter_click.ex
+++ b/lib/vutuv_web/plugs/newsletter_click.ex
@@ -22,6 +22,7 @@ defmodule VutuvWeb.Plug.NewsletterClick do
   import Phoenix.Controller, only: [redirect: 2]
 
   alias Vutuv.Newsletters
+  alias VutuvWeb.ControllerHelpers
   alias VutuvWeb.NewsletterToken
 
   def init(opts), do: opts
@@ -52,9 +53,9 @@ defmodule VutuvWeb.Plug.NewsletterClick do
   # The same path with only the tracking parameter removed, so any other query
   # parameters the link carried are preserved.
   defp clean_path(conn) do
-    case conn.query_params |> Map.delete(NewsletterToken.param()) |> URI.encode_query() do
-      "" -> conn.request_path
-      query -> conn.request_path <> "?" <> query
-    end
+    conn.query_params
+    |> Map.delete(NewsletterToken.param())
+    |> URI.encode_query()
+    |> then(&ControllerHelpers.with_query(conn.request_path, &1))
   end
 end

--- a/lib/vutuv_web/plugs/tag_host.ex
+++ b/lib/vutuv_web/plugs/tag_host.ex
@@ -31,6 +31,7 @@ defmodule VutuvWeb.Plug.TagHost do
 
   alias Vutuv.Fediverse
   alias VutuvWeb.ContentPolicy
+  alias VutuvWeb.ControllerHelpers
   alias VutuvWeb.Endpoint
 
   def init(opts), do: opts
@@ -54,6 +55,6 @@ defmodule VutuvWeb.Plug.TagHost do
 
   defp site_url, do: String.trim_trailing(Endpoint.url(), "/")
 
-  defp path_with_query(%{request_path: path, query_string: ""}), do: path
-  defp path_with_query(%{request_path: path, query_string: query}), do: path <> "?" <> query
+  defp path_with_query(conn),
+    do: ControllerHelpers.with_query(conn.request_path, conn.query_string)
 end

--- a/lib/vutuv_web/plugs/user_resolve_slugs.ex
+++ b/lib/vutuv_web/plugs/user_resolve_slugs.ex
@@ -27,6 +27,7 @@ defmodule VutuvWeb.Plug.UserResolveSlug do
   alias Vutuv.Accounts.User
   alias Vutuv.Organizations
   alias Vutuv.Repo
+  alias VutuvWeb.ControllerHelpers
   alias VutuvWeb.OrganizationController
 
   def init(opts) do
@@ -107,13 +108,10 @@ defmodule VutuvWeb.Plug.UserResolveSlug do
         if segment == old_slug, do: current_slug, else: segment
       end)
 
-    case conn.query_string do
-      "" -> "/" <> path
-      query -> "/" <> path <> "?" <> query
-    end
+    ControllerHelpers.with_query("/" <> path, conn.query_string)
   end
 
   defp invalid_slug(conn) do
-    VutuvWeb.ControllerHelpers.render_error(conn, 404)
+    ControllerHelpers.render_error(conn, 404)
   end
 end

--- a/lib/vutuv_web/templates/import/preview.html.heex
+++ b/lib/vutuv_web/templates/import/preview.html.heex
@@ -37,15 +37,15 @@
     >
       <input type="hidden" name="payload" value={@payload} />
 
-      <.candidate_section title={gettext("Work experience")} items={@candidates.positions}>
+      <.candidate_section title={section_label(:positions)} items={@candidates.positions}>
         <.candidate_row :for={c <- @candidates.positions} id={c.id} label={c.label} duplicate?={c.duplicate?} select?={c.select?} />
       </.candidate_section>
 
-      <.candidate_section title={gettext("Education")} items={@candidates.educations}>
+      <.candidate_section title={section_label(:educations)} items={@candidates.educations}>
         <.candidate_row :for={c <- @candidates.educations} id={c.id} label={c.label} duplicate?={c.duplicate?} select?={c.select?} />
       </.candidate_section>
 
-      <.candidate_section title={gettext("Certificates & licenses")} items={@candidates.certifications}>
+      <.candidate_section title={section_label(:certifications)} items={@candidates.certifications}>
         <p :if={@candidates.certifications != []} class="mb-2 text-xs text-slate-600 dark:text-slate-400">
           {gettext(
             "LinkedIn does not say whether an entry is a certificate or a license, so we import all of them as certificates. Please review the section afterwards and switch any that are licenses."
@@ -57,29 +57,29 @@
       <%!-- Tags are the one capped section: a profile carries at most
       Vutuv.Tags.max_user_tags/0 of them, so the preselection stops at the free
       slots and the section says how many that is. --%>
-      <.candidate_section title={gettext("Tags")} items={@candidates.skills} limit={@tag_capacity.free}>
+      <.candidate_section title={section_label(:skills)} items={@candidates.skills} limit={@tag_capacity.free}>
         <:note>
           <.tag_capacity_note used={@tag_capacity.used} max={@tag_capacity.max} free={@tag_capacity.free} />
         </:note>
         <.candidate_row :for={c <- @candidates.skills} id={c.id} label={c.label} duplicate?={c.duplicate?} select?={c.select?} />
       </.candidate_section>
 
-      <.candidate_section title={gettext("Links")} items={@candidates.urls}>
+      <.candidate_section title={section_label(:urls)} items={@candidates.urls}>
         <.candidate_row :for={c <- @candidates.urls} id={c.id} label={c.label} duplicate?={c.duplicate?} select?={c.select?} />
       </.candidate_section>
 
-      <.candidate_section title={gettext("Social media")} items={@candidates.social}>
+      <.candidate_section title={section_label(:social)} items={@candidates.social}>
         <.candidate_row :for={c <- @candidates.social} id={c.id} label={c.label} duplicate?={c.duplicate?} select?={c.select?} />
       </.candidate_section>
 
-      <.candidate_section title={gettext("Phone numbers")} items={@candidates.phones}>
+      <.candidate_section title={section_label(:phones)} items={@candidates.phones}>
         <.candidate_row :for={c <- @candidates.phones} id={c.id} label={c.label} duplicate?={c.duplicate?} select?={c.select?} />
       </.candidate_section>
 
       <%!-- Profile scalars: offered only when the field is currently blank, so an
       import never overwrites your name or headline. --%>
       <div :if={Enum.any?(@candidates.profile, & &1.fillable?)} class="mt-6" data-select-group>
-        <.select_group_header title={gettext("Profile")} />
+        <.select_group_header title={section_label(:profile)} />
         <ul class="mt-2 divide-y divide-slate-100 dark:divide-slate-800">
           <li :for={c <- @candidates.profile} :if={c.fillable?} class="flex items-start gap-3 py-2">
             <input type="checkbox" name="selected[]" value={c.id} class={checkbox_class()} id={"cand-#{c.id}"} />

--- a/lib/vutuv_web/views/company_html.ex
+++ b/lib/vutuv_web/views/company_html.ex
@@ -6,178 +6,12 @@ defmodule VutuvWeb.CompanyHTML do
   so nothing here goes through `gettext` — a half-translated page reads worse
   than an honestly monolingual one, and the footer labels them in English to
   say so before the click.
-
-  It also owns the investor page's growth curve, drawn as plain server-rendered
-  SVG. No chart library: the page is two paths and a handful of labels, and
-  shipping a JavaScript bundle for that would cost every reader of every other
-  page nothing less than the whole file.
   """
   use VutuvWeb, :html
 
   alias VutuvWeb.UI
 
   embed_templates("../templates/company/*")
-
-  # The plotting box, in SVG user units. The chart scales to its container
-  # through the viewBox, so these are proportions rather than pixels.
-  @width 640
-  @height 220
-  @pad_left 52
-  @pad_right 12
-  @pad_top 12
-  @pad_bottom 28
-
-  @doc """
-  The growth curve: a filled area for the members here and a line above it for
-  the people total (members plus the Fediverse accounts following something on
-  this installation). The gap between the two IS the Fediverse share, which is
-  the only honest way to show a figure two orders of magnitude smaller than the
-  one beside it — a second line against the same axis would lie flat on the
-  floor, and its own axis would suggest the two are comparable in size.
-
-  **The y-axis starts at zero.** Both figures are running totals in the
-  thousands growing by a few a day, so an axis cropped to the data's own range
-  would turn a couple of percent into a mountain. That is the one chart trick
-  an investor page must not play: the reader who notices is the reader we want.
-  """
-  attr(:series, :list, required: true)
-
-  def growth_chart(assigns) do
-    assigns = assign(assigns, :chart, chart(assigns.series))
-
-    ~H"""
-    <figure :if={@chart} class="mt-6">
-      <svg
-        viewBox={@chart.view_box}
-        class="h-auto w-full"
-        role="img"
-        aria-label={@chart.summary}
-        data-growth-chart={length(@series)}
-      >
-        <title>{@chart.summary}</title>
-        <line
-          :for={{_label, y} <- @chart.ticks}
-          x1={@chart.plot_left}
-          x2={@chart.plot_right}
-          y1={y}
-          y2={y}
-          class="stroke-slate-200 dark:stroke-slate-700"
-          stroke-width="1"
-        />
-        <text
-          :for={{label, y} <- @chart.ticks}
-          x={@chart.plot_left - 8}
-          y={y + 4}
-          text-anchor="end"
-          class="fill-slate-500 text-[11px] dark:fill-slate-400"
-        >
-          {label}
-        </text>
-        <path d={@chart.members_area} class="fill-brand-500/25" />
-        <path
-          d={@chart.members_line}
-          fill="none"
-          class="stroke-brand-600 dark:stroke-brand-400"
-          stroke-width="2"
-          stroke-linejoin="round"
-        />
-        <path
-          d={@chart.total_line}
-          fill="none"
-          class="stroke-accent"
-          stroke-width="2"
-          stroke-linejoin="round"
-        />
-        <text
-          x={@chart.plot_left}
-          y={@chart.label_baseline}
-          text-anchor="start"
-          class="fill-slate-500 text-[11px] dark:fill-slate-400"
-        >
-          {@chart.first_day}
-        </text>
-        <text
-          x={@chart.plot_right}
-          y={@chart.label_baseline}
-          text-anchor="end"
-          class="fill-slate-500 text-[11px] dark:fill-slate-400"
-        >
-          {@chart.last_day}
-        </text>
-      </svg>
-      <figcaption class="mt-3 flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-slate-600 dark:text-slate-400">
-        <span class="flex items-center gap-2">
-          <span class="h-2.5 w-2.5 rounded-full bg-brand-600 dark:bg-brand-400"></span>
-          Members on vutuv
-        </span>
-        <span class="flex items-center gap-2">
-          <span class="h-2.5 w-2.5 rounded-full bg-accent"></span>
-          Total people, including Fediverse accounts
-        </span>
-      </figcaption>
-    </figure>
-    """
-  end
-
-  @doc """
-  The chart's geometry, or `nil` for a series too short to draw a line through.
-
-  Public because `company_html_test.exs` checks the arithmetic directly: an
-  off-by-one in the scaling is invisible in a rendered path string and obvious
-  in a coordinate.
-  """
-  def chart(series) when length(series) < 2, do: nil
-
-  def chart(series) do
-    totals = Enum.map(series, &(&1.members + &1.fediverse_accounts))
-    members = Enum.map(series, & &1.members)
-    top = axis_top(Enum.max(totals))
-
-    %{
-      members_area: area_path(members, top, length(series)),
-      members_line: line_path(members, top, length(series)),
-      total_line: line_path(totals, top, length(series)),
-      ticks: ticks(top),
-      first_day: format_day(List.first(series).day),
-      last_day: format_day(List.last(series).day),
-      summary: summary(series),
-      view_box: "0 0 #{@width} #{@height}",
-      plot_left: @pad_left,
-      plot_right: @width - @pad_right,
-      label_baseline: @height - 8
-    }
-  end
-
-  defp summary(series) do
-    first = List.first(series)
-    last = List.last(series)
-
-    "People on vutuv from #{format_day(first.day)} to #{format_day(last.day)}: " <>
-      "#{last.members} members and #{last.fediverse_accounts} Fediverse accounts, " <>
-      "up from #{first.members} and #{first.fediverse_accounts}."
-  end
-
-  # A round number at or above the peak, so the gridline labels read as figures
-  # somebody chose rather than as the maximum of the data. The ladder is fine
-  # enough that the curve fills its box: with only [1, 2, 5, 10] a peak of 5,934
-  # is drawn against an axis of 10,000 and spends its life in the lower half.
-  defp axis_top(peak) when peak <= 0, do: 10
-
-  defp axis_top(peak) do
-    magnitude = :math.pow(10, floor(:math.log10(peak))) |> round()
-
-    Enum.find_value([1, 1.5, 2, 2.5, 3, 4, 5, 6, 8, 10], peak, fn factor ->
-      candidate = round(factor * magnitude)
-      if candidate >= peak, do: candidate
-    end)
-  end
-
-  defp ticks(top) do
-    Enum.map(0..2, fn step ->
-      value = round(top * step / 2)
-      {en_count(value), y(value, top)}
-    end)
-  end
 
   @doc """
   A grouped count in **English**, whatever locale the request carries.
@@ -192,40 +26,9 @@ defmodule VutuvWeb.CompanyHTML do
     Gettext.with_locale(VutuvWeb.Gettext, "en", fn -> UI.delimited_count(n) end)
   end
 
-  defp line_path(values, top, count) do
-    values
-    |> Enum.with_index()
-    |> Enum.map_join(" ", fn {value, index} ->
-      "#{command(index)}#{x(index, count)} #{y(value, top)}"
-    end)
-  end
-
-  # The same line, closed down to the baseline and back, so it fills.
-  defp area_path(values, top, count) do
-    baseline = y(0, top)
-
-    line_path(values, top, count) <>
-      " L#{x(count - 1, count)} #{baseline} L#{x(0, count)} #{baseline} Z"
-  end
-
-  defp command(0), do: "M"
-  defp command(_), do: "L"
-
-  defp x(index, count) do
-    plot_width = @width - @pad_left - @pad_right
-    Float.round(@pad_left + index * plot_width / (count - 1), 2)
-  end
-
-  defp y(value, top) do
-    plot_height = @height - @pad_top - @pad_bottom
-    Float.round(@pad_top + plot_height * (1 - value / top), 2)
-  end
-
-  defp format_day(%Date{} = day), do: Calendar.strftime(day, "%d %b %Y")
-
   @doc """
-  The figure row above the chart. Kept beside it rather than in the template so
-  the page cannot claim a number the curve does not draw.
+  One of the investor page's figure tiles. Kept beside `en_count/1` rather than
+  in the template so every figure on the page is grouped the same way.
   """
   attr(:label, :string, required: true)
   attr(:value, :string, required: true)

--- a/lib/vutuv_web/views/import_html.ex
+++ b/lib/vutuv_web/views/import_html.ex
@@ -60,16 +60,20 @@ defmodule VutuvWeb.ImportHTML do
     """
   end
 
-  # The same words the candidate lists below the table are titled with, so the
-  # summary and the lists can never name a section differently.
-  defp section_label(:positions), do: gettext("Work experience")
-  defp section_label(:educations), do: gettext("Education")
-  defp section_label(:certifications), do: gettext("Certificates & licenses")
-  defp section_label(:skills), do: gettext("Tags")
-  defp section_label(:urls), do: gettext("Links")
-  defp section_label(:social), do: gettext("Social media")
-  defp section_label(:phones), do: gettext("Phone numbers")
-  defp section_label(:profile), do: gettext("Profile")
+  @doc """
+  The name of an import section, in one place: the summary table above the
+  candidate lists and the lists themselves both title themselves from here, so
+  they can never name a section differently. That was the claim of the comment
+  this replaces, while the template wrote all eight words out a second time.
+  """
+  def section_label(:positions), do: gettext("Work experience")
+  def section_label(:educations), do: gettext("Education")
+  def section_label(:certifications), do: gettext("Certificates & licenses")
+  def section_label(:skills), do: gettext("Tags")
+  def section_label(:urls), do: gettext("Links")
+  def section_label(:social), do: gettext("Social media")
+  def section_label(:phones), do: gettext("Phone numbers")
+  def section_label(:profile), do: gettext("Profile")
 
   @doc """
   One selectable candidate: a checkbox + label, greyed when it is a duplicate.

--- a/lib/vutuv_web/views/layout_html.ex
+++ b/lib/vutuv_web/views/layout_html.ex
@@ -57,7 +57,11 @@ defmodule VutuvWeb.LayoutHTML do
 
   def ad_banner(assigns) do
     ~H"""
-    <div id="vutuv-ad" data-ad-banner class="mx-auto max-w-6xl px-4 pt-4">
+    <%!-- `gutter_class()` rather than `px-4` (#1464): the strip is a sibling of
+    the top bar above it and `<main>` below it, both of which step aside from a
+    notched phone's safe area, and the one element that is meant to look
+    deliberately placed must not be the one that does not. --%>
+    <div id="vutuv-ad" data-ad-banner class={["mx-auto max-w-6xl pt-4", gutter_class()]}>
       <.ad_banner_box banner={@banner} dismissible />
     </div>
     """

--- a/lib/vutuv_web/views/user_helpers.ex
+++ b/lib/vutuv_web/views/user_helpers.ex
@@ -17,6 +17,9 @@ defmodule VutuvWeb.UserHelpers do
   alias PhoenixHTMLHelpers.Format, as: HTMLFormat
   alias PhoenixHTMLHelpers.Link, as: HTMLLink
   alias Vutuv.Accounts.User
+  alias Vutuv.Organizations.Organization
+  alias Vutuv.Posts
+  alias Vutuv.Posts.Post
   alias Vutuv.Profiles.Address
   alias Vutuv.Profiles.Education
   alias Vutuv.Profiles.WorkExperience
@@ -35,6 +38,25 @@ defmodule VutuvWeb.UserHelpers do
     |> Enum.reject(&(&1 == "" || &1 == nil))
     |> Enum.join(" ")
   end
+
+  @doc """
+  The visible name of a post's author, whichever kind of author it has (#1334).
+
+  An organization is named by its own name and has no `@handle` line beside it:
+  a page's identity is the name, and the handle is an optional address it may
+  never have claimed. The member who pressed publish for a page is internal and
+  never appears here.
+
+  One definition for every surface that names an author — the post card, the
+  search results, the RSS feed, the screenshot queue, the agent-format
+  siblings — because the fork was written out in each of them and the next kind
+  of author would have to be remembered five times over. It asks
+  `Vutuv.Posts.author/1` rather than matching the preloaded association, which
+  reads as a type check and behaves as a preload check.
+  """
+  def author_name(%Post{} = post), do: author_name(Posts.author(post))
+  def author_name(%Organization{name: name}), do: name
+  def author_name(%User{} = user), do: full_name(user)
 
   @doc """
   The member's name the way a directory files it: `"Özil, Mesut"` — surname

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.300.1",
+      version: "7.300.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260816221319_index_tags_on_match_key.exs
+++ b/priv/repo/migrations/20260816221319_index_tags_on_match_key.exs
@@ -1,0 +1,39 @@
+defmodule Vutuv.Repo.Migrations.IndexTagsOnMatchKey do
+  use Ecto.Migration
+
+  # The match key (#1332) replaced two equality lookups that the unique indexes
+  # on `tags.name` and `tags.slug` served with one expression no index covered,
+  # so every tag lookup became a sequential scan of the catalog: 23 ms on a miss
+  # over 8,632 rows, run five times per post save and once per keystroke of the
+  # add-tag form. The expression is IMMUTABLE (lower, regexp_replace, btrim,
+  # nullif), so it can be indexed as written; measured on a copy of the dev
+  # catalog the same lookup drops to 0.2 ms.
+  #
+  # Keep the expression identical to `Vutuv.Tags.MatchKey.sql/1` — it is the
+  # same key, and a drift here costs speed, not answers.
+  # `test/vutuv/tags/match_key_index_test.exs` fails the build if the query can
+  # no longer use these indexes.
+  @name_key """
+  nullif(btrim(regexp_replace(lower(regexp_replace(name, '[​‌‍﻿]', '', 'g')), '[[:space:]_-]+', '-', 'g'), '-'), '')\
+  """
+
+  @slug_key """
+  nullif(btrim(regexp_replace(lower(regexp_replace(slug, '[​‌‍﻿]', '', 'g')), '[[:space:]_-]+', '-', 'g'), '-'), '')\
+  """
+
+  def up do
+    create(index(:tags, ["(#{@name_key})"], name: :tags_name_match_key_index))
+    create(index(:tags, ["(#{@slug_key})"], name: :tags_slug_match_key_index))
+
+    # An expression index carries no statistics until the table is analyzed, and
+    # without them the planner keeps choosing the sequential scan — the index is
+    # there and unused until autovacuum next looks, which on a catalog that
+    # rarely changes can be days.
+    execute("ANALYZE tags")
+  end
+
+  def down do
+    drop(index(:tags, [], name: :tags_slug_match_key_index))
+    drop(index(:tags, [], name: :tags_name_match_key_index))
+  end
+end

--- a/test/vutuv/dns_test.exs
+++ b/test/vutuv/dns_test.exs
@@ -19,7 +19,12 @@ defmodule Vutuv.DnsTest do
 
     @impl true
     def lookup(name, :ns), do: get(:ns, name, [])
-    def lookup(name, :a), do: get(:a, name, [])
+
+    def lookup(name, :a) do
+      record(:resolved, name)
+      get(:a, name, [])
+    end
+
     def lookup(name, :aaaa), do: get(:aaaa, name, [])
     def lookup(name, :txt), do: get(:txt_resolver, name, [])
 
@@ -32,6 +37,8 @@ defmodule Vutuv.DnsTest do
     def put(key, map), do: Process.put({__MODULE__, key}, map)
 
     def asked, do: Process.get({__MODULE__, :asked}, []) |> Enum.reverse()
+
+    def resolved, do: Process.get({__MODULE__, :resolved}, []) |> Enum.reverse()
 
     defp get(key, subject, default) do
       Process.get({__MODULE__, key}, %{}) |> Map.get(subject, default)
@@ -154,6 +161,8 @@ defmodule Vutuv.DnsTest do
       Stub.put(:a, Map.new(Enum.with_index(names, 1), fn {n, i} -> {n, [{9, 9, 9, i}]} end))
 
       assert length(Dns.nameservers("example.org", Stub)) == 4
+      # And the five it will not use cost no lookup at all.
+      assert Stub.resolved() == Enum.take(names, 4)
     end
   end
 end

--- a/test/vutuv/tags/match_key_index_test.exs
+++ b/test/vutuv/tags/match_key_index_test.exs
@@ -1,0 +1,54 @@
+defmodule Vutuv.Tags.MatchKeyIndexTest do
+  @moduledoc """
+  The match-key lookup must stay indexable.
+
+  `Vutuv.Tags.MatchKey.sql/1` folds two columns through four functions, so no
+  ordinary index covers it and the catalog is scanned end to end unless the
+  expression indexes from `20260816221319_index_tags_on_match_key.exs` match it
+  character for character. Nothing about that failure is visible — the answers
+  stay right and every tag lookup silently costs a sequential scan again, which
+  is what shipped between #1332 and this test.
+
+  Postgres matches an expression index by the parsed expression, so the check is
+  the planner's own: with the sequential scan priced out of reach it will use
+  the index if and only if the two expressions agree.
+  """
+  use Vutuv.DataCase, async: true
+
+  import Ecto.Query
+
+  alias Vutuv.Repo
+  alias Vutuv.Tags.MatchKey
+  alias Vutuv.Tags.Tag
+
+  require MatchKey
+
+  test "the tag lookup by match key can use both expression indexes" do
+    Repo.query!("SET LOCAL enable_seqscan = off")
+
+    plan = explain(from(t in Tag, where: MatchKey.sql(t.name) == ^"elixir", select: t.id))
+    assert plan =~ "tags_name_match_key_index"
+
+    plan = explain(from(t in Tag, where: MatchKey.sql(t.slug) == ^"elixir", select: t.id))
+    assert plan =~ "tags_slug_match_key_index"
+  end
+
+  test "the batched lookup can use them too" do
+    Repo.query!("SET LOCAL enable_seqscan = off")
+
+    keys = ["elixir", "postgresql"]
+
+    plan =
+      explain(
+        from(t in Tag,
+          where: MatchKey.sql(t.name) in ^keys or MatchKey.sql(t.slug) in ^keys,
+          select: t.id
+        )
+      )
+
+    assert plan =~ "tags_name_match_key_index"
+    assert plan =~ "tags_slug_match_key_index"
+  end
+
+  defp explain(query), do: Repo.explain(:all, query)
+end

--- a/test/vutuv/translations/queue_test.exs
+++ b/test/vutuv/translations/queue_test.exs
@@ -28,6 +28,17 @@ defmodule Vutuv.Translations.QueueTest do
     fn _subject, _target -> {:error, error} end
   end
 
+  test "queue/2 does not ask the cache — the page-batch caller already did" do
+    post = insert(:post, body: "Guten Morgen.")
+    {:ok, _} = Translations.store_translation(post, "en", %{body: "Good morning.", model: "m"})
+
+    # `request/2` would answer from the cache here. `queue/2` is for the reader
+    # whose whole page was resolved in one `fresh_translations/2`, so repeating
+    # that lookup per card is the cost it exists to remove.
+    assert %Translation{} = Translations.fresh_translation(post, "en")
+    assert {:queued, %TranslationJob{}} = Translations.queue(post, "en")
+  end
+
   test "a due job translates, stores, completes and broadcasts" do
     post = insert(:post, body: "Guten Morgen.")
     job = queued_job!(post)

--- a/test/vutuv_web/controllers/company_controller_test.exs
+++ b/test/vutuv_web/controllers/company_controller_test.exs
@@ -7,8 +7,6 @@ defmodule VutuvWeb.CompanyControllerTest do
   """
   use VutuvWeb.ConnCase, async: true
 
-  alias Vutuv.BerlinTime
-  alias Vutuv.PeopleHistory
   alias Vutuv.PeopleHistory.Snapshot
   alias Vutuv.Repo
   alias VutuvWeb.AgentDocs.InvestorsDoc
@@ -198,55 +196,6 @@ defmodule VutuvWeb.CompanyControllerTest do
       # three four to the reader this page is written for.
       assert VutuvWeb.UI.delimited_count(5934) == "5.934"
       assert CompanyHTML.en_count(5934) == "5,934"
-    end
-  end
-
-  describe "the growth curve's geometry" do
-    test "needs two points to draw a line" do
-      assert CompanyHTML.chart([]) == nil
-      assert CompanyHTML.chart([%Snapshot{day: ~D[2026-08-01], members: 1}]) == nil
-    end
-
-    test "scales against a zero baseline, never against the data's own floor" do
-      series = [
-        %Snapshot{day: ~D[2026-08-01], members: 500, fediverse_accounts: 0},
-        %Snapshot{day: ~D[2026-08-02], members: 1000, fediverse_accounts: 0}
-      ]
-
-      chart = CompanyHTML.chart(series)
-
-      # Axis top is a round 1000, so the last point sits at the top of the plot
-      # box (y = pad_top = 12) and the first at its exact half (12 + 180/2).
-      # An axis cropped to [500, 1000] would put the first point on the floor
-      # instead - the one chart trick this page must not play.
-      assert chart.members_line == "M52.0 102.0 L628.0 12.0"
-      assert {CompanyHTML.en_count(1000), 12.0} in chart.ticks
-      assert {CompanyHTML.en_count(0), 192.0} in chart.ticks
-    end
-
-    test "the area closes down to the baseline so it can be filled" do
-      series = [
-        %Snapshot{day: ~D[2026-08-01], members: 5, fediverse_accounts: 0},
-        %Snapshot{day: ~D[2026-08-02], members: 10, fediverse_accounts: 0}
-      ]
-
-      chart = CompanyHTML.chart(series)
-
-      assert chart.members_area == "M52.0 102.0 L628.0 12.0 L628.0 192.0 L52.0 192.0 Z"
-    end
-
-    test "the total line runs above the members line by the Fediverse share" do
-      series = [
-        %Snapshot{day: ~D[2026-08-01], members: 50, fediverse_accounts: 0},
-        %Snapshot{day: ~D[2026-08-02], members: 50, fediverse_accounts: 50}
-      ]
-
-      chart = CompanyHTML.chart(series)
-
-      # Same members both days, so that line is flat; the total rises. Axis top
-      # is 100, so 50 lands at the plot box's exact half.
-      assert chart.members_line == "M52.0 102.0 L628.0 102.0"
-      assert chart.total_line == "M52.0 102.0 L628.0 12.0"
     end
   end
 end


### PR DESCRIPTION
Vierter Ganz-App-`/simplify`-Durchgang, geschrieben von fünf Prüf-Agenten über `lib/` und `assets/`, gewichtet auf die 139 Dateien seit `bd7df2f0` (v7.272.1). Diese Hälfte: Tempo und geteilte Nähte, kein Verhaltenswechsel außer den beiden genannten.

**Tempo.** Der Match-Key aus #1332 machte jeden Tag-Lookup zum sequentiellen Scan (gemessen 23 ms bei 8.632 Zeilen, fünfmal pro Beitrag, einmal je Tastendruck im Tag-Feld); zwei Ausdrucks-Indizes bringen ihn auf 0,2 ms. Dazu: NodeInfo zählte Beiträge mit zwei korrelierten Unterabfragen je Beitrag, die beiden Fediverse-Reichweitenzahlen liefen zweimal über dieselbe Tabelle, der Domain-Sweeper holte je Domain die Organisation einzeln, die Übersetzungs-Automatik fragte nach der Sammelabfrage pro Karte noch einmal den Cache.

**Nähte.** `Posts.author_path/1` und `UserHelpers.author_name/1` statt sechs Kopien; `Spec.og_jpeg/2` besitzt den EXIF-Strip, den drei Uploader je selbst schrieben; `WebVerification` benutzt die Ausgehen-Regeln des Clients statt einer eigenen Kopie, die beim User-Agent schon auseinandergelaufen war; die Verwaltungsreiter fragen `role_powers/2` selbst, statt neun Aufrufer zwei Booleans durchreichen zu lassen (fünf davon aus der Route statt vom Betrachter).

**Gelöscht:** die Wachstumskurve der Investorenseite, die #1479 im zweiten Commit von der Seite genommen und im Code stehen gelassen hat. `Vutuv.PeopleHistory` und der nächtliche Recorder bleiben — diese Geschichte lässt sich nur vorwärts sammeln.

`mix precommit` grün: 7.891 Tests, Credo sauber.

---

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*