### PR TITLE
Eine Diagnose, die niemand lesen kann, ist keine (v7.324.2)

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -11,6 +11,9 @@ config :vutuv, VutuvWeb.Endpoint,
   version: Mix.Project.config()[:version],
   locales: ~w(en de)
 
+# Quiet by default, and `LOG_LEVEL` in config/runtime.exs raises the bar for a
+# boot. Anything an operator must be able to read while chasing a problem is
+# logged at `:error` for that reason (see `VutuvWeb.OauthController`).
 config :logger, level: :error
 
 # The SMTP mailer is configured at boot in config/runtime.exs (SMTP_RELAY,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -348,6 +348,33 @@ if config_env() == :prod do
     config :vutuv, :fediverse_counts_per_host, String.to_integer(String.trim(per_host))
   end
 
+  # How much the release writes to the system log. `config/prod.exs` sets
+  # `:error`, which is quiet enough to run on and too quiet to debug on: every
+  # `Logger.warning` in the app is discarded, and the request logger with it.
+  # An operator chasing a problem raises the bar for a boot (`LOG_LEVEL=info`)
+  # and lowers it again afterwards, rather than editing the source (issue
+  # #1561, where the diagnostic naming a runaway OAuth client was silent).
+  #
+  # An unknown value keeps the compiled default instead of raising: a typo in an
+  # env var must never be the reason a release refuses to boot. The levels are
+  # written out as literal atoms for the same reason — `String.to_existing_atom/1`
+  # raises on anything the atom table has not seen, which is a boot-time gamble
+  # on what a config provider happens to have loaded.
+  log_levels = %{
+    "emergency" => :emergency,
+    "alert" => :alert,
+    "critical" => :critical,
+    "error" => :error,
+    "warning" => :warning,
+    "notice" => :notice,
+    "info" => :info,
+    "debug" => :debug
+  }
+
+  if level = log_levels[String.downcase(String.trim(System.get_env("LOG_LEVEL") || ""))] do
+    config :logger, level: level
+  end
+
   # How long the account-activity log keeps an event (issue #1087). It holds
   # devices, IP addresses and what changed when, so how long that may be kept is
   # the operator's call; one year is what vutuv.de runs.

--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -90,6 +90,7 @@ Everything else has a default (the vutuv.de production value):
 | `PHX_URL_PORT` | `443`/`80` | The public port, if not the scheme default |
 | `PORT` | `4003` | Local port the app listens on (loopback; nginx proxies to it) |
 | `CHECK_ORIGINS` | – | Extra allowed websocket origins, comma-separated (host + `www.` twin are always allowed) |
+| `LOG_LEVEL` | `error` | How much the release writes to the system log. The default is deliberately quiet — only failures, and nothing per request. Set `info` for a boot while you are chasing a problem (that adds the request log: one line per request with path, status and duration), `debug` to see every database query as well, and put it back afterwards: `info` on a busy installation is a lot of disk. Anything the app needs an operator to read stays at `error` either way. An unrecognised value is ignored rather than refused, so a typo cannot stop a boot |
 | `DB_USER` | `vutuv` | PostgreSQL user |
 | `DB_NAME` | `vutuv3_prod` | PostgreSQL database |
 | `DB_HOST` | `127.0.0.1` | PostgreSQL host |

--- a/docs/architecture/api.md
+++ b/docs/architecture/api.md
@@ -96,7 +96,12 @@ the release before this — mints a fresh code exactly as it used to. Underneath
 and the route's per-minute consent budget still refuses a runaway client; that
 refusal now also writes one line a minute naming the client's User-Agent, because
 which client resubmits is the open half of #1561 and the browser's own
-User-Agent reaches nothing but the web server's access log.
+User-Agent reaches nothing but the web server's access log. That line is a
+`Logger.error`, and deliberately so: a release runs at `:error`
+(`config/prod.exs`), so as a `Logger.warning` it was discarded by the only
+installation that had the question, while its test passed against a test env
+that logs from `:warning` down. `LOG_LEVEL` raises the bar for a boot when more
+is wanted, but nothing an operator must read may depend on that.
 
 **Who holds a credential, and who may take it away.** `/connected_apps` names,
 per authorization, when it was given and which devices still hold a live token

--- a/lib/vutuv_web/controllers/oauth_controller.ex
+++ b/lib/vutuv_web/controllers/oauth_controller.ex
@@ -135,12 +135,20 @@ defmodule VutuvWeb.OauthController do
   # One line per member, app and minute, through a bucket of its own: the client
   # this exists to name sent a hundred requests in one, and a hundred identical
   # lines is how a log stops being read.
+  #
+  # `error`, not `warning`, and that is the whole point of the line. Production
+  # runs the logger at `:error` (`config/prod.exs`), so the first version of
+  # this diagnostic was discarded by the one installation that had the question
+  # — while its test passed, because the test env logs from `:warning` down. An
+  # installation can now raise the bar with `LOG_LEVEL`, but a diagnostic must
+  # not depend on somebody having done that beforehand: this is also the level
+  # the member sees, since the same event answers their login with a 429.
   defp log_runaway(conn, user, request) do
     if RateLimit.check(nil, :oauth_consent_report, user.id <> ":" <> request.app.id,
          limit: 1,
          window_ms: @consent_window
        ) == :ok do
-      Logger.warning(
+      Logger.error(
         "oauth: consent budget spent, app=#{request.app.name} " <>
           "user_agent=#{UserAgent.capture(conn) || "(none sent)"}"
       )

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.324.1",
+      version: "7.324.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/controllers/oauth_consent_limit_test.exs
+++ b/test/vutuv_web/controllers/oauth_consent_limit_test.exs
@@ -136,9 +136,16 @@ defmodule VutuvWeb.OauthConsentLimitTest do
   # browser's User-Agent reaches only the web server's access log. A client that
   # spends this budget is a runaway by definition, so it names itself in our own
   # log — the app it registered as, and the string the browser sent.
+  #
+  # Captured at `:error`, which is where the bar sits in production
+  # (`config/prod.exs`), because a diagnostic nobody can read is not a
+  # diagnostic: this line shipped as a `Logger.warning` and was therefore
+  # discarded on the one installation that had the question. The test env logs
+  # from `:warning`, so the old level passed a plain `capture_log` while
+  # answering nothing.
   test "a client that spends the budget names itself in the log", %{conn: conn, app: app} do
     log =
-      ExUnit.CaptureLog.capture_log(fn ->
+      ExUnit.CaptureLog.capture_log([level: :error], fn ->
         for _ <- 1..30 do
           conn
           |> recycle()


### PR DESCRIPTION
**Symptom** Die Zeile, die den durchdrehenden OAuth-Client benennen soll (#1561, v7.321.0), erreicht das Produktionsprotokoll nie: ein Release protokolliert ab `:error` (`config/prod.exs`), die Zeile war ein `Logger.warning`. Ihr Test war grün, weil die Testumgebung ab `:warning` protokolliert.

**Geändert**

- `VutuvWeb.OauthController.log_runaway/3` schreibt `Logger.error`.
- `LOG_LEVEL` in `config/runtime.exs` hebt die Schwelle für einen Start an (`info` bringt das Anfrageprotokoll mit, `debug` jede Abfrage); ein unbekannter Wert bleibt beim kompilierten Vorgabewert, statt den Start abzubrechen. In `docs/ADMINS.md` dokumentiert.
- Der Test fängt jetzt bei `:error` ab und ist ohne die Änderung rot (gemessen).

**Zu entscheiden** Ob auf bremen2 `LOG_LEVEL` gesetzt wird. Nötig ist es nicht — die Zeile kommt jetzt auch bei `error` durch.

Kein sichtbarer Anteil, daher kein Screenshot.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*
