### PR TITLE
Der andere Reiter meldet sich, wenn dort etwas landet (v7.302.0)

### DIFF
--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -412,6 +412,38 @@ the feed is open sees the bar on their next load. An empty *tab* keeps the bar
 (reachable once the content leaves under the reader — muting the account it
 came from), or they would be stranded on a tab they cannot leave.
 
+**A tab you are not on says something landed there** (issue #1503) — a coral
+dot beside its label (`post_filter_tabs/1`'s `unseen`), cleared by going there
+(`load_source_filter/2` → `clear_unseen/2`; "All" clears both, a named tab only
+itself). A dot and no count: what the reader needs is that there is something
+over there, and the tab reloads from the top anyway. The socket's
+`:unseen_sources` is never stored — it means "since you have been looking at
+this page", so a fresh mount starting clean is the honest state.
+
+The two halves reach it differently, and the difference is what each write
+knows about the reader:
+
+* **A vutuv post is already broadcast.** `insert_entry/3` used to drop an
+  arrival the open tab cannot hold; now it dots that tab's source instead. The
+  tab check moved **below** `Posts.visible_to?/2` for it: while the answer was
+  "do nothing" the order was free, and it is not free for a dot — lighting a
+  tab for a post the reader is turned away from is exactly the lie to avoid.
+  A regression test is calibrated against the old order.
+* **A fediverse arrival broadcast nothing at all**, so the four writes that put
+  a row on that side now send a bare nudge to the local followers of the account
+  or the resharer: `record_remote_post/2`, `record_remote_boost/2` (both to the
+  followers of the sending account — the boost path reads its row back first,
+  because `ON CONFLICT DO NOTHING` cannot say whether *this* delivery wrote it
+  and an `Announce` arrives once per follower), `repost_remote_post/2` and
+  `repost_note/2` (the resharer plus their unmuted followers here). The nudge
+  carries the stamp the entry will wear in the merged feed and nothing else:
+  whether the row reaches this particular reader depends on their mute, the
+  follow's state, the audience and their language filter, so the feed asks its
+  own sources (`Posts.feed_source_since?/3`, one `LIMIT 1` per source with
+  `Enum.any?/2` short-circuiting, the shape `fediverse_feed_available?/1` uses).
+  Only the tab the reader is **not** on is probed — "All" holds both halves, so
+  nothing ever landed elsewhere — and a member with no tab bar pays no query.
+
 **The discovery rail renders with the page.** The rail (Tags you follow / Who
 to follow / Suggested posts) was lazily loaded for one release (v7.200.3: an
 empty aside plus a `LazyRails` hook asking for it after connect), and the

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -1540,6 +1540,61 @@ defmodule Vutuv.Fediverse do
     |> Enum.each(&Activity.broadcast(&1, :remote_followers_changed))
   end
 
+  ## Telling open feeds that something landed on the other tab (issue #1503)
+
+  # A bare "go and look", never a payload: an open /feed sitting on the tab this
+  # did NOT land on asks its own sources whether the arrival reaches this
+  # particular reader (`Vutuv.Posts.feed_source_since?/3`) and dots the other
+  # tab if it does. It has to ask, because mute, a follow still merely
+  # requested, a narrowed audience, the reader's language filter and the
+  # resharer's standing all decide per member — none of which is knowable from
+  # the write. `at` is the stamp the entry will carry in the merged feed
+  # (naive UTC, like every `Vutuv.FeedPage` entry), so the reader's own newest
+  # row can be compared against it.
+  #
+  # Every other subscriber of the member topic ignores this through its
+  # catch-all `handle_info/2`, exactly like `:remote_follows_changed` above.
+  defp nudge_feeds(user_ids, %NaiveDateTime{} = at) do
+    event = {:remote_feed_arrival, %{at: at}}
+
+    user_ids
+    |> Enum.uniq()
+    |> Enum.each(&Activity.broadcast(&1, event))
+  end
+
+  # Who to nudge when an account out there posts: the members following it here
+  # with the follow unmuted. Mute is the one per-member gate this can answer
+  # itself — it hangs off the very row being joined — and answering it here
+  # spares every muted follower a message and a probe. `user_id` is null for a
+  # page's follow (issue #1336); a page has no open feed to dot.
+  defp followers_of_account(%RemoteAccount{id: account_id}, filters \\ []) do
+    from(f in Follow,
+      where: f.remote_account_id == ^account_id and f.muted == false,
+      where: not is_nil(f.user_id),
+      select: f.user_id
+    )
+    |> accepted_only(filters[:accepted])
+    |> Repo.all()
+  end
+
+  defp accepted_only(query, true), do: where(query, [f], f.state == "accepted")
+  defp accepted_only(query, _any), do: query
+
+  # Who to nudge when a member here passes something on: themselves (their own
+  # reshare is a row in their own feed) plus everyone whose follow of them is
+  # unmuted — the audience `feed_remote_reposts/3` and its note twin scope to.
+  defp resharer_audience(%User{id: user_id}) do
+    followers =
+      Repo.all(
+        from(f in Vutuv.Social.Follow,
+          where: f.followee_id == ^user_id and f.muted == false,
+          select: f.follower_id
+        )
+      )
+
+    [user_id | followers]
+  end
+
   # The members here who follow one of these remote accounts. Read **before** a
   # delete of those accounts: their follows cascade away with them, so asked
   # afterwards the answer is always "nobody" and the page never hears about it.
@@ -2294,6 +2349,11 @@ defmodule Vutuv.Fediverse do
          true <- own_thread?(object, account),
          {:ok, post} <- insert_remote_post(account, object, audience) do
       attach_pictures(post, object)
+      # Only the row this delivery really wrote: the same post arrives once per
+      # local follower until every server speaks to our shared inbox, and each
+      # redelivery leaves the `with` as a `:skip` above, so open feeds are
+      # nudged exactly once rather than once per follower squared.
+      nudge_feeds(followers_of_account(account), DateTime.to_naive(post.published_at))
       :ok
     else
       _ -> :skip
@@ -6078,6 +6138,29 @@ defmodule Vutuv.Fediverse do
     end
   end
 
+  # Wraps the two acts of `outbound_act/3` that are also **feed sources** — a
+  # member passing a cached post or a reply on — so open feeds hear about it
+  # (issue #1503). The two hearts beside them are not wrapped: a like changes a
+  # figure on a card, it puts no row in anybody's timeline.
+  #
+  # The stamp is taken **before** the write, never after: the reader's feed asks
+  # for a row at or after it, and a stamp read afterwards can sit a tick past
+  # the very row it is meant to find. Only a reshare that was really written
+  # says anything — a second tab's press answers `{:ok, :already}` and has
+  # nothing new to point at.
+  defp with_feed_nudge(%User{} = user, act) do
+    at = NaiveDateTime.utc_now(:second)
+
+    case act.() do
+      {:ok, :reposted} = written ->
+        nudge_feeds(resharer_audience(user), at)
+        written
+
+      other ->
+        other
+    end
+  end
+
   # The member as they stand **now**, for the same reason the subject above is
   # re-read: the card was rendered at some earlier moment (issue #1349). Their
   # own copy came from a LiveView mount and every gate here asks about their
@@ -6657,7 +6740,7 @@ defmodule Vutuv.Fediverse do
   decided from the struct the page rendered with.
   """
   def repost_note(%User{} = user, %Note{} = note),
-    do: outbound_act(user, note, note_repost())
+    do: with_feed_nudge(user, fn -> outbound_act(user, note, note_repost()) end)
 
   @doc """
   The member takes the reshare back: drops the row and queues the matching
@@ -7275,8 +7358,48 @@ defmodule Vutuv.Fediverse do
     %PostBoost{remote_account_id: account.id}
     |> PostBoost.changeset(attrs)
     |> Repo.insert(on_conflict: :nothing)
+    |> nudge_boost_feeds(account, target, attrs.announced_at)
 
     :ok
+  end
+
+  # An `Announce` is delivered once per local follower too, so the nudge has to
+  # know whether *this* delivery wrote the row. `DO NOTHING` cannot say (the id
+  # is minted here, not by Postgres, so the struct comes back looking inserted
+  # either way), so the row is read back by what the unique indexes cover and
+  # its id compared — the same read-back `stored_post/2` does for a cached post.
+  #
+  # Which tab lights up follows what was boosted, not where it came from: a
+  # followed account passing a **member's** post on is a vutuv-tab entry
+  # (issue #1167), and the reader may be sitting on the Fediverse tab when it
+  # lands.
+  defp nudge_boost_feeds({:ok, %PostBoost{id: minted}}, account, target, announced_at) do
+    if stored_boost_id(account, target) == minted do
+      nudge_feeds(
+        followers_of_account(account, accepted: true),
+        DateTime.to_naive(announced_at)
+      )
+    end
+  end
+
+  defp nudge_boost_feeds(_result, _account, _target, _announced_at), do: :ok
+
+  defp stored_boost_id(%RemoteAccount{id: account_id}, %RemotePost{id: post_id}) do
+    Repo.one(
+      from(b in PostBoost,
+        where: b.remote_account_id == ^account_id and b.remote_post_id == ^post_id,
+        select: b.id
+      )
+    )
+  end
+
+  defp stored_boost_id(%RemoteAccount{id: account_id}, %Post{id: post_id}) do
+    Repo.one(
+      from(b in PostBoost,
+        where: b.remote_account_id == ^account_id and b.post_id == ^post_id,
+        select: b.id
+      )
+    )
   end
 
   defp boost_target(%RemotePost{id: id}), do: %{remote_post_id: id}
@@ -7628,7 +7751,7 @@ defmodule Vutuv.Fediverse do
   decided from the struct the page rendered with.
   """
   def repost_remote_post(%User{} = user, %RemotePost{} = post),
-    do: outbound_act(user, post, remote_post_repost())
+    do: with_feed_nudge(user, fn -> outbound_act(user, post, remote_post_repost()) end)
 
   @doc """
   The member takes the boost back: drops the row and queues the matching

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -2466,6 +2466,39 @@ defmodule Vutuv.Posts do
     |> Enum.any?(fn fetch -> fetch.(1, nil) != [] end)
   end
 
+  @doc """
+  Whether the tab `source` has anything for `viewer` stamped at or after
+  `since` — what the feed asks before dotting a tab it is not looking at
+  (issue #1503).
+
+  Same shape as `fediverse_feed_available?/1` one question narrower, and for
+  the same reason: **only the reader's own sources know whether a post reaches
+  them**. A mute, a follow still merely requested, an audience narrower than
+  public, a language they filter out and the resharer's own standing all decide
+  per member, so the write that triggered this cannot fan out an answer — it
+  can only say "something landed, go and look". Each source is asked for its
+  newest row and `Enum.any?/2` stops at the first that qualifies.
+
+  It answers "there is something at the top of that tab at least as new as what
+  just landed", not "that exact post reached you". The two come apart only when
+  a server delivers a post published well before now: then the row this finds
+  is the tab's newest rather than the arrival. A tab with fresh content at the
+  top is still what the dot promises, so that is the conservative side to err
+  on — the side it must never err on is a post the reader may not see, which is
+  why the sources answer rather than the fan-out.
+  """
+  def feed_source_since?(%User{} = viewer, source, %NaiveDateTime{} = since)
+      when source in [:vutuv, :fediverse] do
+    viewer
+    |> feed_sources(source)
+    |> Enum.any?(fn fetch ->
+      case fetch.(1, nil) do
+        [entry | _] -> NaiveDateTime.compare(entry.at, since) != :lt
+        [] -> false
+      end
+    end)
+  end
+
   # Everything the six sources produce, made ready to render.
   #
   # The remote sources (issues #1161, #1166) carry a cached post from another network,

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -475,6 +475,11 @@ defmodule VutuvWeb.PostComponents do
   pill, which reads on white and on the canvas alike. That is the same
   vocabulary the shell's top-bar nav uses for the page you are on, so "which
   of these am I on" looks the same everywhere in the app.
+
+  `unseen` dots the tabs holding something the reader has not seen (issue
+  #1503) — the coral dot the notifications list wears, and a dot rather than a
+  count because the host knows *that* something landed there, not how much.
+  The active tab never carries one whatever is passed: you are looking at it.
   """
   attr(:active, :string, required: true)
   attr(:event, :string, default: nil, doc: "phx-click event name → button mode")
@@ -484,6 +489,8 @@ defmodule VutuvWeb.PostComponents do
     default: nil,
     doc: "value/label pairs; defaults to post_filter_options/0"
   )
+
+  attr(:unseen, :list, default: [], doc: "tab values carrying an unseen dot")
 
   attr(:rest, :global, doc: "container attrs, e.g. an id for tests")
 
@@ -506,7 +513,7 @@ defmodule VutuvWeb.PostComponents do
           aria-pressed={to_string(@active == value)}
           class={post_filter_tab_class(@active == value)}
         >
-          {label}
+          {label}<.unseen_dot show={value != @active and value in @unseen} />
         </button>
         <.link
           :if={!@event}
@@ -515,10 +522,28 @@ defmodule VutuvWeb.PostComponents do
           aria-current={@active == value && "page"}
           class={post_filter_tab_class(@active == value)}
         >
-          {label}
+          {label}<.unseen_dot show={value != @active and value in @unseen} />
         </.link>
       <% end %>
     </div>
+    """
+  end
+
+  # The unseen marker: the same 8px coral dot an unread notification row wears,
+  # here riding beside the label rather than over it — a tab is text, so there
+  # is no icon to sit on the corner of. Screen readers get the word; the dot
+  # carries no number, so there is nothing else to say.
+  attr(:show, :boolean, required: true)
+
+  defp unseen_dot(assigns) do
+    ~H"""
+    <span
+      :if={@show}
+      data-post-filter-unseen
+      class="ml-1.5 inline-block h-2 w-2 rounded-full bg-accent align-middle"
+    >
+      <span class="sr-only">{gettext("New")}</span>
+    </span>
     """
   end
 

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -189,6 +189,11 @@ defmodule VutuvWeb.PostLive.Feed do
     # the truth, and the stored column is not read again while the page lives.
     |> assign(:feed_filter, payload.filter)
     |> assign(:source_tabs?, payload.source_tabs?)
+    # The named sources holding something this reader has not seen (issue
+    # #1503), each one a dot on its tab. Socket state on purpose and never
+    # stored: it means "since you have been looking at this page", so a mount
+    # starting clean is the honest state, not a lost one.
+    |> assign(:unseen_sources, MapSet.new())
     |> assign(:more?, payload.more?)
     |> assign(:cursor, payload.cursor)
     |> assign(:empty?, payload.entries == [])
@@ -606,8 +611,18 @@ defmodule VutuvWeb.PostLive.Feed do
     |> assign(:empty?, entries == [])
     |> assign(:pending_posts, [])
     |> assign(:entries, entries)
+    |> clear_unseen(filter)
     |> stream(:posts, entries, reset: true)
   end
+
+  # Landing on a tab clears its dot — the page above is newest-first from the
+  # top, so whatever it was pointing at has now been seen. "All" clears both,
+  # because it shows both; a named tab clears only itself, so a dot waiting on
+  # the other one survives the trip.
+  defp clear_unseen(socket, :all), do: assign(socket, :unseen_sources, MapSet.new())
+
+  defp clear_unseen(socket, source),
+    do: update(socket, :unseen_sources, &MapSet.delete(&1, source))
 
   @impl true
   def handle_info({:new_post, %{post_id: post_id, author_id: author_id}}, socket) do
@@ -690,6 +705,20 @@ defmodule VutuvWeb.PostLive.Feed do
     {:noreply, socket |> assign_who_to_follow() |> assign_discover_posts()}
   end
 
+  # Something landed through the fediverse (issue #1503) — a followed account
+  # posted or boosted, or somebody here passed a remote post or reply on. Unlike
+  # `{:new_post, …}` this carries no entry, because whether that write reaches
+  # THIS reader depends on their mutes, their follow states, the audience and
+  # their language filter; so the nudge only says "look", and the feed asks its
+  # own sources (`Posts.feed_source_since?/3`).
+  #
+  # Only the tab the reader is NOT on can be dotted, which is why "All" ignores
+  # this outright: it shows both halves, so nothing landed elsewhere. A member
+  # with no tab bar has nowhere to put a dot and pays no query either.
+  def handle_info({:remote_feed_arrival, %{at: at}}, socket) do
+    {:noreply, dot_other_tab(socket, at)}
+  end
+
   # The viewer followed / unfollowed a tag elsewhere (a tag page in another tab,
   # issue #872): redraw the "Tags you follow" and "Who to follow" rails so an
   # open feed reflects it live. Posts already streamed stay; the new tag's posts
@@ -767,6 +796,42 @@ defmodule VutuvWeb.PostLive.Feed do
 
   def handle_info(_other, socket), do: {:noreply, socket}
 
+  # The dot half of `{:remote_feed_arrival, …}` above. Three cheap refusals
+  # before the query: "All" has no other tab, a member without the tab bar has
+  # nowhere to show one, and a tab already dotted has nothing to learn.
+  defp dot_other_tab(socket, at) do
+    source = other_source(socket.assigns.feed_filter)
+
+    cond do
+      is_nil(source) or not socket.assigns.source_tabs? ->
+        socket
+
+      MapSet.member?(socket.assigns.unseen_sources, source) ->
+        socket
+
+      Posts.feed_source_since?(socket.assigns.current_user, source, at) ->
+        mark_unseen(socket, source)
+
+      true ->
+        socket
+    end
+  end
+
+  # The other named tab — nil on "All", which is both of them at once.
+  defp other_source(:vutuv), do: :fediverse
+  defp other_source(:fediverse), do: :vutuv
+  defp other_source(_all), do: nil
+
+  # The tab values carrying a dot: the named sources holding something unseen,
+  # plus "All", which shows whatever they hold. The component drops the dot on
+  # whichever tab is active, so this never has to know which one that is.
+  defp unseen_tabs(sources) do
+    case Enum.map(sources, &to_string/1) do
+      [] -> []
+      named -> ["all" | named]
+    end
+  end
+
   # Swap in the post's now-screenshot-carrying copy and re-stream the entry in
   # place (update_only, so an off-page id is a harmless no-op). The entry's other
   # fields — engagement, follow edge, repost roster — are preserved.
@@ -822,19 +887,35 @@ defmodule VutuvWeb.PostLive.Feed do
       Social.blocked_between?(user.id, entry.post.user_id) ->
         {:noreply, socket}
 
+      # Visibility is asked FIRST, and the order is the whole correctness of
+      # the dot below (issue #1503): the tab check used to come first and drop
+      # the arrival, which cost nothing while the answer was "do nothing" and
+      # would now light a tab for a post this reader is not allowed to read.
+      not Posts.visible_to?(entry.post, user) ->
+        {:noreply, socket}
+
       # A post nobody on this tab asked for must not be counted by the pill
       # either: the pill's whole promise is that clicking it shows those posts
       # right here.
-      not Posts.feed_filter_accepts?(socket.assigns.feed_filter, entry) ->
-        {:noreply, socket}
-
-      Posts.visible_to?(entry.post, user) ->
+      Posts.feed_filter_accepts?(socket.assigns.feed_filter, entry) ->
         {:noreply, update(socket, :pending_posts, &[decorate(entry, user, socket) | &1])}
 
+      # It belongs on a tab the reader is not looking at, so say so there
+      # rather than dropping it: a dot, not a count — the point is that
+      # something is over there, and the tab reloads from the top anyway.
       true ->
-        {:noreply, socket}
+        {:noreply, mark_unseen(socket, entry_source(entry))}
     end
   end
+
+  # Which named tab an entry belongs to — the two are a partition, so the one
+  # question `remote_feed_entry?/1` answers decides it.
+  defp entry_source(entry) do
+    if Posts.remote_feed_entry?(entry), do: :fediverse, else: :vutuv
+  end
+
+  defp mark_unseen(socket, source),
+    do: update(socket, :unseen_sources, &MapSet.put(&1, source))
 
   # A newly streamed reply renders the post it answers inline (the threaded
   # card), so drop the parent's standalone row — from the stream and from any
@@ -1146,13 +1227,17 @@ defmodule VutuvWeb.PostLive.Feed do
           it is false on an installation with the fediverse switched off. A
           feed with fediverse content in it is never empty, so no separate
           empty-feed check is needed — and an empty *tab* keeps the bar, or
-          there would be no way back. --%>
+          there would be no way back.
+
+          A tab holding something that landed while the reader was on another
+          one wears a coral dot (issue #1503), cleared by going there. --%>
           <.post_filter_tabs
             :if={@source_tabs?}
             id="feed-source-tabs"
             active={to_string(@feed_filter)}
             event="filter-source"
             options={feed_filter_options()}
+            unseen={unseen_tabs(@unseen_sources)}
           />
 
           <div :if={@pending_posts != []} class="text-center">

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.301.0",
+      version: "7.302.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/fediverse_feed_arrival_test.exs
+++ b/test/vutuv/fediverse_feed_arrival_test.exs
@@ -1,0 +1,302 @@
+defmodule Vutuv.FediverseFeedArrivalTest do
+  @moduledoc """
+  The nudge an open /feed needs to dot a tab it is not looking at (issue #1503).
+
+  Four writes put a row on the Fediverse side of somebody's timeline — a
+  followed account posting or boosting, and a member here passing a cached post
+  or a reply on — and none of them told anybody. The point of this file is that
+  all four now do, that they say it **once** however often the same activity is
+  delivered, and that they say it to the people whose feed the row can actually
+  reach.
+
+  What they deliberately do NOT say is whether the reader may see it: that is
+  the feed's own question (`Vutuv.Posts.feed_source_since?/3`), because mute,
+  follow state, audience and the language filter all answer differently per
+  member.
+
+  `async: false` — the inbound cap and the outbound budget live in the shared
+  `Vutuv.RateLimiter` ETS table, which the SQL sandbox does not roll back.
+  """
+  use Vutuv.DataCase, async: false
+
+  alias Vutuv.Activity
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Follow
+  alias Vutuv.Fediverse.Note
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.Posts
+
+  @actor "https://social.example/users/them"
+  @inbox @actor <> "/inbox"
+  @public "https://www.w3.org/ns/activitystreams#Public"
+
+  setup do
+    Vutuv.RateLimiter.reset()
+    :ok
+  end
+
+  defp account do
+    Repo.insert!(%RemoteAccount{
+      actor_uri: @actor,
+      host: "social.example",
+      handle: "them",
+      name: "Thea Remote",
+      inbox_uri: @inbox
+    })
+  end
+
+  defp federating_member do
+    user = insert(:activated_user, fediverse_followers?: true)
+    {:ok, _actor} = Fediverse.ensure_actor(user)
+    Repo.reload!(user)
+  end
+
+  defp follow(user, acc, attrs \\ []) do
+    Repo.insert!(%Follow{
+      user_id: user.id,
+      remote_account_id: acc.id,
+      state: attrs[:state] || "accepted",
+      muted: attrs[:muted] || false,
+      follow_activity_id: "https://vutuv.test/#{user.id}/actor#f/#{acc.id}"
+    })
+  end
+
+  defp create_activity(overrides \\ %{}) do
+    unique = System.unique_integer([:positive])
+
+    object =
+      Map.merge(
+        %{
+          "id" => "https://social.example/posts/#{unique}",
+          "type" => "Note",
+          "attributedTo" => @actor,
+          "content" => "<p>Frisch von drüben.</p>",
+          "url" => "https://social.example/@them/#{unique}",
+          "published" => DateTime.to_iso8601(DateTime.utc_now(:second)),
+          "to" => [@public]
+        },
+        overrides
+      )
+
+    %{"type" => "Create", "actor" => @actor, "object" => object}
+  end
+
+  defp announce(object_url) do
+    %{
+      "id" => @actor <> "#announces/#{System.unique_integer([:positive])}",
+      "type" => "Announce",
+      "actor" => @actor,
+      "published" => DateTime.to_iso8601(DateTime.utc_now(:second)),
+      "object" => object_url
+    }
+  end
+
+  defp cached_post do
+    now = DateTime.utc_now(:second)
+
+    Repo.insert!(%RemotePost{
+      remote_account_id: account().id,
+      object_uri: "https://social.example/p/#{System.unique_integer([:positive])}",
+      content_text: "Lesenswert.",
+      audience: "public",
+      kind: "note",
+      published_at: now,
+      received_at: now,
+      expires_at: DateTime.add(now, 86_400)
+    })
+    |> Repo.preload(:remote_account)
+  end
+
+  defp note do
+    now = DateTime.utc_now(:second)
+
+    Repo.insert!(%Note{
+      post_id: insert(:post, user: insert(:activated_user)).id,
+      object_uri: "https://social.example/n/#{System.unique_integer([:positive])}",
+      actor_uri: @actor,
+      origin_url: "https://social.example/@them/1",
+      handle: "them",
+      display_name: "Thea Remote",
+      content_text: "Eine Antwort von drüben.",
+      audience: "public",
+      inbox_uri: @inbox,
+      received_at: now,
+      checked_at: now,
+      expires_at: DateTime.add(now, 86_400)
+    })
+  end
+
+  describe "what a followed account writes" do
+    test "a post reaches the local followers' open feeds" do
+      acc = account()
+      reader = insert(:activated_user)
+      follow(reader, acc)
+      Activity.subscribe(reader.id)
+
+      assert :ok = Fediverse.record_remote_post(create_activity(), @actor)
+
+      assert_receive {:remote_feed_arrival, %{at: %NaiveDateTime{}}}
+    end
+
+    test "the stamp is the post's own publication time, not the delivery's" do
+      # The feed compares it against the newest row it can already see, so it
+      # has to be the stamp that row would carry in the merged timeline.
+      acc = account()
+      reader = insert(:activated_user)
+      follow(reader, acc)
+      Activity.subscribe(reader.id)
+
+      published = "2026-07-20T09:00:00Z"
+
+      assert :ok =
+               Fediverse.record_remote_post(create_activity(%{"published" => published}), @actor)
+
+      assert_receive {:remote_feed_arrival, %{at: at}}
+      assert at == ~N[2026-07-20 09:00:00]
+    end
+
+    test "a redelivery says nothing — it is one post arriving once per follower" do
+      acc = account()
+      reader = insert(:activated_user)
+      follow(reader, acc)
+      Activity.subscribe(reader.id)
+
+      activity = create_activity()
+      assert :ok = Fediverse.record_remote_post(activity, @actor)
+      assert_receive {:remote_feed_arrival, _}
+
+      assert :skip = Fediverse.record_remote_post(activity, @actor)
+      refute_receive {:remote_feed_arrival, _}
+    end
+
+    test "a muted follow is left alone" do
+      # The one per-member gate the fan-out can answer itself: it hangs off the
+      # very follow row being joined, so a muted reader pays neither the message
+      # nor the query behind it.
+      acc = account()
+      reader = insert(:activated_user)
+      follow(reader, acc, muted: true)
+      Activity.subscribe(reader.id)
+
+      assert :ok = Fediverse.record_remote_post(create_activity(), @actor)
+
+      refute_receive {:remote_feed_arrival, _}
+    end
+
+    test "a boost reaches them too, and only once" do
+      acc = account()
+      reader = insert(:activated_user)
+      follow(reader, acc)
+      author = federating_member()
+      {:ok, post} = Posts.create_post(author, %{body: "Von hier."})
+      url = "#{VutuvWeb.Endpoint.url()}/#{author.username}/posts/#{post.id}"
+
+      Activity.subscribe(reader.id)
+      assert :ok = Fediverse.record_remote_boost(announce(url), @actor)
+      assert_receive {:remote_feed_arrival, %{at: %NaiveDateTime{}}}
+
+      # A second `Announce` of the same post collides with the row already
+      # there. `DO NOTHING` cannot report that, which is why the boost path
+      # reads the row back before it says anything.
+      assert :ok = Fediverse.record_remote_boost(announce(url), @actor)
+      refute_receive {:remote_feed_arrival, _}
+    end
+
+    test "a follow still merely requested hears nothing about a boost" do
+      # `feed_remote_boosts/4` shows a boost only on an accepted follow, so a
+      # nudge on a requested one could never lead anywhere. Somebody else's
+      # accepted follow is what gets the boost recorded at all.
+      acc = account()
+      follow(insert(:activated_user), acc)
+      waiting = insert(:activated_user)
+      follow(waiting, acc, state: "requested")
+      author = federating_member()
+      {:ok, post} = Posts.create_post(author, %{body: "Von hier."})
+
+      Activity.subscribe(waiting.id)
+
+      assert :ok =
+               Fediverse.record_remote_boost(
+                 announce("#{VutuvWeb.Endpoint.url()}/#{author.username}/posts/#{post.id}"),
+                 @actor
+               )
+
+      refute_receive {:remote_feed_arrival, _}
+    end
+  end
+
+  describe "what a member here passes on" do
+    test "resharing a cached post tells their followers and themselves" do
+      sharer = federating_member()
+      reader = insert(:activated_user)
+      Vutuv.Social.follow(reader, sharer.id)
+
+      Activity.subscribe(reader.id)
+      Activity.subscribe(sharer.id)
+
+      assert {:ok, :reposted} = Fediverse.repost_remote_post(sharer, cached_post())
+
+      assert_receive {:remote_feed_arrival, %{at: %NaiveDateTime{}}}
+      assert_receive {:remote_feed_arrival, %{at: %NaiveDateTime{}}}
+    end
+
+    test "resharing a reply does the same" do
+      sharer = federating_member()
+      reader = insert(:activated_user)
+      Vutuv.Social.follow(reader, sharer.id)
+      Activity.subscribe(reader.id)
+
+      assert {:ok, :reposted} = Fediverse.repost_note(sharer, note())
+
+      assert_receive {:remote_feed_arrival, %{at: %NaiveDateTime{}}}
+    end
+
+    test "the stamp never lands after the row it points at" do
+      # Read before the write on purpose: the feed asks its sources for a row at
+      # or after this moment, and a stamp taken afterwards can sit a tick past
+      # the very row it is meant to find.
+      sharer = federating_member()
+      Activity.subscribe(sharer.id)
+
+      assert {:ok, :reposted} = Fediverse.repost_remote_post(sharer, cached_post())
+
+      assert_receive {:remote_feed_arrival, %{at: at}}
+      [entry] = Fediverse.feed_remote_reposts(sharer, 1, nil)
+      assert NaiveDateTime.compare(entry.at, at) != :lt
+    end
+
+    test "a second tab pressing the same button says nothing" do
+      sharer = federating_member()
+      post = cached_post()
+      assert {:ok, :reposted} = Fediverse.repost_remote_post(sharer, post)
+
+      Activity.subscribe(sharer.id)
+      assert {:ok, :already} = Fediverse.repost_remote_post(sharer, post)
+
+      refute_receive {:remote_feed_arrival, _}
+    end
+
+    test "a muted follower is left alone" do
+      sharer = federating_member()
+      reader = insert(:activated_user)
+      Vutuv.Social.follow(reader, sharer.id)
+      edge = Vutuv.Social.follow_edge(reader.id, sharer.id)
+      Vutuv.Social.toggle_follow_mute!(reader.id, edge.id)
+
+      Activity.subscribe(reader.id)
+      assert {:ok, :reposted} = Fediverse.repost_remote_post(sharer, cached_post())
+
+      refute_receive {:remote_feed_arrival, _}
+    end
+
+    test "a heart is not a feed row and sends nothing" do
+      sharer = federating_member()
+      Activity.subscribe(sharer.id)
+
+      assert {:ok, :liked} = Fediverse.like_remote_post(sharer, cached_post())
+
+      refute_receive {:remote_feed_arrival, _}
+    end
+  end
+end

--- a/test/vutuv_web/components/post_components_test.exs
+++ b/test/vutuv_web/components/post_components_test.exs
@@ -99,4 +99,32 @@ defmodule VutuvWeb.PostComponentsTest do
       refute html =~ "py-1 "
     end
   end
+
+  describe "post_filter_tabs/1 unseen dots (issue #1503)" do
+    # How many tabs the given markup dots.
+    defp dots(html), do: length(String.split(html, "data-post-filter-unseen")) - 1
+
+    test "no dots at all unless a caller asks for them" do
+      # The profile and the `/:slug/posts` archive pass no `unseen`, and their
+      # tabs must look exactly as they did.
+      assert dots(tabs_html()) == 0
+    end
+
+    test "an inactive tab named in unseen wears the coral dot" do
+      html = tabs_html(active: "all", unseen: ["reposts"])
+
+      assert dots(html) == 1
+      assert html =~ "bg-accent"
+      # Icon-free and count-free, so the word is the whole accessible name.
+      assert html =~ "sr-only"
+    end
+
+    test "the active tab never dots, whatever it is passed" do
+      # You are looking at it — the feed's own bookkeeping should never send
+      # this, and the control must not be able to contradict itself if it does.
+      html = tabs_html(active: "reposts", unseen: ["all", "reposts"])
+
+      assert dots(html) == 1
+    end
+  end
 end

--- a/test/vutuv_web/live/feed_source_tabs_test.exs
+++ b/test/vutuv_web/live/feed_source_tabs_test.exs
@@ -448,4 +448,209 @@ defmodule VutuvWeb.FeedSourceTabsTest do
       assert has_element?(view, "[data-post-filter-tab='all'][aria-pressed='true']")
     end
   end
+
+  describe "the tab you are not on says something landed there (issue #1503)" do
+    setup do
+      # `record_remote_post/2` claims the shared inbound cap, which lives in the
+      # RateLimiter's ETS table and outlives a test.
+      Vutuv.RateLimiter.reset()
+      :ok
+    end
+
+    defp dotted?(view, tab) do
+      has_element?(
+        view,
+        "#feed-source-tabs [data-post-filter-tab='#{tab}'] [data-post-filter-unseen]"
+      )
+    end
+
+    # A Create as the servers out there send one, from an account this member
+    # already follows.
+    defp remote_note(account, published \\ DateTime.utc_now(:second)) do
+      unique = System.unique_integer([:positive])
+
+      %{
+        "type" => "Create",
+        "actor" => account.actor_uri,
+        "object" => %{
+          "id" => "https://social.example/posts/#{unique}",
+          "type" => "Note",
+          "attributedTo" => account.actor_uri,
+          "content" => "<p>frisch von drüben</p>",
+          "url" => "https://social.example/@#{account.handle}/#{unique}",
+          "published" => DateTime.to_iso8601(published),
+          "to" => ["https://www.w3.org/ns/activitystreams#Public"]
+        }
+      }
+    end
+
+    test "a vutuv post arriving on the Fediverse tab dots vutuv and All", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      {author, _post} = followed_post(user, "an older post")
+      cached_post(remote_account(user, "them"), "written out there")
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "filter-source", %{"type" => "fediverse"})
+
+      {:ok, _fresh} = Posts.create_post(author, %{body: "arriving live"})
+
+      assert dotted?(view, "vutuv")
+      # "All" would show it too, so it says so.
+      assert dotted?(view, "all")
+      # You are looking at this one, so nothing on it can be unseen.
+      refute dotted?(view, "fediverse")
+    end
+
+    test "landing on the tab clears its dot", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      {author, _post} = followed_post(user, "an older post")
+      cached_post(remote_account(user, "them"), "written out there")
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "filter-source", %{"type" => "fediverse"})
+      {:ok, _fresh} = Posts.create_post(author, %{body: "arriving live"})
+      assert dotted?(view, "vutuv")
+
+      render_click(view, "filter-source", %{"type" => "vutuv"})
+
+      assert timeline(view) =~ "arriving live"
+      # Gone from "All" as well: the only thing it was standing for is read.
+      refute dotted?(view, "all")
+
+      render_click(view, "filter-source", %{"type" => "fediverse"})
+      refute dotted?(view, "vutuv")
+    end
+
+    test "a post the reader may not see dots nothing", %{conn: conn} do
+      # Calibrated against the un-fixed order: `insert_entry/3` used to drop an
+      # arrival on the wrong tab BEFORE asking `visible_to?/2`, which cost
+      # nothing while the answer was "do nothing" and would now light a tab for
+      # a post this member is turned away from.
+      {conn, user} = create_and_login_user(conn)
+      {author, _post} = followed_post(user, "an older post")
+      cached_post(remote_account(user, "them"), "written out there")
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "filter-source", %{"type" => "fediverse"})
+
+      # Only people the author follows — and they do not follow this reader.
+      {:ok, _denied} =
+        Posts.create_post(author, %{
+          body: "not for you",
+          denials: [%{"wildcard" => "non_followees"}]
+        })
+
+      refute dotted?(view, "vutuv")
+      refute dotted?(view, "all")
+    end
+
+    test "a post from another network dots the Fediverse tab", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      {_author, _post} = followed_post(user, "written here on vutuv")
+      account = remote_account(user, "them")
+      cached_post(account, "written out there")
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "filter-source", %{"type" => "vutuv"})
+
+      assert :ok = Fediverse.record_remote_post(remote_note(account), account.actor_uri)
+
+      assert dotted?(view, "fediverse")
+      assert dotted?(view, "all")
+      refute dotted?(view, "vutuv")
+
+      render_click(view, "filter-source", %{"type" => "fediverse"})
+      assert timeline(view) =~ "frisch von drüben"
+      refute dotted?(view, "all")
+    end
+
+    test "a post the reader's own follow does not open dots nothing", %{conn: conn} do
+      # The calibration for the probe: the nudge reaches this member (their
+      # follow is not muted, so the fan-out has nothing to go on), and only
+      # their own sources know that a follow nobody has answered yet does not
+      # open that account's followers-only posts. Skip the probe and the dot
+      # lights up here.
+      {conn, user} = create_and_login_user(conn)
+      {_author, _post} = followed_post(user, "written here on vutuv")
+
+      # An account they asked to follow and that has not answered. Its older
+      # public post is readable, so the tab bar shows and the probe has a real
+      # row to answer with.
+      account = remote_account("private")
+
+      Repo.insert!(%Follow{
+        user_id: user.id,
+        remote_account_id: account.id,
+        state: "requested",
+        follow_activity_id: "https://vutuv.test/#{user.id}/actor#follows/private"
+      })
+
+      old = cached_post(account, "an earlier public post")
+      two_hours_ago = DateTime.add(DateTime.utc_now(:second), -7200)
+      Repo.update!(Ecto.Changeset.change(old, published_at: two_hours_ago))
+
+      # Somebody else's accepted follow is what gets the delivery recorded.
+      Repo.insert!(%Follow{
+        user_id: insert(:user, email_confirmed?: true).id,
+        remote_account_id: account.id,
+        state: "accepted",
+        follow_activity_id: "https://vutuv.test/other/actor#follows/private"
+      })
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "filter-source", %{"type" => "vutuv"})
+
+      followers_only =
+        put_in(remote_note(account), ["object", "to"], [account.actor_uri <> "/followers"])
+
+      assert :ok = Fediverse.record_remote_post(followers_only, account.actor_uri)
+
+      refute dotted?(view, "fediverse")
+      refute dotted?(view, "all")
+    end
+
+    test "a muted account's post dots nothing", %{conn: conn} do
+      # The reader's mute is the one per-member gate the fan-out can answer
+      # itself, so this one never even leaves the write.
+      {conn, user} = create_and_login_user(conn)
+      {_author, _post} = followed_post(user, "written here on vutuv")
+
+      # One account whose old post keeps the tab bar on screen…
+      old = cached_post(remote_account(user, "seen"), "read long ago")
+      two_hours_ago = DateTime.add(DateTime.utc_now(:second), -7200)
+      Repo.update!(Ecto.Changeset.change(old, published_at: two_hours_ago))
+
+      # …and one this member muted.
+      muted = remote_account(user, "muted")
+
+      Repo.get_by!(Follow, remote_account_id: muted.id)
+      |> Ecto.Changeset.change(muted: true)
+      |> Repo.update!()
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      render_click(view, "filter-source", %{"type" => "vutuv"})
+
+      assert :ok = Fediverse.record_remote_post(remote_note(muted), muted.actor_uri)
+
+      refute dotted?(view, "fediverse")
+      refute dotted?(view, "all")
+    end
+
+    test "the All tab is never dotted while it is the open one", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      {author, _post} = followed_post(user, "an older post")
+      account = remote_account(user, "them")
+      cached_post(account, "written out there")
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      {:ok, _fresh} = Posts.create_post(author, %{body: "arriving live"})
+      assert :ok = Fediverse.record_remote_post(remote_note(account), account.actor_uri)
+
+      # "All" holds both halves, so nothing landed somewhere else.
+      refute dotted?(view, "all")
+      refute dotted?(view, "vutuv")
+      refute dotted?(view, "fediverse")
+    end
+  end
 end


### PR DESCRIPTION
**TL;DR** Jeder inaktive Quellen-Reiter auf `/feed` trägt einen korallenen Punkt, solange dort etwas Ungesehenes liegt. Der Besuch löscht ihn. Kein Zähler.

**vutuv → Punkt:** kostet nichts, `{:new_post}` kommt ohnehin an. Die Reiter-Prüfung wandert unter `visible_to?/2` — sonst leuchtet der Punkt für einen Beitrag, den das Mitglied nicht lesen darf. Der Regressionstest ist gegen die alte Reihenfolge geeicht.

**Fediverse → Punkt:** alle vier Schreibwege (`record_remote_post/2`, `record_remote_boost/2`, `repost_remote_post/2`, `repost_note/2`) schicken einen Wink an die hiesigen Follower. Er trägt nur den Zeitstempel: ob die Zeile dieses Mitglied erreicht, entscheiden Stummschaltung, Folgestatus, Publikum und Sprachfilter, also fragt der Feed seine eigenen Quellen (`Posts.feed_source_since?/3`, ein `LIMIT 1` je Quelle). Nur der Reiter, auf dem der Leser *nicht* sitzt, wird gefragt.

Der Boost-Weg liest seine Zeile zurück, weil `ON CONFLICT DO NOTHING` nicht sagen kann, ob *diese* Zustellung sie geschrieben hat — ein `Announce` kommt einmal je Follower.

Closes #1503

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*