### PR TITLE
Die Versionsnummer gehört in die Commit-Zeile, nicht nur in den PR-Titel (v7.305.2)

### DIFF
--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -105,10 +105,13 @@ test suite, and the naive loop ingests its full output once per iteration:
    (blue/green: the *previous* release keeps serving the migrated schema).
 
 7. **Commit** — a short summary line, a blank line, then a body explaining *why*
-   (motivation, context, trade-offs), per Stefan's commit rule. If cold deploy,
-   append `[cold-deploy]` to the summary line. If the user passed `$ARGUMENTS`,
-   use it as the basis. End the body with the plain-paragraph agent-authorship
-   footer. Stage specific paths, never secrets (`.env`, credentials).
+   (motivation, context, trade-offs), per Stefan's commit rule. Put the new
+   version in the **subject**: `<summary> (vX.Y.Z)`. `gh pr merge --squash` takes
+   a single-commit PR's subject, not the PR title, so a version that only lives
+   in the title is dropped from `main`'s log. If cold deploy, append
+   `[cold-deploy]` to the summary line. If the user passed `$ARGUMENTS`, use it
+   as the basis. End the body with the plain-paragraph agent-authorship footer.
+   Stage specific paths, never secrets (`.env`, credentials).
 
 8. **Push the branch — in a Bash call of its own.** The `PreToolUse` hook
    `.claude/hooks/precommit-before-push.sh` intercepts any Bash command

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.305.1",
+      version: "7.305.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
`gh pr merge --squash` nimmt bei einem PR mit genau einem Commit dessen
Betreffzeile, nicht den PR-Titel. Eine Version, die nur im Titel steht, fehlt
danach in der Historie von `main`: zuletzt bei #1524 und #1526, während die
Merges davor ihr `(v7.303.x)` tragen.

Die Deploy-Anleitung sagt es jetzt an der Stelle, an der der Commit entsteht,
statt beim PR — dieser Commit hält sich selbst daran.

Hot deploy, nur Dokumentation und der Versions-Bump.

Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das
problematisch ist.