### PR TITLE
Die nächste Versionsnummer fragt, welche schon vergeben sind (v7.305.1)

### DIFF
--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -82,6 +82,14 @@ test suite, and the naive loop ingests its full output once per iteration:
    rebase onto it **before** bumping (or re-bump after the rebase) so the number
    is monotonic.
 
+   The script also **asks `gh` which numbers the open pull requests already
+   claim** and bumps past the highest of them, because `origin/main` alone does
+   not answer the question: an unmerged PR holds the next number for hours while
+   main still looks free, and two branches that pick the same one get no merge
+   conflict and no warning. It names each claim on stderr, and when `gh` cannot
+   answer it says so and bumps from `mix.exs` as before — so this is a backstop,
+   not a guarantee, and step 11's re-check before merging still stands.
+
 5. **Check the working tree** — `git status --short` and `git diff --stat` to see
    everything that changed (your work + any subagent fixes + the bump).
 
@@ -131,12 +139,18 @@ test suite, and the naive loop ingests its full output once per iteration:
       fix to the branch, and watch again. If it stays red or the failure isn't
       yours to fix, stop and report; leave the PR open.
 
-11. **Merge** — squash, delete the branch (the repo convention, same as
-    `/issues`):
+11. **Merge** — but re-read `origin/main`'s version first, then squash and
+    delete the branch (the repo convention, same as `/issues`):
 
     ```bash
+    git fetch origin && git show origin/main:mix.exs | grep -m1 version
     gh pr merge <nr> --squash --delete-branch
     ```
+
+    Another PR can merge while yours sits in CI, and if it took your number
+    there is no conflict to notice: the squash lands your work without moving
+    the version, and one number names two changes. If it moved, rebase, re-bump
+    (step 4), re-run `mix precommit`, and only then merge.
 
     The merge lands on `main` and that push is what starts
     `.github/workflows/deploy.yml`.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.304.1",
+      version: "7.305.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/scripts/bump_version.exs
+++ b/scripts/bump_version.exs
@@ -10,22 +10,141 @@
 # reasoning tokens on a mechanical bump and could drift. Exits non-zero (so a
 # `set -o pipefail` caller notices) if the version line can't be found or the
 # level is unknown.
+#
+# **It bumps past the numbers other open pull requests have already claimed**,
+# not merely past the one in the local file. Bumping from `origin/main` alone is
+# what kept producing collisions: an unmerged PR holds the next number for
+# hours, so main still looks free, both sides write the same version, and
+# because they agree there is no merge conflict and no warning — one number
+# silently ends up naming two unrelated changes (four times on 2026-08-17
+# alone). Every open PR carries its claim in its own mix.exs, so the claims are
+# readable: this asks `gh` for them and starts from the highest.
+#
+# Skipping a number costs nothing if that PR is later closed, so the answer is
+# allowed to be generous. It is a **backstop, not a guarantee**: a PR opened in
+# the seconds after this runs is still invisible, and when `gh` cannot answer at
+# all (missing, unauthenticated, offline) the script says so on stderr and bumps
+# from the local file exactly as before — refusing to bump would block a deploy
+# over a network hiccup, and the fallback is only as wrong as the old behaviour.
+# So the rule it supports stands: re-check `origin/main` immediately before
+# merging.
+#
+# Runs as a plain `elixir` script, so it may use no dependencies: `gh --jq`
+# renders the PR list as tab-separated lines rather than JSON somebody here
+# would have to parse.
+
+re = ~r/version:\s*"(\d+)\.(\d+)\.(\d+)"/
+
+parse = fn source ->
+  case Regex.run(re, source) do
+    [_full, major, minor, patch] ->
+      {String.to_integer(major), String.to_integer(minor), String.to_integer(patch)}
+
+    _ ->
+      nil
+  end
+end
+
+# `{output, 0}` or `{:error, reason}`. Wrapped because a missing executable
+# raises rather than returning a status.
+run = fn command, args ->
+  try do
+    case System.cmd(command, args, stderr_to_stdout: true) do
+      {out, 0} -> {:ok, out}
+      {out, _status} -> {:error, String.trim(out)}
+    end
+  rescue
+    error -> {:error, Exception.message(error)}
+  end
+end
+
+# The branch this bump belongs to: its own PR must not push the number along
+# again every time the script is re-run after a rebase.
+own_branch =
+  case run.("git", ["rev-parse", "--abbrev-ref", "HEAD"]) do
+    {:ok, out} -> String.trim(out)
+    {:error, _} -> nil
+  end
+
+# The version one PR's branch claims, read from that branch's own mix.exs (one
+# small request per PR — the file itself, never the whole diff).
+claim_of = fn sha ->
+  with {:ok, body} <-
+         run.("gh", ["api", "repos/{owner}/{repo}/contents/mix.exs?ref=#{sha}", "--jq", ".content"]),
+       {:ok, decoded} <- Base.decode64(String.replace(body, ["\n", " "], "")) do
+    parse.(decoded)
+  else
+    _unreadable -> nil
+  end
+end
+
+claimed_versions = fn ->
+  case run.("gh", [
+         "pr",
+         "list",
+         "--state",
+         "open",
+         "--json",
+         "number,headRefName,headRefOid",
+         "--jq",
+         ".[] | [.number, .headRefName, .headRefOid] | @tsv"
+       ]) do
+    {:ok, out} ->
+      out
+      |> String.split("\n", trim: true)
+      |> Enum.flat_map(fn line ->
+        case String.split(line, "\t") do
+          [number, branch, sha] when branch != own_branch ->
+            case claim_of.(sha) do
+              nil -> []
+              version -> [{number, version}]
+            end
+
+          _ ->
+            []
+        end
+      end)
+
+    {:error, reason} ->
+      IO.puts(:stderr, "bump_version: could not read the open PRs (#{reason}); using mix.exs only")
+      []
+  end
+end
 
 level = List.first(System.argv()) || "patch"
 path = "mix.exs"
 source = File.read!(path)
 
-re = ~r/version:\s*"(\d+)\.(\d+)\.(\d+)"/
+case parse.(source) do
+  nil ->
+    IO.puts(:stderr, "could not find a `version: \"X.Y.Z\"` line in #{path}")
+    System.halt(1)
 
-case Regex.run(re, source) do
-  [_full, major, minor, patch] ->
-    {major, minor, patch} = {String.to_integer(major), String.to_integer(minor), String.to_integer(patch)}
+  local ->
+    claims = claimed_versions.()
+
+    # Report every claim that constrains this bump, including one equal to the
+    # local number: that is the dangerous case, the one that produces two
+    # changes wearing the same version with no conflict to warn anybody.
+    for {number, {major, minor, patch} = version} <- claims, version >= local do
+      IO.puts(:stderr, "bump_version: PR ##{number} already claims #{major}.#{minor}.#{patch}")
+    end
+
+    # Start from the highest number anybody has taken, so the bump lands past
+    # every claim instead of beside one.
+    {major, minor, patch} = Enum.max([local | Enum.map(claims, &elem(&1, 1))])
 
     {new_major, new_minor, new_patch} =
       case level do
-        "patch" -> {major, minor, patch + 1}
-        "minor" -> {major, minor + 1, 0}
-        "major" -> {major + 1, 0, 0}
+        "patch" ->
+          {major, minor, patch + 1}
+
+        "minor" ->
+          {major, minor + 1, 0}
+
+        "major" ->
+          {major + 1, 0, 0}
+
         other ->
           IO.puts(:stderr, "unknown level #{inspect(other)} (use patch|minor|major)")
           System.halt(1)
@@ -35,8 +154,4 @@ case Regex.run(re, source) do
     new_source = String.replace(source, re, ~s(version: "#{new_version}"), global: false)
     File.write!(path, new_source)
     IO.puts(new_version)
-
-  _ ->
-    IO.puts(:stderr, "could not find a `version: \"X.Y.Z\"` line in #{path}")
-    System.halt(1)
 end

--- a/test/scripts/bump_version_test.exs
+++ b/test/scripts/bump_version_test.exs
@@ -1,0 +1,159 @@
+defmodule Scripts.BumpVersionTest do
+  @moduledoc """
+  `scripts/bump_version.exs` picks the next version number, and the thing it has
+  to get right is not the arithmetic but the **claims**: an open pull request
+  holds its number in its own `mix.exs` for hours before it merges, so `main`
+  still looks free and two branches pick the same one. That produces no merge
+  conflict and no warning (both sides write the same line), so the collision is
+  only noticed afterwards, when one number names two changes.
+
+  Not async: each test runs the script in its own temp directory, but they share
+  the `PATH` a fake `gh` is put on.
+  """
+  use ExUnit.Case, async: false
+
+  @script Path.expand("../../scripts/bump_version.exs", __DIR__)
+
+  setup do
+    dir = Path.join(System.tmp_dir!(), "bump_version_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(Path.join(dir, "bin"))
+    on_exit(fn -> File.rm_rf!(dir) end)
+    %{dir: dir}
+  end
+
+  defp write_mix(dir, version) do
+    File.write!(Path.join(dir, "mix.exs"), """
+    defmodule Fake.MixProject do
+      def project do
+        [app: :fake, version: "#{version}"]
+      end
+    end
+    """)
+  end
+
+  # A `gh` that answers the two calls the script makes: the open-PR list, and
+  # one mix.exs per PR head. `claims` maps a sha to the version that branch
+  # carries. `status` non-zero simulates gh failing (unauthenticated, offline).
+  defp fake_gh(dir, claims, status \\ 0) do
+    listing =
+      claims
+      |> Enum.with_index(1)
+      |> Enum.map_join("\n", fn {{sha, _version}, i} -> "#{1500 + i}\tbranch-#{i}\t#{sha}" end)
+
+    contents =
+      Enum.map_join(claims, "\n", fn {sha, version} ->
+        encoded = Base.encode64(~s(  version: "#{version}"))
+        ~s(    #{sha}) <> ") echo '#{encoded}';;"
+      end)
+
+    path = Path.join([dir, "bin", "gh"])
+
+    File.write!(path, """
+    #!/bin/bash
+    if [ #{status} -ne 0 ]; then echo "stubbed gh failure" >&2; exit #{status}; fi
+    case "$1" in
+      pr) printf '%s\\n' '#{listing}' ;;
+      api)
+        ref="${2##*ref=}"
+        case "$ref" in
+    #{contents}
+          *) echo "no such ref" >&2; exit 1;;
+        esac
+        ;;
+    esac
+    """)
+
+    File.chmod!(path, 0o755)
+    path
+  end
+
+  defp run(dir, level \\ "patch") do
+    env = [{"PATH", Path.join(dir, "bin") <> ":" <> System.get_env("PATH")}]
+
+    {out, status} =
+      System.cmd("elixir", [@script, level], cd: dir, env: env, stderr_to_stdout: true)
+
+    version =
+      File.read!(Path.join(dir, "mix.exs")) |> then(&Regex.run(~r/"([\d.]+)"/, &1)) |> Enum.at(1)
+
+    %{output: out, status: status, version: version}
+  end
+
+  test "bumps past the number an open PR already claims", %{dir: dir} do
+    write_mix(dir, "7.304.0")
+    fake_gh(dir, %{"sha1" => "7.304.1"})
+
+    result = run(dir)
+
+    assert result.status == 0
+    # 7.304.1 is taken, so the patch bump has to land on .2 — bumping from the
+    # local file alone would have produced the very collision this prevents.
+    assert result.version == "7.304.2"
+    assert result.output =~ "already claims 7.304.1"
+  end
+
+  test "an equal claim is reported too: that is the silent case", %{dir: dir} do
+    write_mix(dir, "7.304.0")
+    fake_gh(dir, %{"sha1" => "7.304.0"})
+
+    result = run(dir)
+
+    assert result.version == "7.304.1"
+    assert result.output =~ "already claims 7.304.0"
+  end
+
+  test "a claim below the local number changes nothing", %{dir: dir} do
+    write_mix(dir, "7.304.0")
+    fake_gh(dir, %{"sha1" => "7.300.1"})
+
+    result = run(dir)
+
+    assert result.version == "7.304.1"
+    refute result.output =~ "already claims"
+  end
+
+  test "minor and major bump from the highest claim as well", %{dir: dir} do
+    write_mix(dir, "7.304.0")
+    fake_gh(dir, %{"sha1" => "7.305.3"})
+
+    assert run(dir, "minor").version == "7.306.0"
+
+    write_mix(dir, "7.304.0")
+    assert run(dir, "major").version == "8.0.0"
+  end
+
+  # Refusing to bump would block a deploy over a network hiccup, and the
+  # fallback is only as wrong as the behaviour before this existed — but it must
+  # say so, or a silent fallback reads as "no claims found".
+  test "gh failing warns and still bumps from mix.exs", %{dir: dir} do
+    write_mix(dir, "7.304.0")
+    fake_gh(dir, %{"sha1" => "7.304.9"}, 4)
+
+    result = run(dir)
+
+    assert result.status == 0
+    assert result.version == "7.304.1"
+    assert result.output =~ "could not read the open PRs"
+  end
+
+  test "gh missing entirely is the same degraded path", %{dir: dir} do
+    write_mix(dir, "7.304.0")
+
+    result = run(dir)
+
+    assert result.status == 0
+    assert result.version == "7.304.1"
+    assert result.output =~ "could not read the open PRs"
+  end
+
+  test "an unknown level fails loudly instead of writing a wrong number", %{dir: dir} do
+    write_mix(dir, "7.304.0")
+    fake_gh(dir, %{})
+
+    result = run(dir, "huge")
+
+    assert result.status == 1
+    assert result.version == "7.304.0"
+    assert result.output =~ "unknown level"
+  end
+end


### PR DESCRIPTION
Vier Versionskollisionen an einem Vormittag, alle nach demselben Muster: `origin/main` sieht frei aus, während eine noch nicht gemergte PR die nächste Nummer längst hält. Beide Seiten schreiben dieselbe Zeile, also gibt es weder Merge-Konflikt noch Warnung, und am Ende trägt eine Nummer zwei Änderungen.

Die Ansprüche stehen offen da: jede offene PR führt ihren Bump in ihrer eigenen `mix.exs`. `scripts/bump_version.exs` liest sie jetzt über `gh` (ein kleiner Request pro PR, nur die Datei, nie der Diff), nennt jeden Anspruch auf stderr und bumpt über den höchsten hinweg. Die eigene PR bleibt außen vor, damit ein erneuter Lauf nach einem Rebase die Nummer nicht weiterschiebt.

Ein Fangnetz, keine Garantie: eine PR, die Sekunden später aufgeht, sieht niemand. Kann `gh` gar nicht antworten (fehlt, nicht angemeldet, offline), sagt das Skript es und rechnet lokal weiter wie bisher — ein Netzwerkschluckauf darf keinen Deploy blockieren. Deshalb steht die Gegenprobe unmittelbar vor dem Merge jetzt auch in Schritt 11 der Deploy-Anleitung, wo sie bisher fehlte.

Der Test ist gegen das alte Skript geeicht: 5 der 7 Fälle gehen dort rot.

Belegt beim Bauen selbst: der Bump für diese PR meldete `PR #1526 already claims 7.304.1` und nahm 7.304.2 — nach der alten Regel wäre es 7.304.1 geworden.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*
