### PR TITLE
Die Sessions stimmen sich über ein Register auf die Versionsnummer ab (v7.306.1)

### DIFF
--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -74,7 +74,8 @@ test suite, and the naive loop ingests its full output once per iteration:
 
    ```bash
    git fetch origin main
-   elixir scripts/bump_version.exs patch   # -> prints the new version
+   elixir scripts/bump_version.exs patch "kurz, woran du arbeitest"
+   elixir scripts/bump_version.exs list    # wer hält gerade welche Nummer
    ```
 
    Default `patch`; `minor` for a new backward-compatible user-facing feature;
@@ -87,8 +88,19 @@ test suite, and the naive loop ingests its full output once per iteration:
    not answer the question: an unmerged PR holds the next number for hours while
    main still looks free, and two branches that pick the same one get no merge
    conflict and no warning. It names each claim on stderr, and when `gh` cannot
-   answer it says so and bumps from `mix.exs` as before — so this is a backstop,
-   not a guarantee, and step 11's re-check before merging still stands.
+   answer it says so and bumps from `mix.exs` as before.
+
+   It then **files its own claim in a register the other sessions read**: one
+   file per version under the shared `.git` (so every worktree of this checkout
+   sees it, and nothing there can be committed or pushed). That covers what
+   GitHub cannot — the minutes between bumping and opening the PR, which is
+   exactly when the parallel sessions collide. The optional second argument is
+   the note the others see beside your number; `list` prints the register and
+   changes nothing. Claims expire by themselves (spent once `main` reaches
+   them, gone after a day).
+
+   Still a backstop, not a guarantee, so step 11's re-check before merging
+   stands.
 
 5. **Check the working tree** — `git status --short` and `git diff --stat` to see
    everything that changed (your work + any subagent fixes + the bump).

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.306.0",
+      version: "7.306.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/scripts/bump_version.exs
+++ b/scripts/bump_version.exs
@@ -32,6 +32,25 @@
 # Runs as a plain `elixir` script, so it may use no dependencies: `gh --jq`
 # renders the PR list as tab-separated lines rather than JSON somebody here
 # would have to parse.
+#
+# **Second register, for the numbers GitHub cannot see yet.** The open-PR check
+# above only sees a claim once the PR exists, and the stretch between bumping
+# and opening one (precommit, commit, push) is minutes long — the very window
+# several sessions work in at once. So a bump also **files its claim locally**,
+# in a directory under the shared `.git`: one file per version, named after it,
+# holding the branch, the note and the time. `.git` is the right home because
+# every worktree of this checkout shares it (`git rev-parse --git-common-dir`)
+# and nothing under it is ever committed or pushed — no `.gitignore` entry to
+# forget, no `git add -A` that can sweep it into a commit.
+#
+# The claim is taken by creating that file **exclusively**, so it is a real
+# lock rather than a note: two sessions racing for the same number cannot both
+# win, the loser simply takes the next one. Claims expire on their own — one
+# whose number `main` has already reached is spent, and anything older than a
+# day belonged to a session that is long gone.
+#
+#   elixir scripts/bump_version.exs list            # who holds what
+#   elixir scripts/bump_version.exs patch "Kurznotiz, woran ich arbeite"
 
 re = ~r/version:\s*"(\d+)\.(\d+)\.(\d+)"/
 
@@ -111,8 +130,125 @@ claimed_versions = fn ->
   end
 end
 
-level = List.first(System.argv()) || "patch"
+# The shared register's directory. Under the **common** git dir, so all
+# worktrees of this checkout see the same one; overridable for the tests, which
+# run the script outside any repository.
+claims_dir =
+  case System.get_env("VUTUV_VERSION_CLAIMS_DIR") do
+    nil ->
+      case run.("git", ["rev-parse", "--git-common-dir"]) do
+        {:ok, out} -> out |> String.trim() |> Path.expand() |> Path.join("vutuv-version-claims")
+        {:error, _not_a_repo} -> nil
+      end
+
+    dir ->
+      dir
+  end
+
+one_day = 24 * 60 * 60
+version_string = fn {major, minor, patch} -> "#{major}.#{minor}.#{patch}" end
+
+# A file name is the claim's version; anything else in the directory is ignored.
+claim_version = fn name -> parse.(~s(version: "#{name}")) end
+
+# Everything the register holds, oldest number first. The file is three
+# `key: value` lines so a person who opens it reads a sentence, not a record.
+read_claims = fn dir ->
+  for name <- File.ls!(dir), version = claim_version.(name) do
+    fields =
+      Path.join(dir, name)
+      |> File.read!()
+      |> String.split("\n", trim: true)
+      |> Map.new(fn line ->
+        case String.split(line, ": ", parts: 2) do
+          [key, value] -> {key, value}
+          [key] -> {key, ""}
+        end
+      end)
+
+    {version, Map.get(fields, "branch", "?"), Map.get(fields, "note", ""),
+     Map.get(fields, "at", "?")}
+  end
+  |> Enum.sort()
+end
+
+# A claim is spent once the version in mix.exs has reached its number, and one
+# older than a day belonged to a session that is not coming back. Its own
+# branch's claims go too, or re-running after a rebase would push the number
+# along again. Deleted rather than skipped, so the register stays readable
+# instead of growing a tail of ghosts.
+prune_claims = fn dir, local, own_branch ->
+  now = System.os_time(:second)
+
+  for name <- File.ls!(dir), version = claim_version.(name) do
+    file = Path.join(dir, name)
+
+    mine_or_stale? =
+      version <= local or
+        Enum.any?(read_claims.(dir), fn {v, branch, _note, _at} ->
+          v == version and branch == own_branch and own_branch != nil
+        end) or
+        case File.stat(file, time: :posix) do
+          {:ok, %{mtime: mtime}} -> now - mtime > one_day
+          _ -> true
+        end
+
+    if mine_or_stale?, do: File.rm(file)
+  end
+end
+
+# Files the claim by creating its file exclusively: `{:ok, _}` means this
+# session got the number, `{:error, :eexist}` that somebody else did between
+# the read above and this write. That race is the whole reason the register is
+# one file per version rather than one shared list.
+file_claim = fn dir, version, own_branch, note ->
+  body = """
+  branch: #{own_branch || "?"}
+  note: #{note || "(keine Notiz)"}
+  at: #{DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()}
+  """
+
+  # `:utf8` is not optional: without it Erlang writes a note's umlauts as raw
+  # latin-1 bytes, and reading the file back then raises on the first "ü".
+  case File.open(Path.join(dir, version_string.(version)), [:write, :exclusive, :utf8]) do
+    {:ok, io} ->
+      IO.write(io, body)
+      File.close(io)
+      :ok
+
+    {:error, _taken} ->
+      :taken
+  end
+end
+
+args = System.argv()
+level = Enum.at(args, 0) || "patch"
+note = Enum.at(args, 1)
 path = "mix.exs"
+
+# `list` answers the question the register exists for and changes nothing.
+if level == "list" do
+  case claims_dir do
+    nil ->
+      IO.puts(:stderr, "no shared git dir found, so there is no claims register here")
+
+    dir ->
+      File.mkdir_p!(dir)
+
+      case read_claims.(dir) do
+        [] ->
+          IO.puts("no version claims filed")
+
+        claims ->
+          for {version, branch, note, at} <- claims do
+            IO.puts("#{version_string.(version)}  #{branch}  #{at}  #{note}")
+          end
+      end
+  end
+
+  System.halt(0)
+end
+
 source = File.read!(path)
 
 case parse.(source) do
@@ -121,20 +257,39 @@ case parse.(source) do
     System.halt(1)
 
   local ->
-    claims = claimed_versions.()
+    pr_claims = claimed_versions.()
 
     # Report every claim that constrains this bump, including one equal to the
     # local number: that is the dangerous case, the one that produces two
     # changes wearing the same version with no conflict to warn anybody.
-    for {number, {major, minor, patch} = version} <- claims, version >= local do
-      IO.puts(:stderr, "bump_version: PR ##{number} already claims #{major}.#{minor}.#{patch}")
+    for {number, version} <- pr_claims, version >= local do
+      IO.puts(:stderr, "bump_version: PR ##{number} already claims #{version_string.(version)}")
     end
+
+    local_claims =
+      case claims_dir do
+        nil ->
+          []
+
+        dir ->
+          File.mkdir_p!(dir)
+          prune_claims.(dir, local, own_branch)
+
+          for {version, branch, note, _at} <- read_claims.(dir) do
+            IO.puts(
+              :stderr,
+              "bump_version: #{branch} claims #{version_string.(version)} (#{note})"
+            )
+
+            version
+          end
+      end
 
     # Start from the highest number anybody has taken, so the bump lands past
     # every claim instead of beside one.
-    {major, minor, patch} = Enum.max([local | Enum.map(claims, &elem(&1, 1))])
+    base = Enum.max([local | Enum.map(pr_claims, &elem(&1, 1)) ++ local_claims])
 
-    {new_major, new_minor, new_patch} =
+    next = fn {major, minor, patch} ->
       case level do
         "patch" ->
           {major, minor, patch + 1}
@@ -149,8 +304,26 @@ case parse.(source) do
           IO.puts(:stderr, "unknown level #{inspect(other)} (use patch|minor|major)")
           System.halt(1)
       end
+    end
 
-    new_version = "#{new_major}.#{new_minor}.#{new_patch}"
+    # Take the number by creating its file; if another session got there in the
+    # meantime, step up and try again. Without a register the first candidate
+    # simply stands.
+    take = fn take, candidate ->
+      case claims_dir do
+        nil ->
+          candidate
+
+        dir ->
+          case file_claim.(dir, candidate, own_branch, note) do
+            :ok -> candidate
+            :taken -> take.(take, next.(candidate))
+          end
+      end
+    end
+
+    version = take.(take, next.(base))
+    new_version = version_string.(version)
     new_source = String.replace(source, re, ~s(version: "#{new_version}"), global: false)
     File.write!(path, new_source)
     IO.puts(new_version)

--- a/test/scripts/bump_version_test.exs
+++ b/test/scripts/bump_version_test.exs
@@ -67,16 +67,57 @@ defmodule Scripts.BumpVersionTest do
     path
   end
 
-  defp run(dir, level \\ "patch") do
-    env = [{"PATH", Path.join(dir, "bin") <> ":" <> System.get_env("PATH")}]
+  # `claims` opts in to the shared register (the env seam the script reads
+  # instead of the git dir); without it the run must behave as if there were
+  # none, which is also what a checkout outside any repository gets.
+  defp run(dir, level \\ "patch", opts \\ []) do
+    env = [
+      {"PATH", Path.join(dir, "bin") <> ":" <> System.get_env("PATH")},
+      {"VUTUV_VERSION_CLAIMS_DIR", opts[:claims]}
+    ]
 
-    {out, status} =
-      System.cmd("elixir", [@script, level], cd: dir, env: env, stderr_to_stdout: true)
+    args = [@script, level] ++ List.wrap(opts[:note])
+
+    {out, status} = System.cmd("elixir", args, cd: dir, env: env, stderr_to_stdout: true)
 
     version =
       File.read!(Path.join(dir, "mix.exs")) |> then(&Regex.run(~r/"([\d.]+)"/, &1)) |> Enum.at(1)
 
     %{output: out, status: status, version: version}
+  end
+
+  defp claims_dir(dir) do
+    path = Path.join(dir, "claims")
+    File.mkdir_p!(path)
+    path
+  end
+
+  defp file_claim(dir, version, branch) do
+    File.write!(Path.join(claims_dir(dir), version), """
+    branch: #{branch}
+    note: irgendwas
+    at: 2026-08-17T09:00:00Z
+    """)
+  end
+
+  # A repository whose current branch has a name, so the script can recognise
+  # its own claims. `git init -b` names it without needing a commit.
+  defp init_repo(dir, branch) do
+    {_, 0} = System.cmd("git", ["init", "-q", "-b", branch], cd: dir)
+
+    {_, 0} =
+      System.cmd("git", ["commit", "-q", "--allow-empty", "-m", "x"], cd: dir, env: git_env())
+
+    :ok
+  end
+
+  defp git_env do
+    [
+      {"GIT_AUTHOR_NAME", "t"},
+      {"GIT_AUTHOR_EMAIL", "t@example.com"},
+      {"GIT_COMMITTER_NAME", "t"},
+      {"GIT_COMMITTER_EMAIL", "t@example.com"}
+    ]
   end
 
   test "bumps past the number an open PR already claims", %{dir: dir} do
@@ -155,5 +196,72 @@ defmodule Scripts.BumpVersionTest do
     assert result.status == 1
     assert result.version == "7.304.0"
     assert result.output =~ "unknown level"
+  end
+
+  # The shared register (a directory under the common `.git`, so every worktree
+  # of one checkout sees it and nothing in it can be committed) closes the gap
+  # GitHub cannot: the minutes between bumping and opening the PR.
+  describe "the local claims register" do
+    test "steps over a number another branch has filed", %{dir: dir} do
+      write_mix(dir, "7.304.0")
+      fake_gh(dir, %{})
+      file_claim(dir, "7.304.1", "somebody-else")
+
+      result = run(dir, "patch", claims: claims_dir(dir))
+
+      assert result.version == "7.304.2"
+      assert result.output =~ "somebody-else claims 7.304.1"
+    end
+
+    test "files its own claim, note and branch included", %{dir: dir} do
+      write_mix(dir, "7.304.0")
+      fake_gh(dir, %{})
+      init_repo(dir, "meine-arbeit")
+
+      result = run(dir, "patch", claims: claims_dir(dir), note: "Zwei Dinge geradegezogen")
+
+      assert result.version == "7.304.1"
+      body = File.read!(Path.join(claims_dir(dir), "7.304.1"))
+      assert body =~ "branch: meine-arbeit"
+      assert body =~ "note: Zwei Dinge geradegezogen"
+    end
+
+    # Otherwise every re-run after a rebase would walk the number up again.
+    test "its own branch's claim does not push the number along", %{dir: dir} do
+      write_mix(dir, "7.304.0")
+      fake_gh(dir, %{})
+      init_repo(dir, "meine-arbeit")
+      file_claim(dir, "7.304.1", "meine-arbeit")
+
+      result = run(dir, "patch", claims: claims_dir(dir))
+
+      assert result.version == "7.304.1"
+    end
+
+    # A claim the released version has reached is spent, and the register must
+    # forget it — otherwise it only ever grows and every bump jumps further.
+    test "a claim at or below the released number is dropped", %{dir: dir} do
+      write_mix(dir, "7.304.0")
+      fake_gh(dir, %{})
+      file_claim(dir, "7.303.9", "long-merged")
+
+      result = run(dir, "patch", claims: claims_dir(dir))
+
+      assert result.version == "7.304.1"
+      refute File.exists?(Path.join(claims_dir(dir), "7.303.9"))
+    end
+
+    test "`list` reports the register and changes nothing", %{dir: dir} do
+      write_mix(dir, "7.304.0")
+      fake_gh(dir, %{})
+      file_claim(dir, "7.305.0", "somebody-else")
+
+      result = run(dir, "list", claims: claims_dir(dir))
+
+      assert result.status == 0
+      assert result.version == "7.304.0"
+      assert result.output =~ "7.305.0"
+      assert result.output =~ "somebody-else"
+    end
   end
 end


### PR DESCRIPTION
Nachtrag zu #1527. Die PR-Abfrage sieht einen Anspruch erst, wenn die PR existiert — zwischen Bump und PR liegen Precommit, Commit und Push, also die Minuten, in denen die parallelen Sessions tatsächlich zusammenstoßen.

Ein Bump legt seinen Anspruch deshalb zusätzlich lokal ab: eine Datei je Version unter dem **gemeinsamen `.git`** (`git rev-parse --git-common-dir`), Inhalt Zweig, Notiz, Zeit. Alle Worktrees eines Checkouts sehen dasselbe Verzeichnis, und nichts unterhalb von `.git` kann committet oder gepusht werden — kein `.gitignore`-Eintrag, den jemand vergisst, kein `git add -A`, das es einsammelt.

Die Datei wird **exklusiv** angelegt (`File.open(:exclusive)`), der Anspruch ist also eine Sperre und keine Notiz: zwei Sessions können dieselbe Nummer nicht beide gewinnen. Ansprüche verfallen von selbst — sobald `main` ihre Nummer erreicht hat, nach einem Tag, und die des eigenen Zweigs sowieso, sonst schöbe jeder Lauf nach einem Rebase die Nummer weiter.

```
elixir scripts/bump_version.exs patch "kurz, woran ich arbeite"
elixir scripts/bump_version.exs list
7.306.1  version-claims-file  2026-08-17T09:59:45Z  Zentrale Datei für Versionsansprüche
```

Fünf neue Tests, gegen die Fassung ohne Register geeicht: vier davon gehen dort rot (der fünfte kann es nicht, ohne Register gibt es nichts, das die Nummer weiterschiebt).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*
