### PR TITLE
Ein veralteter Fork-Branch wird vor dem Precommit abgefangen (v7.331.3)

### DIFF
--- a/.claude/hooks/precommit-before-push.sh
+++ b/.claude/hooks/precommit-before-push.sh
@@ -181,10 +181,59 @@ toplevel=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null)
 [ -f "$toplevel/mix.exs" ] ||
   block "$toplevel is not the vutuv project root (no mix.exs), so the precommit gate cannot vouch for this push."
 
+# In a FORK, check the cheap thing before the expensive one: a branch that was
+# never rebased onto the canonical repository's `main` costs twice, and both
+# costs are silent. The version bump takes a number `main` has already spent —
+# same line, same value, so no merge conflict and no warning — and the pull
+# request carries a diff against a base nobody has any more. Five minutes of
+# `mix precommit` on top of that is wasted either way.
+#
+# Nothing local can prove a checkout IS a fork: it is byte-for-byte identical
+# to its parent, and the relationship exists only on GitHub's servers. So this
+# proves the opposite — that `origin` is the canonical repository — and stays
+# out of the way for everybody who works here directly. Opt out anywhere with
+# `git config vutuv.fork-sync false`.
+fork_freshness() {
+  local canonical=${VUTUV_CANONICAL_REPO:-wintermeyer/vutuv} slug behind
+
+  [ "$(git -C "$toplevel" config --bool vutuv.fork-sync 2>/dev/null)" = "false" ] && return 0
+
+  slug=$(git -C "$toplevel" remote get-url origin 2>/dev/null |
+    sed -E 's,.*github\.com[:/]|\.git$,,g' | tr '[:upper:]' '[:lower:]')
+  # An unchanged slug means the sed matched no GitHub URL — another host, so
+  # none of this applies.
+  case "$slug" in
+    "" | *:* | *//* | "$canonical") return 0 ;;
+  esac
+
+  git -C "$toplevel" remote get-url upstream >/dev/null 2>&1 ||
+    block "this fork has no remote for $canonical, so nothing can tell whether the branch is current. Run \`./scripts/fork_setup.sh\` once."
+
+  # Best effort and bounded: nobody is at this terminal to answer a password
+  # prompt. A failed fetch leaves the last known ref in place, and comparing
+  # against that beats not comparing at all.
+  GIT_TERMINAL_PROMPT=0 GIT_SSH_COMMAND='ssh -oBatchMode=yes -oConnectTimeout=5' \
+    git -C "$toplevel" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=5 \
+    fetch --quiet --no-tags upstream main </dev/null 2>/dev/null
+
+  behind=$(git -C "$toplevel" rev-list --count HEAD..upstream/main 2>/dev/null)
+  [ "${behind:-0}" -gt 0 ] || return 0
+
+  block "\`$(git -C "$toplevel" rev-parse --abbrev-ref HEAD)\` is $behind commit(s) behind \`upstream/main\`.
+Rebase before pushing, or the version bump collides and the pull request's base is stale:
+
+  git fetch upstream main && git rebase upstream/main
+
+Then re-run \`elixir scripts/bump_version.exs …\`. Deliberate stale push: prefix the command with VUTUV_ALLOW_STALE_PUSH=1."
+}
+
 if [ "$explain" -eq 1 ]; then
   echo "PUSH $toplevel"
   exit 0
 fi
+
+[ "${VUTUV_ALLOW_STALE_PUSH:-}" = "1" ] || fork_freshness
+
 
 cd "$toplevel" || block "cannot enter $toplevel."
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.330.0",
+      version: "7.331.3",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/precommit_hook_test.exs
+++ b/test/vutuv/precommit_hook_test.exs
@@ -118,6 +118,82 @@ defmodule Vutuv.PrecommitHookTest do
     end
   end
 
+  describe "the fork freshness check that runs before precommit" do
+    # A branch that was never rebased onto the canonical repository's `main`
+    # collides on the version number without producing a merge conflict, so
+    # spending five minutes of `mix precommit` on it is wasted either way.
+    # These drive the real path, not `--explain`: the check blocks before
+    # `mix precommit` is ever reached, so no build happens here.
+    test "a fork with no remote for the canonical repository is blocked", ctx do
+      repo = fake_project("https://github.com/someone/vutuv.git")
+
+      decision = run(ctx, "git -C #{repo} push")
+
+      assert decision =~ "BLOCKED"
+      assert decision =~ "./scripts/fork_setup.sh"
+    end
+
+    test "a clone of the canonical repository is untouched", ctx do
+      # The one case that must never regress: whoever works on this repository
+      # directly sees none of this. Proven by the push getting past the check
+      # and into `mix precommit` — stubbed here so no build runs.
+      repo = fake_project("https://github.com/wintermeyer/vutuv.git")
+
+      # Reaching the (stubbed) precommit run is the proof it got past the check.
+      decision = run(ctx, "git -C #{repo} push", path: path_with_stub_mise())
+
+      assert decision =~ "Running mix precommit"
+      refute decision =~ "BLOCKED"
+    end
+
+    test "a fork can opt out", ctx do
+      repo = fake_project("https://github.com/someone/vutuv.git")
+      {_, 0} = System.cmd("git", ["config", "vutuv.fork-sync", "false"], cd: repo)
+
+      # Reaching the (stubbed) precommit run is the proof it got past the check.
+      decision = run(ctx, "git -C #{repo} push", path: path_with_stub_mise())
+
+      assert decision =~ "Running mix precommit"
+      refute decision =~ "BLOCKED"
+    end
+  end
+
+  # A throwaway repository that looks enough like this project for the hook to
+  # accept it (it insists on a `mix.exs`), with the given `origin`.
+  defp fake_project(origin_url) do
+    dir = Path.join(System.tmp_dir!(), "precommit-fork-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+    File.write!(Path.join(dir, "mix.exs"), "# fixture\n")
+    {_, 0} = System.cmd("git", ["init", "--quiet", dir])
+    {_, 0} = System.cmd("git", ["remote", "add", "origin", origin_url], cd: dir)
+    dir
+  end
+
+  # The hook shells out to `mise exec -- mix precommit`; a stub that exits 0
+  # stands in for it so a passing check does not trigger a real build.
+  defp path_with_stub_mise do
+    dir = Path.join(System.tmp_dir!(), "precommit-stub-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+
+    for tool <- ~w(bash sh awk git cat sed grep env jq) do
+      case System.find_executable(tool) do
+        nil -> :ok
+        path -> File.ln_s!(path, Path.join(dir, tool))
+      end
+    end
+
+    File.write!(Path.join(dir, "mise"), "#!/bin/sh\nexit 0\n")
+    File.chmod!(Path.join(dir, "mise"), 0o755)
+    dir
+  end
+
+  # Like `decide/3` but without `--explain`, so the checks actually run.
+  defp run(ctx, command, opts \\ []) do
+    decide(ctx, command, Keyword.put(opts, :explain, false))
+  end
+
   # Runs the hook in `--explain` mode against a payload and returns its verdict.
   # `System.cmd/3` cannot feed stdin, so the payload goes in through a file
   # redirect run by `sh`.
@@ -140,7 +216,8 @@ defmodule Vutuv.PrecommitHookTest do
         :error -> []
       end
 
-    script = "bash #{shell_quote(ctx.hook)} --explain < #{shell_quote(payload_file)}"
+    flag = if Keyword.get(opts, :explain, true), do: " --explain", else: ""
+    script = "bash #{shell_quote(ctx.hook)}#{flag} < #{shell_quote(payload_file)}"
 
     {out, _status} =
       System.cmd("sh", ["-c", script], cd: ctx.root, env: env, stderr_to_stdout: true)


### PR DESCRIPTION
Teil 3 von 6 aus #1552. Nennt das Skript aus #1587, funktioniert aber unabhängig.

**TL;DR** Der vorhandene Precommit-Hook lehnt einen Push ab, wenn der Branch aus einem Fork nie auf `upstream/main` rebased wurde. In einem Klon dieses Repositories ändert sich nichts.

**Problem.** So ein Branch kostet zweimal, beides still: der Versions-Bump greift eine Nummer, die `main` schon vergeben hat — gleiche Zeile, gleicher Wert, also kein Merge-Konflikt — und der PR-Diff steht gegen eine Basis, die es nicht mehr gibt.

**Warum in diesem Hook** statt in einem eigenen: zwei Hooks auf demselben Werkzeug laufen parallel, der billige könnte den teuren also nicht aufhalten. So spart die 200-ms-Prüfung fünf Minuten `mix precommit`. Der Hook hat sich beim Bau selbst geblockt.

**Wo:** `.claude/hooks/precommit-before-push.sh`, plus drei Tests.

**Deploy:** hot.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*
