### PR TITLE
Das Prune-Register kennt jetzt Seiten und Themen (v7.300.6)

### DIFF
--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -376,6 +376,36 @@ defmodule Vutuv.Fediverse do
     end
   end
 
+  @doc """
+  Who a follower row (or a prune row) is about: the member, the page (issue
+  #1334) or the topic (issue #1330) being followed. Exactly one of the three is
+  set — the database CHECK says so — which is what makes the `||` chain total.
+
+  The one definition of "whose follower is this", so a surface that renders such
+  a row does not have to remember the third owner kind for itself.
+
+  Needs the associations preloaded, and says so rather than guessing: an
+  unloaded association is truthy, so a plain `||` chain would hand back
+  `%Ecto.Association.NotLoaded{}` and the caller would quietly treat it as an
+  owner it cannot use — which is how the pruner came to sign nothing at all for
+  a page's followers. A forgotten preload is a bug in the query, so it raises
+  here instead of degrading somewhere further along.
+  """
+  def followed(%{user: user, organization: organization, tag: tag}) do
+    [user, organization, tag]
+    |> Enum.reject(&(&1 == nil))
+    |> case do
+      [%Ecto.Association.NotLoaded{} | _] ->
+        raise ArgumentError, "Fediverse.followed/1 needs :user, :organization and :tag preloaded"
+
+      [owner | _] ->
+        owner
+
+      [] ->
+        nil
+    end
+  end
+
   @doc "Drops a page's remote follower (the inbox's Undo). Idempotent."
   def remove_organization_follower(%Organization{id: id}, actor_uri) do
     {count, _} =
@@ -3343,9 +3373,30 @@ defmodule Vutuv.Fediverse do
   defp do_prune_due_followers(now) do
     due = followers_due_for_prune(now)
     actors = actors_by_user_id(due)
+    organization_actors = actors_by_organization_id(due)
+    tag_actors = actors_by_tag_id(due)
 
-    count_pruned(due, &check_follower(&1, actors[&1.user_id], now))
+    count_pruned(
+      due,
+      &check_follower(&1, follower_actor(&1, actors, organization_actors, tag_actors), now)
+    )
   end
+
+  # The key this re-check signs with belongs to whoever is being followed, so a
+  # page's and a topic's followers are checked with their own actor rather than
+  # with nothing. Without this the fetch went out unsigned, an authorized-fetch
+  # server answered 401, and 401 is not a "gone" status — so the dead row was
+  # kept and re-checked forever. Mirrors `signing_actor/4` on the delivery path.
+  defp follower_actor(%Follower{organization_id: id}, _actors, organization_actors, _tag_actors)
+       when is_binary(id),
+       do: organization_actors[id]
+
+  defp follower_actor(%Follower{tag_id: id}, _actors, _organization_actors, tag_actors)
+       when is_binary(id),
+       do: tag_actors[id]
+
+  defp follower_actor(%Follower{user_id: id}, actors, _organization_actors, _tag_actors),
+    do: actors[id]
 
   # Each check is one blocking HTTPS round trip (no DB connection held during
   # it), so run a few at a time instead of summing every remote's latency. Both
@@ -3373,7 +3424,7 @@ defmodule Vutuv.Fediverse do
       # rows would otherwise fill the batch by itself and the per-host cap
       # would leave the run half empty, starving everybody else.
       limit: ^(@prune_batch * 4),
-      preload: [:user]
+      preload: [:user, :organization, :tag]
     )
     |> Repo.all()
     |> spread_across_hosts(&(BlockedInstance.normalize_host(&1.actor_uri) || &1.actor_uri))
@@ -3399,7 +3450,7 @@ defmodule Vutuv.Fediverse do
   end
 
   defp check_follower(%Follower{} = follower, actor, now) do
-    case fetch_remote_actor(follower.actor_uri, signer_for(follower.user, actor)) do
+    case fetch_remote_actor(follower.actor_uri, signer_for(followed(follower), actor)) do
       {:error, {:http, status}} when status in @gone_statuses ->
         prune_follower(follower, status)
 
@@ -3412,10 +3463,20 @@ defmodule Vutuv.Fediverse do
     Repo.delete(follower)
     broadcast_remote_followers_changed([follower.user_id])
 
+    # The ledger row carries the SAME owner the follower row did (member, page
+    # or topic). It used to copy `user_id` whatever the follower was, so a
+    # page's or a topic's removal hit the NOT NULL on that column and raised —
+    # after the follower had already been deleted, which is the worst order:
+    # the removal happened and the report never heard about it.
+    #
     # The host is always parseable here (an unparseable actor URI never gets as
     # far as an HTTP status), but fall back rather than lose the ledger row: a
     # deletion the report cannot see is exactly what this is meant to prevent.
-    %FollowerPrune{user_id: follower.user_id}
+    %FollowerPrune{
+      user_id: follower.user_id,
+      organization_id: follower.organization_id,
+      tag_id: follower.tag_id
+    }
     |> FollowerPrune.changeset(%{
       host: BlockedInstance.normalize_host(follower.actor_uri) || "unknown",
       status: status

--- a/lib/vutuv/fediverse/follower_prune.ex
+++ b/lib/vutuv/fediverse/follower_prune.ex
@@ -5,7 +5,8 @@ defmodule Vutuv.Fediverse.FollowerPrune do
   and the remote server answered `404` or `410`.
 
   The row records **who lost a follower, from which server, on which evidence**
-  — and nothing about the person who left. Storing the actor URI here would
+  — a member, a page or a topic — and nothing about the person who left.
+  Storing the actor URI here would
   undo the very thing the pruning is for: not holding an online identifier of
   somebody who deleted their account. What is left is what the nightly
   Tagesbericht needs, so a mass-prune (a whole server answering 410 after a
@@ -25,7 +26,12 @@ defmodule Vutuv.Fediverse.FollowerPrune do
     field(:host, :string)
     field(:status, :integer)
 
+    # Who lost the follower: a member, a page (issue #1334) or a topic
+    # (issue #1330), CHECK-enforced to exactly one — the same triple
+    # `Vutuv.Fediverse.Follower` carries, because a prune mirrors a follower.
     belongs_to(:user, Vutuv.Accounts.User)
+    belongs_to(:organization, Vutuv.Organizations.Organization)
+    belongs_to(:tag, Vutuv.Tags.Tag)
 
     timestamps()
   end

--- a/lib/vutuv/reports.ex
+++ b/lib/vutuv/reports.ex
@@ -66,7 +66,8 @@ defmodule Vutuv.Reports do
         # whichever of them gained the follower.
         fediverse_followers:
           sample(Follower, [:user, :organization, :tag], day_start, day_end, limit),
-        fediverse_prunes: sample(FollowerPrune, [:user], day_start, day_end, limit),
+        fediverse_prunes:
+          sample(FollowerPrune, [:user, :organization, :tag], day_start, day_end, limit),
         bounces: deliverability_details.bounces,
         deactivations: deliverability_details.deactivations,
         freezes: deliverability_details.freezes,

--- a/lib/vutuv_web/report_details.ex
+++ b/lib/vutuv_web/report_details.ex
@@ -27,6 +27,7 @@ defmodule VutuvWeb.ReportDetails do
   import VutuvWeb.UserHelpers, only: [full_name: 1]
 
   alias Vutuv.Accounts.User
+  alias Vutuv.Fediverse
   alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
   alias Vutuv.Tags.Tag
@@ -110,13 +111,11 @@ defmodule VutuvWeb.ReportDetails do
 
   # A pruned follower is deliberately nameless — only the server it lived on
   # survives the deletion (see Vutuv.Fediverse.FollowerPrune), so the line reads
-  # "mastodon.example (HTTP 410)" against the member who lost the follower.
+  # "mastodon.example (HTTP 410)" against whoever lost the follower: a member, a
+  # page or a topic, the same three kinds the follower row carried.
   defp entry(:fediverse_prunes, prune) do
-    %{
-      primary: prune.host,
-      secondary: "HTTP #{prune.status} · @#{prune.user.username}",
-      path: "/" <> prune.user.username
-    }
+    {label, path} = follow_target(prune)
+    %{primary: prune.host, secondary: "HTTP #{prune.status} · #{label}", path: path}
   end
 
   defp entry(:bounces, %{email: email, status: status}),
@@ -158,9 +157,9 @@ defmodule VutuvWeb.ReportDetails do
   defp actor_label(%Organization{name: name}), do: name
   defp actor_label(actor), do: "@" <> actor.username
 
-  # Who gained the follower, and where that page lives. A remote actor follows a
-  # member, a page (issue #1334) or a topic (issue #1330) — exactly one, and the
-  # database CHECK says so, which is what makes the `||` chain total.
+  # Who gained (or lost) the follower, and where their page lives. Which of the
+  # three owners a row is about is `Vutuv.Fediverse.followed/1`'s business, so
+  # the next owner kind is remembered in one place rather than in every surface.
   #
   # This read `follower.user.username` outright, so the first page or topic to
   # gain a Fediverse follower took the *whole* nightly report down with a
@@ -169,9 +168,7 @@ defmodule VutuvWeb.ReportDetails do
   # GenServer, and `init/1` rescheduled for the following midnight. No mail, no
   # retry, no error anywhere the operator would see it. The same shape as the
   # post-author fix above, one association further along.
-  defp follow_target(follower) do
-    target_entry(follower.user || follower.organization || follower.tag)
-  end
+  defp follow_target(row), do: target_entry(Fediverse.followed(row))
 
   defp target_entry(%Organization{} = organization),
     do: {organization.name, Organizations.canonical_path(organization)}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.300.5",
+      version: "7.300.6",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260817060649_widen_follower_prunes_to_all_owner_kinds.exs
+++ b/priv/repo/migrations/20260817060649_widen_follower_prunes_to_all_owner_kinds.exs
@@ -1,0 +1,61 @@
+defmodule Vutuv.Repo.Migrations.WidenFollowerPrunesToAllOwnerKinds do
+  @moduledoc """
+  The prune ledger only ever knew members. `fediverse_followers` grew a page
+  (#1334) and a topic (#1330) beside the member, but
+  `fediverse_follower_prunes.user_id` stayed `NOT NULL` — so the day a page's or
+  a topic's remote follower deleted their account, `prune_follower/2` wrote a
+  NULL into it and the insert raised. The follower row was already deleted by
+  then, which means the removal happened and simply never reached the
+  Tagesbericht.
+
+  Same shape as the followers table it mirrors: `user_id` becomes nullable,
+  `organization_id` and `tag_id` join it, and a CHECK keeps exactly one of the
+  three set, so the ledger cannot record a removal without saying who lost the
+  follower.
+
+  N-1 safe. Dropping NOT NULL is not a type change, so the previous release's
+  cached prepared statements keep their result type (no 0A000). That release
+  writes only member prunes, which satisfy the widened CHECK, and reads the
+  ledger only through `Vutuv.Reports.daily/1`, which scopes nothing on the new
+  columns — a page or topic row is invisible to it rather than confusing. The
+  release after this one may assume all three.
+  """
+  use Ecto.Migration
+
+  @check :fediverse_follower_prunes_exactly_one_owner
+
+  def up do
+    alter table(:fediverse_follower_prunes) do
+      modify(:user_id, :binary_id, null: true, from: {:binary_id, null: false})
+      add(:organization_id, references(:organizations, type: :binary_id, on_delete: :delete_all))
+      add(:tag_id, references(:tags, type: :binary_id, on_delete: :delete_all))
+    end
+
+    create(
+      constraint(:fediverse_follower_prunes, @check,
+        check: """
+        (CASE WHEN user_id IS NULL THEN 0 ELSE 1 END +
+         CASE WHEN organization_id IS NULL THEN 0 ELSE 1 END +
+         CASE WHEN tag_id IS NULL THEN 0 ELSE 1 END) = 1
+        """
+      )
+    )
+
+    create(index(:fediverse_follower_prunes, [:organization_id]))
+    create(index(:fediverse_follower_prunes, [:tag_id]))
+  end
+
+  def down do
+    drop(index(:fediverse_follower_prunes, [:tag_id]))
+    drop(index(:fediverse_follower_prunes, [:organization_id]))
+    drop(constraint(:fediverse_follower_prunes, @check))
+
+    execute("DELETE FROM fediverse_follower_prunes WHERE user_id IS NULL")
+
+    alter table(:fediverse_follower_prunes) do
+      remove(:tag_id)
+      remove(:organization_id)
+      modify(:user_id, :binary_id, null: false, from: {:binary_id, null: true})
+    end
+  end
+end

--- a/test/vutuv/fediverse_follower_prune_test.exs
+++ b/test/vutuv/fediverse_follower_prune_test.exs
@@ -36,6 +36,20 @@ defmodule Vutuv.FediverseFollowerPruneTest do
     user
   end
 
+  defp organization_follower(organization, host) do
+    Fediverse.add_organization_follower(organization, %{
+      actor_uri: "https://#{host}/users/alice",
+      inbox_uri: "https://#{host}/inbox"
+    })
+  end
+
+  defp tag_follower(tag, host) do
+    Fediverse.add_tag_follower(tag, %{
+      actor_uri: "https://#{host}/users/alice",
+      inbox_uri: "https://#{host}/inbox"
+    })
+  end
+
   defp follower(user, host, attrs \\ []) do
     {:ok, follower} =
       Fediverse.add_follower(user, %{
@@ -94,6 +108,67 @@ defmodule Vutuv.FediverseFollowerPruneTest do
       # Each row was still stamped, so the next run moves on to other followers
       # instead of retrying the same unhappy servers straight away.
       assert Enum.all?(Repo.all(Follower), &(&1.last_checked_at != nil))
+    end
+
+    # A remote account follows a member, a page (#1334) or a topic (#1330). The
+    # ledger row held only `user_id`, NOT NULL, and the pruner wrote
+    # `follower.user_id` into it whatever the follower was — so the day a page's
+    # or a topic's remote account was deleted, the insert raised on a NOT NULL
+    # violation instead of recording the removal. The fetch had no signer for
+    # those two either, so it went out unsigned and an authorized-fetch server
+    # answered 401, which reads as "still there" and kept the dead row forever.
+    test "a page's gone follower is pruned and recorded against the page" do
+      organization = insert(:organization)
+      {:ok, _actor} = Fediverse.ensure_organization_actor(organization)
+      {:ok, _follower} = organization_follower(organization, "gone.example")
+
+      stub_hosts(%{"gone.example" => 410})
+
+      assert Fediverse.prune_due_followers() == 1
+      assert Fediverse.organization_remote_follower_count(organization) == 0
+
+      assert [prune] = Repo.all(FollowerPrune)
+      assert prune.organization_id == organization.id
+      assert prune.user_id == nil
+      assert prune.tag_id == nil
+      assert prune.host == "gone.example"
+    end
+
+    test "a topic's gone follower is pruned and recorded against the tag" do
+      tag = insert(:tag)
+      {:ok, _actor} = Fediverse.ensure_tag_actor(tag)
+      {:ok, _follower} = tag_follower(tag, "gone.example")
+
+      stub_hosts(%{"gone.example" => 410})
+
+      assert Fediverse.prune_due_followers() == 1
+
+      assert [prune] = Repo.all(FollowerPrune)
+      assert prune.tag_id == tag.id
+      assert prune.user_id == nil
+      assert prune.organization_id == nil
+    end
+
+    test "a page's and a topic's actor fetch are signed with their own keys" do
+      organization = insert(:organization)
+      tag = insert(:tag)
+      {:ok, _} = Fediverse.ensure_organization_actor(organization)
+      {:ok, _} = Fediverse.ensure_tag_actor(tag)
+      {:ok, _} = organization_follower(organization, "page.example")
+      {:ok, _} = tag_follower(tag, "topic.example")
+      test_pid = self()
+
+      stub(fn conn ->
+        send(test_pid, {:signature, conn.host, Plug.Conn.get_req_header(conn, "signature")})
+        Plug.Conn.send_resp(conn, 200, "{}")
+      end)
+
+      Fediverse.prune_due_followers()
+
+      assert_received {:signature, "page.example", [page_signature]}
+      assert_received {:signature, "topic.example", [topic_signature]}
+      assert page_signature =~ ~s(keyId=")
+      assert topic_signature =~ ~s(keyId=")
     end
 
     test "the actor fetch is signed with the member's own key" do

--- a/test/vutuv_web/report_details_test.exs
+++ b/test/vutuv_web/report_details_test.exs
@@ -163,6 +163,25 @@ defmodule VutuvWeb.ReportDetailsTest do
              ]
     end
 
+    test "a pruned follower of a topic names the tag, not a member" do
+      tag = insert(:tag)
+
+      Repo.insert!(
+        struct(
+          Vutuv.Fediverse.FollowerPrune,
+          [tag_id: tag.id, host: "social.example", status: 404] ++ at(@on_day)
+        )
+      )
+
+      assert section(Reports.daily(@date), :fediverse_prunes).entries == [
+               %{
+                 primary: "social.example",
+                 secondary: "HTTP 404 · ##{tag.name}",
+                 path: "/tags/#{tag.slug}"
+               }
+             ]
+    end
+
     test "a bounce names the address and its status, with no link" do
       insert(:email_bounce,
         email_value: "dead@example.com",


### PR DESCRIPTION
**TL;DR** Verschwindet der entfernte Account eines Seiten- oder Tag-Followers, raist der Prune-Insert (NOT NULL) — und der Re-Fetch ging für die beiden ohnehin unsigniert raus. Zwilling zu #1509.

**Wo:** `Vutuv.Fediverse.prune_follower/2` + `check_follower/3`, `Vutuv.Fediverse.FollowerPrune`
**Jetzt:** Ein entfernter Account folgt einer Person, einer Seite (#1334) oder einem Thema (#1330), aber das Register kannte nur `user_id`, NOT NULL. Zwei Folgen:
1. **Der Insert raist** — nachdem die Follower-Zeile bereits gelöscht wurde. Die Entfernung ist passiert und erreicht den Tagesbericht nie.
2. **Der Signierer kam aus `follower.user`**, also ging der Re-Fetch für Seite und Thema unsigniert raus. Ein Server mit authorized fetch antwortet 401, und 401 ist kein „gone"-Status — die tote Zeile bleibt liegen und wird alle 30 Tage erneut sinnlos abgefragt.

**Danach:** Beides hängt am Besitzer der Zeile. `Fediverse.followed/1` beantwortet als einzige Stelle, um wen es geht (ein vergessener Preload raist dort, statt still zu „niemand" zu werden); `follower_actor/4` spiegelt `signing_actor/4` vom Delivery-Pfad. Die Berichtszeile nennt jetzt auch bei Prunes Seite oder Tag.

**Migration:** `user_id` nullable, `organization_id` + `tag_id` dazu, CHECK auf genau einen. N-1-sicher — NOT NULL fallen zu lassen ist kein Typwechsel (kein 0A000), die vorige Version schreibt nur Mitglieder-Zeilen und liest das Register nur über `Reports.daily/1`. Gegen `vutuv1_dev` gelaufen, der CHECK validierte die Bestandsdaten anstandslos.

**Tests:** Gegen den kaputten Stand kalibriert — der Prune raiste auf dem CHECK, die Signatur kam als `[]` zurück. `mix precommit` grün (7901, credo clean).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*

https://claude.ai/code/session_01SpnzJU8yafyFcdM8gWfvtU