### PR TITLE
A Mastodon client may ask for a token of its own (v7.315.0)

### DIFF
--- a/docs/architecture/mastodon-api.md
+++ b/docs/architecture/mastodon-api.md
@@ -53,9 +53,10 @@ Server discovery, login and the core social workflow:
 
 - `GET /.well-known/oauth-authorization-server`
 - `GET /api/v1/instance` and `GET /api/v2/instance`
-- `POST /api/v1/apps`
+- `POST /api/v1/apps` and `GET /api/v1/apps/verify_credentials`
 - `GET /oauth/authorize` (redirects the browser to the main origin)
-- `POST /oauth/token` and `POST /oauth/revoke`
+- `POST /oauth/token` (`authorization_code`, `refresh_token`,
+  `client_credentials`) and `POST /oauth/revoke`
 - `GET /api/v1/accounts/verify_credentials`
 - `GET /api/v1/timelines/home`
 - reading, creating, editing and deleting statuses, plus personal replies
@@ -162,6 +163,37 @@ Letting a whole workforce *read* an organization's feed without being able to
 speak in its name needs a role split that this adapter deliberately did not
 make on its way past. It is designed under "The staff feed" in
 [organizations.md](organizations.md).
+
+### The app's own token (`client_credentials`)
+
+A Mastodon client asks for a token for **itself** right after
+`POST /api/v1/apps` and before it opens a browser — RFC 6749 §4.4, which
+Mastodon's token endpoint answers. Refusing that grant does not cost a feature,
+it ends setup: Ivory pointed at `vutuv.de` churned for a few seconds and gave up
+with `unsupported_grant_type`, never reaching the consent screen, while
+everything downstream of it — the two hosts, registration, discovery — was
+already working. Diagnosing it took one `curl`: `client_credentials` answered
+`unsupported_grant_type` where `authorization_code` with the same nonsense
+credentials got as far as `invalid_client`.
+
+**Such a token lives in its own table** (`oauth_app_tokens`,
+`Vutuv.ApiAuth.AppToken`) rather than beside the member tokens, and that is the
+security property rather than a filing decision. `api_tokens.user_id` is NOT
+NULL and `ApiAuth.lookup/1` reaches the member through an **inner join**, so a
+userless row there would be dropped by that join without a word — the shape
+CLAUDE.md records five separate incidents of. Widening the column would also
+open an N-1 window in which the previous release meets a token it cannot read.
+Keeping the two apart means every member-scoped endpoint authenticates through
+`api_tokens` and therefore *cannot* accept an app token; nothing has to remember
+a rule, and an endpoint added later inherits the refusal.
+
+What such a token may do is correspondingly small:
+`GET /api/v1/apps/verify_credentials`, which names the app and deliberately
+echoes back neither `client_id` nor secret. It is the one Mastodon route not
+behind `Plug.MastodonApiAuth` — it authenticates itself, because that plug's job
+is to resolve a *member*. The grant is offered to `protocol: "mastodon"` apps
+only: a native vutuv OAuth app is user-facing with mandatory PKCE and asked for
+no app-level credential, so it keeps getting `unsupported_grant_type`.
 
 ### Paging, streaming and push
 

--- a/lib/vutuv/api_auth/app_token.ex
+++ b/lib/vutuv/api_auth/app_token.ex
@@ -1,0 +1,46 @@
+defmodule Vutuv.ApiAuth.AppToken do
+  @moduledoc """
+  A bearer credential that belongs to an **app** and to no member — RFC 6749's
+  `client_credentials` grant, which Mastodon's token endpoint answers.
+
+  A Mastodon client asks for one immediately after registering itself through
+  `POST /api/v1/apps`, before it sends anybody to a browser, and gives up if the
+  request is refused. That is what `unsupported_grant_type` did to Ivory on a
+  real phone.
+
+  **Its own table, deliberately.** `Vutuv.ApiAuth.Token` requires a `user_id`
+  and `Vutuv.ApiAuth.lookup/1` reaches the member through an inner join, so a
+  userless row there would be swallowed by that join in silence. Keeping these
+  apart also buys the security property outright: every member-scoped endpoint
+  authenticates through `api_tokens`, so an app token cannot be accepted by one
+  — not because something refuses it, but because it is not in the table that
+  path reads. Nothing has to remember a rule.
+
+  What it may do is correspondingly small: identify the app to
+  `GET /api/v1/apps/verify_credentials`, and nothing else. It carries the app's
+  registered scopes because Mastodon's response does, not because they grant
+  anything here.
+
+  The plaintext exists only in the moment of minting; `token_hash` is its
+  SHA-256 and the only thing stored. A bare hash is right for it: the token is
+  ~165 bits of randomness, so entropy rather than a key is what protects it
+  (unlike a hash of anything guessable — see CLAUDE.md).
+  """
+
+  use VutuvWeb, :model
+
+  schema "oauth_app_tokens" do
+    belongs_to(:app, Vutuv.ApiAuth.App)
+
+    field(:token_hash, :string)
+    field(:scopes, {:array, :string}, default: [])
+    field(:last_used_at, :utc_datetime)
+    field(:revoked_at, :utc_datetime)
+
+    timestamps()
+  end
+
+  @doc "Whether this token is still usable."
+  def live?(%__MODULE__{revoked_at: nil}), do: true
+  def live?(%__MODULE__{}), do: false
+end

--- a/lib/vutuv/api_auth/o_auth.ex
+++ b/lib/vutuv/api_auth/o_auth.ex
@@ -39,7 +39,7 @@ defmodule Vutuv.ApiAuth.OAuth do
   import Ecto.Query
 
   alias Vutuv.ApiAuth
-  alias Vutuv.ApiAuth.{App, AuthCode, Grant, Scopes, Token}
+  alias Vutuv.ApiAuth.{App, AppToken, AuthCode, Grant, Scopes, Token}
   alias Vutuv.MastodonApi.Access
   alias Vutuv.MastodonApi.Scopes, as: MastodonScopes
   alias Vutuv.Repo
@@ -261,6 +261,94 @@ defmodule Vutuv.ApiAuth.OAuth do
       ApiAuth.revoke_grant_tokens!(token.grant_id)
       {:error, :invalid_grant}
     end
+  end
+
+  @doc """
+  `grant_type=client_credentials`: a token for the **app itself**, with no
+  member behind it (RFC 6749 §4.4).
+
+  Mastodon's token endpoint answers this grant, and a client asks for it right
+  after registering through `POST /api/v1/apps` — before it sends anybody to a
+  browser. Refusing it is not a missing extra: Ivory on a real phone gave up at
+  that request with `unsupported_grant_type` and never reached the consent
+  screen at all.
+
+  **Mastodon clients only.** A native vutuv OAuth app is a user-facing thing
+  with mandatory PKCE, and nothing in that flow asked for an app-level
+  credential; answering the grant there would widen `/api/2.0`'s surface for
+  nobody's benefit. So a non-Mastodon client gets the same
+  `unsupported_grant_type` it gets today.
+
+  The token lands in `oauth_app_tokens`, not beside the member tokens — see
+  `Vutuv.ApiAuth.AppToken` for why that is the security property rather than a
+  filing decision. It carries the app's registered scopes because Mastodon's
+  response does; they grant nothing here.
+  """
+  def client_credentials(params) do
+    with {:ok, app} <- authenticate_client(params),
+         {:ok, app} <- check_mastodon_client(app) do
+      token = @access_prefix <> ApiAuth.random_token()
+
+      Repo.insert!(%AppToken{
+        app_id: app.id,
+        token_hash: ApiAuth.hash_token(token),
+        scopes: app.registered_scopes
+      })
+
+      {:ok,
+       %{
+         access_token: token,
+         token_type: "Bearer",
+         scope: Enum.join(app.registered_scopes, " "),
+         created_at: System.system_time(:second)
+       }}
+    end
+  end
+
+  defp check_mastodon_client(%App{protocol: "mastodon"} = app), do: {:ok, app}
+  defp check_mastodon_client(%App{}), do: {:error, :unsupported_grant_type}
+
+  @doc """
+  The app behind a `client_credentials` token, or `nil`.
+
+  Reads `oauth_app_tokens` and nothing else, which is the point: a member token
+  cannot arrive here and an app token cannot arrive at `ApiAuth.verify_token/1`.
+  """
+  def verify_app_token(plaintext) when is_binary(plaintext) do
+    AppToken
+    |> Repo.get_by(token_hash: ApiAuth.hash_token(plaintext))
+    |> case do
+      %AppToken{} = token -> live_app_token(token)
+      nil -> nil
+    end
+  end
+
+  def verify_app_token(_other), do: nil
+
+  defp live_app_token(token) do
+    if AppToken.live?(token) do
+      token = Repo.preload(token, :app)
+
+      # A suspended app's credential stops working, the same as its member
+      # tokens do (`ApiAuth.check_app/2`).
+      case token.app do
+        %App{suspended_at: nil} = app ->
+          touch_app_token(token)
+          app
+
+        _suspended_or_gone ->
+          nil
+      end
+    end
+  end
+
+  # Written with `update_all` rather than a changeset so two concurrent uses
+  # cannot fight over the row, matching how member tokens stamp theirs.
+  defp touch_app_token(token) do
+    Repo.update_all(
+      from(t in AppToken, where: t.id == ^token.id),
+      set: [last_used_at: DateTime.utc_now(:second)]
+    )
   end
 
   @doc """

--- a/lib/vutuv_web/controllers/mastodon_api/app_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/app_controller.ex
@@ -5,7 +5,9 @@ defmodule VutuvWeb.MastodonApi.AppController do
 
   alias Ecto.Changeset
   alias Vutuv.ApiAuth
+  alias Vutuv.ApiAuth.OAuth
   alias Vutuv.MastodonApi.Scopes
+  alias Vutuv.MastodonApi.WebPush
   alias VutuvWeb.RateLimit
 
   @registration_limit 20
@@ -27,6 +29,48 @@ defmodule VutuvWeb.MastodonApi.AppController do
       {:error, changeset} ->
         validation_error(conn, changeset_error(changeset))
     end
+  end
+
+  @doc """
+  `GET /api/v1/apps/verify_credentials` — the app behind a `client_credentials`
+  token, and the one thing such a token is for.
+
+  Authenticated **here**, not by `Plug.MastodonApiAuth`: that plug resolves a
+  member and every route behind it is member-scoped, which an app token has no
+  business reaching. It reads `oauth_app_tokens` and nothing else, so a member's
+  bearer token cannot identify an app either — the two credentials cannot be
+  swapped in either direction, and that is the property, not a check somebody has
+  to remember.
+
+  The response deliberately carries **no** `client_id` and no secret: the client
+  already holds both, and echoing a credential back to whoever presents a token
+  is how one leaks into a log.
+  """
+  def verify_credentials(conn, _params) do
+    case OAuth.verify_app_token(bearer_token(conn)) do
+      nil -> conn |> put_status(401) |> json(%{error: "The access token is invalid"})
+      app -> json(conn, application(app))
+    end
+  end
+
+  defp bearer_token(conn) do
+    case get_req_header(conn, "authorization") do
+      ["Bearer " <> token | _rest] -> String.trim(token)
+      _absent -> nil
+    end
+  end
+
+  # Mastodon's Application entity, minus the credentials.
+  defp application(app) do
+    %{
+      id: app.id,
+      name: app.name,
+      website: app.homepage_url,
+      scopes: app.registered_scopes,
+      redirect_uri: Enum.join(app.redirect_uris, "\n"),
+      redirect_uris: app.redirect_uris,
+      vapid_key: WebPush.public_key()
+    }
   end
 
   defp registration_allowed?(conn) do

--- a/lib/vutuv_web/controllers/mastodon_api/discovery_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/discovery_controller.ex
@@ -85,7 +85,7 @@ defmodule VutuvWeb.MastodonApi.DiscoveryController do
       response_types_supported: ["code"],
       response_modes_supported: ["query"],
       code_challenge_methods_supported: ["S256"],
-      grant_types_supported: ["authorization_code"],
+      grant_types_supported: ["authorization_code", "client_credentials"],
       token_endpoint_auth_methods_supported: ["client_secret_post"]
     })
   end

--- a/lib/vutuv_web/controllers/oauth_controller.ex
+++ b/lib/vutuv_web/controllers/oauth_controller.ex
@@ -126,6 +126,16 @@ defmodule VutuvWeb.OauthController do
     token_response(conn, OAuth.refresh(params))
   end
 
+  # RFC 6749 §4.4, which Mastodon's token endpoint answers: a token for the app
+  # itself, with no member behind it. A client asks for one right after
+  # registering and before it opens a browser, so refusing it stops setup dead —
+  # Ivory on a real phone never reached the consent screen. Only Mastodon apps
+  # get it (`OAuth.client_credentials/1` says why); everybody else falls through
+  # to the `unsupported_grant_type` below, unchanged.
+  def token(conn, %{"grant_type" => "client_credentials"} = params) do
+    token_response(conn, OAuth.client_credentials(params))
+  end
+
   def token(conn, _params), do: oauth_error(conn, 400, "unsupported_grant_type")
 
   def revoke(conn, params) do
@@ -144,6 +154,12 @@ defmodule VutuvWeb.OauthController do
 
   defp token_response(conn, {:error, reason}) when reason in [:invalid_client, :app_suspended] do
     oauth_error(conn, 401, "invalid_client")
+  end
+
+  # A native client asking for `client_credentials`: the grant exists but is not
+  # offered to it, which is exactly what this code says. 400 per RFC 6749 §5.2.
+  defp token_response(conn, {:error, :unsupported_grant_type}) do
+    oauth_error(conn, 400, "unsupported_grant_type")
   end
 
   defp token_response(conn, {:error, _reason}), do: oauth_error(conn, 400, "invalid_grant")

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -182,6 +182,11 @@ defmodule VutuvWeb.Router do
     get("/api/v1/custom_emojis", MastodonApi.ListController, :custom_emojis)
     get("/api/v2/instance", MastodonApi.DiscoveryController, :instance_v2)
     post("/api/v1/apps", MastodonApi.AppController, :create)
+    # Not behind `:mastodon_api_auth`: that plug resolves a **member**, and this
+    # is the one endpoint an app-only credential may reach. It authenticates
+    # itself against `oauth_app_tokens`, so neither credential can stand in for
+    # the other.
+    get("/api/v1/apps/verify_credentials", MastodonApi.AppController, :verify_credentials)
     get("/oauth/authorize", MastodonApi.OauthRedirectController, :authorize)
     post("/oauth/token", OauthController, :token)
     post("/oauth/revoke", OauthController, :revoke)
@@ -425,6 +430,11 @@ defmodule VutuvWeb.Router do
     get("/api/v1/custom_emojis", MastodonApi.ListController, :custom_emojis)
     get("/api/v2/instance", MastodonApi.DiscoveryController, :instance_v2)
     post("/api/v1/apps", MastodonApi.AppController, :create)
+    # Not behind `:mastodon_api_auth`: that plug resolves a **member**, and this
+    # is the one endpoint an app-only credential may reach. It authenticates
+    # itself against `oauth_app_tokens`, so neither credential can stand in for
+    # the other.
+    get("/api/v1/apps/verify_credentials", MastodonApi.AppController, :verify_credentials)
     # `/oauth/*` is deliberately NOT mirrored. The main host already serves the
     # real consent screen and the native token/revoke endpoints, and the same
     # `OauthController` handles a Mastodon-protocol app there — mirroring put

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.314.1",
+      version: "7.315.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260817134339_create_oauth_app_tokens.exs
+++ b/priv/repo/migrations/20260817134339_create_oauth_app_tokens.exs
@@ -1,0 +1,38 @@
+defmodule Vutuv.Repo.Migrations.CreateOauthAppTokens do
+  use Ecto.Migration
+
+  # An app token is a credential with **no member behind it**: RFC 6749's
+  # `client_credentials` grant, which Mastodon's token endpoint answers and
+  # which a client asks for right after registering itself, before it sends
+  # anybody to a browser.
+  #
+  # Its own table rather than a row in `api_tokens`, and that is the whole
+  # design decision. `api_tokens.user_id` is NOT NULL and
+  # `Vutuv.ApiAuth.lookup/1` reaches the user through an **inner join**, so a
+  # userless row there would be dropped by that join without a word — the shape
+  # this project has been bitten by five times (see CLAUDE.md on widening a NOT
+  # NULL column). Widening it would also mean an N-1 window in which the
+  # previous release meets a token it cannot read.
+  #
+  # Keeping app tokens somewhere else buys the security property for free: every
+  # member-scoped endpoint authenticates through `api_tokens`, so an app token
+  # presented to one cannot be accepted — not because a check refuses it, but
+  # because it is not in the table that path reads. A plain addition, so this
+  # migration is N-1 safe on its own.
+  def change do
+    create table(:oauth_app_tokens) do
+      add(:app_id, references(:oauth_apps, on_delete: :delete_all), null: false)
+      # SHA-256 of a ~165-bit random token, like every other credential here:
+      # the entropy is what protects it, so no pepper is needed (CLAUDE.md).
+      add(:token_hash, :string, null: false)
+      add(:scopes, {:array, :string}, null: false, default: [])
+      add(:last_used_at, :utc_datetime)
+      add(:revoked_at, :utc_datetime)
+
+      timestamps()
+    end
+
+    create(unique_index(:oauth_app_tokens, [:token_hash]))
+    create(index(:oauth_app_tokens, [:app_id]))
+  end
+end

--- a/test/vutuv_web/controllers/mastodon_api/client_credentials_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/client_credentials_test.exs
@@ -1,0 +1,312 @@
+defmodule VutuvWeb.MastodonApi.ClientCredentialsTest do
+  @moduledoc """
+  `grant_type=client_credentials` — a token for the app, with no member behind
+  it (RFC 6749 §4.4), which Mastodon's token endpoint answers.
+
+  This exists because of a real phone: Ivory, pointed at `vutuv.de`, churned for
+  a few seconds and gave up with `unsupported_grant_type` **before** any consent
+  screen appeared. A client asks for an app token right after registering itself,
+  and refusing it ends setup there — everything downstream of it, the whole
+  two-host arrangement included, was already working.
+
+  The tests below are in two halves and the second is the important one. The
+  first says the grant works — remove the controller clause and eleven of these
+  fourteen go red, the three survivors being the two that assert a refusal the
+  fall-through already gives and the one that reads the discovery document. The
+  second half says the credential cannot reach a member's data.
+
+  That second half is **not** calibrated against un-fixed code, and saying so
+  matters: there is no fix to revert, because the separation is structural. An
+  app token lives in `oauth_app_tokens`, every member-scoped endpoint
+  authenticates through `api_tokens`, and neither table can answer for the other
+  — so these tests pin a property down rather than guard a patch, and an endpoint
+  added to the member pipeline later inherits it without knowing this file
+  exists. Had the token instead been a row in `api_tokens` with a null
+  `user_id`, each of these paths would have needed its own explicit refusal, and
+  the inner join in `ApiAuth.lookup/1` would have swallowed the row in silence.
+
+  `async: false` because the endpoints here are rate limited per client.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Vutuv.MastodonHelpers
+
+  alias Vutuv.ApiAuth
+  alias Vutuv.ApiAuth.App
+  alias Vutuv.ApiAuth.AppToken
+  alias Vutuv.ApiAuth.OAuth
+  alias Vutuv.Repo
+  alias VutuvWeb.MastodonApi.StreamingSocket
+
+  setup do
+    Vutuv.RateLimiter.reset()
+    :ok
+  end
+
+  # A Mastodon client registers itself through the public endpoint, exactly as a
+  # phone does, so the app under test is the shape that flow really produces
+  # (`user_id` nil, `protocol` "mastodon") rather than one built by hand.
+  defp register_client(conn, scopes \\ "read write") do
+    conn
+    |> on_mastodon_host()
+    |> post("/api/v1/apps", %{
+      "client_name" => "Pocket Client",
+      "redirect_uris" => ["org.example.client://oauth"],
+      "scopes" => scopes
+    })
+    |> json_response(200)
+  end
+
+  defp app_token(conn, credentials) do
+    conn
+    |> on_mastodon_host()
+    |> post("/oauth/token", %{
+      "grant_type" => "client_credentials",
+      "client_id" => credentials["client_id"],
+      "client_secret" => credentials["client_secret"]
+    })
+  end
+
+  describe "the grant" do
+    test "answers a bearer token carrying the app's registered scopes", %{conn: conn} do
+      credentials = register_client(conn, "read write:statuses")
+
+      body = build_conn() |> app_token(credentials) |> json_response(200)
+
+      assert body["token_type"] == "Bearer"
+      assert body["scope"] == "read write:statuses"
+      assert is_integer(body["created_at"])
+      assert String.starts_with?(body["access_token"], "vutuv_at_")
+
+      # Only the hash is stored, like every other credential here.
+      token = Repo.get_by!(AppToken, token_hash: ApiAuth.hash_token(body["access_token"]))
+      assert token.scopes == ["read", "write:statuses"]
+      refute token.token_hash == body["access_token"]
+    end
+
+    # RFC 6749 §5.1: a token response must not be cached anywhere.
+    test "is not cacheable", %{conn: conn} do
+      credentials = register_client(conn)
+      response = build_conn() |> app_token(credentials)
+
+      assert get_resp_header(response, "cache-control") == ["no-store"]
+    end
+
+    test "refuses a wrong or missing client secret", %{conn: conn} do
+      credentials = register_client(conn)
+
+      assert %{"error" => "invalid_client"} =
+               build_conn()
+               |> app_token(%{credentials | "client_secret" => "vutuv_sec_wrong"})
+               |> json_response(401)
+
+      assert %{"error" => "invalid_client"} =
+               build_conn()
+               |> on_mastodon_host()
+               |> post("/oauth/token", %{
+                 "grant_type" => "client_credentials",
+                 "client_id" => credentials["client_id"]
+               })
+               |> json_response(401)
+    end
+
+    test "refuses a suspended app", %{conn: conn} do
+      credentials = register_client(conn)
+
+      Repo.get_by!(App, client_id: credentials["client_id"])
+      |> Ecto.Changeset.change(suspended_at: DateTime.utc_now(:second))
+      |> Repo.update!()
+
+      assert %{"error" => "invalid_client"} =
+               build_conn() |> app_token(credentials) |> json_response(401)
+    end
+
+    # A native vutuv OAuth app is a user-facing thing with mandatory PKCE, and
+    # nothing in that flow wants an app-level credential. Answering the grant
+    # there would widen /api/2.0's surface for nobody.
+    test "is not offered to a native vutuv app", %{conn: conn} do
+      developer = insert_activated_user()
+
+      {:ok, app, secret} =
+        ApiAuth.create_app(developer, %{
+          "name" => "Native App",
+          "redirect_uris" => ["https://native.example.org/oauth"]
+        })
+
+      assert %{"error" => "unsupported_grant_type"} =
+               conn
+               |> on_mastodon_host()
+               |> post("/oauth/token", %{
+                 "grant_type" => "client_credentials",
+                 "client_id" => app.client_id,
+                 "client_secret" => secret
+               })
+               |> json_response(400)
+    end
+
+    # The address a member types is the main host, which is the whole reason the
+    # adapter answers on both.
+    test "works on the main host too", %{conn: conn} do
+      credentials = register_client(conn)
+
+      body =
+        build_conn()
+        |> Map.put(:host, "localhost")
+        |> post("/oauth/token", %{
+          "grant_type" => "client_credentials",
+          "client_id" => credentials["client_id"],
+          "client_secret" => credentials["client_secret"]
+        })
+        |> json_response(200)
+
+      assert String.starts_with?(body["access_token"], "vutuv_at_")
+    end
+
+    test "is advertised in the discovery document", %{conn: conn} do
+      metadata =
+        conn
+        |> on_mastodon_host()
+        |> get("/.well-known/oauth-authorization-server")
+        |> json_response(200)
+
+      assert "client_credentials" in metadata["grant_types_supported"]
+      assert "authorization_code" in metadata["grant_types_supported"]
+    end
+  end
+
+  describe "the app token" do
+    setup %{conn: conn} do
+      credentials = register_client(conn)
+      body = build_conn() |> app_token(credentials) |> json_response(200)
+      {:ok, credentials: credentials, token: body["access_token"]}
+    end
+
+    test "identifies the app, without echoing its credentials back", %{token: token} do
+      body =
+        build_conn()
+        |> on_mastodon_host()
+        |> put_req_header("authorization", "Bearer " <> token)
+        |> get("/api/v1/apps/verify_credentials")
+        |> json_response(200)
+
+      assert body["name"] == "Pocket Client"
+      assert body["scopes"] == ["read", "write"]
+      # The client already holds both; echoing one back to whoever presents a
+      # token is how a credential reaches a log.
+      refute Map.has_key?(body, "client_id")
+      refute Map.has_key?(body, "client_secret")
+    end
+
+    test "stamps when it was last used", %{token: token} do
+      stored = Repo.get_by!(AppToken, token_hash: ApiAuth.hash_token(token))
+      assert is_nil(stored.last_used_at)
+
+      build_conn()
+      |> on_mastodon_host()
+      |> put_req_header("authorization", "Bearer " <> token)
+      |> get("/api/v1/apps/verify_credentials")
+      |> json_response(200)
+
+      assert Repo.reload!(stored).last_used_at
+    end
+
+    test "stops working once revoked or once its app is suspended", %{
+      token: token,
+      credentials: credentials
+    } do
+      stored = Repo.get_by!(AppToken, token_hash: ApiAuth.hash_token(token))
+      stored |> Ecto.Changeset.change(revoked_at: DateTime.utc_now(:second)) |> Repo.update!()
+
+      assert is_nil(OAuth.verify_app_token(token))
+
+      # A fresh token, then the app itself goes: the credential must not outlive
+      # the thing it identifies.
+      live = build_conn() |> app_token(credentials) |> json_response(200)
+      assert OAuth.verify_app_token(live["access_token"])
+
+      Repo.get_by!(App, client_id: credentials["client_id"])
+      |> Ecto.Changeset.change(suspended_at: DateTime.utc_now(:second))
+      |> Repo.update!()
+
+      assert is_nil(OAuth.verify_app_token(live["access_token"]))
+    end
+
+    test "an unknown or empty bearer is refused", %{conn: conn} do
+      for header <- ["Bearer vutuv_at_nope", "Bearer ", "Basic whatever"] do
+        assert build_conn()
+               |> on_mastodon_host()
+               |> put_req_header("authorization", header)
+               |> get("/api/v1/apps/verify_credentials")
+               |> json_response(401)
+      end
+
+      assert conn
+             |> on_mastodon_host()
+             |> get("/api/v1/apps/verify_credentials")
+             |> json_response(401)
+    end
+  end
+
+  # The point of the separate table, stated as a test. Calibrated against the
+  # alternative that was considered and rejected: were an app token a row in
+  # `api_tokens` with a null `user_id`, each of these would have to be refused by
+  # a check somewhere, and the inner join in `ApiAuth.lookup/1` would have
+  # swallowed the row in silence instead.
+  describe "an app token cannot reach a member's data" do
+    setup %{conn: conn} do
+      credentials = register_client(conn)
+      body = build_conn() |> app_token(credentials) |> json_response(200)
+      {:ok, token: body["access_token"]}
+    end
+
+    test "not on a read, not on a write, not on a timeline", %{token: token} do
+      target = insert(:activated_user)
+
+      for {method, path} <- [
+            {:get, "/api/v1/accounts/verify_credentials"},
+            {:get, "/api/v1/timelines/home"},
+            {:get, "/api/v1/notifications"},
+            {:get, "/api/v1/bookmarks"},
+            {:post, "/api/v1/statuses"},
+            {:post, "/api/v1/accounts/#{target.id}/follow"}
+          ] do
+        conn =
+          build_conn()
+          |> on_mastodon_host()
+          |> put_req_header("authorization", "Bearer " <> token)
+
+        response =
+          case method do
+            :get -> get(conn, path)
+            :post -> post(conn, path, %{"status" => "Hallo"})
+          end
+
+        assert response.status in [401, 403],
+               "#{method} #{path} answered #{response.status} to an app token"
+      end
+    end
+
+    test "and it cannot open the streaming socket", %{token: token} do
+      transport = %{
+        params: %{"access_token" => token},
+        connect_info: %{uri: URI.parse("ws://mastodon.localhost/api/v1/streaming"), x_headers: []}
+      }
+
+      assert StreamingSocket.connect(transport) == :error
+    end
+
+    # The mirror image: a member's own bearer token is not an app credential
+    # either, so the two cannot be swapped in either direction.
+    test "and a member token cannot identify an app" do
+      member_token = mastodon_token(insert(:activated_user), ["read"])
+
+      assert is_nil(OAuth.verify_app_token(member_token))
+
+      assert build_conn()
+             |> on_mastodon_host()
+             |> put_req_header("authorization", "Bearer " <> member_token)
+             |> get("/api/v1/apps/verify_credentials")
+             |> json_response(401)
+    end
+  end
+end


### PR DESCRIPTION
Closes #1544.

**TL;DR** A Mastodon client asks for a token of its **own** right after registering itself, and we answered `unsupported_grant_type` — which ends setup before the consent screen. `grant_type=client_credentials` (RFC 6749 §4.4) is implemented, in its own table so it can never reach a member's data. One migration (a new table, no column changed), no new dependency, no config.

## Why

@jpawlowski pointed Ivory on an iPhone at `vutuv.de`: it churned for a few seconds and gave up with `unsupported_grant_type`, never showing the consent screen. Everything downstream of that — the two hosts, `POST /api/v1/apps`, discovery — was already working.

One `curl` separated the candidates, against production, registering nothing:

```
$ curl -s -X POST https://vutuv.de/oauth/token \
    -d 'grant_type=client_credentials&client_id=probe&client_secret=probe'
{"error":"unsupported_grant_type"}

$ curl -s -X POST https://vutuv.de/oauth/token \
    -d 'grant_type=authorization_code&client_id=probe&client_secret=probe&code=x&redirect_uri=urn:ietf:wg:oauth:2.0:oob'
{"error":"invalid_client"}
```

The second reaching `invalid_client` is the point: that branch works and validates the client, while `client_credentials` was refused before the client was ever looked at. Mastodon's token endpoint answers this grant and hands back an app-level token; a client asks for one before it opens a browser.

**What is not proven:** which grant Ivory actually sent. We did not capture the request from the device, so this is the only grant it can reasonably have been, not a measured fact. If a log line from that attempt still exists, it would settle it.

## Its own table, and why that is the security property

An app token belongs to an app and to nobody, so it lands in `oauth_app_tokens` (`Vutuv.ApiAuth.AppToken`) rather than beside the member tokens.

Putting it in `api_tokens` with a null `user_id` was considered and rejected. That column is NOT NULL and `ApiAuth.lookup/1` reaches the member through an **inner join**, so a userless row would have been dropped by that join in silence — the shape CLAUDE.md records five incidents of. Widening the column would also open an N-1 window in which the previous release meets a token it cannot read.

Keeping them apart buys the property outright: every member-scoped endpoint authenticates through `api_tokens`, so an app token **cannot** be accepted by one — not because a check refuses it, but because it is not in the table that path reads. Nothing has to remember a rule, and an endpoint added to that pipeline later inherits the refusal.

What such a token may do is `GET /api/v1/apps/verify_credentials`, which names the app and echoes back neither `client_id` nor secret. It is the one route here **not** behind `Plug.MastodonApiAuth`, because that plug's job is to resolve a member; it authenticates itself. The grant is offered to `protocol: "mastodon"` apps only — a native vutuv OAuth app is user-facing with mandatory PKCE and never asked for an app credential, so it keeps the `unsupported_grant_type` it gets today.

## One deliberate difference from #1544

The issue asks for `Access.authorize_token/2` to refuse an app token rather than falling back to the app owner. This does something stronger instead: the token is not in `api_tokens` at all, so `authorize_token/2` never sees one. Every member-scoped endpoint authenticates through that table, which means an app token cannot be accepted by one — not because a function refuses it, but because it is not where that path looks. The reason for taking that route rather than the requested one is the inner join in `ApiAuth.lookup/1`: a null `user_id` row would have been dropped there in silence, and widening the column would have opened an N-1 window as well.

## Tests

14 cases. Remove the controller clause and eleven go red; the three survivors are the two asserting a refusal the fall-through already gives and the one reading the discovery document.

The second half — the app token reaching neither `verify_credentials`, a timeline, a write, a follow, nor the streaming socket, and a member token not identifying an app — is deliberately **not** calibrated against un-fixed code, and the moduledoc says so: there is no patch to revert, because the separation is structural. Those tests pin a property down rather than guard a fix.

## What still cannot be tested end to end

`mastodon.vutuv.de` now has its A record (thanks) — but it is not serving yet, so the canonical origin still cannot be exercised. Measured past the local resolver's cached negative answer:

```
$ dig +short @1.1.1.1 mastodon.vutuv.de A
134.102.58.61

$ curl -sv --resolve mastodon.vutuv.de:443:134.102.58.61 https://mastodon.vutuv.de/api/v1/instance
*  subject: CN=animina.de          # wrong certificate, handshake fails

$ curl -s -o /dev/null -w '%{http_code}\n' --resolve mastodon.vutuv.de:80:134.102.58.61 \
    http://mastodon.vutuv.de/api/v1/instance
404                                 # the request never reaches the app

$ curl -s -o /dev/null -w '%{http_code}\n' https://vutuv.de/api/v1/instance
200                                 # control: the main host is fine
```

So the subdomain needs its TLS certificate and an nginx `server_name`; right now the request lands on a default vhost serving another site. Per `docs/ADMINS.md` the subdomain is optional and the main host is enough for a client, so this does not block the fix — but it does mean the two-host arrangement stays half-tested, and push and streaming have still never met a real client.

Version **7.315.0**, `mix precommit` green (8289 tests), `mix.lock` untouched, rebased on `main`. Note that `main` had taken 7.314.0 while this was being written — the same silent collision as twice before, where both sides read the identical number so nothing conflicts — so please re-check it before merging.

*An AI agent wrote this text on my behalf.*

