### PR TITLE
Aufräum-Pass Nr. 4, Rest: die Nachfrist steht einmal da (v7.300.4)

### DIFF
--- a/lib/vutuv/imports/linked_in.ex
+++ b/lib/vutuv/imports/linked_in.ex
@@ -1148,23 +1148,32 @@ defmodule Vutuv.Imports.LinkedIn do
   # archive with fifty skills used to issue fifty count queries inside this
   # transaction. The guard there still stands — it is the chokepoint every entry
   # point shares — we simply stop walking into it.
+  #
+  # The tally is a map and not a six-element tuple: every branch below used to
+  # rebuild all six positions to change one of them, so a new outcome bucket was
+  # six edits and two swapped positions would have looked identical.
   defp insert_skills(user, existing, candidates) do
-    seen = Map.fetch!(existing, :skills)
-    acc = {seen, 0, 0, 0, 0, Tags.free_user_tag_slots(user)}
+    acc = %{
+      seen: Map.fetch!(existing, :skills),
+      created: 0,
+      skipped: 0,
+      blocked: 0,
+      tag_limit: 0,
+      budget: Tags.free_user_tag_slots(user)
+    }
 
-    {seen, created, skipped, blocked, limited, _budget} =
-      Enum.reduce(candidates, acc, &add_skill(&1, &2, user))
+    acc = Enum.reduce(candidates, acc, &add_skill(&1, &2, user))
 
-    {Map.put(existing, :skills, seen),
-     %{created: created, skipped: skipped, blocked: blocked, tag_limit: limited}}
+    {Map.put(existing, :skills, acc.seen),
+     Map.take(acc, [:created, :skipped, :blocked, :tag_limit])}
   end
 
-  defp add_skill(candidate, {seen, created, skipped, blocked, limited, budget} = acc, user) do
+  defp add_skill(candidate, acc, user) do
     key = String.downcase(candidate.name)
 
     cond do
-      MapSet.member?(seen, key) -> {seen, created, skipped + 1, blocked, limited, budget}
-      budget == 0 -> {seen, created, skipped, blocked, limited + 1, budget}
+      MapSet.member?(acc.seen, key) -> bump(acc, :skipped)
+      acc.budget == 0 -> bump(acc, :tag_limit)
       true -> user |> Tags.add_user_tag(candidate.name) |> tally_skill(key, acc)
     end
   end
@@ -1172,11 +1181,16 @@ defmodule Vutuv.Imports.LinkedIn do
   # A successful add counts as created, remembers its key and spends a slot; a
   # failure (a racing duplicate, an invalid name) is blocked like any other
   # refused insert and spends nothing.
-  defp tally_skill({:ok, _row}, key, {seen, created, skipped, blocked, limited, budget}),
-    do: {MapSet.put(seen, key), created + 1, skipped, blocked, limited, budget - 1}
+  defp tally_skill({:ok, _row}, key, acc) do
+    acc
+    |> Map.update!(:seen, &MapSet.put(&1, key))
+    |> Map.update!(:budget, &(&1 - 1))
+    |> bump(:created)
+  end
 
-  defp tally_skill({:error, _}, _key, {seen, created, skipped, blocked, limited, budget}),
-    do: {seen, created, skipped, blocked + 1, limited, budget}
+  defp tally_skill({:error, _}, _key, acc), do: bump(acc, :blocked)
+
+  defp bump(acc, bucket), do: Map.update!(acc, bucket, &(&1 + 1))
 
   # Fill only the blank profile fields the member selected (name / headline).
   # Guards here too, not just in the controller, so an import can never clobber

--- a/lib/vutuv/organizations.ex
+++ b/lib/vutuv/organizations.ex
@@ -41,6 +41,7 @@ defmodule Vutuv.Organizations do
   alias Vutuv.Profiles.WorkExperience
   alias Vutuv.Repo
   alias Vutuv.SlugHelpers
+  alias Vutuv.WebVerification
 
   # The role vocabulary, taken from the schema so the two can never disagree.
   # It has to be an attribute rather than a call because `add_role/4` guards on
@@ -51,11 +52,10 @@ defmodule Vutuv.Organizations do
   @reserved_slugs ~w(new)
   @directory_per_page 24
   @people_per_page 24
-  # Domain-ownership proofs (a DNS TXT record / a static well-known file) almost
-  # never change once set, so a weekly re-check is plenty; the hourly sweeper
-  # tick just spreads these checks out rather than bursting them.
-  @recheck_interval_hours 24 * 7
-  @grace_days 7
+  # The re-check interval and the grace window come from `Vutuv.WebVerification`,
+  # shared with the profile-link and social-account re-checks: how long a
+  # vanished proof keeps its mark is a promise to the member, and three copies of
+  # "7 days" is three chances for the three features to drift apart.
 
   # How often a domain that is still waiting for its proof is looked at, by how
   # long ago the claim was started: `{claim younger than, check every}` in
@@ -1271,7 +1271,7 @@ defmodule Vutuv.Organizations do
 
   @doc "DNS / well-known domains whose last check is older than the interval."
   def domains_due_for_recheck(now \\ NaiveDateTime.utc_now()) do
-    cutoff = NaiveDateTime.add(now, -@recheck_interval_hours * 3600)
+    cutoff = WebVerification.recheck_cutoff(now)
 
     Repo.all(
       from(d in OrganizationDomain,
@@ -1337,10 +1337,8 @@ defmodule Vutuv.Organizations do
   end
 
   defp handle_recheck_failure(domain, now) do
-    cond do
-      is_nil(domain.grace_deadline_at) ->
-        deadline = NaiveDateTime.add(now, @grace_days * 86_400)
-
+    case WebVerification.grace_step(domain.grace_deadline_at, now) do
+      {:grace_started, deadline} ->
         {:ok, domain} =
           domain
           |> OrganizationDomain.check_changeset(%{
@@ -1356,14 +1354,14 @@ defmodule Vutuv.Organizations do
 
         :grace_started
 
-      NaiveDateTime.compare(now, domain.grace_deadline_at) == :lt ->
+      :in_grace ->
         domain
         |> OrganizationDomain.check_changeset(%{last_checked_at: now})
         |> Repo.update()
 
         :in_grace
 
-      true ->
+      :demote ->
         demote_domain(domain, now)
     end
   end

--- a/lib/vutuv/profiles/link_verification.ex
+++ b/lib/vutuv/profiles/link_verification.ex
@@ -33,10 +33,10 @@ defmodule Vutuv.Profiles.LinkVerification do
   @dns_prefix "vutuv-verify="
   @well_known_path "/.well-known/vutuv-verify.txt"
 
-  @grace_days 7
-  # A verified webpage proof rarely changes, so re-check weekly; the hourly
-  # sweeper tick just spreads the checks out rather than bursting them.
-  @recheck_interval_hours 24 * 7
+  # The re-check interval and the grace window live in `Vutuv.WebVerification`,
+  # shared with the social-account and organization-domain re-checks: how long a
+  # vanished proof keeps its mark is a promise to the member, and the three
+  # features must not make different ones by accident.
 
   @doc "Whether link verification is enabled for this installation."
   def enabled?, do: Application.get_env(:vutuv, :verify_user_links, true)
@@ -157,7 +157,7 @@ defmodule Vutuv.Profiles.LinkVerification do
 
   @doc "Verified links whose last check is older than the interval."
   def links_due_for_recheck(now \\ NaiveDateTime.utc_now()) do
-    cutoff = NaiveDateTime.add(now, -@recheck_interval_hours * 3600)
+    cutoff = WebVerification.recheck_cutoff(now)
 
     Repo.all(
       from(u in Url,
@@ -207,21 +207,19 @@ defmodule Vutuv.Profiles.LinkVerification do
   end
 
   defp handle_recheck_failure(%Url{} = url, now) do
-    cond do
-      is_nil(url.grace_deadline_at) ->
-        deadline = NaiveDateTime.add(now, @grace_days * 86_400)
-
+    case WebVerification.grace_step(url.grace_deadline_at, now) do
+      {:grace_started, deadline} ->
         url
         |> Url.verification_changeset(%{last_checked_at: now, grace_deadline_at: deadline})
         |> Repo.update()
 
         :grace_started
 
-      NaiveDateTime.compare(now, url.grace_deadline_at) == :lt ->
+      :in_grace ->
         url |> Url.verification_changeset(%{last_checked_at: now}) |> Repo.update()
         :in_grace
 
-      true ->
+      :demote ->
         url
         |> Url.verification_changeset(%{
           verification_method: nil,

--- a/lib/vutuv/profiles/messenger.ex
+++ b/lib/vutuv/profiles/messenger.ex
@@ -212,43 +212,42 @@ defmodule Vutuv.Profiles.Messenger do
       else: add_error(changeset, :value, "Enter a phone number or a username")
   end
 
-  # Telegram: a public @username, 5–32 of [A-Za-z0-9_]. Stored without the "@".
-  defp normalize_handle(changeset, "Telegram", value) do
-    handle = String.trim_leading(value, "@")
+  # What each provider's handle looks like once tidied, as `{pattern, message}`.
+  # A table rather than four clauses of the same seven lines, so a new messenger
+  # is a row plus a `tidy/2` clause and the four error sentences can be read
+  # side by side:
+  #
+  #   * Telegram: a public @username, 5–32 of [A-Za-z0-9_], stored without the "@".
+  #   * Threema: an 8-character ID of [A-Z0-9].
+  #   * Matrix: a federated MXID @user:homeserver.
+  #   * Session: a 66-character account ID (05 then 64 hex characters).
+  @handle_rules %{
+    "Telegram" => {~r/^[A-Za-z0-9_]{5,32}$/, "Enter your Telegram username, e.g. @yourname"},
+    "Threema" => {~r/^[A-Z0-9]{8}$/, "Enter your 8-character Threema ID, e.g. ABCD1234"},
+    "Matrix" => {~r/^@[^:\s]+:[^\s]+\.[^\s]+$/, "Enter your Matrix ID, e.g. @you:matrix.org"},
+    "Session" => {~r/^05[0-9a-f]{64}$/, "Enter your 66-character Session ID"}
+  }
 
-    if handle =~ ~r/^[A-Za-z0-9_]{5,32}$/,
-      do: put_change(changeset, :value, handle),
-      else: add_error(changeset, :value, "Enter your Telegram username, e.g. @yourname")
+  defp normalize_handle(changeset, provider, value) do
+    case Map.fetch(@handle_rules, provider) do
+      {:ok, {pattern, message}} ->
+        handle = tidy(provider, value)
+
+        if handle =~ pattern,
+          do: put_change(changeset, :value, handle),
+          else: add_error(changeset, :value, message)
+
+      :error ->
+        changeset
+    end
   end
 
-  # Threema: an 8-character ID of [A-Z0-9] (spaces tolerated, case-folded up).
-  defp normalize_handle(changeset, "Threema", value) do
-    id = value |> String.replace(" ", "") |> String.upcase()
-
-    if id =~ ~r/^[A-Z0-9]{8}$/,
-      do: put_change(changeset, :value, id),
-      else: add_error(changeset, :value, "Enter your 8-character Threema ID, e.g. ABCD1234")
-  end
-
-  # Matrix: a federated MXID @user:homeserver. A leading "@" is added if missing.
-  defp normalize_handle(changeset, "Matrix", value) do
-    id = prepend_at(String.trim(value))
-
-    if id =~ ~r/^@[^:\s]+:[^\s]+\.[^\s]+$/,
-      do: put_change(changeset, :value, id),
-      else: add_error(changeset, :value, "Enter your Matrix ID, e.g. @you:matrix.org")
-  end
-
-  # Session: a 66-character account ID (starts with 05, then 64 hex chars).
-  defp normalize_handle(changeset, "Session", value) do
-    id = value |> String.replace(~r/\s/, "") |> String.downcase()
-
-    if id =~ ~r/^05[0-9a-f]{64}$/,
-      do: put_change(changeset, :value, id),
-      else: add_error(changeset, :value, "Enter your 66-character Session ID")
-  end
-
-  defp normalize_handle(changeset, _provider, _value), do: changeset
+  # Spaces and a missing or stray "@" are typing, not a wrong handle, so each
+  # provider's value is tidied into its stored shape before it is judged.
+  defp tidy("Telegram", value), do: String.trim_leading(value, "@")
+  defp tidy("Threema", value), do: value |> String.replace(" ", "") |> String.upcase()
+  defp tidy("Matrix", value), do: prepend_at(String.trim(value))
+  defp tidy("Session", value), do: value |> String.replace(~r/\s/, "") |> String.downcase()
 
   defp prepend_at("@" <> _ = id), do: id
   defp prepend_at(id), do: "@" <> id

--- a/lib/vutuv/profiles/social_account_verification.ex
+++ b/lib/vutuv/profiles/social_account_verification.ex
@@ -33,13 +33,12 @@ defmodule Vutuv.Profiles.SocialAccountVerification do
   alias Vutuv.Profiles.LinkVerification
   alias Vutuv.Profiles.SocialMediaAccount
   alias Vutuv.Repo
+  alias Vutuv.WebVerification
 
   @method "bluesky_bio"
 
-  @grace_days 7
-  # A bio changes rarely, so re-check weekly; the hourly sweeper tick only
-  # spreads the checks out rather than bursting them.
-  @recheck_interval_hours 24 * 7
+  # The re-check interval and the grace window come from `Vutuv.WebVerification`,
+  # shared with the link and organization-domain re-checks.
 
   @doc "Whether social-account verification is enabled for this installation."
   def enabled?, do: Application.get_env(:vutuv, :verify_social_accounts, true)
@@ -125,7 +124,7 @@ defmodule Vutuv.Profiles.SocialAccountVerification do
 
   @doc "Verified accounts whose last check is older than the interval."
   def accounts_due_for_recheck(now \\ NaiveDateTime.utc_now()) do
-    cutoff = NaiveDateTime.add(now, -@recheck_interval_hours * 3600)
+    cutoff = WebVerification.recheck_cutoff(now)
 
     Repo.all(
       from(a in SocialMediaAccount,
@@ -197,10 +196,8 @@ defmodule Vutuv.Profiles.SocialAccountVerification do
   end
 
   defp handle_recheck_failure(%SocialMediaAccount{} = account, now) do
-    cond do
-      is_nil(account.grace_deadline_at) ->
-        deadline = NaiveDateTime.add(now, @grace_days * 86_400)
-
+    case WebVerification.grace_step(account.grace_deadline_at, now) do
+      {:grace_started, deadline} ->
         account
         |> SocialMediaAccount.verification_changeset(%{
           last_checked_at: now,
@@ -210,14 +207,14 @@ defmodule Vutuv.Profiles.SocialAccountVerification do
 
         :grace_started
 
-      NaiveDateTime.compare(now, account.grace_deadline_at) == :lt ->
+      :in_grace ->
         account
         |> SocialMediaAccount.verification_changeset(%{last_checked_at: now})
         |> Repo.update()
 
         :in_grace
 
-      true ->
+      :demote ->
         account
         |> SocialMediaAccount.verification_changeset(%{
           verification_method: nil,

--- a/lib/vutuv/web_verification.ex
+++ b/lib/vutuv/web_verification.ex
@@ -46,6 +46,38 @@ defmodule Vutuv.WebVerification do
     24 |> :crypto.strong_rand_bytes() |> Base.url_encode64(padding: false)
   end
 
+  # --- the re-check clock -----------------------------------------------------
+  #
+  # Three features re-check a proof they once accepted — a member's webpage
+  # link, their social account, an organization's domain — and all three
+  # answered the same two questions for themselves: how old may a check be
+  # before we look again, and how long does a vanished proof keep its mark. Both
+  # are promises to the member rather than implementation details, so they get
+  # one home: three copies of "7 days" is three chances for a member's link and
+  # a page's domain to be treated differently by accident.
+  #
+  # What each caller keeps is its own writes, which genuinely differ (only the
+  # organization half warns the owners, and only it can demote the whole page).
+  @grace_days 7
+  @recheck_interval_hours 24 * 7
+
+  @doc "How long a vanished proof keeps its mark before it is dropped."
+  def grace_days, do: @grace_days
+
+  @doc "The cutoff a re-check query compares `last_checked_at` against."
+  def recheck_cutoff(now), do: NaiveDateTime.add(now, -@recheck_interval_hours * 3600)
+
+  @doc """
+  Where a failed re-check stands: `{:grace_started, deadline}` the first time a
+  proof is missing, `:in_grace` while that window is open, `:demote` once it has
+  passed.
+  """
+  def grace_step(nil, now), do: {:grace_started, NaiveDateTime.add(now, @grace_days * 86_400)}
+
+  def grace_step(deadline, now) do
+    if NaiveDateTime.compare(now, deadline) == :lt, do: :in_grace, else: :demote
+  end
+
   # --- DNS TXT ----------------------------------------------------------------
 
   # A CNAME and a TXT record cannot coexist on the same DNS name (RFC 1034), so a

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.300.3",
+      version: "7.300.4",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/web_verification_test.exs
+++ b/test/vutuv/web_verification_test.exs
@@ -316,6 +316,35 @@ defmodule Vutuv.WebVerificationTest do
     end
   end
 
+  describe "the shared re-check clock" do
+    test "a first failure opens the grace window, then it runs out" do
+      now = ~N[2026-08-17 12:00:00]
+
+      assert {:grace_started, deadline} = WebVerification.grace_step(nil, now)
+      assert NaiveDateTime.diff(deadline, now) == WebVerification.grace_days() * 86_400
+
+      assert WebVerification.grace_step(deadline, NaiveDateTime.add(deadline, -1)) == :in_grace
+      assert WebVerification.grace_step(deadline, deadline) == :demote
+      assert WebVerification.grace_step(deadline, NaiveDateTime.add(deadline, 1)) == :demote
+    end
+
+    test "no re-checked feature keeps a second copy of the window" do
+      # A member's webpage link, their social account and an organization's
+      # domain each carried their own `@grace_days 7`, so the promise "your mark
+      # survives a week of a missing proof" could come apart between the three
+      # without anything failing. Read off the sources, because an unregistered
+      # module attribute leaves no trace to ask the module about.
+      offenders =
+        ["lib/vutuv/profiles/*.ex", "lib/vutuv/organizations.ex", "lib/vutuv/organizations/*.ex"]
+        |> Enum.flat_map(&Path.wildcard/1)
+        |> Enum.filter(&(File.read!(&1) =~ ~r/@(grace_days|recheck_interval_hours)\s/))
+
+      assert offenders == [],
+             "the grace window and the re-check interval belong to " <>
+               "Vutuv.WebVerification, not to: " <> Enum.join(offenders, ", ")
+    end
+  end
+
   # A Req adapter that answers every request with the given status + body.
   defp adapter(status, body) do
     [adapter: fn req -> {req, %Req.Response{status: status, body: body}} end]


### PR DESCRIPTION
Letzter Teil des vierten Ganz-App-`/simplify`-Durchgangs.

**Die Nachfrist.** Drei Funktionen prüfen einen einmal angenommenen Nachweis erneut nach — der Webseiten-Link eines Mitglieds, sein soziales Konto, die Domain einer Seite — und jede beantwortete sich zwei Fragen selbst: wie alt darf eine Prüfung sein, bis wir wieder hinsehen, und wie lange behält ein verschwundener Nachweis sein Zeichen. Beides ist ein Versprechen an das Mitglied. Drei Kopien von „7 Tage" sind drei Gelegenheiten, dass die drei auseinanderlaufen; `WebVerification` besitzt sie jetzt, die Aufrufer behalten ihre eigenen Schreibvorgänge (nur die Organisationsseite warnt die Inhaber, nur sie kann die ganze Seite zurücksetzen). Ein Test liest die Quellen, damit keine vierte Kopie entsteht — rot kalibriert.

**Zwei kleinere:** der LinkedIn-Import zählte in einem Sechs-Tupel, das jeder Zweig komplett neu baute, um einen einzigen Wert zu ändern (eine neue Kategorie waren sechs Änderungen, zwei vertauschte Positionen sähen identisch aus); und die vier Messenger-Prüfungen sind eine Tabelle, in der die vier Fehlermeldungen nebeneinander lesbar sind.

**Was ich nach Prüfung NICHT gemacht habe:** die 17 Sweeper unter einen Baustein zu ziehen. Nur fünf teilen die try/rescue-Form; die übrigen halten eigenen Zustand, laufen mehrere protokollierte Teildurchgänge oder haben eine andere `init`-Stelligkeit. Ein Baustein, den knapp die Hälfte benutzen kann, macht die abweichenden schwerer mit ihren Geschwistern zu vergleichen.

`mix precommit` grün: 7.893 Tests, Credo sauber.

---

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*