### PR TITLE
Die Tabellen des Suchverlaufs fallen weg (v7.306.1)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.306.0",
+      version: "7.306.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260817102523_drop_search_history_tables.exs
+++ b/priv/repo/migrations/20260817102523_drop_search_history_tables.exs
@@ -1,0 +1,29 @@
+defmodule Vutuv.Repo.Migrations.DropSearchHistoryTables do
+  use Ecto.Migration
+
+  # The contract half of the expand/contract pair that removed the search
+  # history. v7.306.0 deleted every reader and writer — `Search.record_query/2`,
+  # the phonetic matcher that existed only to fill the result table, the
+  # `HistorySweeper` and the three schemas — so the release now serving traffic
+  # does not touch these tables and this drop is N-1 safe.
+  #
+  # They were written on every settled search and read by no feature: the query
+  # string, the members it matched, and one row per search naming who ran it,
+  # kept for 90 days. The privacy policy justified that with a search the rows
+  # would "improve and speed up", which was never built; it now says the query
+  # is answered and discarded (edited at /admin/legal on 2026-08-17).
+
+  def up do
+    # Children before the parent: both carry an FK to search_queries.
+    drop(table(:search_query_results))
+    drop(table(:search_query_requesters))
+    drop(table(:search_queries))
+  end
+
+  def down do
+    raise Ecto.MigrationError,
+      message:
+        "irreversible: the search history was removed on purpose (v7.306.0), " <>
+          "and the rows it held are not worth restoring"
+  end
+end


### PR DESCRIPTION
Die Gegenbuchung (contract) zu #1525. Dort ist jeder Leser und Schreiber des Suchverlaufs verschwunden, die laufende Version v7.306.0 rührt `search_queries`, `search_query_results` und `search_query_requesters` also nicht mehr an — damit ist der Drop N-1-sicher.

Kinder vor Eltern, weil beide Kindtabellen einen Fremdschlüssel auf `search_queries` tragen. Gegen `vutuv1_dev` geprüft: drei Tabellen vorher, keine nachher, Datenbank 75 → 74 MB.

Die Migration ist bewusst nicht umkehrbar. Ein `down`, das leere Tabellen zurückbaut, würde etwas versprechen, was es nicht hält: die Zeilen sind absichtlich weg.

Der Absatz in der Datenschutzerklärung ist seit heute in Produktion nachgezogen (von Hand unter `/admin/legal`); er sagt jetzt, dass die Eingabe beantwortet und verworfen wird.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*
