### PR TITLE
Ein Beitrag einer Seite lässt sich beantworten (v7.294.0)

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -103,22 +103,45 @@ every activity of a member it finds no key for, silently.
   dedupes one row per distinct remote inbox. It is the same code: the same
   installation switch, the same blocklist checked first, the same per-IP limit,
   the same signature and anti-spoofing verification, and then the very same
-  per-member handling. The per-member inbox keeps working forever; it is what
-  every server already knows.
+  per-recipient handling. The per-actor inboxes keep working forever; they are
+  what every server already knows.
 
-  The only thing that differs is where the addressees come from —
+  **All three kinds of actor are recipients here** — a member, a page (#1334) and
+  a topic (#1330) — because all three *advertise* this endpoint: the shared inbox
+  is a fact about the installation, so every actor document carries it, and
+  Mastodon (like most implementations) then prefers it over the actor's own inbox
+  for everything it delivers. So the per-actor inboxes are largely spare doors,
+  and while this resolved members only, **every signed activity for a page or a
+  topic resolved to nobody and was dropped with a 202**: a `Follow` of a page, a
+  favourite of its post, and — as reported — an *answer* to its post, which
+  simply never appeared here. `VutuvWeb.FediverseController.perform_for_recipient/3`
+  dispatches to the per-kind handler the matching per-actor inbox already runs,
+  and `signer/1` signs the actor fetch with that actor's own key, which an
+  authorized-fetch server requires.
+
+  The only other thing that differs is where the addressees come from —
   `Vutuv.Fediverse.inbox_recipients/2` reads them out of the activity instead of
   the URL, from three places: the **addressing** (`to`/`cc`/`bto`/`bcc`/
   `audience` on the activity and its object, plus the object itself and, for an
   `Undo`, the object it wraps — a `Follow` names an actor URL, a `Like` a Note
-  URL, a reply its `inReplyTo`, each of which hangs off the member it belongs
-  to); the **remote actor's own `Update`/`Delete`**, which names no local member
-  at all and is therefore fanned out to exactly the members that actor follows
-  here (this is the case worth having the endpoint for — one account deletion
-  used to be one signed delivery per member); and an author's `Update`/`Delete`
-  **of a note they wrote**, fanned out to the members whose posts hold a copy.
-  Addressee URIs are attacker-chosen text, so the list is cut at 25; the two
-  lifecycle fan-outs are bounded by rows we wrote ourselves and are not.
+  URL, a reply its `inReplyTo`, each of which hangs off the member, page or topic
+  it belongs to; a topic's URL is asked separately, because it lives on the tag
+  host and `local_path/1` would read `https://tags.<host>/hund` as the member
+  `hund`); the **remote actor's own `Update`/`Delete`**, which names no local
+  member at all and is therefore fanned out to exactly the members that actor
+  follows here (this is the case worth having the endpoint for — one account
+  deletion used to be one signed delivery per member); and an author's
+  `Update`/`Delete` **of a note they wrote**, fanned out to the members whose
+  posts hold a copy. Addressee URIs are attacker-chosen text, so the list is cut
+  at 25; the two lifecycle fan-outs are bounded by rows we wrote ourselves and
+  are not.
+
+  **The two lifecycle fan-outs are still member-only, and that is a known gap
+  rather than a decision.** They are about the accounts somebody here follows,
+  and a page can follow since #1336, so a broadcast about an account only a page
+  follows resolves to nobody; the join behind them (`fediverse_followers` inner-
+  joined through `users`) is the other half of that fix. It costs a page's copy of
+  a renamed or deleted remote account, not an answer to one of its posts.
 
   Two deliberate asymmetries. It never answers `404`/`410`: those belong to a
   URL that names one member, where a `410` is how a server learns *that account*
@@ -896,13 +919,25 @@ serves itself — the member endpoint's arrangement one to one. The field is
 the endpoint applies the page's own visibility, so a pending or frozen page
 keeps its picture private like every other byte of it.
 
-**The inbox is deliberately narrower.** A page accepts `Follow` and
-`Undo(Follow)` and acknowledges everything else with the same `202` the member
-inbox gives anything it does not handle. It holds no conversations, answers no
-Follow of its own and does not migrate, so `Like`, `Announce`, `Create(Note)`,
-`Accept`/`Reject` and `Move` would have nothing to act on. Signature
-verification is unchanged — same keyId/actor host pinning, same refusal to
-believe an `actor` field the signature does not cover.
+**What a page's inbox handles.** `Follow` / `Undo(Follow)`, `Like` / `Announce`
+of its posts and their `Undo`, `Accept`/`Reject` answering a Follow the page sent
+(#1336 gave it a following side), and `Create(Note)` answering one of its posts —
+`record_organization_reply/3`, which is the member path minus the pieces that
+have no page: no `fediverse_replies?` switch (a page that publishes outward has
+no comparable reason to want the reach and not the answers), no `restricted?`
+check (a page's post carries no audience by construction) and no per-member
+notification, because the news reaches its team through
+`/organizations/:slug/activity`. `Move` and anything else gets the same `202` the
+member inbox gives what it does not handle. Signature verification is unchanged —
+same keyId/actor host pinning, same refusal to believe an `actor` field the
+signature does not cover.
+
+**But this is rarely the door a delivery uses.** The actor document advertises
+`endpoints.sharedInbox` (it is a fact about the installation), and Mastodon
+prefers it, so in practice the page's activities arrive at `/system/inbox` — which
+resolved members only until the fix described under "Shared inbox" above, and
+therefore dropped every one of them with a 202. Whenever you add a handler here,
+check that the shared inbox reaches it.
 
 **Answering a Follow is not optional politeness.** An unanswered Follow shows on
 Mastodon as pending forever, which is the "pressed Follow and nothing happened"

--- a/docs/architecture/organizations.md
+++ b/docs/architecture/organizations.md
@@ -314,8 +314,8 @@ piece lives:
   **`Vutuv.Posts.author/1` is the one accessor**; reading `post.user` on an
   organization post is the bug to look for. Editing and deleting follow the
   **role, not the person**: any current publisher may, because the post belongs
-  to the page. Organization posts carry no audience and cannot be replied to
-  (both refused outright rather than half-working).
+  to the page. Organization posts carry no audience — there is nobody for a
+  denial to name — and they **are answerable** (see below).
 - **A member switches into it** for a session (#1335). The session carries only
   `acting_as_organization_id`, and it is a **hint, never a credential**:
   `VutuvWeb.Plug.ActingAs` and `Live.InitAssigns.acting_as/2` re-ask
@@ -325,8 +325,23 @@ piece lives:
 - **Members follow it.** `follows.followee_organization_id` (nullable pair +
   CHECK, #1336) — only the followee side; a page following somebody is not built.
   Its posts then reach the follower's feed through `feed_organization_post_items/3`.
+- **Its posts can be answered** — by a member here and by an account on another
+  network (#1336). The gate was refused outright while a page had no reading
+  side; what makes it defensible now is the activity list below, which is where
+  an answer arrives. `post_replies` therefore carries `parent_organization_id`
+  beside `parent_author_id` — the pair is what keeps the answer nameable after
+  the page deletes the post it hangs under, and what the activity list reads —
+  and `broadcast_reply/2` writes **no** notification for a page (no member to
+  address, and a row per publisher would contradict the one shared read marker).
+  Answering stays a member's act: `create_reply/3` takes a `%User{}`, so a page
+  cannot answer anything, its own post included. The post's permalink hosts the
+  conversation through the shared `VutuvWeb.PostLive.Thread`, nested by
+  `live_render` — the same windowed thread, per-card action bars and remote-card
+  takedown controls the member permalink has, rather than a second rendering of
+  one.
 - **It sees what happens to it** at `/organizations/:slug/activity`: new
-  followers, likes and reposts of its posts, and posts naming it by handle.
+  followers, likes and reposts of its posts, posts naming it by handle, and
+  answers to its posts.
   Derived from the source tables, so an unliked post is not "read" — it never
   happened. **One read marker for the whole team** (`activity_read_at`): read
   means somebody read it, never that everybody did, which is why it is a column

--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -71,8 +71,13 @@ section in `organizations.md`.
 Consequences worth knowing:
 
 - Organization posts carry **no audience** (the deny model is built on the
-  author's own follower graph and blocks) and **cannot be replied to**. Both are
-  refused outright rather than silently reaching nobody.
+  author's own follower graph and blocks), so a denial has nobody to name.
+- They **can be answered**, by a member here and from another network (#1336).
+  What used to refuse it was that a reply reaches nobody; the page's activity
+  list is the recipient that made it defensible, so `post_replies` carries
+  `parent_organization_id` beside `parent_author_id` and `broadcast_reply/2`
+  notifies no member for such a parent. Answering itself stays a member's act —
+  `create_reply/3` takes a `%User{}`.
 - They have their own feed source (`feed_organization_post_items/3`), so
   `feed_post_items/3` stays deliberately the member half.
 - Personal scopes exclude them: a member's profile, archive and feed never show
@@ -882,7 +887,13 @@ like/reply quotes.
 **The permalink page renders the conversation as an embedded LiveView**
 (`VutuvWeb.PostLive.Thread`, `live_render` from `PostController` — the
 profile's pattern: the controller keeps the URL and the agent-format
-negotiation, the socket owns the conversation card). A **small conversation
+negotiation, the socket owns the conversation card). A **page's** post permalink
+(`/organizations/:slug/posts/:id`) hosts the same LiveView, nested one level
+deeper inside `VutuvWeb.OrganizationLive.Post`: it needs the identical thread now
+that a page's post can be answered (#1336), and one owner beats a second
+rendering — the page's earlier hand-rolled card plus a read-only remote-reply
+list had no expanders, no batched action bars, and a ⋯ menu whose `phx-click` its
+host did not answer. A **small conversation
 (≤ 25 visible posts) renders whole** (issue #1006) in `thread_order/1` reading
 order via `PostComponents.thread_conversation/1`. A **bigger one opens as a
 window around the permalinked post** (`Vutuv.Posts.thread_window/3`, the issue

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -3593,7 +3593,19 @@ defmodule Vutuv.Fediverse do
   @inbox_addressed_cap 25
 
   @doc """
-  Every local member a delivery to the **shared inbox** is for (issue #1073).
+  Every local **actor** a delivery to the shared inbox is for (issue #1073) — a
+  member, a page (issue #1334) or a topic (issue #1330), as structs the caller
+  dispatches on.
+
+  All three kinds have to be here because all three **advertise this endpoint**:
+  `endpoints.sharedInbox` is a fact about the installation, so every actor
+  document we serve carries it, and Mastodon (like most implementations) then
+  prefers it over the actor's own inbox for everything it delivers. While this
+  resolved members only, every signed activity a server sent for a page or a
+  topic resolved to nobody and was dropped — a `Follow` of a page, a favourite
+  of its post, and (as reported) an **answer** to its post, which simply never
+  appeared here. The page's own `/organizations/:slug/inbox` was not the path
+  those deliveries took.
 
   The per-member inbox learns who the activity is for from the URL; the shared
   one has to read it out of the activity. Three sources, because that is where
@@ -3603,7 +3615,7 @@ defmodule Vutuv.Fediverse do
       activity and on its object — plus the object itself and, for an `Undo`,
       the object it wraps: a `Follow` names an actor URL, a `Like` or
       `Announce` a Note URL, a reply its `inReplyTo`. Every URL of ours resolves
-      to the member it hangs off.
+      to the member, page or topic it hangs off.
     * the **remote actor's own lifecycle** (`Update`/`Delete` of itself), which
       names no local member at all: it is broadcast to everyone with a stake in
       that actor, so the addressees are the members it follows here **and**
@@ -3614,9 +3626,18 @@ defmodule Vutuv.Fediverse do
       names nobody here: the addressees are the members whose posts hold a
       stored copy of it.
 
-  Members who do not federate (or are suspended, frozen, gone) are filtered out,
-  so a delivery to them is silently dropped — never answered differently, or the
-  endpoint would become a way to ask who takes part.
+  Those last two remain **member-only** on purpose, and it is a known gap rather
+  than a decision: they are about the accounts somebody here follows, and a page
+  can follow too since #1336, so a lifecycle broadcast about an account only a
+  page follows still resolves to nobody. It costs a page's copy of a renamed or
+  deleted remote account, not an answer to one of its posts, and the join behind
+  it (`fediverse_followers` inner-joined through `users`) is the second half of
+  that fix rather than this one.
+
+  Actors that do not federate (a member suspended, frozen or gone, a page or
+  topic with its switch off) are filtered out, so a delivery to them is silently
+  dropped — never answered differently, or the endpoint would become a way to
+  ask who takes part.
 
   `actor_uri` is the activity's *claimed* actor. The caller resolves recipients
   before the signature is verified (it needs one of their keys to sign the
@@ -3624,14 +3645,15 @@ defmodule Vutuv.Fediverse do
   afterwards, once that claim is proven.
   """
   def inbox_recipients(activity, actor_uri) when is_map(activity) do
-    (addressed_users(activity) ++ lifecycle_users(activity, actor_uri))
-    |> Enum.uniq_by(& &1.id)
+    (addressed_actors(activity) ++ lifecycle_users(activity, actor_uri))
+    # By kind AND id: three tables, so an id alone is not the identity here.
+    |> Enum.uniq_by(&{&1.__struct__, &1.id})
     |> Enum.filter(&federated?/1)
   end
 
   def inbox_recipients(_activity, _actor_uri), do: []
 
-  defp addressed_users(activity) do
+  defp addressed_actors(activity) do
     object = if is_map(activity["object"]), do: activity["object"], else: %{}
 
     # `object["actor"]` is what names us in an `Accept`/`Reject` (issue #1160):
@@ -3643,8 +3665,57 @@ defmodule Vutuv.Fediverse do
     |> Enum.filter(&is_binary/1)
     |> Enum.uniq()
     |> Enum.take(@inbox_addressed_cap)
-    |> Enum.flat_map(&local_username/1)
-    |> users_by_username()
+    |> Enum.flat_map(&local_actor_ref/1)
+    |> Enum.uniq()
+    |> actors_by_ref()
+  end
+
+  # Which of our own actors a URI names, as `{kind, handle}` — resolved as a
+  # reference first and loaded in one query per kind below, so a delivery naming
+  # twenty URLs still costs three lookups rather than twenty.
+  defp local_actor_ref(uri) do
+    case local_path(uri) do
+      nil -> tag_actor_ref(uri)
+      segments -> ref_from_segments(segments)
+    end
+  end
+
+  # A page's URLs first: they are the more specific shape, and the member clauses
+  # below would otherwise read `/organizations/acme/actor` as the member
+  # `organizations` (a word `Vutuv.Accounts.ReservedSlugs` keeps unclaimable, so
+  # the lookup would miss — but a rule that holds by luck is not a rule).
+  defp ref_from_segments(["organizations", slug, "actor" | _]),
+    do: [{:organization, String.downcase(slug)}]
+
+  defp ref_from_segments(["organizations", slug, "posts", _id | _]),
+    do: [{:organization, String.downcase(slug)}]
+
+  defp ref_from_segments([username, "actor" | _]), do: [{:user, String.downcase(username)}]
+  defp ref_from_segments([username, "posts", _id | _]), do: [{:user, String.downcase(username)}]
+  defp ref_from_segments(_segments), do: []
+
+  # A topic's actor lives on its own host (`tags.<host>`), which is precisely why
+  # `local_path/1` must not answer for it: `https://tags.<host>/hund` would come
+  # back as the member `hund`. So the tag host is asked separately, and the slug
+  # is the whole path — the actor id is `#{tag_base()}/<slug>`.
+  defp tag_actor_ref(uri) do
+    with true <- tag_host?(uri),
+         %URI{path: path} <- URI.parse(uri),
+         [slug | _rest] <- String.split(path || "", "/", trim: true) do
+      [{:tag, String.downcase(slug)}]
+    else
+      _ -> []
+    end
+  end
+
+  # One query per kind for the whole addressee list, not one per URI. A merged
+  # alias is left out of the topic lookup (`merged_into_id`): an alias is another
+  # name for a topic, never a second actor, so a delivery to one is a delivery to
+  # nothing — the same answer `with_federated_tag` gives at the topic's own inbox.
+  defp actors_by_ref(refs) do
+    users_by_username(for {:user, name} <- refs, do: name) ++
+      organizations_by_slug(for {:organization, slug} <- refs, do: slug) ++
+      tags_by_slug(for {:tag, slug} <- refs, do: slug)
   end
 
   defp audience_uris(map) when is_map(map) do
@@ -3659,26 +3730,20 @@ defmodule Vutuv.Fediverse do
 
   defp audience_uris(_other), do: []
 
-  # The member an actor or Note URL of ours hangs off, as a username. Anything
-  # else — a foreign host, the public collection, a malformed URI — is a miss.
-  # Read through `local_path/1`, so the `www.`/`http` spellings a remote server
-  # may have learned for the same member still deliver (issue #1211).
-  defp local_username(uri) do
-    case local_path(uri) do
-      nil -> []
-      segments -> username_from_segments(segments)
-    end
-  end
-
-  defp username_from_segments([username, "actor" | _rest]), do: [String.downcase(username)]
-  defp username_from_segments([username, "posts", _id | _rest]), do: [String.downcase(username)]
-  defp username_from_segments(_segments), do: []
-
-  # One query for the whole addressee list, not one per URI.
   defp users_by_username([]), do: []
 
   defp users_by_username(usernames),
     do: Repo.all(from(u in User, where: u.username in ^usernames))
+
+  defp organizations_by_slug([]), do: []
+
+  defp organizations_by_slug(slugs),
+    do: Repo.all(from(o in Organization, where: o.slug in ^slugs))
+
+  defp tags_by_slug([]), do: []
+
+  defp tags_by_slug(slugs),
+    do: Repo.all(from(t in Tag, where: t.slug in ^slugs and is_nil(t.merged_into_id)))
 
   # A post an account publishes to its followers (issue #1161) names no local
   # member at all — the addressing is the public collection and the author's own

--- a/lib/vutuv/organizations.ex
+++ b/lib/vutuv/organizations.ex
@@ -37,6 +37,7 @@ defmodule Vutuv.Organizations do
   alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostLike
   alias Vutuv.Posts.PostMention
+  alias Vutuv.Posts.PostReply
   alias Vutuv.Posts.PostRepost
   alias Vutuv.Profiles.WorkExperience
   alias Vutuv.Repo
@@ -442,7 +443,9 @@ defmodule Vutuv.Organizations do
   One page of `organization`'s activity, newest first, in the
   `%{entries:, more?:}` shape. Each entry is
   `%{id:, kind:, at:, actor:, post: }` — `kind` one of `"follow"`,
-  `"post_like"`, `"post_repost"`, `post` nil on a follow.
+  `"post_like"`, `"post_repost"`, `"mention"`, `"reply"`; `post` nil on a follow,
+  and on a `"reply"` it is the **answer** (what the team wants to read), not the
+  post of the page's that was answered.
   """
   def activity_page(%Organization{} = organization, opts \\ []) do
     limit = Keyword.get(opts, :limit, @activity_per_page)
@@ -454,7 +457,8 @@ defmodule Vutuv.Organizations do
           &activity_follows(organization, &1, &2),
           &activity_post_engagement(organization, PostLike, "post_like", &1, &2),
           &activity_post_engagement(organization, PostRepost, "post_repost", &1, &2),
-          &activity_mentions(organization, &1, &2)
+          &activity_mentions(organization, &1, &2),
+          &activity_replies(organization, &1, &2)
         ],
         limit,
         offset
@@ -571,6 +575,46 @@ defmodule Vutuv.Organizations do
       # which a tuple `select` could not have carried anyway.
       post = %{post | user: actor}
       %{id: "mention-#{row_id}", kind: "mention", at: at, actor: actor, post: post}
+    end)
+  end
+
+  # Somebody answered one of the page's posts (issue #1336). This is the source
+  # that receives a reply, and its existence is what made answering a page's post
+  # allowed at all: `Vutuv.Posts.broadcast_reply/2` writes no notification for a
+  # page, because there is no member to address and a row written per publisher
+  # would contradict the one shared read marker.
+  #
+  # Read off `post_replies.parent_organization_id`, the page-shaped half of the
+  # pair `Vutuv.Activity` reads as `parent_author_id` for a member — deliberately
+  # not by joining the answered post, which nilifies away when the page deletes
+  # it: "somebody answered you" stays news even then, exactly as it does for a
+  # member.
+  #
+  # `post` is the **answer**: the team wants to read what was written, and the
+  # post of theirs it hangs under is one click further on (the answer's card
+  # carries its own "Replying to …" line). The reply's author is always a member,
+  # so the join to `users` is an inner one by nature rather than by oversight — a
+  # page cannot answer anything.
+  defp activity_replies(%Organization{id: id}, fetch_n, _cursor) do
+    from(r in PostReply,
+      join: p in Post,
+      on: p.id == r.post_id,
+      join: u in User,
+      on: u.id == p.user_id,
+      where: r.parent_organization_id == ^id,
+      where: account_confirmed_row(u) and not account_hidden_row(u),
+      where: not p.images_pending? and is_nil(p.frozen_at),
+      order_by: [desc: r.inserted_at, desc: r.id],
+      limit: ^fetch_n,
+      select: {r.id, r.inserted_at, u, p}
+    )
+    |> Repo.all()
+    |> Enum.map(fn {row_id, at, actor, post} ->
+      # Same reason as the mentions above: `Vutuv.Posts.path/1` reads the
+      # preloaded author, and here the actor IS that author (the join is on
+      # `p.user_id`), so no query and no `preload:`.
+      post = %{post | user: actor}
+      %{id: "reply-#{row_id}", kind: "reply", at: at, actor: actor, post: post}
     end)
   end
 

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -353,34 +353,52 @@ defmodule Vutuv.Posts do
   end
 
   @doc """
-  Whether this post is a kind of post that accepts replies at all — the half of
-  the reply rule that depends on the post alone, with nobody asking yet.
+  Whether this post is in a state that accepts answers at all — the half of the
+  reply rule that depends on the post alone, with nobody asking yet.
+
+  A post published in a page's name is answerable like any other (issue #1336):
+  it was refused outright while a page had no reading side, since every
+  consequence of a reply was member-shaped and the answer would have reached
+  nobody, and the page's activity list is now what receives it. What this asks is
+  the one thing `visible_to?/2` deliberately does **not**: whether the page
+  itself is publicly visible. Page visibility lives in the queries (see
+  `moderation_hidden?/1`), which is right for every list, but the reply page
+  renders the parent card from an id in the URL — so without this a guessed id
+  would confirm and quote the post of a pending or frozen page.
 
   Public because the reply **page** must ask it too. That page cannot run the
   whole of `check_reply_allowed/2` (a quiet block has to let the blocked member
-  reach the composer and be refused on submit, or the block leaks), so without a
-  named predicate it kept its own weaker copy of the rule — and offered a
-  composer for a page's post, whose heading then dereferenced the member author
-  that a page's post does not have.
+  reach the composer and be refused on submit, or the block leaks), so a named
+  predicate is what keeps the two gates from drifting apart.
   """
-  def replyable?(%Post{} = post), do: not organization_post?(post)
+  def answerable?(%Post{organization_id: nil}), do: true
+
+  def answerable?(%Post{organization_id: id}) when is_binary(id) do
+    # Read fresh by id, deliberately **not** through the preloaded
+    # `:organization` — for the same reason `parent_restricted_now?/1` re-queries
+    # the denials: the reply LiveView holds the parent struct from mount, and the
+    # page may have been frozen or sent back to `pending` since. Matching on the
+    # preloaded association would also read as a type check while behaving as a
+    # preload check, which is how a page's post once fell into the member branch.
+    case Organizations.get_organization(id) do
+      nil -> false
+      page -> Organizations.public_visible?(page)
+    end
+  end
 
   defp check_reply_allowed(%User{} = author, %Post{} = parent) do
     cond do
-      # An organization post cannot be answered yet (issue #1334). Everything
-      # downstream of a reply is member-shaped — the parent-author notification,
-      # the block check between the two authors, the thread's "Replying to
-      # @handle" line — and an organization has no inbox to be told about it
-      # until issue #1336 gives it a reading side. Refusing outright beats a
-      # reply that quietly reaches nobody.
-      not replyable?(parent) -> {:error, :restricted}
+      not answerable?(parent) -> {:error, :not_visible}
       not visible_to?(parent, author) -> {:error, :not_visible}
       # Query restriction fresh from the DB, not the (possibly stale) preloaded
       # denials: the reply LiveView holds the parent struct from mount, and the
       # author may have restricted the post after it was loaded.
       parent_restricted_now?(parent) -> {:error, :restricted}
       # A block between author and parent author refuses the reply with the
-      # same opaque :restricted the disabled reply button already explains.
+      # same opaque :restricted the disabled reply button already explains. A
+      # block is between two members, so a page's post has none: `blocked?/2`
+      # reads `parent.user_id`, which is NULL there, and `blocked_between?/2`
+      # answers false for a nil side rather than raising.
       blocked?(author, parent) -> {:error, :restricted}
       true -> :ok
     end
@@ -713,7 +731,12 @@ defmodule Vutuv.Posts do
     Repo.insert!(%PostReply{
       post_id: post.id,
       parent_post_id: parent.id,
+      # Whichever of the two authors the parent has (issue #1334): the columns
+      # are read as a pair everywhere, and the page's own activity list is
+      # derived from `parent_organization_id` the way a member's reply
+      # notification is derived from `parent_author_id`.
       parent_author_id: parent.user_id,
+      parent_organization_id: parent.organization_id,
       root_post_id: thread_root_id(parent)
     })
   end
@@ -4420,16 +4443,17 @@ defmodule Vutuv.Posts do
   @doc """
   Classifies a post's reply parent (from its preloaded `reply_ref`) into one of
   `{:parent, parent_post}` (the parent still exists), `{:author_only, author}`
-  (the parent post is gone but its author remains), `:gone` (author gone too),
-  or `nil` (not a reply). The API (`PostJSON`), the agent docs (`PostDoc`) and
-  the post card all render from this, so they can't disagree on what a reply
-  points at. An un-preloaded `reply_ref` is a truthy `NotLoaded`, hence the
-  struct matches.
+  (the parent post is gone but its author remains — a member or the page it was
+  published in the name of), `:gone` (author gone too), or `nil` (not a reply).
+  The API (`PostJSON`), the agent docs (`PostDoc`) and the post card all render
+  from this, so they can't disagree on what a reply points at. An un-preloaded
+  `reply_ref` is a truthy `NotLoaded`, hence the struct matches.
   """
   def reply_ref_state(%Post{reply_ref: %PostReply{} = ref}) do
     cond do
       match?(%Post{}, ref.parent_post) -> {:parent, ref.parent_post}
       match?(%User{}, ref.parent_author) -> {:author_only, ref.parent_author}
+      match?(%Organization{}, ref.parent_organization) -> {:author_only, ref.parent_organization}
       true -> :gone
     end
   end
@@ -4486,22 +4510,28 @@ defmodule Vutuv.Posts do
       remote_reply_ref: [remote_post: :remote_account],
       denials: [:denied_user],
       tags: from(t in Tag, order_by: t.name),
+      # Both kinds of parent author, at both levels (issue #1336): a member may
+      # answer a post published in a page's name, so the parent card names and
+      # links a page as readily as a member — and `author/1` would otherwise pay
+      # a query per card to find out which.
       reply_ref: [
         :parent_author,
+        :parent_organization,
         parent_post: [
           :images,
           :screenshot,
           :review,
+          :organization,
           # Rendered as a full card, so its author's proven links come along
           # too (issue #1246) — same reason as the top-level `user` above.
           user: verified_links_preload(),
           tags: from(t in Tag, order_by: t.name),
           # The nested parent's own "Replying to …" line, local and remote: the
           # two states it can be in when it is a reply rather than a thread
-          # starter. `parent_post: :user` is deliberately the author alone —
-          # the grandparent is named and linked, never rendered.
+          # starter. `parent_post: [:user, :organization]` is deliberately the
+          # author alone — the grandparent is named and linked, never rendered.
           remote_reply_ref: [remote_post: :remote_account],
-          reply_ref: [:parent_author, parent_post: :user]
+          reply_ref: [:parent_author, :parent_organization, parent_post: [:user, :organization]]
         ]
       ]
     ]
@@ -5218,10 +5248,20 @@ defmodule Vutuv.Posts do
 
   # A new reply ticks the parent's open action bars, notifies its author
   # (self-replies are not news) and tells the thread's other participants.
+  #
+  # An answer to a post published in a page's name notifies nobody here, and
+  # that is the whole arrangement rather than a gap: the page's activity list is
+  # **derived** from `post_replies.parent_organization_id`
+  # (`Vutuv.Organizations.activity_page/2`), the way its likes and reposts are
+  # derived, so an answer appears there — and disappears again with the row —
+  # without anything being written twice. Guarded on the column rather than left
+  # to `notify_reply/4`'s own nil tolerance: reading `nil != reply.user_id` as
+  # "somebody to tell" is exactly the half-read pair that has cost this
+  # milestone sixteen silent failures.
   defp broadcast_reply(%Post{} = parent, %Post{} = reply) do
     broadcast_reply_count(parent.id)
 
-    if parent.user_id != reply.user_id do
+    if is_binary(parent.user_id) and parent.user_id != reply.user_id do
       Vutuv.Activity.notify_reply(parent.user_id, reply.user, parent.id, reply.id)
     end
 

--- a/lib/vutuv/posts/post_reply.ex
+++ b/lib/vutuv/posts/post_reply.ex
@@ -6,11 +6,16 @@ defmodule Vutuv.Posts.PostReply do
   schema "post_replies" do
     # The reply post itself; the row cascades away with it.
     belongs_to(:post, Vutuv.Posts.Post)
-    # The post replied to and its author at reply time. Both nilify on
+    # The post replied to and its author at reply time. All three nilify on
     # deletion, so the reply outlives its parent (see the migration for the
     # banner-state encoding).
     belongs_to(:parent_post, Vutuv.Posts.Post)
+    # The two kinds of author a parent can have (issue #1334): a member, or the
+    # page the parent was published in the name of. Exactly one of them is set
+    # while the parent lives; both are NULL once the account or page behind it
+    # is gone, which is what the nameless banner state reads.
     belongs_to(:parent_author, Vutuv.Accounts.User)
+    belongs_to(:parent_organization, Vutuv.Organizations.Organization)
     # The thread's top post, denormalized at creation (threading is otherwise
     # only a parent-pointer chain) so "all replies in this thread" is one
     # indexed lookup — the seam behind the thread-participation notifications.

--- a/lib/vutuv_web/agent_docs/post_doc.ex
+++ b/lib/vutuv_web/agent_docs/post_doc.ex
@@ -11,6 +11,7 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
 
   use Gettext, backend: VutuvWeb.Gettext
 
+  alias Vutuv.Accounts.User
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.Handle
   alias Vutuv.Fediverse.Note
@@ -181,6 +182,9 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
   defp author_label(%Organization{name: name}), do: name
   defp author_label(author), do: UserHelpers.full_name(author)
 
+  defp author_username(%Organization{username: username}), do: username
+  defp author_username(%User{username: username}), do: username
+
   # The organization's own reference, the counterpart of `AgentDocs.person_ref/1`.
   # `canonical_path/1` prefers the page's opt-in root handle, so the URL here is
   # the one the page answers to rather than the slug form the post lives under.
@@ -302,7 +306,11 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
   # hangs in the thread — the nesting the HTML page draws, as a number the
   # other formats can indent by.
   defp thread_entries(posts) do
-    authors = Map.new(posts, &{&1.id, UserHelpers.full_name(&1.user)})
+    # `author_label/1`, not `full_name/1`: a conversation can hold a post
+    # published in a page's name (issue #1336 — a member may answer one), and
+    # `full_name/1` raised on it, so the `.md`/`.txt`/`.json`/`.xml` sibling of
+    # every answer to a page's post was a 500 while the HTML rendered fine.
+    authors = Map.new(posts, &{&1.id, timeline_author(&1)})
     depths = thread_depths(posts)
 
     Enum.map(posts, fn post ->
@@ -311,8 +319,11 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       %{
         id: post.id,
         url: AgentDocs.abs_url(Posts.path(post)),
-        author: UserHelpers.full_name(post.user),
-        author_username: post.user.username,
+        author: timeline_author(post),
+        # A page's handle is optional (`/organizations/:slug` always works), so
+        # nil here is the honest answer rather than a gap — `author` above names
+        # it either way.
+        author_username: author_username(Posts.author(post)),
         published_on: post.published_on,
         body_markdown: post.body,
         depth: depths[post.id],
@@ -455,14 +466,18 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
 
   defp in_reply_to(post) do
     case Posts.reply_ref_state(post) do
+      # `author_label/1` on both, not `full_name/1`: the post answered may have
+      # been published in a page's name (issue #1336), and `full_name/1` has no
+      # clause for a page — it would raise on the `.md`/`.json` sibling of every
+      # answer to one, i.e. a 500 where the HTML card renders fine.
       {:parent, parent} ->
         %{
           url: AgentDocs.abs_url(Posts.path(parent)),
-          author: UserHelpers.full_name(parent.user)
+          author: author_label(Posts.author(parent))
         }
 
       {:author_only, author} ->
-        %{url: nil, author: UserHelpers.full_name(author)}
+        %{url: nil, author: author_label(author)}
 
       :gone ->
         %{url: nil, author: nil}

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -2633,13 +2633,15 @@ defmodule VutuvWeb.PostComponents do
         <% {:parent, parent_author, parent_path} -> %>
           <.reply_banner_line variant="parent">
             <.link href={parent_path} class="hover:text-brand-700">
-              {gettext("Replying to %{handle}", handle: handle(parent_author))}
+              {gettext("Replying to %{handle}", handle: author_handle(parent_author))}
             </.link>
           </.reply_banner_line>
         <% {:author_only, parent_author} -> %>
           <.reply_banner_line variant="author-only">
-            <.link href={~p"/#{parent_author}"} class="hover:text-brand-700">
-              {gettext("Reply to a now-deleted post by %{handle}", handle: handle(parent_author))}
+            <.link href={author_only_path(parent_author)} class="hover:text-brand-700">
+              {gettext("Reply to a now-deleted post by %{handle}",
+                handle: author_handle(parent_author)
+              )}
             </.link>
           </.reply_banner_line>
         <% {:remote, remote_handle, remote_account_id} -> %>
@@ -3818,7 +3820,10 @@ defmodule VutuvWeb.PostComponents do
 
   defp reply_banner(post, viewer) do
     case Posts.reply_ref_state(post) do
-      {:parent, parent} -> {:parent, parent.user, Posts.path(parent)}
+      # `Posts.author/1`, not `parent.user`: the parent may have been published
+      # in a page's name (issue #1336), and the preloads carry both authors so
+      # this costs no query.
+      {:parent, parent} -> {:parent, Posts.author(parent), Posts.path(parent)}
       # A top-level post that answers a post on another network (issue #1165)
       # has no local parent at all, so its "Replying to" line comes from the
       # sidecar instead. Only ever reached when there is no local reply ref: an
@@ -3850,8 +3855,26 @@ defmodule VutuvWeb.PostComponents do
 
   defp remote_account_id(%PostRemoteReply{}), do: nil
 
-  # Reply system messages name the account handle, never the clear name.
-  defp handle(%User{username: username}), do: "@" <> username
+  # Where the "now-deleted post by …" banner leads once only the author is left:
+  # the same two destinations `author_path/1` names for a live post, so a reply
+  # whose page-published parent is gone still leads to the page.
+  defp author_only_path(%Organization{} = organization),
+    do: Organizations.canonical_path(organization)
+
+  defp author_only_path(%User{username: username}), do: "/#{username}"
+
+  @doc """
+  How a post's author is named in prose about answering them — the card's
+  "Replying to …" banner and the reply page's heading, which must agree.
+
+  A member is named by their `@handle`: it is their address, and the line is
+  about *who* is being answered. A page is named by its **name**, because a page
+  has no handle to speak of — the root handle is an optional address it may
+  never have claimed, so `@…` would be a gap dressed as a fact (the same reason
+  `author_name/1` puts no handle line beside a page's name on the card itself).
+  """
+  def author_handle(%Organization{name: name}), do: name
+  def author_handle(%User{username: username}), do: "@" <> username
 
   # Whether to float a post's single image beside its body (the text wraps around
   # and below it, `.post-clamp--wrap`) rather than stacking a full-width image

--- a/lib/vutuv_web/controllers/fediverse_controller.ex
+++ b/lib/vutuv_web/controllers/fediverse_controller.ex
@@ -196,15 +196,16 @@ defmodule VutuvWeb.FediverseController do
   # The activity's actor must be that same actor, or anyone could sign a
   # Follow as themselves while claiming to be someone else.
   #
-  # `users` is who the activity is for: exactly one member at the per-member
-  # inbox, whoever the activity addressed at the shared one — where it may also
-  # be nobody, which is still verified first and only then dropped, so an
-  # unsigned delivery is a 401 whatever it claims to be addressed to.
-  defp verify_and_perform(conn, users) do
+  # `recipients` is who the activity is for: exactly one member at the
+  # per-member inbox, whoever the activity addressed at the shared one — where it
+  # may be a member, a page or a topic, several of them, or nobody at all, which
+  # is still verified first and only then dropped, so an unsigned delivery is a
+  # 401 whatever it claims to be addressed to.
+  defp verify_and_perform(conn, recipients) do
     activity = conn.body_params
 
     with {:ok, key_id} <- signature_key_id(conn),
-         {:ok, remote} <- Fediverse.fetch_remote_actor(key_id, signer(users)),
+         {:ok, remote} <- Fediverse.fetch_remote_actor(key_id, signer(recipients)),
          # The signing keyId must be served by the same host as the actor id it
          # names — without this an attacker-controlled host can serve a key
          # document claiming `id: "https://good.example/alice"`, spoofing
@@ -214,13 +215,28 @@ defmodule VutuvWeb.FediverseController do
          true <- Fediverse.same_host?(remote.id, key_id),
          :ok <- verify_signature(conn, remote),
          true <- activity["actor"] == remote.id do
-      Enum.each(users, &perform(&1, activity, remote))
+      Enum.each(recipients, &perform_for_recipient(&1, activity, remote))
       perform_once(activity, remote)
       send_resp(conn, 202, "")
     else
       _ -> send_resp(conn, 401, "")
     end
   end
+
+  # One addressee of a shared-inbox delivery, whichever kind of actor it is. The
+  # three `perform*` families below are the per-kind handlers the three
+  # per-actor inboxes already run; this is the only place that has to know all
+  # three exist, and it is what a delivery to `endpoints.sharedInbox` — which
+  # every actor document of ours advertises — needs in order to reach a page or a
+  # topic at all.
+  defp perform_for_recipient(%User{} = user, activity, remote),
+    do: perform(user, activity, remote)
+
+  defp perform_for_recipient(%Organization{} = organization, activity, remote),
+    do: perform_for_organization(organization, activity, remote)
+
+  defp perform_for_recipient(%Tag{} = tag, activity, remote),
+    do: perform_for_tag(tag, activity, remote)
 
   # What one addressed member does with an activity. Deliberately returns
   # nothing the caller uses: the answer is the same 202 whatever any of these
@@ -481,12 +497,15 @@ defmodule VutuvWeb.FediverseController do
     )
   end
 
-  # Remote-actor fetches are signed with the followed member's own key —
+  # Remote-actor fetches are signed with the addressed actor's own key —
   # instances running in authorized-fetch ("secure") mode reject anonymous
-  # GETs. At the shared inbox that is the first addressee we resolved; a
-  # delivery addressed to nobody here falls back to an anonymous fetch, which
-  # such an instance may refuse — and then the delivery is rejected, which is
-  # the right outcome for an activity that was for none of our members anyway.
+  # GETs. At the shared inbox that is the first addressee we resolved, of
+  # whichever kind: a page's delivery has to be signable by the page, or an
+  # authorized-fetch server's answer to a reply under its post could not be
+  # verified and the reply would be lost. A delivery addressed to nobody here
+  # falls back to an anonymous fetch, which such an instance may refuse — and
+  # then the delivery is rejected, which is the right outcome for an activity
+  # that was for none of our actors anyway.
   defp signer([%User{} = user | _rest]) do
     case Fediverse.get_actor(user) do
       nil -> nil
@@ -494,6 +513,8 @@ defmodule VutuvWeb.FediverseController do
     end
   end
 
+  defp signer([%Organization{} = organization | _rest]), do: organization_signer(organization)
+  defp signer([%Tag{} = tag | _rest]), do: tag_signer(tag)
   defp signer([]), do: nil
 
   @doc """

--- a/lib/vutuv_web/fediverse/docs.ex
+++ b/lib/vutuv_web/fediverse/docs.ex
@@ -22,6 +22,7 @@ defmodule VutuvWeb.Fediverse.Docs do
   `/system/` — see `shared_inbox_url/0`.
   """
 
+  alias Vutuv.Accounts.User
   alias Vutuv.Fediverse.Actor
   alias Vutuv.Mentions
   alias Vutuv.Organizations.Organization
@@ -29,6 +30,7 @@ defmodule VutuvWeb.Fediverse.Docs do
   alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostImage
   alias Vutuv.Posts.PostRemoteReply
+  alias Vutuv.Posts.PostReply
   alias Vutuv.Posts.PostReview
   alias Vutuv.ReviewCover
   alias Vutuv.Tags.Tag
@@ -47,7 +49,9 @@ defmodule VutuvWeb.Fediverse.Docs do
     :remote_reply_ref,
     :tags,
     {:post_hashtags, :tag},
-    {:reply_ref, [:parent_author]}
+    # Both kinds of parent author (issue #1336), or an answer to a page's post
+    # would render with no `inReplyTo` — see `parent_author/1`.
+    {:reply_ref, [:parent_author, :parent_organization]}
   ]
 
   @doc "The associations `note/2` needs loaded on a post."
@@ -969,7 +973,7 @@ defmodule VutuvWeb.Fediverse.Docs do
   defp reply_parent(%Post{reply_ref: nil}), do: nil
 
   defp reply_parent(%Post{reply_ref: reply_ref}) do
-    with %Vutuv.Accounts.User{} = author <- reply_ref.parent_author,
+    with author when not is_nil(author) <- parent_author(reply_ref),
          true <- Vutuv.Fediverse.federated?(author),
          false <- Vutuv.Posts.restricted?(%Post{id: reply_ref.parent_post_id}) do
       {author, reply_ref.parent_post_id}
@@ -977,6 +981,17 @@ defmodule VutuvWeb.Fediverse.Docs do
       _ -> nil
     end
   end
+
+  # Either kind of parent author (issue #1336): a member may answer a post
+  # published in a page's name, and `federated?/1` and `note_url/2` both already
+  # speak page as well as member. Matching `%User{}` alone left such an answer
+  # with no `inReplyTo` at all, so it travelled as a standalone post and appeared
+  # on the other server beside the conversation instead of inside it.
+  defp parent_author(%PostReply{parent_author: %User{} = author}), do: author
+
+  defp parent_author(%PostReply{parent_organization: %Organization{} = page}), do: page
+
+  defp parent_author(%PostReply{}), do: nil
 
   # Public posts only federate, and a public post's images are publicly
   # servable through the authorizing proxy — so their URLs can ride along.

--- a/lib/vutuv_web/live/organization_live/activity.ex
+++ b/lib/vutuv_web/live/organization_live/activity.ex
@@ -1,8 +1,13 @@
 defmodule VutuvWeb.OrganizationLive.Activity do
   @moduledoc """
   What happened to an organization page (`/organizations/:slug/activity`,
-  issue #1336): who followed it, who liked or reposted what it published, and
-  who named it by its handle.
+  issue #1336): who followed it, who liked or reposted what it published, who
+  named it by its handle, and who **answered** one of its posts.
+
+  That last one is where the list stops being a courtesy: a reply is addressed to
+  the page and expects to be read, and nothing else in the app tells the team it
+  arrived — which is why answering a page's post stayed refused until this page
+  existed.
 
   **One read marker for the whole team.** Opening this page stamps
   `organizations.activity_read_at`, and it is stamped for everybody — "read"
@@ -83,6 +88,9 @@ defmodule VutuvWeb.OrganizationLive.Activity do
 
   defp line(%{kind: "mention"} = entry),
     do: gettext("%{name} mentioned this page.", name: full_name(entry.actor))
+
+  defp line(%{kind: "reply"} = entry),
+    do: gettext("%{name} answered a post.", name: full_name(entry.actor))
 
   @impl true
   def render(assigns) do

--- a/lib/vutuv_web/live/organization_live/post.ex
+++ b/lib/vutuv_web/live/organization_live/post.ex
@@ -4,26 +4,25 @@ defmodule VutuvWeb.OrganizationLive.Post do
   (`/organizations/:slug/posts/:id`, issue #1334). Embedded via `live_render`
   from `VutuvWeb.OrganizationController`, like the organization page itself.
 
-  The post, the way back to the page that published it, and the replies written
-  on **other networks** (issue #1334 completing #1069 for pages).
+  The way back to the page that published it, and then the post **with its
+  conversation** — the answers written here and the ones written on other
+  networks, woven together in time order.
 
-  Still no vutuv conversation below it: an organization post cannot be answered
-  here (`Vutuv.Posts.check_reply_allowed/2` refuses), because everything a local
-  reply sets in motion is member-shaped. A remote reply is different — it
-  arrives whether or not we host a thread for it, and hiding what a page's own
-  post already collected would only mean the team cannot see it.
-
-  Those cards are **read-only** here, unlike on the member thread that owns
-  them: removing, reporting and the heart all belong to a person, and a page has
-  nobody behind those buttons.
+  That conversation is `VutuvWeb.PostLive.Thread`, nested by `live_render`, and
+  not a second rendering of one: the member permalink has grown a windowed thread
+  with expanders, per-card action bars on one socket, and the hosting of the
+  remote cards' own acts, and a page's post now collects exactly the same things
+  (issue #1336 opened local replies to it). A page's post used to render its own
+  post card plus a read-only list of remote replies, which cost this page every
+  one of those and, less obviously, offered a ⋯ menu whose `phx-click` no handler
+  here answered — the takedown a publisher gained in #1417 was on a card whose
+  host could not perform it.
   """
 
   use VutuvWeb, :live_view
 
-  import VutuvWeb.PostComponents, only: [post_card: 1, remote_reply_card: 1]
   import VutuvWeb.OrganizationComponents, only: [organization_logo: 1]
 
-  alias Vutuv.Fediverse
   alias Vutuv.Organizations
   alias Vutuv.Posts
   alias VutuvWeb.Live.InitAssigns
@@ -45,13 +44,6 @@ defmodule VutuvWeb.OrganizationLive.Post do
        socket
        |> assign(:organization, organization)
        |> assign(:post, post)
-       # Replies from other networks (issue #1334, completing #1069 for pages).
-       # Viewer-scoped by `list_notes/2` like the member permalink, so a reply
-       # addressed to the page alone never reaches anybody else's render.
-       |> assign(
-         :remote_replies,
-         Fediverse.list_notes([post.id], socket.assigns.current_user)[post.id] || []
-       )
        |> assign(:formats?, Organizations.agent_visible?(organization))
        |> assign(:page_title, organization.name)}
     else
@@ -77,16 +69,18 @@ defmodule VutuvWeb.OrganizationLive.Post do
         {@organization.name}
       </.link>
 
+      <%!-- The post and everything answering it, from `VutuvWeb.PostLive.Thread`
+      — the same conversation the member permalink shows, nested here as its own
+      LiveView so the expanders, the per-card action bars and the remote cards'
+      takedown controls all have the host they need. Its dead render is thrown
+      away and re-mounted on connect like any nested child, and it resolves the
+      viewer from the cookie session itself, so this page hands it nothing but
+      the post id. --%>
       <div class="mt-4">
-        <.post_card post={@post} viewer={@current_user} conn_or_socket={@socket} mode={:full} />
-      </div>
-
-      <%!-- Replies written on another network (issue #1334). Read-only here,
-      like the member-facing answering page: the acts on such a card (remove,
-      report, the heart) are hosted by the member thread that owns them, and a
-      page has no member behind those buttons. --%>
-      <div :if={@remote_replies != []} class="mt-4 space-y-3" id="organization-remote-replies">
-        <.remote_reply_card :for={note <- @remote_replies} note={note} viewer={@current_user} />
+        {live_render(@socket, VutuvWeb.PostLive.Thread,
+          id: "organization-post-thread",
+          session: %{"post_id" => @post.id}
+        )}
       </div>
 
       <%!-- The agent-format siblings of this permalink. Shown only when they

--- a/lib/vutuv_web/live/post_live/reply.ex
+++ b/lib/vutuv_web/live/post_live/reply.ex
@@ -1,14 +1,15 @@
 defmodule VutuvWeb.PostLive.Reply do
   @moduledoc """
   Reply page — the parent post (read-only preview) above the same composer
-  as the feed. Only visible, **public**, `Vutuv.Posts.replyable?/1` parents can
+  as the feed. Only visible, **public**, `Vutuv.Posts.answerable?/1` parents can
   be answered; everything else is sent away with the unknown-id flash, so
-  existence never leaks. `replyable?/1` is shared with `create_reply/3`'s own
-  gate, which is what keeps a page's post (issue #1334) off this page — the
-  heading below names the parent's **member** author, which such a post has not
-  got. A block is deliberately *not* part of the gate: quiet blocking has to let
-  the blocked member reach the composer and be refused on submit, or the block
-  leaks.
+  existence never leaks. A post published in a page's name is answerable like any
+  other (issue #1336) as long as the page itself is publicly visible, which is
+  what `answerable?/1` — shared with `create_reply/3`'s own gate — asks; the
+  heading then names whichever author `Vutuv.Posts.author/1` hands back rather
+  than reaching for a member author a page's post has not got. A block is
+  deliberately *not* part of the gate: quiet blocking has to let the blocked
+  member reach the composer and be refused on submit, or the block leaks.
 
   **Quoting a passage** (issue #1114): a reader who marks part of a post before
   pressing Reply arrives here with that text in the `quote` parameter, and the
@@ -35,7 +36,7 @@ defmodule VutuvWeb.PostLive.Reply do
     user = socket.assigns.current_user
     parent = Posts.get_post(id)
 
-    if parent && Posts.replyable?(parent) && Posts.visible_to?(parent, user) &&
+    if parent && Posts.answerable?(parent) && Posts.visible_to?(parent, user) &&
          not Posts.restricted?(parent) do
       {:ok,
        socket
@@ -53,7 +54,7 @@ defmodule VutuvWeb.PostLive.Reply do
     <div id="post-reply" class="py-6">
       <div class="mx-auto max-w-2xl space-y-4">
         <h1 class="text-2xl font-bold text-slate-800 dark:text-slate-100">
-          {gettext("Reply to %{handle}", handle: "@" <> @parent.user.username)}
+          {gettext("Reply to %{handle}", handle: author_handle(Posts.author(@parent)))}
         </h1>
 
         <%!-- quotable={false}: this card's own Reply link leads back to this

--- a/lib/vutuv_web/views/post_json.ex
+++ b/lib/vutuv_web/views/post_json.ex
@@ -51,7 +51,10 @@ defmodule VutuvWeb.PostJSON do
         %{
           post_id: parent.id,
           url: VutuvWeb.Endpoint.url() <> Posts.path(parent),
-          author: author_ref(parent.user)
+          # Whichever author the parent has (issue #1336): a member may answer a
+          # post published in a page's name, and `author_ref/1` already speaks
+          # both — `parent.user` alone would have shipped `nil` here.
+          author: author_ref(Posts.author(parent))
         }
 
       {:author_only, author} ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.293.0",
+      version: "7.294.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -161,7 +161,7 @@ msgstr "Kontakt"
 msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
-#: lib/vutuv_web/components/post_components.ex:2751
+#: lib/vutuv_web/components/post_components.ex:2753
 #: lib/vutuv_web/components/ui.ex:3492
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -210,7 +210,7 @@ msgstr "Inaktivieren"
 msgid "Download"
 msgstr "Download"
 
-#: lib/vutuv_web/components/post_components.ex:2716
+#: lib/vutuv_web/components/post_components.ex:2718
 #: lib/vutuv_web/components/ui.ex:3483
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -474,7 +474,7 @@ msgid "Name"
 msgstr "Name"
 
 #: lib/vutuv_web/live/notification_live/index.ex:647
-#: lib/vutuv_web/live/organization_live/activity.ex:123
+#: lib/vutuv_web/live/organization_live/activity.ex:131
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:3
@@ -1070,22 +1070,22 @@ msgstr "Allgemeines"
 msgid "Verify"
 msgstr "Verifizieren"
 
-#: lib/vutuv/notifications/emailer.ex:213
+#: lib/vutuv/notifications/emailer.ex:280
 #, elixir-autogen
 msgid "Confirm your account deletion"
 msgstr "PIN zum Löschen eines vutuv-Kontos"
 
-#: lib/vutuv/notifications/emailer.ex:207
+#: lib/vutuv/notifications/emailer.ex:274
 #, elixir-autogen
 msgid "Confirm your email"
 msgstr "Weitere E-Mail-Adresse für ein vutuv-Konto bestätigen"
 
-#: lib/vutuv/notifications/emailer.ex:195
+#: lib/vutuv/notifications/emailer.ex:262
 #, elixir-autogen
 msgid "Confirm your vutuv account"
 msgstr "vutuv-Konto einrichten"
 
-#: lib/vutuv/notifications/emailer.ex:201
+#: lib/vutuv/notifications/emailer.ex:268
 #, elixir-autogen
 msgid "Login to vutuv"
 msgstr "vutuv Login-PIN"
@@ -1578,7 +1578,7 @@ msgstr "Verwandte Tags anzeigen"
 msgid "tag name"
 msgstr "Tag-Name"
 
-#: lib/vutuv/notifications/emailer.ex:253
+#: lib/vutuv/notifications/emailer.ex:320
 #, elixir-autogen
 msgid "vutuv Account verified"
 msgstr "verifizierter Account"
@@ -1645,7 +1645,7 @@ msgstr "Zur Startseite"
 msgid "Check your inbox"
 msgstr "Schauen Sie in Ihr Postfach"
 
-#: lib/vutuv_web/components/post_components.ex:3204
+#: lib/vutuv_web/components/post_components.ex:3206
 #: lib/vutuv_web/components/ui.ex:298
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
@@ -1959,7 +1959,7 @@ msgid "Pagination"
 msgstr "Seitennavigation"
 
 #: lib/vutuv_web/components/ui.ex:3627
-#: lib/vutuv_web/live/organization_live/activity.ex:146
+#: lib/vutuv_web/live/organization_live/activity.ex:154
 #: lib/vutuv_web/live/organization_live/feed.ex:101
 #: lib/vutuv_web/live/organization_live/show.ex:637
 #, elixir-autogen, elixir-format
@@ -2126,7 +2126,7 @@ msgid "As soon as anything is hidden, the post is also invisible to logged-out v
 msgstr "Sobald irgendetwas ausgeblendet ist, sehen auch abgemeldete Besucher und Suchmaschinen den Beitrag nicht mehr."
 
 #: lib/vutuv_web/live/post_live/edit.ex:143
-#: lib/vutuv_web/live/post_live/reply.ex:83
+#: lib/vutuv_web/live/post_live/reply.ex:84
 #, elixir-autogen, elixir-format
 msgid "Back to the post"
 msgstr "Zurück zum Beitrag"
@@ -2141,7 +2141,7 @@ msgstr "Upload abbrechen"
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
-#: lib/vutuv_web/components/post_components.ex:2748
+#: lib/vutuv_web/components/post_components.ex:2750
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2184,8 +2184,8 @@ msgstr "Vor einer bestimmten Person verbergen…"
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
 
-#: lib/vutuv_web/components/post_components.ex:2702
 #: lib/vutuv_web/components/post_components.ex:2704
+#: lib/vutuv_web/components/post_components.ex:2706
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
@@ -2235,7 +2235,7 @@ msgstr "Posten"
 msgid "Post deleted successfully."
 msgstr "Beitrag erfolgreich gelöscht."
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:205
+#: lib/vutuv_web/agent_docs/post_doc.ex:209
 #: lib/vutuv_web/controllers/post_controller.ex:60
 #: lib/vutuv_web/controllers/post_controller.ex:69
 #: lib/vutuv_web/controllers/user_controller.ex:77
@@ -2253,13 +2253,13 @@ msgstr "Beitrag erfolgreich gelöscht."
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:3140
-#: lib/vutuv_web/components/post_components.ex:3144
+#: lib/vutuv_web/components/post_components.ex:3142
+#: lib/vutuv_web/components/post_components.ex:3146
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:3141
+#: lib/vutuv_web/components/post_components.ex:3143
 #: lib/vutuv_web/live/fediverse_account_live.ex:320
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2351,27 +2351,27 @@ msgstr "Was gibt's Neues?"
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
 
-#: lib/vutuv_web/components/post_components.ex:2699
+#: lib/vutuv_web/components/post_components.ex:2701
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:4348
+#: lib/vutuv_web/components/post_components.ex:4371
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:4352
+#: lib/vutuv_web/components/post_components.ex:4375
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:4350
+#: lib/vutuv_web/components/post_components.ex:4373
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:4351
+#: lib/vutuv_web/components/post_components.ex:4374
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
@@ -2413,7 +2413,7 @@ msgid "All posts"
 msgstr "Alle Beiträge"
 
 #: lib/vutuv_web/components/post_components.ex:1603
-#: lib/vutuv_web/components/post_components.ex:4436
+#: lib/vutuv_web/components/post_components.ex:4459
 #: lib/vutuv_web/components/ui.ex:3017
 #: lib/vutuv_web/views/user_html.ex:335
 #, elixir-autogen, elixir-format
@@ -2432,7 +2432,7 @@ msgid "Bookmarks"
 msgstr "Lesezeichen"
 
 #: lib/vutuv_web/components/post_components.ex:1567
-#: lib/vutuv_web/components/post_components.ex:4670
+#: lib/vutuv_web/components/post_components.ex:4693
 #: lib/vutuv_web/components/ui.ex:3003
 #: lib/vutuv_web/live/notification_live/index.ex:1038
 #: lib/vutuv_web/views/user_html.ex:345
@@ -2441,7 +2441,7 @@ msgid "Like"
 msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1000
-#: lib/vutuv_web/components/post_components.ex:4679
+#: lib/vutuv_web/components/post_components.ex:4702
 #: lib/vutuv_web/live/notification_live/index.ex:971
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
@@ -2463,13 +2463,13 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:4425
+#: lib/vutuv_web/components/post_components.ex:4448
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
 #: lib/vutuv_web/components/post_components.ex:1603
-#: lib/vutuv_web/components/post_components.ex:4436
+#: lib/vutuv_web/components/post_components.ex:4459
 #: lib/vutuv_web/live/post_live/saved.ex:775
 #: lib/vutuv_web/views/user_html.ex:335
 #, elixir-autogen, elixir-format
@@ -2477,25 +2477,25 @@ msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
 #: lib/vutuv_web/components/post_components.ex:1591
-#: lib/vutuv_web/components/post_components.ex:4422
+#: lib/vutuv_web/components/post_components.ex:4445
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
 #: lib/vutuv_web/components/post_components.ex:1781
-#: lib/vutuv_web/components/post_components.ex:3720
+#: lib/vutuv_web/components/post_components.ex:3722
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
 #: lib/vutuv_web/components/post_components.ex:1591
-#: lib/vutuv_web/components/post_components.ex:4422
+#: lib/vutuv_web/components/post_components.ex:4445
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
-#: lib/vutuv_web/components/post_components.ex:4670
+#: lib/vutuv_web/components/post_components.ex:4693
 #: lib/vutuv_web/live/post_live/saved.ex:774
 #: lib/vutuv_web/views/user_html.ex:345
 #, elixir-autogen, elixir-format
@@ -2521,7 +2521,7 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:4723
+#: lib/vutuv_web/components/post_components.ex:4746
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
@@ -2533,15 +2533,15 @@ msgid "Replies"
 msgstr "Antworten"
 
 #: lib/vutuv_web/components/post_components.ex:1578
-#: lib/vutuv_web/components/post_components.ex:4706
-#: lib/vutuv_web/components/post_components.ex:4707
+#: lib/vutuv_web/components/post_components.ex:4729
+#: lib/vutuv_web/components/post_components.ex:4730
 #: lib/vutuv_web/live/notification_live/index.ex:1035
-#: lib/vutuv_web/live/post_live/reply.ex:42
+#: lib/vutuv_web/live/post_live/reply.ex:43
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:2666
+#: lib/vutuv_web/components/post_components.ex:2668
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
@@ -2565,7 +2565,7 @@ msgstr "hat auf Ihren Beitrag geantwortet."
 #: lib/vutuv_web/components/post_components.ex:2217
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:59
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
-#: lib/vutuv_web/live/post_live/reply.ex:56
+#: lib/vutuv_web/live/post_live/reply.ex:57
 #, elixir-autogen, elixir-format
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
@@ -2576,8 +2576,8 @@ msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 
 #: lib/vutuv_web/components/post_components.ex:2636
-#: lib/vutuv_web/components/post_components.ex:2658
-#: lib/vutuv_web/components/post_components.ex:2661
+#: lib/vutuv_web/components/post_components.ex:2660
+#: lib/vutuv_web/components/post_components.ex:2663
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
@@ -2882,7 +2882,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:4349
+#: lib/vutuv_web/components/post_components.ex:4372
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -2894,7 +2894,7 @@ msgstr "Öffnen Sie ein Profil, um jemandem zu schreiben."
 
 #: lib/vutuv_web/components/organization_components.ex:241
 #: lib/vutuv_web/live/notification_live/index.ex:1050
-#: lib/vutuv_web/live/organization_live/activity.ex:99
+#: lib/vutuv_web/live/organization_live/activity.ex:107
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr "Aktivität"
@@ -3244,7 +3244,7 @@ msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 
 #: lib/vutuv_web/components/post_components.ex:1066
 #: lib/vutuv_web/components/post_components.ex:2042
-#: lib/vutuv_web/components/post_components.ex:2772
+#: lib/vutuv_web/components/post_components.ex:2774
 #: lib/vutuv_web/live/organization_live/show.ex:547
 #: lib/vutuv_web/templates/user/show.html.heex:219
 #, elixir-autogen, elixir-format
@@ -3587,42 +3587,42 @@ msgstr ""
 msgid "yes"
 msgstr "ja"
 
-#: lib/vutuv/notifications/emailer.ex:925
+#: lib/vutuv/notifications/emailer.ex:1002
 #, elixir-autogen, elixir-format
 msgid "A warning for your vutuv account"
 msgstr "Eine Verwarnung für Ihr vutuv-Konto"
 
-#: lib/vutuv/notifications/emailer.ex:1009
+#: lib/vutuv/notifications/emailer.ex:1086
 #, elixir-autogen, elixir-format
 msgid "Moderation: %{count} cases are waiting"
 msgstr "Moderation: %{count} Fälle warten"
 
-#: lib/vutuv/notifications/emailer.ex:987
+#: lib/vutuv/notifications/emailer.ex:1064
 #, elixir-autogen, elixir-format
 msgid "Moderation: a profile was reported"
 msgstr "Moderation: Ein Profil wurde gemeldet"
 
-#: lib/vutuv/notifications/emailer.ex:899
+#: lib/vutuv/notifications/emailer.ex:976
 #, elixir-autogen, elixir-format
 msgid "The content you reported was revised"
 msgstr "Der von Ihnen gemeldete Inhalt wurde überarbeitet"
 
-#: lib/vutuv/notifications/emailer.ex:892
+#: lib/vutuv/notifications/emailer.ex:969
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv is under review"
 msgstr "Ihr Inhalt auf vutuv wird geprüft"
 
-#: lib/vutuv/notifications/emailer.ex:885
+#: lib/vutuv/notifications/emailer.ex:962
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv was reported and is hidden"
 msgstr "Ihr Inhalt auf vutuv wurde gemeldet und ist verborgen"
 
-#: lib/vutuv/notifications/emailer.ex:939
+#: lib/vutuv/notifications/emailer.ex:1016
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account has been deactivated"
 msgstr "Ihr vutuv-Konto wurde deaktiviert"
 
-#: lib/vutuv/notifications/emailer.ex:932
+#: lib/vutuv/notifications/emailer.ex:1009
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account is suspended"
 msgstr "Ihr vutuv-Konto ist gesperrt"
@@ -4034,7 +4034,7 @@ msgstr "Mitglieder mit den meisten Followern"
 msgid "People %{name} follows"
 msgstr "Wem %{name} folgt"
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:206
+#: lib/vutuv_web/agent_docs/post_doc.ex:210
 #, elixir-autogen, elixir-format
 msgid "Post archive of %{name}"
 msgstr "Beitragsarchiv von %{name}"
@@ -5635,9 +5635,9 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:2835
-#: lib/vutuv_web/components/post_components.ex:2887
-#: lib/vutuv_web/components/post_components.ex:3284
+#: lib/vutuv_web/components/post_components.ex:2837
+#: lib/vutuv_web/components/post_components.ex:2889
+#: lib/vutuv_web/components/post_components.ex:3286
 #: lib/vutuv_web/live/notification_live/index.ex:691
 #: lib/vutuv_web/live/post_live/feed.ex:1245
 #: lib/vutuv_web/views/user_html.ex:113
@@ -5645,7 +5645,7 @@ msgstr "Fußzeilen-Navigation"
 msgid "View post"
 msgstr "Beitrag ansehen"
 
-#: lib/vutuv/notifications/emailer.ex:245
+#: lib/vutuv/notifications/emailer.ex:312
 #, elixir-autogen, elixir-format
 msgid "Someone tried to register with your email address"
 msgstr "Registrierungsversuch mit Ihrer E-Mail-Adresse"
@@ -5843,12 +5843,12 @@ msgstr "z. B. Dr. oder Prof."
 msgid "e.g. Jr. or PhD"
 msgstr "z. B. jun. oder B.Sc."
 
-#: lib/vutuv/notifications/emailer.ex:346
+#: lib/vutuv/notifications/emailer.ex:414
 #, elixir-autogen, elixir-format
 msgid "@%{slug} endorsed you on vutuv"
 msgstr "@%{slug} hat Sie auf vutuv empfohlen"
 
-#: lib/vutuv/notifications/emailer.ex:332
+#: lib/vutuv/notifications/emailer.ex:400
 #, elixir-autogen, elixir-format
 msgid "@%{slug} started following you on vutuv"
 msgstr "@%{slug} folgt Ihnen jetzt auf vutuv"
@@ -6093,7 +6093,7 @@ msgstr[1] "vor %{count} Minuten"
 msgid "All other devices have been logged out."
 msgstr "Alle anderen Geräte wurden abgemeldet."
 
-#: lib/vutuv/notifications/emailer.ex:644
+#: lib/vutuv/notifications/emailer.ex:716
 #, elixir-autogen, elixir-format
 msgid "Another session was already active on your account."
 msgstr "Auf Ihrem Konto war bereits eine andere Sitzung aktiv."
@@ -6118,7 +6118,7 @@ msgstr "Von allen Geräten außer diesem abmelden?"
 msgid "Log this device out of your account?"
 msgstr "Dieses Gerät von Ihrem Konto abmelden?"
 
-#: lib/vutuv/notifications/emailer.ex:619
+#: lib/vutuv/notifications/emailer.ex:690
 #, elixir-autogen, elixir-format
 msgid "New sign-in to your vutuv account"
 msgstr "Neue Anmeldung bei Ihrem vutuv-Konto"
@@ -6133,7 +6133,7 @@ msgstr "Angemeldete Geräte"
 msgid "That device has been logged out."
 msgstr "Dieses Gerät wurde abgemeldet."
 
-#: lib/vutuv/notifications/emailer.ex:647
+#: lib/vutuv/notifications/emailer.ex:719
 #, elixir-autogen, elixir-format
 msgid "The location looks different from where you usually sign in."
 msgstr "Der Ort weicht von dem ab, von dem Sie sich üblicherweise anmelden."
@@ -6143,7 +6143,7 @@ msgstr "Der Ort weicht von dem ab, von dem Sie sich üblicherweise anmelden."
 msgid "This device"
 msgstr "Dieses Gerät"
 
-#: lib/vutuv/notifications/emailer.ex:641
+#: lib/vutuv/notifications/emailer.ex:713
 #, elixir-autogen, elixir-format
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
@@ -6926,7 +6926,7 @@ msgstr "Folgen Sie einander, um mit %{name} vernetzt zu sein und ihn zu lesen."
 msgid "Go to profile to follow"
 msgstr "Zum Profil, um zu folgen"
 
-#: lib/vutuv_web/components/post_components.ex:2769
+#: lib/vutuv_web/components/post_components.ex:2771
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr "@%{handle} stummschalten"
@@ -6936,7 +6936,7 @@ msgstr "@%{handle} stummschalten"
 msgid "Professional"
 msgstr "Beruflich"
 
-#: lib/vutuv_web/components/post_components.ex:2768
+#: lib/vutuv_web/components/post_components.ex:2770
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr "@%{handle} nicht mehr stummschalten"
@@ -7642,7 +7642,7 @@ msgstr "Alle abwählen"
 msgid "applies to the whole list, not just this page"
 msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 
-#: lib/vutuv_web/components/post_components.ex:4581
+#: lib/vutuv_web/components/post_components.ex:4604
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -9238,7 +9238,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:3723
+#: lib/vutuv_web/components/post_components.ex:3725
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -13005,7 +13005,7 @@ msgstr "Veröffentlichen"
 
 #: lib/vutuv/accounts/user.ex:1097
 #: lib/vutuv/jobs/job_posting.ex:164
-#: lib/vutuv/notifications/emailer.ex:496
+#: lib/vutuv/notifications/emailer.ex:564
 #: lib/vutuv_web/agent_docs/markdown.ex:389
 #: lib/vutuv_web/agent_docs/markdown.ex:391
 #: lib/vutuv_web/agent_docs/text.ex:411
@@ -13140,12 +13140,12 @@ msgstr "Arbeitsort"
 msgid "You already have the maximum number of published postings."
 msgstr "Sie haben bereits die maximale Anzahl veröffentlichter Anzeigen."
 
-#: lib/vutuv/notifications/emailer.ex:955
+#: lib/vutuv/notifications/emailer.ex:1032
 #, elixir-autogen, elixir-format
 msgid "Your job posting on vutuv expires soon"
 msgstr "Ihre Stellenanzeige auf vutuv läuft bald ab"
 
-#: lib/vutuv/notifications/emailer.ex:833
+#: lib/vutuv/notifications/emailer.ex:910
 #, elixir-autogen, elixir-format
 msgid "A domain of your organization page on vutuv is about to be dropped"
 msgstr "Eine Domain Ihrer Organisationsseite auf vutuv entfällt bald"
@@ -13165,12 +13165,12 @@ msgstr "Nachweis fehlt"
 msgid "We could not read this domain's proof on the last check. Restore it and check again, or the domain loses its verification."
 msgstr "Der Nachweis dieser Domain war bei der letzten Prüfung nicht abrufbar. Stellen Sie ihn wieder her und prüfen Sie erneut, sonst verliert die Domain ihre Verifizierung."
 
-#: lib/vutuv/notifications/emailer.ex:830
+#: lib/vutuv/notifications/emailer.ex:907
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is about to lose its verification"
 msgstr "Ihre Organisationsseite auf vutuv verliert bald ihre Verifizierung"
 
-#: lib/vutuv/notifications/emailer.ex:876
+#: lib/vutuv/notifications/emailer.ex:953
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is no longer public"
 msgstr "Ihre Organisationsseite auf vutuv ist nicht mehr öffentlich"
@@ -13620,7 +13620,7 @@ msgstr "verifizierte Organisationsseite"
 msgid "—"
 msgstr "—"
 
-#: lib/vutuv/notifications/emailer.ex:445
+#: lib/vutuv/notifications/emailer.ex:513
 #, elixir-autogen, elixir-format
 msgid "%{count} new match for your saved searches"
 msgid_plural "%{count} new matches for your saved searches"
@@ -14348,34 +14348,34 @@ msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch imm
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:4211
+#: lib/vutuv_web/components/post_components.ex:4234
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1089
-#: lib/vutuv_web/components/post_components.ex:4168
+#: lib/vutuv_web/components/post_components.ex:4191
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:4212
+#: lib/vutuv_web/components/post_components.ex:4235
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:4214
+#: lib/vutuv_web/components/post_components.ex:4237
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:4210
+#: lib/vutuv_web/components/post_components.ex:4233
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1089
-#: lib/vutuv_web/components/post_components.ex:4167
+#: lib/vutuv_web/components/post_components.ex:4190
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Filmbesprechung"
@@ -14386,12 +14386,12 @@ msgstr "Filmbesprechung"
 msgid "Look up"
 msgstr "Nachschlagen"
 
-#: lib/vutuv_web/components/post_components.ex:4209
+#: lib/vutuv_web/components/post_components.ex:4232
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
 
-#: lib/vutuv_web/components/post_components.ex:4213
+#: lib/vutuv_web/components/post_components.ex:4236
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14411,7 +14411,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:4250
+#: lib/vutuv_web/components/post_components.ex:4273
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14419,27 +14419,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:4280
+#: lib/vutuv_web/components/post_components.ex:4303
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:4281
+#: lib/vutuv_web/components/post_components.ex:4304
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:4279
+#: lib/vutuv_web/components/post_components.ex:4302
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:4239
+#: lib/vutuv_web/components/post_components.ex:4262
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:4286
+#: lib/vutuv_web/components/post_components.ex:4309
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14469,7 +14469,7 @@ msgstr "Mit Qualifikation:"
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:4053
+#: lib/vutuv_web/components/post_components.ex:4076
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
@@ -14517,7 +14517,7 @@ msgstr "folgen Ihnen jetzt."
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:4044
+#: lib/vutuv_web/components/post_components.ex:4067
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
@@ -14760,7 +14760,7 @@ msgstr "Bevorzugte Arbeitsform"
 msgid "Availability"
 msgstr "Verfügbarkeit"
 
-#: lib/vutuv/notifications/emailer.ex:917
+#: lib/vutuv/notifications/emailer.ex:994
 #, elixir-autogen, elixir-format
 msgid "An automated check removed an image from your vutuv account"
 msgstr "Eine automatische Prüfung hat ein Bild aus Ihrem vutuv-Konto entfernt"
@@ -14943,7 +14943,7 @@ msgstr "Dieses Profil ist zurzeit nicht verfügbar."
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das Konto zu finden, das eingefroren werden soll."
 
-#: lib/vutuv_web/components/post_components.ex:4678
+#: lib/vutuv_web/components/post_components.ex:4701
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Der eigene Beitrag lässt sich nicht mit „Gefällt mir“ markieren."
@@ -16132,21 +16132,21 @@ msgstr ""
 "wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
-#: lib/vutuv_web/components/post_components.ex:4626
+#: lib/vutuv_web/components/post_components.ex:4649
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:4630
+#: lib/vutuv_web/components/post_components.ex:4653
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Like"
 msgstr[1] "%{formatted} Likes"
 
-#: lib/vutuv_web/components/post_components.ex:4634
+#: lib/vutuv_web/components/post_components.ex:4657
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -16154,7 +16154,7 @@ msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1038
-#: lib/vutuv_web/components/post_components.ex:4585
+#: lib/vutuv_web/components/post_components.ex:4608
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Bereits in den Zahlen oben enthalten."
@@ -16346,7 +16346,7 @@ msgstr "Bitte bestätigen Sie die Änderung, bevor wir Ihr Konto umbenennen."
 msgid "This confirmation expired. Please start again."
 msgstr "Diese Bestätigung ist abgelaufen. Bitte beginnen Sie von vorn."
 
-#: lib/vutuv/notifications/emailer.ex:227
+#: lib/vutuv/notifications/emailer.ex:294
 #, elixir-autogen, elixir-format
 msgid "Confirm your new username"
 msgstr "Bestätigen Sie Ihren neuen Benutzernamen"
@@ -16919,17 +16919,17 @@ msgstr "Gerät oder Detail"
 msgid "Pinned post"
 msgstr "Angehefteter Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:2735
+#: lib/vutuv_web/components/post_components.ex:2737
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "An Profil anheften"
 
-#: lib/vutuv_web/components/post_components.ex:2743
+#: lib/vutuv_web/components/post_components.ex:2745
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Vom Profil lösen"
 
-#: lib/vutuv_web/components/post_components.ex:2729
+#: lib/vutuv_web/components/post_components.ex:2731
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr "Es lässt sich nur ein Beitrag an Ihr Profil anheften. Diesen anheften und den anderen lösen?"
@@ -17021,7 +17021,7 @@ msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1150
 #: lib/vutuv_web/agent_docs/text.ex:702
-#: lib/vutuv_web/components/post_components.ex:3207
+#: lib/vutuv_web/components/post_components.ex:3209
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr "Original herunterladen"
@@ -17051,7 +17051,7 @@ msgstr "Volle Auflösung, direkt aus dem Beitrag."
 msgid "Just the picture"
 msgstr "Nur das Bild"
 
-#: lib/vutuv_web/components/post_components.ex:3206
+#: lib/vutuv_web/components/post_components.ex:3208
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr "Nächstes Foto"
@@ -17061,7 +17061,7 @@ msgstr "Nächstes Foto"
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
 
-#: lib/vutuv_web/components/post_components.ex:3587
+#: lib/vutuv_web/components/post_components.ex:3589
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post so far."
 msgstr "Bisher sehen nur Sie diesen Beitrag."
@@ -17071,19 +17071,19 @@ msgstr "Bisher sehen nur Sie diesen Beitrag."
 msgid "Open Fediverse settings"
 msgstr "Fediverse-Einstellungen öffnen"
 
-#: lib/vutuv_web/components/post_components.ex:3590
+#: lib/vutuv_web/components/post_components.ex:3592
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] "Unsere KI prüft das Foto. Sobald es durch ist, geht der Beitrag von selbst online."
 msgstr[1] "Unsere KI prüft die Fotos, %{done} von %{total} sind durch. Sobald das letzte durch ist, geht der Beitrag von selbst online."
 
-#: lib/vutuv_web/components/post_components.ex:3413
+#: lib/vutuv_web/components/post_components.ex:3415
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} von %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:2944
+#: lib/vutuv_web/components/post_components.ex:2946
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
@@ -17096,12 +17096,12 @@ msgstr "Foto-Einstellungen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1183
 #: lib/vutuv_web/agent_docs/text.ex:689
-#: lib/vutuv_web/components/post_components.ex:3624
+#: lib/vutuv_web/components/post_components.ex:3626
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Fotos:"
 
-#: lib/vutuv_web/components/post_components.ex:3205
+#: lib/vutuv_web/components/post_components.ex:3207
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr "Vorheriges Foto"
@@ -17269,13 +17269,13 @@ msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exak
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1056
-#: lib/vutuv_web/components/post_components.ex:4623
+#: lib/vutuv_web/components/post_components.ex:4646
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1054
-#: lib/vutuv_web/components/post_components.ex:4620
+#: lib/vutuv_web/components/post_components.ex:4643
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} hat das geteilt"
@@ -17285,7 +17285,7 @@ msgstr "%{handle} hat das geteilt"
 msgid "Fediverse reactions"
 msgstr "Fediverse-Reaktionen"
 
-#: lib/vutuv_web/components/post_components.ex:4512
+#: lib/vutuv_web/components/post_components.ex:4535
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
@@ -19027,19 +19027,19 @@ msgstr "Auf der Seite eines Beitrags stehen direkt unter der Zahl die Mitglieder
 msgid "Liked by"
 msgstr "Gefällt diesen Mitgliedern"
 
-#: lib/vutuv_web/components/post_components.ex:3790
+#: lib/vutuv_web/components/post_components.ex:3792
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Gefällt %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:3792
+#: lib/vutuv_web/components/post_components.ex:3794
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Gefällt %{name} und %{formatted} weiteren"
 msgstr[1] "Gefällt %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/components/post_components.ex:3803
+#: lib/vutuv_web/components/post_components.ex:3805
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr "Nur Sie sehen hier alle: Einige dieser Mitglieder werden anderen Lesern nicht genannt."
@@ -19611,7 +19611,7 @@ msgstr "Wenn die Prüfung eines Ihrer Arbeitszeugnisse fertig ist. Das dauert ei
 msgid "Your employment reference has been reviewed."
 msgstr "Ihr Arbeitszeugnis wurde geprüft."
 
-#: lib/vutuv/notifications/emailer.ex:409
+#: lib/vutuv/notifications/emailer.ex:477
 #, elixir-autogen, elixir-format
 msgid "Your reference “%{title}” has been reviewed"
 msgstr "Ihr Zeugnis „%{title}“ wurde geprüft"
@@ -19686,7 +19686,7 @@ msgstr "Nur nötig, wenn Sie keine Datei zum Hochladen haben."
 msgid "Upload the PDF or the scan. We read the text out of it, and the review always reads that text, never the file itself."
 msgstr "Laden Sie das PDF oder den Scan hoch. Wir lesen den Text daraus aus, und die Prüfung liest immer diesen Text, nie die Datei selbst."
 
-#: lib/vutuv/notifications/emailer.ex:390
+#: lib/vutuv/notifications/emailer.ex:458
 #, elixir-autogen, elixir-format
 msgid "%{count} new notification on vutuv"
 msgid_plural "%{count} new notifications on vutuv"
@@ -20840,32 +20840,32 @@ msgstr "Sie schreiben als %{name}."
 msgid "You are yourself again."
 msgstr "Sie sind wieder Sie selbst."
 
-#: lib/vutuv_web/live/organization_live/activity.ex:76
+#: lib/vutuv_web/live/organization_live/activity.ex:81
 #, elixir-autogen, elixir-format
 msgid "%{name} follows this page."
 msgstr "%{name} folgt dieser Seite."
 
-#: lib/vutuv_web/live/organization_live/activity.ex:79
+#: lib/vutuv_web/live/organization_live/activity.ex:84
 #, elixir-autogen, elixir-format
 msgid "%{name} liked a post."
 msgstr "%{name} gefällt ein Beitrag."
 
-#: lib/vutuv_web/live/organization_live/activity.ex:82
+#: lib/vutuv_web/live/organization_live/activity.ex:87
 #, elixir-autogen, elixir-format
 msgid "%{name} reposted a post."
 msgstr "%{name} hat einen Beitrag geteilt."
 
-#: lib/vutuv_web/live/organization_live/activity.ex:48
+#: lib/vutuv_web/live/organization_live/activity.ex:53
 #, elixir-autogen, elixir-format
 msgid "Activity – %{name}"
 msgstr "Aktivität – %{name}"
 
-#: lib/vutuv_web/live/organization_live/activity.ex:106
+#: lib/vutuv_web/live/organization_live/activity.ex:114
 #, elixir-autogen, elixir-format
 msgid "Nothing has happened yet."
 msgstr "Bisher ist nichts passiert."
 
-#: lib/vutuv_web/live/organization_live/activity.ex:101
+#: lib/vutuv_web/live/organization_live/activity.ex:109
 #, elixir-autogen, elixir-format
 msgid "What happened to this page. Everyone on the team sees the same list, and opening it marks it read for all of you."
 msgstr "Was auf dieser Seite passiert ist. Alle im Team sehen dieselbe Liste, und wer sie öffnet, markiert sie für alle als gelesen."
@@ -20877,7 +20877,7 @@ msgid_plural "%{formatted} new"
 msgstr[0] "%{formatted} neu"
 msgstr[1] "%{formatted} neu"
 
-#: lib/vutuv_web/live/organization_live/activity.ex:85
+#: lib/vutuv_web/live/organization_live/activity.ex:90
 #, elixir-autogen, elixir-format
 msgid "%{name} mentioned this page."
 msgstr "%{name} hat diese Seite erwähnt."
@@ -20998,7 +20998,7 @@ msgstr "Diese Seite folgt noch niemandem auf einem anderen Netzwerk."
 msgid "Too many attempts for now. Try again later."
 msgstr "Zu viele Versuche. Bitte versuchen Sie es später erneut."
 
-#: lib/vutuv/notifications/emailer.ex:282
+#: lib/vutuv/notifications/emailer.ex:350
 #, elixir-autogen, elixir-format
 msgid "New message from %{sender} on vutuv"
 msgstr "Neue Nachricht von %{sender} auf vutuv"
@@ -21378,7 +21378,7 @@ msgstr "Wir haben diese Adresse abgerufen:"
 msgid "What is published there right now:"
 msgstr "Was dort im Moment veröffentlicht ist:"
 
-#: lib/vutuv/notifications/emailer.ex:856
+#: lib/vutuv/notifications/emailer.ex:933
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is verified"
 msgstr "Ihre Organisationsseite auf vutuv ist verifiziert"
@@ -21407,3 +21407,8 @@ msgstr "Ihre Seite verlinkt zurück, aber woandershin:"
 #, elixir-autogen, elixir-format
 msgid "Your page has no rel=\"me\" link at all yet."
 msgstr "Ihre Seite hat noch gar keinen rel=\"me\"-Link."
+
+#: lib/vutuv_web/live/organization_live/activity.ex:93
+#, elixir-autogen, elixir-format
+msgid "%{name} answered a post."
+msgstr "%{name} hat auf einen Beitrag geantwortet."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -161,7 +161,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2751
+#: lib/vutuv_web/components/post_components.ex:2753
 #: lib/vutuv_web/components/ui.ex:3492
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -210,7 +210,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2716
+#: lib/vutuv_web/components/post_components.ex:2718
 #: lib/vutuv_web/components/ui.ex:3483
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -474,7 +474,7 @@ msgid "Name"
 msgstr ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:647
-#: lib/vutuv_web/live/organization_live/activity.ex:123
+#: lib/vutuv_web/live/organization_live/activity.ex:131
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:3
@@ -1049,22 +1049,22 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:213
+#: lib/vutuv/notifications/emailer.ex:280
 #, elixir-autogen
 msgid "Confirm your account deletion"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:207
+#: lib/vutuv/notifications/emailer.ex:274
 #, elixir-autogen
 msgid "Confirm your email"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:195
+#: lib/vutuv/notifications/emailer.ex:262
 #, elixir-autogen
 msgid "Confirm your vutuv account"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:201
+#: lib/vutuv/notifications/emailer.ex:268
 #, elixir-autogen
 msgid "Login to vutuv"
 msgstr ""
@@ -1548,7 +1548,7 @@ msgstr ""
 msgid "tag name"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:253
+#: lib/vutuv/notifications/emailer.ex:320
 #, elixir-autogen
 msgid "vutuv Account verified"
 msgstr ""
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3204
+#: lib/vutuv_web/components/post_components.ex:3206
 #: lib/vutuv_web/components/ui.ex:298
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
@@ -1918,7 +1918,7 @@ msgid "Pagination"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3627
-#: lib/vutuv_web/live/organization_live/activity.ex:146
+#: lib/vutuv_web/live/organization_live/activity.ex:154
 #: lib/vutuv_web/live/organization_live/feed.ex:101
 #: lib/vutuv_web/live/organization_live/show.ex:637
 #, elixir-autogen, elixir-format
@@ -2083,7 +2083,7 @@ msgid "As soon as anything is hidden, the post is also invisible to logged-out v
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/edit.ex:143
-#: lib/vutuv_web/live/post_live/reply.ex:83
+#: lib/vutuv_web/live/post_live/reply.ex:84
 #, elixir-autogen, elixir-format
 msgid "Back to the post"
 msgstr ""
@@ -2098,7 +2098,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2748
+#: lib/vutuv_web/components/post_components.ex:2750
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2141,8 +2141,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2702
 #: lib/vutuv_web/components/post_components.ex:2704
+#: lib/vutuv_web/components/post_components.ex:2706
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2190,7 +2190,7 @@ msgstr ""
 msgid "Post deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:205
+#: lib/vutuv_web/agent_docs/post_doc.ex:209
 #: lib/vutuv_web/controllers/post_controller.ex:60
 #: lib/vutuv_web/controllers/post_controller.ex:69
 #: lib/vutuv_web/controllers/user_controller.ex:77
@@ -2208,13 +2208,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3140
-#: lib/vutuv_web/components/post_components.ex:3144
+#: lib/vutuv_web/components/post_components.ex:3142
+#: lib/vutuv_web/components/post_components.ex:3146
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3141
+#: lib/vutuv_web/components/post_components.ex:3143
 #: lib/vutuv_web/live/fediverse_account_live.ex:320
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2304,27 +2304,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2699
+#: lib/vutuv_web/components/post_components.ex:2701
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4348
+#: lib/vutuv_web/components/post_components.ex:4371
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4352
+#: lib/vutuv_web/components/post_components.ex:4375
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4350
+#: lib/vutuv_web/components/post_components.ex:4373
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4351
+#: lib/vutuv_web/components/post_components.ex:4374
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2366,7 +2366,7 @@ msgid "All posts"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1603
-#: lib/vutuv_web/components/post_components.ex:4436
+#: lib/vutuv_web/components/post_components.ex:4459
 #: lib/vutuv_web/components/ui.ex:3017
 #: lib/vutuv_web/views/user_html.ex:335
 #, elixir-autogen, elixir-format
@@ -2385,7 +2385,7 @@ msgid "Bookmarks"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1567
-#: lib/vutuv_web/components/post_components.ex:4670
+#: lib/vutuv_web/components/post_components.ex:4693
 #: lib/vutuv_web/components/ui.ex:3003
 #: lib/vutuv_web/live/notification_live/index.ex:1038
 #: lib/vutuv_web/views/user_html.ex:345
@@ -2394,7 +2394,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1000
-#: lib/vutuv_web/components/post_components.ex:4679
+#: lib/vutuv_web/components/post_components.ex:4702
 #: lib/vutuv_web/live/notification_live/index.ex:971
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
@@ -2416,13 +2416,13 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4425
+#: lib/vutuv_web/components/post_components.ex:4448
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1603
-#: lib/vutuv_web/components/post_components.ex:4436
+#: lib/vutuv_web/components/post_components.ex:4459
 #: lib/vutuv_web/live/post_live/saved.ex:775
 #: lib/vutuv_web/views/user_html.ex:335
 #, elixir-autogen, elixir-format
@@ -2430,25 +2430,25 @@ msgid "Remove bookmark"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1591
-#: lib/vutuv_web/components/post_components.ex:4422
+#: lib/vutuv_web/components/post_components.ex:4445
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1781
-#: lib/vutuv_web/components/post_components.ex:3720
+#: lib/vutuv_web/components/post_components.ex:3722
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1591
-#: lib/vutuv_web/components/post_components.ex:4422
+#: lib/vutuv_web/components/post_components.ex:4445
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4670
+#: lib/vutuv_web/components/post_components.ex:4693
 #: lib/vutuv_web/live/post_live/saved.ex:774
 #: lib/vutuv_web/views/user_html.ex:345
 #, elixir-autogen, elixir-format
@@ -2474,7 +2474,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4723
+#: lib/vutuv_web/components/post_components.ex:4746
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2486,15 +2486,15 @@ msgid "Replies"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1578
-#: lib/vutuv_web/components/post_components.ex:4706
-#: lib/vutuv_web/components/post_components.ex:4707
+#: lib/vutuv_web/components/post_components.ex:4729
+#: lib/vutuv_web/components/post_components.ex:4730
 #: lib/vutuv_web/live/notification_live/index.ex:1035
-#: lib/vutuv_web/live/post_live/reply.ex:42
+#: lib/vutuv_web/live/post_live/reply.ex:43
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2666
+#: lib/vutuv_web/components/post_components.ex:2668
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2518,7 +2518,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:2217
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:59
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
-#: lib/vutuv_web/live/post_live/reply.ex:56
+#: lib/vutuv_web/live/post_live/reply.ex:57
 #, elixir-autogen, elixir-format
 msgid "Reply to %{handle}"
 msgstr ""
@@ -2529,8 +2529,8 @@ msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2636
-#: lib/vutuv_web/components/post_components.ex:2658
-#: lib/vutuv_web/components/post_components.ex:2661
+#: lib/vutuv_web/components/post_components.ex:2660
+#: lib/vutuv_web/components/post_components.ex:2663
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2831,7 +2831,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4349
+#: lib/vutuv_web/components/post_components.ex:4372
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2843,7 +2843,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:241
 #: lib/vutuv_web/live/notification_live/index.ex:1050
-#: lib/vutuv_web/live/organization_live/activity.ex:99
+#: lib/vutuv_web/live/organization_live/activity.ex:107
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
@@ -3171,7 +3171,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1066
 #: lib/vutuv_web/components/post_components.ex:2042
-#: lib/vutuv_web/components/post_components.ex:2772
+#: lib/vutuv_web/components/post_components.ex:2774
 #: lib/vutuv_web/live/organization_live/show.ex:547
 #: lib/vutuv_web/templates/user/show.html.heex:219
 #, elixir-autogen, elixir-format
@@ -3484,42 +3484,42 @@ msgstr ""
 msgid "yes"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:925
+#: lib/vutuv/notifications/emailer.ex:1002
 #, elixir-autogen, elixir-format
 msgid "A warning for your vutuv account"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1009
+#: lib/vutuv/notifications/emailer.ex:1086
 #, elixir-autogen, elixir-format
 msgid "Moderation: %{count} cases are waiting"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:987
+#: lib/vutuv/notifications/emailer.ex:1064
 #, elixir-autogen, elixir-format
 msgid "Moderation: a profile was reported"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:899
+#: lib/vutuv/notifications/emailer.ex:976
 #, elixir-autogen, elixir-format
 msgid "The content you reported was revised"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:892
+#: lib/vutuv/notifications/emailer.ex:969
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv is under review"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:885
+#: lib/vutuv/notifications/emailer.ex:962
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv was reported and is hidden"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:939
+#: lib/vutuv/notifications/emailer.ex:1016
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account has been deactivated"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:932
+#: lib/vutuv/notifications/emailer.ex:1009
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account is suspended"
 msgstr ""
@@ -3906,7 +3906,7 @@ msgstr ""
 msgid "People %{name} follows"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:206
+#: lib/vutuv_web/agent_docs/post_doc.ex:210
 #, elixir-autogen, elixir-format
 msgid "Post archive of %{name}"
 msgstr ""
@@ -5410,9 +5410,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2835
-#: lib/vutuv_web/components/post_components.ex:2887
-#: lib/vutuv_web/components/post_components.ex:3284
+#: lib/vutuv_web/components/post_components.ex:2837
+#: lib/vutuv_web/components/post_components.ex:2889
+#: lib/vutuv_web/components/post_components.ex:3286
 #: lib/vutuv_web/live/notification_live/index.ex:691
 #: lib/vutuv_web/live/post_live/feed.ex:1245
 #: lib/vutuv_web/views/user_html.ex:113
@@ -5420,7 +5420,7 @@ msgstr ""
 msgid "View post"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:245
+#: lib/vutuv/notifications/emailer.ex:312
 #, elixir-autogen, elixir-format
 msgid "Someone tried to register with your email address"
 msgstr ""
@@ -5615,12 +5615,12 @@ msgstr ""
 msgid "e.g. Jr. or PhD"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:346
+#: lib/vutuv/notifications/emailer.ex:414
 #, elixir-autogen, elixir-format
 msgid "@%{slug} endorsed you on vutuv"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:332
+#: lib/vutuv/notifications/emailer.ex:400
 #, elixir-autogen, elixir-format
 msgid "@%{slug} started following you on vutuv"
 msgstr ""
@@ -5861,7 +5861,7 @@ msgstr[1] ""
 msgid "All other devices have been logged out."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:644
+#: lib/vutuv/notifications/emailer.ex:716
 #, elixir-autogen, elixir-format
 msgid "Another session was already active on your account."
 msgstr ""
@@ -5886,7 +5886,7 @@ msgstr ""
 msgid "Log this device out of your account?"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:619
+#: lib/vutuv/notifications/emailer.ex:690
 #, elixir-autogen, elixir-format
 msgid "New sign-in to your vutuv account"
 msgstr ""
@@ -5901,7 +5901,7 @@ msgstr ""
 msgid "That device has been logged out."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:647
+#: lib/vutuv/notifications/emailer.ex:719
 #, elixir-autogen, elixir-format
 msgid "The location looks different from where you usually sign in."
 msgstr ""
@@ -5911,7 +5911,7 @@ msgstr ""
 msgid "This device"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:641
+#: lib/vutuv/notifications/emailer.ex:713
 #, elixir-autogen, elixir-format
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
@@ -6646,7 +6646,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2769
+#: lib/vutuv_web/components/post_components.ex:2771
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6656,7 +6656,7 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2768
+#: lib/vutuv_web/components/post_components.ex:2770
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -7338,7 +7338,7 @@ msgstr ""
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4581
+#: lib/vutuv_web/components/post_components.ex:4604
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8799,7 +8799,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3723
+#: lib/vutuv_web/components/post_components.ex:3725
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -12347,7 +12347,7 @@ msgstr ""
 
 #: lib/vutuv/accounts/user.ex:1097
 #: lib/vutuv/jobs/job_posting.ex:164
-#: lib/vutuv/notifications/emailer.ex:496
+#: lib/vutuv/notifications/emailer.ex:564
 #: lib/vutuv_web/agent_docs/markdown.ex:389
 #: lib/vutuv_web/agent_docs/markdown.ex:391
 #: lib/vutuv_web/agent_docs/text.ex:411
@@ -12482,12 +12482,12 @@ msgstr ""
 msgid "You already have the maximum number of published postings."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:955
+#: lib/vutuv/notifications/emailer.ex:1032
 #, elixir-autogen, elixir-format
 msgid "Your job posting on vutuv expires soon"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:833
+#: lib/vutuv/notifications/emailer.ex:910
 #, elixir-autogen, elixir-format
 msgid "A domain of your organization page on vutuv is about to be dropped"
 msgstr ""
@@ -12507,12 +12507,12 @@ msgstr ""
 msgid "We could not read this domain's proof on the last check. Restore it and check again, or the domain loses its verification."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:830
+#: lib/vutuv/notifications/emailer.ex:907
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is about to lose its verification"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:876
+#: lib/vutuv/notifications/emailer.ex:953
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is no longer public"
 msgstr ""
@@ -12962,7 +12962,7 @@ msgstr ""
 msgid "—"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:445
+#: lib/vutuv/notifications/emailer.ex:513
 #, elixir-autogen, elixir-format
 msgid "%{count} new match for your saved searches"
 msgid_plural "%{count} new matches for your saved searches"
@@ -13669,34 +13669,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4211
+#: lib/vutuv_web/components/post_components.ex:4234
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1089
-#: lib/vutuv_web/components/post_components.ex:4168
+#: lib/vutuv_web/components/post_components.ex:4191
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4212
+#: lib/vutuv_web/components/post_components.ex:4235
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4214
+#: lib/vutuv_web/components/post_components.ex:4237
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4210
+#: lib/vutuv_web/components/post_components.ex:4233
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1089
-#: lib/vutuv_web/components/post_components.ex:4167
+#: lib/vutuv_web/components/post_components.ex:4190
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13707,12 +13707,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4209
+#: lib/vutuv_web/components/post_components.ex:4232
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4213
+#: lib/vutuv_web/components/post_components.ex:4236
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13732,7 +13732,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4250
+#: lib/vutuv_web/components/post_components.ex:4273
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13740,27 +13740,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4280
+#: lib/vutuv_web/components/post_components.ex:4303
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4281
+#: lib/vutuv_web/components/post_components.ex:4304
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4279
+#: lib/vutuv_web/components/post_components.ex:4302
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4239
+#: lib/vutuv_web/components/post_components.ex:4262
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4286
+#: lib/vutuv_web/components/post_components.ex:4309
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13790,7 +13790,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4053
+#: lib/vutuv_web/components/post_components.ex:4076
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13838,7 +13838,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4044
+#: lib/vutuv_web/components/post_components.ex:4067
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14069,7 +14069,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:917
+#: lib/vutuv/notifications/emailer.ex:994
 #, elixir-autogen, elixir-format
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
@@ -14242,7 +14242,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4678
+#: lib/vutuv_web/components/post_components.ex:4701
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -15415,21 +15415,21 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4626
+#: lib/vutuv_web/components/post_components.ex:4649
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4630
+#: lib/vutuv_web/components/post_components.ex:4653
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4634
+#: lib/vutuv_web/components/post_components.ex:4657
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15437,7 +15437,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1038
-#: lib/vutuv_web/components/post_components.ex:4585
+#: lib/vutuv_web/components/post_components.ex:4608
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15629,7 +15629,7 @@ msgstr ""
 msgid "This confirmation expired. Please start again."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:227
+#: lib/vutuv/notifications/emailer.ex:294
 #, elixir-autogen, elixir-format
 msgid "Confirm your new username"
 msgstr ""
@@ -16198,17 +16198,17 @@ msgstr ""
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2735
+#: lib/vutuv_web/components/post_components.ex:2737
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2743
+#: lib/vutuv_web/components/post_components.ex:2745
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2729
+#: lib/vutuv_web/components/post_components.ex:2731
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16294,7 +16294,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1150
 #: lib/vutuv_web/agent_docs/text.ex:702
-#: lib/vutuv_web/components/post_components.ex:3207
+#: lib/vutuv_web/components/post_components.ex:3209
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
@@ -16324,7 +16324,7 @@ msgstr ""
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3206
+#: lib/vutuv_web/components/post_components.ex:3208
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
@@ -16334,7 +16334,7 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3587
+#: lib/vutuv_web/components/post_components.ex:3589
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post so far."
 msgstr ""
@@ -16344,19 +16344,19 @@ msgstr ""
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3590
+#: lib/vutuv_web/components/post_components.ex:3592
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3413
+#: lib/vutuv_web/components/post_components.ex:3415
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2944
+#: lib/vutuv_web/components/post_components.ex:2946
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16369,12 +16369,12 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1183
 #: lib/vutuv_web/agent_docs/text.ex:689
-#: lib/vutuv_web/components/post_components.ex:3624
+#: lib/vutuv_web/components/post_components.ex:3626
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3205
+#: lib/vutuv_web/components/post_components.ex:3207
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr ""
@@ -16542,13 +16542,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1056
-#: lib/vutuv_web/components/post_components.ex:4623
+#: lib/vutuv_web/components/post_components.ex:4646
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1054
-#: lib/vutuv_web/components/post_components.ex:4620
+#: lib/vutuv_web/components/post_components.ex:4643
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr ""
@@ -16558,7 +16558,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4512
+#: lib/vutuv_web/components/post_components.ex:4535
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr ""
@@ -18275,19 +18275,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3790
+#: lib/vutuv_web/components/post_components.ex:3792
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3792
+#: lib/vutuv_web/components/post_components.ex:3794
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3803
+#: lib/vutuv_web/components/post_components.ex:3805
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -18857,7 +18857,7 @@ msgstr ""
 msgid "Your employment reference has been reviewed."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:409
+#: lib/vutuv/notifications/emailer.ex:477
 #, elixir-autogen, elixir-format
 msgid "Your reference “%{title}” has been reviewed"
 msgstr ""
@@ -18932,7 +18932,7 @@ msgstr ""
 msgid "Upload the PDF or the scan. We read the text out of it, and the review always reads that text, never the file itself."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:390
+#: lib/vutuv/notifications/emailer.ex:458
 #, elixir-autogen, elixir-format
 msgid "%{count} new notification on vutuv"
 msgid_plural "%{count} new notifications on vutuv"
@@ -20068,32 +20068,32 @@ msgstr ""
 msgid "You are yourself again."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/activity.ex:76
+#: lib/vutuv_web/live/organization_live/activity.ex:81
 #, elixir-autogen, elixir-format
 msgid "%{name} follows this page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/activity.ex:79
+#: lib/vutuv_web/live/organization_live/activity.ex:84
 #, elixir-autogen, elixir-format
 msgid "%{name} liked a post."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/activity.ex:82
+#: lib/vutuv_web/live/organization_live/activity.ex:87
 #, elixir-autogen, elixir-format
 msgid "%{name} reposted a post."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/activity.ex:48
+#: lib/vutuv_web/live/organization_live/activity.ex:53
 #, elixir-autogen, elixir-format
 msgid "Activity – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/activity.ex:106
+#: lib/vutuv_web/live/organization_live/activity.ex:114
 #, elixir-autogen, elixir-format
 msgid "Nothing has happened yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/activity.ex:101
+#: lib/vutuv_web/live/organization_live/activity.ex:109
 #, elixir-autogen, elixir-format
 msgid "What happened to this page. Everyone on the team sees the same list, and opening it marks it read for all of you."
 msgstr ""
@@ -20105,7 +20105,7 @@ msgid_plural "%{formatted} new"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/organization_live/activity.ex:85
+#: lib/vutuv_web/live/organization_live/activity.ex:90
 #, elixir-autogen, elixir-format
 msgid "%{name} mentioned this page."
 msgstr ""
@@ -20226,7 +20226,7 @@ msgstr ""
 msgid "Too many attempts for now. Try again later."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:282
+#: lib/vutuv/notifications/emailer.ex:350
 #, elixir-autogen, elixir-format
 msgid "New message from %{sender} on vutuv"
 msgstr ""
@@ -20599,7 +20599,7 @@ msgstr ""
 msgid "What is published there right now:"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:856
+#: lib/vutuv/notifications/emailer.ex:933
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is verified"
 msgstr ""
@@ -20627,4 +20627,9 @@ msgstr ""
 #: lib/vutuv_web/components/verification_components.ex:150
 #, elixir-autogen, elixir-format
 msgid "Your page has no rel=\"me\" link at all yet."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/activity.ex:93
+#, elixir-autogen, elixir-format
+msgid "%{name} answered a post."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -159,7 +159,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2751
+#: lib/vutuv_web/components/post_components.ex:2753
 #: lib/vutuv_web/components/ui.ex:3492
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -208,7 +208,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2716
+#: lib/vutuv_web/components/post_components.ex:2718
 #: lib/vutuv_web/components/ui.ex:3483
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -472,7 +472,7 @@ msgid "Name"
 msgstr ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:647
-#: lib/vutuv_web/live/organization_live/activity.ex:123
+#: lib/vutuv_web/live/organization_live/activity.ex:131
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:3
@@ -1047,22 +1047,22 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:213
+#: lib/vutuv/notifications/emailer.ex:280
 #, elixir-autogen
 msgid "Confirm your account deletion"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:207
+#: lib/vutuv/notifications/emailer.ex:274
 #, elixir-autogen
 msgid "Confirm your email"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:195
+#: lib/vutuv/notifications/emailer.ex:262
 #, elixir-autogen
 msgid "Confirm your vutuv account"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:201
+#: lib/vutuv/notifications/emailer.ex:268
 #, elixir-autogen
 msgid "Login to vutuv"
 msgstr ""
@@ -1546,7 +1546,7 @@ msgstr ""
 msgid "tag name"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:253
+#: lib/vutuv/notifications/emailer.ex:320
 #, elixir-autogen
 msgid "vutuv Account verified"
 msgstr ""
@@ -1611,7 +1611,7 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3204
+#: lib/vutuv_web/components/post_components.ex:3206
 #: lib/vutuv_web/components/ui.ex:298
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
@@ -1916,7 +1916,7 @@ msgid "Pagination"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3627
-#: lib/vutuv_web/live/organization_live/activity.ex:146
+#: lib/vutuv_web/live/organization_live/activity.ex:154
 #: lib/vutuv_web/live/organization_live/feed.ex:101
 #: lib/vutuv_web/live/organization_live/show.ex:637
 #, elixir-autogen, elixir-format
@@ -2081,7 +2081,7 @@ msgid "As soon as anything is hidden, the post is also invisible to logged-out v
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/edit.ex:143
-#: lib/vutuv_web/live/post_live/reply.ex:83
+#: lib/vutuv_web/live/post_live/reply.ex:84
 #, elixir-autogen, elixir-format
 msgid "Back to the post"
 msgstr ""
@@ -2096,7 +2096,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2748
+#: lib/vutuv_web/components/post_components.ex:2750
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2139,8 +2139,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2702
 #: lib/vutuv_web/components/post_components.ex:2704
+#: lib/vutuv_web/components/post_components.ex:2706
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2188,7 +2188,7 @@ msgstr ""
 msgid "Post deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:205
+#: lib/vutuv_web/agent_docs/post_doc.ex:209
 #: lib/vutuv_web/controllers/post_controller.ex:60
 #: lib/vutuv_web/controllers/post_controller.ex:69
 #: lib/vutuv_web/controllers/user_controller.ex:77
@@ -2206,13 +2206,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3140
-#: lib/vutuv_web/components/post_components.ex:3144
+#: lib/vutuv_web/components/post_components.ex:3142
+#: lib/vutuv_web/components/post_components.ex:3146
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3141
+#: lib/vutuv_web/components/post_components.ex:3143
 #: lib/vutuv_web/live/fediverse_account_live.ex:320
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2302,27 +2302,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2699
+#: lib/vutuv_web/components/post_components.ex:2701
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4348
+#: lib/vutuv_web/components/post_components.ex:4371
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4352
+#: lib/vutuv_web/components/post_components.ex:4375
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4350
+#: lib/vutuv_web/components/post_components.ex:4373
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4351
+#: lib/vutuv_web/components/post_components.ex:4374
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2364,7 +2364,7 @@ msgid "All posts"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1603
-#: lib/vutuv_web/components/post_components.ex:4436
+#: lib/vutuv_web/components/post_components.ex:4459
 #: lib/vutuv_web/components/ui.ex:3017
 #: lib/vutuv_web/views/user_html.ex:335
 #, elixir-autogen, elixir-format
@@ -2383,7 +2383,7 @@ msgid "Bookmarks"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1567
-#: lib/vutuv_web/components/post_components.ex:4670
+#: lib/vutuv_web/components/post_components.ex:4693
 #: lib/vutuv_web/components/ui.ex:3003
 #: lib/vutuv_web/live/notification_live/index.ex:1038
 #: lib/vutuv_web/views/user_html.ex:345
@@ -2392,7 +2392,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1000
-#: lib/vutuv_web/components/post_components.ex:4679
+#: lib/vutuv_web/components/post_components.ex:4702
 #: lib/vutuv_web/live/notification_live/index.ex:971
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
@@ -2414,13 +2414,13 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4425
+#: lib/vutuv_web/components/post_components.ex:4448
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1603
-#: lib/vutuv_web/components/post_components.ex:4436
+#: lib/vutuv_web/components/post_components.ex:4459
 #: lib/vutuv_web/live/post_live/saved.ex:775
 #: lib/vutuv_web/views/user_html.ex:335
 #, elixir-autogen, elixir-format
@@ -2428,25 +2428,25 @@ msgid "Remove bookmark"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1591
-#: lib/vutuv_web/components/post_components.ex:4422
+#: lib/vutuv_web/components/post_components.ex:4445
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1781
-#: lib/vutuv_web/components/post_components.ex:3720
+#: lib/vutuv_web/components/post_components.ex:3722
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1591
-#: lib/vutuv_web/components/post_components.ex:4422
+#: lib/vutuv_web/components/post_components.ex:4445
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4670
+#: lib/vutuv_web/components/post_components.ex:4693
 #: lib/vutuv_web/live/post_live/saved.ex:774
 #: lib/vutuv_web/views/user_html.ex:345
 #, elixir-autogen, elixir-format
@@ -2472,7 +2472,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4723
+#: lib/vutuv_web/components/post_components.ex:4746
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2484,15 +2484,15 @@ msgid "Replies"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1578
-#: lib/vutuv_web/components/post_components.ex:4706
-#: lib/vutuv_web/components/post_components.ex:4707
+#: lib/vutuv_web/components/post_components.ex:4729
+#: lib/vutuv_web/components/post_components.ex:4730
 #: lib/vutuv_web/live/notification_live/index.ex:1035
-#: lib/vutuv_web/live/post_live/reply.ex:42
+#: lib/vutuv_web/live/post_live/reply.ex:43
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2666
+#: lib/vutuv_web/components/post_components.ex:2668
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2516,7 +2516,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:2217
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:59
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
-#: lib/vutuv_web/live/post_live/reply.ex:56
+#: lib/vutuv_web/live/post_live/reply.ex:57
 #, elixir-autogen, elixir-format
 msgid "Reply to %{handle}"
 msgstr ""
@@ -2527,8 +2527,8 @@ msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2636
-#: lib/vutuv_web/components/post_components.ex:2658
-#: lib/vutuv_web/components/post_components.ex:2661
+#: lib/vutuv_web/components/post_components.ex:2660
+#: lib/vutuv_web/components/post_components.ex:2663
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2829,7 +2829,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4349
+#: lib/vutuv_web/components/post_components.ex:4372
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2841,7 +2841,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:241
 #: lib/vutuv_web/live/notification_live/index.ex:1050
-#: lib/vutuv_web/live/organization_live/activity.ex:99
+#: lib/vutuv_web/live/organization_live/activity.ex:107
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
@@ -3169,7 +3169,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1066
 #: lib/vutuv_web/components/post_components.ex:2042
-#: lib/vutuv_web/components/post_components.ex:2772
+#: lib/vutuv_web/components/post_components.ex:2774
 #: lib/vutuv_web/live/organization_live/show.ex:547
 #: lib/vutuv_web/templates/user/show.html.heex:219
 #, elixir-autogen, elixir-format
@@ -3482,42 +3482,42 @@ msgstr ""
 msgid "yes"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:925
+#: lib/vutuv/notifications/emailer.ex:1002
 #, elixir-autogen, elixir-format
 msgid "A warning for your vutuv account"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:1009
+#: lib/vutuv/notifications/emailer.ex:1086
 #, elixir-autogen, elixir-format
 msgid "Moderation: %{count} cases are waiting"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:987
+#: lib/vutuv/notifications/emailer.ex:1064
 #, elixir-autogen, elixir-format
 msgid "Moderation: a profile was reported"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:899
+#: lib/vutuv/notifications/emailer.ex:976
 #, elixir-autogen, elixir-format
 msgid "The content you reported was revised"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:892
+#: lib/vutuv/notifications/emailer.ex:969
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv is under review"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:885
+#: lib/vutuv/notifications/emailer.ex:962
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv was reported and is hidden"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:939
+#: lib/vutuv/notifications/emailer.ex:1016
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account has been deactivated"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:932
+#: lib/vutuv/notifications/emailer.ex:1009
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account is suspended"
 msgstr ""
@@ -3904,7 +3904,7 @@ msgstr ""
 msgid "People %{name} follows"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:206
+#: lib/vutuv_web/agent_docs/post_doc.ex:210
 #, elixir-autogen, elixir-format
 msgid "Post archive of %{name}"
 msgstr ""
@@ -5408,9 +5408,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2835
-#: lib/vutuv_web/components/post_components.ex:2887
-#: lib/vutuv_web/components/post_components.ex:3284
+#: lib/vutuv_web/components/post_components.ex:2837
+#: lib/vutuv_web/components/post_components.ex:2889
+#: lib/vutuv_web/components/post_components.ex:3286
 #: lib/vutuv_web/live/notification_live/index.ex:691
 #: lib/vutuv_web/live/post_live/feed.ex:1245
 #: lib/vutuv_web/views/user_html.ex:113
@@ -5418,7 +5418,7 @@ msgstr ""
 msgid "View post"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:245
+#: lib/vutuv/notifications/emailer.ex:312
 #, elixir-autogen, elixir-format
 msgid "Someone tried to register with your email address"
 msgstr ""
@@ -5613,12 +5613,12 @@ msgstr ""
 msgid "e.g. Jr. or PhD"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:346
+#: lib/vutuv/notifications/emailer.ex:414
 #, elixir-autogen, elixir-format
 msgid "@%{slug} endorsed you on vutuv"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:332
+#: lib/vutuv/notifications/emailer.ex:400
 #, elixir-autogen, elixir-format
 msgid "@%{slug} started following you on vutuv"
 msgstr ""
@@ -5859,7 +5859,7 @@ msgstr[1] ""
 msgid "All other devices have been logged out."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:644
+#: lib/vutuv/notifications/emailer.ex:716
 #, elixir-autogen, elixir-format
 msgid "Another session was already active on your account."
 msgstr ""
@@ -5884,7 +5884,7 @@ msgstr ""
 msgid "Log this device out of your account?"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:619
+#: lib/vutuv/notifications/emailer.ex:690
 #, elixir-autogen, elixir-format
 msgid "New sign-in to your vutuv account"
 msgstr ""
@@ -5899,7 +5899,7 @@ msgstr ""
 msgid "That device has been logged out."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:647
+#: lib/vutuv/notifications/emailer.ex:719
 #, elixir-autogen, elixir-format
 msgid "The location looks different from where you usually sign in."
 msgstr ""
@@ -5909,7 +5909,7 @@ msgstr ""
 msgid "This device"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:641
+#: lib/vutuv/notifications/emailer.ex:713
 #, elixir-autogen, elixir-format
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
@@ -6644,7 +6644,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2769
+#: lib/vutuv_web/components/post_components.ex:2771
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6654,7 +6654,7 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2768
+#: lib/vutuv_web/components/post_components.ex:2770
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -7336,7 +7336,7 @@ msgstr ""
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4581
+#: lib/vutuv_web/components/post_components.ex:4604
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8797,7 +8797,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3723
+#: lib/vutuv_web/components/post_components.ex:3725
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -12345,7 +12345,7 @@ msgstr ""
 
 #: lib/vutuv/accounts/user.ex:1097
 #: lib/vutuv/jobs/job_posting.ex:164
-#: lib/vutuv/notifications/emailer.ex:496
+#: lib/vutuv/notifications/emailer.ex:564
 #: lib/vutuv_web/agent_docs/markdown.ex:389
 #: lib/vutuv_web/agent_docs/markdown.ex:391
 #: lib/vutuv_web/agent_docs/text.ex:411
@@ -12480,12 +12480,12 @@ msgstr ""
 msgid "You already have the maximum number of published postings."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:955
+#: lib/vutuv/notifications/emailer.ex:1032
 #, elixir-autogen, elixir-format
 msgid "Your job posting on vutuv expires soon"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:833
+#: lib/vutuv/notifications/emailer.ex:910
 #, elixir-autogen, elixir-format
 msgid "A domain of your organization page on vutuv is about to be dropped"
 msgstr ""
@@ -12505,12 +12505,12 @@ msgstr ""
 msgid "We could not read this domain's proof on the last check. Restore it and check again, or the domain loses its verification."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:830
+#: lib/vutuv/notifications/emailer.ex:907
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is about to lose its verification"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:876
+#: lib/vutuv/notifications/emailer.ex:953
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is no longer public"
 msgstr ""
@@ -12960,7 +12960,7 @@ msgstr ""
 msgid "—"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:445
+#: lib/vutuv/notifications/emailer.ex:513
 #, elixir-autogen, elixir-format
 msgid "%{count} new match for your saved searches"
 msgid_plural "%{count} new matches for your saved searches"
@@ -13667,34 +13667,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4211
+#: lib/vutuv_web/components/post_components.ex:4234
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1089
-#: lib/vutuv_web/components/post_components.ex:4168
+#: lib/vutuv_web/components/post_components.ex:4191
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4212
+#: lib/vutuv_web/components/post_components.ex:4235
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4214
+#: lib/vutuv_web/components/post_components.ex:4237
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4210
+#: lib/vutuv_web/components/post_components.ex:4233
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1089
-#: lib/vutuv_web/components/post_components.ex:4167
+#: lib/vutuv_web/components/post_components.ex:4190
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13705,12 +13705,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4209
+#: lib/vutuv_web/components/post_components.ex:4232
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4213
+#: lib/vutuv_web/components/post_components.ex:4236
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13730,7 +13730,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4250
+#: lib/vutuv_web/components/post_components.ex:4273
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13738,27 +13738,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4280
+#: lib/vutuv_web/components/post_components.ex:4303
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4281
+#: lib/vutuv_web/components/post_components.ex:4304
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4279
+#: lib/vutuv_web/components/post_components.ex:4302
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4239
+#: lib/vutuv_web/components/post_components.ex:4262
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4286
+#: lib/vutuv_web/components/post_components.ex:4309
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13788,7 +13788,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4053
+#: lib/vutuv_web/components/post_components.ex:4076
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13836,7 +13836,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4044
+#: lib/vutuv_web/components/post_components.ex:4067
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14067,7 +14067,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:917
+#: lib/vutuv/notifications/emailer.ex:994
 #, elixir-autogen, elixir-format
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
@@ -14240,7 +14240,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4678
+#: lib/vutuv_web/components/post_components.ex:4701
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -15413,21 +15413,21 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4626
+#: lib/vutuv_web/components/post_components.ex:4649
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4630
+#: lib/vutuv_web/components/post_components.ex:4653
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4634
+#: lib/vutuv_web/components/post_components.ex:4657
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15435,7 +15435,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1038
-#: lib/vutuv_web/components/post_components.ex:4585
+#: lib/vutuv_web/components/post_components.ex:4608
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15627,7 +15627,7 @@ msgstr ""
 msgid "This confirmation expired. Please start again."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:227
+#: lib/vutuv/notifications/emailer.ex:294
 #, elixir-autogen, elixir-format
 msgid "Confirm your new username"
 msgstr ""
@@ -16196,17 +16196,17 @@ msgstr ""
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2735
+#: lib/vutuv_web/components/post_components.ex:2737
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2743
+#: lib/vutuv_web/components/post_components.ex:2745
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2729
+#: lib/vutuv_web/components/post_components.ex:2731
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16292,7 +16292,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1150
 #: lib/vutuv_web/agent_docs/text.ex:702
-#: lib/vutuv_web/components/post_components.ex:3207
+#: lib/vutuv_web/components/post_components.ex:3209
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
@@ -16322,7 +16322,7 @@ msgstr ""
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3206
+#: lib/vutuv_web/components/post_components.ex:3208
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
@@ -16332,7 +16332,7 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3587
+#: lib/vutuv_web/components/post_components.ex:3589
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Only you can see this post so far."
 msgstr ""
@@ -16342,19 +16342,19 @@ msgstr ""
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3590
+#: lib/vutuv_web/components/post_components.ex:3592
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3413
+#: lib/vutuv_web/components/post_components.ex:3415
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2944
+#: lib/vutuv_web/components/post_components.ex:2946
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16367,12 +16367,12 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1183
 #: lib/vutuv_web/agent_docs/text.ex:689
-#: lib/vutuv_web/components/post_components.ex:3624
+#: lib/vutuv_web/components/post_components.ex:3626
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3205
+#: lib/vutuv_web/components/post_components.ex:3207
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Previous photo"
 msgstr ""
@@ -16540,13 +16540,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1056
-#: lib/vutuv_web/components/post_components.ex:4623
+#: lib/vutuv_web/components/post_components.ex:4646
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1054
-#: lib/vutuv_web/components/post_components.ex:4620
+#: lib/vutuv_web/components/post_components.ex:4643
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
 msgstr ""
@@ -16556,7 +16556,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4512
+#: lib/vutuv_web/components/post_components.ex:4535
 #, elixir-autogen, elixir-format, fuzzy
 msgid "From other networks"
 msgstr ""
@@ -18273,19 +18273,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3790
+#: lib/vutuv_web/components/post_components.ex:3792
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3792
+#: lib/vutuv_web/components/post_components.ex:3794
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3803
+#: lib/vutuv_web/components/post_components.ex:3805
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -18855,7 +18855,7 @@ msgstr ""
 msgid "Your employment reference has been reviewed."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:409
+#: lib/vutuv/notifications/emailer.ex:477
 #, elixir-autogen, elixir-format
 msgid "Your reference “%{title}” has been reviewed"
 msgstr ""
@@ -18930,7 +18930,7 @@ msgstr ""
 msgid "Upload the PDF or the scan. We read the text out of it, and the review always reads that text, never the file itself."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:390
+#: lib/vutuv/notifications/emailer.ex:458
 #, elixir-autogen, elixir-format
 msgid "%{count} new notification on vutuv"
 msgid_plural "%{count} new notifications on vutuv"
@@ -20066,32 +20066,32 @@ msgstr ""
 msgid "You are yourself again."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/activity.ex:76
+#: lib/vutuv_web/live/organization_live/activity.ex:81
 #, elixir-autogen, elixir-format
 msgid "%{name} follows this page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/activity.ex:79
+#: lib/vutuv_web/live/organization_live/activity.ex:84
 #, elixir-autogen, elixir-format
 msgid "%{name} liked a post."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/activity.ex:82
+#: lib/vutuv_web/live/organization_live/activity.ex:87
 #, elixir-autogen, elixir-format
 msgid "%{name} reposted a post."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/activity.ex:48
+#: lib/vutuv_web/live/organization_live/activity.ex:53
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Activity – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/activity.ex:106
+#: lib/vutuv_web/live/organization_live/activity.ex:114
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing has happened yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/activity.ex:101
+#: lib/vutuv_web/live/organization_live/activity.ex:109
 #, elixir-autogen, elixir-format
 msgid "What happened to this page. Everyone on the team sees the same list, and opening it marks it read for all of you."
 msgstr ""
@@ -20103,7 +20103,7 @@ msgid_plural "%{formatted} new"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/organization_live/activity.ex:85
+#: lib/vutuv_web/live/organization_live/activity.ex:90
 #, elixir-autogen, elixir-format
 msgid "%{name} mentioned this page."
 msgstr ""
@@ -20224,7 +20224,7 @@ msgstr ""
 msgid "Too many attempts for now. Try again later."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:282
+#: lib/vutuv/notifications/emailer.ex:350
 #, elixir-autogen, elixir-format, fuzzy
 msgid "New message from %{sender} on vutuv"
 msgstr ""
@@ -20597,7 +20597,7 @@ msgstr ""
 msgid "What is published there right now:"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:856
+#: lib/vutuv/notifications/emailer.ex:933
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is verified"
 msgstr ""
@@ -20625,4 +20625,9 @@ msgstr ""
 #: lib/vutuv_web/components/verification_components.ex:150
 #, elixir-autogen, elixir-format
 msgid "Your page has no rel=\"me\" link at all yet."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/activity.ex:93
+#, elixir-autogen, elixir-format
+msgid "%{name} answered a post."
 msgstr ""

--- a/priv/repo/migrations/20260817084500_add_parent_organization_to_post_replies.exs
+++ b/priv/repo/migrations/20260817084500_add_parent_organization_to_post_replies.exs
@@ -1,0 +1,43 @@
+defmodule Vutuv.Repo.Migrations.AddParentOrganizationToPostReplies do
+  @moduledoc """
+  A member may answer a post published in a page's name (issue #1336 closed the
+  reading side #1334 was waiting for), so the companion row that names a reply's
+  parent needs the second kind of parent author beside the first.
+
+  `parent_author_id` is not there to find the parent — `parent_post_id` does
+  that. It is there so a reply **outlives** its parent with the author still
+  nameable: both set means the parent is alive, only `parent_post_id` NULL means
+  "a now-deleted post by X", both NULL means the account is gone too and no name
+  is retained. Without a page-shaped half of that pair, every answer to a page's
+  post would fall straight to the nameless state the moment the page deleted the
+  post, and the page's own activity list would have to reach through the deleted
+  parent to find the answers written to it.
+
+  So: a nullable `parent_organization_id` beside `parent_author_id`, nilifying
+  the same way, with the same `(id, inserted_at)` index behind the derived
+  "somebody answered your post" list. **No CHECK constraint**, deliberately, and
+  this is where the row differs from the nullable pairs in `posts` and
+  `fediverse_followers`: those name an owner and exactly one of them must be
+  set, while here *both* being NULL is a legitimate, reachable state (the parent
+  and its author are both gone) — a CHECK for "exactly one" would reject the
+  very rows the nilify is designed to leave behind.
+
+  N-1 safe: purely additive. The previous release never writes the column and
+  never reads it, and its own reply gate refuses a page's post outright, so it
+  cannot produce a row that would want one.
+  """
+  use Ecto.Migration
+
+  def change do
+    alter table(:post_replies) do
+      add(
+        :parent_organization_id,
+        references(:organizations, type: :binary_id, on_delete: :nilify_all)
+      )
+    end
+
+    # Backs the page's derived "X answered a post of yours" activity source,
+    # the twin of the `parent_author_id` index the member feed reads.
+    create(index(:post_replies, [:parent_organization_id, :inserted_at]))
+  end
+end

--- a/test/vutuv_web/organization_activity_web_test.exs
+++ b/test/vutuv_web/organization_activity_web_test.exs
@@ -88,6 +88,28 @@ defmodule VutuvWeb.OrganizationActivityWebTest do
     assert html =~ "/organizations/#{organization.slug}/activity"
   end
 
+  test "an answer to one of the page's posts reads correctly in German", %{conn: conn} do
+    {conn, owner} = create_and_login_user(conn)
+    organization = active_organization_for(owner)
+    {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
+    {:ok, post} = Vutuv.Posts.create_organization_post(organization, owner, %{body: "Hallo."})
+    reader = insert(:activated_user, first_name: "Rita", last_name: "Leserin")
+    {:ok, _reply} = Vutuv.Posts.create_reply(reader, post, %{body: "Antwort"})
+
+    # Asserted by name and in German on purpose: `gettext.extract --merge`
+    # fuzzy-filled this brand-new msgid with "hat einen Beitrag geteilt"
+    # (*shared* a post), which nothing in an English test would ever have
+    # noticed.
+    html =
+      conn
+      |> recycle()
+      |> put_req_header("accept-language", "de-DE,de")
+      |> get(~p"/organizations/#{organization.slug}/activity")
+      |> html_response(200)
+
+    assert html =~ "Rita Leserin hat auf einen Beitrag geantwortet."
+  end
+
   test "someone outside the team gets a 404", %{conn: conn} do
     {stranger_conn, _stranger} = create_and_login_user(conn)
     owner = insert(:activated_user)

--- a/test/vutuv_web/organization_posts_web_test.exs
+++ b/test/vutuv_web/organization_posts_web_test.exs
@@ -249,31 +249,136 @@ defmodule VutuvWeb.OrganizationPostsWebTest do
   end
 
   describe "replies" do
-    test "an organization post cannot be answered yet", %{conn: _conn} do
-      owner = insert(:activated_user)
+    defp page_post(owner, body) do
       organization = active_organization_for(owner)
       {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
-      {:ok, post} = Posts.create_organization_post(organization, owner, %{body: "Hallo."})
-
-      reader = insert(:activated_user)
-
-      # Refused outright rather than half-working: everything a reply sets in
-      # motion is member-shaped, and an organization has no inbox until #1336.
-      assert {:error, :restricted} = Posts.create_reply(reader, post, %{body: "Antwort"})
+      {:ok, post} = Posts.create_organization_post(organization, owner, %{body: body})
+      {organization, post}
     end
 
-    test "and the reply page turns that refusal away instead of crashing", %{conn: conn} do
-      {conn, _reader} = create_and_login_user(conn)
-      owner = insert(:activated_user)
-      organization = active_organization_for(owner)
-      {:ok, _} = Organizations.add_role(organization, owner, "publisher", owner)
-      {:ok, post} = Posts.create_organization_post(organization, owner, %{body: "Hallo."})
+    defp page_post(body \\ "Hallo."), do: page_post(insert(:activated_user), body)
 
-      # `Posts.restricted?/1` only knows about denial rows, so the page's own
-      # gate lets a page's post through and the composer would then be offered
-      # for something `create_reply/3` refuses one submit later. Reaching it by
-      # URL must land somewhere sensible, not on a crash.
+    test "a member answers a page's post, and the row names the page as the parent author" do
+      {organization, post} = page_post()
+      reader = insert(:activated_user)
+
+      assert {:ok, reply} = Posts.create_reply(reader, post, %{body: "Antwort"})
+
+      # The page-shaped half of the pair `parent_author_id` is for a member: it
+      # is what the page's activity list reads, and what keeps the reply
+      # nameable once the page deletes the post it answers.
+      assert reply.reply_ref.parent_post_id == post.id
+      assert reply.reply_ref.parent_organization_id == organization.id
+      assert is_nil(reply.reply_ref.parent_author_id)
+    end
+
+    test "the reply page names the page and its composer works", %{conn: conn} do
+      # Logging in first: `sent_pin/0` reads the oldest mail in the box, so a
+      # page created before it would put its own mail in front of the PIN.
+      {conn, reader} = create_and_login_user(conn)
+      {organization, post} = page_post("Wir stellen ein.")
+
+      {:ok, live, html} = live(conn, ~p"/posts/#{post.id}/reply")
+
+      # A page has no handle to speak of, so it is named by its name — the
+      # heading used to reach for `@parent.user.username`, which a page's post
+      # has not got, and the gate above it turned every such visitor away with
+      # "page not found".
+      assert html =~ organization.name
+      assert html =~ "composer-form"
+
+      live
+      |> form("#composer-form", %{"post" => %{"body" => "Ich bewerbe mich."}})
+      |> render_submit()
+
+      assert_redirect(live, Posts.path(post))
+      assert [reply] = Posts.list_replies(post, reader)
+      assert reply.body == "Ich bewerbe mich."
+    end
+
+    test "the answer shows up under the page's post and names what it answers", %{conn: conn} do
+      {organization, post} = page_post()
+      reader = insert(:activated_user, first_name: "Rita", last_name: "Leserin")
+      {:ok, _reply} = Posts.create_reply(reader, post, %{body: "Meine Antwort"})
+
+      html = conn |> get(Posts.path(post)) |> html_response(200)
+
+      # The permalink hosts the conversation now (`PostLive.Thread`); without it
+      # an answer to a page's post would be written into a void.
+      assert html =~ "Meine Antwort"
+      assert html =~ "Rita Leserin"
+      # And the answer's own card says whom it answers, by the page's name.
+      assert html =~ organization.name
+    end
+
+    test "a post of a page that is not publicly visible stays unanswerable", %{conn: conn} do
+      {conn, _reader} = create_and_login_user(conn)
+      {organization, post} = page_post()
+
+      {:ok, _} =
+        organization |> Ecto.Changeset.change(%{status: "pending"}) |> Vutuv.Repo.update()
+
+      # `visible_to?/2` deliberately does not ask whether the page is visible —
+      # that lives in the queries, which is right for every list. The reply page
+      # renders the parent card from an id in the URL, so without
+      # `answerable?/1` a guessed id would confirm and quote it.
       assert {:error, {:redirect, %{to: "/"}}} = live(conn, ~p"/posts/#{post.id}/reply")
+
+      assert {:error, :not_visible} =
+               Posts.create_reply(insert(:activated_user), post, %{body: "Antwort"})
+    end
+
+    test "and it is still there once the socket connects", %{conn: conn} do
+      {_organization, post} = page_post()
+      reader = insert(:activated_user)
+      {:ok, _reply} = Posts.create_reply(reader, post, %{body: "Meine Antwort"})
+
+      # The conversation is a LiveView nested inside this page's LiveView, so
+      # its dead render is thrown away and re-mounted on connect: a page that
+      # only renders statically would look right in the assertion above and be
+      # empty in a browser.
+      {:ok, view, _html} = live(conn, Posts.path(post))
+
+      thread =
+        Enum.find(live_children(view), &(&1.module == VutuvWeb.PostLive.Thread))
+
+      assert render(thread) =~ "Meine Antwort"
+    end
+
+    test "the answer's agent-format siblings name the page they answer", %{conn: conn} do
+      {organization, post} = page_post()
+      reader = insert(:activated_user)
+      {:ok, reply} = Posts.create_reply(reader, post, %{body: "Meine Antwort"})
+
+      # `UserHelpers.full_name/1` has no clause for a page, so the `.md`/`.json`
+      # sibling of an answer to one used to be a 500 where the HTML card renders
+      # fine — the drift the agent-doc rule exists to catch.
+      assert conn |> get(Posts.path(reply) <> ".md") |> response(200) =~ organization.name
+
+      json = conn |> get(Posts.path(reply) <> ".json") |> json_response(200)
+      assert json["in_reply_to"]["author"] == organization.name
+      assert json["in_reply_to"]["url"] =~ Posts.path(post)
+    end
+
+    test "the page's team learns about it on the activity page", %{conn: conn} do
+      {conn, owner} = create_and_login_user(conn)
+      {organization, post} = page_post(owner, "Hallo.")
+      reader = insert(:activated_user, first_name: "Rita", last_name: "Leserin")
+      {:ok, reply} = Posts.create_reply(reader, post, %{body: "Meine Antwort"})
+
+      # Derived from the reply row like the page's likes and reposts, so nothing
+      # is written twice — and this is the list that receives an answer at all,
+      # since there is no member to notify and one row per publisher would
+      # contradict the single shared read marker.
+      assert organization.id
+             |> Organizations.get_organization!()
+             |> Organizations.unread_activity_count() == 1
+
+      {:ok, _view, html} = live(conn, ~p"/organizations/#{organization.slug}/activity")
+
+      assert html =~ "Rita Leserin"
+      # The entry links to the ANSWER — that is what the team wants to read.
+      assert html =~ Posts.path(reply)
     end
   end
 end

--- a/test/vutuv_web/shared_inbox_actor_kinds_test.exs
+++ b/test/vutuv_web/shared_inbox_actor_kinds_test.exs
@@ -1,0 +1,202 @@
+defmodule VutuvWeb.SharedInboxActorKindsTest do
+  @moduledoc """
+  The shared inbox (`/system/inbox`) reaching a **page** and a **topic**, not
+  only a member.
+
+  Why this matters more than the per-actor inboxes it duplicates: every actor
+  document we serve advertises `endpoints.sharedInbox` (it is a fact about the
+  installation, not about the actor), and Mastodon — like most implementations —
+  then prefers it over the actor's own inbox for everything it delivers. So a
+  page's `/organizations/:slug/actor/inbox` is largely a spare door, and while
+  the shared inbox resolved members only, every signed activity for a page
+  resolved to nobody and was dropped with a 202: a `Follow` of the page, a
+  favourite of its post, and — as reported — an **answer** to its post, which
+  simply never appeared here.
+
+  `async: false` because remote-actor fetching is stubbed through the application
+  env and the organization helpers flip the DNS-verification flag.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.HttpSignature
+  alias Vutuv.Fediverse.Keys
+  alias Vutuv.Organizations
+  alias Vutuv.Posts
+  alias Vutuv.Repo
+  alias VutuvWeb.Fediverse.Docs
+
+  @remote_actor "https://social.example/users/alice"
+  @remote_key_id @remote_actor <> "#main-key"
+  @remote_inbox @remote_actor <> "/inbox"
+  @public "https://www.w3.org/ns/activitystreams#Public"
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp federating_page(username \\ "acme") do
+    page =
+      insert(:activated_user)
+      |> active_organization_for()
+      |> Ecto.Changeset.change(%{fediverse_followers?: true, username: username})
+      |> Repo.update!()
+
+    {:ok, _} = Fediverse.ensure_organization_actor(page)
+    page
+  end
+
+  defp page_post(page, body) do
+    owner = page |> Organizations.list_roles() |> hd() |> Map.fetch!(:user)
+    {:ok, _} = Organizations.add_role(page, owner, "publisher", owner)
+    {:ok, post} = Posts.create_organization_post(page, owner, %{body: body})
+    post
+  end
+
+  defp host, do: VutuvWeb.Endpoint.host()
+
+  defp stub_remote_actor(pub_pem) do
+    doc =
+      Jason.encode!(%{
+        "id" => @remote_actor,
+        "type" => "Person",
+        "preferredUsername" => "alice",
+        "name" => "Alice Remote",
+        "inbox" => @remote_inbox,
+        "publicKey" => %{"id" => @remote_key_id, "publicKeyPem" => pub_pem}
+      })
+
+    Application.put_env(:vutuv, :fediverse_req_options,
+      plug: fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/activity+json")
+        |> Plug.Conn.send_resp(200, doc)
+      end
+    )
+
+    on_exit(fn -> Application.delete_env(:vutuv, :fediverse_req_options) end)
+  end
+
+  defp shared_post(conn, activity, private_pem) do
+    path = "/system/inbox"
+    body = Jason.encode!(activity)
+
+    headers =
+      HttpSignature.signed_headers(
+        "post",
+        "https://#{host()}#{path}",
+        body,
+        @remote_key_id,
+        private_pem
+      )
+
+    conn = %{conn | host: host()}
+
+    headers
+    |> Enum.reject(fn {name, _} -> name == "host" end)
+    |> Enum.reduce(conn, fn {name, value}, conn -> put_req_header(conn, name, value) end)
+    |> put_req_header("content-type", "application/activity+json")
+    |> post(path, body)
+  end
+
+  describe "which of our actors an activity names" do
+    test "a page, by its actor URL and by one of its post URLs" do
+      page = federating_page()
+      post = page_post(page, "Hallo.")
+
+      for uri <- [Docs.actor_url(page), Docs.note_url(page, post.id)] do
+        activity = %{"type" => "Create", "to" => [uri], "object" => %{}}
+        assert [%Organizations.Organization{id: found}] = recipients(activity)
+        assert found == page.id
+      end
+    end
+
+    test "a topic, whose actor lives on the tag host" do
+      tag = insert(:tag)
+      {:ok, _} = Fediverse.ensure_tag_actor(tag)
+
+      activity = %{"type" => "Follow", "object" => Docs.actor_url(tag)}
+
+      assert [%Vutuv.Tags.Tag{id: found}] = recipients(activity)
+      assert found == tag.id
+    end
+
+    test "a page the `www.` alias names is still the page" do
+      page = federating_page()
+
+      www =
+        page
+        |> Docs.actor_url()
+        |> URI.parse()
+        |> then(&%{&1 | host: "www." <> &1.host})
+        |> URI.to_string()
+
+      assert [%Organizations.Organization{}] = recipients(%{"type" => "Follow", "object" => www})
+    end
+
+    test "a page that has not switched federation on is nobody" do
+      page = insert(:activated_user) |> active_organization_for()
+
+      assert recipients(%{"type" => "Follow", "object" => Docs.actor_url(page)}) == []
+    end
+
+    defp recipients(activity), do: Fediverse.inbox_recipients(activity, @remote_actor)
+  end
+
+  test "an answer to a page's post arrives through the shared inbox", %{conn: conn} do
+    page = federating_page()
+    post = page_post(page, "Wir stellen ein.")
+    {priv, pub} = Keys.generate()
+    stub_remote_actor(pub)
+
+    activity = %{
+      "@context" => "https://www.w3.org/ns/activitystreams",
+      "id" => "https://social.example/notes/1/activity",
+      "type" => "Create",
+      "actor" => @remote_actor,
+      "to" => [@public],
+      "cc" => [Docs.actor_url(page)],
+      "object" => %{
+        "id" => "https://social.example/notes/1",
+        "type" => "Note",
+        "attributedTo" => @remote_actor,
+        "to" => [@public],
+        "inReplyTo" => Docs.note_url(page, post.id),
+        "content" => "<p>Ich bewerbe mich.</p>"
+      }
+    }
+
+    assert conn |> shared_post(activity, priv) |> response(202)
+
+    # The reported bug: the delivery was acknowledged and thrown away, so the
+    # answer existed on the other server and nowhere here.
+    assert [note] = Fediverse.list_notes([post.id], nil)[post.id]
+    assert note.content_text =~ "Ich bewerbe mich."
+  end
+
+  test "a Follow of a page arrives through the shared inbox too", %{conn: conn} do
+    page = federating_page("beta")
+    {priv, pub} = Keys.generate()
+    stub_remote_actor(pub)
+
+    activity = %{
+      "@context" => "https://www.w3.org/ns/activitystreams",
+      "id" => "https://social.example/follows/1",
+      "type" => "Follow",
+      "actor" => @remote_actor,
+      "object" => Docs.actor_url(page)
+    }
+
+    assert conn |> shared_post(activity, priv) |> response(202)
+    assert Fediverse.organization_remote_follower_count(page) == 1
+  end
+end


### PR DESCRIPTION
## Der Bericht

Zwei Dinge, die zusammengehören:

1. Unter einem Beitrag, den eine **Seite** verfasst hat, steht der Antworten-Knopf wie überall — und führt auf *„Die Seite konnte leider nicht gefunden werden"*.
2. Antwortet man **aus dem Fediverse** auf denselben Beitrag, erscheint die Antwort hier nicht.

Der erste Teil war Absicht (#1334): eine Antwort erreichte niemanden, weil alles hinter ihr auf ein Mitglied zugeschnitten war und eine Seite kein Postfach hatte. #1336 hat das geschlossen — nur der Knopf blieb ein Sackgassen-404. Der zweite Teil war kein Design, sondern ein stiller Fehler.

## Antworten von hier

- **`Vutuv.Posts.answerable?/1`** ersetzt das alte pauschale `replyable?/1`: ein Seiten-Beitrag ist beantwortbar, **solange die Seite öffentlich sichtbar ist** — frisch aus der Datenbank gelesen, nicht aus dem (womöglich veralteten) Preload, aus demselben Grund, aus dem `parent_restricted_now?/1` die Denials neu abfragt. `visible_to?/2` fragt das bewusst nicht (Seiten-Sichtbarkeit lebt in den Queries); die Antwortseite rendert die Elternkarte aber aus einer Id in der URL, also hätte eine geratene Id den Beitrag einer wartenden Seite bestätigt und zitiert.
- **Die Aktivitätsliste der Seite ist der Empfänger**, der die Freigabe rechtfertigt: neue Quelle „hat auf einen Beitrag geantwortet", abgeleitet aus der Zeile wie ihre Likes und Reposts — ein Lesezeichen fürs ganze Team, keine doppelte Buchhaltung. Der Eintrag verlinkt die **Antwort**, denn die will das Team lesen.
- `post_replies.parent_organization_id` neben `parent_author_id` (additive Migration, N-1-sicher, ohne CHECK — hier sind *beide* NULL ein erreichbarer Zustand). Das Paar hält eine Antwort benennbar, nachdem die Seite den beantworteten Beitrag gelöscht hat, und ist es, was die Aktivitätsliste liest.
- `broadcast_reply/2` benachrichtigt für eine Seite **niemanden**, auf der Spalte geprüft statt der nil-Toleranz von `notify_reply/4` überlassen.
- Die Beitragsseite einer Seite zeigt das Gespräch jetzt über **`VutuvWeb.PostLive.Thread`** (per `live_render` eingebettet) — dieselbe Fensterung, dieselben gebündelten Aktionsleisten, derselbe Host für die Fediverse-Karten. Vorher: eigene Karte plus schreibgeschützte Liste, ohne Expander und mit einem „Melden", dessen `phx-click` hier niemand beantwortet hat (die Berechtigung aus #1417 saß auf einer Karte, deren Host sie nicht ausführen konnte).

## Antworten von draußen — der eigentliche Fund

Jedes unserer Actor-Dokumente wirbt mit `endpoints.sharedInbox`, und Mastodon nimmt dann diese Adresse statt der eigenen Inbox des Actors. Die Empfänger-Auflösung des gemeinsamen Postfachs kannte aber **nur Mitglieder**: jede signierte Zustellung für eine Seite oder ein Thema löste sich auf niemanden auf und wurde mit einem 202 verworfen. Betroffen war also nicht nur die gemeldete Antwort, sondern auch ein Follow einer Seite, ein Favorit auf ihren Beitrag und die Accept/Reject-Antworten auf ihre eigenen Follows. Die Inbox der Seite selbst war schlicht nicht die Tür, die benutzt wurde.

`inbox_recipients/2` liefert jetzt alle drei Actor-Arten (Thema getrennt geprüft, weil sein Actor auf dem Tag-Host liegt und `local_path/1` `tags.<host>/hund` sonst als Mitglied `hund` liest), `perform_for_recipient/3` verteilt auf die drei bereits vorhandenen Handler-Familien, und `signer/1` signiert die Actor-Abfrage mit dem Schlüssel des betroffenen Actors — was ein Server im authorized-fetch-Modus verlangt.

## Was auf dem Weg noch schief lag

- Die `.md`/`.txt`/`.json`/`.xml`-Geschwister einer Antwort auf einen Seiten-Beitrag waren ein **500er** (`UserHelpers.full_name/1` hat keine Klausel für eine Seite) — im HTML sah dieselbe Antwort korrekt aus.
- Das ausgehende `Create(Note)` trug kein `inReplyTo`, stand also auf dem anderen Server **neben** dem Gespräch statt darin.
- Die „Replying to …"-Zeile, die Antwortseiten-Überschrift und die Elternkarte lesen alle `Posts.author/1` statt `post.user`; `post_preloads/0` trägt beide Autoren auf beiden Ebenen, also kostet das keine Query.

## Bewusst nicht dabei

Die beiden Lifecycle-Fan-outs des gemeinsamen Postfachs (Update/Delete eines entfernten Kontos) bleiben mitglieder-only: sie handeln von den Konten, denen jemand hier folgt, und eine Seite kann seit #1336 folgen. Kostet die Kopie eines umbenannten Kontos, nicht eine Antwort — in `fediverse.md` als offene Hälfte notiert.

## Tests

- `test/vutuv_web/shared_inbox_actor_kinds_test.exs` (neu): Auflösung für Seite/Thema/`www.`-Alias, die Antwort **und** der Follow durch das gemeinsame Postfach. **Gegen den unreparierten Code kalibriert** — 5 von 6 gehen rot, wenn die Auflösung wieder nur Mitglieder liefert.
- `organization_posts_web_test.exs`: die beiden „geht nicht"-Tests sind durch acht ersetzt (Zeile, Antwortseite + Absenden, Permalink toter *und* verbundener Render, Agent-Formate, Aktivitätsliste, unsichtbare Seite).
- `organization_activity_web_test.exs`: der neue deutsche Satz beim Namen — `gettext.extract --merge` hatte ihn fuzzy mit *„hat einen Beitrag geteilt"* gefüllt.

`mix precommit` grün (7746 Tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
