### PR TITLE
Wer zurückfolgt, bekommt dafür kein Glockensignal (v7.303.2)

### DIFF
--- a/lib/vutuv/activity.ex
+++ b/lib/vutuv/activity.ex
@@ -148,6 +148,12 @@ defmodule Vutuv.Activity do
   # "Became vernetzt" events are derived from mutual follows: the pair's
   # timestamp is the later of the two follow times (GREATEST), matching
   # connection_items/3 below.
+  #
+  # This arm deliberately does NOT drop the pairs the member closed themselves,
+  # the way the badge tally does (`count_connections/3`). The marker may see
+  # more than the tally — that only moves it further forward and empties the
+  # badge sooner. The dangerous direction is the other one: a kind the marker
+  # cannot see never clears its badge (#980, #930, v7.200.1).
   defp connection_max(user_id) do
     from(out in Follow,
       join: back in Follow,
@@ -763,10 +769,12 @@ defmodule Vutuv.Activity do
   #   * `report_protection` is ONE source emitting two event families
   #     (severed / restored) with different timestamp columns — so two max
   #     arms and two counts. That is why both list-valued keys are lists.
-  #   * `unread?` (drop events about posts the member already engaged with,
-  #     `mark_post_seen/2`) only reaches reply / thread / mention — the kinds
-  #     whose subject is somebody else's post (`subject_post_id/1`); every
-  #     other kind ignores it.
+  #   * `unread?` marks the badge tally, as opposed to the pager's total, and
+  #     switches on the two "the member already knows this" exceptions. It
+  #     reaches reply / thread / mention (drop events about posts the member
+  #     engaged with, `mark_post_seen/2` — the kinds whose subject is somebody
+  #     else's post, `subject_post_id/1`) and `connection` (drop the pair the
+  #     member made mutual themselves); every other kind ignores it.
   #   * `cv_update` counts sittings, not rows: its read-marker filter lives
   #     inside the grouped query (`CvUpdates.count_query/2`), not in `since/2`.
   #   * The fediverse kinds key on `received_at` (a :utc_datetime), `username`
@@ -805,7 +813,7 @@ defmodule Vutuv.Activity do
         email_pref: :email_on_follower?,
         max_arms: [connection_max(user_id)],
         items: &connection_items(user_id, &1, &2),
-        counts: [count_connections(user_id, read_at)]
+        counts: [count_connections(user_id, read_at, unread?)]
       },
       %{
         kind: "reply",
@@ -1797,7 +1805,21 @@ defmodule Vutuv.Activity do
   # Mutual follows (vernetzt), counted from the same self-join as
   # connection_items/3; the "became mutual" time is the later of the two
   # follows (GREATEST), so the unread filter matches the items.
-  defp count_connections(user_id, read_at) do
+  #
+  # `closed_by_other?` is the badge's half of it: a pair is two follow rows,
+  # and whoever wrote the later one closed the circle on purpose — telling them
+  # about their own click is what put a badge on the bell for something the
+  # member had just done. The other side still hears about it, because a
+  # follow-back can arrive days after the follow and is real news there. Only
+  # the tally asks; the list (`connection_items/3`) and the pager
+  # (`notifications_count/2`) keep showing the entry to both sides, the same
+  # division of labour `mark_post_seen/2` already draws.
+  #
+  # It reads the **ids**, not `inserted_at`: the column keeps whole seconds, so
+  # a quick follow-back ties there and could not be told apart at all, while a
+  # `Vutuv.UUIDv7` carries sub-millisecond ordering bits (the id order this
+  # module's keyset cursors already rely on).
+  defp count_connections(user_id, read_at, closed_by_other? \\ false) do
     query =
       from(out in Follow,
         join: back in Follow,
@@ -1805,6 +1827,11 @@ defmodule Vutuv.Activity do
         where: out.follower_id == ^user_id,
         select: %{count: count()}
       )
+
+    query =
+      if closed_by_other?,
+        do: where(query, [out, back], back.id > out.id),
+        else: query
 
     if read_at do
       where(

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.303.1",
+      version: "7.303.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/activity_test.exs
+++ b/test/vutuv/activity_test.exs
@@ -864,6 +864,84 @@ defmodule Vutuv.ActivityTest do
     end
   end
 
+  describe "a connection the member closed themselves" do
+    # A vernetzt pair is two follow rows, and the later one closed the circle.
+    # Whoever wrote that row acted on purpose and needs no badge for their own
+    # doing; the other side does, because a follow-back can arrive days later.
+    # Both sides keep the entry in their list — only the badge tells them apart.
+
+    test "does not raise the badge for the member who followed back" do
+      me = insert(:user)
+      other = insert(:user)
+
+      follow!(other, me)
+      follow!(me, other)
+
+      # That someone followed me is news. That my own answer made us vernetzt
+      # is not, so the badge stays at one.
+      assert Activity.unread_notification_count(me.id) == 1
+    end
+
+    test "still raises it on the side that was followed back" do
+      me = insert(:user)
+      other = insert(:user)
+
+      follow!(other, me)
+      follow!(me, other)
+
+      # Same pair, other seat: `me` closed the circle, so `other` learns both
+      # that they were followed and that the two are now vernetzt.
+      assert Activity.unread_notification_count(other.id) == 2
+    end
+
+    test "counts the connection when the other side closes the circle" do
+      me = insert(:user)
+      other = insert(:user)
+
+      follow!(me, other)
+      follow!(other, me)
+
+      # I followed first and was followed back — nothing here is my own doing.
+      assert Activity.unread_notification_count(me.id) == 2
+    end
+
+    test "the list, the pager and the 30-day summary keep counting it" do
+      me = insert(:user)
+      other = insert(:user)
+
+      follow!(other, me)
+      follow!(me, other)
+
+      kinds = me.id |> recent_notifications() |> Enum.map(& &1.kind)
+      assert "connection" in kinds
+
+      # A pager that counted less than its list would offer an empty page.
+      assert Activity.notifications_count(me.id) == length(recent_notifications(me.id))
+      assert Activity.notifications_count(me.id, ["connection"]) == 1
+
+      # The "last 30 days" card is a balance sheet, not an alarm.
+      since = NaiveDateTime.add(NaiveDateTime.utc_now(), -30, :day)
+      assert Activity.activity_summary(me.id, since).connections == 1
+    end
+
+    test "tells the two follows apart within the same second" do
+      me = insert(:user)
+      other = insert(:user)
+
+      # `follows.inserted_at` only keeps seconds, so both rows of a quick
+      # follow-back carry the same timestamp and only their UUID v7 ids say who
+      # was last. A timestamp comparison could not answer this at all.
+      follow!(other, me)
+      follow!(me, other)
+
+      [a, b] =
+        Repo.all(from(c in Follow, where: c.followee_id in [^me.id, ^other.id], select: c))
+
+      assert a.inserted_at == b.inserted_at
+      assert Activity.unread_notification_count(me.id) == 1
+    end
+  end
+
   describe "notifications_count/2" do
     test "counts the whole derived feed regardless of the read marker" do
       me = insert(:user)


### PR DESCRIPTION
**TL;DR** Folge ich jemandem zurück, zählte die Glocke die entstandene Vernetzung als Neuigkeit — obwohl ich sie selbst ausgelöst habe.

**Where:** `Vutuv.Activity.count_connections/3` (`lib/vutuv/activity.ex`)
**Now:** Eine Vernetzung ist aus zwei Follow-Zeilen abgeleitet und trägt die spätere der beiden Zeiten. Wer zurückfolgt, schreibt genau diese Zeile — und bekommt dafür ein Signal an der Glocke.
**Want:** Den Zähler interessiert, **wer den Kreis geschlossen hat**. Meine eigene Zeile zählt nicht, die des anderen schon: ein Follow-Back kann Tage später kommen und ist dort echte Neuigkeit.

Der Vergleich läuft über die UUID-v7-Ids, nicht über `inserted_at` — die Spalte hält nur ganze Sekunden, ein schnelles Zurückfolgen wäre darüber gar nicht unterscheidbar.

Unverändert bleiben die Liste auf `/notifications`, der Pager darunter und die Dreißig-Tage-Karte: dieselbe Arbeitsteilung, die `mark_post_seen/2` schon zieht. Auch der Lesemarker filtert bewusst nicht mit — er darf mehr sehen als der Zähler, die gefährliche Richtung ist die andere (#980, #930).

Fünf Tests, davon zwei gegen den ungefixten Stand rot gesehen.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*