### PR TITLE
Was API 6 verspricht, hält jetzt auch (v7.334.0)

### DIFF
--- a/docs/architecture/mastodon-api.md
+++ b/docs/architecture/mastodon-api.md
@@ -71,12 +71,12 @@ Server discovery, login and the core social workflow:
 - `GET /api/v1/accounts/verify_credentials`
 - `GET /api/v1/timelines/home`
 - reading, creating, editing and deleting statuses, plus personal replies
-- `POST /api/v1/media`, `POST /api/v2/media`, `GET /api/v1/media/:id` and
-  `PUT /api/v1/media/:id` for photo attachments
+- `POST /api/v1/media`, `POST /api/v2/media`, `GET /api/v1/media/:id`,
+  `PUT /api/v1/media/:id` and `DELETE /api/v1/media/:id` for photo attachments
 - favourite/unfavourite, reblog/unreblog and bookmark/unbookmark status actions
-- account lookup, relationships and following lists; follow/unfollow,
-  mute/unmute and the local member block/unblock operations that vutuv already
-  supports
+- `GET /api/v1/accounts/lookup`, `/accounts/:id`, relationships and following
+  lists; follow/unfollow, mute/unmute and the local member block/unblock
+  operations that vutuv already supports
 - `GET /api/v2/search` — accounts, statuses and hashtags, plus exact
   `@user@host` resolution
 - `GET /api/v1/statuses/:id/context` and `/source`
@@ -85,13 +85,51 @@ Server discovery, login and the core social workflow:
   tabs asked different questions and got one answer) and
   `/timelines/tag/:hashtag`
 - `GET /api/v1/notifications` (+ `/unread_count`, `/clear`, `/:id`) and the
-  grouped `GET /api/v2/notifications` a 4.3+ client asks for
+  grouped `GET /api/v2/notifications` a 4.3+ client asks for, with its three
+  companions `/api/v2/notifications/:group_key`, `/:group_key/accounts` and
+  `POST /:group_key/dismiss`
+- `GET /api/v1/tags/:id`, `POST /api/v1/tags/:id/follow` / `/unfollow` and
+  `GET /api/v1/followed_tags` — vutuv's own tag subscriptions (issue #872)
 - `GET` and `POST /api/v1/markers` — where a client left off reading
 - `GET /api/v1/bookmarks`, `/favourites`, `/blocks`, `/mutes`,
   `/accounts/:id/followers`, `/statuses/:id/favourited_by` and `/reblogged_by`
 - `PATCH /api/v1/accounts/update_credentials` and `POST /api/v1/reports`
 - `POST|GET|PUT|DELETE /api/v1/push/subscription`
 - the streaming websocket at `/api/v1/streaming`
+
+### What `api_versions` promises
+
+`api_versions.mastodon` is feature detection, not a label: a client reads the
+number and then calls the endpoints it stands for, so every one of them has to
+answer. Mastodon's own history (`lib/mastodon/version.rb`) makes 6 the 4.4
+generation, and each bump names one thing:
+
+| version | what it stands for | here |
+| --- | --- | --- |
+| 1, 2 | grouped notifications, moved to `/api/v2` | the list and its three `group_key` companions |
+| 3 | `attribution_domains` on `update_credentials` | **not served** — vutuv has no such concept; see below |
+| 4 | `DELETE /api/v1/media/:id`, `delete_media` on status delete | the method is served; the flag is moot (see below) |
+| 5 | the `blur` filter action | **not served** — the filter API is a stub; see below |
+| 6 | `POST /api/v1/tags/:name/feature` / `/unfeature` | **not served** — see below |
+
+**`delete_media` is not a flag here, it is the only behaviour.** Mastodon keeps
+a deleted post's pictures around for its delete-and-redraft, and the parameter
+opts out of that; `Vutuv.Posts.delete_post/1` removes the files with the row
+either way. So the promise is kept whichever way a client sends it — and the
+divergence worth knowing is the other direction: a client that deletes a post
+meaning to redraft it finds the `media_attachments` ids it was handed back
+already gone.
+
+The three that are **not** served answer the adapter's JSON 404 rather than the
+website's HTML, so a client meets a missing resource and not a broken server.
+Each needs something vutuv does not have yet: attribution domains have no
+counterpart at all (the nearest thing, `Vutuv.Profiles.LinkVerification`, proves
+a member owns a page and says nothing about who may attribute an article to
+them); the filter API needs `Vutuv.ContentFilters` mapped onto Mastodon's
+`FilterV2`, including an action vutuv's hide-only model has no equivalent for;
+and featuring a hashtag needs a vutuv concept, since the tags on a profile carry
+other members' endorsements and an "unfeature" that dropped them would throw
+away somebody else's vouch.
 
 Status creation accepts public text posts with photos. Organization posts are
 top-level, matching vutuv's existing organization post model. Polls and
@@ -116,6 +154,31 @@ endpoint uses; `one_status/2` is the same path for a single row). Rendering them
 without a viewer, as the first cut did, left every heart empty on a post the
 member had just liked — so tapping it *removed* the like. `shown_counts/1` folds
 in what other networks did with the same post, exactly as the card does.
+
+**A status carries what the post really holds.** Its `tags` are the ones the
+author chose in the composer — the chips the website prints under the card — so
+a client can offer "open hashtag" on them; a `#hashtag` written into the body is
+deliberately not repeated there, because it is already a link inside `content`
+and vutuv files the two apart for exactly that reason
+(`Vutuv.Posts.PostHashtag`). `mentions` comes from the `post_mentions` index the
+`"mention"` notification kind reads, in one query for a whole page, and it is
+what a client builds a reply prefill from. `language` is the author's own
+declaration, which a client filters its timeline on. `edited_at` follows the
+website's rule to the minute — an `updated_at` more than sixty seconds past
+`inserted_at` is what its card calls edited — so the hint and the field cannot
+disagree about a post. All four used to be sent empty, and an empty list is a
+claim: it says the post has no tags and names nobody.
+
+**An account's `fields` are the webpages the member has proved are their own**
+(`Vutuv.Profiles.LinkVerification` — the rel=me, DNS and `.well-known` proofs
+the website marks with an emerald tick), each with the `verified_at` that earns
+the same tick in a client. Only the proven ones: an unproven link would arrive
+with `verified_at: null`, which a client renders as an ordinary row, and that is
+not the statement the field makes. They ride the preload every post already
+carries (`Vutuv.Profiles.VerifiedLinks.preload_spec/0`, the one owner of that
+scope), so a page of statuses pays nothing; the endpoints that answer with a
+single account load them, and a list that did not renders none rather than
+firing a query per row.
 
 **Every account carries its own picture, its banner and its figures.** Mastodon's
 account entity is the same object everywhere, and a client renders a profile

--- a/lib/vutuv/mastodon_api/presenter.ex
+++ b/lib/vutuv/mastodon_api/presenter.ex
@@ -9,15 +9,18 @@ defmodule Vutuv.MastodonApi.Presenter do
   alias Vutuv.Fediverse.Note
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.Identity
   alias Vutuv.MastodonApi
   alias Vutuv.MastodonApi.AccountCounts
   alias Vutuv.Moderation.ImageScans
-  alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
   alias Vutuv.Organizations.OrganizationImage
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostImage
+  alias Vutuv.Profiles.Url
+  alias Vutuv.Profiles.VerifiedLinks
+  alias Vutuv.Tags.Tag
   alias Vutuv.UUIDv7
   alias VutuvWeb.Markdown
   alias VutuvWeb.UserHelpers
@@ -53,17 +56,18 @@ defmodule Vutuv.MastodonApi.Presenter do
       display_name: UserHelpers.full_name(user),
       note: note(user.headline),
       created_at: created_at(user, user.id),
-      url: MastodonApi.main_url("/" <> user.username),
+      url: profile_url(user),
       avatar: avatar,
       header: header,
       header_static: header,
+      fields: account_fields(user),
       group: false
     })
     |> Map.merge(count_fields(counts))
   end
 
   def account(%Organization{} = organization, counts) do
-    handle = organization.username || organization.slug
+    handle = acct_handle(organization)
     header = organization_image(organization.cover, fallback_header())
 
     base_account(%{
@@ -73,7 +77,7 @@ defmodule Vutuv.MastodonApi.Presenter do
       display_name: organization.name,
       note: note(organization.description),
       created_at: created_at(organization, organization.id),
-      url: MastodonApi.main_url(Organizations.canonical_path(organization)),
+      url: profile_url(organization),
       avatar: organization_image(organization.logo, fallback_avatar()),
       header: header,
       header_static: header,
@@ -116,14 +120,13 @@ defmodule Vutuv.MastodonApi.Presenter do
   counts travel with the record.
   """
   def statuses(items, viewer) when is_list(items) do
-    engagements =
-      items
-      |> Enum.map(&engaged_post_id/1)
-      |> Enum.reject(&is_nil/1)
-      |> Posts.post_engagement_map(viewer)
+    post_ids = items |> Enum.map(&engaged_post_id/1) |> Enum.reject(&is_nil/1)
+
+    engagements = Posts.post_engagement_map(post_ids, viewer)
+    mentions = Posts.mention_map(post_ids)
 
     items
-    |> Enum.map(&rendered_status(&1, engagements))
+    |> Enum.map(&rendered_status(&1, engagements, mentions))
     |> fill_account_counts(viewer)
   end
 
@@ -173,13 +176,14 @@ defmodule Vutuv.MastodonApi.Presenter do
   defp engaged_post_id(%{post: %Post{id: id}} = entry) when not is_struct(entry), do: id
   defp engaged_post_id(_other), do: nil
 
-  defp rendered_status(%Post{} = post, engagements), do: status(post, engagements[post.id])
+  defp rendered_status(%Post{} = post, engagements, mentions),
+    do: status(post, engagements[post.id], mentions[post.id])
 
-  defp rendered_status(%{post: %Post{} = post} = entry, engagements)
+  defp rendered_status(%{post: %Post{} = post} = entry, engagements, mentions)
        when not is_struct(entry),
-       do: reshared(entry, status(post, engagements[post.id]))
+       do: reshared(entry, status(post, engagements[post.id], mentions[post.id]))
 
-  defp rendered_status(other, _engagements), do: status_from_entry(other)
+  defp rendered_status(other, _engagements, _mentions), do: status_from_entry(other)
 
   # A reshare in Mastodon's shape: an outer status by whoever passed the post
   # on, carrying the post itself under `reblog`.
@@ -237,9 +241,9 @@ defmodule Vutuv.MastodonApi.Presenter do
   defp reshare_time(%{at: at}), do: timestamp(at)
   defp reshare_time(_entry), do: nil
 
-  def status(post, engagement \\ nil)
+  def status(post, engagement \\ nil, mentions \\ nil)
 
-  def status(%Post{} = post, engagement) do
+  def status(%Post{} = post, engagement, mentions) do
     author = Posts.author(post)
     content = post.body |> Markdown.render_post(loaded_images(post)) |> safe_html()
 
@@ -252,7 +256,11 @@ defmodule Vutuv.MastodonApi.Presenter do
         uri: MastodonApi.main_url(Posts.path(post)),
         account: account(author),
         media_attachments: media_attachments(post),
-        visibility: visibility(post, engagement)
+        visibility: visibility(post, engagement),
+        language: post.language,
+        edited_at: edited_at(post),
+        tags: status_tags(post),
+        mentions: status_mentions(post, mentions)
       }
       |> Map.merge(reply_fields(post))
       |> Map.merge(engagement_fields(engagement))
@@ -260,7 +268,7 @@ defmodule Vutuv.MastodonApi.Presenter do
     base_status(fields)
   end
 
-  def status(%RemotePost{} = post, _engagement) do
+  def status(%RemotePost{} = post, _engagement, _mentions) do
     base_status(%{
       id: "remote-" <> post.id,
       created_at: timestamp(post.published_at),
@@ -273,7 +281,7 @@ defmodule Vutuv.MastodonApi.Presenter do
     })
   end
 
-  def status(%Note{} = note, _engagement) do
+  def status(%Note{} = note, _engagement, _mentions) do
     base_status(%{
       id: "remote-note-" <> note.id,
       created_at: timestamp(note.received_at),
@@ -427,6 +435,48 @@ defmodule Vutuv.MastodonApi.Presenter do
     )
   end
 
+  # Mastodon's profile `fields`, filled from the webpages a member has PROVED
+  # are their own (`Vutuv.Profiles.LinkVerification`) — the rel=me / DNS /
+  # well-known proofs the website marks with an emerald tick. That is the same
+  # claim `verified_at` makes in a client, which is why these and not the whole
+  # link list: an unproven link rendered here would carry no `verified_at`, and
+  # a client draws no distinction between "not proved" and "a plain row", so it
+  # would read as the member's own list of trusted addresses.
+  #
+  # They are already preloaded wherever a post renders
+  # (`Posts.render_preloads/0` scopes the author's `:urls` to exactly this set),
+  # so a page of statuses pays nothing; an account whose links were not loaded
+  # answers the empty list rather than raising, like every other association
+  # here.
+  defp account_fields(%User{} = user),
+    do: user |> VerifiedLinks.of() |> Enum.map(&account_field/1)
+
+  defp account_field(%Url{} = link) do
+    address = VerifiedLinks.address(link)
+
+    %{
+      name: field_name(link, address),
+      value: field_value(link, address),
+      verified_at: timestamp(link.verified_at)
+    }
+  end
+
+  defp field_name(%Url{description: description}, _address)
+       when is_binary(description) and description != "",
+       do: description
+
+  defp field_name(_link, address), do: address
+
+  # HTML, because Mastodon's field value is: a client renders it as markup and
+  # follows the anchor. `rel="me"` is the same statement the proof itself rests
+  # on.
+  defp field_value(%Url{value: value}, address) do
+    ~s(<a href=") <>
+      Plug.HTML.html_escape(value) <>
+      ~s(" rel="me nofollow noopener noreferrer" target="_blank">) <>
+      Plug.HTML.html_escape(address) <> "</a>"
+  end
+
   # The AI image gate is not re-asked here: `Vutuv.Uploads.url/3` answers "no
   # image" for a picture still in moderation limbo (the file waits in
   # quarantine), so a pending avatar already comes back as the `data:` default
@@ -521,6 +571,86 @@ defmodule Vutuv.MastodonApi.Presenter do
       reblogged: engagement.reposted? == true,
       bookmarked: engagement.bookmarked? == true
     }
+  end
+
+  @doc """
+  One tag in Mastodon's shape.
+
+  `name` is the **slug**, not the display name: it is what a client puts back
+  into `/api/v1/timelines/tag/:hashtag` and into a `#hashtag` it composes, so it
+  has to be the spelling `/tags/:slug` answers to. `history` stays empty —
+  vutuv keeps no per-day usage series, and an invented one would be read as
+  fact.
+
+  `following?` is the viewer's own subscription and defaults to false, which is
+  the honest answer for a list rendered without a viewer (a status's own tags,
+  an anonymous search). `featuring` is flat false until vutuv has a concept to
+  fill it (issue #1592); the key stays because a 4.4 client reads it.
+  """
+  def tag(tag, following? \\ false)
+
+  def tag(%Tag{} = tag, following?) do
+    %{
+      name: tag.slug,
+      url: MastodonApi.main_url("/tags/" <> tag.slug),
+      history: [],
+      following: following?,
+      featuring: false
+    }
+  end
+
+  # The tags a client may act on: the ones the author CHOSE in the composer,
+  # which are the chips the website prints under the card. A `#hashtag` written
+  # into the body is deliberately not repeated here — it is already a link
+  # inside `content`, filed apart from the chosen tags for exactly that reason
+  # (`Vutuv.Posts.PostHashtag`), and listing it would print it twice in every
+  # client that renders both.
+  #
+  # Preloaded on every reader that renders a post (`Posts.render_preloads/0`),
+  # so this costs nothing; an unloaded association answers the empty list rather
+  # than raising, the way the rest of this module treats one.
+  defp status_tags(%Post{tags: tags}) when is_list(tags), do: Enum.map(tags, &tag/1)
+  defp status_tags(_post), do: []
+
+  # Who the post names with an `@handle`, from the batch `statuses/2` reads for
+  # the whole page. Every status that reaches a client comes through there —
+  # `one_status/2` wraps a single row into the same path — so an unbatched call
+  # renders no mentions rather than firing a query per post, exactly the way
+  # `status_tags/1` above treats an association nobody preloaded.
+  defp status_mentions(_post, nil), do: []
+  defp status_mentions(_post, mentioned), do: Enum.map(mentioned, &mention/1)
+
+  # A client reads this to prefill a reply and to resolve the `@handle` links in
+  # `content`, so `acct` has to be the handle exactly as the body spells it.
+  #
+  # The URL comes from `Vutuv.Identity.path/1`, the seam that owns where a
+  # member-or-page actor links; a hand-built copy here is one more place the
+  # next author kind would have to be remembered, and it could disagree with the
+  # `url` of the very same account embedded beside it in the status.
+  defp mention(mentioned) do
+    handle = acct_handle(mentioned)
+
+    %{
+      id: mentioned.id,
+      username: handle,
+      acct: handle,
+      url: profile_url(mentioned)
+    }
+  end
+
+  defp profile_url(identity), do: MastodonApi.main_url(Identity.path(identity))
+
+  # A page is addressed by its handle where it has one and by its slug
+  # otherwise — the same fallback its canonical URL uses.
+  defp acct_handle(%User{username: username}), do: username
+
+  defp acct_handle(%Organization{} = organization),
+    do: organization.username || organization.slug
+
+  # `Posts.edited?/1` owns the rule, so the website card's "edited" hint and this
+  # field are the same claim rather than two copies of one threshold.
+  defp edited_at(%Post{} = post) do
+    if Posts.edited?(post), do: timestamp(post.updated_at)
   end
 
   # vutuv has no visibility column: a post is public until it carries a denial,

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -91,7 +91,7 @@ defmodule Vutuv.Posts do
   alias Vutuv.Posts.ScreenshotWorker
   alias Vutuv.Posts.TopPosters
   alias Vutuv.Prefs
-  alias Vutuv.Profiles.Url
+  alias Vutuv.Profiles.VerifiedLinks
   alias Vutuv.Repo
   alias Vutuv.Social.Follow
   alias Vutuv.Tags
@@ -1613,6 +1613,22 @@ defmodule Vutuv.Posts do
       NaiveDateTime.diff(NaiveDateTime.utc_now(), inserted_at) < edit_window_minutes() * 60
   end
 
+  # A save within this many seconds of writing is not an edit: the composer and
+  # the pipeline both touch `updated_at` right after an insert.
+  @edit_mark_slack 60
+
+  @doc """
+  Whether `post` has been changed since it was written.
+
+  vutuv stores no edit timestamp, so the rule is `updated_at` having moved away
+  from `inserted_at`. It lives here rather than at its two readers — the post
+  card's "edited" hint and the Mastodon adapter's `edited_at` — because those
+  two must not be able to disagree about a post, and two copies of one
+  threshold is exactly the arrangement that drifts.
+  """
+  def edited?(%Post{inserted_at: created, updated_at: changed}),
+    do: NaiveDateTime.diff(changed, created) > @edit_mark_slack
+
   @doc """
   Whether the author may still edit this post: inside the edit window and not
   yet liked, reposted or answered by anyone (issue #1023). Costs one query; the
@@ -1894,11 +1910,39 @@ defmodule Vutuv.Posts do
   LiveViews don't each run their own query on mount. `post_id` rides in the
   value too; otherwise the shape matches `post_engagement/2`.
   """
+  def post_engagement_map([], _viewer), do: %{}
+
   def post_engagement_map(post_ids, viewer) do
     from(p in Post, where: p.id in ^post_ids)
     |> engagement_select(engagement_viewer_id(viewer))
     |> Repo.all()
     |> Map.new(fn engagement -> {engagement.id, engagement} end)
+  end
+
+  @doc """
+  Who each of `post_ids` names with an `@handle`, as
+  `%{post_id => [%User{} | %Organization{}]}`.
+
+  One batched read for a whole page, the way `post_engagement_map/2` reads the
+  action bar's figures — a mention list built per post would be a round trip per
+  card. (The `preload` costs three round trips, not one: the rows, then one per
+  association. Three per page, never per post, is the point.) The rows come from `post_mentions`, the resolved index `Vutuv.Posts`
+  reconciles on every save, so this asks the same table the `"mention"`
+  notification kind reads and cannot drift from what was actually notified.
+
+  Both author kinds ride one row (issue #1336, CHECK-enforced to exactly one),
+  so a page is listed here as readily as a member.
+  """
+  def mention_map([]), do: %{}
+
+  def mention_map(post_ids) when is_list(post_ids) do
+    from(m in PostMention,
+      where: m.post_id in ^post_ids,
+      order_by: m.id,
+      preload: [:user, :organization]
+    )
+    |> Repo.all()
+    |> Enum.group_by(& &1.post_id, &(&1.user || &1.organization))
   end
 
   defp engagement_viewer_id(%User{id: id}), do: id
@@ -4962,9 +5006,7 @@ defmodule Vutuv.Posts do
   # with fifty links still ships only the handful they proved — and ordered,
   # because an un-ordered multi-row preload comes back in whatever order
   # Postgres likes (id order is creation order, ids being UUID v7).
-  defp verified_links_preload do
-    [urls: from(u in Url, where: not is_nil(u.verified_at), order_by: u.id)]
-  end
+  defp verified_links_preload, do: VerifiedLinks.preload_spec()
 
   @doc """
   The root-relative permalink path, e.g.

--- a/lib/vutuv/profiles/verified_links.ex
+++ b/lib/vutuv/profiles/verified_links.ex
@@ -74,6 +74,21 @@ defmodule Vutuv.Profiles.VerifiedLinks do
   end
 
   @doc """
+  The `Repo.preload/2` spec that loads exactly the links `of/1` would keep.
+
+  One owner for the scope, because three surfaces load it and a fourth reads
+  the result: the post preloads (`Vutuv.Posts.post_preloads/0`), the Mastodon
+  adapter's account endpoints, and anything else that renders a member outside
+  a post. Scoped in the query rather than filtered afterwards, so a member with
+  fifty links still ships the handful they proved — and ordered, because an
+  un-ordered multi-row preload comes back in whatever order Postgres likes (id
+  order is creation order, ids being UUID v7).
+  """
+  def preload_spec do
+    [urls: from(u in Url, where: not is_nil(u.verified_at), order_by: u.id)]
+  end
+
+  @doc """
   The link among `verified_links` that proves `url`, or `nil`.
 
   Pass only the **post author's** verified links (see the module doc).

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -320,10 +320,7 @@ defmodule VutuvWeb.PostComponents do
       |> assign(:frozen?, post.frozen_at != nil)
       |> assign(:reply_banner, reply_banner(post, assigns.show_reply_banner, assigns[:viewer]))
       |> assign(:reposters, repost_roster(assigns))
-      |> assign(
-        :edited?,
-        NaiveDateTime.diff(post.updated_at, post.inserted_at) > 60
-      )
+      |> assign(:edited?, Posts.edited?(post))
 
     ~H"""
     <.card :if={@surface == :card} class={@class}>

--- a/lib/vutuv_web/controllers/mastodon_api/account_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/account_controller.ex
@@ -13,20 +13,42 @@ defmodule VutuvWeb.MastodonApi.AccountController do
   alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
   alias Vutuv.Posts
+  alias Vutuv.Profiles.VerifiedLinks
+  alias Vutuv.Repo
   alias Vutuv.Social
   alias Vutuv.UUIDv7
+  alias VutuvWeb.MastodonApi.Handles
   alias VutuvWeb.MastodonApi.Pagination
 
   def verify_credentials(conn, _params) do
     subject = conn.assigns.current_organization || conn.assigns.current_user
 
-    json(conn, Presenter.account(subject, counts(conn, subject)))
+    json(conn, Presenter.account(with_links(subject), counts(conn, subject)))
   end
+
+  @doc """
+  The account a handle names (`GET /api/v1/accounts/lookup?acct=…`).
+
+  A client calls this constantly — it is what resolves the `@handle` in a
+  compose box, in a shared link and in a profile it was pointed at — and until
+  now it fell through to the adapter's 404, so every one of those turned into a
+  dead end although the member was right here. Local only, which is Mastodon's
+  own contract for this endpoint (its WebFinger-free twin of search); see
+  `VutuvWeb.MastodonApi.Handles`.
+  """
+  def lookup(conn, %{"acct" => acct}) do
+    case Handles.local(conn, acct) do
+      nil -> not_found(conn)
+      account -> json(conn, Presenter.account(with_links(account), counts(conn, account)))
+    end
+  end
+
+  def lookup(conn, _params), do: not_found(conn)
 
   def show(conn, %{"id" => id}) do
     case target(conn, id) do
       nil -> not_found(conn)
-      account -> json(conn, Presenter.account(account, counts(conn, account)))
+      account -> json(conn, Presenter.account(with_links(account), counts(conn, account)))
     end
   end
 
@@ -434,6 +456,16 @@ defmodule VutuvWeb.MastodonApi.AccountController do
   end
 
   defp visible_target(_conn, nil), do: nil
+
+  # The webpages a member has PROVED are their own, which is what the account's
+  # Mastodon `fields` are built from. Loaded here rather than in the presenter,
+  # so this stays the endpoints that answer with a **single** account: a
+  # follower list renders forty of them, and a presenter that fetched for itself
+  # would turn that page into forty queries. A member whose links were not
+  # loaded renders no fields (`Vutuv.Profiles.VerifiedLinks.of/1`), never a
+  # crash and never a query per row.
+  defp with_links(%User{} = user), do: Repo.preload(user, VerifiedLinks.preload_spec())
+  defp with_links(other), do: other
 
   defp profile_viewer(%{assigns: %{current_organization: nil, current_user: user}}), do: user
   defp profile_viewer(_conn), do: nil

--- a/lib/vutuv_web/controllers/mastodon_api/media_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/media_controller.ex
@@ -61,6 +61,32 @@ defmodule VutuvWeb.MastodonApi.MediaController do
     end
   end
 
+  @doc """
+  Throws away an upload that was never posted (`DELETE /api/v1/media/:id`).
+
+  One of the two methods Mastodon's **API version 4** stands for, and the half a
+  composer needs: a client uploads eagerly, so every picture a member picks and
+  then changes their mind about is already on this server. Without this the file
+  sat there until the next day's sweep of unattached leftovers
+  (`Vutuv.Posts.PendingImageSweeper`) — which is a promise vutuv keeps, but not
+  the one a member makes when they tap the ✕ on a photo.
+
+  Only an **unattached** upload of the member's own, like every other method
+  here: once a picture belongs to a post it is removed through the status, not
+  behind its back. Mastodon answers 200 with an empty body, and a client reads
+  the status rather than the payload.
+  """
+  def delete(conn, %{"id" => id}) do
+    case own_media(conn, id) do
+      %PostImage{} = image ->
+        :ok = Posts.delete_pending_image(image)
+        json(conn, %{})
+
+      nil ->
+        not_found(conn)
+    end
+  end
+
   defp upload(conn, %{"file" => %Plug.Upload{} = upload} = params, ready_status) do
     with :ok <- within_rate_limit(conn),
          {:ok, image} <- Posts.create_pending_image(conn.assigns.current_user, upload) do

--- a/lib/vutuv_web/controllers/mastodon_api/notification_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/notification_controller.ex
@@ -134,6 +134,66 @@ defmodule VutuvWeb.MastodonApi.NotificationController do
   defp group_key(%{type: type, status: %{id: status_id}}), do: type <> "-" <> status_id
   defp group_key(%{id: id}), do: id
 
+  @doc """
+  One group (`GET /api/v2/notifications/:group_key`).
+
+  The companion a 4.3+ client needs beside the grouped list: it opens a row from
+  a push notification, from a deep link or after coming back to a stale list, and
+  it has only the `group_key` the list gave it. Without this the call fell
+  through to the adapter's 404, so the row a member tapped in the notification
+  centre opened on an error.
+
+  The key is looked for over the same window the grouped list pages
+  (`@group_window`), not over all of history: a group is a description of a page
+  of notifications — Mastodon's own grouping is per page too, which is why the
+  entity carries `page_min_id` / `page_max_id` — so a key that has scrolled out
+  of that window no longer names anything, and 404 is the honest answer rather
+  than a group assembled from a different set of rows than the one the client
+  was shown.
+  """
+  def group(conn, %{"group_key" => key}) do
+    case group_members(conn, key) do
+      [] -> not_found(conn)
+      members -> json(conn, notification_group(key, members))
+    end
+  end
+
+  @doc """
+  The accounts behind one group (`GET /api/v2/notifications/:group_key/accounts`).
+
+  What a client calls to fill "Alice, Bob and 4 others liked your post": the
+  grouped list carries `sample_account_ids` only, and the full roster is this.
+  """
+  def group_accounts(conn, %{"group_key" => key}) do
+    case group_members(conn, key) do
+      [] -> not_found(conn)
+      members -> json(conn, members |> Enum.map(& &1.account) |> uniq_by_id())
+    end
+  end
+
+  @doc """
+  Dismisses one group (`POST /api/v2/notifications/:group_key/dismiss`).
+
+  Accepted and does nothing, for the same reason the per-item dismiss does:
+  vutuv's notifications are derived from the likes and follows themselves, so
+  there is no row to remove. A 404 here is what makes a client that swipes a row
+  away show an error instead of letting it go.
+  """
+  def dismiss_group(conn, _params), do: json(conn, %{})
+
+  # The page a group key is resolved against. Wider than a default request page,
+  # because a client holds keys from a list it has scrolled, and narrow enough
+  # that this stays one bounded read.
+  @group_window 80
+
+  defp group_members(conn, key) do
+    conn
+    |> load(%Pagination{limit: @group_window})
+    |> Enum.filter(&mapped?/1)
+    |> then(&notifications(conn, &1))
+    |> Enum.filter(&(group_key(&1) == key))
+  end
+
   def show(conn, %{"id" => id}) do
     bare = bare_id(%{id: id})
 
@@ -142,7 +202,7 @@ defmodule VutuvWeb.MastodonApi.NotificationController do
     |> Enum.filter(&mapped?/1)
     |> Enum.find(&(bare_id(&1) == bare))
     |> case do
-      nil -> conn |> put_status(404) |> json(%{error: "Record not found"})
+      nil -> not_found(conn)
       item -> json(conn, hd(notifications(conn, [item])))
     end
   end
@@ -159,6 +219,8 @@ defmodule VutuvWeb.MastodonApi.NotificationController do
   # Derived items cannot be deleted one at a time; answering 200 keeps a client
   # that swipes a row from treating it as a failure.
   def dismiss(conn, _params), do: json(conn, %{})
+
+  defp not_found(conn), do: conn |> put_status(404) |> json(%{error: "Record not found"})
 
   defp load(conn, page) do
     conn.assigns.current_user.id

--- a/lib/vutuv_web/controllers/mastodon_api/search_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/search_controller.ex
@@ -3,16 +3,12 @@ defmodule VutuvWeb.MastodonApi.SearchController do
 
   use VutuvWeb, :controller
 
-  alias Vutuv.Accounts
   alias Vutuv.Accounts.User
-  alias Vutuv.Fediverse
-  alias Vutuv.MastodonApi
   alias Vutuv.MastodonApi.Presenter
-  alias Vutuv.Moderation
-  alias Vutuv.Organizations
-  alias Vutuv.Organizations.Organization
   alias Vutuv.Posts
   alias Vutuv.Repo
+  alias Vutuv.Tags
+  alias VutuvWeb.MastodonApi.Handles
 
   def search(conn, %{"q" => query} = params) do
     query = String.trim(query)
@@ -25,7 +21,7 @@ defmodule VutuvWeb.MastodonApi.SearchController do
     json(conn, %{
       accounts: section(type, "accounts", fn -> accounts(resolved, free_text, limit) end),
       statuses: section(type, "statuses", fn -> statuses(free_text, limit, viewer(conn)) end),
-      hashtags: section(type, "hashtags", fn -> hashtags(free_text, limit) end)
+      hashtags: section(type, "hashtags", fn -> hashtags(free_text, limit, viewer(conn)) end)
     })
   end
 
@@ -78,22 +74,29 @@ defmodule VutuvWeb.MastodonApi.SearchController do
 
   defp viewer(conn), do: conn.assigns.current_organization || conn.assigns.current_user
 
-  # Mastodon's Tag entity. vutuv tags live at `/tags/:slug` on the main host,
-  # which is where a client's "open in browser" should land.
-  defp hashtags(%{tags: tags}, limit) when is_list(tags) do
+  # Mastodon's Tag entity, rendered by the one owner of that shape
+  # (`Presenter.tag/2`) so the search results, `/api/v1/tags/:id` and
+  # `/api/v1/followed_tags` cannot describe the same topic differently.
+  #
+  # `following` used to be a hardcoded `false`, which is a claim and not a
+  # placeholder: a client draws its Follow button from it, so a topic the member
+  # already follows was offered to them again. One query per search fills it for
+  # the whole page.
+  defp hashtags(%{tags: tags}, limit, viewer) when is_list(tags) do
+    followed = followed_tag_ids(viewer)
+
     tags
     |> Enum.take(limit)
-    |> Enum.map(fn tag ->
-      %{
-        name: tag.slug,
-        url: MastodonApi.main_url("/tags/#{tag.slug}"),
-        history: [],
-        following: false
-      }
-    end)
+    |> Enum.map(&Presenter.tag(&1, MapSet.member?(followed, &1.id)))
   end
 
-  defp hashtags(_no_free_text, _limit), do: []
+  defp hashtags(_no_free_text, _limit, _viewer), do: []
+
+  # A page identity follows topics of its own, but a search runs for whoever is
+  # reading; answering with the page's subscriptions would tick a box the member
+  # never ticked, so an `%Organization{}` falls through to the empty set.
+  defp followed_tag_ids(%User{} = user), do: user |> Tags.followed_tag_ids() |> MapSet.new()
+  defp followed_tag_ids(_page_identity), do: MapSet.new()
 
   defp limit(%{"limit" => value}) do
     case Integer.parse(to_string(value)) do
@@ -104,61 +107,5 @@ defmodule VutuvWeb.MastodonApi.SearchController do
 
   defp limit(_params), do: 20
 
-  defp resolve("@" <> address, conn) do
-    case String.split(address, "@", parts: 2) do
-      [handle] -> resolve_local(conn, handle)
-      [handle, host] -> resolve_qualified(conn, address, handle, String.downcase(host))
-    end
-  end
-
-  defp resolve(query, conn), do: resolve_local(conn, query)
-
-  # `client_host?/1`, not a list of the two hosts we happen to think of: it also
-  # answers for the `www.` alias, and serving a site at both the apex and its
-  # `www.` name is the oldest convention on the web. Spelled out, the miss was
-  # not a polite "unknown handle" — `@member@www.<our host>` fell through to the
-  # remote branch, so this installation WebFingered **itself** over the network
-  # and told the member their own site was unreachable.
-  defp resolve_qualified(conn, address, handle, host) do
-    if MastodonApi.client_host?(host),
-      do: resolve_local(conn, handle),
-      else: resolve_remote(conn, address)
-  end
-
-  defp resolve_remote(conn, address) do
-    subject = conn.assigns.current_organization || conn.assigns.current_user
-
-    case Fediverse.resolve_remote_account(subject, "@" <> address) do
-      {:ok, account} -> account
-      _error -> nil
-    end
-  end
-
-  defp resolve_local(conn, handle) do
-    normalized = String.downcase(handle)
-
-    normalized
-    |> local_account()
-    |> visible_to_identity(conn)
-  end
-
-  defp local_account(handle) do
-    Accounts.get_user_by_username(handle) ||
-      Organizations.get_organization_by_username(handle) ||
-      Organizations.get_organization_by_slug(handle)
-  end
-
-  defp visible_to_identity(%User{} = user, conn) do
-    viewer = if is_nil(conn.assigns.current_organization), do: conn.assigns.current_user
-    if Moderation.profile_visible_to?(user, viewer), do: user
-  end
-
-  defp visible_to_identity(%Organization{} = organization, conn) do
-    current_id = conn.assigns.current_organization && conn.assigns.current_organization.id
-
-    if Organizations.public_visible?(organization) or current_id == organization.id,
-      do: organization
-  end
-
-  defp visible_to_identity(nil, _conn), do: nil
+  defp resolve(query, conn), do: Handles.resolve(conn, query)
 end

--- a/lib/vutuv_web/controllers/mastodon_api/tag_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/tag_controller.ex
@@ -1,0 +1,91 @@
+defmodule VutuvWeb.MastodonApi.TagController do
+  @moduledoc """
+  Mastodon's hashtag endpoints, mapped onto vutuv's topics.
+
+  vutuv has had tag following since issue #872 — a private subscription that
+  pulls a topic's posts into the member's `/feed`, with no owner to notify and
+  no public follower list — which is Mastodon's followed hashtag down to the
+  silence. The adapter nevertheless answered `/api/v1/followed_tags` with a
+  hardcoded empty list and had no follow route at all, so a client showed the
+  member no tags, offered "Follow" on a topic they already followed, and 404ed
+  when they pressed it.
+
+  A **page identity** cannot act here. vutuv does let a page follow a topic
+  (`Tags.follow_tag_as_organization/2`), but Mastodon has no notion of posting
+  as somebody else, so a client acting for a page has no way to say which of the
+  two it means — and silently subscribing the member instead is the wrong guess
+  in the direction that is hardest to notice. It answers 422, the same refusal
+  the account relationships use for an action an identity cannot perform.
+  """
+
+  use VutuvWeb, :controller
+
+  alias Vutuv.MastodonApi.Presenter
+  alias Vutuv.Organizations.Organization
+  alias Vutuv.Tags
+  alias Vutuv.Tags.Tag
+
+  @doc """
+  One topic (`GET /api/v1/tags/:id`).
+
+  The `:id` a client sends is the hashtag as written, so it is matched by slug —
+  and through an alias to the topic it was merged into (#1338), because a client
+  holding an old spelling should land on the topic rather than on a dead end.
+  """
+  def show(conn, %{"id" => id}) do
+    case Tags.resolve_tag_by_slug(id) do
+      %Tag{} = tag -> json(conn, Presenter.tag(tag, following?(conn, tag)))
+      nil -> not_found(conn)
+    end
+  end
+
+  def follow(conn, %{"id" => id}), do: subscribe(conn, id, :follow)
+  def unfollow(conn, %{"id" => id}), do: subscribe(conn, id, :unfollow)
+
+  @doc "The topics this member follows (`GET /api/v1/followed_tags`)."
+  def followed(%{assigns: %{current_organization: %Organization{}}} = conn, _params),
+    do: json(conn, [])
+
+  def followed(conn, _params) do
+    tags = Tags.followed_tags(conn.assigns.current_user)
+
+    # `true` by construction — every tag this list returns is one the member
+    # follows — so there is nothing to look up per row.
+    json(conn, Enum.map(tags, &Presenter.tag(&1, true)))
+  end
+
+  # A page identity is refused before anything is looked up: vutuv does let a
+  # page follow a topic (`Tags.follow_tag_as_organization/2`), but Mastodon has
+  # no notion of acting as somebody else, so a client acting for a page has no
+  # way to say which of the two it means — and quietly subscribing the member
+  # instead is the wrong guess in the direction hardest to notice.
+  defp subscribe(%{assigns: %{current_organization: %Organization{}}} = conn, _id, _action),
+    do: unsupported(conn)
+
+  defp subscribe(conn, id, action) do
+    case Tags.resolve_tag_by_slug(id) do
+      %Tag{} = tag ->
+        apply_subscription(conn.assigns.current_user, tag, action)
+        # The answer states the outcome the action just decided, rather than
+        # asking the database to confirm it: a client flips its button back on
+        # the next read if the reply disagrees.
+        json(conn, Presenter.tag(tag, action == :follow))
+
+      nil ->
+        not_found(conn)
+    end
+  end
+
+  defp apply_subscription(user, tag, :follow), do: Tags.follow_tag(user, tag)
+  defp apply_subscription(user, tag, :unfollow), do: Tags.unfollow_tag(user, tag)
+
+  # `show/2` is the one read that has to ask, because nothing about the request
+  # says whether this member already follows the topic.
+  defp following?(%{assigns: %{current_organization: %Organization{}}}, _tag), do: false
+  defp following?(conn, tag), do: Tags.tag_followed?(conn.assigns.current_user, tag)
+
+  defp not_found(conn), do: conn |> put_status(404) |> json(%{error: "Record not found"})
+
+  defp unsupported(conn),
+    do: conn |> put_status(422) |> json(%{error: "This identity cannot perform that action"})
+end

--- a/lib/vutuv_web/mastodon_api/handles.ex
+++ b/lib/vutuv_web/mastodon_api/handles.ex
@@ -1,0 +1,103 @@
+defmodule VutuvWeb.MastodonApi.Handles do
+  @moduledoc """
+  Turning a handle a client sent into the account it names.
+
+  One owner for the whole grammar, because two endpoints ask the same question
+  and would otherwise answer it differently: `GET /api/v2/search?resolve=true`
+  and `GET /api/v1/accounts/lookup`. They differ in exactly one thing — whether
+  a handle we have never seen may cost a WebFinger request — so that is the one
+  thing this module splits (`resolve/2` may, `local/2` never does).
+
+  Members and organization pages share one handle namespace here, so `@acme`
+  names one of the two and never both; a page is also reachable by its slug,
+  which is the address its canonical URL carries.
+  """
+
+  alias Vutuv.Accounts
+  alias Vutuv.Accounts.User
+  alias Vutuv.Fediverse
+  alias Vutuv.MastodonApi
+  alias Vutuv.Moderation
+  alias Vutuv.Organizations
+  alias Vutuv.Organizations.Organization
+
+  @doc """
+  The account `query` names, resolving an unknown `@user@host` over the network.
+
+  This is the search page's "resolve" behaviour, and the network call is the
+  reason it is not the default anywhere else.
+  """
+  def resolve(conn, query), do: parse(conn, query, true)
+
+  @doc """
+  The account `query` names **without** ever leaving this installation.
+
+  Mastodon's own `/api/v1/accounts/lookup` is defined as the WebFinger-free
+  twin of search, and a client leans on it: it is what the compose window calls
+  on every `@` it sees, so a version that reached out would spend somebody's
+  hourly follow budget on typing. A handle on a host that is not ours therefore
+  answers nothing here rather than being fetched.
+  """
+  def local(conn, query), do: parse(conn, query, false)
+
+  defp parse(conn, "@" <> address, remote?), do: parse(conn, address, remote?)
+
+  defp parse(conn, address, remote?) when is_binary(address) do
+    case String.split(address, "@", parts: 2) do
+      [handle] -> local_account(conn, handle)
+      [handle, host] -> qualified(conn, address, handle, String.downcase(host), remote?)
+    end
+  end
+
+  defp parse(_conn, _query, _remote?), do: nil
+
+  # `client_host?/1`, not a list of the two hosts we happen to think of: it also
+  # answers for the `www.` alias, and serving a site at both the apex and its
+  # `www.` name is the oldest convention on the web. Spelled out, the miss was
+  # not a polite "unknown handle" — `@member@www.<our host>` fell through to the
+  # remote branch, so this installation WebFingered **itself** over the network
+  # and told the member their own site was unreachable.
+  defp qualified(conn, address, handle, host, remote?) do
+    cond do
+      MastodonApi.client_host?(host) -> local_account(conn, handle)
+      remote? -> remote_account(conn, address)
+      true -> nil
+    end
+  end
+
+  defp remote_account(conn, address) do
+    subject = conn.assigns.current_organization || conn.assigns.current_user
+
+    case Fediverse.resolve_remote_account(subject, "@" <> address) do
+      {:ok, account} -> account
+      _error -> nil
+    end
+  end
+
+  defp local_account(conn, handle) do
+    handle
+    |> String.downcase()
+    |> known_account()
+    |> visible_to_identity(conn)
+  end
+
+  defp known_account(handle) do
+    Accounts.get_user_by_username(handle) ||
+      Organizations.get_organization_by_username(handle) ||
+      Organizations.get_organization_by_slug(handle)
+  end
+
+  defp visible_to_identity(%User{} = user, conn) do
+    viewer = if is_nil(conn.assigns.current_organization), do: conn.assigns.current_user
+    if Moderation.profile_visible_to?(user, viewer), do: user
+  end
+
+  defp visible_to_identity(%Organization{} = organization, conn) do
+    current_id = conn.assigns.current_organization && conn.assigns.current_organization.id
+
+    if Organizations.public_visible?(organization) or current_id == organization.id,
+      do: organization
+  end
+
+  defp visible_to_identity(nil, _conn), do: nil
+end

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -233,6 +233,12 @@ defmodule VutuvWeb.Router do
       assigns: %{mastodon_scope: "read:follows"}
     )
 
+    # Before `/accounts/:id`, which would otherwise match "lookup" as an id. The
+    # handle-to-account call a client makes on every `@` it renders.
+    get("/api/v1/accounts/lookup", AccountController, :lookup,
+      assigns: %{mastodon_scope: "read:accounts"}
+    )
+
     get("/api/v1/accounts/:id", AccountController, :show,
       assigns: %{mastodon_scope: "read:accounts"}
     )
@@ -308,6 +314,20 @@ defmodule VutuvWeb.Router do
       assigns: %{mastodon_scope: "read:notifications"}
     )
 
+    # The three companions of that list. A client holds a `group_key` from it and
+    # opens, fills or dismisses the row with these; all three used to 404.
+    get("/api/v2/notifications/:group_key/accounts", NotificationController, :group_accounts,
+      assigns: %{mastodon_scope: "read:notifications"}
+    )
+
+    post("/api/v2/notifications/:group_key/dismiss", NotificationController, :dismiss_group,
+      assigns: %{mastodon_scope: "write:notifications"}
+    )
+
+    get("/api/v2/notifications/:group_key", NotificationController, :group,
+      assigns: %{mastodon_scope: "read:notifications"}
+    )
+
     get("/api/v1/notifications/unread_count", NotificationController, :unread_count,
       assigns: %{mastodon_scope: "read:notifications"}
     )
@@ -332,8 +352,21 @@ defmodule VutuvWeb.Router do
       assigns: %{mastodon_scope: "read:lists"}
     )
 
-    get("/api/v1/followed_tags", CompatibilityController, :empty,
+    # vutuv has followed tags (issue #872); this used to answer a hardcoded
+    # empty list, so a client showed none of them and offered "Follow" on every
+    # topic the member already follows.
+    get("/api/v1/followed_tags", TagController, :followed,
       assigns: %{mastodon_scope: "read:follows"}
+    )
+
+    get("/api/v1/tags/:id", TagController, :show, assigns: %{mastodon_scope: "read"})
+
+    post("/api/v1/tags/:id/follow", TagController, :follow,
+      assigns: %{mastodon_scope: "write:follows"}
+    )
+
+    post("/api/v1/tags/:id/unfollow", TagController, :unfollow,
+      assigns: %{mastodon_scope: "write:follows"}
     )
 
     get("/api/v2/filters", CompatibilityController, :empty,
@@ -416,6 +449,12 @@ defmodule VutuvWeb.Router do
 
     get("/api/v1/media/:id", MediaController, :show, assigns: %{mastodon_scope: "write:media"})
     put("/api/v1/media/:id", MediaController, :update, assigns: %{mastodon_scope: "write:media"})
+
+    # Mastodon API version 4: a client that uploads eagerly can take an unposted
+    # picture back instead of leaving it for the next day's sweep.
+    delete("/api/v1/media/:id", MediaController, :delete,
+      assigns: %{mastodon_scope: "write:media"}
+    )
 
     post("/api/v1/statuses", StatusController, :create,
       assigns: %{mastodon_scope: "write:statuses"}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.332.6",
+      version: "7.334.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/controllers/mastodon_api/api_version_six_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/api_version_six_test.exs
@@ -1,0 +1,285 @@
+defmodule VutuvWeb.MastodonApi.ApiVersionSixTest do
+  @moduledoc """
+  What `api_versions: %{mastodon: 6}` promises a client, checked against what
+  the adapter actually answers.
+
+  Mastodon's API version is a feature-detection number, not a label: a client
+  reads it out of `/api/v2/instance` and then calls the endpoints that number
+  stands for. Each bump names one change (`lib/mastodon/version.rb` in
+  mastodon/mastodon): 3 is `attribution_domains`, **4 the media-deletion
+  methods**, 5 the `blur` filter action and **6 the hashtag feature/unfeature
+  API** — with 1 and 2 carrying grouped notifications and their move to
+  `/api/v2`. Claiming 6 while a client's call for one of them falls through to
+  the adapter's 404 is a broken server, not a missing feature.
+
+  Beside those, the entity fields vutuv has data for and used to send empty.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Vutuv.MastodonHelpers
+
+  alias Vutuv.MastodonApi
+  alias Vutuv.Posts
+  alias Vutuv.Repo
+  alias Vutuv.Social
+  alias Vutuv.Tags
+
+  describe "the status entity carries what a post really holds" do
+    test "tags, mentions, language and the edit mark", %{conn: conn} do
+      author = insert(:activated_user)
+      # `unique_username/1` because the mention grammar is `[A-Za-z0-9_]+` and the
+      # factory's default usernames carry a hyphen, which would truncate the
+      # handle and fail the existence check rather than this endpoint.
+      mentioned = insert(:activated_user, username: unique_username("mentioned"))
+      tag_name = unique_tag_name("Elixir")
+
+      {:ok, post} =
+        Posts.create_post(author, %{
+          body: "Hallo @#{mentioned.username}",
+          tags: tag_name,
+          language: "de"
+        })
+
+      token = mastodon_token(author, ["read"])
+
+      status =
+        conn
+        |> mastodon_conn(token)
+        |> get("/api/v1/statuses/#{post.id}")
+        |> json_response(200)
+
+      # A client linkifies and offers "open hashtag" from this list; it was
+      # always empty, so a post's own tags were unreachable from a phone.
+      assert [%{"name" => slug, "url" => url}] = status["tags"]
+      assert slug == Tags.get_canonical_tag_by_slug(slug).slug
+      assert url =~ "/tags/" <> slug
+
+      # The prefill a client builds a reply from.
+      assert [%{"acct" => acct, "id" => id}] = status["mentions"]
+      assert acct == mentioned.username
+      assert id == mentioned.id
+
+      # Declared by the author (v7.313.0), and a client filters its timeline on
+      # it — an undeclared post is treated as "every language", which is not the
+      # same claim.
+      assert status["language"] == "de"
+
+      # Untouched since it was written.
+      assert status["edited_at"] == nil
+    end
+
+    test "an edited post says when", %{conn: conn} do
+      author = insert(:activated_user)
+      {:ok, post} = Posts.create_post(author, %{body: "Erste Fassung"})
+
+      # The website's own rule: `updated_at` more than a minute past
+      # `inserted_at` is what its card calls edited.
+      edited_at = NaiveDateTime.add(post.inserted_at, 600)
+      post = post |> Ecto.Changeset.change(updated_at: edited_at) |> Repo.update!()
+
+      token = mastodon_token(author, ["read"])
+
+      status =
+        conn
+        |> mastodon_conn(token)
+        |> get("/api/v1/statuses/#{post.id}")
+        |> json_response(200)
+
+      assert status["edited_at"] =~ ~r/^\d{4}-\d{2}-\d{2}T/
+    end
+  end
+
+  describe "the account entity carries the member's proven webpages" do
+    test "a verified link becomes a Mastodon field with verified_at", %{conn: conn} do
+      user = insert(:activated_user)
+
+      insert(:url,
+        user: user,
+        value: "https://example.org/me",
+        description: "Meine Seite",
+        verified_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+      )
+
+      # Unproven links stay out: `verified_at: nil` in a client reads as a plain
+      # row, which is not what a proof-backed field says.
+      insert(:url, user: user, value: "https://unproven.example/", description: "Noch offen")
+
+      token = mastodon_token(user, ["read"])
+
+      account =
+        conn
+        |> mastodon_conn(token)
+        |> get("/api/v1/accounts/verify_credentials")
+        |> json_response(200)
+
+      assert [field] = account["fields"]
+      assert field["name"] == "Meine Seite"
+      assert field["value"] =~ "https://example.org/me"
+      assert field["value"] =~ ~s(rel="me)
+      assert field["verified_at"]
+    end
+  end
+
+  describe "GET /api/v1/accounts/lookup" do
+    test "resolves a bare handle and a fully qualified local one", %{conn: conn} do
+      user = insert(:activated_user)
+      other = insert(:activated_user)
+      token = mastodon_token(user, ["read"])
+
+      found =
+        conn
+        |> mastodon_conn(token)
+        |> get("/api/v1/accounts/lookup", %{"acct" => other.username})
+        |> json_response(200)
+
+      assert found["id"] == other.id
+
+      qualified =
+        build_conn()
+        |> mastodon_conn(token)
+        |> get("/api/v1/accounts/lookup", %{
+          "acct" => "@#{other.username}@#{MastodonApi.local_domain()}"
+        })
+        |> json_response(200)
+
+      assert qualified["id"] == other.id
+    end
+
+    test "an unknown handle is a 404 and not the website's HTML", %{conn: conn} do
+      token = mastodon_token(insert(:activated_user), ["read"])
+
+      assert conn
+             |> mastodon_conn(token)
+             |> get("/api/v1/accounts/lookup", %{"acct" => "nobody-here-at-all"})
+             |> json_response(404)
+    end
+  end
+
+  describe "hashtags (API version 6 territory)" do
+    setup do
+      user = insert(:activated_user)
+      tag = insert(:tag)
+      %{user: user, tag: tag, token: mastodon_token(user, ["read", "write"])}
+    end
+
+    test "GET /api/v1/tags/:id names the topic", %{conn: conn, tag: tag, token: token} do
+      rendered =
+        conn |> mastodon_conn(token) |> get("/api/v1/tags/#{tag.slug}") |> json_response(200)
+
+      assert rendered["name"] == tag.slug
+      assert rendered["url"] =~ "/tags/#{tag.slug}"
+      refute rendered["following"]
+    end
+
+    test "follow and unfollow round-trip through vutuv's own subscription", %{
+      conn: conn,
+      user: user,
+      tag: tag,
+      token: token
+    } do
+      followed =
+        conn
+        |> mastodon_conn(token)
+        |> post("/api/v1/tags/#{tag.slug}/follow")
+        |> json_response(200)
+
+      # The answer has to already say so, or the client flips its button back on
+      # the next read.
+      assert followed["following"]
+      assert Tags.tag_followed?(user, tag)
+
+      listed =
+        build_conn()
+        |> mastodon_conn(token)
+        |> get("/api/v1/followed_tags")
+        |> json_response(200)
+
+      assert [%{"name" => name, "following" => true}] = listed
+      assert name == tag.slug
+
+      dropped =
+        build_conn()
+        |> mastodon_conn(token)
+        |> post("/api/v1/tags/#{tag.slug}/unfollow")
+        |> json_response(200)
+
+      refute dropped["following"]
+      refute Tags.tag_followed?(Repo.reload!(user), tag)
+    end
+
+    test "an unknown hashtag is a 404", %{conn: conn, token: token} do
+      assert conn
+             |> mastodon_conn(token)
+             |> get("/api/v1/tags/no_such_topic_here")
+             |> json_response(404)
+    end
+  end
+
+  describe "grouped notifications (API version 1/2)" do
+    test "a group key opens, fills and dismisses", %{conn: conn} do
+      author = insert(:activated_user)
+      liker = insert(:activated_user)
+      {:ok, post} = Posts.create_post(author, %{body: "Etwas zum Mögen"})
+      :ok = Posts.like_post(liker, post)
+
+      token = mastodon_token(author, ["read", "write"])
+
+      %{"notification_groups" => [group]} =
+        conn |> mastodon_conn(token) |> get("/api/v2/notifications") |> json_response(200)
+
+      key = group["group_key"]
+
+      one =
+        build_conn()
+        |> mastodon_conn(token)
+        |> get("/api/v2/notifications/#{key}")
+        |> json_response(200)
+
+      assert one["group_key"] == key
+      assert one["notifications_count"] == 1
+
+      accounts =
+        build_conn()
+        |> mastodon_conn(token)
+        |> get("/api/v2/notifications/#{key}/accounts")
+        |> json_response(200)
+
+      assert [%{"id" => id}] = accounts
+      assert id == liker.id
+
+      assert build_conn()
+             |> mastodon_conn(token)
+             |> post("/api/v2/notifications/#{key}/dismiss")
+             |> json_response(200)
+    end
+
+    test "an unknown group key is a 404", %{conn: conn} do
+      token = mastodon_token(insert(:activated_user), ["read"])
+
+      assert conn
+             |> mastodon_conn(token)
+             |> get("/api/v2/notifications/favourite-does-not-exist")
+             |> json_response(404)
+    end
+  end
+
+  describe "the search page's hashtags know the viewer" do
+    test "a followed tag reports following: true", %{conn: conn} do
+      user = insert(:activated_user)
+      other = insert(:activated_user)
+      {:ok, _follow} = Social.follow(user, other.id)
+      tag = insert(:tag)
+      {:ok, _} = Tags.follow_tag(user, tag)
+
+      token = mastodon_token(user, ["read"])
+
+      %{"hashtags" => hashtags} =
+        conn
+        |> mastodon_conn(token)
+        |> get("/api/v2/search", %{"q" => tag.name, "type" => "hashtags"})
+        |> json_response(200)
+
+      assert Enum.any?(hashtags, &(&1["name"] == tag.slug and &1["following"]))
+    end
+  end
+end

--- a/test/vutuv_web/controllers/mastodon_api/media_controller_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/media_controller_test.exs
@@ -56,6 +56,50 @@ defmodule VutuvWeb.MastodonApi.MediaControllerTest do
     |> Repo.update!()
   end
 
+  test "an unposted upload can be taken back again", %{conn: conn, tmp: tmp} do
+    user = insert(:activated_user)
+    token = mastodon_token(user, ["read", "write"])
+
+    # Mastodon's API version 4 half a composer needs: a client uploads eagerly,
+    # so a picture the member picks and drops is already here. Without this
+    # method it waited for the next day's sweep of unattached leftovers.
+    uploaded =
+      conn
+      |> mastodon_conn(token)
+      |> post("/api/v1/media", %{"file" => jpeg!(tmp)})
+      |> json_response(200)
+
+    assert build_conn()
+           |> mastodon_conn(token)
+           |> delete("/api/v1/media/#{uploaded["id"]}")
+           |> json_response(200)
+
+    refute Repo.get(PostImage, uploaded["id"])
+
+    assert build_conn()
+           |> mastodon_conn(token)
+           |> get("/api/v1/media/#{uploaded["id"]}")
+           |> json_response(404)
+  end
+
+  test "one member cannot delete another's upload", %{conn: conn, tmp: tmp} do
+    owner = insert(:activated_user)
+    stranger = insert(:activated_user)
+
+    uploaded =
+      conn
+      |> mastodon_conn(mastodon_token(owner, ["read", "write"]))
+      |> post("/api/v1/media", %{"file" => jpeg!(tmp)})
+      |> json_response(200)
+
+    assert build_conn()
+           |> mastodon_conn(mastodon_token(stranger, ["read", "write"]))
+           |> delete("/api/v1/media/#{uploaded["id"]}")
+           |> json_response(404)
+
+    assert Repo.get(PostImage, uploaded["id"])
+  end
+
   test "upload, describe and attach a photo to a status", %{conn: conn, tmp: tmp} do
     user = insert(:activated_user)
     token = mastodon_token(user, ["read", "write"])


### PR DESCRIPTION
Closes #1620, closes #1613.

**Endpunkte.** Die drei Begleiter der gruppierten Meldungen (`:group_key`, `/accounts`, `/dismiss`), `DELETE /api/v1/media/:id`, `GET /api/v1/accounts/lookup` (lokal, ohne WebFinger) und die Hashtag-Endpunkte: `GET /api/v1/tags/:id` plus follow/unfollow, mit echtem `/api/v1/followed_tags`.

**Entitäten.** Status trägt jetzt `tags`, `mentions` (gebündelt pro Seite, nicht pro Beitrag), `language` und `edited_at`; das Konto `fields` mit den bewiesenen Webseiten samt `verified_at`. Nur die bewiesenen — ein unbewiesener Link käme mit `verified_at: null` an, und das ist eine andere Behauptung.

**Aufgeräumt.** Handle-Auflösung und Vorlade-Bereich der bewiesenen Links hatten je zwei Kopien; die Minutenregel für „bearbeitet" auch — sie hat jetzt mit `Posts.edited?/1` einen Besitzer. Profil-URLs laufen über die `Vutuv.Identity`-Naht aus #1594.

**Nicht enthalten:** #1591, #1592, #1593 — die brauchen erst eine Entscheidung auf vutuv-Seite.

**Belege:** 13 Tests, kalibriert; ohne Fix fallen 9. `mix precommit` grün, 8562 Tests. **Deploy:** hot, keine Migration.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*
