### PR TITLE
LinkedIn-Kontakte auf vutuv finden (v7.312.0)

### DIFF
--- a/docs/architecture/settings-and-account.md
+++ b/docs/architecture/settings-and-account.md
@@ -1,8 +1,8 @@
 # Settings & account
 
 How members manage their own account: the settings hub, onboarding, username
-changes, the LinkedIn import and the GDPR data export. Login and sessions are
-covered in [authentication.md](authentication.md).
+changes, the LinkedIn import and contact finder, and the GDPR data export. Login
+and sessions are covered in [authentication.md](authentication.md).
 
 ## Settings hub (user-agnostic `/settings` URLs)
 
@@ -398,8 +398,9 @@ signature, since LinkedIn localizes the names), tolerates a UTF-8 BOM and CRLF,
 and maps Positions → work experiences, Volunteering → work experiences with
 the volunteer category (issue #840), Education → the new education section,
 Skills → tags, and the profile's Websites / Twitter handles → links / social
-accounts; `Connections.csv` is skipped and email addresses are shown read-only
-(never auto-created, since each is PIN-verified).
+accounts; `Connections.csv` is skipped here (it has its own page — see below)
+and email addresses are shown read-only (never auto-created, since each is
+PIN-verified).
 
 It is **preview-and-confirm**: the member sees everything found, entries already
 on their profile are pre-unchecked, each section has a **select-all /
@@ -415,6 +416,58 @@ signature (per-entry / total-uncompressed / entry-count caps, and
 unrecognized/huge members are never inflated), imports are rate-limited per
 member, the CSVs are only ever decompressed into memory (never written to disk),
 and the uploaded temp file is deleted as soon as it is read.
+
+## Find your LinkedIn contacts
+
+The other half of the same archive, on its own page
+(`/settings/import/linkedin/connections`, `VutuvWeb.ImportConnectionsLive`,
+issue #1476): which of a member's LinkedIn contacts are **already vutuv
+members**, so they can follow them. The profile import fills your profile, this
+fills your feed; each is worth doing without the other, so it is a page with its
+own upload rather than a step in that wizard, and the two link to each other.
+
+`Vutuv.Imports.LinkedIn.parse_connections/2` reads `Connections.csv` (the one
+export file with a `Notes:` preamble above its header row) and reduces every
+contact **in the parser** to the only two identifiers a match can rest on:
+`%{email: …, linkedin: …}`. Names, employers, positions and connection dates
+never leave that function.
+
+`Vutuv.Imports.ConnectionMatch.find/2` resolves them, on **exact identifiers
+only**:
+
+| Evidence | Matches against |
+| --- | --- |
+| `:email` | a **public** email address of a confirmed, non-hidden member |
+| `:linkedin` | the LinkedIn account a member links from their profile (`lower(value)`) |
+
+There is deliberately no name / employer / position matching. A guess in a
+"people you already know" list is not neutral — acting on it means following the
+wrong person, publicly — and the LinkedIn side of the issue's proposal is
+narrower than it looks in any case: about 4 % of members link a LinkedIn
+profile, against about half who publish an address.
+
+**Only public addresses**, the same line `Vutuv.Search.search_by_email/1` holds:
+a private address must not even confirm that an account exists, and this asks
+the same question in bulk from a file the member wrote. So a match only ever
+reveals what the matched member's own profile already shows. It halves the
+reach, and that is the trade.
+
+Nothing is stored: the archive is read into memory and dropped, the match list
+lives in the socket and dies with the page (a reconnect means uploading again —
+the follows already made are ordinary follows and stay). Nothing is imported,
+nobody is invited, no email is sent, and no placeholder profile is created.
+
+The list is built for the size an intranet installation produces, where everyone
+in the archive is a member: search by name, a `not following yet / following /
+all` filter, 50 per page, and select-all over the **whole filtered set** rather
+than the visible page. Nothing is preselected — uploading a file must never be
+the act that follows 800 people — and **Follow selected** runs through
+`Vutuv.Social.follow_many/2`, so each one is a normal follow with its normal
+notification. One press is capped at 500, and the button says the number.
+
+It shares the profile import's rate-limit budget (one archive between the two
+pages), keyed on the member alone since a LiveView has no conn to read a client
+address from.
 
 ## Data export (GDPR)
 

--- a/lib/vutuv/imports/connection_match.ex
+++ b/lib/vutuv/imports/connection_match.ex
@@ -1,0 +1,124 @@
+defmodule Vutuv.Imports.ConnectionMatch do
+  @moduledoc """
+  Which vutuv members a member's LinkedIn contact list resolves to (issue #1476).
+
+  It takes the contacts `Vutuv.Imports.LinkedIn.parse_connections/2` reduced the
+  archive to and answers with vutuv members — nothing else is kept, nothing is
+  written, and the contact list itself never reaches the database as data.
+
+  **Exact identifiers only**, two of them:
+
+    * `:email` — a contact's address equals one of a member's addresses.
+    * `:linkedin` — a contact's LinkedIn profile identifier equals the LinkedIn
+      account a member links from their profile.
+
+  There is deliberately no name / employer / position matching. A guess in a
+  "people you already know" list is not neutral: acting on it means following
+  the wrong person, publicly, and telling them so.
+
+  ## Why the email half is restricted to public addresses
+
+  `email.public?` is false by default, and `Vutuv.Search.search_by_email/1`
+  already holds the line that follows from it: *a private address must not even
+  confirm that an account exists.* This asks the same question in bulk, from a
+  file the member wrote, so it holds the same line. What is matched here is
+  therefore only what the matched member's own profile already shows — the
+  address they published, or the LinkedIn account they linked — and the answer
+  discloses nothing that was not public before.
+
+  The consequence is honest and worth knowing: roughly half the member base
+  publishes an address, so roughly half of it can be found this way.
+  """
+
+  import Ecto.Query
+  import Vutuv.Moderation.Query, only: [account_confirmed_row: 1, account_hidden_row: 1]
+
+  alias Vutuv.Accounts.User
+  alias Vutuv.Profiles.SocialMediaAccount
+  alias Vutuv.Repo
+  alias Vutuv.Social
+
+  # An archive may carry tens of thousands of contacts, so the identifier lists
+  # go to Postgres in bounded chunks rather than as one enormous IN list.
+  @chunk 500
+
+  @doc """
+  The members `contacts` resolves to, as `%{user: %User{}, via: :email | :linkedin}`,
+  sorted by name.
+
+  `viewer` is excluded (a member is not their own contact), as is anybody either
+  side has blocked. Members the viewer already follows stay in — the page shows
+  that state rather than pretending they are new, and hiding them would make a
+  second run of the same archive look as if people had vanished.
+  """
+  def find(%User{} = viewer, contacts) when is_list(contacts) do
+    emails = identifiers(contacts, :email)
+    linkedin = identifiers(contacts, :linkedin)
+
+    if emails == [] and linkedin == [] do
+      []
+    else
+      blocked = Social.blocked_user_ids(viewer.id)
+
+      # Email first, so `uniq_by` keeps that label for a member matched by both:
+      # an address is the stronger evidence, and the one the member can check.
+      (tag(users_by_email(emails), :email) ++ tag(users_by_linkedin(linkedin), :linkedin))
+      |> Enum.uniq_by(& &1.user.id)
+      |> Enum.reject(&excluded?(&1, viewer, blocked))
+      |> Enum.sort_by(&sort_key/1)
+    end
+  end
+
+  defp identifiers(contacts, key) do
+    contacts |> Enum.map(&Map.get(&1, key)) |> Enum.reject(&is_nil/1) |> Enum.uniq()
+  end
+
+  defp tag(users, via), do: Enum.map(users, &%{user: &1, via: via})
+
+  defp excluded?(%{user: user}, viewer, blocked) do
+    user.id == viewer.id or MapSet.member?(blocked, user.id)
+  end
+
+  defp sort_key(%{user: user}) do
+    {downcase(user.last_name), downcase(user.first_name)}
+  end
+
+  defp downcase(nil), do: ""
+  defp downcase(value), do: String.downcase(value)
+
+  defp users_by_email([]), do: []
+
+  defp users_by_email(values) do
+    in_chunks(values, fn chunk ->
+      from(u in User,
+        join: e in assoc(u, :emails),
+        where: e.public? == true and e.value in ^chunk,
+        where: account_confirmed_row(u) and not account_hidden_row(u),
+        distinct: u.id
+      )
+    end)
+  end
+
+  defp users_by_linkedin([]), do: []
+
+  defp users_by_linkedin(ids) do
+    in_chunks(ids, fn chunk ->
+      from(u in User,
+        join: s in SocialMediaAccount,
+        on: s.user_id == u.id,
+        # The stored value is the bare handle (SocialMediaAccount.parse_value/1
+        # collapses a pasted URL to its last segment), and a handle is
+        # case-insensitive, so both sides are lowered before they meet.
+        where: s.provider == "LinkedIn" and fragment("lower(?)", s.value) in ^chunk,
+        where: account_confirmed_row(u) and not account_hidden_row(u),
+        distinct: u.id
+      )
+    end)
+  end
+
+  defp in_chunks(values, build_query) do
+    values
+    |> Enum.chunk_every(@chunk)
+    |> Enum.flat_map(&Repo.all(build_query.(&1)))
+  end
+end

--- a/lib/vutuv/imports/linked_in.ex
+++ b/lib/vutuv/imports/linked_in.ex
@@ -15,9 +15,12 @@ defmodule Vutuv.Imports.LinkedIn do
   transaction, reusing the existing schema changesets and skipping anything the
   member already has (so a re-import never doubles a row).
 
-  Deliberately out of scope: `Connections.csv` (not profile data) and email
-  addresses (PIN-verified identities in vutuv — surfaced read-only in the
-  preview, never auto-created).
+  `Connections.csv` is deliberately absent from all of that: it is not profile
+  data, and nothing in it is ever written to a profile. It has its own pure
+  entry point instead, `parse_connections/2` (issue #1476), which reduces each
+  contact to the two identifiers a vutuv member can be recognised by. Email
+  addresses are out of scope too: they are PIN-verified identities here, so the
+  preview shows them read-only and never auto-creates one.
   """
 
   import Ecto.Query
@@ -33,6 +36,7 @@ defmodule Vutuv.Imports.LinkedIn do
   alias Vutuv.Profiles.Url
   alias Vutuv.Profiles.WorkExperience
   alias Vutuv.Repo
+  alias Vutuv.Search
   alias Vutuv.Tags
   alias Vutuv.Tags.Tag
   alias Vutuv.Tags.UserTag
@@ -102,15 +106,43 @@ defmodule Vutuv.Imports.LinkedIn do
     end
   end
 
+  @doc """
+  The `Connections.csv` half of the same archive (issue #1476): the member's
+  first-degree LinkedIn contacts, reduced on the spot to the only two things a
+  match can be made on — `%{email: …, linkedin: …}`, either of which may be nil.
+
+  Names, employers, positions and connection dates are **dropped here**, in the
+  parser, so nothing downstream can hold them by accident: this is a lookup of
+  people who are already on vutuv, not an address book we take a copy of.
+
+  Same archive, same caps, same pure-function contract as `parse/2` — and the
+  same errors.
+  """
+  def parse_connections(zip_binary, opts \\ []) when is_binary(zip_binary) do
+    with {:ok, files} <- inflate_archive(zip_binary, opts), do: {:ok, connections(files)}
+  end
+
+  @doc "Like `parse_connections/2`, but from the uploaded temp file."
+  def parse_connections_file(path, opts \\ []) when is_binary(path) do
+    case File.read(path) do
+      {:ok, bytes} -> parse_connections(bytes, opts)
+      {:error, _} -> {:error, :invalid_archive}
+    end
+  end
+
   defp do_parse(bytes, opts) when is_binary(bytes) do
+    with {:ok, files} <- inflate_archive(bytes, opts), do: {:ok, build(files)}
+  end
+
+  # Unzip under the safety caps: the shared front half of both parses.
+  defp inflate_archive(bytes, opts) when is_binary(bytes) do
     caps = caps(opts)
 
     with {:ok, entries} <- central_directory(bytes),
          {:ok, kept} <- select_entries(entries, caps),
          {:ok, located} <- locate_entries(bytes, kept),
-         :ok <- reject_overlaps(located),
-         {:ok, files} <- inflate_entries(bytes, caps, located) do
-      {:ok, build(files)}
+         :ok <- reject_overlaps(located) do
+      inflate_entries(bytes, caps, located)
     end
   end
 
@@ -521,6 +553,99 @@ defmodule Vutuv.Imports.LinkedIn do
   end
 
   defp subset?(keys, set), do: Enum.all?(keys, &MapSet.member?(set, &1))
+
+  # ── Connections.csv → the two identifiers a match can rest on (issue #1476) ──
+
+  # LinkedIn's own limit on first-degree connections is 30,000, so this bounds a
+  # real export generously while keeping a crafted CSV from asking the database
+  # about an unbounded address list in one upload.
+  @max_connections 30_000
+
+  # Connections.csv opens with a "Notes:" paragraph and a blank line ABOVE the
+  # header row — the one export file that does — so the header is looked for in
+  # the first few rows rather than assumed to be the first. Kept small: a file
+  # that has not named its columns by then is not this file.
+  @preamble_rows 10
+
+  # The signature is checked on the *row*, not the filename, like every other
+  # classification here: LinkedIn localizes filenames but not the header row,
+  # and "Connected On" appears in no other export file.
+  @connections_headers ["First Name", "Connected On"]
+
+  defp connections(files) do
+    files
+    |> Enum.flat_map(&connection_rows/1)
+    |> Enum.take(@max_connections)
+    |> Enum.map(&contact/1)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+  end
+
+  defp connection_rows({_name, content}) do
+    case connections_header(parse_csv(content)) do
+      {headers, data} -> Enum.map(data, &row_map(headers, &1))
+      nil -> []
+    end
+  end
+
+  defp connections_header(rows) do
+    rows
+    |> Enum.take(@preamble_rows)
+    |> Enum.find_index(&connections_header_row?/1)
+    |> case do
+      nil -> nil
+      index -> {Enum.at(rows, index), Enum.drop(rows, index + 1)}
+    end
+  end
+
+  defp connections_header_row?(row) do
+    set = row |> Enum.map(&String.trim/1) |> MapSet.new()
+    subset?(@connections_headers, set)
+  end
+
+  # Everything else in the row — name, employer, position, connected-on — is
+  # dropped right here (see parse_connections/2). A row that carries neither
+  # identifier can never match, so it is not kept as an empty shell either.
+  defp contact(row) do
+    case {contact_email(row["Email Address"]), linkedin_id(row["URL"])} do
+      {nil, nil} -> nil
+      {email, linkedin} -> %{email: email, linkedin: linkedin}
+    end
+  end
+
+  defp contact_email(value) when is_binary(value) do
+    normalized = value |> String.trim() |> String.downcase()
+
+    if Search.email?(normalized) and String.length(normalized) <= 254,
+      do: normalized,
+      else: nil
+  end
+
+  defp contact_email(_value), do: nil
+
+  # A public LinkedIn profile address in every spelling an export, a browser or
+  # a share button produces: with or without scheme, with or without `www.` or a
+  # country subdomain, with a trailing slash, a `?trk=` tracking parameter or a
+  # fragment. What identifies the profile is the segment after `/in/`.
+  @linkedin_profile ~r{^(?:https?://)?(?:[a-z0-9-]+\.)*linkedin\.com/in/([^/?#]+)}i
+
+  defp linkedin_id(value) when is_binary(value) do
+    case Regex.run(@linkedin_profile, String.trim(value)) do
+      [_match, id] -> id |> decode_segment() |> String.downcase() |> blank_nil()
+      _ -> nil
+    end
+  end
+
+  defp linkedin_id(_value), do: nil
+
+  # A percent-encoded segment (LinkedIn writes them for non-ASCII handles) has
+  # to be decoded before it can equal a stored handle; a malformed one is not a
+  # handle at all, and URI.decode/1 raises on it.
+  defp decode_segment(segment) do
+    URI.decode(segment)
+  rescue
+    ArgumentError -> segment
+  end
 
   # ── Profile.csv → name/headline scalars + Websites/Twitter candidates ──
 

--- a/lib/vutuv/social.ex
+++ b/lib/vutuv/social.ex
@@ -98,6 +98,42 @@ defmodule Vutuv.Social do
   end
 
   @doc """
+  Follow several members in one act (the LinkedIn contact finder, issue #1476),
+  and answer with how many follows that really created.
+
+  Edges the member already has are skipped **before** the insert rather than
+  left to the unique index: it is the cheap half, and it keeps the count
+  honest — running the same list twice must report "nothing new", not the same
+  number again. Every follow still goes through `follow/2`, so each one is a
+  normal follow with its normal notification; a batch is a shortcut for the
+  clicks, never a quieter kind of follow.
+
+  Ids that cannot be followed at all (a bad id, the member themselves, a block)
+  are skipped one by one, so one impossible entry cannot take the batch with it.
+  The cast happens **before** the already-following lookup, not only inside
+  `follow/2`: these ids come off checkboxes, and one unparseable string in the
+  list makes `follow_edges/2` raise `Ecto.Query.CastError` on the whole batch.
+  """
+  def follow_many(%User{} = follower, followee_ids) when is_list(followee_ids) do
+    ids =
+      followee_ids
+      |> Enum.map(&Vutuv.UUIDv7.cast_or_nil/1)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.uniq()
+
+    existing = follow_edges(follower.id, ids)
+
+    ids
+    |> Enum.reject(&Map.has_key?(existing, &1))
+    |> Enum.reduce(0, fn id, followed ->
+      case follow(follower, id) do
+        {:ok, _follow} -> followed + 1
+        _error -> followed
+      end
+    end)
+  end
+
+  @doc """
   Follow an organization page (issue #1336), so its posts land in `follower`'s
   feed. Idempotent: following twice returns the edge that already exists rather
   than an error, because the control is a toggle and a double click must not

--- a/lib/vutuv_web/components/ui.ex
+++ b/lib/vutuv_web/components/ui.ex
@@ -4046,6 +4046,19 @@ defmodule VutuvWeb.UI do
            hint: gettext("Topics whose posts reach your feed"),
            terms: gettext("tag topic subscribe follow feed")
          ),
+         # Under "feed" rather than beside Import: that page fills your profile
+         # from a LinkedIn archive, this one fills your feed from it, and this
+         # is the group a member reads when their feed is too quiet.
+         row(
+           :import_connections,
+           gettext("Find your contacts"),
+           ~p"/settings/import/linkedin/connections",
+           hint: gettext("See which of your LinkedIn contacts are already on vutuv"),
+           terms:
+             gettext(
+               "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
+             )
+         ),
          row(:saved_searches, gettext("Saved searches"), ~p"/settings/saved_searches",
            hint: gettext("Job and people searches that email you new matches"),
            terms: gettext("job alert search agent watchlist")

--- a/lib/vutuv_web/live/import_connections_live.ex
+++ b/lib/vutuv_web/live/import_connections_live.ex
@@ -1,0 +1,687 @@
+defmodule VutuvWeb.ImportConnectionsLive do
+  @moduledoc """
+  "Which of my LinkedIn contacts are already here?" (issue #1476), at
+  `/settings/import/linkedin/connections`.
+
+  The member uploads the same data-export ZIP the profile importer takes, this
+  page reads **only** `Connections.csv` out of it, and answers with vutuv
+  members — never the other way round. Nothing is imported, nobody is invited,
+  no email is sent, and no profile is created for a contact who is not here.
+
+  ## Its own page, its own upload
+
+  The profile importer (`VutuvWeb.ImportController`) fills in *your* profile;
+  this fills in *your feed*. Two different jobs, and most members will want one
+  of them, so this is a page of its own rather than a fourth step in that
+  wizard — which also means there is no parsed-archive state to hand between
+  two requests. The two link to each other.
+
+  ## What is kept: nothing
+
+  The archive is read into memory and dropped, `Vutuv.Imports.LinkedIn.parse_connections/2`
+  keeps only the two identifiers a match can rest on, and the match list lives
+  in this socket and dies with the page. There is no table behind it, so a
+  reconnect (or a reload) means uploading again — the follows already made are
+  of course kept, because those are ordinary follows. The copy says so rather
+  than promising a list that comes back.
+
+  ## Following
+
+  Every row carries the normal follow pill, and the selection plus **Follow
+  selected** is a shortcut for pressing many of them — `Vutuv.Social.follow_many/2`
+  makes each one an ordinary follow with its ordinary notification. Nothing is
+  preselected and nothing follows automatically: uploading a file must never be
+  the act that follows 800 people. The batch is capped (`@max_selection`) so one
+  press stays a bounded piece of work; "select all" says how many it took.
+  """
+
+  use VutuvWeb, :live_view
+
+  require Logger
+
+  on_mount({VutuvWeb.Live.InitAssigns, :require_login})
+
+  alias Vutuv.Imports.ConnectionMatch
+  alias Vutuv.Imports.LinkedIn
+  alias Vutuv.Pages
+  alias Vutuv.Social
+  alias VutuvWeb.RateLimit
+  alias VutuvWeb.UserHelpers
+
+  # Mirrors the profile importer's cap, since it is the same archive.
+  @max_upload_bytes 50_000_000
+  @per_page 50
+  # How many members one press of "Follow selected" may follow. Each follow is
+  # an insert plus a notification, so an unbounded press would hold the socket
+  # for seconds; and a pause between batches is the right shape for an act this
+  # public anyway. Everything still selectable stays selectable afterwards.
+  @max_selection 500
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:page_title, gettext("Find your contacts"))
+     |> assign(:user, socket.assigns.current_user)
+     |> assign(:max_upload_bytes, @max_upload_bytes)
+     |> assign(:per_page, @per_page)
+     |> reset_results()
+     |> allow_upload(:archive,
+       accept: ~w(.zip),
+       max_entries: 1,
+       max_file_size: @max_upload_bytes
+     )}
+  end
+
+  # The upload stage, and what every "start over" returns to.
+  defp reset_results(socket) do
+    socket
+    |> assign(:matches, nil)
+    |> assign(:following_by_id, %{})
+    |> assign(:work_info_by_id, %{})
+    |> assign(:selected, MapSet.new())
+    |> assign(:query, "")
+    |> assign(:filter, "new")
+    |> assign(:page, 1)
+    |> assign(:error, nil)
+  end
+
+  # ── Upload → match ────────────────────────────────────────────────────────
+
+  @impl true
+  def handle_event("validate", _params, socket), do: {:noreply, assign(socket, :error, nil)}
+
+  def handle_event("analyze", _params, socket) do
+    case RateLimit.check_linkedin_import(socket.assigns.user) do
+      :ok ->
+        {:noreply, analyze(socket)}
+
+      :rate_limited ->
+        {:noreply,
+         assign(
+           socket,
+           :error,
+           gettext("You have analysed a lot of archives just now. Please try again later.")
+         )}
+    end
+  end
+
+  def handle_event("start_over", _params, socket), do: {:noreply, reset_results(socket)}
+
+  # ── Narrowing the list ────────────────────────────────────────────────────
+
+  def handle_event("search", %{"q" => query}, socket) do
+    {:noreply, socket |> assign(:query, query) |> assign(:page, 1)}
+  end
+
+  def handle_event("filter", %{"filter" => filter}, socket)
+      when filter in ~w(new following all) do
+    {:noreply, socket |> assign(:filter, filter) |> assign(:page, 1)}
+  end
+
+  def handle_event("page", %{"page" => page}, socket) do
+    {:noreply, assign(socket, :page, sanitize_page(page, socket))}
+  end
+
+  # ── Selecting ─────────────────────────────────────────────────────────────
+
+  def handle_event("toggle", %{"id" => id}, socket) do
+    selected = socket.assigns.selected
+
+    selected =
+      if MapSet.member?(selected, id),
+        do: MapSet.delete(selected, id),
+        else: MapSet.put(selected, id)
+
+    {:noreply, assign(socket, :selected, selected)}
+  end
+
+  # "Select all" means the whole filtered list, not the page in front of you:
+  # with a thousand rows the visible fifty are never what the member meant. The
+  # cap is applied here rather than at the follow, so the count on the button
+  # and the count that will be followed are the same number.
+  def handle_event("select_all", _params, socket) do
+    ids =
+      socket
+      |> selectable()
+      |> Enum.take(@max_selection)
+      |> Enum.map(& &1.user.id)
+
+    {:noreply, assign(socket, :selected, MapSet.new(ids))}
+  end
+
+  def handle_event("select_none", _params, socket) do
+    {:noreply, assign(socket, :selected, MapSet.new())}
+  end
+
+  # ── Following ─────────────────────────────────────────────────────────────
+
+  def handle_event("follow_selected", _params, socket) do
+    %{user: user, selected: selected} = socket.assigns
+    followed = Social.follow_many(user, MapSet.to_list(selected))
+
+    {:noreply,
+     socket
+     |> assign(:selected, MapSet.new())
+     |> refresh_following()
+     |> put_flash(:info, followed_message(followed))}
+  end
+
+  def handle_event("follow", %{"followee" => followee_id}, socket) do
+    _ = Social.follow(socket.assigns.user, followee_id)
+    {:noreply, refresh_following(socket)}
+  end
+
+  def handle_event("unfollow", %{"id" => follow_id}, socket) do
+    Social.unfollow!(socket.assigns.user.id, follow_id)
+    {:noreply, refresh_following(socket)}
+  end
+
+  defp analyze(socket) do
+    user = socket.assigns.user
+
+    results =
+      consume_uploaded_entries(socket, :archive, fn %{path: path}, _entry ->
+        {:ok, LinkedIn.parse_connections_file(path)}
+      end)
+
+    case results do
+      [{:ok, contacts}] -> assign_matches(socket, user, contacts)
+      [{:error, reason}] -> assign(socket, :error, upload_error(reason))
+      [] -> assign(socket, :error, gettext("Please choose your LinkedIn export ZIP first."))
+    end
+  rescue
+    error ->
+      Logger.error(
+        "LinkedIn contact match failed: " <> Exception.format(:error, error, __STACKTRACE__)
+      )
+
+      assign(socket, :error, gettext("The file could not be read. Please try again."))
+  end
+
+  defp assign_matches(socket, user, contacts) do
+    matches = ConnectionMatch.find(user, contacts)
+
+    socket
+    |> assign(:matches, matches)
+    |> assign(:error, nil)
+    |> assign(:page, 1)
+    |> assign(:selected, MapSet.new())
+    |> assign(
+      :work_info_by_id,
+      UserHelpers.work_information_map(Enum.map(matches, & &1.user), 45)
+    )
+    |> refresh_following()
+  end
+
+  # One query for the whole page's follow state, re-asked after every follow or
+  # unfollow so the pills and the "already following" filter agree.
+  defp refresh_following(%{assigns: %{matches: nil}} = socket), do: socket
+
+  defp refresh_following(socket) do
+    people = Enum.map(socket.assigns.matches, & &1.user)
+    assign(socket, :following_by_id, UserHelpers.following_map(socket.assigns.user, people))
+  end
+
+  defp upload_error(:archive_too_large),
+    do: gettext("That archive is too large or has too many files to read safely.")
+
+  defp upload_error(_reason), do: gettext("That does not look like a LinkedIn data export ZIP.")
+
+  defp followed_message(0), do: gettext("Nobody new to follow: you already follow them.")
+
+  defp followed_message(count) do
+    ngettext(
+      "You now follow one more member.",
+      "You now follow %{formatted} more members.",
+      count,
+      formatted: delimited_count(count)
+    )
+  end
+
+  # ── The list the page is showing ──────────────────────────────────────────
+
+  # The filtered list, in full. Everything the toolbar reports (the count, what
+  # "select all" takes, what the pager pages through) is derived from this one
+  # function, so the numbers cannot drift apart.
+  defp visible(%{assigns: assigns}) do
+    Enum.filter(assigns.matches, fn match ->
+      matches_filter?(match, assigns.filter, assigns.following_by_id) and
+        matches_query?(match, assigns.query)
+    end)
+  end
+
+  # What "select all" may take: never someone the member already follows —
+  # pressing it must not be able to re-follow, and it would waste the cap.
+  defp selectable(socket) do
+    Enum.reject(socket |> visible(), &following?(&1, socket.assigns.following_by_id))
+  end
+
+  defp matches_filter?(match, "new", following), do: not following?(match, following)
+  defp matches_filter?(match, "following", following), do: following?(match, following)
+  defp matches_filter?(_match, _filter, _following), do: true
+
+  defp following?(%{user: user}, following), do: Map.has_key?(following, user.id)
+
+  defp matches_query?(_match, ""), do: true
+
+  defp matches_query?(%{user: user}, query) do
+    user
+    |> UserHelpers.full_name()
+    |> String.downcase()
+    |> String.contains?(String.downcase(query))
+  end
+
+  defp page_slice(matches, page) do
+    Enum.slice(matches, (page - 1) * @per_page, @per_page)
+  end
+
+  defp sanitize_page(page, socket) do
+    total_pages = Pages.total_pages(length(visible(socket)), @per_page)
+
+    case Integer.parse(to_string(page)) do
+      {number, _rest} -> number |> max(1) |> min(total_pages)
+      :error -> 1
+    end
+  end
+
+  # ── Render ────────────────────────────────────────────────────────────────
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <.settings_shell
+      user={@user}
+      active={:import_connections}
+      title={gettext("Find your LinkedIn contacts")}
+    >
+      <div class="max-w-3xl space-y-6">
+        <.upload_card :if={is_nil(@matches)} {assigns} />
+        <.results_card :if={@matches} {assigns} />
+      </div>
+    </.settings_shell>
+    """
+  end
+
+  defp upload_card(assigns) do
+    ~H"""
+    <.card>
+      <.section_title>{gettext("Who of your LinkedIn contacts is already here?")}</.section_title>
+      <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">
+        {gettext(
+          "Your LinkedIn data export lists your contacts. We read that list, look for the people among them who are already vutuv members, and show you who they are. You decide who to follow."
+        )}
+      </p>
+
+      <%!-- The three promises that make this bearable, said before the upload
+      button rather than in a privacy page nobody opens. --%>
+      <ul class="mt-4 space-y-1.5 text-sm text-slate-700 dark:text-slate-300">
+        <li>{gettext("Nobody is invited and no email is sent.")}</li>
+        <li>{gettext("Nothing is added to your profile.")}</li>
+        <li>
+          {gettext(
+            "Nothing is stored: we read the file, show you the result, and keep neither your contacts nor the list."
+          )}
+        </li>
+      </ul>
+
+      <p class="mt-4 text-sm text-slate-600 dark:text-slate-400">
+        {gettext(
+          "We only recognise someone by an email address they published here, or by the LinkedIn profile they linked from their vutuv profile. We never guess by name, so you will not be offered a stranger who happens to share a name with someone you know."
+        )}
+      </p>
+
+      <p class="mt-4 text-sm text-slate-600 dark:text-slate-400">
+        {gettext("It is the same ZIP file the profile import uses.")}
+        <.link
+          navigate={~p"/settings/import/linkedin"}
+          class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+        >
+          {gettext("How to request it from LinkedIn")}
+        </.link>
+      </p>
+
+      <form
+        id="linkedin-connections-form"
+        phx-submit="analyze"
+        phx-change="validate"
+        class="mt-6 space-y-4"
+      >
+        <label
+          data-dropzone
+          phx-drop-target={@uploads.archive.ref}
+          class="group flex cursor-pointer flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-slate-300 bg-slate-50 px-6 py-10 text-center transition-colors hover:border-brand-400 hover:bg-brand-50 has-[:focus-visible]:border-brand-500 has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-brand-500 dark:border-slate-700 dark:bg-slate-800/50 dark:hover:border-brand-500 dark:hover:bg-slate-800"
+        >
+          <svg
+            class="h-8 w-8 text-slate-400 transition-colors group-hover:text-brand-500 dark:text-slate-500"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="1.5"
+            aria-hidden="true"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5"
+            />
+          </svg>
+          <span class="text-sm text-slate-600 dark:text-slate-400">
+            {gettext("Drag your ZIP file here, or click to choose one.")}
+          </span>
+          <span
+            :for={entry <- @uploads.archive.entries}
+            class="text-sm font-medium text-slate-900 dark:text-slate-100"
+          >
+            {entry.client_name}
+          </span>
+          <span class="text-xs text-slate-600 dark:text-slate-400">
+            {gettext("ZIP file, up to 50 MB.")}
+          </span>
+          <.live_file_input upload={@uploads.archive} class="sr-only" />
+        </label>
+
+        <%!-- Both error levels: a too-large or non-ZIP file is an *entry*
+        error, so asking the upload alone reports nothing and the member is
+        left with a button that quietly does nothing. --%>
+        <p
+          :for={err <- upload_errors(@uploads.archive)}
+          class="text-sm font-medium text-red-600 dark:text-red-400"
+        >
+          {upload_error_message(err)}
+        </p>
+        <%= for entry <- @uploads.archive.entries, err <- upload_errors(@uploads.archive, entry) do %>
+          <p class="text-sm font-medium text-red-600 dark:text-red-400">
+            {upload_error_message(err)}
+          </p>
+        <% end %>
+        <p :if={@error} class="text-sm font-medium text-red-600 dark:text-red-400">{@error}</p>
+
+        <.button type="submit" phx-disable-with={gettext("Reading…")} class="w-full sm:w-auto">
+          {gettext("Find my contacts")}
+        </.button>
+      </form>
+    </.card>
+    """
+  end
+
+  defp results_card(assigns) do
+    shown = visible(%{assigns: assigns})
+    total = length(shown)
+
+    assigns =
+      assigns
+      |> assign(:shown, page_slice(shown, assigns.page))
+      |> assign(:total, total)
+      |> assign(:total_pages, Pages.total_pages(total, @per_page))
+      |> assign(:found, length(assigns.matches))
+      |> assign(:selectable_count, min(length(selectable(%{assigns: assigns})), @max_selection))
+      |> assign(:selected_count, MapSet.size(assigns.selected))
+
+    ~H"""
+    <.card>
+      <div class="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+        <.section_title>{gettext("Your contacts on vutuv")}</.section_title>
+        <button
+          type="button"
+          phx-click="start_over"
+          class="text-sm font-semibold text-slate-600 hover:text-brand-700 dark:text-slate-400 dark:hover:text-brand-300"
+        >
+          {gettext("Analyse another file")}
+        </button>
+      </div>
+
+      <p :if={@found == 0} class="mt-2 text-sm text-slate-600 dark:text-slate-400">
+        {gettext(
+          "None of your contacts is here yet. Or they are, but keep their address private and have not linked their LinkedIn profile. Nothing was stored, and you can try again with a newer archive at any time."
+        )}
+      </p>
+
+      <div :if={@found > 0}>
+        <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">
+          {ngettext(
+            "One of your LinkedIn contacts is already a vutuv member.",
+            "%{formatted} of your LinkedIn contacts are already vutuv members.",
+            @found,
+            formatted: delimited_count(@found)
+          )}
+        </p>
+
+        <%!-- Search + filter. Both narrow the same list the selection and the
+        pager work on, so "select all" always means "all of what I am
+        looking at". --%>
+        <div class="mt-4 flex flex-wrap items-center gap-2">
+          <form phx-change="search" class="min-w-0 flex-1">
+            <label for="contact-search" class="sr-only">{gettext("Search by name")}</label>
+            <input
+              type="search"
+              id="contact-search"
+              name="q"
+              value={@query}
+              phx-debounce="200"
+              placeholder={gettext("Search by name")}
+              autocomplete="off"
+              class={input_class()}
+            />
+          </form>
+          <div class="flex rounded-lg bg-slate-100 p-1 dark:bg-slate-800">
+            <.filter_tab value="new" active={@filter} label={gettext("Not following yet")} />
+            <.filter_tab value="following" active={@filter} label={gettext("Following")} />
+            <.filter_tab value="all" active={@filter} label={gettext("All")} />
+          </div>
+        </div>
+
+        <%!-- The bulk bar. Nothing is preselected, so the primary button only
+        appears once the member has picked somebody; "select all" carries its
+        own number, because a button that follows several hundred people must
+        say how many before it is pressed. --%>
+        <div class="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 border-t border-slate-100 pt-3 text-sm dark:border-slate-800">
+          <button
+            :if={@selectable_count > 0}
+            type="button"
+            phx-click="select_all"
+            class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+          >
+            {gettext("Select all %{count}", count: delimited_count(@selectable_count))}
+          </button>
+          <button
+            :if={@selected_count > 0}
+            type="button"
+            phx-click="select_none"
+            class="font-semibold text-slate-600 hover:text-slate-800 dark:text-slate-400"
+          >
+            {gettext("Select none")}
+          </button>
+          <span :if={@selected_count > 0} class="text-slate-600 dark:text-slate-400">
+            {ngettext("One selected", "%{formatted} selected", @selected_count,
+              formatted: delimited_count(@selected_count)
+            )}
+          </span>
+          <.button
+            :if={@selected_count > 0}
+            type="button"
+            phx-click="follow_selected"
+            phx-disable-with={gettext("Following…")}
+            class="ml-auto"
+          >
+            {gettext("Follow selected")}
+          </.button>
+        </div>
+
+        <%!-- Two ways to end up with an empty list, and they mean opposite
+        things: nothing matched what you typed, or you already follow everybody
+        the archive turned up — the ordinary outcome of running the same file
+        twice, which must not read as a failed search. --%>
+        <p :if={@total == 0} class="mt-4 text-sm text-slate-600 dark:text-slate-400">
+          <%= if @query == "" and @filter == "new" do %>
+            {gettext("You already follow every contact we found.")}
+          <% else %>
+            {gettext("Nobody here matches what you are looking for.")}
+          <% end %>
+        </p>
+
+        <ul id="contact-matches" class="mt-4 divide-y divide-slate-100 dark:divide-slate-800">
+          <.match_row
+            :for={match <- @shown}
+            match={match}
+            user={@user}
+            selected?={MapSet.member?(@selected, match.user.id)}
+            follow_id={Map.get(@following_by_id, match.user.id)}
+            work_line={Map.get(@work_info_by_id, match.user.id)}
+          />
+        </ul>
+
+        <p :if={@total > @per_page} class="mt-4 text-xs text-slate-600 dark:text-slate-400">
+          {gettext("Showing %{first}-%{last} of %{total}.",
+            first: delimited_count((@page - 1) * @per_page + 1),
+            last: delimited_count(min(@page * @per_page, @total)),
+            total: delimited_count(@total)
+          )}
+        </p>
+        <.page_nav page={@page} total_pages={@total_pages} />
+      </div>
+    </.card>
+    """
+  end
+
+  attr(:value, :string, required: true)
+  attr(:active, :string, required: true)
+  attr(:label, :string, required: true)
+
+  defp filter_tab(assigns) do
+    ~H"""
+    <button
+      type="button"
+      phx-click="filter"
+      phx-value-filter={@value}
+      aria-pressed={to_string(@value == @active)}
+      class={[
+        "rounded-md px-3 py-1 text-sm font-medium",
+        if(@value == @active,
+          do: "bg-white text-slate-900 shadow-sm dark:bg-slate-900 dark:text-white",
+          else: "text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
+        )
+      ]}
+    >
+      {@label}
+    </button>
+    """
+  end
+
+  attr(:match, :map, required: true)
+  attr(:user, :any, required: true)
+  attr(:selected?, :boolean, required: true)
+  attr(:follow_id, :any, default: nil)
+  attr(:work_line, :any, default: nil)
+
+  defp match_row(assigns) do
+    ~H"""
+    <li class="flex items-center gap-3 py-3">
+      <%!-- Already following? Then there is nothing to select: the checkbox
+      would offer an act that cannot happen, so the row shows its state and
+      the pill (which can still unfollow) instead. --%>
+      <input
+        :if={is_nil(@follow_id)}
+        type="checkbox"
+        id={"select-#{@match.user.id}"}
+        checked={@selected?}
+        phx-click="toggle"
+        phx-value-id={@match.user.id}
+        class={checkbox_class()}
+      />
+      <span :if={@follow_id} class="w-4 shrink-0" aria-hidden="true"></span>
+      <.link navigate={~p"/#{@match.user}"} class="shrink-0">
+        <.avatar user={@match.user} size="sm" alt={UserHelpers.full_name(@match.user)} />
+      </.link>
+      <div class="min-w-0 flex-1 text-sm">
+        <.link
+          navigate={~p"/#{@match.user}"}
+          class="block truncate font-medium text-slate-800 hover:text-brand-700 dark:text-slate-100"
+        >
+          {UserHelpers.full_name(@match.user)}
+        </.link>
+        <p :if={@work_line} class="mb-0 truncate text-sm text-slate-600 dark:text-slate-400">
+          {@work_line}
+        </p>
+        <p class="mb-0 truncate text-xs text-slate-500 dark:text-slate-500">{evidence(@match.via)}</p>
+      </div>
+      <.follow_button
+        variant="text"
+        follower_id={@user.id}
+        followee_id={@match.user.id}
+        follow_id={@follow_id}
+        live?
+      />
+    </li>
+    """
+  end
+
+  # Why this person is on the list, in the row rather than in a legend: a
+  # grouped list would say it once at the top and be scrolled away by row 40.
+  defp evidence(:email), do: gettext("Same email address as your contact")
+  defp evidence(:linkedin), do: gettext("Links the same LinkedIn profile")
+
+  attr(:page, :integer, required: true)
+  attr(:total_pages, :integer, required: true)
+
+  defp page_nav(assigns) do
+    assigns =
+      assign(
+        assigns,
+        :window,
+        Enum.filter((assigns.page - 3)..(assigns.page + 3), &(&1 in 1..assigns.total_pages))
+      )
+
+    ~H"""
+    <nav
+      :if={@total_pages > 1}
+      aria-label={gettext("Pagination")}
+      class="mt-4 flex flex-wrap items-center justify-center gap-1 text-sm font-semibold"
+    >
+      <%!-- Paging is phx-click rather than a `?page=` link on purpose: this
+      list comes from a file on the member's own disk, so a page URL would look
+      shareable and reloadable while being neither. --%>
+      <.page_button :if={List.first(@window) > 1} page={1} current={@page} />
+      <span :if={List.first(@window) > 2} class="px-1 text-slate-600 dark:text-slate-400">…</span>
+      <.page_button :for={number <- @window} page={number} current={@page} />
+      <span :if={List.last(@window) < @total_pages - 1} class="px-1 text-slate-600 dark:text-slate-400">
+        …
+      </span>
+      <.page_button
+        :if={List.last(@window) < @total_pages}
+        page={@total_pages}
+        current={@page}
+      />
+    </nav>
+    """
+  end
+
+  attr(:page, :integer, required: true)
+  attr(:current, :integer, required: true)
+
+  defp page_button(assigns) do
+    ~H"""
+    <button
+      type="button"
+      phx-click="page"
+      phx-value-page={@page}
+      aria-current={if(@page == @current, do: "page")}
+      class={[
+        "flex h-9 min-w-9 items-center justify-center rounded-lg px-2",
+        if(@page == @current,
+          do: "bg-brand-600 text-white",
+          else: "text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800"
+        )
+      ]}
+    >
+      {@page}
+    </button>
+    """
+  end
+
+  defp upload_error_message(:too_large),
+    do: gettext("This file is too large. Please choose a ZIP of at most 50 MB.")
+
+  defp upload_error_message(:not_accepted), do: gettext("Please choose a ZIP file.")
+  defp upload_error_message(_error), do: gettext("That file could not be read.")
+end

--- a/lib/vutuv_web/rate_limit.ex
+++ b/lib/vutuv_web/rate_limit.ex
@@ -60,8 +60,7 @@ defmodule VutuvWeb.RateLimit do
       # without it a rate-limited client kept writing a fresh identity bucket per
       # distinct email even after its IP budget was spent (F13). `and` short-
       # circuits, so `identities_ok?/4` never runs once the IP key is over.
-      if RateLimiter.hit({event, :ip, ip(conn)}, lim, win) == :ok and
-           identities_ok?(event, extra, lim, win) do
+      if ip_ok?(conn, event, lim, win) and identities_ok?(event, extra, lim, win) do
         :ok
       else
         :rate_limited
@@ -70,6 +69,16 @@ defmodule VutuvWeb.RateLimit do
       :ok
     end
   end
+
+  # `nil` instead of a conn means there is no client address to bucket: a
+  # LiveView socket, whose `connect_info` carries the session and nothing else.
+  # Only a logged-in member reaches those events, so `extra` below is a real
+  # identity and is what does the work; the per-IP half is what protects the
+  # *anonymous* paths, and it is not silently skipped anywhere else.
+  defp ip_ok?(nil, _event, _lim, _win), do: true
+
+  defp ip_ok?(conn, event, lim, win),
+    do: RateLimiter.hit({event, :ip, ip(conn)}, lim, win) == :ok
 
   defp identities_ok?(event, extra, lim, win) do
     event
@@ -104,11 +113,28 @@ defmodule VutuvWeb.RateLimit do
   overridable via `config :vutuv, :linkedin_import_rate_limit, {limit, window_ms}`.
   """
   def check_linkedin_import(conn, user) do
-    {limit, window_ms} =
-      Application.get_env(:vutuv, :linkedin_import_rate_limit, {@import_limit, @import_window_ms})
+    {limit, window_ms} = import_budget()
 
     check(conn, :linkedin_import, user.id, limit: limit, window_ms: window_ms)
   end
+
+  # Anything but a `{limit, window}` pair falls back to the built-in budget
+  # rather than raising: this runs on the upload path, so a config key holding
+  # something unexpected must throttle by the default, never 500 the page.
+  defp import_budget do
+    case Application.get_env(:vutuv, :linkedin_import_rate_limit) do
+      {limit, window_ms} when is_integer(limit) and is_integer(window_ms) -> {limit, window_ms}
+      _other -> {@import_limit, @import_window_ms}
+    end
+  end
+
+  @doc """
+  The socket-side twin for the contact finder (issue #1476), which decompresses
+  the same archive over a LiveView upload. It shares the import budget — the two
+  pages read one archive between them — and is keyed on the member alone,
+  because a LiveView has no conn to read a client address from.
+  """
+  def check_linkedin_import(user), do: check_linkedin_import(nil, user)
 
   @doc """
   Throttles the self-hosted-forge admission check (20 per hour, per IP and per

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -1006,6 +1006,13 @@ defmodule VutuvWeb.Router do
       # the account, exactly when, from where and how it was confirmed. A
       # LiveView because it is a searchable, sortable, paged table.
       live("/activity", AccountActivityLive, :index)
+
+      # "Which of my LinkedIn contacts are already here?" (issue #1476). Its own
+      # upload, separate from the profile importer above: that one fills your
+      # profile, this one fills your feed, and each is worth doing without the
+      # other. A LiveView because the result is a long list to search, filter,
+      # page and follow from — none of which should cost a reload.
+      live("/import/linkedin/connections", ImportConnectionsLive, :index)
     end
   end
 

--- a/lib/vutuv_web/templates/import/new.html.heex
+++ b/lib/vutuv_web/templates/import/new.html.heex
@@ -20,6 +20,24 @@
         "You decide exactly what to add. In the next step we show you everything we found and you pick it entry by entry, so you never import anything sight unseen. Nothing is added until you confirm, and your existing entries are never overwritten."
       )}
     </p>
+
+    <%!-- The other half of the same archive (issue #1476). It is named here
+    rather than only in the settings list, because this is the page a member is
+    on with the ZIP already in hand. --%>
+    <div class="mt-4 border-t border-slate-100 pt-4 dark:border-slate-800">
+      <p class="text-sm text-slate-600 dark:text-slate-400">
+        {gettext(
+          "The same file also lists your LinkedIn contacts. We can show you which of them are already on vutuv, without importing or inviting anyone."
+        )}
+      </p>
+      <.link
+        navigate={~p"/settings/import/linkedin/connections"}
+        class="mt-2 inline-flex items-center gap-1 text-sm font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+      >
+        {gettext("Find your contacts")}
+        <span aria-hidden="true">→</span>
+      </.link>
+    </div>
   </.card>
 
   <.card>

--- a/lib/vutuv_web/templates/import/preview.html.heex
+++ b/lib/vutuv_web/templates/import/preview.html.heex
@@ -114,6 +114,16 @@
         </.link>
       </div>
     </.form>
+
+    <%!-- Below the confirm row, so it never competes with the button this page
+    exists for: the contacts half of the same archive (issue #1476), which the
+    member still has open on their desk. --%>
+    <p class="mt-6 border-t border-slate-100 pt-4 text-sm text-slate-600 dark:border-slate-800 dark:text-slate-400">
+      {gettext("Your export also lists your LinkedIn contacts.")}
+      <.link navigate={~p"/settings/import/linkedin/connections"} class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300">
+        {gettext("See which of them are already on vutuv")}
+      </.link>.
+    </p>
   </.card>
 </div>
 </.settings_shell>

--- a/lib/vutuv_web/templates/user/show.html.heex
+++ b/lib/vutuv_web/templates/user/show.html.heex
@@ -427,12 +427,23 @@ the resulting ~200px rail width. --%>
       <%!-- A quiet link into the LinkedIn importer: the fastest way to fill
       several of the steps above at once. Owner-only (it lives inside this
       owner-only card) and part of the same onboarding push. --%>
-      <div class="mt-4 border-t border-brand-100 pt-4 dark:border-brand-900/50">
+      <div class="mt-4 space-y-1 border-t border-brand-100 pt-4 dark:border-brand-900/50">
         <.link
           navigate={~p"/settings/import/linkedin"}
           class="inline-flex items-center gap-1 text-sm font-semibold text-brand-800 hover:underline dark:text-brand-100"
         >
           {gettext("Import from LinkedIn")}
+          <span aria-hidden="true">→</span>
+        </.link>
+        <%!-- The other thing that same archive is good for (issue #1476), and
+        the fastest way through the "follow other members" step above: the
+        people you already know are better company than any suggestion we can
+        make on a member's first minute here. --%>
+        <.link
+          navigate={~p"/settings/import/linkedin/connections"}
+          class="flex items-center gap-1 text-sm font-semibold text-brand-800 hover:underline dark:text-brand-100"
+        >
+          {gettext("Find people you know from LinkedIn")}
           <span aria-hidden="true">→</span>
         </.link>
       </div>
@@ -1042,6 +1053,7 @@ the resulting ~200px rail width. --%>
     <.who_to_follow_card
       :if={@promote_discovery?}
       promoted
+      owner?={@as_owner?}
       recommended_users={@recommended_users}
       current_user={@current_user}
       current_user_id={@current_user_id}
@@ -1533,6 +1545,7 @@ the resulting ~200px rail width. --%>
     groups it with Followers / Following at the end on a phone. --%>
     <.who_to_follow_card
       :if={!@promote_discovery?}
+      owner?={@as_owner?}
       recommended_users={@recommended_users}
       current_user={@current_user}
       current_user_id={@current_user_id}

--- a/lib/vutuv_web/views/user_html.ex
+++ b/lib/vutuv_web/views/user_html.ex
@@ -187,6 +187,11 @@ defmodule VutuvWeb.UserHTML do
   call sites are mutually exclusive, so the DOM id stays unique.
   """
   attr(:promoted, :boolean, default: false)
+  # The owner gets one extra line under the suggestions: the LinkedIn contact
+  # finder (issue #1476). This is the card a member reads when they are looking
+  # for people to follow, so it is where "and the ones you already know" belongs
+  # — the settings list alone would never be found from here.
+  attr(:owner?, :boolean, default: false)
   attr(:recommended_users, :list, required: true)
   attr(:current_user, :any, required: true)
   attr(:current_user_id, :any, required: true)
@@ -221,6 +226,17 @@ defmodule VutuvWeb.UserHTML do
           live?
         />
       </ul>
+      <div
+        :if={@owner?}
+        class="mt-4 border-t border-slate-100 pt-3 dark:border-slate-800"
+      >
+        <.link
+          navigate={~p"/settings/import/linkedin/connections"}
+          class="text-sm font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+        >
+          {gettext("Find people you know from LinkedIn")} <span aria-hidden="true">→</span>
+        </.link>
+      </div>
     </.card>
     """
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.311.0",
+      version: "7.312.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -38,7 +38,7 @@ msgstr "Eintrag hinzufügen"
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1449
+#: lib/vutuv_web/templates/user/show.html.heex:1461
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -103,7 +103,7 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/agent_docs/markdown.ex:586
 #: lib/vutuv_web/agent_docs/text.ex:550
 #: lib/vutuv_web/agent_docs/text.ex:551
-#: lib/vutuv_web/templates/user/show.html.heex:1081
+#: lib/vutuv_web/templates/user/show.html.heex:1093
 #, elixir-autogen
 msgid "Birthday"
 msgstr "Geburtstag"
@@ -152,7 +152,7 @@ msgstr "Wählen Sie einen Typ aus"
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1119
+#: lib/vutuv_web/templates/user/show.html.heex:1131
 #, elixir-autogen
 msgid "Contact"
 msgstr "Kontakt"
@@ -224,7 +224,7 @@ msgstr "Download"
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:1104
+#: lib/vutuv_web/templates/user/show.html.heex:1116
 #, elixir-autogen
 msgid "Edit"
 msgstr "Ändern"
@@ -289,7 +289,7 @@ msgstr "E-Mail-Adresse eingeben"
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:613
+#: lib/vutuv_web/templates/user/show.html.heex:624
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -333,10 +333,11 @@ msgstr "Follower"
 #: lib/vutuv_web/components/ui.ex:2158
 #: lib/vutuv_web/components/ui.ex:2216
 #: lib/vutuv_web/controllers/followee_controller.ex:29
+#: lib/vutuv_web/live/import_connections_live.ex:469
 #: lib/vutuv_web/live/organization_live/show.ex:471
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:959
+#: lib/vutuv_web/templates/user/show.html.heex:970
 #, elixir-autogen
 msgid "Following"
 msgstr "Folge ich"
@@ -690,13 +691,13 @@ msgstr "Slug"
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1233
+#: lib/vutuv_web/templates/user/show.html.heex:1245
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr "Profile"
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1235
+#: lib/vutuv_web/templates/user/show.html.heex:1247
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr "Profil hinzufügen"
@@ -728,12 +729,12 @@ msgstr "Profil wurde geändert."
 msgid "Profile deleted successfully."
 msgstr "Profil wurde gelöscht."
 
-#: lib/vutuv_web/views/user_html.ex:708
+#: lib/vutuv_web/views/user_html.ex:724
 #, elixir-autogen, elixir-format
 msgid "Social networks"
 msgstr "Soziale Netzwerke"
 
-#: lib/vutuv_web/views/user_html.ex:715
+#: lib/vutuv_web/views/user_html.ex:731
 #, elixir-autogen, elixir-format
 msgid "Code & repositories"
 msgstr "Code & Repositorys"
@@ -854,13 +855,13 @@ msgid "vCard"
 msgstr "vCard"
 
 #: lib/vutuv_web/components/ui.ex:3710
-#: lib/vutuv_web/templates/user/show.html.heex:953
-#: lib/vutuv_web/templates/user/show.html.heex:976
+#: lib/vutuv_web/templates/user/show.html.heex:964
+#: lib/vutuv_web/templates/user/show.html.heex:987
 #, elixir-autogen
 msgid "View All"
 msgstr "Alle anzeigen"
 
-#: lib/vutuv_web/components/ui.ex:4056
+#: lib/vutuv_web/components/ui.ex:4069
 #: lib/vutuv_web/controllers/settings_controller.ex:169
 #: lib/vutuv_web/live/job_posting_live/form.ex:561
 #: lib/vutuv_web/live/organization_live/edit.ex:304
@@ -1062,7 +1063,7 @@ msgstr "Diese Seite ist für Sie gesperrt."
 msgid "An error occurred"
 msgstr "Es gab einen Fehler."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1070
+#: lib/vutuv_web/templates/user/show.html.heex:1082
 #, elixir-autogen
 msgid "General Info"
 msgstr "Allgemeines"
@@ -1231,7 +1232,7 @@ msgstr "Alle Tag-URLs"
 
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:607
+#: lib/vutuv_web/templates/user/show.html.heex:618
 #, elixir-autogen
 msgid "All tags"
 msgstr "Alle Tags"
@@ -1429,7 +1430,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:23
 #: lib/vutuv_web/templates/tag/show.html.heex:25
-#: lib/vutuv_web/templates/user/show.html.heex:577
+#: lib/vutuv_web/templates/user/show.html.heex:588
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
@@ -1728,7 +1729,7 @@ msgstr "Empfehlen"
 #: lib/vutuv_web/live/organization_live/following.ex:411
 #: lib/vutuv_web/live/organization_live/show.ex:440
 #: lib/vutuv_web/live/organization_live/show.ex:469
-#: lib/vutuv_web/templates/user/show.html.heex:1273
+#: lib/vutuv_web/templates/user/show.html.heex:1285
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr "Folgen"
@@ -1879,7 +1880,7 @@ msgstr "Zu viele Versuche. Bitte versuchen Sie es später erneut."
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:27
 #: lib/vutuv_web/templates/social_media_account/verify.html.heex:18
 #: lib/vutuv_web/templates/user/show.html.heex:200
-#: lib/vutuv_web/views/user_html.ex:760
+#: lib/vutuv_web/views/user_html.ex:776
 #, elixir-autogen, elixir-format
 msgid "Verified profile"
 msgstr "Verifiziertes Profil"
@@ -1906,7 +1907,7 @@ msgstr ""
 "unten ein, um die Adresse zu bestätigen."
 
 #: lib/vutuv_web/live/post_live/feed.ex:1435
-#: lib/vutuv_web/views/user_html.ex:208
+#: lib/vutuv_web/views/user_html.ex:213
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr "Vorgeschlagene Profile"
@@ -1959,6 +1960,7 @@ msgstr "folgt Ihnen jetzt."
 
 #: lib/vutuv_web/components/ui.ex:3099
 #: lib/vutuv_web/components/ui.ex:3250
+#: lib/vutuv_web/live/import_connections_live.ex:638
 #: lib/vutuv_web/live/organization_live/index.ex:122
 #, elixir-autogen, elixir-format
 msgid "Pagination"
@@ -2089,12 +2091,12 @@ msgstr "März"
 msgid "May"
 msgstr "Mai"
 
-#: lib/vutuv_web/views/user_html.ex:249
+#: lib/vutuv_web/views/user_html.ex:265
 #, elixir-autogen, elixir-format
 msgid "Member since %{month} %{year}"
 msgstr "Mitglied seit %{month} %{year}"
 
-#: lib/vutuv_web/views/user_html.ex:254
+#: lib/vutuv_web/views/user_html.ex:270
 #, elixir-autogen, elixir-format
 msgid "Member since %{year}"
 msgstr "Mitglied seit %{year}"
@@ -2339,7 +2341,7 @@ msgstr "Zu viele Dateien."
 msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
 
-#: lib/vutuv_web/components/ui.ex:4310
+#: lib/vutuv_web/components/ui.ex:4323
 #: lib/vutuv_web/live/shell_live.ex:791
 #: lib/vutuv_web/templates/post/index.html.heex:17
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2409,7 +2411,7 @@ msgstr "Dateityp wird nicht unterstützt (erlaubt: %{types})."
 msgid "Posts by %{name}"
 msgstr "Beiträge von %{name}"
 
-#: lib/vutuv_web/templates/user/show.html.heex:567
+#: lib/vutuv_web/templates/user/show.html.heex:578
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr "Alle %{count} Beiträge ansehen"
@@ -2422,7 +2424,7 @@ msgstr "Alle Beiträge"
 #: lib/vutuv_web/components/post_components.ex:1666
 #: lib/vutuv_web/components/post_components.ex:4658
 #: lib/vutuv_web/components/ui.ex:3174
-#: lib/vutuv_web/views/user_html.ex:424
+#: lib/vutuv_web/views/user_html.ex:440
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr "Lesezeichen setzen"
@@ -2442,7 +2444,7 @@ msgstr "Lesezeichen"
 #: lib/vutuv_web/components/post_components.ex:4892
 #: lib/vutuv_web/components/ui.ex:3160
 #: lib/vutuv_web/live/notification_live/index.ex:1037
-#: lib/vutuv_web/views/user_html.ex:434
+#: lib/vutuv_web/views/user_html.ex:450
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr "Gefällt mir"
@@ -2478,7 +2480,7 @@ msgstr "Nur öffentliche Beiträge können repostet werden."
 #: lib/vutuv_web/components/post_components.ex:1666
 #: lib/vutuv_web/components/post_components.ex:4658
 #: lib/vutuv_web/live/post_live/saved.ex:775
-#: lib/vutuv_web/views/user_html.ex:424
+#: lib/vutuv_web/views/user_html.ex:440
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
@@ -2504,7 +2506,7 @@ msgstr "Repost zurücknehmen"
 
 #: lib/vutuv_web/components/post_components.ex:4892
 #: lib/vutuv_web/live/post_live/saved.ex:774
-#: lib/vutuv_web/views/user_html.ex:434
+#: lib/vutuv_web/views/user_html.ex:450
 #, elixir-autogen, elixir-format
 msgid "Unlike"
 msgstr "Gefällt mir entfernen"
@@ -2752,45 +2754,45 @@ msgstr "Andere E-Mail-Adresse verwenden"
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
 #: lib/vutuv_web/templates/url/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:889
+#: lib/vutuv_web/templates/user/show.html.heex:900
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr "Link hinzufügen"
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1193
+#: lib/vutuv_web/templates/user/show.html.heex:1205
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr "Telefonnummer hinzufügen"
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1451
+#: lib/vutuv_web/templates/user/show.html.heex:1463
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr "Adresse hinzufügen"
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1121
+#: lib/vutuv_web/templates/user/show.html.heex:1133
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr "E-Mail-Adresse hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1072
+#: lib/vutuv_web/templates/user/show.html.heex:1084
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr "Persönliche Angaben hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:616
+#: lib/vutuv_web/templates/user/show.html.heex:627
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #: lib/vutuv_web/templates/work_experience/new.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Add work experience"
 msgstr "Berufserfahrung hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:477
+#: lib/vutuv_web/templates/user/show.html.heex:488
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
 msgstr "Ersten Beitrag schreiben"
@@ -2803,13 +2805,13 @@ msgstr "Ersten Beitrag schreiben"
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:216
-#: lib/vutuv_web/templates/user/show.html.heex:607
+#: lib/vutuv_web/templates/user/show.html.heex:618
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr "Verwalten"
 
 #: lib/vutuv_web/live/post_live/feed.ex:1206
-#: lib/vutuv_web/templates/user/show.html.heex:477
+#: lib/vutuv_web/templates/user/show.html.heex:488
 #, elixir-autogen, elixir-format
 msgid "Write a post"
 msgstr "Beitrag schreiben"
@@ -2911,7 +2913,7 @@ msgid "Endorsement"
 msgstr "Empfehlung"
 
 #: lib/vutuv_web/live/notification_live/index.ex:1032
-#: lib/vutuv_web/templates/user/show.html.heex:937
+#: lib/vutuv_web/templates/user/show.html.heex:948
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -3158,8 +3160,8 @@ msgstr "Nichts zu sehen, keiner Ihrer Inhalte ist derzeit gemeldet."
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1161
-#: lib/vutuv_web/templates/user/show.html.heex:1162
+#: lib/vutuv_web/templates/user/show.html.heex:1173
+#: lib/vutuv_web/templates/user/show.html.heex:1174
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
@@ -4660,7 +4662,7 @@ msgstr ""
 "beide Richtungen unterbunden. Eine Aufhebung der Blockierung stellt das "
 "Entfernte nicht wieder her."
 
-#: lib/vutuv_web/components/ui.ex:4060
+#: lib/vutuv_web/components/ui.ex:4073
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -4723,7 +4725,7 @@ msgstr "Mitglieder finden"
 #: lib/vutuv_web/live/organization_live/following.ex:303
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:959
+#: lib/vutuv_web/templates/user/show.html.heex:970
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr "Folgt"
@@ -4794,6 +4796,7 @@ msgstr "Ähnliche Namen"
 #: lib/vutuv_web/components/post_components.ex:412
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
+#: lib/vutuv_web/live/import_connections_live.ex:470
 #: lib/vutuv_web/live/notification_live/index.ex:890
 #: lib/vutuv_web/live/search_live.ex:280
 #: lib/vutuv_web/views/qualification_html.ex:90
@@ -4844,7 +4847,7 @@ msgstr "sucht nur in Vornamen (nachname: für Nachnamen)"
 #: lib/vutuv_web/live/job_board_live.ex:388
 #: lib/vutuv_web/live/tag_new_live.ex:48
 #: lib/vutuv_web/live/user_profile_live.ex:1331
-#: lib/vutuv_web/templates/user/show.html.heex:580
+#: lib/vutuv_web/templates/user/show.html.heex:591
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr "Tags hinzufügen"
@@ -5487,7 +5490,7 @@ msgstr "API-Token (%{date})"
 msgid "API documentation"
 msgstr "API-Dokumentation"
 
-#: lib/vutuv_web/components/ui.ex:4120
+#: lib/vutuv_web/components/ui.ex:4133
 #: lib/vutuv_web/controllers/settings_controller.ex:155
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5571,10 +5574,10 @@ msgstr "Tastaturkürzel"
 msgid "Navigation"
 msgstr "Navigation"
 
-#: lib/vutuv_web/components/ui.ex:4217
-#: lib/vutuv_web/components/ui.ex:4222
-#: lib/vutuv_web/components/ui.ex:4301
-#: lib/vutuv_web/components/ui.ex:4365
+#: lib/vutuv_web/components/ui.ex:4230
+#: lib/vutuv_web/components/ui.ex:4235
+#: lib/vutuv_web/components/ui.ex:4314
+#: lib/vutuv_web/components/ui.ex:4378
 #: lib/vutuv_web/controllers/settings_controller.ex:62
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5673,7 +5676,7 @@ msgstr "Andere"
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:33
 #: lib/vutuv_web/views/email_html.ex:12
-#: lib/vutuv_web/views/user_html.ex:885
+#: lib/vutuv_web/views/user_html.ex:901
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr "Privat"
@@ -5693,7 +5696,7 @@ msgstr "Art der E-Mail-Adresse"
 msgid "About you"
 msgstr "Über Sie"
 
-#: lib/vutuv_web/components/ui.ex:4080
+#: lib/vutuv_web/components/ui.ex:4093
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:289
@@ -5749,7 +5752,7 @@ msgstr "Persönliche Tokens für die vutuv-API."
 msgid "Photos"
 msgstr "Fotos"
 
-#: lib/vutuv_web/components/ui.ex:4054
+#: lib/vutuv_web/components/ui.ex:4067
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/templates/page/index.html.heex:174
 #, elixir-autogen, elixir-format
@@ -5864,7 +5867,7 @@ msgstr "@%{slug} folgt Ihnen jetzt auf vutuv"
 msgid "Apps"
 msgstr "Apps"
 
-#: lib/vutuv_web/components/ui.ex:4113
+#: lib/vutuv_web/components/ui.ex:4126
 #: lib/vutuv_web/controllers/settings_controller.ex:179
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -6311,14 +6314,14 @@ msgstr "Kurzbeschreibung"
 #: lib/vutuv_web/components/ui.ex:316
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:887
+#: lib/vutuv_web/templates/user/show.html.heex:898
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
 msgstr[0] "Link"
 msgstr[1] "Links"
 
-#: lib/vutuv_web/templates/user/show.html.heex:451
+#: lib/vutuv_web/templates/user/show.html.heex:462
 #, elixir-autogen, elixir-format
 msgctxt "profile"
 msgid "Post"
@@ -6332,7 +6335,7 @@ msgstr[1] "Beiträge"
 msgid "After choosing a file you can reposition and zoom it."
 msgstr "Nach der Auswahl einer Datei können Sie sie verschieben und zoomen."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1502
+#: lib/vutuv_web/templates/user/show.html.heex:1514
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr "Auch auf"
@@ -6378,8 +6381,8 @@ msgstr "Foto verwenden"
 msgid "Zoom"
 msgstr "Zoom"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1087
-#: lib/vutuv_web/templates/user/show.html.heex:1097
+#: lib/vutuv_web/templates/user/show.html.heex:1099
+#: lib/vutuv_web/templates/user/show.html.heex:1109
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6421,12 +6424,12 @@ msgstr "Tagesbericht für %{day}"
 msgid "Jump to a day"
 msgstr "Zu einem Tag springen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1209
+#: lib/vutuv_web/templates/user/show.html.heex:1221
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr "E-Mails verwalten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1220
+#: lib/vutuv_web/templates/user/show.html.heex:1232
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr "Telefon verwalten"
@@ -6469,7 +6472,7 @@ msgstr "Vorheriger Tag"
 msgid "Reposts"
 msgstr "Reposts"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1218
+#: lib/vutuv_web/templates/user/show.html.heex:1230
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr "Alle Telefonnummern anzeigen"
@@ -6525,9 +6528,9 @@ msgstr "Anzuzeigende Kartendienste"
 msgid "Maps"
 msgstr "Karten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1488
-#: lib/vutuv_web/templates/user/show.html.heex:1496
+#: lib/vutuv_web/templates/user/show.html.heex:1500
 #: lib/vutuv_web/templates/user/show.html.heex:1508
+#: lib/vutuv_web/templates/user/show.html.heex:1520
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr "In %{name} öffnen"
@@ -6941,7 +6944,7 @@ msgstr "Zum Profil, um zu folgen"
 msgid "Mute @%{handle}"
 msgstr "@%{handle} stummschalten"
 
-#: lib/vutuv_web/views/user_html.ex:884
+#: lib/vutuv_web/views/user_html.ex:900
 #, elixir-autogen, elixir-format
 msgid "Professional"
 msgstr "Beruflich"
@@ -8510,7 +8513,7 @@ msgstr[1] "%{count} Berufserfahrungen"
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
 #: lib/vutuv_web/templates/education/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:673
+#: lib/vutuv_web/templates/user/show.html.heex:684
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr "Ausbildung hinzufügen"
@@ -8534,7 +8537,7 @@ msgstr "Abschluss"
 #: lib/vutuv_web/templates/education/new.html.heex:4
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
-#: lib/vutuv_web/templates/user/show.html.heex:670
+#: lib/vutuv_web/templates/user/show.html.heex:681
 #: lib/vutuv_web/views/import_html.ex:70
 #: lib/vutuv_web/views/job_reference_html.ex:265
 #, elixir-autogen, elixir-format
@@ -8582,7 +8585,7 @@ msgstr ""
 " was Sie nicht übernehmen möchten. Einträge, die bereits in Ihrem Profil "
 "stehen, sind für Sie abgewählt."
 
-#: lib/vutuv_web/components/ui.ex:4101
+#: lib/vutuv_web/components/ui.ex:4114
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Import"
@@ -8626,6 +8629,7 @@ msgid "Phone numbers"
 msgstr "Telefonnummern"
 
 #: lib/vutuv_web/controllers/import_controller.ex:82
+#: lib/vutuv_web/live/import_connections_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "Please choose your LinkedIn export ZIP first."
 msgstr "Bitte wählen Sie zuerst Ihre LinkedIn-Export-ZIP-Datei."
@@ -8646,22 +8650,24 @@ msgstr "%{field} setzen:"
 msgid "Social media"
 msgstr "Soziale Medien"
 
-#: lib/vutuv_web/templates/import/new.html.heex:26
+#: lib/vutuv_web/templates/import/new.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "Step 1: Download your LinkedIn data"
 msgstr "Schritt 1: Laden Sie Ihre LinkedIn-Daten herunter"
 
-#: lib/vutuv_web/templates/import/new.html.heex:77
+#: lib/vutuv_web/templates/import/new.html.heex:95
 #, elixir-autogen, elixir-format
 msgid "Step 2: Upload the ZIP here"
 msgstr "Schritt 2: Laden Sie die ZIP-Datei hier hoch"
 
 #: lib/vutuv_web/controllers/import_controller.ex:75
+#: lib/vutuv_web/live/import_connections_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "That does not look like a LinkedIn data export ZIP."
 msgstr "Das sieht nicht nach einem LinkedIn-Datenexport (ZIP) aus."
 
 #: lib/vutuv_web/controllers/import_controller.ex:137
+#: lib/vutuv_web/live/import_connections_live.ex:199
 #, elixir-autogen, elixir-format
 msgid "The file could not be read. Please try again."
 msgstr "Die Datei konnte nicht gelesen werden. Bitte versuchen Sie es erneut."
@@ -8672,7 +8678,7 @@ msgid "The import could not be completed. Please try again."
 msgstr ""
 "Der Import konnte nicht abgeschlossen werden. Bitte versuchen Sie es erneut."
 
-#: lib/vutuv_web/templates/import/new.html.heex:130
+#: lib/vutuv_web/templates/import/new.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "Upload and preview"
 msgstr "Hochladen und Vorschau"
@@ -8713,41 +8719,41 @@ msgstr "Zu viele Importe. Bitte versuchen Sie es in Kürze erneut."
 msgid "Please check the fields marked in red."
 msgstr "Bitte prüfen Sie die rot markierten Felder."
 
-#: lib/vutuv_web/views/user_html.ex:769
+#: lib/vutuv_web/views/user_html.ex:785
 #, elixir-autogen, elixir-format
 msgid "Loading posts"
 msgstr "Beiträge werden geladen"
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:140
-#: lib/vutuv_web/templates/user/show.html.heex:1355
+#: lib/vutuv_web/templates/user/show.html.heex:1367
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr "Social-Media-Beiträge"
 
-#: lib/vutuv_web/templates/import/new.html.heex:51
+#: lib/vutuv_web/templates/import/new.html.heex:69
 #, elixir-autogen, elixir-format
 msgid "Click \"Request archive\"."
 msgstr "Klicken Sie auf „Archiv anfordern“."
 
-#: lib/vutuv_web/templates/import/new.html.heex:63
+#: lib/vutuv_web/templates/import/new.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "LinkedIn's \"Download my data\" page with \"Download larger data archive\" selected and the \"Request archive\" button below it."
 msgstr ""
 "Die LinkedIn-Seite „Meine Daten herunterladen“ mit ausgewähltem „Größeres "
 "Datenarchiv herunterladen“ und der Schaltfläche „Archiv anfordern“ darunter."
 
-#: lib/vutuv_web/templates/import/new.html.heex:39
+#: lib/vutuv_web/templates/import/new.html.heex:57
 #, elixir-autogen, elixir-format
 msgid "Open LinkedIn's data export page"
 msgstr "LinkedIn-Datenexport-Seite öffnen"
 
-#: lib/vutuv_web/templates/import/new.html.heex:73
+#: lib/vutuv_web/templates/import/new.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "Select the larger archive, then click \"Request archive\"."
 msgstr ""
 "Wählen Sie das größere Archiv und klicken Sie dann auf „Archiv anfordern“."
 
-#: lib/vutuv_web/templates/import/new.html.heex:28
+#: lib/vutuv_web/templates/import/new.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "LinkedIn lets you export your own data as a ZIP archive. Open the export page, request the larger archive, and download the ZIP once LinkedIn has finished preparing it (this usually takes a few minutes)."
 msgstr ""
@@ -8756,14 +8762,14 @@ msgstr ""
 " die ZIP-Datei herunter, sobald LinkedIn sie fertig vorbereitet hat (das "
 "dauert meist nur wenige Minuten)."
 
-#: lib/vutuv_web/templates/import/new.html.heex:53
+#: lib/vutuv_web/templates/import/new.html.heex:71
 #, elixir-autogen, elixir-format
 msgid "LinkedIn prepares your archive. When it is ready (usually after a few minutes), download the ZIP to your device."
 msgstr ""
 "LinkedIn bereitet Ihr Archiv vor. Sobald es fertig ist (meist nach wenigen "
 "Minuten), laden Sie die ZIP-Datei auf Ihr Gerät herunter."
 
-#: lib/vutuv_web/templates/import/new.html.heex:79
+#: lib/vutuv_web/templates/import/new.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Then upload the ZIP file below to see the preview and pick what to add."
 msgstr ""
@@ -8792,7 +8798,8 @@ msgstr ""
 "Importieren Sie die Daten Ihres LinkedIn-Profils in Ihr vutuv-Profil. Aus "
 "Ihrem Export können wir übernehmen:"
 
-#: lib/vutuv_web/templates/import/new.html.heex:111
+#: lib/vutuv_web/live/import_connections_live.ex:370
+#: lib/vutuv_web/templates/import/new.html.heex:129
 #, elixir-autogen, elixir-format
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
@@ -8804,7 +8811,7 @@ msgstr ""
 msgid "Basics & photos"
 msgstr "Basisdaten & Fotos"
 
-#: lib/vutuv_web/components/ui.ex:4091
+#: lib/vutuv_web/components/ui.ex:4104
 #: lib/vutuv_web/controllers/settings_controller.ex:123
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8816,7 +8823,7 @@ msgstr "Sprache & Anzeige"
 msgid "More profile sections"
 msgstr "Weitere Profil-Bereiche"
 
-#: lib/vutuv_web/components/ui.ex:4082
+#: lib/vutuv_web/components/ui.ex:4095
 #: lib/vutuv_web/controllers/settings_controller.ex:106
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8826,7 +8833,7 @@ msgstr "Weitere Profil-Bereiche"
 msgid "Sign-in & security"
 msgstr "Anmeldung & Sicherheit"
 
-#: lib/vutuv_web/components/ui.ex:4105
+#: lib/vutuv_web/components/ui.ex:4118
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8894,14 +8901,16 @@ msgstr ""
 msgid "The file you sent is too large."
 msgstr "Die gesendete Datei ist zu groß."
 
-#: lib/vutuv_web/templates/import/new.html.heex:93
+#: lib/vutuv_web/live/import_connections_live.ex:683
+#: lib/vutuv_web/templates/import/new.html.heex:111
 #, elixir-autogen, elixir-format
 msgid "This file is too large. Please choose a ZIP of at most 50 MB."
 msgstr ""
 "Diese Datei ist zu groß. Bitte wählen Sie eine ZIP-Datei mit höchstens 50 "
 "MB."
 
-#: lib/vutuv_web/templates/import/new.html.heex:116
+#: lib/vutuv_web/live/import_connections_live.ex:379
+#: lib/vutuv_web/templates/import/new.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "ZIP file, up to 50 MB."
 msgstr "ZIP-Datei, bis zu 50 MB."
@@ -9065,7 +9074,7 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/agent_docs/text.ex:562
 #: lib/vutuv_web/agent_docs/text.ex:566
 #: lib/vutuv_web/components/organization_components.ex:310
-#: lib/vutuv_web/components/ui.ex:4072
+#: lib/vutuv_web/components/ui.ex:4085
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:355
 #: lib/vutuv_web/controllers/settings_controller.ex:422
@@ -9079,8 +9088,8 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:1001
-#: lib/vutuv_web/templates/user/show.html.heex:1260
+#: lib/vutuv_web/templates/user/show.html.heex:1012
+#: lib/vutuv_web/templates/user/show.html.heex:1272
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr "Fediverse"
@@ -9158,7 +9167,7 @@ msgstr "Praktikum"
 msgid "Internships"
 msgstr "Praktika"
 
-#: lib/vutuv_web/templates/import/new.html.heex:47
+#: lib/vutuv_web/templates/import/new.html.heex:65
 #, elixir-autogen, elixir-format
 msgid "On that page, select \"Download larger data archive\" (profile, positions, volunteering, education, skills)."
 msgstr ""
@@ -9515,7 +9524,7 @@ msgstr "A2 (Grundkenntnisse)"
 
 #: lib/vutuv_web/templates/language/manage.html.heex:8
 #: lib/vutuv_web/templates/language/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:735
+#: lib/vutuv_web/templates/user/show.html.heex:746
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr "Sprache hinzufügen"
@@ -9739,7 +9748,7 @@ msgstr "Sprache erfolgreich aktualisiert."
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:4
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:732
+#: lib/vutuv_web/templates/user/show.html.heex:743
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr "Sprachen"
@@ -10030,7 +10039,7 @@ msgstr[0] "%{count} Zertifikat oder Lizenz"
 msgstr[1] "%{count} Zertifikate oder Lizenzen"
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:841
+#: lib/vutuv_web/templates/user/show.html.heex:852
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr "Zertifikat oder Lizenz hinzufügen"
@@ -10078,7 +10087,7 @@ msgstr "Zertifikate"
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:838
+#: lib/vutuv_web/templates/user/show.html.heex:849
 #: lib/vutuv_web/views/import_html.ex:71
 #: lib/vutuv_web/views/job_reference_html.ex:266
 #, elixir-autogen, elixir-format
@@ -10202,8 +10211,8 @@ msgstr "Bevorzugt"
 msgid "Preferred contact language"
 msgstr "Bevorzugte Kontaktsprache"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1183
-#: lib/vutuv_web/templates/user/show.html.heex:1184
+#: lib/vutuv_web/templates/user/show.html.heex:1195
+#: lib/vutuv_web/templates/user/show.html.heex:1196
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr "+%{code} ist die Ländervorwahl von %{region}"
@@ -10755,15 +10764,15 @@ msgstr[0] "%{count} Stern"
 msgstr[1] "%{count} Sterne"
 
 #: lib/vutuv_web/live/organization_live/show.ex:498
-#: lib/vutuv_web/views/user_html.ex:633
-#: lib/vutuv_web/views/user_html.ex:809
+#: lib/vutuv_web/views/user_html.ex:649
+#: lib/vutuv_web/views/user_html.ex:825
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower"
 msgid_plural "%{formatted} followers"
 msgstr[0] "%{formatted} Follower"
 msgstr[1] "%{formatted} Follower"
 
-#: lib/vutuv_web/views/user_html.ex:626
+#: lib/vutuv_web/views/user_html.ex:642
 #, elixir-autogen, elixir-format
 msgid "%{formatted} star"
 msgid_plural "%{formatted} stars"
@@ -10772,7 +10781,7 @@ msgstr[1] "%{formatted} Sterne"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:63
 #: lib/vutuv_web/agent_docs/text.ex:60
-#: lib/vutuv_web/templates/user/show.html.heex:1329
+#: lib/vutuv_web/templates/user/show.html.heex:1341
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr "Code"
@@ -10791,7 +10800,7 @@ msgstr ""
 "dessen öffentliche Statistiken zeigen: Sterne, Repositories, Follower, "
 "Sprachen und letzte Aktivität."
 
-#: lib/vutuv_web/views/user_html.ex:640
+#: lib/vutuv_web/views/user_html.ex:656
 #, elixir-autogen, elixir-format
 msgid "Last active %{date}"
 msgstr "Zuletzt aktiv %{date}"
@@ -10818,7 +10827,7 @@ msgstr "zuletzt aktiv %{date}"
 msgid "since %{date}"
 msgstr "seit %{date}"
 
-#: lib/vutuv_web/views/user_html.ex:556
+#: lib/vutuv_web/views/user_html.ex:572
 #, elixir-autogen, elixir-format
 msgid "since %{year}"
 msgstr "seit %{year}"
@@ -12476,7 +12485,7 @@ msgstr "Organisation wieder freigegeben."
 #: lib/vutuv_web/agent_docs/markdown.ex:409
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:383
-#: lib/vutuv_web/components/ui.ex:4109
+#: lib/vutuv_web/components/ui.ex:4122
 #: lib/vutuv_web/controllers/settings_controller.ex:211
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
@@ -13711,7 +13720,7 @@ msgstr "Suche speichern"
 msgid "Saved search deleted."
 msgstr "Gespeicherte Suche gelöscht."
 
-#: lib/vutuv_web/components/ui.ex:4049
+#: lib/vutuv_web/components/ui.ex:4062
 #: lib/vutuv_web/controllers/settings_controller.ex:588
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -14236,7 +14245,7 @@ msgstr "Signal und WhatsApp akzeptieren eine Telefonnummer oder einen Benutzerna
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1295
+#: lib/vutuv_web/templates/user/show.html.heex:1307
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr "Messenger hinzufügen"
@@ -14273,7 +14282,7 @@ msgstr "Messenger wurde geändert."
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1293
+#: lib/vutuv_web/templates/user/show.html.heex:1305
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr "Messenger"
@@ -15686,7 +15695,7 @@ msgstr "Anwendung bearbeiten"
 msgid "Book an ad"
 msgstr "Anzeige buchen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1005
+#: lib/vutuv_web/templates/user/show.html.heex:1016
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr "%{name} hat dieses Fediverse-Konto umgezogen. Folgen Sie stattdessen der neuen Adresse:"
@@ -15807,12 +15816,12 @@ msgstr "Die Themen, für die Sie bekannt sind"
 msgid "skill topic keyword expertise endorsement"
 msgstr "fähigkeit kenntnis thema stichwort schlagwort expertise empfehlung"
 
-#: lib/vutuv_web/components/ui.ex:4110
+#: lib/vutuv_web/components/ui.ex:4123
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr "Organisationsseiten, die Sie verwalten"
 
-#: lib/vutuv_web/components/ui.ex:4111
+#: lib/vutuv_web/components/ui.ex:4124
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr "firma unternehmen arbeitgeber betrieb organisation seite"
@@ -15927,72 +15936,72 @@ msgstr "Themen, deren Beiträge in Ihrem Feed landen"
 msgid "tag topic subscribe follow feed"
 msgstr "tag thema abonnieren folgen feed"
 
-#: lib/vutuv_web/components/ui.ex:4050
+#: lib/vutuv_web/components/ui.ex:4063
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr "Job- und Personensuchen, die Ihnen neue Treffer mailen"
 
-#: lib/vutuv_web/components/ui.ex:4051
+#: lib/vutuv_web/components/ui.ex:4064
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr "job stelle stellenangebot suchauftrag suche alarm benachrichtigung merkliste"
 
-#: lib/vutuv_web/components/ui.ex:4057
+#: lib/vutuv_web/components/ui.ex:4070
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr "Suchmaschinen, KI, Online-Status"
 
-#: lib/vutuv_web/components/ui.ex:4058
+#: lib/vutuv_web/components/ui.ex:4071
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr "privatsphäre datenschutz google suchmaschine ki ai llm crawler noindex online punkt öffentlich sichtbar"
 
-#: lib/vutuv_web/components/ui.ex:4061
+#: lib/vutuv_web/components/ui.ex:4074
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr "Personen, die nicht mit Ihnen interagieren können"
 
-#: lib/vutuv_web/components/ui.ex:4062
+#: lib/vutuv_web/components/ui.ex:4075
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr "blockieren sperren bannen stummschalten melden missbrauch belästigung"
 
-#: lib/vutuv_web/components/ui.ex:4083
+#: lib/vutuv_web/components/ui.ex:4096
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr "Passkeys, angemeldete Geräte, Anmeldecodes"
 
-#: lib/vutuv_web/components/ui.ex:4084
+#: lib/vutuv_web/components/ui.ex:4097
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr "passwort kennwort anmelden abmelden login logout sitzung gerät passkey totp 2fa pin sicherheit"
 
-#: lib/vutuv_web/components/ui.ex:4102
+#: lib/vutuv_web/components/ui.ex:4115
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr "Ihre Daten von LinkedIn übernehmen"
 
-#: lib/vutuv_web/components/ui.ex:4103
+#: lib/vutuv_web/components/ui.ex:4116
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr "linkedin hochladen zip übernehmen importieren umzug"
 
-#: lib/vutuv_web/components/ui.ex:4106
+#: lib/vutuv_web/components/ui.ex:4119
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr "Alles herunterladen, was wir über Sie speichern"
 
-#: lib/vutuv_web/components/ui.ex:4107
+#: lib/vutuv_web/components/ui.ex:4120
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr "herunterladen download dsgvo gdpr daten sicherung json lebenslauf auskunft"
 
-#: lib/vutuv_web/components/ui.ex:4121
+#: lib/vutuv_web/components/ui.ex:4134
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr "Ihr Konto und alles darauf entfernen"
 
-#: lib/vutuv_web/components/ui.ex:4122
+#: lib/vutuv_web/components/ui.ex:4135
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr "löschen entfernen schließen kündigen beenden verlassen"
@@ -16293,6 +16302,7 @@ msgid "Show only followers from this server"
 msgstr "Nur Follower von diesem Server zeigen"
 
 #: lib/vutuv_web/components/browse_table.ex:475
+#: lib/vutuv_web/live/import_connections_live.ex:535
 #, elixir-autogen, elixir-format
 msgid "Showing %{first}-%{last} of %{total}."
 msgstr "Angezeigt: %{first}-%{last} von %{total}."
@@ -16461,7 +16471,7 @@ msgstr "API-Token erstellt"
 msgid "Access token revoked"
 msgstr "API-Token widerrufen"
 
-#: lib/vutuv_web/components/ui.ex:4086
+#: lib/vutuv_web/components/ui.ex:4099
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -16808,7 +16818,7 @@ msgstr "Was sich an einem Konto geändert hat, wann, von wo und wie es bestätig
 msgid "What changed on your account, and exactly when."
 msgstr "Was sich an Ihrem Konto geändert hat, und wann genau."
 
-#: lib/vutuv_web/components/ui.ex:4087
+#: lib/vutuv_web/components/ui.ex:4100
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr "Was sich an Ihrem Konto geändert hat, und wann"
@@ -16844,7 +16854,7 @@ msgstr "durch den Betreiber"
 msgid "from a signed-in session"
 msgstr "aus einer angemeldeten Sitzung"
 
-#: lib/vutuv_web/components/ui.ex:4089
+#: lib/vutuv_web/components/ui.ex:4102
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr "protokoll verlauf historie chronik audit sicherheit war ich das wer hat wann geaendert geändert log"
@@ -17380,7 +17390,7 @@ msgstr "Ein Konto in einem anderen Netzwerk"
 msgid "Cancel request"
 msgstr "Anfrage zurückziehen"
 
-#: lib/vutuv_web/components/ui.ex:4073
+#: lib/vutuv_web/components/ui.ex:4086
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr "Konten auf Mastodon folgen, und von dort gefolgt werden"
@@ -17584,7 +17594,7 @@ msgstr "Sie haben Ihre Fediverse-Follower auf ein anderes Konto umgeleitet, desh
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr "Ihr Konto ist derzeit gesperrt, deshalb geht nichts von Ihnen an andere Netzwerke und Sie können dort niemandem folgen. Das endet von selbst, sobald die Sperre abläuft."
 
-#: lib/vutuv_web/components/ui.ex:4075
+#: lib/vutuv_web/components/ui.ex:4088
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr "mastodon activitypub foederation federation follower folgen folge umzug migration entferntes konto"
@@ -17971,7 +17981,7 @@ msgid_plural "You already follow %{count} members."
 msgstr[0] "Sie folgen bereits einem Mitglied."
 msgstr[1] "Sie folgen bereits %{count} Mitgliedern."
 
-#: lib/vutuv_web/views/user_html.ex:210
+#: lib/vutuv_web/views/user_html.ex:215
 #, elixir-autogen, elixir-format
 msgid "Your feed shows the posts of members you follow. Follow a few to fill it."
 msgstr ""
@@ -19053,7 +19063,7 @@ msgstr "Für dieses Zeugnis läuft bereits eine Prüfung."
 #: lib/vutuv_web/controllers/job_reference_controller.ex:144
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:18
 #: lib/vutuv_web/templates/job_reference/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:775
+#: lib/vutuv_web/templates/user/show.html.heex:786
 #, elixir-autogen, elixir-format
 msgid "Add an employment reference"
 msgstr "Arbeitszeugnis hinzufügen"
@@ -19128,7 +19138,7 @@ msgstr "Arbeitszeugnis aktualisiert."
 #: lib/vutuv_web/templates/job_reference/new.html.heex:4
 #: lib/vutuv_web/templates/job_reference/show.html.heex:12
 #: lib/vutuv_web/templates/job_reference/view.html.heex:11
-#: lib/vutuv_web/templates/user/show.html.heex:772
+#: lib/vutuv_web/templates/user/show.html.heex:783
 #, elixir-autogen, elixir-format
 msgid "Employment references"
 msgstr "Arbeitszeugnisse"
@@ -19761,7 +19771,7 @@ msgstr "Ihr vutuv-Benutzername steht fest."
 msgid "by the lawyer Tom Braegelmann"
 msgstr "von Rechtsanwalt Tom Braegelmann"
 
-#: lib/vutuv_web/templates/user/show.html.heex:816
+#: lib/vutuv_web/templates/user/show.html.heex:827
 #, elixir-autogen, elixir-format
 msgid "Documents:"
 msgstr "Belegt:"
@@ -20081,7 +20091,7 @@ msgstr "Ebenfalls löschen"
 msgid "Always keep"
 msgstr "Immer behalten"
 
-#: lib/vutuv_web/components/ui.ex:4066
+#: lib/vutuv_web/components/ui.ex:4079
 #: lib/vutuv_web/controllers/settings_controller.ex:245
 #: lib/vutuv_web/controllers/settings_controller.ex:324
 #: lib/vutuv_web/controllers/settings_controller.ex:336
@@ -20178,7 +20188,7 @@ msgstr "Fotobeiträge behalten"
 msgid "Keep posts that did well"
 msgstr "Beiträge behalten, die gut liefen"
 
-#: lib/vutuv_web/components/ui.ex:4068
+#: lib/vutuv_web/components/ui.ex:4081
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr "Ihre Beiträge nach einer selbst gewählten Zeit auslaufen lassen"
@@ -20287,7 +20297,7 @@ msgstr "Sie können vorher alles herunterladen, was Sie hier haben:"
 msgid "Your rule"
 msgstr "Ihre Regel"
 
-#: lib/vutuv_web/components/ui.ex:4070
+#: lib/vutuv_web/components/ui.ex:4083
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr "löschen entfernen beiträge alter alt ablaufen verfallen automatisch aufräumen aufbewahrung"
@@ -21711,7 +21721,7 @@ msgstr "Ihr Browser meldet: {zone}"
 msgid "ISO 8601 (Sweden, Japan, China)"
 msgstr "ISO 8601 (Schweden, Japan, China)"
 
-#: lib/vutuv_web/components/ui.ex:4093
+#: lib/vutuv_web/components/ui.ex:4106
 #, elixir-autogen, elixir-format
 msgid "Interface language, date format and time zone, feed languages, maps, how posts are shortened"
 msgstr "Sprache der Oberfläche, Datumsformat und Zeitzone, Feed-Sprachen, Karten, wie Beiträge gekürzt werden"
@@ -21721,7 +21731,7 @@ msgstr "Sprache der Oberfläche, Datumsformat und Zeitzone, Feed-Sprachen, Karte
 msgid "Language & display settings changed"
 msgstr "Sprache & Anzeige geändert"
 
-#: lib/vutuv_web/components/ui.ex:4097
+#: lib/vutuv_web/components/ui.ex:4110
 #, elixir-autogen, elixir-format
 msgid "german english locale translation translate map font length hyphenation feed languages hide foreign übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
 msgstr "deutsch englisch locale übersetzung übersetzen karte schrift länge silbentrennung feed sprachen ausblenden fremdsprache zeitzone timezone zone utc datum date uhrzeit uhr format datumsformat 24 stunden"
@@ -21790,12 +21800,12 @@ msgstr "Empfohlen: %{width} × %{height} Pixel (%{ratio})."
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr "Empfohlen: quadratisch, mindestens %{width} × %{height} Pixel."
 
-#: lib/vutuv_web/views/user_html.ex:305
+#: lib/vutuv_web/views/user_html.ex:321
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
 msgstr "Profilbild von %{name}"
 
-#: lib/vutuv_web/views/user_html.ex:308
+#: lib/vutuv_web/views/user_html.ex:324
 #, elixir-autogen, elixir-format
 msgid "Show the profile picture larger"
 msgstr "Profilbild größer anzeigen"
@@ -21841,7 +21851,7 @@ msgstr "Damit können Sie sich von einer Mastodon-kompatiblen App aus bei diesem
 msgid "Mastodon app access changed"
 msgstr "Mastodon-App-Zugriff geändert"
 
-#: lib/vutuv_web/components/ui.ex:4114
+#: lib/vutuv_web/components/ui.ex:4127
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr "Mastodon-Apps, verbundene Apps und Zugriffstoken"
@@ -21887,7 +21897,7 @@ msgstr "Wer etwas geschrieben hat, wird weiter festgehalten, das Team kann also 
 msgid "Your account is then %{handle}."
 msgstr "Dein Konto heißt dann %{handle}."
 
-#: lib/vutuv_web/components/ui.ex:4116
+#: lib/vutuv_web/components/ui.ex:4129
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr "api token oauth entwickler verbunden drittanbieter schnittstelle mastodon app handy telefon client ivory tusky ice cubes anmelden"
@@ -21901,3 +21911,208 @@ msgstr "Apps erlaubt"
 #, elixir-autogen, elixir-format
 msgid "apps not allowed"
 msgstr "Apps nicht erlaubt"
+
+#: lib/vutuv_web/live/import_connections_live.ex:430
+#, elixir-autogen, elixir-format
+msgid "Analyse another file"
+msgstr "Andere Datei auswerten"
+
+#: lib/vutuv_web/live/import_connections_live.ex:401
+#, elixir-autogen, elixir-format
+msgid "Find my contacts"
+msgstr "Kontakte finden"
+
+#: lib/vutuv_web/templates/user/show.html.heex:446
+#: lib/vutuv_web/views/user_html.ex:237
+#, elixir-autogen, elixir-format
+msgid "Find people you know from LinkedIn"
+msgstr "Bekannte aus LinkedIn finden"
+
+#: lib/vutuv_web/live/import_connections_live.ex:296
+#, elixir-autogen, elixir-format
+msgid "Find your LinkedIn contacts"
+msgstr "Ihre LinkedIn-Kontakte finden"
+
+#: lib/vutuv_web/components/ui.ex:4054
+#: lib/vutuv_web/live/import_connections_live.ex:64
+#: lib/vutuv_web/templates/import/new.html.heex:37
+#, elixir-autogen, elixir-format
+msgid "Find your contacts"
+msgstr "Kontakte finden"
+
+#: lib/vutuv_web/live/import_connections_live.ex:507
+#, elixir-autogen, elixir-format
+msgid "Follow selected"
+msgstr "Ausgewählten folgen"
+
+#: lib/vutuv_web/live/import_connections_live.ex:504
+#, elixir-autogen, elixir-format
+msgid "Following…"
+msgstr "Wird gefolgt …"
+
+#: lib/vutuv_web/live/import_connections_live.ex:340
+#, elixir-autogen, elixir-format
+msgid "How to request it from LinkedIn"
+msgstr "So fordern Sie ihn bei LinkedIn an"
+
+#: lib/vutuv_web/live/import_connections_live.ex:335
+#, elixir-autogen, elixir-format
+msgid "It is the same ZIP file the profile import uses."
+msgstr "Es ist dieselbe ZIP-Datei, die auch der Profil-Import verwendet."
+
+#: lib/vutuv_web/live/import_connections_live.ex:622
+#, elixir-autogen, elixir-format
+msgid "Links the same LinkedIn profile"
+msgstr "Verlinkt dasselbe LinkedIn-Profil"
+
+#: lib/vutuv_web/live/import_connections_live.ex:519
+#, elixir-autogen, elixir-format
+msgid "Nobody here matches what you are looking for."
+msgstr "Zu Ihrer Suche passt hier niemand."
+
+#: lib/vutuv_web/live/import_connections_live.ex:319
+#, elixir-autogen, elixir-format
+msgid "Nobody is invited and no email is sent."
+msgstr "Niemand wird eingeladen, und es wird keine E-Mail verschickt."
+
+#: lib/vutuv_web/live/import_connections_live.ex:231
+#, elixir-autogen, elixir-format
+msgid "Nobody new to follow: you already follow them."
+msgstr "Niemand Neues: Diesen Mitgliedern folgen Sie bereits."
+
+#: lib/vutuv_web/live/import_connections_live.ex:435
+#, elixir-autogen, elixir-format
+msgid "None of your contacts is here yet. Or they are, but keep their address private and have not linked their LinkedIn profile. Nothing was stored, and you can try again with a newer archive at any time."
+msgstr "Noch ist keiner Ihrer Kontakte hier. Oder doch, aber die Adresse ist privat und das LinkedIn-Profil nicht verlinkt. Gespeichert wurde nichts, und Sie können es jederzeit mit einem neueren Archiv erneut versuchen."
+
+#: lib/vutuv_web/live/import_connections_live.ex:468
+#, elixir-autogen, elixir-format
+msgid "Not following yet"
+msgstr "Folge ich noch nicht"
+
+#: lib/vutuv_web/live/import_connections_live.ex:320
+#, elixir-autogen, elixir-format
+msgid "Nothing is added to your profile."
+msgstr "Ihrem Profil wird nichts hinzugefügt."
+
+#: lib/vutuv_web/live/import_connections_live.ex:322
+#, elixir-autogen, elixir-format
+msgid "Nothing is stored: we read the file, show you the result, and keep neither your contacts nor the list."
+msgstr "Es wird nichts gespeichert: Wir lesen die Datei, zeigen Ihnen das Ergebnis und behalten weder Ihre Kontakte noch die Liste."
+
+#: lib/vutuv_web/live/import_connections_live.ex:442
+#, elixir-autogen, elixir-format
+msgid "One of your LinkedIn contacts is already a vutuv member."
+msgid_plural "%{formatted} of your LinkedIn contacts are already vutuv members."
+msgstr[0] "Einer Ihrer LinkedIn-Kontakte ist bereits vutuv-Mitglied."
+msgstr[1] "%{formatted} Ihrer LinkedIn-Kontakte sind bereits vutuv-Mitglieder."
+
+#: lib/vutuv_web/live/import_connections_live.ex:496
+#, elixir-autogen, elixir-format
+msgid "One selected"
+msgid_plural "%{formatted} selected"
+msgstr[0] "Eine Person ausgewählt"
+msgstr[1] "%{formatted} Personen ausgewählt"
+
+#: lib/vutuv_web/live/import_connections_live.ex:685
+#, elixir-autogen, elixir-format
+msgid "Please choose a ZIP file."
+msgstr "Bitte wählen Sie eine ZIP-Datei."
+
+#: lib/vutuv_web/live/import_connections_live.ex:400
+#, elixir-autogen, elixir-format
+msgid "Reading…"
+msgstr "Wird gelesen …"
+
+#: lib/vutuv_web/live/import_connections_live.ex:621
+#, elixir-autogen, elixir-format
+msgid "Same email address as your contact"
+msgstr "Gleiche E-Mail-Adresse wie Ihr Kontakt"
+
+#: lib/vutuv_web/live/import_connections_live.ex:455
+#: lib/vutuv_web/live/import_connections_live.ex:462
+#, elixir-autogen, elixir-format
+msgid "Search by name"
+msgstr "Nach Namen suchen"
+
+#: lib/vutuv_web/templates/import/preview.html.heex:124
+#, elixir-autogen, elixir-format
+msgid "See which of them are already on vutuv"
+msgstr "Sehen Sie, wer davon schon auf vutuv ist"
+
+#: lib/vutuv_web/components/ui.ex:4056
+#, elixir-autogen, elixir-format
+msgid "See which of your LinkedIn contacts are already on vutuv"
+msgstr "Sehen, wer aus Ihren LinkedIn-Kontakten schon auf vutuv ist"
+
+#: lib/vutuv_web/live/import_connections_live.ex:485
+#, elixir-autogen, elixir-format
+msgid "Select all %{count}"
+msgstr "Alle %{count} auswählen"
+
+#: lib/vutuv_web/live/import_connections_live.ex:493
+#, elixir-autogen, elixir-format
+msgid "Select none"
+msgstr "Auswahl aufheben"
+
+#: lib/vutuv_web/live/import_connections_live.ex:227
+#, elixir-autogen, elixir-format
+msgid "That archive is too large or has too many files to read safely."
+msgstr "Dieses Archiv ist zu groß oder enthält zu viele Dateien, um es sicher zu lesen."
+
+#: lib/vutuv_web/live/import_connections_live.ex:686
+#, elixir-autogen, elixir-format
+msgid "That file could not be read."
+msgstr "Diese Datei konnte nicht gelesen werden."
+
+#: lib/vutuv_web/templates/import/new.html.heex:29
+#, elixir-autogen, elixir-format
+msgid "The same file also lists your LinkedIn contacts. We can show you which of them are already on vutuv, without importing or inviting anyone."
+msgstr "Dieselbe Datei enthält auch Ihre LinkedIn-Kontakte. Wir zeigen Ihnen, wer davon schon auf vutuv ist, ohne jemanden zu importieren oder einzuladen."
+
+#: lib/vutuv_web/live/import_connections_live.ex:329
+#, elixir-autogen, elixir-format
+msgid "We only recognise someone by an email address they published here, or by the LinkedIn profile they linked from their vutuv profile. We never guess by name, so you will not be offered a stranger who happens to share a name with someone you know."
+msgstr "Wir erkennen jemanden nur an einer E-Mail-Adresse, die er hier veröffentlicht hat, oder an dem LinkedIn-Profil, das er auf seinem vutuv-Profil verlinkt hat. Wir raten nie über den Namen, deshalb bekommen Sie keine Fremden vorgeschlagen, die zufällig so heißen wie jemand, den Sie kennen."
+
+#: lib/vutuv_web/live/import_connections_live.ex:309
+#, elixir-autogen, elixir-format
+msgid "Who of your LinkedIn contacts is already here?"
+msgstr "Wer aus Ihren LinkedIn-Kontakten ist schon hier?"
+
+#: lib/vutuv_web/live/import_connections_live.ex:517
+#, elixir-autogen, elixir-format
+msgid "You already follow every contact we found."
+msgstr "Sie folgen bereits allen Kontakten, die wir gefunden haben."
+
+#: lib/vutuv_web/live/import_connections_live.ex:104
+#, elixir-autogen, elixir-format
+msgid "You have analysed a lot of archives just now. Please try again later."
+msgstr "Sie haben gerade sehr viele Archive ausgewertet. Bitte versuchen Sie es später noch einmal."
+
+#: lib/vutuv_web/live/import_connections_live.ex:234
+#, elixir-autogen, elixir-format
+msgid "You now follow one more member."
+msgid_plural "You now follow %{formatted} more members."
+msgstr[0] "Sie folgen jetzt einem Mitglied mehr."
+msgstr[1] "Sie folgen jetzt %{formatted} Mitgliedern mehr."
+
+#: lib/vutuv_web/live/import_connections_live.ex:311
+#, elixir-autogen, elixir-format
+msgid "Your LinkedIn data export lists your contacts. We read that list, look for the people among them who are already vutuv members, and show you who they are. You decide who to follow."
+msgstr "Ihr LinkedIn-Datenexport enthält Ihre Kontakte. Wir lesen diese Liste, suchen darin die Personen, die schon vutuv-Mitglied sind, und zeigen Ihnen, wer das ist. Wem Sie folgen, entscheiden Sie."
+
+#: lib/vutuv_web/live/import_connections_live.ex:424
+#, elixir-autogen, elixir-format
+msgid "Your contacts on vutuv"
+msgstr "Ihre Kontakte auf vutuv"
+
+#: lib/vutuv_web/templates/import/preview.html.heex:122
+#, elixir-autogen, elixir-format
+msgid "Your export also lists your LinkedIn contacts."
+msgstr "Ihr Export enthält auch Ihre LinkedIn-Kontakte."
+
+#: lib/vutuv_web/components/ui.ex:4058
+#, elixir-autogen, elixir-format
+msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
+msgstr "linkedin kontakte verbindungen adressbuch bekannte kollegen finden folgen zip import netzwerk"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -40,7 +40,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1449
+#: lib/vutuv_web/templates/user/show.html.heex:1461
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -105,7 +105,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:586
 #: lib/vutuv_web/agent_docs/text.ex:550
 #: lib/vutuv_web/agent_docs/text.ex:551
-#: lib/vutuv_web/templates/user/show.html.heex:1081
+#: lib/vutuv_web/templates/user/show.html.heex:1093
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
@@ -152,7 +152,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1119
+#: lib/vutuv_web/templates/user/show.html.heex:1131
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -224,7 +224,7 @@ msgstr ""
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:1104
+#: lib/vutuv_web/templates/user/show.html.heex:1116
 #, elixir-autogen
 msgid "Edit"
 msgstr ""
@@ -289,7 +289,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:613
+#: lib/vutuv_web/templates/user/show.html.heex:624
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -333,10 +333,11 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:2158
 #: lib/vutuv_web/components/ui.ex:2216
 #: lib/vutuv_web/controllers/followee_controller.ex:29
+#: lib/vutuv_web/live/import_connections_live.ex:469
 #: lib/vutuv_web/live/organization_live/show.ex:471
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:959
+#: lib/vutuv_web/templates/user/show.html.heex:970
 #, elixir-autogen
 msgid "Following"
 msgstr ""
@@ -690,13 +691,13 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1233
+#: lib/vutuv_web/templates/user/show.html.heex:1245
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1235
+#: lib/vutuv_web/templates/user/show.html.heex:1247
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -726,12 +727,12 @@ msgstr ""
 msgid "Profile deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:708
+#: lib/vutuv_web/views/user_html.ex:724
 #, elixir-autogen, elixir-format
 msgid "Social networks"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:715
+#: lib/vutuv_web/views/user_html.ex:731
 #, elixir-autogen, elixir-format
 msgid "Code & repositories"
 msgstr ""
@@ -850,13 +851,13 @@ msgid "vCard"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3710
-#: lib/vutuv_web/templates/user/show.html.heex:953
-#: lib/vutuv_web/templates/user/show.html.heex:976
+#: lib/vutuv_web/templates/user/show.html.heex:964
+#: lib/vutuv_web/templates/user/show.html.heex:987
 #, elixir-autogen
 msgid "View All"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4056
+#: lib/vutuv_web/components/ui.ex:4069
 #: lib/vutuv_web/controllers/settings_controller.ex:169
 #: lib/vutuv_web/live/job_posting_live/form.ex:561
 #: lib/vutuv_web/live/organization_live/edit.ex:304
@@ -1041,7 +1042,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1070
+#: lib/vutuv_web/templates/user/show.html.heex:1082
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1207,7 +1208,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:607
+#: lib/vutuv_web/templates/user/show.html.heex:618
 #, elixir-autogen
 msgid "All tags"
 msgstr ""
@@ -1402,7 +1403,7 @@ msgstr ""
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:23
 #: lib/vutuv_web/templates/tag/show.html.heex:25
-#: lib/vutuv_web/templates/user/show.html.heex:577
+#: lib/vutuv_web/templates/user/show.html.heex:588
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
@@ -1696,7 +1697,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:411
 #: lib/vutuv_web/live/organization_live/show.ex:440
 #: lib/vutuv_web/live/organization_live/show.ex:469
-#: lib/vutuv_web/templates/user/show.html.heex:1273
+#: lib/vutuv_web/templates/user/show.html.heex:1285
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr ""
@@ -1844,7 +1845,7 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:27
 #: lib/vutuv_web/templates/social_media_account/verify.html.heex:18
 #: lib/vutuv_web/templates/user/show.html.heex:200
-#: lib/vutuv_web/views/user_html.ex:760
+#: lib/vutuv_web/views/user_html.ex:776
 #, elixir-autogen, elixir-format
 msgid "Verified profile"
 msgstr ""
@@ -1865,7 +1866,7 @@ msgid "We sent a PIN to your new email address. Enter it below to confirm the ad
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:1435
-#: lib/vutuv_web/views/user_html.ex:208
+#: lib/vutuv_web/views/user_html.ex:213
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr ""
@@ -1918,6 +1919,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3099
 #: lib/vutuv_web/components/ui.ex:3250
+#: lib/vutuv_web/live/import_connections_live.ex:638
 #: lib/vutuv_web/live/organization_live/index.ex:122
 #, elixir-autogen, elixir-format
 msgid "Pagination"
@@ -2046,12 +2048,12 @@ msgstr ""
 msgid "May"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:249
+#: lib/vutuv_web/views/user_html.ex:265
 #, elixir-autogen, elixir-format
 msgid "Member since %{month} %{year}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:254
+#: lib/vutuv_web/views/user_html.ex:270
 #, elixir-autogen, elixir-format
 msgid "Member since %{year}"
 msgstr ""
@@ -2292,7 +2294,7 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4310
+#: lib/vutuv_web/components/ui.ex:4323
 #: lib/vutuv_web/live/shell_live.ex:791
 #: lib/vutuv_web/templates/post/index.html.heex:17
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2362,7 +2364,7 @@ msgstr ""
 msgid "Posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:567
+#: lib/vutuv_web/templates/user/show.html.heex:578
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr ""
@@ -2375,7 +2377,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1666
 #: lib/vutuv_web/components/post_components.ex:4658
 #: lib/vutuv_web/components/ui.ex:3174
-#: lib/vutuv_web/views/user_html.ex:424
+#: lib/vutuv_web/views/user_html.ex:440
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr ""
@@ -2395,7 +2397,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:4892
 #: lib/vutuv_web/components/ui.ex:3160
 #: lib/vutuv_web/live/notification_live/index.ex:1037
-#: lib/vutuv_web/views/user_html.ex:434
+#: lib/vutuv_web/views/user_html.ex:450
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr ""
@@ -2431,7 +2433,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1666
 #: lib/vutuv_web/components/post_components.ex:4658
 #: lib/vutuv_web/live/post_live/saved.ex:775
-#: lib/vutuv_web/views/user_html.ex:424
+#: lib/vutuv_web/views/user_html.ex:440
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
@@ -2457,7 +2459,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:4892
 #: lib/vutuv_web/live/post_live/saved.ex:774
-#: lib/vutuv_web/views/user_html.ex:434
+#: lib/vutuv_web/views/user_html.ex:450
 #, elixir-autogen, elixir-format
 msgid "Unlike"
 msgstr ""
@@ -2703,45 +2705,45 @@ msgstr ""
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
 #: lib/vutuv_web/templates/url/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:889
+#: lib/vutuv_web/templates/user/show.html.heex:900
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1193
+#: lib/vutuv_web/templates/user/show.html.heex:1205
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1451
+#: lib/vutuv_web/templates/user/show.html.heex:1463
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1121
+#: lib/vutuv_web/templates/user/show.html.heex:1133
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1072
+#: lib/vutuv_web/templates/user/show.html.heex:1084
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:616
+#: lib/vutuv_web/templates/user/show.html.heex:627
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #: lib/vutuv_web/templates/work_experience/new.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Add work experience"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:477
+#: lib/vutuv_web/templates/user/show.html.heex:488
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
 msgstr ""
@@ -2754,13 +2756,13 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:216
-#: lib/vutuv_web/templates/user/show.html.heex:607
+#: lib/vutuv_web/templates/user/show.html.heex:618
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:1206
-#: lib/vutuv_web/templates/user/show.html.heex:477
+#: lib/vutuv_web/templates/user/show.html.heex:488
 #, elixir-autogen, elixir-format
 msgid "Write a post"
 msgstr ""
@@ -2862,7 +2864,7 @@ msgid "Endorsement"
 msgstr ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:1032
-#: lib/vutuv_web/templates/user/show.html.heex:937
+#: lib/vutuv_web/templates/user/show.html.heex:948
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -3091,8 +3093,8 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1161
-#: lib/vutuv_web/templates/user/show.html.heex:1162
+#: lib/vutuv_web/templates/user/show.html.heex:1173
+#: lib/vutuv_web/templates/user/show.html.heex:1174
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
@@ -4498,7 +4500,7 @@ msgstr ""
 msgid "Block @%{slug}? This removes any follows and connection between you, closes your conversation, and prevents all interaction in both directions. Unblocking will not restore what was removed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4060
+#: lib/vutuv_web/components/ui.ex:4073
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -4554,7 +4556,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:303
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:959
+#: lib/vutuv_web/templates/user/show.html.heex:970
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -4621,6 +4623,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:412
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
+#: lib/vutuv_web/live/import_connections_live.ex:470
 #: lib/vutuv_web/live/notification_live/index.ex:890
 #: lib/vutuv_web/live/search_live.ex:280
 #: lib/vutuv_web/views/qualification_html.ex:90
@@ -4671,7 +4674,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:388
 #: lib/vutuv_web/live/tag_new_live.ex:48
 #: lib/vutuv_web/live/user_profile_live.ex:1331
-#: lib/vutuv_web/templates/user/show.html.heex:580
+#: lib/vutuv_web/templates/user/show.html.heex:591
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr ""
@@ -5269,7 +5272,7 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4120
+#: lib/vutuv_web/components/ui.ex:4133
 #: lib/vutuv_web/controllers/settings_controller.ex:155
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5348,10 +5351,10 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4217
-#: lib/vutuv_web/components/ui.ex:4222
-#: lib/vutuv_web/components/ui.ex:4301
-#: lib/vutuv_web/components/ui.ex:4365
+#: lib/vutuv_web/components/ui.ex:4230
+#: lib/vutuv_web/components/ui.ex:4235
+#: lib/vutuv_web/components/ui.ex:4314
+#: lib/vutuv_web/components/ui.ex:4378
 #: lib/vutuv_web/controllers/settings_controller.ex:62
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5450,7 +5453,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:33
 #: lib/vutuv_web/views/email_html.ex:12
-#: lib/vutuv_web/views/user_html.ex:885
+#: lib/vutuv_web/views/user_html.ex:901
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr ""
@@ -5470,7 +5473,7 @@ msgstr ""
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4080
+#: lib/vutuv_web/components/ui.ex:4093
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:289
@@ -5525,7 +5528,7 @@ msgstr ""
 msgid "Photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4054
+#: lib/vutuv_web/components/ui.ex:4067
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/templates/page/index.html.heex:174
 #, elixir-autogen, elixir-format
@@ -5638,7 +5641,7 @@ msgstr ""
 msgid "Apps"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4113
+#: lib/vutuv_web/components/ui.ex:4126
 #: lib/vutuv_web/controllers/settings_controller.ex:179
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -6069,14 +6072,14 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:316
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:887
+#: lib/vutuv_web/templates/user/show.html.heex:898
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:451
+#: lib/vutuv_web/templates/user/show.html.heex:462
 #, elixir-autogen, elixir-format
 msgctxt "profile"
 msgid "Post"
@@ -6090,7 +6093,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1502
+#: lib/vutuv_web/templates/user/show.html.heex:1514
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6134,8 +6137,8 @@ msgstr ""
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1087
-#: lib/vutuv_web/templates/user/show.html.heex:1097
+#: lib/vutuv_web/templates/user/show.html.heex:1099
+#: lib/vutuv_web/templates/user/show.html.heex:1109
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6175,12 +6178,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1209
+#: lib/vutuv_web/templates/user/show.html.heex:1221
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1220
+#: lib/vutuv_web/templates/user/show.html.heex:1232
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6223,7 +6226,7 @@ msgstr ""
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1218
+#: lib/vutuv_web/templates/user/show.html.heex:1230
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
@@ -6277,9 +6280,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1488
-#: lib/vutuv_web/templates/user/show.html.heex:1496
+#: lib/vutuv_web/templates/user/show.html.heex:1500
 #: lib/vutuv_web/templates/user/show.html.heex:1508
+#: lib/vutuv_web/templates/user/show.html.heex:1520
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -6663,7 +6666,7 @@ msgstr ""
 msgid "Mute @%{handle}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:884
+#: lib/vutuv_web/views/user_html.ex:900
 #, elixir-autogen, elixir-format
 msgid "Professional"
 msgstr ""
@@ -8141,7 +8144,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
 #: lib/vutuv_web/templates/education/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:673
+#: lib/vutuv_web/templates/user/show.html.heex:684
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr ""
@@ -8165,7 +8168,7 @@ msgstr ""
 #: lib/vutuv_web/templates/education/new.html.heex:4
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
-#: lib/vutuv_web/templates/user/show.html.heex:670
+#: lib/vutuv_web/templates/user/show.html.heex:681
 #: lib/vutuv_web/views/import_html.ex:70
 #: lib/vutuv_web/views/job_reference_html.ex:265
 #, elixir-autogen, elixir-format
@@ -8208,7 +8211,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4101
+#: lib/vutuv_web/components/ui.ex:4114
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8252,6 +8255,7 @@ msgid "Phone numbers"
 msgstr ""
 
 #: lib/vutuv_web/controllers/import_controller.ex:82
+#: lib/vutuv_web/live/import_connections_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "Please choose your LinkedIn export ZIP first."
 msgstr ""
@@ -8272,22 +8276,24 @@ msgstr ""
 msgid "Social media"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:26
+#: lib/vutuv_web/templates/import/new.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "Step 1: Download your LinkedIn data"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:77
+#: lib/vutuv_web/templates/import/new.html.heex:95
 #, elixir-autogen, elixir-format
 msgid "Step 2: Upload the ZIP here"
 msgstr ""
 
 #: lib/vutuv_web/controllers/import_controller.ex:75
+#: lib/vutuv_web/live/import_connections_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "That does not look like a LinkedIn data export ZIP."
 msgstr ""
 
 #: lib/vutuv_web/controllers/import_controller.ex:137
+#: lib/vutuv_web/live/import_connections_live.ex:199
 #, elixir-autogen, elixir-format
 msgid "The file could not be read. Please try again."
 msgstr ""
@@ -8297,7 +8303,7 @@ msgstr ""
 msgid "The import could not be completed. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:130
+#: lib/vutuv_web/templates/import/new.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "Upload and preview"
 msgstr ""
@@ -8336,48 +8342,48 @@ msgstr ""
 msgid "Please check the fields marked in red."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:769
+#: lib/vutuv_web/views/user_html.ex:785
 #, elixir-autogen, elixir-format
 msgid "Loading posts"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:140
-#: lib/vutuv_web/templates/user/show.html.heex:1355
+#: lib/vutuv_web/templates/user/show.html.heex:1367
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:51
+#: lib/vutuv_web/templates/import/new.html.heex:69
 #, elixir-autogen, elixir-format
 msgid "Click \"Request archive\"."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:63
+#: lib/vutuv_web/templates/import/new.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "LinkedIn's \"Download my data\" page with \"Download larger data archive\" selected and the \"Request archive\" button below it."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:39
+#: lib/vutuv_web/templates/import/new.html.heex:57
 #, elixir-autogen, elixir-format
 msgid "Open LinkedIn's data export page"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:73
+#: lib/vutuv_web/templates/import/new.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "Select the larger archive, then click \"Request archive\"."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:28
+#: lib/vutuv_web/templates/import/new.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "LinkedIn lets you export your own data as a ZIP archive. Open the export page, request the larger archive, and download the ZIP once LinkedIn has finished preparing it (this usually takes a few minutes)."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:53
+#: lib/vutuv_web/templates/import/new.html.heex:71
 #, elixir-autogen, elixir-format
 msgid "LinkedIn prepares your archive. When it is ready (usually after a few minutes), download the ZIP to your device."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:79
+#: lib/vutuv_web/templates/import/new.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Then upload the ZIP file below to see the preview and pick what to add."
 msgstr ""
@@ -8397,7 +8403,8 @@ msgstr ""
 msgid "Import your LinkedIn profile data into your vutuv profile. From your export we can fill in:"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:111
+#: lib/vutuv_web/live/import_connections_live.ex:370
+#: lib/vutuv_web/templates/import/new.html.heex:129
 #, elixir-autogen, elixir-format
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
@@ -8408,7 +8415,7 @@ msgstr ""
 msgid "Basics & photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4091
+#: lib/vutuv_web/components/ui.ex:4104
 #: lib/vutuv_web/controllers/settings_controller.ex:123
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8420,7 +8427,7 @@ msgstr ""
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4082
+#: lib/vutuv_web/components/ui.ex:4095
 #: lib/vutuv_web/controllers/settings_controller.ex:106
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8430,7 +8437,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4105
+#: lib/vutuv_web/components/ui.ex:4118
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8488,12 +8495,14 @@ msgstr ""
 msgid "The file you sent is too large."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:93
+#: lib/vutuv_web/live/import_connections_live.ex:683
+#: lib/vutuv_web/templates/import/new.html.heex:111
 #, elixir-autogen, elixir-format
 msgid "This file is too large. Please choose a ZIP of at most 50 MB."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:116
+#: lib/vutuv_web/live/import_connections_live.ex:379
+#: lib/vutuv_web/templates/import/new.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "ZIP file, up to 50 MB."
 msgstr ""
@@ -8644,7 +8653,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:562
 #: lib/vutuv_web/agent_docs/text.ex:566
 #: lib/vutuv_web/components/organization_components.ex:310
-#: lib/vutuv_web/components/ui.ex:4072
+#: lib/vutuv_web/components/ui.ex:4085
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:355
 #: lib/vutuv_web/controllers/settings_controller.ex:422
@@ -8658,8 +8667,8 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:1001
-#: lib/vutuv_web/templates/user/show.html.heex:1260
+#: lib/vutuv_web/templates/user/show.html.heex:1012
+#: lib/vutuv_web/templates/user/show.html.heex:1272
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr ""
@@ -8730,7 +8739,7 @@ msgstr ""
 msgid "Internships"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:47
+#: lib/vutuv_web/templates/import/new.html.heex:65
 #, elixir-autogen, elixir-format
 msgid "On that page, select \"Download larger data archive\" (profile, positions, volunteering, education, skills)."
 msgstr ""
@@ -9055,7 +9064,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/language/manage.html.heex:8
 #: lib/vutuv_web/templates/language/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:735
+#: lib/vutuv_web/templates/user/show.html.heex:746
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr ""
@@ -9279,7 +9288,7 @@ msgstr ""
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:4
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:732
+#: lib/vutuv_web/templates/user/show.html.heex:743
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr ""
@@ -9559,7 +9568,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:841
+#: lib/vutuv_web/templates/user/show.html.heex:852
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr ""
@@ -9607,7 +9616,7 @@ msgstr ""
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:838
+#: lib/vutuv_web/templates/user/show.html.heex:849
 #: lib/vutuv_web/views/import_html.ex:71
 #: lib/vutuv_web/views/job_reference_html.ex:266
 #, elixir-autogen, elixir-format
@@ -9726,8 +9735,8 @@ msgstr ""
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1183
-#: lib/vutuv_web/templates/user/show.html.heex:1184
+#: lib/vutuv_web/templates/user/show.html.heex:1195
+#: lib/vutuv_web/templates/user/show.html.heex:1196
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -10232,15 +10241,15 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/live/organization_live/show.ex:498
-#: lib/vutuv_web/views/user_html.ex:633
-#: lib/vutuv_web/views/user_html.ex:809
+#: lib/vutuv_web/views/user_html.ex:649
+#: lib/vutuv_web/views/user_html.ex:825
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower"
 msgid_plural "%{formatted} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_html.ex:626
+#: lib/vutuv_web/views/user_html.ex:642
 #, elixir-autogen, elixir-format
 msgid "%{formatted} star"
 msgid_plural "%{formatted} stars"
@@ -10249,7 +10258,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:63
 #: lib/vutuv_web/agent_docs/text.ex:60
-#: lib/vutuv_web/templates/user/show.html.heex:1329
+#: lib/vutuv_web/templates/user/show.html.heex:1341
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -10265,7 +10274,7 @@ msgstr ""
 msgid "If you list a GitHub, GitLab or Codeberg account, your profile can show its public statistics: stars, repositories, followers, languages and recent activity."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:640
+#: lib/vutuv_web/views/user_html.ex:656
 #, elixir-autogen, elixir-format
 msgid "Last active %{date}"
 msgstr ""
@@ -10290,7 +10299,7 @@ msgstr ""
 msgid "since %{date}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:556
+#: lib/vutuv_web/views/user_html.ex:572
 #, elixir-autogen, elixir-format
 msgid "since %{year}"
 msgstr ""
@@ -11837,7 +11846,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:409
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:383
-#: lib/vutuv_web/components/ui.ex:4109
+#: lib/vutuv_web/components/ui.ex:4122
 #: lib/vutuv_web/controllers/settings_controller.ex:211
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
@@ -13054,7 +13063,7 @@ msgstr ""
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4049
+#: lib/vutuv_web/components/ui.ex:4062
 #: lib/vutuv_web/controllers/settings_controller.ex:588
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -13563,7 +13572,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1295
+#: lib/vutuv_web/templates/user/show.html.heex:1307
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
@@ -13600,7 +13609,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1293
+#: lib/vutuv_web/templates/user/show.html.heex:1305
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
@@ -14989,7 +14998,7 @@ msgstr ""
 msgid "Book an ad"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1005
+#: lib/vutuv_web/templates/user/show.html.heex:1016
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr ""
@@ -15110,12 +15119,12 @@ msgstr ""
 msgid "skill topic keyword expertise endorsement"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4110
+#: lib/vutuv_web/components/ui.ex:4123
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4111
+#: lib/vutuv_web/components/ui.ex:4124
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr ""
@@ -15230,72 +15239,72 @@ msgstr ""
 msgid "tag topic subscribe follow feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4050
+#: lib/vutuv_web/components/ui.ex:4063
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4051
+#: lib/vutuv_web/components/ui.ex:4064
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4057
+#: lib/vutuv_web/components/ui.ex:4070
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4058
+#: lib/vutuv_web/components/ui.ex:4071
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4061
+#: lib/vutuv_web/components/ui.ex:4074
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4062
+#: lib/vutuv_web/components/ui.ex:4075
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4083
+#: lib/vutuv_web/components/ui.ex:4096
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4084
+#: lib/vutuv_web/components/ui.ex:4097
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4102
+#: lib/vutuv_web/components/ui.ex:4115
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4103
+#: lib/vutuv_web/components/ui.ex:4116
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4106
+#: lib/vutuv_web/components/ui.ex:4119
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4107
+#: lib/vutuv_web/components/ui.ex:4120
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4121
+#: lib/vutuv_web/components/ui.ex:4134
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4122
+#: lib/vutuv_web/components/ui.ex:4135
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr ""
@@ -15582,6 +15591,7 @@ msgid "Show only followers from this server"
 msgstr ""
 
 #: lib/vutuv_web/components/browse_table.ex:475
+#: lib/vutuv_web/live/import_connections_live.ex:535
 #, elixir-autogen, elixir-format
 msgid "Showing %{first}-%{last} of %{total}."
 msgstr ""
@@ -15746,7 +15756,7 @@ msgstr ""
 msgid "Access token revoked"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4086
+#: lib/vutuv_web/components/ui.ex:4099
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -16093,7 +16103,7 @@ msgstr ""
 msgid "What changed on your account, and exactly when."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4087
+#: lib/vutuv_web/components/ui.ex:4100
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr ""
@@ -16129,7 +16139,7 @@ msgstr ""
 msgid "from a signed-in session"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4089
+#: lib/vutuv_web/components/ui.ex:4102
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
@@ -16650,7 +16660,7 @@ msgstr ""
 msgid "Cancel request"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4073
+#: lib/vutuv_web/components/ui.ex:4086
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr ""
@@ -16854,7 +16864,7 @@ msgstr ""
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4075
+#: lib/vutuv_web/components/ui.ex:4088
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
@@ -17230,7 +17240,7 @@ msgid_plural "You already follow %{count} members."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_html.ex:210
+#: lib/vutuv_web/views/user_html.ex:215
 #, elixir-autogen, elixir-format
 msgid "Your feed shows the posts of members you follow. Follow a few to fill it."
 msgstr ""
@@ -18305,7 +18315,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/job_reference_controller.ex:144
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:18
 #: lib/vutuv_web/templates/job_reference/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:775
+#: lib/vutuv_web/templates/user/show.html.heex:786
 #, elixir-autogen, elixir-format
 msgid "Add an employment reference"
 msgstr ""
@@ -18380,7 +18390,7 @@ msgstr ""
 #: lib/vutuv_web/templates/job_reference/new.html.heex:4
 #: lib/vutuv_web/templates/job_reference/show.html.heex:12
 #: lib/vutuv_web/templates/job_reference/view.html.heex:11
-#: lib/vutuv_web/templates/user/show.html.heex:772
+#: lib/vutuv_web/templates/user/show.html.heex:783
 #, elixir-autogen, elixir-format
 msgid "Employment references"
 msgstr ""
@@ -19013,7 +19023,7 @@ msgstr ""
 msgid "by the lawyer Tom Braegelmann"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:816
+#: lib/vutuv_web/templates/user/show.html.heex:827
 #, elixir-autogen, elixir-format
 msgid "Documents:"
 msgstr ""
@@ -19315,7 +19325,7 @@ msgstr ""
 msgid "Always keep"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4066
+#: lib/vutuv_web/components/ui.ex:4079
 #: lib/vutuv_web/controllers/settings_controller.ex:245
 #: lib/vutuv_web/controllers/settings_controller.ex:324
 #: lib/vutuv_web/controllers/settings_controller.ex:336
@@ -19412,7 +19422,7 @@ msgstr ""
 msgid "Keep posts that did well"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4068
+#: lib/vutuv_web/components/ui.ex:4081
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr ""
@@ -19521,7 +19531,7 @@ msgstr ""
 msgid "Your rule"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4070
+#: lib/vutuv_web/components/ui.ex:4083
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
@@ -20921,7 +20931,7 @@ msgstr ""
 msgid "ISO 8601 (Sweden, Japan, China)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4093
+#: lib/vutuv_web/components/ui.ex:4106
 #, elixir-autogen, elixir-format
 msgid "Interface language, date format and time zone, feed languages, maps, how posts are shortened"
 msgstr ""
@@ -20931,7 +20941,7 @@ msgstr ""
 msgid "Language & display settings changed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4097
+#: lib/vutuv_web/components/ui.ex:4110
 #, elixir-autogen, elixir-format
 msgid "german english locale translation translate map font length hyphenation feed languages hide foreign übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
 msgstr ""
@@ -21000,12 +21010,12 @@ msgstr ""
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:305
+#: lib/vutuv_web/views/user_html.ex:321
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:308
+#: lib/vutuv_web/views/user_html.ex:324
 #, elixir-autogen, elixir-format
 msgid "Show the profile picture larger"
 msgstr ""
@@ -21051,7 +21061,7 @@ msgstr ""
 msgid "Mastodon app access changed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4114
+#: lib/vutuv_web/components/ui.ex:4127
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr ""
@@ -21097,7 +21107,7 @@ msgstr ""
 msgid "Your account is then %{handle}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4116
+#: lib/vutuv_web/components/ui.ex:4129
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr ""
@@ -21110,4 +21120,209 @@ msgstr ""
 #: lib/vutuv_web/views/account_event_text.ex:184
 #, elixir-autogen, elixir-format
 msgid "apps not allowed"
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:430
+#, elixir-autogen, elixir-format
+msgid "Analyse another file"
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:401
+#, elixir-autogen, elixir-format
+msgid "Find my contacts"
+msgstr ""
+
+#: lib/vutuv_web/templates/user/show.html.heex:446
+#: lib/vutuv_web/views/user_html.ex:237
+#, elixir-autogen, elixir-format
+msgid "Find people you know from LinkedIn"
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:296
+#, elixir-autogen, elixir-format
+msgid "Find your LinkedIn contacts"
+msgstr ""
+
+#: lib/vutuv_web/components/ui.ex:4054
+#: lib/vutuv_web/live/import_connections_live.ex:64
+#: lib/vutuv_web/templates/import/new.html.heex:37
+#, elixir-autogen, elixir-format
+msgid "Find your contacts"
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:507
+#, elixir-autogen, elixir-format
+msgid "Follow selected"
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:504
+#, elixir-autogen, elixir-format
+msgid "Following…"
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:340
+#, elixir-autogen, elixir-format
+msgid "How to request it from LinkedIn"
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:335
+#, elixir-autogen, elixir-format
+msgid "It is the same ZIP file the profile import uses."
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:622
+#, elixir-autogen, elixir-format
+msgid "Links the same LinkedIn profile"
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:519
+#, elixir-autogen, elixir-format
+msgid "Nobody here matches what you are looking for."
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:319
+#, elixir-autogen, elixir-format
+msgid "Nobody is invited and no email is sent."
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:231
+#, elixir-autogen, elixir-format
+msgid "Nobody new to follow: you already follow them."
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:435
+#, elixir-autogen, elixir-format
+msgid "None of your contacts is here yet. Or they are, but keep their address private and have not linked their LinkedIn profile. Nothing was stored, and you can try again with a newer archive at any time."
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:468
+#, elixir-autogen, elixir-format
+msgid "Not following yet"
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:320
+#, elixir-autogen, elixir-format
+msgid "Nothing is added to your profile."
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:322
+#, elixir-autogen, elixir-format
+msgid "Nothing is stored: we read the file, show you the result, and keep neither your contacts nor the list."
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:442
+#, elixir-autogen, elixir-format
+msgid "One of your LinkedIn contacts is already a vutuv member."
+msgid_plural "%{formatted} of your LinkedIn contacts are already vutuv members."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:496
+#, elixir-autogen, elixir-format
+msgid "One selected"
+msgid_plural "%{formatted} selected"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:685
+#, elixir-autogen, elixir-format
+msgid "Please choose a ZIP file."
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:400
+#, elixir-autogen, elixir-format
+msgid "Reading…"
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:621
+#, elixir-autogen, elixir-format
+msgid "Same email address as your contact"
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:455
+#: lib/vutuv_web/live/import_connections_live.ex:462
+#, elixir-autogen, elixir-format
+msgid "Search by name"
+msgstr ""
+
+#: lib/vutuv_web/templates/import/preview.html.heex:124
+#, elixir-autogen, elixir-format
+msgid "See which of them are already on vutuv"
+msgstr ""
+
+#: lib/vutuv_web/components/ui.ex:4056
+#, elixir-autogen, elixir-format
+msgid "See which of your LinkedIn contacts are already on vutuv"
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:485
+#, elixir-autogen, elixir-format
+msgid "Select all %{count}"
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:493
+#, elixir-autogen, elixir-format
+msgid "Select none"
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:227
+#, elixir-autogen, elixir-format
+msgid "That archive is too large or has too many files to read safely."
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:686
+#, elixir-autogen, elixir-format
+msgid "That file could not be read."
+msgstr ""
+
+#: lib/vutuv_web/templates/import/new.html.heex:29
+#, elixir-autogen, elixir-format
+msgid "The same file also lists your LinkedIn contacts. We can show you which of them are already on vutuv, without importing or inviting anyone."
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:329
+#, elixir-autogen, elixir-format
+msgid "We only recognise someone by an email address they published here, or by the LinkedIn profile they linked from their vutuv profile. We never guess by name, so you will not be offered a stranger who happens to share a name with someone you know."
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:309
+#, elixir-autogen, elixir-format
+msgid "Who of your LinkedIn contacts is already here?"
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:517
+#, elixir-autogen, elixir-format
+msgid "You already follow every contact we found."
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:104
+#, elixir-autogen, elixir-format
+msgid "You have analysed a lot of archives just now. Please try again later."
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:234
+#, elixir-autogen, elixir-format
+msgid "You now follow one more member."
+msgid_plural "You now follow %{formatted} more members."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:311
+#, elixir-autogen, elixir-format
+msgid "Your LinkedIn data export lists your contacts. We read that list, look for the people among them who are already vutuv members, and show you who they are. You decide who to follow."
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:424
+#, elixir-autogen, elixir-format
+msgid "Your contacts on vutuv"
+msgstr ""
+
+#: lib/vutuv_web/templates/import/preview.html.heex:122
+#, elixir-autogen, elixir-format
+msgid "Your export also lists your LinkedIn contacts."
+msgstr ""
+
+#: lib/vutuv_web/components/ui.ex:4058
+#, elixir-autogen, elixir-format
+msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -38,7 +38,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1449
+#: lib/vutuv_web/templates/user/show.html.heex:1461
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -103,7 +103,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:586
 #: lib/vutuv_web/agent_docs/text.ex:550
 #: lib/vutuv_web/agent_docs/text.ex:551
-#: lib/vutuv_web/templates/user/show.html.heex:1081
+#: lib/vutuv_web/templates/user/show.html.heex:1093
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
@@ -150,7 +150,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1119
+#: lib/vutuv_web/templates/user/show.html.heex:1131
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -222,7 +222,7 @@ msgstr ""
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:1104
+#: lib/vutuv_web/templates/user/show.html.heex:1116
 #, elixir-autogen
 msgid "Edit"
 msgstr ""
@@ -287,7 +287,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:613
+#: lib/vutuv_web/templates/user/show.html.heex:624
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -331,10 +331,11 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:2158
 #: lib/vutuv_web/components/ui.ex:2216
 #: lib/vutuv_web/controllers/followee_controller.ex:29
+#: lib/vutuv_web/live/import_connections_live.ex:469
 #: lib/vutuv_web/live/organization_live/show.ex:471
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:959
+#: lib/vutuv_web/templates/user/show.html.heex:970
 #, elixir-autogen
 msgid "Following"
 msgstr ""
@@ -688,13 +689,13 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1233
+#: lib/vutuv_web/templates/user/show.html.heex:1245
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1235
+#: lib/vutuv_web/templates/user/show.html.heex:1247
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -724,12 +725,12 @@ msgstr ""
 msgid "Profile deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:708
+#: lib/vutuv_web/views/user_html.ex:724
 #, elixir-autogen, elixir-format
 msgid "Social networks"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:715
+#: lib/vutuv_web/views/user_html.ex:731
 #, elixir-autogen, elixir-format
 msgid "Code & repositories"
 msgstr ""
@@ -848,13 +849,13 @@ msgid "vCard"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3710
-#: lib/vutuv_web/templates/user/show.html.heex:953
-#: lib/vutuv_web/templates/user/show.html.heex:976
+#: lib/vutuv_web/templates/user/show.html.heex:964
+#: lib/vutuv_web/templates/user/show.html.heex:987
 #, elixir-autogen
 msgid "View All"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4056
+#: lib/vutuv_web/components/ui.ex:4069
 #: lib/vutuv_web/controllers/settings_controller.ex:169
 #: lib/vutuv_web/live/job_posting_live/form.ex:561
 #: lib/vutuv_web/live/organization_live/edit.ex:304
@@ -1039,7 +1040,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1070
+#: lib/vutuv_web/templates/user/show.html.heex:1082
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1205,7 +1206,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:607
+#: lib/vutuv_web/templates/user/show.html.heex:618
 #, elixir-autogen
 msgid "All tags"
 msgstr ""
@@ -1400,7 +1401,7 @@ msgstr ""
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:23
 #: lib/vutuv_web/templates/tag/show.html.heex:25
-#: lib/vutuv_web/templates/user/show.html.heex:577
+#: lib/vutuv_web/templates/user/show.html.heex:588
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
@@ -1694,7 +1695,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:411
 #: lib/vutuv_web/live/organization_live/show.ex:440
 #: lib/vutuv_web/live/organization_live/show.ex:469
-#: lib/vutuv_web/templates/user/show.html.heex:1273
+#: lib/vutuv_web/templates/user/show.html.heex:1285
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr ""
@@ -1842,7 +1843,7 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:27
 #: lib/vutuv_web/templates/social_media_account/verify.html.heex:18
 #: lib/vutuv_web/templates/user/show.html.heex:200
-#: lib/vutuv_web/views/user_html.ex:760
+#: lib/vutuv_web/views/user_html.ex:776
 #, elixir-autogen, elixir-format
 msgid "Verified profile"
 msgstr ""
@@ -1863,7 +1864,7 @@ msgid "We sent a PIN to your new email address. Enter it below to confirm the ad
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:1435
-#: lib/vutuv_web/views/user_html.ex:208
+#: lib/vutuv_web/views/user_html.ex:213
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr ""
@@ -1916,6 +1917,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3099
 #: lib/vutuv_web/components/ui.ex:3250
+#: lib/vutuv_web/live/import_connections_live.ex:638
 #: lib/vutuv_web/live/organization_live/index.ex:122
 #, elixir-autogen, elixir-format
 msgid "Pagination"
@@ -2044,12 +2046,12 @@ msgstr ""
 msgid "May"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:249
+#: lib/vutuv_web/views/user_html.ex:265
 #, elixir-autogen, elixir-format
 msgid "Member since %{month} %{year}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:254
+#: lib/vutuv_web/views/user_html.ex:270
 #, elixir-autogen, elixir-format
 msgid "Member since %{year}"
 msgstr ""
@@ -2290,7 +2292,7 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4310
+#: lib/vutuv_web/components/ui.ex:4323
 #: lib/vutuv_web/live/shell_live.ex:791
 #: lib/vutuv_web/templates/post/index.html.heex:17
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2360,7 +2362,7 @@ msgstr ""
 msgid "Posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:567
+#: lib/vutuv_web/templates/user/show.html.heex:578
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr ""
@@ -2373,7 +2375,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1666
 #: lib/vutuv_web/components/post_components.ex:4658
 #: lib/vutuv_web/components/ui.ex:3174
-#: lib/vutuv_web/views/user_html.ex:424
+#: lib/vutuv_web/views/user_html.ex:440
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr ""
@@ -2393,7 +2395,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:4892
 #: lib/vutuv_web/components/ui.ex:3160
 #: lib/vutuv_web/live/notification_live/index.ex:1037
-#: lib/vutuv_web/views/user_html.ex:434
+#: lib/vutuv_web/views/user_html.ex:450
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr ""
@@ -2429,7 +2431,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1666
 #: lib/vutuv_web/components/post_components.ex:4658
 #: lib/vutuv_web/live/post_live/saved.ex:775
-#: lib/vutuv_web/views/user_html.ex:424
+#: lib/vutuv_web/views/user_html.ex:440
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
@@ -2455,7 +2457,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:4892
 #: lib/vutuv_web/live/post_live/saved.ex:774
-#: lib/vutuv_web/views/user_html.ex:434
+#: lib/vutuv_web/views/user_html.ex:450
 #, elixir-autogen, elixir-format
 msgid "Unlike"
 msgstr ""
@@ -2701,45 +2703,45 @@ msgstr ""
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
 #: lib/vutuv_web/templates/url/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:889
+#: lib/vutuv_web/templates/user/show.html.heex:900
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1193
+#: lib/vutuv_web/templates/user/show.html.heex:1205
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1451
+#: lib/vutuv_web/templates/user/show.html.heex:1463
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1121
+#: lib/vutuv_web/templates/user/show.html.heex:1133
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1072
+#: lib/vutuv_web/templates/user/show.html.heex:1084
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:616
+#: lib/vutuv_web/templates/user/show.html.heex:627
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #: lib/vutuv_web/templates/work_experience/new.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Add work experience"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:477
+#: lib/vutuv_web/templates/user/show.html.heex:488
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
 msgstr ""
@@ -2752,13 +2754,13 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:216
-#: lib/vutuv_web/templates/user/show.html.heex:607
+#: lib/vutuv_web/templates/user/show.html.heex:618
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:1206
-#: lib/vutuv_web/templates/user/show.html.heex:477
+#: lib/vutuv_web/templates/user/show.html.heex:488
 #, elixir-autogen, elixir-format
 msgid "Write a post"
 msgstr ""
@@ -2860,7 +2862,7 @@ msgid "Endorsement"
 msgstr ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:1032
-#: lib/vutuv_web/templates/user/show.html.heex:937
+#: lib/vutuv_web/templates/user/show.html.heex:948
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -3089,8 +3091,8 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1161
-#: lib/vutuv_web/templates/user/show.html.heex:1162
+#: lib/vutuv_web/templates/user/show.html.heex:1173
+#: lib/vutuv_web/templates/user/show.html.heex:1174
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
@@ -4496,7 +4498,7 @@ msgstr ""
 msgid "Block @%{slug}? This removes any follows and connection between you, closes your conversation, and prevents all interaction in both directions. Unblocking will not restore what was removed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4060
+#: lib/vutuv_web/components/ui.ex:4073
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -4552,7 +4554,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:303
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:959
+#: lib/vutuv_web/templates/user/show.html.heex:970
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -4619,6 +4621,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:412
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
+#: lib/vutuv_web/live/import_connections_live.ex:470
 #: lib/vutuv_web/live/notification_live/index.ex:890
 #: lib/vutuv_web/live/search_live.ex:280
 #: lib/vutuv_web/views/qualification_html.ex:90
@@ -4669,7 +4672,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:388
 #: lib/vutuv_web/live/tag_new_live.ex:48
 #: lib/vutuv_web/live/user_profile_live.ex:1331
-#: lib/vutuv_web/templates/user/show.html.heex:580
+#: lib/vutuv_web/templates/user/show.html.heex:591
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr ""
@@ -5267,7 +5270,7 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4120
+#: lib/vutuv_web/components/ui.ex:4133
 #: lib/vutuv_web/controllers/settings_controller.ex:155
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5346,10 +5349,10 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4217
-#: lib/vutuv_web/components/ui.ex:4222
-#: lib/vutuv_web/components/ui.ex:4301
-#: lib/vutuv_web/components/ui.ex:4365
+#: lib/vutuv_web/components/ui.ex:4230
+#: lib/vutuv_web/components/ui.ex:4235
+#: lib/vutuv_web/components/ui.ex:4314
+#: lib/vutuv_web/components/ui.ex:4378
 #: lib/vutuv_web/controllers/settings_controller.ex:62
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5448,7 +5451,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:33
 #: lib/vutuv_web/views/email_html.ex:12
-#: lib/vutuv_web/views/user_html.ex:885
+#: lib/vutuv_web/views/user_html.ex:901
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr ""
@@ -5468,7 +5471,7 @@ msgstr ""
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4080
+#: lib/vutuv_web/components/ui.ex:4093
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:289
@@ -5523,7 +5526,7 @@ msgstr ""
 msgid "Photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4054
+#: lib/vutuv_web/components/ui.ex:4067
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/templates/page/index.html.heex:174
 #, elixir-autogen, elixir-format
@@ -5636,7 +5639,7 @@ msgstr ""
 msgid "Apps"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4113
+#: lib/vutuv_web/components/ui.ex:4126
 #: lib/vutuv_web/controllers/settings_controller.ex:179
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -6067,14 +6070,14 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:316
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:887
+#: lib/vutuv_web/templates/user/show.html.heex:898
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:451
+#: lib/vutuv_web/templates/user/show.html.heex:462
 #, elixir-autogen, elixir-format
 msgctxt "profile"
 msgid "Post"
@@ -6088,7 +6091,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1502
+#: lib/vutuv_web/templates/user/show.html.heex:1514
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6132,8 +6135,8 @@ msgstr ""
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1087
-#: lib/vutuv_web/templates/user/show.html.heex:1097
+#: lib/vutuv_web/templates/user/show.html.heex:1099
+#: lib/vutuv_web/templates/user/show.html.heex:1109
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6173,12 +6176,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1209
+#: lib/vutuv_web/templates/user/show.html.heex:1221
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1220
+#: lib/vutuv_web/templates/user/show.html.heex:1232
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6221,7 +6224,7 @@ msgstr ""
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1218
+#: lib/vutuv_web/templates/user/show.html.heex:1230
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
@@ -6275,9 +6278,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1488
-#: lib/vutuv_web/templates/user/show.html.heex:1496
+#: lib/vutuv_web/templates/user/show.html.heex:1500
 #: lib/vutuv_web/templates/user/show.html.heex:1508
+#: lib/vutuv_web/templates/user/show.html.heex:1520
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -6661,7 +6664,7 @@ msgstr ""
 msgid "Mute @%{handle}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:884
+#: lib/vutuv_web/views/user_html.ex:900
 #, elixir-autogen, elixir-format
 msgid "Professional"
 msgstr ""
@@ -8139,7 +8142,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
 #: lib/vutuv_web/templates/education/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:673
+#: lib/vutuv_web/templates/user/show.html.heex:684
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr ""
@@ -8163,7 +8166,7 @@ msgstr ""
 #: lib/vutuv_web/templates/education/new.html.heex:4
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
-#: lib/vutuv_web/templates/user/show.html.heex:670
+#: lib/vutuv_web/templates/user/show.html.heex:681
 #: lib/vutuv_web/views/import_html.ex:70
 #: lib/vutuv_web/views/job_reference_html.ex:265
 #, elixir-autogen, elixir-format
@@ -8206,7 +8209,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4101
+#: lib/vutuv_web/components/ui.ex:4114
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8250,6 +8253,7 @@ msgid "Phone numbers"
 msgstr ""
 
 #: lib/vutuv_web/controllers/import_controller.ex:82
+#: lib/vutuv_web/live/import_connections_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "Please choose your LinkedIn export ZIP first."
 msgstr ""
@@ -8270,22 +8274,24 @@ msgstr ""
 msgid "Social media"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:26
+#: lib/vutuv_web/templates/import/new.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "Step 1: Download your LinkedIn data"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:77
+#: lib/vutuv_web/templates/import/new.html.heex:95
 #, elixir-autogen, elixir-format
 msgid "Step 2: Upload the ZIP here"
 msgstr ""
 
 #: lib/vutuv_web/controllers/import_controller.ex:75
+#: lib/vutuv_web/live/import_connections_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "That does not look like a LinkedIn data export ZIP."
 msgstr ""
 
 #: lib/vutuv_web/controllers/import_controller.ex:137
+#: lib/vutuv_web/live/import_connections_live.ex:199
 #, elixir-autogen, elixir-format
 msgid "The file could not be read. Please try again."
 msgstr ""
@@ -8295,7 +8301,7 @@ msgstr ""
 msgid "The import could not be completed. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:130
+#: lib/vutuv_web/templates/import/new.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "Upload and preview"
 msgstr ""
@@ -8334,48 +8340,48 @@ msgstr ""
 msgid "Please check the fields marked in red."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:769
+#: lib/vutuv_web/views/user_html.ex:785
 #, elixir-autogen, elixir-format
 msgid "Loading posts"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:140
-#: lib/vutuv_web/templates/user/show.html.heex:1355
+#: lib/vutuv_web/templates/user/show.html.heex:1367
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:51
+#: lib/vutuv_web/templates/import/new.html.heex:69
 #, elixir-autogen, elixir-format
 msgid "Click \"Request archive\"."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:63
+#: lib/vutuv_web/templates/import/new.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "LinkedIn's \"Download my data\" page with \"Download larger data archive\" selected and the \"Request archive\" button below it."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:39
+#: lib/vutuv_web/templates/import/new.html.heex:57
 #, elixir-autogen, elixir-format
 msgid "Open LinkedIn's data export page"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:73
+#: lib/vutuv_web/templates/import/new.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "Select the larger archive, then click \"Request archive\"."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:28
+#: lib/vutuv_web/templates/import/new.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "LinkedIn lets you export your own data as a ZIP archive. Open the export page, request the larger archive, and download the ZIP once LinkedIn has finished preparing it (this usually takes a few minutes)."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:53
+#: lib/vutuv_web/templates/import/new.html.heex:71
 #, elixir-autogen, elixir-format
 msgid "LinkedIn prepares your archive. When it is ready (usually after a few minutes), download the ZIP to your device."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:79
+#: lib/vutuv_web/templates/import/new.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Then upload the ZIP file below to see the preview and pick what to add."
 msgstr ""
@@ -8395,7 +8401,8 @@ msgstr ""
 msgid "Import your LinkedIn profile data into your vutuv profile. From your export we can fill in:"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:111
+#: lib/vutuv_web/live/import_connections_live.ex:370
+#: lib/vutuv_web/templates/import/new.html.heex:129
 #, elixir-autogen, elixir-format
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
@@ -8406,7 +8413,7 @@ msgstr ""
 msgid "Basics & photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4091
+#: lib/vutuv_web/components/ui.ex:4104
 #: lib/vutuv_web/controllers/settings_controller.ex:123
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8418,7 +8425,7 @@ msgstr ""
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4082
+#: lib/vutuv_web/components/ui.ex:4095
 #: lib/vutuv_web/controllers/settings_controller.ex:106
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8428,7 +8435,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4105
+#: lib/vutuv_web/components/ui.ex:4118
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8486,12 +8493,14 @@ msgstr ""
 msgid "The file you sent is too large."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:93
+#: lib/vutuv_web/live/import_connections_live.ex:683
+#: lib/vutuv_web/templates/import/new.html.heex:111
 #, elixir-autogen, elixir-format
 msgid "This file is too large. Please choose a ZIP of at most 50 MB."
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:116
+#: lib/vutuv_web/live/import_connections_live.ex:379
+#: lib/vutuv_web/templates/import/new.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "ZIP file, up to 50 MB."
 msgstr ""
@@ -8642,7 +8651,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:562
 #: lib/vutuv_web/agent_docs/text.ex:566
 #: lib/vutuv_web/components/organization_components.ex:310
-#: lib/vutuv_web/components/ui.ex:4072
+#: lib/vutuv_web/components/ui.ex:4085
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:355
 #: lib/vutuv_web/controllers/settings_controller.ex:422
@@ -8656,8 +8665,8 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:1001
-#: lib/vutuv_web/templates/user/show.html.heex:1260
+#: lib/vutuv_web/templates/user/show.html.heex:1012
+#: lib/vutuv_web/templates/user/show.html.heex:1272
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr ""
@@ -8728,7 +8737,7 @@ msgstr ""
 msgid "Internships"
 msgstr ""
 
-#: lib/vutuv_web/templates/import/new.html.heex:47
+#: lib/vutuv_web/templates/import/new.html.heex:65
 #, elixir-autogen, elixir-format
 msgid "On that page, select \"Download larger data archive\" (profile, positions, volunteering, education, skills)."
 msgstr ""
@@ -9053,7 +9062,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/language/manage.html.heex:8
 #: lib/vutuv_web/templates/language/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:735
+#: lib/vutuv_web/templates/user/show.html.heex:746
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr ""
@@ -9277,7 +9286,7 @@ msgstr ""
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:4
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:732
+#: lib/vutuv_web/templates/user/show.html.heex:743
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr ""
@@ -9557,7 +9566,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:841
+#: lib/vutuv_web/templates/user/show.html.heex:852
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr ""
@@ -9605,7 +9614,7 @@ msgstr ""
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:838
+#: lib/vutuv_web/templates/user/show.html.heex:849
 #: lib/vutuv_web/views/import_html.ex:71
 #: lib/vutuv_web/views/job_reference_html.ex:266
 #, elixir-autogen, elixir-format
@@ -9724,8 +9733,8 @@ msgstr ""
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1183
-#: lib/vutuv_web/templates/user/show.html.heex:1184
+#: lib/vutuv_web/templates/user/show.html.heex:1195
+#: lib/vutuv_web/templates/user/show.html.heex:1196
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -10230,15 +10239,15 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/live/organization_live/show.ex:498
-#: lib/vutuv_web/views/user_html.ex:633
-#: lib/vutuv_web/views/user_html.ex:809
+#: lib/vutuv_web/views/user_html.ex:649
+#: lib/vutuv_web/views/user_html.ex:825
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower"
 msgid_plural "%{formatted} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_html.ex:626
+#: lib/vutuv_web/views/user_html.ex:642
 #, elixir-autogen, elixir-format
 msgid "%{formatted} star"
 msgid_plural "%{formatted} stars"
@@ -10247,7 +10256,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:63
 #: lib/vutuv_web/agent_docs/text.ex:60
-#: lib/vutuv_web/templates/user/show.html.heex:1329
+#: lib/vutuv_web/templates/user/show.html.heex:1341
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -10263,7 +10272,7 @@ msgstr ""
 msgid "If you list a GitHub, GitLab or Codeberg account, your profile can show its public statistics: stars, repositories, followers, languages and recent activity."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:640
+#: lib/vutuv_web/views/user_html.ex:656
 #, elixir-autogen, elixir-format
 msgid "Last active %{date}"
 msgstr ""
@@ -10288,7 +10297,7 @@ msgstr ""
 msgid "since %{date}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:556
+#: lib/vutuv_web/views/user_html.ex:572
 #, elixir-autogen, elixir-format
 msgid "since %{year}"
 msgstr ""
@@ -11835,7 +11844,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:409
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:383
-#: lib/vutuv_web/components/ui.ex:4109
+#: lib/vutuv_web/components/ui.ex:4122
 #: lib/vutuv_web/controllers/settings_controller.ex:211
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
@@ -13052,7 +13061,7 @@ msgstr ""
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4049
+#: lib/vutuv_web/components/ui.ex:4062
 #: lib/vutuv_web/controllers/settings_controller.ex:588
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -13561,7 +13570,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1295
+#: lib/vutuv_web/templates/user/show.html.heex:1307
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
@@ -13598,7 +13607,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1293
+#: lib/vutuv_web/templates/user/show.html.heex:1305
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
@@ -14987,7 +14996,7 @@ msgstr ""
 msgid "Book an ad"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1005
+#: lib/vutuv_web/templates/user/show.html.heex:1016
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr ""
@@ -15108,12 +15117,12 @@ msgstr ""
 msgid "skill topic keyword expertise endorsement"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4110
+#: lib/vutuv_web/components/ui.ex:4123
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4111
+#: lib/vutuv_web/components/ui.ex:4124
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr ""
@@ -15228,72 +15237,72 @@ msgstr ""
 msgid "tag topic subscribe follow feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4050
+#: lib/vutuv_web/components/ui.ex:4063
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4051
+#: lib/vutuv_web/components/ui.ex:4064
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4057
+#: lib/vutuv_web/components/ui.ex:4070
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4058
+#: lib/vutuv_web/components/ui.ex:4071
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4061
+#: lib/vutuv_web/components/ui.ex:4074
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4062
+#: lib/vutuv_web/components/ui.ex:4075
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4083
+#: lib/vutuv_web/components/ui.ex:4096
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4084
+#: lib/vutuv_web/components/ui.ex:4097
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4102
+#: lib/vutuv_web/components/ui.ex:4115
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4103
+#: lib/vutuv_web/components/ui.ex:4116
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4106
+#: lib/vutuv_web/components/ui.ex:4119
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4107
+#: lib/vutuv_web/components/ui.ex:4120
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4121
+#: lib/vutuv_web/components/ui.ex:4134
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4122
+#: lib/vutuv_web/components/ui.ex:4135
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr ""
@@ -15580,6 +15589,7 @@ msgid "Show only followers from this server"
 msgstr ""
 
 #: lib/vutuv_web/components/browse_table.ex:475
+#: lib/vutuv_web/live/import_connections_live.ex:535
 #, elixir-autogen, elixir-format
 msgid "Showing %{first}-%{last} of %{total}."
 msgstr ""
@@ -15744,7 +15754,7 @@ msgstr ""
 msgid "Access token revoked"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4086
+#: lib/vutuv_web/components/ui.ex:4099
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -16091,7 +16101,7 @@ msgstr ""
 msgid "What changed on your account, and exactly when."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4087
+#: lib/vutuv_web/components/ui.ex:4100
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr ""
@@ -16127,7 +16137,7 @@ msgstr ""
 msgid "from a signed-in session"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4089
+#: lib/vutuv_web/components/ui.ex:4102
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
@@ -16648,7 +16658,7 @@ msgstr ""
 msgid "Cancel request"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4073
+#: lib/vutuv_web/components/ui.ex:4086
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr ""
@@ -16852,7 +16862,7 @@ msgstr ""
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4075
+#: lib/vutuv_web/components/ui.ex:4088
 #, elixir-autogen, elixir-format, fuzzy
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
@@ -17228,7 +17238,7 @@ msgid_plural "You already follow %{count} members."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_html.ex:210
+#: lib/vutuv_web/views/user_html.ex:215
 #, elixir-autogen, elixir-format
 msgid "Your feed shows the posts of members you follow. Follow a few to fill it."
 msgstr ""
@@ -18303,7 +18313,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/job_reference_controller.ex:144
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:18
 #: lib/vutuv_web/templates/job_reference/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:775
+#: lib/vutuv_web/templates/user/show.html.heex:786
 #, elixir-autogen, elixir-format
 msgid "Add an employment reference"
 msgstr ""
@@ -18378,7 +18388,7 @@ msgstr ""
 #: lib/vutuv_web/templates/job_reference/new.html.heex:4
 #: lib/vutuv_web/templates/job_reference/show.html.heex:12
 #: lib/vutuv_web/templates/job_reference/view.html.heex:11
-#: lib/vutuv_web/templates/user/show.html.heex:772
+#: lib/vutuv_web/templates/user/show.html.heex:783
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Employment references"
 msgstr ""
@@ -19011,7 +19021,7 @@ msgstr ""
 msgid "by the lawyer Tom Braegelmann"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:816
+#: lib/vutuv_web/templates/user/show.html.heex:827
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Documents:"
 msgstr ""
@@ -19313,7 +19323,7 @@ msgstr ""
 msgid "Always keep"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4066
+#: lib/vutuv_web/components/ui.ex:4079
 #: lib/vutuv_web/controllers/settings_controller.ex:245
 #: lib/vutuv_web/controllers/settings_controller.ex:324
 #: lib/vutuv_web/controllers/settings_controller.ex:336
@@ -19410,7 +19420,7 @@ msgstr ""
 msgid "Keep posts that did well"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4068
+#: lib/vutuv_web/components/ui.ex:4081
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr ""
@@ -19519,7 +19529,7 @@ msgstr ""
 msgid "Your rule"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4070
+#: lib/vutuv_web/components/ui.ex:4083
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
@@ -20919,7 +20929,7 @@ msgstr ""
 msgid "ISO 8601 (Sweden, Japan, China)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4093
+#: lib/vutuv_web/components/ui.ex:4106
 #, elixir-autogen, elixir-format
 msgid "Interface language, date format and time zone, feed languages, maps, how posts are shortened"
 msgstr ""
@@ -20929,7 +20939,7 @@ msgstr ""
 msgid "Language & display settings changed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4097
+#: lib/vutuv_web/components/ui.ex:4110
 #, elixir-autogen, elixir-format, fuzzy
 msgid "german english locale translation translate map font length hyphenation feed languages hide foreign übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
 msgstr ""
@@ -20998,12 +21008,12 @@ msgstr ""
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:305
+#: lib/vutuv_web/views/user_html.ex:321
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:308
+#: lib/vutuv_web/views/user_html.ex:324
 #, elixir-autogen, elixir-format
 msgid "Show the profile picture larger"
 msgstr ""
@@ -21049,7 +21059,7 @@ msgstr ""
 msgid "Mastodon app access changed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4114
+#: lib/vutuv_web/components/ui.ex:4127
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr ""
@@ -21095,7 +21105,7 @@ msgstr ""
 msgid "Your account is then %{handle}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4116
+#: lib/vutuv_web/components/ui.ex:4129
 #, elixir-autogen, elixir-format, fuzzy
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr ""
@@ -21108,4 +21118,209 @@ msgstr ""
 #: lib/vutuv_web/views/account_event_text.ex:184
 #, elixir-autogen, elixir-format
 msgid "apps not allowed"
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:430
+#, elixir-autogen, elixir-format
+msgid "Analyse another file"
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:401
+#, elixir-autogen, elixir-format
+msgid "Find my contacts"
+msgstr ""
+
+#: lib/vutuv_web/templates/user/show.html.heex:446
+#: lib/vutuv_web/views/user_html.ex:237
+#, elixir-autogen, elixir-format
+msgid "Find people you know from LinkedIn"
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:296
+#, elixir-autogen, elixir-format
+msgid "Find your LinkedIn contacts"
+msgstr ""
+
+#: lib/vutuv_web/components/ui.ex:4054
+#: lib/vutuv_web/live/import_connections_live.ex:64
+#: lib/vutuv_web/templates/import/new.html.heex:37
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Find your contacts"
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:507
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Follow selected"
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:504
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Following…"
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:340
+#, elixir-autogen, elixir-format
+msgid "How to request it from LinkedIn"
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:335
+#, elixir-autogen, elixir-format
+msgid "It is the same ZIP file the profile import uses."
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:622
+#, elixir-autogen, elixir-format
+msgid "Links the same LinkedIn profile"
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:519
+#, elixir-autogen, elixir-format
+msgid "Nobody here matches what you are looking for."
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:319
+#, elixir-autogen, elixir-format
+msgid "Nobody is invited and no email is sent."
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:231
+#, elixir-autogen, elixir-format
+msgid "Nobody new to follow: you already follow them."
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:435
+#, elixir-autogen, elixir-format
+msgid "None of your contacts is here yet. Or they are, but keep their address private and have not linked their LinkedIn profile. Nothing was stored, and you can try again with a newer archive at any time."
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:468
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Not following yet"
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:320
+#, elixir-autogen, elixir-format
+msgid "Nothing is added to your profile."
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:322
+#, elixir-autogen, elixir-format
+msgid "Nothing is stored: we read the file, show you the result, and keep neither your contacts nor the list."
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:442
+#, elixir-autogen, elixir-format
+msgid "One of your LinkedIn contacts is already a vutuv member."
+msgid_plural "%{formatted} of your LinkedIn contacts are already vutuv members."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:496
+#, elixir-autogen, elixir-format
+msgid "One selected"
+msgid_plural "%{formatted} selected"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:685
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Please choose a ZIP file."
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:400
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Reading…"
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:621
+#, elixir-autogen, elixir-format
+msgid "Same email address as your contact"
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:455
+#: lib/vutuv_web/live/import_connections_live.ex:462
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Search by name"
+msgstr ""
+
+#: lib/vutuv_web/templates/import/preview.html.heex:124
+#, elixir-autogen, elixir-format
+msgid "See which of them are already on vutuv"
+msgstr ""
+
+#: lib/vutuv_web/components/ui.ex:4056
+#, elixir-autogen, elixir-format
+msgid "See which of your LinkedIn contacts are already on vutuv"
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:485
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Select all %{count}"
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:493
+#, elixir-autogen, elixir-format
+msgid "Select none"
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:227
+#, elixir-autogen, elixir-format, fuzzy
+msgid "That archive is too large or has too many files to read safely."
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:686
+#, elixir-autogen, elixir-format, fuzzy
+msgid "That file could not be read."
+msgstr ""
+
+#: lib/vutuv_web/templates/import/new.html.heex:29
+#, elixir-autogen, elixir-format
+msgid "The same file also lists your LinkedIn contacts. We can show you which of them are already on vutuv, without importing or inviting anyone."
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:329
+#, elixir-autogen, elixir-format
+msgid "We only recognise someone by an email address they published here, or by the LinkedIn profile they linked from their vutuv profile. We never guess by name, so you will not be offered a stranger who happens to share a name with someone you know."
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:309
+#, elixir-autogen, elixir-format
+msgid "Who of your LinkedIn contacts is already here?"
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:517
+#, elixir-autogen, elixir-format, fuzzy
+msgid "You already follow every contact we found."
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:104
+#, elixir-autogen, elixir-format
+msgid "You have analysed a lot of archives just now. Please try again later."
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:234
+#, elixir-autogen, elixir-format
+msgid "You now follow one more member."
+msgid_plural "You now follow %{formatted} more members."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:311
+#, elixir-autogen, elixir-format
+msgid "Your LinkedIn data export lists your contacts. We read that list, look for the people among them who are already vutuv members, and show you who they are. You decide who to follow."
+msgstr ""
+
+#: lib/vutuv_web/live/import_connections_live.ex:424
+#, elixir-autogen, elixir-format
+msgid "Your contacts on vutuv"
+msgstr ""
+
+#: lib/vutuv_web/templates/import/preview.html.heex:122
+#, elixir-autogen, elixir-format
+msgid "Your export also lists your LinkedIn contacts."
+msgstr ""
+
+#: lib/vutuv_web/components/ui.ex:4058
+#, elixir-autogen, elixir-format
+msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
 msgstr ""

--- a/test/vutuv/imports/connection_match_test.exs
+++ b/test/vutuv/imports/connection_match_test.exs
@@ -1,0 +1,160 @@
+defmodule Vutuv.Imports.ConnectionMatchTest do
+  @moduledoc """
+  Which vutuv members a LinkedIn contact list resolves to (issue #1476). Only
+  exact identifiers count, and the email half deliberately reaches **public**
+  addresses only — the same line `Vutuv.Search.search_by_email/1` holds, because
+  a private address must not even confirm that an account exists.
+  """
+  use Vutuv.DataCase
+
+  alias Vutuv.Imports.ConnectionMatch
+  alias Vutuv.Social
+
+  defp member(attrs \\ []) do
+    insert_activated_user(attrs)
+  end
+
+  defp with_email(user, value, opts \\ []) do
+    insert(:email,
+      user: user,
+      value: value,
+      public?: Keyword.get(opts, :public?, true),
+      md5sum: :crypto.hash(:md5, value) |> Base.encode16(case: :lower)
+    )
+
+    user
+  end
+
+  defp with_linkedin(user, handle) do
+    insert(:social_media_account, user: user, provider: "LinkedIn", value: handle)
+    user
+  end
+
+  defp email_contact(value), do: %{email: value, linkedin: nil}
+  defp linkedin_contact(value), do: %{email: nil, linkedin: value}
+
+  describe "find/2 — email" do
+    test "finds the member behind a public address", %{} do
+      viewer = member()
+      target = member() |> with_email("conni@example.com")
+
+      assert [%{user: found, via: :email}] =
+               ConnectionMatch.find(viewer, [email_contact("conni@example.com")])
+
+      assert found.id == target.id
+    end
+
+    test "does not find a member whose address is private" do
+      viewer = member()
+      _target = member() |> with_email("secret@example.com", public?: false)
+
+      assert [] = ConnectionMatch.find(viewer, [email_contact("secret@example.com")])
+    end
+
+    test "an unconfirmed account is not a member yet" do
+      viewer = member()
+      pending = insert(:user)
+      with_email(pending, "pending@example.com")
+
+      assert [] = ConnectionMatch.find(viewer, [email_contact("pending@example.com")])
+    end
+
+    test "a deactivated account stays out of the results" do
+      viewer = member()
+
+      member(deactivated_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second))
+      |> with_email("gone@example.com")
+
+      assert [] = ConnectionMatch.find(viewer, [email_contact("gone@example.com")])
+    end
+  end
+
+  describe "find/2 — LinkedIn profile" do
+    test "finds the member who links that LinkedIn profile" do
+      viewer = member()
+      target = member() |> with_linkedin("conni-contact")
+
+      assert [%{user: found, via: :linkedin}] =
+               ConnectionMatch.find(viewer, [linkedin_contact("conni-contact")])
+
+      assert found.id == target.id
+    end
+
+    test "the comparison ignores case on both sides" do
+      viewer = member()
+      target = member() |> with_linkedin("Conni-Contact")
+
+      assert [%{user: found}] = ConnectionMatch.find(viewer, [linkedin_contact("conni-contact")])
+      assert found.id == target.id
+    end
+
+    test "another provider with the same handle is not a LinkedIn profile" do
+      viewer = member()
+      insert(:social_media_account, user: member(), provider: "GitHub", value: "conni-contact")
+
+      assert [] = ConnectionMatch.find(viewer, [linkedin_contact("conni-contact")])
+    end
+  end
+
+  describe "find/2 — the result set" do
+    test "one member matched twice is listed once, and the address wins the label" do
+      viewer = member()
+
+      target =
+        member()
+        |> with_email("conni@example.com")
+        |> with_linkedin("conni")
+
+      assert [%{user: found, via: :email}] =
+               ConnectionMatch.find(viewer, [
+                 %{email: "conni@example.com", linkedin: "conni"}
+               ])
+
+      assert found.id == target.id
+    end
+
+    test "the member doing the lookup is never their own contact" do
+      viewer = member() |> with_email("me@example.com")
+
+      assert [] = ConnectionMatch.find(viewer, [email_contact("me@example.com")])
+    end
+
+    test "a blocked pair does not find each other" do
+      viewer = member()
+      blocked = member() |> with_email("blocked@example.com")
+      {:ok, _} = Social.block_user(viewer, blocked)
+
+      assert [] = ConnectionMatch.find(viewer, [email_contact("blocked@example.com")])
+    end
+
+    test "someone the member already follows stays in the list" do
+      viewer = member()
+      target = member() |> with_email("followed@example.com")
+      follow!(viewer, target)
+
+      assert [%{user: found}] =
+               ConnectionMatch.find(viewer, [email_contact("followed@example.com")])
+
+      assert found.id == target.id
+    end
+
+    test "results are sorted by name" do
+      viewer = member()
+      member(first_name: "Zoe", last_name: "Adams") |> with_email("zoe@example.com")
+      member(first_name: "Anna", last_name: "Zeller") |> with_email("anna@example.com")
+
+      assert [%{user: first}, %{user: second}] =
+               ConnectionMatch.find(viewer, [
+                 email_contact("zoe@example.com"),
+                 email_contact("anna@example.com")
+               ])
+
+      assert first.last_name == "Adams"
+      assert second.last_name == "Zeller"
+    end
+
+    test "an empty contact list asks the database nothing and finds nobody" do
+      assert [] = ConnectionMatch.find(member(), [])
+    end
+  end
+end

--- a/test/vutuv/imports/linked_in_connections_test.exs
+++ b/test/vutuv/imports/linked_in_connections_test.exs
@@ -1,0 +1,137 @@
+defmodule Vutuv.Imports.LinkedInConnectionsTest do
+  @moduledoc """
+  The `Connections.csv` half of the export parser (issue #1476): pure, no Repo,
+  and it keeps only the two exact identifiers a match can be made on.
+  """
+  use ExUnit.Case, async: true
+
+  alias Vutuv.Imports.LinkedIn
+
+  defp zip(files) do
+    entries = Enum.map(files, fn {name, content} -> {String.to_charlist(name), content} end)
+    {:ok, {_name, binary}} = :zip.create(~c"export.zip", entries, [:memory])
+    binary
+  end
+
+  @headers "First Name,Last Name,URL,Email Address,Company,Position,Connected On"
+
+  # What LinkedIn really ships: two note lines and a blank one above the header
+  # row. Every row below is quoted the way the export quotes them.
+  defp real_export(rows) do
+    """
+    Notes:
+    "When exporting your connection data, you may notice that some of the email addresses are missing. You will only see email addresses for connections who have allowed their connections to see or download their email address using this setting https://www.linkedin.com/psettings/privacy/email. You can learn more here https://www.linkedin.com/help/linkedin/answer/261"
+
+    #{@headers}
+    #{rows}
+    """
+  end
+
+  describe "parse_connections/2" do
+    test "reads the rows below LinkedIn's own notes preamble" do
+      csv =
+        real_export("""
+        Conni,Contact,https://www.linkedin.com/in/conni-contact,conni@example.com,Acme GmbH,CEO,01 Jan 2020
+        """)
+
+      {:ok, contacts} = LinkedIn.parse_connections(zip([{"Connections.csv", csv}]))
+
+      assert contacts == [%{email: "conni@example.com", linkedin: "conni-contact"}]
+    end
+
+    test "reads a file with no preamble at all" do
+      csv = """
+      #{@headers}
+      Conni,Contact,https://www.linkedin.com/in/conni,conni@example.com,Acme,CEO,01 Jan 2020
+      """
+
+      {:ok, contacts} = LinkedIn.parse_connections(zip([{"Connections.csv", csv}]))
+
+      assert contacts == [%{email: "conni@example.com", linkedin: "conni"}]
+    end
+
+    test "classifies by header signature, so a localized filename still works" do
+      csv =
+        real_export("""
+        Conni,Contact,https://www.linkedin.com/in/conni,conni@example.com,Acme,CEO,01 Jan 2020
+        """)
+
+      {:ok, contacts} = LinkedIn.parse_connections(zip([{"Kontakte.csv", csv}]))
+
+      assert [%{email: "conni@example.com"}] = contacts
+    end
+
+    test "normalizes the profile URL down to the LinkedIn identifier" do
+      csv =
+        real_export("""
+        A,One,https://www.linkedin.com/in/example,,Acme,CEO,01 Jan 2020
+        B,Two,https://linkedin.com/in/Example/,,Acme,CEO,01 Jan 2020
+        C,Three,http://de.linkedin.com/in/example?trk=foo,,Acme,CEO,01 Jan 2020
+        D,Four,www.linkedin.com/in/example#about,,Acme,CEO,01 Jan 2020
+        """)
+
+      {:ok, contacts} = LinkedIn.parse_connections(zip([{"Connections.csv", csv}]))
+
+      # All four spellings name the same profile, so they collapse to one contact.
+      assert contacts == [%{email: nil, linkedin: "example"}]
+    end
+
+    test "downcases and trims email addresses, and drops ones that are not addresses" do
+      csv =
+        real_export("""
+        A,One,, Conni@Example.COM ,Acme,CEO,01 Jan 2020
+        B,Two,,not an address,Acme,CEO,01 Jan 2020
+        """)
+
+      {:ok, contacts} = LinkedIn.parse_connections(zip([{"Connections.csv", csv}]))
+
+      assert contacts == [%{email: "conni@example.com", linkedin: nil}]
+    end
+
+    test "keeps nothing but the two identifiers — no name, employer or position" do
+      csv =
+        real_export("""
+        Conni,Contact,https://www.linkedin.com/in/conni,conni@example.com,Acme GmbH,CEO,01 Jan 2020
+        """)
+
+      {:ok, [contact]} = LinkedIn.parse_connections(zip([{"Connections.csv", csv}]))
+
+      assert Map.keys(contact) == [:email, :linkedin]
+    end
+
+    test "drops rows carrying neither an address nor a profile URL" do
+      csv =
+        real_export("""
+        Nameless,Person,,,Acme,CEO,01 Jan 2020
+        """)
+
+      assert {:ok, []} = LinkedIn.parse_connections(zip([{"Connections.csv", csv}]))
+    end
+
+    test "an archive without a connections file yields no contacts" do
+      csv = """
+      Company Name,Title,Description,Location,Started On,Finished On
+      Acme,Engineer,,Berlin,2020,
+      """
+
+      assert {:ok, []} = LinkedIn.parse_connections(zip([{"Positions.csv", csv}]))
+    end
+
+    test "anything that is not a readable ZIP is refused" do
+      assert {:error, :invalid_archive} = LinkedIn.parse_connections("not a zip")
+    end
+
+    test "the profile parse still ignores Connections.csv" do
+      csv =
+        real_export("""
+        Conni,Contact,https://www.linkedin.com/in/conni,conni@example.com,Acme,CEO,01 Jan 2020
+        """)
+
+      {:ok, result} = LinkedIn.parse(zip([{"Connections.csv", csv}]))
+
+      assert result.positions == []
+      assert result.emails == []
+      assert result.social == []
+    end
+  end
+end

--- a/test/vutuv/social_test.exs
+++ b/test/vutuv/social_test.exs
@@ -73,6 +73,46 @@ defmodule Vutuv.SocialTest do
     end
   end
 
+  describe "follow_many/2" do
+    test "follows every member it was given and says how many that was" do
+      follower = insert(:user)
+      a = insert(:user)
+      b = insert(:user)
+
+      assert Social.follow_many(follower, [a.id, b.id]) == 2
+      assert Social.user_follows_user?(follower.id, a.id)
+      assert Social.user_follows_user?(follower.id, b.id)
+    end
+
+    test "an id the member already follows is not counted again" do
+      follower = insert(:user)
+      already = insert(:user)
+      fresh = insert(:user)
+      {:ok, _} = Social.follow(follower, already.id)
+
+      assert Social.follow_many(follower, [already.id, fresh.id]) == 1
+    end
+
+    test "a repeated id in the same batch is followed once" do
+      follower = insert(:user)
+      target = insert(:user)
+
+      assert Social.follow_many(follower, [target.id, target.id]) == 1
+    end
+
+    test "one impossible id does not take the rest of the batch down" do
+      follower = insert(:user)
+      target = insert(:user)
+
+      assert Social.follow_many(follower, ["not-a-uuid", follower.id, target.id]) == 1
+      assert Social.user_follows_user?(follower.id, target.id)
+    end
+
+    test "nothing to follow is not an error" do
+      assert Social.follow_many(insert(:user), []) == 0
+    end
+  end
+
   describe "unfollow!/2" do
     test "is idempotent: a second unfollow (edge already gone) is a no-op, not a crash" do
       follower = insert(:user)

--- a/test/vutuv_web/controllers/import_rate_limit_test.exs
+++ b/test/vutuv_web/controllers/import_rate_limit_test.exs
@@ -8,17 +8,30 @@ defmodule VutuvWeb.ImportRateLimitTest do
 
   setup do
     Vutuv.RateLimiter.reset()
-    prev_rate_limit = Application.get_env(:vutuv, :rate_limit)
-    prev_import = Application.get_env(:vutuv, :linkedin_import_rate_limit)
-    Application.put_env(:vutuv, :rate_limit, enabled: true)
-    Application.put_env(:vutuv, :linkedin_import_rate_limit, {2, 60_000})
-
-    on_exit(fn ->
-      Application.put_env(:vutuv, :rate_limit, prev_rate_limit)
-      Application.put_env(:vutuv, :linkedin_import_rate_limit, prev_import)
-    end)
+    put_config(:rate_limit, enabled: true)
+    put_config(:linkedin_import_rate_limit, {2, 60_000})
 
     :ok
+  end
+
+  # `:linkedin_import_rate_limit` is normally ABSENT, and `Application.get_env/2`
+  # answers nil for absent and for nil alike — so the obvious
+  # `put_env(key, get_env(key))` restore wrote nil back as a real value and
+  # poisoned the key for every later test in the run. The next reader then did
+  # not get the function's default, it got nil, which crashed the contact
+  # finder's upload with a MatchError (11 tests, in a file that has nothing to
+  # do with rate limits). Capture with fetch_env/2 and restore the two cases
+  # apart.
+  defp put_config(key, value) do
+    original = Application.fetch_env(:vutuv, key)
+    Application.put_env(:vutuv, key, value)
+
+    on_exit(fn ->
+      case original do
+        {:ok, was} -> Application.put_env(:vutuv, key, was)
+        :error -> Application.delete_env(:vutuv, key)
+      end
+    end)
   end
 
   defp upload_zip do

--- a/test/vutuv_web/live/import_connections_live_test.exs
+++ b/test/vutuv_web/live/import_connections_live_test.exs
@@ -1,0 +1,238 @@
+defmodule VutuvWeb.ImportConnectionsLiveTest do
+  @moduledoc """
+  The LinkedIn contact finder (/settings/import/linkedin/connections, issue
+  #1476): upload an export, see the contacts who are already members, narrow the
+  list, and follow them — one pill at a time or a selection at once.
+  """
+  use VutuvWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.Social
+
+  @headers "First Name,Last Name,URL,Email Address,Company,Position,Connected On"
+
+  defp archive(rows) do
+    csv = @headers <> "\n" <> Enum.join(rows, "\n") <> "\n"
+
+    {:ok, {_name, binary}} =
+      :zip.create(~c"export.zip", [{~c"Connections.csv", csv}], [:memory])
+
+    binary
+  end
+
+  defp row(email, opts \\ []) do
+    url = Keyword.get(opts, :url, "")
+    "A,Contact,#{url},#{email},Acme,CEO,01 Jan 2020"
+  end
+
+  # Drives the page's own upload, exactly the way a member does.
+  defp analyze(live, binary) do
+    live
+    |> file_input("#linkedin-connections-form", :archive, [
+      %{
+        name: "export.zip",
+        content: binary,
+        type: "application/zip",
+        size: byte_size(binary)
+      }
+    ])
+    |> render_upload("export.zip")
+
+    live |> element("#linkedin-connections-form") |> render_submit()
+  end
+
+  defp member_with_public_email(value, attrs \\ []) do
+    user = insert_activated_user(attrs)
+
+    insert(:email,
+      user: user,
+      value: value,
+      public?: true,
+      md5sum: :crypto.hash(:md5, value) |> Base.encode16(case: :lower)
+    )
+
+    user
+  end
+
+  test "an anonymous visitor is sent away", %{conn: conn} do
+    conn = get(conn, ~p"/settings/import/linkedin/connections")
+    assert redirected_to(conn) == ~p"/"
+  end
+
+  test "it says what it does and does not do before anything is uploaded", %{conn: conn} do
+    {conn, _user} = create_and_login_user(conn)
+
+    {:ok, live, html} = live(conn, ~p"/settings/import/linkedin/connections")
+
+    assert html =~ "Nobody is invited"
+    assert html =~ "Nothing is stored"
+    assert has_element?(live, "#linkedin-connections-form")
+    refute has_element?(live, "#contact-matches")
+  end
+
+  # vutuv is a German site, and the whole page is new copy — including the
+  # one-word labels gettext's fuzzy merge is most likely to have filled with
+  # something plausible and wrong. So the German render is asserted by name.
+  test "the German render says what the page is, in German", %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+    {:ok, _user} = Vutuv.Accounts.update_user(user, %{"locale" => "de"})
+    member_with_public_email("bekannt@example.com", first_name: "Bekannte", last_name: "Person")
+
+    {:ok, live, html} = live(conn, ~p"/settings/import/linkedin/connections")
+
+    assert html =~ "Wer aus Ihren LinkedIn-Kontakten ist schon hier?"
+    assert html =~ "Niemand wird eingeladen"
+
+    html = analyze(live, archive([row("bekannt@example.com")]))
+
+    assert html =~ "Ihre Kontakte auf vutuv"
+    assert html =~ "Gleiche E-Mail-Adresse wie Ihr Kontakt"
+    assert html =~ "Folge ich noch nicht"
+    assert html =~ "Alle 1 auswählen"
+
+    html = live |> element("button", "Alle 1 auswählen") |> render_click()
+    assert html =~ "Ausgewählten folgen"
+  end
+
+  describe "after an upload" do
+    setup %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      {:ok, conn: conn, user: user}
+    end
+
+    test "the contacts who are members are listed with the reason", %{conn: conn} do
+      known = member_with_public_email("known@example.com", first_name: "Known", last_name: "One")
+
+      {:ok, live, _html} = live(conn, ~p"/settings/import/linkedin/connections")
+
+      html = analyze(live, archive([row("known@example.com"), row("stranger@example.com")]))
+
+      assert html =~ "Known One"
+      assert html =~ "Same email address"
+      refute html =~ "stranger@example.com"
+      assert has_element?(live, "#select-#{known.id}")
+    end
+
+    test "a contact who is not a member is not named anywhere", %{conn: conn} do
+      {:ok, live, _html} = live(conn, ~p"/settings/import/linkedin/connections")
+
+      html = analyze(live, archive([row("nobody@example.com")]))
+
+      assert html =~ "None of your contacts is here yet"
+    end
+
+    test "a file that is not a LinkedIn archive is refused, not crashed on", %{conn: conn} do
+      {:ok, live, _html} = live(conn, ~p"/settings/import/linkedin/connections")
+
+      html = analyze(live, "this is not a zip file")
+
+      assert html =~ "does not look like a LinkedIn data export"
+    end
+
+    test "select all then follow selected really follows them", %{conn: conn, user: user} do
+      a = member_with_public_email("a@example.com")
+      b = member_with_public_email("b@example.com")
+
+      {:ok, live, _html} = live(conn, ~p"/settings/import/linkedin/connections")
+      analyze(live, archive([row("a@example.com"), row("b@example.com")]))
+
+      live |> element("button", "Select all") |> render_click()
+      html = live |> element("button", "Follow selected") |> render_click()
+
+      assert Social.user_follows_user?(user.id, a.id)
+      assert Social.user_follows_user?(user.id, b.id)
+      # The rows stay, now showing the new state rather than offering it again.
+      assert html =~ "Following"
+    end
+
+    test "nothing is preselected, so the follow button is not even offered", %{conn: conn} do
+      member_with_public_email("a@example.com")
+
+      {:ok, live, _html} = live(conn, ~p"/settings/import/linkedin/connections")
+      analyze(live, archive([row("a@example.com")]))
+
+      refute has_element?(live, "button", "Follow selected")
+    end
+
+    test "one row's follow pill follows just that member", %{conn: conn, user: user} do
+      target = member_with_public_email("a@example.com")
+
+      {:ok, live, _html} = live(conn, ~p"/settings/import/linkedin/connections")
+      analyze(live, archive([row("a@example.com")]))
+
+      live
+      |> element("button[phx-value-followee='#{target.id}']")
+      |> render_click()
+
+      assert Social.user_follows_user?(user.id, target.id)
+    end
+
+    test "the default view hides members you already follow, the filter brings them back",
+         %{conn: conn, user: user} do
+      followed =
+        member_with_public_email("followed@example.com",
+          first_name: "Already",
+          last_name: "Followed"
+        )
+
+      follow!(user, followed)
+
+      {:ok, live, _html} = live(conn, ~p"/settings/import/linkedin/connections")
+      html = analyze(live, archive([row("followed@example.com")]))
+
+      # Found and counted, but not in the "not following yet" view — and the
+      # empty list says why, instead of reading as a failed search.
+      assert html =~ "of your LinkedIn contacts"
+      refute html =~ "Already Followed"
+      assert html =~ "You already follow every contact we found."
+
+      html = live |> element("button[phx-value-filter='all']") |> render_click()
+      assert html =~ "Already Followed"
+    end
+
+    test "the search box narrows the list by name", %{conn: conn} do
+      member_with_public_email("a@example.com", first_name: "Anna", last_name: "Alpha")
+      member_with_public_email("b@example.com", first_name: "Bert", last_name: "Beta")
+
+      {:ok, live, _html} = live(conn, ~p"/settings/import/linkedin/connections")
+      analyze(live, archive([row("a@example.com"), row("b@example.com")]))
+
+      html = live |> form("form[phx-change='search']", %{"q" => "anna"}) |> render_change()
+
+      assert html =~ "Anna Alpha"
+      refute html =~ "Bert Beta"
+    end
+
+    test "a long list is paged, and page two holds the rest", %{conn: conn} do
+      for index <- 1..55 do
+        member_with_public_email("member#{index}@example.com",
+          first_name: "Member",
+          last_name: String.pad_leading("#{index}", 3, "0")
+        )
+      end
+
+      {:ok, live, _html} = live(conn, ~p"/settings/import/linkedin/connections")
+      html = analyze(live, archive(for index <- 1..55, do: row("member#{index}@example.com")))
+
+      assert html =~ "Showing 1-50 of 55."
+      assert has_element?(live, "button[phx-value-page='2']")
+
+      html = live |> element("button[phx-value-page='2']") |> render_click()
+      assert html =~ "Showing 51-55 of 55."
+    end
+
+    test "a LinkedIn profile link matches too, and says so", %{conn: conn} do
+      target = insert_activated_user(first_name: "Linked", last_name: "In")
+      insert(:social_media_account, user: target, provider: "LinkedIn", value: "linked-in")
+
+      {:ok, live, _html} = live(conn, ~p"/settings/import/linkedin/connections")
+
+      html =
+        analyze(live, archive([row("", url: "https://www.linkedin.com/in/Linked-In/")]))
+
+      assert html =~ "Linked In"
+      assert html =~ "Links the same LinkedIn profile"
+    end
+  end
+end


### PR DESCRIPTION
Schließt #1476.

Der LinkedIn-Export listet die eigenen Kontakte, und der Importer hat diese
Datei bisher verworfen. Neu unter `/settings/import/linkedin/connections`:
wer davon schon Mitglied ist, mit Follow-Knopf.

**Nur sichere Treffer.** Gleiche E-Mail-Adresse oder gleiches LinkedIn-Profil,
beides Angaben, die auf dem Profil der Gegenseite ohnehin stehen. Nur
**veröffentlichte** Adressen zählen, wie schon in `Search.search_by_email/1` –
sonst wäre eine selbstgeschriebene CSV eine Abfragemaschine dafür, wer hier
Mitglied ist. Das Raten über Name, Arbeitgeber und Position aus dem Issue fällt
weg: 4 % der Profile verlinken LinkedIn, knapp die Hälfte veröffentlicht eine
Adresse, und ein falscher Treffer heißt hier, öffentlich der falschen Person zu
folgen.

**Gespeichert wird nichts**, niemand wird eingeladen, es geht keine E-Mail raus.
Die Liste ist für die Größe gebaut, die eine Intranet-Installation erzeugt:
Suche, Filter, 50 pro Seite, "alle auswählen" über die ganze gefilterte Liste –
aber nichts ist vorausgewählt.

Verlinkt von der Einstellungsliste, der Importseite, der Import-Vorschau, der
"Vorgeschlagene Profile"-Karte und der Onboarding-Karte.

Nebenbei repariert: `import_rate_limit_test.exs` stellte einen zuvor nicht
gesetzten Config-Key mit `put_env(key, nil)` wieder her und vergiftete ihn damit
für den Rest des Laufs.

Im Browser geprüft: Upload, Trefferliste, Suche, Filter, Auswahl, Sammel-Follow
und Blättern.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das
problematisch ist.*