### PR TITLE
Bewerberländer: Pillen statt einer Sechs-Zeilen-Liste, plus Regionen (v7.326.0)

### DIFF
--- a/lib/vutuv/countries.ex
+++ b/lib/vutuv/countries.ex
@@ -13,14 +13,17 @@ defmodule Vutuv.Countries do
   of officially assigned ISO 3166-1 alpha-2 codes together with their English
   and German short names, and it exposes the helpers the rest of the app needs:
   validation (`valid?/1`), localized lookup (`name/2`), a sorted option list for
-  form selects (`select_options/1`), and the small set of countries that use a
+  form selects (`select_options/1`), the localized names of a set of codes
+  (`names/2`), substring search over those names (`search/2`), the named groups
+  of countries the remote-job presets are built from (`regions/1`,
+  `region_codes/1`, `region_for/1`), and the small set of countries that use a
   state or province in postal addresses (`uses_state?/1`).
 
   vutuv supports exactly two locales, `"en"` and `"de"` (see the `:locales`
   config). An unknown locale falls back to English; an unknown code falls back
   to the uppercased code itself, so callers never have to guard against a raise.
 
-  Used by the verified organization pages and, later, by job postings.
+  Used by the verified organization pages and by job postings.
   """
 
   # ISO 3166-1 alpha-2: {uppercase code, English short name, German short name}.
@@ -291,6 +294,52 @@ defmodule Vutuv.Countries do
   # UK, ...) address purely by city and postal code, so they are omitted.
   @state_countries ~w(US CA AU BR IN MX CN)
 
+  # Named groups of countries, the vocabulary the remote-job presets are built
+  # from (issue #1559). Membership is spelled out as codes rather than derived,
+  # because these are business conventions and not geography: Turkey counts as
+  # Middle East, Cyprus as Europe, Central Asia as APAC, and every one of those
+  # is a judgement call somebody has to be able to read and correct.
+  #
+  # What IS derived is every overlap that moves: Europe is the union with the
+  # EU rather than a second copy of its 27, and EMEA is composed from its three
+  # parts rather than listed a fourth time. An accession then has one place to
+  # be remembered.
+  @eu ~w(AT BE BG CY CZ DE DK EE ES FI FR GR HR HU IE IT LT LU LV MT NL PL PT
+         RO SE SI SK)
+  @europe @eu ++
+            ~w(AD AL AM AX AZ BA BY CH FO GB GE GG GI IM IS JE LI MC MD ME MK
+               NO RS RU SJ SM UA VA)
+  @middle_east ~w(AE BH IL IQ IR JO KW LB OM PS QA SA SY TR YE)
+  @africa ~w(AO BF BI BJ BW CD CF CG CI CM CV DJ DZ EG EH ER ET GA GH GM GN GQ
+             GW KE KM LR LS LY MA MG ML MR MU MW MZ NA NE NG RE RW SC SD SH SL
+             SN SO SS ST SZ TD TG TN TZ UG YT ZA ZM ZW)
+  @mena ~w(AE BH DZ EG IL IQ IR JO KW LB LY MA OM PS QA SA SY TN YE)
+  @apac ~w(AF AS AU BD BN BT CC CK CN CX FJ FM GU HK ID IN JP KG KH KI KP KR KZ
+           LA LK MH MM MN MO MP MV MY NC NF NP NR NU NZ PF PG PH PK PN PW SB SG
+           TH TJ TK TL TM TO TV TW UZ VN VU WF WS)
+
+  # {key, English name, German name, codes}. The key is the acronym the preset
+  # button shows and is deliberately not translated: EU / EMEA / MENA / APAC are
+  # the words a recruiter writes in either language. Codes are stored sorted, so
+  # `region_for/1` can compare a selection against them directly.
+  @regions [
+    {"EU", "European Union", "Europäische Union", Enum.sort(@eu)},
+    {"EMEA", "Europe, Middle East and Africa", "Europa, Naher Osten und Afrika",
+     Enum.sort(Enum.uniq(@europe ++ @middle_east ++ @africa))},
+    {"MENA", "Middle East and North Africa", "Naher Osten und Nordafrika", Enum.sort(@mena)},
+    {"APAC", "Asia-Pacific", "Asien-Pazifik", Enum.sort(@apac)}
+  ]
+
+  # A region naming a code this module does not know is a typo, and a typo here
+  # is a preset that silently drops a country. Fail the build on it.
+  for {key, _en, _de, codes} <- @regions, code <- codes do
+    unless Map.has_key?(@by_code, code) do
+      raise "Vutuv.Countries: region #{key} lists unknown country code #{inspect(code)}"
+    end
+  end
+
+  @region_codes Map.new(@regions, fn {key, _en, _de, codes} -> {key, codes} end)
+
   @doc """
   All country codes as uppercase alpha-2 strings, in ISO code order.
   """
@@ -345,8 +394,143 @@ defmodule Vutuv.Countries do
       display = if resolved == :de, do: de, else: en
       {display, code}
     end)
-    |> Enum.sort_by(fn {display, _code} -> sort_key(display) end)
+    |> Enum.sort_by(fn {display, _code} -> fold(display) end)
   end
+
+  @doc """
+  `codes` as `{localized_name, code}` tuples, sorted like `select_options/1`.
+
+  Unknown codes are dropped and duplicates collapse, so this is also the
+  narrowing step for a stored list: whatever comes back is a name a reader can
+  act on.
+  """
+  @spec names([String.t()], String.t() | atom() | nil) :: [{String.t(), String.t()}]
+  def names(codes, locale \\ nil)
+
+  def names([], _locale), do: []
+
+  def names(codes, locale) when is_list(codes) do
+    codes
+    |> Enum.uniq()
+    |> Enum.filter(&valid?/1)
+    |> Enum.map(&{name(&1, locale), &1})
+    |> Enum.sort_by(fn {display, _code} -> fold(display) end)
+  end
+
+  def names(_codes, _locale), do: []
+
+  @doc """
+  Countries whose localized name contains `query`, as `{localized_name, code}`
+  tuples in the same order `select_options/1` uses.
+
+  The match is diacritic-folded and case-insensitive on both sides (the same
+  folding the sort uses), so "osterreich" finds Österreich and "cote" finds
+  Côte d'Ivoire — a member typing into a picker cannot be asked to produce an
+  umlaut before the country they want shows up. A two-letter query also matches
+  that ISO code exactly, and the code match is listed first: "AT" means Austria
+  to anyone who types it, even though it is also a substring of "Guatemala".
+
+  Hits are ranked before they are sorted — a name that *begins* with the query
+  first, then one whose later words do, then a match anywhere. Alphabetical
+  order alone answered "sch" with Amerikanisch-Samoa and Aserbaidschan while
+  Schweiz fell outside the first eight, which is the whole list a picker shows.
+
+  A blank query returns `[]` rather than all 249 countries: the caller is a
+  search box, and "nothing typed" means "nothing to show", not "show
+  everything".
+  """
+  @spec search(term(), String.t() | atom() | nil) :: [{String.t(), String.t()}]
+  def search(query, locale \\ nil)
+
+  def search(query, locale) when is_binary(query) do
+    trimmed = String.trim(query)
+    needle = fold(trimmed)
+    exact = String.upcase(trimmed)
+
+    cond do
+      needle == "" ->
+        []
+
+      valid?(exact) ->
+        [{name(exact, locale), exact} | by_name(needle, locale, exact)]
+
+      true ->
+        by_name(needle, locale, nil)
+    end
+  end
+
+  def search(_query, _locale), do: []
+
+  defp by_name(needle, locale, skip) do
+    locale
+    |> select_options()
+    |> Enum.reject(fn {_name, code} -> code == skip end)
+    |> Enum.map(fn {name, code} -> {rank(fold(name), needle), name, code} end)
+    |> Enum.filter(fn {rank, _name, _code} -> rank end)
+    |> Enum.sort_by(fn {rank, _name, _code} -> rank end)
+    |> Enum.map(fn {_rank, name, code} -> {name, code} end)
+  end
+
+  # 0 = the name begins with what was typed, 1 = a word inside it does, 2 = it
+  # merely occurs somewhere, nil = no match. Without this, "sch" answered
+  # alphabetically with Amerikanisch-Samoa, Aserbaidschan and Bangladesch, and
+  # Schweiz was nowhere in the first eight hits. `Enum.sort_by/2` is stable, so
+  # each band keeps the option list's own alphabetical order.
+  defp rank(folded, needle) do
+    cond do
+      String.starts_with?(folded, needle) -> 0
+      String.contains?(folded, " " <> needle) -> 1
+      String.contains?(folded, "-" <> needle) -> 1
+      String.contains?(folded, needle) -> 2
+      true -> nil
+    end
+  end
+
+  @doc """
+  The regions, in display order, as
+  `%{key: "EU", name: "Europäische Union", count: 27}`.
+
+  `key` is the acronym a preset button shows, `name` the localized long form for
+  its tooltip, `count` how many countries the preset adds. Ask `region_codes/1`
+  for the expansion itself — that is what gets stored:
+  `Vutuv.Jobs.filter_location/4` matches a searched country against
+  `job_postings.remote_countries`, so a posting advertised for "EU" has to carry
+  the 27 codes rather than the word.
+  """
+  @spec regions(String.t() | atom() | nil) :: [
+          %{key: String.t(), name: String.t(), count: non_neg_integer()}
+        ]
+  def regions(locale \\ nil) do
+    resolved = normalize_locale(locale)
+
+    Enum.map(@regions, fn {key, en, de, codes} ->
+      %{key: key, name: if(resolved == :de, do: de, else: en), count: length(codes)}
+    end)
+  end
+
+  @doc "The country codes of one region key, or `[]` for anything unknown."
+  @spec region_codes(term()) :: [String.t()]
+  def region_codes(key) when is_binary(key), do: Map.get(@region_codes, key, [])
+  def region_codes(_key), do: []
+
+  @doc """
+  The region key `codes` covers exactly, or `nil`.
+
+  Used to say "Remote (EU)" instead of listing 27 codes on a job card. Exact
+  set equality only: a member who takes one country back out of a preset means
+  something narrower than the region, and naming it anyway would misdescribe
+  where they will hire.
+  """
+  @spec region_for(term()) :: String.t() | nil
+  def region_for(codes) when is_list(codes) do
+    sorted = codes |> Enum.uniq() |> Enum.sort()
+
+    Enum.find_value(@regions, fn {key, _en, _de, region_codes} ->
+      if sorted == region_codes, do: key
+    end)
+  end
+
+  def region_for(_codes), do: nil
 
   @doc """
   True only for the small set of countries that customarily use a state,
@@ -360,6 +544,28 @@ defmodule Vutuv.Countries do
   @spec uses_state?(term()) :: boolean()
   def uses_state?(code) when is_binary(code), do: code in @state_countries
   def uses_state?(_code), do: false
+
+  @doc """
+  Diacritic-folded, case-insensitive key for a country name. Public because it
+  is the ordering `select_options/1` promises and the matching `search/2`
+  performs, so a caller asserting on either needs the same rule rather than a
+  copy of it.
+
+  Decomposing to NFD and dropping the combining marks folds every accent the
+  names carry — not a hand-kept list of the ones somebody thought of, which is
+  how "Côte d'Ivoire" stayed unreachable by "cote". Eszett is spelled out
+  because it has no decomposition. Not a slug:
+  `Vutuv.SlugHelpers.transliterate/1` deliberately spells "ä" as "ae", which is
+  right for a URL and wrong here.
+  """
+  @spec fold(String.t()) :: String.t()
+  def fold(display) do
+    display
+    |> String.downcase()
+    |> String.replace("ß", "ss")
+    |> String.normalize(:nfd)
+    |> String.replace(~r/\p{Mn}/u, "")
+  end
 
   # Normalize a locale argument to a known atom without ever calling
   # String.to_atom on caller input. Anything unrecognized falls back to English.
@@ -376,25 +582,4 @@ defmodule Vutuv.Countries do
   end
 
   defp normalize_locale(_other), do: :en
-
-  # Diacritic-folded, case-insensitive sort key. Folds the German umlauts and
-  # eszett plus the common accented letters that appear in country names, so the
-  # ordering is locale-friendly without pulling in a full collation library.
-  defp sort_key(display) do
-    display
-    |> String.downcase()
-    |> String.replace("ä", "a")
-    |> String.replace("ö", "o")
-    |> String.replace("ü", "u")
-    |> String.replace("ß", "ss")
-    |> String.replace("å", "a")
-    |> String.replace("á", "a")
-    |> String.replace("à", "a")
-    |> String.replace("é", "e")
-    |> String.replace("è", "e")
-    |> String.replace("ç", "c")
-    |> String.replace("í", "i")
-    |> String.replace("ó", "o")
-    |> String.replace("ú", "u")
-  end
 end

--- a/lib/vutuv_web/agent_docs/job_posting_doc.ex
+++ b/lib/vutuv_web/agent_docs/job_posting_doc.ex
@@ -28,6 +28,7 @@ defmodule VutuvWeb.AgentDocs.JobPostingDoc do
       employment_type: JobPosting.employment_type_label(posting.employment_type),
       workplace_type: JobPosting.workplace_type_label(posting.workplace_type),
       location: location(posting),
+      remote_region: Countries.region_for(posting.remote_countries),
       remote_countries: remote_countries(posting),
       salary_line: salary_line(posting),
       salary: JobPosting.salary_fields(posting),
@@ -83,6 +84,7 @@ defmodule VutuvWeb.AgentDocs.JobPostingDoc do
       employment_type: JobPosting.employment_type_label(posting.employment_type),
       workplace_type: JobPosting.workplace_type_label(posting.workplace_type),
       location: location(posting),
+      remote_region: Countries.region_for(posting.remote_countries),
       remote_countries: remote_countries(posting),
       salary_line: salary_line(posting),
       salary: JobPosting.salary_fields(posting),
@@ -116,6 +118,9 @@ defmodule VutuvWeb.AgentDocs.JobPostingDoc do
     }
   end
 
+  # The full list stays, so an agent can filter on it; `remote_region` beside it
+  # carries the word the HTML page shows when the selection is exactly a region
+  # ("EMEA" rather than 128 names), which is the poster's own framing.
   defp remote_countries(%JobPosting{workplace_type: :remote} = posting) do
     Enum.map(posting.remote_countries, &%{code: &1, name: Countries.name(&1)})
   end

--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -454,11 +454,18 @@ defmodule VutuvWeb.AgentDocs.Markdown do
     do:
       "- #{gettext("Location")}: #{[city, country] |> Enum.reject(&(&1 in [nil, ""])) |> Enum.join(", ")}"
 
-  defp job_location(%{remote_countries: [_ | _] = countries}),
-    do:
-      "- #{gettext("Location")}: #{gettext("Remote")} (#{Enum.map_join(countries, ", ", & &1.name)})"
+  defp job_location(%{remote_countries: [_ | _] = countries} = doc),
+    do: "- #{gettext("Location")}: #{gettext("Remote")} (#{remote_where(doc, countries)})"
 
   defp job_location(_doc), do: "- #{gettext("Location")}: #{gettext("Remote")}"
+
+  # The countries in full — an agent filters on them — with the poster's own
+  # word in front when their selection is exactly a region, so the machine
+  # formats say "EMEA" where the HTML page does.
+  defp remote_where(%{remote_region: region}, countries) when is_binary(region),
+    do: "#{region}: #{Enum.map_join(countries, ", ", & &1.name)}"
+
+  defp remote_where(_doc, countries), do: Enum.map_join(countries, ", ", & &1.name)
 
   defp job_tags(_label, []), do: nil
 

--- a/lib/vutuv_web/agent_docs/text.ex
+++ b/lib/vutuv_web/agent_docs/text.ex
@@ -475,11 +475,18 @@ defmodule VutuvWeb.AgentDocs.Text do
     do:
       "- #{gettext("Location")}: #{[city, country] |> Enum.reject(&(&1 in [nil, ""])) |> Enum.join(", ")}"
 
-  defp job_location(%{remote_countries: [_ | _] = countries}),
-    do:
-      "- #{gettext("Location")}: #{gettext("Remote")} (#{Enum.map_join(countries, ", ", & &1.name)})"
+  defp job_location(%{remote_countries: [_ | _] = countries} = doc),
+    do: "- #{gettext("Location")}: #{gettext("Remote")} (#{remote_where(doc, countries)})"
 
   defp job_location(_doc), do: "- #{gettext("Location")}: #{gettext("Remote")}"
+
+  # The countries in full — an agent filters on them — with the poster's own
+  # word in front when their selection is exactly a region, so the machine
+  # formats say "EMEA" where the HTML page does.
+  defp remote_where(%{remote_region: region}, countries) when is_binary(region),
+    do: "#{region}: #{Enum.map_join(countries, ", ", & &1.name)}"
+
+  defp remote_where(_doc, countries), do: Enum.map_join(countries, ", ", & &1.name)
 
   defp job_tags(_label, []), do: nil
 

--- a/lib/vutuv_web/components/job_components.ex
+++ b/lib/vutuv_web/components/job_components.ex
@@ -136,9 +136,9 @@ defmodule VutuvWeb.JobComponents do
 
   @doc "The card's location chip: 'City, Country' (country only when it differs from the default) or 'Remote (DE, AT)'."
   def card_location(%JobPosting{workplace_type: :remote} = posting) do
-    case posting.remote_countries do
-      [] -> gettext("Remote")
-      codes -> gettext("Remote") <> " (" <> Enum.join(codes, ", ") <> ")"
+    case remote_countries_label(posting.remote_countries) do
+      nil -> gettext("Remote")
+      label -> gettext("Remote") <> " (" <> label <> ")"
     end
   end
 
@@ -156,6 +156,44 @@ defmodule VutuvWeb.JobComponents do
   defp country_suffix(country) do
     if country in [nil, "", Geo.default_country()], do: nil, else: Countries.name(country)
   end
+
+  @remote_codes_shown 3
+
+  @doc """
+  How a remote posting's applicant countries read in one line, or `nil` for
+  none. `kind` picks the vocabulary: `:code` for the board card's tight chip,
+  `:name` for the localized names on the detail page.
+
+  A whole region is named rather than spelled out ("EU", not 27 codes), which is
+  the point of the presets in the editor (issue #1559); anything else lists the
+  first few and counts the rest, because a preset stores its expansion and 128
+  countries in a chip is not a chip.
+  """
+  def remote_countries_label(codes, kind \\ :code)
+
+  def remote_countries_label([], _kind), do: nil
+
+  def remote_countries_label(codes, kind) when is_list(codes) do
+    case Countries.region_for(codes) do
+      nil -> capped_countries(codes, kind)
+      region -> region
+    end
+  end
+
+  def remote_countries_label(_codes, _kind), do: nil
+
+  defp capped_countries(codes, kind) do
+    shown =
+      codes |> Enum.take(@remote_codes_shown) |> Enum.map_join(", ", &country_label(&1, kind))
+
+    case length(codes) - @remote_codes_shown do
+      rest when rest > 0 -> shown <> " " <> gettext("+%{count} more", count: compact_count(rest))
+      _none -> shown
+    end
+  end
+
+  defp country_label(code, :name), do: Countries.name(code)
+  defp country_label(code, :code), do: code
 
   @doc "The card's pay line: the range, 'Ehrenamtlich' for a volunteer posting, or nothing."
   def salary_line(%JobPosting{employment_type: :volunteer}), do: gettext("Voluntary")

--- a/lib/vutuv_web/live/job_posting_live/form.ex
+++ b/lib/vutuv_web/live/job_posting_live/form.ex
@@ -6,10 +6,33 @@ defmodule VutuvWeb.JobPostingLive.Form do
   workplace, apply target, salary unless volunteer) and the anti-abuse gate.
 
   The workplace choice drives the form: on-site / hybrid show the address block,
-  remote shows the applicant-countries select. Visibility leads with the human
+  remote shows the applicant-country picker. Visibility leads with the human
   audience (everyone / members); the SEO / GEO machine toggles show only for an
   `everyone` posting. A live, non-blocking AGG hint nudges a gender-neutral
   title.
+
+  ## The applicant-country picker (issues #1558, #1559)
+
+  249 countries in a six-row `<select multiple>` hid what you had picked the
+  moment you scrolled, and its "hold Ctrl / Cmd" hint means nothing on a phone.
+  It is a pill box now, in the tag field's visual language: region presets
+  (EU / EMEA / MENA / APAC) fill in a whole region at a click, a search box
+  finds one country by a fragment of its localized name, and every chosen
+  country sits below as a removable pill that never scrolls out of view.
+
+  The picked codes are held in the changeset like any other field and rendered
+  as hidden `job_posting[remote_countries][]` inputs, so a save carries them
+  without this module keeping a second copy of the selection. A preset stores
+  its **expansion** rather than the region's name, which is what keeps the board
+  filter (`Vutuv.Jobs.filter_location/4` matches a searched country against
+  `remote_countries`) working untouched; the word is re-derived for display by
+  `Vutuv.Countries.region_for/1`.
+
+  The search box is the one control that is *not* part of the posting form: it
+  is associated with the tiny sibling `#job-country-search` form through its
+  `form=` attribute, because Enter inside the posting form means "publish" and
+  half a country name is nobody's idea of a finished posting. Over there Enter
+  means "take the top match" instead.
   """
 
   use VutuvWeb, :live_view
@@ -17,10 +40,16 @@ defmodule VutuvWeb.JobPostingLive.Form do
   import VutuvWeb.ErrorHelpers
 
   alias Vutuv.Countries
+  alias Vutuv.Geo
   alias Vutuv.Jobs
   alias Vutuv.Jobs.JobPosting
   alias Vutuv.Organizations
   alias Vutuv.Salary
+
+  # How many search hits the box offers at once. Long enough that a two-letter
+  # fragment still shows the country you meant, short enough to stay a list you
+  # read rather than scroll.
+  @matches_shown 8
 
   @impl true
   def mount(params, _session, socket) do
@@ -91,6 +120,7 @@ defmodule VutuvWeb.JobPostingLive.Form do
       auto_upload: true,
       progress: &handle_progress/3
     )
+    |> assign(:country_query, "")
     |> assign_form(changeset)
   end
 
@@ -98,6 +128,23 @@ defmodule VutuvWeb.JobPostingLive.Form do
     socket
     |> assign(:changeset, changeset)
     |> assign(:form, to_form(changeset, as: :job_posting))
+    |> assign(:remote_countries, Countries.names(current(changeset, :remote_countries) || []))
+    |> assign_country_matches()
+  end
+
+  # The hits the search box offers: what the query finds, minus what is already
+  # a pill. Offering a country you have picked would answer a tap with nothing
+  # visibly happening.
+  defp assign_country_matches(socket) do
+    chosen = MapSet.new(socket.assigns.remote_countries, fn {_name, code} -> code end)
+
+    matches =
+      socket.assigns.country_query
+      |> Countries.search()
+      |> Enum.reject(fn {_name, code} -> MapSet.member?(chosen, code) end)
+      |> Enum.take(@matches_shown)
+
+    assign(socket, :country_matches, matches)
   end
 
   # --- events ----------------------------------------------------------------
@@ -106,7 +153,7 @@ defmodule VutuvWeb.JobPostingLive.Form do
   def handle_event("validate", %{"job_posting" => params}, socket) do
     changeset =
       socket.assigns.posting
-      |> Jobs.change_job_posting(params)
+      |> Jobs.change_job_posting(seed_remote_countries(params, socket.assigns.changeset))
       |> Map.put(:action, :validate)
 
     {:noreply,
@@ -114,6 +161,38 @@ defmodule VutuvWeb.JobPostingLive.Form do
      |> assign_form(changeset)
      |> assign(:required_tags, params["required_tags"] || "")
      |> assign(:nice_tags, params["nice_to_have_tags"] || "")}
+  end
+
+  def handle_event("country-search", %{"country_query" => query}, socket) do
+    {:noreply, socket |> assign(:country_query, query) |> assign_country_matches()}
+  end
+
+  def handle_event("country-add", %{"code" => code}, socket) do
+    # A tap moves the focus onto the result button, so the emptied query really
+    # reaches the box — LiveView never patches the value of a *focused* input.
+    {:noreply, socket |> assign(:country_query, "") |> add_countries([code])}
+  end
+
+  # Enter in the search box (see the moduledoc: it belongs to the sibling form).
+  # The query stays, because the box keeps the typed text either way and a
+  # server that pretended otherwise would show a list that does not match it.
+  def handle_event("country-add-first", _params, socket) do
+    case socket.assigns.country_matches do
+      [{_name, code} | _rest] -> {:noreply, add_countries(socket, [code])}
+      [] -> {:noreply, socket}
+    end
+  end
+
+  def handle_event("country-region", %{"region" => key}, socket) do
+    {:noreply, add_countries(socket, Countries.region_codes(key))}
+  end
+
+  def handle_event("country-remove", %{"code" => code}, socket) do
+    {:noreply, put_countries(socket, List.delete(selected_codes(socket), code))}
+  end
+
+  def handle_event("country-clear", _params, socket) do
+    {:noreply, put_countries(socket, [])}
   end
 
   def handle_event("save", %{"do" => action, "job_posting" => params}, socket) do
@@ -140,6 +219,49 @@ defmodule VutuvWeb.JobPostingLive.Form do
   def handle_event("cancel-upload", %{"ref" => ref}, socket) do
     {:noreply, cancel_upload(socket, :images, ref)}
   end
+
+  # --- applicant countries ---------------------------------------------------
+
+  # From the changeset, not from the rendered pills: `@remote_countries` has
+  # already been narrowed to codes the ISO table carries, so deriving the
+  # selection from it would drop an unknown stored code as a side effect of
+  # taking an unrelated pill out.
+  defp selected_codes(socket),
+    do: current(socket.assigns.changeset, :remote_countries) || []
+
+  defp add_countries(socket, codes),
+    do: put_countries(socket, Enum.uniq(selected_codes(socket) ++ codes))
+
+  # The selection lives in the changeset, not in a second assign beside it, so
+  # the pills, the hidden inputs and what a save writes can never disagree. The
+  # form's own action is carried over rather than set to `:validate`: picking a
+  # country is not the member asking to have the whole posting checked, and
+  # popping the error banner on them for it would read as a rejection.
+  defp put_countries(socket, codes) do
+    params = Map.put(socket.assigns.changeset.params || %{}, "remote_countries", codes)
+
+    changeset =
+      socket.assigns.posting
+      |> Jobs.change_job_posting(params)
+      |> Map.put(:action, socket.assigns.changeset.action)
+
+    assign_form(socket, changeset)
+  end
+
+  # The moment the workplace becomes remote, the picker appears empty; preselect
+  # the installation's own country there, the way the on-site country select
+  # does. Read off the transition (the working changeset holds the workplace the
+  # member had, the params the one they just chose) rather than off whether the
+  # browser sent the field, so it is the server's own state that decides. Every
+  # later change leaves the list alone: once the field has been on screen, an
+  # empty selection is the member's answer.
+  defp seed_remote_countries(%{"workplace_type" => "remote"} = params, changeset) do
+    if current(changeset, :workplace_type) == :remote,
+      do: params,
+      else: Map.put(params, "remote_countries", [Geo.default_country()])
+  end
+
+  defp seed_remote_countries(params, _changeset), do: params
 
   defp handle_progress(:images, entry, socket) do
     if entry.done? do
@@ -286,6 +408,12 @@ defmodule VutuvWeb.JobPostingLive.Form do
     <div class="py-6">
       <h1 class="mb-6 text-2xl font-bold text-slate-900 dark:text-slate-100">{@page_title}</h1>
 
+    <%!-- The applicant-country search box sits in the Location card below but
+          belongs to THIS form (through its `form=` attribute), so Enter there
+          takes the top match instead of publishing the posting. It has to be a
+          sibling: HTML has no nested forms. --%>
+      <form id="job-country-search" phx-submit="country-add-first" class="hidden"></form>
+
       <.form for={@form} id="job-posting-form" phx-change="validate" phx-submit="save" class="space-y-6">
         <.form_error :if={@changeset.action} changeset={@changeset} />
 
@@ -420,25 +548,92 @@ defmodule VutuvWeb.JobPostingLive.Form do
             </div>
           </div>
 
-          <div :if={current(@changeset, :workplace_type) == :remote}>
-            <label class="mb-1 block text-sm font-medium" for="job_posting_remote_countries">
+          <div :if={current(@changeset, :workplace_type) == :remote} class="space-y-3">
+            <label class="block text-sm font-medium" for="job-country-query">
               {gettext("Applicants must be located in")}
             </label>
-            <select
-              name="job_posting[remote_countries][]"
-              id="job_posting_remote_countries"
-              multiple
-              size="6"
+
+            <div class="flex flex-wrap gap-2">
+              <button
+                :for={region <- Countries.regions()}
+                type="button"
+                phx-click="country-region"
+                phx-value-region={region.key}
+                title={region.name}
+                class="inline-flex items-center gap-1.5 rounded-lg bg-slate-100 px-3 py-1.5 text-sm font-semibold text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+              >
+                + {region.key}
+                <span class="font-normal text-slate-500 dark:text-slate-400">
+                  {delimited_count(region.count)}
+                </span>
+              </button>
+            </div>
+
+            <input
+              type="text"
+              id="job-country-query"
+              name="country_query"
+              form="job-country-search"
+              value={@country_query}
+              phx-change="country-search"
+              phx-debounce="150"
+              autocomplete="off"
+              placeholder={gettext("Search for a country")}
               class={input_class()}
+            />
+
+            <ul
+              :if={@country_matches != []}
+              class="divide-y divide-slate-100 overflow-hidden rounded-lg ring-1 ring-slate-200 dark:divide-slate-800 dark:ring-slate-700"
             >
-              <option
-                :for={{label, value} <- Countries.select_options()}
-                value={value}
-                selected={value in remote_country_values(@changeset)}
-              >{label}</option>
-            </select>
+              <li :for={{name, code} <- @country_matches}>
+                <button
+                  type="button"
+                  phx-click="country-add"
+                  phx-value-code={code}
+                  class="flex w-full items-center justify-between gap-3 px-3 py-2.5 text-left text-sm hover:bg-brand-50 dark:hover:bg-slate-800"
+                >
+                  <span>{name}</span>
+                  <span class="text-xs text-slate-500 dark:text-slate-400">{code}</span>
+                </button>
+              </li>
+            </ul>
+            <p :if={@country_query != "" and @country_matches == []} class="editform__hint">
+              {gettext("No country left to add for that.")}
+            </p>
+
+            <%!-- An emptied selection must still post its key, or the changeset
+                  would fall back to the countries the posting was saved with. --%>
+            <input type="hidden" name="job_posting[remote_countries][]" value="" />
+
+            <%= if @remote_countries == [] do %>
+              <p class="editform__hint">{gettext("No country chosen yet.")}</p>
+            <% else %>
+              <div class="flex max-h-64 flex-wrap gap-1.5 overflow-y-auto">
+                <span :for={{name, code} <- @remote_countries} class="tag-input__pill">
+                  <input type="hidden" name="job_posting[remote_countries][]" value={code} />
+                  <span class="tag-input__name">{name}</span>
+                  <button
+                    type="button"
+                    class="tag-input__remove"
+                    phx-click="country-remove"
+                    phx-value-code={code}
+                    aria-label={gettext("Remove %{country}", country: name)}
+                  >×</button>
+                </span>
+              </div>
+              <p class="text-xs text-slate-600 dark:text-slate-400">
+                {chosen_line(@remote_countries)}
+                <button
+                  type="button"
+                  phx-click="country-clear"
+                  class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+                >
+                  {gettext("Remove all")}
+                </button>
+              </p>
+            <% end %>
             {error_tag(@form, :remote_countries)}
-            <p class="editform__hint">{gettext("Hold Ctrl / Cmd to select more than one.")}</p>
           </div>
         </.card>
 
@@ -618,13 +813,17 @@ defmodule VutuvWeb.JobPostingLive.Form do
 
   # A new posting preselects the installation's default country (issue #932);
   # an existing one keeps its own.
-  defp country_value(changeset), do: current(changeset, :country) || Vutuv.Geo.default_country()
+  defp country_value(changeset), do: current(changeset, :country) || Geo.default_country()
 
-  defp remote_country_values(changeset) do
-    case current(changeset, :remote_countries) do
-      [] -> [Vutuv.Geo.default_country()]
-      codes -> codes
-    end
+  # `%{formatted}` rather than `%{count}`: ngettext/4 binds `%{count}` to the
+  # raw integer and a `count:` binding does not override it, so the grouped
+  # number would be silently replaced by "1234".
+  defp chosen_line(countries) do
+    n = length(countries)
+
+    ngettext("%{formatted} country chosen.", "%{formatted} countries chosen.", n,
+      formatted: delimited_count(n)
+    )
   end
 
   defp agg_hint?(form), do: JobPosting.agg_hint?(form[:title].value || "")

--- a/lib/vutuv_web/live/job_posting_live/show.ex
+++ b/lib/vutuv_web/live/job_posting_live/show.ex
@@ -253,7 +253,11 @@ defmodule VutuvWeb.JobPostingLive.Show do
     Jobs.tags_of(posting, :required) != [] or Jobs.tags_of(posting, :nice_to_have) != []
   end
 
-  defp location_line(%{workplace_type: :remote}), do: nil
+  # A remote posting's "location" is where its applicants may live. It used to
+  # show nothing at all, so the countries the poster chose were visible only in
+  # the agent formats and on the board card (issues #1558/#1559).
+  defp location_line(%{workplace_type: :remote} = posting),
+    do: JobComponents.remote_countries_label(posting.remote_countries, :name)
 
   defp location_line(%{zip_code: zip, city: city, country: country}) do
     [[zip, city] |> Enum.reject(&blank?/1) |> Enum.join(" "), Vutuv.Countries.name(country)]

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.325.0",
+      version: "7.326.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -99,10 +99,10 @@ msgstr "Avatar"
 msgid "Birthdate"
 msgstr "Geburtstag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:595
-#: lib/vutuv_web/agent_docs/markdown.ex:596
-#: lib/vutuv_web/agent_docs/text.ex:561
-#: lib/vutuv_web/agent_docs/text.ex:562
+#: lib/vutuv_web/agent_docs/markdown.ex:602
+#: lib/vutuv_web/agent_docs/markdown.ex:603
+#: lib/vutuv_web/agent_docs/text.ex:568
+#: lib/vutuv_web/agent_docs/text.ex:569
 #: lib/vutuv_web/templates/user/show.html.heex:1093
 #, elixir-autogen
 msgid "Birthday"
@@ -113,7 +113,7 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
-#: lib/vutuv_web/live/job_posting_live/form.ex:605
+#: lib/vutuv_web/live/job_posting_live/form.ex:800
 #: lib/vutuv_web/live/organization_live/edit.ex:351
 #: lib/vutuv_web/live/organization_live/new.ex:231
 #: lib/vutuv_web/live/post_live/composer.ex:1399
@@ -176,7 +176,7 @@ msgstr "%{name} konnte nicht zurückgefolgt werden."
 msgid "Delete"
 msgstr "Löschen"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:481
+#: lib/vutuv_web/live/job_posting_live/form.ex:676
 #: lib/vutuv_web/live/organization_live/edit.ex:276
 #: lib/vutuv_web/live/organization_live/edit.ex:285
 #: lib/vutuv_web/templates/address/card_list.html.heex:5
@@ -305,14 +305,14 @@ msgstr "Lebenslauf"
 msgid "Fax"
 msgstr "Fax"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:581
+#: lib/vutuv_web/agent_docs/markdown.ex:588
 #: lib/vutuv_web/templates/user/edit.html.heex:169
 #, elixir-autogen
 msgid "First Name"
 msgstr "Vorname"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:616
-#: lib/vutuv_web/agent_docs/text.ex:582
+#: lib/vutuv_web/agent_docs/markdown.ex:623
+#: lib/vutuv_web/agent_docs/text.ex:589
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
 #: lib/vutuv_web/live/notification_live/index.ex:968
@@ -323,8 +323,8 @@ msgstr "Vorname"
 msgid "Followers"
 msgstr "Follower"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:617
-#: lib/vutuv_web/agent_docs/text.ex:583
+#: lib/vutuv_web/agent_docs/markdown.ex:624
+#: lib/vutuv_web/agent_docs/text.ex:590
 #: lib/vutuv_web/components/fediverse_components.ex:313
 #: lib/vutuv_web/components/ui.ex:2132
 #: lib/vutuv_web/components/ui.ex:2157
@@ -384,7 +384,7 @@ msgstr "Stellenbezeichnung"
 msgid "Language"
 msgstr "Sprache"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:583
+#: lib/vutuv_web/agent_docs/markdown.ex:590
 #: lib/vutuv_web/templates/user/edit.html.heex:174
 #, elixir-autogen
 msgid "Last Name"
@@ -451,7 +451,7 @@ msgstr "Ausloggen"
 msgid "Log in"
 msgstr "Einloggen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:582
+#: lib/vutuv_web/agent_docs/markdown.ex:589
 #: lib/vutuv_web/templates/user/edit.html.heex:179
 #, elixir-autogen
 msgid "Middle Name"
@@ -486,7 +486,7 @@ msgstr "Name"
 msgid "New"
 msgstr "Neu"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:585
+#: lib/vutuv_web/agent_docs/markdown.ex:592
 #: lib/vutuv_web/templates/user/edit.html.heex:184
 #, elixir-autogen
 msgid "Nickname"
@@ -567,7 +567,7 @@ msgstr "Telefonnummer wurde gelöscht."
 msgid "Phone number updated successfully."
 msgstr "Telefonnummer wurde geändert."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:580
+#: lib/vutuv_web/agent_docs/markdown.ex:587
 #: lib/vutuv_web/templates/user/edit.html.heex:189
 #, elixir-autogen
 msgid "Prefix"
@@ -752,7 +752,7 @@ msgstr "Etwas ist schiefgelaufen"
 msgid "Submit a bugreport or a feature request."
 msgstr "Fehler auf der Seite melden."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:584
+#: lib/vutuv_web/agent_docs/markdown.ex:591
 #: lib/vutuv_web/templates/user/edit.html.heex:194
 #, elixir-autogen
 msgid "Suffix"
@@ -863,7 +863,7 @@ msgstr "Alle anzeigen"
 
 #: lib/vutuv_web/components/ui.ex:4081
 #: lib/vutuv_web/controllers/settings_controller.ex:169
-#: lib/vutuv_web/live/job_posting_live/form.ex:561
+#: lib/vutuv_web/live/job_posting_live/form.ex:756
 #: lib/vutuv_web/live/organization_live/edit.ex:304
 #: lib/vutuv_web/templates/email/card_list.html.heex:7
 #: lib/vutuv_web/templates/email/show.html.heex:24
@@ -1399,11 +1399,11 @@ msgid "Tag urls"
 msgstr "Tag-URLs"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:34
-#: lib/vutuv_web/agent_docs/markdown.ex:488
-#: lib/vutuv_web/agent_docs/markdown.ex:1063
+#: lib/vutuv_web/agent_docs/markdown.ex:495
+#: lib/vutuv_web/agent_docs/markdown.ex:1070
 #: lib/vutuv_web/agent_docs/text.ex:31
-#: lib/vutuv_web/agent_docs/text.ex:509
-#: lib/vutuv_web/agent_docs/text.ex:746
+#: lib/vutuv_web/agent_docs/text.ex:516
+#: lib/vutuv_web/agent_docs/text.ex:753
 #: lib/vutuv_web/components/ui.ex:4012
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1414,7 +1414,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:433
 #: lib/vutuv_web/live/cv_live.ex:315
 #: lib/vutuv_web/live/job_board_live.ex:277
-#: lib/vutuv_web/live/job_posting_live/form.ex:510
+#: lib/vutuv_web/live/job_posting_live/form.ex:705
 #: lib/vutuv_web/live/search_live.ex:282
 #: lib/vutuv_web/live/search_live.ex:716
 #: lib/vutuv_web/live/tag_new_live.ex:36
@@ -1595,7 +1595,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:776
 #: lib/vutuv_web/live/job_board_live.ex:360
-#: lib/vutuv_web/live/job_posting_live/form.ex:410
+#: lib/vutuv_web/live/job_posting_live/form.ex:538
 #: lib/vutuv_web/live/organization_live/edit.ex:300
 #: lib/vutuv_web/live/organization_live/new.ex:142
 #: lib/vutuv_web/templates/ad/new.html.heex:114
@@ -2123,7 +2123,7 @@ msgstr "September"
 msgid "Markdown is supported: bold, italics, links and lists."
 msgstr "Markdown wird unterstützt: Fett, Kursiv, Links und Listen."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:504
+#: lib/vutuv_web/live/job_posting_live/form.ex:699
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr "Bilder hinzufügen"
@@ -2429,7 +2429,7 @@ msgstr "Alle Beiträge"
 msgid "Bookmark"
 msgstr "Lesezeichen setzen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1101
+#: lib/vutuv_web/agent_docs/markdown.ex:1108
 #: lib/vutuv_web/live/post_live/saved.ex:175
 #: lib/vutuv_web/live/post_live/saved.ex:488
 #: lib/vutuv_web/live/shell_live.ex:730
@@ -2449,7 +2449,7 @@ msgstr "Lesezeichen"
 msgid "Like"
 msgstr "Gefällt mir"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1100
+#: lib/vutuv_web/agent_docs/markdown.ex:1107
 #: lib/vutuv_web/components/post_components.ex:4916
 #: lib/vutuv_web/live/notification_live/index.ex:970
 #: lib/vutuv_web/live/post_live/saved.ex:174
@@ -2838,8 +2838,8 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] "+1 weiteres Tag"
 msgstr[1] "+%{formatted} weitere Tags"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:618
-#: lib/vutuv_web/agent_docs/text.ex:584
+#: lib/vutuv_web/agent_docs/markdown.ex:625
+#: lib/vutuv_web/agent_docs/text.ex:591
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/live/notification_live/index.ex:969
 #: lib/vutuv_web/templates/connection/index.html.heex:5
@@ -3953,12 +3953,12 @@ msgstr "gemeldete Nachricht"
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr "Im Rahmen scrollen oder klicken, um das ganze Bild zu öffnen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:715
+#: lib/vutuv_web/agent_docs/markdown.ex:722
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr "%{count} Empfehlungen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1222
+#: lib/vutuv_web/agent_docs/markdown.ex:1229
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr "%{count} auf dieser Seite, weitere mit ?page=N"
@@ -3972,11 +3972,11 @@ msgstr "%{count} Beiträge von %{name}"
 #: lib/vutuv_web/agent_docs/markdown.ex:83
 #: lib/vutuv_web/agent_docs/markdown.ex:194
 #: lib/vutuv_web/agent_docs/markdown.ex:208
-#: lib/vutuv_web/agent_docs/markdown.ex:1063
+#: lib/vutuv_web/agent_docs/markdown.ex:1070
 #: lib/vutuv_web/agent_docs/text.ex:80
 #: lib/vutuv_web/agent_docs/text.ex:179
 #: lib/vutuv_web/agent_docs/text.ex:193
-#: lib/vutuv_web/agent_docs/text.ex:746
+#: lib/vutuv_web/agent_docs/text.ex:753
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr "%{count} insgesamt"
@@ -3990,33 +3990,33 @@ msgstr "Follower von %{name}"
 #: lib/vutuv_web/agent_docs/markdown.ex:149
 #: lib/vutuv_web/agent_docs/text.ex:106
 #: lib/vutuv_web/agent_docs/text.ex:137
-#: lib/vutuv_web/live/job_posting_live/form.ex:494
+#: lib/vutuv_web/live/job_posting_live/form.ex:689
 #, elixir-autogen, elixir-format
 msgid "Images"
 msgstr "Bilder"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1081
-#: lib/vutuv_web/agent_docs/text.ex:757
+#: lib/vutuv_web/agent_docs/markdown.ex:1088
+#: lib/vutuv_web/agent_docs/text.ex:764
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr "Antwort auf einen gelöschten Beitrag von %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1078
-#: lib/vutuv_web/agent_docs/text.ex:754
+#: lib/vutuv_web/agent_docs/markdown.ex:1085
+#: lib/vutuv_web/agent_docs/text.ex:761
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr "Antwort auf einen gelöschten Beitrag."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1085
-#: lib/vutuv_web/agent_docs/markdown.ex:1299
-#: lib/vutuv_web/agent_docs/text.ex:760
-#: lib/vutuv_web/agent_docs/text.ex:804
+#: lib/vutuv_web/agent_docs/markdown.ex:1092
+#: lib/vutuv_web/agent_docs/markdown.ex:1306
+#: lib/vutuv_web/agent_docs/text.ex:767
+#: lib/vutuv_web/agent_docs/text.ex:811
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr "Antwort auf einen Beitrag von %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:553
-#: lib/vutuv_web/agent_docs/text.ex:547
+#: lib/vutuv_web/agent_docs/markdown.ex:560
+#: lib/vutuv_web/agent_docs/text.ex:554
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr "Mitglied seit"
@@ -4059,23 +4059,23 @@ msgstr "Beitrag von %{name}"
 msgid "Posts (%{count} total)"
 msgstr "Beiträge (insgesamt %{count})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:547
-#: lib/vutuv_web/agent_docs/text.ex:541
+#: lib/vutuv_web/agent_docs/markdown.ex:554
+#: lib/vutuv_web/agent_docs/text.ex:548
 #, elixir-autogen, elixir-format
 msgid "Verified profile: yes"
 msgstr "Verifiziertes Profil: ja"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1032
+#: lib/vutuv_web/agent_docs/markdown.ex:1039
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr "repostet von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:928
+#: lib/vutuv_web/agent_docs/markdown.ex:935
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr "heute"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:929
+#: lib/vutuv_web/agent_docs/markdown.ex:936
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr "bis %{date}"
@@ -4178,7 +4178,7 @@ msgid "Booking requires a vutuv login."
 msgstr "Für die Buchung ist ein vutuv-Login erforderlich."
 
 #: lib/vutuv_web/live/admin/organization_live.ex:245
-#: lib/vutuv_web/live/job_posting_live/form.ex:404
+#: lib/vutuv_web/live/job_posting_live/form.ex:532
 #: lib/vutuv_web/live/organization_live/edit.ex:296
 #: lib/vutuv_web/live/organization_live/new.ex:138
 #: lib/vutuv_web/templates/ad/new.html.heex:108
@@ -6075,7 +6075,7 @@ msgstr "Gespeicherte durchsuchen"
 msgid "Sort"
 msgstr "Sortieren"
 
-#: lib/vutuv_web/components/job_components.ex:182
+#: lib/vutuv_web/components/job_components.ex:220
 #: lib/vutuv_web/views/settings_html.ex:501
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
@@ -6389,8 +6389,8 @@ msgid_plural "%{count} years old"
 msgstr[0] "%{count} Jahr"
 msgstr[1] "%{count} Jahre"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:597
-#: lib/vutuv_web/agent_docs/text.ex:563
+#: lib/vutuv_web/agent_docs/markdown.ex:604
+#: lib/vutuv_web/agent_docs/text.ex:570
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr "Alter"
@@ -6464,7 +6464,7 @@ msgstr "Tagesbericht öffnen"
 msgid "Previous day"
 msgstr "Vorheriger Tag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1100
+#: lib/vutuv_web/agent_docs/markdown.ex:1107
 #: lib/vutuv_web/components/post_components.ex:396
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
@@ -6575,7 +6575,7 @@ msgstr "Noch keine Empfehlungen."
 msgid "and %{count} more"
 msgstr "und %{count} weitere"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1076
+#: lib/vutuv_web/agent_docs/markdown.ex:1083
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr "empfohlen am %{date}"
@@ -7114,7 +7114,7 @@ msgstr "Entwurf"
 
 #: lib/vutuv_web/controllers/admin/newsletter_controller.ex:36
 #: lib/vutuv_web/controllers/admin/newsletter_controller.ex:103
-#: lib/vutuv_web/live/job_posting_live/form.ex:195
+#: lib/vutuv_web/live/job_posting_live/form.ex:317
 #, elixir-autogen, elixir-format
 msgid "Draft saved."
 msgstr "Entwurf gespeichert."
@@ -7340,7 +7340,7 @@ msgstr "Zurücksetzen"
 msgid "Save audience"
 msgstr "Zielgruppe speichern"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:602
+#: lib/vutuv_web/live/job_posting_live/form.ex:797
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:16
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:11
 #, elixir-autogen, elixir-format
@@ -7654,6 +7654,7 @@ msgstr "Alle abwählen"
 msgid "applies to the whole list, not just this page"
 msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 
+#: lib/vutuv_web/components/job_components.ex:190
 #: lib/vutuv_web/components/post_components.ex:4818
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
@@ -7843,17 +7844,17 @@ msgstr "Feed von %{name}"
 msgid "The vutuv newsfeed of %{name}"
 msgstr "Der vutuv-Newsfeed von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1227
+#: lib/vutuv_web/agent_docs/markdown.ex:1234
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr "Ihr Feed ist leer."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1230
+#: lib/vutuv_web/agent_docs/markdown.ex:1237
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr "%{count} Beiträge auf dieser Seite"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1237
+#: lib/vutuv_web/agent_docs/markdown.ex:1244
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr "weitere Beiträge verfügbar, ?cursor=%{cursor} anhängen"
@@ -8080,7 +8081,7 @@ msgstr "Mitglieder, die gerade online sind"
 msgid "New members"
 msgstr "Neue Mitglieder"
 
-#: lib/vutuv_web/components/job_components.ex:181
+#: lib/vutuv_web/components/job_components.ex:219
 #: lib/vutuv_web/live/admin/dashboard_live.ex:287
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:457
 #: lib/vutuv_web/live/notification_live/index.ex:919
@@ -9069,10 +9070,10 @@ msgstr "Die Seite wurde veröffentlicht."
 msgid "Write it under Admin › Legal pages"
 msgstr "Unter Admin › Rechtstexte verfassen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:607
-#: lib/vutuv_web/agent_docs/markdown.ex:611
-#: lib/vutuv_web/agent_docs/text.ex:573
-#: lib/vutuv_web/agent_docs/text.ex:577
+#: lib/vutuv_web/agent_docs/markdown.ex:614
+#: lib/vutuv_web/agent_docs/markdown.ex:618
+#: lib/vutuv_web/agent_docs/text.ex:580
+#: lib/vutuv_web/agent_docs/text.ex:584
 #: lib/vutuv_web/components/organization_components.ex:310
 #: lib/vutuv_web/components/ui.ex:4097
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
@@ -9208,13 +9209,13 @@ msgstr "Ihr Profil als Lebenslauf"
 msgid "Higher Education"
 msgstr "Studium"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:805
+#: lib/vutuv_web/agent_docs/markdown.ex:812
 #: lib/vutuv_web/views/education_html.ex:23
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr "Schulbildung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:804
+#: lib/vutuv_web/agent_docs/markdown.ex:811
 #: lib/vutuv_web/views/education_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -9250,7 +9251,7 @@ msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] "Repostet von %{name} und %{formatted} weiteren"
 msgstr[1] "Repostet von %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1035
+#: lib/vutuv_web/agent_docs/markdown.ex:1042
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr "repostet von %{name} und %{count} weiteren"
@@ -9502,8 +9503,8 @@ msgstr "Ehren-Tag"
 msgid "Honor tag (only site admins can assign it)"
 msgstr "Ehren-Tag (nur Admins können es vergeben)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:627
-#: lib/vutuv_web/agent_docs/text.ex:591
+#: lib/vutuv_web/agent_docs/markdown.ex:634
+#: lib/vutuv_web/agent_docs/text.ex:598
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr "Ehren-Tag"
@@ -9925,8 +9926,8 @@ msgstr "Walisisch"
 msgid "Yoruba"
 msgstr "Yoruba"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:549
-#: lib/vutuv_web/agent_docs/text.ex:543
+#: lib/vutuv_web/agent_docs/markdown.ex:556
+#: lib/vutuv_web/agent_docs/text.ex:550
 #, elixir-autogen, elixir-format
 msgid "Employment status"
 msgstr "Beschäftigungsstatus"
@@ -10040,7 +10041,7 @@ msgstr[1] "%{count} Zertifikate oder Lizenzen"
 msgid "Add a certificate or license"
 msgstr "Zertifikat oder Lizenz hinzufügen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:922
+#: lib/vutuv_web/agent_docs/markdown.ex:929
 #: lib/vutuv_web/views/qualification_html.ex:14
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -10120,7 +10121,7 @@ msgstr "Läuft nicht ab"
 msgid "Expired"
 msgstr "Abgelaufen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:897
+#: lib/vutuv_web/agent_docs/markdown.ex:904
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr "ID: %{id}"
@@ -10137,7 +10138,7 @@ msgstr "Ausgestellt"
 msgid "Issuer"
 msgstr "Aussteller"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:921
+#: lib/vutuv_web/agent_docs/markdown.ex:928
 #: lib/vutuv_web/views/qualification_html.ex:15
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -10167,7 +10168,7 @@ msgstr "Nachweis"
 msgid "Verification link"
 msgstr "Nachweislink"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:895
+#: lib/vutuv_web/agent_docs/markdown.ex:902
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr "ausgestellt %{date}"
@@ -10182,7 +10183,7 @@ msgstr "z. B. AWS Solutions Architect – Associate"
 msgid "e.g. Amazon Web Services"
 msgstr "z. B. Amazon Web Services"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:896
+#: lib/vutuv_web/agent_docs/markdown.ex:903
 #: lib/vutuv_web/views/qualification_html.ex:91
 #, elixir-autogen, elixir-format
 msgid "valid until %{date}"
@@ -10200,7 +10201,7 @@ msgstr ""
 msgid "Preferred"
 msgstr "Bevorzugt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:732
+#: lib/vutuv_web/agent_docs/markdown.ex:739
 #: lib/vutuv_web/live/section_reorder_live.ex:293
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
@@ -10738,21 +10739,21 @@ msgstr ""
 msgid "set it up on this device"
 msgstr "auf diesem Gerät einrichten"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:692
+#: lib/vutuv_web/agent_docs/markdown.ex:699
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] "%{count} Follower"
 msgstr[1] "%{count} Follower"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:690
+#: lib/vutuv_web/agent_docs/markdown.ex:697
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] "%{count} Repository"
 msgstr[1] "%{count} Repositories"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:688
+#: lib/vutuv_web/agent_docs/markdown.ex:695
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10813,12 +10814,12 @@ msgstr ""
 "Wenn deaktiviert, zeigt die Social-Media-Karte Ihre Konten nur als einfache "
 "Links."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:706
+#: lib/vutuv_web/agent_docs/markdown.ex:713
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr "zuletzt aktiv %{date}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:693
+#: lib/vutuv_web/agent_docs/markdown.ex:700
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr "seit %{date}"
@@ -11438,7 +11439,7 @@ msgstr "Niemand"
 
 #: lib/vutuv/accounts/user.ex:1187
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
-#: lib/vutuv_web/live/job_posting_live/form.ex:566
+#: lib/vutuv_web/live/job_posting_live/form.ex:761
 #, elixir-autogen, elixir-format
 msgid "Signed-in members only"
 msgstr "Nur angemeldete Mitglieder"
@@ -11455,7 +11456,7 @@ msgstr "Wer kann Ihre Verfügbarkeit sehen?"
 msgid "Amount"
 msgstr "Betrag"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:464
+#: lib/vutuv_web/live/job_posting_live/form.ex:659
 #: lib/vutuv_web/templates/user/edit.html.heex:326
 #: lib/vutuv_web/templates/welcome/show.html.heex:131
 #, elixir-autogen, elixir-format
@@ -11484,7 +11485,7 @@ msgstr ""
 "Benachrichtigungen, indem Stellen darunter herausgefiltert werden. Lassen "
 "Sie den Betrag leer, um die Angabe zu entfernen."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:471
+#: lib/vutuv_web/live/job_posting_live/form.ex:666
 #: lib/vutuv_web/templates/user/edit.html.heex:322
 #: lib/vutuv_web/templates/welcome/show.html.heex:127
 #, elixir-autogen, elixir-format
@@ -12229,8 +12230,8 @@ msgstr "Per Rück-Link verifizieren"
 msgid "Verify via file"
 msgstr "Per Datei verifizieren"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:942
-#: lib/vutuv_web/agent_docs/text.ex:719
+#: lib/vutuv_web/agent_docs/markdown.ex:949
+#: lib/vutuv_web/agent_docs/text.ex:726
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr "verifizierte Webseite"
@@ -12661,37 +12662,37 @@ msgstr "%{views} Aufrufe · %{clicks} Bewerbungsklicks"
 msgid "A fake, misleading or discriminatory job advertisement."
 msgstr "Eine gefälschte, irreführende oder diskriminierende Stellenanzeige."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:448
+#: lib/vutuv_web/live/job_posting_live/form.ex:643
 #, elixir-autogen, elixir-format
 msgid "A pay range is required to publish (except volunteer postings)."
 msgstr "Zum Veröffentlichen ist eine Gehaltsspanne erforderlich (außer bei Ehrenämtern)."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:543
+#: lib/vutuv_web/live/job_posting_live/form.ex:738
 #, elixir-autogen, elixir-format
 msgid "A vutuv message to me"
 msgstr "Eine vutuv-Nachricht an mich"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:541
+#: lib/vutuv_web/live/job_posting_live/form.ex:736
 #, elixir-autogen, elixir-format
 msgid "A website"
 msgstr "Eine Website"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:542
+#: lib/vutuv_web/live/job_posting_live/form.ex:737
 #, elixir-autogen, elixir-format
 msgid "An e-mail address"
 msgstr "Eine E-Mail-Adresse"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:425
+#: lib/vutuv_web/live/job_posting_live/form.ex:553
 #, elixir-autogen, elixir-format
 msgid "Applicants must be located in"
 msgstr "Bewerber:innen müssen ansässig sein in"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:547
+#: lib/vutuv_web/live/job_posting_live/form.ex:742
 #, elixir-autogen, elixir-format
 msgid "Application URL"
 msgstr "Bewerbungs-URL"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:553
+#: lib/vutuv_web/live/job_posting_live/form.ex:748
 #, elixir-autogen, elixir-format
 msgid "Application e-mail"
 msgstr "Bewerbungs-E-Mail"
@@ -12701,17 +12702,17 @@ msgstr "Bewerbungs-E-Mail"
 msgid "Application: %{title}"
 msgstr "Bewerbung: %{title}"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:539
+#: lib/vutuv_web/live/job_posting_live/form.ex:734
 #, elixir-autogen, elixir-format
 msgid "Applications go to"
 msgstr "Bewerbungen gehen an"
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:271
+#: lib/vutuv_web/live/job_posting_live/show.ex:275
 #, elixir-autogen, elixir-format
 msgid "Apply by e-mail"
 msgstr "Per E-Mail bewerben"
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:270
+#: lib/vutuv_web/live/job_posting_live/show.ex:274
 #, elixir-autogen, elixir-format
 msgid "Apply on website"
 msgstr "Auf Website bewerben"
@@ -12733,7 +12734,7 @@ msgstr "Geschlossen"
 msgid "Contract"
 msgstr "Freie Mitarbeit"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:487
+#: lib/vutuv_web/live/job_posting_live/form.ex:682
 #, elixir-autogen, elixir-format
 msgid "Describe the role. Markdown is supported."
 msgstr "Beschreiben Sie die Stelle. Markdown wird unterstützt."
@@ -12743,15 +12744,15 @@ msgstr "Beschreiben Sie die Stelle. Markdown wird unterstützt."
 msgid "Drafts"
 msgstr "Entwürfe"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:84
+#: lib/vutuv_web/live/job_posting_live/form.ex:113
 #, elixir-autogen, elixir-format
 msgid "Edit posting"
 msgstr "Anzeige bearbeiten"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:272
-#: lib/vutuv_web/agent_docs/markdown.ex:473
+#: lib/vutuv_web/agent_docs/markdown.ex:480
 #: lib/vutuv_web/agent_docs/text.ex:258
-#: lib/vutuv_web/agent_docs/text.ex:494
+#: lib/vutuv_web/agent_docs/text.ex:501
 #: lib/vutuv_web/live/admin/job_live.ex:344
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:17
 #: lib/vutuv_web/views/account_event_text.ex:225
@@ -12759,27 +12760,27 @@ msgstr "Anzeige bearbeiten"
 msgid "Employer"
 msgstr "Arbeitgeber"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:330
+#: lib/vutuv_web/live/job_posting_live/form.ex:458
 #, elixir-autogen, elixir-format
 msgid "Employer name (optional)"
 msgstr "Name des Arbeitgebers (optional)"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:273
-#: lib/vutuv_web/agent_docs/markdown.ex:474
+#: lib/vutuv_web/agent_docs/markdown.ex:481
 #: lib/vutuv_web/agent_docs/text.ex:259
-#: lib/vutuv_web/agent_docs/text.ex:495
+#: lib/vutuv_web/agent_docs/text.ex:502
 #: lib/vutuv_web/live/job_board_live.ex:367
-#: lib/vutuv_web/live/job_posting_live/form.ex:345
+#: lib/vutuv_web/live/job_posting_live/form.ex:473
 #, elixir-autogen, elixir-format
 msgid "Employment type"
 msgstr "Anstellungsart"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:565
+#: lib/vutuv_web/live/job_posting_live/form.ex:760
 #, elixir-autogen, elixir-format
 msgid "Everyone (public)"
 msgstr "Alle (öffentlich)"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:452
+#: lib/vutuv_web/live/job_posting_live/form.ex:647
 #: lib/vutuv_web/live/tag_live/timeline.ex:264
 #: lib/vutuv_web/templates/education/form_content.html.heex:41
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:63
@@ -12797,12 +12798,7 @@ msgstr "Vollzeit"
 msgid "Highlighted tags match your profile."
 msgstr "Hervorgehobene Tags passen zu Ihrem Profil."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:441
-#, elixir-autogen, elixir-format
-msgid "Hold Ctrl / Cmd to select more than one."
-msgstr "Halten Sie Strg / Cmd gedrückt, um mehrere auszuwählen."
-
-#: lib/vutuv_web/live/job_posting_live/form.ex:537
+#: lib/vutuv_web/live/job_posting_live/form.ex:732
 #, elixir-autogen, elixir-format
 msgid "How to apply"
 msgstr "So bewerben Sie sich"
@@ -12818,12 +12814,12 @@ msgstr "Hybrid"
 msgid "I'm interested in your posting: %{url}"
 msgstr "Ich interessiere mich für Ihre Anzeige: %{url}"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:486
+#: lib/vutuv_web/live/job_posting_live/form.ex:681
 #, elixir-autogen, elixir-format
 msgid "Job description"
 msgstr "Stellenbeschreibung"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:297
+#: lib/vutuv_web/live/job_posting_live/form.ex:425
 #, elixir-autogen, elixir-format
 msgid "Job title"
 msgstr "Stellenbezeichnung"
@@ -12839,18 +12835,18 @@ msgstr "Stellenbezeichnung"
 msgid "Jobs"
 msgstr "Jobs"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:575
+#: lib/vutuv_web/live/job_posting_live/form.ex:770
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this posting."
 msgstr "Suchmaschinen dürfen diese Anzeige indexieren."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:455
-#: lib/vutuv_web/agent_docs/markdown.ex:459
-#: lib/vutuv_web/agent_docs/markdown.ex:461
+#: lib/vutuv_web/agent_docs/markdown.ex:458
+#: lib/vutuv_web/agent_docs/markdown.ex:460
 #: lib/vutuv_web/agent_docs/text.ex:476
-#: lib/vutuv_web/agent_docs/text.ex:480
-#: lib/vutuv_web/agent_docs/text.ex:482
-#: lib/vutuv_web/live/job_posting_live/form.ex:386
+#: lib/vutuv_web/agent_docs/text.ex:479
+#: lib/vutuv_web/agent_docs/text.ex:481
+#: lib/vutuv_web/live/job_posting_live/form.ex:514
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr "Standort"
@@ -12865,7 +12861,7 @@ msgstr "Als besetzt markieren"
 msgid "Mark this posting as filled and close it?"
 msgstr "Diese Anzeige als besetzt markieren und schließen?"
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:272
+#: lib/vutuv_web/live/job_posting_live/show.ex:276
 #, elixir-autogen, elixir-format
 msgid "Message the poster"
 msgstr "Anbieter:in anschreiben"
@@ -12887,20 +12883,20 @@ msgstr "Irreführende Stellenanzeige"
 msgid "My postings"
 msgstr "Meine Anzeigen"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:273
+#: lib/vutuv_web/live/job_posting_live/form.ex:395
 #, elixir-autogen, elixir-format
 msgid "New accounts can publish after a few days."
 msgstr "Neue Konten können nach einigen Tagen veröffentlichen."
 
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:103
-#: lib/vutuv_web/live/job_posting_live/form.ex:84
+#: lib/vutuv_web/live/job_posting_live/form.ex:113
 #, elixir-autogen, elixir-format
 msgid "New posting"
 msgstr "Neue Anzeige"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:284
 #: lib/vutuv_web/agent_docs/text.ex:269
-#: lib/vutuv_web/live/job_posting_live/form.ex:525
+#: lib/vutuv_web/live/job_posting_live/form.ex:720
 #: lib/vutuv_web/live/job_posting_live/show.ex:154
 #, elixir-autogen, elixir-format
 msgid "Nice to have"
@@ -12921,7 +12917,7 @@ msgstr "Hier ist noch nichts. Jobs mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Jobs you like show up here."
 msgstr "Hier ist noch nichts. Jobs, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:581
+#: lib/vutuv_web/live/job_posting_live/form.ex:776
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) für KI-Agenten anbieten."
@@ -12942,17 +12938,17 @@ msgstr "Nur Sie sehen diese Anzeige, während eine Meldung dazu bearbeitet wird.
 msgid "Part-time"
 msgstr "Teilzeit"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:446
+#: lib/vutuv_web/live/job_posting_live/form.ex:641
 #, elixir-autogen, elixir-format
 msgid "Pay"
 msgstr "Bezahlung"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:272
+#: lib/vutuv_web/live/job_posting_live/form.ex:394
 #, elixir-autogen, elixir-format
 msgid "Please confirm your e-mail address first."
 msgstr "Bitte bestätigen Sie zuerst Ihre E-Mail-Adresse."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:41
+#: lib/vutuv_web/live/job_posting_live/form.ex:70
 #, elixir-autogen, elixir-format
 msgid "Please confirm your email address before posting a job."
 msgstr "Bitte bestätigen Sie Ihre E-Mail-Adresse, bevor Sie eine Stelle ausschreiben."
@@ -12962,7 +12958,7 @@ msgstr "Bitte bestätigen Sie Ihre E-Mail-Adresse, bevor Sie eine Stelle ausschr
 msgid "Please log in to message the poster."
 msgstr "Bitte melden Sie sich an, um die Anbieter:in anzuschreiben."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:47
+#: lib/vutuv_web/live/job_posting_live/form.ex:76
 #, elixir-autogen, elixir-format
 msgid "Please log in to post a job."
 msgstr "Bitte melden Sie sich an, um eine Stelle auszuschreiben."
@@ -12972,38 +12968,38 @@ msgstr "Bitte melden Sie sich an, um eine Stelle auszuschreiben."
 msgid "Please log in to see your postings."
 msgstr "Bitte melden Sie sich an, um Ihre Anzeigen zu sehen."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:318
+#: lib/vutuv_web/live/job_posting_live/form.ex:446
 #, elixir-autogen, elixir-format
 msgid "Post as"
 msgstr "Veröffentlichen als"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:398
+#: lib/vutuv_web/live/job_posting_live/form.ex:526
 #: lib/vutuv_web/templates/welcome/show.html.heex:67
 #, elixir-autogen, elixir-format
 msgid "Postal code"
 msgstr "Postleitzahl"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:277
-#: lib/vutuv_web/agent_docs/markdown.ex:478
+#: lib/vutuv_web/agent_docs/markdown.ex:485
 #: lib/vutuv_web/agent_docs/text.ex:263
-#: lib/vutuv_web/agent_docs/text.ex:499
+#: lib/vutuv_web/agent_docs/text.ex:506
 #: lib/vutuv_web/live/job_posting_live/show.ex:133
 #, elixir-autogen, elixir-format
 msgid "Posted"
 msgstr "Veröffentlicht"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:376
+#: lib/vutuv_web/live/job_posting_live/form.ex:504
 #, elixir-autogen, elixir-format
 msgid "Posting language"
 msgstr "Sprache der Anzeige"
 
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:50
-#: lib/vutuv_web/live/job_posting_live/form.ex:74
+#: lib/vutuv_web/live/job_posting_live/form.ex:103
 #, elixir-autogen, elixir-format
 msgid "Posting not found."
 msgstr "Anzeige nicht gefunden."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:598
+#: lib/vutuv_web/live/job_posting_live/form.ex:793
 #, elixir-autogen, elixir-format
 msgid "Publish"
 msgstr "Veröffentlichen"
@@ -13011,10 +13007,10 @@ msgstr "Veröffentlichen"
 #: lib/vutuv/accounts/user.ex:1159
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:564
-#: lib/vutuv_web/agent_docs/markdown.ex:459
-#: lib/vutuv_web/agent_docs/markdown.ex:461
-#: lib/vutuv_web/agent_docs/text.ex:480
-#: lib/vutuv_web/agent_docs/text.ex:482
+#: lib/vutuv_web/agent_docs/markdown.ex:458
+#: lib/vutuv_web/agent_docs/markdown.ex:460
+#: lib/vutuv_web/agent_docs/text.ex:479
+#: lib/vutuv_web/agent_docs/text.ex:481
 #: lib/vutuv_web/components/job_components.ex:140
 #: lib/vutuv_web/components/job_components.ex:141
 #, elixir-autogen, elixir-format
@@ -13028,47 +13024,47 @@ msgstr "Diese Anzeige melden"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:283
 #: lib/vutuv_web/agent_docs/text.ex:268
-#: lib/vutuv_web/live/job_posting_live/form.ex:515
+#: lib/vutuv_web/live/job_posting_live/form.ex:710
 #: lib/vutuv_web/live/job_posting_live/show.ex:149
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr "Erforderlich"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:276
-#: lib/vutuv_web/agent_docs/markdown.ex:477
+#: lib/vutuv_web/agent_docs/markdown.ex:484
 #: lib/vutuv_web/agent_docs/text.ex:262
-#: lib/vutuv_web/agent_docs/text.ex:498
+#: lib/vutuv_web/agent_docs/text.ex:505
 #, elixir-autogen, elixir-format
 msgid "Salary"
 msgstr "Gehalt"
 
-#: lib/vutuv_web/components/job_components.ex:162
+#: lib/vutuv_web/components/job_components.ex:200
 #, elixir-autogen, elixir-format
 msgid "Salary on request"
 msgstr "Gehalt auf Anfrage"
 
 #: lib/vutuv_web/controllers/settings_controller.ex:393
-#: lib/vutuv_web/live/job_posting_live/form.ex:231
+#: lib/vutuv_web/live/job_posting_live/form.ex:353
 #, elixir-autogen, elixir-format
 msgid "Saved."
 msgstr "Gespeichert."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:339
+#: lib/vutuv_web/live/job_posting_live/form.ex:467
 #, elixir-autogen, elixir-format
 msgid "Shown as an unverified employer name."
 msgstr "Wird als nicht verifizierter Arbeitgebername angezeigt."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:261
+#: lib/vutuv_web/live/job_posting_live/form.ex:383
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again."
 msgstr "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:391
+#: lib/vutuv_web/live/job_posting_live/form.ex:519
 #, elixir-autogen, elixir-format
 msgid "Street (optional)"
 msgstr "Straße (optional)"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:512
+#: lib/vutuv_web/live/job_posting_live/form.ex:707
 #, elixir-autogen, elixir-format
 msgid "Tags match your posting to members. Separate them with commas; a tag may be several words long, like Ruby on Rails."
 msgstr "Tags bringen Ihre Anzeige mit Mitgliedern zusammen. Mit Kommas trennen; ein Tag darf aus mehreren Wörtern bestehen, zum Beispiel Ruby on Rails."
@@ -13078,17 +13074,17 @@ msgstr "Tags bringen Ihre Anzeige mit Mitgliedern zusammen. Mit Kommas trennen; 
 msgid "Temporary"
 msgstr "Befristet"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:153
+#: lib/vutuv_web/live/job_posting_live/form.ex:275
 #, elixir-autogen, elixir-format
 msgid "That image could not be uploaded."
 msgstr "Dieses Bild konnte nicht hochgeladen werden."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:293
+#: lib/vutuv_web/live/job_posting_live/form.ex:421
 #, elixir-autogen, elixir-format
 msgid "The role"
 msgstr "Die Stelle"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:279
+#: lib/vutuv_web/live/job_posting_live/form.ex:401
 #, elixir-autogen, elixir-format
 msgid "This organization has reached its published-postings limit."
 msgstr "Diese Organisation hat ihr Limit an veröffentlichten Anzeigen erreicht."
@@ -13098,7 +13094,7 @@ msgstr "Diese Organisation hat ihr Limit an veröffentlichten Anzeigen erreicht.
 msgid "This position is no longer available."
 msgstr "Diese Stelle ist nicht mehr verfügbar."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:312
+#: lib/vutuv_web/live/job_posting_live/form.ex:440
 #, elixir-autogen, elixir-format
 msgid "Tip: adding a gender marker like (m/w/d) helps your posting comply with the AGG. This is a suggestion, not legal advice."
 msgstr "Tipp: Ein Geschlechtszusatz wie (m/w/d) hilft Ihrer Anzeige, dem AGG zu entsprechen. Das ist ein Hinweis, keine Rechtsberatung."
@@ -13109,8 +13105,8 @@ msgstr "Tipp: Ein Geschlechtszusatz wie (m/w/d) hilft Ihrer Anzeige, dem AGG zu 
 msgid "Verified organization"
 msgstr "Verifizierte Organisation"
 
-#: lib/vutuv_web/agent_docs/job_posting_doc.ex:126
-#: lib/vutuv_web/components/job_components.ex:161
+#: lib/vutuv_web/agent_docs/job_posting_doc.ex:131
+#: lib/vutuv_web/components/job_components.ex:199
 #, elixir-autogen, elixir-format
 msgid "Voluntary"
 msgstr "Ehrenamtlich"
@@ -13120,7 +13116,7 @@ msgstr "Ehrenamtlich"
 msgid "Volunteer"
 msgstr "Ehrenamt"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:563
+#: lib/vutuv_web/live/job_posting_live/form.ex:758
 #: lib/vutuv_web/templates/email/form_content.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Who can see it"
@@ -13132,15 +13128,15 @@ msgid "Working student"
 msgstr "Werkstudent:in"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:274
-#: lib/vutuv_web/agent_docs/markdown.ex:475
+#: lib/vutuv_web/agent_docs/markdown.ex:482
 #: lib/vutuv_web/agent_docs/text.ex:260
-#: lib/vutuv_web/agent_docs/text.ex:496
-#: lib/vutuv_web/live/job_posting_live/form.ex:360
+#: lib/vutuv_web/agent_docs/text.ex:503
+#: lib/vutuv_web/live/job_posting_live/form.ex:488
 #, elixir-autogen, elixir-format
 msgid "Workplace"
 msgstr "Arbeitsort"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:276
+#: lib/vutuv_web/live/job_posting_live/form.ex:398
 #, elixir-autogen, elixir-format
 msgid "You already have the maximum number of published postings."
 msgstr "Sie haben bereits die maximale Anzahl veröffentlichter Anzeigen."
@@ -13185,18 +13181,18 @@ msgstr "Ihre Organisationsseite auf vutuv ist nicht mehr öffentlich"
 msgid "Your posting"
 msgstr "Ihre Anzeige"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:211
-#: lib/vutuv_web/live/job_posting_live/form.ex:254
+#: lib/vutuv_web/live/job_posting_live/form.ex:333
+#: lib/vutuv_web/live/job_posting_live/form.ex:376
 #, elixir-autogen, elixir-format
 msgid "Your posting is live."
 msgstr "Ihre Anzeige ist online."
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:321
+#: lib/vutuv_web/live/job_posting_live/form.ex:449
 #, elixir-autogen, elixir-format
 msgid "Yourself (personal posting)"
 msgstr "Sie selbst (persönliche Anzeige)"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:458
+#: lib/vutuv_web/live/job_posting_live/form.ex:653
 #, elixir-autogen, elixir-format
 msgid "up to"
 msgstr "bis"
@@ -13310,14 +13306,14 @@ msgstr "Nur eine verifizierte Organisationsseite kann ein Handle beanspruchen."
 msgid "Value"
 msgstr "Wert"
 
-#: lib/vutuv_web/components/job_components.ex:184
+#: lib/vutuv_web/components/job_components.ex:222
 #, elixir-autogen, elixir-format
 msgid "%{count} month ago"
 msgid_plural "%{count} months ago"
 msgstr[0] "vor %{count} Monat"
 msgstr[1] "vor %{count} Monaten"
 
-#: lib/vutuv_web/components/job_components.ex:183
+#: lib/vutuv_web/components/job_components.ex:221
 #, elixir-autogen, elixir-format
 msgid "%{count} week ago"
 msgid_plural "%{count} weeks ago"
@@ -13334,13 +13330,13 @@ msgstr "%{km} km"
 msgid "All countries"
 msgstr "Alle Länder"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:496
+#: lib/vutuv_web/agent_docs/markdown.ex:503
 #: lib/vutuv_web/templates/tag/show.html.heex:75
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr "Alle Stellen mit diesem Tag"
 
-#: lib/vutuv_web/agent_docs/text.ex:516
+#: lib/vutuv_web/agent_docs/text.ex:523
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag: %{url}"
 msgstr "Alle Stellen mit diesem Tag: %{url}"
@@ -13406,10 +13402,10 @@ msgstr "Noch keine Stellenanzeigen."
 msgid "No matching positions. Try adjusting the filters."
 msgstr "Keine passenden Stellen. Passen Sie die Filter an."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:494
-#: lib/vutuv_web/agent_docs/markdown.ex:506
-#: lib/vutuv_web/agent_docs/text.ex:514
-#: lib/vutuv_web/agent_docs/text.ex:526
+#: lib/vutuv_web/agent_docs/markdown.ex:501
+#: lib/vutuv_web/agent_docs/markdown.ex:513
+#: lib/vutuv_web/agent_docs/text.ex:521
+#: lib/vutuv_web/agent_docs/text.ex:533
 #: lib/vutuv_web/live/organization_live/show.ex:676
 #: lib/vutuv_web/templates/tag/show.html.heex:69
 #, elixir-autogen, elixir-format
@@ -13870,7 +13866,7 @@ msgstr "Wird eine Organisation ausgeschlossen, ist die Anzeige auch für ihre be
 msgid "Hide from specific viewers"
 msgstr "Vor bestimmten Personen verbergen"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:587
+#: lib/vutuv_web/live/job_posting_live/form.ex:782
 #, elixir-autogen, elixir-format
 msgid "Hide from specific viewers (competitors, your own staff, a person) →"
 msgstr "Vor bestimmten Personen verbergen (Wettbewerber, eigene Belegschaft, Einzelpersonen) →"
@@ -13891,7 +13887,7 @@ msgstr "Ausschlussliste"
 msgid "Job exclusions – %{name}"
 msgstr "Ausschlussliste – %{name}"
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:590
+#: lib/vutuv_web/live/job_posting_live/form.ex:785
 #, elixir-autogen, elixir-format
 msgid "Keep this posting on the board for everyone except a chosen few."
 msgstr "Halten Sie diese Anzeige für alle im Stellenmarkt sichtbar, außer für wenige Ausgewählte."
@@ -14359,7 +14355,7 @@ msgstr "hat %{count} neue Einträge im Lebenslauf:"
 msgid "Audiobook"
 msgstr "Hörbuch"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1189
+#: lib/vutuv_web/agent_docs/markdown.ex:1196
 #: lib/vutuv_web/components/post_components.ex:4405
 #, elixir-autogen, elixir-format
 msgid "Book review"
@@ -14380,7 +14376,7 @@ msgstr "DVD/Blu-ray"
 msgid "E-book"
 msgstr "E-Book"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1189
+#: lib/vutuv_web/agent_docs/markdown.ex:1196
 #: lib/vutuv_web/components/post_components.ex:4404
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -14470,7 +14466,7 @@ msgstr "Qualifikation"
 msgid "With qualification:"
 msgstr "Mit Qualifikation:"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:761
+#: lib/vutuv_web/agent_docs/markdown.ex:768
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
@@ -14564,19 +14560,19 @@ msgid_plural "Used for %{formatted} jobs"
 msgstr[0] "Für %{formatted} Job genutzt"
 msgstr[1] "Für %{formatted} Jobs genutzt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:911
+#: lib/vutuv_web/agent_docs/markdown.ex:918
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr "aktuell genutzt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:910
+#: lib/vutuv_web/agent_docs/markdown.ex:917
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] "für %{count} Job genutzt"
 msgstr[1] "für %{count} Jobs genutzt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:916
+#: lib/vutuv_web/agent_docs/markdown.ex:923
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
@@ -14656,8 +14652,8 @@ msgstr "Hochgeladener Nachweis für %{name}"
 msgid "View the uploaded proof (%{label})"
 msgstr "Hochgeladenen Nachweis ansehen (%{label})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:847
-#: lib/vutuv_web/agent_docs/text.ex:698
+#: lib/vutuv_web/agent_docs/markdown.ex:854
+#: lib/vutuv_web/agent_docs/text.ex:705
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr "Nachweis"
@@ -14752,8 +14748,8 @@ msgstr "Speichern und weiter"
 msgid "Skip for now"
 msgstr "Erstmal überspringen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:551
-#: lib/vutuv_web/agent_docs/text.ex:545
+#: lib/vutuv_web/agent_docs/markdown.ex:558
+#: lib/vutuv_web/agent_docs/text.ex:552
 #, elixir-autogen, elixir-format
 msgid "Preferred workplace"
 msgstr "Bevorzugte Arbeitsform"
@@ -15358,7 +15354,7 @@ msgstr "%{blocked} Server blockiert, am aktivsten eingehend: %{host}."
 msgid "none yet"
 msgstr "noch keiner"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1136
+#: lib/vutuv_web/agent_docs/markdown.ex:1143
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr "Reaktionen aus anderen Netzwerken"
@@ -15742,8 +15738,8 @@ msgstr "%{server} hat nicht geantwortet. Kopieren Sie stattdessen die Adresse ob
 msgid "Your server"
 msgstr "Ihr Server"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:608
-#: lib/vutuv_web/agent_docs/text.ex:574
+#: lib/vutuv_web/agent_docs/markdown.ex:615
+#: lib/vutuv_web/agent_docs/text.ex:581
 #, elixir-autogen, elixir-format
 msgid "moved to %{address}"
 msgstr "umgezogen nach %{address}"
@@ -16141,7 +16137,7 @@ msgid_plural "%{formatted} reposts"
 msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1138
+#: lib/vutuv_web/agent_docs/markdown.ex:1145
 #: lib/vutuv_web/components/post_components.ex:4822
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
@@ -16152,8 +16148,8 @@ msgstr "Bereits in den Zahlen oben enthalten."
 msgid "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
 msgstr "Antworten, die dort draußen geschrieben werden, erscheinen unter Ihrem Beitrag, gekennzeichnet als aus einem anderen Netzwerk. Wir speichern eine Kopie für bis zu sechs Monate und prüfen ab und zu, ob sie dort noch veröffentlicht ist; löscht sie die Autorin oder der Autor, verschwindet auch unsere. Sie können jede einzelne Antwort entfernen, und wenn Sie das hier ausschalten, werden alle gelöscht."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1320
-#: lib/vutuv_web/agent_docs/text.ex:818
+#: lib/vutuv_web/agent_docs/markdown.ex:1327
+#: lib/vutuv_web/agent_docs/text.ex:825
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr "Inhaltswarnung"
@@ -16177,7 +16173,7 @@ msgstr "Vom Mitglied entfernt"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:126
 #: lib/vutuv_web/agent_docs/markdown.ex:157
-#: lib/vutuv_web/agent_docs/markdown.ex:1137
+#: lib/vutuv_web/agent_docs/markdown.ex:1144
 #: lib/vutuv_web/agent_docs/text.ex:117
 #: lib/vutuv_web/agent_docs/text.ex:145
 #, elixir-autogen, elixir-format
@@ -16235,7 +16231,7 @@ msgstr "Danke. Die Antwort wurde sofort gelöscht."
 msgid "That reply is not yours to remove."
 msgstr "Diese Antwort können Sie nicht entfernen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1322
+#: lib/vutuv_web/agent_docs/markdown.ex:1329
 #: lib/vutuv_web/components/post_components.ex:1153
 #: lib/vutuv_web/components/post_components.ex:1353
 #: lib/vutuv_web/components/post_components.ex:2178
@@ -16942,13 +16938,13 @@ msgstr ""
 msgid "Unpinned. The post is a normal post again."
 msgstr "Nicht mehr angeheftet. Der Beitrag ist wieder ein normaler Beitrag."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1018
+#: lib/vutuv_web/agent_docs/markdown.ex:1025
 #, elixir-autogen, elixir-format
 msgid "pinned post"
 msgstr "angehefteter Beitrag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:545
-#: lib/vutuv_web/agent_docs/text.ex:536
+#: lib/vutuv_web/agent_docs/markdown.ex:552
+#: lib/vutuv_web/agent_docs/text.ex:543
 #: lib/vutuv_web/templates/user/edit.html.heex:224
 #: lib/vutuv_web/templates/user/show.html.heex:247
 #: lib/vutuv_web/views/account_event_text.ex:213
@@ -17010,8 +17006,8 @@ msgstr "Titelbild"
 msgid "Describe the photo for people who can't see it"
 msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1250
-#: lib/vutuv_web/agent_docs/text.ex:785
+#: lib/vutuv_web/agent_docs/markdown.ex:1257
+#: lib/vutuv_web/agent_docs/text.ex:792
 #: lib/vutuv_web/components/ui.ex:2471
 #, elixir-autogen, elixir-format
 msgid "Download the original"
@@ -17073,8 +17069,8 @@ msgstr "Foto wird geprüft"
 msgid "Photo options"
 msgstr "Foto-Einstellungen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1283
-#: lib/vutuv_web/agent_docs/text.ex:772
+#: lib/vutuv_web/agent_docs/markdown.ex:1290
+#: lib/vutuv_web/agent_docs/text.ex:779
 #: lib/vutuv_web/components/post_components.ex:3753
 #, elixir-autogen, elixir-format
 msgid "Photos:"
@@ -17247,13 +17243,13 @@ msgid_plural "Some of these photos carry the location they were taken at, and th
 msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exakte Datei gibt ihn weiter."
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1156
+#: lib/vutuv_web/agent_docs/markdown.ex:1163
 #: lib/vutuv_web/components/post_components.ex:4860
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1154
+#: lib/vutuv_web/agent_docs/markdown.ex:1161
 #: lib/vutuv_web/components/post_components.ex:4857
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
@@ -17885,7 +17881,7 @@ msgstr "Variante"
 msgid "What is being measured"
 msgstr "Was gemessen wird"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1013
+#: lib/vutuv_web/agent_docs/markdown.ex:1020
 #, elixir-autogen, elixir-format
 msgid "(a picture)"
 msgid_plural "(%{count} pictures)"
@@ -18049,8 +18045,8 @@ msgstr "Profil verifizieren"
 msgid "We could not reach the network just now. Please try again in a moment."
 msgstr "Wir konnten das Netzwerk gerade nicht erreichen. Bitte versuchen Sie es gleich noch einmal."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:956
-#: lib/vutuv_web/agent_docs/text.ex:620
+#: lib/vutuv_web/agent_docs/markdown.ex:963
+#: lib/vutuv_web/agent_docs/text.ex:627
 #, elixir-autogen, elixir-format, fuzzy
 msgid "verified profile"
 msgstr "verifiziertes Profil"
@@ -18983,7 +18979,7 @@ msgstr "Höchstens %{max} Tags. Entfernen Sie eines, um ein anderes hinzuzufüge
 msgid "A post's page shows the members who liked it, right under the count. This is whether you are one of the faces."
 msgstr "Auf der Seite eines Beitrags stehen direkt unter der Zahl die Mitglieder, denen er gefällt. Hier legen Sie fest, ob Sie zu diesen Gesichtern gehören."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1124
+#: lib/vutuv_web/agent_docs/markdown.ex:1131
 #, elixir-autogen, elixir-format
 msgid "Liked by"
 msgstr "Gefällt diesen Mitgliedern"
@@ -19025,12 +19021,12 @@ msgstr "Wenn aus, sehen andere Mitglieder Sie nicht mehr bei den Likes eines Bei
 msgid "Your likes follow the site default again."
 msgstr "Ihre Likes folgen wieder dem Standardwert der Website."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1179
+#: lib/vutuv_web/agent_docs/markdown.ex:1186
 #, elixir-autogen, elixir-format
 msgid "%{address} (this page only)"
 msgstr "%{address} (nur diese Seite)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1176
+#: lib/vutuv_web/agent_docs/markdown.ex:1183
 #, elixir-autogen, elixir-format
 msgid "%{address} (whole website)"
 msgstr "%{address} (ganze Website)"
@@ -19040,7 +19036,7 @@ msgstr "%{address} (ganze Website)"
 msgid "Verified webpage of the author (%{address})"
 msgstr "Verifizierte Webseite der Autorin oder des Autors (%{address})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1168
+#: lib/vutuv_web/agent_docs/markdown.ex:1175
 #, elixir-autogen, elixir-format
 msgid "Verified webpages of the author linked here: %{addresses}"
 msgstr ""
@@ -19372,7 +19368,7 @@ msgstr "Weder den Prompt noch das Modell haben wir geschrieben."
 msgid "Employment references of %{name}"
 msgstr "Arbeitszeugnisse von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:829
+#: lib/vutuv_web/agent_docs/markdown.ex:836
 #, elixir-autogen, elixir-format
 msgid "document"
 msgstr "Dokument"
@@ -22260,3 +22256,35 @@ msgstr "Ihr E-Mail-Programm öffnet sich mit ausgefülltem Betreff."
 msgctxt "qualification detail"
 msgid "Jobs"
 msgstr "Jobs"
+
+#: lib/vutuv_web/live/job_posting_live/form.ex:824
+#, elixir-autogen, elixir-format
+msgid "%{formatted} country chosen."
+msgid_plural "%{formatted} countries chosen."
+msgstr[0] "%{formatted} Land ausgewählt."
+msgstr[1] "%{formatted} Länder ausgewählt."
+
+#: lib/vutuv_web/live/job_posting_live/form.ex:610
+#, elixir-autogen, elixir-format
+msgid "No country chosen yet."
+msgstr "Noch kein Land ausgewählt."
+
+#: lib/vutuv_web/live/job_posting_live/form.ex:602
+#, elixir-autogen, elixir-format
+msgid "No country left to add for that."
+msgstr "Dazu ist kein weiteres Land offen."
+
+#: lib/vutuv_web/live/job_posting_live/form.ex:621
+#, elixir-autogen, elixir-format
+msgid "Remove %{country}"
+msgstr "%{country} entfernen"
+
+#: lib/vutuv_web/live/job_posting_live/form.ex:632
+#, elixir-autogen, elixir-format
+msgid "Remove all"
+msgstr "Alle entfernen"
+
+#: lib/vutuv_web/live/job_posting_live/form.ex:581
+#, elixir-autogen, elixir-format
+msgid "Search for a country"
+msgstr "Land suchen"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -101,10 +101,10 @@ msgstr ""
 msgid "Birthdate"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:595
-#: lib/vutuv_web/agent_docs/markdown.ex:596
-#: lib/vutuv_web/agent_docs/text.ex:561
-#: lib/vutuv_web/agent_docs/text.ex:562
+#: lib/vutuv_web/agent_docs/markdown.ex:602
+#: lib/vutuv_web/agent_docs/markdown.ex:603
+#: lib/vutuv_web/agent_docs/text.ex:568
+#: lib/vutuv_web/agent_docs/text.ex:569
 #: lib/vutuv_web/templates/user/show.html.heex:1093
 #, elixir-autogen
 msgid "Birthday"
@@ -115,7 +115,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
-#: lib/vutuv_web/live/job_posting_live/form.ex:605
+#: lib/vutuv_web/live/job_posting_live/form.ex:800
 #: lib/vutuv_web/live/organization_live/edit.ex:351
 #: lib/vutuv_web/live/organization_live/new.ex:231
 #: lib/vutuv_web/live/post_live/composer.ex:1399
@@ -176,7 +176,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:481
+#: lib/vutuv_web/live/job_posting_live/form.ex:676
 #: lib/vutuv_web/live/organization_live/edit.ex:276
 #: lib/vutuv_web/live/organization_live/edit.ex:285
 #: lib/vutuv_web/templates/address/card_list.html.heex:5
@@ -305,14 +305,14 @@ msgstr ""
 msgid "Fax"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:581
+#: lib/vutuv_web/agent_docs/markdown.ex:588
 #: lib/vutuv_web/templates/user/edit.html.heex:169
 #, elixir-autogen
 msgid "First Name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:616
-#: lib/vutuv_web/agent_docs/text.ex:582
+#: lib/vutuv_web/agent_docs/markdown.ex:623
+#: lib/vutuv_web/agent_docs/text.ex:589
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
 #: lib/vutuv_web/live/notification_live/index.ex:968
@@ -323,8 +323,8 @@ msgstr ""
 msgid "Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:617
-#: lib/vutuv_web/agent_docs/text.ex:583
+#: lib/vutuv_web/agent_docs/markdown.ex:624
+#: lib/vutuv_web/agent_docs/text.ex:590
 #: lib/vutuv_web/components/fediverse_components.ex:313
 #: lib/vutuv_web/components/ui.ex:2132
 #: lib/vutuv_web/components/ui.ex:2157
@@ -384,7 +384,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:583
+#: lib/vutuv_web/agent_docs/markdown.ex:590
 #: lib/vutuv_web/templates/user/edit.html.heex:174
 #, elixir-autogen
 msgid "Last Name"
@@ -451,7 +451,7 @@ msgstr ""
 msgid "Log in"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:582
+#: lib/vutuv_web/agent_docs/markdown.ex:589
 #: lib/vutuv_web/templates/user/edit.html.heex:179
 #, elixir-autogen
 msgid "Middle Name"
@@ -486,7 +486,7 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:585
+#: lib/vutuv_web/agent_docs/markdown.ex:592
 #: lib/vutuv_web/templates/user/edit.html.heex:184
 #, elixir-autogen
 msgid "Nickname"
@@ -567,7 +567,7 @@ msgstr ""
 msgid "Phone number updated successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:580
+#: lib/vutuv_web/agent_docs/markdown.ex:587
 #: lib/vutuv_web/templates/user/edit.html.heex:189
 #, elixir-autogen
 msgid "Prefix"
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Submit a bugreport or a feature request."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:584
+#: lib/vutuv_web/agent_docs/markdown.ex:591
 #: lib/vutuv_web/templates/user/edit.html.heex:194
 #, elixir-autogen
 msgid "Suffix"
@@ -859,7 +859,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4081
 #: lib/vutuv_web/controllers/settings_controller.ex:169
-#: lib/vutuv_web/live/job_posting_live/form.ex:561
+#: lib/vutuv_web/live/job_posting_live/form.ex:756
 #: lib/vutuv_web/live/organization_live/edit.ex:304
 #: lib/vutuv_web/templates/email/card_list.html.heex:7
 #: lib/vutuv_web/templates/email/show.html.heex:24
@@ -1372,11 +1372,11 @@ msgid "Tag urls"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:34
-#: lib/vutuv_web/agent_docs/markdown.ex:488
-#: lib/vutuv_web/agent_docs/markdown.ex:1063
+#: lib/vutuv_web/agent_docs/markdown.ex:495
+#: lib/vutuv_web/agent_docs/markdown.ex:1070
 #: lib/vutuv_web/agent_docs/text.ex:31
-#: lib/vutuv_web/agent_docs/text.ex:509
-#: lib/vutuv_web/agent_docs/text.ex:746
+#: lib/vutuv_web/agent_docs/text.ex:516
+#: lib/vutuv_web/agent_docs/text.ex:753
 #: lib/vutuv_web/components/ui.ex:4012
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1387,7 +1387,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:433
 #: lib/vutuv_web/live/cv_live.ex:315
 #: lib/vutuv_web/live/job_board_live.ex:277
-#: lib/vutuv_web/live/job_posting_live/form.ex:510
+#: lib/vutuv_web/live/job_posting_live/form.ex:705
 #: lib/vutuv_web/live/search_live.ex:282
 #: lib/vutuv_web/live/search_live.ex:716
 #: lib/vutuv_web/live/tag_new_live.ex:36
@@ -1563,7 +1563,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:776
 #: lib/vutuv_web/live/job_board_live.ex:360
-#: lib/vutuv_web/live/job_posting_live/form.ex:410
+#: lib/vutuv_web/live/job_posting_live/form.ex:538
 #: lib/vutuv_web/live/organization_live/edit.ex:300
 #: lib/vutuv_web/live/organization_live/new.ex:142
 #: lib/vutuv_web/templates/ad/new.html.heex:114
@@ -2080,7 +2080,7 @@ msgstr ""
 msgid "Markdown is supported: bold, italics, links and lists."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:504
+#: lib/vutuv_web/live/job_posting_live/form.ex:699
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr ""
@@ -2382,7 +2382,7 @@ msgstr ""
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1101
+#: lib/vutuv_web/agent_docs/markdown.ex:1108
 #: lib/vutuv_web/live/post_live/saved.ex:175
 #: lib/vutuv_web/live/post_live/saved.ex:488
 #: lib/vutuv_web/live/shell_live.ex:730
@@ -2402,7 +2402,7 @@ msgstr ""
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1100
+#: lib/vutuv_web/agent_docs/markdown.ex:1107
 #: lib/vutuv_web/components/post_components.ex:4916
 #: lib/vutuv_web/live/notification_live/index.ex:970
 #: lib/vutuv_web/live/post_live/saved.ex:174
@@ -2789,8 +2789,8 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:618
-#: lib/vutuv_web/agent_docs/text.ex:584
+#: lib/vutuv_web/agent_docs/markdown.ex:625
+#: lib/vutuv_web/agent_docs/text.ex:591
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/live/notification_live/index.ex:969
 #: lib/vutuv_web/templates/connection/index.html.heex:5
@@ -3827,12 +3827,12 @@ msgstr ""
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:715
+#: lib/vutuv_web/agent_docs/markdown.ex:722
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1222
+#: lib/vutuv_web/agent_docs/markdown.ex:1229
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
@@ -3846,11 +3846,11 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:83
 #: lib/vutuv_web/agent_docs/markdown.ex:194
 #: lib/vutuv_web/agent_docs/markdown.ex:208
-#: lib/vutuv_web/agent_docs/markdown.ex:1063
+#: lib/vutuv_web/agent_docs/markdown.ex:1070
 #: lib/vutuv_web/agent_docs/text.ex:80
 #: lib/vutuv_web/agent_docs/text.ex:179
 #: lib/vutuv_web/agent_docs/text.ex:193
-#: lib/vutuv_web/agent_docs/text.ex:746
+#: lib/vutuv_web/agent_docs/text.ex:753
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr ""
@@ -3864,33 +3864,33 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:149
 #: lib/vutuv_web/agent_docs/text.ex:106
 #: lib/vutuv_web/agent_docs/text.ex:137
-#: lib/vutuv_web/live/job_posting_live/form.ex:494
+#: lib/vutuv_web/live/job_posting_live/form.ex:689
 #, elixir-autogen, elixir-format
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1081
-#: lib/vutuv_web/agent_docs/text.ex:757
+#: lib/vutuv_web/agent_docs/markdown.ex:1088
+#: lib/vutuv_web/agent_docs/text.ex:764
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1078
-#: lib/vutuv_web/agent_docs/text.ex:754
+#: lib/vutuv_web/agent_docs/markdown.ex:1085
+#: lib/vutuv_web/agent_docs/text.ex:761
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1085
-#: lib/vutuv_web/agent_docs/markdown.ex:1299
-#: lib/vutuv_web/agent_docs/text.ex:760
-#: lib/vutuv_web/agent_docs/text.ex:804
+#: lib/vutuv_web/agent_docs/markdown.ex:1092
+#: lib/vutuv_web/agent_docs/markdown.ex:1306
+#: lib/vutuv_web/agent_docs/text.ex:767
+#: lib/vutuv_web/agent_docs/text.ex:811
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:553
-#: lib/vutuv_web/agent_docs/text.ex:547
+#: lib/vutuv_web/agent_docs/markdown.ex:560
+#: lib/vutuv_web/agent_docs/text.ex:554
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr ""
@@ -3933,23 +3933,23 @@ msgstr ""
 msgid "Posts (%{count} total)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:547
-#: lib/vutuv_web/agent_docs/text.ex:541
+#: lib/vutuv_web/agent_docs/markdown.ex:554
+#: lib/vutuv_web/agent_docs/text.ex:548
 #, elixir-autogen, elixir-format
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1032
+#: lib/vutuv_web/agent_docs/markdown.ex:1039
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:928
+#: lib/vutuv_web/agent_docs/markdown.ex:935
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:929
+#: lib/vutuv_web/agent_docs/markdown.ex:936
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr ""
@@ -4050,7 +4050,7 @@ msgid "Booking requires a vutuv login."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/organization_live.ex:245
-#: lib/vutuv_web/live/job_posting_live/form.ex:404
+#: lib/vutuv_web/live/job_posting_live/form.ex:532
 #: lib/vutuv_web/live/organization_live/edit.ex:296
 #: lib/vutuv_web/live/organization_live/new.ex:138
 #: lib/vutuv_web/templates/ad/new.html.heex:108
@@ -5845,7 +5845,7 @@ msgstr ""
 msgid "Sort"
 msgstr ""
 
-#: lib/vutuv_web/components/job_components.ex:182
+#: lib/vutuv_web/components/job_components.ex:220
 #: lib/vutuv_web/views/settings_html.ex:501
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
@@ -6145,8 +6145,8 @@ msgid_plural "%{count} years old"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:597
-#: lib/vutuv_web/agent_docs/text.ex:563
+#: lib/vutuv_web/agent_docs/markdown.ex:604
+#: lib/vutuv_web/agent_docs/text.ex:570
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr ""
@@ -6218,7 +6218,7 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1100
+#: lib/vutuv_web/agent_docs/markdown.ex:1107
 #: lib/vutuv_web/components/post_components.ex:396
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
@@ -6323,7 +6323,7 @@ msgstr ""
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1076
+#: lib/vutuv_web/agent_docs/markdown.ex:1083
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -6828,7 +6828,7 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/admin/newsletter_controller.ex:36
 #: lib/vutuv_web/controllers/admin/newsletter_controller.ex:103
-#: lib/vutuv_web/live/job_posting_live/form.ex:195
+#: lib/vutuv_web/live/job_posting_live/form.ex:317
 #, elixir-autogen, elixir-format
 msgid "Draft saved."
 msgstr ""
@@ -7050,7 +7050,7 @@ msgstr ""
 msgid "Save audience"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:602
+#: lib/vutuv_web/live/job_posting_live/form.ex:797
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:16
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:11
 #, elixir-autogen, elixir-format
@@ -7352,6 +7352,7 @@ msgstr ""
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
+#: lib/vutuv_web/components/job_components.ex:190
 #: lib/vutuv_web/components/post_components.ex:4818
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
@@ -7527,17 +7528,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1227
+#: lib/vutuv_web/agent_docs/markdown.ex:1234
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1230
+#: lib/vutuv_web/agent_docs/markdown.ex:1237
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1237
+#: lib/vutuv_web/agent_docs/markdown.ex:1244
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -7743,7 +7744,7 @@ msgstr ""
 msgid "New members"
 msgstr ""
 
-#: lib/vutuv_web/components/job_components.ex:181
+#: lib/vutuv_web/components/job_components.ex:219
 #: lib/vutuv_web/live/admin/dashboard_live.ex:287
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:457
 #: lib/vutuv_web/live/notification_live/index.ex:919
@@ -8648,10 +8649,10 @@ msgstr ""
 msgid "Write it under Admin › Legal pages"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:607
-#: lib/vutuv_web/agent_docs/markdown.ex:611
-#: lib/vutuv_web/agent_docs/text.ex:573
-#: lib/vutuv_web/agent_docs/text.ex:577
+#: lib/vutuv_web/agent_docs/markdown.ex:614
+#: lib/vutuv_web/agent_docs/markdown.ex:618
+#: lib/vutuv_web/agent_docs/text.ex:580
+#: lib/vutuv_web/agent_docs/text.ex:584
 #: lib/vutuv_web/components/organization_components.ex:310
 #: lib/vutuv_web/components/ui.ex:4097
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
@@ -8778,13 +8779,13 @@ msgstr ""
 msgid "Higher Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:805
+#: lib/vutuv_web/agent_docs/markdown.ex:812
 #: lib/vutuv_web/views/education_html.ex:23
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:804
+#: lib/vutuv_web/agent_docs/markdown.ex:811
 #: lib/vutuv_web/views/education_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -8817,7 +8818,7 @@ msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1035
+#: lib/vutuv_web/agent_docs/markdown.ex:1042
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -9042,8 +9043,8 @@ msgstr ""
 msgid "Honor tag (only site admins can assign it)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:627
-#: lib/vutuv_web/agent_docs/text.ex:591
+#: lib/vutuv_web/agent_docs/markdown.ex:634
+#: lib/vutuv_web/agent_docs/text.ex:598
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr ""
@@ -9465,8 +9466,8 @@ msgstr ""
 msgid "Yoruba"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:549
-#: lib/vutuv_web/agent_docs/text.ex:543
+#: lib/vutuv_web/agent_docs/markdown.ex:556
+#: lib/vutuv_web/agent_docs/text.ex:550
 #, elixir-autogen, elixir-format
 msgid "Employment status"
 msgstr ""
@@ -9569,7 +9570,7 @@ msgstr[1] ""
 msgid "Add a certificate or license"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:922
+#: lib/vutuv_web/agent_docs/markdown.ex:929
 #: lib/vutuv_web/views/qualification_html.ex:14
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -9649,7 +9650,7 @@ msgstr ""
 msgid "Expired"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:897
+#: lib/vutuv_web/agent_docs/markdown.ex:904
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr ""
@@ -9666,7 +9667,7 @@ msgstr ""
 msgid "Issuer"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:921
+#: lib/vutuv_web/agent_docs/markdown.ex:928
 #: lib/vutuv_web/views/qualification_html.ex:15
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -9693,7 +9694,7 @@ msgstr ""
 msgid "Verification link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:895
+#: lib/vutuv_web/agent_docs/markdown.ex:902
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr ""
@@ -9708,7 +9709,7 @@ msgstr ""
 msgid "e.g. Amazon Web Services"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:896
+#: lib/vutuv_web/agent_docs/markdown.ex:903
 #: lib/vutuv_web/views/qualification_html.ex:91
 #, elixir-autogen, elixir-format
 msgid "valid until %{date}"
@@ -9724,7 +9725,7 @@ msgstr ""
 msgid "Preferred"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:732
+#: lib/vutuv_web/agent_docs/markdown.ex:739
 #: lib/vutuv_web/live/section_reorder_live.ex:293
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
@@ -10215,21 +10216,21 @@ msgstr ""
 msgid "set it up on this device"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:692
+#: lib/vutuv_web/agent_docs/markdown.ex:699
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:690
+#: lib/vutuv_web/agent_docs/markdown.ex:697
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:688
+#: lib/vutuv_web/agent_docs/markdown.ex:695
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10285,12 +10286,12 @@ msgstr ""
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:706
+#: lib/vutuv_web/agent_docs/markdown.ex:713
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:693
+#: lib/vutuv_web/agent_docs/markdown.ex:700
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr ""
@@ -10854,7 +10855,7 @@ msgstr ""
 
 #: lib/vutuv/accounts/user.ex:1187
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
-#: lib/vutuv_web/live/job_posting_live/form.ex:566
+#: lib/vutuv_web/live/job_posting_live/form.ex:761
 #, elixir-autogen, elixir-format
 msgid "Signed-in members only"
 msgstr ""
@@ -10871,7 +10872,7 @@ msgstr ""
 msgid "Amount"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:464
+#: lib/vutuv_web/live/job_posting_live/form.ex:659
 #: lib/vutuv_web/templates/user/edit.html.heex:326
 #: lib/vutuv_web/templates/welcome/show.html.heex:131
 #, elixir-autogen, elixir-format
@@ -10894,7 +10895,7 @@ msgstr ""
 msgid "Optional. Even when hidden, it sharpens your own job search and alerts by filtering out postings below it. Leave the amount empty to remove it."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:471
+#: lib/vutuv_web/live/job_posting_live/form.ex:666
 #: lib/vutuv_web/templates/user/edit.html.heex:322
 #: lib/vutuv_web/templates/welcome/show.html.heex:127
 #, elixir-autogen, elixir-format
@@ -11613,8 +11614,8 @@ msgstr ""
 msgid "Verify via file"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:942
-#: lib/vutuv_web/agent_docs/text.ex:719
+#: lib/vutuv_web/agent_docs/markdown.ex:949
+#: lib/vutuv_web/agent_docs/text.ex:726
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr ""
@@ -12009,37 +12010,37 @@ msgstr ""
 msgid "A fake, misleading or discriminatory job advertisement."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:448
+#: lib/vutuv_web/live/job_posting_live/form.ex:643
 #, elixir-autogen, elixir-format
 msgid "A pay range is required to publish (except volunteer postings)."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:543
+#: lib/vutuv_web/live/job_posting_live/form.ex:738
 #, elixir-autogen, elixir-format
 msgid "A vutuv message to me"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:541
+#: lib/vutuv_web/live/job_posting_live/form.ex:736
 #, elixir-autogen, elixir-format
 msgid "A website"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:542
+#: lib/vutuv_web/live/job_posting_live/form.ex:737
 #, elixir-autogen, elixir-format
 msgid "An e-mail address"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:425
+#: lib/vutuv_web/live/job_posting_live/form.ex:553
 #, elixir-autogen, elixir-format
 msgid "Applicants must be located in"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:547
+#: lib/vutuv_web/live/job_posting_live/form.ex:742
 #, elixir-autogen, elixir-format
 msgid "Application URL"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:553
+#: lib/vutuv_web/live/job_posting_live/form.ex:748
 #, elixir-autogen, elixir-format
 msgid "Application e-mail"
 msgstr ""
@@ -12049,17 +12050,17 @@ msgstr ""
 msgid "Application: %{title}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:539
+#: lib/vutuv_web/live/job_posting_live/form.ex:734
 #, elixir-autogen, elixir-format
 msgid "Applications go to"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:271
+#: lib/vutuv_web/live/job_posting_live/show.ex:275
 #, elixir-autogen, elixir-format
 msgid "Apply by e-mail"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:270
+#: lib/vutuv_web/live/job_posting_live/show.ex:274
 #, elixir-autogen, elixir-format
 msgid "Apply on website"
 msgstr ""
@@ -12081,7 +12082,7 @@ msgstr ""
 msgid "Contract"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:487
+#: lib/vutuv_web/live/job_posting_live/form.ex:682
 #, elixir-autogen, elixir-format
 msgid "Describe the role. Markdown is supported."
 msgstr ""
@@ -12091,15 +12092,15 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:84
+#: lib/vutuv_web/live/job_posting_live/form.ex:113
 #, elixir-autogen, elixir-format
 msgid "Edit posting"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:272
-#: lib/vutuv_web/agent_docs/markdown.ex:473
+#: lib/vutuv_web/agent_docs/markdown.ex:480
 #: lib/vutuv_web/agent_docs/text.ex:258
-#: lib/vutuv_web/agent_docs/text.ex:494
+#: lib/vutuv_web/agent_docs/text.ex:501
 #: lib/vutuv_web/live/admin/job_live.ex:344
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:17
 #: lib/vutuv_web/views/account_event_text.ex:225
@@ -12107,27 +12108,27 @@ msgstr ""
 msgid "Employer"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:330
+#: lib/vutuv_web/live/job_posting_live/form.ex:458
 #, elixir-autogen, elixir-format
 msgid "Employer name (optional)"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:273
-#: lib/vutuv_web/agent_docs/markdown.ex:474
+#: lib/vutuv_web/agent_docs/markdown.ex:481
 #: lib/vutuv_web/agent_docs/text.ex:259
-#: lib/vutuv_web/agent_docs/text.ex:495
+#: lib/vutuv_web/agent_docs/text.ex:502
 #: lib/vutuv_web/live/job_board_live.ex:367
-#: lib/vutuv_web/live/job_posting_live/form.ex:345
+#: lib/vutuv_web/live/job_posting_live/form.ex:473
 #, elixir-autogen, elixir-format
 msgid "Employment type"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:565
+#: lib/vutuv_web/live/job_posting_live/form.ex:760
 #, elixir-autogen, elixir-format
 msgid "Everyone (public)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:452
+#: lib/vutuv_web/live/job_posting_live/form.ex:647
 #: lib/vutuv_web/live/tag_live/timeline.ex:264
 #: lib/vutuv_web/templates/education/form_content.html.heex:41
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:63
@@ -12145,12 +12146,7 @@ msgstr ""
 msgid "Highlighted tags match your profile."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:441
-#, elixir-autogen, elixir-format
-msgid "Hold Ctrl / Cmd to select more than one."
-msgstr ""
-
-#: lib/vutuv_web/live/job_posting_live/form.ex:537
+#: lib/vutuv_web/live/job_posting_live/form.ex:732
 #, elixir-autogen, elixir-format
 msgid "How to apply"
 msgstr ""
@@ -12166,12 +12162,12 @@ msgstr ""
 msgid "I'm interested in your posting: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:486
+#: lib/vutuv_web/live/job_posting_live/form.ex:681
 #, elixir-autogen, elixir-format
 msgid "Job description"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:297
+#: lib/vutuv_web/live/job_posting_live/form.ex:425
 #, elixir-autogen, elixir-format
 msgid "Job title"
 msgstr ""
@@ -12187,18 +12183,18 @@ msgstr ""
 msgid "Jobs"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:575
+#: lib/vutuv_web/live/job_posting_live/form.ex:770
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this posting."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:455
-#: lib/vutuv_web/agent_docs/markdown.ex:459
-#: lib/vutuv_web/agent_docs/markdown.ex:461
+#: lib/vutuv_web/agent_docs/markdown.ex:458
+#: lib/vutuv_web/agent_docs/markdown.ex:460
 #: lib/vutuv_web/agent_docs/text.ex:476
-#: lib/vutuv_web/agent_docs/text.ex:480
-#: lib/vutuv_web/agent_docs/text.ex:482
-#: lib/vutuv_web/live/job_posting_live/form.ex:386
+#: lib/vutuv_web/agent_docs/text.ex:479
+#: lib/vutuv_web/agent_docs/text.ex:481
+#: lib/vutuv_web/live/job_posting_live/form.ex:514
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr ""
@@ -12213,7 +12209,7 @@ msgstr ""
 msgid "Mark this posting as filled and close it?"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:272
+#: lib/vutuv_web/live/job_posting_live/show.ex:276
 #, elixir-autogen, elixir-format
 msgid "Message the poster"
 msgstr ""
@@ -12235,20 +12231,20 @@ msgstr ""
 msgid "My postings"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:273
+#: lib/vutuv_web/live/job_posting_live/form.ex:395
 #, elixir-autogen, elixir-format
 msgid "New accounts can publish after a few days."
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:103
-#: lib/vutuv_web/live/job_posting_live/form.ex:84
+#: lib/vutuv_web/live/job_posting_live/form.ex:113
 #, elixir-autogen, elixir-format
 msgid "New posting"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:284
 #: lib/vutuv_web/agent_docs/text.ex:269
-#: lib/vutuv_web/live/job_posting_live/form.ex:525
+#: lib/vutuv_web/live/job_posting_live/form.ex:720
 #: lib/vutuv_web/live/job_posting_live/show.ex:154
 #, elixir-autogen, elixir-format
 msgid "Nice to have"
@@ -12269,7 +12265,7 @@ msgstr ""
 msgid "Nothing here yet. Jobs you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:581
+#: lib/vutuv_web/live/job_posting_live/form.ex:776
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
@@ -12290,17 +12286,17 @@ msgstr ""
 msgid "Part-time"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:446
+#: lib/vutuv_web/live/job_posting_live/form.ex:641
 #, elixir-autogen, elixir-format
 msgid "Pay"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:272
+#: lib/vutuv_web/live/job_posting_live/form.ex:394
 #, elixir-autogen, elixir-format
 msgid "Please confirm your e-mail address first."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:41
+#: lib/vutuv_web/live/job_posting_live/form.ex:70
 #, elixir-autogen, elixir-format
 msgid "Please confirm your email address before posting a job."
 msgstr ""
@@ -12310,7 +12306,7 @@ msgstr ""
 msgid "Please log in to message the poster."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:47
+#: lib/vutuv_web/live/job_posting_live/form.ex:76
 #, elixir-autogen, elixir-format
 msgid "Please log in to post a job."
 msgstr ""
@@ -12320,38 +12316,38 @@ msgstr ""
 msgid "Please log in to see your postings."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:318
+#: lib/vutuv_web/live/job_posting_live/form.ex:446
 #, elixir-autogen, elixir-format
 msgid "Post as"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:398
+#: lib/vutuv_web/live/job_posting_live/form.ex:526
 #: lib/vutuv_web/templates/welcome/show.html.heex:67
 #, elixir-autogen, elixir-format
 msgid "Postal code"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:277
-#: lib/vutuv_web/agent_docs/markdown.ex:478
+#: lib/vutuv_web/agent_docs/markdown.ex:485
 #: lib/vutuv_web/agent_docs/text.ex:263
-#: lib/vutuv_web/agent_docs/text.ex:499
+#: lib/vutuv_web/agent_docs/text.ex:506
 #: lib/vutuv_web/live/job_posting_live/show.ex:133
 #, elixir-autogen, elixir-format
 msgid "Posted"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:376
+#: lib/vutuv_web/live/job_posting_live/form.ex:504
 #, elixir-autogen, elixir-format
 msgid "Posting language"
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:50
-#: lib/vutuv_web/live/job_posting_live/form.ex:74
+#: lib/vutuv_web/live/job_posting_live/form.ex:103
 #, elixir-autogen, elixir-format
 msgid "Posting not found."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:598
+#: lib/vutuv_web/live/job_posting_live/form.ex:793
 #, elixir-autogen, elixir-format
 msgid "Publish"
 msgstr ""
@@ -12359,10 +12355,10 @@ msgstr ""
 #: lib/vutuv/accounts/user.ex:1159
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:564
-#: lib/vutuv_web/agent_docs/markdown.ex:459
-#: lib/vutuv_web/agent_docs/markdown.ex:461
-#: lib/vutuv_web/agent_docs/text.ex:480
-#: lib/vutuv_web/agent_docs/text.ex:482
+#: lib/vutuv_web/agent_docs/markdown.ex:458
+#: lib/vutuv_web/agent_docs/markdown.ex:460
+#: lib/vutuv_web/agent_docs/text.ex:479
+#: lib/vutuv_web/agent_docs/text.ex:481
 #: lib/vutuv_web/components/job_components.ex:140
 #: lib/vutuv_web/components/job_components.ex:141
 #, elixir-autogen, elixir-format
@@ -12376,47 +12372,47 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:283
 #: lib/vutuv_web/agent_docs/text.ex:268
-#: lib/vutuv_web/live/job_posting_live/form.ex:515
+#: lib/vutuv_web/live/job_posting_live/form.ex:710
 #: lib/vutuv_web/live/job_posting_live/show.ex:149
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:276
-#: lib/vutuv_web/agent_docs/markdown.ex:477
+#: lib/vutuv_web/agent_docs/markdown.ex:484
 #: lib/vutuv_web/agent_docs/text.ex:262
-#: lib/vutuv_web/agent_docs/text.ex:498
+#: lib/vutuv_web/agent_docs/text.ex:505
 #, elixir-autogen, elixir-format
 msgid "Salary"
 msgstr ""
 
-#: lib/vutuv_web/components/job_components.ex:162
+#: lib/vutuv_web/components/job_components.ex:200
 #, elixir-autogen, elixir-format
 msgid "Salary on request"
 msgstr ""
 
 #: lib/vutuv_web/controllers/settings_controller.ex:393
-#: lib/vutuv_web/live/job_posting_live/form.ex:231
+#: lib/vutuv_web/live/job_posting_live/form.ex:353
 #, elixir-autogen, elixir-format
 msgid "Saved."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:339
+#: lib/vutuv_web/live/job_posting_live/form.ex:467
 #, elixir-autogen, elixir-format
 msgid "Shown as an unverified employer name."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:261
+#: lib/vutuv_web/live/job_posting_live/form.ex:383
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:391
+#: lib/vutuv_web/live/job_posting_live/form.ex:519
 #, elixir-autogen, elixir-format
 msgid "Street (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:512
+#: lib/vutuv_web/live/job_posting_live/form.ex:707
 #, elixir-autogen, elixir-format
 msgid "Tags match your posting to members. Separate them with commas; a tag may be several words long, like Ruby on Rails."
 msgstr ""
@@ -12426,17 +12422,17 @@ msgstr ""
 msgid "Temporary"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:153
+#: lib/vutuv_web/live/job_posting_live/form.ex:275
 #, elixir-autogen, elixir-format
 msgid "That image could not be uploaded."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:293
+#: lib/vutuv_web/live/job_posting_live/form.ex:421
 #, elixir-autogen, elixir-format
 msgid "The role"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:279
+#: lib/vutuv_web/live/job_posting_live/form.ex:401
 #, elixir-autogen, elixir-format
 msgid "This organization has reached its published-postings limit."
 msgstr ""
@@ -12446,7 +12442,7 @@ msgstr ""
 msgid "This position is no longer available."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:312
+#: lib/vutuv_web/live/job_posting_live/form.ex:440
 #, elixir-autogen, elixir-format
 msgid "Tip: adding a gender marker like (m/w/d) helps your posting comply with the AGG. This is a suggestion, not legal advice."
 msgstr ""
@@ -12457,8 +12453,8 @@ msgstr ""
 msgid "Verified organization"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/job_posting_doc.ex:126
-#: lib/vutuv_web/components/job_components.ex:161
+#: lib/vutuv_web/agent_docs/job_posting_doc.ex:131
+#: lib/vutuv_web/components/job_components.ex:199
 #, elixir-autogen, elixir-format
 msgid "Voluntary"
 msgstr ""
@@ -12468,7 +12464,7 @@ msgstr ""
 msgid "Volunteer"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:563
+#: lib/vutuv_web/live/job_posting_live/form.ex:758
 #: lib/vutuv_web/templates/email/form_content.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Who can see it"
@@ -12480,15 +12476,15 @@ msgid "Working student"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:274
-#: lib/vutuv_web/agent_docs/markdown.ex:475
+#: lib/vutuv_web/agent_docs/markdown.ex:482
 #: lib/vutuv_web/agent_docs/text.ex:260
-#: lib/vutuv_web/agent_docs/text.ex:496
-#: lib/vutuv_web/live/job_posting_live/form.ex:360
+#: lib/vutuv_web/agent_docs/text.ex:503
+#: lib/vutuv_web/live/job_posting_live/form.ex:488
 #, elixir-autogen, elixir-format
 msgid "Workplace"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:276
+#: lib/vutuv_web/live/job_posting_live/form.ex:398
 #, elixir-autogen, elixir-format
 msgid "You already have the maximum number of published postings."
 msgstr ""
@@ -12533,18 +12529,18 @@ msgstr ""
 msgid "Your posting"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:211
-#: lib/vutuv_web/live/job_posting_live/form.ex:254
+#: lib/vutuv_web/live/job_posting_live/form.ex:333
+#: lib/vutuv_web/live/job_posting_live/form.ex:376
 #, elixir-autogen, elixir-format
 msgid "Your posting is live."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:321
+#: lib/vutuv_web/live/job_posting_live/form.ex:449
 #, elixir-autogen, elixir-format
 msgid "Yourself (personal posting)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:458
+#: lib/vutuv_web/live/job_posting_live/form.ex:653
 #, elixir-autogen, elixir-format
 msgid "up to"
 msgstr ""
@@ -12658,14 +12654,14 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: lib/vutuv_web/components/job_components.ex:184
+#: lib/vutuv_web/components/job_components.ex:222
 #, elixir-autogen, elixir-format
 msgid "%{count} month ago"
 msgid_plural "%{count} months ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/job_components.ex:183
+#: lib/vutuv_web/components/job_components.ex:221
 #, elixir-autogen, elixir-format
 msgid "%{count} week ago"
 msgid_plural "%{count} weeks ago"
@@ -12682,13 +12678,13 @@ msgstr ""
 msgid "All countries"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:496
+#: lib/vutuv_web/agent_docs/markdown.ex:503
 #: lib/vutuv_web/templates/tag/show.html.heex:75
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:516
+#: lib/vutuv_web/agent_docs/text.ex:523
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag: %{url}"
 msgstr ""
@@ -12754,10 +12750,10 @@ msgstr ""
 msgid "No matching positions. Try adjusting the filters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:494
-#: lib/vutuv_web/agent_docs/markdown.ex:506
-#: lib/vutuv_web/agent_docs/text.ex:514
-#: lib/vutuv_web/agent_docs/text.ex:526
+#: lib/vutuv_web/agent_docs/markdown.ex:501
+#: lib/vutuv_web/agent_docs/markdown.ex:513
+#: lib/vutuv_web/agent_docs/text.ex:521
+#: lib/vutuv_web/agent_docs/text.ex:533
 #: lib/vutuv_web/live/organization_live/show.ex:676
 #: lib/vutuv_web/templates/tag/show.html.heex:69
 #, elixir-autogen, elixir-format
@@ -13206,7 +13202,7 @@ msgstr ""
 msgid "Hide from specific viewers"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:587
+#: lib/vutuv_web/live/job_posting_live/form.ex:782
 #, elixir-autogen, elixir-format
 msgid "Hide from specific viewers (competitors, your own staff, a person) →"
 msgstr ""
@@ -13227,7 +13223,7 @@ msgstr ""
 msgid "Job exclusions – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:590
+#: lib/vutuv_web/live/job_posting_live/form.ex:785
 #, elixir-autogen, elixir-format
 msgid "Keep this posting on the board for everyone except a chosen few."
 msgstr ""
@@ -13686,7 +13682,7 @@ msgstr ""
 msgid "Audiobook"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1189
+#: lib/vutuv_web/agent_docs/markdown.ex:1196
 #: lib/vutuv_web/components/post_components.ex:4405
 #, elixir-autogen, elixir-format
 msgid "Book review"
@@ -13707,7 +13703,7 @@ msgstr ""
 msgid "E-book"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1189
+#: lib/vutuv_web/agent_docs/markdown.ex:1196
 #: lib/vutuv_web/components/post_components.ex:4404
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -13797,7 +13793,7 @@ msgstr ""
 msgid "With qualification:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:761
+#: lib/vutuv_web/agent_docs/markdown.ex:768
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr ""
@@ -13891,19 +13887,19 @@ msgid_plural "Used for %{formatted} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:911
+#: lib/vutuv_web/agent_docs/markdown.ex:918
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:910
+#: lib/vutuv_web/agent_docs/markdown.ex:917
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:916
+#: lib/vutuv_web/agent_docs/markdown.ex:923
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
@@ -13983,8 +13979,8 @@ msgstr ""
 msgid "View the uploaded proof (%{label})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:847
-#: lib/vutuv_web/agent_docs/text.ex:698
+#: lib/vutuv_web/agent_docs/markdown.ex:854
+#: lib/vutuv_web/agent_docs/text.ex:705
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr ""
@@ -14067,8 +14063,8 @@ msgstr ""
 msgid "Skip for now"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:551
-#: lib/vutuv_web/agent_docs/text.ex:545
+#: lib/vutuv_web/agent_docs/markdown.ex:558
+#: lib/vutuv_web/agent_docs/text.ex:552
 #, elixir-autogen, elixir-format
 msgid "Preferred workplace"
 msgstr ""
@@ -14661,7 +14657,7 @@ msgstr ""
 msgid "none yet"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1136
+#: lib/vutuv_web/agent_docs/markdown.ex:1143
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr ""
@@ -15045,8 +15041,8 @@ msgstr ""
 msgid "Your server"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:608
-#: lib/vutuv_web/agent_docs/text.ex:574
+#: lib/vutuv_web/agent_docs/markdown.ex:615
+#: lib/vutuv_web/agent_docs/text.ex:581
 #, elixir-autogen, elixir-format
 msgid "moved to %{address}"
 msgstr ""
@@ -15430,7 +15426,7 @@ msgid_plural "%{formatted} reposts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1138
+#: lib/vutuv_web/agent_docs/markdown.ex:1145
 #: lib/vutuv_web/components/post_components.ex:4822
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
@@ -15441,8 +15437,8 @@ msgstr ""
 msgid "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1320
-#: lib/vutuv_web/agent_docs/text.ex:818
+#: lib/vutuv_web/agent_docs/markdown.ex:1327
+#: lib/vutuv_web/agent_docs/text.ex:825
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr ""
@@ -15466,7 +15462,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:126
 #: lib/vutuv_web/agent_docs/markdown.ex:157
-#: lib/vutuv_web/agent_docs/markdown.ex:1137
+#: lib/vutuv_web/agent_docs/markdown.ex:1144
 #: lib/vutuv_web/agent_docs/text.ex:117
 #: lib/vutuv_web/agent_docs/text.ex:145
 #, elixir-autogen, elixir-format
@@ -15524,7 +15520,7 @@ msgstr ""
 msgid "That reply is not yours to remove."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1322
+#: lib/vutuv_web/agent_docs/markdown.ex:1329
 #: lib/vutuv_web/components/post_components.ex:1153
 #: lib/vutuv_web/components/post_components.ex:1353
 #: lib/vutuv_web/components/post_components.ex:2178
@@ -16225,13 +16221,13 @@ msgstr ""
 msgid "Unpinned. The post is a normal post again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1018
+#: lib/vutuv_web/agent_docs/markdown.ex:1025
 #, elixir-autogen, elixir-format
 msgid "pinned post"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:545
-#: lib/vutuv_web/agent_docs/text.ex:536
+#: lib/vutuv_web/agent_docs/markdown.ex:552
+#: lib/vutuv_web/agent_docs/text.ex:543
 #: lib/vutuv_web/templates/user/edit.html.heex:224
 #: lib/vutuv_web/templates/user/show.html.heex:247
 #: lib/vutuv_web/views/account_event_text.ex:213
@@ -16289,8 +16285,8 @@ msgstr ""
 msgid "Describe the photo for people who can't see it"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1250
-#: lib/vutuv_web/agent_docs/text.ex:785
+#: lib/vutuv_web/agent_docs/markdown.ex:1257
+#: lib/vutuv_web/agent_docs/text.ex:792
 #: lib/vutuv_web/components/ui.ex:2471
 #, elixir-autogen, elixir-format
 msgid "Download the original"
@@ -16352,8 +16348,8 @@ msgstr ""
 msgid "Photo options"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1283
-#: lib/vutuv_web/agent_docs/text.ex:772
+#: lib/vutuv_web/agent_docs/markdown.ex:1290
+#: lib/vutuv_web/agent_docs/text.ex:779
 #: lib/vutuv_web/components/post_components.ex:3753
 #, elixir-autogen, elixir-format
 msgid "Photos:"
@@ -16526,13 +16522,13 @@ msgid_plural "Some of these photos carry the location they were taken at, and th
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1156
+#: lib/vutuv_web/agent_docs/markdown.ex:1163
 #: lib/vutuv_web/components/post_components.ex:4860
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1154
+#: lib/vutuv_web/agent_docs/markdown.ex:1161
 #: lib/vutuv_web/components/post_components.ex:4857
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
@@ -17155,7 +17151,7 @@ msgstr ""
 msgid "What is being measured"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1013
+#: lib/vutuv_web/agent_docs/markdown.ex:1020
 #, elixir-autogen, elixir-format
 msgid "(a picture)"
 msgid_plural "(%{count} pictures)"
@@ -17306,8 +17302,8 @@ msgstr ""
 msgid "We could not reach the network just now. Please try again in a moment."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:956
-#: lib/vutuv_web/agent_docs/text.ex:620
+#: lib/vutuv_web/agent_docs/markdown.ex:963
+#: lib/vutuv_web/agent_docs/text.ex:627
 #, elixir-autogen, elixir-format
 msgid "verified profile"
 msgstr ""
@@ -18237,7 +18233,7 @@ msgstr ""
 msgid "A post's page shows the members who liked it, right under the count. This is whether you are one of the faces."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1124
+#: lib/vutuv_web/agent_docs/markdown.ex:1131
 #, elixir-autogen, elixir-format
 msgid "Liked by"
 msgstr ""
@@ -18279,12 +18275,12 @@ msgstr ""
 msgid "Your likes follow the site default again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1179
+#: lib/vutuv_web/agent_docs/markdown.ex:1186
 #, elixir-autogen, elixir-format
 msgid "%{address} (this page only)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1176
+#: lib/vutuv_web/agent_docs/markdown.ex:1183
 #, elixir-autogen, elixir-format
 msgid "%{address} (whole website)"
 msgstr ""
@@ -18294,7 +18290,7 @@ msgstr ""
 msgid "Verified webpage of the author (%{address})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1168
+#: lib/vutuv_web/agent_docs/markdown.ex:1175
 #, elixir-autogen, elixir-format
 msgid "Verified webpages of the author linked here: %{addresses}"
 msgstr ""
@@ -18624,7 +18620,7 @@ msgstr ""
 msgid "Employment references of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:829
+#: lib/vutuv_web/agent_docs/markdown.ex:836
 #, elixir-autogen, elixir-format
 msgid "document"
 msgstr ""
@@ -21469,4 +21465,36 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgctxt "qualification detail"
 msgid "Jobs"
+msgstr ""
+
+#: lib/vutuv_web/live/job_posting_live/form.ex:824
+#, elixir-autogen, elixir-format
+msgid "%{formatted} country chosen."
+msgid_plural "%{formatted} countries chosen."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/job_posting_live/form.ex:610
+#, elixir-autogen, elixir-format
+msgid "No country chosen yet."
+msgstr ""
+
+#: lib/vutuv_web/live/job_posting_live/form.ex:602
+#, elixir-autogen, elixir-format
+msgid "No country left to add for that."
+msgstr ""
+
+#: lib/vutuv_web/live/job_posting_live/form.ex:621
+#, elixir-autogen, elixir-format
+msgid "Remove %{country}"
+msgstr ""
+
+#: lib/vutuv_web/live/job_posting_live/form.ex:632
+#, elixir-autogen, elixir-format
+msgid "Remove all"
+msgstr ""
+
+#: lib/vutuv_web/live/job_posting_live/form.ex:581
+#, elixir-autogen, elixir-format
+msgid "Search for a country"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -99,10 +99,10 @@ msgstr ""
 msgid "Birthdate"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:595
-#: lib/vutuv_web/agent_docs/markdown.ex:596
-#: lib/vutuv_web/agent_docs/text.ex:561
-#: lib/vutuv_web/agent_docs/text.ex:562
+#: lib/vutuv_web/agent_docs/markdown.ex:602
+#: lib/vutuv_web/agent_docs/markdown.ex:603
+#: lib/vutuv_web/agent_docs/text.ex:568
+#: lib/vutuv_web/agent_docs/text.ex:569
 #: lib/vutuv_web/templates/user/show.html.heex:1093
 #, elixir-autogen
 msgid "Birthday"
@@ -113,7 +113,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
-#: lib/vutuv_web/live/job_posting_live/form.ex:605
+#: lib/vutuv_web/live/job_posting_live/form.ex:800
 #: lib/vutuv_web/live/organization_live/edit.ex:351
 #: lib/vutuv_web/live/organization_live/new.ex:231
 #: lib/vutuv_web/live/post_live/composer.ex:1399
@@ -174,7 +174,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:481
+#: lib/vutuv_web/live/job_posting_live/form.ex:676
 #: lib/vutuv_web/live/organization_live/edit.ex:276
 #: lib/vutuv_web/live/organization_live/edit.ex:285
 #: lib/vutuv_web/templates/address/card_list.html.heex:5
@@ -303,14 +303,14 @@ msgstr ""
 msgid "Fax"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:581
+#: lib/vutuv_web/agent_docs/markdown.ex:588
 #: lib/vutuv_web/templates/user/edit.html.heex:169
 #, elixir-autogen
 msgid "First Name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:616
-#: lib/vutuv_web/agent_docs/text.ex:582
+#: lib/vutuv_web/agent_docs/markdown.ex:623
+#: lib/vutuv_web/agent_docs/text.ex:589
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
 #: lib/vutuv_web/live/notification_live/index.ex:968
@@ -321,8 +321,8 @@ msgstr ""
 msgid "Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:617
-#: lib/vutuv_web/agent_docs/text.ex:583
+#: lib/vutuv_web/agent_docs/markdown.ex:624
+#: lib/vutuv_web/agent_docs/text.ex:590
 #: lib/vutuv_web/components/fediverse_components.ex:313
 #: lib/vutuv_web/components/ui.ex:2132
 #: lib/vutuv_web/components/ui.ex:2157
@@ -382,7 +382,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:583
+#: lib/vutuv_web/agent_docs/markdown.ex:590
 #: lib/vutuv_web/templates/user/edit.html.heex:174
 #, elixir-autogen
 msgid "Last Name"
@@ -449,7 +449,7 @@ msgstr ""
 msgid "Log in"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:582
+#: lib/vutuv_web/agent_docs/markdown.ex:589
 #: lib/vutuv_web/templates/user/edit.html.heex:179
 #, elixir-autogen
 msgid "Middle Name"
@@ -484,7 +484,7 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:585
+#: lib/vutuv_web/agent_docs/markdown.ex:592
 #: lib/vutuv_web/templates/user/edit.html.heex:184
 #, elixir-autogen
 msgid "Nickname"
@@ -565,7 +565,7 @@ msgstr ""
 msgid "Phone number updated successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:580
+#: lib/vutuv_web/agent_docs/markdown.ex:587
 #: lib/vutuv_web/templates/user/edit.html.heex:189
 #, elixir-autogen
 msgid "Prefix"
@@ -748,7 +748,7 @@ msgstr ""
 msgid "Submit a bugreport or a feature request."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:584
+#: lib/vutuv_web/agent_docs/markdown.ex:591
 #: lib/vutuv_web/templates/user/edit.html.heex:194
 #, elixir-autogen
 msgid "Suffix"
@@ -857,7 +857,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4081
 #: lib/vutuv_web/controllers/settings_controller.ex:169
-#: lib/vutuv_web/live/job_posting_live/form.ex:561
+#: lib/vutuv_web/live/job_posting_live/form.ex:756
 #: lib/vutuv_web/live/organization_live/edit.ex:304
 #: lib/vutuv_web/templates/email/card_list.html.heex:7
 #: lib/vutuv_web/templates/email/show.html.heex:24
@@ -1370,11 +1370,11 @@ msgid "Tag urls"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:34
-#: lib/vutuv_web/agent_docs/markdown.ex:488
-#: lib/vutuv_web/agent_docs/markdown.ex:1063
+#: lib/vutuv_web/agent_docs/markdown.ex:495
+#: lib/vutuv_web/agent_docs/markdown.ex:1070
 #: lib/vutuv_web/agent_docs/text.ex:31
-#: lib/vutuv_web/agent_docs/text.ex:509
-#: lib/vutuv_web/agent_docs/text.ex:746
+#: lib/vutuv_web/agent_docs/text.ex:516
+#: lib/vutuv_web/agent_docs/text.ex:753
 #: lib/vutuv_web/components/ui.ex:4012
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1385,7 +1385,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:433
 #: lib/vutuv_web/live/cv_live.ex:315
 #: lib/vutuv_web/live/job_board_live.ex:277
-#: lib/vutuv_web/live/job_posting_live/form.ex:510
+#: lib/vutuv_web/live/job_posting_live/form.ex:705
 #: lib/vutuv_web/live/search_live.ex:282
 #: lib/vutuv_web/live/search_live.ex:716
 #: lib/vutuv_web/live/tag_new_live.ex:36
@@ -1561,7 +1561,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:776
 #: lib/vutuv_web/live/job_board_live.ex:360
-#: lib/vutuv_web/live/job_posting_live/form.ex:410
+#: lib/vutuv_web/live/job_posting_live/form.ex:538
 #: lib/vutuv_web/live/organization_live/edit.ex:300
 #: lib/vutuv_web/live/organization_live/new.ex:142
 #: lib/vutuv_web/templates/ad/new.html.heex:114
@@ -2078,7 +2078,7 @@ msgstr ""
 msgid "Markdown is supported: bold, italics, links and lists."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:504
+#: lib/vutuv_web/live/job_posting_live/form.ex:699
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr ""
@@ -2380,7 +2380,7 @@ msgstr ""
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1101
+#: lib/vutuv_web/agent_docs/markdown.ex:1108
 #: lib/vutuv_web/live/post_live/saved.ex:175
 #: lib/vutuv_web/live/post_live/saved.ex:488
 #: lib/vutuv_web/live/shell_live.ex:730
@@ -2400,7 +2400,7 @@ msgstr ""
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1100
+#: lib/vutuv_web/agent_docs/markdown.ex:1107
 #: lib/vutuv_web/components/post_components.ex:4916
 #: lib/vutuv_web/live/notification_live/index.ex:970
 #: lib/vutuv_web/live/post_live/saved.ex:174
@@ -2787,8 +2787,8 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:618
-#: lib/vutuv_web/agent_docs/text.ex:584
+#: lib/vutuv_web/agent_docs/markdown.ex:625
+#: lib/vutuv_web/agent_docs/text.ex:591
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/live/notification_live/index.ex:969
 #: lib/vutuv_web/templates/connection/index.html.heex:5
@@ -3825,12 +3825,12 @@ msgstr ""
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:715
+#: lib/vutuv_web/agent_docs/markdown.ex:722
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1222
+#: lib/vutuv_web/agent_docs/markdown.ex:1229
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
@@ -3844,11 +3844,11 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:83
 #: lib/vutuv_web/agent_docs/markdown.ex:194
 #: lib/vutuv_web/agent_docs/markdown.ex:208
-#: lib/vutuv_web/agent_docs/markdown.ex:1063
+#: lib/vutuv_web/agent_docs/markdown.ex:1070
 #: lib/vutuv_web/agent_docs/text.ex:80
 #: lib/vutuv_web/agent_docs/text.ex:179
 #: lib/vutuv_web/agent_docs/text.ex:193
-#: lib/vutuv_web/agent_docs/text.ex:746
+#: lib/vutuv_web/agent_docs/text.ex:753
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr ""
@@ -3862,33 +3862,33 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:149
 #: lib/vutuv_web/agent_docs/text.ex:106
 #: lib/vutuv_web/agent_docs/text.ex:137
-#: lib/vutuv_web/live/job_posting_live/form.ex:494
+#: lib/vutuv_web/live/job_posting_live/form.ex:689
 #, elixir-autogen, elixir-format
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1081
-#: lib/vutuv_web/agent_docs/text.ex:757
+#: lib/vutuv_web/agent_docs/markdown.ex:1088
+#: lib/vutuv_web/agent_docs/text.ex:764
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1078
-#: lib/vutuv_web/agent_docs/text.ex:754
+#: lib/vutuv_web/agent_docs/markdown.ex:1085
+#: lib/vutuv_web/agent_docs/text.ex:761
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1085
-#: lib/vutuv_web/agent_docs/markdown.ex:1299
-#: lib/vutuv_web/agent_docs/text.ex:760
-#: lib/vutuv_web/agent_docs/text.ex:804
+#: lib/vutuv_web/agent_docs/markdown.ex:1092
+#: lib/vutuv_web/agent_docs/markdown.ex:1306
+#: lib/vutuv_web/agent_docs/text.ex:767
+#: lib/vutuv_web/agent_docs/text.ex:811
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:553
-#: lib/vutuv_web/agent_docs/text.ex:547
+#: lib/vutuv_web/agent_docs/markdown.ex:560
+#: lib/vutuv_web/agent_docs/text.ex:554
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr ""
@@ -3931,23 +3931,23 @@ msgstr ""
 msgid "Posts (%{count} total)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:547
-#: lib/vutuv_web/agent_docs/text.ex:541
+#: lib/vutuv_web/agent_docs/markdown.ex:554
+#: lib/vutuv_web/agent_docs/text.ex:548
 #, elixir-autogen, elixir-format
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1032
+#: lib/vutuv_web/agent_docs/markdown.ex:1039
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:928
+#: lib/vutuv_web/agent_docs/markdown.ex:935
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:929
+#: lib/vutuv_web/agent_docs/markdown.ex:936
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr ""
@@ -4048,7 +4048,7 @@ msgid "Booking requires a vutuv login."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/organization_live.ex:245
-#: lib/vutuv_web/live/job_posting_live/form.ex:404
+#: lib/vutuv_web/live/job_posting_live/form.ex:532
 #: lib/vutuv_web/live/organization_live/edit.ex:296
 #: lib/vutuv_web/live/organization_live/new.ex:138
 #: lib/vutuv_web/templates/ad/new.html.heex:108
@@ -5843,7 +5843,7 @@ msgstr ""
 msgid "Sort"
 msgstr ""
 
-#: lib/vutuv_web/components/job_components.ex:182
+#: lib/vutuv_web/components/job_components.ex:220
 #: lib/vutuv_web/views/settings_html.ex:501
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
@@ -6143,8 +6143,8 @@ msgid_plural "%{count} years old"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:597
-#: lib/vutuv_web/agent_docs/text.ex:563
+#: lib/vutuv_web/agent_docs/markdown.ex:604
+#: lib/vutuv_web/agent_docs/text.ex:570
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr ""
@@ -6216,7 +6216,7 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1100
+#: lib/vutuv_web/agent_docs/markdown.ex:1107
 #: lib/vutuv_web/components/post_components.ex:396
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
@@ -6321,7 +6321,7 @@ msgstr ""
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1076
+#: lib/vutuv_web/agent_docs/markdown.ex:1083
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -6826,7 +6826,7 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/admin/newsletter_controller.ex:36
 #: lib/vutuv_web/controllers/admin/newsletter_controller.ex:103
-#: lib/vutuv_web/live/job_posting_live/form.ex:195
+#: lib/vutuv_web/live/job_posting_live/form.ex:317
 #, elixir-autogen, elixir-format
 msgid "Draft saved."
 msgstr ""
@@ -7048,7 +7048,7 @@ msgstr ""
 msgid "Save audience"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:602
+#: lib/vutuv_web/live/job_posting_live/form.ex:797
 #: lib/vutuv_web/templates/admin/newsletter/edit.html.heex:16
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:11
 #, elixir-autogen, elixir-format
@@ -7350,6 +7350,7 @@ msgstr ""
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
+#: lib/vutuv_web/components/job_components.ex:190
 #: lib/vutuv_web/components/post_components.ex:4818
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
@@ -7525,17 +7526,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1227
+#: lib/vutuv_web/agent_docs/markdown.ex:1234
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1230
+#: lib/vutuv_web/agent_docs/markdown.ex:1237
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1237
+#: lib/vutuv_web/agent_docs/markdown.ex:1244
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -7741,7 +7742,7 @@ msgstr ""
 msgid "New members"
 msgstr ""
 
-#: lib/vutuv_web/components/job_components.ex:181
+#: lib/vutuv_web/components/job_components.ex:219
 #: lib/vutuv_web/live/admin/dashboard_live.ex:287
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:457
 #: lib/vutuv_web/live/notification_live/index.ex:919
@@ -8646,10 +8647,10 @@ msgstr ""
 msgid "Write it under Admin › Legal pages"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:607
-#: lib/vutuv_web/agent_docs/markdown.ex:611
-#: lib/vutuv_web/agent_docs/text.ex:573
-#: lib/vutuv_web/agent_docs/text.ex:577
+#: lib/vutuv_web/agent_docs/markdown.ex:614
+#: lib/vutuv_web/agent_docs/markdown.ex:618
+#: lib/vutuv_web/agent_docs/text.ex:580
+#: lib/vutuv_web/agent_docs/text.ex:584
 #: lib/vutuv_web/components/organization_components.ex:310
 #: lib/vutuv_web/components/ui.ex:4097
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
@@ -8776,13 +8777,13 @@ msgstr ""
 msgid "Higher Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:805
+#: lib/vutuv_web/agent_docs/markdown.ex:812
 #: lib/vutuv_web/views/education_html.ex:23
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:804
+#: lib/vutuv_web/agent_docs/markdown.ex:811
 #: lib/vutuv_web/views/education_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -8815,7 +8816,7 @@ msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1035
+#: lib/vutuv_web/agent_docs/markdown.ex:1042
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -9040,8 +9041,8 @@ msgstr ""
 msgid "Honor tag (only site admins can assign it)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:627
-#: lib/vutuv_web/agent_docs/text.ex:591
+#: lib/vutuv_web/agent_docs/markdown.ex:634
+#: lib/vutuv_web/agent_docs/text.ex:598
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr ""
@@ -9463,8 +9464,8 @@ msgstr ""
 msgid "Yoruba"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:549
-#: lib/vutuv_web/agent_docs/text.ex:543
+#: lib/vutuv_web/agent_docs/markdown.ex:556
+#: lib/vutuv_web/agent_docs/text.ex:550
 #, elixir-autogen, elixir-format
 msgid "Employment status"
 msgstr ""
@@ -9567,7 +9568,7 @@ msgstr[1] ""
 msgid "Add a certificate or license"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:922
+#: lib/vutuv_web/agent_docs/markdown.ex:929
 #: lib/vutuv_web/views/qualification_html.ex:14
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -9647,7 +9648,7 @@ msgstr ""
 msgid "Expired"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:897
+#: lib/vutuv_web/agent_docs/markdown.ex:904
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr ""
@@ -9664,7 +9665,7 @@ msgstr ""
 msgid "Issuer"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:921
+#: lib/vutuv_web/agent_docs/markdown.ex:928
 #: lib/vutuv_web/views/qualification_html.ex:15
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -9691,7 +9692,7 @@ msgstr ""
 msgid "Verification link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:895
+#: lib/vutuv_web/agent_docs/markdown.ex:902
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr ""
@@ -9706,7 +9707,7 @@ msgstr ""
 msgid "e.g. Amazon Web Services"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:896
+#: lib/vutuv_web/agent_docs/markdown.ex:903
 #: lib/vutuv_web/views/qualification_html.ex:91
 #, elixir-autogen, elixir-format
 msgid "valid until %{date}"
@@ -9722,7 +9723,7 @@ msgstr ""
 msgid "Preferred"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:732
+#: lib/vutuv_web/agent_docs/markdown.ex:739
 #: lib/vutuv_web/live/section_reorder_live.ex:293
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
@@ -10213,21 +10214,21 @@ msgstr ""
 msgid "set it up on this device"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:692
+#: lib/vutuv_web/agent_docs/markdown.ex:699
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:690
+#: lib/vutuv_web/agent_docs/markdown.ex:697
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:688
+#: lib/vutuv_web/agent_docs/markdown.ex:695
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10283,12 +10284,12 @@ msgstr ""
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:706
+#: lib/vutuv_web/agent_docs/markdown.ex:713
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:693
+#: lib/vutuv_web/agent_docs/markdown.ex:700
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr ""
@@ -10852,7 +10853,7 @@ msgstr ""
 
 #: lib/vutuv/accounts/user.ex:1187
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
-#: lib/vutuv_web/live/job_posting_live/form.ex:566
+#: lib/vutuv_web/live/job_posting_live/form.ex:761
 #, elixir-autogen, elixir-format
 msgid "Signed-in members only"
 msgstr ""
@@ -10869,7 +10870,7 @@ msgstr ""
 msgid "Amount"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:464
+#: lib/vutuv_web/live/job_posting_live/form.ex:659
 #: lib/vutuv_web/templates/user/edit.html.heex:326
 #: lib/vutuv_web/templates/welcome/show.html.heex:131
 #, elixir-autogen, elixir-format
@@ -10892,7 +10893,7 @@ msgstr ""
 msgid "Optional. Even when hidden, it sharpens your own job search and alerts by filtering out postings below it. Leave the amount empty to remove it."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:471
+#: lib/vutuv_web/live/job_posting_live/form.ex:666
 #: lib/vutuv_web/templates/user/edit.html.heex:322
 #: lib/vutuv_web/templates/welcome/show.html.heex:127
 #, elixir-autogen, elixir-format
@@ -11611,8 +11612,8 @@ msgstr ""
 msgid "Verify via file"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:942
-#: lib/vutuv_web/agent_docs/text.ex:719
+#: lib/vutuv_web/agent_docs/markdown.ex:949
+#: lib/vutuv_web/agent_docs/text.ex:726
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr ""
@@ -12007,37 +12008,37 @@ msgstr ""
 msgid "A fake, misleading or discriminatory job advertisement."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:448
+#: lib/vutuv_web/live/job_posting_live/form.ex:643
 #, elixir-autogen, elixir-format
 msgid "A pay range is required to publish (except volunteer postings)."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:543
+#: lib/vutuv_web/live/job_posting_live/form.ex:738
 #, elixir-autogen, elixir-format
 msgid "A vutuv message to me"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:541
+#: lib/vutuv_web/live/job_posting_live/form.ex:736
 #, elixir-autogen, elixir-format
 msgid "A website"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:542
+#: lib/vutuv_web/live/job_posting_live/form.ex:737
 #, elixir-autogen, elixir-format
 msgid "An e-mail address"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:425
+#: lib/vutuv_web/live/job_posting_live/form.ex:553
 #, elixir-autogen, elixir-format
 msgid "Applicants must be located in"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:547
+#: lib/vutuv_web/live/job_posting_live/form.ex:742
 #, elixir-autogen, elixir-format
 msgid "Application URL"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:553
+#: lib/vutuv_web/live/job_posting_live/form.ex:748
 #, elixir-autogen, elixir-format
 msgid "Application e-mail"
 msgstr ""
@@ -12047,17 +12048,17 @@ msgstr ""
 msgid "Application: %{title}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:539
+#: lib/vutuv_web/live/job_posting_live/form.ex:734
 #, elixir-autogen, elixir-format
 msgid "Applications go to"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:271
+#: lib/vutuv_web/live/job_posting_live/show.ex:275
 #, elixir-autogen, elixir-format
 msgid "Apply by e-mail"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:270
+#: lib/vutuv_web/live/job_posting_live/show.ex:274
 #, elixir-autogen, elixir-format
 msgid "Apply on website"
 msgstr ""
@@ -12079,7 +12080,7 @@ msgstr ""
 msgid "Contract"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:487
+#: lib/vutuv_web/live/job_posting_live/form.ex:682
 #, elixir-autogen, elixir-format
 msgid "Describe the role. Markdown is supported."
 msgstr ""
@@ -12089,15 +12090,15 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:84
+#: lib/vutuv_web/live/job_posting_live/form.ex:113
 #, elixir-autogen, elixir-format
 msgid "Edit posting"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:272
-#: lib/vutuv_web/agent_docs/markdown.ex:473
+#: lib/vutuv_web/agent_docs/markdown.ex:480
 #: lib/vutuv_web/agent_docs/text.ex:258
-#: lib/vutuv_web/agent_docs/text.ex:494
+#: lib/vutuv_web/agent_docs/text.ex:501
 #: lib/vutuv_web/live/admin/job_live.ex:344
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:17
 #: lib/vutuv_web/views/account_event_text.ex:225
@@ -12105,27 +12106,27 @@ msgstr ""
 msgid "Employer"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:330
+#: lib/vutuv_web/live/job_posting_live/form.ex:458
 #, elixir-autogen, elixir-format
 msgid "Employer name (optional)"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:273
-#: lib/vutuv_web/agent_docs/markdown.ex:474
+#: lib/vutuv_web/agent_docs/markdown.ex:481
 #: lib/vutuv_web/agent_docs/text.ex:259
-#: lib/vutuv_web/agent_docs/text.ex:495
+#: lib/vutuv_web/agent_docs/text.ex:502
 #: lib/vutuv_web/live/job_board_live.ex:367
-#: lib/vutuv_web/live/job_posting_live/form.ex:345
+#: lib/vutuv_web/live/job_posting_live/form.ex:473
 #, elixir-autogen, elixir-format
 msgid "Employment type"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:565
+#: lib/vutuv_web/live/job_posting_live/form.ex:760
 #, elixir-autogen, elixir-format
 msgid "Everyone (public)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:452
+#: lib/vutuv_web/live/job_posting_live/form.ex:647
 #: lib/vutuv_web/live/tag_live/timeline.ex:264
 #: lib/vutuv_web/templates/education/form_content.html.heex:41
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:63
@@ -12143,12 +12144,7 @@ msgstr ""
 msgid "Highlighted tags match your profile."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:441
-#, elixir-autogen, elixir-format
-msgid "Hold Ctrl / Cmd to select more than one."
-msgstr ""
-
-#: lib/vutuv_web/live/job_posting_live/form.ex:537
+#: lib/vutuv_web/live/job_posting_live/form.ex:732
 #, elixir-autogen, elixir-format
 msgid "How to apply"
 msgstr ""
@@ -12164,12 +12160,12 @@ msgstr ""
 msgid "I'm interested in your posting: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:486
+#: lib/vutuv_web/live/job_posting_live/form.ex:681
 #, elixir-autogen, elixir-format
 msgid "Job description"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:297
+#: lib/vutuv_web/live/job_posting_live/form.ex:425
 #, elixir-autogen, elixir-format
 msgid "Job title"
 msgstr ""
@@ -12185,18 +12181,18 @@ msgstr ""
 msgid "Jobs"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:575
+#: lib/vutuv_web/live/job_posting_live/form.ex:770
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this posting."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:455
-#: lib/vutuv_web/agent_docs/markdown.ex:459
-#: lib/vutuv_web/agent_docs/markdown.ex:461
+#: lib/vutuv_web/agent_docs/markdown.ex:458
+#: lib/vutuv_web/agent_docs/markdown.ex:460
 #: lib/vutuv_web/agent_docs/text.ex:476
-#: lib/vutuv_web/agent_docs/text.ex:480
-#: lib/vutuv_web/agent_docs/text.ex:482
-#: lib/vutuv_web/live/job_posting_live/form.ex:386
+#: lib/vutuv_web/agent_docs/text.ex:479
+#: lib/vutuv_web/agent_docs/text.ex:481
+#: lib/vutuv_web/live/job_posting_live/form.ex:514
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr ""
@@ -12211,7 +12207,7 @@ msgstr ""
 msgid "Mark this posting as filled and close it?"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:272
+#: lib/vutuv_web/live/job_posting_live/show.ex:276
 #, elixir-autogen, elixir-format
 msgid "Message the poster"
 msgstr ""
@@ -12233,20 +12229,20 @@ msgstr ""
 msgid "My postings"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:273
+#: lib/vutuv_web/live/job_posting_live/form.ex:395
 #, elixir-autogen, elixir-format
 msgid "New accounts can publish after a few days."
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:103
-#: lib/vutuv_web/live/job_posting_live/form.ex:84
+#: lib/vutuv_web/live/job_posting_live/form.ex:113
 #, elixir-autogen, elixir-format
 msgid "New posting"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:284
 #: lib/vutuv_web/agent_docs/text.ex:269
-#: lib/vutuv_web/live/job_posting_live/form.ex:525
+#: lib/vutuv_web/live/job_posting_live/form.ex:720
 #: lib/vutuv_web/live/job_posting_live/show.ex:154
 #, elixir-autogen, elixir-format
 msgid "Nice to have"
@@ -12267,7 +12263,7 @@ msgstr ""
 msgid "Nothing here yet. Jobs you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:581
+#: lib/vutuv_web/live/job_posting_live/form.ex:776
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
@@ -12288,17 +12284,17 @@ msgstr ""
 msgid "Part-time"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:446
+#: lib/vutuv_web/live/job_posting_live/form.ex:641
 #, elixir-autogen, elixir-format
 msgid "Pay"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:272
+#: lib/vutuv_web/live/job_posting_live/form.ex:394
 #, elixir-autogen, elixir-format
 msgid "Please confirm your e-mail address first."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:41
+#: lib/vutuv_web/live/job_posting_live/form.ex:70
 #, elixir-autogen, elixir-format
 msgid "Please confirm your email address before posting a job."
 msgstr ""
@@ -12308,7 +12304,7 @@ msgstr ""
 msgid "Please log in to message the poster."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:47
+#: lib/vutuv_web/live/job_posting_live/form.ex:76
 #, elixir-autogen, elixir-format
 msgid "Please log in to post a job."
 msgstr ""
@@ -12318,38 +12314,38 @@ msgstr ""
 msgid "Please log in to see your postings."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:318
+#: lib/vutuv_web/live/job_posting_live/form.ex:446
 #, elixir-autogen, elixir-format
 msgid "Post as"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:398
+#: lib/vutuv_web/live/job_posting_live/form.ex:526
 #: lib/vutuv_web/templates/welcome/show.html.heex:67
 #, elixir-autogen, elixir-format
 msgid "Postal code"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:277
-#: lib/vutuv_web/agent_docs/markdown.ex:478
+#: lib/vutuv_web/agent_docs/markdown.ex:485
 #: lib/vutuv_web/agent_docs/text.ex:263
-#: lib/vutuv_web/agent_docs/text.ex:499
+#: lib/vutuv_web/agent_docs/text.ex:506
 #: lib/vutuv_web/live/job_posting_live/show.ex:133
 #, elixir-autogen, elixir-format
 msgid "Posted"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:376
+#: lib/vutuv_web/live/job_posting_live/form.ex:504
 #, elixir-autogen, elixir-format
 msgid "Posting language"
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:50
-#: lib/vutuv_web/live/job_posting_live/form.ex:74
+#: lib/vutuv_web/live/job_posting_live/form.ex:103
 #, elixir-autogen, elixir-format
 msgid "Posting not found."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:598
+#: lib/vutuv_web/live/job_posting_live/form.ex:793
 #, elixir-autogen, elixir-format
 msgid "Publish"
 msgstr ""
@@ -12357,10 +12353,10 @@ msgstr ""
 #: lib/vutuv/accounts/user.ex:1159
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:564
-#: lib/vutuv_web/agent_docs/markdown.ex:459
-#: lib/vutuv_web/agent_docs/markdown.ex:461
-#: lib/vutuv_web/agent_docs/text.ex:480
-#: lib/vutuv_web/agent_docs/text.ex:482
+#: lib/vutuv_web/agent_docs/markdown.ex:458
+#: lib/vutuv_web/agent_docs/markdown.ex:460
+#: lib/vutuv_web/agent_docs/text.ex:479
+#: lib/vutuv_web/agent_docs/text.ex:481
 #: lib/vutuv_web/components/job_components.ex:140
 #: lib/vutuv_web/components/job_components.ex:141
 #, elixir-autogen, elixir-format
@@ -12374,47 +12370,47 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:283
 #: lib/vutuv_web/agent_docs/text.ex:268
-#: lib/vutuv_web/live/job_posting_live/form.ex:515
+#: lib/vutuv_web/live/job_posting_live/form.ex:710
 #: lib/vutuv_web/live/job_posting_live/show.ex:149
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:276
-#: lib/vutuv_web/agent_docs/markdown.ex:477
+#: lib/vutuv_web/agent_docs/markdown.ex:484
 #: lib/vutuv_web/agent_docs/text.ex:262
-#: lib/vutuv_web/agent_docs/text.ex:498
+#: lib/vutuv_web/agent_docs/text.ex:505
 #, elixir-autogen, elixir-format
 msgid "Salary"
 msgstr ""
 
-#: lib/vutuv_web/components/job_components.ex:162
+#: lib/vutuv_web/components/job_components.ex:200
 #, elixir-autogen, elixir-format
 msgid "Salary on request"
 msgstr ""
 
 #: lib/vutuv_web/controllers/settings_controller.ex:393
-#: lib/vutuv_web/live/job_posting_live/form.ex:231
+#: lib/vutuv_web/live/job_posting_live/form.ex:353
 #, elixir-autogen, elixir-format
 msgid "Saved."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:339
+#: lib/vutuv_web/live/job_posting_live/form.ex:467
 #, elixir-autogen, elixir-format
 msgid "Shown as an unverified employer name."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:261
+#: lib/vutuv_web/live/job_posting_live/form.ex:383
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:391
+#: lib/vutuv_web/live/job_posting_live/form.ex:519
 #, elixir-autogen, elixir-format
 msgid "Street (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:512
+#: lib/vutuv_web/live/job_posting_live/form.ex:707
 #, elixir-autogen, elixir-format
 msgid "Tags match your posting to members. Separate them with commas; a tag may be several words long, like Ruby on Rails."
 msgstr ""
@@ -12424,17 +12420,17 @@ msgstr ""
 msgid "Temporary"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:153
+#: lib/vutuv_web/live/job_posting_live/form.ex:275
 #, elixir-autogen, elixir-format
 msgid "That image could not be uploaded."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:293
+#: lib/vutuv_web/live/job_posting_live/form.ex:421
 #, elixir-autogen, elixir-format
 msgid "The role"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:279
+#: lib/vutuv_web/live/job_posting_live/form.ex:401
 #, elixir-autogen, elixir-format
 msgid "This organization has reached its published-postings limit."
 msgstr ""
@@ -12444,7 +12440,7 @@ msgstr ""
 msgid "This position is no longer available."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:312
+#: lib/vutuv_web/live/job_posting_live/form.ex:440
 #, elixir-autogen, elixir-format
 msgid "Tip: adding a gender marker like (m/w/d) helps your posting comply with the AGG. This is a suggestion, not legal advice."
 msgstr ""
@@ -12455,8 +12451,8 @@ msgstr ""
 msgid "Verified organization"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/job_posting_doc.ex:126
-#: lib/vutuv_web/components/job_components.ex:161
+#: lib/vutuv_web/agent_docs/job_posting_doc.ex:131
+#: lib/vutuv_web/components/job_components.ex:199
 #, elixir-autogen, elixir-format
 msgid "Voluntary"
 msgstr ""
@@ -12466,7 +12462,7 @@ msgstr ""
 msgid "Volunteer"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:563
+#: lib/vutuv_web/live/job_posting_live/form.ex:758
 #: lib/vutuv_web/templates/email/form_content.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Who can see it"
@@ -12478,15 +12474,15 @@ msgid "Working student"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:274
-#: lib/vutuv_web/agent_docs/markdown.ex:475
+#: lib/vutuv_web/agent_docs/markdown.ex:482
 #: lib/vutuv_web/agent_docs/text.ex:260
-#: lib/vutuv_web/agent_docs/text.ex:496
-#: lib/vutuv_web/live/job_posting_live/form.ex:360
+#: lib/vutuv_web/agent_docs/text.ex:503
+#: lib/vutuv_web/live/job_posting_live/form.ex:488
 #, elixir-autogen, elixir-format
 msgid "Workplace"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:276
+#: lib/vutuv_web/live/job_posting_live/form.ex:398
 #, elixir-autogen, elixir-format
 msgid "You already have the maximum number of published postings."
 msgstr ""
@@ -12531,18 +12527,18 @@ msgstr ""
 msgid "Your posting"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:211
-#: lib/vutuv_web/live/job_posting_live/form.ex:254
+#: lib/vutuv_web/live/job_posting_live/form.ex:333
+#: lib/vutuv_web/live/job_posting_live/form.ex:376
 #, elixir-autogen, elixir-format
 msgid "Your posting is live."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:321
+#: lib/vutuv_web/live/job_posting_live/form.ex:449
 #, elixir-autogen, elixir-format
 msgid "Yourself (personal posting)"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:458
+#: lib/vutuv_web/live/job_posting_live/form.ex:653
 #, elixir-autogen, elixir-format
 msgid "up to"
 msgstr ""
@@ -12656,14 +12652,14 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: lib/vutuv_web/components/job_components.ex:184
+#: lib/vutuv_web/components/job_components.ex:222
 #, elixir-autogen, elixir-format
 msgid "%{count} month ago"
 msgid_plural "%{count} months ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/job_components.ex:183
+#: lib/vutuv_web/components/job_components.ex:221
 #, elixir-autogen, elixir-format
 msgid "%{count} week ago"
 msgid_plural "%{count} weeks ago"
@@ -12680,13 +12676,13 @@ msgstr ""
 msgid "All countries"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:496
+#: lib/vutuv_web/agent_docs/markdown.ex:503
 #: lib/vutuv_web/templates/tag/show.html.heex:75
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:516
+#: lib/vutuv_web/agent_docs/text.ex:523
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag: %{url}"
 msgstr ""
@@ -12752,10 +12748,10 @@ msgstr ""
 msgid "No matching positions. Try adjusting the filters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:494
-#: lib/vutuv_web/agent_docs/markdown.ex:506
-#: lib/vutuv_web/agent_docs/text.ex:514
-#: lib/vutuv_web/agent_docs/text.ex:526
+#: lib/vutuv_web/agent_docs/markdown.ex:501
+#: lib/vutuv_web/agent_docs/markdown.ex:513
+#: lib/vutuv_web/agent_docs/text.ex:521
+#: lib/vutuv_web/agent_docs/text.ex:533
 #: lib/vutuv_web/live/organization_live/show.ex:676
 #: lib/vutuv_web/templates/tag/show.html.heex:69
 #, elixir-autogen, elixir-format
@@ -13204,7 +13200,7 @@ msgstr ""
 msgid "Hide from specific viewers"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:587
+#: lib/vutuv_web/live/job_posting_live/form.ex:782
 #, elixir-autogen, elixir-format
 msgid "Hide from specific viewers (competitors, your own staff, a person) →"
 msgstr ""
@@ -13225,7 +13221,7 @@ msgstr ""
 msgid "Job exclusions – %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/form.ex:590
+#: lib/vutuv_web/live/job_posting_live/form.ex:785
 #, elixir-autogen, elixir-format
 msgid "Keep this posting on the board for everyone except a chosen few."
 msgstr ""
@@ -13684,7 +13680,7 @@ msgstr ""
 msgid "Audiobook"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1189
+#: lib/vutuv_web/agent_docs/markdown.ex:1196
 #: lib/vutuv_web/components/post_components.ex:4405
 #, elixir-autogen, elixir-format
 msgid "Book review"
@@ -13705,7 +13701,7 @@ msgstr ""
 msgid "E-book"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1189
+#: lib/vutuv_web/agent_docs/markdown.ex:1196
 #: lib/vutuv_web/components/post_components.ex:4404
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -13795,7 +13791,7 @@ msgstr ""
 msgid "With qualification:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:761
+#: lib/vutuv_web/agent_docs/markdown.ex:768
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr ""
@@ -13889,19 +13885,19 @@ msgid_plural "Used for %{formatted} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:911
+#: lib/vutuv_web/agent_docs/markdown.ex:918
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:910
+#: lib/vutuv_web/agent_docs/markdown.ex:917
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:916
+#: lib/vutuv_web/agent_docs/markdown.ex:923
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
@@ -13981,8 +13977,8 @@ msgstr ""
 msgid "View the uploaded proof (%{label})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:847
-#: lib/vutuv_web/agent_docs/text.ex:698
+#: lib/vutuv_web/agent_docs/markdown.ex:854
+#: lib/vutuv_web/agent_docs/text.ex:705
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr ""
@@ -14065,8 +14061,8 @@ msgstr ""
 msgid "Skip for now"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:551
-#: lib/vutuv_web/agent_docs/text.ex:545
+#: lib/vutuv_web/agent_docs/markdown.ex:558
+#: lib/vutuv_web/agent_docs/text.ex:552
 #, elixir-autogen, elixir-format
 msgid "Preferred workplace"
 msgstr ""
@@ -14659,7 +14655,7 @@ msgstr ""
 msgid "none yet"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1136
+#: lib/vutuv_web/agent_docs/markdown.ex:1143
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr ""
@@ -15043,8 +15039,8 @@ msgstr ""
 msgid "Your server"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:608
-#: lib/vutuv_web/agent_docs/text.ex:574
+#: lib/vutuv_web/agent_docs/markdown.ex:615
+#: lib/vutuv_web/agent_docs/text.ex:581
 #, elixir-autogen, elixir-format
 msgid "moved to %{address}"
 msgstr ""
@@ -15428,7 +15424,7 @@ msgid_plural "%{formatted} reposts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1138
+#: lib/vutuv_web/agent_docs/markdown.ex:1145
 #: lib/vutuv_web/components/post_components.ex:4822
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
@@ -15439,8 +15435,8 @@ msgstr ""
 msgid "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1320
-#: lib/vutuv_web/agent_docs/text.ex:818
+#: lib/vutuv_web/agent_docs/markdown.ex:1327
+#: lib/vutuv_web/agent_docs/text.ex:825
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Content warning"
 msgstr ""
@@ -15464,7 +15460,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:126
 #: lib/vutuv_web/agent_docs/markdown.ex:157
-#: lib/vutuv_web/agent_docs/markdown.ex:1137
+#: lib/vutuv_web/agent_docs/markdown.ex:1144
 #: lib/vutuv_web/agent_docs/text.ex:117
 #: lib/vutuv_web/agent_docs/text.ex:145
 #, elixir-autogen, elixir-format
@@ -15522,7 +15518,7 @@ msgstr ""
 msgid "That reply is not yours to remove."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1322
+#: lib/vutuv_web/agent_docs/markdown.ex:1329
 #: lib/vutuv_web/components/post_components.ex:1153
 #: lib/vutuv_web/components/post_components.ex:1353
 #: lib/vutuv_web/components/post_components.ex:2178
@@ -16223,13 +16219,13 @@ msgstr ""
 msgid "Unpinned. The post is a normal post again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1018
+#: lib/vutuv_web/agent_docs/markdown.ex:1025
 #, elixir-autogen, elixir-format
 msgid "pinned post"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:545
-#: lib/vutuv_web/agent_docs/text.ex:536
+#: lib/vutuv_web/agent_docs/markdown.ex:552
+#: lib/vutuv_web/agent_docs/text.ex:543
 #: lib/vutuv_web/templates/user/edit.html.heex:224
 #: lib/vutuv_web/templates/user/show.html.heex:247
 #: lib/vutuv_web/views/account_event_text.ex:213
@@ -16287,8 +16283,8 @@ msgstr ""
 msgid "Describe the photo for people who can't see it"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1250
-#: lib/vutuv_web/agent_docs/text.ex:785
+#: lib/vutuv_web/agent_docs/markdown.ex:1257
+#: lib/vutuv_web/agent_docs/text.ex:792
 #: lib/vutuv_web/components/ui.ex:2471
 #, elixir-autogen, elixir-format
 msgid "Download the original"
@@ -16350,8 +16346,8 @@ msgstr ""
 msgid "Photo options"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1283
-#: lib/vutuv_web/agent_docs/text.ex:772
+#: lib/vutuv_web/agent_docs/markdown.ex:1290
+#: lib/vutuv_web/agent_docs/text.ex:779
 #: lib/vutuv_web/components/post_components.ex:3753
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
@@ -16524,13 +16520,13 @@ msgid_plural "Some of these photos carry the location they were taken at, and th
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1156
+#: lib/vutuv_web/agent_docs/markdown.ex:1163
 #: lib/vutuv_web/components/post_components.ex:4860
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1154
+#: lib/vutuv_web/agent_docs/markdown.ex:1161
 #: lib/vutuv_web/components/post_components.ex:4857
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
@@ -17153,7 +17149,7 @@ msgstr ""
 msgid "What is being measured"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1013
+#: lib/vutuv_web/agent_docs/markdown.ex:1020
 #, elixir-autogen, elixir-format
 msgid "(a picture)"
 msgid_plural "(%{count} pictures)"
@@ -17304,8 +17300,8 @@ msgstr ""
 msgid "We could not reach the network just now. Please try again in a moment."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:956
-#: lib/vutuv_web/agent_docs/text.ex:620
+#: lib/vutuv_web/agent_docs/markdown.ex:963
+#: lib/vutuv_web/agent_docs/text.ex:627
 #, elixir-autogen, elixir-format, fuzzy
 msgid "verified profile"
 msgstr ""
@@ -18235,7 +18231,7 @@ msgstr ""
 msgid "A post's page shows the members who liked it, right under the count. This is whether you are one of the faces."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1124
+#: lib/vutuv_web/agent_docs/markdown.ex:1131
 #, elixir-autogen, elixir-format
 msgid "Liked by"
 msgstr ""
@@ -18277,12 +18273,12 @@ msgstr ""
 msgid "Your likes follow the site default again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1179
+#: lib/vutuv_web/agent_docs/markdown.ex:1186
 #, elixir-autogen, elixir-format
 msgid "%{address} (this page only)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1176
+#: lib/vutuv_web/agent_docs/markdown.ex:1183
 #, elixir-autogen, elixir-format
 msgid "%{address} (whole website)"
 msgstr ""
@@ -18292,7 +18288,7 @@ msgstr ""
 msgid "Verified webpage of the author (%{address})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1168
+#: lib/vutuv_web/agent_docs/markdown.ex:1175
 #, elixir-autogen, elixir-format
 msgid "Verified webpages of the author linked here: %{addresses}"
 msgstr ""
@@ -18622,7 +18618,7 @@ msgstr ""
 msgid "Employment references of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:829
+#: lib/vutuv_web/agent_docs/markdown.ex:836
 #, elixir-autogen, elixir-format, fuzzy
 msgid "document"
 msgstr ""
@@ -21467,4 +21463,36 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgctxt "qualification detail"
 msgid "Jobs"
+msgstr ""
+
+#: lib/vutuv_web/live/job_posting_live/form.ex:824
+#, elixir-autogen, elixir-format
+msgid "%{formatted} country chosen."
+msgid_plural "%{formatted} countries chosen."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/job_posting_live/form.ex:610
+#, elixir-autogen, elixir-format
+msgid "No country chosen yet."
+msgstr ""
+
+#: lib/vutuv_web/live/job_posting_live/form.ex:602
+#, elixir-autogen, elixir-format
+msgid "No country left to add for that."
+msgstr ""
+
+#: lib/vutuv_web/live/job_posting_live/form.ex:621
+#, elixir-autogen, elixir-format
+msgid "Remove %{country}"
+msgstr ""
+
+#: lib/vutuv_web/live/job_posting_live/form.ex:632
+#, elixir-autogen, elixir-format
+msgid "Remove all"
+msgstr ""
+
+#: lib/vutuv_web/live/job_posting_live/form.ex:581
+#, elixir-autogen, elixir-format
+msgid "Search for a country"
 msgstr ""

--- a/test/vutuv/countries_test.exs
+++ b/test/vutuv/countries_test.exs
@@ -72,7 +72,7 @@ defmodule Vutuv.CountriesTest do
 
     test "options are sorted by the folded localized name" do
       options = Countries.select_options(:de)
-      keys = Enum.map(options, fn {name, _code} -> fold(name) end)
+      keys = Enum.map(options, fn {name, _code} -> Countries.fold(name) end)
       assert keys == Enum.sort(keys)
     end
 
@@ -98,6 +98,110 @@ defmodule Vutuv.CountriesTest do
     end
   end
 
+  describe "names/2" do
+    test "pairs codes with their localized names, sorted like the option list" do
+      assert Countries.names(~w(CH AT DE), :de) == [
+               {"Deutschland", "DE"},
+               {"Österreich", "AT"},
+               {"Schweiz", "CH"}
+             ]
+    end
+
+    test "drops unknown codes and collapses duplicates" do
+      assert Countries.names(~w(DE XX de DE), :en) == [{"Germany", "DE"}]
+      assert Countries.names([], :en) == []
+      assert Countries.names(nil, :en) == []
+    end
+  end
+
+  describe "search/2" do
+    test "matches a fragment of the localized name" do
+      assert {"Deutschland", "DE"} in Countries.search("eutschl", :de)
+      assert {"Germany", "DE"} in Countries.search("germ", :en)
+    end
+
+    test "folds diacritics and case on both sides" do
+      # The point of the folding: nobody types an umlaut into a search box.
+      assert {"Österreich", "AT"} in Countries.search("oster", :de)
+      assert {"Côte d'Ivoire", "CI"} in Countries.search("COTE", :de)
+    end
+
+    test "an exact ISO code is listed first" do
+      assert [{"Österreich", "AT"} | _rest] = Countries.search("AT", :de)
+      assert [{"Italien", "IT"} | _rest] = Countries.search("it", :de)
+    end
+
+    test "names that begin with the query come before matches buried mid-word" do
+      # Alphabetical order alone answered "sch" with Amerikanisch-Samoa,
+      # Aserbaidschan and Bangladesch, and pushed Schweiz past the eight hits a
+      # picker shows.
+      top = Countries.search("sch", :de) |> Enum.take(4) |> Enum.map(&elem(&1, 0))
+      assert "Schweden" in top
+      assert "Schweiz" in top
+
+      # A later word counts too: "staaten" finds "Vereinigte Staaten".
+      assert [{"Vereinigte Staaten", "US"} | _rest] = Countries.search("staaten", :de)
+    end
+
+    test "a blank or non-binary query finds nothing" do
+      assert Countries.search("", :de) == []
+      assert Countries.search("   ", :de) == []
+      assert Countries.search(nil, :de) == []
+    end
+  end
+
+  describe "regions/1" do
+    test "the four presets carry localized names and their size" do
+      assert ["EU", "EMEA", "MENA", "APAC"] == Enum.map(Countries.regions(:de), & &1.key)
+
+      eu = Enum.find(Countries.regions(:de), &(&1.key == "EU"))
+      assert eu.name == "Europäische Union"
+      assert eu.count == 27
+      assert eu.count == length(Countries.region_codes("EU"))
+
+      assert Enum.find(Countries.regions(:en), &(&1.key == "EU")).name == "European Union"
+    end
+
+    test "the EU expansion is the 27 member states" do
+      eu = Countries.region_codes("EU")
+      assert "DE" in eu
+      refute "CH" in eu
+      refute "GB" in eu
+    end
+
+    test "EMEA is the union of Europe, the Middle East and Africa" do
+      emea = Countries.region_codes("EMEA")
+      # One from each of the three parts, and nothing from the Americas or APAC.
+      assert "NO" in emea
+      assert "SA" in emea
+      assert "KE" in emea
+      refute "US" in emea
+      refute "JP" in emea
+      assert Enum.uniq(emea) == emea
+    end
+
+    test "region_codes/1 answers [] for anything unknown" do
+      assert Countries.region_codes("LATAM") == []
+      assert Countries.region_codes(nil) == []
+    end
+  end
+
+  describe "region_for/1" do
+    test "names the region a selection covers exactly, in any order" do
+      assert Countries.region_for(Countries.region_codes("EU")) == "EU"
+      assert Countries.region_for(Enum.reverse(Countries.region_codes("APAC"))) == "APAC"
+    end
+
+    test "a selection that is not exactly a region is not named as one" do
+      # Taking one country back out means something narrower than the region,
+      # and calling it "EU" anyway would misdescribe where they will hire.
+      [_dropped | rest] = Countries.region_codes("EU")
+      assert Countries.region_for(rest) == nil
+      assert Countries.region_for(["DE", "AT"]) == nil
+      assert Countries.region_for([]) == nil
+    end
+  end
+
   describe "all/0" do
     test "covers the full ISO 3166-1 alpha-2 set" do
       codes = Countries.all()
@@ -105,25 +209,5 @@ defmodule Vutuv.CountriesTest do
       assert "DE" in codes
       assert Enum.all?(codes, &(&1 == String.upcase(&1)))
     end
-  end
-
-  # Mirror of the module's private sort key, so the sort assertion checks the
-  # same folded ordering the module produces.
-  defp fold(name) do
-    name
-    |> String.downcase()
-    |> String.replace("ä", "a")
-    |> String.replace("ö", "o")
-    |> String.replace("ü", "u")
-    |> String.replace("ß", "ss")
-    |> String.replace("å", "a")
-    |> String.replace("á", "a")
-    |> String.replace("à", "a")
-    |> String.replace("é", "e")
-    |> String.replace("è", "e")
-    |> String.replace("ç", "c")
-    |> String.replace("í", "i")
-    |> String.replace("ó", "o")
-    |> String.replace("ú", "u")
   end
 end

--- a/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
+++ b/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
@@ -1432,6 +1432,48 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     assert_fact_everywhere(rendered, phoenix)
   end
 
+  test "a remote posting's applicant countries appear in every format" do
+    # The HTML detail page used to show nothing at all for a remote posting,
+    # so the countries the poster picked existed only in the agent documents
+    # (issues #1558/#1559).
+    posting =
+      Vutuv.JobsHelpers.publish_job!(nil, %{
+        "title" => "Remote Elixir Engineer",
+        "workplace_type" => "remote",
+        "remote_countries" => ["DE", "AT"],
+        "required_tags" => unique_tag_name("Elixir")
+      })
+
+    rendered = formats_for("/jobs/#{posting.slug}")
+    assert_fact_everywhere(rendered, "Germany")
+    assert_fact_everywhere(rendered, "Austria")
+  end
+
+  test "a region preset is named in every format, not only spelled out" do
+    # The HTML chip says "EU" where the poster picked the preset; the agent
+    # formats keep all 27 names AND carry the word (issue #1559).
+    posting =
+      Vutuv.JobsHelpers.publish_job!(nil, %{
+        "title" => "EU-wide Elixir Engineer",
+        "workplace_type" => "remote",
+        "remote_countries" => Vutuv.Countries.region_codes("EU"),
+        "required_tags" => unique_tag_name("Elixir")
+      })
+
+    rendered = formats_for("/jobs/#{posting.slug}")
+
+    # Not assert_fact_everywhere: "EU" is a substring of the EUR currency the
+    # salary line carries, so a bare search would pass without the region.
+    assert rendered.html =~ ~r/>\s*EU\s*</
+    assert rendered.md =~ "(EU: "
+    assert rendered.txt =~ "(EU: "
+    assert Jason.decode!(rendered.json)["remote_region"] == "EU"
+    assert rendered.xml =~ "<remote_region>EU</remote_region>"
+
+    # The enumeration survives for anything filtering on it.
+    for format <- [:md, :txt, :json, :xml], do: assert(rendered[format] =~ "Portugal")
+  end
+
   test "the job board appears in every format" do
     Vutuv.JobsHelpers.publish_job!(nil, %{
       "title" => "Board Tester Role",

--- a/test/vutuv_web/job_posting_test.exs
+++ b/test/vutuv_web/job_posting_test.exs
@@ -110,6 +110,150 @@ defmodule VutuvWeb.JobPostingTest do
     end
   end
 
+  # Form params for a remote posting. The address block is gone from the DOM
+  # once the workplace is remote, and `form/3` refuses to fill a field the
+  # rendered form does not have.
+  defp remote_params(overrides \\ %{}) do
+    overrides
+    |> Map.put("workplace_type", "remote")
+    |> form_params()
+    |> Map.drop(["zip_code", "city", "country"])
+  end
+
+  # Switch the workplace to remote so the applicant-country picker renders, and
+  # hand back the HTML it produced.
+  defp go_remote(view) do
+    view
+    |> form("#job-posting-form", job_posting: form_params(%{"workplace_type" => "remote"}))
+    |> render_change()
+  end
+
+  describe "applicant countries (issues #1558, #1559)" do
+    test "the picker shows the chosen countries as pills, never a 249-row select",
+         %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+      {:ok, view, _html} = live(conn, ~p"/jobs/new")
+
+      html = go_remote(view)
+
+      # The whole point of #1558: the old control hid the selection.
+      refute html =~ ~s(id="job_posting_remote_countries")
+      refute html =~ "Hold Ctrl"
+      # Switching to remote preselects the installation's own country, visibly
+      # (the test conn speaks English, so the pill reads "Germany").
+      assert html =~ "Germany"
+      assert html =~ ~s(name="job_posting[remote_countries][]" value="DE")
+
+      html = render_click(view, "country-add", %{"code" => "AT"})
+      assert html =~ ~s(name="job_posting[remote_countries][]" value="AT")
+
+      html = render_click(view, "country-remove", %{"code" => "DE"})
+      refute html =~ ~s(name="job_posting[remote_countries][]" value="DE")
+      assert html =~ ~s(name="job_posting[remote_countries][]" value="AT")
+    end
+
+    test "an emptied list stays empty across the next form change", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+      {:ok, view, _html} = live(conn, ~p"/jobs/new")
+
+      go_remote(view)
+      render_click(view, "country-clear", %{})
+
+      # The seed must fire only the first time the field appears. Typing on in
+      # the form re-sends the (now empty) field, and putting Germany back would
+      # overrule an answer the member gave on purpose.
+      html =
+        view
+        |> form("#job-posting-form", job_posting: remote_params(%{"title" => "Remote Role"}))
+        |> render_change()
+
+      refute html =~ ~s(name="job_posting[remote_countries][]" value="DE")
+      assert html =~ "No country chosen yet."
+    end
+
+    test "the search box finds a country and adding one drops it from the hits",
+         %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+      {:ok, view, _html} = live(conn, ~p"/jobs/new")
+      go_remote(view)
+
+      html = render_change(view, "country-search", %{"country_query" => "witzerl"})
+      assert html =~ "Switzerland"
+      assert html =~ ~s(phx-click="country-add" phx-value-code="CH")
+
+      # Enter in the box takes the top hit (the sibling form's phx-submit), so
+      # it can never publish the posting half-finished.
+      html = render_submit(view, "country-add-first", %{})
+      assert html =~ ~s(name="job_posting[remote_countries][]" value="CH")
+      # Offered once, then it is a pill — a hit you have already taken would
+      # answer a tap with nothing visibly happening.
+      refute html =~ ~s(phx-click="country-add" phx-value-code="CH")
+    end
+
+    test "a region preset fills in its whole expansion and publishes with it",
+         %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      age_account(user)
+      {:ok, view, _html} = live(conn, ~p"/jobs/new")
+      go_remote(view)
+
+      render_click(view, "country-clear", %{})
+      render_click(view, "country-region", %{"region" => "EU"})
+
+      {:error, {:live_redirect, %{to: to}}} =
+        view
+        |> form("#job-posting-form", job_posting: remote_params())
+        |> render_submit(%{"do" => "publish"})
+
+      posting = Jobs.get_job_posting_by_slug(to |> String.split("/") |> List.last())
+      # The expansion is what gets stored, so Jobs.filter_location/4 keeps
+      # working against remote_countries untouched (issue #1559).
+      assert Enum.sort(posting.remote_countries) == Vutuv.Countries.region_codes("EU")
+      assert length(posting.remote_countries) == 27
+    end
+
+    test "a whole region reads as its name on the card and the detail page" do
+      posting =
+        publish_job!(nil, %{
+          "workplace_type" => "remote",
+          "remote_countries" => Vutuv.Countries.region_codes("EU")
+        })
+
+      assert VutuvWeb.JobComponents.card_location(posting) =~ "(EU)"
+
+      assert VutuvWeb.JobComponents.remote_countries_label(posting.remote_countries, :name) ==
+               "EU"
+    end
+
+    test "the picker speaks German to a German browser", %{conn: conn} do
+      # `mix gettext.extract --merge` fuzzy-filled every one of these labels
+      # with an unrelated translation ("Land suchen" arrived as "Konto zum
+      # Einfrieren suchen"), and nothing in the build says so.
+      {conn, user} = create_and_login_user(conn)
+      user |> Ecto.Changeset.change(%{locale: nil}) |> Repo.update!()
+
+      {:ok, view, _html} =
+        conn
+        |> recycle()
+        |> put_req_header("accept-language", "de-DE,de;q=0.9")
+        |> live(~p"/jobs/new")
+
+      html = go_remote(view)
+      assert html =~ "Land suchen"
+      assert html =~ "1 Land ausgewählt."
+      assert html =~ "Alle entfernen"
+      assert html =~ "Deutschland entfernen"
+
+      assert render_click(view, "country-clear", %{}) =~ "Noch kein Land ausgewählt."
+    end
+
+    test "a long selection is capped instead of spelling out every country" do
+      # 128 codes in a card chip is not a chip.
+      label = VutuvWeb.JobComponents.remote_countries_label(~w(DE AT CH FR IT), :code)
+      assert label == "DE, AT, CH +2 more"
+    end
+  end
+
   describe "detail page + gating" do
     test "a public posting shows salary, employer and JSON-LD with validThrough", %{conn: conn} do
       posting = publish_job!()


### PR DESCRIPTION
**Symptom:** auf `/jobs/new` mit Arbeitsort „Remote" waren die Bewerberländer ein `<select multiple size="6">` über 249 Länder — einmal gescrollt, und niemand sah mehr, was gewählt war (#1558). Eine EU-weite Stelle kostete 27 Klicks (#1559).

**Geändert:** `VutuvWeb.JobPostingLive.Form`. Jedes Land ist eine Pille mit ✕, eine Suche findet es über einen Namensteil (diakritikfrei, „oster" findet Österreich), und vier Voreinstellungen — EU, EMEA, MENA, APAC — füllen eine Region auf einen Klick. Gespeichert wird die **Ausweitung**, nicht das Wort, damit `Jobs.filter_location/4` unangetastet bleibt; `Countries.region_for/1` leitet „EU" für Karte, Detailseite und Agentenformate wieder her. Nebenbei: die Detailseite zeigte für Remote-Anzeigen bisher gar keine Länder.

**Zu entscheiden:** die Regionszuschnitte sind Konvention, nicht Geographie (Türkei = Naher Osten, Zentralasien = APAC). Sie stehen als `@regions` in `lib/vutuv/countries.ex`.

Hot deploy, v7.326.0.

<img src="https://raw.githubusercontent.com/wintermeyer/vutuv/shots/pr-1578/picker.jpg" width="440"> <img src="https://raw.githubusercontent.com/wintermeyer/vutuv/shots/pr-1578/search.jpg" width="440">

Closes #1558
Closes #1559

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*
