### PR TITLE
Ein Zeugnis nennt die Arbeit, die es ermöglicht hat (v7.325.0)

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -309,6 +309,31 @@ body.stretch main {
 .card p {
   color: #334155;
 }
+/* A detail page's facts as a two-column grid (issue #1109). One label/value
+   pair per row turns a card with six facts into a ladder you have to scroll to
+   read, and it wastes the whole right half of the card. Lives here, not as
+   utilities on one template: `.card__label`'s 1rem gap and the global
+   `p { margin-bottom: 15px }` both have to be cancelled inside the grid, and a
+   page that copies thirteen overrides to opt in is how legacy pages drift.
+   Every entry show page can wear it. Mobile-last, like this file's other
+   responsive rules. */
+.card__facts {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem 2rem;
+  margin-bottom: 1rem;
+}
+.card .card__facts .card__label {
+  margin-bottom: 0.25rem;
+}
+.card .card__facts p {
+  margin-bottom: 0;
+}
+@media (width < 40rem) {
+  .card__facts {
+    grid-template-columns: 1fr;
+  }
+}
 /* Card links inherit the global `a` element color. No `.card a` rule here:
    its (0,1,1) specificity would beat `.button` (0,1,0) and paint anchor
    buttons inside cards brand-on-brand. */

--- a/docs/architecture/profiles.md
+++ b/docs/architecture/profiles.md
@@ -588,12 +588,32 @@ convention `CvSection.order_by_date/1` sorts by) or a slate "Last used: M/YYYY"
 the "not used at all" signal, keeping rows calm. The policy lives in
 `Qualification.job_usage/1`, reading the `work_experiences` preload spliced in
 via `Qualification.citing_jobs_preload/0`; like `cited_qualification/1` it
-falls through to nil on an unloaded association. The entry show page renders
-the same facts as one "Jobs" line (`QualificationHTML.usage_line/1`), and the
-agent formats carry a `jobs: {count, in_use, last_used}` map per entry
+falls through to nil on an unloaded association. The agent formats carry a
+`jobs: {count, in_use, last_used, entries}` map per entry
 (`SectionDocs.qualification_entry/1`; md/txt append "used for N jobs ·
 currently in use" to the facts line), kept honest by the drift test; `/api/2.0`
 qualification entries include the same map.
+
+**The credential's own page names the jobs (issue #1109).** `/:slug/qualifications/<id>`
+does not summarise the count — it lists the roles, `QualificationHTML.citing_jobs/1`
+under a "Jobs" caption carrying the same in-use / last-used pill the list rows
+wear (`usage_status_pill/1`, shared with `qualification_row/1`). Each row links
+the role's own page and, where the employer is a verified organization page, that
+page too (`WorkExperienceHTML.linked_organization/1` decides, so a frozen or
+pending page stays plain text exactly as on the timeline), with the period and —
+for anything but a plain job — the CV category on the meta line. The roles ride
+in on `Qualification.citing_jobs_detail_preload/0`, which is
+`citing_jobs_preload/0` plus each job's `organization_page`: a second preload on
+purpose, since the list badges only count and must not pay for the extra query.
+The `jobs.entries` list in the agent formats is the same roster (title,
+employer, kind, period and the role's absolute URL), so an agent holding the
+credential can follow it to the work it earned; md/txt indent one line per role
+under the credential, the way a code-forge account lists its repositories. The
+page's facts (type, issuer, issued, expires, credential id, verification link)
+sit in a two-column grid from `sm` up rather than one stacked ladder, and an
+expired credential wears the "Expired" pill for **every** viewer here — unlike
+the list rows, where the pill is owner-only because a visitor never sees an
+expired row in the first place.
 
 ## Qualification proof documents (the uploaded Nachweis)
 

--- a/lib/vutuv/profiles/qualification.ex
+++ b/lib/vutuv/profiles/qualification.ex
@@ -295,6 +295,17 @@ defmodule Vutuv.Profiles.Qualification do
   end
 
   @doc """
+  `citing_jobs_preload/0` plus each citing job's verified organization page —
+  what the credential's own page needs to render the jobs it earned (issue
+  #1109). Deliberately a second preload: the list badges only count the jobs,
+  so the profile card and the section list must not pay for the extra query.
+  """
+  def citing_jobs_detail_preload do
+    [work_experiences: query] = citing_jobs_preload()
+    [work_experiences: {query, [:organization_page]}]
+  end
+
+  @doc """
   How the member's jobs use this credential (issue #1005), read from the
   preloaded `work_experiences` (see `citing_jobs_preload/0`): `%{count:,
   current?:, last_end:}`. `current?` is true while any citing job is ongoing —

--- a/lib/vutuv/profiles/work_experience.ex
+++ b/lib/vutuv/profiles/work_experience.ex
@@ -5,6 +5,8 @@ defmodule Vutuv.Profiles.WorkExperience do
   import Vutuv.Organizations.Query, only: [organization_public_row: 1]
   alias Vutuv.ChangesetHelpers
   alias Vutuv.Mentions
+  alias Vutuv.Organizations
+  alias Vutuv.Organizations.Organization
   alias Vutuv.Profiles.CvSection
   alias Vutuv.Profiles.Qualification
 
@@ -161,6 +163,22 @@ defmodule Vutuv.Profiles.WorkExperience do
   """
   def cited_qualification(%{qualification: %Qualification{} = qualification}), do: qualification
   def cited_qualification(_work), do: nil
+
+  @doc """
+  The linked organization page of this job (issue #931), or nil — free-text
+  only, the association not preloaded, or a page that is no longer public
+  (pending, frozen, archived), which renders exactly like an unlinked one.
+
+  Beside `cited_qualification/1` for the same reason: it is a display policy,
+  and every surface that names an employer has to apply the same one — the
+  profile timeline and section page (`WorkExperienceHTML.employer_name/1`), the
+  credential page's list of the jobs it earned, and the agent documents.
+  """
+  def linked_organization(%{organization_page: %Organization{} = organization}) do
+    if Organizations.public_visible?(organization), do: organization
+  end
+
+  def linked_organization(_work), do: nil
 
   @doc """
   Splits an already-ordered list into its CV categories: `{kind, entries}`

--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -766,18 +766,10 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   # The non-default CV categories (issue #840) are called out on the entry
   # line, mirroring the HTML pages' category headings; a plain job stays
   # unmarked, like the page's jobs-only timeline. Shared with the text
-  # renderer. Singular wording (one entry), the same msgids as the form's
-  # category picker.
+  # renderer, and one rule with the HTML rows — `kind_note/1` owns both which
+  # kinds are worth naming and the wording (the form's category picker msgids).
   @doc false
-  def work_kind_note(work) do
-    case Map.get(work, :kind) do
-      "self_employed" -> gettext("Freelance / Self-employed")
-      "internship" -> gettext("Internship")
-      "volunteer" -> gettext("Volunteering & hobbies")
-      "other" -> gettext("Other activities")
-      _employment -> nil
-    end
-  end
+  defdelegate work_kind_note(work), to: VutuvWeb.WorkExperienceHTML, as: :kind_note
 
   # Shares work_period/1 (the education entry carries the same :start / :end
   # keys). Degree + school lead, then the period, then field of study and
@@ -847,12 +839,45 @@ defmodule VutuvWeb.AgentDocs.Markdown do
         do: "- #{md_text(qualification.name)}",
         else: "- #{md_text(qualification.name)}: #{md_text(facts)}"
 
-    base
-    |> append_if(qualification.url, &(&1 <> " <#{md_url(qualification.url)}>"))
-    |> append_if(
-      qualification.document,
-      &(&1 <> " [#{gettext("proof document")}](#{md_url(qualification.document.url)})")
-    )
+    line =
+      base
+      |> append_if(qualification.url, &(&1 <> " <#{md_url(qualification.url)}>"))
+      |> append_if(
+        qualification.document,
+        &(&1 <> " [#{gettext("proof document")}](#{md_url(qualification.document.url)})")
+      )
+
+    # The jobs the credential earned (issue #1109), one indented line each —
+    # the same tight nested list the code-forge accounts use for their repos.
+    Enum.join([line | Enum.map(citing_jobs(qualification), &citing_job_line/1)], "\n")
+  end
+
+  # The credential's citing roles, or [] for an entry that has none (or came
+  # from a surface that did not preload them).
+  @doc false
+  def citing_jobs(qualification) do
+    case Map.get(qualification, :jobs) do
+      %{entries: [_ | _] = entries} -> entries
+      _no_jobs -> []
+    end
+  end
+
+  defp citing_job_line(job) do
+    title = md_text(job.title)
+    linked = if job.url, do: "[#{title}](#{md_url(job.url)})", else: title
+    facts = citing_job_facts(job)
+
+    if facts == "", do: "  - #{linked}", else: "  - #{linked}: #{md_text(facts)}"
+  end
+
+  # One citing role's facts beside its title — the employer, its period and,
+  # for anything but a plain job, the CV category. Shared with the plain-text
+  # renderer so the two read the same.
+  @doc false
+  def citing_job_facts(job) do
+    [job.organization, work_period(job), work_kind_note(job)]
+    |> Enum.filter(& &1)
+    |> Enum.join(" · ")
   end
 
   defp append_if(line, nil, _fun), do: line

--- a/lib/vutuv_web/agent_docs/section_docs.ex
+++ b/lib/vutuv_web/agent_docs/section_docs.ex
@@ -22,7 +22,6 @@ defmodule VutuvWeb.AgentDocs.SectionDocs do
   alias Vutuv.JobReferenceDocument
   alias Vutuv.Languages
   alias Vutuv.Organizations
-  alias Vutuv.Organizations.Organization
   alias Vutuv.Phone
   alias Vutuv.Profiles.Messenger
   alias Vutuv.Profiles.Qualification
@@ -77,7 +76,7 @@ defmodule VutuvWeb.AgentDocs.SectionDocs do
   @doc "A single entry's show page (`/:slug/<section>/<id-or-slug>`)."
   def build_show(user, section, record) when is_map_key(@sections, section) do
     segment = Atom.to_string(section)
-    path = "/#{user.username}/#{segment}/#{Phoenix.Param.to_param(record)}"
+    path = entry_path(user, segment, record)
     entry = section |> entry(record, user) |> maybe_add_endorsers(section, record)
 
     AgentDocs.doc_meta(@sections[section], path, noindex: true, noai: true)
@@ -89,6 +88,12 @@ defmodule VutuvWeb.AgentDocs.SectionDocs do
       entry: entry
     })
   end
+
+  # A section entry's path under its member, spelled once (issue #1109 gave the
+  # credential's citing roles a URL and would otherwise have been the second
+  # place to remember the shape).
+  defp entry_path(user, segment, record),
+    do: "/#{user.username}/#{segment}/#{Phoenix.Param.to_param(record)}"
 
   defp index_title(:work_experiences, name), do: gettext("Work experience of %{name}", name: name)
   defp index_title(:educations, name), do: gettext("Education of %{name}", name: name)
@@ -219,16 +224,20 @@ defmodule VutuvWeb.AgentDocs.SectionDocs do
     end
   end
 
-  defp organization_ref(%{organization_page: %Organization{} = organization}) do
-    if Organizations.public_visible?(organization) do
-      %{
-        name: organization.name,
-        url: AgentDocs.abs_url(Organizations.canonical_path(organization))
-      }
+  # `WorkExperience.linked_organization/1` owns which page still counts as
+  # linked, so the docs and the HTML pages cannot answer that differently.
+  defp organization_ref(work) do
+    case WorkExperience.linked_organization(work) do
+      nil ->
+        nil
+
+      organization ->
+        %{
+          name: organization.name,
+          url: AgentDocs.abs_url(Organizations.canonical_path(organization))
+        }
     end
   end
-
-  defp organization_ref(_work), do: nil
 
   @doc false
   def education_entry(edu) do
@@ -311,9 +320,10 @@ defmodule VutuvWeb.AgentDocs.SectionDocs do
       awarded: CV.year_month(qualification.awarded_year, qualification.awarded_month),
       expires: CV.year_month(qualification.expires_year, qualification.expires_month),
       # The jobs earned with this credential (issue #1005), mirroring the HTML
-      # usage badges. nil when no job cites it — and, like qualification_ref/1
-      # on the work entry, when the citing jobs were not preloaded.
-      jobs: job_usage_ref(qualification),
+      # usage badges and, since #1109, the credential page's list of them. nil
+      # when no job cites it — and, like qualification_ref/1 on the work entry,
+      # when the citing jobs were not preloaded.
+      jobs: job_usage_ref(qualification, user),
       # The uploaded, member-consented proof document — only once the AI scan
       # released it (the docs are the anonymous public view), and only when
       # the caller supplied the user its URL lives under.
@@ -338,7 +348,7 @@ defmodule VutuvWeb.AgentDocs.SectionDocs do
 
   defp document_ref(_qualification, _user), do: nil
 
-  defp job_usage_ref(qualification) do
+  defp job_usage_ref(qualification, user) do
     case Qualification.job_usage(qualification) do
       nil ->
         nil
@@ -347,10 +357,34 @@ defmodule VutuvWeb.AgentDocs.SectionDocs do
         %{
           count: usage.count,
           in_use: usage.current?,
-          last_used: last_used(usage.last_end)
+          last_used: last_used(usage.last_end),
+          # The roles themselves (issue #1109), in the page's order: a reader
+          # that has the credential in hand can follow it to the work it earned
+          # instead of only learning how many there were.
+          entries: Enum.map(qualification.work_experiences, &citing_job_ref(&1, user))
         }
     end
   end
+
+  # A citing role as the credential names it: enough to recognise the job, plus
+  # the URL of its own page. Deliberately slimmer than work_entry/1 — the
+  # description and the CV links belong to the work-experience documents.
+  defp citing_job_ref(work, user) do
+    %{
+      id: work.id,
+      title: work.title,
+      organization: work.organization,
+      kind: work.kind,
+      start: CV.year_month(work.start_year, work.start_month),
+      end: CV.year_month(work.end_year, work.end_month),
+      url: citing_job_url(work, user)
+    }
+  end
+
+  defp citing_job_url(work, %{username: _username} = user),
+    do: AgentDocs.abs_url(entry_path(user, "work_experiences", work))
+
+  defp citing_job_url(_work, _user), do: nil
 
   defp last_used(nil), do: nil
   defp last_used({year, month}), do: CV.year_month(year, month)

--- a/lib/vutuv_web/agent_docs/text.ex
+++ b/lib/vutuv_web/agent_docs/text.ex
@@ -690,11 +690,25 @@ defmodule VutuvWeb.AgentDocs.Text do
 
     facts = Markdown.qualification_facts(qualification)
 
-    "* " <>
-      qualification.name <>
+    line =
+      "* " <>
+        qualification.name <>
+        if(facts == "", do: "", else: ": #{facts}") <>
+        if(qualification.url, do: " #{qualification.url}", else: "") <>
+        if(document, do: " #{gettext("proof document")}: #{document.url}", else: "")
+
+    # The jobs the credential earned (issue #1109), indented under it like the
+    # code-forge accounts list their repositories.
+    Enum.join([line | Enum.map(Markdown.citing_jobs(qualification), &citing_job_line/1)], "\n")
+  end
+
+  defp citing_job_line(job) do
+    facts = Markdown.citing_job_facts(job)
+
+    "  * " <>
+      job.title <>
       if(facts == "", do: "", else: ": #{facts}") <>
-      if(qualification.url, do: " #{qualification.url}", else: "") <>
-      if(document, do: " #{gettext("proof document")}: #{document.url}", else: "")
+      if(job.url, do: " #{job.url}", else: "")
   end
 
   defp link_line(%{description: nil, url: url} = link), do: "* #{url}" <> verified_suffix(link)

--- a/lib/vutuv_web/controllers/qualification_controller.ex
+++ b/lib/vutuv_web/controllers/qualification_controller.ex
@@ -102,16 +102,24 @@ defmodule VutuvWeb.QualificationController do
 
   def show(conn, _params) do
     # resolve_qualification scoped :qualification to conn.assigns[:user]; the
-    # citing jobs ride along for the usage line (issue #1005).
+    # citing jobs ride along for the usage line (issue #1005) and, since #1109,
+    # for the list of jobs the credential earned.
     qualification =
       Repo.preload(conn.assigns[:qualification], Qualification.citing_jobs_preload())
 
     AgentDocs.respond(conn,
-      html:
-        &render(&1, "show.html",
-          qualification: qualification,
-          page_title: entry_page_title(conn.assigns[:user], qualification)
-        ),
+      html: fn conn ->
+        # Only the HTML page links each job's employer to its organization
+        # page, so only the HTML branch pays for that second query. Preloading
+        # it above would bill every .md/.txt/.json/.xml request for rows no
+        # doc builder reads.
+        detailed = Repo.preload(qualification, Qualification.citing_jobs_detail_preload())
+
+        render(conn, "show.html",
+          qualification: detailed,
+          page_title: entry_page_title(conn.assigns[:user], detailed)
+        )
+      end,
       doc: fn ->
         SectionDocs.build_show(conn.assigns[:user], :qualifications, qualification)
       end

--- a/lib/vutuv_web/templates/qualification/show.html.heex
+++ b/lib/vutuv_web/templates/qualification/show.html.heex
@@ -16,44 +16,63 @@
     delete_to={~p"/settings/qualifications/#{@qualification}"}
   />
 
-  <h2 class="card__label"><%= gettext("Type") %></h2>
-  <p><%= kind_name(@qualification.kind) %></p>
+  <%!-- Two facts per row (`.card__facts`, components.css). As one stacked
+  ladder they pushed everything worth reading below the fold. --%>
+  <div class="card__facts">
+    <div>
+      <h2 class="card__label">{gettext("Type")}</h2>
+      <p>{kind_name(@qualification.kind)}</p>
+    </div>
 
-  <%= if @qualification.issuer do %>
-    <h2 class="card__label"><%= gettext("Issuer") %></h2>
-    <p><%= @qualification.issuer %></p>
-  <% end %>
+    <div :if={@qualification.issuer}>
+      <h2 class="card__label">{gettext("Issuer")}</h2>
+      <p>{@qualification.issuer}</p>
+    </div>
 
-  <%= if @qualification.awarded_year do %>
-    <h2 class="card__label"><%= gettext("Issued") %></h2>
-    <p><%= Enum.reject([@qualification.awarded_month, @qualification.awarded_year], &is_nil/1) |> Enum.join("/") %></p>
-  <% end %>
+    <div :if={awarded_text(@qualification)}>
+      <h2 class="card__label">{gettext("Issued")}</h2>
+      <p>{awarded_text(@qualification)}</p>
+    </div>
 
-  <%= if @qualification.expires_year do %>
-    <h2 class="card__label"><%= gettext("Expires") %></h2>
-    <p><%= Enum.reject([@qualification.expires_month, @qualification.expires_year], &is_nil/1) |> Enum.join("/") %></p>
-  <% end %>
+    <div :if={expires_text(@qualification)}>
+      <h2 class="card__label">{gettext("Expires")}</h2>
+      <p class="flex flex-wrap items-center gap-2">
+        {expires_text(@qualification)}
+        <%!-- Unlike the list rows, this page stays reachable for an expired
+        credential by anyone holding its link, so everyone gets the marker. --%>
+        <.pill :if={expired?(@qualification)} data-expired>{gettext("Expired")}</.pill>
+      </p>
+    </div>
 
-  <%= if usage = usage_line(@qualification) do %>
-    <h2 class="card__label"><%= gettext("Jobs") %></h2>
-    <p data-qualification-usage><%= usage %></p>
-  <% end %>
+    <div :if={@qualification.credential_id}>
+      <h2 class="card__label">{gettext("Credential ID")}</h2>
+      <p class="breakwrap">{@qualification.credential_id}</p>
+    </div>
 
-  <%= if @qualification.credential_id do %>
-    <h2 class="card__label"><%= gettext("Credential ID") %></h2>
-    <p><%= @qualification.credential_id %></p>
-  <% end %>
+    <div :if={@qualification.url}>
+      <h2 class="card__label">{gettext("Verification link")}</h2>
+      <p>
+        <a
+          href={@qualification.url}
+          target="_blank"
+          rel="nofollow noopener noreferrer"
+          class="breakwrap"
+        >
+          {@qualification.url}
+        </a>
+      </p>
+    </div>
+  </div>
 
-  <%= if @qualification.url do %>
-    <h2 class="card__label"><%= gettext("Verification link") %></h2>
-    <p><a href={@qualification.url} target="_blank" rel="nofollow noopener noreferrer"><%= @qualification.url %></a></p>
-  <% end %>
+  <%!-- Issue #1109: the jobs this credential earned, the reverse of each
+  role's own "With qualification: …" line. --%>
+  <.citing_jobs user={@user} qualification={@qualification} />
 
   <%!-- The uploaded proof document (owner sees it during moderation limbo,
   everyone once released): a larger preview plus the explicit download. --%>
-  <%= if show_document?(@qualification, same_user?(@user, @current_user)) do %>
-    <h2 class="card__label"><%= gettext("Uploaded proof") %></h2>
-    <div class="mt-2" data-document-thumb>
+  <div :if={show_document?(@qualification, same_user?(@user, @current_user))} class="mt-6">
+    <h2 class="card__label">{gettext("Uploaded proof")}</h2>
+    <div data-document-thumb>
       <a
         href={document_url(@user, @qualification)}
         target="_blank"
@@ -72,19 +91,14 @@
           class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
           data-document-download
         >
-          <%= gettext("Download original (%{label})", label: document_label(@qualification)) %>
+          {gettext("Download original (%{label})", label: document_label(@qualification))}
         </a>
       </p>
-      <%= if same_user?(@user, @current_user) and not Qualification.document_released?(@qualification) do %>
-        <p>
-          <span
-            class="inline-flex items-center rounded-lg bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-200"
-            data-document-pending
-          >
-            <%= gettext("Being reviewed") %>
-          </span>
-        </p>
-      <% end %>
+      <p :if={
+        same_user?(@user, @current_user) and not Qualification.document_released?(@qualification)
+      }>
+        <.pill tone={:warning} data-document-pending>{gettext("Being reviewed")}</.pill>
+      </p>
     </div>
-  <% end %>
+  </div>
 </.card_section>

--- a/lib/vutuv_web/views/qualification_html.ex
+++ b/lib/vutuv_web/views/qualification_html.ex
@@ -2,10 +2,13 @@ defmodule VutuvWeb.QualificationHTML do
   @moduledoc false
   use VutuvWeb, :html
   import VutuvWeb.UserHelpers
+  import VutuvWeb.WorkExperienceHTML, only: [employer_name: 1]
 
   alias Vutuv.BerlinTime
   alias Vutuv.Profiles.Qualification
+  alias Vutuv.Profiles.WorkExperience
   alias Vutuv.QualificationDocument
+  alias VutuvWeb.WorkExperienceHTML
 
   @doc "The singular name of a kind, for the form picker and the row badge."
   def kind_name("certification"), do: gettext("Certificate")
@@ -49,7 +52,7 @@ defmodule VutuvWeb.QualificationHTML do
   def expiry_year_options, do: (BerlinTime.today().year + 20)..1920//-1
 
   @doc "The month `<select>` options (translated), reused from work experience."
-  defdelegate month_number_options, to: VutuvWeb.WorkExperienceHTML, as: :month_options
+  defdelegate month_number_options, to: WorkExperienceHTML, as: :month_options
 
   @doc """
   The meta line under a credential name: issuer, awarded year, and the "valid
@@ -66,18 +69,28 @@ defmodule VutuvWeb.QualificationHTML do
     |> Enum.join(" · ")
   end
 
-  defp awarded_text(%{awarded_year: nil}), do: nil
-  defp awarded_text(%{awarded_month: nil, awarded_year: year}), do: Integer.to_string(year)
-  defp awarded_text(%{awarded_month: month, awarded_year: year}), do: "#{month}/#{year}"
+  @doc ~S(The award date as `2018` or `3/2018`, nil when the member gave none.)
+  def awarded_text(qualification),
+    do: month_year(qualification.awarded_month, qualification.awarded_year)
+
+  @doc ~S(The expiry date as `2026` or `3/2026`, nil for a credential that never expires.)
+  def expires_text(qualification),
+    do: month_year(qualification.expires_month, qualification.expires_year)
+
+  # The one month/year rule of this page: a bare year until the member named a
+  # month. Every date this module shows (awarded, expires, last used) reads the
+  # same because they all come through here.
+  defp month_year(_month, nil), do: nil
+  defp month_year(nil, year), do: Integer.to_string(year)
+  defp month_year(month, year), do: "#{month}/#{year}"
 
   # "valid until 2026" (year) or "valid until 3/2026" (month + year).
-  defp valid_until_text(%{expires_year: nil}), do: nil
-
-  defp valid_until_text(%{expires_month: nil, expires_year: year}),
-    do: gettext("valid until %{date}", date: Integer.to_string(year))
-
-  defp valid_until_text(%{expires_month: month, expires_year: year}),
-    do: gettext("valid until %{date}", date: "#{month}/#{year}")
+  defp valid_until_text(qualification) do
+    case expires_text(qualification) do
+      nil -> nil
+      date -> gettext("valid until %{date}", date: date)
+    end
+  end
 
   @doc "Whether this member has both a certificate and a licence to tab between."
   def mixed_kinds?(qualifications) do
@@ -121,40 +134,144 @@ defmodule VutuvWeb.QualificationHTML do
 
   defdelegate expired?(qualification), to: Qualification
 
-  @doc """
-  The usage facts of a credential as one " · "-joined sentence (issue #1005),
-  for the entry show page: "Used for 2 jobs · Currently in use". nil when no
-  job cites it (or the citing jobs were not preloaded), so the caller can drop
-  the whole block.
-  """
-  def usage_line(qualification) do
-    case Qualification.job_usage(qualification) do
-      nil ->
-        nil
-
-      usage ->
-        [usage_count_text(usage), usage_status_text(usage)]
-        |> Enum.reject(&is_nil/1)
-        |> Enum.join(" · ")
-    end
-  end
-
   defp usage_count_text(usage) do
     ngettext("Used for %{formatted} job", "Used for %{formatted} jobs", usage.count,
       formatted: compact_count(usage.count)
     )
   end
 
-  defp usage_status_text(%{current?: true}), do: gettext("Currently in use")
+  @doc """
+  Whether the credential is still earning its keep (issue #1005): the emerald
+  "Currently in use" pill while any citing job is ongoing, otherwise the calm
+  "Last used: 9/2019" one. Renders nothing when neither applies, so it drops in
+  wherever a `Qualification.job_usage/1` map is at hand — the list rows and the
+  credential's own page share this one rendering.
+  """
+  attr(:usage, :map, required: true)
 
-  defp usage_status_text(%{last_end: {_year, _month} = last_end}),
-    do: gettext("Last used: %{date}", date: end_text(last_end))
+  def usage_status_pill(assigns) do
+    ~H"""
+    <.pill :if={@usage.current?} tone={:positive} data-usage-current>
+      {gettext("Currently in use")}
+    </.pill>
+    <.pill :if={not @usage.current? and @usage.last_end != nil} tone={:neutral} data-usage-last>
+      {gettext("Last used: %{date}", date: end_text(@usage.last_end))}
+    </.pill>
+    """
+  end
 
-  defp usage_status_text(_usage), do: nil
+  @doc """
+  The small status pill this page's markings all wear: the usage badges, the
+  "Expired" marker and the document's "Being reviewed" note. One shell, four
+  tones, so a pill on the list row and the same pill on the entry page cannot
+  drift apart — which is exactly what six hand-copied class strings had started
+  to do. Extra attributes (the `data-*` test hooks) pass straight through.
+  """
+  attr(:tone, :atom, default: :neutral, values: [:brand, :positive, :neutral, :warning])
+  attr(:class, :any, default: nil)
+  attr(:rest, :global)
+  slot(:inner_block, required: true)
 
-  # The badge's month/year form, matching the meta line's "3/2026" style.
-  defp end_text({year, nil}), do: Integer.to_string(year)
-  defp end_text({year, month}), do: "#{month}/#{year}"
+  def pill(assigns) do
+    ~H"""
+    <span
+      class={[
+        "inline-flex items-center rounded-lg px-2 py-0.5 text-xs font-medium",
+        pill_tone(@tone),
+        @class
+      ]}
+      {@rest}
+    >
+      {render_slot(@inner_block)}
+    </span>
+    """
+  end
+
+  # Brand tint for a plain count, emerald for the reserved active/verified
+  # signal, slate for a calm past fact, amber for moderation limbo (never for a
+  # past fact — amber is reserved for moderation).
+  defp pill_tone(:brand),
+    do: "bg-brand-50 text-brand-700 dark:bg-brand-900/40 dark:text-brand-100"
+
+  defp pill_tone(:positive),
+    do: "bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300"
+
+  defp pill_tone(:neutral),
+    do: "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400"
+
+  defp pill_tone(:warning),
+    do: "bg-amber-50 text-amber-800 dark:bg-amber-900/30 dark:text-amber-200"
+
+  # `job_usage/1` reports the last end as a `{year, month}` pair.
+  defp end_text({year, month}), do: month_year(month, year)
+
+  @doc """
+  The jobs a member earned with this credential (issue #1109) — the reverse of
+  each role's own "With qualification: …" line, and what the count badge on the
+  list rows only summarised. Every row links the role's page, and an employer
+  that is a verified organization page links there too, so the credential is a
+  hub rather than a dead end. Ongoing roles come first (the
+  `Qualification.citing_jobs_detail_preload/0` order).
+
+  Renders nothing when no job cites the credential — and, since it asks
+  `Qualification.job_usage/1`, nothing on a surface that did not preload the
+  citing jobs either.
+  """
+  attr(:user, :any, required: true)
+  attr(:qualification, :any, required: true)
+
+  def citing_jobs(assigns) do
+    assigns = assign(assigns, :usage, Qualification.job_usage(assigns.qualification))
+
+    ~H"""
+    <div :if={@usage} class="mt-6">
+      <div class="flex flex-wrap items-center gap-2" data-qualification-usage>
+        <h2 class="card__label mb-0">{pgettext("qualification detail", "Jobs")}</h2>
+        <.usage_status_pill usage={@usage} />
+      </div>
+      <ul
+        class="mt-2 divide-y divide-slate-200 overflow-hidden rounded-xl ring-1 ring-slate-200 dark:divide-slate-800 dark:ring-slate-800"
+        data-citing-jobs
+      >
+        <li :for={job <- @qualification.work_experiences} class="px-3 py-2.5">
+          <.link
+            href={~p"/#{@user}/work_experiences/#{job}"}
+            class="block font-semibold text-slate-900 hover:text-brand-700 dark:text-white dark:hover:text-brand-400"
+          >
+            {job.title}
+          </.link>
+          <p class="mb-0 text-sm text-slate-600 dark:text-slate-400">
+            <.employer_name
+              organization={WorkExperience.linked_organization(job)}
+              text={job.organization}
+            />
+            {job_facts(job)}
+          </p>
+        </li>
+      </ul>
+    </div>
+    """
+  end
+
+  # What still fits on a row's meta line beside the employer. Joined into one
+  # string rather than rendered per fact — adjacent HEEx elements carry no
+  # whitespace between them, so a span per fact glues "10/2024· Internship".
+  defp job_facts(job) do
+    case Enum.reject([job_period(job), WorkExperienceHTML.kind_note(job)], &is_nil/1) do
+      [] -> nil
+      facts -> "· " <> Enum.join(facts, " · ")
+    end
+  end
+
+  # An entry with no dates at all has no period — `format_duration/4` would
+  # read that as "Present", which is a claim the member never made.
+  defp job_period(%{start_year: nil, end_year: nil}), do: nil
+
+  defp job_period(job) do
+    job.start_month
+    |> WorkExperienceHTML.format_duration(job.start_year, job.end_month, job.end_year)
+    |> IO.iodata_to_binary()
+  end
 
   @doc """
   Whether this viewer gets the document block: everyone once the AI scan
@@ -239,13 +356,14 @@ defmodule VutuvWeb.QualificationHTML do
         <span class="block text-xs text-slate-600 dark:text-slate-400">
           {document_label(@qualification)}
         </span>
-        <span
+        <.pill
           :if={@as_owner? and not Qualification.document_released?(@qualification)}
-          class="mt-1 inline-flex items-center rounded-lg bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-200"
+          tone={:warning}
+          class="mt-1"
           data-document-pending
         >
           {gettext("Being reviewed")}
-        </span>
+        </.pill>
       </div>
     </div>
     """
@@ -276,38 +394,17 @@ defmodule VutuvWeb.QualificationHTML do
       >
         {@qualification.name}
       </.link>
-      <span
-        :if={@as_owner? and expired?(@qualification)}
-        class="ml-2 inline-flex items-center rounded-lg bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-400"
-      >
+      <.pill :if={@as_owner? and expired?(@qualification)} class="ml-2" data-expired>
         {gettext("Expired")}
-      </span>
+      </.pill>
       <p :if={@meta != ""} class="text-sm text-slate-600 dark:text-slate-400">{@meta}</p>
       <p
         :if={@usage}
         class="mt-1 flex flex-wrap items-center gap-1.5"
         data-qualification-usage
       >
-        <span
-          class="inline-flex items-center rounded-lg bg-brand-50 px-2 py-0.5 text-xs font-medium text-brand-700 dark:bg-brand-900/40 dark:text-brand-100"
-          data-usage-jobs
-        >
-          {usage_count_text(@usage)}
-        </span>
-        <span
-          :if={@usage.current?}
-          class="inline-flex items-center rounded-lg bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300"
-          data-usage-current
-        >
-          {gettext("Currently in use")}
-        </span>
-        <span
-          :if={not @usage.current? and @usage.last_end != nil}
-          class="inline-flex items-center rounded-lg bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-400"
-          data-usage-last
-        >
-          {gettext("Last used: %{date}", date: end_text(@usage.last_end))}
-        </span>
+        <.pill tone={:brand} data-usage-jobs>{usage_count_text(@usage)}</.pill>
+        <.usage_status_pill usage={@usage} />
       </p>
       <a
         :if={@qualification.url}

--- a/lib/vutuv_web/views/work_experience_html.ex
+++ b/lib/vutuv_web/views/work_experience_html.ex
@@ -5,7 +5,6 @@ defmodule VutuvWeb.WorkExperienceHTML do
   import VutuvWeb.UserHelpers
 
   alias Vutuv.Organizations
-  alias Vutuv.Organizations.Organization
   alias Vutuv.Profiles.WorkExperience
   alias VutuvWeb.UserProfileLive
 
@@ -41,6 +40,25 @@ defmodule VutuvWeb.WorkExperienceHTML do
   @doc "The `{label, value}` options for the form's category select."
   def kind_options do
     for kind <- WorkExperience.kinds(), do: {kind_name(kind), kind}
+  end
+
+  # Everything but the plain job, which stays unmarked the way the jobs-only
+  # timeline does. Derived from the schema, so a new kind is noteworthy by
+  # default rather than by somebody remembering this list.
+  @noteworthy_kinds WorkExperience.kinds() -- ["employment"]
+
+  @doc """
+  The CV category of an entry (issue #840), named only when it is not the plain
+  job everyone assumes: a role done as an internship or an Ehrenamt reads
+  differently. nil for employment, for an unknown kind, and for a map carrying
+  no `:kind` at all — so the agent-doc renderers can hand it their doc maps.
+  The single owner of that rule; `kind_name/1` stays the label source.
+  """
+  def kind_note(entry) do
+    case Map.get(entry, :kind) do
+      kind when kind in @noteworthy_kinds -> kind_name(kind)
+      _plain_job_or_unknown -> nil
+    end
   end
 
   @doc """
@@ -211,7 +229,7 @@ defmodule VutuvWeb.WorkExperienceHTML do
       # non-frozen organization qualifies, so a frozen/archived page renders the block
       # exactly as an unlinked one (plain text). Kept under a distinct key from the
       # free-text `organization` string above so the two never collide.
-      organization_page: linked_organization(newest),
+      organization_page: WorkExperience.linked_organization(newest),
       multi?: multi?,
       roles: circles,
       span: span,
@@ -220,15 +238,6 @@ defmodule VutuvWeb.WorkExperienceHTML do
       size: circle_rem(months, max_months)
     }
   end
-
-  # The linked, currently-verified organization of a work experience, or nil. Guards
-  # on a loaded, active, non-frozen %Organization{}: an unloaded association, a
-  # free-text-only role, or a frozen/archived page all fall through to nil.
-  defp linked_organization(%{organization_page: %Organization{} = organization}) do
-    if Organizations.public_visible?(organization), do: organization
-  end
-
-  defp linked_organization(_job), do: nil
 
   @doc """
   The employer name on a timeline block: when the experience is linked to a

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.324.3",
+      version: "7.325.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -27,7 +27,7 @@ msgid "Add"
 msgstr "Eintrag hinzufügen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:255
-#: lib/vutuv_web/agent_docs/section_docs.ex:127
+#: lib/vutuv_web/agent_docs/section_docs.ex:132
 #: lib/vutuv_web/agent_docs/text.ex:240
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
@@ -205,7 +205,7 @@ msgstr "Inaktivieren"
 #: lib/vutuv_web/live/post_live/composer.ex:1723
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/templates/user/show.html.heex:340
-#: lib/vutuv_web/views/qualification_html.ex:237
+#: lib/vutuv_web/views/qualification_html.ex:354
 #, elixir-autogen
 msgid "Download"
 msgstr "Download"
@@ -702,7 +702,7 @@ msgstr "Profile"
 msgid "Add a profile"
 msgstr "Profil hinzufügen"
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:103
+#: lib/vutuv_web/agent_docs/section_docs.ex:108
 #, elixir-autogen, elixir-format
 msgid "Profiles of %{name}"
 msgstr "Profile von %{name}"
@@ -1127,8 +1127,8 @@ msgstr "100 Usern mit den meisten Followern"
 msgid "Curious? Have a look at the "
 msgstr "Neugierig? Hier ist die Liste "
 
-#: lib/vutuv_web/views/work_experience_html.ex:300
-#: lib/vutuv_web/views/work_experience_html.ex:353
+#: lib/vutuv_web/views/work_experience_html.ex:309
+#: lib/vutuv_web/views/work_experience_html.ex:362
 #, elixir-autogen
 msgid "Present"
 msgstr "Heute"
@@ -1400,10 +1400,10 @@ msgstr "Tag-URLs"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:34
 #: lib/vutuv_web/agent_docs/markdown.ex:488
-#: lib/vutuv_web/agent_docs/markdown.ex:1038
+#: lib/vutuv_web/agent_docs/markdown.ex:1063
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:509
-#: lib/vutuv_web/agent_docs/text.ex:732
+#: lib/vutuv_web/agent_docs/text.ex:746
 #: lib/vutuv_web/components/ui.ex:4012
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1619,7 +1619,7 @@ msgstr "Vorgeschlagen"
 msgid "Admin Area"
 msgstr "Admin-Bereich"
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:106
+#: lib/vutuv_web/agent_docs/section_docs.ex:111
 #: lib/vutuv_web/templates/address/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Addresses of %{name}"
@@ -1848,7 +1848,7 @@ msgstr "Quellcode"
 msgid "Submit a bug report or feature request"
 msgstr "Fehler melden oder Feature vorschlagen"
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:109
+#: lib/vutuv_web/agent_docs/section_docs.ex:114
 #: lib/vutuv_web/templates/user_tag/index.html.heex:21
 #, elixir-autogen, elixir-format
 msgid "Tags of %{name}"
@@ -1992,26 +1992,26 @@ msgstr "Eintrag löschen"
 msgid "Options"
 msgstr "Optionen"
 
-#: lib/vutuv_web/views/work_experience_html.ex:412
+#: lib/vutuv_web/views/work_experience_html.ex:421
 #, elixir-autogen, elixir-format
 msgid "%{count} month"
 msgid_plural "%{count} months"
 msgstr[0] "%{count} Monat"
 msgstr[1] "%{count} Monate"
 
-#: lib/vutuv_web/views/work_experience_html.ex:415
+#: lib/vutuv_web/views/work_experience_html.ex:424
 #, elixir-autogen, elixir-format
 msgid "%{count} year"
 msgid_plural "%{count} years"
 msgstr[0] "%{count} Jahr"
 msgstr[1] "%{count} Jahre"
 
-#: lib/vutuv_web/views/work_experience_html.ex:497
+#: lib/vutuv_web/views/work_experience_html.ex:506
 #, elixir-autogen, elixir-format
 msgid "Time in this role"
 msgstr "Dauer in dieser Position"
 
-#: lib/vutuv_web/views/work_experience_html.ex:496
+#: lib/vutuv_web/views/work_experience_html.ex:505
 #, elixir-autogen, elixir-format
 msgid "Total time at this employer"
 msgstr "Gesamtdauer bei diesem Arbeitgeber"
@@ -2429,7 +2429,7 @@ msgstr "Alle Beiträge"
 msgid "Bookmark"
 msgstr "Lesezeichen setzen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1076
+#: lib/vutuv_web/agent_docs/markdown.ex:1101
 #: lib/vutuv_web/live/post_live/saved.ex:175
 #: lib/vutuv_web/live/post_live/saved.ex:488
 #: lib/vutuv_web/live/shell_live.ex:730
@@ -2449,7 +2449,7 @@ msgstr "Lesezeichen"
 msgid "Like"
 msgstr "Gefällt mir"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1075
+#: lib/vutuv_web/agent_docs/markdown.ex:1100
 #: lib/vutuv_web/components/post_components.ex:4916
 #: lib/vutuv_web/live/notification_live/index.ex:970
 #: lib/vutuv_web/live/post_live/saved.ex:174
@@ -3477,7 +3477,7 @@ msgstr "Vertrauenswürdig"
 #: lib/vutuv_web/templates/email/show.html.heex:21
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:26
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:12
-#: lib/vutuv_web/templates/qualification/show.html.heex:19
+#: lib/vutuv_web/templates/qualification/show.html.heex:23
 #, elixir-autogen, elixir-format
 msgid "Type"
 msgstr "Typ"
@@ -3958,7 +3958,7 @@ msgstr "Im Rahmen scrollen oder klicken, um das ganze Bild zu öffnen."
 msgid "%{count} endorsements"
 msgstr "%{count} Empfehlungen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1197
+#: lib/vutuv_web/agent_docs/markdown.ex:1222
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr "%{count} auf dieser Seite, weitere mit ?page=N"
@@ -3972,11 +3972,11 @@ msgstr "%{count} Beiträge von %{name}"
 #: lib/vutuv_web/agent_docs/markdown.ex:83
 #: lib/vutuv_web/agent_docs/markdown.ex:194
 #: lib/vutuv_web/agent_docs/markdown.ex:208
-#: lib/vutuv_web/agent_docs/markdown.ex:1038
+#: lib/vutuv_web/agent_docs/markdown.ex:1063
 #: lib/vutuv_web/agent_docs/text.ex:80
 #: lib/vutuv_web/agent_docs/text.ex:179
 #: lib/vutuv_web/agent_docs/text.ex:193
-#: lib/vutuv_web/agent_docs/text.ex:732
+#: lib/vutuv_web/agent_docs/text.ex:746
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr "%{count} insgesamt"
@@ -3995,22 +3995,22 @@ msgstr "Follower von %{name}"
 msgid "Images"
 msgstr "Bilder"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1056
-#: lib/vutuv_web/agent_docs/text.ex:743
+#: lib/vutuv_web/agent_docs/markdown.ex:1081
+#: lib/vutuv_web/agent_docs/text.ex:757
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr "Antwort auf einen gelöschten Beitrag von %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1053
-#: lib/vutuv_web/agent_docs/text.ex:740
+#: lib/vutuv_web/agent_docs/markdown.ex:1078
+#: lib/vutuv_web/agent_docs/text.ex:754
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr "Antwort auf einen gelöschten Beitrag."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1060
-#: lib/vutuv_web/agent_docs/markdown.ex:1274
-#: lib/vutuv_web/agent_docs/text.ex:746
-#: lib/vutuv_web/agent_docs/text.ex:790
+#: lib/vutuv_web/agent_docs/markdown.ex:1085
+#: lib/vutuv_web/agent_docs/markdown.ex:1299
+#: lib/vutuv_web/agent_docs/text.ex:760
+#: lib/vutuv_web/agent_docs/text.ex:804
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr "Antwort auf einen Beitrag von %{name}."
@@ -4065,17 +4065,17 @@ msgstr "Beiträge (insgesamt %{count})"
 msgid "Verified profile: yes"
 msgstr "Verifiziertes Profil: ja"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1007
+#: lib/vutuv_web/agent_docs/markdown.ex:1032
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr "repostet von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:903
+#: lib/vutuv_web/agent_docs/markdown.ex:928
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr "heute"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:904
+#: lib/vutuv_web/agent_docs/markdown.ex:929
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr "bis %{date}"
@@ -4090,22 +4090,22 @@ msgstr "Diese Seite auf %{language}: %{url}"
 msgid "Connections of %{name}"
 msgstr "Vernetzungen von %{name}"
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:108
+#: lib/vutuv_web/agent_docs/section_docs.ex:113
 #, elixir-autogen, elixir-format
 msgid "Email addresses of %{name}"
 msgstr "E-Mail-Adressen von %{name}"
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:100
+#: lib/vutuv_web/agent_docs/section_docs.ex:105
 #, elixir-autogen, elixir-format
 msgid "Links of %{name}"
 msgstr "Links von %{name}"
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:107
+#: lib/vutuv_web/agent_docs/section_docs.ex:112
 #, elixir-autogen, elixir-format
 msgid "Phone numbers of %{name}"
 msgstr "Telefonnummern von %{name}"
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:93
+#: lib/vutuv_web/agent_docs/section_docs.ex:98
 #, elixir-autogen, elixir-format
 msgid "Work experience of %{name}"
 msgstr "Lebenslauf von %{name}"
@@ -4799,7 +4799,7 @@ msgstr "Ähnliche Namen"
 #: lib/vutuv_web/live/import_connections_live.ex:470
 #: lib/vutuv_web/live/notification_live/index.ex:890
 #: lib/vutuv_web/live/search_live.ex:280
-#: lib/vutuv_web/views/qualification_html.ex:90
+#: lib/vutuv_web/views/qualification_html.ex:103
 #, elixir-autogen, elixir-format
 msgid "All"
 msgstr "Alle"
@@ -4906,7 +4906,7 @@ msgstr "Ihr Profil und seine Bereiche bearbeiten"
 #: lib/vutuv_web/live/job_posting_live/show.ex:136
 #: lib/vutuv_web/templates/access_token/new.html.heex:42
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:45
-#: lib/vutuv_web/templates/qualification/show.html.heex:33
+#: lib/vutuv_web/templates/qualification/show.html.heex:38
 #, elixir-autogen, elixir-format
 msgid "Expires"
 msgstr "Gültig bis"
@@ -5109,7 +5109,7 @@ msgstr "API-Anwendungen"
 msgid "Active"
 msgstr "Aktiv"
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:79
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:82
 #, elixir-autogen, elixir-format
 msgid "Allow access"
 msgstr "Zugriff erlauben"
@@ -5173,7 +5173,7 @@ msgstr ""
 "\"%{name}\" löschen? Alle Freigaben von Mitgliedern und alle Tokens dieser "
 "Anwendung funktionieren sofort nicht mehr."
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:88
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "Deny"
 msgstr "Ablehnen"
@@ -5234,7 +5234,7 @@ msgstr ""
 "Eine pro Zeile. Exakte https://-URLs (http://localhost ist für die "
 "Entwicklung erlaubt). Die Autorisierung leitet nur an diese Adressen weiter."
 
-#: lib/vutuv_web/controllers/oauth_controller.ex:56
+#: lib/vutuv_web/controllers/oauth_controller.ex:59
 #, elixir-autogen, elixir-format
 msgid "Please log in to connect %{app} with your account."
 msgstr "Bitte melden Sie sich an, um %{app} mit Ihrem Konto zu verbinden."
@@ -5861,7 +5861,7 @@ msgid "@%{slug} started following you on vutuv"
 msgstr "@%{slug} folgt Ihnen jetzt auf vutuv"
 
 #: lib/vutuv_web/components/organization_components.ex:318
-#: lib/vutuv_web/live/organization_live/apps.ex:162
+#: lib/vutuv_web/live/organization_live/apps.ex:167
 #: lib/vutuv_web/templates/settings/apps.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Apps"
@@ -6464,7 +6464,7 @@ msgstr "Tagesbericht öffnen"
 msgid "Previous day"
 msgstr "Vorheriger Tag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1075
+#: lib/vutuv_web/agent_docs/markdown.ex:1100
 #: lib/vutuv_web/components/post_components.ex:396
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
@@ -6575,7 +6575,7 @@ msgstr "Noch keine Empfehlungen."
 msgid "and %{count} more"
 msgstr "und %{count} weitere"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1051
+#: lib/vutuv_web/agent_docs/markdown.ex:1076
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr "empfohlen am %{date}"
@@ -7843,17 +7843,17 @@ msgstr "Feed von %{name}"
 msgid "The vutuv newsfeed of %{name}"
 msgstr "Der vutuv-Newsfeed von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1202
+#: lib/vutuv_web/agent_docs/markdown.ex:1227
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr "Ihr Feed ist leer."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1205
+#: lib/vutuv_web/agent_docs/markdown.ex:1230
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr "%{count} Beiträge auf dieser Seite"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1212
+#: lib/vutuv_web/agent_docs/markdown.ex:1237
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr "weitere Beiträge verfügbar, ?cursor=%{cursor} anhängen"
@@ -8554,7 +8554,7 @@ msgstr "Ausbildung erfolgreich erstellt."
 msgid "Education deleted successfully."
 msgstr "Ausbildung erfolgreich gelöscht."
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:94
+#: lib/vutuv_web/agent_docs/section_docs.ex:99
 #, elixir-autogen, elixir-format
 msgid "Education of %{name}"
 msgstr "Ausbildung von %{name}"
@@ -9150,19 +9150,18 @@ msgstr ""
 msgid "Category"
 msgstr "Kategorie"
 
-#: lib/vutuv_web/views/work_experience_html.ex:25
+#: lib/vutuv_web/views/work_experience_html.ex:24
 #, elixir-autogen, elixir-format
 msgid "Employment"
 msgstr "Anstellung"
 
 #: lib/vutuv/jobs/job_posting.ex:153
-#: lib/vutuv_web/agent_docs/markdown.ex:775
-#: lib/vutuv_web/views/work_experience_html.ex:27
+#: lib/vutuv_web/views/work_experience_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Internship"
 msgstr "Praktikum"
 
-#: lib/vutuv_web/views/work_experience_html.ex:37
+#: lib/vutuv_web/views/work_experience_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Internships"
 msgstr "Praktika"
@@ -9174,14 +9173,13 @@ msgstr ""
 "Wählen Sie auf dieser Seite „Größeres Datenarchiv herunterladen“ (Profil, "
 "Positionen, Ehrenämter, Ausbildung, Kenntnisse)."
 
-#: lib/vutuv_web/views/work_experience_html.ex:35
+#: lib/vutuv_web/views/work_experience_html.ex:34
 #, elixir-autogen, elixir-format
 msgid "Professional Experience"
 msgstr "Berufserfahrung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:776
-#: lib/vutuv_web/views/work_experience_html.ex:31
-#: lib/vutuv_web/views/work_experience_html.ex:38
+#: lib/vutuv_web/views/work_experience_html.ex:30
+#: lib/vutuv_web/views/work_experience_html.ex:37
 #, elixir-autogen, elixir-format
 msgid "Volunteering & hobbies"
 msgstr "Ehrenamt, Hobby & Freiwilligenarbeit"
@@ -9210,13 +9208,13 @@ msgstr "Ihr Profil als Lebenslauf"
 msgid "Higher Education"
 msgstr "Studium"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:813
+#: lib/vutuv_web/agent_docs/markdown.ex:805
 #: lib/vutuv_web/views/education_html.ex:23
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr "Schulbildung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:812
+#: lib/vutuv_web/agent_docs/markdown.ex:804
 #: lib/vutuv_web/views/education_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -9252,7 +9250,7 @@ msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] "Repostet von %{name} und %{formatted} weiteren"
 msgstr[1] "Repostet von %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1010
+#: lib/vutuv_web/agent_docs/markdown.ex:1035
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr "repostet von %{name} und %{count} weiteren"
@@ -9345,16 +9343,14 @@ msgstr ""
 "Der Lebenslauf von %{name} auf vutuv: Berufserfahrung, Ausbildung und "
 "Kenntnisse zum Ansehen und Herunterladen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:774
-#: lib/vutuv_web/views/work_experience_html.ex:26
-#: lib/vutuv_web/views/work_experience_html.ex:36
+#: lib/vutuv_web/views/work_experience_html.ex:25
+#: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr "Freiberuflich / Selbstständig"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:777
-#: lib/vutuv_web/views/work_experience_html.ex:32
-#: lib/vutuv_web/views/work_experience_html.ex:39
+#: lib/vutuv_web/views/work_experience_html.ex:31
+#: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
 msgid "Other activities"
 msgstr "Sonstige Tätigkeiten"
@@ -9753,7 +9749,7 @@ msgstr "Sprache erfolgreich aktualisiert."
 msgid "Languages"
 msgstr "Sprachen"
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:99
+#: lib/vutuv_web/agent_docs/section_docs.ex:104
 #, elixir-autogen, elixir-format
 msgid "Languages of %{name}"
 msgstr "Sprachen von %{name}"
@@ -10044,8 +10040,8 @@ msgstr[1] "%{count} Zertifikate oder Lizenzen"
 msgid "Add a certificate or license"
 msgstr "Zertifikat oder Lizenz hinzufügen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:897
-#: lib/vutuv_web/views/qualification_html.ex:11
+#: lib/vutuv_web/agent_docs/markdown.ex:922
+#: lib/vutuv_web/views/qualification_html.ex:14
 #, elixir-autogen, elixir-format
 msgid "Certificate"
 msgstr "Zertifikat"
@@ -10055,17 +10051,17 @@ msgstr "Zertifikat"
 msgid "Certificate or license added successfully."
 msgstr "Zertifikat oder Lizenz erfolgreich hinzugefügt."
 
-#: lib/vutuv_web/controllers/qualification_controller.ex:156
+#: lib/vutuv_web/controllers/qualification_controller.ex:164
 #, elixir-autogen, elixir-format
 msgid "Certificate or license deleted successfully."
 msgstr "Zertifikat oder Lizenz erfolgreich gelöscht."
 
-#: lib/vutuv_web/controllers/qualification_controller.ex:144
+#: lib/vutuv_web/controllers/qualification_controller.ex:152
 #, elixir-autogen, elixir-format
 msgid "Certificate or license updated successfully."
 msgstr "Zertifikat oder Lizenz erfolgreich aktualisiert."
 
-#: lib/vutuv_web/views/qualification_html.ex:15
+#: lib/vutuv_web/views/qualification_html.ex:18
 #, elixir-autogen, elixir-format
 msgid "Certificates"
 msgstr "Zertifikate"
@@ -10075,7 +10071,7 @@ msgstr "Zertifikate"
 #: lib/vutuv_web/components/ui.ex:3999
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
-#: lib/vutuv_web/controllers/qualification_controller.ex:124
+#: lib/vutuv_web/controllers/qualification_controller.ex:132
 #: lib/vutuv_web/cv/docx.ex:183
 #: lib/vutuv_web/cv/html.ex:169
 #: lib/vutuv_web/cv/latex.ex:140
@@ -10099,13 +10095,13 @@ msgstr "Zertifikate & Lizenzen"
 msgid "Certificates & licenses of "
 msgstr "Zertifikate & Lizenzen von "
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:97
+#: lib/vutuv_web/agent_docs/section_docs.ex:102
 #, elixir-autogen, elixir-format
 msgid "Certificates & licenses of %{name}"
 msgstr "Zertifikate & Lizenzen von %{name}"
 
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:65
-#: lib/vutuv_web/templates/qualification/show.html.heex:43
+#: lib/vutuv_web/templates/qualification/show.html.heex:48
 #, elixir-autogen, elixir-format
 msgid "Credential ID"
 msgstr "Ausweisnummer"
@@ -10118,35 +10114,36 @@ msgstr "Läuft nicht ab"
 #: lib/vutuv_web/live/admin/job_live.ex:164
 #: lib/vutuv_web/live/admin/job_live.ex:180
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:183
-#: lib/vutuv_web/views/qualification_html.ex:283
+#: lib/vutuv_web/templates/qualification/show.html.heex:43
+#: lib/vutuv_web/views/qualification_html.ex:398
 #, elixir-autogen, elixir-format
 msgid "Expired"
 msgstr "Abgelaufen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:872
+#: lib/vutuv_web/agent_docs/markdown.ex:897
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr "ID: %{id}"
 
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:27
-#: lib/vutuv_web/templates/qualification/show.html.heex:28
+#: lib/vutuv_web/templates/qualification/show.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "Issued"
 msgstr "Ausgestellt"
 
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:18
-#: lib/vutuv_web/templates/qualification/show.html.heex:23
+#: lib/vutuv_web/templates/qualification/show.html.heex:28
 #, elixir-autogen, elixir-format
 msgid "Issuer"
 msgstr "Aussteller"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:896
-#: lib/vutuv_web/views/qualification_html.ex:12
+#: lib/vutuv_web/agent_docs/markdown.ex:921
+#: lib/vutuv_web/views/qualification_html.ex:15
 #, elixir-autogen, elixir-format
 msgid "License"
 msgstr "Lizenz"
 
-#: lib/vutuv_web/views/qualification_html.ex:16
+#: lib/vutuv_web/views/qualification_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "Licenses"
 msgstr "Lizenzen"
@@ -10159,18 +10156,18 @@ msgstr ""
 "Deshalb importieren wir alle als Zertifikate. Bitte prüfen Sie den Bereich "
 "anschließend und ändern Sie alle Einträge, die Lizenzen sind."
 
-#: lib/vutuv_web/views/qualification_html.ex:319
+#: lib/vutuv_web/views/qualification_html.ex:416
 #, elixir-autogen, elixir-format
 msgid "Proof"
 msgstr "Nachweis"
 
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:74
-#: lib/vutuv_web/templates/qualification/show.html.heex:48
+#: lib/vutuv_web/templates/qualification/show.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Verification link"
 msgstr "Nachweislink"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:870
+#: lib/vutuv_web/agent_docs/markdown.ex:895
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr "ausgestellt %{date}"
@@ -10185,9 +10182,8 @@ msgstr "z. B. AWS Solutions Architect – Associate"
 msgid "e.g. Amazon Web Services"
 msgstr "z. B. Amazon Web Services"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:871
-#: lib/vutuv_web/views/qualification_html.ex:77
-#: lib/vutuv_web/views/qualification_html.ex:80
+#: lib/vutuv_web/agent_docs/markdown.ex:896
+#: lib/vutuv_web/views/qualification_html.ex:91
 #, elixir-autogen, elixir-format
 msgid "valid until %{date}"
 msgstr "gültig bis %{date}"
@@ -11043,12 +11039,12 @@ msgstr "PHP, JavaScript, Ruby on Rails"
 msgid "Separate tags with a comma. A tag may be several words long, like Ruby on Rails."
 msgstr "Tags mit Komma trennen. Ein Tag darf aus mehreren Wörtern bestehen, zum Beispiel Ruby on Rails."
 
-#: lib/vutuv_web/views/work_experience_html.ex:428
+#: lib/vutuv_web/views/work_experience_html.ex:437
 #, elixir-autogen, elixir-format
 msgid "%{n}m"
 msgstr "%{n} M."
 
-#: lib/vutuv_web/views/work_experience_html.ex:429
+#: lib/vutuv_web/views/work_experience_html.ex:438
 #, elixir-autogen, elixir-format
 msgid "%{n}y"
 msgstr "%{n} J."
@@ -12233,8 +12229,8 @@ msgstr "Per Rück-Link verifizieren"
 msgid "Verify via file"
 msgstr "Per Datei verifizieren"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:917
-#: lib/vutuv_web/agent_docs/text.ex:705
+#: lib/vutuv_web/agent_docs/markdown.ex:942
+#: lib/vutuv_web/agent_docs/text.ex:719
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr "verifizierte Webseite"
@@ -12839,7 +12835,6 @@ msgstr "Stellenbezeichnung"
 #: lib/vutuv_web/live/post_live/saved.ex:504
 #: lib/vutuv_web/live/shell_live.ex:636
 #: lib/vutuv_web/templates/layout/app.html.heex:101
-#: lib/vutuv_web/templates/qualification/show.html.heex:38
 #, elixir-autogen, elixir-format
 msgid "Jobs"
 msgstr "Jobs"
@@ -14292,7 +14287,7 @@ msgstr "Messenger"
 msgid "Messengers of "
 msgstr "Messenger von "
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:105
+#: lib/vutuv_web/agent_docs/section_docs.ex:110
 #, elixir-autogen, elixir-format
 msgid "Messengers of %{name}"
 msgstr "Messenger von %{name}"
@@ -14364,7 +14359,7 @@ msgstr "hat %{count} neue Einträge im Lebenslauf:"
 msgid "Audiobook"
 msgstr "Hörbuch"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1164
+#: lib/vutuv_web/agent_docs/markdown.ex:1189
 #: lib/vutuv_web/components/post_components.ex:4405
 #, elixir-autogen, elixir-format
 msgid "Book review"
@@ -14385,7 +14380,7 @@ msgstr "DVD/Blu-ray"
 msgid "E-book"
 msgstr "E-Book"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1164
+#: lib/vutuv_web/agent_docs/markdown.ex:1189
 #: lib/vutuv_web/components/post_components.ex:4404
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -14470,7 +14465,7 @@ msgstr "Optional: das Zertifikat oder die Lizenz, mit der Sie diese Stelle erlan
 msgid "Qualification"
 msgstr "Qualifikation"
 
-#: lib/vutuv_web/views/work_experience_html.ex:616
+#: lib/vutuv_web/views/work_experience_html.ex:625
 #, elixir-autogen, elixir-format
 msgid "With qualification:"
 msgstr "Mit Qualifikation:"
@@ -14552,45 +14547,43 @@ msgid_plural "%{formatted} new members today"
 msgstr[0] "%{formatted} neues Mitglied heute"
 msgstr[1] "%{formatted} neue Mitglieder heute"
 
-#: lib/vutuv_web/views/qualification_html.ex:148
-#: lib/vutuv_web/views/qualification_html.ex:302
+#: lib/vutuv_web/views/qualification_html.ex:155
 #, elixir-autogen, elixir-format
 msgid "Currently in use"
 msgstr "Aktuell genutzt"
 
-#: lib/vutuv_web/views/qualification_html.ex:151
-#: lib/vutuv_web/views/qualification_html.ex:309
+#: lib/vutuv_web/views/qualification_html.ex:158
 #, elixir-autogen, elixir-format
 msgid "Last used: %{date}"
 msgstr "Zuletzt genutzt: %{date}"
 
-#: lib/vutuv_web/views/qualification_html.ex:143
+#: lib/vutuv_web/views/qualification_html.ex:138
 #, elixir-autogen, elixir-format
 msgid "Used for %{formatted} job"
 msgid_plural "Used for %{formatted} jobs"
 msgstr[0] "Für %{formatted} Job genutzt"
 msgstr[1] "Für %{formatted} Jobs genutzt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:886
+#: lib/vutuv_web/agent_docs/markdown.ex:911
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr "aktuell genutzt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:885
+#: lib/vutuv_web/agent_docs/markdown.ex:910
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] "für %{count} Job genutzt"
 msgstr[1] "für %{count} Jobs genutzt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:891
+#: lib/vutuv_web/agent_docs/markdown.ex:916
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
 msgstr "zuletzt genutzt %{date}"
 
-#: lib/vutuv_web/templates/qualification/show.html.heex:84
-#: lib/vutuv_web/views/qualification_html.ex:247
+#: lib/vutuv_web/templates/qualification/show.html.heex:100
+#: lib/vutuv_web/views/qualification_html.ex:365
 #, elixir-autogen, elixir-format
 msgid "Being reviewed"
 msgstr "Wird geprüft"
@@ -14600,7 +14593,7 @@ msgstr "Wird geprüft"
 msgid "Choosing a new file below replaces this one."
 msgstr "Wenn Sie unten eine neue Datei wählen, wird diese ersetzt."
 
-#: lib/vutuv_web/templates/qualification/show.html.heex:75
+#: lib/vutuv_web/templates/qualification/show.html.heex:94
 #, elixir-autogen, elixir-format
 msgid "Download original (%{label})"
 msgstr "Original herunterladen (%{label})"
@@ -14611,7 +14604,7 @@ msgid "I agree that the uploaded file is shown publicly on my profile and can be
 msgstr "Ich bin damit einverstanden, dass die hochgeladene Datei öffentlich auf meinem Profil angezeigt wird und von jedem angesehen und heruntergeladen werden kann. Laden Sie nur Dokumente hoch, die Sie veröffentlichen dürfen und möchten; schwärzen Sie sensible Angaben (z. B. Adresse oder Ausweisnummern) am besten vorher."
 
 #: lib/vutuv_web/views/job_reference_html.ex:160
-#: lib/vutuv_web/views/qualification_html.ex:192
+#: lib/vutuv_web/views/qualification_html.ex:309
 #, elixir-autogen, elixir-format
 msgid "Image"
 msgstr "Bild"
@@ -14641,30 +14634,30 @@ msgstr "Hochgeladene Datei entfernen? Der Eintrag selbst bleibt bestehen."
 msgid "Show this file publicly"
 msgstr "Diese Datei öffentlich anzeigen"
 
-#: lib/vutuv_web/controllers/qualification_controller.ex:176
+#: lib/vutuv_web/controllers/qualification_controller.ex:184
 #, elixir-autogen, elixir-format
 msgid "The uploaded file was removed."
 msgstr "Die hochgeladene Datei wurde entfernt."
 
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:89
-#: lib/vutuv_web/templates/qualification/show.html.heex:55
+#: lib/vutuv_web/templates/qualification/show.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "Uploaded proof"
 msgstr "Hochgeladener Nachweis"
 
-#: lib/vutuv_web/templates/qualification/show.html.heex:65
-#: lib/vutuv_web/views/qualification_html.ex:227
+#: lib/vutuv_web/templates/qualification/show.html.heex:84
+#: lib/vutuv_web/views/qualification_html.ex:344
 #, elixir-autogen, elixir-format
 msgid "Uploaded proof for %{name}"
 msgstr "Hochgeladener Nachweis für %{name}"
 
-#: lib/vutuv_web/views/qualification_html.ex:222
+#: lib/vutuv_web/views/qualification_html.ex:339
 #, elixir-autogen, elixir-format
 msgid "View the uploaded proof (%{label})"
 msgstr "Hochgeladenen Nachweis ansehen (%{label})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:854
-#: lib/vutuv_web/agent_docs/text.ex:697
+#: lib/vutuv_web/agent_docs/markdown.ex:847
+#: lib/vutuv_web/agent_docs/text.ex:698
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr "Nachweis"
@@ -15365,7 +15358,7 @@ msgstr "%{blocked} Server blockiert, am aktivsten eingehend: %{host}."
 msgid "none yet"
 msgstr "noch keiner"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1111
+#: lib/vutuv_web/agent_docs/markdown.ex:1136
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr "Reaktionen aus anderen Netzwerken"
@@ -16148,7 +16141,7 @@ msgid_plural "%{formatted} reposts"
 msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1113
+#: lib/vutuv_web/agent_docs/markdown.ex:1138
 #: lib/vutuv_web/components/post_components.ex:4822
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
@@ -16159,8 +16152,8 @@ msgstr "Bereits in den Zahlen oben enthalten."
 msgid "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
 msgstr "Antworten, die dort draußen geschrieben werden, erscheinen unter Ihrem Beitrag, gekennzeichnet als aus einem anderen Netzwerk. Wir speichern eine Kopie für bis zu sechs Monate und prüfen ab und zu, ob sie dort noch veröffentlicht ist; löscht sie die Autorin oder der Autor, verschwindet auch unsere. Sie können jede einzelne Antwort entfernen, und wenn Sie das hier ausschalten, werden alle gelöscht."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1295
-#: lib/vutuv_web/agent_docs/text.ex:804
+#: lib/vutuv_web/agent_docs/markdown.ex:1320
+#: lib/vutuv_web/agent_docs/text.ex:818
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr "Inhaltswarnung"
@@ -16184,7 +16177,7 @@ msgstr "Vom Mitglied entfernt"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:126
 #: lib/vutuv_web/agent_docs/markdown.ex:157
-#: lib/vutuv_web/agent_docs/markdown.ex:1112
+#: lib/vutuv_web/agent_docs/markdown.ex:1137
 #: lib/vutuv_web/agent_docs/text.ex:117
 #: lib/vutuv_web/agent_docs/text.ex:145
 #, elixir-autogen, elixir-format
@@ -16242,7 +16235,7 @@ msgstr "Danke. Die Antwort wurde sofort gelöscht."
 msgid "That reply is not yours to remove."
 msgstr "Diese Antwort können Sie nicht entfernen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1297
+#: lib/vutuv_web/agent_docs/markdown.ex:1322
 #: lib/vutuv_web/components/post_components.ex:1153
 #: lib/vutuv_web/components/post_components.ex:1353
 #: lib/vutuv_web/components/post_components.ex:2178
@@ -16949,7 +16942,7 @@ msgstr ""
 msgid "Unpinned. The post is a normal post again."
 msgstr "Nicht mehr angeheftet. Der Beitrag ist wieder ein normaler Beitrag."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:993
+#: lib/vutuv_web/agent_docs/markdown.ex:1018
 #, elixir-autogen, elixir-format
 msgid "pinned post"
 msgstr "angehefteter Beitrag"
@@ -17017,8 +17010,8 @@ msgstr "Titelbild"
 msgid "Describe the photo for people who can't see it"
 msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1225
-#: lib/vutuv_web/agent_docs/text.ex:771
+#: lib/vutuv_web/agent_docs/markdown.ex:1250
+#: lib/vutuv_web/agent_docs/text.ex:785
 #: lib/vutuv_web/components/ui.ex:2471
 #, elixir-autogen, elixir-format
 msgid "Download the original"
@@ -17080,8 +17073,8 @@ msgstr "Foto wird geprüft"
 msgid "Photo options"
 msgstr "Foto-Einstellungen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1258
-#: lib/vutuv_web/agent_docs/text.ex:758
+#: lib/vutuv_web/agent_docs/markdown.ex:1283
+#: lib/vutuv_web/agent_docs/text.ex:772
 #: lib/vutuv_web/components/post_components.ex:3753
 #, elixir-autogen, elixir-format
 msgid "Photos:"
@@ -17254,13 +17247,13 @@ msgid_plural "Some of these photos carry the location they were taken at, and th
 msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exakte Datei gibt ihn weiter."
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1131
+#: lib/vutuv_web/agent_docs/markdown.ex:1156
 #: lib/vutuv_web/components/post_components.ex:4860
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1129
+#: lib/vutuv_web/agent_docs/markdown.ex:1154
 #: lib/vutuv_web/components/post_components.ex:4857
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
@@ -17892,7 +17885,7 @@ msgstr "Variante"
 msgid "What is being measured"
 msgstr "Was gemessen wird"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:988
+#: lib/vutuv_web/agent_docs/markdown.ex:1013
 #, elixir-autogen, elixir-format
 msgid "(a picture)"
 msgid_plural "(%{count} pictures)"
@@ -18056,7 +18049,7 @@ msgstr "Profil verifizieren"
 msgid "We could not reach the network just now. Please try again in a moment."
 msgstr "Wir konnten das Netzwerk gerade nicht erreichen. Bitte versuchen Sie es gleich noch einmal."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:931
+#: lib/vutuv_web/agent_docs/markdown.ex:956
 #: lib/vutuv_web/agent_docs/text.ex:620
 #, elixir-autogen, elixir-format, fuzzy
 msgid "verified profile"
@@ -18990,7 +18983,7 @@ msgstr "Höchstens %{max} Tags. Entfernen Sie eines, um ein anderes hinzuzufüge
 msgid "A post's page shows the members who liked it, right under the count. This is whether you are one of the faces."
 msgstr "Auf der Seite eines Beitrags stehen direkt unter der Zahl die Mitglieder, denen er gefällt. Hier legen Sie fest, ob Sie zu diesen Gesichtern gehören."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1099
+#: lib/vutuv_web/agent_docs/markdown.ex:1124
 #, elixir-autogen, elixir-format
 msgid "Liked by"
 msgstr "Gefällt diesen Mitgliedern"
@@ -19032,12 +19025,12 @@ msgstr "Wenn aus, sehen andere Mitglieder Sie nicht mehr bei den Likes eines Bei
 msgid "Your likes follow the site default again."
 msgstr "Ihre Likes folgen wieder dem Standardwert der Website."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1154
+#: lib/vutuv_web/agent_docs/markdown.ex:1179
 #, elixir-autogen, elixir-format
 msgid "%{address} (this page only)"
 msgstr "%{address} (nur diese Seite)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1151
+#: lib/vutuv_web/agent_docs/markdown.ex:1176
 #, elixir-autogen, elixir-format
 msgid "%{address} (whole website)"
 msgstr "%{address} (ganze Website)"
@@ -19047,7 +19040,7 @@ msgstr "%{address} (ganze Website)"
 msgid "Verified webpage of the author (%{address})"
 msgstr "Verifizierte Webseite der Autorin oder des Autors (%{address})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1143
+#: lib/vutuv_web/agent_docs/markdown.ex:1168
 #, elixir-autogen, elixir-format
 msgid "Verified webpages of the author linked here: %{addresses}"
 msgstr ""
@@ -19089,13 +19082,13 @@ msgstr "Mit dem Lebenslauf verknüpfen"
 msgid "Attached to your CV"
 msgstr "Mit dem Lebenslauf verknüpft"
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:281
+#: lib/vutuv_web/agent_docs/section_docs.ex:290
 #: lib/vutuv_web/views/job_reference_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "Ausbildungszeugnis"
 msgstr "Ausbildungszeugnis"
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:282
+#: lib/vutuv_web/agent_docs/section_docs.ex:291
 #: lib/vutuv_web/views/job_reference_html.ex:23
 #, elixir-autogen, elixir-format
 msgid "Dienstzeugnis"
@@ -19113,7 +19106,7 @@ msgstr "Dokument herunterladen"
 msgid "Edit employment reference"
 msgstr "Arbeitszeugnis bearbeiten"
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:279
+#: lib/vutuv_web/agent_docs/section_docs.ex:288
 #: lib/vutuv_web/views/job_reference_html.ex:20
 #, elixir-autogen, elixir-format
 msgid "Einfaches Zeugnis"
@@ -19189,7 +19182,7 @@ msgstr "Wird geladen …"
 msgid "Preview of the reference"
 msgstr "Vorschau des Zeugnisses"
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:278
+#: lib/vutuv_web/agent_docs/section_docs.ex:287
 #: lib/vutuv_web/views/job_reference_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "Qualifiziertes Zeugnis"
@@ -19333,7 +19326,7 @@ msgstr "Sie haben den Text nach dieser Prüfung geändert. Sie beschreibt die fr
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr "Ihre Arbeitszeugnisse, privat bis Sie sie veröffentlichen"
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:280
+#: lib/vutuv_web/agent_docs/section_docs.ex:289
 #: lib/vutuv_web/views/job_reference_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "Zwischenzeugnis"
@@ -19374,12 +19367,12 @@ msgstr "Wir prüfen Ihren Fall nicht. Sie sehen eine automatische Einordnung des
 msgid "We wrote neither the prompt nor the model."
 msgstr "Weder den Prompt noch das Modell haben wir geschrieben."
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:112
+#: lib/vutuv_web/agent_docs/section_docs.ex:117
 #, elixir-autogen, elixir-format
 msgid "Employment references of %{name}"
 msgstr "Arbeitszeugnisse von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:837
+#: lib/vutuv_web/agent_docs/markdown.ex:829
 #, elixir-autogen, elixir-format
 msgid "document"
 msgstr "Dokument"
@@ -19782,7 +19775,7 @@ msgstr "von Rechtsanwalt Tom Braegelmann"
 msgid "Documents:"
 msgstr "Belegt:"
 
-#: lib/vutuv_web/views/work_experience_html.ex:655
+#: lib/vutuv_web/views/work_experience_html.ex:664
 #, elixir-autogen, elixir-format
 msgid "Employment reference:"
 msgstr "Arbeitszeugnis:"
@@ -21396,14 +21389,14 @@ msgstr "Konten blockieren oder Blockierungen aufheben"
 msgid "Mute or unmute accounts"
 msgstr "Konten stummschalten oder Stummschaltungen aufheben"
 
-#: lib/vutuv_web/live/organization_live/apps.ex:176
+#: lib/vutuv_web/live/organization_live/apps.ex:181
 #: lib/vutuv_web/templates/settings/apps.html.heex:42
 #: lib/vutuv_web/views/account_event_text.ex:235
 #, elixir-autogen, elixir-format
 msgid "Mastodon-compatible apps"
 msgstr "Mastodon-kompatible Apps"
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:67
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:70
 #, elixir-autogen, elixir-format
 msgid "Mastodon client access is disabled for every identity available to you."
 msgstr "Der Zugriff durch Mastodon-Clients ist für alle Ihnen verfügbaren Identitäten deaktiviert."
@@ -21413,7 +21406,7 @@ msgstr "Der Zugriff durch Mastodon-Clients ist für alle Ihnen verfügbaren Iden
 msgid "Read data visible to this identity"
 msgstr "Für diese Identität sichtbare Daten lesen"
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:41
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "Use this identity"
 msgstr "Diese Identität verwenden"
@@ -21807,7 +21800,7 @@ msgstr "Profilbild von %{name}"
 msgid "Show the profile picture larger"
 msgstr "Profilbild größer anzeigen"
 
-#: lib/vutuv_web/live/organization_live/apps.ex:178
+#: lib/vutuv_web/live/organization_live/apps.ex:183
 #, elixir-autogen, elixir-format
 msgid "The page's Editorial team can use this organization as a separate identity in a compatible phone app, with the same rights they already have here. Those rights are checked again on every request."
 msgstr "Die Redaktion der Seite kann diese Organisation in einer kompatiblen Smartphone-App als eigene Identität verwenden, mit denselben Rechten, die sie hier schon hat. Diese Rechte werden bei jeder Anfrage erneut geprüft."
@@ -21817,7 +21810,7 @@ msgstr "Die Redaktion der Seite kann diese Organisation in einer kompatiblen Sma
 msgid "App settings saved."
 msgstr "App-Einstellungen gespeichert."
 
-#: lib/vutuv_web/live/organization_live/apps.ex:164
+#: lib/vutuv_web/live/organization_live/apps.ex:169
 #, elixir-autogen, elixir-format
 msgid "Apps built for Mastodon can write in this page's name, read its feed and notify its team."
 msgstr "Apps, die für Mastodon gebaut wurden, können im Namen dieser Seite schreiben, ihren Feed lesen und ihr Team benachrichtigen."
@@ -21832,7 +21825,7 @@ msgstr "Apps, die für Mastodon gebaut wurden (Ivory, Tusky, Ice Cubes und ander
 msgid "Apps – %{name}"
 msgstr "Apps – %{name}"
 
-#: lib/vutuv_web/live/organization_live/apps.ex:321
+#: lib/vutuv_web/live/organization_live/apps.ex:326
 #: lib/vutuv_web/templates/settings/apps.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "How to set up an app"
@@ -21853,38 +21846,38 @@ msgstr "Mastodon-App-Zugriff geändert"
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr "Mastodon-Apps, verbundene Apps und Zugriffstoken"
 
-#: lib/vutuv_web/live/organization_live/apps.ex:307
+#: lib/vutuv_web/live/organization_live/apps.ex:312
 #, elixir-autogen, elixir-format
 msgid "Sign in with your own account, then pick %{name} on the approval screen."
 msgstr "Melden Sie sich mit Ihrem eigenen Konto an und wählen Sie dann %{name} im Zustimmungsbildschirm."
 
-#: lib/vutuv_web/live/organization_live/apps.ex:312
+#: lib/vutuv_web/live/organization_live/apps.ex:317
 #, elixir-autogen, elixir-format
 msgid "Sign in with your own account, then pick this page on the approval screen. A short @name is not needed for that, only for being followed from another server."
 msgstr "Melden Sie sich mit Ihrem eigenen Konto an und wählen Sie dann diese Seite im Zustimmungsbildschirm. Ein kurzer @Name ist dafür nicht nötig, sondern nur dafür, von einem anderen Server aus gefolgt zu werden."
 
-#: lib/vutuv_web/live/organization_live/apps.ex:302
+#: lib/vutuv_web/live/organization_live/apps.ex:307
 #: lib/vutuv_web/templates/settings/apps.html.heex:70
 #, elixir-autogen, elixir-format
 msgid "The address to type into the app"
 msgstr "Die Adresse, die Sie in die App eintippen"
 
-#: lib/vutuv_web/live/organization_live/apps.ex:171
+#: lib/vutuv_web/live/organization_live/apps.ex:176
 #, elixir-autogen, elixir-format
 msgid "This vutuv serves no app interface, so nothing here has any effect."
 msgstr "Dieses vutuv stellt keine App-Schnittstelle bereit, hier hat also nichts eine Wirkung."
 
-#: lib/vutuv_web/live/organization_live/apps.ex:204
+#: lib/vutuv_web/live/organization_live/apps.ex:209
 #, elixir-autogen, elixir-format
 msgid "Turn app access off"
 msgstr "App-Zugriff ausschalten"
 
-#: lib/vutuv_web/live/organization_live/apps.ex:205
+#: lib/vutuv_web/live/organization_live/apps.ex:210
 #, elixir-autogen, elixir-format
 msgid "Turn app access on"
 msgstr "App-Zugriff einschalten"
 
-#: lib/vutuv_web/live/organization_live/apps.ex:183
+#: lib/vutuv_web/live/organization_live/apps.ex:188
 #, elixir-autogen, elixir-format
 msgid "Whoever posted stays recorded, so the team can always tell who wrote what — and an app signed in as this page cannot block anybody, because blocking is between two people."
 msgstr "Wer etwas geschrieben hat, wird weiter festgehalten, das Team kann also immer nachvollziehen, wer was geschrieben hat — und eine App, die als diese Seite angemeldet ist, kann niemanden blockieren, denn Blockieren ist eine Sache zwischen zwei Menschen."
@@ -22139,56 +22132,56 @@ msgstr "%{name} hat auf einen Beitrag geantwortet."
 msgid "This application asked to be connected too many times in a row. Please wait a moment and try again."
 msgstr "Diese Anwendung hat zu oft hintereinander um eine Verbindung gebeten. Bitte warten Sie einen Moment und versuchen Sie es erneut."
 
-#: lib/vutuv_web/live/organization_live/apps.ex:213
+#: lib/vutuv_web/live/organization_live/apps.ex:218
 #, elixir-autogen, elixir-format
 msgid "App access in use"
 msgstr "Genutzte App-Zugänge"
 
-#: lib/vutuv_web/live/organization_live/apps.ex:137
+#: lib/vutuv_web/live/organization_live/apps.ex:142
 #, elixir-autogen, elixir-format
 msgid "App access is off. One app token was withdrawn."
 msgid_plural "App access is off. %{count} app tokens were withdrawn."
 msgstr[0] "App-Zugriff ist aus. Ein App-Zugang wurde entzogen."
 msgstr[1] "App-Zugriff ist aus. %{count} App-Zugänge wurden entzogen."
 
-#: lib/vutuv_web/live/organization_live/apps.ex:215
+#: lib/vutuv_web/live/organization_live/apps.ex:220
 #, elixir-autogen, elixir-format
 msgid "Each row is one app signed in as this page, issued by the team member named on it. Withdrawing one stops that app immediately; the member keeps their own account."
 msgstr "Jede Zeile ist eine App, die als diese Seite angemeldet ist, ausgestellt von dem genannten Teammitglied. Wer einen Zugang entzieht, stoppt diese App sofort; das eigene Konto des Mitglieds bleibt unberührt."
 
-#: lib/vutuv_web/live/organization_live/apps.ex:230
+#: lib/vutuv_web/live/organization_live/apps.ex:235
 #, elixir-autogen, elixir-format
 msgid "Filter by member (name or @handle)"
 msgstr "Nach Mitglied filtern (Name oder @Name)"
 
-#: lib/vutuv_web/live/organization_live/apps.ex:222
+#: lib/vutuv_web/live/organization_live/apps.ex:227
 #, elixir-autogen, elixir-format
 msgid "Filter by the member who issued the token"
 msgstr "Nach dem Mitglied filtern, das den Zugang ausgestellt hat"
 
-#: lib/vutuv_web/live/organization_live/apps.ex:263
+#: lib/vutuv_web/live/organization_live/apps.ex:268
 #, elixir-autogen, elixir-format
 msgid "Issued by"
 msgstr "Ausgestellt von"
 
-#: lib/vutuv_web/live/organization_live/apps.ex:237
+#: lib/vutuv_web/live/organization_live/apps.ex:242
 #, elixir-autogen, elixir-format
 msgid "No app is signed in as this page."
 msgstr "Keine App ist als diese Seite angemeldet."
 
-#: lib/vutuv_web/live/organization_live/apps.ex:238
+#: lib/vutuv_web/live/organization_live/apps.ex:243
 #, elixir-autogen, elixir-format
 msgid "No token matches that member."
 msgstr "Zu diesem Mitglied gibt es keinen Zugang."
 
-#: lib/vutuv_web/live/organization_live/apps.ex:247
+#: lib/vutuv_web/live/organization_live/apps.ex:252
 #, elixir-autogen, elixir-format
 msgid "One app token"
 msgid_plural "%{formatted} app tokens"
 msgstr[0] "Ein App-Zugang"
 msgstr[1] "%{formatted} App-Zugänge"
 
-#: lib/vutuv_web/live/organization_live/apps.ex:260
+#: lib/vutuv_web/live/organization_live/apps.ex:265
 #, elixir-autogen, elixir-format
 msgid "Personal access token"
 msgstr "Persönlicher Zugangs-Token"
@@ -22198,24 +22191,24 @@ msgstr "Persönlicher Zugangs-Token"
 msgid "The app can no longer act for this page."
 msgstr "Die App kann nicht mehr für diese Seite handeln."
 
-#: lib/vutuv_web/live/organization_live/apps.ex:196
+#: lib/vutuv_web/live/organization_live/apps.ex:201
 #, elixir-autogen, elixir-format
 msgid "Turn app access off? The one app token issued for this page is withdrawn and stops working immediately."
 msgid_plural "Turn app access off? All %{count} app tokens issued for this page are withdrawn and stop working immediately."
 msgstr[0] "App-Zugriff abschalten? Der eine für diese Seite ausgestellte App-Zugang wird entzogen und hört sofort auf zu funktionieren."
 msgstr[1] "App-Zugriff abschalten? Alle %{count} für diese Seite ausgestellten App-Zugänge werden entzogen und hören sofort auf zu funktionieren."
 
-#: lib/vutuv_web/live/organization_live/apps.ex:282
+#: lib/vutuv_web/live/organization_live/apps.ex:287
 #, elixir-autogen, elixir-format
 msgid "Withdraw"
 msgstr "Entziehen"
 
-#: lib/vutuv_web/live/organization_live/apps.ex:279
+#: lib/vutuv_web/live/organization_live/apps.ex:284
 #, elixir-autogen, elixir-format
 msgid "Withdraw this app's access to the page? It stops working immediately."
 msgstr "Der App den Zugriff auf die Seite entziehen? Sie hört sofort auf zu funktionieren."
 
-#: lib/vutuv_web/live/organization_live/apps.ex:153
+#: lib/vutuv_web/live/organization_live/apps.ex:158
 #, elixir-autogen, elixir-format
 msgid "unknown device"
 msgstr "unbekanntes Gerät"
@@ -22230,17 +22223,19 @@ msgstr "Verbunden am"
 msgid "Confirm the follow on your own server."
 msgstr "Bestätigen Sie das Folgen auf Ihrem eigenen Server."
 
-#: lib/vutuv_web/views/outbound_html.ex:71
+#: lib/vutuv_web/views/outbound_html.ex:68
+#: lib/vutuv_web/views/outbound_html.ex:81
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr "Weiter"
 
-#: lib/vutuv_web/views/outbound_html.ex:63
+#: lib/vutuv_web/views/outbound_html.ex:67
+#: lib/vutuv_web/views/outbound_html.ex:80
 #, elixir-autogen, elixir-format
 msgid "Continue to %{server}"
 msgstr "Weiter zu %{server}"
 
-#: lib/vutuv_web/views/outbound_html.ex:62
+#: lib/vutuv_web/views/outbound_html.ex:60
 #, elixir-autogen, elixir-format
 msgid "E-mail to %{address}"
 msgstr "E-Mail an %{address}"
@@ -22250,7 +22245,7 @@ msgstr "E-Mail an %{address}"
 msgid "The employer takes applications on their own website."
 msgstr "Das Unternehmen nimmt Bewerbungen auf der eigenen Webseite entgegen."
 
-#: lib/vutuv_web/views/outbound_html.ex:70
+#: lib/vutuv_web/views/outbound_html.ex:61
 #, elixir-autogen, elixir-format
 msgid "Write e-mail"
 msgstr "E-Mail schreiben"
@@ -22259,3 +22254,9 @@ msgstr "E-Mail schreiben"
 #, elixir-autogen, elixir-format
 msgid "Your e-mail program opens with the subject filled in."
 msgstr "Ihr E-Mail-Programm öffnet sich mit ausgefülltem Betreff."
+
+#: lib/vutuv_web/views/qualification_html.ex:229
+#, elixir-autogen, elixir-format
+msgctxt "qualification detail"
+msgid "Jobs"
+msgstr "Jobs"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -29,7 +29,7 @@ msgid "Add"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:255
-#: lib/vutuv_web/agent_docs/section_docs.ex:127
+#: lib/vutuv_web/agent_docs/section_docs.ex:132
 #: lib/vutuv_web/agent_docs/text.ex:240
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
@@ -205,7 +205,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/composer.ex:1723
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/templates/user/show.html.heex:340
-#: lib/vutuv_web/views/qualification_html.ex:237
+#: lib/vutuv_web/views/qualification_html.ex:354
 #, elixir-autogen
 msgid "Download"
 msgstr ""
@@ -702,7 +702,7 @@ msgstr ""
 msgid "Add a profile"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:103
+#: lib/vutuv_web/agent_docs/section_docs.ex:108
 #, elixir-autogen, elixir-format
 msgid "Profiles of %{name}"
 msgstr ""
@@ -1103,8 +1103,8 @@ msgstr ""
 msgid "Curious? Have a look at the "
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:300
-#: lib/vutuv_web/views/work_experience_html.ex:353
+#: lib/vutuv_web/views/work_experience_html.ex:309
+#: lib/vutuv_web/views/work_experience_html.ex:362
 #, elixir-autogen
 msgid "Present"
 msgstr ""
@@ -1373,10 +1373,10 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:34
 #: lib/vutuv_web/agent_docs/markdown.ex:488
-#: lib/vutuv_web/agent_docs/markdown.ex:1038
+#: lib/vutuv_web/agent_docs/markdown.ex:1063
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:509
-#: lib/vutuv_web/agent_docs/text.ex:732
+#: lib/vutuv_web/agent_docs/text.ex:746
 #: lib/vutuv_web/components/ui.ex:4012
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1587,7 +1587,7 @@ msgstr ""
 msgid "Admin Area"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:106
+#: lib/vutuv_web/agent_docs/section_docs.ex:111
 #: lib/vutuv_web/templates/address/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Addresses of %{name}"
@@ -1813,7 +1813,7 @@ msgstr ""
 msgid "Submit a bug report or feature request"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:109
+#: lib/vutuv_web/agent_docs/section_docs.ex:114
 #: lib/vutuv_web/templates/user_tag/index.html.heex:21
 #, elixir-autogen, elixir-format
 msgid "Tags of %{name}"
@@ -1949,26 +1949,26 @@ msgstr ""
 msgid "Options"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:412
+#: lib/vutuv_web/views/work_experience_html.ex:421
 #, elixir-autogen, elixir-format
 msgid "%{count} month"
 msgid_plural "%{count} months"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:415
+#: lib/vutuv_web/views/work_experience_html.ex:424
 #, elixir-autogen, elixir-format
 msgid "%{count} year"
 msgid_plural "%{count} years"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:497
+#: lib/vutuv_web/views/work_experience_html.ex:506
 #, elixir-autogen, elixir-format
 msgid "Time in this role"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:496
+#: lib/vutuv_web/views/work_experience_html.ex:505
 #, elixir-autogen, elixir-format
 msgid "Total time at this employer"
 msgstr ""
@@ -2382,7 +2382,7 @@ msgstr ""
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1076
+#: lib/vutuv_web/agent_docs/markdown.ex:1101
 #: lib/vutuv_web/live/post_live/saved.ex:175
 #: lib/vutuv_web/live/post_live/saved.ex:488
 #: lib/vutuv_web/live/shell_live.ex:730
@@ -2402,7 +2402,7 @@ msgstr ""
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1075
+#: lib/vutuv_web/agent_docs/markdown.ex:1100
 #: lib/vutuv_web/components/post_components.ex:4916
 #: lib/vutuv_web/live/notification_live/index.ex:970
 #: lib/vutuv_web/live/post_live/saved.ex:174
@@ -3388,7 +3388,7 @@ msgstr ""
 #: lib/vutuv_web/templates/email/show.html.heex:21
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:26
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:12
-#: lib/vutuv_web/templates/qualification/show.html.heex:19
+#: lib/vutuv_web/templates/qualification/show.html.heex:23
 #, elixir-autogen, elixir-format
 msgid "Type"
 msgstr ""
@@ -3832,7 +3832,7 @@ msgstr ""
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1197
+#: lib/vutuv_web/agent_docs/markdown.ex:1222
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
@@ -3846,11 +3846,11 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:83
 #: lib/vutuv_web/agent_docs/markdown.ex:194
 #: lib/vutuv_web/agent_docs/markdown.ex:208
-#: lib/vutuv_web/agent_docs/markdown.ex:1038
+#: lib/vutuv_web/agent_docs/markdown.ex:1063
 #: lib/vutuv_web/agent_docs/text.ex:80
 #: lib/vutuv_web/agent_docs/text.ex:179
 #: lib/vutuv_web/agent_docs/text.ex:193
-#: lib/vutuv_web/agent_docs/text.ex:732
+#: lib/vutuv_web/agent_docs/text.ex:746
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr ""
@@ -3869,22 +3869,22 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1056
-#: lib/vutuv_web/agent_docs/text.ex:743
+#: lib/vutuv_web/agent_docs/markdown.ex:1081
+#: lib/vutuv_web/agent_docs/text.ex:757
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1053
-#: lib/vutuv_web/agent_docs/text.ex:740
+#: lib/vutuv_web/agent_docs/markdown.ex:1078
+#: lib/vutuv_web/agent_docs/text.ex:754
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1060
-#: lib/vutuv_web/agent_docs/markdown.ex:1274
-#: lib/vutuv_web/agent_docs/text.ex:746
-#: lib/vutuv_web/agent_docs/text.ex:790
+#: lib/vutuv_web/agent_docs/markdown.ex:1085
+#: lib/vutuv_web/agent_docs/markdown.ex:1299
+#: lib/vutuv_web/agent_docs/text.ex:760
+#: lib/vutuv_web/agent_docs/text.ex:804
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
@@ -3939,17 +3939,17 @@ msgstr ""
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1007
+#: lib/vutuv_web/agent_docs/markdown.ex:1032
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:903
+#: lib/vutuv_web/agent_docs/markdown.ex:928
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:904
+#: lib/vutuv_web/agent_docs/markdown.ex:929
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr ""
@@ -3964,22 +3964,22 @@ msgstr ""
 msgid "Connections of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:108
+#: lib/vutuv_web/agent_docs/section_docs.ex:113
 #, elixir-autogen, elixir-format
 msgid "Email addresses of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:100
+#: lib/vutuv_web/agent_docs/section_docs.ex:105
 #, elixir-autogen, elixir-format
 msgid "Links of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:107
+#: lib/vutuv_web/agent_docs/section_docs.ex:112
 #, elixir-autogen, elixir-format
 msgid "Phone numbers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:93
+#: lib/vutuv_web/agent_docs/section_docs.ex:98
 #, elixir-autogen, elixir-format
 msgid "Work experience of %{name}"
 msgstr ""
@@ -4626,7 +4626,7 @@ msgstr ""
 #: lib/vutuv_web/live/import_connections_live.ex:470
 #: lib/vutuv_web/live/notification_live/index.ex:890
 #: lib/vutuv_web/live/search_live.ex:280
-#: lib/vutuv_web/views/qualification_html.ex:90
+#: lib/vutuv_web/views/qualification_html.ex:103
 #, elixir-autogen, elixir-format
 msgid "All"
 msgstr ""
@@ -4731,7 +4731,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_posting_live/show.ex:136
 #: lib/vutuv_web/templates/access_token/new.html.heex:42
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:45
-#: lib/vutuv_web/templates/qualification/show.html.heex:33
+#: lib/vutuv_web/templates/qualification/show.html.heex:38
 #, elixir-autogen, elixir-format
 msgid "Expires"
 msgstr ""
@@ -4919,7 +4919,7 @@ msgstr ""
 msgid "Active"
 msgstr ""
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:79
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:82
 #, elixir-autogen, elixir-format
 msgid "Allow access"
 msgstr ""
@@ -4981,7 +4981,7 @@ msgstr ""
 msgid "Delete \"%{name}\"? Every member authorization and every token of this application stops working immediately."
 msgstr ""
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:88
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "Deny"
 msgstr ""
@@ -5036,7 +5036,7 @@ msgstr ""
 msgid "One per line. Exact https:// URLs (http://localhost is allowed for development). The authorization flow only ever redirects to these."
 msgstr ""
 
-#: lib/vutuv_web/controllers/oauth_controller.ex:56
+#: lib/vutuv_web/controllers/oauth_controller.ex:59
 #, elixir-autogen, elixir-format
 msgid "Please log in to connect %{app} with your account."
 msgstr ""
@@ -5635,7 +5635,7 @@ msgid "@%{slug} started following you on vutuv"
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:318
-#: lib/vutuv_web/live/organization_live/apps.ex:162
+#: lib/vutuv_web/live/organization_live/apps.ex:167
 #: lib/vutuv_web/templates/settings/apps.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Apps"
@@ -6218,7 +6218,7 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1075
+#: lib/vutuv_web/agent_docs/markdown.ex:1100
 #: lib/vutuv_web/components/post_components.ex:396
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
@@ -6323,7 +6323,7 @@ msgstr ""
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1051
+#: lib/vutuv_web/agent_docs/markdown.ex:1076
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -7527,17 +7527,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1202
+#: lib/vutuv_web/agent_docs/markdown.ex:1227
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1205
+#: lib/vutuv_web/agent_docs/markdown.ex:1230
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1212
+#: lib/vutuv_web/agent_docs/markdown.ex:1237
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -8185,7 +8185,7 @@ msgstr ""
 msgid "Education deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:94
+#: lib/vutuv_web/agent_docs/section_docs.ex:99
 #, elixir-autogen, elixir-format
 msgid "Education of %{name}"
 msgstr ""
@@ -8722,19 +8722,18 @@ msgstr ""
 msgid "Category"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:25
+#: lib/vutuv_web/views/work_experience_html.ex:24
 #, elixir-autogen, elixir-format
 msgid "Employment"
 msgstr ""
 
 #: lib/vutuv/jobs/job_posting.ex:153
-#: lib/vutuv_web/agent_docs/markdown.ex:775
-#: lib/vutuv_web/views/work_experience_html.ex:27
+#: lib/vutuv_web/views/work_experience_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Internship"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:37
+#: lib/vutuv_web/views/work_experience_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Internships"
 msgstr ""
@@ -8744,14 +8743,13 @@ msgstr ""
 msgid "On that page, select \"Download larger data archive\" (profile, positions, volunteering, education, skills)."
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:35
+#: lib/vutuv_web/views/work_experience_html.ex:34
 #, elixir-autogen, elixir-format
 msgid "Professional Experience"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:776
-#: lib/vutuv_web/views/work_experience_html.ex:31
-#: lib/vutuv_web/views/work_experience_html.ex:38
+#: lib/vutuv_web/views/work_experience_html.ex:30
+#: lib/vutuv_web/views/work_experience_html.ex:37
 #, elixir-autogen, elixir-format
 msgid "Volunteering & hobbies"
 msgstr ""
@@ -8780,13 +8778,13 @@ msgstr ""
 msgid "Higher Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:813
+#: lib/vutuv_web/agent_docs/markdown.ex:805
 #: lib/vutuv_web/views/education_html.ex:23
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:812
+#: lib/vutuv_web/agent_docs/markdown.ex:804
 #: lib/vutuv_web/views/education_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -8819,7 +8817,7 @@ msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1010
+#: lib/vutuv_web/agent_docs/markdown.ex:1035
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -8897,16 +8895,14 @@ msgstr ""
 msgid "The CV of %{name} on vutuv: work experience, education and skills to view and download."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:774
-#: lib/vutuv_web/views/work_experience_html.ex:26
-#: lib/vutuv_web/views/work_experience_html.ex:36
+#: lib/vutuv_web/views/work_experience_html.ex:25
+#: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:777
-#: lib/vutuv_web/views/work_experience_html.ex:32
-#: lib/vutuv_web/views/work_experience_html.ex:39
+#: lib/vutuv_web/views/work_experience_html.ex:31
+#: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
 msgid "Other activities"
 msgstr ""
@@ -9293,7 +9289,7 @@ msgstr ""
 msgid "Languages"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:99
+#: lib/vutuv_web/agent_docs/section_docs.ex:104
 #, elixir-autogen, elixir-format
 msgid "Languages of %{name}"
 msgstr ""
@@ -9573,8 +9569,8 @@ msgstr[1] ""
 msgid "Add a certificate or license"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:897
-#: lib/vutuv_web/views/qualification_html.ex:11
+#: lib/vutuv_web/agent_docs/markdown.ex:922
+#: lib/vutuv_web/views/qualification_html.ex:14
 #, elixir-autogen, elixir-format
 msgid "Certificate"
 msgstr ""
@@ -9584,17 +9580,17 @@ msgstr ""
 msgid "Certificate or license added successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/qualification_controller.ex:156
+#: lib/vutuv_web/controllers/qualification_controller.ex:164
 #, elixir-autogen, elixir-format
 msgid "Certificate or license deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/qualification_controller.ex:144
+#: lib/vutuv_web/controllers/qualification_controller.ex:152
 #, elixir-autogen, elixir-format
 msgid "Certificate or license updated successfully."
 msgstr ""
 
-#: lib/vutuv_web/views/qualification_html.ex:15
+#: lib/vutuv_web/views/qualification_html.ex:18
 #, elixir-autogen, elixir-format
 msgid "Certificates"
 msgstr ""
@@ -9604,7 +9600,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3999
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
-#: lib/vutuv_web/controllers/qualification_controller.ex:124
+#: lib/vutuv_web/controllers/qualification_controller.ex:132
 #: lib/vutuv_web/cv/docx.ex:183
 #: lib/vutuv_web/cv/html.ex:169
 #: lib/vutuv_web/cv/latex.ex:140
@@ -9628,13 +9624,13 @@ msgstr ""
 msgid "Certificates & licenses of "
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:97
+#: lib/vutuv_web/agent_docs/section_docs.ex:102
 #, elixir-autogen, elixir-format
 msgid "Certificates & licenses of %{name}"
 msgstr ""
 
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:65
-#: lib/vutuv_web/templates/qualification/show.html.heex:43
+#: lib/vutuv_web/templates/qualification/show.html.heex:48
 #, elixir-autogen, elixir-format
 msgid "Credential ID"
 msgstr ""
@@ -9647,35 +9643,36 @@ msgstr ""
 #: lib/vutuv_web/live/admin/job_live.ex:164
 #: lib/vutuv_web/live/admin/job_live.ex:180
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:183
-#: lib/vutuv_web/views/qualification_html.ex:283
+#: lib/vutuv_web/templates/qualification/show.html.heex:43
+#: lib/vutuv_web/views/qualification_html.ex:398
 #, elixir-autogen, elixir-format
 msgid "Expired"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:872
+#: lib/vutuv_web/agent_docs/markdown.ex:897
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr ""
 
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:27
-#: lib/vutuv_web/templates/qualification/show.html.heex:28
+#: lib/vutuv_web/templates/qualification/show.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "Issued"
 msgstr ""
 
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:18
-#: lib/vutuv_web/templates/qualification/show.html.heex:23
+#: lib/vutuv_web/templates/qualification/show.html.heex:28
 #, elixir-autogen, elixir-format
 msgid "Issuer"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:896
-#: lib/vutuv_web/views/qualification_html.ex:12
+#: lib/vutuv_web/agent_docs/markdown.ex:921
+#: lib/vutuv_web/views/qualification_html.ex:15
 #, elixir-autogen, elixir-format
 msgid "License"
 msgstr ""
 
-#: lib/vutuv_web/views/qualification_html.ex:16
+#: lib/vutuv_web/views/qualification_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "Licenses"
 msgstr ""
@@ -9685,18 +9682,18 @@ msgstr ""
 msgid "LinkedIn does not say whether an entry is a certificate or a license, so we import all of them as certificates. Please review the section afterwards and switch any that are licenses."
 msgstr ""
 
-#: lib/vutuv_web/views/qualification_html.ex:319
+#: lib/vutuv_web/views/qualification_html.ex:416
 #, elixir-autogen, elixir-format
 msgid "Proof"
 msgstr ""
 
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:74
-#: lib/vutuv_web/templates/qualification/show.html.heex:48
+#: lib/vutuv_web/templates/qualification/show.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Verification link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:870
+#: lib/vutuv_web/agent_docs/markdown.ex:895
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr ""
@@ -9711,9 +9708,8 @@ msgstr ""
 msgid "e.g. Amazon Web Services"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:871
-#: lib/vutuv_web/views/qualification_html.ex:77
-#: lib/vutuv_web/views/qualification_html.ex:80
+#: lib/vutuv_web/agent_docs/markdown.ex:896
+#: lib/vutuv_web/views/qualification_html.ex:91
 #, elixir-autogen, elixir-format
 msgid "valid until %{date}"
 msgstr ""
@@ -10499,12 +10495,12 @@ msgstr ""
 msgid "Separate tags with a comma. A tag may be several words long, like Ruby on Rails."
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:428
+#: lib/vutuv_web/views/work_experience_html.ex:437
 #, elixir-autogen, elixir-format
 msgid "%{n}m"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:429
+#: lib/vutuv_web/views/work_experience_html.ex:438
 #, elixir-autogen, elixir-format
 msgid "%{n}y"
 msgstr ""
@@ -11617,8 +11613,8 @@ msgstr ""
 msgid "Verify via file"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:917
-#: lib/vutuv_web/agent_docs/text.ex:705
+#: lib/vutuv_web/agent_docs/markdown.ex:942
+#: lib/vutuv_web/agent_docs/text.ex:719
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr ""
@@ -12187,7 +12183,6 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:504
 #: lib/vutuv_web/live/shell_live.ex:636
 #: lib/vutuv_web/templates/layout/app.html.heex:101
-#: lib/vutuv_web/templates/qualification/show.html.heex:38
 #, elixir-autogen, elixir-format
 msgid "Jobs"
 msgstr ""
@@ -13619,7 +13614,7 @@ msgstr ""
 msgid "Messengers of "
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:105
+#: lib/vutuv_web/agent_docs/section_docs.ex:110
 #, elixir-autogen, elixir-format
 msgid "Messengers of %{name}"
 msgstr ""
@@ -13691,7 +13686,7 @@ msgstr ""
 msgid "Audiobook"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1164
+#: lib/vutuv_web/agent_docs/markdown.ex:1189
 #: lib/vutuv_web/components/post_components.ex:4405
 #, elixir-autogen, elixir-format
 msgid "Book review"
@@ -13712,7 +13707,7 @@ msgstr ""
 msgid "E-book"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1164
+#: lib/vutuv_web/agent_docs/markdown.ex:1189
 #: lib/vutuv_web/components/post_components.ex:4404
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -13797,7 +13792,7 @@ msgstr ""
 msgid "Qualification"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:616
+#: lib/vutuv_web/views/work_experience_html.ex:625
 #, elixir-autogen, elixir-format
 msgid "With qualification:"
 msgstr ""
@@ -13879,45 +13874,43 @@ msgid_plural "%{formatted} new members today"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/qualification_html.ex:148
-#: lib/vutuv_web/views/qualification_html.ex:302
+#: lib/vutuv_web/views/qualification_html.ex:155
 #, elixir-autogen, elixir-format
 msgid "Currently in use"
 msgstr ""
 
-#: lib/vutuv_web/views/qualification_html.ex:151
-#: lib/vutuv_web/views/qualification_html.ex:309
+#: lib/vutuv_web/views/qualification_html.ex:158
 #, elixir-autogen, elixir-format
 msgid "Last used: %{date}"
 msgstr ""
 
-#: lib/vutuv_web/views/qualification_html.ex:143
+#: lib/vutuv_web/views/qualification_html.ex:138
 #, elixir-autogen, elixir-format
 msgid "Used for %{formatted} job"
 msgid_plural "Used for %{formatted} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:886
+#: lib/vutuv_web/agent_docs/markdown.ex:911
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:885
+#: lib/vutuv_web/agent_docs/markdown.ex:910
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:891
+#: lib/vutuv_web/agent_docs/markdown.ex:916
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
 msgstr ""
 
-#: lib/vutuv_web/templates/qualification/show.html.heex:84
-#: lib/vutuv_web/views/qualification_html.ex:247
+#: lib/vutuv_web/templates/qualification/show.html.heex:100
+#: lib/vutuv_web/views/qualification_html.ex:365
 #, elixir-autogen, elixir-format
 msgid "Being reviewed"
 msgstr ""
@@ -13927,7 +13920,7 @@ msgstr ""
 msgid "Choosing a new file below replaces this one."
 msgstr ""
 
-#: lib/vutuv_web/templates/qualification/show.html.heex:75
+#: lib/vutuv_web/templates/qualification/show.html.heex:94
 #, elixir-autogen, elixir-format
 msgid "Download original (%{label})"
 msgstr ""
@@ -13938,7 +13931,7 @@ msgid "I agree that the uploaded file is shown publicly on my profile and can be
 msgstr ""
 
 #: lib/vutuv_web/views/job_reference_html.ex:160
-#: lib/vutuv_web/views/qualification_html.ex:192
+#: lib/vutuv_web/views/qualification_html.ex:309
 #, elixir-autogen, elixir-format
 msgid "Image"
 msgstr ""
@@ -13968,30 +13961,30 @@ msgstr ""
 msgid "Show this file publicly"
 msgstr ""
 
-#: lib/vutuv_web/controllers/qualification_controller.ex:176
+#: lib/vutuv_web/controllers/qualification_controller.ex:184
 #, elixir-autogen, elixir-format
 msgid "The uploaded file was removed."
 msgstr ""
 
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:89
-#: lib/vutuv_web/templates/qualification/show.html.heex:55
+#: lib/vutuv_web/templates/qualification/show.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "Uploaded proof"
 msgstr ""
 
-#: lib/vutuv_web/templates/qualification/show.html.heex:65
-#: lib/vutuv_web/views/qualification_html.ex:227
+#: lib/vutuv_web/templates/qualification/show.html.heex:84
+#: lib/vutuv_web/views/qualification_html.ex:344
 #, elixir-autogen, elixir-format
 msgid "Uploaded proof for %{name}"
 msgstr ""
 
-#: lib/vutuv_web/views/qualification_html.ex:222
+#: lib/vutuv_web/views/qualification_html.ex:339
 #, elixir-autogen, elixir-format
 msgid "View the uploaded proof (%{label})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:854
-#: lib/vutuv_web/agent_docs/text.ex:697
+#: lib/vutuv_web/agent_docs/markdown.ex:847
+#: lib/vutuv_web/agent_docs/text.ex:698
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr ""
@@ -14668,7 +14661,7 @@ msgstr ""
 msgid "none yet"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1111
+#: lib/vutuv_web/agent_docs/markdown.ex:1136
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr ""
@@ -15437,7 +15430,7 @@ msgid_plural "%{formatted} reposts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1113
+#: lib/vutuv_web/agent_docs/markdown.ex:1138
 #: lib/vutuv_web/components/post_components.ex:4822
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
@@ -15448,8 +15441,8 @@ msgstr ""
 msgid "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1295
-#: lib/vutuv_web/agent_docs/text.ex:804
+#: lib/vutuv_web/agent_docs/markdown.ex:1320
+#: lib/vutuv_web/agent_docs/text.ex:818
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr ""
@@ -15473,7 +15466,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:126
 #: lib/vutuv_web/agent_docs/markdown.ex:157
-#: lib/vutuv_web/agent_docs/markdown.ex:1112
+#: lib/vutuv_web/agent_docs/markdown.ex:1137
 #: lib/vutuv_web/agent_docs/text.ex:117
 #: lib/vutuv_web/agent_docs/text.ex:145
 #, elixir-autogen, elixir-format
@@ -15531,7 +15524,7 @@ msgstr ""
 msgid "That reply is not yours to remove."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1297
+#: lib/vutuv_web/agent_docs/markdown.ex:1322
 #: lib/vutuv_web/components/post_components.ex:1153
 #: lib/vutuv_web/components/post_components.ex:1353
 #: lib/vutuv_web/components/post_components.ex:2178
@@ -16232,7 +16225,7 @@ msgstr ""
 msgid "Unpinned. The post is a normal post again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:993
+#: lib/vutuv_web/agent_docs/markdown.ex:1018
 #, elixir-autogen, elixir-format
 msgid "pinned post"
 msgstr ""
@@ -16296,8 +16289,8 @@ msgstr ""
 msgid "Describe the photo for people who can't see it"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1225
-#: lib/vutuv_web/agent_docs/text.ex:771
+#: lib/vutuv_web/agent_docs/markdown.ex:1250
+#: lib/vutuv_web/agent_docs/text.ex:785
 #: lib/vutuv_web/components/ui.ex:2471
 #, elixir-autogen, elixir-format
 msgid "Download the original"
@@ -16359,8 +16352,8 @@ msgstr ""
 msgid "Photo options"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1258
-#: lib/vutuv_web/agent_docs/text.ex:758
+#: lib/vutuv_web/agent_docs/markdown.ex:1283
+#: lib/vutuv_web/agent_docs/text.ex:772
 #: lib/vutuv_web/components/post_components.ex:3753
 #, elixir-autogen, elixir-format
 msgid "Photos:"
@@ -16533,13 +16526,13 @@ msgid_plural "Some of these photos carry the location they were taken at, and th
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1131
+#: lib/vutuv_web/agent_docs/markdown.ex:1156
 #: lib/vutuv_web/components/post_components.ex:4860
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1129
+#: lib/vutuv_web/agent_docs/markdown.ex:1154
 #: lib/vutuv_web/components/post_components.ex:4857
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
@@ -17162,7 +17155,7 @@ msgstr ""
 msgid "What is being measured"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:988
+#: lib/vutuv_web/agent_docs/markdown.ex:1013
 #, elixir-autogen, elixir-format
 msgid "(a picture)"
 msgid_plural "(%{count} pictures)"
@@ -17313,7 +17306,7 @@ msgstr ""
 msgid "We could not reach the network just now. Please try again in a moment."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:931
+#: lib/vutuv_web/agent_docs/markdown.ex:956
 #: lib/vutuv_web/agent_docs/text.ex:620
 #, elixir-autogen, elixir-format
 msgid "verified profile"
@@ -18244,7 +18237,7 @@ msgstr ""
 msgid "A post's page shows the members who liked it, right under the count. This is whether you are one of the faces."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1099
+#: lib/vutuv_web/agent_docs/markdown.ex:1124
 #, elixir-autogen, elixir-format
 msgid "Liked by"
 msgstr ""
@@ -18286,12 +18279,12 @@ msgstr ""
 msgid "Your likes follow the site default again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1154
+#: lib/vutuv_web/agent_docs/markdown.ex:1179
 #, elixir-autogen, elixir-format
 msgid "%{address} (this page only)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1151
+#: lib/vutuv_web/agent_docs/markdown.ex:1176
 #, elixir-autogen, elixir-format
 msgid "%{address} (whole website)"
 msgstr ""
@@ -18301,7 +18294,7 @@ msgstr ""
 msgid "Verified webpage of the author (%{address})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1143
+#: lib/vutuv_web/agent_docs/markdown.ex:1168
 #, elixir-autogen, elixir-format
 msgid "Verified webpages of the author linked here: %{addresses}"
 msgstr ""
@@ -18341,13 +18334,13 @@ msgstr ""
 msgid "Attached to your CV"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:281
+#: lib/vutuv_web/agent_docs/section_docs.ex:290
 #: lib/vutuv_web/views/job_reference_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "Ausbildungszeugnis"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:282
+#: lib/vutuv_web/agent_docs/section_docs.ex:291
 #: lib/vutuv_web/views/job_reference_html.ex:23
 #, elixir-autogen, elixir-format
 msgid "Dienstzeugnis"
@@ -18365,7 +18358,7 @@ msgstr ""
 msgid "Edit employment reference"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:279
+#: lib/vutuv_web/agent_docs/section_docs.ex:288
 #: lib/vutuv_web/views/job_reference_html.ex:20
 #, elixir-autogen, elixir-format
 msgid "Einfaches Zeugnis"
@@ -18441,7 +18434,7 @@ msgstr ""
 msgid "Preview of the reference"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:278
+#: lib/vutuv_web/agent_docs/section_docs.ex:287
 #: lib/vutuv_web/views/job_reference_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "Qualifiziertes Zeugnis"
@@ -18585,7 +18578,7 @@ msgstr ""
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:280
+#: lib/vutuv_web/agent_docs/section_docs.ex:289
 #: lib/vutuv_web/views/job_reference_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "Zwischenzeugnis"
@@ -18626,12 +18619,12 @@ msgstr ""
 msgid "We wrote neither the prompt nor the model."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:112
+#: lib/vutuv_web/agent_docs/section_docs.ex:117
 #, elixir-autogen, elixir-format
 msgid "Employment references of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:837
+#: lib/vutuv_web/agent_docs/markdown.ex:829
 #, elixir-autogen, elixir-format
 msgid "document"
 msgstr ""
@@ -19034,7 +19027,7 @@ msgstr ""
 msgid "Documents:"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:655
+#: lib/vutuv_web/views/work_experience_html.ex:664
 #, elixir-autogen, elixir-format
 msgid "Employment reference:"
 msgstr ""
@@ -20623,14 +20616,14 @@ msgstr ""
 msgid "Mute or unmute accounts"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:176
+#: lib/vutuv_web/live/organization_live/apps.ex:181
 #: lib/vutuv_web/templates/settings/apps.html.heex:42
 #: lib/vutuv_web/views/account_event_text.ex:235
 #, elixir-autogen, elixir-format
 msgid "Mastodon-compatible apps"
 msgstr ""
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:67
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:70
 #, elixir-autogen, elixir-format
 msgid "Mastodon client access is disabled for every identity available to you."
 msgstr ""
@@ -20640,7 +20633,7 @@ msgstr ""
 msgid "Read data visible to this identity"
 msgstr ""
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:41
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "Use this identity"
 msgstr ""
@@ -21017,7 +21010,7 @@ msgstr ""
 msgid "Show the profile picture larger"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:178
+#: lib/vutuv_web/live/organization_live/apps.ex:183
 #, elixir-autogen, elixir-format
 msgid "The page's Editorial team can use this organization as a separate identity in a compatible phone app, with the same rights they already have here. Those rights are checked again on every request."
 msgstr ""
@@ -21027,7 +21020,7 @@ msgstr ""
 msgid "App settings saved."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:164
+#: lib/vutuv_web/live/organization_live/apps.ex:169
 #, elixir-autogen, elixir-format
 msgid "Apps built for Mastodon can write in this page's name, read its feed and notify its team."
 msgstr ""
@@ -21042,7 +21035,7 @@ msgstr ""
 msgid "Apps – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:321
+#: lib/vutuv_web/live/organization_live/apps.ex:326
 #: lib/vutuv_web/templates/settings/apps.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "How to set up an app"
@@ -21063,38 +21056,38 @@ msgstr ""
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:307
+#: lib/vutuv_web/live/organization_live/apps.ex:312
 #, elixir-autogen, elixir-format
 msgid "Sign in with your own account, then pick %{name} on the approval screen."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:312
+#: lib/vutuv_web/live/organization_live/apps.ex:317
 #, elixir-autogen, elixir-format
 msgid "Sign in with your own account, then pick this page on the approval screen. A short @name is not needed for that, only for being followed from another server."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:302
+#: lib/vutuv_web/live/organization_live/apps.ex:307
 #: lib/vutuv_web/templates/settings/apps.html.heex:70
 #, elixir-autogen, elixir-format
 msgid "The address to type into the app"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:171
+#: lib/vutuv_web/live/organization_live/apps.ex:176
 #, elixir-autogen, elixir-format
 msgid "This vutuv serves no app interface, so nothing here has any effect."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:204
+#: lib/vutuv_web/live/organization_live/apps.ex:209
 #, elixir-autogen, elixir-format
 msgid "Turn app access off"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:205
+#: lib/vutuv_web/live/organization_live/apps.ex:210
 #, elixir-autogen, elixir-format
 msgid "Turn app access on"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:183
+#: lib/vutuv_web/live/organization_live/apps.ex:188
 #, elixir-autogen, elixir-format
 msgid "Whoever posted stays recorded, so the team can always tell who wrote what — and an app signed in as this page cannot block anybody, because blocking is between two people."
 msgstr ""
@@ -21349,56 +21342,56 @@ msgstr ""
 msgid "This application asked to be connected too many times in a row. Please wait a moment and try again."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:213
+#: lib/vutuv_web/live/organization_live/apps.ex:218
 #, elixir-autogen, elixir-format
 msgid "App access in use"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:137
+#: lib/vutuv_web/live/organization_live/apps.ex:142
 #, elixir-autogen, elixir-format
 msgid "App access is off. One app token was withdrawn."
 msgid_plural "App access is off. %{count} app tokens were withdrawn."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:215
+#: lib/vutuv_web/live/organization_live/apps.ex:220
 #, elixir-autogen, elixir-format
 msgid "Each row is one app signed in as this page, issued by the team member named on it. Withdrawing one stops that app immediately; the member keeps their own account."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:230
+#: lib/vutuv_web/live/organization_live/apps.ex:235
 #, elixir-autogen, elixir-format
 msgid "Filter by member (name or @handle)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:222
+#: lib/vutuv_web/live/organization_live/apps.ex:227
 #, elixir-autogen, elixir-format
 msgid "Filter by the member who issued the token"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:263
+#: lib/vutuv_web/live/organization_live/apps.ex:268
 #, elixir-autogen, elixir-format
 msgid "Issued by"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:237
+#: lib/vutuv_web/live/organization_live/apps.ex:242
 #, elixir-autogen, elixir-format
 msgid "No app is signed in as this page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:238
+#: lib/vutuv_web/live/organization_live/apps.ex:243
 #, elixir-autogen, elixir-format
 msgid "No token matches that member."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:247
+#: lib/vutuv_web/live/organization_live/apps.ex:252
 #, elixir-autogen, elixir-format
 msgid "One app token"
 msgid_plural "%{formatted} app tokens"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:260
+#: lib/vutuv_web/live/organization_live/apps.ex:265
 #, elixir-autogen, elixir-format
 msgid "Personal access token"
 msgstr ""
@@ -21408,24 +21401,24 @@ msgstr ""
 msgid "The app can no longer act for this page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:196
+#: lib/vutuv_web/live/organization_live/apps.ex:201
 #, elixir-autogen, elixir-format
 msgid "Turn app access off? The one app token issued for this page is withdrawn and stops working immediately."
 msgid_plural "Turn app access off? All %{count} app tokens issued for this page are withdrawn and stop working immediately."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:282
+#: lib/vutuv_web/live/organization_live/apps.ex:287
 #, elixir-autogen, elixir-format
 msgid "Withdraw"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:279
+#: lib/vutuv_web/live/organization_live/apps.ex:284
 #, elixir-autogen, elixir-format
 msgid "Withdraw this app's access to the page? It stops working immediately."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:153
+#: lib/vutuv_web/live/organization_live/apps.ex:158
 #, elixir-autogen, elixir-format
 msgid "unknown device"
 msgstr ""
@@ -21440,17 +21433,19 @@ msgstr ""
 msgid "Confirm the follow on your own server."
 msgstr ""
 
-#: lib/vutuv_web/views/outbound_html.ex:71
+#: lib/vutuv_web/views/outbound_html.ex:68
+#: lib/vutuv_web/views/outbound_html.ex:81
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr ""
 
-#: lib/vutuv_web/views/outbound_html.ex:63
+#: lib/vutuv_web/views/outbound_html.ex:67
+#: lib/vutuv_web/views/outbound_html.ex:80
 #, elixir-autogen, elixir-format
 msgid "Continue to %{server}"
 msgstr ""
 
-#: lib/vutuv_web/views/outbound_html.ex:62
+#: lib/vutuv_web/views/outbound_html.ex:60
 #, elixir-autogen, elixir-format
 msgid "E-mail to %{address}"
 msgstr ""
@@ -21460,7 +21455,7 @@ msgstr ""
 msgid "The employer takes applications on their own website."
 msgstr ""
 
-#: lib/vutuv_web/views/outbound_html.ex:70
+#: lib/vutuv_web/views/outbound_html.ex:61
 #, elixir-autogen, elixir-format
 msgid "Write e-mail"
 msgstr ""
@@ -21468,4 +21463,10 @@ msgstr ""
 #: lib/vutuv_web/controllers/job_posting_controller.ex:120
 #, elixir-autogen, elixir-format
 msgid "Your e-mail program opens with the subject filled in."
+msgstr ""
+
+#: lib/vutuv_web/views/qualification_html.ex:229
+#, elixir-autogen, elixir-format
+msgctxt "qualification detail"
+msgid "Jobs"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -27,7 +27,7 @@ msgid "Add"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:255
-#: lib/vutuv_web/agent_docs/section_docs.ex:127
+#: lib/vutuv_web/agent_docs/section_docs.ex:132
 #: lib/vutuv_web/agent_docs/text.ex:240
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
@@ -203,7 +203,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/composer.ex:1723
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/templates/user/show.html.heex:340
-#: lib/vutuv_web/views/qualification_html.ex:237
+#: lib/vutuv_web/views/qualification_html.ex:354
 #, elixir-autogen
 msgid "Download"
 msgstr ""
@@ -700,7 +700,7 @@ msgstr ""
 msgid "Add a profile"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:103
+#: lib/vutuv_web/agent_docs/section_docs.ex:108
 #, elixir-autogen, elixir-format
 msgid "Profiles of %{name}"
 msgstr ""
@@ -1101,8 +1101,8 @@ msgstr ""
 msgid "Curious? Have a look at the "
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:300
-#: lib/vutuv_web/views/work_experience_html.ex:353
+#: lib/vutuv_web/views/work_experience_html.ex:309
+#: lib/vutuv_web/views/work_experience_html.ex:362
 #, elixir-autogen
 msgid "Present"
 msgstr ""
@@ -1371,10 +1371,10 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:34
 #: lib/vutuv_web/agent_docs/markdown.ex:488
-#: lib/vutuv_web/agent_docs/markdown.ex:1038
+#: lib/vutuv_web/agent_docs/markdown.ex:1063
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:509
-#: lib/vutuv_web/agent_docs/text.ex:732
+#: lib/vutuv_web/agent_docs/text.ex:746
 #: lib/vutuv_web/components/ui.ex:4012
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1585,7 +1585,7 @@ msgstr ""
 msgid "Admin Area"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:106
+#: lib/vutuv_web/agent_docs/section_docs.ex:111
 #: lib/vutuv_web/templates/address/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Addresses of %{name}"
@@ -1811,7 +1811,7 @@ msgstr ""
 msgid "Submit a bug report or feature request"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:109
+#: lib/vutuv_web/agent_docs/section_docs.ex:114
 #: lib/vutuv_web/templates/user_tag/index.html.heex:21
 #, elixir-autogen, elixir-format
 msgid "Tags of %{name}"
@@ -1947,26 +1947,26 @@ msgstr ""
 msgid "Options"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:412
+#: lib/vutuv_web/views/work_experience_html.ex:421
 #, elixir-autogen, elixir-format
 msgid "%{count} month"
 msgid_plural "%{count} months"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:415
+#: lib/vutuv_web/views/work_experience_html.ex:424
 #, elixir-autogen, elixir-format
 msgid "%{count} year"
 msgid_plural "%{count} years"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:497
+#: lib/vutuv_web/views/work_experience_html.ex:506
 #, elixir-autogen, elixir-format
 msgid "Time in this role"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:496
+#: lib/vutuv_web/views/work_experience_html.ex:505
 #, elixir-autogen, elixir-format
 msgid "Total time at this employer"
 msgstr ""
@@ -2380,7 +2380,7 @@ msgstr ""
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1076
+#: lib/vutuv_web/agent_docs/markdown.ex:1101
 #: lib/vutuv_web/live/post_live/saved.ex:175
 #: lib/vutuv_web/live/post_live/saved.ex:488
 #: lib/vutuv_web/live/shell_live.ex:730
@@ -2400,7 +2400,7 @@ msgstr ""
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1075
+#: lib/vutuv_web/agent_docs/markdown.ex:1100
 #: lib/vutuv_web/components/post_components.ex:4916
 #: lib/vutuv_web/live/notification_live/index.ex:970
 #: lib/vutuv_web/live/post_live/saved.ex:174
@@ -3386,7 +3386,7 @@ msgstr ""
 #: lib/vutuv_web/templates/email/show.html.heex:21
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:26
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:12
-#: lib/vutuv_web/templates/qualification/show.html.heex:19
+#: lib/vutuv_web/templates/qualification/show.html.heex:23
 #, elixir-autogen, elixir-format
 msgid "Type"
 msgstr ""
@@ -3830,7 +3830,7 @@ msgstr ""
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1197
+#: lib/vutuv_web/agent_docs/markdown.ex:1222
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
@@ -3844,11 +3844,11 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:83
 #: lib/vutuv_web/agent_docs/markdown.ex:194
 #: lib/vutuv_web/agent_docs/markdown.ex:208
-#: lib/vutuv_web/agent_docs/markdown.ex:1038
+#: lib/vutuv_web/agent_docs/markdown.ex:1063
 #: lib/vutuv_web/agent_docs/text.ex:80
 #: lib/vutuv_web/agent_docs/text.ex:179
 #: lib/vutuv_web/agent_docs/text.ex:193
-#: lib/vutuv_web/agent_docs/text.ex:732
+#: lib/vutuv_web/agent_docs/text.ex:746
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr ""
@@ -3867,22 +3867,22 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1056
-#: lib/vutuv_web/agent_docs/text.ex:743
+#: lib/vutuv_web/agent_docs/markdown.ex:1081
+#: lib/vutuv_web/agent_docs/text.ex:757
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1053
-#: lib/vutuv_web/agent_docs/text.ex:740
+#: lib/vutuv_web/agent_docs/markdown.ex:1078
+#: lib/vutuv_web/agent_docs/text.ex:754
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1060
-#: lib/vutuv_web/agent_docs/markdown.ex:1274
-#: lib/vutuv_web/agent_docs/text.ex:746
-#: lib/vutuv_web/agent_docs/text.ex:790
+#: lib/vutuv_web/agent_docs/markdown.ex:1085
+#: lib/vutuv_web/agent_docs/markdown.ex:1299
+#: lib/vutuv_web/agent_docs/text.ex:760
+#: lib/vutuv_web/agent_docs/text.ex:804
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
@@ -3937,17 +3937,17 @@ msgstr ""
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1007
+#: lib/vutuv_web/agent_docs/markdown.ex:1032
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:903
+#: lib/vutuv_web/agent_docs/markdown.ex:928
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:904
+#: lib/vutuv_web/agent_docs/markdown.ex:929
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr ""
@@ -3962,22 +3962,22 @@ msgstr ""
 msgid "Connections of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:108
+#: lib/vutuv_web/agent_docs/section_docs.ex:113
 #, elixir-autogen, elixir-format
 msgid "Email addresses of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:100
+#: lib/vutuv_web/agent_docs/section_docs.ex:105
 #, elixir-autogen, elixir-format
 msgid "Links of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:107
+#: lib/vutuv_web/agent_docs/section_docs.ex:112
 #, elixir-autogen, elixir-format
 msgid "Phone numbers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:93
+#: lib/vutuv_web/agent_docs/section_docs.ex:98
 #, elixir-autogen, elixir-format
 msgid "Work experience of %{name}"
 msgstr ""
@@ -4624,7 +4624,7 @@ msgstr ""
 #: lib/vutuv_web/live/import_connections_live.ex:470
 #: lib/vutuv_web/live/notification_live/index.ex:890
 #: lib/vutuv_web/live/search_live.ex:280
-#: lib/vutuv_web/views/qualification_html.ex:90
+#: lib/vutuv_web/views/qualification_html.ex:103
 #, elixir-autogen, elixir-format
 msgid "All"
 msgstr ""
@@ -4729,7 +4729,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_posting_live/show.ex:136
 #: lib/vutuv_web/templates/access_token/new.html.heex:42
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:45
-#: lib/vutuv_web/templates/qualification/show.html.heex:33
+#: lib/vutuv_web/templates/qualification/show.html.heex:38
 #, elixir-autogen, elixir-format
 msgid "Expires"
 msgstr ""
@@ -4917,7 +4917,7 @@ msgstr ""
 msgid "Active"
 msgstr ""
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:79
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:82
 #, elixir-autogen, elixir-format
 msgid "Allow access"
 msgstr ""
@@ -4979,7 +4979,7 @@ msgstr ""
 msgid "Delete \"%{name}\"? Every member authorization and every token of this application stops working immediately."
 msgstr ""
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:88
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "Deny"
 msgstr ""
@@ -5034,7 +5034,7 @@ msgstr ""
 msgid "One per line. Exact https:// URLs (http://localhost is allowed for development). The authorization flow only ever redirects to these."
 msgstr ""
 
-#: lib/vutuv_web/controllers/oauth_controller.ex:56
+#: lib/vutuv_web/controllers/oauth_controller.ex:59
 #, elixir-autogen, elixir-format
 msgid "Please log in to connect %{app} with your account."
 msgstr ""
@@ -5633,7 +5633,7 @@ msgid "@%{slug} started following you on vutuv"
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:318
-#: lib/vutuv_web/live/organization_live/apps.ex:162
+#: lib/vutuv_web/live/organization_live/apps.ex:167
 #: lib/vutuv_web/templates/settings/apps.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Apps"
@@ -6216,7 +6216,7 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1075
+#: lib/vutuv_web/agent_docs/markdown.ex:1100
 #: lib/vutuv_web/components/post_components.ex:396
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
@@ -6321,7 +6321,7 @@ msgstr ""
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1051
+#: lib/vutuv_web/agent_docs/markdown.ex:1076
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -7525,17 +7525,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1202
+#: lib/vutuv_web/agent_docs/markdown.ex:1227
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1205
+#: lib/vutuv_web/agent_docs/markdown.ex:1230
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1212
+#: lib/vutuv_web/agent_docs/markdown.ex:1237
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -8183,7 +8183,7 @@ msgstr ""
 msgid "Education deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:94
+#: lib/vutuv_web/agent_docs/section_docs.ex:99
 #, elixir-autogen, elixir-format
 msgid "Education of %{name}"
 msgstr ""
@@ -8720,19 +8720,18 @@ msgstr ""
 msgid "Category"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:25
+#: lib/vutuv_web/views/work_experience_html.ex:24
 #, elixir-autogen, elixir-format
 msgid "Employment"
 msgstr ""
 
 #: lib/vutuv/jobs/job_posting.ex:153
-#: lib/vutuv_web/agent_docs/markdown.ex:775
-#: lib/vutuv_web/views/work_experience_html.ex:27
+#: lib/vutuv_web/views/work_experience_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Internship"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:37
+#: lib/vutuv_web/views/work_experience_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Internships"
 msgstr ""
@@ -8742,14 +8741,13 @@ msgstr ""
 msgid "On that page, select \"Download larger data archive\" (profile, positions, volunteering, education, skills)."
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:35
+#: lib/vutuv_web/views/work_experience_html.ex:34
 #, elixir-autogen, elixir-format
 msgid "Professional Experience"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:776
-#: lib/vutuv_web/views/work_experience_html.ex:31
-#: lib/vutuv_web/views/work_experience_html.ex:38
+#: lib/vutuv_web/views/work_experience_html.ex:30
+#: lib/vutuv_web/views/work_experience_html.ex:37
 #, elixir-autogen, elixir-format
 msgid "Volunteering & hobbies"
 msgstr ""
@@ -8778,13 +8776,13 @@ msgstr ""
 msgid "Higher Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:813
+#: lib/vutuv_web/agent_docs/markdown.ex:805
 #: lib/vutuv_web/views/education_html.ex:23
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:812
+#: lib/vutuv_web/agent_docs/markdown.ex:804
 #: lib/vutuv_web/views/education_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -8817,7 +8815,7 @@ msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1010
+#: lib/vutuv_web/agent_docs/markdown.ex:1035
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -8895,16 +8893,14 @@ msgstr ""
 msgid "The CV of %{name} on vutuv: work experience, education and skills to view and download."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:774
-#: lib/vutuv_web/views/work_experience_html.ex:26
-#: lib/vutuv_web/views/work_experience_html.ex:36
+#: lib/vutuv_web/views/work_experience_html.ex:25
+#: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:777
-#: lib/vutuv_web/views/work_experience_html.ex:32
-#: lib/vutuv_web/views/work_experience_html.ex:39
+#: lib/vutuv_web/views/work_experience_html.ex:31
+#: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
 msgid "Other activities"
 msgstr ""
@@ -9291,7 +9287,7 @@ msgstr ""
 msgid "Languages"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:99
+#: lib/vutuv_web/agent_docs/section_docs.ex:104
 #, elixir-autogen, elixir-format
 msgid "Languages of %{name}"
 msgstr ""
@@ -9571,8 +9567,8 @@ msgstr[1] ""
 msgid "Add a certificate or license"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:897
-#: lib/vutuv_web/views/qualification_html.ex:11
+#: lib/vutuv_web/agent_docs/markdown.ex:922
+#: lib/vutuv_web/views/qualification_html.ex:14
 #, elixir-autogen, elixir-format
 msgid "Certificate"
 msgstr ""
@@ -9582,17 +9578,17 @@ msgstr ""
 msgid "Certificate or license added successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/qualification_controller.ex:156
+#: lib/vutuv_web/controllers/qualification_controller.ex:164
 #, elixir-autogen, elixir-format
 msgid "Certificate or license deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/qualification_controller.ex:144
+#: lib/vutuv_web/controllers/qualification_controller.ex:152
 #, elixir-autogen, elixir-format
 msgid "Certificate or license updated successfully."
 msgstr ""
 
-#: lib/vutuv_web/views/qualification_html.ex:15
+#: lib/vutuv_web/views/qualification_html.ex:18
 #, elixir-autogen, elixir-format
 msgid "Certificates"
 msgstr ""
@@ -9602,7 +9598,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3999
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
-#: lib/vutuv_web/controllers/qualification_controller.ex:124
+#: lib/vutuv_web/controllers/qualification_controller.ex:132
 #: lib/vutuv_web/cv/docx.ex:183
 #: lib/vutuv_web/cv/html.ex:169
 #: lib/vutuv_web/cv/latex.ex:140
@@ -9626,13 +9622,13 @@ msgstr ""
 msgid "Certificates & licenses of "
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:97
+#: lib/vutuv_web/agent_docs/section_docs.ex:102
 #, elixir-autogen, elixir-format
 msgid "Certificates & licenses of %{name}"
 msgstr ""
 
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:65
-#: lib/vutuv_web/templates/qualification/show.html.heex:43
+#: lib/vutuv_web/templates/qualification/show.html.heex:48
 #, elixir-autogen, elixir-format
 msgid "Credential ID"
 msgstr ""
@@ -9645,35 +9641,36 @@ msgstr ""
 #: lib/vutuv_web/live/admin/job_live.ex:164
 #: lib/vutuv_web/live/admin/job_live.ex:180
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:183
-#: lib/vutuv_web/views/qualification_html.ex:283
+#: lib/vutuv_web/templates/qualification/show.html.heex:43
+#: lib/vutuv_web/views/qualification_html.ex:398
 #, elixir-autogen, elixir-format
 msgid "Expired"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:872
+#: lib/vutuv_web/agent_docs/markdown.ex:897
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr ""
 
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:27
-#: lib/vutuv_web/templates/qualification/show.html.heex:28
+#: lib/vutuv_web/templates/qualification/show.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "Issued"
 msgstr ""
 
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:18
-#: lib/vutuv_web/templates/qualification/show.html.heex:23
+#: lib/vutuv_web/templates/qualification/show.html.heex:28
 #, elixir-autogen, elixir-format
 msgid "Issuer"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:896
-#: lib/vutuv_web/views/qualification_html.ex:12
+#: lib/vutuv_web/agent_docs/markdown.ex:921
+#: lib/vutuv_web/views/qualification_html.ex:15
 #, elixir-autogen, elixir-format
 msgid "License"
 msgstr ""
 
-#: lib/vutuv_web/views/qualification_html.ex:16
+#: lib/vutuv_web/views/qualification_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "Licenses"
 msgstr ""
@@ -9683,18 +9680,18 @@ msgstr ""
 msgid "LinkedIn does not say whether an entry is a certificate or a license, so we import all of them as certificates. Please review the section afterwards and switch any that are licenses."
 msgstr ""
 
-#: lib/vutuv_web/views/qualification_html.ex:319
+#: lib/vutuv_web/views/qualification_html.ex:416
 #, elixir-autogen, elixir-format
 msgid "Proof"
 msgstr ""
 
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:74
-#: lib/vutuv_web/templates/qualification/show.html.heex:48
+#: lib/vutuv_web/templates/qualification/show.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Verification link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:870
+#: lib/vutuv_web/agent_docs/markdown.ex:895
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr ""
@@ -9709,9 +9706,8 @@ msgstr ""
 msgid "e.g. Amazon Web Services"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:871
-#: lib/vutuv_web/views/qualification_html.ex:77
-#: lib/vutuv_web/views/qualification_html.ex:80
+#: lib/vutuv_web/agent_docs/markdown.ex:896
+#: lib/vutuv_web/views/qualification_html.ex:91
 #, elixir-autogen, elixir-format
 msgid "valid until %{date}"
 msgstr ""
@@ -10497,12 +10493,12 @@ msgstr ""
 msgid "Separate tags with a comma. A tag may be several words long, like Ruby on Rails."
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:428
+#: lib/vutuv_web/views/work_experience_html.ex:437
 #, elixir-autogen, elixir-format
 msgid "%{n}m"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:429
+#: lib/vutuv_web/views/work_experience_html.ex:438
 #, elixir-autogen, elixir-format
 msgid "%{n}y"
 msgstr ""
@@ -11615,8 +11611,8 @@ msgstr ""
 msgid "Verify via file"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:917
-#: lib/vutuv_web/agent_docs/text.ex:705
+#: lib/vutuv_web/agent_docs/markdown.ex:942
+#: lib/vutuv_web/agent_docs/text.ex:719
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr ""
@@ -12185,7 +12181,6 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:504
 #: lib/vutuv_web/live/shell_live.ex:636
 #: lib/vutuv_web/templates/layout/app.html.heex:101
-#: lib/vutuv_web/templates/qualification/show.html.heex:38
 #, elixir-autogen, elixir-format
 msgid "Jobs"
 msgstr ""
@@ -13617,7 +13612,7 @@ msgstr ""
 msgid "Messengers of "
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:105
+#: lib/vutuv_web/agent_docs/section_docs.ex:110
 #, elixir-autogen, elixir-format
 msgid "Messengers of %{name}"
 msgstr ""
@@ -13689,7 +13684,7 @@ msgstr ""
 msgid "Audiobook"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1164
+#: lib/vutuv_web/agent_docs/markdown.ex:1189
 #: lib/vutuv_web/components/post_components.ex:4405
 #, elixir-autogen, elixir-format
 msgid "Book review"
@@ -13710,7 +13705,7 @@ msgstr ""
 msgid "E-book"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1164
+#: lib/vutuv_web/agent_docs/markdown.ex:1189
 #: lib/vutuv_web/components/post_components.ex:4404
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -13795,7 +13790,7 @@ msgstr ""
 msgid "Qualification"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:616
+#: lib/vutuv_web/views/work_experience_html.ex:625
 #, elixir-autogen, elixir-format
 msgid "With qualification:"
 msgstr ""
@@ -13877,45 +13872,43 @@ msgid_plural "%{formatted} new members today"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/qualification_html.ex:148
-#: lib/vutuv_web/views/qualification_html.ex:302
+#: lib/vutuv_web/views/qualification_html.ex:155
 #, elixir-autogen, elixir-format
 msgid "Currently in use"
 msgstr ""
 
-#: lib/vutuv_web/views/qualification_html.ex:151
-#: lib/vutuv_web/views/qualification_html.ex:309
+#: lib/vutuv_web/views/qualification_html.ex:158
 #, elixir-autogen, elixir-format
 msgid "Last used: %{date}"
 msgstr ""
 
-#: lib/vutuv_web/views/qualification_html.ex:143
+#: lib/vutuv_web/views/qualification_html.ex:138
 #, elixir-autogen, elixir-format
 msgid "Used for %{formatted} job"
 msgid_plural "Used for %{formatted} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:886
+#: lib/vutuv_web/agent_docs/markdown.ex:911
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:885
+#: lib/vutuv_web/agent_docs/markdown.ex:910
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:891
+#: lib/vutuv_web/agent_docs/markdown.ex:916
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
 msgstr ""
 
-#: lib/vutuv_web/templates/qualification/show.html.heex:84
-#: lib/vutuv_web/views/qualification_html.ex:247
+#: lib/vutuv_web/templates/qualification/show.html.heex:100
+#: lib/vutuv_web/views/qualification_html.ex:365
 #, elixir-autogen, elixir-format
 msgid "Being reviewed"
 msgstr ""
@@ -13925,7 +13918,7 @@ msgstr ""
 msgid "Choosing a new file below replaces this one."
 msgstr ""
 
-#: lib/vutuv_web/templates/qualification/show.html.heex:75
+#: lib/vutuv_web/templates/qualification/show.html.heex:94
 #, elixir-autogen, elixir-format
 msgid "Download original (%{label})"
 msgstr ""
@@ -13936,7 +13929,7 @@ msgid "I agree that the uploaded file is shown publicly on my profile and can be
 msgstr ""
 
 #: lib/vutuv_web/views/job_reference_html.ex:160
-#: lib/vutuv_web/views/qualification_html.ex:192
+#: lib/vutuv_web/views/qualification_html.ex:309
 #, elixir-autogen, elixir-format
 msgid "Image"
 msgstr ""
@@ -13966,30 +13959,30 @@ msgstr ""
 msgid "Show this file publicly"
 msgstr ""
 
-#: lib/vutuv_web/controllers/qualification_controller.ex:176
+#: lib/vutuv_web/controllers/qualification_controller.ex:184
 #, elixir-autogen, elixir-format
 msgid "The uploaded file was removed."
 msgstr ""
 
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:89
-#: lib/vutuv_web/templates/qualification/show.html.heex:55
+#: lib/vutuv_web/templates/qualification/show.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "Uploaded proof"
 msgstr ""
 
-#: lib/vutuv_web/templates/qualification/show.html.heex:65
-#: lib/vutuv_web/views/qualification_html.ex:227
+#: lib/vutuv_web/templates/qualification/show.html.heex:84
+#: lib/vutuv_web/views/qualification_html.ex:344
 #, elixir-autogen, elixir-format
 msgid "Uploaded proof for %{name}"
 msgstr ""
 
-#: lib/vutuv_web/views/qualification_html.ex:222
+#: lib/vutuv_web/views/qualification_html.ex:339
 #, elixir-autogen, elixir-format
 msgid "View the uploaded proof (%{label})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:854
-#: lib/vutuv_web/agent_docs/text.ex:697
+#: lib/vutuv_web/agent_docs/markdown.ex:847
+#: lib/vutuv_web/agent_docs/text.ex:698
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr ""
@@ -14666,7 +14659,7 @@ msgstr ""
 msgid "none yet"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1111
+#: lib/vutuv_web/agent_docs/markdown.ex:1136
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr ""
@@ -15435,7 +15428,7 @@ msgid_plural "%{formatted} reposts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1113
+#: lib/vutuv_web/agent_docs/markdown.ex:1138
 #: lib/vutuv_web/components/post_components.ex:4822
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
@@ -15446,8 +15439,8 @@ msgstr ""
 msgid "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1295
-#: lib/vutuv_web/agent_docs/text.ex:804
+#: lib/vutuv_web/agent_docs/markdown.ex:1320
+#: lib/vutuv_web/agent_docs/text.ex:818
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Content warning"
 msgstr ""
@@ -15471,7 +15464,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:126
 #: lib/vutuv_web/agent_docs/markdown.ex:157
-#: lib/vutuv_web/agent_docs/markdown.ex:1112
+#: lib/vutuv_web/agent_docs/markdown.ex:1137
 #: lib/vutuv_web/agent_docs/text.ex:117
 #: lib/vutuv_web/agent_docs/text.ex:145
 #, elixir-autogen, elixir-format
@@ -15529,7 +15522,7 @@ msgstr ""
 msgid "That reply is not yours to remove."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1297
+#: lib/vutuv_web/agent_docs/markdown.ex:1322
 #: lib/vutuv_web/components/post_components.ex:1153
 #: lib/vutuv_web/components/post_components.ex:1353
 #: lib/vutuv_web/components/post_components.ex:2178
@@ -16230,7 +16223,7 @@ msgstr ""
 msgid "Unpinned. The post is a normal post again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:993
+#: lib/vutuv_web/agent_docs/markdown.ex:1018
 #, elixir-autogen, elixir-format
 msgid "pinned post"
 msgstr ""
@@ -16294,8 +16287,8 @@ msgstr ""
 msgid "Describe the photo for people who can't see it"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1225
-#: lib/vutuv_web/agent_docs/text.ex:771
+#: lib/vutuv_web/agent_docs/markdown.ex:1250
+#: lib/vutuv_web/agent_docs/text.ex:785
 #: lib/vutuv_web/components/ui.ex:2471
 #, elixir-autogen, elixir-format
 msgid "Download the original"
@@ -16357,8 +16350,8 @@ msgstr ""
 msgid "Photo options"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1258
-#: lib/vutuv_web/agent_docs/text.ex:758
+#: lib/vutuv_web/agent_docs/markdown.ex:1283
+#: lib/vutuv_web/agent_docs/text.ex:772
 #: lib/vutuv_web/components/post_components.ex:3753
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
@@ -16531,13 +16524,13 @@ msgid_plural "Some of these photos carry the location they were taken at, and th
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1131
+#: lib/vutuv_web/agent_docs/markdown.ex:1156
 #: lib/vutuv_web/components/post_components.ex:4860
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1129
+#: lib/vutuv_web/agent_docs/markdown.ex:1154
 #: lib/vutuv_web/components/post_components.ex:4857
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
@@ -17160,7 +17153,7 @@ msgstr ""
 msgid "What is being measured"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:988
+#: lib/vutuv_web/agent_docs/markdown.ex:1013
 #, elixir-autogen, elixir-format
 msgid "(a picture)"
 msgid_plural "(%{count} pictures)"
@@ -17311,7 +17304,7 @@ msgstr ""
 msgid "We could not reach the network just now. Please try again in a moment."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:931
+#: lib/vutuv_web/agent_docs/markdown.ex:956
 #: lib/vutuv_web/agent_docs/text.ex:620
 #, elixir-autogen, elixir-format, fuzzy
 msgid "verified profile"
@@ -18242,7 +18235,7 @@ msgstr ""
 msgid "A post's page shows the members who liked it, right under the count. This is whether you are one of the faces."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1099
+#: lib/vutuv_web/agent_docs/markdown.ex:1124
 #, elixir-autogen, elixir-format
 msgid "Liked by"
 msgstr ""
@@ -18284,12 +18277,12 @@ msgstr ""
 msgid "Your likes follow the site default again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1154
+#: lib/vutuv_web/agent_docs/markdown.ex:1179
 #, elixir-autogen, elixir-format
 msgid "%{address} (this page only)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1151
+#: lib/vutuv_web/agent_docs/markdown.ex:1176
 #, elixir-autogen, elixir-format
 msgid "%{address} (whole website)"
 msgstr ""
@@ -18299,7 +18292,7 @@ msgstr ""
 msgid "Verified webpage of the author (%{address})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1143
+#: lib/vutuv_web/agent_docs/markdown.ex:1168
 #, elixir-autogen, elixir-format
 msgid "Verified webpages of the author linked here: %{addresses}"
 msgstr ""
@@ -18339,13 +18332,13 @@ msgstr ""
 msgid "Attached to your CV"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:281
+#: lib/vutuv_web/agent_docs/section_docs.ex:290
 #: lib/vutuv_web/views/job_reference_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "Ausbildungszeugnis"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:282
+#: lib/vutuv_web/agent_docs/section_docs.ex:291
 #: lib/vutuv_web/views/job_reference_html.ex:23
 #, elixir-autogen, elixir-format
 msgid "Dienstzeugnis"
@@ -18363,7 +18356,7 @@ msgstr ""
 msgid "Edit employment reference"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:279
+#: lib/vutuv_web/agent_docs/section_docs.ex:288
 #: lib/vutuv_web/views/job_reference_html.ex:20
 #, elixir-autogen, elixir-format
 msgid "Einfaches Zeugnis"
@@ -18439,7 +18432,7 @@ msgstr ""
 msgid "Preview of the reference"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:278
+#: lib/vutuv_web/agent_docs/section_docs.ex:287
 #: lib/vutuv_web/views/job_reference_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "Qualifiziertes Zeugnis"
@@ -18583,7 +18576,7 @@ msgstr ""
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:280
+#: lib/vutuv_web/agent_docs/section_docs.ex:289
 #: lib/vutuv_web/views/job_reference_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "Zwischenzeugnis"
@@ -18624,12 +18617,12 @@ msgstr ""
 msgid "We wrote neither the prompt nor the model."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:112
+#: lib/vutuv_web/agent_docs/section_docs.ex:117
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Employment references of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:837
+#: lib/vutuv_web/agent_docs/markdown.ex:829
 #, elixir-autogen, elixir-format, fuzzy
 msgid "document"
 msgstr ""
@@ -19032,7 +19025,7 @@ msgstr ""
 msgid "Documents:"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:655
+#: lib/vutuv_web/views/work_experience_html.ex:664
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Employment reference:"
 msgstr ""
@@ -20621,14 +20614,14 @@ msgstr ""
 msgid "Mute or unmute accounts"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:176
+#: lib/vutuv_web/live/organization_live/apps.ex:181
 #: lib/vutuv_web/templates/settings/apps.html.heex:42
 #: lib/vutuv_web/views/account_event_text.ex:235
 #, elixir-autogen, elixir-format
 msgid "Mastodon-compatible apps"
 msgstr ""
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:67
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:70
 #, elixir-autogen, elixir-format
 msgid "Mastodon client access is disabled for every identity available to you."
 msgstr ""
@@ -20638,7 +20631,7 @@ msgstr ""
 msgid "Read data visible to this identity"
 msgstr ""
 
-#: lib/vutuv_web/templates/oauth/authorize.html.heex:41
+#: lib/vutuv_web/templates/oauth/authorize.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "Use this identity"
 msgstr ""
@@ -21015,7 +21008,7 @@ msgstr ""
 msgid "Show the profile picture larger"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:178
+#: lib/vutuv_web/live/organization_live/apps.ex:183
 #, elixir-autogen, elixir-format
 msgid "The page's Editorial team can use this organization as a separate identity in a compatible phone app, with the same rights they already have here. Those rights are checked again on every request."
 msgstr ""
@@ -21025,7 +21018,7 @@ msgstr ""
 msgid "App settings saved."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:164
+#: lib/vutuv_web/live/organization_live/apps.ex:169
 #, elixir-autogen, elixir-format
 msgid "Apps built for Mastodon can write in this page's name, read its feed and notify its team."
 msgstr ""
@@ -21040,7 +21033,7 @@ msgstr ""
 msgid "Apps – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:321
+#: lib/vutuv_web/live/organization_live/apps.ex:326
 #: lib/vutuv_web/templates/settings/apps.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "How to set up an app"
@@ -21061,38 +21054,38 @@ msgstr ""
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:307
+#: lib/vutuv_web/live/organization_live/apps.ex:312
 #, elixir-autogen, elixir-format
 msgid "Sign in with your own account, then pick %{name} on the approval screen."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:312
+#: lib/vutuv_web/live/organization_live/apps.ex:317
 #, elixir-autogen, elixir-format
 msgid "Sign in with your own account, then pick this page on the approval screen. A short @name is not needed for that, only for being followed from another server."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:302
+#: lib/vutuv_web/live/organization_live/apps.ex:307
 #: lib/vutuv_web/templates/settings/apps.html.heex:70
 #, elixir-autogen, elixir-format
 msgid "The address to type into the app"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:171
+#: lib/vutuv_web/live/organization_live/apps.ex:176
 #, elixir-autogen, elixir-format
 msgid "This vutuv serves no app interface, so nothing here has any effect."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:204
+#: lib/vutuv_web/live/organization_live/apps.ex:209
 #, elixir-autogen, elixir-format
 msgid "Turn app access off"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:205
+#: lib/vutuv_web/live/organization_live/apps.ex:210
 #, elixir-autogen, elixir-format
 msgid "Turn app access on"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:183
+#: lib/vutuv_web/live/organization_live/apps.ex:188
 #, elixir-autogen, elixir-format
 msgid "Whoever posted stays recorded, so the team can always tell who wrote what — and an app signed in as this page cannot block anybody, because blocking is between two people."
 msgstr ""
@@ -21347,56 +21340,56 @@ msgstr ""
 msgid "This application asked to be connected too many times in a row. Please wait a moment and try again."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:213
+#: lib/vutuv_web/live/organization_live/apps.ex:218
 #, elixir-autogen, elixir-format
 msgid "App access in use"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:137
+#: lib/vutuv_web/live/organization_live/apps.ex:142
 #, elixir-autogen, elixir-format
 msgid "App access is off. One app token was withdrawn."
 msgid_plural "App access is off. %{count} app tokens were withdrawn."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:215
+#: lib/vutuv_web/live/organization_live/apps.ex:220
 #, elixir-autogen, elixir-format
 msgid "Each row is one app signed in as this page, issued by the team member named on it. Withdrawing one stops that app immediately; the member keeps their own account."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:230
+#: lib/vutuv_web/live/organization_live/apps.ex:235
 #, elixir-autogen, elixir-format
 msgid "Filter by member (name or @handle)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:222
+#: lib/vutuv_web/live/organization_live/apps.ex:227
 #, elixir-autogen, elixir-format
 msgid "Filter by the member who issued the token"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:263
+#: lib/vutuv_web/live/organization_live/apps.ex:268
 #, elixir-autogen, elixir-format
 msgid "Issued by"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:237
+#: lib/vutuv_web/live/organization_live/apps.ex:242
 #, elixir-autogen, elixir-format
 msgid "No app is signed in as this page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:238
+#: lib/vutuv_web/live/organization_live/apps.ex:243
 #, elixir-autogen, elixir-format
 msgid "No token matches that member."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:247
+#: lib/vutuv_web/live/organization_live/apps.ex:252
 #, elixir-autogen, elixir-format
 msgid "One app token"
 msgid_plural "%{formatted} app tokens"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:260
+#: lib/vutuv_web/live/organization_live/apps.ex:265
 #, elixir-autogen, elixir-format
 msgid "Personal access token"
 msgstr ""
@@ -21406,24 +21399,24 @@ msgstr ""
 msgid "The app can no longer act for this page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:196
+#: lib/vutuv_web/live/organization_live/apps.ex:201
 #, elixir-autogen, elixir-format
 msgid "Turn app access off? The one app token issued for this page is withdrawn and stops working immediately."
 msgid_plural "Turn app access off? All %{count} app tokens issued for this page are withdrawn and stop working immediately."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:282
+#: lib/vutuv_web/live/organization_live/apps.ex:287
 #, elixir-autogen, elixir-format
 msgid "Withdraw"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:279
+#: lib/vutuv_web/live/organization_live/apps.ex:284
 #, elixir-autogen, elixir-format
 msgid "Withdraw this app's access to the page? It stops working immediately."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/apps.ex:153
+#: lib/vutuv_web/live/organization_live/apps.ex:158
 #, elixir-autogen, elixir-format
 msgid "unknown device"
 msgstr ""
@@ -21438,17 +21431,19 @@ msgstr ""
 msgid "Confirm the follow on your own server."
 msgstr ""
 
-#: lib/vutuv_web/views/outbound_html.ex:71
+#: lib/vutuv_web/views/outbound_html.ex:68
+#: lib/vutuv_web/views/outbound_html.ex:81
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Continue"
 msgstr ""
 
-#: lib/vutuv_web/views/outbound_html.ex:63
+#: lib/vutuv_web/views/outbound_html.ex:67
+#: lib/vutuv_web/views/outbound_html.ex:80
 #, elixir-autogen, elixir-format
 msgid "Continue to %{server}"
 msgstr ""
 
-#: lib/vutuv_web/views/outbound_html.ex:62
+#: lib/vutuv_web/views/outbound_html.ex:60
 #, elixir-autogen, elixir-format, fuzzy
 msgid "E-mail to %{address}"
 msgstr ""
@@ -21458,7 +21453,7 @@ msgstr ""
 msgid "The employer takes applications on their own website."
 msgstr ""
 
-#: lib/vutuv_web/views/outbound_html.ex:70
+#: lib/vutuv_web/views/outbound_html.ex:61
 #, elixir-autogen, elixir-format
 msgid "Write e-mail"
 msgstr ""
@@ -21466,4 +21461,10 @@ msgstr ""
 #: lib/vutuv_web/controllers/job_posting_controller.ex:120
 #, elixir-autogen, elixir-format
 msgid "Your e-mail program opens with the subject filled in."
+msgstr ""
+
+#: lib/vutuv_web/views/qualification_html.ex:229
+#, elixir-autogen, elixir-format
+msgctxt "qualification detail"
+msgid "Jobs"
 msgstr ""

--- a/test/vutuv_web/controllers/qualification_controller_test.exs
+++ b/test/vutuv_web/controllers/qualification_controller_test.exs
@@ -178,7 +178,7 @@ defmodule VutuvWeb.QualificationControllerTest do
       assert html =~ "Currently in use"
     end
 
-    test "the entry page shows the usage line and its doc siblings carry it",
+    test "the entry page shows the in-use pill and its doc siblings carry it",
          %{owner: owner} do
       qualification = insert(:qualification, user: owner, name: "Meisterbrief")
       insert(:work_experience, user: owner, qualification: qualification, end_year: nil)
@@ -189,7 +189,6 @@ defmodule VutuvWeb.QualificationControllerTest do
         |> html_response(200)
 
       assert html =~ "data-qualification-usage"
-      assert html =~ "Used for 1 job"
       assert html =~ "Currently in use"
 
       json =
@@ -227,6 +226,132 @@ defmodule VutuvWeb.QualificationControllerTest do
       md = build_conn() |> get("/#{owner.username}/qualifications.md") |> Map.get(:resp_body)
       assert md =~ "used for 1 job"
       assert md =~ "last used 2019-09"
+    end
+  end
+
+  describe "the jobs a credential earned (issue #1109)" do
+    setup %{conn: conn} do
+      {conn, owner} = create_and_login_user(conn)
+      %{conn: conn, owner: owner}
+    end
+
+    test "the entry page lists them newest first and links each role",
+         %{owner: owner} do
+      qualification = insert(:qualification, user: owner, name: "Meisterbrief")
+
+      insert(:work_experience,
+        user: owner,
+        qualification: qualification,
+        title: "Metallbauer",
+        organization: "Schmidt GmbH",
+        start_year: 2015,
+        end_year: 2019,
+        end_month: 3,
+        slug: "metallbauer-schmidt"
+      )
+
+      insert(:work_experience,
+        user: owner,
+        qualification: qualification,
+        title: "Werkstattleiter",
+        organization: "Krause KG",
+        start_year: 2019,
+        end_year: nil,
+        slug: "werkstattleiter-krause"
+      )
+
+      html =
+        build_conn()
+        |> get(~p"/#{owner}/qualifications/#{qualification}")
+        |> html_response(200)
+
+      assert html =~ "data-citing-jobs"
+      assert html =~ "Werkstattleiter"
+      assert html =~ "Krause KG"
+      assert html =~ ~p"/#{owner}/work_experiences/werkstattleiter-krause"
+      assert html =~ ~p"/#{owner}/work_experiences/metallbauer-schmidt"
+      # The period rides along on the meta line, so a reader can tell the
+      # current role from the one that ended.
+      assert html =~ "3/2019"
+
+      # The ongoing role comes first (citing_jobs_detail_preload/0 order).
+      assert :binary.match(html, "Werkstattleiter") < :binary.match(html, "Metallbauer")
+    end
+
+    test "an employer with a verified organization page is linked to it",
+         %{owner: owner} do
+      qualification = insert(:qualification, user: owner, name: "Meisterbrief")
+      organization = insert(:organization, name: "Krause KG")
+
+      insert(:work_experience,
+        user: owner,
+        qualification: qualification,
+        title: "Werkstattleiter",
+        organization: "Krause",
+        organization_page: organization
+      )
+
+      html =
+        build_conn()
+        |> get(~p"/#{owner}/qualifications/#{qualification}")
+        |> html_response(200)
+
+      assert html =~ Vutuv.Organizations.canonical_path(organization)
+      assert html =~ "Krause KG"
+    end
+
+    test "a credential no job cites shows no jobs block", %{owner: owner} do
+      qualification = insert(:qualification, user: owner, name: "Unused cert")
+
+      html =
+        build_conn()
+        |> get(~p"/#{owner}/qualifications/#{qualification}")
+        |> html_response(200)
+
+      refute html =~ "data-citing-jobs"
+      refute html =~ "data-qualification-usage"
+    end
+
+    test "the doc siblings carry the roles, not just the count", %{owner: owner} do
+      qualification = insert(:qualification, user: owner, name: "Meisterbrief")
+
+      insert(:work_experience,
+        user: owner,
+        qualification: qualification,
+        title: "Werkstattleiter",
+        organization: "Krause KG",
+        start_year: 2019,
+        end_year: nil,
+        slug: "werkstattleiter-krause"
+      )
+
+      json =
+        build_conn()
+        |> get("/#{owner.username}/qualifications/#{qualification.id}.json")
+        |> Map.get(:resp_body)
+        |> Jason.decode!()
+
+      assert [job] = json["entry"]["jobs"]["entries"]
+      assert job["title"] == "Werkstattleiter"
+      assert job["organization"] == "Krause KG"
+      assert job["start"] == "2019-01"
+      assert job["url"] =~ "/work_experiences/werkstattleiter-krause"
+
+      md =
+        build_conn()
+        |> get("/#{owner.username}/qualifications/#{qualification.id}.md")
+        |> Map.get(:resp_body)
+
+      assert md =~ "[Werkstattleiter]("
+      assert md =~ "Krause KG"
+
+      txt =
+        build_conn()
+        |> get("/#{owner.username}/qualifications/#{qualification.id}.txt")
+        |> Map.get(:resp_body)
+
+      assert txt =~ "Werkstattleiter"
+      assert txt =~ "Krause KG"
     end
   end
 


### PR DESCRIPTION
Die Detailseite eines Zertifikats zählte die Jobs nur ("Für 4 Jobs genutzt"). Sie listet sie jetzt, wie @shaedrich es in #1109 skizziert hat: jede Rolle verlinkt auf ihre eigene Seite, ein Arbeitgeber mit verifizierter Seite auch auf diese, dazu Zeitraum und — außer beim gewöhnlichen Job — die Kategorie.

<img src="https://raw.githubusercontent.com/wintermeyer/vutuv/shots/pr-1576/desktop.png" width="440"> <img src="https://raw.githubusercontent.com/wintermeyer/vutuv/shots/pr-1576/mobile.png" width="190">

Die Fakten stehen dafür ab `sm` in zwei Spalten. Als Leiter aus Label und Wert schob eine Lizenz mit Aussteller, Datum, Ablauf, Ausweisnummer und Nachweislink alles Lesenswerte unter die Falz. Die Regel liegt als `.card__facts` in `components.css`, nicht als dreizehn Utility-Klassen in der Vorlage — die anderen Detailseiten übernehmen sie mit einer Klasse.

<img src="https://raw.githubusercontent.com/wintermeyer/vutuv/shots/pr-1576/full.png" width="440">

`/:slug/qualifications/<id>` · `QualificationHTML.citing_jobs/1` · die `.md`/`.txt`/`.json`/`.xml`-Geschwister tragen die Rollen als `jobs.entries` mit.

Zu entscheiden: ob die anderen Entry-Seiten (Berufserfahrung, Ausbildung, …) `.card__facts` gleich mitbekommen sollen oder einzeln.

Closes #1109

Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.
