### PR TITLE
Die eigenen Sprachen stehen vorn, der Rest klappt aus (v7.314.0)

### DIFF
--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -95,6 +95,7 @@ defmodule Vutuv.Posts do
   alias Vutuv.Social.Follow
   alias Vutuv.Tags
   alias Vutuv.Tags.Tag
+  alias Vutuv.Translations
   alias Vutuv.Uploads.Crop
   alias Vutuv.UUIDv7
   alias Vutuv.WebAddress
@@ -2326,14 +2327,49 @@ defmodule Vutuv.Posts do
   @doc """
   The languages the member marked as their own (the chips on
   /settings/preferences), normalized for reading: `[]` when they never chose
-  any. The one raw read of the `feed_languages` column — its two consumers,
-  the hide filter below and the translate mode's "is this post foreign?"
-  test (`VutuvWeb.Live.PostTranslations`), interpret an empty choice
-  differently BY DESIGN: hide mode with no chips hides nothing
-  (`feed_language_filter/1` answers nil), while translate mode with no
-  chips treats only the UI locale as the member's own.
+  any. The one raw read of the `feed_languages` column — its three consumers,
+  the hide filter below, the translate mode's "is this post foreign?"
+  test (`VutuvWeb.Live.PostTranslations`) and the settings card's ticked
+  chips, interpret an empty choice differently BY DESIGN: hide mode with no
+  chips hides nothing (`feed_language_filter/1` answers nil), translate mode
+  with no chips treats only the UI locale as the member's own, and the card
+  ticks nothing at all while offering a suggestion beside it
+  (`suggested_feed_languages/1`).
   """
   def chosen_feed_languages(%User{feed_languages: chosen}), do: chosen || []
+
+  @doc """
+  The languages the Feed-languages card puts in the open (issue #1537): what
+  this account already says the member reads — their interface language plus the
+  language skills on their profile.
+
+  A **suggestion**, not a choice, and the card is careful about the difference:
+  it decides which chips are visible without a disclosure and ticks nothing. A
+  pre-ticked suggestion would be a filter nobody chose, and it would ride along
+  the next save of the neighbouring "posts in other languages" select.
+
+  The profile half is read here rather than taken from a preload, so the answer
+  cannot depend on whether a call site remembered one. The order is not part of
+  the answer — the card lays its chips out by localized label — so this does not
+  pay for `Vutuv.Profiles.Language.ordered/1`.
+  """
+  def suggested_feed_languages(%User{} = user) do
+    Enum.uniq([interface_language(user) | profile_language_skills(user)])
+  end
+
+  # `cast_language/1` on both, or a third-party installation running a regioned
+  # locale ("pt-BR") suggests a code the chips do not carry and the card opens
+  # with nothing in the open at all.
+  defp interface_language(%User{locale: locale}) do
+    Translations.cast_language(locale) ||
+      Translations.cast_language(Gettext.get_locale(VutuvWeb.Gettext))
+  end
+
+  defp profile_language_skills(%User{id: id}) do
+    from(l in Vutuv.Profiles.Language, where: l.user_id == ^id, select: l.language_code)
+    |> Repo.all()
+    |> Enum.flat_map(&List.wrap(Translations.cast_language(&1)))
+  end
 
   @doc """
   The chosen-languages list the viewer's feed HIDES by (issue #1461), or nil

--- a/lib/vutuv_web/templates/settings/preferences.html.heex
+++ b/lib/vutuv_web/templates/settings/preferences.html.heex
@@ -179,11 +179,16 @@ shortened and hyphenated. Each form posts its own subset and lands back here. --
     <%!-- Feed languages (issue #1461, Mastodon's chosen-languages filter plus
           a translate mode): which languages the feed shows, and what happens
           to the rest — original (shipped default), auto-translated into the
-          interface language, or hidden. All boxes ticked (or none) means "all
+          interface language, or hidden. No language chosen means "all
           languages", stored as inheriting. Posts that declare no language
           always show and are never auto-translated. The translate option only
           does anything on installations with translations enabled; the select
-          still offers it so the choice survives the flag being turned on. --%>
+          still offers it so the choice survives the flag being turned on.
+
+          The languages are chips, not a grid of every curated language with all
+          sixty-odd boxes ticked (issue #1537) — see
+          `VutuvWeb.SettingsHTML.feed_language_chips/1` for what sits in the open
+          and why the suggestion deliberately does not tick anything. --%>
     <.card>
       <.section_title>{gettext("Feed languages")}</.section_title>
       <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
@@ -197,30 +202,13 @@ shortened and hyphenated. Each form posts its own subset and lands back here. --
 
         <fieldset class="space-y-3">
           <legend class="text-sm font-medium text-slate-900 dark:text-white">
-            {gettext("Show these languages")}
+            {gettext("These languages I read")}
           </legend>
           <p class="text-sm text-slate-600 dark:text-slate-400">
-            {gettext("Ticking every box (or none) means: all languages.")}
+            {gettext("Choosing none means: all languages.")}
           </p>
 
-          <div class="grid grid-cols-2 gap-x-4 gap-y-2 sm:grid-cols-3">
-            <label
-              :for={{label, code} <- Vutuv.Languages.options()}
-              class="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300"
-            >
-              <input
-                type="checkbox"
-                name="user[feed_languages][]"
-                value={code}
-                checked={
-                  Ecto.Changeset.get_field(@changeset, :feed_languages) == nil or
-                    code in (Ecto.Changeset.get_field(@changeset, :feed_languages) || [])
-                }
-                class={checkbox_class()}
-              />
-              <span>{label}</span>
-            </label>
-          </div>
+          <.feed_language_chips user={@user} changeset={@changeset} />
         </fieldset>
 
         <div class="sm:max-w-xs">

--- a/lib/vutuv_web/views/settings_html.ex
+++ b/lib/vutuv_web/views/settings_html.ex
@@ -26,6 +26,8 @@ defmodule VutuvWeb.SettingsHTML do
   import Phoenix.HTML.Form, only: [input_id: 2]
 
   alias Vutuv.Accounts.User
+  alias Vutuv.Languages
+  alias Vutuv.Posts
   alias Vutuv.SavedSearches
 
   embed_templates("../templates/settings/*")
@@ -112,6 +114,109 @@ defmodule VutuvWeb.SettingsHTML do
   defp dm_delay_label(30), do: gettext("After 30 minutes")
   defp dm_delay_label(60), do: gettext("After 1 hour")
   defp dm_delay_label(120), do: gettext("After 2 hours")
+
+  @doc """
+  The Feed-languages card's chips (issue #1537): the languages this member is
+  likely to want first, then the whole curated list behind a disclosure.
+
+  It replaced a checkbox per curated language with all sixty-odd ticked (nil
+  means "all languages"), where naming two languages meant unticking the rest —
+  and nobody did it. What is ticked here is only ever the member's **stored**
+  choice, read from the changeset so a failed save keeps what they just picked.
+
+  The suggestion — interface language plus the language skills on their profile
+  (`Vutuv.Posts.suggested_feed_languages/1`) — decides which chips sit in the
+  open, and deliberately **does not tick them**. A pre-ticked suggestion is a
+  choice nobody made, and this card shares one form with the "posts in other
+  languages" select: a member who opened it to switch that dropdown to "hide"
+  would have submitted the suggestion with it and left with a feed that silently
+  hides every other language. Preselecting the *visible set* costs them one tap
+  and claims nothing.
+  """
+  attr(:user, :any, required: true)
+  attr(:changeset, :any, required: true)
+
+  def feed_language_chips(assigns) do
+    chosen = Ecto.Changeset.get_field(assigns.changeset, :feed_languages) || []
+    likely = chosen ++ Posts.suggested_feed_languages(assigns.user)
+
+    {own, other} =
+      Enum.split_with(Languages.options(), fn {_label, code} -> code in likely end)
+
+    assigns = assign(assigns, chosen: chosen, own: own, other: other)
+
+    ~H"""
+    <div class="flex flex-wrap gap-2">
+      <.language_chip
+        :for={{label, code} <- @own}
+        code={code}
+        label={label}
+        checked={code in @chosen}
+      />
+    </div>
+
+    <details class="group" data-language-more>
+      <summary class="inline-flex min-h-10 cursor-pointer list-none items-center gap-1.5 text-sm font-semibold text-brand-600 hover:text-brand-700 [&::-webkit-details-marker]:hidden dark:text-brand-400 dark:hover:text-brand-300">
+        <span aria-hidden="true" class="transition-transform group-open:rotate-90">›</span>
+        {gettext("Add another language")}
+      </summary>
+      <div class="mt-3 flex flex-wrap gap-2">
+        <.language_chip
+          :for={{label, code} <- @other}
+          code={code}
+          label={label}
+          checked={code in @chosen}
+        />
+      </div>
+    </details>
+    """
+  end
+
+  @doc """
+  One language on the Feed-languages card (issue #1537): a chip that is an
+  ordinary checkbox.
+
+  The box itself is `sr-only` rather than hidden, so it keeps its place in the
+  tab order and its label, and the chip carries the focus ring for it. Checked
+  reads as the brand-filled chip with a ✓; unchecked as the quiet outline. No
+  JavaScript takes part — with the box invisible but real, the form submits the
+  same `user[feed_languages][]` list it always did.
+
+  The ✓ is not decoration: a filled chip and an outlined chip differ by colour
+  alone otherwise, and colour may not be the only carrier of state (WCAG 1.4.1).
+  It rides a `before:` pseudo-element on the chip, for two reasons — a
+  `peer-checked:` utility only reaches the peer's **siblings**, never a span
+  nested inside one, and a mark toggled with `hidden` beside a second display
+  utility is the issue #880 trap (whichever Tailwind emits later wins, so the
+  hide silently does nothing). Generated content does land in the accessible
+  name, so a ticked chip announces its state twice ("check mark Deutsch,
+  checkbox, checked"); that verbosity is the accepted price for not carrying
+  state in colour alone.
+
+  The focus ring is a **solid** brand ring, not the `/40` wash the text inputs
+  use: those keep a border change beside it, while here the real control is
+  invisible, so the ring is the whole indicator and has to clear 3:1 on its own.
+  """
+  attr(:code, :string, required: true)
+  attr(:label, :string, required: true)
+  attr(:checked, :boolean, default: false)
+
+  def language_chip(assigns) do
+    ~H"""
+    <label class="cursor-pointer">
+      <input
+        type="checkbox"
+        name="user[feed_languages][]"
+        value={@code}
+        checked={@checked}
+        class="peer sr-only"
+      />
+      <span class="inline-flex min-h-10 items-center rounded-full border border-slate-300 px-3 text-sm font-medium text-slate-700 peer-checked:border-brand-600 peer-checked:bg-brand-600 peer-checked:text-white peer-checked:before:mr-1.5 peer-checked:before:content-['✓'] peer-focus-visible:ring-3 peer-focus-visible:ring-brand-500 dark:border-slate-700 dark:text-slate-200 dark:peer-checked:border-brand-500 dark:peer-checked:bg-brand-600">
+        {@label}
+      </span>
+    </label>
+    """
+  end
 
   @doc """
   One row on the settings subpages' cards: a title, an optional sub-line, and a

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.313.0",
+      version: "7.314.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -626,12 +626,12 @@ msgstr "Öffentlich"
 #: lib/vutuv_web/templates/settings/notifications.html.heex:79
 #: lib/vutuv_web/templates/settings/preferences.html.heex:84
 #: lib/vutuv_web/templates/settings/preferences.html.heex:157
-#: lib/vutuv_web/templates/settings/preferences.html.heex:240
-#: lib/vutuv_web/templates/settings/preferences.html.heex:360
+#: lib/vutuv_web/templates/settings/preferences.html.heex:254
+#: lib/vutuv_web/templates/settings/preferences.html.heex:374
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:462
-#: lib/vutuv_web/views/settings_html.ex:175
+#: lib/vutuv_web/views/settings_html.ex:215
 #, elixir-autogen
 msgid "Save"
 msgstr "Speichern"
@@ -862,7 +862,7 @@ msgid "View All"
 msgstr "Alle anzeigen"
 
 #: lib/vutuv_web/components/ui.ex:4069
-#: lib/vutuv_web/controllers/settings_controller.ex:169
+#: lib/vutuv_web/controllers/settings_controller.ex:186
 #: lib/vutuv_web/live/job_posting_live/form.ex:561
 #: lib/vutuv_web/live/organization_live/edit.ex:304
 #: lib/vutuv_web/templates/email/card_list.html.heex:7
@@ -1748,7 +1748,7 @@ msgstr ""
 "Folgen!"
 
 #: lib/vutuv_web/live/shell_live.ex:844
-#: lib/vutuv_web/views/settings_html.ex:262
+#: lib/vutuv_web/views/settings_html.ex:302
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr "Ausloggen"
@@ -2256,7 +2256,7 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/live/post_live/saved.ex:495
 #: lib/vutuv_web/live/search_live.ex:283
 #: lib/vutuv_web/live/search_live.ex:730
-#: lib/vutuv_web/templates/settings/preferences.html.heex:273
+#: lib/vutuv_web/templates/settings/preferences.html.heex:287
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Posts"
@@ -2287,7 +2287,7 @@ msgstr "Weniger anzeigen"
 #: lib/vutuv_web/live/post_live/saved.ex:619
 #: lib/vutuv_web/live/post_live/saved.ex:647
 #: lib/vutuv_web/templates/connection/index.html.heex:40
-#: lib/vutuv_web/views/settings_html.ex:308
+#: lib/vutuv_web/views/settings_html.ex:348
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Entfernen"
@@ -2345,7 +2345,7 @@ msgstr "Upload fehlgeschlagen."
 #: lib/vutuv_web/live/shell_live.ex:791
 #: lib/vutuv_web/templates/post/index.html.heex:17
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
-#: lib/vutuv_web/views/settings_html.ex:209
+#: lib/vutuv_web/views/settings_html.ex:249
 #, elixir-autogen, elixir-format
 msgid "View profile"
 msgstr "Profil ansehen"
@@ -2365,28 +2365,28 @@ msgstr "Was gibt's Neues? Markdown wird unterstützt."
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:4570
+#: lib/vutuv_web/components/post_components.ex:4566
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:4574
+#: lib/vutuv_web/components/post_components.ex:4570
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:4572
+#: lib/vutuv_web/components/post_components.ex:4568
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:4573
+#: lib/vutuv_web/components/post_components.ex:4569
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
 
 #: lib/vutuv_web/views/post_html.ex:19
-#: lib/vutuv_web/views/settings_html.ex:387
+#: lib/vutuv_web/views/settings_html.ex:427
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr "unbekannt"
@@ -2422,7 +2422,7 @@ msgid "All posts"
 msgstr "Alle Beiträge"
 
 #: lib/vutuv_web/components/post_components.ex:1666
-#: lib/vutuv_web/components/post_components.ex:4658
+#: lib/vutuv_web/components/post_components.ex:4654
 #: lib/vutuv_web/components/ui.ex:3174
 #: lib/vutuv_web/views/user_html.ex:440
 #, elixir-autogen, elixir-format
@@ -2441,7 +2441,7 @@ msgid "Bookmarks"
 msgstr "Lesezeichen"
 
 #: lib/vutuv_web/components/post_components.ex:1630
-#: lib/vutuv_web/components/post_components.ex:4892
+#: lib/vutuv_web/components/post_components.ex:4888
 #: lib/vutuv_web/components/ui.ex:3160
 #: lib/vutuv_web/live/notification_live/index.ex:1037
 #: lib/vutuv_web/views/user_html.ex:450
@@ -2450,7 +2450,7 @@ msgid "Like"
 msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1065
-#: lib/vutuv_web/components/post_components.ex:4901
+#: lib/vutuv_web/components/post_components.ex:4897
 #: lib/vutuv_web/live/notification_live/index.ex:970
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
@@ -2472,13 +2472,13 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:4647
+#: lib/vutuv_web/components/post_components.ex:4643
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
 #: lib/vutuv_web/components/post_components.ex:1666
-#: lib/vutuv_web/components/post_components.ex:4658
+#: lib/vutuv_web/components/post_components.ex:4654
 #: lib/vutuv_web/live/post_live/saved.ex:775
 #: lib/vutuv_web/views/user_html.ex:440
 #, elixir-autogen, elixir-format
@@ -2486,7 +2486,7 @@ msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
 #: lib/vutuv_web/components/post_components.ex:1654
-#: lib/vutuv_web/components/post_components.ex:4644
+#: lib/vutuv_web/components/post_components.ex:4640
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
@@ -2499,12 +2499,12 @@ msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
 #: lib/vutuv_web/components/post_components.ex:1654
-#: lib/vutuv_web/components/post_components.ex:4644
+#: lib/vutuv_web/components/post_components.ex:4640
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
-#: lib/vutuv_web/components/post_components.ex:4892
+#: lib/vutuv_web/components/post_components.ex:4888
 #: lib/vutuv_web/live/post_live/saved.ex:774
 #: lib/vutuv_web/views/user_html.ex:450
 #, elixir-autogen, elixir-format
@@ -2530,7 +2530,7 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:4945
+#: lib/vutuv_web/components/post_components.ex:4941
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
@@ -2542,8 +2542,8 @@ msgid "Replies"
 msgstr "Antworten"
 
 #: lib/vutuv_web/components/post_components.ex:1641
-#: lib/vutuv_web/components/post_components.ex:4928
-#: lib/vutuv_web/components/post_components.ex:4929
+#: lib/vutuv_web/components/post_components.ex:4924
+#: lib/vutuv_web/components/post_components.ex:4925
 #: lib/vutuv_web/live/notification_live/index.ex:1034
 #: lib/vutuv_web/live/post_live/reply.ex:42
 #, elixir-autogen, elixir-format
@@ -2885,7 +2885,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:4571
+#: lib/vutuv_web/components/post_components.ex:4567
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -5104,7 +5104,7 @@ msgstr "API-Anwendungen"
 #: lib/vutuv_web/live/admin/api_app_live.ex:98
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:181
 #: lib/vutuv_web/views/settings_html.ex:75
-#: lib/vutuv_web/views/settings_html.ex:253
+#: lib/vutuv_web/views/settings_html.ex:293
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr "Aktiv"
@@ -5491,7 +5491,7 @@ msgid "API documentation"
 msgstr "API-Dokumentation"
 
 #: lib/vutuv_web/components/ui.ex:4133
-#: lib/vutuv_web/controllers/settings_controller.ex:155
+#: lib/vutuv_web/controllers/settings_controller.ex:172
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
 #: lib/vutuv_web/live/admin/user_delete_live.ex:103
@@ -5578,7 +5578,7 @@ msgstr "Navigation"
 #: lib/vutuv_web/components/ui.ex:4235
 #: lib/vutuv_web/components/ui.ex:4314
 #: lib/vutuv_web/components/ui.ex:4378
-#: lib/vutuv_web/controllers/settings_controller.ex:62
+#: lib/vutuv_web/controllers/settings_controller.ex:64
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:303
@@ -5590,7 +5590,7 @@ msgstr "Navigation"
 #: lib/vutuv_web/templates/login_code/index.html.heex:4
 #: lib/vutuv_web/templates/totp/new.html.heex:4
 #: lib/vutuv_web/templates/username/confirm.html.heex:23
-#: lib/vutuv_web/views/settings_html.ex:204
+#: lib/vutuv_web/views/settings_html.ex:244
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr "Einstellungen"
@@ -5732,7 +5732,7 @@ msgstr ""
 msgid "Email addresses"
 msgstr "E-Mail-Adressen"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:569
+#: lib/vutuv_web/controllers/settings_controller.ex:586
 #, elixir-autogen, elixir-format
 msgid "Notification settings saved."
 msgstr "Benachrichtigungseinstellungen gespeichert."
@@ -5759,7 +5759,7 @@ msgstr "Fotos"
 msgid "Privacy"
 msgstr "Privatsphäre"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:221
+#: lib/vutuv_web/controllers/settings_controller.ex:238
 #, elixir-autogen, elixir-format
 msgid "Privacy settings saved."
 msgstr "Datenschutzeinstellungen gespeichert."
@@ -5868,7 +5868,7 @@ msgid "Apps"
 msgstr "Apps"
 
 #: lib/vutuv_web/components/ui.ex:4126
-#: lib/vutuv_web/controllers/settings_controller.ex:179
+#: lib/vutuv_web/controllers/settings_controller.ex:196
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
 msgstr "Apps & API-Zugang"
@@ -5897,7 +5897,7 @@ msgstr "Benachrichtigungen in der App"
 msgid "New followers"
 msgstr "Neue Follower"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:559
+#: lib/vutuv_web/controllers/settings_controller.ex:576
 #, elixir-autogen, elixir-format
 msgid "Notification settings"
 msgstr "Benachrichtigungseinstellungen"
@@ -6076,28 +6076,28 @@ msgid "Sort"
 msgstr "Sortieren"
 
 #: lib/vutuv_web/components/job_components.ex:182
-#: lib/vutuv_web/views/settings_html.ex:396
+#: lib/vutuv_web/views/settings_html.ex:436
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] "vor %{count} Tag"
 msgstr[1] "vor %{count} Tagen"
 
-#: lib/vutuv_web/views/settings_html.ex:395
+#: lib/vutuv_web/views/settings_html.ex:435
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] "vor %{count} Stunde"
 msgstr[1] "vor %{count} Stunden"
 
-#: lib/vutuv_web/views/settings_html.ex:394
+#: lib/vutuv_web/views/settings_html.ex:434
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
 msgstr[0] "vor %{count} Minute"
 msgstr[1] "vor %{count} Minuten"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:900
+#: lib/vutuv_web/controllers/settings_controller.ex:917
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr "Alle anderen Geräte wurden abgemeldet."
@@ -6107,7 +6107,7 @@ msgstr "Alle anderen Geräte wurden abgemeldet."
 msgid "Another session was already active on your account."
 msgstr "Auf Ihrem Konto war bereits eine andere Sitzung aktiv."
 
-#: lib/vutuv_web/views/settings_html.ex:242
+#: lib/vutuv_web/views/settings_html.ex:282
 #, elixir-autogen, elixir-format
 msgid "Last active"
 msgstr "Zuletzt aktiv"
@@ -6122,7 +6122,7 @@ msgstr "Alle anderen Geräte abmelden"
 msgid "Log out of every device except this one?"
 msgstr "Von allen Geräten außer diesem abmelden?"
 
-#: lib/vutuv_web/views/settings_html.ex:259
+#: lib/vutuv_web/views/settings_html.ex:299
 #, elixir-autogen, elixir-format
 msgid "Log this device out of your account?"
 msgstr "Dieses Gerät von Ihrem Konto abmelden?"
@@ -6137,7 +6137,7 @@ msgstr "Neue Anmeldung bei Ihrem vutuv-Konto"
 msgid "Signed-in devices"
 msgstr "Angemeldete Geräte"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:887
+#: lib/vutuv_web/controllers/settings_controller.ex:904
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr "Dieses Gerät wurde abgemeldet."
@@ -6147,7 +6147,7 @@ msgstr "Dieses Gerät wurde abgemeldet."
 msgid "The location looks different from where you usually sign in."
 msgstr "Der Ort weicht von dem ab, von dem Sie sich üblicherweise anmelden."
 
-#: lib/vutuv_web/views/settings_html.ex:243
+#: lib/vutuv_web/views/settings_html.ex:283
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr "Dieses Gerät"
@@ -6159,7 +6159,7 @@ msgstr ""
 "Das ist die erste Anmeldung, die wir von diesem Gerät oder Browser gesehen "
 "haben."
 
-#: lib/vutuv_web/views/settings_html.ex:393
+#: lib/vutuv_web/views/settings_html.ex:433
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr "gerade eben"
@@ -6197,7 +6197,7 @@ msgstr "Passkey hinzufügen"
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
 #: lib/vutuv_web/live/admin/screenshot_live.ex:309
 #: lib/vutuv_web/live/fediverse_following_live.ex:291
-#: lib/vutuv_web/views/settings_html.ex:294
+#: lib/vutuv_web/views/settings_html.ex:334
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr "Hinzugefügt"
@@ -6208,7 +6208,7 @@ msgid "Could not add the passkey. Please try again."
 msgstr ""
 "Der Passkey konnte nicht hinzugefügt werden. Bitte versuchen Sie es erneut."
 
-#: lib/vutuv_web/views/settings_html.ex:297
+#: lib/vutuv_web/views/settings_html.ex:337
 #, elixir-autogen, elixir-format
 msgid "Last used"
 msgstr "Zuletzt verwendet"
@@ -6218,7 +6218,7 @@ msgstr "Zuletzt verwendet"
 msgid "Name (optional)"
 msgstr "Name (optional)"
 
-#: lib/vutuv_web/views/settings_html.ex:291
+#: lib/vutuv_web/views/settings_html.ex:331
 #, elixir-autogen, elixir-format
 msgid "Passkey"
 msgstr "Passkey"
@@ -6238,7 +6238,7 @@ msgstr "Passkey entfernt."
 msgid "Passkeys"
 msgstr "Passkeys"
 
-#: lib/vutuv_web/views/settings_html.ex:305
+#: lib/vutuv_web/views/settings_html.ex:345
 #, elixir-autogen, elixir-format
 msgid "Remove this passkey?"
 msgstr "Diesen Passkey entfernen?"
@@ -6512,7 +6512,7 @@ msgstr "Empfehlung zurücknehmen"
 msgid "Default map"
 msgstr "Standardkarte"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:750
+#: lib/vutuv_web/controllers/settings_controller.ex:767
 #, elixir-autogen, elixir-format
 msgid "Map preferences saved."
 msgstr "Karteneinstellungen gespeichert."
@@ -7654,7 +7654,7 @@ msgstr "Alle abwählen"
 msgid "applies to the whole list, not just this page"
 msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 
-#: lib/vutuv_web/components/post_components.ex:4803
+#: lib/vutuv_web/components/post_components.ex:4799
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8812,7 +8812,7 @@ msgid "Basics & photos"
 msgstr "Basisdaten & Fotos"
 
 #: lib/vutuv_web/components/ui.ex:4104
-#: lib/vutuv_web/controllers/settings_controller.ex:123
+#: lib/vutuv_web/controllers/settings_controller.ex:128
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Language & display"
@@ -8824,7 +8824,7 @@ msgid "More profile sections"
 msgstr "Weitere Profil-Bereiche"
 
 #: lib/vutuv_web/components/ui.ex:4095
-#: lib/vutuv_web/controllers/settings_controller.ex:106
+#: lib/vutuv_web/controllers/settings_controller.ex:108
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
 #: lib/vutuv_web/templates/settings/security.html.heex:11
@@ -9076,8 +9076,8 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/components/organization_components.ex:310
 #: lib/vutuv_web/components/ui.ex:4085
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
-#: lib/vutuv_web/controllers/settings_controller.ex:355
-#: lib/vutuv_web/controllers/settings_controller.ex:422
+#: lib/vutuv_web/controllers/settings_controller.ex:372
+#: lib/vutuv_web/controllers/settings_controller.ex:439
 #: lib/vutuv_web/live/fediverse_followers_live.ex:169
 #: lib/vutuv_web/live/fediverse_following_live.ex:304
 #: lib/vutuv_web/live/organization_live/fediverse.ex:76
@@ -9114,7 +9114,7 @@ msgstr ""
 "als Link in Ihren Mastodon-Profileinstellungen ein, und Mastodon zeigt ihn "
 "grün als bestätigt an."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:435
+#: lib/vutuv_web/controllers/settings_controller.ex:452
 #, elixir-autogen, elixir-format
 msgid "Fediverse settings saved."
 msgstr "Fediverse-Einstellungen gespeichert."
@@ -11060,14 +11060,14 @@ msgid_plural "You have %{formatted} new messages."
 msgstr[0] "Sie haben %{formatted} neue Nachricht."
 msgstr[1] "Sie haben %{formatted} neue Nachrichten."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:344
+#: lib/vutuv_web/templates/settings/preferences.html.heex:358
 #, elixir-autogen, elixir-format
 msgid "Break long words at syllable points so the text wraps evenly. Helpful in the narrow phone column."
 msgstr ""
 "Trennt lange Wörter an Silbengrenzen, damit der Text gleichmäßig umbricht. "
 "Hilfreich in der schmalen Smartphone-Spalte."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:275
+#: lib/vutuv_web/templates/settings/preferences.html.heex:289
 #, elixir-autogen, elixir-format
 msgid "How posts you read are shortened in your feed and on profiles. These are your own reading preferences."
 msgstr ""
@@ -11075,47 +11075,47 @@ msgstr ""
 "Das sind Ihre eigenen Anzeige-Einstellungen."
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:68
-#: lib/vutuv_web/templates/settings/preferences.html.heex:351
+#: lib/vutuv_web/templates/settings/preferences.html.heex:365
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on desktop"
 msgstr "Silbentrennung am Desktop"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:69
-#: lib/vutuv_web/templates/settings/preferences.html.heex:355
+#: lib/vutuv_web/templates/settings/preferences.html.heex:369
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on mobile"
 msgstr "Silbentrennung auf dem Smartphone"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:341
+#: lib/vutuv_web/templates/settings/preferences.html.heex:355
 #, elixir-autogen, elixir-format
 msgid "Hyphenation"
 msgstr "Silbentrennung"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:66
-#: lib/vutuv_web/templates/settings/preferences.html.heex:298
+#: lib/vutuv_web/templates/settings/preferences.html.heex:312
 #, elixir-autogen, elixir-format
 msgid "Lines on desktop"
 msgstr "Zeilen am Desktop"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:67
-#: lib/vutuv_web/templates/settings/preferences.html.heex:307
+#: lib/vutuv_web/templates/settings/preferences.html.heex:321
 #, elixir-autogen, elixir-format
 msgid "Lines on mobile"
 msgstr "Zeilen auf dem Smartphone"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:293
+#: lib/vutuv_web/templates/settings/preferences.html.heex:307
 #, elixir-autogen, elixir-format
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
 "Längere Beiträge erhalten einen „Weiterlesen“-Link. Mit 0 (oder leer) wird "
 "nie gekürzt."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:764
+#: lib/vutuv_web/controllers/settings_controller.ex:781
 #, elixir-autogen, elixir-format
 msgid "Post display settings saved."
 msgstr "Anzeige-Einstellungen für Beiträge gespeichert."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:290
+#: lib/vutuv_web/templates/settings/preferences.html.heex:304
 #, elixir-autogen, elixir-format
 msgid "Shorten a post after"
 msgstr "Beitrag kürzen nach"
@@ -11169,7 +11169,7 @@ msgstr ""
 msgid "Installation default (%{value})"
 msgstr "Standard der Installation (%{value})"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:796
+#: lib/vutuv_web/controllers/settings_controller.ex:813
 #, elixir-autogen, elixir-format
 msgid "Map preferences reset to the site defaults."
 msgstr "Karteneinstellungen auf die Standardwerte zurückgesetzt."
@@ -11188,7 +11188,7 @@ msgstr ""
 "Eigener Wert; leeren Sie das Feld, um zum Standard der Installation "
 "zurückzukehren."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:792
+#: lib/vutuv_web/controllers/settings_controller.ex:809
 #, elixir-autogen, elixir-format
 msgid "Post display settings reset to the site defaults."
 msgstr ""
@@ -11217,8 +11217,8 @@ msgstr "Einstellungen von %{name}"
 
 #: lib/vutuv_web/templates/settings/preferences.html.heex:101
 #: lib/vutuv_web/templates/settings/preferences.html.heex:174
-#: lib/vutuv_web/templates/settings/preferences.html.heex:257
-#: lib/vutuv_web/templates/settings/preferences.html.heex:375
+#: lib/vutuv_web/templates/settings/preferences.html.heex:271
+#: lib/vutuv_web/templates/settings/preferences.html.heex:389
 #, elixir-autogen, elixir-format
 msgid "Reset to the site defaults"
 msgstr "Auf die Standardwerte zurücksetzen"
@@ -12486,7 +12486,7 @@ msgstr "Organisation wieder freigegeben."
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:383
 #: lib/vutuv_web/components/ui.ex:4122
-#: lib/vutuv_web/controllers/settings_controller.ex:211
+#: lib/vutuv_web/controllers/settings_controller.ex:228
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:501
@@ -13052,7 +13052,7 @@ msgstr "Gehalt"
 msgid "Salary on request"
 msgstr "Gehalt auf Anfrage"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:393
+#: lib/vutuv_web/controllers/settings_controller.ex:410
 #: lib/vutuv_web/live/job_posting_live/form.ex:231
 #, elixir-autogen, elixir-format
 msgid "Saved."
@@ -13642,7 +13642,7 @@ msgstr[1] "%{count} neue Treffer für Ihre gespeicherten Suchen"
 msgid "Alert frequency"
 msgstr "Häufigkeit der Benachrichtigung"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:678
+#: lib/vutuv_web/controllers/settings_controller.ex:695
 #, elixir-autogen, elixir-format
 msgid "Alert updated."
 msgstr "Benachrichtigung aktualisiert."
@@ -13715,13 +13715,13 @@ msgstr ""
 msgid "Save search"
 msgstr "Suche speichern"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:696
+#: lib/vutuv_web/controllers/settings_controller.ex:713
 #, elixir-autogen, elixir-format
 msgid "Saved search deleted."
 msgstr "Gespeicherte Suche gelöscht."
 
 #: lib/vutuv_web/components/ui.ex:4062
-#: lib/vutuv_web/controllers/settings_controller.ex:588
+#: lib/vutuv_web/controllers/settings_controller.ex:605
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
 #, elixir-autogen, elixir-format
@@ -13742,8 +13742,8 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2257
 #: lib/vutuv_web/components/saved_search_components.ex:43
-#: lib/vutuv_web/controllers/settings_controller.ex:683
-#: lib/vutuv_web/controllers/settings_controller.ex:701
+#: lib/vutuv_web/controllers/settings_controller.ex:700
+#: lib/vutuv_web/controllers/settings_controller.ex:718
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:387
 #: lib/vutuv_web/live/organization_live/following.ex:281
 #: lib/vutuv_web/live/organization_live/following.ex:288
@@ -14193,7 +14193,7 @@ msgstr ""
 "Seite."
 
 #: lib/vutuv_web/components/ui.ex:4045
-#: lib/vutuv_web/controllers/settings_controller.ex:602
+#: lib/vutuv_web/controllers/settings_controller.ex:619
 #: lib/vutuv_web/live/post_live/feed.ex:1410
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
@@ -14359,34 +14359,34 @@ msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch imm
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:4433
+#: lib/vutuv_web/components/post_components.ex:4429
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1154
-#: lib/vutuv_web/components/post_components.ex:4390
+#: lib/vutuv_web/components/post_components.ex:4386
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:4434
+#: lib/vutuv_web/components/post_components.ex:4430
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:4436
+#: lib/vutuv_web/components/post_components.ex:4432
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:4432
+#: lib/vutuv_web/components/post_components.ex:4428
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1154
-#: lib/vutuv_web/components/post_components.ex:4389
+#: lib/vutuv_web/components/post_components.ex:4385
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Filmbesprechung"
@@ -14397,12 +14397,12 @@ msgstr "Filmbesprechung"
 msgid "Look up"
 msgstr "Nachschlagen"
 
-#: lib/vutuv_web/components/post_components.ex:4431
+#: lib/vutuv_web/components/post_components.ex:4427
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
 
-#: lib/vutuv_web/components/post_components.ex:4435
+#: lib/vutuv_web/components/post_components.ex:4431
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14422,7 +14422,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:4472
+#: lib/vutuv_web/components/post_components.ex:4468
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14430,27 +14430,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:4502
+#: lib/vutuv_web/components/post_components.ex:4498
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:4503
+#: lib/vutuv_web/components/post_components.ex:4499
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:4501
+#: lib/vutuv_web/components/post_components.ex:4497
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:4461
+#: lib/vutuv_web/components/post_components.ex:4457
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:4508
+#: lib/vutuv_web/components/post_components.ex:4504
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14480,7 +14480,7 @@ msgstr "Mit Qualifikation:"
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:4275
+#: lib/vutuv_web/components/post_components.ex:4271
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
@@ -14528,7 +14528,7 @@ msgstr "folgen Ihnen jetzt."
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:4266
+#: lib/vutuv_web/components/post_components.ex:4262
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
@@ -14670,7 +14670,7 @@ msgid "proof document"
 msgstr "Nachweis"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:74
-#: lib/vutuv_web/templates/settings/preferences.html.heex:329
+#: lib/vutuv_web/templates/settings/preferences.html.heex:343
 #, elixir-autogen, elixir-format
 msgid "Lines in notifications"
 msgstr "Zeilen in Benachrichtigungen"
@@ -14680,12 +14680,12 @@ msgstr "Zeilen in Benachrichtigungen"
 msgid "How much of a post a notification quotes before it is cut off."
 msgstr "Wie viel von einem Beitrag eine Benachrichtigung zitiert, bevor abgeschnitten wird."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:320
+#: lib/vutuv_web/templates/settings/preferences.html.heex:334
 #, elixir-autogen, elixir-format
 msgid "Quoted posts in notifications"
 msgstr "Zitierte Beiträge in Benachrichtigungen"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:323
+#: lib/vutuv_web/templates/settings/preferences.html.heex:337
 #, elixir-autogen, elixir-format
 msgid "Your notifications quote the post someone liked or replied to. Leave the field empty to follow the site default."
 msgstr ""
@@ -14954,7 +14954,7 @@ msgstr "Dieses Profil ist zurzeit nicht verfügbar."
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das Konto zu finden, das eingefroren werden soll."
 
-#: lib/vutuv_web/components/post_components.ex:4900
+#: lib/vutuv_web/components/post_components.ex:4896
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Der eigene Beitrag lässt sich nicht mit „Gefällt mir“ markieren."
@@ -15004,7 +15004,7 @@ msgstr "Konto, zu dem Sie umziehen"
 msgid "Cancel redirect"
 msgstr "Weiterleitung aufheben"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:487
+#: lib/vutuv_web/controllers/settings_controller.ex:504
 #, elixir-autogen, elixir-format
 msgid "Done. Your Fediverse followers have been asked to follow your new account, and new posts are no longer federated from here. Your vutuv profile is unchanged."
 msgstr "Fertig. Ihre Fediverse-Follower wurden gebeten, Ihrem neuen Konto zu folgen, und neue Beiträge werden von hier nicht mehr föderiert. Ihr vutuv-Profil bleibt unverändert."
@@ -15019,12 +15019,12 @@ msgstr "Tragen Sie unten die Adresse dieses Kontos ein und leiten Sie weiter."
 msgid "On your other account, add your vutuv handle"
 msgstr "Fügen Sie auf Ihrem anderen Konto Ihr vutuv-Handle"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:526
+#: lib/vutuv_web/controllers/settings_controller.ex:543
 #, elixir-autogen, elixir-format
 msgid "Please enter the full https address of the account you are moving to."
 msgstr "Bitte geben Sie die vollständige https-Adresse des Kontos ein, zu dem Sie umziehen."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:512
+#: lib/vutuv_web/controllers/settings_controller.ex:529
 #, elixir-autogen, elixir-format
 msgid "Redirect cancelled. Your posts federate from here again."
 msgstr "Weiterleitung aufgehoben. Ihre Beiträge werden wieder von hier föderiert."
@@ -15039,17 +15039,17 @@ msgstr "Meine Follower weiterleiten"
 msgid "Redirected on %{date}"
 msgstr "Weitergeleitet am %{date}"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:539
+#: lib/vutuv_web/controllers/settings_controller.ex:556
 #, elixir-autogen, elixir-format
 msgid "That account could not be reached. Check the address, and that the other server is online."
 msgstr "Dieses Konto war nicht erreichbar. Prüfen Sie die Adresse und ob der andere Server online ist."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:533
+#: lib/vutuv_web/controllers/settings_controller.ex:550
 #, elixir-autogen, elixir-format
 msgid "That account does not list your vutuv profile as an alias yet. Add this profile's address there first, then try again."
 msgstr "Dieses Konto führt Ihr vutuv-Profil noch nicht als Alias. Fügen Sie dort zuerst die Adresse dieses Profils hinzu und versuchen Sie es dann erneut."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:529
+#: lib/vutuv_web/controllers/settings_controller.ex:546
 #, elixir-autogen, elixir-format
 msgid "That is this account. Enter the account you are moving to."
 msgstr "Das ist dieses Konto. Geben Sie das Konto an, zu dem Sie umziehen."
@@ -15059,12 +15059,12 @@ msgstr "Das ist dieses Konto. Geben Sie das Konto an, zu dem Sie umziehen."
 msgid "This tells your Fediverse followers to follow your new account instead, and stops federating your posts from here. Your vutuv profile is not affected. Continue?"
 msgstr "Damit werden Ihre Fediverse-Follower gebeten, stattdessen Ihrem neuen Konto zu folgen, und Ihre Beiträge werden von hier nicht mehr föderiert. Ihr vutuv-Profil ist nicht betroffen. Fortfahren?"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:517
+#: lib/vutuv_web/controllers/settings_controller.ex:534
 #, elixir-autogen, elixir-format
 msgid "Turn on federation first, then you can redirect your followers."
 msgstr "Schalten Sie zuerst die Föderation ein, dann können Sie Ihre Follower weiterleiten."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:521
+#: lib/vutuv_web/controllers/settings_controller.ex:538
 #, elixir-autogen, elixir-format
 msgid "You can only move once every %{days} days."
 msgstr "Sie können nur alle %{days} Tage umziehen."
@@ -15086,7 +15086,7 @@ msgstr[1] "%{formatted} Empfehlungen"
 msgid "All endorsers"
 msgstr "Alle Empfehlenden"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:627
+#: lib/vutuv_web/controllers/settings_controller.ex:644
 #, elixir-autogen, elixir-format
 msgid "Filter added. Matching posts are now hidden from your feed."
 msgstr "Filter hinzugefügt. Passende Beiträge sind jetzt in Ihrem Feed ausgeblendet."
@@ -15096,7 +15096,7 @@ msgstr "Filter hinzugefügt. Passende Beiträge sind jetzt in Ihrem Feed ausgebl
 msgid "Filter by a tag"
 msgstr "Nach einem Tag filtern"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:657
+#: lib/vutuv_web/controllers/settings_controller.ex:674
 #, elixir-autogen, elixir-format
 msgid "Filter removed."
 msgstr "Filter entfernt."
@@ -15117,7 +15117,7 @@ msgid "Match whole words only (word/phrase)"
 msgstr "Nur ganze Wörter treffen (Wort/Phrase)"
 
 #: lib/vutuv_web/components/ui.ex:4041
-#: lib/vutuv_web/controllers/settings_controller.ex:668
+#: lib/vutuv_web/controllers/settings_controller.ex:685
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
 #, elixir-autogen, elixir-format
@@ -15212,7 +15212,7 @@ msgstr "Sie dürfen den Benutzernamen dieser Organisation nicht ändern."
 msgid "You have not muted anything yet."
 msgstr "Sie haben noch nichts stummgeschaltet."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:635
+#: lib/vutuv_web/controllers/settings_controller.ex:652
 #, elixir-autogen, elixir-format
 msgid "You have reached the maximum of %{count} filters."
 msgstr "Sie haben das Maximum von %{count} Filtern erreicht."
@@ -15434,7 +15434,7 @@ msgstr "Verwandte Themen"
 msgid "Moving to or away from another Fediverse account?"
 msgstr "Ziehen Sie zu einem anderen Fediverse-Konto um oder von dort zu vutuv?"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:377
+#: lib/vutuv_web/controllers/settings_controller.ex:394
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:201
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:12
 #, elixir-autogen, elixir-format
@@ -16079,7 +16079,7 @@ msgstr "Verstanden, abschalten"
 msgid "I understand, take part"
 msgstr "Verstanden, teilnehmen"
 
-#: lib/vutuv_web/views/settings_html.ex:375
+#: lib/vutuv_web/views/settings_html.ex:415
 #, elixir-autogen, elixir-format
 msgid "Most of them, not all: we cannot check whether they do it, and anything that was re-shared, archived or indexed elsewhere stays out of reach. If you take part again later, people there have to follow you anew."
 msgstr ""
@@ -16087,7 +16087,7 @@ msgstr ""
 "anderswo geteilt, archiviert oder indexiert wurde, bleibt außer Reichweite. "
 "Wenn Sie später wieder teilnehmen, müssen Ihnen die Leute dort erneut folgen."
 
-#: lib/vutuv_web/views/settings_html.ex:370
+#: lib/vutuv_web/views/settings_html.ex:410
 #, elixir-autogen, elixir-format
 msgid "No new posts go out, and your followers from other networks are removed here. The next time those servers look you up they learn that this account is gone, and most of them then delete their copies of your posts."
 msgstr ""
@@ -16096,25 +16096,25 @@ msgstr ""
 "erfahren sie, dass dieses Konto nicht mehr existiert, und die meisten löschen "
 "daraufhin ihre Kopien Ihrer Beiträge."
 
-#: lib/vutuv_web/views/settings_html.ex:351
+#: lib/vutuv_web/views/settings_html.ex:391
 #, elixir-autogen, elixir-format
 msgid "Once a post has left vutuv, it is out of our hands"
 msgstr ""
 "Was einmal von vutuv aus verschickt wurde, können wir nicht zurückholen"
 
-#: lib/vutuv_web/views/settings_html.ex:353
+#: lib/vutuv_web/views/settings_html.ex:393
 #, elixir-autogen, elixir-format
 msgid "Switching off does not delete what is already out there"
 msgstr "Abschalten löscht nicht, was bereits draußen ist"
 
-#: lib/vutuv_web/views/settings_html.ex:364
+#: lib/vutuv_web/views/settings_html.ex:404
 #, elixir-autogen, elixir-format
 msgid "Switching this off again later stops new posts from going out. It cannot bring back what has already been delivered."
 msgstr ""
 "Wenn Sie das später wieder abschalten, gehen keine neuen Beiträge mehr "
 "hinaus. Bereits zugestellte Beiträge holt das nicht zurück."
 
-#: lib/vutuv_web/views/settings_html.ex:359
+#: lib/vutuv_web/views/settings_html.ex:399
 #, elixir-autogen, elixir-format
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
@@ -16123,21 +16123,21 @@ msgstr ""
 "wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
-#: lib/vutuv_web/components/post_components.ex:4848
+#: lib/vutuv_web/components/post_components.ex:4844
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:4852
+#: lib/vutuv_web/components/post_components.ex:4848
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Like"
 msgstr[1] "%{formatted} Likes"
 
-#: lib/vutuv_web/components/post_components.ex:4856
+#: lib/vutuv_web/components/post_components.ex:4852
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -16145,7 +16145,7 @@ msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1103
-#: lib/vutuv_web/components/post_components.ex:4807
+#: lib/vutuv_web/components/post_components.ex:4803
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Bereits in den Zahlen oben enthalten."
@@ -17249,13 +17249,13 @@ msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exak
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1121
-#: lib/vutuv_web/components/post_components.ex:4845
+#: lib/vutuv_web/components/post_components.ex:4841
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1119
-#: lib/vutuv_web/components/post_components.ex:4842
+#: lib/vutuv_web/components/post_components.ex:4838
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} hat das geteilt"
@@ -17265,7 +17265,7 @@ msgstr "%{handle} hat das geteilt"
 msgid "Fediverse reactions"
 msgstr "Fediverse-Reaktionen"
 
-#: lib/vutuv_web/components/post_components.ex:4734
+#: lib/vutuv_web/components/post_components.ex:4730
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
@@ -18989,19 +18989,19 @@ msgstr "Auf der Seite eines Beitrags stehen direkt unter der Zahl die Mitglieder
 msgid "Liked by"
 msgstr "Gefällt diesen Mitgliedern"
 
-#: lib/vutuv_web/components/post_components.ex:4003
+#: lib/vutuv_web/components/post_components.ex:3999
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Gefällt %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:4005
+#: lib/vutuv_web/components/post_components.ex:4001
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Gefällt %{name} und %{formatted} weiteren"
 msgstr[1] "Gefällt %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/components/post_components.ex:4016
+#: lib/vutuv_web/components/post_components.ex:4012
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr "Nur Sie sehen hier alle: Einige dieser Mitglieder werden anderen Lesern nicht genannt."
@@ -19021,7 +19021,7 @@ msgstr "Meinen Namen bei Beiträgen zeigen, die mir gefallen"
 msgid "When off, other members no longer see you among the likes of a post. The author of the post still does: we named you in the notification they got when you liked it. Either way the post keeps the same number of likes."
 msgstr "Wenn aus, sehen andere Mitglieder Sie nicht mehr bei den Likes eines Beitrags. Die Autorin oder der Autor des Beitrags sieht es weiterhin: In der Benachrichtigung von damals haben wir Sie namentlich genannt. Der Beitrag hat in beiden Fällen gleich viele Likes."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:834
+#: lib/vutuv_web/controllers/settings_controller.ex:851
 #, elixir-autogen, elixir-format
 msgid "Your likes follow the site default again."
 msgstr "Ihre Likes folgen wieder dem Standardwert der Website."
@@ -20092,9 +20092,9 @@ msgid "Always keep"
 msgstr "Immer behalten"
 
 #: lib/vutuv_web/components/ui.ex:4079
-#: lib/vutuv_web/controllers/settings_controller.ex:245
-#: lib/vutuv_web/controllers/settings_controller.ex:324
-#: lib/vutuv_web/controllers/settings_controller.ex:336
+#: lib/vutuv_web/controllers/settings_controller.ex:262
+#: lib/vutuv_web/controllers/settings_controller.ex:341
+#: lib/vutuv_web/controllers/settings_controller.ex:353
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:20
 #: lib/vutuv_web/views/account_event_text.ex:254
 #, elixir-autogen, elixir-format
@@ -20255,12 +20255,12 @@ msgid_plural "Saving this rule deletes %{formatted} posts straight away. This ca
 msgstr[0] "Mit dieser Regel wird %{count} Beitrag sofort gelöscht. Das lässt sich nicht rückgängig machen."
 msgstr[1] "Mit dieser Regel werden %{formatted} Beiträge sofort gelöscht. Das lässt sich nicht rückgängig machen."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:305
+#: lib/vutuv_web/controllers/settings_controller.ex:322
 #, elixir-autogen, elixir-format
 msgid "Settings saved."
 msgstr "Einstellungen gespeichert."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:308
+#: lib/vutuv_web/controllers/settings_controller.ex:325
 #, elixir-autogen, elixir-format
 msgid "Settings saved. %{count} post was deleted."
 msgid_plural "Settings saved. %{formatted} posts were deleted."
@@ -21611,35 +21611,25 @@ msgstr "Übersetzt aus %{language}"
 msgid "Translating…"
 msgstr "Wird übersetzt …"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:823
+#: lib/vutuv_web/controllers/settings_controller.ex:840
 #, elixir-autogen, elixir-format
 msgid "Feed language settings reset to the site defaults."
 msgstr "Feed-Spracheinstellungen auf die Website-Vorgaben zurückgesetzt."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:812
+#: lib/vutuv_web/controllers/settings_controller.ex:829
 #, elixir-autogen, elixir-format
 msgid "Feed language settings saved."
 msgstr "Feed-Spracheinstellungen gespeichert."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:188
+#: lib/vutuv_web/templates/settings/preferences.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Feed languages"
 msgstr "Feed-Sprachen"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:190
+#: lib/vutuv_web/templates/settings/preferences.html.heex:200
 #, elixir-autogen, elixir-format
 msgid "Pick which languages your feed shows, and what happens to posts in other languages. Posts that declare no language always show."
 msgstr "Wählen Sie, welche Sprachen Ihr Feed zeigt und was mit Beiträgen in anderen Sprachen passiert. Beiträge ohne Sprachangabe werden immer gezeigt."
-
-#: lib/vutuv_web/templates/settings/preferences.html.heex:200
-#, elixir-autogen, elixir-format
-msgid "Show these languages"
-msgstr "Diese Sprachen zeigen"
-
-#: lib/vutuv_web/templates/settings/preferences.html.heex:203
-#, elixir-autogen, elixir-format
-msgid "Ticking every box (or none) means: all languages."
-msgstr "Alle Kästchen angehakt (oder keins) bedeutet: alle Sprachen."
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:83
 #, elixir-autogen, elixir-format
@@ -21666,7 +21656,7 @@ msgstr "Was Ihr Feed mit Beiträgen außerhalb Ihrer gewählten Sprachen macht: 
 msgid "Date & time"
 msgstr "Datum & Uhrzeit"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:736
+#: lib/vutuv_web/controllers/settings_controller.ex:753
 #, elixir-autogen, elixir-format
 msgid "Date and time settings reset to the site defaults."
 msgstr "Datum und Uhrzeit folgen wieder den Voreinstellungen der Website."
@@ -21681,7 +21671,7 @@ msgstr "Datumsformat"
 msgid "Germany, Austria, Switzerland"
 msgstr "Deutschland, Österreich, Schweiz"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:730
+#: lib/vutuv_web/controllers/settings_controller.ex:747
 #, elixir-autogen, elixir-format
 msgid "Language and region saved."
 msgstr "Sprache und Region gespeichert."
@@ -21815,7 +21805,7 @@ msgstr "Profilbild größer anzeigen"
 msgid "The page's Editorial team can use this organization as a separate identity in a compatible phone app, with the same rights they already have here. Those rights are checked again on every request."
 msgstr "Die Redaktion der Seite kann diese Organisation in einer kompatiblen Smartphone-App als eigene Identität verwenden, mit denselben Rechten, die sie hier schon hat. Diese Rechte werden bei jeder Anfrage erneut geprüft."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:195
+#: lib/vutuv_web/controllers/settings_controller.ex:212
 #, elixir-autogen, elixir-format
 msgid "App settings saved."
 msgstr "App-Einstellungen gespeichert."
@@ -22116,3 +22106,18 @@ msgstr "Ihr Export enthält auch Ihre LinkedIn-Kontakte."
 #, elixir-autogen, elixir-format
 msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
 msgstr "linkedin kontakte verbindungen adressbuch bekannte kollegen finden folgen zip import netzwerk"
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:227
+#, elixir-autogen, elixir-format
+msgid "Add another language"
+msgstr "Weitere Sprache hinzufügen"
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:213
+#, elixir-autogen, elixir-format
+msgid "Choosing none means: all languages."
+msgstr "Keine Auswahl bedeutet: alle Sprachen."
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:210
+#, elixir-autogen, elixir-format
+msgid "These languages I read"
+msgstr "Diese Sprachen lese ich"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -626,12 +626,12 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/notifications.html.heex:79
 #: lib/vutuv_web/templates/settings/preferences.html.heex:84
 #: lib/vutuv_web/templates/settings/preferences.html.heex:157
-#: lib/vutuv_web/templates/settings/preferences.html.heex:240
-#: lib/vutuv_web/templates/settings/preferences.html.heex:360
+#: lib/vutuv_web/templates/settings/preferences.html.heex:254
+#: lib/vutuv_web/templates/settings/preferences.html.heex:374
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:462
-#: lib/vutuv_web/views/settings_html.ex:175
+#: lib/vutuv_web/views/settings_html.ex:215
 #, elixir-autogen
 msgid "Save"
 msgstr ""
@@ -858,7 +858,7 @@ msgid "View All"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4069
-#: lib/vutuv_web/controllers/settings_controller.ex:169
+#: lib/vutuv_web/controllers/settings_controller.ex:186
 #: lib/vutuv_web/live/job_posting_live/form.ex:561
 #: lib/vutuv_web/live/organization_live/edit.ex:304
 #: lib/vutuv_web/templates/email/card_list.html.heex:7
@@ -1713,7 +1713,7 @@ msgid "It doesn't look like you're following anyone yet. Open the profile of som
 msgstr ""
 
 #: lib/vutuv_web/live/shell_live.ex:844
-#: lib/vutuv_web/views/settings_html.ex:262
+#: lib/vutuv_web/views/settings_html.ex:302
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr ""
@@ -2211,7 +2211,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:495
 #: lib/vutuv_web/live/search_live.ex:283
 #: lib/vutuv_web/live/search_live.ex:730
-#: lib/vutuv_web/templates/settings/preferences.html.heex:273
+#: lib/vutuv_web/templates/settings/preferences.html.heex:287
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Posts"
@@ -2242,7 +2242,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:619
 #: lib/vutuv_web/live/post_live/saved.ex:647
 #: lib/vutuv_web/templates/connection/index.html.heex:40
-#: lib/vutuv_web/views/settings_html.ex:308
+#: lib/vutuv_web/views/settings_html.ex:348
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
@@ -2298,7 +2298,7 @@ msgstr ""
 #: lib/vutuv_web/live/shell_live.ex:791
 #: lib/vutuv_web/templates/post/index.html.heex:17
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
-#: lib/vutuv_web/views/settings_html.ex:209
+#: lib/vutuv_web/views/settings_html.ex:249
 #, elixir-autogen, elixir-format
 msgid "View profile"
 msgstr ""
@@ -2318,28 +2318,28 @@ msgstr ""
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4570
+#: lib/vutuv_web/components/post_components.ex:4566
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4574
+#: lib/vutuv_web/components/post_components.ex:4570
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4572
+#: lib/vutuv_web/components/post_components.ex:4568
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4573
+#: lib/vutuv_web/components/post_components.ex:4569
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
 
 #: lib/vutuv_web/views/post_html.ex:19
-#: lib/vutuv_web/views/settings_html.ex:387
+#: lib/vutuv_web/views/settings_html.ex:427
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr ""
@@ -2375,7 +2375,7 @@ msgid "All posts"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1666
-#: lib/vutuv_web/components/post_components.ex:4658
+#: lib/vutuv_web/components/post_components.ex:4654
 #: lib/vutuv_web/components/ui.ex:3174
 #: lib/vutuv_web/views/user_html.ex:440
 #, elixir-autogen, elixir-format
@@ -2394,7 +2394,7 @@ msgid "Bookmarks"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1630
-#: lib/vutuv_web/components/post_components.ex:4892
+#: lib/vutuv_web/components/post_components.ex:4888
 #: lib/vutuv_web/components/ui.ex:3160
 #: lib/vutuv_web/live/notification_live/index.ex:1037
 #: lib/vutuv_web/views/user_html.ex:450
@@ -2403,7 +2403,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1065
-#: lib/vutuv_web/components/post_components.ex:4901
+#: lib/vutuv_web/components/post_components.ex:4897
 #: lib/vutuv_web/live/notification_live/index.ex:970
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
@@ -2425,13 +2425,13 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4647
+#: lib/vutuv_web/components/post_components.ex:4643
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1666
-#: lib/vutuv_web/components/post_components.ex:4658
+#: lib/vutuv_web/components/post_components.ex:4654
 #: lib/vutuv_web/live/post_live/saved.ex:775
 #: lib/vutuv_web/views/user_html.ex:440
 #, elixir-autogen, elixir-format
@@ -2439,7 +2439,7 @@ msgid "Remove bookmark"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1654
-#: lib/vutuv_web/components/post_components.ex:4644
+#: lib/vutuv_web/components/post_components.ex:4640
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
@@ -2452,12 +2452,12 @@ msgid "Reposted by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1654
-#: lib/vutuv_web/components/post_components.ex:4644
+#: lib/vutuv_web/components/post_components.ex:4640
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4892
+#: lib/vutuv_web/components/post_components.ex:4888
 #: lib/vutuv_web/live/post_live/saved.ex:774
 #: lib/vutuv_web/views/user_html.ex:450
 #, elixir-autogen, elixir-format
@@ -2483,7 +2483,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4945
+#: lib/vutuv_web/components/post_components.ex:4941
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2495,8 +2495,8 @@ msgid "Replies"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1641
-#: lib/vutuv_web/components/post_components.ex:4928
-#: lib/vutuv_web/components/post_components.ex:4929
+#: lib/vutuv_web/components/post_components.ex:4924
+#: lib/vutuv_web/components/post_components.ex:4925
 #: lib/vutuv_web/live/notification_live/index.ex:1034
 #: lib/vutuv_web/live/post_live/reply.ex:42
 #, elixir-autogen, elixir-format
@@ -2836,7 +2836,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4571
+#: lib/vutuv_web/components/post_components.ex:4567
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -4914,7 +4914,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/api_app_live.ex:98
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:181
 #: lib/vutuv_web/views/settings_html.ex:75
-#: lib/vutuv_web/views/settings_html.ex:253
+#: lib/vutuv_web/views/settings_html.ex:293
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
@@ -5273,7 +5273,7 @@ msgid "API documentation"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4133
-#: lib/vutuv_web/controllers/settings_controller.ex:155
+#: lib/vutuv_web/controllers/settings_controller.ex:172
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
 #: lib/vutuv_web/live/admin/user_delete_live.ex:103
@@ -5355,7 +5355,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:4235
 #: lib/vutuv_web/components/ui.ex:4314
 #: lib/vutuv_web/components/ui.ex:4378
-#: lib/vutuv_web/controllers/settings_controller.ex:62
+#: lib/vutuv_web/controllers/settings_controller.ex:64
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:303
@@ -5367,7 +5367,7 @@ msgstr ""
 #: lib/vutuv_web/templates/login_code/index.html.heex:4
 #: lib/vutuv_web/templates/totp/new.html.heex:4
 #: lib/vutuv_web/templates/username/confirm.html.heex:23
-#: lib/vutuv_web/views/settings_html.ex:204
+#: lib/vutuv_web/views/settings_html.ex:244
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -5508,7 +5508,7 @@ msgstr ""
 msgid "Email addresses"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:569
+#: lib/vutuv_web/controllers/settings_controller.ex:586
 #, elixir-autogen, elixir-format
 msgid "Notification settings saved."
 msgstr ""
@@ -5535,7 +5535,7 @@ msgstr ""
 msgid "Privacy"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:221
+#: lib/vutuv_web/controllers/settings_controller.ex:238
 #, elixir-autogen, elixir-format
 msgid "Privacy settings saved."
 msgstr ""
@@ -5642,7 +5642,7 @@ msgid "Apps"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4126
-#: lib/vutuv_web/controllers/settings_controller.ex:179
+#: lib/vutuv_web/controllers/settings_controller.ex:196
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
 msgstr ""
@@ -5671,7 +5671,7 @@ msgstr ""
 msgid "New followers"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:559
+#: lib/vutuv_web/controllers/settings_controller.ex:576
 #, elixir-autogen, elixir-format
 msgid "Notification settings"
 msgstr ""
@@ -5846,28 +5846,28 @@ msgid "Sort"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:182
-#: lib/vutuv_web/views/settings_html.ex:396
+#: lib/vutuv_web/views/settings_html.ex:436
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:395
+#: lib/vutuv_web/views/settings_html.ex:435
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:394
+#: lib/vutuv_web/views/settings_html.ex:434
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:900
+#: lib/vutuv_web/controllers/settings_controller.ex:917
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr ""
@@ -5877,7 +5877,7 @@ msgstr ""
 msgid "Another session was already active on your account."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:242
+#: lib/vutuv_web/views/settings_html.ex:282
 #, elixir-autogen, elixir-format
 msgid "Last active"
 msgstr ""
@@ -5892,7 +5892,7 @@ msgstr ""
 msgid "Log out of every device except this one?"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:259
+#: lib/vutuv_web/views/settings_html.ex:299
 #, elixir-autogen, elixir-format
 msgid "Log this device out of your account?"
 msgstr ""
@@ -5907,7 +5907,7 @@ msgstr ""
 msgid "Signed-in devices"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:887
+#: lib/vutuv_web/controllers/settings_controller.ex:904
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr ""
@@ -5917,7 +5917,7 @@ msgstr ""
 msgid "The location looks different from where you usually sign in."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:243
+#: lib/vutuv_web/views/settings_html.ex:283
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr ""
@@ -5927,7 +5927,7 @@ msgstr ""
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:393
+#: lib/vutuv_web/views/settings_html.ex:433
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr ""
@@ -5961,7 +5961,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
 #: lib/vutuv_web/live/admin/screenshot_live.ex:309
 #: lib/vutuv_web/live/fediverse_following_live.ex:291
-#: lib/vutuv_web/views/settings_html.ex:294
+#: lib/vutuv_web/views/settings_html.ex:334
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr ""
@@ -5971,7 +5971,7 @@ msgstr ""
 msgid "Could not add the passkey. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:297
+#: lib/vutuv_web/views/settings_html.ex:337
 #, elixir-autogen, elixir-format
 msgid "Last used"
 msgstr ""
@@ -5981,7 +5981,7 @@ msgstr ""
 msgid "Name (optional)"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:291
+#: lib/vutuv_web/views/settings_html.ex:331
 #, elixir-autogen, elixir-format
 msgid "Passkey"
 msgstr ""
@@ -6001,7 +6001,7 @@ msgstr ""
 msgid "Passkeys"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:305
+#: lib/vutuv_web/views/settings_html.ex:345
 #, elixir-autogen, elixir-format
 msgid "Remove this passkey?"
 msgstr ""
@@ -6264,7 +6264,7 @@ msgstr ""
 msgid "Default map"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:750
+#: lib/vutuv_web/controllers/settings_controller.ex:767
 #, elixir-autogen, elixir-format
 msgid "Map preferences saved."
 msgstr ""
@@ -7352,7 +7352,7 @@ msgstr ""
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4803
+#: lib/vutuv_web/components/post_components.ex:4799
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8416,7 +8416,7 @@ msgid "Basics & photos"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4104
-#: lib/vutuv_web/controllers/settings_controller.ex:123
+#: lib/vutuv_web/controllers/settings_controller.ex:128
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Language & display"
@@ -8428,7 +8428,7 @@ msgid "More profile sections"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4095
-#: lib/vutuv_web/controllers/settings_controller.ex:106
+#: lib/vutuv_web/controllers/settings_controller.ex:108
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
 #: lib/vutuv_web/templates/settings/security.html.heex:11
@@ -8655,8 +8655,8 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:310
 #: lib/vutuv_web/components/ui.ex:4085
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
-#: lib/vutuv_web/controllers/settings_controller.ex:355
-#: lib/vutuv_web/controllers/settings_controller.ex:422
+#: lib/vutuv_web/controllers/settings_controller.ex:372
+#: lib/vutuv_web/controllers/settings_controller.ex:439
 #: lib/vutuv_web/live/fediverse_followers_live.ex:169
 #: lib/vutuv_web/live/fediverse_following_live.ex:304
 #: lib/vutuv_web/live/organization_live/fediverse.ex:76
@@ -8688,7 +8688,7 @@ msgstr ""
 msgid "as a link in your Mastodon profile settings, and Mastodon will show it as verified with a green check."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:435
+#: lib/vutuv_web/controllers/settings_controller.ex:452
 #, elixir-autogen, elixir-format
 msgid "Fediverse settings saved."
 msgstr ""
@@ -10516,56 +10516,56 @@ msgid_plural "You have %{formatted} new messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:344
+#: lib/vutuv_web/templates/settings/preferences.html.heex:358
 #, elixir-autogen, elixir-format
 msgid "Break long words at syllable points so the text wraps evenly. Helpful in the narrow phone column."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:275
+#: lib/vutuv_web/templates/settings/preferences.html.heex:289
 #, elixir-autogen, elixir-format
 msgid "How posts you read are shortened in your feed and on profiles. These are your own reading preferences."
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:68
-#: lib/vutuv_web/templates/settings/preferences.html.heex:351
+#: lib/vutuv_web/templates/settings/preferences.html.heex:365
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on desktop"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:69
-#: lib/vutuv_web/templates/settings/preferences.html.heex:355
+#: lib/vutuv_web/templates/settings/preferences.html.heex:369
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on mobile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:341
+#: lib/vutuv_web/templates/settings/preferences.html.heex:355
 #, elixir-autogen, elixir-format
 msgid "Hyphenation"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:66
-#: lib/vutuv_web/templates/settings/preferences.html.heex:298
+#: lib/vutuv_web/templates/settings/preferences.html.heex:312
 #, elixir-autogen, elixir-format
 msgid "Lines on desktop"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:67
-#: lib/vutuv_web/templates/settings/preferences.html.heex:307
+#: lib/vutuv_web/templates/settings/preferences.html.heex:321
 #, elixir-autogen, elixir-format
 msgid "Lines on mobile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:293
+#: lib/vutuv_web/templates/settings/preferences.html.heex:307
 #, elixir-autogen, elixir-format
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:764
+#: lib/vutuv_web/controllers/settings_controller.ex:781
 #, elixir-autogen, elixir-format
 msgid "Post display settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:290
+#: lib/vutuv_web/templates/settings/preferences.html.heex:304
 #, elixir-autogen, elixir-format
 msgid "Shorten a post after"
 msgstr ""
@@ -10609,7 +10609,7 @@ msgstr ""
 msgid "Installation default (%{value})"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:796
+#: lib/vutuv_web/controllers/settings_controller.ex:813
 #, elixir-autogen, elixir-format
 msgid "Map preferences reset to the site defaults."
 msgstr ""
@@ -10624,7 +10624,7 @@ msgstr ""
 msgid "Own value; blank the field to go back to the installation default."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:792
+#: lib/vutuv_web/controllers/settings_controller.ex:809
 #, elixir-autogen, elixir-format
 msgid "Post display settings reset to the site defaults."
 msgstr ""
@@ -10652,8 +10652,8 @@ msgstr ""
 
 #: lib/vutuv_web/templates/settings/preferences.html.heex:101
 #: lib/vutuv_web/templates/settings/preferences.html.heex:174
-#: lib/vutuv_web/templates/settings/preferences.html.heex:257
-#: lib/vutuv_web/templates/settings/preferences.html.heex:375
+#: lib/vutuv_web/templates/settings/preferences.html.heex:271
+#: lib/vutuv_web/templates/settings/preferences.html.heex:389
 #, elixir-autogen, elixir-format
 msgid "Reset to the site defaults"
 msgstr ""
@@ -11847,7 +11847,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:383
 #: lib/vutuv_web/components/ui.ex:4122
-#: lib/vutuv_web/controllers/settings_controller.ex:211
+#: lib/vutuv_web/controllers/settings_controller.ex:228
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:501
@@ -12400,7 +12400,7 @@ msgstr ""
 msgid "Salary on request"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:393
+#: lib/vutuv_web/controllers/settings_controller.ex:410
 #: lib/vutuv_web/live/job_posting_live/form.ex:231
 #, elixir-autogen, elixir-format
 msgid "Saved."
@@ -12990,7 +12990,7 @@ msgstr[1] ""
 msgid "Alert frequency"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:678
+#: lib/vutuv_web/controllers/settings_controller.ex:695
 #, elixir-autogen, elixir-format
 msgid "Alert updated."
 msgstr ""
@@ -13058,13 +13058,13 @@ msgstr ""
 msgid "Save search"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:696
+#: lib/vutuv_web/controllers/settings_controller.ex:713
 #, elixir-autogen, elixir-format
 msgid "Saved search deleted."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4062
-#: lib/vutuv_web/controllers/settings_controller.ex:588
+#: lib/vutuv_web/controllers/settings_controller.ex:605
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
 #, elixir-autogen, elixir-format
@@ -13084,8 +13084,8 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2257
 #: lib/vutuv_web/components/saved_search_components.ex:43
-#: lib/vutuv_web/controllers/settings_controller.ex:683
-#: lib/vutuv_web/controllers/settings_controller.ex:701
+#: lib/vutuv_web/controllers/settings_controller.ex:700
+#: lib/vutuv_web/controllers/settings_controller.ex:718
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:387
 #: lib/vutuv_web/live/organization_live/following.ex:281
 #: lib/vutuv_web/live/organization_live/following.ex:288
@@ -13522,7 +13522,7 @@ msgid "Posts tagged with a tag you follow show up in your feed, and people known
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4045
-#: lib/vutuv_web/controllers/settings_controller.ex:602
+#: lib/vutuv_web/controllers/settings_controller.ex:619
 #: lib/vutuv_web/live/post_live/feed.ex:1410
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
@@ -13686,34 +13686,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4433
+#: lib/vutuv_web/components/post_components.ex:4429
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1154
-#: lib/vutuv_web/components/post_components.ex:4390
+#: lib/vutuv_web/components/post_components.ex:4386
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4434
+#: lib/vutuv_web/components/post_components.ex:4430
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4436
+#: lib/vutuv_web/components/post_components.ex:4432
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4432
+#: lib/vutuv_web/components/post_components.ex:4428
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1154
-#: lib/vutuv_web/components/post_components.ex:4389
+#: lib/vutuv_web/components/post_components.ex:4385
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13724,12 +13724,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4431
+#: lib/vutuv_web/components/post_components.ex:4427
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4435
+#: lib/vutuv_web/components/post_components.ex:4431
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13749,7 +13749,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4472
+#: lib/vutuv_web/components/post_components.ex:4468
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13757,27 +13757,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4502
+#: lib/vutuv_web/components/post_components.ex:4498
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4503
+#: lib/vutuv_web/components/post_components.ex:4499
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4501
+#: lib/vutuv_web/components/post_components.ex:4497
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4461
+#: lib/vutuv_web/components/post_components.ex:4457
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4508
+#: lib/vutuv_web/components/post_components.ex:4504
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13807,7 +13807,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4275
+#: lib/vutuv_web/components/post_components.ex:4271
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13855,7 +13855,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4266
+#: lib/vutuv_web/components/post_components.ex:4262
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -13997,7 +13997,7 @@ msgid "proof document"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:74
-#: lib/vutuv_web/templates/settings/preferences.html.heex:329
+#: lib/vutuv_web/templates/settings/preferences.html.heex:343
 #, elixir-autogen, elixir-format
 msgid "Lines in notifications"
 msgstr ""
@@ -14007,12 +14007,12 @@ msgstr ""
 msgid "How much of a post a notification quotes before it is cut off."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:320
+#: lib/vutuv_web/templates/settings/preferences.html.heex:334
 #, elixir-autogen, elixir-format
 msgid "Quoted posts in notifications"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:323
+#: lib/vutuv_web/templates/settings/preferences.html.heex:337
 #, elixir-autogen, elixir-format
 msgid "Your notifications quote the post someone liked or replied to. Leave the field empty to follow the site default."
 msgstr ""
@@ -14259,7 +14259,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4900
+#: lib/vutuv_web/components/post_components.ex:4896
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14309,7 +14309,7 @@ msgstr ""
 msgid "Cancel redirect"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:487
+#: lib/vutuv_web/controllers/settings_controller.ex:504
 #, elixir-autogen, elixir-format
 msgid "Done. Your Fediverse followers have been asked to follow your new account, and new posts are no longer federated from here. Your vutuv profile is unchanged."
 msgstr ""
@@ -14324,12 +14324,12 @@ msgstr ""
 msgid "On your other account, add your vutuv handle"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:526
+#: lib/vutuv_web/controllers/settings_controller.ex:543
 #, elixir-autogen, elixir-format
 msgid "Please enter the full https address of the account you are moving to."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:512
+#: lib/vutuv_web/controllers/settings_controller.ex:529
 #, elixir-autogen, elixir-format
 msgid "Redirect cancelled. Your posts federate from here again."
 msgstr ""
@@ -14344,17 +14344,17 @@ msgstr ""
 msgid "Redirected on %{date}"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:539
+#: lib/vutuv_web/controllers/settings_controller.ex:556
 #, elixir-autogen, elixir-format
 msgid "That account could not be reached. Check the address, and that the other server is online."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:533
+#: lib/vutuv_web/controllers/settings_controller.ex:550
 #, elixir-autogen, elixir-format
 msgid "That account does not list your vutuv profile as an alias yet. Add this profile's address there first, then try again."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:529
+#: lib/vutuv_web/controllers/settings_controller.ex:546
 #, elixir-autogen, elixir-format
 msgid "That is this account. Enter the account you are moving to."
 msgstr ""
@@ -14364,12 +14364,12 @@ msgstr ""
 msgid "This tells your Fediverse followers to follow your new account instead, and stops federating your posts from here. Your vutuv profile is not affected. Continue?"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:517
+#: lib/vutuv_web/controllers/settings_controller.ex:534
 #, elixir-autogen, elixir-format
 msgid "Turn on federation first, then you can redirect your followers."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:521
+#: lib/vutuv_web/controllers/settings_controller.ex:538
 #, elixir-autogen, elixir-format
 msgid "You can only move once every %{days} days."
 msgstr ""
@@ -14391,7 +14391,7 @@ msgstr[1] ""
 msgid "All endorsers"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:627
+#: lib/vutuv_web/controllers/settings_controller.ex:644
 #, elixir-autogen, elixir-format
 msgid "Filter added. Matching posts are now hidden from your feed."
 msgstr ""
@@ -14401,7 +14401,7 @@ msgstr ""
 msgid "Filter by a tag"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:657
+#: lib/vutuv_web/controllers/settings_controller.ex:674
 #, elixir-autogen, elixir-format
 msgid "Filter removed."
 msgstr ""
@@ -14422,7 +14422,7 @@ msgid "Match whole words only (word/phrase)"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4041
-#: lib/vutuv_web/controllers/settings_controller.ex:668
+#: lib/vutuv_web/controllers/settings_controller.ex:685
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
 #, elixir-autogen, elixir-format
@@ -14515,7 +14515,7 @@ msgstr ""
 msgid "You have not muted anything yet."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:635
+#: lib/vutuv_web/controllers/settings_controller.ex:652
 #, elixir-autogen, elixir-format
 msgid "You have reached the maximum of %{count} filters."
 msgstr ""
@@ -14737,7 +14737,7 @@ msgstr ""
 msgid "Moving to or away from another Fediverse account?"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:377
+#: lib/vutuv_web/controllers/settings_controller.ex:394
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:201
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:12
 #, elixir-autogen, elixir-format
@@ -15382,51 +15382,51 @@ msgstr ""
 msgid "I understand, take part"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:375
+#: lib/vutuv_web/views/settings_html.ex:415
 #, elixir-autogen, elixir-format
 msgid "Most of them, not all: we cannot check whether they do it, and anything that was re-shared, archived or indexed elsewhere stays out of reach. If you take part again later, people there have to follow you anew."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:370
+#: lib/vutuv_web/views/settings_html.ex:410
 #, elixir-autogen, elixir-format
 msgid "No new posts go out, and your followers from other networks are removed here. The next time those servers look you up they learn that this account is gone, and most of them then delete their copies of your posts."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:351
+#: lib/vutuv_web/views/settings_html.ex:391
 #, elixir-autogen, elixir-format
 msgid "Once a post has left vutuv, it is out of our hands"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:353
+#: lib/vutuv_web/views/settings_html.ex:393
 #, elixir-autogen, elixir-format
 msgid "Switching off does not delete what is already out there"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:364
+#: lib/vutuv_web/views/settings_html.ex:404
 #, elixir-autogen, elixir-format
 msgid "Switching this off again later stops new posts from going out. It cannot bring back what has already been delivered."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:359
+#: lib/vutuv_web/views/settings_html.ex:399
 #, elixir-autogen, elixir-format
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4848
+#: lib/vutuv_web/components/post_components.ex:4844
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4852
+#: lib/vutuv_web/components/post_components.ex:4848
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4856
+#: lib/vutuv_web/components/post_components.ex:4852
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15434,7 +15434,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1103
-#: lib/vutuv_web/components/post_components.ex:4807
+#: lib/vutuv_web/components/post_components.ex:4803
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -16528,13 +16528,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1121
-#: lib/vutuv_web/components/post_components.ex:4845
+#: lib/vutuv_web/components/post_components.ex:4841
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1119
-#: lib/vutuv_web/components/post_components.ex:4842
+#: lib/vutuv_web/components/post_components.ex:4838
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr ""
@@ -16544,7 +16544,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4734
+#: lib/vutuv_web/components/post_components.ex:4730
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr ""
@@ -18243,19 +18243,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4003
+#: lib/vutuv_web/components/post_components.ex:3999
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4005
+#: lib/vutuv_web/components/post_components.ex:4001
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4016
+#: lib/vutuv_web/components/post_components.ex:4012
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -18275,7 +18275,7 @@ msgstr ""
 msgid "When off, other members no longer see you among the likes of a post. The author of the post still does: we named you in the notification they got when you liked it. Either way the post keeps the same number of likes."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:834
+#: lib/vutuv_web/controllers/settings_controller.ex:851
 #, elixir-autogen, elixir-format
 msgid "Your likes follow the site default again."
 msgstr ""
@@ -19326,9 +19326,9 @@ msgid "Always keep"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4079
-#: lib/vutuv_web/controllers/settings_controller.ex:245
-#: lib/vutuv_web/controllers/settings_controller.ex:324
-#: lib/vutuv_web/controllers/settings_controller.ex:336
+#: lib/vutuv_web/controllers/settings_controller.ex:262
+#: lib/vutuv_web/controllers/settings_controller.ex:341
+#: lib/vutuv_web/controllers/settings_controller.ex:353
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:20
 #: lib/vutuv_web/views/account_event_text.ex:254
 #, elixir-autogen, elixir-format
@@ -19489,12 +19489,12 @@ msgid_plural "Saving this rule deletes %{formatted} posts straight away. This ca
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:305
+#: lib/vutuv_web/controllers/settings_controller.ex:322
 #, elixir-autogen, elixir-format
 msgid "Settings saved."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:308
+#: lib/vutuv_web/controllers/settings_controller.ex:325
 #, elixir-autogen, elixir-format
 msgid "Settings saved. %{count} post was deleted."
 msgid_plural "Settings saved. %{formatted} posts were deleted."
@@ -20821,34 +20821,24 @@ msgstr ""
 msgid "Translating…"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:823
+#: lib/vutuv_web/controllers/settings_controller.ex:840
 #, elixir-autogen, elixir-format
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:812
+#: lib/vutuv_web/controllers/settings_controller.ex:829
 #, elixir-autogen, elixir-format
 msgid "Feed language settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:188
+#: lib/vutuv_web/templates/settings/preferences.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Feed languages"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:190
-#, elixir-autogen, elixir-format
-msgid "Pick which languages your feed shows, and what happens to posts in other languages. Posts that declare no language always show."
-msgstr ""
-
 #: lib/vutuv_web/templates/settings/preferences.html.heex:200
 #, elixir-autogen, elixir-format
-msgid "Show these languages"
-msgstr ""
-
-#: lib/vutuv_web/templates/settings/preferences.html.heex:203
-#, elixir-autogen, elixir-format
-msgid "Ticking every box (or none) means: all languages."
+msgid "Pick which languages your feed shows, and what happens to posts in other languages. Posts that declare no language always show."
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:83
@@ -20876,7 +20866,7 @@ msgstr ""
 msgid "Date & time"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:736
+#: lib/vutuv_web/controllers/settings_controller.ex:753
 #, elixir-autogen, elixir-format
 msgid "Date and time settings reset to the site defaults."
 msgstr ""
@@ -20891,7 +20881,7 @@ msgstr ""
 msgid "Germany, Austria, Switzerland"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:730
+#: lib/vutuv_web/controllers/settings_controller.ex:747
 #, elixir-autogen, elixir-format
 msgid "Language and region saved."
 msgstr ""
@@ -21025,7 +21015,7 @@ msgstr ""
 msgid "The page's Editorial team can use this organization as a separate identity in a compatible phone app, with the same rights they already have here. Those rights are checked again on every request."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:195
+#: lib/vutuv_web/controllers/settings_controller.ex:212
 #, elixir-autogen, elixir-format
 msgid "App settings saved."
 msgstr ""
@@ -21325,4 +21315,19 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:4058
 #, elixir-autogen, elixir-format
 msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:227
+#, elixir-autogen, elixir-format
+msgid "Add another language"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:213
+#, elixir-autogen, elixir-format
+msgid "Choosing none means: all languages."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:210
+#, elixir-autogen, elixir-format
+msgid "These languages I read"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -624,12 +624,12 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/notifications.html.heex:79
 #: lib/vutuv_web/templates/settings/preferences.html.heex:84
 #: lib/vutuv_web/templates/settings/preferences.html.heex:157
-#: lib/vutuv_web/templates/settings/preferences.html.heex:240
-#: lib/vutuv_web/templates/settings/preferences.html.heex:360
+#: lib/vutuv_web/templates/settings/preferences.html.heex:254
+#: lib/vutuv_web/templates/settings/preferences.html.heex:374
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:462
-#: lib/vutuv_web/views/settings_html.ex:175
+#: lib/vutuv_web/views/settings_html.ex:215
 #, elixir-autogen
 msgid "Save"
 msgstr ""
@@ -856,7 +856,7 @@ msgid "View All"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4069
-#: lib/vutuv_web/controllers/settings_controller.ex:169
+#: lib/vutuv_web/controllers/settings_controller.ex:186
 #: lib/vutuv_web/live/job_posting_live/form.ex:561
 #: lib/vutuv_web/live/organization_live/edit.ex:304
 #: lib/vutuv_web/templates/email/card_list.html.heex:7
@@ -1711,7 +1711,7 @@ msgid "It doesn't look like you're following anyone yet. Open the profile of som
 msgstr ""
 
 #: lib/vutuv_web/live/shell_live.ex:844
-#: lib/vutuv_web/views/settings_html.ex:262
+#: lib/vutuv_web/views/settings_html.ex:302
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr ""
@@ -2209,7 +2209,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:495
 #: lib/vutuv_web/live/search_live.ex:283
 #: lib/vutuv_web/live/search_live.ex:730
-#: lib/vutuv_web/templates/settings/preferences.html.heex:273
+#: lib/vutuv_web/templates/settings/preferences.html.heex:287
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Posts"
@@ -2240,7 +2240,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:619
 #: lib/vutuv_web/live/post_live/saved.ex:647
 #: lib/vutuv_web/templates/connection/index.html.heex:40
-#: lib/vutuv_web/views/settings_html.ex:308
+#: lib/vutuv_web/views/settings_html.ex:348
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
@@ -2296,7 +2296,7 @@ msgstr ""
 #: lib/vutuv_web/live/shell_live.ex:791
 #: lib/vutuv_web/templates/post/index.html.heex:17
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
-#: lib/vutuv_web/views/settings_html.ex:209
+#: lib/vutuv_web/views/settings_html.ex:249
 #, elixir-autogen, elixir-format
 msgid "View profile"
 msgstr ""
@@ -2316,28 +2316,28 @@ msgstr ""
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4570
+#: lib/vutuv_web/components/post_components.ex:4566
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4574
+#: lib/vutuv_web/components/post_components.ex:4570
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4572
+#: lib/vutuv_web/components/post_components.ex:4568
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4573
+#: lib/vutuv_web/components/post_components.ex:4569
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
 
 #: lib/vutuv_web/views/post_html.ex:19
-#: lib/vutuv_web/views/settings_html.ex:387
+#: lib/vutuv_web/views/settings_html.ex:427
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr ""
@@ -2373,7 +2373,7 @@ msgid "All posts"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1666
-#: lib/vutuv_web/components/post_components.ex:4658
+#: lib/vutuv_web/components/post_components.ex:4654
 #: lib/vutuv_web/components/ui.ex:3174
 #: lib/vutuv_web/views/user_html.ex:440
 #, elixir-autogen, elixir-format
@@ -2392,7 +2392,7 @@ msgid "Bookmarks"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1630
-#: lib/vutuv_web/components/post_components.ex:4892
+#: lib/vutuv_web/components/post_components.ex:4888
 #: lib/vutuv_web/components/ui.ex:3160
 #: lib/vutuv_web/live/notification_live/index.ex:1037
 #: lib/vutuv_web/views/user_html.ex:450
@@ -2401,7 +2401,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1065
-#: lib/vutuv_web/components/post_components.ex:4901
+#: lib/vutuv_web/components/post_components.ex:4897
 #: lib/vutuv_web/live/notification_live/index.ex:970
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
@@ -2423,13 +2423,13 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4647
+#: lib/vutuv_web/components/post_components.ex:4643
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1666
-#: lib/vutuv_web/components/post_components.ex:4658
+#: lib/vutuv_web/components/post_components.ex:4654
 #: lib/vutuv_web/live/post_live/saved.ex:775
 #: lib/vutuv_web/views/user_html.ex:440
 #, elixir-autogen, elixir-format
@@ -2437,7 +2437,7 @@ msgid "Remove bookmark"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1654
-#: lib/vutuv_web/components/post_components.ex:4644
+#: lib/vutuv_web/components/post_components.ex:4640
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
@@ -2450,12 +2450,12 @@ msgid "Reposted by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1654
-#: lib/vutuv_web/components/post_components.ex:4644
+#: lib/vutuv_web/components/post_components.ex:4640
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4892
+#: lib/vutuv_web/components/post_components.ex:4888
 #: lib/vutuv_web/live/post_live/saved.ex:774
 #: lib/vutuv_web/views/user_html.ex:450
 #, elixir-autogen, elixir-format
@@ -2481,7 +2481,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4945
+#: lib/vutuv_web/components/post_components.ex:4941
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2493,8 +2493,8 @@ msgid "Replies"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1641
-#: lib/vutuv_web/components/post_components.ex:4928
-#: lib/vutuv_web/components/post_components.ex:4929
+#: lib/vutuv_web/components/post_components.ex:4924
+#: lib/vutuv_web/components/post_components.ex:4925
 #: lib/vutuv_web/live/notification_live/index.ex:1034
 #: lib/vutuv_web/live/post_live/reply.ex:42
 #, elixir-autogen, elixir-format
@@ -2834,7 +2834,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4571
+#: lib/vutuv_web/components/post_components.ex:4567
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -4912,7 +4912,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/api_app_live.ex:98
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:181
 #: lib/vutuv_web/views/settings_html.ex:75
-#: lib/vutuv_web/views/settings_html.ex:253
+#: lib/vutuv_web/views/settings_html.ex:293
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
@@ -5271,7 +5271,7 @@ msgid "API documentation"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4133
-#: lib/vutuv_web/controllers/settings_controller.ex:155
+#: lib/vutuv_web/controllers/settings_controller.ex:172
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
 #: lib/vutuv_web/live/admin/user_delete_live.ex:103
@@ -5353,7 +5353,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:4235
 #: lib/vutuv_web/components/ui.ex:4314
 #: lib/vutuv_web/components/ui.ex:4378
-#: lib/vutuv_web/controllers/settings_controller.ex:62
+#: lib/vutuv_web/controllers/settings_controller.ex:64
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:303
@@ -5365,7 +5365,7 @@ msgstr ""
 #: lib/vutuv_web/templates/login_code/index.html.heex:4
 #: lib/vutuv_web/templates/totp/new.html.heex:4
 #: lib/vutuv_web/templates/username/confirm.html.heex:23
-#: lib/vutuv_web/views/settings_html.ex:204
+#: lib/vutuv_web/views/settings_html.ex:244
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -5506,7 +5506,7 @@ msgstr ""
 msgid "Email addresses"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:569
+#: lib/vutuv_web/controllers/settings_controller.ex:586
 #, elixir-autogen, elixir-format
 msgid "Notification settings saved."
 msgstr ""
@@ -5533,7 +5533,7 @@ msgstr ""
 msgid "Privacy"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:221
+#: lib/vutuv_web/controllers/settings_controller.ex:238
 #, elixir-autogen, elixir-format
 msgid "Privacy settings saved."
 msgstr ""
@@ -5640,7 +5640,7 @@ msgid "Apps"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4126
-#: lib/vutuv_web/controllers/settings_controller.ex:179
+#: lib/vutuv_web/controllers/settings_controller.ex:196
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
 msgstr ""
@@ -5669,7 +5669,7 @@ msgstr ""
 msgid "New followers"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:559
+#: lib/vutuv_web/controllers/settings_controller.ex:576
 #, elixir-autogen, elixir-format
 msgid "Notification settings"
 msgstr ""
@@ -5844,28 +5844,28 @@ msgid "Sort"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:182
-#: lib/vutuv_web/views/settings_html.ex:396
+#: lib/vutuv_web/views/settings_html.ex:436
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:395
+#: lib/vutuv_web/views/settings_html.ex:435
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:394
+#: lib/vutuv_web/views/settings_html.ex:434
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:900
+#: lib/vutuv_web/controllers/settings_controller.ex:917
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr ""
@@ -5875,7 +5875,7 @@ msgstr ""
 msgid "Another session was already active on your account."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:242
+#: lib/vutuv_web/views/settings_html.ex:282
 #, elixir-autogen, elixir-format
 msgid "Last active"
 msgstr ""
@@ -5890,7 +5890,7 @@ msgstr ""
 msgid "Log out of every device except this one?"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:259
+#: lib/vutuv_web/views/settings_html.ex:299
 #, elixir-autogen, elixir-format
 msgid "Log this device out of your account?"
 msgstr ""
@@ -5905,7 +5905,7 @@ msgstr ""
 msgid "Signed-in devices"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:887
+#: lib/vutuv_web/controllers/settings_controller.ex:904
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr ""
@@ -5915,7 +5915,7 @@ msgstr ""
 msgid "The location looks different from where you usually sign in."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:243
+#: lib/vutuv_web/views/settings_html.ex:283
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr ""
@@ -5925,7 +5925,7 @@ msgstr ""
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:393
+#: lib/vutuv_web/views/settings_html.ex:433
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr ""
@@ -5959,7 +5959,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
 #: lib/vutuv_web/live/admin/screenshot_live.ex:309
 #: lib/vutuv_web/live/fediverse_following_live.ex:291
-#: lib/vutuv_web/views/settings_html.ex:294
+#: lib/vutuv_web/views/settings_html.ex:334
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr ""
@@ -5969,7 +5969,7 @@ msgstr ""
 msgid "Could not add the passkey. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:297
+#: lib/vutuv_web/views/settings_html.ex:337
 #, elixir-autogen, elixir-format
 msgid "Last used"
 msgstr ""
@@ -5979,7 +5979,7 @@ msgstr ""
 msgid "Name (optional)"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:291
+#: lib/vutuv_web/views/settings_html.ex:331
 #, elixir-autogen, elixir-format
 msgid "Passkey"
 msgstr ""
@@ -5999,7 +5999,7 @@ msgstr ""
 msgid "Passkeys"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:305
+#: lib/vutuv_web/views/settings_html.ex:345
 #, elixir-autogen, elixir-format
 msgid "Remove this passkey?"
 msgstr ""
@@ -6262,7 +6262,7 @@ msgstr ""
 msgid "Default map"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:750
+#: lib/vutuv_web/controllers/settings_controller.ex:767
 #, elixir-autogen, elixir-format
 msgid "Map preferences saved."
 msgstr ""
@@ -7350,7 +7350,7 @@ msgstr ""
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4803
+#: lib/vutuv_web/components/post_components.ex:4799
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8414,7 +8414,7 @@ msgid "Basics & photos"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4104
-#: lib/vutuv_web/controllers/settings_controller.ex:123
+#: lib/vutuv_web/controllers/settings_controller.ex:128
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Language & display"
@@ -8426,7 +8426,7 @@ msgid "More profile sections"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4095
-#: lib/vutuv_web/controllers/settings_controller.ex:106
+#: lib/vutuv_web/controllers/settings_controller.ex:108
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
 #: lib/vutuv_web/templates/settings/security.html.heex:11
@@ -8653,8 +8653,8 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:310
 #: lib/vutuv_web/components/ui.ex:4085
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
-#: lib/vutuv_web/controllers/settings_controller.ex:355
-#: lib/vutuv_web/controllers/settings_controller.ex:422
+#: lib/vutuv_web/controllers/settings_controller.ex:372
+#: lib/vutuv_web/controllers/settings_controller.ex:439
 #: lib/vutuv_web/live/fediverse_followers_live.ex:169
 #: lib/vutuv_web/live/fediverse_following_live.ex:304
 #: lib/vutuv_web/live/organization_live/fediverse.ex:76
@@ -8686,7 +8686,7 @@ msgstr ""
 msgid "as a link in your Mastodon profile settings, and Mastodon will show it as verified with a green check."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:435
+#: lib/vutuv_web/controllers/settings_controller.ex:452
 #, elixir-autogen, elixir-format
 msgid "Fediverse settings saved."
 msgstr ""
@@ -10514,56 +10514,56 @@ msgid_plural "You have %{formatted} new messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:344
+#: lib/vutuv_web/templates/settings/preferences.html.heex:358
 #, elixir-autogen, elixir-format
 msgid "Break long words at syllable points so the text wraps evenly. Helpful in the narrow phone column."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:275
+#: lib/vutuv_web/templates/settings/preferences.html.heex:289
 #, elixir-autogen, elixir-format
 msgid "How posts you read are shortened in your feed and on profiles. These are your own reading preferences."
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:68
-#: lib/vutuv_web/templates/settings/preferences.html.heex:351
+#: lib/vutuv_web/templates/settings/preferences.html.heex:365
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on desktop"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:69
-#: lib/vutuv_web/templates/settings/preferences.html.heex:355
+#: lib/vutuv_web/templates/settings/preferences.html.heex:369
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on mobile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:341
+#: lib/vutuv_web/templates/settings/preferences.html.heex:355
 #, elixir-autogen, elixir-format
 msgid "Hyphenation"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:66
-#: lib/vutuv_web/templates/settings/preferences.html.heex:298
+#: lib/vutuv_web/templates/settings/preferences.html.heex:312
 #, elixir-autogen, elixir-format
 msgid "Lines on desktop"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:67
-#: lib/vutuv_web/templates/settings/preferences.html.heex:307
+#: lib/vutuv_web/templates/settings/preferences.html.heex:321
 #, elixir-autogen, elixir-format
 msgid "Lines on mobile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:293
+#: lib/vutuv_web/templates/settings/preferences.html.heex:307
 #, elixir-autogen, elixir-format
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:764
+#: lib/vutuv_web/controllers/settings_controller.ex:781
 #, elixir-autogen, elixir-format
 msgid "Post display settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:290
+#: lib/vutuv_web/templates/settings/preferences.html.heex:304
 #, elixir-autogen, elixir-format
 msgid "Shorten a post after"
 msgstr ""
@@ -10607,7 +10607,7 @@ msgstr ""
 msgid "Installation default (%{value})"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:796
+#: lib/vutuv_web/controllers/settings_controller.ex:813
 #, elixir-autogen, elixir-format
 msgid "Map preferences reset to the site defaults."
 msgstr ""
@@ -10622,7 +10622,7 @@ msgstr ""
 msgid "Own value; blank the field to go back to the installation default."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:792
+#: lib/vutuv_web/controllers/settings_controller.ex:809
 #, elixir-autogen, elixir-format
 msgid "Post display settings reset to the site defaults."
 msgstr ""
@@ -10650,8 +10650,8 @@ msgstr ""
 
 #: lib/vutuv_web/templates/settings/preferences.html.heex:101
 #: lib/vutuv_web/templates/settings/preferences.html.heex:174
-#: lib/vutuv_web/templates/settings/preferences.html.heex:257
-#: lib/vutuv_web/templates/settings/preferences.html.heex:375
+#: lib/vutuv_web/templates/settings/preferences.html.heex:271
+#: lib/vutuv_web/templates/settings/preferences.html.heex:389
 #, elixir-autogen, elixir-format
 msgid "Reset to the site defaults"
 msgstr ""
@@ -11845,7 +11845,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:383
 #: lib/vutuv_web/components/ui.ex:4122
-#: lib/vutuv_web/controllers/settings_controller.ex:211
+#: lib/vutuv_web/controllers/settings_controller.ex:228
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:501
@@ -12398,7 +12398,7 @@ msgstr ""
 msgid "Salary on request"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:393
+#: lib/vutuv_web/controllers/settings_controller.ex:410
 #: lib/vutuv_web/live/job_posting_live/form.ex:231
 #, elixir-autogen, elixir-format
 msgid "Saved."
@@ -12988,7 +12988,7 @@ msgstr[1] ""
 msgid "Alert frequency"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:678
+#: lib/vutuv_web/controllers/settings_controller.ex:695
 #, elixir-autogen, elixir-format
 msgid "Alert updated."
 msgstr ""
@@ -13056,13 +13056,13 @@ msgstr ""
 msgid "Save search"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:696
+#: lib/vutuv_web/controllers/settings_controller.ex:713
 #, elixir-autogen, elixir-format
 msgid "Saved search deleted."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4062
-#: lib/vutuv_web/controllers/settings_controller.ex:588
+#: lib/vutuv_web/controllers/settings_controller.ex:605
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
 #, elixir-autogen, elixir-format
@@ -13082,8 +13082,8 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2257
 #: lib/vutuv_web/components/saved_search_components.ex:43
-#: lib/vutuv_web/controllers/settings_controller.ex:683
-#: lib/vutuv_web/controllers/settings_controller.ex:701
+#: lib/vutuv_web/controllers/settings_controller.ex:700
+#: lib/vutuv_web/controllers/settings_controller.ex:718
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:387
 #: lib/vutuv_web/live/organization_live/following.ex:281
 #: lib/vutuv_web/live/organization_live/following.ex:288
@@ -13520,7 +13520,7 @@ msgid "Posts tagged with a tag you follow show up in your feed, and people known
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4045
-#: lib/vutuv_web/controllers/settings_controller.ex:602
+#: lib/vutuv_web/controllers/settings_controller.ex:619
 #: lib/vutuv_web/live/post_live/feed.ex:1410
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
@@ -13684,34 +13684,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4433
+#: lib/vutuv_web/components/post_components.ex:4429
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1154
-#: lib/vutuv_web/components/post_components.ex:4390
+#: lib/vutuv_web/components/post_components.ex:4386
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4434
+#: lib/vutuv_web/components/post_components.ex:4430
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4436
+#: lib/vutuv_web/components/post_components.ex:4432
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4432
+#: lib/vutuv_web/components/post_components.ex:4428
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1154
-#: lib/vutuv_web/components/post_components.ex:4389
+#: lib/vutuv_web/components/post_components.ex:4385
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13722,12 +13722,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4431
+#: lib/vutuv_web/components/post_components.ex:4427
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4435
+#: lib/vutuv_web/components/post_components.ex:4431
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13747,7 +13747,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4472
+#: lib/vutuv_web/components/post_components.ex:4468
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13755,27 +13755,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4502
+#: lib/vutuv_web/components/post_components.ex:4498
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4503
+#: lib/vutuv_web/components/post_components.ex:4499
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4501
+#: lib/vutuv_web/components/post_components.ex:4497
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4461
+#: lib/vutuv_web/components/post_components.ex:4457
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4508
+#: lib/vutuv_web/components/post_components.ex:4504
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13805,7 +13805,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4275
+#: lib/vutuv_web/components/post_components.ex:4271
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13853,7 +13853,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4266
+#: lib/vutuv_web/components/post_components.ex:4262
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -13995,7 +13995,7 @@ msgid "proof document"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:74
-#: lib/vutuv_web/templates/settings/preferences.html.heex:329
+#: lib/vutuv_web/templates/settings/preferences.html.heex:343
 #, elixir-autogen, elixir-format
 msgid "Lines in notifications"
 msgstr ""
@@ -14005,12 +14005,12 @@ msgstr ""
 msgid "How much of a post a notification quotes before it is cut off."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:320
+#: lib/vutuv_web/templates/settings/preferences.html.heex:334
 #, elixir-autogen, elixir-format
 msgid "Quoted posts in notifications"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:323
+#: lib/vutuv_web/templates/settings/preferences.html.heex:337
 #, elixir-autogen, elixir-format
 msgid "Your notifications quote the post someone liked or replied to. Leave the field empty to follow the site default."
 msgstr ""
@@ -14257,7 +14257,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4900
+#: lib/vutuv_web/components/post_components.ex:4896
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14307,7 +14307,7 @@ msgstr ""
 msgid "Cancel redirect"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:487
+#: lib/vutuv_web/controllers/settings_controller.ex:504
 #, elixir-autogen, elixir-format
 msgid "Done. Your Fediverse followers have been asked to follow your new account, and new posts are no longer federated from here. Your vutuv profile is unchanged."
 msgstr ""
@@ -14322,12 +14322,12 @@ msgstr ""
 msgid "On your other account, add your vutuv handle"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:526
+#: lib/vutuv_web/controllers/settings_controller.ex:543
 #, elixir-autogen, elixir-format
 msgid "Please enter the full https address of the account you are moving to."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:512
+#: lib/vutuv_web/controllers/settings_controller.ex:529
 #, elixir-autogen, elixir-format
 msgid "Redirect cancelled. Your posts federate from here again."
 msgstr ""
@@ -14342,17 +14342,17 @@ msgstr ""
 msgid "Redirected on %{date}"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:539
+#: lib/vutuv_web/controllers/settings_controller.ex:556
 #, elixir-autogen, elixir-format
 msgid "That account could not be reached. Check the address, and that the other server is online."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:533
+#: lib/vutuv_web/controllers/settings_controller.ex:550
 #, elixir-autogen, elixir-format
 msgid "That account does not list your vutuv profile as an alias yet. Add this profile's address there first, then try again."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:529
+#: lib/vutuv_web/controllers/settings_controller.ex:546
 #, elixir-autogen, elixir-format
 msgid "That is this account. Enter the account you are moving to."
 msgstr ""
@@ -14362,12 +14362,12 @@ msgstr ""
 msgid "This tells your Fediverse followers to follow your new account instead, and stops federating your posts from here. Your vutuv profile is not affected. Continue?"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:517
+#: lib/vutuv_web/controllers/settings_controller.ex:534
 #, elixir-autogen, elixir-format
 msgid "Turn on federation first, then you can redirect your followers."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:521
+#: lib/vutuv_web/controllers/settings_controller.ex:538
 #, elixir-autogen, elixir-format
 msgid "You can only move once every %{days} days."
 msgstr ""
@@ -14389,7 +14389,7 @@ msgstr[1] ""
 msgid "All endorsers"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:627
+#: lib/vutuv_web/controllers/settings_controller.ex:644
 #, elixir-autogen, elixir-format
 msgid "Filter added. Matching posts are now hidden from your feed."
 msgstr ""
@@ -14399,7 +14399,7 @@ msgstr ""
 msgid "Filter by a tag"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:657
+#: lib/vutuv_web/controllers/settings_controller.ex:674
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Filter removed."
 msgstr ""
@@ -14420,7 +14420,7 @@ msgid "Match whole words only (word/phrase)"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4041
-#: lib/vutuv_web/controllers/settings_controller.ex:668
+#: lib/vutuv_web/controllers/settings_controller.ex:685
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
 #, elixir-autogen, elixir-format
@@ -14513,7 +14513,7 @@ msgstr ""
 msgid "You have not muted anything yet."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:635
+#: lib/vutuv_web/controllers/settings_controller.ex:652
 #, elixir-autogen, elixir-format
 msgid "You have reached the maximum of %{count} filters."
 msgstr ""
@@ -14735,7 +14735,7 @@ msgstr ""
 msgid "Moving to or away from another Fediverse account?"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:377
+#: lib/vutuv_web/controllers/settings_controller.ex:394
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:201
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:12
 #, elixir-autogen, elixir-format
@@ -15380,51 +15380,51 @@ msgstr ""
 msgid "I understand, take part"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:375
+#: lib/vutuv_web/views/settings_html.ex:415
 #, elixir-autogen, elixir-format
 msgid "Most of them, not all: we cannot check whether they do it, and anything that was re-shared, archived or indexed elsewhere stays out of reach. If you take part again later, people there have to follow you anew."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:370
+#: lib/vutuv_web/views/settings_html.ex:410
 #, elixir-autogen, elixir-format
 msgid "No new posts go out, and your followers from other networks are removed here. The next time those servers look you up they learn that this account is gone, and most of them then delete their copies of your posts."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:351
+#: lib/vutuv_web/views/settings_html.ex:391
 #, elixir-autogen, elixir-format
 msgid "Once a post has left vutuv, it is out of our hands"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:353
+#: lib/vutuv_web/views/settings_html.ex:393
 #, elixir-autogen, elixir-format
 msgid "Switching off does not delete what is already out there"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:364
+#: lib/vutuv_web/views/settings_html.ex:404
 #, elixir-autogen, elixir-format
 msgid "Switching this off again later stops new posts from going out. It cannot bring back what has already been delivered."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:359
+#: lib/vutuv_web/views/settings_html.ex:399
 #, elixir-autogen, elixir-format
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4848
+#: lib/vutuv_web/components/post_components.ex:4844
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4852
+#: lib/vutuv_web/components/post_components.ex:4848
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4856
+#: lib/vutuv_web/components/post_components.ex:4852
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15432,7 +15432,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1103
-#: lib/vutuv_web/components/post_components.ex:4807
+#: lib/vutuv_web/components/post_components.ex:4803
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -16526,13 +16526,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1121
-#: lib/vutuv_web/components/post_components.ex:4845
+#: lib/vutuv_web/components/post_components.ex:4841
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1119
-#: lib/vutuv_web/components/post_components.ex:4842
+#: lib/vutuv_web/components/post_components.ex:4838
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
 msgstr ""
@@ -16542,7 +16542,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4734
+#: lib/vutuv_web/components/post_components.ex:4730
 #, elixir-autogen, elixir-format, fuzzy
 msgid "From other networks"
 msgstr ""
@@ -18241,19 +18241,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4003
+#: lib/vutuv_web/components/post_components.ex:3999
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4005
+#: lib/vutuv_web/components/post_components.ex:4001
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4016
+#: lib/vutuv_web/components/post_components.ex:4012
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -18273,7 +18273,7 @@ msgstr ""
 msgid "When off, other members no longer see you among the likes of a post. The author of the post still does: we named you in the notification they got when you liked it. Either way the post keeps the same number of likes."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:834
+#: lib/vutuv_web/controllers/settings_controller.ex:851
 #, elixir-autogen, elixir-format
 msgid "Your likes follow the site default again."
 msgstr ""
@@ -19324,9 +19324,9 @@ msgid "Always keep"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4079
-#: lib/vutuv_web/controllers/settings_controller.ex:245
-#: lib/vutuv_web/controllers/settings_controller.ex:324
-#: lib/vutuv_web/controllers/settings_controller.ex:336
+#: lib/vutuv_web/controllers/settings_controller.ex:262
+#: lib/vutuv_web/controllers/settings_controller.ex:341
+#: lib/vutuv_web/controllers/settings_controller.ex:353
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:20
 #: lib/vutuv_web/views/account_event_text.ex:254
 #, elixir-autogen, elixir-format
@@ -19487,12 +19487,12 @@ msgid_plural "Saving this rule deletes %{formatted} posts straight away. This ca
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:305
+#: lib/vutuv_web/controllers/settings_controller.ex:322
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Settings saved."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:308
+#: lib/vutuv_web/controllers/settings_controller.ex:325
 #, elixir-autogen, elixir-format
 msgid "Settings saved. %{count} post was deleted."
 msgid_plural "Settings saved. %{formatted} posts were deleted."
@@ -20819,34 +20819,24 @@ msgstr ""
 msgid "Translating…"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:823
+#: lib/vutuv_web/controllers/settings_controller.ex:840
 #, elixir-autogen, elixir-format
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:812
+#: lib/vutuv_web/controllers/settings_controller.ex:829
 #, elixir-autogen, elixir-format
 msgid "Feed language settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:188
+#: lib/vutuv_web/templates/settings/preferences.html.heex:198
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Feed languages"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:190
-#, elixir-autogen, elixir-format
-msgid "Pick which languages your feed shows, and what happens to posts in other languages. Posts that declare no language always show."
-msgstr ""
-
 #: lib/vutuv_web/templates/settings/preferences.html.heex:200
 #, elixir-autogen, elixir-format
-msgid "Show these languages"
-msgstr ""
-
-#: lib/vutuv_web/templates/settings/preferences.html.heex:203
-#, elixir-autogen, elixir-format
-msgid "Ticking every box (or none) means: all languages."
+msgid "Pick which languages your feed shows, and what happens to posts in other languages. Posts that declare no language always show."
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:83
@@ -20874,7 +20864,7 @@ msgstr ""
 msgid "Date & time"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:736
+#: lib/vutuv_web/controllers/settings_controller.ex:753
 #, elixir-autogen, elixir-format
 msgid "Date and time settings reset to the site defaults."
 msgstr ""
@@ -20889,7 +20879,7 @@ msgstr ""
 msgid "Germany, Austria, Switzerland"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:730
+#: lib/vutuv_web/controllers/settings_controller.ex:747
 #, elixir-autogen, elixir-format
 msgid "Language and region saved."
 msgstr ""
@@ -21023,7 +21013,7 @@ msgstr ""
 msgid "The page's Editorial team can use this organization as a separate identity in a compatible phone app, with the same rights they already have here. Those rights are checked again on every request."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:195
+#: lib/vutuv_web/controllers/settings_controller.ex:212
 #, elixir-autogen, elixir-format
 msgid "App settings saved."
 msgstr ""
@@ -21323,4 +21313,19 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:4058
 #, elixir-autogen, elixir-format
 msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:227
+#, elixir-autogen, elixir-format
+msgid "Add another language"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:213
+#, elixir-autogen, elixir-format
+msgid "Choosing none means: all languages."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:210
+#, elixir-autogen, elixir-format
+msgid "These languages I read"
 msgstr ""

--- a/test/vutuv_web/controllers/feed_language_chips_test.exs
+++ b/test/vutuv_web/controllers/feed_language_chips_test.exs
@@ -1,0 +1,141 @@
+defmodule VutuvWeb.FeedLanguageChipsTest do
+  @moduledoc """
+  The Feed-languages card on /settings/preferences (issue #1537): the languages
+  a member reads, as chips, instead of a grid of every curated language with all
+  sixty-odd boxes ticked. The load-bearing assertions:
+
+    * the suggestion (interface language + the profile's language skills) decides
+      which chips sit in the **open**, and ticks nothing — a pre-ticked
+      suggestion would ride along the next save of the neighbouring select and
+      leave the member with a language filter they never chose
+    * what is ticked is the stored choice, read from the changeset, so a failed
+      save keeps what they just picked
+    * saving with no chip means "all languages" again (the changeset maps [] to
+      nil)
+  """
+  use VutuvWeb.ConnCase
+
+  alias Vutuv.Accounts
+  alias Vutuv.Posts
+  alias Vutuv.Profiles.Language
+
+  defp chip(html, code) do
+    html
+    |> LazyHTML.from_document()
+    |> LazyHTML.query(~s|input[name="user[feed_languages][]"][value="#{code}"]|)
+    |> Enum.to_list()
+  end
+
+  defp chip_checked?(html, code) do
+    case chip(html, code) do
+      [input] -> LazyHTML.attribute(input, "checked") != []
+      [] -> false
+    end
+  end
+
+  defp chip_present?(html, code), do: chip(html, code) != []
+
+  # The chips in the open, i.e. outside the <details> disclosure.
+  defp chips_in_the_open(html) do
+    doc = LazyHTML.from_document(html)
+    all = doc |> LazyHTML.query(~s|input[name="user[feed_languages][]"]|) |> attr_values()
+
+    folded =
+      doc
+      |> LazyHTML.query(~s|details input[name="user[feed_languages][]"]|)
+      |> attr_values()
+
+    all -- folded
+  end
+
+  defp attr_values(nodes) do
+    nodes |> Enum.to_list() |> Enum.flat_map(&LazyHTML.attribute(&1, "value"))
+  end
+
+  describe "suggested_feed_languages/1" do
+    test "answers the interface language plus the profile's language skills" do
+      user = insert(:user, locale: "de", feed_languages: nil)
+      Repo.insert!(%Language{user_id: user.id, language_code: "fr", proficiency: "c2"})
+
+      suggested = Posts.suggested_feed_languages(user)
+
+      assert "de" in suggested
+      assert "fr" in suggested
+    end
+
+    test "is a suggestion, not the stored choice — it answers the same either way" do
+      user = insert(:user, locale: "de", feed_languages: ["en"])
+
+      assert Posts.suggested_feed_languages(user) == ["de"]
+    end
+
+    test "only curated codes, no duplicates" do
+      user = insert(:user, locale: "de", feed_languages: nil)
+      Repo.insert!(%Language{user_id: user.id, language_code: "de", proficiency: "native"})
+
+      assert Posts.suggested_feed_languages(user) == ["de"]
+    end
+  end
+
+  describe "the card" do
+    setup %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      {:ok, conn: conn, user: user}
+    end
+
+    test "puts the member's own languages in the open and ticks none of them", %{
+      conn: conn,
+      user: user
+    } do
+      {:ok, _user} = Accounts.update_user(user, %{"locale" => "de"})
+      Repo.insert!(%Language{user_id: user.id, language_code: "fr", proficiency: "c2"})
+
+      html = conn |> get(~p"/settings/preferences") |> html_response(200)
+
+      open = chips_in_the_open(html)
+      assert "de" in open
+      assert "fr" in open
+      refute "ja" in open
+
+      # Nothing is ticked: the suggestion must not become a filter by riding
+      # along a save of the select beside it.
+      refute chip_checked?(html, "de")
+      refute chip_checked?(html, "fr")
+      # The rest are still reachable, just folded away.
+      assert chip_present?(html, "ja")
+      assert html =~ "data-language-more"
+
+      # The German wording, by name: `gettext.extract --merge` fuzzy-filled
+      # "Add another language" with "Weiteren Tag hinzufügen" (another *tag*),
+      # and nothing in the build would have failed on it.
+      assert html =~ "Diese Sprachen lese ich"
+      assert html =~ "Weitere Sprache hinzufügen"
+      assert html =~ "Keine Auswahl bedeutet: alle Sprachen."
+    end
+
+    test "the stored choice is what shows as ticked, and it sits in the open", %{
+      conn: conn,
+      user: user
+    } do
+      {:ok, _user} = Accounts.update_user(user, %{"feed_languages" => ["en", "it"]})
+
+      html = conn |> get(~p"/settings/preferences") |> html_response(200)
+
+      assert chip_checked?(html, "en")
+      assert chip_checked?(html, "it")
+      refute chip_checked?(html, "de")
+
+      open = chips_in_the_open(html)
+      assert "en" in open
+      assert "it" in open
+    end
+
+    test "clearing every chip means all languages again", %{conn: conn, user: user} do
+      {:ok, _user} = Accounts.update_user(user, %{"feed_languages" => ["de"]})
+
+      put(conn, ~p"/settings/feed_languages", %{"user" => %{"feed_foreign_posts" => "original"}})
+
+      assert Accounts.get_user(user.id).feed_languages == nil
+    end
+  end
+end

--- a/test/vutuv_web/live/feed_translate_mode_test.exs
+++ b/test/vutuv_web/live/feed_translate_mode_test.exs
@@ -108,7 +108,9 @@ defmodule VutuvWeb.FeedTranslateModeTest do
       assert html =~ "Beiträge in anderen Sprachen"
       assert html =~ "In meine Sprache übersetzen"
       assert html =~ "Ausblenden"
-      assert html =~ "Diese Sprachen zeigen"
+      # The chips' own heading (issue #1537 replaced the checkbox grid);
+      # feed_language_chips_test.exs covers the card's behaviour.
+      assert html =~ "Diese Sprachen lese ich"
     end
   end
 end


### PR DESCRIPTION
Die Karte „Feed-Sprachen" zeigte ein Kästchen je kuratierte Sprache, alle angehakt (keine Auswahl heißt „alle Sprachen"). Wer zwei Sprachen wollte, musste über sechzig abwählen — niemand tat das.

**Jetzt:** Chips. Vorn stehen die Sprachen, die dieses Konto schon nennt (Oberflächensprache + Sprachkenntnisse aus dem Profil, `Posts.suggested_feed_languages/1`), der Rest hinter „Weitere Sprache hinzufügen".

**Der Vorschlag hakt nichts an, und das ist der Kern.** Vorgehakte, nicht gespeicherte Chips wären eine Auswahl, die niemand getroffen hat — und die Karte teilt ein Formular mit „Beiträge in anderen Sprachen": ein Mitglied, das dort nur „Ausblenden" einstellt und speichert, hätte den Vorschlag mitgeschickt und danach einen Feed, der jede andere Sprache verbirgt, ohne Hinweis und nur über den Zurücksetzen-Link umkehrbar. Vorgeschlagen wird deshalb nur die **Sichtbarkeit** der Chips. Angehakt ist, was gespeichert ist — gelesen aus dem Changeset, damit ein fehlgeschlagenes Speichern die gerade getroffene Wahl behält (vorher las das Template die gespeicherte Zeile).

**Der Chip** ist eine gewöhnliche Checkbox mit `sr-only`-Kästchen (dasselbe Muster wie der Anzeigenkalender): kein JavaScript, Tab-Reihenfolge und Beschriftung bleiben, der Zustand kommt nativ. Fokusring deckend statt der 40-Prozent-Fassung der Textfelder — dort wandert zusätzlich der Rahmen, hier ist das Bedienelement unsichtbar, der Ring also der ganze Hinweis (WCAG 2.4.11). Das ✓ trägt den Zustand ein zweites Mal, damit er nicht allein an der Farbe hängt. 40px Ziele, `list-none` + der WebKit-Marker-Reset am `<summary>`, sonst zeigt iOS Safari sein eigenes Dreieck neben dem Link.

**Aus dem Prüf-Pass** außerdem: die Kartenlogik sitzt als Komponente in `SettingsHTML` statt als zwei Controller-Assigns plus eigener `error_assigns`-Klausel (die Assign-Liste einer Seite an zwei Stellen zu pflegen ist die Falle, die den Fehlerpfad überhaupt erst brach), `LazyHTML` im Test statt selbstgebauter HTML-Zerlegung, und `cast_language/1` liegt jetzt auch auf der Oberflächensprache — eine Installation mit `pt-BR` hätte sonst einen Code vorgeschlagen, für den es keinen Chip gibt, und die Karte wäre leer aufgegangen.

**Gettext-Falle dokumentiert:** `--merge` hat „Add another language" fuzzy als „Weiteren Tag hinzufügen" gefüllt. Alle drei neuen Texte sind von Hand geschrieben, das Flag ist weg, und der Test prüft die deutschen Sätze namentlich.

Closes #1537

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*
