### PR TITLE
Aufräum-Pass Nr. 4, zweite Hälfte: der Ansichts-Teil (v7.300.3)

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -924,8 +924,7 @@ input[type="submit"].button--secondary {
   background: #f1f5f9;
   color: #334155;
 }
-.btns-right,
-.btns {
+.btns-right {
   display: flex;
   gap: 0.5rem;
   justify-content: flex-end;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -831,7 +831,7 @@ function setupOrganizationLink() {
         render(labels.linked, nameEl, unlink)
       } else if (suggestion && suggestion.id !== idInput.value) {
         const nameEl = Object.assign(document.createElement("strong"), { textContent: suggestion.name })
-        const link = button(labels.link, "font-semibold text-brand-600 underline hover:text-brand-700", () => {
+        const link = button(labels.link, "font-semibold text-brand-600 underline hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300", () => {
           idInput.value = suggestion.id
           linked = suggestion
           suggestion = null

--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -18,6 +18,7 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   alias Vutuv.Isbn
   alias VutuvWeb.AgentDocs.InvestorsDoc
   alias VutuvWeb.PostComponents
+  alias VutuvWeb.UI
 
   # The per-user people lists (followers/following/connections) share one
   # clause; the set lives in ListDocs.
@@ -666,15 +667,28 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   The facts inside a code-forge account line's parentheses — every fact the
   forge exposed, dot-separated. Shared with the text renderer so the two
   human-readable formats read the same.
+
+  The counts go through `compact_count/1`, like the card these lines mirror:
+  these two formats are read by people, and a run-together `12345` is a bug
+  wherever one of them shows up. `.json` and `.xml` keep the raw figures — that
+  is what a machine reader takes them from. (`ngettext/3` binds `%{count}` to
+  the raw integer and a `count:` binding does not override it, hence the
+  separate `%{formatted}` placeholder — the same msgids the card uses.)
   """
   def code_stats_facts(account) do
     [
       account.total_stars &&
-        ngettext("%{count} star", "%{count} stars", account.total_stars),
+        ngettext("%{formatted} star", "%{formatted} stars", account.total_stars,
+          formatted: UI.compact_count(account.total_stars)
+        ),
       account.public_repos &&
-        ngettext("%{count} repository", "%{count} repositories", account.public_repos),
+        ngettext("%{formatted} repository", "%{formatted} repositories", account.public_repos,
+          formatted: UI.compact_count(account.public_repos)
+        ),
       account.followers &&
-        ngettext("%{count} follower", "%{count} followers", account.followers),
+        ngettext("%{formatted} follower", "%{formatted} followers", account.followers,
+          formatted: UI.compact_count(account.followers)
+        ),
       account.member_since && gettext("since %{date}", date: account.member_since),
       code_dormant_fact(account),
       account.languages != [] && Enum.join(account.languages, ", ")

--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -18,7 +18,6 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   alias Vutuv.Isbn
   alias VutuvWeb.AgentDocs.InvestorsDoc
   alias VutuvWeb.PostComponents
-  alias VutuvWeb.UI
 
   # The per-user people lists (followers/following/connections) share one
   # clause; the set lives in ListDocs.
@@ -668,27 +667,19 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   forge exposed, dot-separated. Shared with the text renderer so the two
   human-readable formats read the same.
 
-  The counts go through `compact_count/1`, like the card these lines mirror:
-  these two formats are read by people, and a run-together `12345` is a bug
-  wherever one of them shows up. `.json` and `.xml` keep the raw figures — that
-  is what a machine reader takes them from. (`ngettext/3` binds `%{count}` to
-  the raw integer and a `count:` binding does not override it, hence the
-  separate `%{formatted}` placeholder — the same msgids the card uses.)
+  The counts stay **exact** here, where the card shows `compact_count/1`'s
+  `2K`. These formats are written for agents (the frontmatter is the
+  "markdown for agents" shape), and a reader that came for the figure is worse
+  served by a rounded one — `user_profile_code_stats_test.exs` pins it.
   """
   def code_stats_facts(account) do
     [
       account.total_stars &&
-        ngettext("%{formatted} star", "%{formatted} stars", account.total_stars,
-          formatted: UI.compact_count(account.total_stars)
-        ),
+        ngettext("%{count} star", "%{count} stars", account.total_stars),
       account.public_repos &&
-        ngettext("%{formatted} repository", "%{formatted} repositories", account.public_repos,
-          formatted: UI.compact_count(account.public_repos)
-        ),
+        ngettext("%{count} repository", "%{count} repositories", account.public_repos),
       account.followers &&
-        ngettext("%{formatted} follower", "%{formatted} followers", account.followers,
-          formatted: UI.compact_count(account.followers)
-        ),
+        ngettext("%{count} follower", "%{count} followers", account.followers),
       account.member_since && gettext("since %{date}", date: account.member_since),
       code_dormant_fact(account),
       account.languages != [] && Enum.join(account.languages, ", ")

--- a/lib/vutuv_web/components/fediverse_components.ex
+++ b/lib/vutuv_web/components/fediverse_components.ex
@@ -494,12 +494,17 @@ defmodule VutuvWeb.FediverseComponents do
         "This vutuv does not exchange anything with other networks. That is an operator setting, not yours."
       )
 
-  @doc "Where a refused member can act on it, as `{path, label}` — `nil` when nowhere."
+  @doc """
+  Where a refused member can act on it, as `%{path:, label:}` — `nil` when
+  nowhere. A map rather than a tuple because both call sites render it in HEEx,
+  where a tuple costs an `elem(@refusal_link, 0)` and the next reader a trip
+  back here to learn which element is the path.
+  """
   def lookup_refusal_link(:not_federating),
-    do: {~p"/settings/fediverse", gettext("Fediverse settings")}
+    do: %{path: ~p"/settings/fediverse", label: gettext("Fediverse settings")}
 
   def lookup_refusal_link(:moved),
-    do: {~p"/settings/fediverse/move", gettext("Your account move")}
+    do: %{path: ~p"/settings/fediverse/move", label: gettext("Your account move")}
 
   def lookup_refusal_link(_disabled), do: nil
 end

--- a/lib/vutuv_web/components/job_components.ex
+++ b/lib/vutuv_web/components/job_components.ex
@@ -25,6 +25,7 @@ defmodule VutuvWeb.JobComponents do
 
   import VutuvWeb.UI
 
+  alias Vutuv.Accounts.User
   alias Vutuv.BerlinTime
   alias Vutuv.Countries
   alias Vutuv.Geo
@@ -98,7 +99,10 @@ defmodule VutuvWeb.JobComponents do
   defp employer_line(assigns) do
     ~H"""
     <div class="mt-1.5 flex flex-wrap items-center gap-1.5 text-sm">
-      <%= if @posting.organization do %>
+      <%!-- On the id, never on the association: an %Ecto.Association.NotLoaded{}
+      is truthy, so a posting that reached here without its preload would take
+      this branch and raise inside `canonical_path/1`. --%>
+      <%= if @posting.organization_id do %>
         <.link
           navigate={Organizations.canonical_path(@posting.organization)}
           class="font-semibold text-brand-700 hover:text-brand-800 dark:text-brand-300"
@@ -118,7 +122,11 @@ defmodule VutuvWeb.JobComponents do
   defp employer_name(%JobPosting{hiring_org_name: name}) when is_binary(name) and name != "",
     do: name
 
-  defp employer_name(%JobPosting{user: %{} = user}), do: UserHelpers.full_name(user)
+  # `%User{}`, not a bare `%{}`: a NotLoaded association is a struct and so a
+  # map, so the loose pattern matched it and then raised in `full_name/1`
+  # instead of falling through to the "no employer name" clause below, which is
+  # exactly what that clause is for.
+  defp employer_name(%JobPosting{user: %User{} = user}), do: UserHelpers.full_name(user)
   defp employer_name(_posting), do: nil
 
   @doc false

--- a/lib/vutuv_web/components/organization_components.ex
+++ b/lib/vutuv_web/components/organization_components.ex
@@ -83,6 +83,46 @@ defmodule VutuvWeb.OrganizationComponents do
   end
 
   attr(:organization, :map, required: true)
+  slot(:inner_block)
+  slot(:actions)
+
+  @doc """
+  One organization in a list: logo, name and location. The default slot carries
+  whatever belongs under the name (a row of role badges), `:actions` whatever
+  sits at the right edge of the row (an unfollow button).
+
+  The three lists that show organizations — a member's followers, the
+  organizations they follow, and the ones they administer — each carried their
+  own copy of these fifteen lines, and the third had already drifted: it built
+  its own `/organizations/:slug` path instead of asking
+  `Organizations.canonical_path/1`, so a page with an opt-in root handle was
+  linked by its slug there and by its handle in the other two.
+  """
+  def organization_row(assigns) do
+    ~H"""
+    <li class="flex items-center gap-4 py-4">
+      <.link navigate={Organizations.canonical_path(@organization)} class="shrink-0">
+        <.organization_logo organization={@organization} class="h-12 w-12" />
+      </.link>
+      <div class="min-w-0 flex-1">
+        <.link
+          navigate={Organizations.canonical_path(@organization)}
+          class="block truncate font-semibold text-slate-900 hover:text-brand-700 dark:text-slate-100 dark:hover:text-brand-300"
+        >
+          {@organization.name}
+        </.link>
+        <.organization_location
+          organization={@organization}
+          class="truncate text-sm text-slate-600 dark:text-slate-400"
+        />
+        {render_slot(@inner_block)}
+      </div>
+      {render_slot(@actions)}
+    </li>
+    """
+  end
+
+  attr(:organization, :map, required: true)
   attr(:class, :string, default: nil)
 
   @doc "The organization's \"City, Country\" line (nil parts folded away)."

--- a/lib/vutuv_web/components/ui.ex
+++ b/lib/vutuv_web/components/ui.ex
@@ -623,6 +623,27 @@ defmodule VutuvWeb.UI do
   def dev_mailbox?, do: Application.get_env(:vutuv, :dev_mailbox, false)
 
   @doc """
+  The link to that mailbox, rendered only where it exists — the whole block the
+  login screen and both PIN screens each carried a byte-identical copy of.
+  Untranslated on purpose: it is a developer's convenience and never reaches a
+  member's browser.
+  """
+  def dev_mailbox_link(assigns) do
+    ~H"""
+    <p :if={dev_mailbox?()} class="mt-2 text-sm text-slate-600 dark:text-slate-400">
+      <a
+        href="/sent_emails"
+        target="_blank"
+        rel="noopener"
+        class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+      >
+        Open the dev email inbox
+      </a>
+    </p>
+    """
+  end
+
+  @doc """
   The "stuck on the PIN page" escape hatches, shared by both PIN-entry screens
   (login and post-registration). "Resend PIN" re-mints and re-mails the one-time
   PIN for the pending email (rate limited); the second control abandons the
@@ -2000,7 +2021,7 @@ defmodule VutuvWeb.UI do
 
   defp button_class("ghost"),
     do:
-      "#{@button_base} text-brand-600 hover:bg-brand-50 hover:text-brand-700 dark:hover:bg-slate-800"
+      "#{@button_base} text-brand-600 hover:bg-brand-50 hover:text-brand-700 dark:text-brand-400 dark:hover:bg-slate-800 dark:hover:text-brand-300"
 
   defp button_class("danger"), do: "#{@button_base} bg-red-600 text-white hover:bg-red-700"
   defp button_class(_), do: "#{@button_base} bg-brand-600 text-white hover:bg-brand-700"

--- a/lib/vutuv_web/fediverse/docs.ex
+++ b/lib/vutuv_web/fediverse/docs.ex
@@ -139,48 +139,29 @@ defmodule VutuvWeb.Fediverse.Docs do
 
   @doc "The Person document WebFinger points at."
   def actor(user, %Actor{} = actor) do
-    actor_url = actor_url(user)
-
-    %{
-      "@context" => [
-        "https://www.w3.org/ns/activitystreams",
-        "https://w3id.org/security/v1"
-      ],
-      "id" => actor_url,
+    user
+    |> base_actor(actor, user.inserted_at)
+    |> Map.merge(%{
       "type" => "Person",
       "preferredUsername" => user.username,
       "name" => UserHelpers.full_name(user),
       "summary" => summary(user),
       "url" => "#{base()}/#{user.username}",
-      "inbox" => actor_url <> "/inbox",
-      "outbox" => outbox_url(user),
-      "followers" => followers_url(user),
       # Count-only like the followers collection, and for the same reason: who
       # a member reads is theirs to know (issue #1160). Always advertised, so a
       # remote server never has to guess whether this actor can follow back.
       "following" => following_url(user),
-      # The installation-wide inbox (issue #1073). The per-member one above is
-      # what every server already knows and keeps working forever; this is the
-      # offer to deliver a broadcast once for all of them.
-      "endpoints" => %{"sharedInbox" => shared_inbox_url()},
       # Where a remote server looks for the pinned post (issue #1110). Always
       # advertised, even with nothing pinned: the collection is then simply
       # empty, and an actor that only sometimes names the field would make the
       # profile a remote server renders depend on when it last fetched.
       "featured" => featured_url(user),
-      "manuallyApprovesFollowers" => false,
-      "published" => iso8601(user.inserted_at),
-      "publicKey" => %{
-        "id" => key_id(user),
-        "owner" => actor_url,
-        "publicKeyPem" => actor.public_key_pem
-      },
       "icon" => %{
         "type" => "Image",
         "mediaType" => "image/jpeg",
         "url" => "#{base()}/#{user.username}/avatar.jpg"
       }
-    }
+    })
     |> put_also_known_as(user)
     |> put_moved_to(user)
   end
@@ -199,7 +180,30 @@ defmodule VutuvWeb.Fediverse.Docs do
   where a human reads the topic, and it is the one link a remote reader wants.
   """
   def tag_actor(%Tag{} = tag, %Actor{} = actor) do
-    actor_url = actor_url(tag)
+    tag
+    |> base_actor(actor, tag.inserted_at)
+    |> Map.merge(%{
+      "type" => "Group",
+      "preferredUsername" => tag.slug,
+      "name" => tag.name,
+      "summary" => tag_summary(tag),
+      "url" => "#{base()}/tags/#{tag.slug}"
+    })
+  end
+
+  # The half of an actor document that says nothing about who the actor is: the
+  # context, the collections derived from its own URL, this installation's
+  # shared inbox (issue #1073 — the per-actor inbox is what every server
+  # already knows and keeps working forever; this is the offer to deliver a
+  # broadcast once for all of them), the approval flag and the key.
+  #
+  # It was written out three times, and the two lines that must never differ
+  # between a member, a page and a topic — the `@context` list and the shared
+  # inbox — were among the copies. The per-kind builders stay separate on
+  # purpose, because half of the member document has no meaning for a page or a
+  # topic; only this half is shared.
+  defp base_actor(subject, %Actor{} = actor, published_at) do
+    actor_url = actor_url(subject)
 
     %{
       "@context" => [
@@ -207,19 +211,14 @@ defmodule VutuvWeb.Fediverse.Docs do
         "https://w3id.org/security/v1"
       ],
       "id" => actor_url,
-      "type" => "Group",
-      "preferredUsername" => tag.slug,
-      "name" => tag.name,
-      "summary" => tag_summary(tag),
-      "url" => "#{base()}/tags/#{tag.slug}",
       "inbox" => actor_url <> "/inbox",
-      "outbox" => actor_url <> "/outbox",
-      "followers" => actor_url <> "/followers",
+      "outbox" => outbox_url(subject),
+      "followers" => followers_url(subject),
       "endpoints" => %{"sharedInbox" => shared_inbox_url()},
       "manuallyApprovesFollowers" => false,
-      "published" => iso8601(tag.inserted_at),
+      "published" => iso8601(published_at),
       "publicKey" => %{
-        "id" => actor_url <> "#main-key",
+        "id" => key_id(subject),
         "owner" => actor_url,
         "publicKeyPem" => actor.public_key_pem
       }
@@ -257,14 +256,9 @@ defmodule VutuvWeb.Fediverse.Docs do
   is.
   """
   def organization_actor(%Organization{} = organization, %Actor{} = actor) do
-    actor_url = actor_url(organization)
-
-    %{
-      "@context" => [
-        "https://www.w3.org/ns/activitystreams",
-        "https://w3id.org/security/v1"
-      ],
-      "id" => actor_url,
+    organization
+    |> base_actor(actor, organization.inserted_at)
+    |> Map.merge(%{
       "type" => "Organization",
       # The page's claimed handle. Federating without one is not possible —
       # WebFinger's `subject` and this field both need an address — which is why
@@ -272,19 +266,8 @@ defmodule VutuvWeb.Fediverse.Docs do
       "preferredUsername" => organization.username,
       "name" => organization.name,
       "summary" => organization_summary(organization),
-      "url" => "#{base()}/organizations/#{organization.slug}",
-      "inbox" => actor_url <> "/inbox",
-      "outbox" => actor_url <> "/outbox",
-      "followers" => actor_url <> "/followers",
-      "endpoints" => %{"sharedInbox" => shared_inbox_url()},
-      "manuallyApprovesFollowers" => false,
-      "published" => iso8601(organization.inserted_at),
-      "publicKey" => %{
-        "id" => actor_url <> "#main-key",
-        "owner" => actor_url,
-        "publicKeyPem" => actor.public_key_pem
-      }
-    }
+      "url" => "#{base()}/organizations/#{organization.slug}"
+    })
     |> put_organization_icon(organization)
   end
 

--- a/lib/vutuv_web/live/fediverse_lookup_live.ex
+++ b/lib/vutuv_web/live/fediverse_lookup_live.ex
@@ -192,11 +192,11 @@ defmodule VutuvWeb.FediverseLookupLive do
             <p class="mb-0">{lookup_refusal_text(@refusal)}</p>
             <p :if={@refusal_link} class="mb-0 mt-3">
               <.link
-                navigate={elem(@refusal_link, 0)}
+                navigate={@refusal_link.path}
                 id="lookup-refusal-link"
                 class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
               >
-                {elem(@refusal_link, 1)} ›
+                {@refusal_link.label} ›
               </.link>
             </p>
           </div>

--- a/lib/vutuv_web/live/search_live.ex
+++ b/lib/vutuv_web/live/search_live.ex
@@ -558,11 +558,11 @@ defmodule VutuvWeb.SearchLive do
         </.button>
         <.link
           :if={@signed_in? and @refusal_link}
-          navigate={elem(@refusal_link, 0)}
+          navigate={@refusal_link.path}
           id="search-lookup-refusal-link"
           class="text-sm font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
         >
-          {elem(@refusal_link, 1)} ›
+          {@refusal_link.label} ›
         </.link>
         <.link
           :if={!@signed_in?}

--- a/lib/vutuv_web/templates/followee/index.html.heex
+++ b/lib/vutuv_web/templates/followee/index.html.heex
@@ -15,35 +15,22 @@ all, and the only way to unfollow one was to find it again. --%>
     </h2>
 
     <ul class="mt-2 divide-y divide-slate-100 dark:divide-slate-800">
-      <li :for={{follow_id, organization} <- @organizations} class="flex items-center gap-4 py-4">
-        <.link navigate={Vutuv.Organizations.canonical_path(organization)} class="shrink-0">
-          <.organization_logo organization={organization} class="h-12 w-12" />
-        </.link>
-        <div class="min-w-0 flex-1">
-          <.link
-            navigate={Vutuv.Organizations.canonical_path(organization)}
-            class="block truncate font-semibold text-slate-900 hover:text-brand-700 dark:text-slate-100 dark:hover:text-brand-300"
+      <.organization_row :for={{follow_id, organization} <- @organizations} organization={organization}>
+        <:actions>
+          <%!-- Owner only: unfollowing is the whole reason this list is reachable.
+          `DELETE /follows/:id` already handles a page follow — its broadcast drops
+          the nil followee — so no second route is needed. --%>
+          <.button
+            :if={same_user?(@user, @current_user)}
+            href={~p"/follows/#{follow_id}"}
+            method="delete"
+            variant="secondary"
+            class="shrink-0"
           >
-            {organization.name}
-          </.link>
-          <.organization_location
-            organization={organization}
-            class="truncate text-sm text-slate-600 dark:text-slate-400"
-          />
-        </div>
-        <%!-- Owner only: unfollowing is the whole reason this list is reachable.
-        `DELETE /follows/:id` already handles a page follow — its broadcast drops
-        the nil followee — so no second route is needed. --%>
-        <.button
-          :if={same_user?(@user, @current_user)}
-          href={~p"/follows/#{follow_id}"}
-          method="delete"
-          variant="secondary"
-          class="shrink-0"
-        >
-          {gettext("Unfollow")}
-        </.button>
-      </li>
+            {gettext("Unfollow")}
+          </.button>
+        </:actions>
+      </.organization_row>
     </ul>
   </section>
 </div>

--- a/lib/vutuv_web/templates/follower/index.html.heex
+++ b/lib/vutuv_web/templates/follower/index.html.heex
@@ -14,23 +14,10 @@ control: this follow belongs to the page, not to the member being followed. --%>
     </h2>
 
     <ul class="mt-2 divide-y divide-slate-100 dark:divide-slate-800">
-      <li :for={{_follow_id, organization} <- @organizations} class="flex items-center gap-4 py-4">
-        <.link navigate={Vutuv.Organizations.canonical_path(organization)} class="shrink-0">
-          <.organization_logo organization={organization} class="h-12 w-12" />
-        </.link>
-        <div class="min-w-0 flex-1">
-          <.link
-            navigate={Vutuv.Organizations.canonical_path(organization)}
-            class="block truncate font-semibold text-slate-900 hover:text-brand-700 dark:text-slate-100 dark:hover:text-brand-300"
-          >
-            {organization.name}
-          </.link>
-          <.organization_location
-            organization={organization}
-            class="truncate text-sm text-slate-600 dark:text-slate-400"
-          />
-        </div>
-      </li>
+      <.organization_row
+        :for={{_follow_id, organization} <- @organizations}
+        organization={organization}
+      />
     </ul>
   </section>
 </div>

--- a/lib/vutuv_web/templates/moderation_case/index.html.heex
+++ b/lib/vutuv_web/templates/moderation_case/index.html.heex
@@ -22,7 +22,7 @@
               {Calendar.strftime(case_record.inserted_at, "%Y-%m-%d")}
             </span>
           </span>
-          <span class="shrink-0 text-sm font-semibold text-brand-600 group-hover:text-brand-700">
+          <span class="shrink-0 text-sm font-semibold text-brand-600 group-hover:text-brand-700 dark:text-brand-400 dark:group-hover:text-brand-300">
             {gettext("Review")} ›
           </span>
         </a>

--- a/lib/vutuv_web/templates/page/legal.html.heex
+++ b/lib/vutuv_web/templates/page/legal.html.heex
@@ -1,7 +1,7 @@
 <div class="mx-auto max-w-3xl py-6">
   <.page_header title={@page_title} />
 
-  <.card class="leading-relaxed text-slate-700 dark:text-slate-300 [&_a]:font-medium [&_a]:text-brand-600 hover:[&_a]:text-brand-700 [&_h3]:mt-8 [&_h3]:mb-3 [&_h3]:text-lg [&_h3]:font-bold [&_h3]:text-slate-900 dark:[&_h3]:text-white [&_h4]:mt-6 [&_h4]:mb-2 [&_h4]:font-semibold [&_h4]:text-slate-900 dark:[&_h4]:text-white">
+  <.card class="leading-relaxed text-slate-700 dark:text-slate-300 [&_a]:font-medium [&_a]:text-brand-600 [&_a]:hover:text-brand-700 dark:[&_a]:text-brand-400 dark:[&_a]:hover:text-brand-300 [&_h3]:mt-8 [&_h3]:mb-3 [&_h3]:text-lg [&_h3]:font-bold [&_h3]:text-slate-900 dark:[&_h3]:text-white [&_h4]:mt-6 [&_h4]:mb-2 [&_h4]:font-semibold [&_h4]:text-slate-900 dark:[&_h4]:text-white">
     <%= if @page do %>
       <div class="markdown text-slate-800 dark:text-slate-200">
         {raw(VutuvWeb.DevDocMarkdown.to_html(@page.body, breaks: true))}

--- a/lib/vutuv_web/templates/page/pin_new_registration.html.heex
+++ b/lib/vutuv_web/templates/page/pin_new_registration.html.heex
@@ -75,18 +75,7 @@
 
     <.pin_actions email={@pending_email} context={@pin_flow} />
 
-    <%= if dev_mailbox?() do %>
-      <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">
-        <a
-          href="/sent_emails"
-          target="_blank"
-          rel="noopener"
-          class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
-        >
-          Open the dev email inbox
-        </a>
-      </p>
-    <% end %>
+    <.dev_mailbox_link />
   </div>
 
   <%!-- The way out, and better news than the hero above it: an abandoned

--- a/lib/vutuv_web/templates/session/new.html.heex
+++ b/lib/vutuv_web/templates/session/new.html.heex
@@ -43,16 +43,5 @@
     <a href={~p"/"} class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300">{gettext("Sign up here.")}</a>
   </p>
 
-  <%= if dev_mailbox?() do %>
-    <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">
-      <a
-        href="/sent_emails"
-        target="_blank"
-        rel="noopener"
-        class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
-      >
-        Open the dev email inbox
-      </a>
-    </p>
-  <% end %>
+  <.dev_mailbox_link />
 </.auth_layout>

--- a/lib/vutuv_web/templates/session/pin_user_login.html.heex
+++ b/lib/vutuv_web/templates/session/pin_user_login.html.heex
@@ -25,16 +25,5 @@
 
   <.pin_actions email={@pending_email} context={@pin_flow} />
 
-  <%= if dev_mailbox?() do %>
-    <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">
-      <a
-        href="/sent_emails"
-        target="_blank"
-        rel="noopener"
-        class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
-      >
-        Open the dev email inbox
-      </a>
-    </p>
-  <% end %>
+  <.dev_mailbox_link />
 </.auth_layout>

--- a/lib/vutuv_web/templates/url/verify.html.heex
+++ b/lib/vutuv_web/templates/url/verify.html.heex
@@ -84,7 +84,7 @@ success the link earns the verified mark shown on the profile + section pages. -
       </p>
       <code
         phx-no-curly-interpolation
-        class="mt-2 block overflow-x-auto rounded bg-white px-3 py-2 font-mono text-slate-900 ring-1 ring-slate-200 dark:bg-slate-900 dark:text-slate-100 dark:ring-slate-700"
+        class="mt-2 block overflow-x-auto rounded bg-white px-3 py-2 font-mono text-xs text-slate-900 ring-1 ring-slate-200 dark:bg-slate-900 dark:text-slate-100 dark:ring-slate-700"
       ><%= @dns_challenge_name %></code>
     </div>
 

--- a/lib/vutuv_web/templates/user/show.html.heex
+++ b/lib/vutuv_web/templates/user/show.html.heex
@@ -283,7 +283,7 @@ the resulting ~200px rail width. --%>
         muted sub-line. --%>
         <div
           :if={@user.headline}
-          class="mt-1.5 text-slate-600 dark:text-slate-400 [&_p]:m-0 [&_p+p]:mt-1 [&_ul]:my-1 [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:my-1 [&_ol]:list-decimal [&_ol]:pl-5 [&_a]:text-brand-600 dark:[&_a]:text-brand-400 [&_a]:hover:text-brand-700 [&_code]:rounded [&_code]:bg-black/10 [&_code]:px-1 [&_code]:font-mono [&_code]:text-[0.9em] dark:[&_code]:bg-white/10"
+          class="mt-1.5 text-slate-600 dark:text-slate-400 [&_p]:m-0 [&_p+p]:mt-1 [&_ul]:my-1 [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:my-1 [&_ol]:list-decimal [&_ol]:pl-5 [&_a]:text-brand-600 dark:[&_a]:text-brand-400 [&_a]:hover:text-brand-700 dark:[&_a]:hover:text-brand-300 [&_code]:rounded [&_code]:bg-black/10 [&_code]:px-1 [&_code]:font-mono [&_code]:text-[0.9em] dark:[&_code]:bg-white/10"
         >
           {VutuvWeb.Markdown.render(@user.headline)}
         </div>

--- a/lib/vutuv_web/views/followee_html.ex
+++ b/lib/vutuv_web/views/followee_html.ex
@@ -6,7 +6,7 @@ defmodule VutuvWeb.FolloweeHTML do
   # The "Organizations" section renders the pages this member follows in the
   # same row shape /settings/organizations uses, so a page reads the same
   # wherever it is listed.
-  import VutuvWeb.OrganizationComponents, only: [organization_logo: 1, organization_location: 1]
+  import VutuvWeb.OrganizationComponents, only: [organization_row: 1]
 
   embed_templates("../templates/followee/*")
 end

--- a/lib/vutuv_web/views/follower_html.ex
+++ b/lib/vutuv_web/views/follower_html.ex
@@ -5,7 +5,7 @@ defmodule VutuvWeb.FollowerHTML do
 
   # The "Organizations" section renders the pages following this member in the
   # same row shape the Following page and /settings/organizations use.
-  import VutuvWeb.OrganizationComponents, only: [organization_logo: 1, organization_location: 1]
+  import VutuvWeb.OrganizationComponents, only: [organization_row: 1]
 
   embed_templates("../templates/follower/*")
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.300.2",
+      version: "7.300.3",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/brand_link_dark_mode_test.exs
+++ b/test/vutuv_web/brand_link_dark_mode_test.exs
@@ -3,37 +3,70 @@ defmodule VutuvWeb.BrandLinkDarkModeTest do
   The brand text-link recipe (`.claude/rules/design.md`) had drifted into a
   dozen spellings — 83 call sites carried no `dark:` variant at all, so those
   links lost contrast in dark mode — until the 2026-07-30 sweep normalized
-  every one to the canonical pair. This guard keeps it that way: wherever the
-  light half appears in the sources, the canonical dark half must follow
-  verbatim, so dark mode can never silently lose a link again (the "clean
-  dark mode" house rule).
+  every one to the canonical pair. This guard keeps it that way.
+
+  What identifies a link is **both light halves on one line under the same
+  variant chain**, not the two words side by side. The first version matched the
+  literal `text-brand-600 hover:text-brand-700`, so two spellings of the very
+  same recipe walked past it, both of them genuinely missing their dark pair: an
+  arbitrary variant (`[&_a]:text-brand-600 [&_a]:hover:text-brand-700`, how the
+  legal pages colour the links inside a Markdown body) and a class written
+  between the two (`text-brand-600 underline hover:text-brand-700`).
+
+  Asking for the pair is what keeps it precise. Each of these utilities has a
+  second life on its own — a bare `hover:text-brand-700` is the slate link that
+  turns brand on hover, a bare `text-brand-600 dark:text-brand-300` is an "on"
+  state — and neither owes anything to this recipe.
   """
   use ExUnit.Case, async: true
 
-  @canonical "text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
-  @light "text-brand-600 hover:text-brand-700"
+  @light_base "text-brand-600"
+  @light_hover "hover:text-brand-700"
+  @dark_base "dark:text-brand-400"
+  @dark_hover "dark:hover:text-brand-300"
 
   test "every brand text link carries the canonical dark-mode pair" do
     offenders =
       ["lib/**/*.ex", "lib/**/*.heex", "assets/js/**/*.js"]
       |> Enum.flat_map(&Path.wildcard/1)
-      |> Enum.flat_map(fn file ->
-        file
-        |> File.read!()
-        |> String.split("\n")
-        |> Enum.with_index(1)
-        |> Enum.filter(fn {line, _n} ->
-          # Remove every canonical occurrence first: whatever light half is
-          # left over is one that lacks its dark pair.
-          String.contains?(line, @light) and
-            line |> String.replace(@canonical, "") |> String.contains?(@light)
-        end)
-        |> Enum.map(fn {_line, n} -> "#{file}:#{n}" end)
-      end)
+      |> Enum.flat_map(&offenders_in/1)
 
     assert offenders == [],
-           "Brand links missing the canonical dark pair — use\n  #{@canonical}\n" <>
-             "(see the text-link recipe in .claude/rules/design.md):\n" <>
+           "Brand text links missing the canonical dark pair — use\n" <>
+             "  #{@light_base} #{@light_hover} #{@dark_base} #{@dark_hover}\n" <>
+             "(a variant chain repeats verbatim under dark:, see .claude/rules/design.md):\n" <>
              Enum.join(offenders, "\n")
+  end
+
+  defp offenders_in(file) do
+    file
+    |> File.read!()
+    |> String.split("\n")
+    |> Enum.with_index(1)
+    |> Enum.flat_map(fn {line, n} ->
+      for chain <- unpaired_chains(line), do: "#{file}:#{n} (#{chain}#{@light_base})"
+    end)
+  end
+
+  # The variant chains this line spells the whole light recipe under and does
+  # not spell the whole dark one under.
+  defp unpaired_chains(line) do
+    ~r/([^\s"'{}=]*)#{Regex.escape(@light_base)}/
+    |> Regex.scan(line)
+    |> Enum.map(fn [_match, chain] -> chain end)
+    |> Enum.uniq()
+    |> Enum.reject(&String.contains?(&1, "dark:"))
+    |> Enum.filter(&has_token?(line, &1 <> @light_hover))
+    |> Enum.reject(fn chain ->
+      has_token?(line, "dark:" <> chain <> String.trim_leading(@dark_base, "dark:")) and
+        has_token?(line, "dark:" <> chain <> String.trim_leading(@dark_hover, "dark:"))
+    end)
+  end
+
+  # A whole class, not a substring of one: without the boundary,
+  # `group-hover:text-brand-700` answers for `hover:text-brand-700` and the
+  # guard then asks for a dark half under the wrong variant.
+  defp has_token?(line, token) do
+    Regex.match?(~r/(?<![^\s"'{}=])#{Regex.escape(token)}/, line)
   end
 end


### PR DESCRIPTION
Zweite Hälfte des vierten Ganz-App-`/simplify`-Durchgangs, diesmal die Ansichts-Seite.

**Ein echter Fehler.** Die Impressums- und Datenschutzkarte schrieb `hover:[&_a]:text-brand-700`, was zu `.card:hover a` kompiliert und nicht zu `a:hover`: wer irgendwo auf die Karte zeigte, färbte alle Links des Dokuments auf einmal. Dieselbe Zeile hatte gar keine Dunkelmodus-Farbe. Der Wächter (`brand_link_dark_mode_test.exs`) konnte das nicht sehen — er prüfte auf zwei Wörter nebeneinander — und liest jetzt die Klasse: wo beide hellen Hälften unter derselben Variantenkette stehen, müssen beide dunklen folgen. Das fand drei weitere Stellen ohne Dunkelmodus-Paar.

**Kopien.** Der Entwickler-Postfachlink (3×) ist ein Baustein, die Organisationszeile zweier Listen (von 3) auch, und die drei Actor-Dokumente teilen sich ihre neun gemeinsamen Felder — darunter `@context` und der geteilte Posteingang, also genau die zwei Zeilen, die zwischen Mitglied, Seite und Thema nie auseinandergehen dürfen.

**Kleinigkeiten:** ein `elem(@refusal_link, 0)` im Template wird `.path`; `job_components` matchte auf `%{}` und auf eine vorgeladene Assoziation, beides lässt eine `NotLoaded`-Struktur durch; ein Code-Kasten auf `/settings/links/../verify` fehlte `text-xs` und stand eine Größe neben seinen fünf Geschwistern; `.btns` war die einzige tote Regel in `components.css`.

**Bewusst nicht gemacht** (Begründungen im Sweep-Bericht): die zehn Proof-Kästen auf zwei Rezepte zu vereinheitlichen (verschiebt Pixel), die Overlay-Dialoge (4 Kopien + doppelter Fokus-Trap in JS, braucht einen Browser-Check), die `.md`/`.txt`-Zahlen auf `compact_count/1` (diese Formate sind für Agenten geschrieben, `2K` statt `2312` wäre dort ein Verlust — der Test sagt das ausdrücklich).

`mix precommit` grün: 7.891 Tests, Credo sauber.

---

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*