### PR TITLE
Der Tagesbericht überlebt den ersten Follower einer Seite (v7.300.5)

### DIFF
--- a/lib/vutuv/reports.ex
+++ b/lib/vutuv/reports.ex
@@ -61,7 +61,11 @@ defmodule Vutuv.Reports do
         reposts: sample(PostRepost, [:user, :post], day_start, day_end, limit),
         likes: sample(PostLike, [:user, :post], day_start, day_end, limit),
         bookmarks: sample(PostBookmark, [:user, :post], day_start, day_end, limit),
-        fediverse_followers: sample(Follower, [:user], day_start, day_end, limit),
+        # All three owner kinds: a remote actor follows a member, a page
+        # (issue #1334) or a topic (issue #1330), and the detail line names
+        # whichever of them gained the follower.
+        fediverse_followers:
+          sample(Follower, [:user, :organization, :tag], day_start, day_end, limit),
         fediverse_prunes: sample(FollowerPrune, [:user], day_start, day_end, limit),
         bounces: deliverability_details.bounces,
         deactivations: deliverability_details.deactivations,

--- a/lib/vutuv/reports/daily_reporter.ex
+++ b/lib/vutuv/reports/daily_reporter.ex
@@ -9,7 +9,9 @@ defmodule Vutuv.Reports.DailyReporter do
   trigger instant and sleeps until then, a real cron tick rather than a busy
   poll. After firing it reschedules for the following day, so a DST shift is
   picked up each time (the trigger is computed in Berlin local time via
-  `Vutuv.BerlinTime`). The marker is implicit in the timer, so a restart in
+  `Vutuv.BerlinTime`). A report that raises is logged and skipped rather than
+  taken as a crash, so one bad day is visible in the log instead of vanishing.
+  The marker is implicit in the timer, so a restart in
   the few minutes between local midnight and the trigger can miss that one
   day's mail. That is harmless for a stats notice and rare (it only coincides
   with a deploy landing in that window). Disabled in tests
@@ -42,9 +44,25 @@ defmodule Vutuv.Reports.DailyReporter do
   def handle_info(:run, state) do
     yesterday = Date.add(BerlinTime.today(), -1)
 
-    case Reports.deliver_daily_email(yesterday) do
-      {:ok, _report} -> Logger.info("Mailed the daily report for #{yesterday}")
-      :skipped -> :ok
+    # Deliberately rescued: a raise here used to be invisible. The GenServer
+    # died inside its own timer callback, the supervisor restarted it, and
+    # `init/1` scheduled the *following* midnight — so a broken report cost
+    # that day's mail with no error anywhere the operator would look, and the
+    # next night's mail arrived as if nothing had happened. That is exactly how
+    # the first Fediverse follower of a page or a topic silently swallowed a
+    # day's report (`VutuvWeb.ReportDetails`). Logging the day and the reason
+    # keeps the loss visible; rescheduling either way keeps one bad day from
+    # taking the following ones with it.
+    try do
+      case Reports.deliver_daily_email(yesterday) do
+        {:ok, _report} -> Logger.info("Mailed the daily report for #{yesterday}")
+        :skipped -> :ok
+      end
+    rescue
+      error ->
+        Logger.error(
+          "Daily report for #{yesterday} failed: #{Exception.format(:error, error, __STACKTRACE__)}"
+        )
     end
 
     schedule_next()

--- a/lib/vutuv_web/report_details.ex
+++ b/lib/vutuv_web/report_details.ex
@@ -26,6 +26,10 @@ defmodule VutuvWeb.ReportDetails do
 
   import VutuvWeb.UserHelpers, only: [full_name: 1]
 
+  alias Vutuv.Accounts.User
+  alias Vutuv.Organizations
+  alias Vutuv.Organizations.Organization
+  alias Vutuv.Tags.Tag
   alias VutuvWeb.AgentDocs
 
   # Section order + German headings for the email; the admin page keys its own
@@ -100,11 +104,8 @@ defmodule VutuvWeb.ReportDetails do
   defp entry(:bookmarks, bookmark), do: post_entry(bookmark.post, bookmark.user)
 
   defp entry(:fediverse_followers, follower) do
-    %{
-      primary: follower_display(follower),
-      secondary: "@" <> follower.user.username,
-      path: "/" <> follower.user.username
-    }
+    {label, path} = follow_target(follower)
+    %{primary: follower_display(follower), secondary: label, path: path}
   end
 
   # A pruned follower is deliberately nameless — only the server it lived on
@@ -154,8 +155,29 @@ defmodule VutuvWeb.ReportDetails do
   # A member is named by handle, an organization by its name — it may never have
   # claimed a handle. Without this the daily report crashed on the first day any
   # page published (issue #1334).
-  defp actor_label(%Vutuv.Organizations.Organization{name: name}), do: name
+  defp actor_label(%Organization{name: name}), do: name
   defp actor_label(actor), do: "@" <> actor.username
+
+  # Who gained the follower, and where that page lives. A remote actor follows a
+  # member, a page (issue #1334) or a topic (issue #1330) — exactly one, and the
+  # database CHECK says so, which is what makes the `||` chain total.
+  #
+  # This read `follower.user.username` outright, so the first page or topic to
+  # gain a Fediverse follower took the *whole* nightly report down with a
+  # BadMapError on nil — and silently: the crash happened inside the
+  # `Vutuv.Reports.DailyReporter` timer callback, the supervisor restarted the
+  # GenServer, and `init/1` rescheduled for the following midnight. No mail, no
+  # retry, no error anywhere the operator would see it. The same shape as the
+  # post-author fix above, one association further along.
+  defp follow_target(follower) do
+    target_entry(follower.user || follower.organization || follower.tag)
+  end
+
+  defp target_entry(%Organization{} = organization),
+    do: {organization.name, Organizations.canonical_path(organization)}
+
+  defp target_entry(%Tag{} = tag), do: {"#" <> tag.name, "/tags/#{tag.slug}"}
+  defp target_entry(%User{username: username}), do: {"@" <> username, "/" <> username}
 
   # The remote actor's own label, best first: its @handle, then its display
   # name, falling back to the raw actor URI (always present).

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.300.4",
+      version: "7.300.5",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/reports_test.exs
+++ b/test/vutuv/reports_test.exs
@@ -190,6 +190,41 @@ defmodule Vutuv.ReportsTest do
       assert Reports.deliver_daily_email(@date) == :skipped
       assert_no_email_sent()
     end
+
+    # The whole mail, both bodies, for the day a page and a topic each gained a
+    # Fediverse follower — the case that used to raise while building the detail
+    # lines, so no mail went out at all and the loss was silent (the crash
+    # happened inside the `DailyReporter` timer callback and the restart simply
+    # rescheduled for the next midnight).
+    test "renders both bodies when a page and a topic gained a Fediverse follower" do
+      organization = insert(:organization)
+      tag = insert(:tag)
+
+      for {key, id} <- [organization_id: organization.id, tag_id: tag.id] do
+        Repo.insert!(
+          struct(
+            Vutuv.Fediverse.Follower,
+            [
+              {key, id},
+              {:actor_uri, "https://remote.example/users/#{id}"},
+              {:inbox_uri, "https://remote.example/users/#{id}/inbox"},
+              {:handle, "@follower_#{id}@remote.example"}
+            ] ++ at(@on_day)
+          )
+        )
+      end
+
+      assert {:ok, report} = Reports.deliver_daily_email(@date)
+      assert report.fediverse_followers == 2
+
+      assert_email_sent(fn email ->
+        assert email.subject =~ "2 neue Fediverse-Follower"
+        assert email.text_body =~ organization.name
+        assert email.text_body =~ "##{tag.name}"
+        assert email.text_body =~ "/tags/#{tag.slug}"
+        assert email.html_body =~ organization.name
+      end)
+    end
   end
 
   describe "deliverability metrics" do

--- a/test/vutuv_web/report_details_test.exs
+++ b/test/vutuv_web/report_details_test.exs
@@ -73,6 +73,81 @@ defmodule VutuvWeb.ReportDetailsTest do
              ]
     end
 
+    test "a new Fediverse follower of a member names them and links the profile" do
+      user = insert(:user, username: "erik")
+
+      Repo.insert!(
+        struct(
+          Vutuv.Fediverse.Follower,
+          [
+            user_id: user.id,
+            actor_uri: "https://remote.example/users/frida",
+            inbox_uri: "https://remote.example/users/frida/inbox",
+            handle: "@frida@remote.example"
+          ] ++ at(@on_day)
+        )
+      )
+
+      assert section(Reports.daily(@date), :fediverse_followers).entries == [
+               %{primary: "@frida@remote.example", secondary: "@erik", path: "/erik"}
+             ]
+    end
+
+    # A remote follower follows a member, a page (#1334) or a topic (#1330),
+    # CHECK-enforced to exactly one — so `follower.user` is nil for the latter
+    # two. Reading `follower.user.username` unconditionally crashed the whole
+    # nightly report the first day a page or a topic gained one: the GenServer
+    # died inside its own `handle_info`, the supervisor restarted it, and
+    # `init/1` rescheduled for the *next* day, so the day's mail was lost
+    # without a trace. Same bug shape the post entries already carry a fix for.
+    test "a new Fediverse follower of a page names the page and links it" do
+      organization = insert(:organization)
+
+      Repo.insert!(
+        struct(
+          Vutuv.Fediverse.Follower,
+          [
+            organization_id: organization.id,
+            actor_uri: "https://remote.example/users/greta",
+            inbox_uri: "https://remote.example/users/greta/inbox",
+            handle: "@greta@remote.example"
+          ] ++ at(@on_day)
+        )
+      )
+
+      assert section(Reports.daily(@date), :fediverse_followers).entries == [
+               %{
+                 primary: "@greta@remote.example",
+                 secondary: organization.name,
+                 path: Vutuv.Organizations.canonical_path(organization)
+               }
+             ]
+    end
+
+    test "a new Fediverse follower of a topic names the tag and links it" do
+      tag = insert(:tag)
+
+      Repo.insert!(
+        struct(
+          Vutuv.Fediverse.Follower,
+          [
+            tag_id: tag.id,
+            actor_uri: "https://remote.example/users/hilde",
+            inbox_uri: "https://remote.example/users/hilde/inbox",
+            handle: "@hilde@remote.example"
+          ] ++ at(@on_day)
+        )
+      )
+
+      assert section(Reports.daily(@date), :fediverse_followers).entries == [
+               %{
+                 primary: "@hilde@remote.example",
+                 secondary: "##{tag.name}",
+                 path: "/tags/#{tag.slug}"
+               }
+             ]
+    end
+
     test "a pruned Fediverse follower names the server, not the person who left" do
       user = insert(:user, username: "dora")
 


### PR DESCRIPTION
**TL;DR** Der nächtliche Tagesbericht ist letzte Nacht nicht rausgegangen: die Detailzeile für einen neuen Fediverse-Follower las `follower.user.username` ohne Nachfrage und stürzte auf nil ab.

**Wo:** `VutuvWeb.ReportDetails.entry/2` + `Vutuv.Reports.daily/1`
**Jetzt:** Ein entfernter Account folgt einer Person, einer Seite (#1334) oder einem Thema (#1330) — genau einem, per CHECK. Bei den letzten beiden ist `user` nil, also räumt der erste solche Follower den ganzen Bericht mit einem BadMapError ab. Lautlos: der Absturz passiert im Timer-Callback des `DailyReporter`, der Supervisor startet neu, `init/1` legt den nächsten Termin auf die folgende Mitternacht. Keine Mail, kein Fehler, keine Wiederholung. Dieselbe Seite trifft es auch unter `/admin/reports`, die den Bericht aus denselben `sections/1` rendert.
**Danach:** Die Zeile nennt, wer den Follower bekommen hat (Person, Seite oder Tag) und verlinkt die passende Seite; `daily/1` lädt alle drei Besitzarten vor. Der `DailyReporter` protokolliert einen fehlgeschlagenen Bericht, statt daran zu sterben.
**Tests:** Gegen den kaputten Stand kalibriert — beide Regressionstests waren rot, bevor der Fix stand. `mix precommit` grün (7897).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*

https://claude.ai/code/session_01SpnzJU8yafyFcdM8gWfvtU