### PR TITLE
Ein Fork sieht beim Sitzungsstart, dass er zurückliegt (v7.330.1)

### DIFF
--- a/.claude/hooks/fork-status.sh
+++ b/.claude/hooks/fork-status.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# SessionStart hook: in a fork, report how far it has fallen behind the
+# canonical repository. A SessionStart hook's stdout is added to the session's
+# context, so this reaches an agent before it picks a base branch.
+#
+# Silent unless there is something to say — and silent altogether in a clone of
+# the canonical repository. Nothing local can prove a checkout *is* a fork (it
+# is byte-for-byte identical to its parent), so this proves the opposite: that
+# `origin` is the canonical repository. Opt out with
+# `git config vutuv.fork-sync false`.
+
+set -uo pipefail
+
+CANONICAL_REPO=${VUTUV_CANONICAL_REPO:-wintermeyer/vutuv}
+
+toplevel=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+cd "$toplevel" || exit 0
+
+[ "$(git config --bool vutuv.fork-sync 2>/dev/null)" = "false" ] && exit 0
+
+origin_url=$(git remote get-url origin 2>/dev/null) || exit 0
+origin_slug=$(printf '%s' "$origin_url" |
+  sed -E 's,.*github\.com[:/]|\.git$,,g' | tr '[:upper:]' '[:lower:]')
+
+# An unchanged slug means the sed matched no GitHub URL, so this is some other
+# host and none of the advice below applies.
+case "$origin_slug" in
+  "" | *:* | *//* | "$CANONICAL_REPO") exit 0 ;;
+esac
+
+if ! git remote get-url upstream >/dev/null 2>&1; then
+  echo "This looks like a fork of $CANONICAL_REPO with no remote for it."
+  echo "Run \`./scripts/fork_setup.sh\` once, then branch from \`upstream/main\`."
+  exit 0
+fi
+
+# Bounded and non-interactive: nobody is at this terminal to answer a password
+# prompt, and a stalled network must not hold up the session.
+export GIT_TERMINAL_PROMPT=0
+export GIT_SSH_COMMAND='ssh -oBatchMode=yes -oConnectTimeout=5'
+fetch() {
+  git -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=5 \
+    fetch --quiet --no-tags "$1" main </dev/null 2>/dev/null
+}
+
+if ! fetch upstream || ! git rev-parse --verify --quiet upstream/main >/dev/null; then
+  echo "Could not reach $CANONICAL_REPO — cannot tell how far behind this fork is."
+  exit 0
+fi
+fetch origin
+
+mirror_behind=$(git rev-list --count origin/main..upstream/main)
+head_behind=$(git rev-list --count HEAD..upstream/main)
+[ "${mirror_behind:-0}" -eq 0 ] && [ "${head_behind:-0}" -eq 0 ] && exit 0
+
+echo "## Fork status"
+echo
+[ "${mirror_behind:-0}" -gt 0 ] &&
+  echo "- \`origin/main\` is **$mirror_behind behind** — \`gh repo sync $origin_slug --source $CANONICAL_REPO --branch main && git fetch origin\`"
+[ "${head_behind:-0}" -gt 0 ] &&
+  echo "- \`$(git rev-parse --abbrev-ref HEAD)\` is **$head_behind behind** — \`git rebase upstream/main\`"
+echo
+echo "Branch from and rebase onto \`upstream/main\`; \`origin/main\` is only a mirror of it."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,18 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/fork-status.sh\"",
+            "timeout": 30,
+            "statusMessage": "Checking fork status…"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,19 @@ developer guide (`mise` for Erlang/Elixir, PostgreSQL 17, libvips, then
 PIN login flow. Installing vutuv to *run* it (rather than develop it) is
 covered separately in [docs/ADMINS.md](docs/ADMINS.md).
 
+## Working from a fork
+
+Set your clone up once, right after cloning:
+
+```bash
+./scripts/fork_setup.sh
+```
+
+It adds an `upstream` remote for this repository and makes it fetch-only, so
+`origin` (your fork) stays the only thing you push to. Branch from and rebase
+onto `upstream/main` — this repository moves fast enough that a fork is behind
+within hours, and your fork's `main` is only a mirror of it.
+
 ## Ground rules
 
 - **Start every feature or bugfix with a test** that covers it, then make it

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.329.1",
+      version: "7.330.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.328.2",
+      version: "7.329.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/scripts/fork_setup.sh
+++ b/scripts/fork_setup.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Sets a fork of this repository up to track it: adds a fetch-only `upstream`
+# remote, fetches it, and points `gh` at the canonical repository. Safe to
+# re-run at any time.
+#
+#   ./scripts/fork_setup.sh
+#
+# The `gh` step is not cosmetic: without a default repository, `gh api
+# repos/{owner}/{repo}` resolves to nothing in a fork clone, and
+# `scripts/bump_version.exs` quietly falls back to reading `mix.exs` alone.
+
+set -euo pipefail
+
+CANONICAL_REPO=${VUTUV_CANONICAL_REPO:-wintermeyer/vutuv}
+CANONICAL_URL="https://github.com/$CANONICAL_REPO.git"
+
+toplevel=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "Run this from inside your fork's checkout." >&2
+  exit 1
+}
+cd "$toplevel"
+
+origin_url=$(git remote get-url origin 2>/dev/null) || origin_url=""
+origin_slug=$(printf '%s' "$origin_url" |
+  sed -E 's,.*github\.com[:/]|\.git$,,g' | tr '[:upper:]' '[:lower:]')
+
+if [ "$origin_slug" = "$CANONICAL_REPO" ]; then
+  echo "origin is $CANONICAL_REPO — this is not a fork, nothing to set up."
+  exit 0
+fi
+
+echo "Setting up a fork of $CANONICAL_REPO (origin: ${origin_slug:-none})"
+
+# Replace the remote rather than rewriting its URL: `git remote set-url` leaves
+# a missing or stale fetch refspec in place, and then nothing ever lands in
+# `upstream/main` while every command still reports success.
+git remote remove upstream 2>/dev/null || true
+git remote add upstream "$CANONICAL_URL"
+# Fetch-only, so that a stray `git push upstream` cannot aim at someone else's
+# repository.
+git remote set-url --push upstream DISABLED_use_origin
+echo "  ✓ upstream → $CANONICAL_REPO (fetch-only)"
+
+# GIT_TERMINAL_PROMPT=0 and the closed stdin matter: on a 401 the fetch would
+# otherwise sit on a username prompt forever, and nobody is at this terminal.
+if err=$(GIT_TERMINAL_PROMPT=0 git fetch --quiet upstream main 2>&1 </dev/null) &&
+  sha=$(git rev-parse --short upstream/main 2>/dev/null); then
+  echo "  ✓ fetched upstream/main ($sha)"
+else
+  echo "  ! could not fetch upstream/main: ${err:-no such branch}"
+fi
+
+if command -v gh >/dev/null 2>&1; then
+  if err=$(gh repo set-default "$CANONICAL_REPO" 2>&1 </dev/null); then
+    echo "  ✓ gh default repository → $CANONICAL_REPO"
+  else
+    echo "  ! gh repo set-default failed: $err"
+  fi
+else
+  echo "  ! gh is not installed — run 'gh repo set-default $CANONICAL_REPO' later"
+fi
+
+echo
+echo "Branch from upstream/main and push to origin only."
+case "$origin_slug" in
+  "" | *:*) ;;
+  */*) echo "Keep your fork's main a mirror: gh repo sync $origin_slug --source $CANONICAL_REPO --branch main" ;;
+esac


### PR DESCRIPTION
Teil 2 von 6 aus #1552, baut auf #1587 auf.

**TL;DR** Ein Hook, der beim Sitzungsstart meldet, wie weit ein Fork hinter `main` liegt. In einem Klon dieses Repositories bleibt er stumm.

**Problem.** Ein Fork fällt hier innerhalb von Stunden zurück, ohne Hinweis. Der Branch startet dann von veralteter Basis, und der Versions-Bump greift eine Nummer, die `main` schon vergeben hat — beides fällt erst beim Merge auf.

**Warum beim Sitzungsstart:** dort fällt die Entscheidung über die Basis; beim Push ist es zu spät.

**Wo:** `.claude/hooks/fork-status.sh`, registriert in `.claude/settings.json`.

**Kostet dieses Repository nichts:** ist `origin` `wintermeyer/vutuv`, endet der Hook sofort — 42 ms für zehn Läufe, keine Ausgabe, kein Netz. Er liest nur, schweigt wenn nichts zurückliegt, und ist per `git config vutuv.fork-sync false` abschaltbar.

**Deploy:** hot.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*
