### PR TITLE
Eine Zustimmung ergibt genau einen Code (v7.322.2)

### DIFF
--- a/docs/architecture/api.md
+++ b/docs/architecture/api.md
@@ -71,6 +71,26 @@ validates nothing: `https://evil.example.org;script-src 'unsafe-inline'/cb`
 registers cleanly and comes back with that whole run as its "host", which in a
 header would be a second directive of the app author's choosing.
 
+**One consent, one code.** A phone client resubmitted a single loaded consent
+page about a hundred times, up to eight a second, and every submission minted an
+authorization code of its own, each redeemable for ten minutes (issue #1561).
+Nothing here resubmits that form, so what this can fix is the cost of a repeat:
+the page carries a nonce, and `OAuth.approve/4` **derives** the code from the
+consent itself — member, app, redirect URI, scopes, PKCE challenge, acting
+identity and that nonce, HMAC'd under a pepper from `secret_key_base` — so the
+second submission finds the row the first one wrote and is answered with the code
+that already went out, writing nothing. Deriving rather than reading it back is
+forced by the storage rule: only the SHA-256 of a code is kept, so the plaintext
+is either reconstructible or gone. A spent or expired code is never handed out
+again (a second redemption is the RFC's theft signal, so that would report the
+member's own client as a thief), and a submission carrying no nonce — a page from
+the release before this — mints a fresh code exactly as it used to. Underneath it
+`prune_unused_codes/2` still caps the unused codes per member and app at three,
+and the route's per-minute consent budget still refuses a runaway client; that
+refusal now also writes one line a minute naming the client's User-Agent, because
+which client resubmits is the open half of #1561 and the browser's own
+User-Agent reaches nothing but the web server's access log.
+
 **Who holds a credential, and who may take it away.** `/connected_apps` names,
 per authorization, when it was given and which devices still hold a live token
 under it (`Vutuv.ApiAuth.UserAgent` reads a short platform label out of the

--- a/lib/vutuv/api_auth/o_auth.ex
+++ b/lib/vutuv/api_auth/o_auth.ex
@@ -2,7 +2,7 @@ defmodule Vutuv.ApiAuth.OAuth do
   @moduledoc """
   The OAuth 2 authorization-code flow (RFC 6749 + PKCE per RFC 7636,
   hardened per RFC 9700): `validate_authorize/1` checks an incoming
-  authorize request, `approve/2` records the user's consent and mints the
+  authorize request, `approve/4` records the user's consent and mints the
   one-time code, `exchange/1` and `refresh/1` are the token endpoint's two
   grant types, `revoke/1` is RFC 7009.
 
@@ -140,46 +140,154 @@ defmodule Vutuv.ApiAuth.OAuth do
   created or refreshed (scopes are the union of old and new — consent only
   ever widens, revocation is explicit), the code carries the PKCE
   challenge. Returns the code plaintext for the redirect.
-  """
-  def approve(user, request, identity \\ nil)
 
-  def approve(user, %{app: %App{protocol: "mastodon"}} = request, identity) do
+  `consent_nonce` is the nonce the consent form carried (`new_consent_nonce/0`).
+  Pass it and the same submission answers with the same code however often it
+  arrives; pass nothing and every call mints a fresh one, as before.
+  """
+  def approve(user, request, identity \\ nil, consent_nonce \\ nil)
+
+  def approve(user, %{app: %App{protocol: "mastodon"}} = request, identity, consent_nonce) do
     with {:ok, organization, scopes} <- Access.select(user, identity, request.scopes) do
-      do_approve(user, request, organization, scopes)
+      do_approve(user, request, organization, scopes, usable_nonce(consent_nonce))
     end
   end
 
-  def approve(user, request, _identity), do: do_approve(user, request, nil, request.scopes)
+  def approve(user, request, _identity, consent_nonce),
+    do: do_approve(user, request, nil, request.scopes, usable_nonce(consent_nonce))
 
-  defp do_approve(user, %{app: app} = request, organization, scopes) do
-    code = @code_prefix <> ApiAuth.random_token()
+  @doc """
+  A nonce for one rendering of the consent form (issue #1561).
 
+  It rides the form as a hidden field and comes back with the submission, which
+  is what makes each *rendering* a consent of its own — and every resubmission
+  of one rendering the same consent, answered with the same code.
+  """
+  def new_consent_nonce, do: ApiAuth.random_token(16)
+
+  # A submission with no nonce mints a fresh code, exactly as before: a page
+  # rendered by an older release, or a client that builds the POST itself.
+  defp do_approve(user, request, organization, scopes, nil),
+    do: mint(user, request, organization, scopes, random_code())
+
+  # One consent, one code (issue #1561). A phone client resubmitted a single
+  # loaded consent page about a hundred times, up to eight times a second, and
+  # every submission minted its own authorization code — each a bearer
+  # credential for ten minutes. `prune_unused_codes/2` bounds the pile that
+  # leaves behind and the route's budget bounds the rate, but neither makes the
+  # second submission of the *same* consent harmless.
+  #
+  # Only the SHA-256 of a code is stored, so a repeat cannot be answered by
+  # reading the code back out of its row. It is answered by deriving the same
+  # string again: the code IS the consent, keyed with a pepper off
+  # `secret_key_base` (the invitation and login-PIN construction). So the second
+  # submission finds the row the first one wrote, hands back the code that
+  # already went out, and writes nothing. Nothing new is stored and nothing new
+  # is sent to the browser.
+  #
+  # The nonce is the part that makes each *rendering* of the form its own
+  # consent: without it every future authorize for the same scopes would derive
+  # a code the member had long since spent. It rides the form, so a client can
+  # pin it — which costs nothing, since the only code it can ever pin is its own.
+  defp do_approve(user, request, organization, scopes, nonce) do
+    code = consent_code(user, request, organization, scopes, nonce)
+
+    case Repo.get_by(AuthCode, code_hash: ApiAuth.hash_token(code)) do
+      nil ->
+        mint(user, request, organization, scopes, code)
+
+      existing ->
+        if redeemable?(existing),
+          do: {:ok, code},
+          else: mint(user, request, organization, scopes, random_code())
+    end
+  end
+
+  # A derived code is a function of its consent, so a spent or expired one would
+  # be derived again for as long as its row is around. Those repeats get a random
+  # code instead: handing out a spent one would report the member's own client as
+  # a thief (`consume_code/1` treats a second redemption as theft), and the unique
+  # index on `code_hash` would refuse the row anyway.
+  defp redeemable?(%AuthCode{used_at: nil, expires_at: expires}),
+    do: DateTime.after?(expires, DateTime.utc_now())
+
+  defp redeemable?(%AuthCode{}), do: false
+
+  defp mint(user, %{app: app} = request, organization, scopes, code) do
     {:ok, _auth_code} =
       Repo.transaction(fn ->
         grant = upsert_grant!(user, app, scopes)
 
-        Repo.insert!(%AuthCode{
-          user_id: user.id,
-          app_id: app.id,
-          grant_id: grant.id,
-          organization_id: organization && organization.id,
-          code_hash: ApiAuth.hash_token(code),
-          redirect_uri: request.redirect_uri,
-          scopes: scopes,
-          code_challenge: request.code_challenge,
-          expires_at: seconds_from_now(@code_ttl_seconds)
-        })
+        # Two submissions of one consent can be in flight at once (that client
+        # sent eight a second), and both derive the same code: the loser of the
+        # race writes nothing rather than raising on the unique index, and its
+        # answer is the winner's row — the same code either way.
+        Repo.insert!(
+          %AuthCode{
+            user_id: user.id,
+            app_id: app.id,
+            grant_id: grant.id,
+            organization_id: organization && organization.id,
+            code_hash: ApiAuth.hash_token(code),
+            redirect_uri: request.redirect_uri,
+            scopes: scopes,
+            code_challenge: request.code_challenge,
+            expires_at: seconds_from_now(@code_ttl_seconds)
+          },
+          on_conflict: :nothing,
+          conflict_target: :code_hash
+        )
         |> tap(fn _ -> prune_unused_codes(user, app) end)
       end)
 
     {:ok, code}
   end
 
-  # Only the hash of a code is stored, so a repeated consent cannot be answered
-  # with the code it already handed out — every submission has to mint a new row,
-  # and each is a bearer credential for ten minutes. One phone client resubmitted
-  # the consent form about a hundred times from a single loaded page, so one
-  # login held about a hundred live codes at once (issue #1561).
+  defp random_code, do: @code_prefix <> ApiAuth.random_token()
+
+  # Everything the row records, so a resubmission that changed any of it (the
+  # identity picked in the select, a different scope) is a different consent and
+  # gets a code of its own. Newline-separated because none of these values can
+  # hold one, so no two consents can spell the same input.
+  defp consent_code(user, request, organization, scopes, nonce) do
+    fingerprint =
+      Enum.map_join(
+        [
+          user.id,
+          request.app.id,
+          nonce,
+          request.redirect_uri,
+          Enum.join(scopes, " "),
+          request.code_challenge,
+          organization && organization.id
+        ],
+        "\n",
+        &to_string/1
+      )
+
+    digest = :crypto.mac(:hmac, :sha256, consent_pepper(), fingerprint)
+
+    @code_prefix <> Base.encode32(digest, case: :lower, padding: false)
+  end
+
+  # Dedicated pepper derived from `secret_key_base` with domain separation, so
+  # it never equals the raw secret and lives outside the database. Without it a
+  # code would be a plain function of a fingerprint the client itself supplies.
+  defp consent_pepper do
+    secret = Application.fetch_env!(:vutuv, VutuvWeb.Endpoint)[:secret_key_base]
+    :crypto.hash(:sha256, "vutuv/oauth_consent/pepper/v1" <> secret)
+  end
+
+  # The nonce comes off a form, so it is the client's string: anything but a
+  # short binary is treated as absent rather than fed to the HMAC.
+  defp usable_nonce(nonce) when is_binary(nonce) and byte_size(nonce) in 1..64, do: nonce
+  defp usable_nonce(_missing_or_unusable), do: nil
+
+  # The backstop under the repeat guard above, for everything it cannot answer:
+  # a submission carrying no consent nonce still mints a row of its own, and each
+  # row is a bearer credential for ten minutes. One phone client resubmitted the
+  # consent form about a hundred times from a single loaded page, so one login
+  # held about a hundred live codes at once (issue #1561).
   #
   # The budget on the consent route bounds the *rate*; this bounds the *pile*,
   # which is the part that matters and which a rate limit cannot do: a client

--- a/lib/vutuv_web/controllers/oauth_controller.ex
+++ b/lib/vutuv_web/controllers/oauth_controller.ex
@@ -22,6 +22,8 @@ defmodule VutuvWeb.OauthController do
 
   use VutuvWeb, :controller
 
+  require Logger
+
   alias Vutuv.ApiAuth.OAuth
   alias Vutuv.ApiAuth.UserAgent
   alias Vutuv.MastodonApi.Access
@@ -46,7 +48,8 @@ defmodule VutuvWeb.OauthController do
             request: request,
             params: params,
             identities: identities,
-            consent_scopes: consent_scopes(request, identities)
+            consent_scopes: consent_scopes(request, identities),
+            consent_nonce: OAuth.new_consent_nonce()
           )
         else
           conn
@@ -90,10 +93,9 @@ defmodule VutuvWeb.OauthController do
   # loaded page, up to eight times a second, and each submission minted its own
   # authorization code (issue #1561). Nothing of ours resubmits it, so this does
   # not chase that client's bug — it saves the wasted round trips and tells a
-  # runaway client that something is wrong. What bounds the *pile* of live codes
-  # is `OAuth.prune_unused_codes/2` at the mint site, because no per-minute
-  # budget can: a client resubmitting every seven seconds stays inside any budget
-  # and still accumulates codes for their whole ten-minute lifetime.
+  # runaway client that something is wrong. What makes those repeats harmless is
+  # `OAuth.approve/4`, which answers one consent with one code however often it
+  # arrives; this bounds what a client can spend getting there.
   #
   # The ceiling sits far above anything a person does, because it must never
   # touch a working login: nobody presses Allow ten times in a minute. The guard
@@ -104,9 +106,12 @@ defmodule VutuvWeb.OauthController do
   @consent_window :timer.minutes(1)
 
   defp decide(conn, user, request, "allow") do
-    if within_consent_budget?(user, request),
-      do: mint_code(conn, user, request),
-      else: conn |> put_status(429) |> render("error.html", reason: :too_many_requests)
+    if within_consent_budget?(user, request) do
+      mint_code(conn, user, request)
+    else
+      log_runaway(conn, user, request)
+      conn |> put_status(429) |> render("error.html", reason: :too_many_requests)
+    end
   end
 
   defp decide(conn, _user, request, _deny) do
@@ -119,8 +124,36 @@ defmodule VutuvWeb.OauthController do
       else: redirect(conn, external: callback_url(request, error: "access_denied"))
   end
 
+  # The half of issue #1561 nobody could answer: *which* client resubmits. The
+  # browser's User-Agent reaches only the web server's access log, where nobody
+  # is looking while it happens — and by the time the report arrives, the log
+  # has rotated. Spending this budget is the definition of a runaway client, so
+  # it is the one place where naming it costs nothing, and every installation
+  # then finds the answer in its own log instead of ours. The app is named
+  # rather than the member: what is wanted here is the client, not who they are.
+  #
+  # One line per member, app and minute, through a bucket of its own: the client
+  # this exists to name sent a hundred requests in one, and a hundred identical
+  # lines is how a log stops being read.
+  defp log_runaway(conn, user, request) do
+    if RateLimit.check(nil, :oauth_consent_report, user.id <> ":" <> request.app.id,
+         limit: 1,
+         window_ms: @consent_window
+       ) == :ok do
+      Logger.warning(
+        "oauth: consent budget spent, app=#{request.app.name} " <>
+          "user_agent=#{UserAgent.capture(conn) || "(none sent)"}"
+      )
+    end
+  end
+
   defp mint_code(conn, user, request) do
-    case OAuth.approve(user, request, conn.params["identity"]) do
+    case OAuth.approve(
+           user,
+           request,
+           conn.params["identity"],
+           conn.params["consent_nonce"]
+         ) do
       {:ok, code} ->
         if request.redirect_uri == @oob_redirect,
           do: conn |> put_resp_header("cache-control", "no-store") |> text(code),

--- a/lib/vutuv_web/templates/oauth/authorize.html.heex
+++ b/lib/vutuv_web/templates/oauth/authorize.html.heex
@@ -35,6 +35,9 @@
       <%= for key <- ~w(response_type client_id redirect_uri scope state code_challenge code_challenge_method) do %>
         <input :if={@params[key]} type="hidden" name={key} value={@params[key]} />
       <% end %>
+      <%!-- This page's own consent: however often it is submitted, it yields
+            one authorization code (issue #1561, `Vutuv.ApiAuth.OAuth`). --%>
+      <input type="hidden" name="consent_nonce" value={@consent_nonce} />
 
       <div :if={length(@identities) > 1} class="mb-5">
         <label for="oauth-identity" class="block text-sm font-semibold text-slate-800 dark:text-slate-200">

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.322.1",
+      version: "7.322.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/controllers/oauth_consent_idempotency_test.exs
+++ b/test/vutuv_web/controllers/oauth_consent_idempotency_test.exs
@@ -1,0 +1,160 @@
+defmodule VutuvWeb.OauthConsentIdempotencyTest do
+  @moduledoc """
+  One consent, one authorization code (issue #1561).
+
+  A phone client resubmitted a single loaded consent page about a hundred times,
+  up to eight times a second, and every submission minted its own code — each a
+  bearer credential for ten minutes. The route's budget bounds the rate and
+  `OAuth.prune_unused_codes/2` bounds the pile, but neither makes the second
+  submission of the *same* consent harmless.
+
+  So the form carries a nonce and the code is **derived** from the consent it
+  belongs to (`Vutuv.ApiAuth.OAuth`, peppered HMAC): the second submission finds
+  the row the first one wrote and hands back the code that already went out.
+  Only the hash of a code is stored, which is why it has to be re-derived rather
+  than read back.
+
+  These tests submit **through the rendered form** — the nonce is a hidden field,
+  so a hand-built POST would test a page that does not exist. `mix test` runs
+  with the rate limiter off, so the route's separate consent budget (covered in
+  `oauth_consent_limit_test.exs`) does not cut these runs short.
+  """
+  use VutuvWeb.ConnCase, async: true
+
+  import Vutuv.MastodonHelpers
+
+  alias Vutuv.ApiAuth.AuthCode
+  alias Vutuv.Repo
+
+  @redirect "org.example.client://oauth"
+
+  setup %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+
+    {:ok, conn: conn, user: allow_mastodon_clients(user), app: register_mastodon_app()}
+  end
+
+  defp consent_page(conn, app) do
+    get(
+      conn,
+      ~p"/oauth/authorize?#{[response_type: "code", client_id: app.client_id, redirect_uri: @redirect, scope: "read"]}"
+    )
+  end
+
+  # Everything the browser would send back: the hidden fields the page rendered
+  # (the nonce among them) plus the button that was pressed.
+  defp form_params(page) do
+    ~r/<input[^>]*type="hidden"[^>]*>/
+    |> Regex.scan(page.resp_body)
+    |> Enum.map(fn [input] -> {field(input, "name"), field(input, "value")} end)
+    |> Map.new()
+    |> Map.put("decision", "allow")
+  end
+
+  defp field(input, attribute) do
+    case Regex.run(~r/#{attribute}="([^"]*)"/, input) do
+      [_, value] -> value
+      nil -> nil
+    end
+  end
+
+  defp submit(conn, params), do: post(conn, ~p"/oauth/authorize", params)
+
+  defp code_of(response) do
+    [_, code] = Regex.run(~r/[?&]code=([^&]+)/, redirected_to(response, 302))
+    URI.decode(code)
+  end
+
+  test "the consent form carries a nonce of its own", %{conn: conn, app: app} do
+    params = conn |> consent_page(app) |> form_params()
+
+    assert byte_size(params["consent_nonce"]) > 16
+
+    refute params["consent_nonce"] ==
+             (conn |> consent_page(app) |> form_params())["consent_nonce"]
+  end
+
+  # The measured failure, in one assertion. Calibrate by dropping the
+  # `consent_nonce` field from the template: this goes red with 100 codes.
+  test "one page resubmitted a hundred times yields one code", %{conn: conn, app: app} do
+    params = conn |> consent_page(app) |> form_params()
+
+    codes = for _ <- 1..100, into: MapSet.new(), do: conn |> submit(params) |> code_of()
+
+    assert MapSet.size(codes) == 1
+    assert Repo.aggregate(AuthCode, :count) == 1
+  end
+
+  test "and the code it repeats is a working one", %{conn: conn, app: app} do
+    params = conn |> consent_page(app) |> form_params()
+
+    first = conn |> submit(params) |> code_of()
+    repeat = conn |> submit(params) |> code_of()
+
+    assert repeat == first
+    assert %AuthCode{used_at: nil} = Repo.get_by!(AuthCode, code_hash: hash(first))
+  end
+
+  # A member connecting the app a second time is consenting a second time, and
+  # must not be handed a code that was already spent (or is about to be).
+  test "a freshly opened consent page mints a code of its own", %{conn: conn, app: app} do
+    first = conn |> consent_page(app) |> form_params() |> then(&submit(conn, &1)) |> code_of()
+    second = conn |> consent_page(app) |> form_params() |> then(&submit(conn, &1)) |> code_of()
+
+    refute second == first
+    assert Repo.aggregate(AuthCode, :count) == 2
+  end
+
+  # Once the code has been redeemed, repeating the page cannot answer with it:
+  # a spent code is exactly what makes a replay detectable, so handing it out
+  # again would report the member's own client as a thief.
+  test "a resubmission after the code was redeemed mints a new one", %{conn: conn, app: app} do
+    params = conn |> consent_page(app) |> form_params()
+    code = conn |> submit(params) |> code_of()
+
+    Repo.get_by!(AuthCode, code_hash: hash(code))
+    |> Ecto.Changeset.change(used_at: DateTime.utc_now() |> DateTime.truncate(:second))
+    |> Repo.update!()
+
+    later = conn |> submit(params) |> code_of()
+
+    refute later == code
+    assert %AuthCode{used_at: %DateTime{}} = Repo.get_by!(AuthCode, code_hash: hash(code))
+  end
+
+  # The nonce rides a form, so it is the client's string by the time it comes
+  # back. Nothing about a fixed one is dangerous — the only code it can pin is
+  # its own — but it must not raise, and it must not reach across members.
+  test "two members sending the same nonce get their own codes", %{conn: conn, app: app} do
+    params = %{
+      "response_type" => "code",
+      "client_id" => app.client_id,
+      "redirect_uri" => @redirect,
+      "scope" => "read",
+      "identity" => "person",
+      "decision" => "allow",
+      "consent_nonce" => "the-same-string"
+    }
+
+    {other_conn, other} =
+      create_and_login_user(build_conn() |> Plug.Test.init_test_session(%{}))
+
+    allow_mastodon_clients(other)
+
+    mine = conn |> submit(params) |> code_of()
+    theirs = other_conn |> submit(params) |> code_of()
+
+    refute theirs == mine
+  end
+
+  # N-1: the release before this one rendered a form without the field, and
+  # those pages are still open in somebody's browser when the new one takes over.
+  test "a page rendered before this shipped still connects", %{conn: conn, app: app} do
+    params =
+      conn |> consent_page(app) |> form_params() |> Map.delete("consent_nonce")
+
+    assert conn |> submit(params) |> redirected_to(302) =~ "#{@redirect}?code="
+  end
+
+  defp hash(code), do: Vutuv.ApiAuth.hash_token(code)
+end

--- a/test/vutuv_web/controllers/oauth_consent_limit_test.exs
+++ b/test/vutuv_web/controllers/oauth_consent_limit_test.exs
@@ -132,6 +132,26 @@ defmodule VutuvWeb.OauthConsentLimitTest do
     assert body =~ "zu oft hintereinander um eine Verbindung gebeten"
   end
 
+  # Which client resubmits is the half of #1561 that stayed open, and the
+  # browser's User-Agent reaches only the web server's access log. A client that
+  # spends this budget is a runaway by definition, so it names itself in our own
+  # log — the app it registered as, and the string the browser sent.
+  test "a client that spends the budget names itself in the log", %{conn: conn, app: app} do
+    log =
+      ExUnit.CaptureLog.capture_log(fn ->
+        for _ <- 1..30 do
+          conn
+          |> recycle()
+          |> put_req_header("user-agent", "Mozilla/5.0 (iPhone; CPU iPhone OS 26_0) Ivory/1.2")
+          |> post(~p"/oauth/authorize", consent_params(app))
+        end
+      end)
+
+    assert log =~ "consent budget spent"
+    assert log =~ "app=#{app.name}"
+    assert log =~ "Ivory/1.2"
+  end
+
   # A budget shared across apps would let one looping client lock a member out
   # of connecting a different one.
   test "the budget is per app, so another client still connects", %{conn: conn, app: app} do


### PR DESCRIPTION
**Symptom:** Eine geladene Zustimmungsseite wurde rund hundertmal abgeschickt, und jede Absendung prägte einen eigenen, zehn Minuten lang einlösbaren Autorisierungscode (#1561). Das Budget aus v7.321.0 begrenzt die Rate, nicht die Wiederholung.

**Änderung** in `Vutuv.ApiAuth.OAuth.approve/4`: Die Seite trägt eine Nonce, und der Code wird aus der Zustimmung abgeleitet (HMAC über Mitglied, App, redirect_uri, Scopes, PKCE-Challenge, Identität, Nonce; Pfeffer aus `secret_key_base`). Die zweite Absendung findet damit die Zeile der ersten und bekommt deren Code zurück, ohne etwas zu schreiben. Gespeichert wird weiterhin nur der Hash; ohne Nonce, also bei einer Seite aus der Vorversion, bleibt alles wie bisher.

**Gemessen** am lokalen Server: fünf Absendungen einer Seite, ein Code, eine Zeile, und der Code löst ein Token ein. Der Regressionstest ist am ungefixten Stand kalibriert.

**Offen bleibt, wer absendet.** Der User-Agent steht nur im Zugriffslog, deshalb nennt sich ein Client, der das Zustimmungsbudget ausschöpft, jetzt einmal pro Minute in unserem eigenen Log.

<img src="https://raw.githubusercontent.com/wintermeyer/vutuv/shots/pr-1568/consent.jpg" width="440">

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*
