### PR TITLE
Eine gecachte Fediverse-Antwort zeigt ihren lokalen Elternbeitrag (v7.332.4)

### DIFF
--- a/lib/vutuv_web/controllers/mastodon_api/status_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/status_controller.ex
@@ -12,6 +12,10 @@ defmodule VutuvWeb.MastodonApi.StatusController do
   alias Vutuv.Posts.Post
   alias Vutuv.Repo
 
+  # The empty conversation, in Mastodon's own shape — the honest answer
+  # wherever there is nothing local to show.
+  @empty_context %{ancestors: [], descendants: []}
+
   @doc """
   One status by the id a client was given.
 
@@ -185,12 +189,35 @@ defmodule VutuvWeb.MastodonApi.StatusController do
 
   defp context_payload(conn, %Post{} = post), do: thread_context(conn, post)
 
+  # A cached reply is by definition an answer to a local post (`note.post_id`),
+  # so the reader who opens it gets the conversation above: the parent post's
+  # own chain plus the parent, oldest first. Gated like every other read here —
+  # a parent the viewer may not see must not ride in on its reply's id, and
+  # `list_thread/2` unions the focus post back in unconditionally, so the check
+  # cannot be left to the query. The bare row is enough for that gate
+  # (`visible_to?/2` looks up whatever is not preloaded), and the copy that gets
+  # rendered comes out of `list_thread/2` preloaded. Descendants stay empty: a
+  # local answer to this reply lives in the parent's thread and is read there.
+  defp context_payload(conn, %Note{} = note) do
+    with %Post{} = parent <- Repo.get(Post, note.post_id),
+         true <- status_visible?(conn, parent) do
+      viewer = viewer(conn)
+      %{posts: posts} = Posts.list_thread(parent, viewer)
+      parents = Map.new(posts, &{&1.id, parent_id(&1)})
+      by_id = Map.new(posts, &{&1.id, &1})
+      chain = for id <- ancestor_chain(parents, parent.id, []), p = by_id[id], do: p
+      %{ancestors: Presenter.statuses(chain, viewer), descendants: []}
+    else
+      _gone_or_closed -> @empty_context
+    end
+  end
+
   # A status from another network has no place in the local reply tree, but a
   # client asks for its context the moment somebody opens it — and a 404 to
   # that call is an error screen where the post should be. The honest answer is
-  # the empty conversation, in Mastodon's own shape (the visibility gate has
-  # already been asked by `with_visible_status/3`, like on every other read).
-  defp context_payload(_conn, _remote), do: %{ancestors: [], descendants: []}
+  # the empty conversation (the visibility gate has already been asked by
+  # `with_visible_status/3`, like on every other read).
+  defp context_payload(_conn, _remote), do: @empty_context
 
   @doc """
   The status as its author typed it — the Markdown source, not the rendered
@@ -422,12 +449,12 @@ defmodule VutuvWeb.MastodonApi.StatusController do
   end
 
   defp thread_context(conn, %Post{} = post) do
-    viewer = conn.assigns.current_organization || conn.assigns.current_user
+    viewer = viewer(conn)
     %{posts: posts} = Posts.list_thread(post, viewer)
 
     parents = Map.new(posts, &{&1.id, parent_id(&1)})
     by_id = Map.new(posts, &{&1.id, &1})
-    ancestors = for id <- ancestor_chain(parents, parents[post.id], []), by_id[id], do: by_id[id]
+    ancestors = for id <- ancestor_chain(parents, parents[post.id], []), p = by_id[id], do: p
     descendants = Enum.filter(posts, &below?(parents, &1.id, post.id))
 
     # **One render for both halves.** A thread is mostly the same handful of

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.332.2",
+      version: "7.332.4",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -344,6 +344,26 @@ defmodule Vutuv.Factory do
     }
   end
 
+  # A stored public reply from another network, the way the inbox writes one.
+  def note_factory do
+    now = DateTime.utc_now(:second)
+    actor = sequence(:note_actor, &"https://social.example/users/alice#{&1}")
+
+    %Vutuv.Fediverse.Note{
+      post: build(:post),
+      object_uri: sequence(:note_object, &"https://social.example/statuses/#{&1}"),
+      actor_uri: actor,
+      inbox_uri: actor <> "/inbox",
+      handle: "alice",
+      display_name: "Alice Anders",
+      content_text: "Guter Punkt.",
+      audience: "public",
+      received_at: now,
+      checked_at: now,
+      expires_at: DateTime.add(now, Vutuv.Fediverse.note_retention_days() * 86_400)
+    }
+  end
+
   def post_review_factory do
     %Vutuv.Posts.PostReview{
       post: build(:post),

--- a/test/vutuv/posts_remote_replies_test.exs
+++ b/test/vutuv/posts_remote_replies_test.exs
@@ -11,7 +11,6 @@ defmodule Vutuv.PostsRemoteRepliesTest do
 
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.Delivery
-  alias Vutuv.Fediverse.Note
   alias Vutuv.Posts
   alias Vutuv.Posts.PostRemoteReply
 
@@ -27,30 +26,9 @@ defmodule Vutuv.PostsRemoteRepliesTest do
     {:ok, author: author, post: post, note: insert_note!(post)}
   end
 
-  # A stored public reply from another network, the way the inbox writes one.
-  defp insert_note!(post, attrs \\ %{}) do
-    now = DateTime.utc_now(:second)
-
-    %Note{post_id: post.id}
-    |> Note.changeset(
-      Map.merge(
-        %{
-          object_uri: "#{@actor}/statuses/#{System.unique_integer([:positive])}",
-          actor_uri: @actor,
-          inbox_uri: @inbox,
-          handle: "alice",
-          display_name: "Alice Anders",
-          content_text: "Guter Punkt.",
-          audience: "public",
-          received_at: now,
-          checked_at: now,
-          expires_at: DateTime.add(now, 183 * 86_400)
-        },
-        attrs
-      )
-    )
-    |> Repo.insert!()
-  end
+  # The shared `:note` factory, pinned to the actor the assertions below name.
+  defp insert_note!(post, attrs \\ %{}),
+    do: insert(:note, Map.merge(%{post: post, actor_uri: @actor, inbox_uri: @inbox}, attrs))
 
   describe "create_remote_reply/3" do
     test "creates an ordinary reply plus the sidecar naming what it answers", %{

--- a/test/vutuv_web/controllers/mastodon_api/discovery_extras_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/discovery_extras_test.exs
@@ -65,6 +65,50 @@ defmodule VutuvWeb.MastodonApi.DiscoveryExtrasTest do
                Enum.sort([first.id, second.id])
     end
 
+    # Issue #1599: a %Note{} is a cached reply to a local post, so opening it in
+    # a client shows the conversation above instead of an orphan.
+    test "a cached remote reply answers its local parent chain as ancestors", %{conn: conn} do
+      author = insert(:activated_user)
+      {:ok, root} = Posts.create_post(author, %{body: "Die Wurzel"})
+      {:ok, parent} = Posts.create_reply(author, root, %{body: "Die Mitte"})
+      note = insert(:note, post: parent)
+
+      token = mastodon_token(insert(:activated_user), ["read"])
+
+      context =
+        conn
+        |> mastodon_conn(token)
+        |> get("/api/v1/statuses/remote-note-#{note.id}/context")
+        |> json_response(200)
+
+      assert Enum.map(context["ancestors"], & &1["id"]) == [root.id, parent.id]
+      assert context["descendants"] == []
+    end
+
+    # Without the explicit gate the chain would still carry the closed parent
+    # (list_thread unions the focus post back in unconditionally), so this test
+    # goes red the moment the visibility check is dropped.
+    test "a parent the reader may not see stays out of a reply's context", %{conn: conn} do
+      author = insert(:activated_user)
+
+      {:ok, closed} =
+        Posts.create_post(author, %{
+          body: "Nur für Follower",
+          denials: [%{wildcard: "non_followers"}]
+        })
+
+      note = insert(:note, post: closed)
+      token = mastodon_token(insert(:activated_user), ["read"])
+
+      context =
+        conn
+        |> mastodon_conn(token)
+        |> get("/api/v1/statuses/remote-note-#{note.id}/context")
+        |> json_response(200)
+
+      assert context == %{"ancestors" => [], "descendants" => []}
+    end
+
     test "a status nobody may see is a 404, not an empty context", %{conn: conn} do
       author = insert(:activated_user)
       stranger = insert(:activated_user)

--- a/test/vutuv_web/live/post_feed_live_test.exs
+++ b/test/vutuv_web/live/post_feed_live_test.exs
@@ -9,33 +9,10 @@ defmodule VutuvWeb.PostFeedLiveTest do
   import Phoenix.LiveViewTest
 
   alias Vutuv.Activity
-  alias Vutuv.Fediverse.Note
   alias Vutuv.Posts
   alias Vutuv.Posts.PostImage
 
   defp other_user(attrs \\ []), do: insert(:user, Keyword.merge([email_confirmed?: true], attrs))
-
-  # A stored public reply from another network, the way the inbox writes one
-  # (it feeds the "fediverse_reply" arm of the unread notification count).
-  defp insert_note!(post) do
-    now = DateTime.utc_now(:second)
-    actor = "https://social.example/users/alice#{System.unique_integer([:positive])}"
-
-    %Note{post_id: post.id}
-    |> Note.changeset(%{
-      object_uri: "#{actor}/statuses/#{System.unique_integer([:positive])}",
-      actor_uri: actor,
-      inbox_uri: "#{actor}/inbox",
-      handle: "alice",
-      display_name: "Alice Anders",
-      content_text: "Guter Punkt.",
-      audience: "public",
-      received_at: now,
-      checked_at: now,
-      expires_at: DateTime.add(now, 183 * 86_400)
-    })
-    |> Repo.insert!()
-  end
 
   # The discovery rail renders with the page again (the v7.200.3 laziness was
   # undone — see FeedRailsTest); the helper name survives at the call sites.
@@ -1368,7 +1345,7 @@ defmodule VutuvWeb.PostFeedLiveTest do
       friend = other_user()
       insert(:follow, follower: user, followee: friend)
       {:ok, mine} = Posts.create_post(user, %{body: "federated far and wide"})
-      insert_note!(mine)
+      insert(:note, post: mine)
 
       {:ok, live, _html} = live(conn, ~p"/feed")
 


### PR DESCRIPTION
**Symptom:** Wer in einem Mastodon-Client (Ivory) eine gecachte Fediverse-Antwort öffnet, sah sie als Waise ohne Elternbeitrag: `GET /api/v1/statuses/remote-note-<id>/context` antwortete die leere Konversation, obwohl ein `%Note{}` per Definition einen lokalen Beitrag beantwortet (#1599).

**Änderung:** `VutuvWeb.MastodonApi.StatusController.context_payload/2` bekommt eine `%Note{}`-Klausel: die Kette des Elternbeitrags (samt Eltern, älteste zuerst) als `ancestors`, explizit sichtbarkeitsgeprüft, weil `list_thread/2` den Anker ungeprüft zurückvereinigt. `descendants` bleiben leer, `RemotePost`s behalten die leere Antwort. Nebenbei: die dreifach kopierte Note-Test-Fixture ist jetzt eine gemeinsame Factory.

**Bewusst ausgelassen:** `in_reply_to_id` im Presenter zu füllen würde die Existenz eines geschlossenen Beitrags ungeprüft bestätigen; das wäre separat zu entscheiden. Reiner JSON-Endpunkt, daher kein Screenshot.

Closes #1599.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*