### PR TITLE
Eine Adresse auf unserem eigenen Host ist eine Erwähnung (v7.320.0)

### DIFF
--- a/docs/architecture/mentions.md
+++ b/docs/architecture/mentions.md
@@ -12,9 +12,22 @@ the notification below. They share one definition in **`Vutuv.Mentions`**,
 which owns the entity grammar (`entity_regex/0`, read back by
 `VutuvWeb.Markdown` so the renderer can never drift from it).
 
-Only the **local** `@handle` form is a vutuv handle. A fediverse `@user@host`
-handle and a `#hashtag` are never touched, and a handle inside a code span/block
-is sample text, not a mention (matching what the renderer links).
+What counts is decided by the **host**, not by the shape (issue #1560).
+`@ada` and `@ada@vutuv.de` name the same member: the second is the address
+written out in full, which is how every remote server writes a mention of one of
+us, so both are a mention and both link to the profile. Only the host is asked,
+through `Vutuv.Fediverse.local_host?/1`, so the `www.` alias, a port and a
+shouted spelling all count as us. An address on any **other** host is somebody
+else's account and is never touched; `@php@tags.vutuv.de` is a topic of ours and
+joins `hashtags/1` instead (issue #1330); a handle inside a code span/block is
+sample text, not a mention (matching what the renderer links).
+
+Before that, `local_handles/1` dropped every `@user@host` hit by design, and the
+renderer sent an address on our own host to `https://vutuv.de/@ada` — the
+Mastodon-web convention applied to a host that is not Mastodon, a path vutuv
+does not serve. So the one clickable thing in a sentence naming a member 404ed
+on our own domain, being named that way notified nobody, and a rename left the
+address behind pointing at a handle its owner had given up.
 
 ## The mention surfaces
 
@@ -57,8 +70,12 @@ reads it. The rows are a reconciled index of the body, so editing the mention
 out takes the entry with it, and a page naming *itself* is not news to its own
 team.
 
-- Detection skips code spans/blocks, emails and fediverse handles, and matches
-  whole handles (so `@old` is not found inside `@older`).
+- Detection skips code spans/blocks, emails and other servers' addresses, and
+  matches whole handles (so `@old` is not found inside `@older`).
+- Because the full address counts, a post naming `@nobody@vutuv.de` is refused
+  exactly like one naming `@nobody`. That is the same rule, not a new one: the
+  reservation attack works through either spelling, since `used_in_content?/1`
+  reads the same `local_handles/1`.
 - Detection **sees through a Markdown escape** inside a handle. The Milkdown
   WYSIWYG editor serializes `@ulrich_wolf` as `@ulrich\_wolf` (remark escapes the
   `_`, a Markdown emphasis char). Earmark undoes that before the renderer links
@@ -116,9 +133,10 @@ changeset refuses it with a sentence naming the rule ("We allow at most 5
 accounts per post. Please remove some mentions."), which the composer surfaces
 like any other body error.
 
-- Counted **after the dedupe**, so naming one person five times is one account.
-- Fediverse `@user@host` handles and handles in code spans don't count —
-  nothing here is notified by either.
+- Counted **after the dedupe**, so naming one person five times is one account —
+  and `@ada` beside `@ada@vutuv.de` is still one account.
+- Addresses on another server and handles in code spans don't count — nothing
+  here is notified by either.
 - Like the existence check it runs only when the body **changed**, so an old
   post is not held hostage by a cap that did not exist when it was written, and
   a rename rewrite (which bypasses changesets) never trips it.
@@ -150,8 +168,10 @@ candidate precisely.
 1. update the user + move the `handles` registry row + write the
    `username_changes` ledger row (unchanged),
 2. `Mentions.rewrite_everywhere/3` rewrites every stored `@old` to `@new` across
-   all surfaces — via `Ecto.Changeset.change/2`, bypassing each schema's
-   changeset, so a body's other now-dead mentions never block the rewrite,
+   all surfaces — including `@old@vutuv.de`, which becomes `@new@vutuv.de` with
+   the host kept as the author spelled it — via `Ecto.Changeset.change/2`,
+   bypassing each schema's changeset, so a body's other now-dead mentions never
+   block the rewrite,
 3. file one `handle_change_notifications` row per **other** author whose posts
    were rewritten (the renamer's own posts are rewritten but never
    self-notified), with the ids of *their* affected posts.
@@ -186,7 +206,8 @@ posts (the newest five, plus an "and N more" count).
 - `lib/vutuv/accounts/handle_change_notification.ex` — the durable row.
 - `lib/vutuv_web/live/notification_live/index.ex` — the `mention` and
   `handle_change` renderings.
-- `test/vutuv/mentions_test.exs`, `mention_existence_test.exs`,
+- `test/vutuv/mentions_test.exs`, `mentions_local_address_test.exs`,
+  `vutuv_web/markdown_local_address_test.exs`, `mention_existence_test.exs`,
   `mention_limit_test.exs`,
   `mention_notifications_test.exs`, `handle_availability_test.exs`,
   `accounts/handle_change_propagation_test.exs`,

--- a/lib/vutuv/mentions.ex
+++ b/lib/vutuv/mentions.ex
@@ -29,10 +29,14 @@ defmodule Vutuv.Mentions do
       (`used_in_content?/1`), so a rename cannot hijack someone else's existing
       `@new` links.
 
-  Only the **local** `@handle` form is a vutuv handle. A fediverse `@user@host`
-  handle and a `#hashtag` are never touched by any function here, and a handle
-  inside a code span/block is sample text, not a mention (matching what the
-  renderer links).
+  What counts is decided by the **host**, not by the shape (issue #1560).
+  `@handle` and `@handle@<our own host>` name the same member — the second is
+  just the address written out in full, which is how every remote server writes
+  a mention of us — so both are a mention here and both link to the profile.
+  An address on any *other* host is somebody else's account and is never
+  touched, `@slug@<our tag host>` is a topic of ours and joins `hashtags/1`
+  rather than the handles, and a handle inside a code span/block is sample
+  text, not a mention (matching what the renderer links).
 
   These functions read the raw Markdown **source**. The Milkdown WYSIWYG editor
   serializes `@ulrich_wolf` as `@ulrich\\_wolf` (remark escapes the `_`, a
@@ -52,6 +56,7 @@ defmodule Vutuv.Mentions do
   alias Vutuv.Accounts.User
   alias Vutuv.Ads.Ad
   alias Vutuv.Chat.Message
+  alias Vutuv.Fediverse
   alias Vutuv.Handles
   alias Vutuv.Jobs.JobPosting
   alias Vutuv.Organizations
@@ -66,8 +71,9 @@ defmodule Vutuv.Mentions do
   # rendering, validation and rewriting share ONE definition; `VutuvWeb.Markdown`
   # reads it through `entity_regex/0`. The leading `@`/`#` must not sit
   # mid-token — no email `a@b`, no `@@`, no `/path#frag` — hence the negative
-  # lookbehinds. The fediverse form is tried first, so `@a@b.social` links to
-  # the remote account instead of the local member `@a`. Captures: 1 = fediverse
+  # lookbehinds. The fediverse form is tried first, so `@a@b.social` is read as
+  # one whole address rather than the local member `@a` followed by loose text;
+  # the **host** then decides whose it is. Captures: 1 = fediverse
   # user, 2 = fediverse host, 3 = local handle, 4 = hashtag (exactly one kind is
   # set per hit).
   @entity ~r{(?<![\w@/])@([A-Za-z0-9_]+)@([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)+)|(?<![\w@/])@([A-Za-z0-9_]+)|(?<![\w#/&])#([A-Za-z0-9_]+)}
@@ -115,8 +121,11 @@ defmodule Vutuv.Mentions do
   @doc """
   The unique, lowercased local `@handles` mentioned in `text`.
 
-  Fediverse `@user@host` handles and `#hashtags` are excluded; handles inside
-  code spans/blocks are ignored.
+  `@handle` and `@handle@<our own host>` both count and collapse to the one
+  handle: the second is the same member's address written out in full, which is
+  how a remote server names one of us. An address on any other host (including
+  our tag host) and a `#hashtag` are excluded; handles inside code spans/blocks
+  are ignored.
   """
   def local_handles(text) when is_binary(text) do
     if String.contains?(text, "@") do
@@ -142,10 +151,14 @@ defmodule Vutuv.Mentions do
   `#berlin` and not finding the post they clicked it in.
 
   Lowercased because the slug is: `#Berlin`, `#berlin` and `#BERLIN` are one
-  tag, which is also how the renderer resolves them.
+  tag, which is also how the renderer resolves them. A topic's Fediverse address
+  `@berlin@<our tag host>` (issue #1330) names the same tag and is counted with
+  them, for the same reason: that is what the renderer links.
   """
   def hashtags(text) when is_binary(text) do
-    if String.contains?(text, "#") do
+    # `@` as well as `#`, because a tag can be named by its address — a body
+    # carrying `@berlin@tags.<our host>` and no `#` at all still names one.
+    if String.contains?(text, "#") or String.contains?(text, "@") do
       text
       |> text_chunks()
       |> Enum.flat_map(&scan_hashtags/1)
@@ -208,7 +221,10 @@ defmodule Vutuv.Mentions do
   Rewrites every local `@old` mention in `text` to `@new`, returning
   `{rewritten, count}`.
 
-  Emails, hashtags, fediverse handles and code spans are left untouched, and a
+  A full address on our own host is rewritten as one — `@old@vutuv.de` becomes
+  `@new@vutuv.de`, keeping the host as the author spelled it — so a rename does
+  not leave that form behind as a link to a handle its owner has left. Emails,
+  hashtags, addresses on any other host and code spans are left untouched, and a
   body with nothing to change round-trips byte-for-byte.
   """
   def rewrite(text, old, new) when is_binary(text) do
@@ -223,7 +239,7 @@ defmodule Vutuv.Mentions do
         |> chunks()
         |> Enum.map_reduce(0, fn
           {:code, chunk}, acc -> {chunk, acc}
-          {:text, chunk}, acc -> rewrite_chunk(chunk, old_n, "@" <> new_n, acc)
+          {:text, chunk}, acc -> rewrite_chunk(chunk, old_n, new_n, acc)
         end)
 
       {IO.iodata_to_binary(chunks), count}
@@ -329,9 +345,11 @@ defmodule Vutuv.Mentions do
   editing an old body is not blocked by a cap that did not exist when it was
   written, unless the body itself is touched.
 
-  Fediverse `@user@host` handles do not count — nobody here is notified by one —
+  An address on another server does not count — nobody here is notified by one —
   and neither do handles inside code spans, for the same reason the renderer
-  does not link them.
+  does not link them. An address on **our** host does count, and counts as the
+  same account as the bare handle: it reaches the same notification feed, so a
+  list of twenty spelled out in full would otherwise walk straight past the cap.
   """
   def validate_mention_limit(changeset, field \\ :body) do
     case Changeset.get_change(changeset, field) do
@@ -462,7 +480,17 @@ defmodule Vutuv.Mentions do
   # `Regex.scan` truncates trailing unmatched groups, so a hit's length says
   # which kind it is: fediverse `["user", "host"]`, local `["", "", "handle"]`,
   # hashtag `["", "", "", "hashtag"]`.
-  defp handle_of([user, host | _]) when user != "" and host != "", do: []
+  #
+  # An address on our **own** host is the same member written out in full — the
+  # spelling every remote server uses to name one of us, and the one the
+  # renderer links to the profile — so it is a mention here too (issue #1560).
+  # `local_host?/1` folds case, port and the `www.` alias, so every spelling of
+  # this installation counts; our tag host is a different host and belongs to
+  # `hashtag_of/1`.
+  defp handle_of([user, host | _]) when user != "" and host != "" do
+    if Fediverse.local_host?(host), do: [String.downcase(user)], else: []
+  end
+
   defp handle_of([_, _, handle | _]) when handle != "", do: [String.downcase(handle)]
   defp handle_of(_), do: []
 
@@ -473,11 +501,19 @@ defmodule Vutuv.Mentions do
   end
 
   # Same truncation rule as `handle_of/1`: only a hashtag hit has a fourth
-  # group, so anything shorter is one of the two `@` forms.
+  # group, so anything shorter is one of the two `@` forms — and the `@` form on
+  # our **tag** host is a topic of ours (`@php@tags.<our host>`, issue #1330),
+  # which the renderer links to `/tags/:slug` exactly like the `#php` that means
+  # the same thing. So it names a tag here too, and a post writing it is filed
+  # under that tag instead of pointing readers at a page it is not on.
+  defp hashtag_of([user, host | _]) when user != "" and host != "" do
+    if Fediverse.tag_host?(host), do: [String.downcase(user)], else: []
+  end
+
   defp hashtag_of([_, _, _, hashtag]) when hashtag != "", do: [String.downcase(hashtag)]
   defp hashtag_of(_), do: []
 
-  defp rewrite_chunk(chunk, old_n, replacement, acc) do
+  defp rewrite_chunk(chunk, old_n, new_n, acc) do
     hits =
       @entity
       |> Regex.scan(chunk, capture: :all_but_first)
@@ -486,24 +522,36 @@ defmodule Vutuv.Mentions do
     if hits == 0 do
       {chunk, acc}
     else
-      {replace_old_mentions(chunk, old_n, replacement), acc + hits}
+      {replace_old_mentions(chunk, old_n, new_n), acc + hits}
     end
   end
 
-  defp replace_old_mentions(chunk, old_n, replacement) do
+  # The host of an address on our own host is kept verbatim rather than
+  # re-derived from the endpoint: the author wrote `www.` (or a shouted case)
+  # for a reason, and only the handle is what the rename changed.
+  defp replace_old_mentions(chunk, old_n, new_n) do
     Regex.replace(@entity, chunk, fn
       whole, "", "", handle, "" ->
-        if String.downcase(handle) == old_n, do: replacement, else: whole
+        if String.downcase(handle) == old_n, do: "@" <> new_n, else: whole
+
+      whole, user, host, "", "" ->
+        if local_handle_match?(user, host, old_n), do: "@#{new_n}@#{host}", else: whole
 
       whole, _user, _host, _handle, _hashtag ->
         whole
     end)
   end
 
+  defp local_match?([user, host | _], old_n) when user != "" and host != "",
+    do: local_handle_match?(user, host, old_n)
+
   defp local_match?([_, _, handle | _], old_n) when handle != "",
     do: String.downcase(handle) == old_n
 
   defp local_match?(_, _), do: false
+
+  defp local_handle_match?(user, host, old_n),
+    do: String.downcase(user) == old_n and Fediverse.local_host?(host)
 
   # Splits `text` into `{:text, _}` / `{:code, _}` chunks that rejoin exactly.
   defp chunks(text) do

--- a/lib/vutuv/remote_html.ex
+++ b/lib/vutuv/remote_html.ex
@@ -35,10 +35,13 @@ defmodule Vutuv.RemoteHtml do
   deliberately leaves a bare `@name` in remote content unlinked (it would point
   at whatever vutuv member shares the handle). So `to_text/3` takes those
   `Mention` tags and widens each short form to the full `@user@host`, which the
-  renderer then links to the remote profile like any typed fediverse handle.
+  renderer then links to the remote profile like any typed fediverse handle —
+  **including a mention of one of our own members**, whose address on our host
+  the renderer now resolves to their profile (issue #1560); it used to be left
+  short, because the full form was linked straight back at this server as
+  `https://host/@user`, a path vutuv does not serve.
   """
 
-  alias Vutuv.Fediverse
   alias Vutuv.Mentions
   alias Vutuv.SocialFeed.Post
 
@@ -131,11 +134,7 @@ defmodule Vutuv.RemoteHtml do
   defp mention_handle(%{"type" => "Mention", "name" => name, "href" => href})
        when is_binary(name) and is_binary(href) do
     with {user, host} <- split_mention(name, href),
-         true <- linkable?(user, host),
-         # A mention of an account on this very installation stays short: the
-         # renderer would link the full form straight back at this server
-         # (`https://host/@user`), which is not a page vutuv serves.
-         false <- Fediverse.local_host?(host) do
+         true <- linkable?(user, host) do
       [{user, host}]
     else
       _ -> []

--- a/lib/vutuv_web/markdown.ex
+++ b/lib/vutuv_web/markdown.ex
@@ -79,8 +79,9 @@ defmodule VutuvWeb.Markdown do
   # shared by rendering, mention-existence validation and the rename rewrite),
   # so it can never drift from what those paths detect. The leading `@`/`#` must
   # not sit mid-token (no email `a@b`, no `/path#frag`); the fediverse form is
-  # tried **first**, so `@a@b.social` links to the remote account, not the local
-  # member `@a`; handles/tags match permissively and are validated against the
+  # tried **first**, so `@a@b.social` is read as one whole address rather than
+  # the member `@a` plus loose text, and the **host** then decides where it
+  # points; handles/tags match permissively and are validated against the
   # DB by `linkify_entities/1`. Captures: 1 = fediverse user, 2 = fediverse
   # host, 3 = local handle, 4 = hashtag (exactly one kind is set per hit).
   @entity Vutuv.Mentions.entity_regex()
@@ -152,7 +153,9 @@ defmodule VutuvWeb.Markdown do
       remote content, and a hotlink would leak each reader's IP;
     * `#hashtags` link to our tag pages through the same non-empty-tag gate;
     * a fully-qualified `@user@host` fediverse handle links to that remote
-      account (it unambiguously names one), the same as in a member post;
+      account (it unambiguously names one), the same as in a member post — and
+      an address on **our** host names one of our members just as
+      unambiguously, so it links to that profile (issue #1560);
     * bare `@mentions` deliberately stay plain text — a Mastodon `@name` names
       an account in the fediverse, not the vutuv member who happens to share
       the handle, so linking it would point at the wrong person;
@@ -187,8 +190,9 @@ defmodule VutuvWeb.Markdown do
   (`open_links_in_new_tab/1` for URLs in the body, `linkify_entities/2` for a
   `@user@host` handle), so the marker cannot be forgotten on one of them. Links
   to **our own** pages carry no `rel` at all — a `#hashtag` resolves to
-  `/tags/:slug` — so they are left alone: nofollowing our own tag pages would
-  throw away the internal linking they exist for.
+  `/tags/:slug`, an address on our own host to that member's profile — so they
+  are left alone: nofollowing our own pages would throw away the internal
+  linking they exist for.
   """
   def mark_foreign_links(html) when is_binary(html) do
     String.replace(
@@ -935,21 +939,26 @@ defmodule VutuvWeb.Markdown do
     tokens = tokenize_html(html)
 
     case entity_candidates(tokens) do
-      {[], [], false} ->
+      {[], [], [], false} ->
         html
 
-      {mentions, hashtags, _fediverse?} ->
-        # With an empty user map every mention falls through as plain text
-        # (`mention_link/3`), which is exactly what :hashtags_only wants. A body
-        # carrying only fediverse handles still reaches here (they need no
-        # lookup, so both `mentions` and `hashtags` stay empty) and gets linked.
-        users =
-          if mode == :all, do: mention_targets(mentions), else: %{}
-
+      {mentions, local_mentions, hashtags, _fediverse?} ->
+        # `:hashtags_only` drops the **bare** handles — in remote content a
+        # `@name` names an account over there, not the vutuv member who happens
+        # to share the handle. A fully-qualified address on our own host has no
+        # such ambiguity (the host names us), so it is resolved in both modes,
+        # which is why the two forms read from two maps rather than one: sharing
+        # a map would have the address lookup quietly link the bare handles too.
+        # With nothing to look up either form falls through as plain text. A
+        # body carrying only foreign addresses still reaches here (they need no
+        # lookup) and gets linked.
+        handles = if mode == :all, do: mentions ++ local_mentions, else: local_mentions
+        targets = if handles == [], do: %{}, else: mention_targets(handles)
+        bare_users = if mode == :all, do: targets, else: %{}
         tags = Tags.linkable_slugs(hashtags)
 
         tokens
-        |> map_linkable_text(&link_entities_in_text(&1, users, tags))
+        |> map_linkable_text(&link_entities_in_text(&1, bare_users, targets, tags))
         |> IO.iodata_to_binary()
     end
   end
@@ -958,42 +967,49 @@ defmodule VutuvWeb.Markdown do
   # tokens), so a tag-depth walk can tell text apart from markup.
   defp tokenize_html(html), do: Regex.split(~r/<[^>]+>/, html, include_captures: true)
 
-  # The unique, lowercased {handles, hashtags} sitting in linkable text.
+  # The unique, lowercased {handles, own-host handles, hashtags} sitting in
+  # linkable text.
   defp entity_candidates(tokens) do
-    {mentions, hashtags, fediverse?} =
-      reduce_linkable_text(tokens, {[], [], false}, fn text, acc ->
+    {mentions, local_mentions, hashtags, fediverse?} =
+      reduce_linkable_text(tokens, {[], [], [], false}, fn text, acc ->
         @entity
         |> Regex.scan(text, capture: :all_but_first)
         |> Enum.reduce(acc, &collect_candidate/2)
       end)
 
-    {Enum.uniq(mentions), Enum.uniq(hashtags), fediverse?}
+    {Enum.uniq(mentions), Enum.uniq(local_mentions), Enum.uniq(hashtags), fediverse?}
   end
 
   # `Regex.scan` truncates trailing unmatched groups, so each hit arrives at a
   # different length: a fediverse handle as `["user", "host"]`, a mention as
   # `["", "", "handle"]`, a hashtag as `["", "", "", "hashtag"]`. Dispatch on
-  # which group is set. A fediverse handle needs no DB lookup, so it only raises
-  # the `fediverse?` flag — that keeps the token walk from being skipped for a
-  # body whose only entities are fediverse handles.
+  # which group is set. An address on somebody else's host needs no DB lookup,
+  # so it only raises the `fediverse?` flag — that keeps the token walk from
+  # being skipped for a body whose only entities are foreign addresses.
   #
-  # The one exception is our **own tag host** (issue #1330): `@php@tags.<host>`
-  # is a topic of this installation wearing a Fediverse address, so its user
-  # part is a tag slug and joins the hashtags — resolved by the same single
-  # `Tags.linkable_slugs/1` call, alias redirects included.
-  defp collect_candidate([user, host | _], {mentions, hashtags, _fediverse?})
+  # Two of our own hosts wear that same shape and neither leaves the site. Our
+  # **tag host** (issue #1330): `@php@tags.<host>` is a topic of this
+  # installation, so its user part is a tag slug and joins the hashtags —
+  # resolved by the same single `Tags.linkable_slugs/1` call, alias redirects
+  # included. Our **main host** (issue #1560): `@ada@<host>` is a member or a
+  # page of ours, so its user part is a handle and gets looked up like a bare
+  # `@ada` — kept in its own list because it resolves even in `:hashtags_only`
+  # mode, where a bare handle deliberately does not.
+  defp collect_candidate([user, host | _], {mentions, local, hashtags, _fediverse?})
        when user != "" and host != "" do
-    if Fediverse.tag_host?(host),
-      do: {mentions, [String.downcase(user) | hashtags], true},
-      else: {mentions, hashtags, true}
+    cond do
+      Fediverse.tag_host?(host) -> {mentions, local, [String.downcase(user) | hashtags], true}
+      Fediverse.local_host?(host) -> {mentions, [String.downcase(user) | local], hashtags, true}
+      true -> {mentions, local, hashtags, true}
+    end
   end
 
-  defp collect_candidate([_, _, handle | _], {mentions, hashtags, fediverse?})
+  defp collect_candidate([_, _, handle | _], {mentions, local, hashtags, fediverse?})
        when handle != "",
-       do: {[String.downcase(handle) | mentions], hashtags, fediverse?}
+       do: {[String.downcase(handle) | mentions], local, hashtags, fediverse?}
 
-  defp collect_candidate([_, _, _, hashtag], {mentions, hashtags, fediverse?}),
-    do: {mentions, [String.downcase(hashtag) | hashtags], fediverse?}
+  defp collect_candidate([_, _, _, hashtag], {mentions, local, hashtags, fediverse?}),
+    do: {mentions, local, [String.downcase(hashtag) | hashtags], fediverse?}
 
   # Walks the token stream, applying `fun` to every text token outside a
   # skip element and leaving tags and skipped text untouched.
@@ -1037,21 +1053,41 @@ defmodule VutuvWeb.Markdown do
 
   defp skip_tag?(name), do: String.downcase(name) in @entity_skip_tags
 
-  defp link_entities_in_text(text, users, tags) do
+  defp link_entities_in_text(text, bare_users, address_users, tags) do
     Regex.replace(@entity, text, fn
-      whole, user, host, "", "" -> fediverse_link(whole, user, host, tags)
-      whole, "", "", handle, "" -> mention_link(whole, handle, users)
+      whole, user, host, "", "" -> fediverse_link(whole, user, host, address_users, tags)
+      whole, "", "", handle, "" -> mention_link(whole, handle, bare_users)
       whole, "", "", "", hashtag -> hashtag_link(whole, hashtag, tags)
     end)
   end
 
   # A fully-qualified `@user@host` address. Almost always somebody else's
-  # account — but our **own tag host** wears the same shape, and there the
-  # reader wants the tag page here rather than a trip to another server.
-  defp fediverse_link(whole, user, host, tags) do
-    if Fediverse.tag_host?(host),
-      do: tag_actor_link(whole, user, tags),
-      else: remote_actor_link(user, host)
+  # account — but two of our own hosts wear the same shape, and for both the
+  # reader wants a page here rather than a trip to another server: our tag host
+  # names a topic, and our main host names a member or a page of ours.
+  defp fediverse_link(whole, user, host, users, tags) do
+    cond do
+      Fediverse.tag_host?(host) -> tag_actor_link(whole, user, tags)
+      Fediverse.local_host?(host) -> local_address_link(whole, user, host, users)
+      true -> remote_actor_link(user, host)
+    end
+  end
+
+  # `@ada@vutuv.de` is the member `@ada`, spelled the way a remote server writes
+  # a mention of one of us — so it links to the profile in the same tab, exactly
+  # like the bare `@ada` (issue #1560). Sending the reader to
+  # `https://vutuv.de/@ada` was the Mastodon-web convention applied to a host
+  # that is not Mastodon: that path is not a page vutuv serves, so the one
+  # clickable thing in a sentence naming a member 404ed on our own domain.
+  #
+  # The **address stays the visible text**: the author wrote it in full so a
+  # reader on another network can copy it, and shortening it to `@ada` would
+  # take that away. An unresolved handle stays plain text, like a bare mention.
+  defp local_address_link(whole, user, host, users) do
+    case Map.get(users, String.downcase(user)) do
+      nil -> whole
+      target -> mention_anchor(target, "#{user}@#{host}")
+    end
   end
 
   # A topic's Fediverse address (issue #1330) is `@<slug>@tags.<our host>`, so a

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.319.0",
+      version: "7.320.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260723162235_create_post_mentions.exs
+++ b/priv/repo/migrations/20260723162235_create_post_mentions.exs
@@ -41,10 +41,14 @@ defmodule Vutuv.Repo.Migrations.CreatePostMentions do
   # like every other one in this feed: someone mentioned last week sees it the
   # first time they open /notifications after this ships.
   #
-  # The grammar lives in `Vutuv.Mentions` and is deliberately called rather than
-  # re-implemented here — a backfill that disagreed with the running code about
-  # what counts as a mention would be worse than no backfill at all. Bodies
-  # without an `@` short-circuit inside `local_handles/1`.
+  # The grammar below is a **snapshot** of `Vutuv.Mentions.local_handles/1` as
+  # it stood the day this ran, copied rather than called for the reason
+  # `backfill_hashtag_filings` copies its own: a migration must keep meaning
+  # what it meant then. It called that function until issue #1560 taught it that
+  # an address on our own host is a mention too — which it decides by asking
+  # `VutuvWeb.Endpoint.host/0`, and a migration runs before the endpoint is
+  # started, so the call would raise `could not find persistent term for
+  # endpoint` on any replay against real rows.
   #
   # Timestamps and the UUID v7 id are stamped from the **post**, not from now,
   # so a backfilled mention lands in the feed at the moment it was written
@@ -81,8 +85,47 @@ defmodule Vutuv.Repo.Migrations.CreatePostMentions do
 
   defp resolve(body, by_handle) do
     body
-    |> Vutuv.Mentions.local_handles()
+    |> local_handles()
     |> Enum.flat_map(&List.wrap(Map.get(by_handle, &1)))
     |> Enum.uniq()
+  end
+
+  # The snapshot. `@` may not sit mid-token (no email `a@b`, no `@@`), an
+  # `@user@host` address is matched whole so it is not read as the member
+  # `@user` plus loose text, a handle inside code is sample text, and a Markdown
+  # escape inside a handle (`@ulrich\_wolf`, what the editor used to write) is
+  # dropped before scanning.
+  @entity ~r{(?<![\w@/])@([A-Za-z0-9_]+)@([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)+)|(?<![\w@/])@([A-Za-z0-9_]+)}
+  @code ~r/```[\s\S]*?```|~~~[\s\S]*?~~~|`[^`\n]*`/
+
+  defp local_handles(body) do
+    if String.contains?(body, "@") do
+      @code
+      |> Regex.split(body, include_captures: true)
+      |> Enum.with_index()
+      |> Enum.flat_map(fn
+        {chunk, index} when rem(index, 2) == 0 -> scan_handles(chunk)
+        {_code, _index} -> []
+      end)
+      |> Enum.uniq()
+    else
+      []
+    end
+  end
+
+  defp scan_handles(chunk) do
+    @entity
+    |> Regex.scan(unescape(chunk), capture: :all_but_first)
+    |> Enum.flat_map(fn
+      [user, host] when user != "" and host != "" -> []
+      [_, _, handle] when handle != "" -> [String.downcase(handle)]
+      _ -> []
+    end)
+  end
+
+  defp unescape(chunk) do
+    if String.contains?(chunk, "\\"),
+      do: Regex.replace(~r/\\([A-Za-z0-9_])/, chunk, "\\1"),
+      else: chunk
   end
 end

--- a/test/vutuv/mention_existence_test.exs
+++ b/test/vutuv/mention_existence_test.exs
@@ -35,7 +35,7 @@ defmodule Vutuv.MentionExistenceTest do
       refute Post.changeset(%Post{}, %{body: "hi @older"}).valid?
     end
 
-    test "a fediverse @user@host handle needs no local account" do
+    test "an address on another server needs no local account" do
       assert Post.changeset(%Post{}, %{body: "boost @bob@geno.social"}).valid?
     end
 

--- a/test/vutuv/mention_limit_test.exs
+++ b/test/vutuv/mention_limit_test.exs
@@ -50,7 +50,7 @@ defmodule Vutuv.MentionLimitTest do
       refute Post.changeset(%Post{}, %{body: body(members ++ [org])}).valid?
     end
 
-    test "fediverse handles do not count — nobody here is notified by one" do
+    test "addresses on another server do not count — nobody here is notified" do
       body = body(handles(Mentions.max_post_mentions())) <> " @bob@geno.social @ann@geno.social"
 
       assert Post.changeset(%Post{}, %{body: body}).valid?

--- a/test/vutuv/mentions_local_address_test.exs
+++ b/test/vutuv/mentions_local_address_test.exs
@@ -1,0 +1,184 @@
+defmodule Vutuv.MentionsLocalAddressTest do
+  @moduledoc """
+  An address on **our own** host is a mention (issue #1560).
+
+  `@ada@vutuv.de` and `@ada` name the same member — the first is simply the
+  address written out in full, which is how every other server writes a mention
+  of one of us. So all four concerns `Vutuv.Mentions` keeps in step have to see
+  it: the renderer's link, the notification, the per-post cap and the rename
+  rewrite. Before this, `local_handles/1` dropped every `@user@host` hit by
+  design, so being named that way notified nobody and survived a rename as a
+  link to a handle its owner had left.
+
+  `async: false` and its own file because `with_endpoint_host/1` changes global
+  endpoint config the SQL sandbox does not roll back: the test endpoint answers
+  "localhost", which has no dot and therefore cannot match the address half of
+  the entity grammar at all.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.EndpointHostHelper
+  import Vutuv.PostsHelpers
+
+  alias Vutuv.Accounts
+  alias Vutuv.Mentions
+  alias Vutuv.Posts.Post
+  alias Vutuv.Posts.PostMention
+
+  setup do
+    with_endpoint_host("vutuv.test")
+    :ok
+  end
+
+  defp mentionable(attrs \\ []) do
+    insert(:activated_user, Keyword.put_new(attrs, :username, unique_username()))
+  end
+
+  describe "local_handles/1" do
+    test "an address on our own host is the same mention as the bare handle" do
+      assert Mentions.local_handles("hi @ada@vutuv.test!") == ["ada"]
+    end
+
+    test "the www alias and a shouted host are the same installation" do
+      assert Mentions.local_handles("@ada@www.vutuv.test") == ["ada"]
+      assert Mentions.local_handles("@ada@VUTUV.TEST") == ["ada"]
+    end
+
+    test "both spellings of one member collapse to one handle" do
+      assert Mentions.local_handles("@ada and @Ada@vutuv.test") == ["ada"]
+    end
+
+    test "an address on another server is still nobody here" do
+      assert Mentions.local_handles("say hi to @bob@geno.social") == []
+      assert Mentions.local_handles("@them@vutuv.test.evil.example") == []
+    end
+
+    test "our tag host names a topic, not a member" do
+      assert Mentions.local_handles("@php@tags.vutuv.test") == []
+    end
+
+    test "an address inside a code span is sample text" do
+      assert Mentions.local_handles("type `@ada@vutuv.test` to mention") == []
+    end
+  end
+
+  describe "hashtags/1" do
+    test "a topic's address on our tag host names that tag" do
+      assert Mentions.hashtags("read @php@tags.vutuv.test") == ["php"]
+    end
+
+    test "the address and the hashtag spelling collapse to one tag" do
+      assert Mentions.hashtags("#PHP and @php@tags.vutuv.test") == ["php"]
+    end
+
+    test "an address on our main host or another server is not a tag" do
+      assert Mentions.hashtags("@ada@vutuv.test and @bob@geno.social") == []
+    end
+  end
+
+  describe "rewrite/3" do
+    test "rewrites the full address and keeps the host as written" do
+      assert Mentions.rewrite("hi @old@vutuv.test!", "old", "new") ==
+               {"hi @new@vutuv.test!", 1}
+
+      assert Mentions.rewrite("hi @Old@WWW.vutuv.test", "old", "new") ==
+               {"hi @new@WWW.vutuv.test", 1}
+    end
+
+    test "counts both spellings of the same member" do
+      assert Mentions.rewrite("@old and @old@vutuv.test", "old", "new") ==
+               {"@new and @new@vutuv.test", 2}
+    end
+
+    test "leaves an address on another server alone" do
+      text = "boost @old@geno.social and @old@tags.vutuv.test"
+      assert Mentions.rewrite(text, "old", "new") == {text, 0}
+    end
+
+    test "never touches an address inside a code span" do
+      text = "code `@old@vutuv.test`"
+      assert Mentions.rewrite(text, "old", "new") == {text, 0}
+    end
+  end
+
+  describe "existence validation" do
+    test "accepts a full address of a member who exists" do
+      handle = unique_username()
+      insert(:user, username: handle)
+      assert Post.changeset(%Post{}, %{body: "hi @#{handle}@vutuv.test"}).valid?
+    end
+
+    test "rejects a full address of a handle nobody holds" do
+      changeset = Post.changeset(%Post{}, %{body: "hi @ghost@vutuv.test"})
+      refute changeset.valid?
+      assert %{body: [message]} = errors_on(changeset)
+      assert message =~ "@ghost"
+    end
+
+    test "an address on another server still needs no local account" do
+      assert Post.changeset(%Post{}, %{body: "boost @ghost@geno.social"}).valid?
+    end
+  end
+
+  describe "the per-post cap" do
+    test "the full address counts, and counts as the same account" do
+      handles = for _ <- 1..Mentions.max_post_mentions(), do: unique_username()
+      Enum.each(handles, &insert(:user, username: &1))
+      extra = unique_username()
+      insert(:user, username: extra)
+
+      at_cap = Enum.map_join(handles, " ", &"@#{&1}@vutuv.test")
+      assert Post.changeset(%Post{}, %{body: at_cap}).valid?
+
+      # The same five spelled both ways are still five accounts.
+      both_ways = at_cap <> " " <> Enum.map_join(handles, " ", &"@#{&1}")
+      assert Post.changeset(%Post{}, %{body: both_ways}).valid?
+
+      changeset = Post.changeset(%Post{}, %{body: at_cap <> " @#{extra}@vutuv.test"})
+      refute changeset.valid?
+      assert %{body: [message]} = errors_on(changeset)
+      assert message =~ "#{Mentions.max_post_mentions()}"
+    end
+  end
+
+  describe "being named by their address is a notification" do
+    test "a post naming a member in full records the mention" do
+      author = mentionable()
+      mentioned = mentionable()
+
+      create_post!(author, %{body: "Ask @#{mentioned.username}@vutuv.test about it."})
+
+      assert [%PostMention{user_id: user_id}] = Repo.all(PostMention)
+      assert user_id == mentioned.id
+    end
+
+    test "naming the same member both ways records one mention" do
+      author = mentionable()
+      mentioned = mentionable()
+      handle = mentioned.username
+
+      create_post!(author, %{body: "@#{handle} — that is @#{handle}@vutuv.test"})
+
+      assert [%PostMention{user_id: user_id}] = Repo.all(PostMention)
+      assert user_id == mentioned.id
+    end
+  end
+
+  describe "availability and rename propagation" do
+    test "a handle linked only by its full address is not claimable" do
+      insert(:post, body: "shout out to @ghost@vutuv.test")
+      assert Mentions.mentioned_in_posts?("ghost")
+      assert Mentions.count_post_mentions("ghost") == 1
+    end
+
+    test "a rename rewrites the full address across the surfaces" do
+      victim = insert(:user, username: "oldname")
+      author = insert(:user, username: "writer")
+      post = insert(:post, user: author, body: "great point @oldname@vutuv.test!")
+
+      assert {:ok, _} = Accounts.update_username(victim, %{"username" => "newname"})
+      assert Repo.get!(Post, post.id).body == "great point @newname@vutuv.test!"
+      refute Mentions.mentioned_in_posts?("oldname")
+    end
+  end
+end

--- a/test/vutuv/mentions_test.exs
+++ b/test/vutuv/mentions_test.exs
@@ -16,7 +16,7 @@ defmodule Vutuv.MentionsTest do
       assert Mentions.local_handles("@older") == ["older"]
     end
 
-    test "a fediverse @user@host handle is not a local mention" do
+    test "an address on another server is not a local mention" do
       assert Mentions.local_handles("say hi to @bob@geno.social") == []
     end
 
@@ -84,7 +84,7 @@ defmodule Vutuv.MentionsTest do
       assert Mentions.rewrite("@older and @old", "old", "new") == {"@older and @new", 1}
     end
 
-    test "never touches emails, hashtags, fediverse handles or code spans" do
+    test "never touches emails, hashtags, other servers' addresses or code spans" do
       text = "mail bob@old.de, tag #old, boost @old@host.io, code `@old`"
       assert Mentions.rewrite(text, "old", "new") == {text, 0}
     end

--- a/test/vutuv/remote_html_test.exs
+++ b/test/vutuv/remote_html_test.exs
@@ -118,17 +118,18 @@ defmodule Vutuv.RemoteHtmlTest do
       assert RemoteHtml.to_text("<p>@herrkaschke</p>", nil, [@mention, other]) == "@herrkaschke"
     end
 
-    test "a mention of an account on this very installation stays as written" do
-      # The renderer would link the full form straight back at this server
-      # (`https://host/@user`), which is not a page vutuv serves — so the
-      # short form stays plain, exactly as before. `www.` is us (issue #1211).
+    test "a mention of an account on this very installation is expanded too" do
+      # It used to be left short, because the renderer sent the full form back
+      # at this server as `https://host/@user`, a path vutuv does not serve.
+      # It resolves that address to the member's profile now (issue #1560), so
+      # a remote post naming one of us links to them. `www.` is us (#1211).
       local = %{
         "type" => "Mention",
         "href" => "https://www.localhost/users/stefan",
         "name" => "@stefan@www.localhost"
       }
 
-      assert RemoteHtml.to_text("<p>@stefan</p>", nil, [local]) == "@stefan"
+      assert RemoteHtml.to_text("<p>@stefan</p>", nil, [local]) == "@stefan@www.localhost"
     end
 
     test "a name the renderer could not link is not expanded" do

--- a/test/vutuv_web/markdown_local_address_test.exs
+++ b/test/vutuv_web/markdown_local_address_test.exs
@@ -1,0 +1,103 @@
+defmodule VutuvWeb.MarkdownLocalAddressTest do
+  @moduledoc """
+  An address on **our own** host renders as a mention (issue #1560).
+
+  `@ada@vutuv.de` is the member `@ada` written out in full — the spelling every
+  other server uses to name one of us — so it links to the profile, in the same
+  tab, keeping the address as its visible text. It used to be sent through the
+  Mastodon-web convention `https://<host>/@<user>`, a path vutuv does not serve,
+  so the one clickable thing in a sentence naming a member 404ed on our own
+  domain and opened in a second tab to do it.
+
+  `async: false` and its own file because `with_endpoint_host/1` changes global
+  endpoint config the SQL sandbox does not roll back; the test endpoint's
+  "localhost" has no dot and cannot match the address grammar at all.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.EndpointHostHelper
+  import Vutuv.Factory
+
+  alias VutuvWeb.Markdown
+
+  setup do
+    with_endpoint_host("vutuv.test")
+    :ok
+  end
+
+  defp render(text), do: text |> Markdown.render() |> Phoenix.HTML.safe_to_string()
+
+  defp ada do
+    handle = "ada#{System.unique_integer([:positive])}"
+    insert(:user, username: handle, first_name: "Ada", last_name: "Lovelace")
+    handle
+  end
+
+  test "an address on our host links to the profile, same tab, address intact" do
+    handle = ada()
+    html = render("Thanks @#{handle}@vutuv.test for the help!")
+
+    assert html =~ ~s(href="/#{handle}")
+    assert html =~ ~s(title="Ada Lovelace")
+    assert html =~ ">@#{handle}@vutuv.test</a>"
+    refute html =~ "target=\"_blank\""
+    refute html =~ "vutuv.test/@"
+  end
+
+  test "the www alias is us too" do
+    handle = ada()
+    html = render("cc @#{handle}@www.vutuv.test")
+
+    assert html =~ ~s(href="/#{handle}")
+    assert html =~ ">@#{handle}@www.vutuv.test</a>"
+  end
+
+  test "an organization on our host links to its page" do
+    handle = "acme#{System.unique_integer([:positive])}"
+    organization = insert(:organization, username: handle, name: "Acme GmbH")
+    html = render("join @#{handle}@vutuv.test")
+
+    assert html =~ ~s(href="#{Vutuv.Organizations.canonical_path(organization)}")
+    assert html =~ ~s(title="Acme GmbH")
+  end
+
+  test "an address of a handle nobody holds stays plain text" do
+    html = render("hi @nobody_here@vutuv.test")
+
+    refute html =~ "<a"
+    assert html =~ "@nobody_here@vutuv.test"
+  end
+
+  test "an address on another server still leaves the site" do
+    html = render("boost @bob@geno.social")
+
+    assert html =~ ~s(href="https://geno.social/@bob")
+    assert html =~ ~s(target="_blank")
+  end
+
+  test "an address inside inline code is sample text" do
+    handle = ada()
+    html = render("type `@#{handle}@vutuv.test` to mention them")
+
+    refute html =~ ~s(href="/#{handle}")
+  end
+
+  # Remote content deliberately leaves a bare `@name` unlinked — over there it
+  # names an account in the fediverse, not the vutuv member sharing the handle.
+  # A full address on our host carries no such ambiguity: the host names us.
+  test "remote content links an address on our host but not a bare handle" do
+    handle = ada()
+    html = Markdown.render_remote("hallo @#{handle}@vutuv.test und @#{handle}")
+
+    assert html =~ ~s(href="/#{handle}")
+    assert html =~ ">@#{handle}@vutuv.test</a>"
+    refute html =~ ">@#{handle}</a>"
+  end
+
+  test "our own profile link in remote content is not nofollowed" do
+    handle = ada()
+    html = Markdown.render_remote("hallo @#{handle}@vutuv.test")
+
+    refute html =~ "nofollow"
+  end
+end


### PR DESCRIPTION
`@ada@vutuv.de` verlinkte auf `https://vutuv.de/@ada` — ein Pfad, den vutuv nicht
ausliefert. Der einzige anklickbare Teil eines Satzes über ein Mitglied lief also
auf der eigenen Domain ins 404, niemand wurde benachrichtigt, und eine
Umbenennung ließ die Adresse als toten Link stehen. Genau so schreibt aber jeder
fremde Server eine Erwähnung von uns.

Jetzt entscheidet der Host, nicht die Form (`Vutuv.Fediverse.local_host?/1`, also
zählen `www.`, Port und Großschreibung mit). Die Adresse gilt in `Vutuv.Mentions`
überall gleich: Link, Benachrichtigung, Fünfer-Grenze, Verfügbarkeit,
Umbenennungs-Rewrite.

**Zu entscheiden:** Die Existenzprüfung lehnt damit auch `@nobody@vutuv.de` ab.
Das ist dieselbe Regel wie für `@nobody`, keine neue — der Reservierungs-Trick
funktioniert über beide Schreibweisen, und `used_in_content?/1` liest dieselbe
Funktion. Getrennte Wege hätten zwei Wahrheiten über „was ist eine Erwähnung"
bedeutet.

`hashtags/1` erkennt zusätzlich `@php@tags.vutuv.de`. 17 der neuen Tests sind
gegen den ungefixten Stand kalibriert.

Closes #1560

<img src="https://raw.githubusercontent.com/wintermeyer/vutuv/shots/pr-1563/post.png" width="700">

<img src="https://raw.githubusercontent.com/wintermeyer/vutuv/shots/pr-1563/profile.png" width="700">

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*
