### PR TITLE
Eine Seite bekommt ihr Gesicht in der "Gefällt"-Zeile (v7.328.2) (#1410)

### DIFF
--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -1475,7 +1475,10 @@ defmodule Vutuv.Posts do
 
   Hidden accounts (frozen, deactivated, suspended, unreachable) and unconfirmed
   ones drop out like they do from every other public people list; their likes
-  still count, they simply have no face to show.
+  still count, they simply have no face to show. A **page's** like (issue
+  #1410) is listed like a member's — a `%Organization{}` among the users —
+  behind its own gate (`organization_public_row/1`), so a frozen page loses
+  its face the same way a frozen member does.
   """
   def post_likers(post_id, opts \\ []) when is_binary(post_id) do
     # Matches `<.avatar_stack>`'s cap, so the row never queries rows it would
@@ -1484,17 +1487,26 @@ defmodule Vutuv.Posts do
     limit = Keyword.get(opts, :limit, @likers_shown)
 
     from(l in PostLike,
-      join: u in User,
+      left_join: u in User,
       on: u.id == l.user_id,
+      left_join: o in Organization,
+      on: o.id == l.organization_id,
       where: l.post_id == ^post_id,
-      where: account_confirmed_row(u) and not account_hidden_row(u),
+      # Each actor kind passes its own gate: on a LEFT-joined missing users
+      # row `is_nil(u.email_confirmed?)` is TRUE, so an unscoped member gate
+      # would wave every page row through, frozen ones included (the #1408
+      # shape).
+      where:
+        (not is_nil(l.user_id) and account_confirmed_row(u) and not account_hidden_row(u)) or
+          (not is_nil(l.organization_id) and organization_public_row(o)),
       # UUID v7: id order is creation order, so this is newest liker first.
       order_by: [desc: l.id],
       limit: ^limit,
-      select: u
+      select: {u, o}
     )
     |> scope_attributed(Keyword.get(opts, :include_hidden?, false))
     |> Repo.all()
+    |> Enum.map(fn {user, page} -> page || user end)
   end
 
   @doc """
@@ -1551,8 +1563,16 @@ defmodule Vutuv.Posts do
   defp scope_attributed(query, false) do
     default = Prefs.default(:like_attribution?)
 
-    from([_l, u] in query,
-      where: coalesce(field(u, :like_attribution?), type(^default, :boolean)) == true
+    # Scoped per actor kind, like every gate on the nullable pair: attribution
+    # is a member's preference, and a page's like (issue #1410) has no such
+    # column — its NULL would resolve to the installation default and could
+    # silently drop every page. The members-only queries below never produce a
+    # page row, so the second arm is structurally inert there.
+    from([l, u] in query,
+      where:
+        (not is_nil(l.user_id) and
+           coalesce(field(u, :like_attribution?), type(^default, :boolean)) == true) or
+          not is_nil(l.organization_id)
     )
   end
 
@@ -4927,6 +4947,9 @@ defmodule Vutuv.Posts do
   association: the association-shaped clause reads as a type check but behaves
   as a preload check, so a bare `%Post{}` out of a query drew a page's post as a
   nil member's.
+
+  Not only authors: any member-or-page actor links through here — a liker in
+  the permalink's row (issue #1410), a reposter, a chat party.
   """
   def author_path(%Post{} = post), do: author_path(author(post))
   def author_path(%Organization{} = organization), do: Organizations.canonical_path(organization)

--- a/lib/vutuv_web/agent_docs/post_doc.ex
+++ b/lib/vutuv_web/agent_docs/post_doc.ex
@@ -116,7 +116,7 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       # time), and the reader of a doc is never that author — not through a
       # `.md` sibling and not through the authenticated `/api/2.0`, which
       # `build/3` also serves.
-      likers: Enum.map(Posts.post_likers(post.id), &AgentDocs.person_ref/1),
+      likers: Enum.map(Posts.post_likers(post.id), &liker_ref/1),
       repost_count: counts.reposts,
       bookmark_count: engagement.bookmarks,
       # ...and the breakdown the card's "from other networks" panel shows when
@@ -187,7 +187,7 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       thread: thread_entries(thread),
       thread_truncated: thread_truncated?,
       like_count: counts.likes,
-      likers: Enum.map(Posts.post_likers(post.id), &AgentDocs.person_ref/1),
+      likers: Enum.map(Posts.post_likers(post.id), &liker_ref/1),
       repost_count: counts.reposts,
       bookmark_count: engagement.bookmarks,
       fediverse_like_count: engagement.fediverse_likes,
@@ -198,6 +198,11 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       fediverse_replies: remote_replies
     })
   end
+
+  # A liker is a member or a page (issue #1410); the md/txt renderers read
+  # `.name` off either shape, JSON/XML carry the map as is.
+  defp liker_ref(%Organization{} = page), do: organization_ref(page)
+  defp liker_ref(%User{} = user), do: AgentDocs.person_ref(user)
 
   # The organization's own reference, the counterpart of `AgentDocs.person_ref/1`.
   # `canonical_path/1` prefers the page's opt-in root handle, so the URL here is

--- a/lib/vutuv_web/components/organization_components.ex
+++ b/lib/vutuv_web/components/organization_components.ex
@@ -1,8 +1,9 @@
 defmodule VutuvWeb.OrganizationComponents do
   @moduledoc """
-  Shared kit-page pieces for verified organization pages (issue #929): the logo tile
-  (uploaded image or an initials fallback) and the verified-domain badge. Not
-  globally imported — `import VutuvWeb.OrganizationComponents` at the call site.
+  Shared kit-page pieces for verified organization pages (issue #929), the
+  verified-domain badge among them. Not globally imported — `import
+  VutuvWeb.OrganizationComponents` at the call site. The logo tile lives in
+  `VutuvWeb.UI` (issue #1410).
   """
 
   use Phoenix.Component
@@ -10,39 +11,13 @@ defmodule VutuvWeb.OrganizationComponents do
   use Gettext, backend: VutuvWeb.Gettext
 
   import VutuvWeb.ErrorHelpers
-  import VutuvWeb.UI, only: [input_class: 2]
+  # `organization_logo/1` lives in the kit (issue #1410): the shared face
+  # strips render it too, and `VutuvWeb.UI` cannot import this module back.
+  import VutuvWeb.UI, only: [input_class: 2, organization_logo: 1]
 
   alias Vutuv.Countries
   alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
-  alias Vutuv.Organizations.OrganizationImage
-
-  attr(:organization, :map, required: true)
-  attr(:version, :string, default: "feed")
-  attr(:class, :string, default: "h-16 w-16")
-
-  @doc "An organization's logo, or a brand-tint initials tile when it has none."
-  def organization_logo(assigns) do
-    ~H"""
-    <%= if @organization.logo do %>
-      <img
-        src={OrganizationImage.token_url(@organization.logo, @version)}
-        alt={@organization.name}
-        class={[@class, "rounded-2xl object-cover ring-1 ring-slate-200 dark:ring-slate-800"]}
-      />
-    <% else %>
-      <span
-        class={[
-          @class,
-          "flex items-center justify-center rounded-2xl bg-brand-50 font-bold text-brand-700 dark:bg-brand-900/40 dark:text-brand-100"
-        ]}
-        aria-hidden="true"
-      >
-        {initial(@organization.name)}
-      </span>
-    <% end %>
-    """
-  end
 
   attr(:domain, :string, required: true)
   attr(:class, :string, default: nil)
@@ -366,12 +341,4 @@ defmodule VutuvWeb.OrganizationComponents do
   def alias_kind_label("brand"), do: gettext("Brand")
   def alias_kind_label("abbreviation"), do: gettext("Abbreviation")
   def alias_kind_label(_), do: gettext("Alias")
-
-  defp initial(name) do
-    name
-    |> String.trim()
-    |> String.first()
-    |> Kernel.||("?")
-    |> String.upcase()
-  end
 end

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -25,9 +25,6 @@ defmodule VutuvWeb.PostComponents do
 
   import VutuvWeb.UI
   import VutuvWeb.UserHelpers, only: [full_name: 1]
-  # An organization post wears its organization's logo where a member's post
-  # wears an avatar (issue #1334).
-  import VutuvWeb.OrganizationComponents, only: [organization_logo: 1]
 
   alias Vutuv.Accounts.User
   alias Vutuv.Fediverse
@@ -3844,16 +3841,19 @@ defmodule VutuvWeb.PostComponents do
       names them, so the stack itself is decorative for assistive tech. --%>
       <.avatar_stack users={@reposters} cap={@cap} />
       <span class="min-w-0 truncate">
+        <%!-- `author_name/1` / `author_path/1`, not `full_name/1` / `~p`: a
+        reposter can be a page (`Posts.reposter_rosters/2`), which crashed the
+        member-only pair (issue #1410). --%>
         <%= if @others == 0 do %>
-          <.link href={~p"/#{@primary}"} class="hover:text-brand-700">
-            {gettext("Reposted by %{name}", name: full_name(@primary))}
+          <.link href={Posts.author_path(@primary)} class="hover:text-brand-700">
+            {gettext("Reposted by %{name}", name: UserHelpers.author_name(@primary))}
           </.link>
         <% else %>
           {ngettext(
             "Reposted by %{name} and %{formatted} other",
             "Reposted by %{name} and %{formatted} others",
             @others,
-            name: full_name(@primary),
+            name: UserHelpers.author_name(@primary),
             formatted: compact_count(@others)
           )}
         <% end %>
@@ -4001,14 +4001,16 @@ defmodule VutuvWeb.PostComponents do
           cap={Posts.likers_shown()}
         />
         <span class="min-w-0 text-sm text-slate-600 dark:text-slate-400">
+          <%!-- `author_name/1`, not `full_name/1`: the newest liker can be a
+          page (issue #1410), and `full_name/1` has no clause for one. --%>
           <%= if @others == 0 do %>
-            {gettext("Liked by %{name}", name: full_name(@primary))}
+            {gettext("Liked by %{name}", name: UserHelpers.author_name(@primary))}
           <% else %>
             {ngettext(
               "Liked by %{name} and %{formatted} other",
               "Liked by %{name} and %{formatted} others",
               @others,
-              name: full_name(@primary),
+              name: UserHelpers.author_name(@primary),
               formatted: compact_count(@others)
             )}
           <% end %>

--- a/lib/vutuv_web/components/ui.ex
+++ b/lib/vutuv_web/components/ui.ex
@@ -28,6 +28,9 @@ defmodule VutuvWeb.UI do
 
   alias Vutuv.Accounts.User
   alias Vutuv.DateRegions
+  alias Vutuv.Organizations.Organization
+  alias Vutuv.Organizations.OrganizationImage
+  alias Vutuv.Posts
   alias Vutuv.Tags.UserTag
   alias Vutuv.Uploads.Spec
   alias Vutuv.ViewerClock
@@ -1736,6 +1739,48 @@ defmodule VutuvWeb.UI do
     )
   end
 
+  attr(:organization, :map, required: true)
+  attr(:version, :string, default: "feed")
+  attr(:class, :string, default: "h-16 w-16")
+
+  @doc """
+  An organization's logo, or a brand-tint initials tile when it has none — the
+  page's twin of `<.avatar>`. Lives in the kit (issue #1410) because the shared
+  face strips render it too, and `VutuvWeb.OrganizationComponents` cannot be
+  imported here (it imports this module).
+  """
+  def organization_logo(assigns) do
+    ~H"""
+    <%= if @organization.logo do %>
+      <img
+        src={OrganizationImage.token_url(@organization.logo, @version)}
+        alt={@organization.name}
+        class={[@class, "rounded-2xl object-cover ring-1 ring-slate-200 dark:ring-slate-800"]}
+      />
+    <% else %>
+      <span
+        class={[
+          @class,
+          "flex items-center justify-center rounded-2xl bg-brand-50 font-bold text-brand-700 dark:bg-brand-900/40 dark:text-brand-100"
+        ]}
+        aria-hidden="true"
+      >
+        {organization_initial(@organization.name)}
+      </span>
+    <% end %>
+    """
+  end
+
+  # A page's monogram is deliberately ONE letter — the shipped look of every
+  # organization tile — where a member's `name_initials/1` takes two.
+  defp organization_initial(name) do
+    name
+    |> String.trim()
+    |> String.first()
+    |> Kernel.||("?")
+    |> String.upcase()
+  end
+
   @doc """
   A **stack of overlapping avatars**, each linking to that member's profile and
   carrying their name as its tooltip, with the rest collapsing into a trailing
@@ -1744,6 +1789,9 @@ defmodule VutuvWeb.UI do
   `aria-hidden` decoration. Used by the post card's "Reposted by" banner; the
   tag list page's bar (`<.endorsed_by>`) shares only the faces, since it is one
   link and needs its own geometry.
+
+  An entry is a member **or a page** (issue #1410, the permalink's "Liked by"
+  row): a `%Organization{}` renders its logo, named and linked to its own page.
   """
   attr(:users, :list, required: true)
   attr(:cap, :integer, default: 5)
@@ -1794,32 +1842,49 @@ defmodule VutuvWeb.UI do
   # The shingled faces, shared by `<.avatar_stack>` and the tag page's bar: a
   # profile link per face where the strip is decoration beside a sentence, plain
   # spans where the strip is itself one link (an <a> inside an <a> is invalid).
-  attr(:shown, :list, required: true, doc: "{user, index} pairs")
+  attr(:shown, :list, required: true, doc: "{member-or-page, index} pairs")
   attr(:size, :string, required: true)
   attr(:pull, :any, required: true)
   attr(:link?, :boolean, default: false)
 
   defp stack_faces(assigns) do
     ~H"""
-    <%= for {user, i} <- @shown do %>
+    <%= for {account, i} <- @shown do %>
       <.link
         :if={@link?}
-        href={~p"/#{user}"}
-        title={VutuvWeb.UserHelpers.full_name(user)}
+        href={Posts.author_path(account)}
+        title={VutuvWeb.UserHelpers.author_name(account)}
         class={["rounded-full ring-2 ring-white dark:ring-slate-900", i > 0 && @pull]}
         data-stack-face
       >
-        <.avatar user={user} size={@size} />
+        <.stack_face account={account} size={@size} />
       </.link>
       <span
         :if={!@link?}
-        title={VutuvWeb.UserHelpers.full_name(user)}
+        title={VutuvWeb.UserHelpers.author_name(account)}
         class={["rounded-full ring-2 ring-white dark:ring-slate-900", i > 0 && @pull]}
         data-stack-face
       >
-        <.avatar user={user} size={@size} />
+        <.stack_face account={account} size={@size} />
       </span>
     <% end %>
+    """
+  end
+
+  attr(:account, :map, required: true)
+  attr(:size, :string, required: true)
+
+  # A page's logo at the avatar's size: `rounded-2xl` on a face this small is a
+  # circle anyway, so the wrapper's `rounded-full` ring still hugs it.
+  defp stack_face(%{account: %Organization{}} = assigns) do
+    ~H"""
+    <.organization_logo organization={@account} class={avatar_size(@size)} />
+    """
+  end
+
+  defp stack_face(assigns) do
+    ~H"""
+    <.avatar user={@account} size={@size} />
     """
   end
 

--- a/lib/vutuv_web/live/message_live/index.ex
+++ b/lib/vutuv_web/live/message_live/index.ex
@@ -17,12 +17,11 @@ defmodule VutuvWeb.MessageLive.Index do
   """
   use VutuvWeb, :live_view
 
-  import VutuvWeb.OrganizationComponents, only: [organization_logo: 1]
-
   alias Vutuv.Chat
   alias Vutuv.Chat.{Conversation, Message}
   alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
+  alias Vutuv.Posts
   alias VutuvWeb.{Markdown, Presence}
 
   @typing_clear_ms 2500
@@ -557,8 +556,6 @@ defmodule VutuvWeb.MessageLive.Index do
 
   # Where the name links to. A page lives under /organizations/<slug>, and a
   # member at the root - one function so no call site has to remember which.
-  defp party_path(%Organization{} = page), do: Organizations.canonical_path(page)
-  defp party_path(user), do: ~p"/#{user}"
 
   # Only a member can be online or blocked. Deliberately NOT used for "is there
   # a request to answer" or "may I write here": a page conversation is created
@@ -719,7 +716,7 @@ defmodule VutuvWeb.MessageLive.Index do
                 <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
               </svg>
             </.link>
-            <.link navigate={party_path(@other)} class="flex min-w-0 items-center gap-2">
+            <.link navigate={Posts.author_path(@other)} class="flex min-w-0 items-center gap-2">
               <.party_avatar party={@other} />
               <h1 class="truncate font-semibold text-slate-800 dark:text-slate-100">
                 {display_name(@other)}

--- a/lib/vutuv_web/live/organization_live/following.ex
+++ b/lib/vutuv_web/live/organization_live/following.ex
@@ -28,9 +28,9 @@ defmodule VutuvWeb.OrganizationLive.Following do
   use VutuvWeb, :live_view
 
   import VutuvWeb.OrganizationComponents,
-    only: [manage_header: 1, organization_logo: 1, organization_location: 1]
+    only: [manage_header: 1, organization_location: 1]
 
-  import VutuvWeb.UserHelpers, only: [full_name: 1]
+  import VutuvWeb.UserHelpers, only: [author_name: 1]
 
   alias Vutuv.Accounts
   alias Vutuv.Accounts.User
@@ -40,6 +40,7 @@ defmodule VutuvWeb.OrganizationLive.Following do
   alias Vutuv.Moderation
   alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
+  alias Vutuv.Posts
   alias Vutuv.Social
   alias Vutuv.Tags
   alias VutuvWeb.Live.InitAssigns
@@ -171,14 +172,6 @@ defmodule VutuvWeb.OrganizationLive.Following do
 
   @impl true
   def handle_info(_message, socket), do: {:noreply, socket}
-
-  defp followee_name(%Organization{name: name}), do: name
-  defp followee_name(%User{} = user), do: full_name(user)
-
-  defp followee_path(%Organization{} = organization),
-    do: Organizations.canonical_path(organization)
-
-  defp followee_path(%User{username: username}), do: "/#{username}"
 
   defp follow_local(socket, organization, account) do
     case Social.follow_as_organization(organization, account) do
@@ -343,7 +336,7 @@ defmodule VutuvWeb.OrganizationLive.Following do
 
         <ul :if={@followees != []} class="mt-2 divide-y divide-slate-100 dark:divide-slate-800">
           <li :for={{follow, followee} <- @followees} class="flex items-center gap-4 py-4">
-            <.link navigate={followee_path(followee)} class="shrink-0">
+            <.link navigate={Posts.author_path(followee)} class="shrink-0">
               <.organization_logo
                 :if={match?(%Organization{}, followee)}
                 organization={followee}
@@ -354,10 +347,10 @@ defmodule VutuvWeb.OrganizationLive.Following do
 
             <div class="min-w-0 flex-1">
               <.link
-                navigate={followee_path(followee)}
+                navigate={Posts.author_path(followee)}
                 class="block truncate font-semibold text-slate-900 hover:text-brand-700 dark:text-slate-100 dark:hover:text-brand-300"
               >
-                {followee_name(followee)}
+                {author_name(followee)}
               </.link>
               <.organization_location
                 :if={match?(%Organization{}, followee)}

--- a/lib/vutuv_web/live/organization_live/post.ex
+++ b/lib/vutuv_web/live/organization_live/post.ex
@@ -21,8 +21,6 @@ defmodule VutuvWeb.OrganizationLive.Post do
 
   use VutuvWeb, :live_view
 
-  import VutuvWeb.OrganizationComponents, only: [organization_logo: 1]
-
   alias Vutuv.Organizations
   alias Vutuv.Posts
   alias VutuvWeb.Live.InitAssigns

--- a/lib/vutuv_web/live/post_live/thread.ex
+++ b/lib/vutuv_web/live/post_live/thread.ex
@@ -46,6 +46,7 @@ defmodule VutuvWeb.PostLive.Thread do
 
   use Gettext, backend: VutuvWeb.Gettext
 
+  alias Vutuv.Accounts.User
   alias Vutuv.Fediverse
   alias Vutuv.Posts
   alias Vutuv.Prefs
@@ -306,7 +307,11 @@ defmodule VutuvWeb.PostLive.Thread do
     %{
       users: users,
       total: (engagement && Posts.shown_counts(engagement).likes) || length(users),
-      private?: author? and Enum.any?(users, &(not Prefs.get(&1, :like_attribution?)))
+      # Members only: a page in the list (issue #1410) has no attribution
+      # preference to have opted out of.
+      private?:
+        author? and
+          Enum.any?(users, &(is_struct(&1, User) and not Prefs.get(&1, :like_attribution?)))
     }
   end
 

--- a/lib/vutuv_web/live/search_live.ex
+++ b/lib/vutuv_web/live/search_live.ex
@@ -32,8 +32,6 @@ defmodule VutuvWeb.SearchLive do
 
   import VutuvWeb.SavedSearchComponents
 
-  import VutuvWeb.OrganizationComponents, only: [organization_logo: 1]
-
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.RemoteFollow
   alias Vutuv.Posts

--- a/lib/vutuv_web/views/settings_html.ex
+++ b/lib/vutuv_web/views/settings_html.ex
@@ -6,7 +6,7 @@ defmodule VutuvWeb.SettingsHTML do
   # badge / role label pieces so a member's own pages read exactly like the
   # public directory rows.
   import VutuvWeb.OrganizationComponents,
-    only: [organization_logo: 1, organization_location: 1, kind_badge: 1, role_label: 1]
+    only: [organization_location: 1, kind_badge: 1, role_label: 1]
 
   # Saved-search view helpers (cadence options, kind badge, filter summary) are
   # the same ones the /jobs and /search "Save search" control uses (issue #935).

--- a/lib/vutuv_web/views/user_helpers.ex
+++ b/lib/vutuv_web/views/user_helpers.ex
@@ -52,7 +52,9 @@ defmodule VutuvWeb.UserHelpers do
   siblings — because the fork was written out in each of them and the next kind
   of author would have to be remembered five times over. It asks
   `Vutuv.Posts.author/1` rather than matching the preloaded association, which
-  reads as a type check and behaves as a preload check.
+  reads as a type check and behaves as a preload check. Not only authors: any
+  member-or-page actor is named through here — a liker (issue #1410), a
+  reposter, an organization's followee row.
   """
   def author_name(%Post{} = post), do: author_name(Posts.author(post))
   def author_name(%Organization{name: name}), do: name

--- a/lib/vutuv_web/views/work_experience_html.ex
+++ b/lib/vutuv_web/views/work_experience_html.ex
@@ -1,7 +1,6 @@
 defmodule VutuvWeb.WorkExperienceHTML do
   @moduledoc false
   use VutuvWeb, :html
-  import VutuvWeb.OrganizationComponents, only: [organization_logo: 1]
   import VutuvWeb.UserHelpers
 
   alias Vutuv.Organizations

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.328.1",
+      version: "7.328.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/support/posts_helpers.ex
+++ b/test/support/posts_helpers.ex
@@ -2,6 +2,8 @@ defmodule Vutuv.PostsHelpers do
   @moduledoc false
 
   alias Vutuv.Posts
+  alias Vutuv.Posts.PostLike
+  alias Vutuv.Repo
 
   @doc """
   Creates a post for `author`, unwrapping the `{:ok, post}` tuple so tests can
@@ -10,5 +12,13 @@ defmodule Vutuv.PostsHelpers do
   def create_post!(author, attrs) do
     {:ok, post} = Posts.create_post(author, attrs)
     post
+  end
+
+  @doc """
+  A page's like on `post` (issue #1410), inserted directly — without the
+  publisher-role and DNS-verification pipeline `Posts.like_post/3` sits behind.
+  """
+  def page_like!(post, page) do
+    Repo.insert!(%PostLike{post_id: post.id, organization_id: page.id})
   end
 end

--- a/test/vutuv/post_likers_test.exs
+++ b/test/vutuv/post_likers_test.exs
@@ -85,6 +85,46 @@ defmodule Vutuv.PostLikersTest do
     end
   end
 
+  describe "a page's like (issue #1410)" do
+    test "a page is listed beside the members, newest first", %{post: post} do
+      fan = insert_activated_user()
+      :ok = Posts.like_post(fan, post)
+      page = insert(:organization)
+      page_like!(post, page)
+
+      assert liker_ids(post) == [page.id, fan.id]
+    end
+
+    test "a frozen page keeps its count but loses its face", %{post: post} do
+      page = insert(:organization, frozen_at: NaiveDateTime.utc_now(:second))
+      page_like!(post, page)
+
+      # The #1408 shape — see the per-kind gate in `Posts.post_likers/2`.
+      assert liker_ids(post) == []
+      assert Posts.engagement_counts(post.id).likes == 1
+    end
+
+    test "a page that is not active has no face either", %{post: post} do
+      page = insert(:organization, status: "pending", verified_at: nil)
+      page_like!(post, page)
+
+      assert liker_ids(post) == []
+    end
+
+    test "a page has no attribution preference and is always named", %{post: post} do
+      with_installation_defaults(%{like_attribution?: false})
+
+      untouched = insert_activated_user()
+      :ok = Posts.like_post(untouched, post)
+      page = insert(:organization)
+      page_like!(post, page)
+
+      # The member inherits the installation's opt-out; the page must not —
+      # see the page exemption in `scope_attributed/2`.
+      assert liker_ids(post) == [page.id]
+    end
+  end
+
   describe "the preference resolves through all three layers" do
     test "the shipped default attributes a member who never touched it", %{post: post} do
       assert Prefs.shipped_defaults()[:like_attribution?] == true

--- a/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
+++ b/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
@@ -607,6 +607,20 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     end
   end
 
+  test "post permalink: a page's like is named like a member's (issue #1410)", %{post: post} do
+    page = insert(:organization, name: "Drift Likering GmbH")
+    page_like!(post, page)
+
+    rendered = formats_for("/drift_tester/posts/#{post.id}")
+
+    doc = Jason.decode!(rendered.json)
+    assert [liker] = doc["likers"]
+    assert liker["name"] == "Drift Likering GmbH"
+    assert liker["url"] =~ "/organizations/#{page.slug}"
+
+    for format <- [rendered.md, rendered.txt], do: assert(format =~ "Drift Likering GmbH")
+  end
+
   test "post permalink: a liker who opted out is named in no format, and still counted", %{
     post: post
   } do

--- a/test/vutuv_web/live/post_feed_live_test.exs
+++ b/test/vutuv_web/live/post_feed_live_test.exs
@@ -1175,6 +1175,27 @@ defmodule VutuvWeb.PostFeedLiveTest do
     end
   end
 
+  describe "a page's repost (issue #1410)" do
+    test "the banner names the page like a member", %{conn: conn} do
+      {conn, viewer} = create_and_login_user(conn)
+      author = other_user()
+      page = insert(:organization, name: "Bannerwerk GmbH")
+
+      Repo.insert!(%Vutuv.Social.Follow{
+        follower_id: viewer.id,
+        followee_organization_id: page.id
+      })
+
+      {:ok, post} = Posts.create_post(author, %{body: "Reshared by a page."})
+      Repo.insert!(%Vutuv.Posts.PostRepost{post_id: post.id, organization_id: page.id})
+
+      {:ok, _live, html} = live(conn, ~p"/feed")
+
+      assert html =~ "Reposted by Bannerwerk GmbH"
+      assert html =~ ~s(href="/organizations/#{page.slug}")
+    end
+  end
+
   describe "mute from the feed" do
     test "a followed author's post carries a Mute toggle wired to the mute route", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)

--- a/test/vutuv_web/live/post_likers_row_test.exs
+++ b/test/vutuv_web/live/post_likers_row_test.exs
@@ -95,6 +95,34 @@ defmodule VutuvWeb.PostLikersRowTest do
     end
   end
 
+  describe "a page's like (issue #1410)" do
+    test "a page gets a face: its name in the sentence, its logo linking to its page", %{
+      post: post
+    } do
+      page = insert(:organization, name: "Formkurve GmbH")
+      page_like!(post, page)
+
+      {:ok, _view, html} = thread_view(post)
+
+      assert html =~ "data-post-likers"
+      assert html =~ "Liked by Formkurve GmbH"
+      assert face_count(html) == 1
+      assert html =~ ~s(href="/organizations/#{page.slug}")
+    end
+
+    test "a page and a member share the row like two members would", %{post: post} do
+      like!(post, first_name: "Fanny", last_name: "Fan")
+      page = insert(:organization, name: "Formkurve GmbH")
+      page_like!(post, page)
+
+      {:ok, _view, html} = thread_view(post)
+
+      # The page liked last, so the sentence names it; the member keeps a face.
+      assert html =~ "Liked by Formkurve GmbH and 1 other"
+      assert face_count(html) == 2
+    end
+  end
+
   describe "the post's author" do
     test "sees the liker who opted out, and is told the row is theirs alone", %{
       post: post,


### PR DESCRIPTION
**Symptom:** Das Like einer Seite bekam in der „Gefällt …"-Zeile des Beitrags-Permalinks nie ein Gesicht, es faltete sich stumm ins „+N" (#1410).

**Änderung:** `Posts.post_likers/2` listet jetzt Mitglieder und Seiten, jede Art hinter ihrem eigenen Sichtbarkeits-Gatter: eine eingefrorene Seite fällt raus wie ein eingefrorenes Mitglied, die Attribution-Einstellung bleibt eine Mitglieder-Sache. `organization_logo/1` zieht dafür ins `VutuvWeb.UI`-Kit. Gesichter-Leiste, Satz daneben und die Agent-Formate nennen die Seite mit Logo, Namen und Link auf ihre Seite.

**Nebenbei:** Das „Reposted by"-Banner crashte, sobald der neueste Reposter eine Seite war (`full_name/1` kennt keine Seiten) — gleiche Weiche, mit Regressionstest behoben.

<img src="https://raw.githubusercontent.com/wintermeyer/vutuv/shots/pr-1583/liked_by_row.png" width="560">

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*
