### PR TITLE
Fediverse-Einstellungen erscheinen wieder im Kontoprotokoll (v7.300.7)

### DIFF
--- a/lib/vutuv/account_events.ex
+++ b/lib/vutuv/account_events.ex
@@ -105,7 +105,10 @@ defmodule Vutuv.AccountEvents do
     # Privacy and reach
     "privacy_changed" => ["fields"],
     "notifications_changed" => ["fields"],
-    "fediverse_changed" => ["enabled"],
+    # Both halves, like its three siblings above: which switches the save
+    # carried, plus the state the take-part switch ended in — the one fediverse
+    # setting whose consequences nobody can take back.
+    "fediverse_changed" => ["enabled", "fields"],
     "member_blocked" => ["handle"],
     "member_unblocked" => ["handle"],
     "filter_added" => ["filter_kind"],

--- a/lib/vutuv_web/views/account_event_text.ex
+++ b/lib/vutuv_web/views/account_event_text.ex
@@ -152,17 +152,27 @@ defmodule VutuvWeb.AccountEventText do
     ngettext("%{count} post", "%{formatted} posts", count, formatted: UI.delimited_count(count))
   end
 
-  defp detail("fediverse_changed", %{"enabled" => true}),
-    do: gettext("taking part in the Fediverse")
-
-  defp detail("fediverse_changed", %{"enabled" => false}),
-    do: gettext("not taking part in the Fediverse")
-
-  defp detail(_kind, %{"fields" => fields}) when is_list(fields) and fields != [] do
-    Enum.map_join(fields, ", ", &field_label/1)
+  # The fediverse save is the one that says both things: which switches it
+  # carried, and where the take-part switch stands afterwards — the setting
+  # whose consequences nobody can take back, and the reason a row reading only
+  # "Fediverse participation" would leave the member guessing which way it went.
+  defp detail("fediverse_changed", %{"enabled" => enabled} = details)
+       when is_boolean(enabled) do
+    case field_list(details) do
+      nil -> participation_label(enabled)
+      fields -> fields <> " · " <> participation_label(enabled)
+    end
   end
 
-  defp detail(_kind, _details), do: nil
+  defp detail(_kind, details), do: field_list(details)
+
+  defp field_list(%{"fields" => fields}) when is_list(fields) and fields != [],
+    do: Enum.map_join(fields, ", ", &field_label/1)
+
+  defp field_list(_details), do: nil
+
+  defp participation_label(true), do: gettext("taking part in the Fediverse")
+  defp participation_label(false), do: gettext("not taking part in the Fediverse")
 
   @doc """
   How the change was confirmed, as a phrase to hang off the row. `nil` for a

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.300.6",
+      version: "7.300.7",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/account_event_hooks_test.exs
+++ b/test/vutuv_web/account_event_hooks_test.exs
@@ -156,6 +156,21 @@ defmodule VutuvWeb.AccountEventHooksTest do
       assert event.details["fields"] == ["noindex?"]
     end
 
+    test "a fediverse save records both the participation state and the fields", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      {:ok, _on} = Vutuv.Accounts.update_user(user, %{"fediverse_followers?" => "true"})
+
+      # No acknowledgement needed: this save leaves the take-part switch alone.
+      put(conn, ~p"/settings/fediverse",
+        user: %{"fediverse_followers?" => "true", "fediverse_reactions?" => "false"}
+      )
+
+      assert [event] = events(user, "fediverse_changed")
+      assert event.details["enabled"] == true
+
+      assert event.details["fields"] == ["fediverse_followers?", "fediverse_reactions?"]
+    end
+
     test "a content filter records its kind, never the muted word", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
 

--- a/test/vutuv_web/live/account_activity_live_test.exs
+++ b/test/vutuv_web/live/account_activity_live_test.exs
@@ -134,6 +134,25 @@ defmodule VutuvWeb.AccountActivityLiveTest do
     end
   end
 
+  # Issue #1511: the kind declared only "enabled" while the settings controller
+  # sent "fields" beside it, so every fediverse save was rejected by the
+  # changeset and this row never existed.
+  test "a fediverse save reads as the switches touched plus where they stand", %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+
+    :ok =
+      AccountEvents.record(user, "fediverse_changed",
+        details: %{fields: ["fediverse_followers?", "fediverse_reactions?"], enabled: true}
+      )
+
+    {:ok, live, _html} = live(conn, ~p"/settings/activity")
+
+    row = live |> element("#activity-events") |> render()
+    assert row =~ "Fediverse settings changed"
+    assert row =~ "Fediverse participation, Fediverse reactions"
+    assert row =~ "taking part in the Fediverse"
+  end
+
   test "an event somebody else caused is marked as such", %{conn: conn} do
     {conn, user} = create_and_login_user(conn)
     admin = insert(:user, admin?: true)


### PR DESCRIPTION
Behebt #1511.

Die Art `fediverse_changed` erlaubte im Register nur `enabled`, der Speichern-Zweig
schickte aber `fields` daneben. Der Changeset wies deshalb jede Zeile ab, `record/3`
protokollierte das und gab `:ok` zurück, und auf `/settings/activity` erschien nie eine
Zeile. Jetzt nennt die Art beide Schlüssel, wie ihre drei Geschwister.

Die Zeile liest sich als die berührten Schalter plus der Stand der Teilnahme
("Fediverse-Teilnahme, Fediverse-Reaktionen · Teilnahme am Fediverse"). Vorher wäre sie
bei jedem Speichern derselbe Zustandssatz gewesen, egal welcher Schalter bewegt wurde,
und die vier Feldnamen in `field_label/1` blieben tot.

Zwei Tests, beide gegen den alten Stand kalibriert: der Hook-Test (die Zeile entsteht
überhaupt) und der Seiten-Test (sie liest sich richtig). `mix precommit` grün.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*
