### PR TITLE
Nur nennen, was auch eine CSP-Quelle sein kann (v7.322.1)

### DIFF
--- a/docs/architecture/api.md
+++ b/docs/architecture/api.md
@@ -65,7 +65,11 @@ policy through `ContentSecurityPolicy.allow_form_action/2` with the app's
 (`ivory:`) for a native client's own scheme. It is never built from the raw
 query parameter — `OAuth.validate_authorize/1` has already matched it against
 the app's registered `redirect_uris`, so the policy names a destination the
-server was going to redirect to anyway.
+server was going to redirect to anyway. Scheme and host are still re-checked
+where the source is spelled, because registration is public and `URI.parse/1`
+validates nothing: `https://evil.example.org;script-src 'unsafe-inline'/cb`
+registers cleanly and comes back with that whole run as its "host", which in a
+header would be a second directive of the app author's choosing.
 
 **Who holds a credential, and who may take it away.** `/connected_apps` names,
 per authorization, when it was given and which devices still hold a live token

--- a/docs/architecture/mastodon-api.md
+++ b/docs/architecture/mastodon-api.md
@@ -284,6 +284,30 @@ redeemable at once; the prune leaves three. What the budget buys is the wasted
 round trips and a signal to the client that something is wrong. It sits far above
 anything a person does, because it must never touch a working login.
 
+### Why "Allow access" looked dead in one browser and not another
+
+The consent screen's redirect and the `form-action` widening that lets it
+through are in [api.md](api.md). What belongs here is the shape of the report,
+because it is the shape every client-compatibility bug takes.
+
+**Nothing about it was visible from the server.** We answered 302 and minted the
+code as usual; the browser dropped the redirect and the client sat waiting for a
+callback that never came. The table read as consent given and never used: 4
+codes for Tuba (issue #1562), none redeemed, and two POSTs a few seconds apart
+per attempt, which is a member pressing the button again because nothing
+happened.
+
+**And the browsers disagree, so the same build works for one member and not the
+next.** Measured in Chrome across all three custom-scheme shapes in use here —
+Tuba's `tuba://auth_code`, Tusky's `oauth2redirect://…`, Ivory's
+`com.tapbots…:/…` — every one is blocked, as is an ordinary third-party
+`https://` callback on another host; meanwhile Ivory on iOS Safari and Tusky in
+an Android WebView redeemed their codes the same evening. So a client's own
+report ("nothing happens when I tap Allow") is evidence about a *browser*, not
+about that client, and the two must not be conflated when the next one arrives.
+The console message compounds it by naming the **pre-redirect** URL — ours —
+which reads as if we blocked a form posting to our own origin.
+
 ### Paging, streaming and push
 
 Every list takes Mastodon's `limit` / `max_id` / `since_id` / `min_id` and

--- a/lib/vutuv_web/plugs/content_security_policy.ex
+++ b/lib/vutuv_web/plugs/content_security_policy.ex
@@ -66,14 +66,32 @@ defmodule VutuvWeb.Plug.ContentSecurityPolicy do
     end
   end
 
+  # What CSP's own `host-source` grammar can spell: letters, digits, `-`, `.`.
+  # `URI.parse/1` validates nothing, so `https://evil.example.org;script-src
+  # 'unsafe-inline'/cb` — which app registration accepts, and registration is
+  # public — comes back with that whole run as its "host". Spliced into the
+  # header that is a second directive of the caller's choosing, so a host we
+  # cannot spell widens nothing. The scheme needs no such check: a scheme
+  # outside the grammar makes `URI.parse/1` answer `nil` (measured), which the
+  # first clause below turns away.
+  @host ~r/^[a-z0-9.\-]+$/i
+
   @doc """
-  The CSP source expression that permits a form submission to end at `uri`.
+  The CSP source expression that permits a form submission to end at `uri`,
+  or `nil` for a target no source expression can name.
 
   `http(s)` gets the exact origin, which is as narrow as CSP can express and
   is where narrowness is worth having. Anything else is a native app's own
   scheme (`ivory://oauth-callback`, `com.example.app:/cb`) whose shape varies
   too much to pin down as a host-source, so it gets the scheme-source
   (`ivory:`) — a scheme registered to that one app.
+
+  Two targets deliberately widen nothing. A `urn:` is a name and not a place:
+  the out-of-band flow (`urn:ietf:wg:oauth:2.0:oob`) prints the code on our
+  own page instead of redirecting, so there is no hop to permit. And a host
+  outside CSP's grammar — an intranet name with an underscore, an IPv6
+  literal, or anything carrying a `;` — has no source expression at all, so
+  the strict policy stands and the redirect stays blocked.
   """
   def form_action_source(uri) when is_binary(uri) do
     case URI.parse(uri) do
@@ -81,7 +99,10 @@ defmodule VutuvWeb.Plug.ContentSecurityPolicy do
         nil
 
       %URI{scheme: scheme, host: host, port: port} when scheme in ["http", "https"] ->
-        if is_binary(host) and host != "", do: origin(scheme, host, port)
+        if is_binary(host) and Regex.match?(@host, host), do: origin(scheme, host, port)
+
+      %URI{scheme: "urn"} ->
+        nil
 
       %URI{scheme: scheme} ->
         scheme <> ":"
@@ -90,10 +111,11 @@ defmodule VutuvWeb.Plug.ContentSecurityPolicy do
 
   def form_action_source(_uri), do: nil
 
-  defp origin("http", host, 80), do: "http://" <> host
-  defp origin("https", host, 443), do: "https://" <> host
-  defp origin(scheme, host, nil), do: scheme <> "://" <> host
-  defp origin(scheme, host, port), do: "#{scheme}://#{host}:#{port}"
+  # A source with no port matches only the scheme's default port, so 443/80
+  # must stay off and a dev callback's :4000 must ride along — which is what
+  # `URI.to_string/1` does with a port, for `ws`/`wss` as much as `http(s)`.
+  defp origin(scheme, host, port),
+    do: URI.to_string(%URI{scheme: scheme, host: host, port: port})
 
   # DEV-ONLY escape hatch. When true we add `script-src 'self' 'unsafe-eval'` so
   # Tidewave's `browser_eval` tool works locally: it injects JS and runs it with
@@ -160,15 +182,6 @@ defmodule VutuvWeb.Plug.ContentSecurityPolicy do
   # along only when non-standard (dev's :4000); the production 443 must not
   # appear (the public origin has no explicit port).
   defp ws_origin(conn) do
-    scheme = if conn.scheme == :https, do: "wss", else: "ws"
-
-    port =
-      case {conn.scheme, conn.port} do
-        {:http, 80} -> ""
-        {:https, 443} -> ""
-        {_, port} -> ":#{port}"
-      end
-
-    "#{scheme}://#{conn.host}#{port}"
+    origin(if(conn.scheme == :https, do: "wss", else: "ws"), conn.host, conn.port)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.322.0",
+      version: "7.322.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/plugs/content_security_policy_test.exs
+++ b/test/vutuv_web/plugs/content_security_policy_test.exs
@@ -113,6 +113,20 @@ defmodule VutuvWeb.Plug.ContentSecurityPolicyTest do
     test "every other page keeps the bare directive", %{conn: conn} do
       assert csp(get(conn, ~p"/")) =~ "form-action 'self';"
     end
+
+    test "a registered URI that would splice a second directive widens nothing",
+         %{conn: conn} do
+      # App registration is public and `URI.parse/1` validates nothing, so
+      # everything up to the first "/" comes back as the "host".
+      policy = consent_policy(conn, "https://evil.example.org;script-src 'unsafe-inline'/cb")
+
+      assert policy =~ "form-action 'self';"
+      refute policy =~ "unsafe-inline'/cb"
+    end
+
+    test "the out-of-band flow stays strict, because it never redirects", %{conn: conn} do
+      assert consent_policy(conn, "urn:ietf:wg:oauth:2.0:oob") =~ "form-action 'self';"
+    end
   end
 
   describe "form_action_source/1" do
@@ -134,6 +148,14 @@ defmodule VutuvWeb.Plug.ContentSecurityPolicyTest do
     test "nothing usable yields nil, so the policy is left alone" do
       assert ContentSecurityPolicy.form_action_source("/relative") == nil
       assert ContentSecurityPolicy.form_action_source(nil) == nil
+    end
+
+    test "a host CSP cannot spell yields nil rather than a header we did not write" do
+      assert ContentSecurityPolicy.form_action_source("https://a.example;script-src 'x'/cb") ==
+               nil
+
+      assert ContentSecurityPolicy.form_action_source("https://intra_net.example/cb") == nil
+      assert ContentSecurityPolicy.form_action_source("urn:ietf:wg:oauth:2.0:oob") == nil
     end
   end
 


### PR DESCRIPTION
Nachtrag zu #1565 (Issue #1562). Zwei Ränder, die dort offen blieben.

**Der Host wird geprüft.** `URI.parse/1` validiert nichts, und die App-Registrierung ist öffentlich: `https://evil.example.org;script-src 'unsafe-inline'/cb` registriert sich sauber und kommt als *ein* Host zurück, im Header also als zweite Direktive nach Wahl des App-Autors.

```
form-action 'self' https://evil.example.org;script-src 'unsafe-inline'; frame-ancestors 'self'
```

Genannt wird jetzt nur, was CSPs eigene `host-source`-Grammatik hergibt; alles andere erweitert nichts, und die Weiterleitung dorthin bleibt blockiert. Das Schema braucht keine solche Prüfung, weil `URI.parse/1` außerhalb der Grammatik `nil` antwortet (gemessen).

**`urn:…:oob` erweitert nichts mehr.** Der Out-of-Band-Fluss druckt den Code auf unserer eigenen Seite; es gibt keinen Sprung zu erlauben, bisher stand ein sinnloses `urn:` im Header.

Dazu teilen sich Ziel- und Websocket-Herkunft `URI.to_string/1`, und mastodon-api.md hält fest, warum derselbe Client in einem Browser durchkommt und im nächsten nicht. Drei neue Tests, ohne den Fix rot (kalibriert). `mix precommit` grün (8423 Tests).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*
