### PR TITLE
Ein Fremder trägt sein eigenes Gesicht in der Benachrichtigungsliste (v7.332.6)

### DIFF
--- a/docs/architecture/mastodon-api.md
+++ b/docs/architecture/mastodon-api.md
@@ -127,7 +127,13 @@ and cover, and the cached picture of an account on another network
 (`RemoteAccount.avatar_url/1`, the one chokepoint that answers `nil` unless the
 gate cleared it). An account with no cover gets a plain brand banner
 (`/images/header-placeholder.png`) rather than the installation's square icon,
-which is what a client used to draw across the top of every profile.
+which is what a client used to draw across the top of every profile. The
+**notification actor** goes through the same chokepoint (issue #1598): an
+activity item for somebody on another network carries only their handle and
+actor URI, so `Notifications.accounts/1` — the one loader both the REST list
+and the streaming socket render through — resolves the cached `RemoteAccount`
+by that URI (`Fediverse.remote_accounts_by_uris/1`, batched per page) and only
+an actor nobody here stored falls back to the hand-built placeholder account.
 
 The three counts are `Vutuv.MastodonApi.AccountCounts`, one query per figure for
 a whole page rather than three per row — ours are real aggregates where

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -1332,6 +1332,23 @@ defmodule Vutuv.Fediverse do
   def get_remote_account(id), do: UUIDv7.with_cast(id, &Repo.get(RemoteAccount, &1))
 
   @doc """
+  The stored remote accounts these actor URIs name, keyed by URI — one query
+  for a whole page. A URI nobody here stored is simply absent, so callers
+  fall back per actor.
+  """
+  def remote_accounts_by_uris(actor_uris) do
+    case actor_uris |> Enum.filter(&is_binary/1) |> Enum.uniq() do
+      [] ->
+        %{}
+
+      uris ->
+        from(a in RemoteAccount, where: a.actor_uri in ^uris)
+        |> Repo.all()
+        |> Map.new(&{&1.actor_uri, &1})
+    end
+  end
+
+  @doc """
   The member or page takes the follow back: a best-effort `Undo(Follow)` to
   the other server, then the row goes.
 

--- a/lib/vutuv/mastodon_api/notifications.ex
+++ b/lib/vutuv/mastodon_api/notifications.ex
@@ -18,7 +18,10 @@ defmodule Vutuv.MastodonApi.Notifications do
   not served, not pushed and not streamed.
   """
 
+  import Ecto.Query, only: [where: 3]
+
   alias Vutuv.Accounts.User
+  alias Vutuv.Fediverse
   alias Vutuv.MastodonApi.Presenter
   alias Vutuv.Organizations.Organization
   alias Vutuv.Repo
@@ -47,24 +50,47 @@ defmodule Vutuv.MastodonApi.Notifications do
   @doc "Whether this kind is one Mastodon has a type for."
   def mapped?(item), do: not is_nil(type(item))
 
-  @doc """
-  The account one notification names, as a single lookup.
+  @doc "The account one notification names — `accounts/1` for a single item."
+  def account(item), do: accounts([item])[item[:id]]
 
-  For the batch path (`/api/v1/notifications` renders a page at a time) the
-  controller has its own two-query loader; this is for the callers that hold
-  exactly one item, where a batch would be a batch of one.
+  @doc """
+  The accounts a page of items names, rendered and keyed by **item id** — one
+  query per actor kind (members, pages, cached remote accounts) rather than
+  one per row. Both readers that name an actor — the REST controller and the
+  streaming socket — render through here, for the same reason the type table
+  lives here: two copies of "who is this" is how they come to disagree.
+
+  A remote actor has no vutuv profile, so `Vutuv.Activity` carries only their
+  handle and actor URI — but whoever's reply or reaction was stored got a
+  `RemoteAccount` row too, gate-cleared avatar included, found under that URI
+  and rendered through `Presenter.account/1`, the chokepoint the status path
+  uses (issue #1598). So the actor and their statuses are one account to a
+  client, face and all. Only an actor whose row is gone, or whom nobody here
+  ever stored, falls back to `placeholder_account/1`.
   """
-  def account(item) do
-    case {item[:actor_id], item[:actor_kind]} do
-      {nil, _kind} -> placeholder_account(item)
-      {id, "organization"} -> lookup(Organization, id) || placeholder_account(item)
-      {id, _member} -> lookup(User, id) || placeholder_account(item)
-    end
+  def accounts(items) do
+    {remote, local} = Enum.split_with(items, &is_nil(&1[:actor_id]))
+    {organizations, users} = Enum.split_with(local, &(&1[:actor_kind] == "organization"))
+
+    # A local actor is keyed by row id, a remote one by actor URI; the two
+    # keyspaces cannot collide.
+    resolved =
+      Map.merge(
+        accounts_by_id(User, Enum.map(users, & &1.actor_id)),
+        Map.merge(
+          accounts_by_id(Organization, Enum.map(organizations, & &1.actor_id)),
+          remote_accounts(remote)
+        )
+      )
+
+    Map.new(items, fn item ->
+      {item[:id], resolved[item[:actor_id] || item[:actor_url]] || placeholder_account(item)}
+    end)
   end
 
   @doc """
-  The stand-in account for an actor with no vutuv profile — somebody on another
-  network, whose handle is all `Vutuv.Activity` carries.
+  The stand-in account for a remote actor nobody here ever stored — then their
+  handle really is all `Vutuv.Activity` carries.
 
   Built through `Presenter.base_account/1` like every other account this adapter
   renders, so it carries the keys a client reads unconditionally (`emojis`,
@@ -86,10 +112,19 @@ defmodule Vutuv.MastodonApi.Notifications do
     })
   end
 
-  defp lookup(schema, id) do
-    case Repo.get(schema, id) do
-      nil -> nil
-      record -> Presenter.account(record)
-    end
+  defp accounts_by_id(_schema, []), do: %{}
+
+  defp accounts_by_id(schema, ids) do
+    schema
+    |> where([r], r.id in ^Enum.uniq(ids))
+    |> Repo.all()
+    |> Map.new(&{&1.id, Presenter.account(&1)})
+  end
+
+  defp remote_accounts(items) do
+    items
+    |> Enum.map(& &1[:actor_url])
+    |> Fediverse.remote_accounts_by_uris()
+    |> Map.new(fn {uri, account} -> {uri, Presenter.account(account)} end)
   end
 end

--- a/lib/vutuv_web/controllers/mastodon_api/notification_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/notification_controller.ex
@@ -24,15 +24,10 @@ defmodule VutuvWeb.MastodonApi.NotificationController do
 
   use VutuvWeb, :controller
 
-  import Ecto.Query, only: [where: 3]
-
-  alias Vutuv.Accounts.User
   alias Vutuv.Activity
   alias Vutuv.MastodonApi.Notifications
   alias Vutuv.MastodonApi.Presenter
-  alias Vutuv.Organizations.Organization
   alias Vutuv.Posts
-  alias Vutuv.Repo
   alias Vutuv.UUIDv7
   alias VutuvWeb.MastodonApi.Pagination
 
@@ -196,7 +191,9 @@ defmodule VutuvWeb.MastodonApi.NotificationController do
   end
 
   defp notifications(conn, items) do
-    accounts = load_accounts(items)
+    # Who each item names is `Notifications.accounts/1`'s answer — the same one
+    # the streaming socket serves — keyed by item id, one query per actor kind.
+    accounts = Notifications.accounts(items)
     statuses = load_statuses(conn, items)
 
     Enum.map(items, fn item ->
@@ -204,35 +201,10 @@ defmodule VutuvWeb.MastodonApi.NotificationController do
         id: item.id,
         type: type(item),
         created_at: timestamp(item.at),
-        account: accounts[item[:actor_id]] || placeholder_account(item),
+        account: accounts[item.id],
         status: statuses[item[:post_id]]
       }
     end)
-  end
-
-  # One query per actor kind rather than one per row: a page of twenty
-  # notifications is usually twenty different people.
-  defp load_accounts(items) do
-    {organizations, users} =
-      items
-      |> Enum.filter(& &1[:actor_id])
-      |> Enum.split_with(&(&1[:actor_kind] == "organization"))
-
-    Map.merge(
-      accounts_by_id(User, Enum.map(users, & &1.actor_id)),
-      accounts_by_id(Organization, Enum.map(organizations, & &1.actor_id))
-    )
-  end
-
-  defp accounts_by_id(_schema, []), do: %{}
-
-  defp accounts_by_id(schema, ids) do
-    ids = Enum.uniq(ids)
-
-    schema
-    |> where([r], r.id in ^ids)
-    |> Repo.all()
-    |> Map.new(&{&1.id, Presenter.account(&1)})
   end
 
   defp load_statuses(conn, items) do
@@ -247,11 +219,6 @@ defmodule VutuvWeb.MastodonApi.NotificationController do
       posts |> Enum.map(& &1.id) |> Enum.zip(rendered) |> Map.new()
     end)
   end
-
-  # Somebody on another network has no vutuv profile, so `Vutuv.Activity` leaves
-  # the local actor fields nil and carries their handle instead. A Mastodon
-  # notification must still name an account, so it is built from what there is.
-  defp placeholder_account(item), do: Notifications.placeholder_account(item)
 
   defp type(item), do: Notifications.type(item)
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.332.4",
+      version: "7.332.6",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/mastodon_api/notifications_test.exs
+++ b/test/vutuv/mastodon_api/notifications_test.exs
@@ -1,0 +1,61 @@
+defmodule Vutuv.MastodonApi.NotificationsTest do
+  @moduledoc """
+  The account a notification names when its actor lives on another network
+  (issue #1598): the item carries only the actor's handle and URI, so the
+  cached `RemoteAccount` — with its gate-cleared face — has to be resolved
+  from that URI, and the hand-built placeholder is only for actors nobody
+  here ever stored. Calibrated against the un-fixed code, where every remote
+  actor wore the installation icon.
+  """
+  use Vutuv.DataCase, async: true
+
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.MastodonApi
+  alias Vutuv.MastodonApi.Notifications
+  alias Vutuv.MastodonApi.Presenter
+
+  defp stored_account(actor_uri) do
+    Repo.insert!(%RemoteAccount{
+      actor_uri: actor_uri,
+      host: URI.parse(actor_uri).host,
+      handle: "carol",
+      name: "Carol",
+      inbox_uri: actor_uri <> "/inbox",
+      avatar: "avatar-abc123.avif",
+      avatar_moderation: "approved"
+    })
+  end
+
+  # The shape `Vutuv.Activity.remote_actor_fields/1` gives both the derived
+  # items and the live notify payloads, so this covers the streaming path too.
+  defp item(actor_uri) do
+    %{
+      id: "fediverse_reaction-test",
+      kind: "fediverse_reaction",
+      actor_id: nil,
+      actor_name: "@carol@social.example",
+      actor_handle: "@carol@social.example",
+      actor_url: actor_uri
+    }
+  end
+
+  test "resolves the cached account by its actor URI" do
+    actor_uri = "https://social.example/users/carol-#{System.unique_integer([:positive])}"
+    stored = stored_account(actor_uri)
+
+    account = Notifications.account(item(actor_uri))
+
+    assert account.id == "remote-" <> stored.id
+    assert account.avatar == MastodonApi.main_url(RemoteAccount.avatar_url(stored))
+    refute account.avatar == Presenter.fallback_avatar()
+  end
+
+  test "falls back to the placeholder for an actor nobody here stored" do
+    actor_uri = "https://social.example/users/carol-#{System.unique_integer([:positive])}"
+
+    account = Notifications.account(item(actor_uri))
+
+    assert account.acct == "carol@social.example"
+    assert account.avatar == Presenter.fallback_avatar()
+  end
+end

--- a/test/vutuv_web/controllers/mastodon_api/notification_controller_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/notification_controller_test.exs
@@ -8,6 +8,10 @@ defmodule VutuvWeb.MastodonApi.NotificationControllerTest do
   import Vutuv.MastodonHelpers
 
   alias Vutuv.Activity
+  alias Vutuv.Fediverse.Reaction
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.MastodonApi
+  alias Vutuv.MastodonApi.Presenter
   alias Vutuv.Posts
   alias Vutuv.Repo
   alias Vutuv.Social
@@ -168,6 +172,72 @@ defmodule VutuvWeb.MastodonApi.NotificationControllerTest do
              MapSet.new(second, & &1["id"])
            ),
            "the second page repeated the first — the boundary never reached the query"
+  end
+
+  # A favourite or boost from another network names an actor with no vutuv
+  # profile, so `Vutuv.Activity` carries only their handle and actor URI — but
+  # when somebody's reply or reaction was stored, their `RemoteAccount` was
+  # too, gate-cleared avatar included. Statuses learned to wear that face in
+  # #1588; the notification list hardcoded the installation icon (issue #1598).
+  describe "a favourite arriving from another network" do
+    test "wears the actor's cached face, not the installation icon", %{conn: conn} do
+      member = insert(:activated_user)
+      {:ok, post} = Posts.create_post(member, %{body: "Bis ins Fediverse"})
+
+      actor_uri = "https://social.example/users/carol-#{System.unique_integer([:positive])}"
+
+      account =
+        Repo.insert!(%RemoteAccount{
+          actor_uri: actor_uri,
+          host: "social.example",
+          handle: "carol",
+          name: "Carol",
+          inbox_uri: actor_uri <> "/inbox",
+          avatar: "avatar-abc123.avif",
+          avatar_moderation: "approved"
+        })
+
+      remote_reaction(post, actor_uri, "carol")
+
+      token = mastodon_token(member, ["read"])
+
+      [favourite] =
+        conn |> mastodon_conn(token) |> get("/api/v1/notifications") |> json_response(200)
+
+      assert favourite["type"] == "favourite"
+      assert favourite["account"]["id"] == "remote-" <> account.id
+
+      assert favourite["account"]["avatar"] ==
+               MastodonApi.main_url(RemoteAccount.avatar_url(account))
+
+      refute favourite["account"]["avatar"] == Presenter.fallback_avatar()
+    end
+
+    test "keeps the stand-in for an actor nobody here stored", %{conn: conn} do
+      member = insert(:activated_user)
+      {:ok, post} = Posts.create_post(member, %{body: "Auch bis ins Fediverse"})
+
+      actor_uri = "https://social.example/users/nobody-#{System.unique_integer([:positive])}"
+      remote_reaction(post, actor_uri, "nobody")
+
+      token = mastodon_token(member, ["read"])
+
+      [favourite] =
+        conn |> mastodon_conn(token) |> get("/api/v1/notifications") |> json_response(200)
+
+      assert favourite["account"]["acct"] == "nobody@social.example"
+      assert favourite["account"]["avatar"] == Presenter.fallback_avatar()
+    end
+  end
+
+  defp remote_reaction(post, actor_uri, handle) do
+    Repo.insert!(%Reaction{
+      post_id: post.id,
+      actor_uri: actor_uri,
+      handle: handle,
+      kind: "like",
+      received_at: DateTime.utc_now(:second)
+    })
   end
 
   # The unmappable kinds are dropped **after** the read, so a full read can


### PR DESCRIPTION
Closes #1598.

**Symptom:** Ein Favourite oder Boost aus dem Fediverse zeigte im Mastodon-Client (`GET /api/v1/notifications`, Streaming-Socket) das vutuv-Icon statt des gecachten, gate-geprüften Avatars des Akteurs — Statuses bekamen ihr Gesicht schon in #1588.

**Änderung:** `Vutuv.MastodonApi.Notifications.accounts/1` besitzt jetzt allein die Frage "wen nennt dieses Item": REST-Controller und Socket rendern beide hindurch. Der `RemoteAccount` wird pro Seite gebatcht über die Actor-URI aufgelöst (neu: `Fediverse.remote_accounts_by_uris/1`) und durch `Presenter.account/1` gerendert — derselbe Chokepoint wie beim Status, der Akteur und seine Posts sind damit ein Account. Nur ein nie gespeicherter Akteur fällt auf den Platzhalter zurück.

Kein Web-UI betroffen, daher kein Screenshot; Tests decken beide Pfade ab.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*