### PR TITLE
Ein Formular nach außen endet auf einer Seite, nicht in einer 302 (v7.324.1)

### DIFF
--- a/docs/architecture/api.md
+++ b/docs/architecture/api.md
@@ -71,6 +71,13 @@ validates nothing: `https://evil.example.org;script-src 'unsafe-inline'/cb`
 registers cleanly and comes back with that whole run as its "host", which in a
 header would be a second directive of the app author's choosing.
 
+Widening the header is the exception, not the pattern: it works here only
+because the destination is registered and known while the page renders. The
+other two forms that leave the site — "follow us from your own server" and the
+job board's easy apply — answer with a page instead
+(`VutuvWeb.ControllerHelpers.hand_off/3`, issue #1569); `VutuvWeb.OutboundHTML`
+says why, and it is the shape to copy for anything new.
+
 **One consent, one code.** A phone client resubmitted a single loaded consent
 page about a hundred times, up to eight a second, and every submission minted an
 authorization code of its own, each redeemable for ten minutes (issue #1561).

--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -677,8 +677,8 @@ apps, paste it into a search box and wait. The Fediverse's answer is the
 **remote-follow (OStatus subscribe) template**, which every server publishes in
 its own WebFinger document. So the profile card asks the visitor for *their*
 address, `Vutuv.Fediverse.RemoteFollow` looks up *their* server's follow dialog
-and `VutuvWeb.RemoteFollowController` (`POST /:slug/fediverse/follow`) redirects
-them into it with the member's `acct:` URI filled in. The follow is then
+and `VutuvWeb.RemoteFollowController` (`POST /:slug/fediverse/follow`) hands
+them on to it with the member's `acct:` URI filled in. The follow is then
 confirmed where the visitor's account actually lives; no credential ever reaches
 vutuv and the typed address is used for one lookup and forgotten.
 
@@ -690,6 +690,17 @@ It is a plain HTML form post, not a `phx-click`: the person it is for arrives
 from another network and is the last visitor whose JavaScript we should assume
 anything about. (The profile is a LiveView, which loads the session's CSRF state,
 so the token the form stamps is valid from a live render too.)
+
+**The last hop is a page, not a 302** (issue #1569). `form-action 'self'` is
+enforced on every hop of a form submission, redirects included, so answering
+this POST with `redirect(conn, external: …)` was dropped by Chrome and WebKit —
+invisibly on both sides, and the console blamed our own URL. The consent
+screen's fix does not carry over, because the destination here only exists once
+the address the visitor typed has been resolved. So the submission ends at a
+200 (`VutuvWeb.ControllerHelpers.hand_off/3`, rendered by
+`VutuvWeb.OutboundHTML`) and the layout's `<meta http-equiv="refresh">` takes
+the visitor on: the hop that leaves vutuv is then an ordinary navigation, which
+the directive does not govern.
 
 This is also the **only outbound fetch an anonymous visitor can trigger**, so it
 is fenced like the inbox path it borrows its shape from: the installation switch

--- a/docs/architecture/jobs.md
+++ b/docs/architecture/jobs.md
@@ -243,6 +243,14 @@ and the crawl path — the board is a shared-footer + top-bar nav link). PubSub
 - **No applications table** — applying routes to the employer's channel (an
   outbound URL, a prefilled mailto, or a vutuv conversation with the poster), so
   vutuv never becomes controller of rejected-candidate data (§26 BDSG / AGG).
+  The two outbound channels answer the POST with a hand-off page rather than a
+  302 (`VutuvWeb.ControllerHelpers.hand_off/3`, issue #1569): `form-action
+  'self'` is enforced on a submission's redirects too, and this page cannot
+  widen the header for its own destination because the apply button sits in a
+  LiveView the visitor may have reached by live navigation. The website
+  destination forwards itself; the `mailto:` waits for the button, because a
+  browser hands a URL to an external program on a user gesture. The
+  conversation stays a plain redirect — it is same-origin.
 
 ## Salary normalization
 

--- a/lib/vutuv_web/controllers/controller_helpers.ex
+++ b/lib/vutuv_web/controllers/controller_helpers.ex
@@ -209,6 +209,42 @@ defmodule VutuvWeb.ControllerHelpers do
   end
 
   @doc """
+  Answers a form submission whose destination is another site: a 200 that
+  names `url`, explains itself with `note`, and links on (issue #1569).
+
+  **Use this instead of `redirect(conn, external: …)` in reply to a POST.**
+  `form-action 'self'` is enforced on a submission's redirects too, so the 302
+  is dropped by Chrome and WebKit with nothing to see on either side. The full
+  reasoning, and why an `http(s)` destination still costs no click, is in
+  `VutuvWeb.OutboundHTML`.
+
+  A same-origin destination needs none of this — keep redirecting to those.
+  """
+  def hand_off(%Conn{} = conn, url, note) when is_binary(url) and is_binary(note) do
+    copy = VutuvWeb.OutboundHTML.hand_off_copy(url)
+
+    conn
+    |> Conn.assign(:meta_refresh, copy.auto_forward)
+    |> chrome_for(copy)
+    |> Phoenix.Controller.put_view(html: VutuvWeb.OutboundHTML)
+    |> Phoenix.Controller.render("hand_off.html", url: url, note: note, copy: copy)
+  end
+
+  # A page that forwards itself is never read, so it does not pay for the app
+  # chrome. The saving is not the dead render itself — `ShellLive.mount_static/3`
+  # runs no query, and it costs 20–30 KB and well under a millisecond. It is
+  # that `app.html.heex` holds the document's **only live root**, so without it
+  # `liveSocket.connect()` takes its dead branch and never opens a socket at
+  # all: no connected `ShellLive` mount (5 queries and ~2.3 ms for a signed-in
+  # member, measured), no presence track and untrack, for a document the
+  # browser replaces in the same frame. Dropping the *app* layout keeps the
+  # *root* one, which is where the meta refresh has to live anyway. The page
+  # that waits for a click is read, so it keeps the chrome — a bare dead end
+  # there is worse than the render.
+  defp chrome_for(conn, %{auto_forward: nil}), do: conn
+  defp chrome_for(conn, _forwards_itself), do: Phoenix.Controller.put_layout(conn, html: false)
+
+  @doc """
   Renders the "this profile is currently unavailable" page and halts with the
   given status (issue #812): `403` for a reversible hold (frozen / suspended /
   unreachable), `410` for a permanently deactivated account. Unlike

--- a/lib/vutuv_web/controllers/job_posting_controller.ex
+++ b/lib/vutuv_web/controllers/job_posting_controller.ex
@@ -94,17 +94,31 @@ defmodule VutuvWeb.JobPostingController do
     end
   end
 
+  # The two outbound channels answer with a hand-off page rather than a 302:
+  # `form-action 'self'` covers a submission's redirects, and this page cannot
+  # widen the header for its own destination because the button sits in a
+  # LiveView the visitor may have reached by live navigation (issue #1569).
   defp do_apply(conn, %{apply_kind: :url, apply_url: url} = posting, _viewer)
        when is_binary(url) do
     Jobs.increment_apply_click(posting)
-    redirect(conn, external: url)
+
+    ControllerHelpers.hand_off(
+      conn,
+      url,
+      gettext("The employer takes applications on their own website.")
+    )
   end
 
   defp do_apply(conn, %{apply_kind: :email, apply_email: email} = posting, _viewer)
        when is_binary(email) do
     Jobs.increment_apply_click(posting)
     subject = URI.encode_www_form(gettext("Application: %{title}", title: posting.title))
-    redirect(conn, external: "mailto:#{email}?subject=#{subject}")
+
+    ControllerHelpers.hand_off(
+      conn,
+      "mailto:#{email}?subject=#{subject}",
+      gettext("Your e-mail program opens with the subject filled in.")
+    )
   end
 
   defp do_apply(conn, %{apply_kind: :message}, nil) do

--- a/lib/vutuv_web/controllers/remote_follow_controller.ex
+++ b/lib/vutuv_web/controllers/remote_follow_controller.ex
@@ -89,7 +89,15 @@ defmodule VutuvWeb.RemoteFollowController do
     else
       case RemoteFollow.subscribe_url(address, Docs.acct(subject)) do
         {:ok, url} ->
-          redirect(conn, external: url)
+          # A hand-off page, not a 302: `form-action 'self'` covers a
+          # submission's redirects, and the destination here is only known
+          # once the visitor's address has been resolved, so the header the
+          # consent screen widens cannot be written in advance (issue #1569).
+          ControllerHelpers.hand_off(
+            conn,
+            url,
+            gettext("Confirm the follow on your own server.")
+          )
 
         {:error, reason} ->
           conn

--- a/lib/vutuv_web/plugs/content_security_policy.ex
+++ b/lib/vutuv_web/plugs/content_security_policy.ex
@@ -39,6 +39,14 @@ defmodule VutuvWeb.Plug.ContentSecurityPolicy do
   app's registered `redirect_uris`, so this names a destination the server was
   going to redirect to anyway — never anything read straight off the query
   string.
+
+  That makes widening the exception rather than the pattern: it works here only
+  because the destination is registered and known while the page renders. The
+  other two submissions bound for another site cannot say that, so they leave
+  the header alone and answer with a page, letting an ordinary navigation make
+  the hop (`VutuvWeb.OutboundHTML`, issue #1569). Prefer that shape for
+  anything new; reach for `allow_form_action/2` only when the destination is
+  pinned in advance.
   """
 
   @behaviour Plug

--- a/lib/vutuv_web/templates/layout/root.html.heex
+++ b/lib/vutuv_web/templates/layout/root.html.heex
@@ -8,6 +8,15 @@
     <% end %>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <%!-- The hand-off page takes itself onward (VutuvWeb.OutboundHTML): a form
+    submission bound for another site has to end at a 200 here, because
+    `form-action 'self'` is enforced on a submission's redirects too. Set for
+    http(s) destinations only, and by that one response. --%>
+    <meta
+      :if={assigns[:meta_refresh]}
+      http-equiv="refresh"
+      content={"0;url=" <> assigns[:meta_refresh]}
+    />
     <%!-- live_title so client-side page_title updates (live navigation, tab
     patches) keep the suffix; no suffix on the bare site name. --%>
     <.live_title default="vutuv" suffix={page_title(assigns) && " - vutuv"}>{page_title(assigns)}</.live_title>

--- a/lib/vutuv_web/templates/outbound/hand_off.html.heex
+++ b/lib/vutuv_web/templates/outbound/hand_off.html.heex
@@ -1,0 +1,10 @@
+<%!-- The hand-off page (VutuvWeb.ControllerHelpers.hand_off/3). An http(s)
+destination is taken by the layout's meta refresh before this paints, so what
+is written here is for the case where it *is* read — a mailto, or a refresh
+that did not fire: the destination is named and the button is the whole point
+of the page. See VutuvWeb.OutboundHTML for why this is not a 302. --%>
+<.card class="mx-auto max-w-md text-center">
+  <h1 class="text-xl font-bold text-slate-900 dark:text-white">{@copy.title}</h1>
+  <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">{@note}</p>
+  <.button href={@url} rel="noopener" class="mt-6">{@copy.label}</.button>
+</.card>

--- a/lib/vutuv_web/views/outbound_html.ex
+++ b/lib/vutuv_web/views/outbound_html.ex
@@ -1,0 +1,86 @@
+defmodule VutuvWeb.OutboundHTML do
+  @moduledoc """
+  The hand-off page (issue #1569): the one response shape a form submission
+  uses when its real destination is another site.
+
+  `form-action 'self'` is checked against **every hop of a submission,
+  redirects included**, so answering such a POST with `redirect(conn,
+  external: …)` is refused by Chrome and WebKit. The refusal is invisible from
+  here — the POST arrives, we answer 302, the browser drops it — and the
+  console names *our own* URL as the blocked one, so it reads like a bug in a
+  page that has nothing to do with the destination. See
+  `VutuvWeb.Plug.ContentSecurityPolicy` for the directive itself.
+
+  The consent screen widens the directive instead, because its destination is
+  registered and known while the page renders. Neither caller here can do
+  that: `VutuvWeb.RemoteFollowController` resolves its destination from an
+  address the visitor types, and the job page's apply button lives in a
+  LiveView the visitor may have reached by live navigation, so the document
+  holding the form is not the one that would have carried the header.
+
+  So the submission **ends here**, at a 200. `form-action` is satisfied by the
+  same-origin POST, and the hop that actually leaves vutuv is an ordinary
+  navigation, which the directive does not govern — both halves measured in
+  Chrome against a bare `form-action 'self'`.
+
+  An `http(s)` destination is taken automatically: `hand_off/3` sets
+  `:meta_refresh` and the layout's head emits `<meta http-equiv="refresh">`,
+  so the page flashes past unseen and the flow is the one click it always was.
+  Every other scheme waits for the button, because a browser hands a URL to an
+  external program on a user gesture rather than on a page's say-so — which is
+  the job board's `mailto:`, and reading the address before writing to it is
+  no loss.
+
+  Both callers' destinations are scheme-checked where they are produced
+  (`Vutuv.Fediverse.RemoteFollow`'s subscribe template must be `https`,
+  `apply_url` passes `ChangesetHelpers.validate_url/2`), so nothing exotic
+  reaches the `href`; `Phoenix.Component.link/1`'s own check is the backstop,
+  and it fails loudly rather than rendering.
+  """
+  use VutuvWeb, :html
+
+  embed_templates("../templates/outbound/*")
+
+  @doc """
+  Everything this page says about `url`, decided once: the heading, the button
+  label, and the URL the layout may forward to on its own (`nil` when it may
+  not).
+
+  One function rather than three, because all three answers turn on the same
+  question — what kind of destination is this — and three separate parses can
+  disagree about it. The heading names the destination before the visitor gets
+  there: the host for a website, the address itself for a mail.
+  """
+  def hand_off_copy(url) when is_binary(url) do
+    case URI.parse(url) do
+      # `mailto:jobs@example.com?subject=…` parses with the address as the path
+      # and the subject as the query, so the address is read off `path` alone.
+      %URI{scheme: "mailto", path: address} when is_binary(address) ->
+        %{
+          title: gettext("E-mail to %{address}", address: address),
+          label: gettext("Write e-mail"),
+          auto_forward: nil
+        }
+
+      %URI{scheme: scheme, host: host} when scheme in ["http", "https"] and is_binary(host) ->
+        %{
+          title: gettext("Continue to %{server}", server: host),
+          label: gettext("Continue"),
+          auto_forward: url
+        }
+
+      # Neither caller can produce this — the subscribe template is https and
+      # `apply_url` passes `ChangesetHelpers.validate_url/2` — so it is here
+      # only so an unexpected destination renders a page rather than raising on
+      # a missing clause. Forwarding to one we cannot name is a different
+      # matter, hence no `auto_forward`; refusing a dangerous `href` stays
+      # `Phoenix.Component.link/1`'s job.
+      _unnameable ->
+        %{
+          title: gettext("Continue to %{server}", server: url),
+          label: gettext("Continue"),
+          auto_forward: nil
+        }
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.323.0",
+      version: "7.324.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -741,7 +741,7 @@ msgstr "Code & Repositorys"
 
 #: lib/vutuv_web/controllers/block_controller.ex:34
 #: lib/vutuv_web/controllers/follow_controller.ex:24
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:166
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:174
 #: lib/vutuv_web/controllers/user_save_controller.ex:45
 #: lib/vutuv_web/live/user_profile_live.ex:159
 #, elixir-autogen
@@ -12700,7 +12700,7 @@ msgstr "Bewerbungs-URL"
 msgid "Application e-mail"
 msgstr "Bewerbungs-E-Mail"
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:106
+#: lib/vutuv_web/controllers/job_posting_controller.ex:115
 #, elixir-autogen, elixir-format
 msgid "Application: %{title}"
 msgstr "Bewerbung: %{title}"
@@ -12817,7 +12817,7 @@ msgstr "So bewerben Sie sich"
 msgid "Hybrid"
 msgstr "Hybrid"
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:120
+#: lib/vutuv_web/controllers/job_posting_controller.ex:134
 #, elixir-autogen, elixir-format
 msgid "I'm interested in your posting: %{url}"
 msgstr "Ich interessiere mich für Ihre Anzeige: %{url}"
@@ -12962,7 +12962,7 @@ msgstr "Bitte bestätigen Sie zuerst Ihre E-Mail-Adresse."
 msgid "Please confirm your email address before posting a job."
 msgstr "Bitte bestätigen Sie Ihre E-Mail-Adresse, bevor Sie eine Stelle ausschreiben."
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:112
+#: lib/vutuv_web/controllers/job_posting_controller.ex:126
 #, elixir-autogen, elixir-format
 msgid "Please log in to message the poster."
 msgstr "Bitte melden Sie sich an, um die Anbieter:in anzuschreiben."
@@ -15724,27 +15724,27 @@ msgstr "@name@example.social"
 msgid "Your address is used once, to send you to your own server's follow dialog. It is never stored here."
 msgstr "Ihre Adresse wird einmal verwendet, um Sie zum Folgen-Dialog Ihres eigenen Servers zu schicken. Gespeichert wird sie hier nicht."
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:197
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:205
 #, elixir-autogen, elixir-format
 msgid "This profile is not on the Fediverse."
 msgstr "Dieses Profil ist nicht im Fediverse."
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:213
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:221
 #, elixir-autogen, elixir-format
 msgid "That is not a Fediverse address. It looks like @you@example.social."
 msgstr "Das ist keine Fediverse-Adresse. Eine sieht so aus: @name@example.social."
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:217
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:225
 #, elixir-autogen, elixir-format
 msgid "%{server} did not offer a follow dialog. Copy the handle above and paste it into your app's search instead."
 msgstr "%{server} bietet keinen Folgen-Dialog an. Kopieren Sie stattdessen die Adresse oben und fügen Sie sie in die Suche Ihrer App ein."
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:224
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:232
 #, elixir-autogen, elixir-format
 msgid "%{server} did not answer. Copy the handle above and paste it into your app's search instead."
 msgstr "%{server} hat nicht geantwortet. Kopieren Sie stattdessen die Adresse oben und fügen Sie sie in die Suche Ihrer App ein."
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:235
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:243
 #, elixir-autogen, elixir-format
 msgid "Your server"
 msgstr "Ihr Server"
@@ -18475,7 +18475,7 @@ msgstr "@%{handle} ist auf diesem vutuv. Sie folgen dem Mitglied jetzt direkt hi
 msgid "That address is on this vutuv, but it names no member here."
 msgstr "Diese Adresse gehört zu diesem vutuv, aber es gibt hier kein Mitglied mit diesem Namen."
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:208
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:216
 #, elixir-autogen, elixir-format
 msgid "That address is on this vutuv. Sign in and use the Follow button on this profile."
 msgstr "Diese Adresse gehört zu diesem vutuv. Melden Sie sich an, dann können Sie diesem Mitglied direkt hier folgen."
@@ -18485,17 +18485,17 @@ msgstr "Diese Adresse gehört zu diesem vutuv. Melden Sie sich an, dann können 
 msgid "That is your own address. You cannot follow yourself."
 msgstr "Das ist Ihre eigene Adresse. Sie können sich nicht selbst folgen."
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:150
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:158
 #, elixir-autogen, elixir-format
 msgid "That is your own profile. You cannot follow yourself."
 msgstr "Das ist Ihr eigenes Profil. Sie können sich nicht selbst folgen."
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:161
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:169
 #, elixir-autogen, elixir-format
 msgid "You already follow @%{handle} here."
 msgstr "Sie folgen @%{handle} hier bereits."
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:143
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:151
 #, elixir-autogen, elixir-format
 msgid "You are on this vutuv yourself, so you now follow @%{handle} right here."
 msgstr "Sie sind selbst auf diesem vutuv. Sie folgen @%{handle} jetzt direkt hier."
@@ -20977,13 +20977,13 @@ msgstr "Neue Nachricht von %{sender} auf vutuv"
 msgid "This page cannot receive messages."
 msgstr "Diese Organisation kann keine Nachrichten empfangen."
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:200
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:204
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:208
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:212
 #, elixir-autogen, elixir-format
 msgid "That address is on this vutuv. Sign in and use the Follow button on this page."
 msgstr "Diese Adresse gehört zu diesem vutuv. Melden Sie sich an, dann können Sie dieser Seite direkt hier folgen."
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:195
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:203
 #, elixir-autogen, elixir-format
 msgid "This page is not on the Fediverse."
 msgstr "Diese Seite ist nicht im Fediverse."
@@ -21147,17 +21147,17 @@ msgstr[1] "Ihre Registrierung wurde nicht bestätigt, deshalb löschen wir sie a
 msgid "#%{tag} is a topic on this vutuv, so you now follow the tag here."
 msgstr "#%{tag} ist ein Thema auf diesem vutuv. Sie folgen dem Tag jetzt hier."
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:192
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:200
 #, elixir-autogen, elixir-format
 msgid "This topic is not on the Fediverse."
 msgstr "Dieses Thema ist nicht im Fediverse."
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:154
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:162
 #, elixir-autogen, elixir-format
 msgid "You already follow #%{tag} here."
 msgstr "Sie folgen #%{tag} hier bereits."
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:133
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:141
 #, elixir-autogen, elixir-format
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr "Sie sind selbst auf diesem vutuv. Sie folgen #%{tag} jetzt direkt hier."
@@ -22224,3 +22224,38 @@ msgstr "unbekanntes Gerät"
 #, elixir-autogen, elixir-format
 msgid "Connected on"
 msgstr "Verbunden am"
+
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:99
+#, elixir-autogen, elixir-format
+msgid "Confirm the follow on your own server."
+msgstr "Bestätigen Sie das Folgen auf Ihrem eigenen Server."
+
+#: lib/vutuv_web/views/outbound_html.ex:71
+#, elixir-autogen, elixir-format
+msgid "Continue"
+msgstr "Weiter"
+
+#: lib/vutuv_web/views/outbound_html.ex:63
+#, elixir-autogen, elixir-format
+msgid "Continue to %{server}"
+msgstr "Weiter zu %{server}"
+
+#: lib/vutuv_web/views/outbound_html.ex:62
+#, elixir-autogen, elixir-format
+msgid "E-mail to %{address}"
+msgstr "E-Mail an %{address}"
+
+#: lib/vutuv_web/controllers/job_posting_controller.ex:108
+#, elixir-autogen, elixir-format
+msgid "The employer takes applications on their own website."
+msgstr "Das Unternehmen nimmt Bewerbungen auf der eigenen Webseite entgegen."
+
+#: lib/vutuv_web/views/outbound_html.ex:70
+#, elixir-autogen, elixir-format
+msgid "Write e-mail"
+msgstr "E-Mail schreiben"
+
+#: lib/vutuv_web/controllers/job_posting_controller.ex:120
+#, elixir-autogen, elixir-format
+msgid "Your e-mail program opens with the subject filled in."
+msgstr "Ihr E-Mail-Programm öffnet sich mit ausgefülltem Betreff."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -739,7 +739,7 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/block_controller.ex:34
 #: lib/vutuv_web/controllers/follow_controller.ex:24
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:166
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:174
 #: lib/vutuv_web/controllers/user_save_controller.ex:45
 #: lib/vutuv_web/live/user_profile_live.ex:159
 #, elixir-autogen
@@ -12048,7 +12048,7 @@ msgstr ""
 msgid "Application e-mail"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:106
+#: lib/vutuv_web/controllers/job_posting_controller.ex:115
 #, elixir-autogen, elixir-format
 msgid "Application: %{title}"
 msgstr ""
@@ -12165,7 +12165,7 @@ msgstr ""
 msgid "Hybrid"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:120
+#: lib/vutuv_web/controllers/job_posting_controller.ex:134
 #, elixir-autogen, elixir-format
 msgid "I'm interested in your posting: %{url}"
 msgstr ""
@@ -12310,7 +12310,7 @@ msgstr ""
 msgid "Please confirm your email address before posting a job."
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:112
+#: lib/vutuv_web/controllers/job_posting_controller.ex:126
 #, elixir-autogen, elixir-format
 msgid "Please log in to message the poster."
 msgstr ""
@@ -15027,27 +15027,27 @@ msgstr ""
 msgid "Your address is used once, to send you to your own server's follow dialog. It is never stored here."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:197
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:205
 #, elixir-autogen, elixir-format
 msgid "This profile is not on the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:213
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:221
 #, elixir-autogen, elixir-format
 msgid "That is not a Fediverse address. It looks like @you@example.social."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:217
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:225
 #, elixir-autogen, elixir-format
 msgid "%{server} did not offer a follow dialog. Copy the handle above and paste it into your app's search instead."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:224
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:232
 #, elixir-autogen, elixir-format
 msgid "%{server} did not answer. Copy the handle above and paste it into your app's search instead."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:235
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:243
 #, elixir-autogen, elixir-format
 msgid "Your server"
 msgstr ""
@@ -17732,7 +17732,7 @@ msgstr ""
 msgid "That address is on this vutuv, but it names no member here."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:208
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:216
 #, elixir-autogen, elixir-format
 msgid "That address is on this vutuv. Sign in and use the Follow button on this profile."
 msgstr ""
@@ -17742,17 +17742,17 @@ msgstr ""
 msgid "That is your own address. You cannot follow yourself."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:150
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:158
 #, elixir-autogen, elixir-format
 msgid "That is your own profile. You cannot follow yourself."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:161
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:169
 #, elixir-autogen, elixir-format
 msgid "You already follow @%{handle} here."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:143
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:151
 #, elixir-autogen, elixir-format
 msgid "You are on this vutuv yourself, so you now follow @%{handle} right here."
 msgstr ""
@@ -20211,13 +20211,13 @@ msgstr ""
 msgid "This page cannot receive messages."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:200
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:204
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:208
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:212
 #, elixir-autogen, elixir-format
 msgid "That address is on this vutuv. Sign in and use the Follow button on this page."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:195
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:203
 #, elixir-autogen, elixir-format
 msgid "This page is not on the Fediverse."
 msgstr ""
@@ -20381,17 +20381,17 @@ msgstr[1] ""
 msgid "#%{tag} is a topic on this vutuv, so you now follow the tag here."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:192
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:200
 #, elixir-autogen, elixir-format
 msgid "This topic is not on the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:154
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:162
 #, elixir-autogen, elixir-format
 msgid "You already follow #%{tag} here."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:133
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:141
 #, elixir-autogen, elixir-format
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr ""
@@ -21433,4 +21433,39 @@ msgstr ""
 #: lib/vutuv_web/templates/connected_app/index.html.heex:28
 #, elixir-autogen, elixir-format
 msgid "Connected on"
+msgstr ""
+
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:99
+#, elixir-autogen, elixir-format
+msgid "Confirm the follow on your own server."
+msgstr ""
+
+#: lib/vutuv_web/views/outbound_html.ex:71
+#, elixir-autogen, elixir-format
+msgid "Continue"
+msgstr ""
+
+#: lib/vutuv_web/views/outbound_html.ex:63
+#, elixir-autogen, elixir-format
+msgid "Continue to %{server}"
+msgstr ""
+
+#: lib/vutuv_web/views/outbound_html.ex:62
+#, elixir-autogen, elixir-format
+msgid "E-mail to %{address}"
+msgstr ""
+
+#: lib/vutuv_web/controllers/job_posting_controller.ex:108
+#, elixir-autogen, elixir-format
+msgid "The employer takes applications on their own website."
+msgstr ""
+
+#: lib/vutuv_web/views/outbound_html.ex:70
+#, elixir-autogen, elixir-format
+msgid "Write e-mail"
+msgstr ""
+
+#: lib/vutuv_web/controllers/job_posting_controller.ex:120
+#, elixir-autogen, elixir-format
+msgid "Your e-mail program opens with the subject filled in."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -737,7 +737,7 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/block_controller.ex:34
 #: lib/vutuv_web/controllers/follow_controller.ex:24
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:166
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:174
 #: lib/vutuv_web/controllers/user_save_controller.ex:45
 #: lib/vutuv_web/live/user_profile_live.ex:159
 #, elixir-autogen
@@ -12046,7 +12046,7 @@ msgstr ""
 msgid "Application e-mail"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:106
+#: lib/vutuv_web/controllers/job_posting_controller.ex:115
 #, elixir-autogen, elixir-format
 msgid "Application: %{title}"
 msgstr ""
@@ -12163,7 +12163,7 @@ msgstr ""
 msgid "Hybrid"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:120
+#: lib/vutuv_web/controllers/job_posting_controller.ex:134
 #, elixir-autogen, elixir-format
 msgid "I'm interested in your posting: %{url}"
 msgstr ""
@@ -12308,7 +12308,7 @@ msgstr ""
 msgid "Please confirm your email address before posting a job."
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:112
+#: lib/vutuv_web/controllers/job_posting_controller.ex:126
 #, elixir-autogen, elixir-format
 msgid "Please log in to message the poster."
 msgstr ""
@@ -15025,27 +15025,27 @@ msgstr ""
 msgid "Your address is used once, to send you to your own server's follow dialog. It is never stored here."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:197
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:205
 #, elixir-autogen, elixir-format
 msgid "This profile is not on the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:213
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:221
 #, elixir-autogen, elixir-format
 msgid "That is not a Fediverse address. It looks like @you@example.social."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:217
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:225
 #, elixir-autogen, elixir-format
 msgid "%{server} did not offer a follow dialog. Copy the handle above and paste it into your app's search instead."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:224
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:232
 #, elixir-autogen, elixir-format
 msgid "%{server} did not answer. Copy the handle above and paste it into your app's search instead."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:235
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:243
 #, elixir-autogen, elixir-format
 msgid "Your server"
 msgstr ""
@@ -17730,7 +17730,7 @@ msgstr ""
 msgid "That address is on this vutuv, but it names no member here."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:208
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:216
 #, elixir-autogen, elixir-format
 msgid "That address is on this vutuv. Sign in and use the Follow button on this profile."
 msgstr ""
@@ -17740,17 +17740,17 @@ msgstr ""
 msgid "That is your own address. You cannot follow yourself."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:150
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:158
 #, elixir-autogen, elixir-format
 msgid "That is your own profile. You cannot follow yourself."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:161
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:169
 #, elixir-autogen, elixir-format
 msgid "You already follow @%{handle} here."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:143
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:151
 #, elixir-autogen, elixir-format
 msgid "You are on this vutuv yourself, so you now follow @%{handle} right here."
 msgstr ""
@@ -20209,13 +20209,13 @@ msgstr ""
 msgid "This page cannot receive messages."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:200
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:204
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:208
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:212
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That address is on this vutuv. Sign in and use the Follow button on this page."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:195
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:203
 #, elixir-autogen, elixir-format, fuzzy
 msgid "This page is not on the Fediverse."
 msgstr ""
@@ -20379,17 +20379,17 @@ msgstr[1] ""
 msgid "#%{tag} is a topic on this vutuv, so you now follow the tag here."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:192
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:200
 #, elixir-autogen, elixir-format, fuzzy
 msgid "This topic is not on the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:154
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:162
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You already follow #%{tag} here."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:133
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:141
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr ""
@@ -21431,4 +21431,39 @@ msgstr ""
 #: lib/vutuv_web/templates/connected_app/index.html.heex:28
 #, elixir-autogen, elixir-format
 msgid "Connected on"
+msgstr ""
+
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:99
+#, elixir-autogen, elixir-format
+msgid "Confirm the follow on your own server."
+msgstr ""
+
+#: lib/vutuv_web/views/outbound_html.ex:71
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Continue"
+msgstr ""
+
+#: lib/vutuv_web/views/outbound_html.ex:63
+#, elixir-autogen, elixir-format
+msgid "Continue to %{server}"
+msgstr ""
+
+#: lib/vutuv_web/views/outbound_html.ex:62
+#, elixir-autogen, elixir-format, fuzzy
+msgid "E-mail to %{address}"
+msgstr ""
+
+#: lib/vutuv_web/controllers/job_posting_controller.ex:108
+#, elixir-autogen, elixir-format
+msgid "The employer takes applications on their own website."
+msgstr ""
+
+#: lib/vutuv_web/views/outbound_html.ex:70
+#, elixir-autogen, elixir-format
+msgid "Write e-mail"
+msgstr ""
+
+#: lib/vutuv_web/controllers/job_posting_controller.ex:120
+#, elixir-autogen, elixir-format
+msgid "Your e-mail program opens with the subject filled in."
 msgstr ""

--- a/test/support/fediverse_helpers.ex
+++ b/test/support/fediverse_helpers.ex
@@ -1,0 +1,51 @@
+defmodule Vutuv.FediverseHelpers do
+  @moduledoc """
+  The HTTP stub every "follow from your own server" test needs: a fake remote
+  server answering the one WebFinger lookup `Vutuv.Fediverse.RemoteFollow`
+  makes before it can hand a visitor to their own follow dialog.
+
+  It lives here because three test files drive that lookup — the profile card,
+  the page card and the hand-off shape (issue #1569) — and the stub is not
+  free-form: `RemoteFollow` reads the `#subscribe` rel and demands an `https`
+  template carrying `{uri}`, and Req's decode step branches on the
+  content-type, so a stub that answers without `application/jrd+json` hands the
+  client a binary where the real server's answer arrives decoded. Pinning that
+  contract in one place is the point; a copy per file is a copy that drifts.
+
+  A test module using this **must be `async: false`** — the stub is a global
+  `Application.put_env/3`, so it is visible to everything running beside it.
+  """
+
+  import ExUnit.Callbacks, only: [on_exit: 1]
+
+  @doc """
+  Serves `fun` as the whole Fediverse HTTP client for one test, and takes the
+  stub back down afterwards.
+  """
+  def stub_remote(fun) do
+    Application.put_env(:vutuv, :fediverse_req_options, plug: fun)
+    on_exit(fn -> Application.delete_env(:vutuv, :fediverse_req_options) end)
+  end
+
+  @doc """
+  The happy path: a remote server that publishes a remote-follow dialog at
+  `https://social.example/authorize_interaction?uri={uri}`.
+  """
+  def serve_subscribe_template do
+    stub_remote(fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/jrd+json")
+      |> Plug.Conn.send_resp(
+        200,
+        Jason.encode!(%{
+          "links" => [
+            %{
+              "rel" => "http://ostatus.org/spec/1.0#subscribe",
+              "template" => "https://social.example/authorize_interaction?uri={uri}"
+            }
+          ]
+        })
+      )
+    end)
+  end
+end

--- a/test/vutuv_web/controllers/outbound_hand_off_test.exs
+++ b/test/vutuv_web/controllers/outbound_hand_off_test.exs
@@ -1,0 +1,98 @@
+defmodule VutuvWeb.OutboundHandOffTest do
+  @moduledoc """
+  The two form submissions whose destination is another site (issue #1569):
+  "follow us from your own server" and the job board's easy apply.
+
+  `form-action 'self'` is checked against every hop of a submission, redirects
+  included, so answering either POST with a 302 to the outside is dropped by
+  Chrome and WebKit — silently, which is why the button read as dead. The fix
+  is a shape, not a header: the submission ends at a 200 here and the hop that
+  leaves vutuv is an ordinary navigation. **These tests are calibrated against
+  the un-fixed code**: every one of them goes red on a `redirect(external:)`.
+
+  Only the two outbound channels moved. That the same-origin ones did *not* is
+  covered where they already were — the apply-by-conversation redirect in
+  `VutuvWeb.JobPostingTest`, the refusal flashes in
+  `VutuvWeb.UserProfileFediverseTest`.
+
+  Not async — the HTTP stub for the remote WebFinger lookup lives in the
+  application env.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Vutuv.FediverseHelpers
+  import Vutuv.JobsHelpers
+
+  alias Vutuv.Repo
+  alias VutuvWeb.Fediverse.Docs
+
+  describe "follow from your own server" do
+    test "ends the submission here and links on to the dialog", %{conn: conn} do
+      user = insert_activated_user(fediverse_followers?: true)
+      serve_subscribe_template()
+
+      conn = post(conn, ~p"/#{user}/fediverse/follow", %{"address" => "@them@social.example"})
+
+      dialog =
+        "https://social.example/authorize_interaction?uri=" <>
+          URI.encode_www_form("acct:" <> Docs.acct(user))
+
+      # 200, not 302: the hop the browser refused is gone...
+      body = html_response(conn, 200)
+      assert body =~ ~s|href="#{dialog}"|
+      # ...and it is taken without a click, so the page is never seen.
+      assert body =~ ~s|content="0;url=#{dialog}"|
+    end
+
+    test "German visitors read the server's name in the heading", %{conn: conn} do
+      user = insert_activated_user(fediverse_followers?: true)
+      serve_subscribe_template()
+
+      conn =
+        conn
+        |> put_req_header("accept-language", "de-DE,de")
+        |> post(~p"/#{user}/fediverse/follow", %{"address" => "@them@social.example"})
+
+      body = html_response(conn, 200)
+      assert body =~ "Weiter zu social.example"
+      assert body =~ "Bestätigen Sie das Folgen auf Ihrem eigenen Server."
+    end
+  end
+
+  describe "easy apply" do
+    test "an employer's website is linked and taken automatically", %{conn: conn} do
+      posting =
+        publish_job!(nil, %{"apply_kind" => "url", "apply_url" => "https://acme.example/jobs"})
+
+      conn = post(conn, ~p"/jobs/#{posting.slug}/apply")
+
+      body = html_response(conn, 200)
+      assert body =~ ~s|href="https://acme.example/jobs"|
+      assert body =~ ~s|content="0;url=https://acme.example/jobs"|
+      assert Repo.reload!(posting).apply_click_count == 1
+
+      # Nobody reads a page the browser replaces in the same frame, so it does
+      # not pay for the shell — but it must keep the head the refresh lives in.
+      refute body =~ ~s|id="app-shell"|
+    end
+
+    test "a mailto waits for the click", %{conn: conn} do
+      posting =
+        publish_job!(nil, %{"apply_kind" => "email", "apply_email" => "jobs@acme.example"})
+
+      conn = post(conn, ~p"/jobs/#{posting.slug}/apply")
+
+      body = html_response(conn, 200)
+      assert body =~ ~s|href="mailto:jobs@acme.example?subject=|
+      assert body =~ "jobs@acme.example"
+
+      # A browser hands a URL to an external program on a user gesture, not on
+      # a page's say-so, so this one is a button and not a self-forward.
+      refute body =~ ~s|http-equiv="refresh"|
+      assert Repo.reload!(posting).apply_click_count == 1
+
+      # This one IS read, so it gets the chrome — a bare dead end is worse.
+      assert body =~ ~s|id="app-shell"|
+    end
+  end
+end

--- a/test/vutuv_web/live/user_profile_fediverse_test.exs
+++ b/test/vutuv_web/live/user_profile_fediverse_test.exs
@@ -9,6 +9,7 @@ defmodule VutuvWeb.UserProfileFediverseTest do
 
   import Phoenix.LiveViewTest
   import Vutuv.EndpointHostHelper
+  import Vutuv.FediverseHelpers
 
   alias Vutuv.Social
   alias VutuvWeb.Fediverse.Docs
@@ -25,29 +26,6 @@ defmodule VutuvWeb.UserProfileFediverseTest do
   defp position(html, id) do
     {at, _len} = :binary.match(html, ~s|id="#{id}"|)
     at
-  end
-
-  defp stub_remote(fun) do
-    Application.put_env(:vutuv, :fediverse_req_options, plug: fun)
-    on_exit(fn -> Application.delete_env(:vutuv, :fediverse_req_options) end)
-  end
-
-  defp serve_subscribe_template do
-    stub_remote(fn conn ->
-      conn
-      |> Plug.Conn.put_resp_content_type("application/jrd+json")
-      |> Plug.Conn.send_resp(
-        200,
-        Jason.encode!(%{
-          "links" => [
-            %{
-              "rel" => "http://ostatus.org/spec/1.0#subscribe",
-              "template" => "https://social.example/authorize_interaction?uri={uri}"
-            }
-          ]
-        })
-      )
-    end)
   end
 
   describe "the card" do
@@ -175,7 +153,9 @@ defmodule VutuvWeb.UserProfileFediverseTest do
 
       conn = post(conn, ~p"/#{user}/fediverse/follow", %{"address" => "@them@social.example"})
 
-      assert redirected_to(conn) ==
+      # A hand-off page rather than a 302, because `form-action 'self'` covers
+      # a submission's redirects (issue #1569) — see OutboundHandOffTest.
+      assert html_response(conn, 200) =~
                "https://social.example/authorize_interaction?uri=" <>
                  URI.encode_www_form("acct:" <> Docs.acct(user))
     end
@@ -195,7 +175,7 @@ defmodule VutuvWeb.UserProfileFediverseTest do
           "address" => "@them@social.example"
         })
 
-      assert redirected_to(conn) =~ "https://social.example/authorize_interaction"
+      assert html_response(conn, 200) =~ "https://social.example/authorize_interaction"
     end
 
     test "explains a typo instead of guessing", %{conn: conn} do

--- a/test/vutuv_web/organization_fediverse_card_test.exs
+++ b/test/vutuv_web/organization_fediverse_card_test.exs
@@ -19,6 +19,7 @@ defmodule VutuvWeb.OrganizationFediverseCardTest do
 
   import Phoenix.LiveViewTest
   import Vutuv.EndpointHostHelper
+  import Vutuv.FediverseHelpers
   import Vutuv.OrganizationsHelpers
 
   alias Vutuv.Repo
@@ -46,29 +47,6 @@ defmodule VutuvWeb.OrganizationFediverseCardTest do
     active_organization_for(insert(:activated_user))
     |> Ecto.Changeset.change(Map.merge(%{fediverse_followers?: true, username: "acme"}, attrs))
     |> Repo.update!()
-  end
-
-  defp stub_remote(fun) do
-    Application.put_env(:vutuv, :fediverse_req_options, plug: fun)
-    on_exit(fn -> Application.delete_env(:vutuv, :fediverse_req_options) end)
-  end
-
-  defp serve_subscribe_template do
-    stub_remote(fn conn ->
-      conn
-      |> Plug.Conn.put_resp_content_type("application/jrd+json")
-      |> Plug.Conn.send_resp(
-        200,
-        Jason.encode!(%{
-          "links" => [
-            %{
-              "rel" => "http://ostatus.org/spec/1.0#subscribe",
-              "template" => "https://social.example/authorize_interaction?uri={uri}"
-            }
-          ]
-        })
-      )
-    end)
   end
 
   describe "the card" do
@@ -210,7 +188,9 @@ defmodule VutuvWeb.OrganizationFediverseCardTest do
           "address" => "@them@social.example"
         })
 
-      assert redirected_to(conn) ==
+      # A hand-off page rather than a 302, because `form-action 'self'` covers
+      # a submission's redirects (issue #1569) — see OutboundHandOffTest.
+      assert html_response(conn, 200) =~
                "https://social.example/authorize_interaction?uri=" <>
                  URI.encode_www_form("acct:" <> Docs.acct(page))
     end
@@ -230,7 +210,7 @@ defmodule VutuvWeb.OrganizationFediverseCardTest do
           "address" => "@them@social.example"
         })
 
-      assert redirected_to(conn) =~ "https://social.example/authorize_interaction"
+      assert html_response(conn, 200) =~ "https://social.example/authorize_interaction"
     end
 
     test "explains a typo instead of guessing, back on the card", %{conn: conn} do


### PR DESCRIPTION
Behebt #1569.

**Symptom:** „Folgen Sie uns von Ihrem eigenen Server" (Profil, Seite, Tag) und „Auf der Webseite bewerben" / „Per E-Mail bewerben" taten in Chrome nichts. `form-action 'self'` gilt für jeden Sprung einer Formularabsendung, Weiterleitungen eingeschlossen — der POST kam an, wir antworteten 302, der Browser verwarf sie. Kein Fehler, keine Logzeile, und in der Konsole stand unsere eigene URL als blockierte Adresse.

**Geändert:** Beide Absendungen enden jetzt bei einer 200 (`ControllerHelpers.hand_off/3`, `VutuvWeb.OutboundHTML`). Danach ist der Sprung nach außen eine gewöhnliche Navigation, die die Direktive nicht abdeckt. Eine http(s)-Adresse nimmt die Seite selbst per Meta-Refresh, es bleibt also ein Klick; `mailto:` wartet auf den Knopf, weil ein Browser eine Adresse nur auf eine Nutzergeste an ein fremdes Programm übergibt. Der Header-Trick aus #1562 half hier nicht: das Folgen-Ziel tippt der Besucher erst ins Formular.

Gemessen statt vermutet: in Chrome ist die 302 blockiert, Meta-Refresh und Klick kommen an. Der echte Ablauf aus dem Issue landet jetzt auf `mastodon.social/authorize_interaction`.

**Zu entscheiden:** ob die selbst-weiterleitende Seite auch das Root-Layout verlieren soll (ein paar hundert Byte statt 2,8 KB, dafür wäre die Rückfallanzeige ungestylt). Ich habe sie gestylt gelassen.

Die Seite, wie sie aussieht, wenn man sie zu sehen bekommt:

<img src="https://raw.githubusercontent.com/wintermeyer/vutuv/shots/pr-1571/hand-off.jpg" width="440">

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*