### PR TITLE
Ein harter Zeilenumbruch endet nicht mehr auf einem Backslash (v7.308.1)

### DIFF
--- a/lib/vutuv_web/markdown.ex
+++ b/lib/vutuv_web/markdown.ex
@@ -570,11 +570,13 @@ defmodule VutuvWeb.Markdown do
   # (a lone Enter is a deliberate break), so they keep the default. **Posts**
   # pass `breaks: false`: a post body is prose, and Milkdown (the composer)
   # never emits a lone soft-wrap newline — it serializes a real break as a
-  # trailing backslash and a paragraph as a blank line, both of which render the
-  # same either way. The only bodies with lone newlines are ones hard-wrapped in
-  # an external editor or pasted in source mode, where `breaks: true` turned
-  # every ~80-column wrap into a visible break (a wall of stray `<br>`s next to
-  # long links); `breaks: false` reflows them into flowing paragraphs.
+  # trailing backslash and a paragraph as a blank line. The only bodies with
+  # lone newlines are ones hard-wrapped in an external editor or pasted in
+  # source mode, where `breaks: true` turned every ~80-column wrap into a
+  # visible break (a wall of stray `<br>`s next to long links); `breaks: false`
+  # reflows them into flowing paragraphs. The two settings agree on the
+  # backslash only because `normalize_hard_breaks/1` respells it first — see
+  # there, and don't drop it on the assumption that Earmark reads both.
   defp render_pipeline(text, opts \\ []) do
     # Footnotes bracket the whole pipeline: the syntax becomes plain-text markers
     # before Earmark sees it, and the real markup is built after the scrubber has
@@ -585,7 +587,11 @@ defmodule VutuvWeb.Markdown do
     # word, so `Fences.normalize/1` folds the info string into one before it
     # ever gets there. See `VutuvWeb.CodeHighlight.Fences`.
     {prepared, footnotes} =
-      text |> Fences.normalize() |> strip_break_artifacts() |> Footnotes.prepare()
+      text
+      |> Fences.normalize()
+      |> strip_break_artifacts()
+      |> normalize_hard_breaks()
+      |> Footnotes.prepare()
 
     prepared
     |> String.replace("<", "&lt;")
@@ -654,6 +660,30 @@ defmodule VutuvWeb.Markdown do
       text
     end
   end
+
+  # CommonMark spells a hard break two ways — a trailing backslash and two
+  # trailing spaces — and **Earmark reads the backslash only while `breaks:` is
+  # off**: `breaks: true` swaps its `<br>` rule for one matching bare whitespace
+  # before the newline, which drops the backslash alternative, so the `\` falls
+  # through as ordinary text and the newline becomes the break separately. Every
+  # hard-broken line of a chat message therefore ended in a visible `\` (reported
+  # on a DM thread, 2026-08-17) — and the same for a tagline, an organization
+  # description or a job posting, since all four render with the default. The
+  # writer never typed that character: it is how Milkdown serializes the break
+  # (`assets/js/markdown_editor.js`), which is why `render_post/3` was unaffected
+  # and the bug looked like it belonged to messages.
+  #
+  # So respell it as the two spaces, which **both** settings consume. Doing it
+  # here rather than at write time repairs the already-stored bodies too, so this
+  # needs none of the repair migrations the other Milkdown round-trip fixes did.
+  # `map_outside_code/2` keeps a code fence's line continuations (`curl \`)
+  # verbatim, and the lookbehind keeps an escaped backslash (`\\`) at a line end,
+  # which is a literal character and not a break.
+  defp normalize_hard_breaks(text) do
+    if String.contains?(text, "\\"), do: map_outside_code(text, &hard_break_chunk/1), else: text
+  end
+
+  defp hard_break_chunk(chunk), do: Regex.replace(~r/(?<!\\)\\(\r?\n)/, chunk, "  \\1")
 
   @doc """
   Render a feed preview: the Markdown source is cut at a block boundary

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.307.0",
+      version: "7.308.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/markdown_test.exs
+++ b/test/vutuv_web/markdown_test.exs
@@ -155,6 +155,37 @@ defmodule VutuvWeb.MarkdownTest do
     assert render("line one\nline two") =~ "<br"
   end
 
+  describe "the editor's trailing-backslash hard break" do
+    test "breaks the line without leaving the backslash visible" do
+      # Milkdown serializes a hard break as `\` + newline. Earmark understands
+      # that spelling only while `breaks:` is off — with `breaks: true` (chat,
+      # taglines, organization and job descriptions) its `<br>` rule matches the
+      # bare newline instead, so the backslash fell through as literal text and
+      # every hard-broken line ended in a visible `\` (reported on a DM thread).
+      html = render("line one\\\nline two")
+
+      assert html =~ "<br"
+      refute html =~ "\\"
+    end
+
+    test "an empty line between two breaks leaves no lone backslash" do
+      # Two hard breaks in a row — the writer's blank line — serialized `\`,
+      # newline, `\`, newline, which rendered as a line holding just a `\`.
+      refute render("line one\\\n\\\nline two") =~ "\\"
+    end
+
+    test "keeps a backslash that is not a break" do
+      assert render("a \\ b") =~ "a \\ b"
+      assert render("C:\\\\path") =~ "C:\\"
+    end
+
+    test "leaves a line continuation inside a code fence alone" do
+      # A shell snippet ends its lines with a backslash on purpose, and a fence
+      # is the one place that backslash is content rather than an editor artifact.
+      assert render("```\ncurl \\\n  https://example.com\n```") =~ "curl \\"
+    end
+  end
+
   describe "post line breaks (breaks: false)" do
     defp post(text), do: text |> Markdown.render_post([]) |> Phoenix.HTML.safe_to_string()
 


### PR DESCRIPTION
**TL;DR** Ein harter Zeilenumbruch aus dem Editor stand als sichtbarer `\` am Zeilenende — in Nachrichten, Taglines, Organisations- und Stellenbeschreibungen.

**Wo:** `VutuvWeb.Markdown.render_pipeline/2`
**Vorher:** Milkdown serialisiert einen harten Umbruch als `\` + Newline. Earmark liest diese CommonMark-Schreibweise nur mit `breaks: false` — mit `breaks: true` ersetzt es seine `<br>`-Regel durch eine, die nur Whitespace vor dem Newline kennt, der Backslash fällt als Text durch:

```
Quelle: "erinnerst.\" + newline
breaks: true   →  <p>erinnerst.\  <br>…      ← so steht es in Produktion
breaks: false  →  <p>erinnerst.  <br>…       ← korrekt
```

Beiträge (`render_post/3`, `breaks: false`) waren deshalb sauber, weshalb es nach einem reinen Nachrichten-Problem aussah.

**Jetzt:** `normalize_hard_breaks/1` schreibt den Umbruch vor Earmark in die zwei Leerzeichen um, die beide Einstellungen verstehen. Durch `map_outside_code/2` geführt, ein `curl \` im Codeblock bleibt also. Das repariert die schon gespeicherten Texte mit, anders als die früheren Milkdown-Rundreise-Fehler braucht es keine Migration.

Die zwei Kern-Tests sind gegen den ungefixten Stand kalibriert und werden dort rot, mit exakt dem Produktions-Output.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*
