### PR TITLE
Eine Naht entscheidet, wer spricht: Mitglied oder Seite (v7.331.1)

### DIFF
--- a/docs/architecture/organizations.md
+++ b/docs/architecture/organizations.md
@@ -415,8 +415,18 @@ and `publisher` must never arrive by accident.
 
 ## Speaking as a page (#1334, #1335, #1336)
 
-A page is an identity, not only a brochure. What it can do now, and where each
-piece lives:
+A page is an identity, not only a brochure. **`Vutuv.Identity`** (issue #1416)
+is the named seam over the two kinds: a protocol implemented for `User` and
+`Organization` (kind, display name, handle, path, image token, `hidden?`,
+PubSub topic, ActivityPub type, and the doc/JSON `ref` map the API and agent
+docs share), so a display surface asks the identity instead of re-matching the
+nullable `user_id | organization_id` pair. Its query half,
+`Vutuv.Identity.Query`, spells the column-pair idiom once (`party_is`,
+`join_party`, `shown_party`) — the pair's NULL semantics produced the
+milestone's whole silent-failure class. A third actor kind would implement the
+protocol instead of being excavated into every call site.
+
+What a page can do now, and where each piece lives:
 
 - **It publishes.** `posts` carries `user_id | organization_id` (CHECK exactly
   one) plus `acting_user_id` — who pressed publish, `nilify_all`, never shown.

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -1454,4 +1454,36 @@ defmodule Vutuv.Accounts.User do
   defimpl List.Chars, for: Vutuv.Accounts.User do
     def to_charlist(user), do: ~c"#{user.first_name} #{user.last_name}"
   end
+
+  defimpl Vutuv.Identity, for: Vutuv.Accounts.User do
+    def kind(_user), do: :user
+
+    def id(user), do: user.id
+
+    def display_name(user) do
+      [user.honorific_prefix, user.first_name, user.last_name, user.honorific_suffix]
+      |> Enum.reject(&(&1 in [nil, ""]))
+      |> Enum.join(" ")
+    end
+
+    def handle(user), do: user.username
+
+    def path(user), do: "/" <> user.username
+
+    def image(user), do: user.avatar
+
+    def hidden?(user), do: not Vutuv.Moderation.profile_visible_to?(user, nil)
+
+    def topic(user), do: "user:#{user.id}"
+
+    def ap_type(_user), do: "Person"
+
+    def ref(user) do
+      %{
+        name: display_name(user),
+        username: user.username,
+        url: VutuvWeb.Endpoint.url() <> path(user)
+      }
+    end
+  end
 end

--- a/lib/vutuv/activity.ex
+++ b/lib/vutuv/activity.ex
@@ -32,12 +32,15 @@ defmodule Vutuv.Activity do
       the page keeps listing those events, it just stops calling them new.
   """
   import Ecto.Query
+  import Vutuv.Identity.Query, only: [join_party: 3, shown_party: 2]
+
   alias Vutuv.Accounts.HandleChangeNotification
   alias Vutuv.Accounts.User
   alias Vutuv.Activity.NotificationPostRead
   alias Vutuv.Engagement
   alias Vutuv.Fediverse.Note
   alias Vutuv.Fediverse.Reaction
+  alias Vutuv.Identity
   alias Vutuv.MastodonApi.PushDispatcher
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.Organizations.Organization
@@ -56,28 +59,14 @@ defmodule Vutuv.Activity do
   @pubsub Vutuv.PubSub
   @default_limit 50
 
-  defp topic(%Vutuv.Organizations.Organization{id: id}), do: "organization:#{id}"
+  # Struct callers get the one topic grammar (`Vutuv.Identity.topic/1`); the
+  # bare-id clause spells the member topic again because most callers hold only
+  # an id — `Vutuv.IdentityTest` pins the impl to this exact string.
+  defp topic(party) when is_struct(party), do: Identity.topic(party)
   defp topic(user_id), do: "user:#{user_id}"
 
   def subscribe(nil), do: :ok
   def subscribe(party), do: Phoenix.PubSub.subscribe(@pubsub, topic(party))
-
-  # Whether a follow row has a follower worth showing. The member side is left
-  # exactly as it was — the row existing is the whole test, no moderation gate,
-  # which is what the old inner join amounted to — so this changes nothing for
-  # members. The page side additionally has to be one a reader may open, or the
-  # notification would link somewhere they are turned away from.
-  #
-  # It lives here, shared by the list and both badge queries, because those
-  # three drifting apart is exactly the bug: a badge counting what the list
-  # cannot show.
-  defmacrop shown_follower(u, o) do
-    quote do
-      not is_nil(unquote(u).id) or
-        (not is_nil(unquote(o).id) and unquote(o).status == "active" and
-           is_nil(unquote(o).frozen_at))
-    end
-  end
 
   @doc "Broadcast a raw event to a user's topic (no-op for a nil recipient)."
   def broadcast(nil, _event), do: :ok
@@ -127,15 +116,10 @@ defmodule Vutuv.Activity do
   # mirrors the filters of its kind's items/count queries below.
 
   defp follower_max(user_id) do
-    from(c in Follow,
-      left_join: u in User,
-      on: u.id == c.follower_id,
-      left_join: o in Organization,
-      on: o.id == c.follower_organization_id,
-      where: c.followee_id == ^user_id,
-      where: shown_follower(u, o),
-      select: %{ts: max(c.inserted_at)}
-    )
+    from(c in Follow, where: c.followee_id == ^user_id)
+    |> join_party(:follower_id, :follower_organization_id)
+    |> where([c, u, o], shown_party(u, o))
+    |> select([c], %{ts: max(c.inserted_at)})
   end
 
   defp endorsement_max(user_id) do
@@ -1056,15 +1040,11 @@ defmodule Vutuv.Activity do
       )
       |> at_or_before(cursor)
 
-    from(e in subquery(newest),
-      left_join: f in User,
-      on: f.id == e.actor_id,
-      left_join: o in Organization,
-      on: o.id == e.actor_organization_id,
-      where: shown_follower(f, o),
-      order_by: [desc: e.at, desc: e.id],
-      select: {e.id, e.at, struct(f, ^User.listing_fields()), o}
-    )
+    from(e in subquery(newest))
+    |> join_party(:actor_id, :actor_organization_id)
+    |> where([e, f, o], shown_party(f, o))
+    |> order_by([e], desc: e.at, desc: e.id)
+    |> select([e, f, o], {e.id, e.at, struct(f, ^User.listing_fields()), o})
     |> Repo.all()
     |> Enum.map(fn {id, at, follower, organization} ->
       actor_item("follower-#{id}", "follower", at, follower || organization)
@@ -1811,15 +1791,10 @@ defmodule Vutuv.Activity do
   # Each count helper returns a query selecting a single count, so total_count/2
   # can fold all three into one round trip via scalar subqueries.
   defp count_followers(user_id, read_at) do
-    from(c in Follow,
-      left_join: u in User,
-      on: u.id == c.follower_id,
-      left_join: o in Organization,
-      on: o.id == c.follower_organization_id,
-      where: c.followee_id == ^user_id,
-      where: shown_follower(u, o),
-      select: %{count: count()}
-    )
+    from(c in Follow, where: c.followee_id == ^user_id)
+    |> join_party(:follower_id, :follower_organization_id)
+    |> where([c, u, o], shown_party(u, o))
+    |> select([c], %{count: count()})
     |> since(read_at)
   end
 
@@ -2004,17 +1979,19 @@ defmodule Vutuv.Activity do
   defp actor_avatar(%Organization{}), do: nil
   defp actor_avatar(_), do: nil
 
-  defp display_name(%Organization{name: name}), do: name
+  defp display_name(%Organization{} = organization), do: Identity.display_name(organization)
+
+  defp display_name(%User{} = user), do: or_someone(Identity.display_name(user))
 
   defp display_name(%{first_name: first, last_name: last}) do
     [first, last]
     |> Enum.reject(&(&1 in [nil, ""]))
     |> Enum.join(" ")
-    |> case do
-      "" -> "Someone"
-      name -> name
-    end
+    |> or_someone()
   end
 
   defp display_name(_), do: "Someone"
+
+  defp or_someone(""), do: "Someone"
+  defp or_someone(name), do: name
 end

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -40,6 +40,7 @@ defmodule Vutuv.Fediverse do
   use Gettext, backend: VutuvWeb.Gettext
 
   import Ecto.Query
+  import Vutuv.Identity.Query, only: [party_is: 2]
   import Vutuv.Moderation.Query, only: [account_confirmed_row: 1, account_hidden_row: 1]
 
   require Logger
@@ -200,61 +201,49 @@ defmodule Vutuv.Fediverse do
   # now. Turning the switch off does not unsend what other servers already have,
   # so anything that still has to reach them keys on this, not on `federated?/1`.
   def ever_federated?(%Organization{} = organization),
-    do: enabled?() and get_organization_actor(organization) != nil
+    do: enabled?() and get_actor(organization) != nil
 
   ## Actors
 
-  @doc "The member's actor (keypair), created on first use. Race-safe."
-  def ensure_actor(%User{} = user) do
-    case get_actor(user) do
-      nil ->
-        {private_pem, public_pem} = Keys.generate()
-
-        %Actor{user_id: user.id, private_key_pem: private_pem, public_key_pem: public_pem}
-        |> Repo.insert(on_conflict: :nothing, conflict_target: [:user_id])
-
-        {:ok, get_actor(user)}
-
-      actor ->
-        {:ok, actor}
-    end
-  end
-
-  def get_actor(%User{id: user_id}), do: Repo.get_by(Actor, user_id: user_id)
-
   @doc """
-  A **page's** actor (issue #1334), created on first use. Race-safe, and the
-  exact twin of `ensure_actor/1` — the keypair is the same thing, only its
-  owner column differs.
+  The member's or page's actor (keypair), created on first use. Race-safe;
+  one function with a head per kind (issue #1416), because the keypair is the
+  same thing and only its owner column differs.
 
-  Nothing calls this from a user-facing path yet, and that is deliberate. A
-  keypair is invisible outside this database, so it can exist alone; the parts
-  other servers see (WebFinger, the actor document, delivery, an inbox that
-  answers Follow) have to arrive together, because being findable without a
-  working inbox means somebody presses Follow and nothing ever happens.
+  A page's keypair can exist before anything is federated — it is invisible
+  outside this database. The parts other servers see (WebFinger, the actor
+  document, delivery, an inbox that answers Follow) have to arrive together,
+  because being findable without a working inbox means somebody presses Follow
+  and nothing ever happens.
   """
-  def ensure_organization_actor(%Organization{} = organization) do
-    case get_organization_actor(organization) do
+  def ensure_actor(subject) do
+    case get_actor(subject) do
       nil ->
         {private_pem, public_pem} = Keys.generate()
 
-        %Actor{
-          organization_id: organization.id,
-          private_key_pem: private_pem,
-          public_key_pem: public_pem
-        }
-        |> Repo.insert(on_conflict: :nothing, conflict_target: [:organization_id])
+        subject
+        |> new_actor(private_pem, public_pem)
+        |> Repo.insert(on_conflict: :nothing, conflict_target: actor_conflict_target(subject))
 
-        {:ok, get_organization_actor(organization)}
+        {:ok, get_actor(subject)}
 
       actor ->
         {:ok, actor}
     end
   end
 
-  @doc "The page's actor, or nil."
-  def get_organization_actor(%Organization{id: id}),
-    do: Repo.get_by(Actor, organization_id: id)
+  defp new_actor(%User{id: id}, private_pem, public_pem),
+    do: %Actor{user_id: id, private_key_pem: private_pem, public_key_pem: public_pem}
+
+  defp new_actor(%Organization{id: id}, private_pem, public_pem),
+    do: %Actor{organization_id: id, private_key_pem: private_pem, public_key_pem: public_pem}
+
+  defp actor_conflict_target(%User{}), do: [:user_id]
+  defp actor_conflict_target(%Organization{}), do: [:organization_id]
+
+  @doc "The member's or page's actor, or nil."
+  def get_actor(%User{id: user_id}), do: Repo.get_by(Actor, user_id: user_id)
+  def get_actor(%Organization{id: id}), do: Repo.get_by(Actor, organization_id: id)
 
   @doc """
   The keypair a **tag** signs with, minted on first use (issue #1330).
@@ -417,10 +406,6 @@ defmodule Vutuv.Fediverse do
     count
   end
 
-  @doc "How many remote accounts follow this page."
-  def organization_remote_follower_count(%Organization{id: id}),
-    do: Repo.aggregate(from(f in Follower, where: f.organization_id == ^id), :count)
-
   @doc """
   Records a remote follower of a **topic** (issue #1330), idempotently: a server
   that re-delivers its `Follow` refreshes the row it already has rather than
@@ -502,8 +487,13 @@ defmodule Vutuv.Fediverse do
     :ok
   end
 
+  @doc "How many remote accounts follow this member or page."
   def follower_count(%User{id: user_id}) do
     Repo.aggregate(from(f in Follower, where: f.user_id == ^user_id), :count)
+  end
+
+  def follower_count(%Organization{id: id}) do
+    Repo.aggregate(from(f in Follower, where: f.organization_id == ^id), :count)
   end
 
   @doc """
@@ -554,7 +544,7 @@ defmodule Vutuv.Fediverse do
 
   def departed?(%Organization{} = organization) do
     enabled?() and not organization.fediverse_followers? and
-      get_organization_actor(organization) != nil
+      get_actor(organization) != nil
   end
 
   @doc """
@@ -937,9 +927,9 @@ defmodule Vutuv.Fediverse do
   end
 
   @doc """
-  The distinct inboxes a member's activities go to: one per server where the
-  remote declared a sharedInbox (however many followers live there), else the
-  per-actor inbox.
+  The distinct inboxes a member's or page's activities go to: one per server
+  where the remote declared a sharedInbox (however many followers live there),
+  else the per-actor inbox.
   """
   def delivery_inboxes(%User{id: user_id}) do
     Repo.all(
@@ -951,8 +941,7 @@ defmodule Vutuv.Fediverse do
     )
   end
 
-  @doc "The distinct inboxes of a page's remote followers (issue #1334)."
-  def organization_delivery_inboxes(%Organization{id: id}) do
+  def delivery_inboxes(%Organization{id: id}) do
     Repo.all(
       from(f in Follower,
         where: f.organization_id == ^id,
@@ -1380,27 +1369,11 @@ defmodule Vutuv.Fediverse do
   nothing but their own row. Returns `:ok` either way — muting something you do
   not follow is not an error worth a message.
   """
-  def set_remote_follow_mute(%User{id: user_id}, remote_account_id, muted?) do
-    UUIDv7.with_cast(remote_account_id, fn account_id ->
-      Repo.update_all(
-        from(f in Follow, where: f.user_id == ^user_id and f.remote_account_id == ^account_id),
-        set: [muted: muted?, updated_at: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)]
-      )
-    end)
-
-    :ok
-  end
-
-  @doc "Sets the mute flag on a page's existing remote follow."
-  def set_organization_remote_follow_mute(
-        %Organization{id: organization_id},
-        remote_account_id,
-        muted?
-      ) do
+  def set_remote_follow_mute(party, remote_account_id, muted?) do
     UUIDv7.with_cast(remote_account_id, fn account_id ->
       Repo.update_all(
         from(f in Follow,
-          where: f.organization_id == ^organization_id and f.remote_account_id == ^account_id
+          where: party_is(f, party) and f.remote_account_id == ^account_id
         ),
         set: [muted: muted?, updated_at: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)]
       )
@@ -1438,11 +1411,15 @@ defmodule Vutuv.Fediverse do
   end
 
   @doc """
-  The member's follow of one remote account, or nil — what the account page's
-  button branches on.
+  The member's or page's follow of one remote account, or nil — what the
+  account page's button branches on.
   """
   def remote_follow_for(%User{id: user_id}, %RemoteAccount{id: account_id}) do
     Repo.get_by(Follow, user_id: user_id, remote_account_id: account_id)
+  end
+
+  def remote_follow_for(%Organization{id: id}, %RemoteAccount{id: account_id}) do
+    Repo.get_by(Follow, organization_id: id, remote_account_id: account_id)
   end
 
   # One of the member's own follows, with the remote account preloaded, or nil.
@@ -2030,17 +2007,10 @@ defmodule Vutuv.Fediverse do
       else: :ok
   end
 
-  # Signed with the member's own key: instances in authorized-fetch mode refuse
-  # an anonymous GET, and this is the one fetch we make on their behalf.
-  defp fetch_follow_target(actor_uri, %Organization{} = page) do
-    case fetch_remote_actor(actor_uri, signer_for(page, get_organization_actor(page))) do
-      {:ok, remote} -> {:ok, remote}
-      _error -> {:error, :unreachable_actor}
-    end
-  end
-
-  defp fetch_follow_target(actor_uri, %User{} = user) do
-    case fetch_remote_actor(actor_uri, signer(user)) do
+  # Signed with the follower's own key: instances in authorized-fetch mode
+  # refuse an anonymous GET, and this is the one fetch we make on their behalf.
+  defp fetch_follow_target(actor_uri, follower) do
+    case fetch_remote_actor(actor_uri, signer(follower)) do
       {:ok, remote} -> {:ok, remote}
       _error -> {:error, :unreachable_actor}
     end
@@ -2124,7 +2094,7 @@ defmodule Vutuv.Fediverse do
     with :ok <- check_can_resolve(),
          true <- federated?(page),
          {:ok, account} <- resolve_remote_account(page, address),
-         {:ok, follow} <- insert_organization_remote_follow(page, account) do
+         {:ok, follow} <- insert_remote_follow(page, account) do
       enqueue(
         page,
         [account.inbox_uri],
@@ -2135,21 +2105,6 @@ defmodule Vutuv.Fediverse do
     else
       false -> {:error, :not_federated}
       other -> other
-    end
-  end
-
-  defp insert_organization_remote_follow(%Organization{} = page, %RemoteAccount{} = account) do
-    id = UUIDv7.generate()
-
-    %Follow{id: id, organization_id: page.id, remote_account_id: account.id}
-    |> Follow.changeset(%{
-      state: "requested",
-      follow_activity_id: Docs.follow_activity_id(page, id)
-    })
-    |> Repo.insert()
-    |> case do
-      {:ok, follow} -> {:ok, follow}
-      {:error, _changeset} -> {:error, :already_following}
     end
   end
 
@@ -2188,11 +2143,6 @@ defmodule Vutuv.Fediverse do
     end
   end
 
-  @doc "Whether `page` already follows (or has asked to follow) this account."
-  def organization_remote_follow_for(%Organization{id: id}, %RemoteAccount{id: account_id}) do
-    Repo.get_by(Follow, organization_id: id, remote_account_id: account_id)
-  end
-
   @doc "The accounts `page` follows out there, newest first."
   def list_organization_remote_follows(%Organization{id: id}) do
     Repo.all(
@@ -2204,16 +2154,18 @@ defmodule Vutuv.Fediverse do
     )
   end
 
-  defp insert_remote_follow(%User{} = user, %RemoteAccount{} = account) do
-    # The activity id names the row, so the id is minted before the insert
-    # rather than read back after it: an `Accept` finds its follow by this
-    # string and by nothing else.
+  # One head per follower kind (issue #1416); only the owner column differs.
+  # The activity id names the row, so the id is minted before the insert
+  # rather than read back after it: an `Accept` finds its follow by this
+  # string and by nothing else.
+  defp insert_remote_follow(follower, %RemoteAccount{} = account) do
     id = UUIDv7.generate()
 
-    %Follow{id: id, user_id: user.id, remote_account_id: account.id}
+    follower
+    |> new_remote_follow(id, account)
     |> Follow.changeset(%{
       state: "requested",
-      follow_activity_id: Docs.follow_activity_id(user, id)
+      follow_activity_id: Docs.follow_activity_id(follower, id)
     })
     |> Repo.insert()
     |> case do
@@ -2221,6 +2173,12 @@ defmodule Vutuv.Fediverse do
       {:error, _changeset} -> {:error, :already_following}
     end
   end
+
+  defp new_remote_follow(%User{} = user, id, account),
+    do: %Follow{id: id, user_id: user.id, remote_account_id: account.id}
+
+  defp new_remote_follow(%Organization{} = page, id, account),
+    do: %Follow{id: id, organization_id: page.id, remote_account_id: account.id}
 
   defp undo_remote_follow(%User{} = user, %Follow{} = follow),
     do: undo_remote_follows(user, [follow])
@@ -3691,16 +3649,12 @@ defmodule Vutuv.Fediverse do
     :kept
   end
 
-  defp signer_for(%User{} = user, %Actor{} = actor),
-    do: {Docs.key_id(user), actor.private_key_pem}
+  # One clause for all three kinds: `Docs.key_id/1` is `actor_url/1` plus
+  # `#main-key`, and `actor_url/1` dispatches on the subject itself.
+  defp signer_for(subject, %Actor{} = actor) when not is_nil(subject),
+    do: {Docs.key_id(subject), actor.private_key_pem}
 
-  defp signer_for(%Organization{} = organization, %Actor{} = actor),
-    do: {Docs.actor_url(organization) <> "#main-key", actor.private_key_pem}
-
-  defp signer_for(%Tag{} = tag, %Actor{} = actor),
-    do: {Docs.actor_url(tag) <> "#main-key", actor.private_key_pem}
-
-  defp signer_for(_user, _actor), do: nil
+  defp signer_for(_subject, _actor), do: nil
 
   ## Blocked instances and inbound caps (issue #1067)
 
@@ -4259,50 +4213,13 @@ defmodule Vutuv.Fediverse do
 
     with true <- enabled?(),
          true <- federated?(page),
-         %Post{} = post <- resolve_own_organization_note(page, object),
+         %Post{} = post <- resolve_own_note(page, object),
          :ok <- check_inbound_cap(actor_uri),
          {:ok, _reaction} <- insert_reaction(post, actor, kind) do
       Posts.broadcast_post_counters(post.id)
       :ok
     else
       _ -> :skip
-    end
-  end
-
-  @doc """
-  The page twin of `remove_reaction/4`. Unconditional like its sibling: an
-  upstream withdrawal is the deletion path that makes storing the row
-  defensible, so it must not depend on any switch still being on.
-  """
-  def remove_organization_reaction(%Organization{} = page, object, kind, actor_uri)
-      when kind in ~w(like announce) do
-    with %Post{} = post <- resolve_own_organization_note(page, object) do
-      {count, _} =
-        Repo.delete_all(
-          from(r in Reaction,
-            where: r.post_id == ^post.id and r.actor_uri == ^actor_uri and r.kind == ^kind
-          )
-        )
-
-      if count > 0, do: Posts.broadcast_post_counters(post.id)
-    end
-
-    :ok
-  end
-
-  # The page's own note, by the permalink shape `Docs.note_url/2` mints for it.
-  # A member's note lives at `/:handle/posts/:id`, a page's under
-  # `/organizations/:slug/posts/:id`, so this cannot share `resolve_own_note/2`
-  # — and the ownership check is the point: a Like naming somebody else's post
-  # must not be recorded against this page.
-  defp resolve_own_organization_note(%Organization{id: page_id, slug: slug}, object) do
-    with uri when is_binary(uri) <- activity_object_id(object),
-         ["organizations", ^slug, "posts", post_id] <- local_path(uri),
-         %Post{organization_id: ^page_id} = post <-
-           UUIDv7.with_cast(post_id, &Repo.get(Post, &1)) do
-      post
-    else
-      _ -> nil
     end
   end
 
@@ -4321,13 +4238,13 @@ defmodule Vutuv.Fediverse do
   defp notify_reaction(_user, _post, :exists), do: :ok
 
   @doc """
-  Removes a reaction the remote side took back (`Undo(Like)` / `Undo(Announce)`).
-  Honoured at once and unconditionally — an upstream withdrawal is the deletion
-  path that makes storing the row defensible, so it must not depend on any
-  switch still being on.
+  Removes a reaction the remote side took back (`Undo(Like)` / `Undo(Announce)`)
+  from a member's or a page's post. Honoured at once and unconditionally — an
+  upstream withdrawal is the deletion path that makes storing the row
+  defensible, so it must not depend on any switch still being on.
   """
-  def remove_reaction(%User{} = user, object, kind, actor_uri) when kind in ~w(like announce) do
-    with %Post{} = post <- resolve_own_note(user, object) do
+  def remove_reaction(owner, object, kind, actor_uri) when kind in ~w(like announce) do
+    with %Post{} = post <- resolve_own_note(owner, object) do
       {count, _} =
         Repo.delete_all(
           from(r in Reaction,
@@ -4406,11 +4323,27 @@ defmodule Vutuv.Fediverse do
   defp truncate_handle(_handle), do: nil
 
   # The post behind an activity's `object`, but only when it is a Note URL of
-  # ours naming *this* member's post. Ownership is checked on the row's own
-  # `user_id` — the id names the post, and the handle beside it goes stale on a
-  # rename — and `local_path/1` reads the URL, so the `www.`/`http` spellings
-  # count too (issue #1211). A URL naming somebody else's post, a foreign host,
-  # or a malformed id is a miss (nil), never a raise.
+  # ours naming *this* member's or page's post — the ownership check is the
+  # point: a Like naming somebody else's post must not be recorded against this
+  # owner. One head per kind, because `Docs.note_url/2` mints two path shapes.
+  # A member's note lives at `/:handle/posts/:id`; ownership is checked on the
+  # row's own `user_id` and the handle segment stays unpinned — the id names
+  # the post, and the handle beside it goes stale on a rename. A page's lives
+  # under `/organizations/:slug/posts/:id`, whose slug segment is pinned.
+  # `local_path/1` reads the URL, so the `www.`/`http` spellings count too
+  # (issue #1211). A URL naming somebody else's post, a foreign host, or a
+  # malformed id is a miss (nil), never a raise.
+  defp resolve_own_note(%Organization{id: page_id, slug: slug}, object) do
+    with uri when is_binary(uri) <- activity_object_id(object),
+         ["organizations", ^slug, "posts", post_id] <- local_path(uri),
+         %Post{organization_id: ^page_id} = post <-
+           UUIDv7.with_cast(post_id, &Repo.get(Post, &1)) do
+      post
+    else
+      _ -> nil
+    end
+  end
+
   defp resolve_own_note(user, object) do
     with uri when is_binary(uri) <- activity_object_id(object),
          [_username, "posts", post_id] <- local_path(uri),
@@ -4494,7 +4427,7 @@ defmodule Vutuv.Fediverse do
     with true <- enabled?(),
          true <- federated?(page),
          %{} = object <- note_object(activity["object"]),
-         %Post{} = post <- resolve_own_organization_note(page, object["inReplyTo"]),
+         %Post{} = post <- resolve_own_note(page, object["inReplyTo"]),
          :ok <- check_inbound_cap(actor.uri),
          {:ok, _note} <- insert_note(page, post, activity, object, actor) do
       Posts.broadcast_post_counters(post.id)
@@ -5969,9 +5902,12 @@ defmodule Vutuv.Fediverse do
     end
   end
 
-  # The member's own key, to sign the target-actor fetch (authorized-fetch
-  # instances reject anonymous GETs). federated?/1 guaranteed the actor exists.
-  defp signer(user), do: signer_for(user, get_actor(user))
+  # The member's or page's own key, to sign a remote-actor fetch
+  # (authorized-fetch instances reject anonymous GETs); nil without an actor.
+  # Public so the inbox controller signs the same way instead of re-spelling
+  # the key-id shape.
+  @doc false
+  def signer(subject), do: signer_for(subject, get_actor(subject))
 
   ## Answering another network (issue #1070)
 
@@ -8101,7 +8037,7 @@ defmodule Vutuv.Fediverse do
          %Organization{} = page <- Organizations.get_organization(id),
          true <- federated?(page),
          post = Repo.preload(post, Docs.note_preloads()),
-         [_ | _] = inboxes <- organization_delivery_inboxes(page) do
+         [_ | _] = inboxes <- delivery_inboxes(page) do
       record_post_deliveries(page, post, inboxes)
       enqueue(page, inboxes, builder.(post, page), hold_opts(post, kind))
     else
@@ -8463,7 +8399,7 @@ defmodule Vutuv.Fediverse do
   defp resharer_moved?(%Organization{}), do: false
 
   defp repost_inboxes(%User{} = user), do: delivery_inboxes(user)
-  defp repost_inboxes(%Organization{} = page), do: organization_delivery_inboxes(page)
+  defp repost_inboxes(%Organization{} = page), do: delivery_inboxes(page)
 
   ## The pinned post as the `featured` collection (issue #1110)
 

--- a/lib/vutuv/identity.ex
+++ b/lib/vutuv/identity.ex
@@ -1,0 +1,73 @@
+defprotocol Vutuv.Identity do
+  @moduledoc """
+  The one answer to "who is speaking" for the two identity kinds vutuv has:
+  a member (`Vutuv.Accounts.User`) and an organization page
+  (`Vutuv.Organizations.Organization`) — issue #1416.
+
+  Since the organization milestone (#1333-#1336) most shared surfaces carry a
+  nullable `user_id | organization_id` pair and decide per call site which side
+  speaks. This protocol is the display/dispatch half of that seam: name, path,
+  image, PubSub topic, ActivityPub type and the doc/JSON reference all live
+  here, so a surface asks the identity instead of pattern-matching the pair
+  again. The query half is `Vutuv.Identity.Query`. Should a third actor kind
+  ever arrive, it implements this protocol instead of being excavated into
+  every call site.
+
+  Deliberately dispatching on structs (loud `Protocol.UndefinedError` for
+  anything else): the milestone's silent failures all came from code that
+  answered quietly for the kind it did not know.
+  """
+
+  @doc "The identity's kind: `:user` or `:organization`."
+  def kind(identity)
+
+  @doc "The identity's id (UUID v7)."
+  def id(identity)
+
+  @doc """
+  The visible name: a member's full name (honorifics included), a page's name.
+  """
+  def display_name(identity)
+
+  @doc """
+  The `@`-less handle, or nil: a member always has one, a page only once it
+  claimed its opt-in root handle.
+  """
+  def handle(identity)
+
+  @doc """
+  The root-relative profile/page path: `/<handle>` for a member,
+  `Vutuv.Organizations.canonical_path/1` for a page (which prefers the root
+  handle over `/organizations/<slug>`).
+  """
+  def path(identity)
+
+  @doc """
+  The stored image token (`users.avatar` | `organizations.logo`), or nil.
+  Rendering stays with `<.avatar>` / `<.organization_logo>` — the two kinds
+  draw different fallback tiles on purpose.
+  """
+  def image(identity)
+
+  @doc """
+  Whether the identity is hidden from the anonymous public: a member who is
+  unconfirmed or moderation-hidden (`Vutuv.Moderation.profile_visible_to?/2`
+  with a nil viewer), a page that is not publicly visible
+  (`Vutuv.Organizations.public_visible?/1`).
+  """
+  def hidden?(identity)
+
+  @doc ~S|The identity's PubSub topic: `"user:<id>"` / `"organization:<id>"`.|
+  def topic(identity)
+
+  @doc ~S|The ActivityPub actor type: `"Person"` / `"Organization"`.|
+  def ap_type(identity)
+
+  @doc """
+  The doc/JSON reference map naming the identity: `name` plus the member's
+  `username` or the page's `slug`, and the absolute `url` of `path/1`. The one
+  shape behind the API, the post JSON and the agent docs (it used to exist
+  three times, each slightly different).
+  """
+  def ref(identity)
+end

--- a/lib/vutuv/identity/query.ex
+++ b/lib/vutuv/identity/query.ex
@@ -1,0 +1,78 @@
+defmodule Vutuv.Identity.Query do
+  @moduledoc """
+  Query macros for the nullable `user_id | organization_id` column pair
+  (issue #1416) — the query half of the `Vutuv.Identity` seam.
+
+  Fourteen tables carry the pair, and its NULL semantics produced the
+  milestone's whole silent-failure class: `x NOT IN (…, NULL)` is never true,
+  `x == ^nil` raises, and a gate written for one kind waves the other through.
+  These macros spell the idiom once, so a call site cannot forget the side it
+  did not think of.
+  """
+
+  import Vutuv.Organizations.Query, only: [organization_public_row: 1]
+
+  alias Vutuv.Accounts.User
+  alias Vutuv.Organizations.Organization
+
+  @doc """
+  Whether the row's `user_id | organization_id` pair names `party` (a `%User{}`
+  or `%Organization{}`, passed as a bound variable — it is read twice).
+
+  Expands to one static SQL shape for both kinds,
+  `(user_id = $u OR organization_id = $o)`, with the other kind's parameter
+  NULL: `col = NULL` is never true in SQL, so the wrong-kind arm can never
+  match — and going through `fragment/1` is what allows the NULL parameter at
+  all, since Ecto refuses `== ^nil` at runtime.
+  """
+  defmacro party_is(row, party) do
+    quote do
+      fragment(
+        "(? = ? OR ? = ?)",
+        unquote(row).user_id,
+        type(^Vutuv.Identity.Query.user_side(unquote(party)), Vutuv.UUIDv7),
+        unquote(row).organization_id,
+        type(^Vutuv.Identity.Query.organization_side(unquote(party)), Vutuv.UUIDv7)
+      )
+    end
+  end
+
+  @doc """
+  LEFT-joins both parties of a column pair onto `query`'s root binding: the
+  member first, the page second (positionally, in that order). Pass the pair's
+  column names, e.g. `join_party(query, :follower_id, :follower_organization_id)`.
+  """
+  defmacro join_party(query, user_field, organization_field) do
+    quote do
+      unquote(query)
+      |> Ecto.Query.join(:left, [x], u in Vutuv.Accounts.User,
+        on: u.id == field(x, unquote(user_field))
+      )
+      |> Ecto.Query.join(:left, [x], o in Vutuv.Organizations.Organization,
+        on: o.id == field(x, unquote(organization_field))
+      )
+    end
+  end
+
+  @doc """
+  Whether a `join_party/3` pair resolves to a party worth showing: any member
+  row (the row existing is the whole test — no moderation gate, matching what
+  the pre-#1336 inner join to `users` amounted to), or a page a reader may
+  open (`Vutuv.Organizations.Query.organization_public_row/1`, the one SQL
+  spelling of a page's public visibility). Takes the two joined bindings.
+  """
+  defmacro shown_party(u, o) do
+    quote do
+      not is_nil(unquote(u).id) or
+        (not is_nil(unquote(o).id) and organization_public_row(unquote(o)))
+    end
+  end
+
+  @doc false
+  def user_side(%User{id: id}), do: id
+  def user_side(%Organization{}), do: nil
+
+  @doc false
+  def organization_side(%Organization{id: id}), do: id
+  def organization_side(%User{}), do: nil
+end

--- a/lib/vutuv/moderation/image_subjects.ex
+++ b/lib/vutuv/moderation/image_subjects.ex
@@ -909,9 +909,8 @@ defmodule Vutuv.Moderation.ImageSubjects do
   # Live pages re-render the affected image (or drop the limbo pill) with no
   # reload; dead pages catch up on the next request.
   defp broadcast(%ImageScan{} = scan, verdict) do
-    Phoenix.PubSub.broadcast(
-      Vutuv.PubSub,
-      "user:#{scan.owner_user_id}",
+    Vutuv.Activity.broadcast(
+      scan.owner_user_id,
       {:image_moderation, scan.kind, scan.subject_id, verdict}
     )
   end

--- a/lib/vutuv/organizations.ex
+++ b/lib/vutuv/organizations.ex
@@ -979,7 +979,7 @@ defmodule Vutuv.Organizations do
         # the same reason). Minted here rather than lazily on the first request,
         # so a remote server that resolves the handle a second later finds a
         # complete actor instead of waiting on an RSA keygen.
-        if Fediverse.federated?(updated), do: Fediverse.ensure_organization_actor(updated)
+        if Fediverse.federated?(updated), do: Fediverse.ensure_actor(updated)
 
         {:ok, updated}
 

--- a/lib/vutuv/organizations/organization.ex
+++ b/lib/vutuv/organizations/organization.ex
@@ -271,4 +271,32 @@ defmodule Vutuv.Organizations.Organization do
 
   defp upcase(nil), do: nil
   defp upcase(value), do: value |> String.trim() |> String.upcase()
+
+  defimpl Vutuv.Identity, for: Vutuv.Organizations.Organization do
+    def kind(_organization), do: :organization
+
+    def id(organization), do: organization.id
+
+    def display_name(organization), do: organization.name
+
+    def handle(organization), do: organization.username
+
+    def path(organization), do: Vutuv.Organizations.canonical_path(organization)
+
+    def image(organization), do: organization.logo
+
+    def hidden?(organization), do: not Vutuv.Organizations.public_visible?(organization)
+
+    def topic(organization), do: "organization:#{organization.id}"
+
+    def ap_type(_organization), do: "Organization"
+
+    def ref(organization) do
+      %{
+        name: organization.name,
+        slug: organization.slug,
+        url: VutuvWeb.Endpoint.url() <> path(organization)
+      }
+    end
+  end
 end

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -48,6 +48,7 @@ defmodule Vutuv.Posts do
   """
 
   import Ecto.Query
+  import Vutuv.Identity.Query, only: [party_is: 2]
 
   import Vutuv.Moderation.Query,
     only: [account_hidden: 1, account_confirmed_row: 1, account_hidden_row: 1]
@@ -1702,9 +1703,8 @@ defmodule Vutuv.Posts do
 
   # "This actor's row", as a query fragment. Never a bare `e.user_id == ^id`:
   # that column is NULL on a page's row, and the comparison would answer NULL
-  # rather than false — the trap this milestone has already paid for repeatedly.
-  defp engaged_by(%User{id: id}), do: dynamic([e], e.user_id == ^id)
-  defp engaged_by(%Organization{id: id}), do: dynamic([e], e.organization_id == ^id)
+  # rather than false — `party_is/2` spells the pair predicate once.
+  defp engaged_by(party), do: dynamic([e], party_is(e, party))
 
   # The four engagement counters (likes / bookmarks / reposts / replies),
   # counted live from the rows. Defined once here so both `engagement_counts/1`
@@ -5011,8 +5011,7 @@ defmodule Vutuv.Posts do
   the permalink's row (issue #1410), a reposter, a chat party.
   """
   def author_path(%Post{} = post), do: author_path(author(post))
-  def author_path(%Organization{} = organization), do: Organizations.canonical_path(organization)
-  def author_path(%User{username: username}), do: "/" <> username
+  def author_path(author), do: Vutuv.Identity.path(author)
 
   ## Images
 

--- a/lib/vutuv_web/agent_docs/agent_docs.ex
+++ b/lib/vutuv_web/agent_docs/agent_docs.ex
@@ -303,14 +303,12 @@ defmodule VutuvWeb.AgentDocs do
   def iso_date(%NaiveDateTime{} = naive),
     do: naive |> NaiveDateTime.to_date() |> Date.to_iso8601()
 
-  @doc "The doc representation of a person: name, slug, profile URL."
-  def person_ref(user) do
-    %{
-      name: VutuvWeb.UserHelpers.full_name(user),
-      username: user.username,
-      url: abs_url("/" <> user.username)
-    }
-  end
+  @doc """
+  The doc reference of a member or page: `Vutuv.Identity.ref/1` (name plus
+  username or slug, absolute URL). The name survives from when only a person
+  could appear in a doc.
+  """
+  def person_ref(identity), do: Vutuv.Identity.ref(identity)
 
   @doc "The one-line excerpt the list-like docs show of a post body."
   def excerpt(body) do

--- a/lib/vutuv_web/agent_docs/list_docs.ex
+++ b/lib/vutuv_web/agent_docs/list_docs.ex
@@ -22,7 +22,6 @@ defmodule VutuvWeb.AgentDocs.ListDocs do
   alias VutuvWeb.UI
   alias VutuvWeb.UserHelpers
 
-  alias Vutuv.Organizations
   alias Vutuv.Tags.Tag
   alias Vutuv.Tags.UserTag
 
@@ -76,9 +75,9 @@ defmodule VutuvWeb.AgentDocs.ListDocs do
 
   # The pages a member follows (issue #1336), as their own key rather than mixed
   # into `people`: an agent reading this document must be able to tell a person
-  # from an organization, and `person_ref/1` cannot describe a page anyway. Only
-  # the Following list has them, so the key is absent everywhere else instead of
-  # being an empty list on the follower and connection documents.
+  # from an organization. Only the Following list has them, so the key is absent
+  # everywhere else instead of being an empty list on the follower and
+  # connection documents.
   defp put_followed_organizations(doc, nil), do: doc
 
   defp put_followed_organizations(doc, organizations) do
@@ -86,11 +85,7 @@ defmodule VutuvWeb.AgentDocs.ListDocs do
       doc,
       :organizations,
       Enum.map(organizations, fn {_follow_id, organization} ->
-        %{
-          name: organization.name,
-          slug: organization.slug,
-          url: AgentDocs.abs_url(Organizations.canonical_path(organization))
-        }
+        Vutuv.Identity.ref(organization)
       end)
     )
   end

--- a/lib/vutuv_web/agent_docs/post_doc.ex
+++ b/lib/vutuv_web/agent_docs/post_doc.ex
@@ -18,7 +18,6 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Fediverse.RemoteImage
   alias Vutuv.Fediverse.RemotePost
-  alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
   alias Vutuv.Posts
   alias Vutuv.Posts.PhotoLicense
@@ -67,7 +66,7 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       id: post.id,
       title: "#{UserHelpers.full_name(author)} · #{Date.to_iso8601(post.published_on)}",
       description: AgentDocs.excerpt(post.body),
-      author: AgentDocs.person_ref(author),
+      author: Vutuv.Identity.ref(author),
       published_on: post.published_on,
       body_markdown: post.body,
       # The links in that body pointing at a webpage the author has PROVED is
@@ -116,7 +115,7 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       # time), and the reader of a doc is never that author — not through a
       # `.md` sibling and not through the authenticated `/api/2.0`, which
       # `build/3` also serves.
-      likers: Enum.map(Posts.post_likers(post.id), &liker_ref/1),
+      likers: Enum.map(Posts.post_likers(post.id), &Vutuv.Identity.ref/1),
       repost_count: counts.reposts,
       bookmark_count: engagement.bookmarks,
       # ...and the breakdown the card's "from other networks" panel shows when
@@ -173,7 +172,7 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       id: post.id,
       title: "#{organization.name} · #{Date.to_iso8601(post.published_on)}",
       description: AgentDocs.excerpt(post.body),
-      author: organization_ref(organization),
+      author: Vutuv.Identity.ref(organization),
       published_on: post.published_on,
       body_markdown: post.body,
       review: review_entry(post.review),
@@ -187,7 +186,9 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       thread: thread_entries(thread),
       thread_truncated: thread_truncated?,
       like_count: counts.likes,
-      likers: Enum.map(Posts.post_likers(post.id), &liker_ref/1),
+      # A liker is a member or a page (issue #1410); the md/txt renderers read
+      # `.name` off either ref shape, JSON/XML carry the map as is.
+      likers: Enum.map(Posts.post_likers(post.id), &Vutuv.Identity.ref/1),
       repost_count: counts.reposts,
       bookmark_count: engagement.bookmarks,
       fediverse_like_count: engagement.fediverse_likes,
@@ -197,22 +198,6 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       fediverse_reply_count: engagement.fediverse_replies,
       fediverse_replies: remote_replies
     })
-  end
-
-  # A liker is a member or a page (issue #1410); the md/txt renderers read
-  # `.name` off either shape, JSON/XML carry the map as is.
-  defp liker_ref(%Organization{} = page), do: organization_ref(page)
-  defp liker_ref(%User{} = user), do: AgentDocs.person_ref(user)
-
-  # The organization's own reference, the counterpart of `AgentDocs.person_ref/1`.
-  # `canonical_path/1` prefers the page's opt-in root handle, so the URL here is
-  # the one the page answers to rather than the slug form the post lives under.
-  defp organization_ref(%Organization{} = organization) do
-    %{
-      name: organization.name,
-      slug: organization.slug,
-      url: AgentDocs.abs_url(Organizations.canonical_path(organization))
-    }
   end
 
   @doc """
@@ -227,7 +212,7 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       title:
         "#{UserHelpers.full_name(author)} · #{gettext("Posts")}" <> period_suffix(period_label),
       description: gettext("Post archive of %{name}", name: UserHelpers.full_name(author)),
-      author: AgentDocs.person_ref(author),
+      author: Vutuv.Identity.ref(author),
       period: period_label,
       total: total,
       posts: Enum.map(entries, &timeline_entry/1)
@@ -308,15 +293,14 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
     %{
       id: post.id,
       url: AgentDocs.abs_url(Posts.path(post)),
-      # Whichever kind of author the post has (issue #1334) — the reposters
-      # below stay members, since only a member can repost.
-      # The name the entry is signed with: a page by its own name, the member
-      # who published for it stays internal, exactly as on the HTML card.
+      # The name the entry is signed with, whichever kind of author (issue
+      # #1334): a page by its own name, the member who published for it stays
+      # internal, exactly as on the HTML card. Reposters can be pages too.
       author: UserHelpers.author_name(post),
       published_on: post.published_on,
       excerpt: AgentDocs.excerpt(post.body),
-      reposted_by: entry[:reposted_by] && UserHelpers.full_name(entry[:reposted_by]),
-      reposters: Enum.map(reposters, &UserHelpers.full_name/1)
+      reposted_by: entry[:reposted_by] && UserHelpers.author_name(entry[:reposted_by]),
+      reposters: Enum.map(reposters, &UserHelpers.author_name/1)
     }
   end
 

--- a/lib/vutuv_web/controllers/api_v2/post_controller.ex
+++ b/lib/vutuv_web/controllers/api_v2/post_controller.ex
@@ -19,7 +19,6 @@ defmodule VutuvWeb.ApiV2.PostController do
 
   use VutuvWeb, :controller
 
-  alias Vutuv.Organizations.Organization
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias VutuvWeb.AgentDocs.PostDoc
@@ -175,11 +174,6 @@ defmodule VutuvWeb.ApiV2.PostController do
     end
   end
 
-  defp author_ref(%Organization{} = organization),
-    do: %{name: organization.name, slug: organization.slug}
-
-  defp author_ref(author), do: VutuvWeb.AgentDocs.person_ref(author)
-
   defp engagement_doc(%Post{} = post, viewer) do
     post.id
     |> Posts.post_engagement(viewer)
@@ -193,16 +187,16 @@ defmodule VutuvWeb.ApiV2.PostController do
     %{
       id: post.id,
       url: VutuvWeb.AgentDocs.abs_url(Posts.path(post)),
-      # A feed entry may be by a page (issue #1336), which `person_ref/1`
-      # cannot describe — `Posts.author/1` decides which of the two speaks.
-      author: author_ref(Posts.author(post)),
+      # A feed entry may be by a page (issue #1336) — `Posts.author/1` decides
+      # which of the two speaks, `Vutuv.Identity.ref/1` describes either.
+      author: Vutuv.Identity.ref(Posts.author(post)),
       published_on: post.published_on,
       body_markdown: post.body,
       tags: Enum.map(post.tags, & &1.name),
       # `reposted_by` stays the newest reposter (unchanged shape); `reposters`
       # adds the whole follow-scoped roster behind the entry, newest first.
-      reposted_by: entry[:reposted_by] && VutuvWeb.AgentDocs.person_ref(entry[:reposted_by]),
-      reposters: Enum.map(reposters, &VutuvWeb.AgentDocs.person_ref/1)
+      reposted_by: entry[:reposted_by] && Vutuv.Identity.ref(entry[:reposted_by]),
+      reposters: Enum.map(reposters, &Vutuv.Identity.ref/1)
     }
   end
 

--- a/lib/vutuv_web/controllers/fediverse_controller.ex
+++ b/lib/vutuv_web/controllers/fediverse_controller.ex
@@ -519,15 +519,8 @@ defmodule VutuvWeb.FediverseController do
   # falls back to an anonymous fetch, which such an instance may refuse — and
   # then the delivery is rejected, which is the right outcome for an activity
   # that was for none of our actors anyway.
-  defp signer([%User{} = user | _rest]) do
-    case Fediverse.get_actor(user) do
-      nil -> nil
-      actor -> {Docs.key_id(user), actor.private_key_pem}
-    end
-  end
-
-  defp signer([%Organization{} = organization | _rest]), do: organization_signer(organization)
   defp signer([%Tag{} = tag | _rest]), do: tag_signer(tag)
+  defp signer([subject | _rest]), do: Fediverse.signer(subject)
   defp signer([]), do: nil
 
   @doc """
@@ -537,7 +530,7 @@ defmodule VutuvWeb.FediverseController do
   """
   def organization_actor(conn, %{"slug" => slug}) do
     with_federated_organization(conn, slug, fn organization ->
-      {:ok, actor} = Fediverse.ensure_organization_actor(organization)
+      {:ok, actor} = Fediverse.ensure_actor(organization)
 
       send_activity_json(conn, Docs.organization_actor(organization, actor))
     end)
@@ -550,7 +543,7 @@ defmodule VutuvWeb.FediverseController do
         conn,
         Docs.count_collection(
           Docs.actor_url(organization) <> "/followers",
-          Fediverse.organization_remote_follower_count(organization)
+          Fediverse.follower_count(organization)
         )
       )
     end)
@@ -730,7 +723,7 @@ defmodule VutuvWeb.FediverseController do
     activity = conn.body_params
 
     with {:ok, key_id} <- signature_key_id(conn),
-         {:ok, remote} <- Fediverse.fetch_remote_actor(key_id, organization_signer(organization)),
+         {:ok, remote} <- Fediverse.fetch_remote_actor(key_id, Fediverse.signer(organization)),
          true <- Fediverse.same_host?(remote.id, key_id),
          :ok <- verify_signature(conn, remote),
          true <- activity["actor"] == remote.id do
@@ -799,7 +792,7 @@ defmodule VutuvWeb.FediverseController do
          remote
        )
        when kind in ["Like", "Announce"] do
-    Fediverse.remove_organization_reaction(
+    Fediverse.remove_reaction(
       organization,
       object["object"],
       String.downcase(kind),
@@ -826,13 +819,6 @@ defmodule VutuvWeb.FediverseController do
 
   # Everything else: acknowledged and dropped, like the member inbox.
   defp perform_for_organization(_organization, _activity, _remote), do: :ok
-
-  defp organization_signer(organization) do
-    case Fediverse.get_organization_actor(organization) do
-      nil -> nil
-      actor -> {Docs.actor_url(organization) <> "#main-key", actor.private_key_pem}
-    end
-  end
 
   @doc """
   The page's outbox, count-only like a member's.

--- a/lib/vutuv_web/controllers/mastodon_api/account_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/account_controller.ex
@@ -222,7 +222,7 @@ defmodule VutuvWeb.MastodonApi.AccountController do
         end
 
       organization ->
-        case Fediverse.organization_remote_follow_for(organization, target) do
+        case Fediverse.remote_follow_for(organization, target) do
           nil -> :ok
           follow -> Fediverse.unfollow_remote_as_organization(organization, follow.id)
         end
@@ -237,7 +237,7 @@ defmodule VutuvWeb.MastodonApi.AccountController do
         Fediverse.set_remote_follow_mute(conn.assigns.current_user, id, muted?)
 
       {%Organization{} = organization, %RemoteAccount{id: id}} ->
-        Fediverse.set_organization_remote_follow_mute(organization, id, muted?)
+        Fediverse.set_remote_follow_mute(organization, id, muted?)
 
       {nil, local} ->
         Social.set_follow_mute(conn.assigns.current_user, local, muted?)
@@ -313,7 +313,7 @@ defmodule VutuvWeb.MastodonApi.AccountController do
   defp following?(conn, %RemoteAccount{} = target) do
     case conn.assigns.current_organization do
       nil -> not is_nil(Fediverse.remote_follow_for(conn.assigns.current_user, target))
-      organization -> not is_nil(Fediverse.organization_remote_follow_for(organization, target))
+      organization -> not is_nil(Fediverse.remote_follow_for(organization, target))
     end
   end
 
@@ -334,7 +334,7 @@ defmodule VutuvWeb.MastodonApi.AccountController do
     follow =
       case conn.assigns.current_organization do
         nil -> Fediverse.remote_follow_for(conn.assigns.current_user, target)
-        organization -> Fediverse.organization_remote_follow_for(organization, target)
+        organization -> Fediverse.remote_follow_for(organization, target)
       end
 
     muted_follow?(follow)
@@ -374,7 +374,7 @@ defmodule VutuvWeb.MastodonApi.AccountController do
     follow =
       case conn.assigns.current_organization do
         nil -> Fediverse.remote_follow_for(conn.assigns.current_user, target)
-        organization -> Fediverse.organization_remote_follow_for(organization, target)
+        organization -> Fediverse.remote_follow_for(organization, target)
       end
 
     match?(%{state: "requested"}, follow)

--- a/lib/vutuv_web/controllers/mastodon_api/status_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/status_controller.ex
@@ -394,7 +394,7 @@ defmodule VutuvWeb.MastodonApi.StatusController do
     RemotePost.open?(post) or
       match?(
         %{state: "accepted"},
-        Fediverse.organization_remote_follow_for(organization, post.remote_account)
+        Fediverse.remote_follow_for(organization, post.remote_account)
       )
   end
 

--- a/lib/vutuv_web/controllers/organization_controller.ex
+++ b/lib/vutuv_web/controllers/organization_controller.ex
@@ -82,7 +82,7 @@ defmodule VutuvWeb.OrganizationController do
       # their copies; 404 otherwise), which reads to an AP client as "nothing
       # here" rather than choking on HTML. The member twin is `UserController`.
       FediverseController.ap_request?(conn) and Fediverse.federated?(organization) ->
-        {:ok, actor} = Fediverse.ensure_organization_actor(organization)
+        {:ok, actor} = Fediverse.ensure_actor(organization)
 
         conn
         |> put_resp_content_type("application/activity+json")

--- a/lib/vutuv_web/fediverse/docs.ex
+++ b/lib/vutuv_web/fediverse/docs.ex
@@ -146,7 +146,7 @@ defmodule VutuvWeb.Fediverse.Docs do
     user
     |> base_actor(actor, user.inserted_at)
     |> Map.merge(%{
-      "type" => "Person",
+      "type" => Vutuv.Identity.ap_type(user),
       "preferredUsername" => user.username,
       "name" => UserHelpers.full_name(user),
       "summary" => summary(user),
@@ -263,7 +263,7 @@ defmodule VutuvWeb.Fediverse.Docs do
     organization
     |> base_actor(actor, organization.inserted_at)
     |> Map.merge(%{
-      "type" => "Organization",
+      "type" => Vutuv.Identity.ap_type(organization),
       # The page's claimed handle. Federating without one is not possible —
       # WebFinger's `subject` and this field both need an address — which is why
       # `Fediverse.federated?/1` refuses a page that has not claimed one.

--- a/lib/vutuv_web/live/message_live/index.ex
+++ b/lib/vutuv_web/live/message_live/index.ex
@@ -528,10 +528,8 @@ defmodule VutuvWeb.MessageLive.Index do
 
   defp display_name(nil), do: gettext("Deleted account")
 
-  defp display_name(%Organization{name: name}), do: name
-
-  defp display_name(user) do
-    case VutuvWeb.UserHelpers.full_name(user) do
+  defp display_name(party) do
+    case Vutuv.Identity.display_name(party) do
       "" -> gettext("Member")
       name -> name
     end

--- a/lib/vutuv_web/live/organization_live/fediverse.ex
+++ b/lib/vutuv_web/live/organization_live/fediverse.ex
@@ -41,7 +41,7 @@ defmodule VutuvWeb.OrganizationLive.Fediverse do
     |> assign(:federated?, Fediverse.federated?(organization))
     |> assign(:ever_federated?, Fediverse.ever_federated?(organization))
     |> assign(:enabled?, Fediverse.enabled?())
-    |> assign(:remote_followers, Fediverse.organization_remote_follower_count(organization))
+    |> assign(:remote_followers, Fediverse.follower_count(organization))
   end
 
   @impl true
@@ -55,7 +55,7 @@ defmodule VutuvWeb.OrganizationLive.Fediverse do
     # remote server that resolves the handle a second later must find a complete
     # actor, and generating a key inside that request would be the slowest
     # possible moment for it.
-    if on?, do: Fediverse.ensure_organization_actor(organization)
+    if on?, do: Fediverse.ensure_actor(organization)
 
     {:noreply, assign_state(socket, organization)}
   end

--- a/lib/vutuv_web/live/organization_live/fediverse_followers.ex
+++ b/lib/vutuv_web/live/organization_live/fediverse_followers.ex
@@ -61,7 +61,7 @@ defmodule VutuvWeb.OrganizationLive.FediverseFollowers do
     organization = socket.assigns.organization
 
     socket
-    |> assign(:total_followers, Fediverse.organization_remote_follower_count(organization))
+    |> assign(:total_followers, Fediverse.follower_count(organization))
     |> assign(:hosts, Fediverse.follower_hosts(organization))
   end
 

--- a/lib/vutuv_web/live/organization_live/following.ex
+++ b/lib/vutuv_web/live/organization_live/following.ex
@@ -37,7 +37,6 @@ defmodule VutuvWeb.OrganizationLive.Following do
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.MastodonApi
-  alias Vutuv.Moderation
   alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
   alias Vutuv.Posts
@@ -217,15 +216,11 @@ defmodule VutuvWeb.OrganizationLive.Following do
     end
   end
 
-  defp visible_local_account(%User{} = user) do
-    if Moderation.profile_visible_to?(user, nil), do: user
-  end
-
-  defp visible_local_account(%Organization{} = organization) do
-    if Organizations.public_visible?(organization), do: organization
-  end
-
   defp visible_local_account(nil), do: nil
+
+  defp visible_local_account(account) do
+    if not Vutuv.Identity.hidden?(account), do: account
+  end
 
   defp set_local_mute(socket, follow_id, muted?) do
     with_publisher(socket, fn organization ->
@@ -236,7 +231,7 @@ defmodule VutuvWeb.OrganizationLive.Following do
 
   defp set_remote_mute(socket, account_id, muted?) do
     with_publisher(socket, fn organization ->
-      :ok = Fediverse.set_organization_remote_follow_mute(organization, account_id, muted?)
+      :ok = Fediverse.set_remote_follow_mute(organization, account_id, muted?)
       {:noreply, load_following(socket)}
     end)
   end

--- a/lib/vutuv_web/views/post_json.ex
+++ b/lib/vutuv_web/views/post_json.ex
@@ -11,7 +11,6 @@ defmodule VutuvWeb.PostJSON do
   """
 
   alias Vutuv.Accounts.User
-  alias Vutuv.Organizations.Organization
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostImage
@@ -25,7 +24,7 @@ defmodule VutuvWeb.PostJSON do
     %{
       id: post.id,
       url: VutuvWeb.Endpoint.url() <> Posts.path(post),
-      author: author_ref(Posts.author(post)),
+      author: Vutuv.Identity.ref(Posts.author(post)),
       body_markdown: post.body,
       body_html:
         post.body
@@ -54,11 +53,11 @@ defmodule VutuvWeb.PostJSON do
           # Whichever author the parent has (issue #1336): a member may answer a
           # post published in a page's name, and `author_ref/1` already speaks
           # both — `parent.user` alone would have shipped `nil` here.
-          author: author_ref(Posts.author(parent))
+          author: Vutuv.Identity.ref(Posts.author(parent))
         }
 
       {:author_only, author} ->
-        %{post_id: nil, url: nil, author: author_ref(author)}
+        %{post_id: nil, url: nil, author: Vutuv.Identity.ref(author)}
 
       :gone ->
         %{post_id: nil, url: nil, author: nil}
@@ -84,16 +83,6 @@ defmodule VutuvWeb.PostJSON do
       _other ->
         Posts.released_images(post)
     end
-  end
-
-  defp author_ref(%User{} = user) do
-    %{username: user.username, name: VutuvWeb.UserHelpers.full_name(user)}
-  end
-
-  # A page has a name and a slug where a member has a handle (issue #1334); it
-  # may hold no handle at all, so `username` would be a lie rather than a gap.
-  defp author_ref(%Organization{} = organization) do
-    %{slug: organization.slug, name: organization.name}
   end
 
   defp image(%PostImage{} = image) do

--- a/lib/vutuv_web/views/user_helpers.ex
+++ b/lib/vutuv_web/views/user_helpers.ex
@@ -17,7 +17,6 @@ defmodule VutuvWeb.UserHelpers do
   alias PhoenixHTMLHelpers.Format, as: HTMLFormat
   alias PhoenixHTMLHelpers.Link, as: HTMLLink
   alias Vutuv.Accounts.User
-  alias Vutuv.Organizations.Organization
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias Vutuv.Profiles.Address
@@ -28,16 +27,7 @@ defmodule VutuvWeb.UserHelpers do
   alias Vutuv.Tags
   alias Vutuv.Tags.UserTag
 
-  def full_name(%User{
-        first_name: first_name,
-        last_name: last_name,
-        honorific_prefix: honorific_prefix,
-        honorific_suffix: honorific_suffix
-      }) do
-    [honorific_prefix, first_name, last_name, honorific_suffix]
-    |> Enum.reject(&(&1 == "" || &1 == nil))
-    |> Enum.join(" ")
-  end
+  def full_name(%User{} = user), do: Vutuv.Identity.display_name(user)
 
   @doc """
   The visible name of a post's author, whichever kind of author it has (#1334).
@@ -57,8 +47,7 @@ defmodule VutuvWeb.UserHelpers do
   reposter, an organization's followee row.
   """
   def author_name(%Post{} = post), do: author_name(Posts.author(post))
-  def author_name(%Organization{name: name}), do: name
-  def author_name(%User{} = user), do: full_name(user)
+  def author_name(author), do: Vutuv.Identity.display_name(author)
 
   @doc """
   The member's name the way a directory files it: `"Özil, Mesut"` — surname

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.330.0",
+      version: "7.331.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/fediverse_follower_prune_test.exs
+++ b/test/vutuv/fediverse_follower_prune_test.exs
@@ -119,13 +119,13 @@ defmodule Vutuv.FediverseFollowerPruneTest do
     # answered 401, which reads as "still there" and kept the dead row forever.
     test "a page's gone follower is pruned and recorded against the page" do
       organization = insert(:organization)
-      {:ok, _actor} = Fediverse.ensure_organization_actor(organization)
+      {:ok, _actor} = Fediverse.ensure_actor(organization)
       {:ok, _follower} = organization_follower(organization, "gone.example")
 
       stub_hosts(%{"gone.example" => 410})
 
       assert Fediverse.prune_due_followers() == 1
-      assert Fediverse.organization_remote_follower_count(organization) == 0
+      assert Fediverse.follower_count(organization) == 0
 
       assert [prune] = Repo.all(FollowerPrune)
       assert prune.organization_id == organization.id
@@ -152,7 +152,7 @@ defmodule Vutuv.FediverseFollowerPruneTest do
     test "a page's and a topic's actor fetch are signed with their own keys" do
       organization = insert(:organization)
       tag = insert(:tag)
-      {:ok, _} = Fediverse.ensure_organization_actor(organization)
+      {:ok, _} = Fediverse.ensure_actor(organization)
       {:ok, _} = Fediverse.ensure_tag_actor(tag)
       {:ok, _} = organization_follower(organization, "page.example")
       {:ok, _} = tag_follower(tag, "topic.example")

--- a/test/vutuv/identity_test.exs
+++ b/test/vutuv/identity_test.exs
@@ -1,0 +1,147 @@
+defmodule Vutuv.IdentityTest do
+  use Vutuv.DataCase, async: true
+
+  import Ecto.Query
+  import Vutuv.Factory
+  import Vutuv.Identity.Query
+
+  alias Vutuv.Identity
+  alias Vutuv.Posts.Post
+
+  describe "Identity protocol, User" do
+    test "kind/id/handle/display_name" do
+      user = insert(:user, honorific_prefix: "Dr.", first_name: "Max", last_name: "Muster")
+
+      assert Identity.kind(user) == :user
+      assert Identity.id(user) == user.id
+      assert Identity.handle(user) == user.username
+      assert Identity.display_name(user) == "Dr. Max Muster"
+    end
+
+    test "path and ref build from the handle" do
+      user = insert(:user)
+
+      assert Identity.path(user) == "/" <> user.username
+
+      assert Identity.ref(user) == %{
+               name: Identity.display_name(user),
+               username: user.username,
+               url: VutuvWeb.Endpoint.url() <> "/" <> user.username
+             }
+    end
+
+    test "image, topic and ap_type" do
+      user = insert(:user, avatar: "some-token")
+
+      assert Identity.image(user) == "some-token"
+      assert Identity.topic(user) == "user:#{user.id}"
+      assert Identity.ap_type(user) == "Person"
+    end
+
+    test "hidden? follows the anonymous profile visibility" do
+      refute Identity.hidden?(insert(:activated_user))
+      # Unconfirmed members are not publicly visible.
+      assert Identity.hidden?(insert(:user))
+
+      frozen =
+        insert(:activated_user,
+          frozen_at: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+        )
+
+      assert Identity.hidden?(frozen)
+    end
+  end
+
+  describe "Identity protocol, Organization" do
+    test "kind/id/display_name" do
+      organization = insert(:organization, name: "Acme GmbH")
+
+      assert Identity.kind(organization) == :organization
+      assert Identity.id(organization) == organization.id
+      assert Identity.display_name(organization) == "Acme GmbH"
+    end
+
+    test "handle and path prefer the opt-in root handle" do
+      bare = insert(:organization)
+      handled = insert(:organization, username: "acme-handle")
+
+      assert Identity.handle(bare) == nil
+      assert Identity.path(bare) == "/organizations/#{bare.slug}"
+      assert Identity.handle(handled) == "acme-handle"
+      assert Identity.path(handled) == "/acme-handle"
+    end
+
+    test "ref carries name, slug and the canonical URL" do
+      organization = insert(:organization)
+
+      assert Identity.ref(organization) == %{
+               name: organization.name,
+               slug: organization.slug,
+               url: VutuvWeb.Endpoint.url() <> "/organizations/#{organization.slug}"
+             }
+    end
+
+    test "image, topic and ap_type" do
+      organization = insert(:organization, logo: "logo-token")
+
+      assert Identity.image(organization) == "logo-token"
+      assert Identity.topic(organization) == "organization:#{organization.id}"
+      assert Identity.ap_type(organization) == "Organization"
+    end
+
+    test "hidden? follows the public page visibility" do
+      refute Identity.hidden?(insert(:organization))
+      assert Identity.hidden?(insert(:organization, status: "pending"))
+
+      frozen =
+        insert(:organization,
+          frozen_at: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+        )
+
+      assert Identity.hidden?(frozen)
+    end
+  end
+
+  describe "party_is/2" do
+    test "matches only the given party's rows, whichever kind" do
+      user = insert(:activated_user)
+      organization = insert(:organization)
+      user_post = insert(:post, user: user)
+      organization_post = insert(:post, user: nil, organization: organization)
+
+      found_for_user =
+        Repo.all(from(p in Post, where: party_is(p, user), select: p.id))
+
+      found_for_organization =
+        Repo.all(from(p in Post, where: party_is(p, organization), select: p.id))
+
+      assert found_for_user == [user_post.id]
+      assert found_for_organization == [organization_post.id]
+    end
+  end
+
+  describe "join_party/3 + shown_party/2" do
+    test "keeps every member row and only publicly visible pages" do
+      member_post = insert(:post, user: insert(:user))
+      shown_page_post = insert(:post, user: nil, organization: insert(:organization))
+
+      frozen_page =
+        insert(:organization,
+          frozen_at: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+        )
+
+      _hidden_page_post = insert(:post, user: nil, organization: frozen_page)
+
+      shown =
+        from(p in Post)
+        |> join_party(:user_id, :organization_id)
+        |> where([p, u, o], shown_party(u, o))
+        |> select([p], p.id)
+        |> Repo.all()
+
+      assert member_post.id in shown
+      assert shown_page_post.id in shown
+      assert length(shown) == 2
+    end
+  end
+end

--- a/test/vutuv/organization_fediverse_actor_test.exs
+++ b/test/vutuv/organization_fediverse_actor_test.exs
@@ -57,13 +57,13 @@ defmodule Vutuv.OrganizationFediverseActorTest do
   test "a page gets one keypair, and asking twice returns the same one" do
     organization = active_organization_for(insert(:activated_user))
 
-    assert {:ok, actor} = Fediverse.ensure_organization_actor(organization)
+    assert {:ok, actor} = Fediverse.ensure_actor(organization)
     assert actor.organization_id == organization.id
     assert is_nil(actor.user_id)
     assert actor.private_key_pem =~ "PRIVATE KEY"
     assert actor.public_key_pem =~ "PUBLIC KEY"
 
-    assert {:ok, same} = Fediverse.ensure_organization_actor(organization)
+    assert {:ok, same} = Fediverse.ensure_actor(organization)
     assert same.id == actor.id
   end
 
@@ -71,7 +71,7 @@ defmodule Vutuv.OrganizationFediverseActorTest do
     member = insert(:activated_user)
     organization = active_organization_for(insert(:activated_user))
 
-    {:ok, _} = Fediverse.ensure_organization_actor(organization)
+    {:ok, _} = Fediverse.ensure_actor(organization)
 
     # `get_actor/1` reads `user_id`, which a page row leaves NULL — so the two
     # namespaces cannot bleed into each other even though they share a table.
@@ -79,16 +79,16 @@ defmodule Vutuv.OrganizationFediverseActorTest do
 
     {:ok, member_actor} = Fediverse.ensure_actor(member)
     assert Fediverse.get_actor(member).id == member_actor.id
-    assert Fediverse.get_organization_actor(organization).organization_id == organization.id
-    refute Fediverse.get_organization_actor(organization).id == member_actor.id
+    assert Fediverse.get_actor(organization).organization_id == organization.id
+    refute Fediverse.get_actor(organization).id == member_actor.id
   end
 
   test "deleting the page takes its keypair with it" do
     organization = active_organization_for(insert(:activated_user))
-    {:ok, _} = Fediverse.ensure_organization_actor(organization)
+    {:ok, _} = Fediverse.ensure_actor(organization)
 
     {:ok, _} = Vutuv.Organizations.delete_organization(organization)
 
-    refute Fediverse.get_organization_actor(organization)
+    refute Fediverse.get_actor(organization)
   end
 end

--- a/test/vutuv/organization_fediverse_followers_test.exs
+++ b/test/vutuv/organization_fediverse_followers_test.exs
@@ -77,7 +77,7 @@ defmodule Vutuv.OrganizationFediverseFollowersTest do
     assert {:ok, again} =
              Fediverse.add_organization_follower(organization, attrs(%{name: "Frida F."}))
 
-    assert Fediverse.organization_remote_follower_count(organization) == 1
+    assert Fediverse.follower_count(organization) == 1
     assert again.name == "Frida F."
 
     # The returned struct must BE the stored row. With client-generated UUIDs an
@@ -96,7 +96,7 @@ defmodule Vutuv.OrganizationFediverseFollowersTest do
     # Two different relationships, so two rows — and neither unique index may
     # mistake one for the other.
     assert Fediverse.follower_count(member) == 1
-    assert Fediverse.organization_remote_follower_count(organization) == 1
+    assert Fediverse.follower_count(organization) == 1
   end
 
   test "an Undo drops only that page's row" do
@@ -108,7 +108,7 @@ defmodule Vutuv.OrganizationFediverseFollowersTest do
 
     assert Fediverse.remove_organization_follower(organization, attrs().actor_uri) == 1
 
-    assert Fediverse.organization_remote_follower_count(organization) == 0
+    assert Fediverse.follower_count(organization) == 0
     assert Fediverse.follower_count(member) == 1
 
     # Idempotent: an Undo for a follow that is already gone is a no-op.
@@ -132,7 +132,7 @@ defmodule Vutuv.OrganizationFediverseFollowersTest do
 
     {:ok, _} = Vutuv.Organizations.delete_organization(organization)
 
-    assert Fediverse.organization_remote_follower_count(organization) == 0
+    assert Fediverse.follower_count(organization) == 0
   end
 
   describe "browsing them" do

--- a/test/vutuv/organization_fediverse_gate_test.exs
+++ b/test/vutuv/organization_fediverse_gate_test.exs
@@ -99,7 +99,7 @@ defmodule Vutuv.OrganizationFediverseGateTest do
     # afterwards keys on the keypair having existed, not on the current flag.
     refute Fediverse.ever_federated?(organization)
 
-    {:ok, _} = Fediverse.ensure_organization_actor(organization)
+    {:ok, _} = Fediverse.ensure_actor(organization)
     assert Fediverse.ever_federated?(organization)
 
     switched_off =

--- a/test/vutuv/organization_fediverse_publish_test.exs
+++ b/test/vutuv/organization_fediverse_publish_test.exs
@@ -39,7 +39,7 @@ defmodule Vutuv.OrganizationFediversePublishTest do
       |> Ecto.Changeset.change(Enum.into(opts, %{fediverse_followers?: true, username: "acme"}))
       |> Repo.update!()
 
-    {:ok, _} = Fediverse.ensure_organization_actor(page)
+    {:ok, _} = Fediverse.ensure_actor(page)
     {page, owner}
   end
 

--- a/test/vutuv/organization_fediverse_reactions_test.exs
+++ b/test/vutuv/organization_fediverse_reactions_test.exs
@@ -45,7 +45,7 @@ defmodule Vutuv.OrganizationFediverseReactionsTest do
       |> Ecto.Changeset.change(Enum.into(opts, %{fediverse_followers?: true, username: "acme"}))
       |> Repo.update!()
 
-    if page.fediverse_followers?, do: {:ok, _} = Fediverse.ensure_organization_actor(page)
+    if page.fediverse_followers?, do: {:ok, _} = Fediverse.ensure_actor(page)
     {:ok, post} = Posts.create_organization_post(page, owner, %{body: "Nach draußen."})
     {page, post}
   end
@@ -77,7 +77,7 @@ defmodule Vutuv.OrganizationFediverseReactionsTest do
 
     # Unconditional by design: an upstream withdrawal is the deletion path that
     # makes storing somebody else's act defensible in the first place.
-    :ok = Fediverse.remove_organization_reaction(page, uri, "announce", @actor)
+    :ok = Fediverse.remove_reaction(page, uri, "announce", @actor)
     assert counts(post).reposts == 0
   end
 

--- a/test/vutuv/organization_fediverse_replies_test.exs
+++ b/test/vutuv/organization_fediverse_replies_test.exs
@@ -54,7 +54,7 @@ defmodule Vutuv.OrganizationFediverseRepliesTest do
       |> Ecto.Changeset.change(Enum.into(opts, %{fediverse_followers?: true, username: "acme"}))
       |> Repo.update!()
 
-    if page.fediverse_followers?, do: {:ok, _} = Fediverse.ensure_organization_actor(page)
+    if page.fediverse_followers?, do: {:ok, _} = Fediverse.ensure_actor(page)
     {:ok, post} = Posts.create_organization_post(page, owner, %{body: "Nach draußen."})
     {page, post, owner}
   end

--- a/test/vutuv/organization_remote_follow_test.exs
+++ b/test/vutuv/organization_remote_follow_test.exs
@@ -45,7 +45,7 @@ defmodule Vutuv.OrganizationRemoteFollowTest do
       |> Ecto.Changeset.change(%{fediverse_followers?: true, username: "acme"})
       |> Repo.update!()
 
-    {:ok, _} = Fediverse.ensure_organization_actor(page)
+    {:ok, _} = Fediverse.ensure_actor(page)
     page
   end
 

--- a/test/vutuv/organizations_test.exs
+++ b/test/vutuv/organizations_test.exs
@@ -627,12 +627,12 @@ defmodule Vutuv.OrganizationsTest do
       # becomes reachable, and the keypair has to exist by then — a federating
       # page without one has its deliveries DELETED as undeliverable, silently.
       refute Vutuv.Fediverse.federated?(page)
-      assert is_nil(Vutuv.Fediverse.get_organization_actor(page))
+      assert is_nil(Vutuv.Fediverse.get_actor(page))
 
       {:ok, page} = Organizations.claim_handle(page, %{"username" => "acme"})
 
       assert Vutuv.Fediverse.federated?(page)
-      assert %Vutuv.Fediverse.Actor{} = Vutuv.Fediverse.get_organization_actor(page)
+      assert %Vutuv.Fediverse.Actor{} = Vutuv.Fediverse.get_actor(page)
     end
 
     test "a page that did not opt in gets no keypair from claiming its @name" do
@@ -640,7 +640,7 @@ defmodule Vutuv.OrganizationsTest do
 
       {:ok, page} = Organizations.claim_handle(page, %{"username" => "quietco"})
 
-      assert is_nil(Vutuv.Fediverse.get_organization_actor(page))
+      assert is_nil(Vutuv.Fediverse.get_actor(page))
     end
   end
 end

--- a/test/vutuv_web/live/post_thread_remote_replies_test.exs
+++ b/test/vutuv_web/live/post_thread_remote_replies_test.exs
@@ -382,7 +382,7 @@ defmodule VutuvWeb.PostThreadRemoteRepliesTest do
       {page, post, _publisher} = page_post()
       note = note!(post)
 
-      {:ok, _} = Fediverse.ensure_organization_actor(page)
+      {:ok, _} = Fediverse.ensure_actor(page)
       {:ok, view, _html} = thread_view(post, cookie)
 
       view

--- a/test/vutuv_web/organization_fediverse_actor_web_test.exs
+++ b/test/vutuv_web/organization_fediverse_actor_web_test.exs
@@ -147,7 +147,7 @@ defmodule VutuvWeb.OrganizationFediverseActorWebTest do
 
   test "a page that switched federation off answers 410, not 404", %{conn: conn} do
     page = federating_page()
-    {:ok, _} = Vutuv.Fediverse.ensure_organization_actor(page)
+    {:ok, _} = Vutuv.Fediverse.ensure_actor(page)
 
     _page = page |> Ecto.Changeset.change(%{fediverse_followers?: false}) |> Repo.update!()
 

--- a/test/vutuv_web/organization_fediverse_followers_web_test.exs
+++ b/test/vutuv_web/organization_fediverse_followers_web_test.exs
@@ -38,7 +38,7 @@ defmodule VutuvWeb.OrganizationFediverseFollowersWebTest do
       |> Ecto.Changeset.change(%{username: "acme", fediverse_followers?: true})
       |> Repo.update!()
 
-    {:ok, _} = Fediverse.ensure_organization_actor(page)
+    {:ok, _} = Fediverse.ensure_actor(page)
 
     {conn, page, owner}
   end

--- a/test/vutuv_web/organization_fediverse_inbox_test.exs
+++ b/test/vutuv_web/organization_fediverse_inbox_test.exs
@@ -44,7 +44,7 @@ defmodule VutuvWeb.OrganizationFediverseInboxTest do
       |> Ecto.Changeset.change(%{fediverse_followers?: true, username: "acme"})
       |> Repo.update!()
 
-    {:ok, _} = Fediverse.ensure_organization_actor(page)
+    {:ok, _} = Fediverse.ensure_actor(page)
     page
   end
 
@@ -109,7 +109,7 @@ defmodule VutuvWeb.OrganizationFediverseInboxTest do
 
     assert conn |> signed_post(page, follow_activity(page), priv) |> response(202)
 
-    assert Fediverse.organization_remote_follower_count(page) == 1
+    assert Fediverse.follower_count(page) == 1
 
     # The Accept is what stops Mastodon showing the follow as pending forever,
     # so its absence would be the actual failure, not a missing nicety.
@@ -126,7 +126,7 @@ defmodule VutuvWeb.OrganizationFediverseInboxTest do
     stub_remote_actor(pub)
 
     conn |> signed_post(page, follow_activity(page), priv) |> response(202)
-    assert Fediverse.organization_remote_follower_count(page) == 1
+    assert Fediverse.follower_count(page) == 1
 
     undo = %{
       "@context" => "https://www.w3.org/ns/activitystreams",
@@ -137,7 +137,7 @@ defmodule VutuvWeb.OrganizationFediverseInboxTest do
     }
 
     assert build_conn() |> signed_post(page, undo, priv) |> response(202)
-    assert Fediverse.organization_remote_follower_count(page) == 0
+    assert Fediverse.follower_count(page) == 0
   end
 
   test "a Follow naming another actor is not a follow of this page", %{conn: conn} do
@@ -149,7 +149,7 @@ defmodule VutuvWeb.OrganizationFediverseInboxTest do
 
     # Acknowledged — the signature was valid — but it must not mint a follower.
     assert conn |> signed_post(page, elsewhere, priv) |> response(202)
-    assert Fediverse.organization_remote_follower_count(page) == 0
+    assert Fediverse.follower_count(page) == 0
   end
 
   test "an unsigned delivery is refused", %{conn: conn} do
@@ -163,7 +163,7 @@ defmodule VutuvWeb.OrganizationFediverseInboxTest do
            )
            |> response(401)
 
-    assert Fediverse.organization_remote_follower_count(page) == 0
+    assert Fediverse.follower_count(page) == 0
   end
 
   test "a page that has not opted in has no inbox", %{conn: conn} do

--- a/test/vutuv_web/organization_fediverse_switch_test.exs
+++ b/test/vutuv_web/organization_fediverse_switch_test.exs
@@ -56,7 +56,7 @@ defmodule VutuvWeb.OrganizationFediverseSwitchTest do
 
     # Minted on the way in, not lazily on the first request: a remote server
     # resolving the handle a second later must find a complete actor.
-    assert Fediverse.get_organization_actor(page)
+    assert Fediverse.get_actor(page)
   end
 
   test "switching off stops federating but keeps the keypair", %{conn: conn} do

--- a/test/vutuv_web/organization_feed_web_test.exs
+++ b/test/vutuv_web/organization_feed_web_test.exs
@@ -113,7 +113,7 @@ defmodule VutuvWeb.OrganizationFeedWebTest do
       |> Ecto.Changeset.change(%{fediverse_followers?: true, username: "acme"})
       |> Repo.update!()
 
-    {:ok, _} = Fediverse.ensure_organization_actor(page)
+    {:ok, _} = Fediverse.ensure_actor(page)
     {:ok, _} = Organizations.add_role(page, owner, "publisher", owner)
 
     account =

--- a/test/vutuv_web/organization_remote_follow_web_test.exs
+++ b/test/vutuv_web/organization_remote_follow_web_test.exs
@@ -49,7 +49,7 @@ defmodule VutuvWeb.OrganizationRemoteFollowWebTest do
       |> Ecto.Changeset.change(Enum.into(opts, %{fediverse_followers?: true, username: "acme"}))
       |> Repo.update!()
 
-    if page.fediverse_followers?, do: {:ok, _} = Fediverse.ensure_organization_actor(page)
+    if page.fediverse_followers?, do: {:ok, _} = Fediverse.ensure_actor(page)
     {conn, page}
   end
 

--- a/test/vutuv_web/organization_test.exs
+++ b/test/vutuv_web/organization_test.exs
@@ -230,7 +230,7 @@ defmodule VutuvWeb.OrganizationTest do
       # publish an unverified page to other servers.
       assert page.fediverse_followers?
       refute Vutuv.Fediverse.federated?(page)
-      assert is_nil(Vutuv.Fediverse.get_organization_actor(page))
+      assert is_nil(Vutuv.Fediverse.get_actor(page))
     end
   end
 

--- a/test/vutuv_web/shared_inbox_actor_kinds_test.exs
+++ b/test/vutuv_web/shared_inbox_actor_kinds_test.exs
@@ -51,7 +51,7 @@ defmodule VutuvWeb.SharedInboxActorKindsTest do
       |> Ecto.Changeset.change(%{fediverse_followers?: true, username: username})
       |> Repo.update!()
 
-    {:ok, _} = Fediverse.ensure_organization_actor(page)
+    {:ok, _} = Fediverse.ensure_actor(page)
     page
   end
 
@@ -197,6 +197,6 @@ defmodule VutuvWeb.SharedInboxActorKindsTest do
     }
 
     assert conn |> shared_post(activity, priv) |> response(202)
-    assert Fediverse.organization_remote_follower_count(page) == 1
+    assert Fediverse.follower_count(page) == 1
   end
 end

--- a/test/vutuv_web/views/post_json_test.exs
+++ b/test/vutuv_web/views/post_json_test.exs
@@ -58,7 +58,12 @@ defmodule VutuvWeb.PostJSONTest do
     assert json.reply_count == 0
     assert json.in_reply_to.post_id == parent.id
     assert String.ends_with?(json.in_reply_to.url, Posts.path(parent))
-    assert json.in_reply_to.author == %{username: parent_author.username, name: "Petra Parent"}
+
+    assert json.in_reply_to.author == %{
+             username: parent_author.username,
+             name: "Petra Parent",
+             url: VutuvWeb.Endpoint.url() <> "/" <> parent_author.username
+           }
 
     # Parent deleted, account alive: no post left, the author still named.
     {:ok, _} = Posts.delete_post(parent)


### PR DESCRIPTION
**Closes #1416.** Wer spricht — Mitglied oder Seite — wurde an ~286 Einzelstellen per Pattern-Match entschieden; die NOT-IN/NULL-Klasse dieses Spaltenpaars kostete im Milestone 24 stille Fehler.

Drei Züge, kein Schemawechsel:

1. **`Vutuv.Identity`** (Protokoll für `User` + `Organization`): Name, Handle, Pfad, Bild, `hidden?`, PubSub-Topic, AP-Typ, Ref-Map. Die drei `author_ref`-Kopien (API v2, PostJSON, AgentDocs) sind eine Funktion.
2. **`Vutuv.Identity.Query`**: `party_is`, `join_party`, `shown_party` — das `shown_follower`-Makro verallgemeinert, Seiten-Sichtbarkeit über `organization_public_row/1`.
3. **Fediverse**: mechanische `_organization`-Zwillinge gefaltet (`ensure_actor`, `get_actor`, `follower_count`, `delivery_inboxes`, `remote_follow_for`, `set_remote_follow_mute`, `remove_reaction`, Signer). Nicht-mechanische bleiben absichtlich stehen.

Sichtbare Deltas: JSON-Refs tragen zusätzlich `url` (additiv), Benachrichtigungen nennen Ehrentitel wie jede andere Fläche. Sonst keine UI-Änderung, daher kein Screenshot. 8.525 Tests grün.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*
