### PR TITLE
Eine Gruppe ist eine Gruppe, und eine Seite hat eine Leseposition (v7.322.3)

### DIFF
--- a/lib/vutuv/api_auth.ex
+++ b/lib/vutuv/api_auth.ex
@@ -377,7 +377,11 @@ defmodule Vutuv.ApiAuth do
     count
   end
 
-  @doc "How many live app tokens are issued for `organization` — the switch's confirmation."
+  @doc """
+  How many live app tokens are issued for `organization`, ignoring the list's
+  filter — what the switch's confirmation names, because turning app access off
+  withdraws every one of them and not only the rows on screen.
+  """
   def count_organization_tokens(%Organization{} = organization) do
     organization |> organization_tokens_query(nil) |> Repo.aggregate(:count)
   end

--- a/lib/vutuv/api_auth/user_agent.ex
+++ b/lib/vutuv/api_auth/user_agent.ex
@@ -23,7 +23,10 @@ defmodule Vutuv.ApiAuth.UserAgent do
   # A client string is not ours to bound, so the column is `text` — but nothing
   # here needs more than a header's worth, and an unbounded body must not become
   # a row. Long enough for the wordiest desktop browser several times over.
-  @max_bytes 500
+  #
+  # Characters, not bytes: `String.slice/3` counts graphemes, and the column is
+  # `text`, so there is no byte limit for the two to disagree about.
+  @max_chars 500
 
   @doc """
   The string to store, from a `Plug.Conn` or a raw header value.
@@ -39,14 +42,14 @@ defmodule Vutuv.ApiAuth.UserAgent do
   def capture(value) when is_binary(value) do
     case String.trim(value) do
       "" -> nil
-      trimmed -> String.slice(trimmed, 0, @max_bytes)
+      trimmed -> String.slice(trimmed, 0, @max_chars)
     end
   end
 
   def capture(_absent), do: nil
 
   @doc "The cap `capture/1` applies, so a test can state it rather than assume it."
-  def max_bytes, do: @max_bytes
+  def max_chars, do: @max_chars
 
   @doc """
   A short device phrase for a stored string, or `nil` when nothing in it is

--- a/lib/vutuv/mastodon_api/markers.ex
+++ b/lib/vutuv/mastodon_api/markers.ex
@@ -35,7 +35,11 @@ defmodule Vutuv.MastodonApi.Markers do
   The identity's markers as a map of `timeline => %Marker{}`.
 
   `only` narrows to the timelines a client asked for (`timeline[]=home`); an
-  empty or missing list answers everything, which is what Mastodon does.
+  empty or missing list answers everything. Mastodon answers `{}` there
+  (`where(timeline: Array(params[:timeline]))` over an empty array), which is
+  an accident of its query rather than a shape a client depends on — every one
+  of them names the timelines it wants, and answering the lot is the more
+  useful reading of "no filter".
   """
   def get(identity, only \\ []) do
     wanted = Enum.filter(only, &(&1 in @timelines))
@@ -77,20 +81,40 @@ defmodule Vutuv.MastodonApi.Markers do
 
   # `version` counts writes, the way Mastodon's does, so a client can tell its
   # own echo from somebody else's write on another device.
+  #
+  # One statement rather than a read and then a write: two of a member's own
+  # devices posting a position in the same instant both saw no row and both
+  # inserted, and the loser met the unique index as an `Ecto.ConstraintError` —
+  # a 500 on exactly the several-installs case this endpoint exists for.
+  # `conflict_target` has to repeat each index's `WHERE`, because both are
+  # partial; Postgres cannot infer a partial index without its predicate.
+  #
+  # The member half of that race has **no test**, deliberately: reproducing it
+  # needs two connections stopped between their read and their write, and a
+  # test that merely writes twice passes against the old code too. The page
+  # half is covered, because there the same collision is reachable without a
+  # race at all — two publishers, one position (`markers_test.exs`).
   defp upsert!(identity, timeline, last_read_id) do
-    case identity |> scope() |> where([m], m.timeline == ^timeline) |> Repo.one() do
-      nil ->
-        identity
-        |> new_marker()
-        |> Map.merge(%{timeline: timeline, last_read_id: last_read_id})
-        |> Repo.insert!()
-
-      %Marker{} = marker ->
-        marker
-        |> Ecto.Changeset.change(last_read_id: last_read_id, version: marker.version + 1)
-        |> Repo.update!()
-    end
+    identity
+    |> new_marker()
+    |> Map.merge(%{timeline: timeline, last_read_id: last_read_id})
+    |> Repo.insert!(
+      on_conflict: [
+        set: [last_read_id: last_read_id, updated_at: NaiveDateTime.utc_now(:second)],
+        inc: [version: 1]
+      ],
+      conflict_target: conflict_target(identity),
+      returning: true
+    )
   end
+
+  # A page's row keeps the `user_id` of whoever wrote it first: the position is
+  # the page's, and the column only records where it came from.
+  defp conflict_target(%User{}),
+    do: {:unsafe_fragment, "(user_id, timeline) WHERE organization_id IS NULL"}
+
+  defp conflict_target({%User{}, %Organization{}}),
+    do: {:unsafe_fragment, "(organization_id, timeline) WHERE organization_id IS NOT NULL"}
 
   defp new_marker(%User{id: user_id}), do: %Marker{user_id: user_id}
 

--- a/lib/vutuv_web/controllers/mastodon_api/notification_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/notification_controller.ex
@@ -99,24 +99,39 @@ defmodule VutuvWeb.MastodonApi.NotificationController do
 
   defp uniq_by_id(list), do: Enum.uniq_by(list, &(&1[:id] || &1["id"]))
 
+  # Gathered across the **whole page**, not over consecutive runs. `chunk_by/2`
+  # reads like grouping and is not: two likes on one post with a follow timed
+  # between them came back as three groups, two of them carrying the identical
+  # `favourite-<post id>` key and each counting one. A client keys its list by
+  # that string, so a duplicate is not a cosmetic slip. Mastodon's own grouping
+  # is over the whole page too.
+  #
+  # The order is first-appearance, which is newest-first because the page is:
+  # `Enum.group_by/2` answers a map, and a map has no order to inherit.
   defp notification_groups(rendered) do
-    rendered
-    |> Enum.chunk_by(&group_key/1)
-    |> Enum.map(fn [newest | _rest] = group ->
-      ids = Enum.map(group, & &1.id)
+    by_key = Enum.group_by(rendered, &group_key/1)
 
-      %{
-        group_key: group_key(newest),
-        notifications_count: length(group),
-        type: newest.type,
-        most_recent_notification_id: newest.id,
-        page_min_id: Enum.min(ids),
-        page_max_id: Enum.max(ids),
-        latest_page_notification_at: newest.created_at,
-        sample_account_ids: group |> Enum.map(& &1.account.id) |> Enum.uniq() |> Enum.take(8),
-        status_id: newest.status[:id]
-      }
-    end)
+    rendered
+    |> Enum.map(&group_key/1)
+    |> Enum.uniq()
+    |> Enum.map(&notification_group(&1, Map.fetch!(by_key, &1)))
+  end
+
+  defp notification_group(key, [newest | _rest] = group) do
+    ids = Enum.map(group, & &1.id)
+
+    %{
+      group_key: key,
+      notifications_count: length(group),
+      type: newest.type,
+      most_recent_notification_id: newest.id,
+      page_min_id: Enum.min(ids),
+      page_max_id: Enum.max(ids),
+      latest_page_notification_at: newest.created_at,
+      # Mastodon's own `SAMPLE_ACCOUNTS_SIZE`.
+      sample_account_ids: group |> Enum.map(& &1.account.id) |> Enum.uniq() |> Enum.take(8),
+      status_id: newest.status[:id]
+    }
   end
 
   # A group is one type over one status. Without a status there is nothing to

--- a/lib/vutuv_web/live/organization_live/apps.ex
+++ b/lib/vutuv_web/live/organization_live/apps.ex
@@ -120,12 +120,17 @@ defmodule VutuvWeb.OrganizationLive.Apps do
   @impl true
   def handle_info(_message, socket), do: {:noreply, socket}
 
+  # Two counts, because they answer two questions. `@tokens.total` is how many
+  # rows the filter found, which is what the list says about itself; the switch
+  # withdraws **every** token, so its confirmation has to name the unfiltered
+  # count. Sharing one number let a filter narrowed to a single colleague
+  # promise that "the one app token" was going, with thirty behind it.
   defp load_tokens(socket, page) do
-    assign(
-      socket,
-      :tokens,
-      ApiAuth.organization_tokens(socket.assigns.organization, socket.assigns.filter, page)
-    )
+    organization = socket.assigns.organization
+
+    socket
+    |> assign(:tokens, ApiAuth.organization_tokens(organization, socket.assigns.filter, page))
+    |> assign(:token_count, ApiAuth.count_organization_tokens(organization))
   end
 
   defp maybe_report_revoked(socket, 0), do: socket
@@ -192,11 +197,11 @@ defmodule VutuvWeb.OrganizationLive.Apps do
           phx-click="toggle"
           variant="secondary"
           data-confirm={
-            @organization.mastodon_clients? && @tokens.total > 0 &&
+            @organization.mastodon_clients? && @token_count > 0 &&
               ngettext(
                 "Turn app access off? The one app token issued for this page is withdrawn and stops working immediately.",
                 "Turn app access off? All %{count} app tokens issued for this page are withdrawn and stop working immediately.",
-                @tokens.total
+                @token_count
               )
           }
         >

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -456,8 +456,9 @@ defmodule VutuvWeb.Router do
 
   # The **unauthenticated** half on the main host, which is the one place the two
   # hosts genuinely differ and so cannot join the loop above: the subdomain's
-  # block ends in a catch-all, and mirroring that here would swallow the whole
-  # website — an unmatched `/api/v1/...` has to fall through to the normal 404.
+  # block ends in a catch-all over `/*path`, and mirroring *that* here would
+  # swallow the whole website. This scope's catch-all is narrowed to Mastodon's
+  # two version prefixes instead — see the comment on it below.
   scope "/", VutuvWeb do
     pipe_through(:mastodon_api)
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.322.2",
+      version: "7.322.3",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260818053316_fix_mastodon_marker_page_uniqueness.exs
+++ b/priv/repo/migrations/20260818053316_fix_mastodon_marker_page_uniqueness.exs
@@ -1,0 +1,62 @@
+defmodule Vutuv.Repo.Migrations.FixMastodonMarkerPageUniqueness do
+  use Ecto.Migration
+
+  @moduledoc """
+  A page's reading position is one row, and the index has to say so.
+
+  `mastodon_markers` shipped one migration ago (v7.322.0) with the page's
+  uniqueness spread over `(user_id, organization_id, timeline)`, while every
+  read in `Vutuv.MastodonApi.Markers` is scoped to `organization_id` alone —
+  the position belongs to the page, not to whichever publisher looked at it.
+  An index narrower than the invariant its queries assume permits exactly what
+  they cannot survive: two publishers writing in the same instant each insert
+  their own row, and from then on the `Repo.one/1` behind every read raises
+  `Ecto.MultipleResultsError`. Not a slow path — a 500 on that page's markers,
+  for good, because nothing ever removes the second row.
+
+  So the index loses `user_id`. The column stays: it still records which
+  publisher's client first stored a position, which is worth having and is no
+  longer part of what makes the row unique.
+
+  **The fold comes first**, because a duplicate may already exist by the time
+  this runs and `CREATE UNIQUE INDEX` would refuse it — leaving the table with
+  no page-level uniqueness at all, which is worse than what it replaces. The
+  newest row per page and timeline wins: these are bookmarks, and the most
+  recently written one is the position a client last reported.
+
+  N-1 compatible. The running release neither reads nor writes through the old
+  index (it finds the page's row by `organization_id` and updates it), so the
+  only behaviour it can newly meet is the collision it already raised on.
+  """
+
+  def up do
+    execute("""
+    DELETE FROM mastodon_markers m
+    USING mastodon_markers keep
+    WHERE m.organization_id IS NOT NULL
+      AND m.organization_id = keep.organization_id
+      AND m.timeline = keep.timeline
+      AND (keep.updated_at, keep.id) > (m.updated_at, m.id)
+    """)
+
+    drop(index(:mastodon_markers, [:user_id, :organization_id, :timeline], name: :mastodon_markers_organization_timeline_index))
+
+    create(
+      unique_index(:mastodon_markers, [:organization_id, :timeline],
+        where: "organization_id IS NOT NULL",
+        name: :mastodon_markers_organization_timeline_index
+      )
+    )
+  end
+
+  def down do
+    drop(index(:mastodon_markers, [:organization_id, :timeline], name: :mastodon_markers_organization_timeline_index))
+
+    create(
+      unique_index(:mastodon_markers, [:user_id, :organization_id, :timeline],
+        where: "organization_id IS NOT NULL",
+        name: :mastodon_markers_organization_timeline_index
+      )
+    )
+  end
+end

--- a/test/vutuv/api_auth/app_token_oversight_test.exs
+++ b/test/vutuv/api_auth/app_token_oversight_test.exs
@@ -40,9 +40,9 @@ defmodule Vutuv.ApiAuth.AppTokenOversightTest do
 
   describe "UserAgent.capture/1" do
     test "caps the stored string so a body cannot become a row" do
-      long = String.duplicate("x", UserAgent.max_bytes() * 3)
+      long = String.duplicate("x", UserAgent.max_chars() * 3)
 
-      assert String.length(UserAgent.capture(long)) == UserAgent.max_bytes()
+      assert String.length(UserAgent.capture(long)) == UserAgent.max_chars()
     end
 
     test "a missing or blank header is nil, so the column says 'not recorded'" do

--- a/test/vutuv_web/controllers/mastodon_api/client_expectations_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/client_expectations_test.exs
@@ -12,6 +12,7 @@ defmodule VutuvWeb.MastodonApi.ClientExpectationsTest do
   import Vutuv.MastodonHelpers
 
   alias Vutuv.Posts
+  alias Vutuv.Repo
 
   describe "times are stamped the way a client parses them" do
     # Mastodon always sends `2019-11-26T22:37:36.000Z`, and Apple's
@@ -175,6 +176,60 @@ defmodule VutuvWeb.MastodonApi.ClientExpectationsTest do
       # resolves the ids against.
       assert Enum.map(body["accounts"], & &1["id"]) == [liker.id]
       assert Enum.map(body["statuses"], & &1["id"]) == [post.id]
+    end
+
+    test "gather over the whole page, not over a consecutive run", %{
+      conn: conn,
+      token: token,
+      post: post,
+      liker: liker
+    } do
+      # `Enum.chunk_by/2` reads like grouping and only collapses neighbours, so
+      # anything timed between two likes on one post split them into two groups
+      # carrying the identical `group_key` — which is the string a client keys
+      # its list by. Reverting `notification_groups/1` to `chunk_by` turns this
+      # red; the single-notification case above stays green either way.
+      author = Repo.get!(Vutuv.Accounts.User, post.user_id)
+      follower = insert(:activated_user)
+      second_liker = insert(:activated_user)
+
+      {:ok, _} = Vutuv.Social.follow(follower, author.id)
+      :ok = Posts.like_post(second_liker, post)
+
+      # Second-granularity stamps make the order of one test run a coin toss,
+      # so the follow is put between the two likes on purpose.
+      now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+      stamp("post_likes", :user_id, liker.id, NaiveDateTime.add(now, -120))
+      stamp("follows", :follower_id, follower.id, NaiveDateTime.add(now, -60))
+      stamp("post_likes", :user_id, second_liker.id, now)
+
+      groups =
+        conn
+        |> mastodon_conn(token)
+        |> get("/api/v2/notifications")
+        |> json_response(200)
+        |> Map.fetch!("notification_groups")
+
+      keys = Enum.map(groups, & &1["group_key"])
+      assert keys == Enum.uniq(keys), "a group_key appeared twice: #{inspect(keys)}"
+
+      assert [favourites] = Enum.filter(groups, &(&1["type"] == "favourite"))
+      assert favourites["notifications_count"] == 2
+      assert favourites["status_id"] == post.id
+      assert liker.id in favourites["sample_account_ids"]
+      assert second_liker.id in favourites["sample_account_ids"]
+
+      # Newest first, which is the order of the page it was gathered from.
+      assert Enum.map(groups, & &1["type"]) == ["favourite", "follow"]
+    end
+
+    defp stamp(table, column, id, at) do
+      Repo.update_all(
+        Ecto.Query.from(r in table,
+          where: field(r, ^column) == type(^id, Vutuv.UUIDv7)
+        ),
+        set: [inserted_at: at]
+      )
     end
   end
 

--- a/test/vutuv_web/controllers/mastodon_api/markers_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/markers_test.exs
@@ -12,8 +12,10 @@ defmodule VutuvWeb.MastodonApi.MarkersTest do
 
   import Vutuv.MastodonHelpers
 
+  alias Vutuv.MastodonApi.Marker
   alias Vutuv.MastodonApi.Markers
   alias Vutuv.Organizations
+  alias Vutuv.Repo
 
   setup do
     member = insert(:activated_user)
@@ -145,5 +147,55 @@ defmodule VutuvWeb.MastodonApi.MarkersTest do
 
     # And the member's own timeline is untouched by it.
     assert Markers.get(member) == %{}
+  end
+
+  test "a page has one row however many publishers write it", %{conn: conn, member: member} do
+    # The read is scoped to the organization alone, so the uniqueness has to be
+    # too. While the index also named `user_id`, two publishers writing in the
+    # same instant each inserted their own row — and every later read raised
+    # `Ecto.MultipleResultsError`, which is a 500 on that page's markers for
+    # good. Restoring `[:user_id, :organization_id, :timeline]` in the
+    # migration turns this red.
+    organization = insert(:organization)
+    {:ok, organization} = Organizations.set_mastodon_clients(organization, true)
+    colleague = insert(:activated_user)
+
+    for reader <- [member, colleague] do
+      {:ok, _} = Organizations.add_role(organization, reader, "publisher", member)
+    end
+
+    Markers.put({member, organization}, %{"home" => %{"last_read_id" => "first"}})
+
+    # What the losing side of that race attempts: a blind insert, having read
+    # no row of its own.
+    assert {:error, changeset} =
+             Repo.insert(
+               Ecto.Changeset.change(%Marker{},
+                 user_id: colleague.id,
+                 organization_id: organization.id,
+                 timeline: "home",
+                 last_read_id: "second"
+               )
+               |> Ecto.Changeset.unique_constraint([:organization_id, :timeline],
+                 name: :mastodon_markers_organization_timeline_index
+               )
+             )
+
+    assert changeset.errors != []
+    assert Repo.aggregate(Marker, :count) == 1
+
+    # And the colleague writing through the endpoint moves the page's one
+    # position rather than raising.
+    token = mastodon_token(colleague, ["read", "write"], organization)
+
+    assert conn
+           |> mastodon_conn(token)
+           |> post("/api/v1/markers", %{"home" => %{"last_read_id" => "second"}})
+           |> json_response(200)
+
+    assert %{"home" => marker} = Markers.get({member, organization})
+    assert marker.last_read_id == "second"
+    assert marker.version == 2
+    assert Repo.aggregate(Marker, :count) == 1
   end
 end

--- a/test/vutuv_web/organization_app_tokens_test.exs
+++ b/test/vutuv_web/organization_app_tokens_test.exs
@@ -90,6 +90,27 @@ defmodule VutuvWeb.OrganizationAppTokensTest do
     refute html =~ "Bartholomew"
   end
 
+  test "the switch's confirmation counts every token, not the filtered rows", %{conn: conn} do
+    # The switch withdraws all of them, so its confirmation may not read the
+    # list's filtered total: narrowed to one colleague it promised that "the
+    # one app token" was going, with two more behind it. Pointing `data-confirm`
+    # back at `@tokens.total` turns this red.
+    {conn, organization, _owner} = owned_page_with_apps_on(conn)
+    issue(organization, insert(:activated_user, first_name: "Zoraida"))
+    issue(organization, insert(:activated_user, first_name: "Bartholomew"))
+    issue(organization, insert(:activated_user, first_name: "Cornelius"))
+
+    {:ok, view, _html} = live(conn, ~p"/organizations/#{organization.slug}/apps")
+
+    html = view |> form("form[phx-change=filter]", %{"query" => "zorai"}) |> render_change()
+
+    assert html =~ "All 3 app tokens issued for this page are withdrawn"
+    refute html =~ "The one app token issued for this page is withdrawn"
+    # The list still says what the filter found.
+    assert html =~ "Zoraida"
+    refute html =~ "Bartholomew"
+  end
+
   test "an owner withdraws one token and the rest stay", %{conn: conn} do
     {conn, organization, _owner} = owned_page_with_apps_on(conn)
     doomed = issue(organization, insert(:activated_user))


### PR DESCRIPTION
**TL;DR** Drei Fehler aus #1565 (v7.322.0), alle gemessen und gegen den ungefixten Code kalibriert.

**Gruppen.** `Enum.chunk_by/2` fasst nur Nachbarn zusammen. Zwei Likes auf denselben Beitrag mit einem Follow dazwischen kamen als drei Gruppen zurück, zwei davon mit identischem `group_key` — der Zeichenkette, an der ein Client seine Liste aufhängt. Mastodon gruppiert über die ganze Seite; jetzt auch `/api/v2/notifications`.

**Leseposition einer Seite.** Der Index nannte `user_id`, jede Lesung fragt aber nur nach `organization_id`. Zwei Publisher im selben Moment legen je eine Zeile an, und danach wirft jede Lesung `Ecto.MultipleResultsError` — 500 auf die Marker dieser Seite, dauerhaft. Der Index verliert `user_id`, `upsert!/3` wird ein Statement statt Lesen-dann-Schreiben.

**Rückfrage vor dem Abschalten.** Zählte die gefilterten Zeilen: mit aktivem Filter versprach sie, „der eine" Zugang werde entzogen, während dreißig dahinter hingen.

**Migration:** die von gestern läuft bereits, also korrigiert eine neue den Index und faltet vorher Doppelzeilen zusammen (an echten Doppeldaten geprüft, nicht nur auf leerer DB).

**Deploy:** hot. `mix precommit` grün, 8423 Tests. Kein Screenshot: die sichtbare Änderung ist eine Zahl in einem `confirm()`-Dialog, alles Übrige ist JSON.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*
