### PR TITLE
Ein Kommando richtet einen Fork ein (v7.329.1)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,19 @@ developer guide (`mise` for Erlang/Elixir, PostgreSQL 17, libvips, then
 PIN login flow. Installing vutuv to *run* it (rather than develop it) is
 covered separately in [docs/ADMINS.md](docs/ADMINS.md).
 
+## Working from a fork
+
+Set your clone up once, right after cloning:
+
+```bash
+./scripts/fork_setup.sh
+```
+
+It adds an `upstream` remote for this repository and makes it fetch-only, so
+`origin` (your fork) stays the only thing you push to. Branch from and rebase
+onto `upstream/main` — this repository moves fast enough that a fork is behind
+within hours, and your fork's `main` is only a mirror of it.
+
 ## Ground rules
 
 - **Start every feature or bugfix with a test** that covers it, then make it

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.328.2",
+      version: "7.329.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/scripts/fork_setup.sh
+++ b/scripts/fork_setup.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Sets a fork of this repository up to track it: adds a fetch-only `upstream`
+# remote, fetches it, and points `gh` at the canonical repository. Safe to
+# re-run at any time.
+#
+#   ./scripts/fork_setup.sh
+#
+# The `gh` step is not cosmetic: without a default repository, `gh api
+# repos/{owner}/{repo}` resolves to nothing in a fork clone, and
+# `scripts/bump_version.exs` quietly falls back to reading `mix.exs` alone.
+
+set -euo pipefail
+
+CANONICAL_REPO=${VUTUV_CANONICAL_REPO:-wintermeyer/vutuv}
+CANONICAL_URL="https://github.com/$CANONICAL_REPO.git"
+
+toplevel=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "Run this from inside your fork's checkout." >&2
+  exit 1
+}
+cd "$toplevel"
+
+origin_url=$(git remote get-url origin 2>/dev/null) || origin_url=""
+origin_slug=$(printf '%s' "$origin_url" |
+  sed -E 's,.*github\.com[:/]|\.git$,,g' | tr '[:upper:]' '[:lower:]')
+
+if [ "$origin_slug" = "$CANONICAL_REPO" ]; then
+  echo "origin is $CANONICAL_REPO — this is not a fork, nothing to set up."
+  exit 0
+fi
+
+echo "Setting up a fork of $CANONICAL_REPO (origin: ${origin_slug:-none})"
+
+# Replace the remote rather than rewriting its URL: `git remote set-url` leaves
+# a missing or stale fetch refspec in place, and then nothing ever lands in
+# `upstream/main` while every command still reports success.
+git remote remove upstream 2>/dev/null || true
+git remote add upstream "$CANONICAL_URL"
+# Fetch-only, so that a stray `git push upstream` cannot aim at someone else's
+# repository.
+git remote set-url --push upstream DISABLED_use_origin
+echo "  ✓ upstream → $CANONICAL_REPO (fetch-only)"
+
+# GIT_TERMINAL_PROMPT=0 and the closed stdin matter: on a 401 the fetch would
+# otherwise sit on a username prompt forever, and nobody is at this terminal.
+if err=$(GIT_TERMINAL_PROMPT=0 git fetch --quiet upstream main 2>&1 </dev/null) &&
+  sha=$(git rev-parse --short upstream/main 2>/dev/null); then
+  echo "  ✓ fetched upstream/main ($sha)"
+else
+  echo "  ! could not fetch upstream/main: ${err:-no such branch}"
+fi
+
+if command -v gh >/dev/null 2>&1; then
+  if err=$(gh repo set-default "$CANONICAL_REPO" 2>&1 </dev/null); then
+    echo "  ✓ gh default repository → $CANONICAL_REPO"
+  else
+    echo "  ! gh repo set-default failed: $err"
+  fi
+else
+  echo "  ! gh is not installed — run 'gh repo set-default $CANONICAL_REPO' later"
+fi
+
+echo
+echo "Branch from upstream/main and push to origin only."
+case "$origin_slug" in
+  "" | *:*) ;;
+  */*) echo "Keep your fork's main a mirror: gh repo sync $origin_slug --source $CANONICAL_REPO --branch main" ;;
+esac


### PR DESCRIPTION
Teil 1 von 6 aus #1552.

**TL;DR** Ein Skript, das einen Fork-Klon einmalig einrichtet. Wer dieses Repository direkt geklont hat, merkt nichts davon.

**Problem.** Wer aus einem Fork beiträgt, legt `upstream` von Hand an und übersieht dabei zwei Dinge: die Push-URL bleibt scharf, ein versehentliches `git push upstream` zielt also hierher; und ohne `gh repo set-default` löst `gh api repos/{owner}/{repo}` im Fork-Klon nichts auf — `scripts/bump_version.exs` liest dann still nur `mix.exs` statt der Nummern, die offene PRs belegen.

**Jetzt:** `./scripts/fork_setup.sh` erledigt beides, mehrfach ausführbar.

**Für andere ändert sich nichts.** Ist `origin` dieses Repository, endet das Skript mit „nothing to set up"; automatisch aufgerufen wird es nirgends.

**Deploy:** hot.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*
