### PR TITLE
Mastodon-Clients bekommen Antworten, die sie verwenden können (v7.322.0)

### DIFF
--- a/docs/architecture/api.md
+++ b/docs/architecture/api.md
@@ -67,6 +67,21 @@ query parameter — `OAuth.validate_authorize/1` has already matched it against
 the app's registered `redirect_uris`, so the policy names a destination the
 server was going to redirect to anyway.
 
+**Who holds a credential, and who may take it away.** `/connected_apps` names,
+per authorization, when it was given and which devices still hold a live token
+under it (`Vutuv.ApiAuth.UserAgent` reads a short platform label out of the
+client string stored on the token; nothing recognisable stays "unknown device"
+rather than becoming a guess). That is not cosmetic: a Mastodon client registers
+a **new** OAuth app per install, so several installs are several rows of one
+name, and without a time and a device there was nothing to pick the right one
+by. The page twin is `/organizations/:slug/apps`, where the **owner** sees every
+token issued for the page — filtered by the issuing member, paged, each
+withdrawable on its own — because a member issues such a token of their own
+accord and until then only they could see or stop it. Turning the page's app
+access off withdraws them all, after a confirmation that names how many:
+leaving them alive would make the switch a lie, since they stop working while it
+is off and would come back the moment somebody turned it on again.
+
 **Webhooks** (`Vutuv.Webhooks`): per-app subscriptions deliver signed thin event
 envelopes (HMAC-SHA256 in `X-Vutuv-Signature`, ids/usernames only, never
 content) for members who granted the matching scope; DB-backed queue with

--- a/docs/architecture/api.md
+++ b/docs/architecture/api.md
@@ -51,6 +51,22 @@ that fails every app token on its next request), members approve scopes on the
 `/oauth/authorize` consent screen and manage/withdraw access at
 `/connected_apps`.
 
+The consent screen is the one page whose form is *meant* to end up off-site,
+and that collides with the site-wide `form-action 'self'` in
+`VutuvWeb.Plug.ContentSecurityPolicy`: browsers enforce `form-action` on every
+hop of a submission, **redirects included**, so the 302 to the client's
+`redirect_uri` (`ivory://…` for a phone client, an off-origin `https://`
+callback for a web one) was refused. Nothing about that failure is visible —
+the POST arrives, the code is minted, and the member is left on the consent
+screen with no token and no error, which is what an Ivory user reported as a
+dead "Allow access" button. So both legs of `/oauth/authorize` re-stamp the
+policy through `ContentSecurityPolicy.allow_form_action/2` with the app's
+**validated** redirect URI: the exact origin for `http(s)`, the bare scheme
+(`ivory:`) for a native client's own scheme. It is never built from the raw
+query parameter — `OAuth.validate_authorize/1` has already matched it against
+the app's registered `redirect_uris`, so the policy names a destination the
+server was going to redirect to anyway.
+
 **Webhooks** (`Vutuv.Webhooks`): per-app subscriptions deliver signed thin event
 envelopes (HMAC-SHA256 in `X-Vutuv-Signature`, ids/usernames only, never
 content) for members who granted the matching scope; DB-backed queue with

--- a/docs/architecture/mastodon-api.md
+++ b/docs/architecture/mastodon-api.md
@@ -399,6 +399,45 @@ pair (`docs/ADMINS.md`).
 Nothing here is a bug in what ships; each is a place where a client sees less
 than it asks for, or a decision that was left open on purpose.
 
+**A client parses shapes it never asks about, and the times are one of them.**
+Mastodon stamps every time as `2019-11-26T22:37:36.000Z`, always with three
+fractional digits, and Apple's `ISO8601DateFormatter` with
+`.withFractionalSeconds` — what an Ivory or Ice Cubes builds once and reuses —
+**fails outright** on a string without them. A client that cannot parse a date
+falls back to "now", so every post in the timeline carried the moment the
+account was added to the app, all showing the same relative time. Second
+precision is enough for us; printing it in Mastodon's shape is what makes it
+readable. `Presenter.timestamp/1` is the one owner of that shape — the
+notification list used to hold a second copy, which kept second precision after
+the other was fixed.
+
+**Advertising a version is a promise about the shape of the API.** This adapter
+says it is compatible with 4.4, and a client reads that to decide which
+endpoints exist: Ice Cubes therefore calls `GET /api/v2/notifications` (the
+grouped list, 4.3+), which answered 404 while the v1 list beside it was fine —
+its whole notifications tab, and its "@ mentions" page, showed "an error
+occurred". The grouped list is served from the same derived items, with the
+accounts and statuses hoisted into two shared lists; a group is one type over
+one status, which is what makes several likes on one post a single row. The same
+reasoning covers the tabs that have no content here: `trends/statuses|tags|links`,
+`announcements` and `suggestions` answer the **empty list** Mastodon itself
+answers when an instance has them switched off, because the difference between
+"off" and "not implemented" is the difference between an empty tab and an error
+a member is told to retry.
+
+**`pinned=true` asks for the pinned post.** It was ignored on
+`/accounts/:id/statuses`, so a client rendering an account's pinned row got the
+whole timeline back and showed its newest entry as pinned — a member's only post
+looked pinned although they had never pinned anything. vutuv has a real pin
+(`users.pinned_post_id`, #1110), so the answer is that one post or none; a page
+and a remote account have no pin of their own and answer the empty list.
+
+**Where vutuv's rules are stricter than Mastodon's, the refusal says which
+rule.** Editing closes once a post is liked, boosted or answered, and once the
+edit window has passed (`Posts.update_post/2`) — Mastodon allows both. Those
+three reasons are spelled out in the 422 rather than collapsing into "The status
+is invalid", which sends a member looking for a mistake in their own text.
+
 - **Some startup stubs still answer empty.** `conversations`, `lists`,
   `followed_tags`, `filters` and `markers` return `[]`/`{}`
   (`MastodonApi.CompatibilityController`). Notifications no longer do. vutuv has

--- a/docs/architecture/mastodon-api.md
+++ b/docs/architecture/mastodon-api.md
@@ -75,7 +75,10 @@ Server discovery, login and the core social workflow:
 - `GET /api/v2/search` — accounts, statuses and hashtags, plus exact
   `@user@host` resolution
 - `GET /api/v1/statuses/:id/context` and `/source`
-- `GET /api/v1/timelines/public` and `/timelines/tag/:hashtag`
+- `GET /api/v1/timelines/public` (honouring `local` / `remote`, which are a
+  client's "Local" and "Federated" tabs — both used to be ignored, so the two
+  tabs asked different questions and got one answer) and
+  `/timelines/tag/:hashtag`
 - `GET /api/v1/notifications` (+ `/unread_count`, `/clear`, `/:id`)
 - `GET /api/v1/bookmarks`, `/favourites`, `/blocks`, `/mutes`,
   `/accounts/:id/followers`, `/statuses/:id/favourited_by` and `/reblogged_by`
@@ -320,6 +323,32 @@ host test as the HTTP gate (`MastodonApi.client_host?/1`), so a client that
 signed in on the main host can open a stream there too — demanding the subdomain
 here let an app authenticate and then never connect.
 
+**That path is the whole address, and Phoenix does not serve it by default.**
+Mastodon's streaming endpoint *is* `wss://<host>/api/v1/streaming`, and
+`socket/3` appends the transport name unless told otherwise, so the socket
+answered only at `/api/v1/streaming/websocket` — a spelling no client has any
+reason to try. Measured 2026-08-17: 404 for the documented path against 101 for
+the suffixed one. It takes `websocket: [path: "/"]`, and the instance document
+has to *name* it (`configuration.urls.streaming`, v1's `urls.streaming_api`),
+which it answered as `nil`. Between the two, no client could open a stream at
+all, which an Ivory user reported as a home timeline that spun and then said
+"No Posts found" while Local and Federated — plain fetches, no stream — filled
+at once.
+
+**The instance document is read as a promise, so every figure in it is derived.**
+A client asks what this server can do *before* it does anything, and believes the
+answer: `configuration.media_attachments.supported_mime_types` is what a phone
+client converts a picture from the photo library **into**, and it was `[]`, so
+there was nothing to convert to and the camera's original HEIC went up and was
+refused with "Send a JPEG, PNG or WebP image". Beside it,
+`statuses.max_media_attachments` was `0` (posts take no pictures at all) and
+`media_attachments.image_size_limit` was `0`. All three now come from
+`Vutuv.Posts` and the uploader's own extension whitelist, so an installation
+whose libvips decodes HEIC advertises HEIC without anybody editing a list — and
+the media endpoint's refusal is written from the same whitelist, so the sentence
+a member reads after the upload has already gone up cannot contradict what the
+document promised.
+
 **A photo that has not cleared the AI scan holds the announcement, not the
 post.** `update` carries a finished status — an attachment list has no "still
 processing" state (only the media endpoint does, as a `null` url) and a client
@@ -374,7 +403,16 @@ than it asks for, or a decision that was left open on purpose.
   `followed_tags`, `filters` and `markers` return `[]`/`{}`
   (`MastodonApi.CompatibilityController`). Notifications no longer do. vutuv has
   real filters (muted words and tags), real direct messages and real followed
-  tags behind three of those, so they are the next worthwhile ones.
+  tags behind three of those, so they are the next worthwhile ones. `markers` is
+  read-only: `POST /api/v1/markers` is not implemented, so a client's reading
+  position is not remembered across devices.
+- **A path this adapter does not implement answers JSON, on both hosts.** The
+  subdomain always had a catch-all; the **main host** — the one a member types
+  into a phone app, and so the one every client actually uses — did not, so an
+  unrouted `/api/v1/…` fell through to the website and handed the client an HTML
+  error page where it expected an object. The catch-all names Mastodon's two
+  version prefixes only (`/api/v1/*`, `/api/v2/*`), so vutuv's own `/api/2.0` and
+  the site below it are untouched.
 - **vutuv's own notification kinds are not pushed or listed.** Tag
   endorsements, CV updates, moderation cases, role grants and handle changes
   have no Mastodon type; serving them under an invented one is worse than

--- a/docs/architecture/mastodon-api.md
+++ b/docs/architecture/mastodon-api.md
@@ -79,7 +79,9 @@ Server discovery, login and the core social workflow:
   client's "Local" and "Federated" tabs — both used to be ignored, so the two
   tabs asked different questions and got one answer) and
   `/timelines/tag/:hashtag`
-- `GET /api/v1/notifications` (+ `/unread_count`, `/clear`, `/:id`)
+- `GET /api/v1/notifications` (+ `/unread_count`, `/clear`, `/:id`) and the
+  grouped `GET /api/v2/notifications` a 4.3+ client asks for
+- `GET` and `POST /api/v1/markers` — where a client left off reading
 - `GET /api/v1/bookmarks`, `/favourites`, `/blocks`, `/mutes`,
   `/accounts/:id/followers`, `/statuses/:id/favourited_by` and `/reblogged_by`
 - `PATCH /api/v1/accounts/update_credentials` and `POST /api/v1/reports`
@@ -425,6 +427,19 @@ answers when an instance has them switched off, because the difference between
 "off" and "not implemented" is the difference between an empty tab and an error
 a member is told to retry.
 
+**A reading position is stored now** (`Vutuv.MastodonApi.Markers`). `GET
+/api/v1/markers` answered a bare `{}` and there was no `POST` at all — which
+also meant the write fell through to the website's HTML error page — so the
+position was never kept and never restored, and relaunching an app dropped its
+timeline back to whatever it could fetch. It is the **client's** bookmark and
+deliberately not wired to vutuv's own unread marker
+(`users.notifications_read_at`): scrolling past a notification in a phone app is
+not having read it on the website, and one surface silently clearing another's
+badge is a worse answer than two honest ones. A page identity's position belongs
+to the page, the way its feed does. The stored id is kept exactly as the client
+sent it, prefix and all, because the ids this adapter mints are not all uuids
+and a bookmark whose entry is since gone must not fail a write.
+
 **`pinned=true` asks for the pinned post.** It was ignored on
 `/accounts/:id/statuses`, so a client rendering an account's pinned row got the
 whole timeline back and showed its newest entry as pinned — a member's only post
@@ -439,12 +454,11 @@ three reasons are spelled out in the 422 rather than collapsing into "The status
 is invalid", which sends a member looking for a mistake in their own text.
 
 - **Some startup stubs still answer empty.** `conversations`, `lists`,
-  `followed_tags`, `filters` and `markers` return `[]`/`{}`
-  (`MastodonApi.CompatibilityController`). Notifications no longer do. vutuv has
-  real filters (muted words and tags), real direct messages and real followed
-  tags behind three of those, so they are the next worthwhile ones. `markers` is
-  read-only: `POST /api/v1/markers` is not implemented, so a client's reading
-  position is not remembered across devices.
+  `followed_tags` and `filters` return `[]`
+  (`MastodonApi.CompatibilityController`). Notifications and markers no longer
+  do. vutuv has real filters (muted words and tags), real direct messages and
+  real followed tags behind three of those, so they are the next worthwhile
+  ones.
 - **A path this adapter does not implement answers JSON, on both hosts.** The
   subdomain always had a catch-all; the **main host** — the one a member types
   into a phone app, and so the one every client actually uses — did not, so an

--- a/lib/vutuv/api_auth.ex
+++ b/lib/vutuv/api_auth.ex
@@ -20,6 +20,7 @@ defmodule Vutuv.ApiAuth do
 
   alias Vutuv.Accounts.User
   alias Vutuv.ApiAuth.{App, AppToken, AuthCode, Grant, Token}
+  alias Vutuv.ApiAuth.UserAgent
   alias Vutuv.MastodonApi.PushSubscription
   alias Vutuv.{Moderation, Repo}
   alias Vutuv.Organizations.Organization
@@ -185,15 +186,51 @@ defmodule Vutuv.ApiAuth do
 
   # ── Grants (the user × app authorizations) ──
 
-  @doc "The user's active app authorizations, app preloaded — the Connected apps page."
+  @doc """
+  The user's active app authorizations, app preloaded — the Connected apps page.
+
+  Each grant carries two virtual fields the page needs to tell one row from the
+  next: `connected_at`, when the authorization was first given, and `devices`,
+  the distinct devices its live tokens were minted from
+  (`Vutuv.ApiAuth.UserAgent`). Both matter because a Mastodon client registers
+  a **new** OAuth app per install, so a member with the app on a phone and a
+  laptop sees two rows of the same name — and used to have nothing on them to
+  choose by.
+
+  One extra query for the whole list, not one per row.
+  """
   def list_grants(%User{} = user) do
-    Repo.all(
-      from(g in Grant,
-        where: g.user_id == ^user.id and is_nil(g.revoked_at),
-        order_by: [desc: g.updated_at],
-        preload: :app
+    grants =
+      Repo.all(
+        from(g in Grant,
+          where: g.user_id == ^user.id and is_nil(g.revoked_at),
+          order_by: [desc: g.updated_at],
+          preload: :app
+        )
       )
+
+    devices = grant_devices(Enum.map(grants, & &1.id))
+
+    Enum.map(grants, fn grant ->
+      %{grant | connected_at: grant.inserted_at, devices: Map.get(devices, grant.id, [])}
+    end)
+  end
+
+  # The devices behind each grant, from its live tokens. A rotation carries the
+  # device forward, so a long-lived session stays one entry rather than growing
+  # one per refresh.
+  defp grant_devices([]), do: %{}
+
+  defp grant_devices(grant_ids) do
+    from(t in Token,
+      where: t.grant_id in ^grant_ids and is_nil(t.revoked_at) and not is_nil(t.user_agent),
+      select: {t.grant_id, t.user_agent}
     )
+    |> Repo.all()
+    |> Enum.group_by(&elem(&1, 0), &UserAgent.label(elem(&1, 1)))
+    |> Map.new(fn {grant_id, labels} ->
+      {grant_id, labels |> Enum.reject(&is_nil/1) |> Enum.uniq()}
+    end)
   end
 
   def get_grant(%User{} = user, id) do
@@ -217,6 +254,132 @@ defmodule Vutuv.ApiAuth do
       end)
 
     grant
+  end
+
+  # ── An organization's app tokens (the owner's oversight) ──
+
+  @doc """
+  How many entries one page of `organization_tokens/3` holds.
+  """
+  def organization_tokens_per_page, do: 25
+
+  @doc """
+  One page of the live tokens issued **for** `organization`, newest first, with
+  the member who issued each one and the app it belongs to.
+
+  A member turns a page's app access into a token of their own accord, and until
+  now only that member could see or withdraw it — so an owner could not tell who
+  was reaching the page from an app, let alone stop one. `query` filters by the
+  issuing member (name or handle, case-insensitive), because on a page with a
+  large Editorial team "who issued this" is the only question that narrows a
+  list of look-alike rows.
+
+  Returns `%{entries:, total:, page:, pages:}` — offset paging rather than the
+  keyset the API lists use, because this one is a table somebody scans with a
+  filter, and it needs a total to say how much there is.
+  """
+  def organization_tokens(%Organization{} = organization, query \\ nil, page \\ 1) do
+    base = organization_tokens_query(organization, query)
+    total = Repo.aggregate(base, :count)
+    per_page = organization_tokens_per_page()
+
+    page = max(page, 1)
+    # Computed here, not in the query: `offset(^a * ^b)` sends the
+    # multiplication to Postgres, which cannot type two unknown parameters and
+    # answers 42725 "operator is not unique: unknown * unknown".
+    skip = (page - 1) * per_page
+
+    entries =
+      base
+      |> order_by([t], desc: t.inserted_at, desc: t.id)
+      |> limit(^per_page)
+      |> offset(^skip)
+      |> preload([:user, :app])
+      |> Repo.all()
+
+    %{entries: entries, total: total, page: page, pages: Vutuv.Pages.total_pages(total, per_page)}
+  end
+
+  defp organization_tokens_query(%Organization{id: organization_id}, query) do
+    from(t in Token,
+      join: u in assoc(t, :user),
+      where: t.organization_id == ^organization_id and is_nil(t.revoked_at),
+      where: is_nil(t.expires_at) or t.expires_at > ^DateTime.utc_now(:second)
+    )
+    |> filter_by_issuer(query)
+  end
+
+  defp filter_by_issuer(query, term) when is_binary(term) do
+    case String.trim(term) do
+      "" ->
+        query
+
+      trimmed ->
+        like = "%" <> trimmed <> "%"
+
+        from([t, u] in query,
+          where:
+            ilike(u.username, ^like) or ilike(u.first_name, ^like) or ilike(u.last_name, ^like)
+        )
+    end
+  end
+
+  defp filter_by_issuer(query, _absent), do: query
+
+  @doc """
+  Withdraws one of an organization's app tokens, as its owner.
+
+  Scoped to the organization in the query rather than checked afterwards: an id
+  belonging to some other page's token must not be revocable from here, and the
+  cheapest way to guarantee that is for the row never to be found.
+  """
+  def revoke_organization_token(%Organization{id: organization_id}, id) do
+    Vutuv.UUIDv7.with_cast(id, fn uuid ->
+      from(t in Token,
+        where: t.id == ^uuid and t.organization_id == ^organization_id and is_nil(t.revoked_at)
+      )
+      |> Repo.one()
+      |> case do
+        nil ->
+          {:error, :not_found}
+
+        %Token{} = token ->
+          drop_push_subscriptions!(from(t in Token, where: t.id == ^token.id, select: t.id))
+
+          {1, _} =
+            Repo.update_all(from(t in Token, where: t.id == ^token.id),
+              set: [revoked_at: DateTime.utc_now(:second)]
+            )
+
+          {:ok, token}
+      end
+    end) || {:error, :not_found}
+  end
+
+  @doc """
+  Withdraws **every** live app token issued for `organization`, and answers how
+  many there were.
+
+  This is what turning the page's app access off has to do. Leaving the tokens
+  alive would make the switch a lie: `Vutuv.MastodonApi.Access.authorize_token/2`
+  re-checks the flag on every request, so they would stop working — but they
+  would still be listed, still be revocable, and would come back to life the
+  moment somebody turned the switch on again, which is not what "off" means to
+  the person who pressed it.
+  """
+  def revoke_organization_tokens!(%Organization{id: organization_id}) do
+    live =
+      from(t in Token, where: t.organization_id == ^organization_id and is_nil(t.revoked_at))
+
+    drop_push_subscriptions!(from(t in live, select: t.id))
+
+    {count, _} = Repo.update_all(live, set: [revoked_at: DateTime.utc_now(:second)])
+    count
+  end
+
+  @doc "How many live app tokens are issued for `organization` — the switch's confirmation."
+  def count_organization_tokens(%Organization{} = organization) do
+    organization |> organization_tokens_query(nil) |> Repo.aggregate(:count)
   end
 
   @doc false

--- a/lib/vutuv/api_auth/grant.ex
+++ b/lib/vutuv/api_auth/grant.ex
@@ -15,6 +15,13 @@ defmodule Vutuv.ApiAuth.Grant do
     field(:scopes, {:array, :string}, default: [])
     field(:revoked_at, :utc_datetime)
 
+    # Filled by `Vutuv.ApiAuth.list_grants/1` for the Connected apps page.
+    # Virtual because they are a question about how this row is *shown* — when
+    # the member connected the app, and which devices still hold a live token
+    # under it — rather than facts about the grant row itself.
+    field(:connected_at, :naive_datetime, virtual: true)
+    field(:devices, {:array, :string}, virtual: true, default: [])
+
     timestamps()
   end
 end

--- a/lib/vutuv/api_auth/o_auth.ex
+++ b/lib/vutuv/api_auth/o_auth.ex
@@ -255,17 +255,26 @@ defmodule Vutuv.ApiAuth.OAuth do
   credentials → an access/refresh pair. Errors use the RFC's vocabulary
   (`:invalid_client` answers 401, the rest 400).
   """
-  def exchange(params) do
+  def exchange(params, user_agent \\ nil) do
     with {:ok, app} <- authenticate_client(params),
          {:ok, code} <- fetch_code(app, params["code"]),
          :ok <- consume_code(code),
          :ok <- check_code_params(code, params) do
-      mint_pair(code.grant_id, code.user_id, code.organization_id, app, code.scopes)
+      mint_pair(
+        %{
+          grant_id: code.grant_id,
+          user_id: code.user_id,
+          organization_id: code.organization_id,
+          scopes: code.scopes,
+          user_agent: user_agent
+        },
+        app
+      )
     end
   end
 
   @doc "`grant_type=refresh_token`: rotate the pair; reuse revokes the grant's tokens."
-  def refresh(params) do
+  def refresh(params, user_agent \\ nil) do
     with {:ok, app} <- authenticate_client(params),
          {:ok, token} <- fetch_refresh(app, params["refresh_token"]) do
       cond do
@@ -278,7 +287,7 @@ defmodule Vutuv.ApiAuth.OAuth do
           {:error, :invalid_grant}
 
         true ->
-          rotate_refresh(token, app)
+          rotate_refresh(token, app, user_agent)
       end
     end
   end
@@ -286,7 +295,7 @@ defmodule Vutuv.ApiAuth.OAuth do
   # Atomic rotation: the `is_nil(revoked_at)` guard lets exactly one of two
   # concurrent refreshes win. The loser saw zero rows, so its token was already
   # rotated — treat it as reuse and revoke the grant.
-  defp rotate_refresh(token, app) do
+  defp rotate_refresh(token, app, user_agent) do
     {n, _} =
       Repo.update_all(
         from(t in Token, where: t.id == ^token.id and is_nil(t.revoked_at)),
@@ -294,7 +303,18 @@ defmodule Vutuv.ApiAuth.OAuth do
       )
 
     if n == 1 do
-      mint_pair(token.grant_id, token.user_id, token.organization_id, app, token.scopes)
+      mint_pair(
+        %{
+          grant_id: token.grant_id,
+          user_id: token.user_id,
+          organization_id: token.organization_id,
+          scopes: token.scopes,
+          # A rotation is the same device carrying on, so the fresh token keeps
+          # the device the pair was minted from unless this request named one.
+          user_agent: user_agent || token.user_agent
+        },
+        app
+      )
     else
       ApiAuth.revoke_grant_tokens!(token.grant_id)
       {:error, :invalid_grant}
@@ -546,46 +566,27 @@ defmodule Vutuv.ApiAuth.OAuth do
     not Repo.exists?(from(g in Grant, where: g.id == ^grant_id and is_nil(g.revoked_at)))
   end
 
-  defp mint_pair(grant_id, user_id, organization_id, %App{protocol: "mastodon"} = app, scopes) do
+  defp mint_pair(%{} = fields, %App{protocol: "mastodon"} = app) do
     access = @access_prefix <> ApiAuth.random_token()
-    insert_token!(grant_id, user_id, organization_id, app.id, scopes, "access", access, nil)
+    insert_token!(fields, app, "access", access, nil)
 
     {:ok,
      %{
        access_token: access,
        token_type: "Bearer",
-       scope: Enum.join(scopes, " "),
+       scope: Enum.join(fields.scopes, " "),
        created_at: System.system_time(:second)
      }}
   end
 
-  defp mint_pair(grant_id, user_id, organization_id, %App{} = app, scopes) do
+  defp mint_pair(%{} = fields, %App{} = app) do
     access = @access_prefix <> ApiAuth.random_token()
     refresh = @refresh_prefix <> ApiAuth.random_token()
 
     {:ok, _} =
       Repo.transaction(fn ->
-        insert_token!(
-          grant_id,
-          user_id,
-          organization_id,
-          app.id,
-          scopes,
-          "access",
-          access,
-          @access_ttl_seconds
-        )
-
-        insert_token!(
-          grant_id,
-          user_id,
-          organization_id,
-          app.id,
-          scopes,
-          "refresh",
-          refresh,
-          @refresh_ttl_days * 86_400
-        )
+        insert_token!(fields, app, "access", access, @access_ttl_seconds)
+        insert_token!(fields, app, "refresh", refresh, @refresh_ttl_days * 86_400)
       end)
 
     {:ok,
@@ -594,28 +595,23 @@ defmodule Vutuv.ApiAuth.OAuth do
        refresh_token: refresh,
        token_type: "Bearer",
        expires_in: @access_ttl_seconds,
-       scope: Enum.join(scopes, " ")
+       scope: Enum.join(fields.scopes, " ")
      }}
   end
 
-  defp insert_token!(
-         grant_id,
-         user_id,
-         organization_id,
-         app_id,
-         scopes,
-         kind,
-         plaintext,
-         ttl_seconds
-       ) do
+  # One map rather than the eight positional arguments this used to take: the
+  # ninth (the device) would have been the point where a caller silently swaps
+  # two of them.
+  defp insert_token!(%{} = fields, %App{} = app, kind, plaintext, ttl_seconds) do
     Repo.insert!(%Token{
-      user_id: user_id,
-      organization_id: organization_id,
-      app_id: app_id,
-      grant_id: grant_id,
+      user_id: fields.user_id,
+      organization_id: fields.organization_id,
+      app_id: app.id,
+      grant_id: fields.grant_id,
       kind: kind,
       token_hash: ApiAuth.hash_token(plaintext),
-      scopes: scopes,
+      scopes: fields.scopes,
+      user_agent: fields[:user_agent],
       expires_at: expires_at(ttl_seconds)
     })
   end

--- a/lib/vutuv/api_auth/token.ex
+++ b/lib/vutuv/api_auth/token.ex
@@ -27,6 +27,11 @@ defmodule Vutuv.ApiAuth.Token do
     field(:scopes, {:array, :string}, default: [])
     field(:expires_at, :utc_datetime)
     field(:last_used_at, :utc_datetime)
+    # The client string of the request the token was minted from, so the
+    # Connected apps page can say which device a row belongs to (several
+    # installs of one Mastodon client are several rows of the same name).
+    # Stored whole and capped on the way in — see `Vutuv.ApiAuth.UserAgent`.
+    field(:user_agent, :string)
     field(:revoked_at, :utc_datetime)
 
     timestamps()

--- a/lib/vutuv/api_auth/user_agent.ex
+++ b/lib/vutuv/api_auth/user_agent.ex
@@ -1,0 +1,83 @@
+defmodule Vutuv.ApiAuth.UserAgent do
+  @moduledoc """
+  The device a token was minted from, as a member can read it.
+
+  The Connected apps page listed rows a member could not tell apart: a Mastodon
+  client registers a **new** OAuth app per install, so several installs of the
+  same app are several rows all called "Ivory", and with neither a time nor a
+  device on them there was no way to pick the one to withdraw.
+
+  Two functions, and the split matters. `capture/1` is what goes in the column:
+  the client's own string, whole, because it is evidence and cutting it up at
+  write time throws away what a later question might need. `label/1` is what a
+  page shows: a short, honest phrase read out of that string.
+
+  **The label never guesses.** A User-Agent is a self-declaration by a remote
+  client, and one that names nothing recognisable gets `nil` — a page then says
+  "unknown device", which is true, rather than a confident wrong answer built
+  out of a substring that happened to match. That is also why the platform
+  patterns are matched in a deliberate order: an iPad and an iPhone both say
+  "like Mac OS X", and Android says "Linux".
+  """
+
+  # A client string is not ours to bound, so the column is `text` — but nothing
+  # here needs more than a header's worth, and an unbounded body must not become
+  # a row. Long enough for the wordiest desktop browser several times over.
+  @max_bytes 500
+
+  @doc """
+  The string to store, from a `Plug.Conn` or a raw header value.
+
+  `nil` for a request that sent none (every HTTP client sends one, but nothing
+  makes it obligatory) or an empty one, so the column says "not recorded"
+  rather than "".
+  """
+  def capture(%Plug.Conn{} = conn) do
+    conn |> Plug.Conn.get_req_header("user-agent") |> List.first() |> capture()
+  end
+
+  def capture(value) when is_binary(value) do
+    case String.trim(value) do
+      "" -> nil
+      trimmed -> String.slice(trimmed, 0, @max_bytes)
+    end
+  end
+
+  def capture(_absent), do: nil
+
+  @doc "The cap `capture/1` applies, so a test can state it rather than assume it."
+  def max_bytes, do: @max_bytes
+
+  @doc """
+  A short device phrase for a stored string, or `nil` when nothing in it is
+  recognisable.
+
+  Deliberately coarse — the platform, not a version — because the question a
+  member is answering is "which of my devices is this", and a version number
+  changes under them while the answer stays the same.
+  """
+  def label(value) when is_binary(value) do
+    Enum.find_value(platforms(), fn {pattern, label} ->
+      if String.contains?(value, pattern), do: label
+    end)
+  end
+
+  def label(_absent), do: nil
+
+  # Order is load-bearing: an iPad and an iPhone both carry "like Mac OS X", so
+  # the specific device has to be asked about before the desktop; and Android
+  # carries "Linux", so it has to come before it.
+  defp platforms do
+    [
+      {"iPhone", "iPhone"},
+      {"iPad", "iPad"},
+      {"Android", "Android"},
+      {"Mac OS X", "macOS"},
+      {"Macintosh", "macOS"},
+      {"Windows", "Windows"},
+      {"CrOS", "ChromeOS"},
+      {"Linux", "Linux"},
+      {"FreeBSD", "FreeBSD"}
+    ]
+  end
+end

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -76,6 +76,7 @@ defmodule Vutuv.Fediverse do
   alias Vutuv.Fediverse.RemoteImage
   alias Vutuv.Fediverse.RemotePost
   alias Vutuv.Handles
+  alias Vutuv.Keyset
   alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
   alias Vutuv.Pages
@@ -2473,6 +2474,39 @@ defmodule Vutuv.Fediverse do
       |> utc_at_or_before(cursor, :published_at)
       |> Repo.all()
       |> Enum.map(&remote_feed_entry/1)
+    else
+      []
+    end
+  end
+
+  @doc """
+  The public remote posts this installation holds, newest first — the federated
+  half of the Mastodon-compatible public timeline.
+
+  Viewer-independent, unlike every other reader here: a client's "Federated" tab
+  asks what the *instance* knows, not what one member follows. The gate is
+  therefore the strictest one, `audience == "public"` — not
+  `RemotePost.open_audiences/0`, which also lets a followers-only post through
+  for somebody who actually follows that account. Expired copies are left out
+  the way `Vutuv.Tags.Timeline.remote_posts_query/1` leaves them out.
+
+  Takes a `Vutuv.Keyset` window (`:max_id` / `:since_id` / `:min_id` / `:limit`),
+  so it walks by the same ids the local half does — every id here is a
+  `Vutuv.UUIDv7`, so ordering by id is ordering by when the post reached us,
+  which is what a federated timeline is ordered by anyway.
+  """
+  def recent_public_remote_posts(opts \\ []) do
+    if enabled?() do
+      from(p in RemotePost,
+        join: a in RemoteAccount,
+        on: a.id == p.remote_account_id,
+        where: p.audience == "public",
+        where: p.expires_at > ^DateTime.utc_now(:second),
+        preload: [:screenshot, remote_account: a]
+      )
+      |> Keyset.scope(opts)
+      |> Repo.all()
+      |> Keyset.restore(opts)
     else
       []
     end

--- a/lib/vutuv/mastodon_api.ex
+++ b/lib/vutuv/mastodon_api.ex
@@ -61,6 +61,21 @@ defmodule Vutuv.MastodonApi do
   def main_url(path), do: absolute_url(local_domain(), path)
   def api_url(path), do: absolute_url(api_host(), path)
 
+  @doc """
+  The streaming endpoint as a client must dial it: the `ws(s)` form of
+  `client_url/2`, on the host this request arrived on.
+
+  Named on the caller's host for the same reason every other endpoint is — a
+  client that signed in on the main host would drop its bearer token crossing
+  to the subdomain, and the streaming socket authenticates with that token.
+  """
+  def streaming_url(host) do
+    host
+    |> client_url("/api/v1/streaming")
+    |> String.replace_prefix("https://", "wss://")
+    |> String.replace_prefix("http://", "ws://")
+  end
+
   defp absolute_url(host, path) do
     uri = URI.parse(Endpoint.url())
     URI.to_string(%{uri | host: host, path: path, query: nil, fragment: nil})

--- a/lib/vutuv/mastodon_api/marker.ex
+++ b/lib/vutuv/mastodon_api/marker.ex
@@ -1,0 +1,22 @@
+defmodule Vutuv.MastodonApi.Marker do
+  @moduledoc """
+  One client's reading position in one timeline (see `Vutuv.MastodonApi.Markers`).
+
+  `last_read_id` is a `:string` and not a reference on purpose: the id a client
+  hands back may be a derived one this adapter mints (`remote-<uuid>`,
+  `like-<uuid>`), and a bookmark whose entry is gone must not fail a write.
+  """
+
+  use VutuvWeb, :model
+
+  schema "mastodon_markers" do
+    belongs_to(:user, Vutuv.Accounts.User)
+    belongs_to(:organization, Vutuv.Organizations.Organization)
+
+    field(:timeline, :string)
+    field(:last_read_id, :string)
+    field(:version, :integer, default: 1)
+
+    timestamps()
+  end
+end

--- a/lib/vutuv/mastodon_api/markers.ex
+++ b/lib/vutuv/mastodon_api/markers.ex
@@ -1,0 +1,108 @@
+defmodule Vutuv.MastodonApi.Markers do
+  @moduledoc """
+  Where a client left off reading, per identity and timeline —
+  Mastodon's `/api/v1/markers`.
+
+  The endpoint answered `{}` and had no `POST`, so a position was never stored
+  and never restored: relaunching an app dropped its timeline back to whatever
+  it could fetch. It is the client's own bookmark, not a read receipt — vutuv's
+  own unread marker (`users.notifications_read_at`) stays what the website uses,
+  and the two are deliberately not wired together: a member scrolling past a
+  notification in a phone app has not read it on the website, and one surface
+  silently marking another's badge away is a worse answer than two honest ones.
+
+  `last_read_id` is stored as the client sent it, prefix and all. A Mastodon id
+  here can be a vutuv uuid or one of the derived ids this adapter mints
+  (`remote-<uuid>`, `like-<uuid>`), and validating it against a row would fail
+  a write for the one case that must not fail: a bookmark whose entry is since
+  gone. It scrolls to nothing, which is what a bookmark into a deleted post does
+  everywhere.
+  """
+
+  import Ecto.Query
+
+  alias Vutuv.Accounts.User
+  alias Vutuv.MastodonApi.Marker
+  alias Vutuv.Organizations.Organization
+  alias Vutuv.Repo
+
+  @timelines ~w(home notifications)
+
+  @doc "The timelines Mastodon defines a marker for; anything else is ignored."
+  def timelines, do: @timelines
+
+  @doc """
+  The identity's markers as a map of `timeline => %Marker{}`.
+
+  `only` narrows to the timelines a client asked for (`timeline[]=home`); an
+  empty or missing list answers everything, which is what Mastodon does.
+  """
+  def get(identity, only \\ []) do
+    wanted = Enum.filter(only, &(&1 in @timelines))
+    wanted = if wanted == [], do: @timelines, else: wanted
+
+    identity
+    |> scope()
+    |> where([m], m.timeline in ^wanted)
+    |> Repo.all()
+    |> Map.new(&{&1.timeline, &1})
+  end
+
+  @doc """
+  Records a position. Returns the stored markers for the timelines it wrote.
+
+  Mastodon's shape is `home[last_read_id]=…`, so `params` is that outer map.
+  Unknown timelines and blank ids are skipped rather than refused: a client
+  sending one of each in the same request must still get its good half stored.
+  """
+  def put(identity, params) when is_map(params) do
+    @timelines
+    |> Enum.flat_map(fn timeline ->
+      case last_read_id(params[timeline]) do
+        nil -> []
+        id -> [{timeline, upsert!(identity, timeline, id)}]
+      end
+    end)
+    |> Map.new()
+  end
+
+  defp last_read_id(%{"last_read_id" => id}) when is_binary(id) do
+    case String.trim(id) do
+      "" -> nil
+      trimmed -> String.slice(trimmed, 0, 255)
+    end
+  end
+
+  defp last_read_id(_absent), do: nil
+
+  # `version` counts writes, the way Mastodon's does, so a client can tell its
+  # own echo from somebody else's write on another device.
+  defp upsert!(identity, timeline, last_read_id) do
+    case identity |> scope() |> where([m], m.timeline == ^timeline) |> Repo.one() do
+      nil ->
+        identity
+        |> new_marker()
+        |> Map.merge(%{timeline: timeline, last_read_id: last_read_id})
+        |> Repo.insert!()
+
+      %Marker{} = marker ->
+        marker
+        |> Ecto.Changeset.change(last_read_id: last_read_id, version: marker.version + 1)
+        |> Repo.update!()
+    end
+  end
+
+  defp new_marker(%User{id: user_id}), do: %Marker{user_id: user_id}
+
+  defp new_marker({%User{id: user_id}, %Organization{id: organization_id}}),
+    do: %Marker{user_id: user_id, organization_id: organization_id}
+
+  # An organization identity's marker is the page's, not the member's: two
+  # publishers reading the page from their own phones share one position, the
+  # same way they share the page's feed.
+  defp scope(%User{id: user_id}),
+    do: from(m in Marker, where: m.user_id == ^user_id and is_nil(m.organization_id))
+
+  defp scope({%User{}, %Organization{id: organization_id}}),
+    do: from(m in Marker, where: m.organization_id == ^organization_id)
+end

--- a/lib/vutuv/mastodon_api/presenter.ex
+++ b/lib/vutuv/mastodon_api/presenter.ex
@@ -12,6 +12,7 @@ defmodule Vutuv.MastodonApi.Presenter do
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
+  alias Vutuv.Organizations.OrganizationImage
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostImage
@@ -54,7 +55,6 @@ defmodule Vutuv.MastodonApi.Presenter do
 
   def account(%Organization{} = organization, counts) do
     handle = organization.username || organization.slug
-    icon = fallback_avatar()
 
     base_account(%{
       id: organization.id,
@@ -64,8 +64,13 @@ defmodule Vutuv.MastodonApi.Presenter do
       note: note(organization.description),
       created_at: created_at(organization, organization.id),
       url: MastodonApi.main_url(Organizations.canonical_path(organization)),
-      avatar: icon,
+      avatar: organization_image(organization.logo),
       group: true
+    })
+    |> Map.merge(%{
+      header: organization_image(organization.cover),
+      header_static: organization_image(organization.cover),
+      avatar_static: organization_image(organization.logo)
     })
     |> Map.merge(count_fields(counts))
   end
@@ -282,6 +287,15 @@ defmodule Vutuv.MastodonApi.Presenter do
       absolute -> absolute
     end
   end
+
+  # A page's own logo and cover, which this used to skip entirely: every
+  # organization account was rendered with the installation's default icon, so a
+  # client showed the vutuv logo beside a page that has had a picture all along.
+  # `nil` (no picture stored) keeps the stand-in.
+  defp organization_image(nil), do: fallback_avatar()
+
+  defp organization_image(token),
+    do: MastodonApi.main_url(OrganizationImage.token_url(token, "large"))
 
   defp note_account(%Note{account_id: id} = note) when is_binary(id) do
     case Fediverse.get_remote_account(id) do

--- a/lib/vutuv/mastodon_api/presenter.ex
+++ b/lib/vutuv/mastodon_api/presenter.ex
@@ -418,17 +418,41 @@ defmodule Vutuv.MastodonApi.Presenter do
 
   defp safe_html(value), do: value |> Safe.to_iodata() |> IO.iodata_to_binary()
 
-  defp timestamp(%NaiveDateTime{} = value),
-    do: value |> DateTime.from_naive!("Etc/UTC") |> DateTime.to_iso8601()
+  @doc """
+  A time in Mastodon's shape, and the **one** place that decides it.
 
-  defp timestamp(%DateTime{} = value), do: DateTime.to_iso8601(value)
+  Public because notifications render their own rows: the same conversion
+  existed twice, which is how one of them kept second precision after the other
+  was fixed. See the comment below for why the milliseconds matter.
+  """
+  def timestamp(value)
+
+  # **Milliseconds are not decoration.** Mastodon stamps every time as
+  # `2019-11-26T22:37:36.000Z`, always with three fractional digits, and the
+  # clients are written against exactly that: Apple's `ISO8601DateFormatter`
+  # with `.withFractionalSeconds` — what an Ivory or Ice Cubes builds once and
+  # reuses — **fails outright** on a string without them, and a client that
+  # cannot parse a date falls back to "now". So every post in the timeline
+  # carried the moment the account was added to the app, all with the same
+  # relative time, which is what a member reported. Second precision is enough
+  # for us; printing it in Mastodon's shape is what makes it readable.
+  def timestamp(%NaiveDateTime{} = value),
+    do: value |> DateTime.from_naive!("Etc/UTC") |> timestamp()
+
+  def timestamp(%DateTime{} = value) do
+    value
+    |> DateTime.shift_zone!("Etc/UTC")
+    |> DateTime.truncate(:millisecond)
+    |> Map.put(:microsecond, {elem(value.microsecond, 0), 3})
+    |> DateTime.to_iso8601()
+  end
 
   # Not every caller hands over a fully loaded row: `Vutuv.Search` selects the
   # few columns a result list needs, so `inserted_at` can be absent. Raising
   # over a missing display timestamp would be the wrong trade, and there is a
   # better answer than nil — the id is a UUIDv7 and carries its own creation
   # time.
-  defp timestamp(_missing), do: nil
+  def timestamp(_missing), do: nil
 
   defp created_at(%{inserted_at: at}, _id) when not is_nil(at), do: timestamp(at)
   defp created_at(_record, id), do: timestamp(UUIDv7.timestamp(id))

--- a/lib/vutuv_web/controllers/mastodon_api/account_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/account_controller.ex
@@ -84,6 +84,25 @@ defmodule VutuvWeb.MastodonApi.AccountController do
     json(conn, relationships)
   end
 
+  def statuses(conn, %{"id" => id, "pinned" => pinned})
+      when pinned in [true, "true", "1"] do
+    # **`pinned=true` asks for the pinned post, not for the timeline.** It was
+    # ignored, so a client showing an account's pinned row got the whole
+    # timeline back and treated its newest entry as pinned — a member's only
+    # post appeared "pinned" although they had never pinned anything. vutuv has
+    # a real pin (`users.pinned_post_id`, issue #1110), so the honest answer is
+    # that one post, or none. A page has no pin of its own, and neither does a
+    # remote account we only cache, so both answer the empty list rather than
+    # their newest post.
+    posts =
+      case target(conn, id) do
+        %User{} = user -> user |> Posts.pinned_post(profile_viewer(conn)) |> List.wrap()
+        _page_or_remote -> []
+      end
+
+    json(conn, Presenter.statuses(posts, viewer(conn)))
+  end
+
   def statuses(conn, %{"id" => id} = params) do
     page = Pagination.params(params, strip: &bare_id/1)
     opts = Pagination.opts(page)

--- a/lib/vutuv_web/controllers/mastodon_api/compatibility_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/compatibility_controller.ex
@@ -3,6 +3,9 @@ defmodule VutuvWeb.MastodonApi.CompatibilityController do
 
   use VutuvWeb, :controller
 
+  alias Vutuv.MastodonApi.Markers
+  alias Vutuv.MastodonApi.Presenter
+
   def preferences(conn, _params) do
     json(conn, %{
       "posting:default:visibility" => "public",
@@ -13,6 +16,45 @@ defmodule VutuvWeb.MastodonApi.CompatibilityController do
     })
   end
 
-  def markers(conn, _params), do: json(conn, %{})
+  @doc """
+  Where this client left off reading (`GET /api/v1/markers`).
+
+  Answered a bare `{}` until now, with no `POST` to fill it — so a position was
+  never stored and never restored, and relaunching an app dropped its timeline
+  back to whatever it could fetch.
+  """
+  def markers(conn, params) do
+    json(conn, rendered_markers(Markers.get(identity(conn), asked_for(params))))
+  end
+
+  @doc "Records the position (`POST /api/v1/markers`)."
+  def put_markers(conn, params) do
+    json(conn, rendered_markers(Markers.put(identity(conn), params)))
+  end
+
   def empty(conn, _params), do: json(conn, [])
+
+  # A page identity's position is the page's, so the marker is keyed on the
+  # organization rather than on whoever happens to be reading for it.
+  defp identity(conn) do
+    case conn.assigns.current_organization do
+      nil -> conn.assigns.current_user
+      organization -> {conn.assigns.current_user, organization}
+    end
+  end
+
+  # `timeline[]=home&timeline[]=notifications`. Plug gives the repeated
+  # parameter as a list under `timeline`; a single one arrives as a bare string.
+  defp asked_for(params), do: List.wrap(params["timeline"] || params["timeline[]"])
+
+  defp rendered_markers(markers) do
+    Map.new(markers, fn {timeline, marker} ->
+      {timeline,
+       %{
+         last_read_id: marker.last_read_id,
+         version: marker.version,
+         updated_at: Presenter.timestamp(marker.updated_at)
+       }}
+    end)
+  end
 end

--- a/lib/vutuv_web/controllers/mastodon_api/discovery_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/discovery_controller.ex
@@ -9,7 +9,9 @@ defmodule VutuvWeb.MastodonApi.DiscoveryController do
   alias Vutuv.MastodonApi
   alias Vutuv.MastodonApi.Scopes
   alias Vutuv.NodeInfo
+  alias Vutuv.Posts
   alias Vutuv.Posts.Post
+  alias Vutuv.Uploads.Spec
 
   @source_url "https://github.com/wintermeyer/vutuv"
   def instance_v2(conn, _params) do
@@ -31,7 +33,7 @@ defmodule VutuvWeb.MastodonApi.DiscoveryController do
         }
       },
       languages: locales(),
-      configuration: configuration(),
+      configuration: configuration(conn),
       registrations: %{enabled: false, approval_required: false, message: nil},
       contact: %{email: "", account: nil},
       rules: []
@@ -48,7 +50,7 @@ defmodule VutuvWeb.MastodonApi.DiscoveryController do
       description: node_description(),
       email: "",
       version: MastodonApi.compatibility_version(),
-      urls: %{streaming_api: nil},
+      urls: %{streaming_api: MastodonApi.streaming_url(conn.host)},
       stats: %{
         user_count: usage.users.total,
         status_count: usage.local_posts + usage.local_comments,
@@ -59,7 +61,7 @@ defmodule VutuvWeb.MastodonApi.DiscoveryController do
       registrations: false,
       approval_required: false,
       invites_enabled: false,
-      configuration: configuration(),
+      configuration: configuration(conn),
       contact_account: nil,
       rules: [],
       max_toot_chars: Post.max_body_length()
@@ -90,21 +92,58 @@ defmodule VutuvWeb.MastodonApi.DiscoveryController do
     })
   end
 
-  def not_found(conn, _params), do: send_resp(conn, 404, "")
+  @doc """
+  The answer for a Mastodon path this adapter does not implement.
 
-  defp configuration do
+  JSON, in Mastodon's own error shape, because a client decodes **every**
+  response body as JSON. On the main host — the one a member types into a phone
+  app, and so the one every client actually uses — an unrouted `/api/v1/…` used
+  to fall through to the website's HTML error page, so a startup call for a
+  resource we simply do not have (`/api/v1/announcements`, `/api/v1/trends/…`,
+  `POST /api/v1/markers`) handed the client a page of markup where it expected
+  an object. That is not a missing feature to a client, it is a broken server.
+  """
+  def not_found(conn, _params) do
+    conn |> put_status(404) |> json(%{error: "Record not found"})
+  end
+
+  # The MIME types the post-image uploader really accepts, from its own
+  # extension whitelist, so this cannot drift from what an upload does.
+  defp supported_mime_types do
+    Vutuv.PostImageStore.extension_whitelist()
+    |> Enum.map(&MIME.from_path("x" <> &1))
+    |> Enum.uniq()
+  end
+
+  # Mastodon states the pixel budget of an image, not its dimensions. Ours is
+  # the largest served version squared — a generous bound, since a picture is
+  # scaled down to that width anyway.
+  defp image_matrix_limit do
+    width = Spec.max_width(:post_image)
+    width * width
+  end
+
+  # What this installation can actually do. Every figure here used to be a zero
+  # or an empty list, and a client believes them: `supported_mime_types: []` is
+  # what a phone client reads before it converts a picture out of the photo
+  # library, so with nothing to convert *to* it uploads the camera's original
+  # HEIC, which the uploader then refuses — the "Send a JPEG, PNG or WebP image"
+  # a member saw after waiting for the upload. `max_media_attachments: 0` says
+  # posts take no pictures at all. They are derived now, so an installation
+  # whose libvips decodes HEIC advertises it without anybody editing this.
+  defp configuration(conn) do
     %{
-      urls: %{streaming: nil},
+      urls: %{streaming: MastodonApi.streaming_url(conn.host)},
       accounts: %{max_featured_tags: 10},
       statuses: %{
         max_characters: Post.max_body_length(),
-        max_media_attachments: 0,
+        max_media_attachments: Posts.max_images_per_post(),
         characters_reserved_per_url: 0
       },
       media_attachments: %{
-        supported_mime_types: [],
-        image_size_limit: 0,
-        image_matrix_limit: 0,
+        supported_mime_types: supported_mime_types(),
+        image_size_limit: Posts.max_image_filesize(),
+        image_matrix_limit: image_matrix_limit(),
         video_size_limit: 0,
         video_frame_rate_limit: 0,
         video_matrix_limit: 0

--- a/lib/vutuv_web/controllers/mastodon_api/discovery_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/discovery_controller.ex
@@ -93,6 +93,17 @@ defmodule VutuvWeb.MastodonApi.DiscoveryController do
   end
 
   @doc """
+  The root of the technical API host, for the person who typed it.
+
+  Everything on this origin is for a client, and every other path answers JSON,
+  so the one address a human plausibly reaches by hand deserves the site rather
+  than an error. It is a redirect and not a page on purpose: this host must not
+  start serving anything readable, or it becomes a second address for the same
+  content.
+  """
+  def root(conn, _params), do: redirect(conn, external: MastodonApi.main_url("/"))
+
+  @doc """
   The answer for a Mastodon path this adapter does not implement.
 
   JSON, in Mastodon's own error shape, because a client decodes **every**

--- a/lib/vutuv_web/controllers/mastodon_api/media_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/media_controller.ex
@@ -78,12 +78,28 @@ defmodule VutuvWeb.MastodonApi.MediaController do
         |> json(%{error: "File exceeds #{Posts.max_image_filesize()} bytes"})
 
       {:error, _invalid} ->
-        validation_error(conn, "Send a JPEG, PNG or WebP image in the \"file\" field.")
+        validation_error(conn, "Send #{accepted_types()} in the \"file\" field.")
     end
   end
 
   defp upload(conn, _params, _ready_status),
     do: validation_error(conn, "Send multipart/form-data with the file in the \"file\" field.")
+
+  # Named from the uploader's own whitelist rather than typed out here. The
+  # fixed sentence said "a JPEG, PNG or WebP image" whatever the installation
+  # could really take, so an installation whose libvips decodes HEIC refused to
+  # admit it — and this is the message a member reads after the upload has
+  # already gone up, so it is the one place the answer has to be exact. What
+  # this endpoint accepts is also what `/api/v2/instance` advertises
+  # (`supported_mime_types`), which is where a client looks before it converts
+  # a picture out of the phone's photo library at all.
+  defp accepted_types do
+    Vutuv.PostImageStore.extension_whitelist()
+    |> Enum.map(&(&1 |> String.trim_leading(".") |> String.upcase()))
+    |> Enum.uniq()
+    |> Enum.join(", ")
+    |> then(&"an image (#{&1})")
+  end
 
   # Only the member's own, still-unattached uploads. An attached picture belongs
   # to its post from then on and is edited or removed through the status.

--- a/lib/vutuv_web/controllers/mastodon_api/notification_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/notification_controller.ex
@@ -57,6 +57,73 @@ defmodule VutuvWeb.MastodonApi.NotificationController do
     |> json(notifications(conn, items))
   end
 
+  @doc """
+  The **grouped** notifications a Mastodon 4.3+ client asks for
+  (`GET /api/v2/notifications`).
+
+  Not optional for us: this adapter advertises compatibility with 4.4, and a
+  client reads that version to decide which endpoint to call. Ice Cubes does,
+  so its whole notifications tab — and its "@ mentions" activity page, the same
+  endpoint under a type filter — answered "an error occurred" against a server
+  that served the v1 list perfectly well. Advertising a version is a promise
+  about the shape of the API, not only about its features.
+
+  The payload is the same items the v1 list serves, said differently: the
+  accounts and statuses are hoisted into two shared lists and each group names
+  them by id. vutuv's notifications are derived rather than stored, so a group
+  is exactly the set of items that share a **type and a status** — several
+  people liking one post is one group, which is the whole point of the shape —
+  and anything without a status (a follow) groups by its own id.
+  """
+  def grouped(conn, params) do
+    page = Pagination.params(params, strip: &bare_id/1)
+    read = load(conn, page)
+
+    items =
+      read
+      |> Enum.filter(&mapped?/1)
+      |> filter_types(params)
+      |> Pagination.window(page, &bare_id/1)
+
+    more? = length(read) >= Pagination.fetch_size(page)
+    rendered = notifications(conn, items)
+
+    conn
+    |> Pagination.link_header(Enum.map(items, &bare_id/1), page, more?: more?)
+    |> json(%{
+      accounts: rendered |> Enum.map(& &1.account) |> uniq_by_id(),
+      statuses: rendered |> Enum.map(& &1.status) |> Enum.reject(&is_nil/1) |> uniq_by_id(),
+      notification_groups: notification_groups(rendered)
+    })
+  end
+
+  defp uniq_by_id(list), do: Enum.uniq_by(list, &(&1[:id] || &1["id"]))
+
+  defp notification_groups(rendered) do
+    rendered
+    |> Enum.chunk_by(&group_key/1)
+    |> Enum.map(fn [newest | _rest] = group ->
+      ids = Enum.map(group, & &1.id)
+
+      %{
+        group_key: group_key(newest),
+        notifications_count: length(group),
+        type: newest.type,
+        most_recent_notification_id: newest.id,
+        page_min_id: Enum.min(ids),
+        page_max_id: Enum.max(ids),
+        latest_page_notification_at: newest.created_at,
+        sample_account_ids: group |> Enum.map(& &1.account.id) |> Enum.uniq() |> Enum.take(8),
+        status_id: newest.status[:id]
+      }
+    end)
+  end
+
+  # A group is one type over one status. Without a status there is nothing to
+  # collapse onto, so the item is its own group.
+  defp group_key(%{type: type, status: %{id: status_id}}), do: type <> "-" <> status_id
+  defp group_key(%{id: id}), do: id
+
   def show(conn, %{"id" => id}) do
     bare = bare_id(%{id: id})
 
@@ -186,10 +253,9 @@ defmodule VutuvWeb.MastodonApi.NotificationController do
     end
   end
 
-  defp timestamp(%DateTime{} = at), do: DateTime.to_iso8601(at)
-
-  defp timestamp(%NaiveDateTime{} = at),
-    do: at |> DateTime.from_naive!("Etc/UTC") |> DateTime.to_iso8601()
-
-  defp timestamp(_missing), do: nil
+  # One owner for the shape (see `Presenter.timestamp/1`): this used to be a
+  # second copy of the same conversion, and it kept second precision after the
+  # other was fixed — so every notification carried a date no client could
+  # parse while the statuses beside them were fine.
+  defp timestamp(at), do: Presenter.timestamp(at)
 end

--- a/lib/vutuv_web/controllers/mastodon_api/status_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/status_controller.ex
@@ -94,10 +94,42 @@ defmodule VutuvWeb.MastodonApi.StatusController do
       attrs = Map.merge(Posts.unchanged_audience_attrs(post), %{body: body, image_ids: image_ids})
 
       case Posts.update_post(post, attrs) do
-        {:ok, updated} -> json(conn, Presenter.one_status(updated, viewer(conn)))
-        {:error, :invalid_images} -> validation_error(conn, "Unknown or foreign media ids.")
-        {:error, :too_many_images} -> validation_error(conn, "Too many images.")
-        {:error, reason} -> validation_error(conn, changeset_error(reason))
+        {:ok, updated} ->
+          json(conn, Presenter.one_status(updated, viewer(conn)))
+
+        {:error, :invalid_images} ->
+          validation_error(conn, "Unknown or foreign media ids.")
+
+        {:error, :too_many_images} ->
+          validation_error(conn, "Too many images.")
+
+        # vutuv closes editing where Mastodon leaves it open, so the two reasons
+        # for that are spelled out rather than collapsing into "the status is
+        # invalid" — the member is not being told about a broken request but
+        # about a rule, and one they can neither see nor work around from a
+        # client. See `Posts.update_post/2`.
+        {:error, :edit_engaged} ->
+          validation_error(
+            conn,
+            "This post can no longer be edited: somebody has liked, boosted or replied to it, " <>
+              "and an edit would rewrite what they put their name to. You can still delete it."
+          )
+
+        {:error, :edit_window_closed} ->
+          validation_error(
+            conn,
+            "This post can no longer be edited: the #{Posts.edit_window_minutes()}-minute " <>
+              "edit window has closed. You can still delete it."
+          )
+
+        {:error, :visibility_locked} ->
+          validation_error(
+            conn,
+            "This post's audience can no longer be narrowed: somebody has boosted or replied to it."
+          )
+
+        {:error, reason} ->
+          validation_error(conn, changeset_error(reason))
       end
     else
       {:error, :unsupported_visibility} ->

--- a/lib/vutuv_web/controllers/mastodon_api/timeline_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/timeline_controller.ex
@@ -13,6 +13,7 @@ defmodule VutuvWeb.MastodonApi.TimelineController do
 
   use VutuvWeb, :controller
 
+  alias Vutuv.Fediverse
   alias Vutuv.MastodonApi.Presenter
   alias Vutuv.Posts
   alias Vutuv.Tags
@@ -63,21 +64,62 @@ defmodule VutuvWeb.MastodonApi.TimelineController do
   # page identity engages as the page, a member as themselves.
   defp viewer(conn), do: conn.assigns.current_organization || conn.assigns.current_user
 
+  # `local=true` is this site's own posts, `remote=true` the ones that reached
+  # it from other networks, neither is both. Mastodon sends these as strings, and
+  # a client that means "off" may send `false` rather than leave the parameter
+  # out, so only a true-ish value narrows anything. Asking for both at once is
+  # the same request as asking for neither.
+  defp public_source(params) do
+    case {truthy?(params["local"]), truthy?(params["remote"])} do
+      {true, false} -> :vutuv
+      {false, true} -> :fediverse
+      _both_or_neither -> :all
+    end
+  end
+
+  defp truthy?(value), do: value in [true, "true", "1"]
+
+  defp public_items(:vutuv, page), do: Posts.recent_public_posts(:all, Pagination.opts(page))
+
+  defp public_items(:fediverse, page),
+    do: Fediverse.recent_public_remote_posts(Pagination.opts(page))
+
+  # Both halves, merged. They share no query but they do share an id space —
+  # every id here is a `Vutuv.UUIDv7`, so the same window bounds both and
+  # ordering by id orders the merge. Each side is asked for a full page, which
+  # is what keeps the merged page full however lopsided the two sources are.
+  defp public_items(:all, page) do
+    opts = Pagination.opts(page)
+
+    (Posts.recent_public_posts(:all, opts) ++ Fediverse.recent_public_remote_posts(opts))
+    |> Enum.sort_by(& &1.id, :desc)
+    |> then(fn merged -> if page.min_id, do: Enum.take(merged, -page.limit), else: merged end)
+    |> Enum.take(page.limit)
+  end
+
   @doc """
   The instance-wide public timeline.
 
-  Built on `Posts.recent_public_posts(:all, …)`, which is the site feed the RSS
+  Built on `Posts.recent_public_posts(source, …)`, which is the site feed the RSS
   aggregate already uses — and that matters: it lists only authors who opted out
   of **nothing**, neither of search engines nor of AI use. So this endpoint
   inherits vutuv's existing consent rule for aggregate surfaces rather than
   inventing a firehose the website does not offer.
+
+  **`local` and `remote` are what a client's "Local" and "Federated" tabs are.**
+  Both used to be ignored, so the two tabs asked different questions and got the
+  same answer — one list under two names, with the site's own posts and the
+  posts from other networks mixed into both. They map onto the `feed_sources`
+  split the website's own feed tabs use, so a tab means here what it means
+  there.
   """
   def public(conn, params) do
     page = Pagination.params(params)
 
     statuses =
-      :all
-      |> Posts.recent_public_posts(Pagination.opts(page))
+      params
+      |> public_source()
+      |> public_items(page)
       |> Presenter.statuses(viewer(conn))
 
     conn

--- a/lib/vutuv_web/controllers/oauth_controller.ex
+++ b/lib/vutuv_web/controllers/oauth_controller.ex
@@ -8,6 +8,12 @@ defmodule VutuvWeb.OauthController do
   is CSRF-protected like every browser form and re-validates the request
   before minting the code, so nothing tampered survives the round trip.
 
+  Both legs re-stamp the CSP so `form-action` names the app's registered
+  redirect URI: the site's blanket `form-action 'self'` is enforced on the
+  redirect this endpoint answers with, and would otherwise leave the member
+  staring at the consent screen with a minted code they never receive. See
+  `VutuvWeb.Plug.ContentSecurityPolicy`.
+
   `POST /oauth/token` and `POST /oauth/revoke` are machine endpoints
   (form-encoded in, JSON out, no session/CSRF). Client/redirect problems
   never redirect — an authorize endpoint that redirects on a bad
@@ -18,6 +24,7 @@ defmodule VutuvWeb.OauthController do
 
   alias Vutuv.ApiAuth.OAuth
   alias Vutuv.MastodonApi.Access
+  alias VutuvWeb.Plug.ContentSecurityPolicy
   alias VutuvWeb.RateLimit
 
   @oob_redirect "urn:ietf:wg:oauth:2.0:oob"
@@ -30,7 +37,11 @@ defmodule VutuvWeb.OauthController do
         if conn.assigns[:current_user] do
           identities = identities(conn.assigns.current_user, request)
 
-          render(conn, "authorize.html",
+          # The consent screen owns the form, so its policy is the one the
+          # browser checks the POST's redirect against.
+          conn
+          |> ContentSecurityPolicy.allow_form_action(request.redirect_uri)
+          |> render("authorize.html",
             request: request,
             params: params,
             identities: identities,
@@ -60,7 +71,12 @@ defmodule VutuvWeb.OauthController do
 
     case user && OAuth.validate_authorize(params) do
       {:ok, request} ->
-        decide(conn, user, request, decision)
+        # Belt and braces: the consent screen's policy is what a browser
+        # enforces here, but a client that re-POSTs this endpoint from a page
+        # of its own gets the same permission from the response itself.
+        conn
+        |> ContentSecurityPolicy.allow_form_action(request.redirect_uri)
+        |> decide(user, request, decision)
 
       _invalid_or_logged_out ->
         conn

--- a/lib/vutuv_web/controllers/oauth_controller.ex
+++ b/lib/vutuv_web/controllers/oauth_controller.ex
@@ -23,6 +23,7 @@ defmodule VutuvWeb.OauthController do
   use VutuvWeb, :controller
 
   alias Vutuv.ApiAuth.OAuth
+  alias Vutuv.ApiAuth.UserAgent
   alias Vutuv.MastodonApi.Access
   alias VutuvWeb.Plug.ContentSecurityPolicy
   alias VutuvWeb.RateLimit
@@ -174,11 +175,11 @@ defmodule VutuvWeb.OauthController do
   # ── The token endpoints (machine pipeline, no session/CSRF) ──
 
   def token(conn, %{"grant_type" => "authorization_code"} = params) do
-    token_response(conn, OAuth.exchange(params))
+    token_response(conn, OAuth.exchange(params, UserAgent.capture(conn)))
   end
 
   def token(conn, %{"grant_type" => "refresh_token"} = params) do
-    token_response(conn, OAuth.refresh(params))
+    token_response(conn, OAuth.refresh(params, UserAgent.capture(conn)))
   end
 
   # RFC 6749 §4.4, which Mastodon's token endpoint answers: a token for the app

--- a/lib/vutuv_web/endpoint.ex
+++ b/lib/vutuv_web/endpoint.ex
@@ -26,8 +26,18 @@ defmodule VutuvWeb.Endpoint do
   # Mastodon's streaming API. Mounted on the shared endpoint because a socket
   # cannot be host-scoped here; the handler checks the API host itself, so this
   # path stays inert on the main origin.
+  #
+  # `path: "/"` is not cosmetic. Mastodon's streaming endpoint **is**
+  # `wss://<host>/api/v1/streaming` — that exact path, with `stream=` and
+  # `access_token=` in the query — and every client connects there. Phoenix's
+  # default appends the transport name, so this socket answered only at
+  # `/api/v1/streaming/websocket` and the documented address 404ed: measured
+  # 2026-08-17, 404 for the bare path against 101 for the suffixed one. A client
+  # cannot find the suffixed spelling and has no reason to look for it, so the
+  # whole stream was unreachable while every part of it worked.
   socket("/api/v1/streaming", VutuvWeb.MastodonApi.StreamingSocket,
-    websocket: [connect_info: [:x_headers, :uri], max_frame_size: 64_000]
+    websocket: [path: "/", connect_info: [:x_headers, :uri], max_frame_size: 64_000],
+    longpoll: false
   )
 
   # In dev, serve static assets with `cache-control: no-cache` so the browser

--- a/lib/vutuv_web/live/organization_live/apps.ex
+++ b/lib/vutuv_web/live/organization_live/apps.ex
@@ -19,12 +19,28 @@ defmodule VutuvWeb.OrganizationLive.Apps do
   all, which address to type into the app — an adapter nobody can find an
   address for is not a feature. The host comes from the endpoint, so an
   installation that is not vutuv.de shows its own.
+
+  **It also lists the tokens issued for the page, and that is the half that was
+  missing.** A member turns the page's app access into a credential of their
+  own accord; until now only that member could see or withdraw it, so an owner
+  could not tell who was reaching the page from an app and had no way to stop
+  one. The list is filtered by the issuing member and paged, because on a page
+  with a large Editorial team the rows look alike and "who issued this" is the
+  only question that narrows them.
+
+  **Turning the switch off withdraws them all**, after saying how many. Leaving
+  them alive would make the switch a lie: they stop working while it is off
+  (`Access.authorize_token/2` re-checks the flag per request) and come back the
+  moment somebody turns it on again, which is not what "off" means to whoever
+  pressed it.
   """
 
   use VutuvWeb, :live_view
 
   import VutuvWeb.OrganizationComponents, only: [manage_header: 1]
 
+  alias Vutuv.ApiAuth
+  alias Vutuv.ApiAuth.UserAgent
   alias Vutuv.MastodonApi
   alias Vutuv.Organizations
   alias VutuvWeb.Live.InitAssigns
@@ -38,7 +54,9 @@ defmodule VutuvWeb.OrganizationLive.Apps do
      socket
      |> assign(:page_title, gettext("Apps – %{name}", name: organization.name))
      |> assign(:enabled?, MastodonApi.enabled?())
-     |> assign(:organization, organization)}
+     |> assign(:organization, organization)
+     |> assign(:filter, "")
+     |> load_tokens(1)}
   end
 
   @impl true
@@ -46,10 +64,53 @@ defmodule VutuvWeb.OrganizationLive.Apps do
     organization = socket.assigns.organization
 
     if Organizations.owner?(organization, socket.assigns.current_user) do
+      turning_off? = organization.mastodon_clients?
+
       {:ok, organization} =
         Organizations.set_mastodon_clients(organization, !organization.mastodon_clients?)
 
-      {:noreply, assign(socket, :organization, organization)}
+      # Every live token goes with the switch. The confirmation the owner
+      # answered before this event named the count, so nothing is destroyed
+      # without them having been told how much.
+      revoked = if turning_off?, do: ApiAuth.revoke_organization_tokens!(organization), else: 0
+
+      socket =
+        socket
+        |> assign(:organization, organization)
+        |> load_tokens(1)
+        |> maybe_report_revoked(revoked)
+
+      {:noreply, socket}
+    else
+      {:noreply,
+       put_flash(socket, :error, gettext("You are not allowed to change this organization."))}
+    end
+  end
+
+  def handle_event("filter", %{"query" => query}, socket) do
+    {:noreply, socket |> assign(:filter, query) |> load_tokens(1)}
+  end
+
+  def handle_event("page", %{"page" => page}, socket) do
+    {:noreply, load_tokens(socket, String.to_integer(page))}
+  end
+
+  def handle_event("revoke", %{"id" => id}, socket) do
+    organization = socket.assigns.organization
+
+    # Re-asked here, not trusted from mount: a socket outlives the grant that
+    # opened it, so the role is checked on the write and not only on the read.
+    if Organizations.owner?(organization, socket.assigns.current_user) do
+      case ApiAuth.revoke_organization_token(organization, id) do
+        {:ok, _token} ->
+          {:noreply,
+           socket
+           |> put_flash(:info, gettext("The app can no longer act for this page."))
+           |> load_tokens(socket.assigns.tokens.page)}
+
+        {:error, :not_found} ->
+          {:noreply, load_tokens(socket, socket.assigns.tokens.page)}
+      end
     else
       {:noreply,
        put_flash(socket, :error, gettext("You are not allowed to change this organization."))}
@@ -58,6 +119,39 @@ defmodule VutuvWeb.OrganizationLive.Apps do
 
   @impl true
   def handle_info(_message, socket), do: {:noreply, socket}
+
+  defp load_tokens(socket, page) do
+    assign(
+      socket,
+      :tokens,
+      ApiAuth.organization_tokens(socket.assigns.organization, socket.assigns.filter, page)
+    )
+  end
+
+  defp maybe_report_revoked(socket, 0), do: socket
+
+  defp maybe_report_revoked(socket, count) do
+    put_flash(
+      socket,
+      :info,
+      ngettext(
+        "App access is off. One app token was withdrawn.",
+        "App access is off. %{count} app tokens were withdrawn.",
+        count
+      )
+    )
+  end
+
+  @doc """
+  The device a token was minted from, as a row shows it.
+
+  The label and not the raw string: a member is answering "which of my devices
+  is this", and a client string that names nothing recognisable is better said
+  as "unknown device" than guessed at. See `Vutuv.ApiAuth.UserAgent`.
+  """
+  def device_label(token) do
+    UserAgent.label(token.user_agent) || gettext("unknown device")
+  end
 
   @impl true
   def render(assigns) do
@@ -90,11 +184,114 @@ defmodule VutuvWeb.OrganizationLive.Apps do
             "Whoever posted stays recorded, so the team can always tell who wrote what — and an app signed in as this page cannot block anybody, because blocking is between two people."
           )}
         </p>
-        <.button class="mt-3" phx-click="toggle" variant="secondary">
+        <%!-- Turning it off withdraws every token, so the confirmation names
+        how many rather than asking about an abstraction. Turning it on takes
+        nothing away and asks nothing. --%>
+        <.button
+          class="mt-3"
+          phx-click="toggle"
+          variant="secondary"
+          data-confirm={
+            @organization.mastodon_clients? && @tokens.total > 0 &&
+              ngettext(
+                "Turn app access off? The one app token issued for this page is withdrawn and stops working immediately.",
+                "Turn app access off? All %{count} app tokens issued for this page are withdrawn and stop working immediately.",
+                @tokens.total
+              )
+          }
+        >
           {if @organization.mastodon_clients?,
             do: gettext("Turn app access off"),
             else: gettext("Turn app access on")}
         </.button>
+      </.card>
+
+      <%!-- Who is reaching this page from an app. A member issues such a token
+      themselves, and until now only they could see or withdraw it — so an owner
+      could not tell who had one, let alone stop one. --%>
+      <.card :if={@organization.mastodon_clients?} class="mt-6" id="organization-app-tokens">
+        <.section_title>{gettext("App access in use")}</.section_title>
+        <p class="mt-2 text-sm text-slate-700 dark:text-slate-300">
+          {gettext(
+            "Each row is one app signed in as this page, issued by the team member named on it. Withdrawing one stops that app immediately; the member keeps their own account."
+          )}
+        </p>
+
+        <form phx-change="filter" phx-submit="filter" class="mt-4">
+          <label for="token-filter" class="sr-only">
+            {gettext("Filter by the member who issued the token")}
+          </label>
+          <input
+            type="search"
+            id="token-filter"
+            name="query"
+            value={@filter}
+            phx-debounce="300"
+            placeholder={gettext("Filter by member (name or @handle)")}
+            class={input_class()}
+          />
+        </form>
+
+        <p :if={@tokens.entries == []} class="card__empty">
+          {if @filter in [nil, ""],
+            do: gettext("No app is signed in as this page."),
+            else: gettext("No token matches that member.")}
+        </p>
+
+        <div :if={@tokens.entries != []} class="mt-4">
+          <p class="text-sm text-slate-600 dark:text-slate-400">
+            <%!-- The exact figure, not a compacted one: an owner deciding
+            whether to turn the switch off is counting credentials. `ngettext/3`
+            binds %{count} to the raw integer and a binding cannot override it,
+            so the formatted number rides its own placeholder. --%>
+            {ngettext("One app token", "%{formatted} app tokens", @tokens.total,
+              formatted: delimited_count(@tokens.total)
+            )}
+          </p>
+
+          <ul class="mt-2 divide-y divide-slate-100 dark:divide-slate-800">
+            <li
+              :for={token <- @tokens.entries}
+              class="flex flex-wrap items-start gap-3 py-4 first:pt-0 last:pb-0"
+              data-app-token={token.id}
+            >
+              <div class="min-w-0 flex-1">
+                <p class="font-medium text-slate-800 dark:text-slate-100">
+                  {(token.app && token.app.name) || gettext("Personal access token")}
+                </p>
+                <p class="mt-0.5 text-sm text-slate-600 dark:text-slate-400">
+                  {gettext("Issued by")}
+                  <.link
+                    navigate={~p"/#{token.user.username}"}
+                    class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+                  >
+                    {VutuvWeb.UserHelpers.full_name(token.user)}
+                  </.link>
+                  · <.local_time at={token.inserted_at} id={"token-at-#{token.id}"} style={:datetime} />
+                  · {device_label(token)}
+                </p>
+              </div>
+              <.button
+                variant="danger"
+                phx-click="revoke"
+                phx-value-id={token.id}
+                data-confirm={
+                  gettext("Withdraw this app's access to the page? It stops working immediately.")
+                }
+              >
+                {gettext("Withdraw")}
+              </.button>
+            </li>
+          </ul>
+
+          <.admin_pager
+            :if={@tokens.pages > 1}
+            page={@tokens.page}
+            pages={@tokens.pages}
+            prev_id="tokens-prev"
+            next_id="tokens-next"
+          />
+        </div>
       </.card>
 
       <%!-- The address, verbatim and selectable, because typing the wrong one is

--- a/lib/vutuv_web/plugs/content_security_policy.ex
+++ b/lib/vutuv_web/plugs/content_security_policy.ex
@@ -19,6 +19,26 @@ defmodule VutuvWeb.Plug.ContentSecurityPolicy do
   socket cannot join. Derived per request from scheme/host/port, so dev
   (`ws://localhost:4000`) and prod (`wss://vutuv.de`) both come out
   right without configuration.
+
+  ## `form-action` and the OAuth consent screen
+
+  `form-action` is checked against **every hop of the submission, redirects
+  included** (Chrome and WebKit both do this; the enforcing policy is the one
+  of the document that owns the form). The OAuth consent screen is the one
+  page here whose form is *supposed* to end up somewhere else: `POST
+  /oauth/authorize` answers 302 to the client's registered `redirect_uri` —
+  `ivory://…` for a phone client, an off-origin `https://` callback for a web
+  one — and under a bare `form-action 'self'` the browser refuses that hop.
+  The failure is silent and reads as a dead button: the POST *does* reach the
+  server, a code *is* minted, and the member is left looking at the consent
+  screen with no token, which is what an Ivory user reported.
+
+  So `allow_form_action/2` lets that one response widen the directive to the
+  exact redirect target. It is only ever called with a URI
+  `Vutuv.ApiAuth.OAuth.validate_authorize/1` has already matched against the
+  app's registered `redirect_uris`, so this names a destination the server was
+  going to redirect to anyway — never anything read straight off the query
+  string.
   """
 
   @behaviour Plug
@@ -28,8 +48,52 @@ defmodule VutuvWeb.Plug.ContentSecurityPolicy do
 
   @impl true
   def call(conn, _opts) do
-    Plug.Conn.put_resp_header(conn, "content-security-policy", policy(conn))
+    Plug.Conn.put_resp_header(conn, "content-security-policy", policy(conn, []))
   end
+
+  @doc """
+  Re-stamps this response's policy with `redirect_uri` added to `form-action`,
+  so a form on this page may submit to an endpoint that redirects there.
+
+  For the OAuth consent screen, see the moduledoc. Pass the **validated**
+  redirect URI (the one matched against the app's registered list), never a
+  raw parameter. An unusable URI (no scheme) leaves the policy alone.
+  """
+  def allow_form_action(conn, redirect_uri) do
+    case form_action_source(redirect_uri) do
+      nil -> conn
+      source -> Plug.Conn.put_resp_header(conn, "content-security-policy", policy(conn, [source]))
+    end
+  end
+
+  @doc """
+  The CSP source expression that permits a form submission to end at `uri`.
+
+  `http(s)` gets the exact origin, which is as narrow as CSP can express and
+  is where narrowness is worth having. Anything else is a native app's own
+  scheme (`ivory://oauth-callback`, `com.example.app:/cb`) whose shape varies
+  too much to pin down as a host-source, so it gets the scheme-source
+  (`ivory:`) — a scheme registered to that one app.
+  """
+  def form_action_source(uri) when is_binary(uri) do
+    case URI.parse(uri) do
+      %URI{scheme: nil} ->
+        nil
+
+      %URI{scheme: scheme, host: host, port: port} when scheme in ["http", "https"] ->
+        if is_binary(host) and host != "", do: origin(scheme, host, port)
+
+      %URI{scheme: scheme} ->
+        scheme <> ":"
+    end
+  end
+
+  def form_action_source(_uri), do: nil
+
+  defp origin("http", host, 80), do: "http://" <> host
+  defp origin("https", host, 443), do: "https://" <> host
+  defp origin(scheme, host, nil), do: scheme <> "://" <> host
+  defp origin(scheme, host, port), do: "#{scheme}://#{host}:#{port}"
 
   # DEV-ONLY escape hatch. When true we add `script-src 'self' 'unsafe-eval'` so
   # Tidewave's `browser_eval` tool works locally: it injects JS and runs it with
@@ -59,23 +123,30 @@ defmodule VutuvWeb.Plug.ContentSecurityPolicy do
     "style-src 'self' 'unsafe-inline'"
   ]
 
-  @suffix_directives [
-    "font-src 'self' data:",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ]
+  # `form-action` sits between these two halves so the one response that widens
+  # it (the OAuth consent screen) can rebuild that directive alone. With no
+  # extra sources the emitted header stays byte-identical to the old one.
+  @suffix_before ["font-src 'self' data:", "object-src 'none'", "base-uri 'self'"]
+  @suffix_after ["frame-ancestors 'self'"]
 
   @static_prefix Enum.join(@prefix_directives, "; ")
-  @static_suffix Enum.join(@suffix_directives, "; ")
+  @static_suffix_before Enum.join(@suffix_before, "; ")
+  @static_suffix_after Enum.join(@suffix_after, "; ")
 
-  defp policy(conn) do
+  defp policy(conn, form_action_sources) do
     directives =
-      @static_prefix <> "; connect-src 'self' " <> ws_origin(conn) <> "; " <> @static_suffix
+      @static_prefix <>
+        "; connect-src 'self' " <>
+        ws_origin(conn) <>
+        "; " <>
+        @static_suffix_before <>
+        "; " <> form_action(form_action_sources) <> "; " <> @static_suffix_after
 
     maybe_allow_eval(directives)
   end
+
+  defp form_action(sources),
+    do: Enum.reduce(sources, "form-action 'self'", &(&2 <> " " <> &1))
 
   defp maybe_allow_eval(directives) do
     if @allow_eval do

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -302,6 +302,12 @@ defmodule VutuvWeb.Router do
       assigns: %{mastodon_scope: "read:notifications"}
     )
 
+    # The grouped list a 4.3+ client asks for. We advertise 4.4 compatibility,
+    # and a client reads that version to decide which of the two to call.
+    get("/api/v2/notifications", NotificationController, :grouped,
+      assigns: %{mastodon_scope: "read:notifications"}
+    )
+
     get("/api/v1/notifications/unread_count", NotificationController, :unread_count,
       assigns: %{mastodon_scope: "read:notifications"}
     )
@@ -336,6 +342,36 @@ defmodule VutuvWeb.Router do
 
     get("/api/v1/markers", CompatibilityController, :markers,
       assigns: %{mastodon_scope: "read:statuses"}
+    )
+
+    # Trends, announcements and follow suggestions: served as the empty lists
+    # Mastodon itself serves when an instance has them switched off. This site
+    # has none of the three, and the difference between "off" and "not
+    # implemented" is the difference between an empty tab and Ice Cubes'
+    # "an error occurred while loading posts, please try again" — which is what
+    # its Trending and News tabs showed.
+    get("/api/v1/trends/statuses", CompatibilityController, :empty,
+      assigns: %{mastodon_scope: "read:statuses"}
+    )
+
+    get("/api/v1/trends/tags", CompatibilityController, :empty,
+      assigns: %{mastodon_scope: "read:statuses"}
+    )
+
+    get("/api/v1/trends/links", CompatibilityController, :empty,
+      assigns: %{mastodon_scope: "read:statuses"}
+    )
+
+    get("/api/v1/announcements", CompatibilityController, :empty,
+      assigns: %{mastodon_scope: "read:accounts"}
+    )
+
+    get("/api/v1/suggestions", CompatibilityController, :empty,
+      assigns: %{mastodon_scope: "read:accounts"}
+    )
+
+    get("/api/v2/suggestions", CompatibilityController, :empty,
+      assigns: %{mastodon_scope: "read:accounts"}
     )
 
     get("/api/v1/timelines/home", TimelineController, :home,

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -492,6 +492,16 @@ defmodule VutuvWeb.Router do
 
   scope "/", VutuvWeb.MastodonApi, host: "mastodon." do
     pipe_through(:mastodon_api)
+
+    # Somebody typed the technical name into a browser. Nothing here is for
+    # reading — the catch-all below answers every other path as JSON, which is
+    # right for a client and a dead end for a person — so send them to the site.
+    # (On vutuv.de this host is not served at all today: the DNS record exists
+    # without the certificate and the `server_name` that have to come with it,
+    # so nginx answers from its default virtual host and the app never sees the
+    # request. See the `MASTODON_API_ENABLED` row in `docs/ADMINS.md`.)
+    get("/", DiscoveryController, :root)
+
     match(:*, "/*path", DiscoveryController, :not_found)
   end
 

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -440,6 +440,18 @@ defmodule VutuvWeb.Router do
     # `OauthController` handles a Mastodon-protocol app there — mirroring put
     # the subdomain's redirect-to-main-host controller in front of the consent
     # screen, which then pointed at itself.
+
+    # Everything under Mastodon's two version prefixes that this adapter does
+    # not implement, answered as JSON like the subdomain's catch-all — and only
+    # those two prefixes, so the website below is untouched (vutuv's own API is
+    # `/api/2.0`, a different word). A client decodes every body as JSON, and
+    # the main host is the one a member types into a phone app, so without this
+    # a startup call for something we simply do not have
+    # (`/api/v1/announcements`, `POST /api/v1/markers`, `/api/v1/trends/…`)
+    # handed the client the website's HTML error page. Last in the scope: a
+    # wildcard matches before any route defined after it.
+    match(:*, "/api/v1/*path", MastodonApi.DiscoveryController, :not_found)
+    match(:*, "/api/v2/*path", MastodonApi.DiscoveryController, :not_found)
   end
 
   scope "/", VutuvWeb.MastodonApi, host: "mastodon." do

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -344,6 +344,13 @@ defmodule VutuvWeb.Router do
       assigns: %{mastodon_scope: "read:statuses"}
     )
 
+    # The write half. Without it a client's reading position was never stored,
+    # so relaunching the app dropped its timeline back to whatever it could
+    # fetch — and the request itself fell through to the website's HTML 404.
+    post("/api/v1/markers", CompatibilityController, :put_markers,
+      assigns: %{mastodon_scope: "write:statuses"}
+    )
+
     # Trends, announcements and follow suggestions: served as the empty lists
     # Mastodon itself serves when an instance has them switched off. This site
     # has none of the three, and the difference between "off" and "not

--- a/lib/vutuv_web/templates/connected_app/index.html.heex
+++ b/lib/vutuv_web/templates/connected_app/index.html.heex
@@ -16,6 +16,21 @@
           <li class="flex flex-wrap items-start gap-3 py-4 first:pt-0 last:pb-0">
             <div class="min-w-0 flex-1">
               <p class="font-medium text-slate-800 dark:text-slate-100">{grant.app.name}</p>
+              <%!-- What tells two rows of the same name apart. A Mastodon client
+              registers its own OAuth app per install, so a member with the app
+              on a phone and a laptop sees two entries called "Ivory"; without
+              a time and a device there was nothing to choose the right one by,
+              and "withdraw access" was a guess. --%>
+              <%!-- Its own msgid, not the existing "Connected": that one is
+              translated "Vernetzt" for the mutual-follow relationship, and a
+              msgid is a key rather than a phrase. --%>
+              <p class="mt-0.5 text-sm text-slate-600 dark:text-slate-400">
+                {gettext("Connected on")}
+                <.local_time at={grant.connected_at} style={:datetime} />
+                <%= if grant.devices != [] do %>
+                  · {Enum.join(grant.devices, ", ")}
+                <% end %>
+              </p>
               <ul class="mt-1 space-y-0.5">
                 <li
                   :for={scope <- grant.scopes}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.321.0",
+      version: "7.322.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -5234,7 +5234,7 @@ msgstr ""
 "Eine pro Zeile. Exakte https://-URLs (http://localhost ist für die "
 "Entwicklung erlaubt). Die Autorisierung leitet nur an diese Adressen weiter."
 
-#: lib/vutuv_web/controllers/oauth_controller.ex:44
+#: lib/vutuv_web/controllers/oauth_controller.ex:56
 #, elixir-autogen, elixir-format
 msgid "Please log in to connect %{app} with your account."
 msgstr "Bitte melden Sie sich an, um %{app} mit Ihrem Konto zu verbinden."
@@ -5350,12 +5350,12 @@ msgstr ""
 msgid "Token URL:"
 msgstr "Token-URL:"
 
-#: lib/vutuv_web/templates/connected_app/index.html.heex:38
+#: lib/vutuv_web/templates/connected_app/index.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Withdraw access"
 msgstr "Zugriff entziehen"
 
-#: lib/vutuv_web/templates/connected_app/index.html.heex:33
+#: lib/vutuv_web/templates/connected_app/index.html.heex:48
 #, elixir-autogen, elixir-format
 msgid "Withdraw access for \"%{name}\"? It stops working immediately."
 msgstr "\"%{name}\" den Zugriff entziehen? Es funktioniert sofort nicht mehr."
@@ -5861,7 +5861,7 @@ msgid "@%{slug} started following you on vutuv"
 msgstr "@%{slug} folgt Ihnen jetzt auf vutuv"
 
 #: lib/vutuv_web/components/organization_components.ex:318
-#: lib/vutuv_web/live/organization_live/apps.ex:68
+#: lib/vutuv_web/live/organization_live/apps.ex:162
 #: lib/vutuv_web/templates/settings/apps.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Apps"
@@ -19042,7 +19042,7 @@ msgstr "%{address} (nur diese Seite)"
 msgid "%{address} (whole website)"
 msgstr "%{address} (ganze Website)"
 
-#: lib/vutuv_web/markdown.ex:323
+#: lib/vutuv_web/markdown.ex:327
 #, elixir-autogen, elixir-format
 msgid "Verified webpage of the author (%{address})"
 msgstr "Verifizierte Webseite der Autorin oder des Autors (%{address})"
@@ -21396,7 +21396,7 @@ msgstr "Konten blockieren oder Blockierungen aufheben"
 msgid "Mute or unmute accounts"
 msgstr "Konten stummschalten oder Stummschaltungen aufheben"
 
-#: lib/vutuv_web/live/organization_live/apps.ex:82
+#: lib/vutuv_web/live/organization_live/apps.ex:176
 #: lib/vutuv_web/templates/settings/apps.html.heex:42
 #: lib/vutuv_web/views/account_event_text.ex:235
 #, elixir-autogen, elixir-format
@@ -21443,7 +21443,8 @@ msgstr "Eine Organisation kann sich nicht selbst folgen."
 msgid "No visible local account has that handle."
 msgstr "Unter diesem Alias wurde kein sichtbares lokales Konto gefunden."
 
-#: lib/vutuv_web/live/organization_live/apps.ex:55
+#: lib/vutuv_web/live/organization_live/apps.ex:86
+#: lib/vutuv_web/live/organization_live/apps.ex:116
 #: lib/vutuv_web/live/organization_live/following.ex:259
 #, elixir-autogen, elixir-format
 msgid "You are not allowed to change this organization."
@@ -21806,7 +21807,7 @@ msgstr "Profilbild von %{name}"
 msgid "Show the profile picture larger"
 msgstr "Profilbild größer anzeigen"
 
-#: lib/vutuv_web/live/organization_live/apps.ex:84
+#: lib/vutuv_web/live/organization_live/apps.ex:178
 #, elixir-autogen, elixir-format
 msgid "The page's Editorial team can use this organization as a separate identity in a compatible phone app, with the same rights they already have here. Those rights are checked again on every request."
 msgstr "Die Redaktion der Seite kann diese Organisation in einer kompatiblen Smartphone-App als eigene Identität verwenden, mit denselben Rechten, die sie hier schon hat. Diese Rechte werden bei jeder Anfrage erneut geprüft."
@@ -21816,7 +21817,7 @@ msgstr "Die Redaktion der Seite kann diese Organisation in einer kompatiblen Sma
 msgid "App settings saved."
 msgstr "App-Einstellungen gespeichert."
 
-#: lib/vutuv_web/live/organization_live/apps.ex:70
+#: lib/vutuv_web/live/organization_live/apps.ex:164
 #, elixir-autogen, elixir-format
 msgid "Apps built for Mastodon can write in this page's name, read its feed and notify its team."
 msgstr "Apps, die für Mastodon gebaut wurden, können im Namen dieser Seite schreiben, ihren Feed lesen und ihr Team benachrichtigen."
@@ -21826,12 +21827,12 @@ msgstr "Apps, die für Mastodon gebaut wurden, können im Namen dieser Seite sch
 msgid "Apps built for Mastodon — Ivory, Tusky, Ice Cubes and the rest — can read your feed, post, and notify you. Off unless you turn it on."
 msgstr "Apps, die für Mastodon gebaut wurden (Ivory, Tusky, Ice Cubes und andere), können Ihren Feed lesen, Beiträge schreiben und Sie benachrichtigen. Aus, solange Sie es nicht einschalten."
 
-#: lib/vutuv_web/live/organization_live/apps.ex:39
+#: lib/vutuv_web/live/organization_live/apps.ex:55
 #, elixir-autogen, elixir-format
 msgid "Apps – %{name}"
 msgstr "Apps – %{name}"
 
-#: lib/vutuv_web/live/organization_live/apps.ex:124
+#: lib/vutuv_web/live/organization_live/apps.ex:321
 #: lib/vutuv_web/templates/settings/apps.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "How to set up an app"
@@ -21852,38 +21853,38 @@ msgstr "Mastodon-App-Zugriff geändert"
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr "Mastodon-Apps, verbundene Apps und Zugriffstoken"
 
-#: lib/vutuv_web/live/organization_live/apps.ex:110
+#: lib/vutuv_web/live/organization_live/apps.ex:307
 #, elixir-autogen, elixir-format
 msgid "Sign in with your own account, then pick %{name} on the approval screen."
 msgstr "Melden Sie sich mit Ihrem eigenen Konto an und wählen Sie dann %{name} im Zustimmungsbildschirm."
 
-#: lib/vutuv_web/live/organization_live/apps.ex:115
+#: lib/vutuv_web/live/organization_live/apps.ex:312
 #, elixir-autogen, elixir-format
 msgid "Sign in with your own account, then pick this page on the approval screen. A short @name is not needed for that, only for being followed from another server."
 msgstr "Melden Sie sich mit Ihrem eigenen Konto an und wählen Sie dann diese Seite im Zustimmungsbildschirm. Ein kurzer @Name ist dafür nicht nötig, sondern nur dafür, von einem anderen Server aus gefolgt zu werden."
 
-#: lib/vutuv_web/live/organization_live/apps.ex:105
+#: lib/vutuv_web/live/organization_live/apps.ex:302
 #: lib/vutuv_web/templates/settings/apps.html.heex:70
 #, elixir-autogen, elixir-format
 msgid "The address to type into the app"
 msgstr "Die Adresse, die Sie in die App eintippen"
 
-#: lib/vutuv_web/live/organization_live/apps.ex:77
+#: lib/vutuv_web/live/organization_live/apps.ex:171
 #, elixir-autogen, elixir-format
 msgid "This vutuv serves no app interface, so nothing here has any effect."
 msgstr "Dieses vutuv stellt keine App-Schnittstelle bereit, hier hat also nichts eine Wirkung."
 
-#: lib/vutuv_web/live/organization_live/apps.ex:95
+#: lib/vutuv_web/live/organization_live/apps.ex:204
 #, elixir-autogen, elixir-format
 msgid "Turn app access off"
 msgstr "App-Zugriff ausschalten"
 
-#: lib/vutuv_web/live/organization_live/apps.ex:96
+#: lib/vutuv_web/live/organization_live/apps.ex:205
 #, elixir-autogen, elixir-format
 msgid "Turn app access on"
 msgstr "App-Zugriff einschalten"
 
-#: lib/vutuv_web/live/organization_live/apps.ex:89
+#: lib/vutuv_web/live/organization_live/apps.ex:183
 #, elixir-autogen, elixir-format
 msgid "Whoever posted stays recorded, so the team can always tell who wrote what — and an app signed in as this page cannot block anybody, because blocking is between two people."
 msgstr "Wer etwas geschrieben hat, wird weiter festgehalten, das Team kann also immer nachvollziehen, wer was geschrieben hat — und eine App, die als diese Seite angemeldet ist, kann niemanden blockieren, denn Blockieren ist eine Sache zwischen zwei Menschen."
@@ -22137,3 +22138,89 @@ msgstr "%{name} hat auf einen Beitrag geantwortet."
 #, elixir-autogen, elixir-format
 msgid "This application asked to be connected too many times in a row. Please wait a moment and try again."
 msgstr "Diese Anwendung hat zu oft hintereinander um eine Verbindung gebeten. Bitte warten Sie einen Moment und versuchen Sie es erneut."
+
+#: lib/vutuv_web/live/organization_live/apps.ex:213
+#, elixir-autogen, elixir-format
+msgid "App access in use"
+msgstr "Genutzte App-Zugänge"
+
+#: lib/vutuv_web/live/organization_live/apps.ex:137
+#, elixir-autogen, elixir-format
+msgid "App access is off. One app token was withdrawn."
+msgid_plural "App access is off. %{count} app tokens were withdrawn."
+msgstr[0] "App-Zugriff ist aus. Ein App-Zugang wurde entzogen."
+msgstr[1] "App-Zugriff ist aus. %{count} App-Zugänge wurden entzogen."
+
+#: lib/vutuv_web/live/organization_live/apps.ex:215
+#, elixir-autogen, elixir-format
+msgid "Each row is one app signed in as this page, issued by the team member named on it. Withdrawing one stops that app immediately; the member keeps their own account."
+msgstr "Jede Zeile ist eine App, die als diese Seite angemeldet ist, ausgestellt von dem genannten Teammitglied. Wer einen Zugang entzieht, stoppt diese App sofort; das eigene Konto des Mitglieds bleibt unberührt."
+
+#: lib/vutuv_web/live/organization_live/apps.ex:230
+#, elixir-autogen, elixir-format
+msgid "Filter by member (name or @handle)"
+msgstr "Nach Mitglied filtern (Name oder @Name)"
+
+#: lib/vutuv_web/live/organization_live/apps.ex:222
+#, elixir-autogen, elixir-format
+msgid "Filter by the member who issued the token"
+msgstr "Nach dem Mitglied filtern, das den Zugang ausgestellt hat"
+
+#: lib/vutuv_web/live/organization_live/apps.ex:263
+#, elixir-autogen, elixir-format
+msgid "Issued by"
+msgstr "Ausgestellt von"
+
+#: lib/vutuv_web/live/organization_live/apps.ex:237
+#, elixir-autogen, elixir-format
+msgid "No app is signed in as this page."
+msgstr "Keine App ist als diese Seite angemeldet."
+
+#: lib/vutuv_web/live/organization_live/apps.ex:238
+#, elixir-autogen, elixir-format
+msgid "No token matches that member."
+msgstr "Zu diesem Mitglied gibt es keinen Zugang."
+
+#: lib/vutuv_web/live/organization_live/apps.ex:247
+#, elixir-autogen, elixir-format
+msgid "One app token"
+msgid_plural "%{formatted} app tokens"
+msgstr[0] "Ein App-Zugang"
+msgstr[1] "%{formatted} App-Zugänge"
+
+#: lib/vutuv_web/live/organization_live/apps.ex:260
+#, elixir-autogen, elixir-format
+msgid "Personal access token"
+msgstr "Persönlicher Zugangs-Token"
+
+#: lib/vutuv_web/live/organization_live/apps.ex:108
+#, elixir-autogen, elixir-format
+msgid "The app can no longer act for this page."
+msgstr "Die App kann nicht mehr für diese Seite handeln."
+
+#: lib/vutuv_web/live/organization_live/apps.ex:196
+#, elixir-autogen, elixir-format
+msgid "Turn app access off? The one app token issued for this page is withdrawn and stops working immediately."
+msgid_plural "Turn app access off? All %{count} app tokens issued for this page are withdrawn and stop working immediately."
+msgstr[0] "App-Zugriff abschalten? Der eine für diese Seite ausgestellte App-Zugang wird entzogen und hört sofort auf zu funktionieren."
+msgstr[1] "App-Zugriff abschalten? Alle %{count} für diese Seite ausgestellten App-Zugänge werden entzogen und hören sofort auf zu funktionieren."
+
+#: lib/vutuv_web/live/organization_live/apps.ex:282
+#, elixir-autogen, elixir-format
+msgid "Withdraw"
+msgstr "Entziehen"
+
+#: lib/vutuv_web/live/organization_live/apps.ex:279
+#, elixir-autogen, elixir-format
+msgid "Withdraw this app's access to the page? It stops working immediately."
+msgstr "Der App den Zugriff auf die Seite entziehen? Sie hört sofort auf zu funktionieren."
+
+#: lib/vutuv_web/live/organization_live/apps.ex:153
+#, elixir-autogen, elixir-format
+msgid "unknown device"
+msgstr "unbekanntes Gerät"
+
+#: lib/vutuv_web/templates/connected_app/index.html.heex:28
+#, elixir-autogen, elixir-format
+msgid "Connected on"
+msgstr "Verbunden am"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -5036,7 +5036,7 @@ msgstr ""
 msgid "One per line. Exact https:// URLs (http://localhost is allowed for development). The authorization flow only ever redirects to these."
 msgstr ""
 
-#: lib/vutuv_web/controllers/oauth_controller.ex:44
+#: lib/vutuv_web/controllers/oauth_controller.ex:56
 #, elixir-autogen, elixir-format
 msgid "Please log in to connect %{app} with your account."
 msgstr ""
@@ -5145,12 +5145,12 @@ msgstr ""
 msgid "Token URL:"
 msgstr ""
 
-#: lib/vutuv_web/templates/connected_app/index.html.heex:38
+#: lib/vutuv_web/templates/connected_app/index.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Withdraw access"
 msgstr ""
 
-#: lib/vutuv_web/templates/connected_app/index.html.heex:33
+#: lib/vutuv_web/templates/connected_app/index.html.heex:48
 #, elixir-autogen, elixir-format
 msgid "Withdraw access for \"%{name}\"? It stops working immediately."
 msgstr ""
@@ -5635,7 +5635,7 @@ msgid "@%{slug} started following you on vutuv"
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:318
-#: lib/vutuv_web/live/organization_live/apps.ex:68
+#: lib/vutuv_web/live/organization_live/apps.ex:162
 #: lib/vutuv_web/templates/settings/apps.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Apps"
@@ -18296,7 +18296,7 @@ msgstr ""
 msgid "%{address} (whole website)"
 msgstr ""
 
-#: lib/vutuv_web/markdown.ex:323
+#: lib/vutuv_web/markdown.ex:327
 #, elixir-autogen, elixir-format
 msgid "Verified webpage of the author (%{address})"
 msgstr ""
@@ -20623,7 +20623,7 @@ msgstr ""
 msgid "Mute or unmute accounts"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:82
+#: lib/vutuv_web/live/organization_live/apps.ex:176
 #: lib/vutuv_web/templates/settings/apps.html.heex:42
 #: lib/vutuv_web/views/account_event_text.ex:235
 #, elixir-autogen, elixir-format
@@ -20670,7 +20670,8 @@ msgstr ""
 msgid "No visible local account has that handle."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:55
+#: lib/vutuv_web/live/organization_live/apps.ex:86
+#: lib/vutuv_web/live/organization_live/apps.ex:116
 #: lib/vutuv_web/live/organization_live/following.ex:259
 #, elixir-autogen, elixir-format
 msgid "You are not allowed to change this organization."
@@ -21016,7 +21017,7 @@ msgstr ""
 msgid "Show the profile picture larger"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:84
+#: lib/vutuv_web/live/organization_live/apps.ex:178
 #, elixir-autogen, elixir-format
 msgid "The page's Editorial team can use this organization as a separate identity in a compatible phone app, with the same rights they already have here. Those rights are checked again on every request."
 msgstr ""
@@ -21026,7 +21027,7 @@ msgstr ""
 msgid "App settings saved."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:70
+#: lib/vutuv_web/live/organization_live/apps.ex:164
 #, elixir-autogen, elixir-format
 msgid "Apps built for Mastodon can write in this page's name, read its feed and notify its team."
 msgstr ""
@@ -21036,12 +21037,12 @@ msgstr ""
 msgid "Apps built for Mastodon — Ivory, Tusky, Ice Cubes and the rest — can read your feed, post, and notify you. Off unless you turn it on."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:39
+#: lib/vutuv_web/live/organization_live/apps.ex:55
 #, elixir-autogen, elixir-format
 msgid "Apps – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:124
+#: lib/vutuv_web/live/organization_live/apps.ex:321
 #: lib/vutuv_web/templates/settings/apps.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "How to set up an app"
@@ -21062,38 +21063,38 @@ msgstr ""
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:110
+#: lib/vutuv_web/live/organization_live/apps.ex:307
 #, elixir-autogen, elixir-format
 msgid "Sign in with your own account, then pick %{name} on the approval screen."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:115
+#: lib/vutuv_web/live/organization_live/apps.ex:312
 #, elixir-autogen, elixir-format
 msgid "Sign in with your own account, then pick this page on the approval screen. A short @name is not needed for that, only for being followed from another server."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:105
+#: lib/vutuv_web/live/organization_live/apps.ex:302
 #: lib/vutuv_web/templates/settings/apps.html.heex:70
 #, elixir-autogen, elixir-format
 msgid "The address to type into the app"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:77
+#: lib/vutuv_web/live/organization_live/apps.ex:171
 #, elixir-autogen, elixir-format
 msgid "This vutuv serves no app interface, so nothing here has any effect."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:95
+#: lib/vutuv_web/live/organization_live/apps.ex:204
 #, elixir-autogen, elixir-format
 msgid "Turn app access off"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:96
+#: lib/vutuv_web/live/organization_live/apps.ex:205
 #, elixir-autogen, elixir-format
 msgid "Turn app access on"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:89
+#: lib/vutuv_web/live/organization_live/apps.ex:183
 #, elixir-autogen, elixir-format
 msgid "Whoever posted stays recorded, so the team can always tell who wrote what — and an app signed in as this page cannot block anybody, because blocking is between two people."
 msgstr ""
@@ -21346,4 +21347,90 @@ msgstr ""
 #: lib/vutuv_web/views/oauth_html.ex:27
 #, elixir-autogen, elixir-format
 msgid "This application asked to be connected too many times in a row. Please wait a moment and try again."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/apps.ex:213
+#, elixir-autogen, elixir-format
+msgid "App access in use"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/apps.ex:137
+#, elixir-autogen, elixir-format
+msgid "App access is off. One app token was withdrawn."
+msgid_plural "App access is off. %{count} app tokens were withdrawn."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/organization_live/apps.ex:215
+#, elixir-autogen, elixir-format
+msgid "Each row is one app signed in as this page, issued by the team member named on it. Withdrawing one stops that app immediately; the member keeps their own account."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/apps.ex:230
+#, elixir-autogen, elixir-format
+msgid "Filter by member (name or @handle)"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/apps.ex:222
+#, elixir-autogen, elixir-format
+msgid "Filter by the member who issued the token"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/apps.ex:263
+#, elixir-autogen, elixir-format
+msgid "Issued by"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/apps.ex:237
+#, elixir-autogen, elixir-format
+msgid "No app is signed in as this page."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/apps.ex:238
+#, elixir-autogen, elixir-format
+msgid "No token matches that member."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/apps.ex:247
+#, elixir-autogen, elixir-format
+msgid "One app token"
+msgid_plural "%{formatted} app tokens"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/organization_live/apps.ex:260
+#, elixir-autogen, elixir-format
+msgid "Personal access token"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/apps.ex:108
+#, elixir-autogen, elixir-format
+msgid "The app can no longer act for this page."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/apps.ex:196
+#, elixir-autogen, elixir-format
+msgid "Turn app access off? The one app token issued for this page is withdrawn and stops working immediately."
+msgid_plural "Turn app access off? All %{count} app tokens issued for this page are withdrawn and stop working immediately."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/organization_live/apps.ex:282
+#, elixir-autogen, elixir-format
+msgid "Withdraw"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/apps.ex:279
+#, elixir-autogen, elixir-format
+msgid "Withdraw this app's access to the page? It stops working immediately."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/apps.ex:153
+#, elixir-autogen, elixir-format
+msgid "unknown device"
+msgstr ""
+
+#: lib/vutuv_web/templates/connected_app/index.html.heex:28
+#, elixir-autogen, elixir-format
+msgid "Connected on"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -5034,7 +5034,7 @@ msgstr ""
 msgid "One per line. Exact https:// URLs (http://localhost is allowed for development). The authorization flow only ever redirects to these."
 msgstr ""
 
-#: lib/vutuv_web/controllers/oauth_controller.ex:44
+#: lib/vutuv_web/controllers/oauth_controller.ex:56
 #, elixir-autogen, elixir-format
 msgid "Please log in to connect %{app} with your account."
 msgstr ""
@@ -5143,12 +5143,12 @@ msgstr ""
 msgid "Token URL:"
 msgstr ""
 
-#: lib/vutuv_web/templates/connected_app/index.html.heex:38
+#: lib/vutuv_web/templates/connected_app/index.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Withdraw access"
 msgstr ""
 
-#: lib/vutuv_web/templates/connected_app/index.html.heex:33
+#: lib/vutuv_web/templates/connected_app/index.html.heex:48
 #, elixir-autogen, elixir-format
 msgid "Withdraw access for \"%{name}\"? It stops working immediately."
 msgstr ""
@@ -5633,7 +5633,7 @@ msgid "@%{slug} started following you on vutuv"
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:318
-#: lib/vutuv_web/live/organization_live/apps.ex:68
+#: lib/vutuv_web/live/organization_live/apps.ex:162
 #: lib/vutuv_web/templates/settings/apps.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Apps"
@@ -18294,7 +18294,7 @@ msgstr ""
 msgid "%{address} (whole website)"
 msgstr ""
 
-#: lib/vutuv_web/markdown.ex:323
+#: lib/vutuv_web/markdown.ex:327
 #, elixir-autogen, elixir-format
 msgid "Verified webpage of the author (%{address})"
 msgstr ""
@@ -20621,7 +20621,7 @@ msgstr ""
 msgid "Mute or unmute accounts"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:82
+#: lib/vutuv_web/live/organization_live/apps.ex:176
 #: lib/vutuv_web/templates/settings/apps.html.heex:42
 #: lib/vutuv_web/views/account_event_text.ex:235
 #, elixir-autogen, elixir-format
@@ -20668,7 +20668,8 @@ msgstr ""
 msgid "No visible local account has that handle."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:55
+#: lib/vutuv_web/live/organization_live/apps.ex:86
+#: lib/vutuv_web/live/organization_live/apps.ex:116
 #: lib/vutuv_web/live/organization_live/following.ex:259
 #, elixir-autogen, elixir-format
 msgid "You are not allowed to change this organization."
@@ -21014,7 +21015,7 @@ msgstr ""
 msgid "Show the profile picture larger"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:84
+#: lib/vutuv_web/live/organization_live/apps.ex:178
 #, elixir-autogen, elixir-format
 msgid "The page's Editorial team can use this organization as a separate identity in a compatible phone app, with the same rights they already have here. Those rights are checked again on every request."
 msgstr ""
@@ -21024,7 +21025,7 @@ msgstr ""
 msgid "App settings saved."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:70
+#: lib/vutuv_web/live/organization_live/apps.ex:164
 #, elixir-autogen, elixir-format
 msgid "Apps built for Mastodon can write in this page's name, read its feed and notify its team."
 msgstr ""
@@ -21034,12 +21035,12 @@ msgstr ""
 msgid "Apps built for Mastodon — Ivory, Tusky, Ice Cubes and the rest — can read your feed, post, and notify you. Off unless you turn it on."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:39
+#: lib/vutuv_web/live/organization_live/apps.ex:55
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Apps – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:124
+#: lib/vutuv_web/live/organization_live/apps.ex:321
 #: lib/vutuv_web/templates/settings/apps.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "How to set up an app"
@@ -21060,38 +21061,38 @@ msgstr ""
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:110
+#: lib/vutuv_web/live/organization_live/apps.ex:307
 #, elixir-autogen, elixir-format
 msgid "Sign in with your own account, then pick %{name} on the approval screen."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:115
+#: lib/vutuv_web/live/organization_live/apps.ex:312
 #, elixir-autogen, elixir-format
 msgid "Sign in with your own account, then pick this page on the approval screen. A short @name is not needed for that, only for being followed from another server."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:105
+#: lib/vutuv_web/live/organization_live/apps.ex:302
 #: lib/vutuv_web/templates/settings/apps.html.heex:70
 #, elixir-autogen, elixir-format
 msgid "The address to type into the app"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:77
+#: lib/vutuv_web/live/organization_live/apps.ex:171
 #, elixir-autogen, elixir-format
 msgid "This vutuv serves no app interface, so nothing here has any effect."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:95
+#: lib/vutuv_web/live/organization_live/apps.ex:204
 #, elixir-autogen, elixir-format
 msgid "Turn app access off"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:96
+#: lib/vutuv_web/live/organization_live/apps.ex:205
 #, elixir-autogen, elixir-format
 msgid "Turn app access on"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:89
+#: lib/vutuv_web/live/organization_live/apps.ex:183
 #, elixir-autogen, elixir-format
 msgid "Whoever posted stays recorded, so the team can always tell who wrote what — and an app signed in as this page cannot block anybody, because blocking is between two people."
 msgstr ""
@@ -21344,4 +21345,90 @@ msgstr ""
 #: lib/vutuv_web/views/oauth_html.ex:27
 #, elixir-autogen, elixir-format
 msgid "This application asked to be connected too many times in a row. Please wait a moment and try again."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/apps.ex:213
+#, elixir-autogen, elixir-format
+msgid "App access in use"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/apps.ex:137
+#, elixir-autogen, elixir-format
+msgid "App access is off. One app token was withdrawn."
+msgid_plural "App access is off. %{count} app tokens were withdrawn."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/organization_live/apps.ex:215
+#, elixir-autogen, elixir-format
+msgid "Each row is one app signed in as this page, issued by the team member named on it. Withdrawing one stops that app immediately; the member keeps their own account."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/apps.ex:230
+#, elixir-autogen, elixir-format
+msgid "Filter by member (name or @handle)"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/apps.ex:222
+#, elixir-autogen, elixir-format
+msgid "Filter by the member who issued the token"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/apps.ex:263
+#, elixir-autogen, elixir-format
+msgid "Issued by"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/apps.ex:237
+#, elixir-autogen, elixir-format
+msgid "No app is signed in as this page."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/apps.ex:238
+#, elixir-autogen, elixir-format
+msgid "No token matches that member."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/apps.ex:247
+#, elixir-autogen, elixir-format
+msgid "One app token"
+msgid_plural "%{formatted} app tokens"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/organization_live/apps.ex:260
+#, elixir-autogen, elixir-format
+msgid "Personal access token"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/apps.ex:108
+#, elixir-autogen, elixir-format
+msgid "The app can no longer act for this page."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/apps.ex:196
+#, elixir-autogen, elixir-format
+msgid "Turn app access off? The one app token issued for this page is withdrawn and stops working immediately."
+msgid_plural "Turn app access off? All %{count} app tokens issued for this page are withdrawn and stop working immediately."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/organization_live/apps.ex:282
+#, elixir-autogen, elixir-format
+msgid "Withdraw"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/apps.ex:279
+#, elixir-autogen, elixir-format
+msgid "Withdraw this app's access to the page? It stops working immediately."
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/apps.ex:153
+#, elixir-autogen, elixir-format
+msgid "unknown device"
+msgstr ""
+
+#: lib/vutuv_web/templates/connected_app/index.html.heex:28
+#, elixir-autogen, elixir-format
+msgid "Connected on"
 msgstr ""

--- a/priv/repo/migrations/20260817225253_add_user_agent_to_api_tokens.exs
+++ b/priv/repo/migrations/20260817225253_add_user_agent_to_api_tokens.exs
@@ -1,0 +1,27 @@
+defmodule Vutuv.Repo.Migrations.AddUserAgentToApiTokens do
+  use Ecto.Migration
+
+  @moduledoc """
+  What the Connected apps page could not say: which device a token was minted
+  from.
+
+  A member sees several rows named "Ivory" because a Mastodon client registers
+  a **new** OAuth app per install, and with neither a time nor a device on the
+  row there was no way to tell one from another — so there was no way to
+  withdraw the right one either.
+
+  `text`, not varchar(255): a User-Agent is a remote client's string and not
+  ours to bound (the same reasoning as `fediverse_followers.inbox_uri`). It is
+  capped on the way in all the same, in `Vutuv.ApiAuth`, so a client cannot
+  push an unbounded body into the column.
+
+  Plain nullable addition, so it is N-1 compatible: the running release neither
+  reads nor writes it.
+  """
+
+  def change do
+    alter table(:api_tokens) do
+      add(:user_agent, :text)
+    end
+  end
+end

--- a/priv/repo/migrations/20260817232940_create_mastodon_markers.exs
+++ b/priv/repo/migrations/20260817232940_create_mastodon_markers.exs
@@ -1,0 +1,52 @@
+defmodule Vutuv.Repo.Migrations.CreateMastodonMarkers do
+  use Ecto.Migration
+
+  @moduledoc """
+  Where a client left off reading (Mastodon's `/api/v1/markers`).
+
+  `GET` answered `{}` and there was no `POST` at all, so a client's reading
+  position was never stored and never restored: relaunching the app dropped it
+  back to whatever it could fetch, which is what a member sees as a timeline
+  that "lost" everything it had.
+
+  One row per identity **and** timeline. The identity is a member or a page
+  acting through them, so `organization_id` is nullable — which the uniqueness
+  has to survive: Postgres treats NULLs as distinct, so a single unique index
+  over the three columns would let a member accumulate a new row per write.
+  Two partial indexes instead, one for each side of that nil.
+
+  `last_read_id` is a plain string, not a reference: a Mastodon id here can be a
+  vutuv uuid **or** a prefixed derived id (`remote-<uuid>`, `like-<uuid>`), and
+  it is the client's bookmark rather than our foreign key — an id whose row is
+  since gone must not fail a write, it just scrolls to nothing.
+
+  New table, so N-1 compatible: the running release neither reads nor writes it.
+  """
+
+  def change do
+    create table(:mastodon_markers) do
+      add(:user_id, references(:users, on_delete: :delete_all), null: false)
+      add(:organization_id, references(:organizations, on_delete: :delete_all))
+      add(:timeline, :string, null: false)
+      add(:last_read_id, :string, null: false)
+      # Mastodon's own optimistic-concurrency counter, which clients read back.
+      add(:version, :integer, null: false, default: 1)
+
+      timestamps()
+    end
+
+    create(
+      unique_index(:mastodon_markers, [:user_id, :timeline],
+        where: "organization_id IS NULL",
+        name: :mastodon_markers_member_timeline_index
+      )
+    )
+
+    create(
+      unique_index(:mastodon_markers, [:user_id, :organization_id, :timeline],
+        where: "organization_id IS NOT NULL",
+        name: :mastodon_markers_organization_timeline_index
+      )
+    )
+  end
+end

--- a/test/vutuv/api_auth/app_token_oversight_test.exs
+++ b/test/vutuv/api_auth/app_token_oversight_test.exs
@@ -1,0 +1,196 @@
+defmodule Vutuv.ApiAuth.AppTokenOversightTest do
+  @moduledoc """
+  Who holds a credential for an account, and who may take it away.
+
+  Two gaps this covers. A member's Connected apps page listed rows it gave them
+  no way to tell apart — a Mastodon client registers a **new** OAuth app per
+  install, so several installs are several rows of one name. And a token issued
+  **for a page** was visible and revocable only to the member who issued it, so
+  the page's owner could not see who was reaching it from an app.
+  """
+  use Vutuv.DataCase
+
+  alias Vutuv.ApiAuth
+  alias Vutuv.ApiAuth.UserAgent
+  alias Vutuv.Organizations
+
+  describe "UserAgent.label/1" do
+    test "names the platform a member would recognise" do
+      assert UserAgent.label("Ivory/1.0 (iPhone; iOS 18.2)") == "iPhone"
+      assert UserAgent.label("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)") == "macOS"
+      assert UserAgent.label("Mozilla/5.0 (Windows NT 10.0; Win64; x64)") == "Windows"
+      assert UserAgent.label("Mozilla/5.0 (Linux; Android 14; Pixel 8)") == "Android"
+    end
+
+    test "an iPad is not a Mac, and an Android is not a Linux desktop" do
+      # Both carry the other's marker, so the order the patterns are tried in is
+      # load-bearing rather than incidental.
+      assert UserAgent.label("Mozilla/5.0 (iPad; CPU OS 18_2 like Mac OS X)") == "iPad"
+      assert UserAgent.label("Mozilla/5.0 (iPhone; CPU iPhone OS 18_2 like Mac OS X)") == "iPhone"
+      assert UserAgent.label("Dalvik/2.1.0 (Linux; U; Android 13)") == "Android"
+    end
+
+    test "nothing recognisable is nil, never a guess" do
+      # A client string is a self-declaration. A confident wrong device is worse
+      # than "unknown device", which is at least true.
+      assert UserAgent.label("some-http-library/2.1") == nil
+      assert UserAgent.label(nil) == nil
+    end
+  end
+
+  describe "UserAgent.capture/1" do
+    test "caps the stored string so a body cannot become a row" do
+      long = String.duplicate("x", UserAgent.max_bytes() * 3)
+
+      assert String.length(UserAgent.capture(long)) == UserAgent.max_bytes()
+    end
+
+    test "a missing or blank header is nil, so the column says 'not recorded'" do
+      assert UserAgent.capture(nil) == nil
+      assert UserAgent.capture("   ") == nil
+    end
+  end
+
+  describe "an organization's app tokens" do
+    setup do
+      owner = insert(:activated_user)
+      organization = insert(:organization)
+
+      Repo.insert!(%Vutuv.Organizations.OrganizationRole{
+        organization_id: organization.id,
+        user_id: owner.id,
+        role: "owner"
+      })
+
+      {:ok, owner: owner, organization: organization}
+    end
+
+    defp issue(organization, user, opts \\ []) do
+      app = insert(:oauth_app, user: nil, protocol: "mastodon")
+
+      insert(:api_token,
+        user: user,
+        app: app,
+        organization: organization,
+        kind: "access",
+        name: nil,
+        scopes: ["read"],
+        expires_at: nil,
+        user_agent: Keyword.get(opts, :user_agent),
+        token_hash: ApiAuth.hash_token("vutuv_at_" <> ApiAuth.random_token())
+      )
+    end
+
+    test "are listed with the member who issued them", %{organization: organization} do
+      issuer = insert(:activated_user)
+      issue(organization, issuer)
+
+      page = ApiAuth.organization_tokens(organization)
+
+      assert page.total == 1
+      assert [token] = page.entries
+      assert token.user.id == issuer.id
+    end
+
+    test "another page's token is not among them", %{organization: organization} do
+      issue(insert(:organization), insert(:activated_user))
+
+      assert ApiAuth.organization_tokens(organization).total == 0
+    end
+
+    test "the filter narrows by the issuing member", %{organization: organization} do
+      wanted = insert(:activated_user, first_name: "Zoraida")
+      issue(organization, wanted)
+      issue(organization, insert(:activated_user, first_name: "Other"))
+
+      page = ApiAuth.organization_tokens(organization, "zorai")
+
+      assert page.total == 1
+      assert [%{user: %{id: id}}] = page.entries
+      assert id == wanted.id
+    end
+
+    test "pages, so a large team's list stays readable", %{organization: organization} do
+      per_page = ApiAuth.organization_tokens_per_page()
+      for _ <- 1..(per_page + 3), do: issue(organization, insert(:activated_user))
+
+      first = ApiAuth.organization_tokens(organization, nil, 1)
+      second = ApiAuth.organization_tokens(organization, nil, 2)
+
+      assert first.total == per_page + 3
+      assert length(first.entries) == per_page
+      assert length(second.entries) == 3
+      assert first.pages == 2
+
+      # No row appears on both pages.
+      assert MapSet.disjoint?(
+               MapSet.new(first.entries, & &1.id),
+               MapSet.new(second.entries, & &1.id)
+             )
+    end
+
+    test "one can be withdrawn, and only from its own page", %{organization: organization} do
+      token = issue(organization, insert(:activated_user))
+      foreign = insert(:organization)
+
+      # Scoped in the query, so a foreign id is not found rather than found and
+      # then refused — there is no branch left where the check can be skipped.
+      assert ApiAuth.revoke_organization_token(foreign, token.id) == {:error, :not_found}
+      assert ApiAuth.organization_tokens(organization).total == 1
+
+      assert {:ok, _token} = ApiAuth.revoke_organization_token(organization, token.id)
+      assert ApiAuth.organization_tokens(organization).total == 0
+    end
+
+    test "a junk id is refused rather than raising", %{organization: organization} do
+      assert ApiAuth.revoke_organization_token(organization, "not-a-uuid") == {:error, :not_found}
+    end
+
+    test "turning app access off withdraws every one of them", %{
+      organization: organization
+    } do
+      {:ok, organization} = Organizations.set_mastodon_clients(organization, true)
+      for _ <- 1..3, do: issue(organization, insert(:activated_user))
+
+      assert ApiAuth.count_organization_tokens(organization) == 3
+      assert ApiAuth.revoke_organization_tokens!(organization) == 3
+      assert ApiAuth.count_organization_tokens(organization) == 0
+    end
+  end
+
+  describe "a member's connected apps" do
+    test "say when the app was connected and from which device" do
+      member = insert(:activated_user)
+      app = insert(:oauth_app, user: nil, protocol: "mastodon")
+
+      grant =
+        Repo.insert!(%Vutuv.ApiAuth.Grant{user_id: member.id, app_id: app.id, scopes: ["read"]})
+
+      insert(:api_token,
+        user: member,
+        app: app,
+        grant: grant,
+        kind: "access",
+        name: nil,
+        scopes: ["read"],
+        expires_at: nil,
+        user_agent: "Ivory/1.0 (iPhone; iOS 18.2)",
+        token_hash: ApiAuth.hash_token("vutuv_at_" <> ApiAuth.random_token())
+      )
+
+      assert [listed] = ApiAuth.list_grants(member)
+      assert listed.connected_at == grant.inserted_at
+      assert listed.devices == ["iPhone"]
+    end
+
+    test "a grant with no recorded device simply has none" do
+      member = insert(:activated_user)
+      app = insert(:oauth_app, user: nil, protocol: "mastodon")
+      Repo.insert!(%Vutuv.ApiAuth.Grant{user_id: member.id, app_id: app.id, scopes: ["read"]})
+
+      assert [listed] = ApiAuth.list_grants(member)
+      assert listed.devices == []
+      refute is_nil(listed.connected_at)
+    end
+  end
+end

--- a/test/vutuv_web/controllers/mastodon_api/client_compatibility_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/client_compatibility_test.exs
@@ -79,7 +79,7 @@ defmodule VutuvWeb.MastodonApi.ClientCompatibilityTest do
         conn
         |> Map.put(:host, "localhost")
         |> Plug.Conn.put_req_header("authorization", "Bearer " <> token)
-        |> post("/api/v1/markers", %{})
+        |> post("/api/v1/scheduled_statuses", %{})
 
       assert json_response(conn, 404) == %{"error" => "Record not found"}
     end

--- a/test/vutuv_web/controllers/mastodon_api/client_compatibility_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/client_compatibility_test.exs
@@ -1,0 +1,229 @@
+defmodule VutuvWeb.MastodonApi.ClientCompatibilityTest do
+  @moduledoc """
+  What a Mastodon client believes about this server before it does anything, and
+  what it gets for a resource we do not have.
+
+  These are not endpoint features. They are the answers a client reads to decide
+  whether to open a stream, what to convert a photo into, and whether the server
+  is working at all — and each one used to say something untrue, which a client
+  has no way to see past. An Ivory user reported the three symptoms together
+  (home timeline spinning, photo upload refused, page logo missing) and they all
+  live here.
+  """
+  use VutuvWeb.ConnCase
+
+  import Vutuv.MastodonHelpers
+
+  alias Vutuv.PostImageStore
+  alias Vutuv.Posts
+
+  describe "the instance document says what this installation can really do" do
+    setup %{conn: conn} do
+      {:ok, instance: conn |> on_mastodon_host() |> get("/api/v2/instance") |> json_response(200)}
+    end
+
+    test "names the streaming endpoint instead of nil", %{instance: instance} do
+      # A client that reads no streaming URL opens no stream, so the home
+      # timeline never learns about anything after the page it fetched.
+      assert instance["configuration"]["urls"]["streaming"] ==
+               "ws://mastodon.localhost:4001/api/v1/streaming"
+    end
+
+    test "the v1 document names it too", %{conn: conn} do
+      v1 = conn |> on_mastodon_host() |> get("/api/v1/instance") |> json_response(200)
+
+      assert v1["urls"]["streaming_api"] == "ws://mastodon.localhost:4001/api/v1/streaming"
+    end
+
+    test "admits that a post takes pictures", %{instance: instance} do
+      # `0` told every client this server accepts no attachments at all.
+      assert instance["configuration"]["statuses"]["max_media_attachments"] ==
+               Posts.max_images_per_post()
+
+      assert Posts.max_images_per_post() > 0
+    end
+
+    test "lists the image types the uploader really accepts", %{instance: instance} do
+      # The empty list is what left a phone client with nothing to convert the
+      # photo library's HEIC *into*, so it sent the original and got a 422.
+      media = instance["configuration"]["media_attachments"]
+
+      assert media["supported_mime_types"] != []
+      assert "image/jpeg" in media["supported_mime_types"]
+
+      # Derived, so an installation whose libvips decodes HEIC advertises it.
+      expected =
+        PostImageStore.extension_whitelist()
+        |> Enum.map(&MIME.from_path("x" <> &1))
+        |> Enum.uniq()
+
+      assert media["supported_mime_types"] == expected
+      assert media["image_size_limit"] == Posts.max_image_filesize()
+      assert media["image_matrix_limit"] > 0
+    end
+  end
+
+  describe "a path this adapter does not implement" do
+    setup do
+      {:ok, token: mastodon_token(insert(:activated_user), ["read", "write"])}
+    end
+
+    test "answers JSON on the main host, not the website's HTML error page", %{
+      conn: conn,
+      token: token
+    } do
+      # The main host is the one a member types into a phone app, so this is the
+      # host every client actually uses. An unrouted /api/v1/… fell through to
+      # the website and handed the client markup where it expected an object.
+      conn =
+        conn
+        |> Map.put(:host, "localhost")
+        |> Plug.Conn.put_req_header("authorization", "Bearer " <> token)
+        |> post("/api/v1/markers", %{})
+
+      assert json_response(conn, 404) == %{"error" => "Record not found"}
+    end
+
+    test "and on the API subdomain", %{conn: conn, token: token} do
+      conn = conn |> mastodon_conn(token) |> get("/api/v1/announcements")
+
+      assert json_response(conn, 404) == %{"error" => "Record not found"}
+    end
+
+    test "leaves the website alone", %{conn: conn} do
+      # The catch-all names Mastodon's two version prefixes only, so a site path
+      # still gets the site's own answer and not this JSON error.
+      conn = conn |> Map.put(:host, "localhost") |> get("/no-such-member-here")
+
+      assert html_response(conn, 404)
+    end
+  end
+
+  describe "Local and Federated are different lists" do
+    setup do
+      author = insert(:activated_user)
+      post = insert(:post, user: author)
+      viewer = insert(:activated_user)
+
+      {:ok, token: mastodon_token(viewer, ["read"]), post: post}
+    end
+
+    test "local=true is this site's own posts", %{conn: conn, token: token, post: post} do
+      ids =
+        conn
+        |> mastodon_conn(token)
+        |> get("/api/v1/timelines/public", %{"local" => "true"})
+        |> json_response(200)
+        |> Enum.map(& &1["id"])
+
+      assert post.id in ids
+    end
+
+    test "remote=true excludes them", %{conn: conn, token: token, post: post} do
+      # Both flags used to be ignored, so a client's two tabs asked different
+      # questions and got one answer — the same list under two names.
+      ids =
+        conn
+        |> mastodon_conn(token)
+        |> get("/api/v1/timelines/public", %{"remote" => "true"})
+        |> json_response(200)
+        |> Enum.map(& &1["id"])
+
+      refute post.id in ids
+    end
+
+    test "no flag is both, so the site's own posts are still there", %{
+      conn: conn,
+      token: token,
+      post: post
+    } do
+      ids =
+        conn
+        |> mastodon_conn(token)
+        |> get("/api/v1/timelines/public")
+        |> json_response(200)
+        |> Enum.map(& &1["id"])
+
+      assert post.id in ids
+    end
+  end
+
+  describe "an organization account" do
+    test "carries its own logo and cover, not the installation's icon", %{conn: conn} do
+      member = insert(:activated_user)
+
+      organization =
+        insert(:organization, logo: "orglogotoken", cover: "orgcovertoken")
+        |> allow_mastodon_clients()
+
+      token = mastodon_token(member, ["read"])
+
+      account =
+        conn
+        |> mastodon_conn(token)
+        |> get("/api/v1/accounts/#{organization.id}")
+        |> json_response(200)
+
+      assert account["group"] == true
+      assert account["avatar"] =~ "/organization_images/orglogotoken/"
+      assert account["avatar_static"] == account["avatar"]
+      assert account["header"] =~ "/organization_images/orgcovertoken/"
+      refute account["avatar"] =~ "icon-512"
+    end
+
+    test "a page with no picture keeps the stand-in", %{conn: conn} do
+      member = insert(:activated_user)
+      organization = insert(:organization) |> allow_mastodon_clients()
+      token = mastodon_token(member, ["read"])
+
+      account =
+        conn
+        |> mastodon_conn(token)
+        |> get("/api/v1/accounts/#{organization.id}")
+        |> json_response(200)
+
+      assert account["avatar"] =~ "icon-512"
+    end
+  end
+
+  describe "the media endpoint's refusal" do
+    test "names what this installation accepts rather than a fixed list", %{conn: conn} do
+      token = mastodon_token(insert(:activated_user), ["write"])
+
+      upload = %Plug.Upload{
+        path: Path.join(System.tmp_dir!(), "not-an-image.txt"),
+        filename: "photo.heic",
+        content_type: "image/heic"
+      }
+
+      File.write!(upload.path, "not an image")
+      on_exit(fn -> File.rm(upload.path) end)
+
+      body =
+        conn
+        |> mastodon_conn(token)
+        |> post("/api/v1/media", %{"file" => upload})
+        |> json_response(422)
+
+      # Whatever the whitelist holds, the sentence has to hold the same thing —
+      # this is the message a member reads after the upload already went up.
+      for extension <- PostImageStore.extension_whitelist() do
+        assert body["error"] =~ String.upcase(String.trim_leading(extension, "."))
+      end
+    end
+  end
+
+  describe "the streaming socket" do
+    test "answers at Mastodon's documented path, not Phoenix's suffixed one" do
+      # Every client dials wss://<host>/api/v1/streaming — that exact path.
+      # Phoenix's default appends the transport name, so the documented address
+      # 404ed and the stream was unreachable although every part of it worked.
+      {path, _module, opts} =
+        VutuvWeb.Endpoint.__sockets__()
+        |> Enum.find(fn {path, _module, _opts} -> path == "/api/v1/streaming" end)
+
+      assert path == "/api/v1/streaming"
+      assert opts[:websocket][:path] == "/"
+    end
+  end
+end

--- a/test/vutuv_web/controllers/mastodon_api/client_compatibility_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/client_compatibility_test.exs
@@ -90,6 +90,14 @@ defmodule VutuvWeb.MastodonApi.ClientCompatibilityTest do
       assert json_response(conn, 404) == %{"error" => "Record not found"}
     end
 
+    test "the root of the API host sends a person to the site", %{conn: conn} do
+      # Everything else on that origin answers JSON, which is right for a client
+      # and a dead end for somebody who typed the technical name by hand.
+      conn = conn |> on_mastodon_host() |> get("/")
+
+      assert redirected_to(conn) == "http://localhost:4001/"
+    end
+
     test "leaves the website alone", %{conn: conn} do
       # The catch-all names Mastodon's two version prefixes only, so a site path
       # still gets the site's own answer and not this JSON error.

--- a/test/vutuv_web/controllers/mastodon_api/client_compatibility_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/client_compatibility_test.exs
@@ -85,7 +85,7 @@ defmodule VutuvWeb.MastodonApi.ClientCompatibilityTest do
     end
 
     test "and on the API subdomain", %{conn: conn, token: token} do
-      conn = conn |> mastodon_conn(token) |> get("/api/v1/announcements")
+      conn = conn |> mastodon_conn(token) |> get("/api/v1/scheduled_statuses")
 
       assert json_response(conn, 404) == %{"error" => "Record not found"}
     end

--- a/test/vutuv_web/controllers/mastodon_api/client_expectations_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/client_expectations_test.exs
@@ -1,0 +1,201 @@
+defmodule VutuvWeb.MastodonApi.ClientExpectationsTest do
+  @moduledoc """
+  Shapes a Mastodon client parses without asking, and the endpoints it calls
+  because this adapter says it is compatible with 4.4.
+
+  Every case here was reported from a real client (Ivory, Ice Cubes) as a
+  feature that "does not work", and every one of them was the server answering
+  something a client cannot use rather than a missing feature.
+  """
+  use VutuvWeb.ConnCase
+
+  import Vutuv.MastodonHelpers
+
+  alias Vutuv.Posts
+
+  describe "times are stamped the way a client parses them" do
+    # Mastodon always sends `2019-11-26T22:37:36.000Z`, and Apple's
+    # `ISO8601DateFormatter` with `.withFractionalSeconds` — what these clients
+    # build once and reuse — FAILS on a string without the milliseconds. A
+    # client that cannot parse a date falls back to "now", which is why every
+    # post in the timeline showed the same relative time, starting at the moment
+    # the account was added to the app.
+    @iso8601_ms ~r/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+
+    setup do
+      author = insert(:activated_user)
+      post = insert(:post, user: author)
+      viewer = insert(:activated_user)
+
+      {:ok, token: mastodon_token(viewer, ["read"]), post: post, author: author, viewer: viewer}
+    end
+
+    test "a status and its account", %{conn: conn, token: token, post: post} do
+      status =
+        conn
+        |> mastodon_conn(token)
+        |> get("/api/v1/statuses/#{post.id}")
+        |> json_response(200)
+
+      assert status["created_at"] =~ @iso8601_ms
+      assert status["account"]["created_at"] =~ @iso8601_ms
+    end
+
+    test "and a notification, which used to keep its own copy of the conversion",
+         %{conn: conn, post: post, author: author, viewer: viewer} do
+      :ok = Posts.like_post(viewer, post)
+      token = mastodon_token(author, ["read"])
+
+      [notification | _] =
+        conn
+        |> mastodon_conn(token)
+        |> get("/api/v1/notifications")
+        |> json_response(200)
+
+      assert notification["created_at"] =~ @iso8601_ms
+    end
+  end
+
+  describe "pinned=true asks for the pinned post" do
+    setup do
+      member = insert(:activated_user)
+      post = insert(:post, user: member)
+
+      {:ok, token: mastodon_token(member, ["read"]), member: member, post: post}
+    end
+
+    test "nothing pinned is an empty list, not the newest post", %{
+      conn: conn,
+      token: token,
+      member: member
+    } do
+      # The parameter was ignored, so a client asking for the pinned row got the
+      # whole timeline and showed its newest entry as pinned — a member's only
+      # post looked pinned although they had never pinned anything.
+      assert conn
+             |> mastodon_conn(token)
+             |> get("/api/v1/accounts/#{member.id}/statuses", %{"pinned" => "true"})
+             |> json_response(200) == []
+    end
+
+    test "a pinned post is the one that comes back", %{
+      conn: conn,
+      token: token,
+      member: member,
+      post: post
+    } do
+      {:ok, _pinned} = Posts.pin_to_profile(member, post)
+
+      ids =
+        conn
+        |> mastodon_conn(token)
+        |> get("/api/v1/accounts/#{member.id}/statuses", %{"pinned" => "true"})
+        |> json_response(200)
+        |> Enum.map(& &1["id"])
+
+      assert ids == [post.id]
+    end
+
+    test "without the parameter the timeline is untouched", %{
+      conn: conn,
+      token: token,
+      member: member,
+      post: post
+    } do
+      ids =
+        conn
+        |> mastodon_conn(token)
+        |> get("/api/v1/accounts/#{member.id}/statuses")
+        |> json_response(200)
+        |> Enum.map(& &1["id"])
+
+      assert post.id in ids
+    end
+  end
+
+  describe "the tabs a 4.4-compatible client expects to exist" do
+    setup do
+      {:ok, token: mastodon_token(insert(:activated_user), ["read"])}
+    end
+
+    test "trends, news and announcements answer an empty list, not an error", %{
+      conn: conn,
+      token: token
+    } do
+      # Mastodon answers these empty when an instance has them switched off.
+      # The difference between "off" and "not implemented" is the difference
+      # between an empty tab and Ice Cubes' "an error occurred, please try
+      # again" — which is what its Trending and News tabs showed.
+      for path <- [
+            "/api/v1/trends/statuses",
+            "/api/v1/trends/tags",
+            "/api/v1/trends/links",
+            "/api/v1/announcements",
+            "/api/v1/suggestions",
+            "/api/v2/suggestions"
+          ] do
+        assert conn |> mastodon_conn(token) |> get(path) |> json_response(200) == [],
+               "expected #{path} to answer an empty list"
+      end
+    end
+  end
+
+  describe "grouped notifications" do
+    setup do
+      author = insert(:activated_user)
+      post = insert(:post, user: author)
+      liker = insert(:activated_user)
+      :ok = Posts.like_post(liker, post)
+
+      {:ok, token: mastodon_token(author, ["read"]), post: post, liker: liker}
+    end
+
+    test "answer the 4.3+ shape a client asks for at /api/v2/notifications", %{
+      conn: conn,
+      token: token,
+      post: post,
+      liker: liker
+    } do
+      # We advertise compatibility with 4.4, and a client reads that version to
+      # decide which of the two endpoints to call. Ice Cubes does, so its whole
+      # notifications tab errored against a server whose v1 list was fine.
+      body =
+        conn
+        |> mastodon_conn(token)
+        |> get("/api/v2/notifications")
+        |> json_response(200)
+
+      assert [group] = body["notification_groups"]
+      assert group["type"] == "favourite"
+      assert group["status_id"] == post.id
+      assert group["notifications_count"] == 1
+      assert liker.id in group["sample_account_ids"]
+
+      # The accounts and statuses are hoisted into the two shared lists a client
+      # resolves the ids against.
+      assert Enum.map(body["accounts"], & &1["id"]) == [liker.id]
+      assert Enum.map(body["statuses"], & &1["id"]) == [post.id]
+    end
+  end
+
+  describe "an edit vutuv refuses" do
+    test "says which rule closed it, not that the status is invalid", %{conn: conn} do
+      author = insert(:activated_user)
+      post = insert(:post, user: author)
+      :ok = Posts.like_post(insert(:activated_user), post)
+      token = mastodon_token(author, ["write"])
+
+      body =
+        conn
+        |> mastodon_conn(token)
+        |> put("/api/v1/statuses/#{post.id}", %{"status" => "edited"})
+        |> json_response(422)
+
+      # Mastodon allows this edit and vutuv does not, so the answer has to name
+      # the rule — a member reading "The status is invalid" looks for a mistake
+      # in their own text.
+      assert body["error"] =~ "liked"
+      refute body["error"] =~ "The status is invalid"
+    end
+  end
+end

--- a/test/vutuv_web/controllers/mastodon_api/discovery_controller_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/discovery_controller_test.exs
@@ -67,7 +67,12 @@ defmodule VutuvWeb.MastodonApi.DiscoveryControllerTest do
     end
 
     test "does not expose the website through the API origin", %{conn: conn} do
-      assert conn |> on_mastodon_host() |> get("/") |> response(404)
+      # The root sends a person who typed the technical name to the site; what
+      # must not happen is this origin *serving* a page of its own, so the claim
+      # is checked where it matters — on a real site path.
+      assert redirected_to(conn |> on_mastodon_host() |> get("/")) == "http://localhost:4001/"
+
+      assert conn |> on_mastodon_host() |> get("/system/members") |> response(404)
     end
 
     test "returns 404 when the installation switch is off", %{conn: conn} do

--- a/test/vutuv_web/controllers/mastodon_api/markers_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/markers_test.exs
@@ -1,0 +1,149 @@
+defmodule VutuvWeb.MastodonApi.MarkersTest do
+  @moduledoc """
+  Where a client left off reading (`/api/v1/markers`).
+
+  `GET` answered a bare `{}` and there was no `POST` at all — which also meant
+  the write fell through to the website's HTML error page — so a position was
+  never stored and never restored. Relaunching an app dropped its timeline back
+  to whatever it could fetch, which is what a member reads as a timeline that
+  lost everything it had.
+  """
+  use VutuvWeb.ConnCase
+
+  import Vutuv.MastodonHelpers
+
+  alias Vutuv.MastodonApi.Markers
+  alias Vutuv.Organizations
+
+  setup do
+    member = insert(:activated_user)
+    {:ok, member: member, token: mastodon_token(member, ["read", "write"])}
+  end
+
+  test "nothing recorded is an empty object, not an error", %{conn: conn, token: token} do
+    assert conn |> mastodon_conn(token) |> get("/api/v1/markers") |> json_response(200) == %{}
+  end
+
+  test "a recorded position comes back", %{conn: conn, token: token} do
+    written =
+      conn
+      |> mastodon_conn(token)
+      |> post("/api/v1/markers", %{"home" => %{"last_read_id" => "01a0-abc"}})
+      |> json_response(200)
+
+    assert written["home"]["last_read_id"] == "01a0-abc"
+    assert written["home"]["version"] == 1
+
+    read = build_conn() |> mastodon_conn(token) |> get("/api/v1/markers") |> json_response(200)
+
+    assert read["home"]["last_read_id"] == "01a0-abc"
+  end
+
+  test "writing again moves it and counts the write", %{conn: conn, token: token} do
+    conn |> mastodon_conn(token) |> post("/api/v1/markers", %{"home" => %{"last_read_id" => "a"}})
+
+    second =
+      build_conn()
+      |> mastodon_conn(token)
+      |> post("/api/v1/markers", %{"home" => %{"last_read_id" => "b"}})
+      |> json_response(200)
+
+    assert second["home"]["last_read_id"] == "b"
+    # Mastodon's own counter, which a client reads to tell its echo from another
+    # device's write.
+    assert second["home"]["version"] == 2
+  end
+
+  test "both timelines are kept apart", %{conn: conn, token: token} do
+    conn
+    |> mastodon_conn(token)
+    |> post("/api/v1/markers", %{
+      "home" => %{"last_read_id" => "h1"},
+      "notifications" => %{"last_read_id" => "n1"}
+    })
+
+    read = build_conn() |> mastodon_conn(token) |> get("/api/v1/markers") |> json_response(200)
+
+    assert read["home"]["last_read_id"] == "h1"
+    assert read["notifications"]["last_read_id"] == "n1"
+  end
+
+  test "a client can ask for one of them", %{conn: conn, token: token} do
+    conn
+    |> mastodon_conn(token)
+    |> post("/api/v1/markers", %{
+      "home" => %{"last_read_id" => "h1"},
+      "notifications" => %{"last_read_id" => "n1"}
+    })
+
+    read =
+      build_conn()
+      |> mastodon_conn(token)
+      |> get("/api/v1/markers", %{"timeline" => ["home"]})
+      |> json_response(200)
+
+    assert Map.keys(read) == ["home"]
+  end
+
+  test "an unknown timeline is skipped, and its good half still stored", %{
+    conn: conn,
+    token: token
+  } do
+    # A client sending one of each in the same request must not lose the one we
+    # understand.
+    written =
+      conn
+      |> mastodon_conn(token)
+      |> post("/api/v1/markers", %{
+        "home" => %{"last_read_id" => "h1"},
+        "wishlist" => %{"last_read_id" => "x"}
+      })
+      |> json_response(200)
+
+    assert Map.keys(written) == ["home"]
+  end
+
+  test "an id whose entry is since gone is still a valid bookmark", %{conn: conn, token: token} do
+    # Stored as sent, prefix and all: the ids this adapter mints are not all
+    # uuids, and a bookmark into a deleted post must not fail a write.
+    written =
+      conn
+      |> mastodon_conn(token)
+      |> post("/api/v1/markers", %{"home" => %{"last_read_id" => "remote-01a0-deleted"}})
+      |> json_response(200)
+
+    assert written["home"]["last_read_id"] == "remote-01a0-deleted"
+  end
+
+  test "one member's position is not another's", %{conn: conn, token: token} do
+    conn |> mastodon_conn(token) |> post("/api/v1/markers", %{"home" => %{"last_read_id" => "a"}})
+
+    other = mastodon_token(insert(:activated_user), ["read"])
+
+    assert build_conn() |> mastodon_conn(other) |> get("/api/v1/markers") |> json_response(200) ==
+             %{}
+  end
+
+  test "a page's position belongs to the page, not to whoever read for it", %{
+    conn: conn,
+    member: member
+  } do
+    organization = insert(:organization)
+    {:ok, organization} = Organizations.set_mastodon_clients(organization, true)
+    {:ok, _} = Organizations.add_role(organization, member, "publisher", member)
+    token = mastodon_token(member, ["read", "write"], organization)
+
+    assert conn
+           |> mastodon_conn(token)
+           |> post("/api/v1/markers", %{"home" => %{"last_read_id" => "page-position"}})
+           |> json_response(200)
+
+    # The page's, so two publishers reading it from their own phones share one
+    # position — the same way they share the page's feed.
+    assert %{"home" => marker} = Markers.get({member, organization})
+    assert marker.last_read_id == "page-position"
+
+    # And the member's own timeline is untouched by it.
+    assert Markers.get(member) == %{}
+  end
+end

--- a/test/vutuv_web/organization_app_tokens_test.exs
+++ b/test/vutuv_web/organization_app_tokens_test.exs
@@ -1,0 +1,165 @@
+defmodule VutuvWeb.OrganizationAppTokensTest do
+  @moduledoc """
+  The owner's oversight of the app tokens issued for their page
+  (`/organizations/:slug/apps`).
+
+  A member turns the page's app access into a credential of their own accord,
+  and until now only that member could see or withdraw it — so an owner could
+  not tell who was reaching the page from an app, let alone stop one.
+
+  `async: false` for the same reason as `organization_apps_switch_test.exs`: the
+  organization helpers flip the global `:verify_organization_domains` flag and
+  the DNS-resolver stub beside it.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Vutuv.OrganizationsHelpers
+
+  alias Vutuv.ApiAuth
+  alias Vutuv.Organizations
+  alias Vutuv.Organizations.OrganizationRole
+  alias Vutuv.Repo
+
+  setup do
+    Application.put_env(:vutuv, :verify_organization_domains, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :verify_organization_domains, false)
+      Application.delete_env(:vutuv, :organizations_dns_resolver)
+    end)
+
+    :ok
+  end
+
+  defp owned_page_with_apps_on(conn) do
+    {conn, owner} = create_and_login_user(conn)
+    organization = active_organization_for(owner)
+    {:ok, organization} = Organizations.set_mastodon_clients(organization, true)
+
+    {conn, organization, owner}
+  end
+
+  defp issue(organization, user, user_agent \\ nil) do
+    app = insert(:oauth_app, user: nil, protocol: "mastodon", name: "Ivory")
+
+    insert(:api_token,
+      user: user,
+      app: app,
+      organization: organization,
+      kind: "access",
+      name: nil,
+      scopes: ["read"],
+      expires_at: nil,
+      user_agent: user_agent,
+      token_hash: ApiAuth.hash_token("vutuv_at_" <> ApiAuth.random_token())
+    )
+  end
+
+  test "lists who is signed in as the page, with device and time", %{conn: conn} do
+    {conn, organization, _owner} = owned_page_with_apps_on(conn)
+    issuer = insert(:activated_user, first_name: "Ada", last_name: "Lovelace")
+    token = issue(organization, issuer, "Ivory/1.0 (iPhone; iOS 18.2)")
+
+    {:ok, _view, html} = live(conn, ~p"/organizations/#{organization.slug}/apps")
+
+    assert html =~ "Ada Lovelace"
+    assert html =~ "iPhone"
+    assert html =~ ~s(data-app-token="#{token.id}")
+  end
+
+  test "a client string it cannot place is called unknown, never guessed", %{conn: conn} do
+    {conn, organization, _owner} = owned_page_with_apps_on(conn)
+    issue(organization, insert(:activated_user), "some-http-library/2.1")
+
+    {:ok, _view, html} = live(conn, ~p"/organizations/#{organization.slug}/apps")
+
+    assert html =~ "unknown device"
+  end
+
+  test "the filter narrows the list to one member", %{conn: conn} do
+    {conn, organization, _owner} = owned_page_with_apps_on(conn)
+    issue(organization, insert(:activated_user, first_name: "Zoraida"))
+    issue(organization, insert(:activated_user, first_name: "Bartholomew"))
+
+    {:ok, view, _html} = live(conn, ~p"/organizations/#{organization.slug}/apps")
+
+    html = view |> form("form[phx-change=filter]", %{"query" => "zorai"}) |> render_change()
+
+    assert html =~ "Zoraida"
+    refute html =~ "Bartholomew"
+  end
+
+  test "an owner withdraws one token and the rest stay", %{conn: conn} do
+    {conn, organization, _owner} = owned_page_with_apps_on(conn)
+    doomed = issue(organization, insert(:activated_user))
+    kept = issue(organization, insert(:activated_user))
+
+    {:ok, view, _html} = live(conn, ~p"/organizations/#{organization.slug}/apps")
+
+    html = view |> element(~s([data-app-token="#{doomed.id}"] button)) |> render_click()
+
+    refute html =~ ~s(data-app-token="#{doomed.id}")
+    assert html =~ ~s(data-app-token="#{kept.id}")
+    assert ApiAuth.count_organization_tokens(organization) == 1
+  end
+
+  test "turning app access off withdraws every token", %{conn: conn} do
+    {conn, organization, _owner} = owned_page_with_apps_on(conn)
+    for _ <- 1..3, do: issue(organization, insert(:activated_user))
+
+    {:ok, view, _html} = live(conn, ~p"/organizations/#{organization.slug}/apps")
+
+    # Leaving them alive would make the switch a lie: they stop working while it
+    # is off and come back the moment somebody turns it on again.
+    view |> element("#mastodon-client-access button") |> render_click()
+
+    assert ApiAuth.count_organization_tokens(organization) == 0
+    refute Organizations.get_organization!(organization.id).mastodon_clients?
+  end
+
+  test "the confirmation names how many are about to go", %{conn: conn} do
+    {conn, organization, _owner} = owned_page_with_apps_on(conn)
+    for _ <- 1..2, do: issue(organization, insert(:activated_user))
+
+    {:ok, _view, html} = live(conn, ~p"/organizations/#{organization.slug}/apps")
+
+    # Nothing is destroyed without the owner having been told how much.
+    assert html =~ "All 2 app tokens"
+  end
+
+  test "the German page says it in German", %{conn: conn} do
+    {conn, organization, _owner} = owned_page_with_apps_on(conn)
+    issue(organization, insert(:activated_user), "Ivory/1.0 (iPhone; iOS 18.2)")
+
+    # vutuv is a German site, and `?lang=de` without the header renders English
+    # — so the header is what a locale test has to carry. Asserted by name
+    # because every one of these strings was fuzzy-filled by
+    # `gettext.extract --merge`: "Connected on" came back as "Vernetzt", the
+    # word this project uses for a mutual follow.
+    {:ok, _view, html} =
+      conn
+      |> recycle()
+      |> Plug.Conn.put_req_header("accept-language", "de-DE,de")
+      |> live(~p"/organizations/#{organization.slug}/apps")
+
+    assert html =~ "Genutzte App-Zugänge"
+    assert html =~ "Ausgestellt von"
+    assert html =~ "Entziehen"
+  end
+
+  # The page is gated before it mounts, but a socket outlives the grant that
+  # opened it, so the write re-asks. Calibrated against the un-checked handler:
+  # without the `owner?/2` guard the token really does die here.
+  test "an open page stops withdrawing after the ownership is withdrawn", %{conn: conn} do
+    {conn, organization, _owner} = owned_page_with_apps_on(conn)
+    token = issue(organization, insert(:activated_user))
+
+    {:ok, view, _html} = live(conn, ~p"/organizations/#{organization.slug}/apps")
+
+    Repo.delete!(Repo.get_by!(OrganizationRole, organization_id: organization.id, role: "owner"))
+    render_click(view, "revoke", %{"id" => token.id})
+
+    assert ApiAuth.count_organization_tokens(organization) == 1
+  end
+end

--- a/test/vutuv_web/plugs/content_security_policy_test.exs
+++ b/test/vutuv_web/plugs/content_security_policy_test.exs
@@ -40,6 +40,103 @@ defmodule VutuvWeb.Plug.ContentSecurityPolicyTest do
     assert policy =~ "default-src 'self'"
   end
 
+  # `form-action` is enforced on every hop of a submission, redirects included,
+  # and POST /oauth/authorize answers 302 to the client's callback. Under a bare
+  # `form-action 'self'` the browser blocks that hop: the POST lands, a code is
+  # minted, and the member is left on the consent screen with no token and no
+  # error — the Ivory report ("nothing happens when I tap Allow"). Reverting
+  # VutuvWeb.Plug.ContentSecurityPolicy.allow_form_action/2 must turn these red.
+  defp consent_policy(conn, redirect_uri) do
+    {:ok, app, _secret} =
+      Vutuv.ApiAuth.create_mastodon_app(%{
+        "name" => "Phone Client",
+        "redirect_uris" => [redirect_uri],
+        "registered_scopes" => ["read"]
+      })
+
+    query =
+      URI.encode_query(%{
+        "response_type" => "code",
+        "client_id" => app.client_id,
+        "redirect_uri" => redirect_uri,
+        "scope" => "read"
+      })
+
+    conn = get(conn, "/oauth/authorize?#{query}")
+    assert html_response(conn, 200) =~ "Phone Client"
+    csp(conn)
+  end
+
+  describe "form-action on the OAuth consent screen" do
+    setup %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      {:ok, conn: conn, user: user}
+    end
+
+    test "a native client's scheme is allowed, so the ivory:// hop is not blocked",
+         %{conn: conn} do
+      assert consent_policy(conn, "ivory://oauth-callback") =~ "form-action 'self' ivory:;"
+    end
+
+    test "an https callback is allowed by exact origin, not by wildcard", %{conn: conn} do
+      policy = consent_policy(conn, "https://client.example.org/cb")
+
+      assert policy =~ "form-action 'self' https://client.example.org;"
+      refute policy =~ "form-action 'self' *"
+    end
+
+    test "the approve response carries it too", %{conn: conn, user: user} do
+      # Consent for a Mastodon client needs the member's own kill switch on.
+      user |> Ecto.Changeset.change(%{mastodon_clients?: true}) |> Repo.update!()
+
+      {:ok, app, _secret} =
+        Vutuv.ApiAuth.create_mastodon_app(%{
+          "name" => "Phone Client",
+          "redirect_uris" => ["ivory://oauth-callback"],
+          "registered_scopes" => ["read"]
+        })
+
+      params = %{
+        "response_type" => "code",
+        "client_id" => app.client_id,
+        "redirect_uri" => "ivory://oauth-callback",
+        "scope" => "read"
+      }
+
+      conn = get(conn, "/oauth/authorize?#{URI.encode_query(params)}")
+      conn = submit_with_csrf(conn, "/oauth/authorize", Map.put(params, "decision", "allow"))
+
+      assert redirected_to(conn) =~ "ivory://oauth-callback?code="
+      assert csp(conn) =~ "form-action 'self' ivory:;"
+    end
+
+    test "every other page keeps the bare directive", %{conn: conn} do
+      assert csp(get(conn, ~p"/")) =~ "form-action 'self';"
+    end
+  end
+
+  describe "form_action_source/1" do
+    alias VutuvWeb.Plug.ContentSecurityPolicy
+
+    test "http(s) gets an origin, a default port is left off" do
+      assert ContentSecurityPolicy.form_action_source("https://a.example/cb") ==
+               "https://a.example"
+
+      assert ContentSecurityPolicy.form_action_source("http://localhost:4000/cb") ==
+               "http://localhost:4000"
+    end
+
+    test "a native scheme gets the scheme, whatever shape the rest has" do
+      assert ContentSecurityPolicy.form_action_source("ivory://oauth-callback") == "ivory:"
+      assert ContentSecurityPolicy.form_action_source("com.example.app:/cb") == "com.example.app:"
+    end
+
+    test "nothing usable yields nil, so the policy is left alone" do
+      assert ContentSecurityPolicy.form_action_source("/relative") == nil
+      assert ContentSecurityPolicy.form_action_source(nil) == nil
+    end
+  end
+
   test "the strict default never allows eval (the dev escape hatch is off here)",
        %{conn: conn} do
     # `script-src 'self' 'unsafe-eval'` is added only when


### PR DESCRIPTION
**TL;DR** Mastodon-Clients (Ivory, Ice Cubes) scheiterten an zwölf Stellen an Antworten, die sie nicht verwenden können — nicht an fehlenden Funktionen. Nachfolger von #1555.

**Zustimmung.** `form-action` gilt über jeden Sprung einer Formularabsendung, Weiterleitungen eingeschlossen, also verbot `'self'` den 302 auf die `redirect_uri`. Stumm: POST kommt an, Code entsteht, kein Token.

**Streaming.** Mastodons Endpunkt *ist* `/api/v1/streaming`; Phoenix hängt den Transportnamen an, also antwortete nur `/streaming/websocket`, und das Instanz-Dokument nannte gar keine URL. Kein Client konnte streamen — der Home-Feed drehte sich.

**Zeiten.** Ohne Millisekunden scheitert Apples `ISO8601DateFormatter` und fällt auf "jetzt" zurück: alle Beiträge zeigten dieselbe relative Zeit.

**Leseposition.** `/api/v1/markers` antwortete `{}` und hatte kein `POST`, wurde also nie gespeichert: nach einem App-Neustart stand die Timeline wieder auf dem, was gerade abrufbar war.

**Berechtigungen.** Verbundene Apps nennen jetzt Zeitpunkt und Gerät — ein Client registriert pro Installation eine eigene App, mehrere Zeilen hießen also gleich. Ein Seiten-Eigentümer sieht unter `/organizations/:slug/apps` alle für die Seite ausgestellten Token, nach Aussteller filterbar und seitenweise; Abschalten entzieht alle nach Rückfrage.

**Dazu:** echte Medien-Fähigkeiten im Instanz-Dokument (leere `supported_mime_types` ließen iOS unkonvertiertes HEIC hochladen); `/api/v2/notifications`, Trends und News statt Fehlern; `local`/`remote`; `pinned=true`; Org-Logos; JSON statt HTML bei unbekannten Pfaden; Bearbeiten-Absage nennt die Regel.

**Belege:** iOS-Simulator mit echtem Fingertipp (ohne Fix `302 →` Bildschirm unverändert, mit Fix Callback mit Code); alles Übrige gegen einen laufenden Server gemessen, die Org-Ansicht auch im Browser. 48 neue Tests, kalibriert. `mix precommit` grün, 8420 Tests.

**Deploy:** hot. Zwei Migrationen — eine nullable Spalte und eine neue Tabelle, beide N-1-verträglich.

**Nicht geprüft:** kein echter Ivory/Ice-Cubes-Lauf gegen den Fix — die Ursachen sind gemessen, die Client-Symptome nicht nachverfolgt.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*
