### PR TITLE
Was der laufende Server tut, sagt nicht die Konfigurationsdatei (v7.324.3)

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -348,12 +348,13 @@ if config_env() == :prod do
     config :vutuv, :fediverse_counts_per_host, String.to_integer(String.trim(per_host))
   end
 
-  # How much the release writes to the system log. `config/prod.exs` sets
-  # `:error`, which is quiet enough to run on and too quiet to debug on: every
-  # `Logger.warning` in the app is discarded, and the request logger with it.
-  # An operator chasing a problem raises the bar for a boot (`LOG_LEVEL=info`)
-  # and lowers it again afterwards, rather than editing the source (issue
-  # #1561, where the diagnostic naming a runaway OAuth client was silent).
+  # How much the release writes to the system log. `config/prod.exs` compiles in
+  # `:error`, which is quiet enough to run on and too quiet to debug on: at that
+  # level every `Logger.warning` in the app goes, and the request logger with
+  # it. An operator chasing a problem raises the bar for a boot
+  # (`LOG_LEVEL=info`) and lowers it again afterwards, rather than editing the
+  # source — which is what it took while issue #1561 wanted to know which client
+  # was resubmitting a form.
   #
   # An unknown value keeps the compiled default instead of raising: a typo in an
   # env var must never be the reason a release refuses to boot. The levels are

--- a/docs/architecture/api.md
+++ b/docs/architecture/api.md
@@ -97,11 +97,11 @@ and the route's per-minute consent budget still refuses a runaway client; that
 refusal now also writes one line a minute naming the client's User-Agent, because
 which client resubmits is the open half of #1561 and the browser's own
 User-Agent reaches nothing but the web server's access log. That line is a
-`Logger.error`, and deliberately so: a release runs at `:error`
-(`config/prod.exs`), so as a `Logger.warning` it was discarded by the only
-installation that had the question, while its test passed against a test env
-that logs from `:warning` down. `LOG_LEVEL` raises the bar for a boot when more
-is wanted, but nothing an operator must read may depend on that.
+`Logger.error`, and deliberately so: a release's compiled default is `:error`
+(`config/prod.exs`), so a `Logger.warning` is not guaranteed to be readable
+anywhere — and its test proved nothing while it captured at `:warning`, which is
+where the test env logs. `LOG_LEVEL` raises the bar for a boot when more is
+wanted, but nothing an operator must read may depend on that.
 
 **Who holds a credential, and who may take it away.** `/connected_apps` names,
 per authorization, when it was given and which devices still hold a live token

--- a/lib/vutuv_web/controllers/oauth_controller.ex
+++ b/lib/vutuv_web/controllers/oauth_controller.ex
@@ -136,13 +136,14 @@ defmodule VutuvWeb.OauthController do
   # this exists to name sent a hundred requests in one, and a hundred identical
   # lines is how a log stops being read.
   #
-  # `error`, not `warning`, and that is the whole point of the line. Production
-  # runs the logger at `:error` (`config/prod.exs`), so the first version of
-  # this diagnostic was discarded by the one installation that had the question
-  # — while its test passed, because the test env logs from `:warning` down. An
-  # installation can now raise the bar with `LOG_LEVEL`, but a diagnostic must
-  # not depend on somebody having done that beforehand: this is also the level
-  # the member sees, since the same event answers their login with a 429.
+  # `error`, not `warning`, because a release's compiled default is `:error`
+  # (`config/prod.exs`): a `Logger.warning` is therefore not guaranteed to be
+  # readable on any installation, and this line exists only to be read. Its test
+  # captures at `:error` for the same reason — at `:warning`, which is where the
+  # test env logs, it passed without proving anything. `LOG_LEVEL` lets an
+  # operator raise the bar for a boot, but a diagnostic must not depend on
+  # somebody having done that beforehand. `:error` is also honest about what
+  # happened: the same event answers the member's login with a 429.
   defp log_runaway(conn, user, request) do
     if RateLimit.check(nil, :oauth_consent_report, user.id <> ":" <> request.app.id,
          limit: 1,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.324.2",
+      version: "7.324.3",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/controllers/oauth_consent_limit_test.exs
+++ b/test/vutuv_web/controllers/oauth_consent_limit_test.exs
@@ -137,12 +137,11 @@ defmodule VutuvWeb.OauthConsentLimitTest do
   # spends this budget is a runaway by definition, so it names itself in our own
   # log — the app it registered as, and the string the browser sent.
   #
-  # Captured at `:error`, which is where the bar sits in production
-  # (`config/prod.exs`), because a diagnostic nobody can read is not a
-  # diagnostic: this line shipped as a `Logger.warning` and was therefore
-  # discarded on the one installation that had the question. The test env logs
-  # from `:warning`, so the old level passed a plain `capture_log` while
-  # answering nothing.
+  # Captured at `:error`, the level a release compiles in (`config/prod.exs`),
+  # because a diagnostic that is only readable on a louder installation is not
+  # one. This shipped as a `Logger.warning` and the test said nothing about it:
+  # the test env logs from `:warning`, so a plain `capture_log` was green at a
+  # level no release is obliged to keep.
   test "a client that spends the budget names itself in the log", %{conn: conn, app: app} do
     log =
       ExUnit.CaptureLog.capture_log([level: :error], fn ->


### PR DESCRIPTION
**Symptom** v7.324.2 begründet den Wechsel auf `Logger.error` damit, dass Produktion die Zeile verwerfe. Das war aus `config/prod.exs` geschlossen, nicht gemessen — im Journal des aktiven Slots stehen `[warning]`-Zeilen (`image_scan service_error`, gleiche PID, Stunden auseinander). Der laufende Knoten ist lauter als seine Konfiguration.

**Geändert** Nur Text: Kommentar in `OauthController`, `config/runtime.exs`, `docs/architecture/api.md` und der Testkommentar behaupten nichts mehr über den laufenden Server. Stehen bleibt die belegbare Zusage: kompilierter Vorgabewert ist `:error`, also ist `Logger.warning` nirgends garantiert lesbar. Kein Verhalten geändert, `LOG_LEVEL` und `Logger.error` bleiben.

**Zu entscheiden** Warum der Knoten lauter ist als `config :logger, level: :error`, ist offen. Weder `lib/`, `config/` noch `deps/` enthalten einen Laufzeitpfad, der den Level anhebt. Ich lege das als eigenes Issue ab, wenn Du es sehen willst.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*
