### PR TITLE
Die Nummer für den Tabellen-Drop nachgetragen (v7.306.2)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.306.1",
+      version: "7.306.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
#1530 und #1531 haben beide 7.306.1 gewählt und sind kurz nacheinander gelandet. Weil auf beiden Seiten dieselbe Zahl stand, gab es weder einen Konflikt noch eine Warnung: Der Squash von #1531 brachte die Migration nach `main`, ohne die Version zu bewegen. `git log origin/main -- mix.exs` führt #1531 deshalb nicht auf, und eine Nummer benennt zwei unabhängige Änderungen.

Dieser PR trägt nur die fehlende Erhöhung nach.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*
