### PR TITLE
Ein Bildlader bringt keine Sitzung mit, also trägt die URL ihre Erlaubnis (v7.332.8)

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -1588,12 +1588,19 @@ conflated:
 chokepoints ("we have the file **and** the gate cleared it"), read both at
 render time and again in `VutuvWeb.RemoteMediaController` — the authorizing
 proxy at `/system/remote_media/…`, which re-checks per request that the reader
-is signed in, that the post's own audience reaches them, that the gate cleared
+belongs here, that the post's own audience reaches them, that the gate cleared
 the picture, and that the URL's version segment names the exact fingerprinted
 file we currently store. Everything else is a 404, and every response carries
 `X-Robots-Tag: noindex, noimageindex`: this is somebody else's photograph, and
 it must never surface as ours in an image search. An unguessable URL is not an
 access control.
+
+"Belongs here" is a session for a browser, and on the avatar route also a
+`VutuvWeb.RemoteMediaToken` in `t` — the capability the Mastodon adapter appends
+because a phone app's image loader sends neither the cookie nor the bearer token
+the API call beside it used. It is unforgeable, it expires, and it names one
+account's one stored file, so it opens nothing else and stops opening that one
+the moment the file is replaced.
 
 A post can now be a **photograph and nothing else**, which used to be dropped
 for having no text. Its `content_text` is then the empty string — emphatically

--- a/docs/architecture/mastodon-api.md
+++ b/docs/architecture/mastodon-api.md
@@ -127,13 +127,29 @@ and cover, and the cached picture of an account on another network
 (`RemoteAccount.avatar_url/1`, the one chokepoint that answers `nil` unless the
 gate cleared it). An account with no cover gets a plain brand banner
 (`/images/header-placeholder.png`) rather than the installation's square icon,
-which is what a client used to draw across the top of every profile. The
-**notification actor** goes through the same chokepoint (issue #1598): an
-activity item for somebody on another network carries only their handle and
-actor URI, so `Notifications.accounts/1` — the one loader both the REST list
-and the streaming socket render through — resolves the cached `RemoteAccount`
-by that URI (`Fediverse.remote_accounts_by_uris/1`, batched per page) and only
-an actor nobody here stored falls back to the hand-built placeholder account.
+which is what a client used to draw across the top of every profile. A remote
+account has no banner at all — we cache an actor's `icon`, never its `image` —
+so it always gets that one. The **notification actor** goes through the same
+chokepoint (issue #1598): an activity item for somebody on another network
+carries only their handle and actor URI, so `Notifications.accounts/1` — the one
+loader both the REST list and the streaming socket render through — resolves the
+cached `RemoteAccount` by that URI (`Fediverse.remote_accounts_by_uris/1`,
+batched per page) and only an actor nobody here stored falls back to the
+hand-built placeholder account.
+
+**A cached remote picture needs a capability, because an image loader carries
+no credentials.** `/system/remote_media/…` asks for a signed-in reader, and a
+phone app fetches an image with a bare `GET`: no cookie, no bearer, whatever
+the API call beside it used. So naming the real picture (v7.330.0) named it at
+a URL the client could not fetch, and every account out of the fediverse went
+blank — its profile, its posts, and from v7.332.6 its notifications too. The
+adapter appends `VutuvWeb.RemoteMediaToken` — signed, expiring, and naming
+exactly the account and stored file it opens — and the proxy takes it in place
+of the session. The AI gate and the stored-file whitelist are still re-asked per
+request, so it widens nothing. Its `signed_at` is pinned to the UTC day so a
+client is handed the same URL all day and its image cache keeps working; a
+per-render timestamp would re-download every face in the timeline on every
+refresh.
 
 The three counts are `Vutuv.MastodonApi.AccountCounts`, one query per figure for
 a whole page rather than three per row — ours are real aggregates where

--- a/lib/vutuv/mastodon_api.ex
+++ b/lib/vutuv/mastodon_api.ex
@@ -95,8 +95,14 @@ defmodule Vutuv.MastodonApi do
   """
   def operator_handle, do: Application.get_env(:vutuv, :operator_handle)
 
-  def main_url(path), do: absolute_url(local_domain(), path)
-  def api_url(path), do: absolute_url(api_host(), path)
+  @doc """
+  An absolute URL on the main host. `query` is passed separately because
+  `absolute_url/3` builds the URI from parts — a query folded into `path`
+  would be escaped into the path rather than kept as one.
+  """
+  def main_url(path, query \\ nil), do: absolute_url(local_domain(), path, query)
+
+  def api_url(path), do: absolute_url(api_host(), path, nil)
 
   @doc """
   The streaming endpoint as a client must dial it: the `ws(s)` form of
@@ -113,8 +119,8 @@ defmodule Vutuv.MastodonApi do
     |> String.replace_prefix("http://", "ws://")
   end
 
-  defp absolute_url(host, path) do
+  defp absolute_url(host, path, query) do
     uri = URI.parse(Endpoint.url())
-    URI.to_string(%{uri | host: host, path: path, query: nil, fragment: nil})
+    URI.to_string(%{uri | host: host, path: path, query: query, fragment: nil})
   end
 end

--- a/lib/vutuv/mastodon_api/presenter.ex
+++ b/lib/vutuv/mastodon_api/presenter.ex
@@ -20,6 +20,7 @@ defmodule Vutuv.MastodonApi.Presenter do
   alias Vutuv.Posts.PostImage
   alias Vutuv.UUIDv7
   alias VutuvWeb.Markdown
+  alias VutuvWeb.RemoteMediaToken
   alias VutuvWeb.UserHelpers
 
   def identity_name(%User{} = user),
@@ -470,10 +471,20 @@ defmodule Vutuv.MastodonApi.Presenter do
   # rendered the vutuv logo beside every remote author. `avatar_url/1` is the
   # one chokepoint that answers nil unless the AI gate cleared the file, so a
   # picture we may not show still falls back rather than leaking.
+  #
+  # The capability rides along because the proxy that serves these bytes asks
+  # for a signed-in reader, and the thing fetching this URL is an image loader
+  # with no cookie and no bearer — which is why naming the real picture, on its
+  # own, only turned every remote face into a 404. See
+  # `VutuvWeb.RemoteMediaToken`; the website keeps using the bare path and its
+  # session.
   defp remote_avatar(%RemoteAccount{} = account) do
     case RemoteAccount.avatar_url(account) do
-      path when is_binary(path) -> MastodonApi.main_url(path)
-      nil -> fallback_avatar()
+      path when is_binary(path) ->
+        MastodonApi.main_url(path, RemoteMediaToken.avatar_query(account.id, account.avatar))
+
+      nil ->
+        fallback_avatar()
     end
   end
 

--- a/lib/vutuv_web/controllers/remote_media_controller.ex
+++ b/lib/vutuv_web/controllers/remote_media_controller.ex
@@ -34,6 +34,21 @@ defmodule VutuvWeb.RemoteMediaController do
   cannot be lost by a route moving scope, and it is the same `%User{}` gate on
   both actions: the routes sit in the plain `:browser` scope, where nothing
   else would ask.
+
+  **Or a signed capability, on the avatar.** A session is how a *browser*
+  proves it is a member, and the Mastodon adapter's readers are phone apps
+  whose image loader sends neither the cookie nor the bearer token the API call
+  beside it used. So the avatar action takes a `VutuvWeb.RemoteMediaToken` as
+  the equivalent claim — unforgeable, expiring, and naming exactly the account
+  and stored file it opens. Everything else on the way in is unchanged and
+  re-asked per request, so it widens what may be seen by nothing; without it,
+  v7.330.0 named every remote picture in an API response at a URL no client
+  could fetch. `post_image/2` has no such door because the adapter names no
+  remote attachment — see `VutuvWeb.RemoteMediaToken`.
+
+  Both actions open on `Vutuv.Fediverse.enabled?/0`: switching federation off
+  has to close the proxy too, or the pictures it cached go on being served
+  after the feature that justified them is gone.
   """
 
   use VutuvWeb, :controller
@@ -44,9 +59,11 @@ defmodule VutuvWeb.RemoteMediaController do
   alias Vutuv.Fediverse.RemoteImage
   alias Vutuv.RemoteMedia
   alias VutuvWeb.ImageProxy
+  alias VutuvWeb.RemoteMediaToken
 
   def post_image(conn, %{"id" => id, "version" => version_file}) do
-    with %User{} = viewer <- viewer(conn),
+    with true <- Fediverse.enabled?(),
+         %User{} = viewer <- conn.assigns[:current_user],
          %RemoteImage{} = image <- Fediverse.get_remote_image(id),
          true <- RemoteImage.released?(image),
          version when not is_nil(version) <- parse_version(version_file, image.file),
@@ -62,11 +79,22 @@ defmodule VutuvWeb.RemoteMediaController do
 
   # An avatar has no per-post audience: it is the picture of an account
   # somebody here follows, shown wherever that account is named. So the check
-  # is the gate plus a signed-in reader.
-  def avatar(conn, %{"id" => id, "version" => version_file}) do
-    with %User{} <- viewer(conn),
+  # is the gate plus a reader who belongs here — a session, or the capability
+  # the API hands its clients.
+  #
+  # `signed_in?/1` is asked twice on purpose. The second time is the real
+  # check, and it needs the row, because a capability names the file the row
+  # currently holds. The first is a pre-filter: this route answers without a
+  # session, and a caller who brings neither claim must not be able to make us
+  # read the database at all.
+  def avatar(conn, %{"id" => id, "version" => version_file} = params) do
+    token = params[RemoteMediaToken.param()]
+
+    with true <- Fediverse.enabled?(),
+         true <- signed_in?(conn) or is_binary(token),
          %RemoteAccount{} = account <- Fediverse.get_remote_account(id),
          true <- RemoteAccount.avatar_ready?(account),
+         true <- signed_in?(conn) or RemoteMediaToken.avatar?(token, account.id, account.avatar),
          version when not is_nil(version) <- parse_version(version_file, account.avatar) do
       serve(conn, version,
         accel: &RemoteMedia.avatar_accel_path(account.id, &1),
@@ -77,12 +105,7 @@ defmodule VutuvWeb.RemoteMediaController do
     end
   end
 
-  # A signed-in reader, and only while the installation federates at all:
-  # switching federation off has to close the proxy too, or the pictures it
-  # cached go on being served after the feature that justified them is gone.
-  defp viewer(conn) do
-    if Fediverse.enabled?(), do: conn.assigns[:current_user]
-  end
+  defp signed_in?(conn), do: match?(%User{}, conn.assigns[:current_user])
 
   defp serve(conn, version, accel: accel, path: path) do
     conn

--- a/lib/vutuv_web/remote_media_token.ex
+++ b/lib/vutuv_web/remote_media_token.ex
@@ -1,0 +1,76 @@
+defmodule VutuvWeb.RemoteMediaToken do
+  @moduledoc """
+  The capability that lets an **API client** load a picture cached from another
+  network — the second door into `VutuvWeb.RemoteMediaController`, beside the
+  signed-in reader it already knew.
+
+  A phone app fetches an image with a bare `GET`. Its image loader carries
+  neither the session cookie nor the OAuth token the API call itself used, and
+  no header we could ask for would arrive — that is how every image loader on
+  every platform works. So from v7.330.0, when the Mastodon adapter started
+  naming the cached picture instead of the installation's icon, every account
+  out of the fediverse came back 404 and sat blank in the app. The adapter now
+  mints a capability for exactly that picture and the proxy takes it instead of
+  a session.
+
+  This is **not** the "unguessable URL" the proxy's moduledoc rightly refuses:
+  it is unforgeable, it expires, it names one account's one stored file, and it
+  only ever leaves the building inside an authenticated API response. And it
+  widens nothing else — the AI gate and the stored-file whitelist are re-asked
+  on every request, so a picture the gate takes back or a file that gets
+  rotated stops answering with the capability still in hand.
+
+  `signed_at` is pinned to the UTC day rather than to the moment, so a client
+  is handed the same URL all day and its image cache keeps working. A
+  per-render timestamp would re-mint every avatar URL on every timeline
+  refresh, and a client caches by URL — every face in the timeline would be
+  downloaded again each time. `@max_age` is a day longer than the window a
+  client may still be showing a cached timeline from, so the pinning can never
+  hand out a capability that is already stale.
+
+  **Avatars only, and that is a decision rather than an oversight.** The proxy's
+  other route serves a cached post's attachments, and the adapter never names
+  one: `Vutuv.MastodonApi.Presenter.status/2` leaves `media_attachments` at the
+  empty default for a `%RemotePost{}` and a `%Note{}`, so a capability there
+  would be dead code today. The subject is a tagged tuple, so the day that
+  changes is a second tag and a second pair of heads here — not a second module.
+  """
+
+  alias VutuvWeb.Endpoint
+
+  @salt "remote media capability"
+  @bucket 60 * 60 * 24
+  @max_age 60 * 60 * 24 * 8
+
+  @doc "The query-parameter name a capability travels in."
+  def param, do: "t"
+
+  @doc """
+  The capability for one account's currently stored avatar, as the query string
+  the adapter appends to the picture's URL.
+  """
+  def avatar_query(account_id, file) when is_binary(account_id) and is_binary(file) do
+    token = Phoenix.Token.sign(Endpoint, @salt, {:avatar, account_id, file}, signed_at: bucket())
+    URI.encode_query(%{param() => token})
+  end
+
+  @doc """
+  Whether `token` opens exactly this account's exactly this file. Anything else
+  — a made-up string, an expired one, one minted for another account or for the
+  picture this row used to hold — is false, which the proxy answers as 404 like
+  every other refusal it makes.
+  """
+  def avatar?(token, account_id, file)
+      when is_binary(token) and is_binary(account_id) and is_binary(file) do
+    case Phoenix.Token.verify(Endpoint, @salt, token, max_age: @max_age) do
+      {:ok, {:avatar, ^account_id, ^file}} -> true
+      _other -> false
+    end
+  end
+
+  # nil is the ordinary case on the website, where the session answers instead.
+  def avatar?(_token, _account_id, _file), do: false
+
+  # The start of the current UTC day, in the seconds `Phoenix.Token` wants.
+  defp bucket, do: div(System.os_time(:second), @bucket) * @bucket
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.332.6",
+      version: "7.332.8",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/mastodon_api/notifications_test.exs
+++ b/test/vutuv/mastodon_api/notifications_test.exs
@@ -46,7 +46,13 @@ defmodule Vutuv.MastodonApi.NotificationsTest do
     account = Notifications.account(item(actor_uri))
 
     assert account.id == "remote-" <> stored.id
-    assert account.avatar == MastodonApi.main_url(RemoteAccount.avatar_url(stored))
+    # The URL carries the proxy's capability beside the path — an image loader
+    # brings no session of its own.
+    assert String.starts_with?(
+             account.avatar,
+             MastodonApi.main_url(RemoteAccount.avatar_url(stored)) <> "?"
+           )
+
     refute account.avatar == Presenter.fallback_avatar()
   end
 

--- a/test/vutuv_web/controllers/mastodon_api/fediverse_client_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/fediverse_client_test.exs
@@ -28,6 +28,8 @@ defmodule VutuvWeb.MastodonApi.FediverseClientTest do
   alias Vutuv.MastodonApi.Presenter
   alias Vutuv.Posts
   alias Vutuv.Repo
+  alias Vutuv.UUIDv7
+  alias VutuvWeb.RemoteMediaToken
 
   setup do
     Vutuv.RateLimiter.reset()
@@ -182,10 +184,25 @@ defmodule VutuvWeb.MastodonApi.FediverseClientTest do
       account = remote_account(avatar: "pic.avif", avatar_moderation: "approved")
 
       rendered = Presenter.account(account)
+      picture = MastodonApi.main_url(RemoteAccount.avatar_url(account))
 
-      assert rendered.avatar == MastodonApi.main_url(RemoteAccount.avatar_url(account))
+      assert String.starts_with?(rendered.avatar, picture <> "?")
       assert rendered.avatar_static == rendered.avatar
       refute rendered.avatar == Presenter.fallback_avatar()
+    end
+
+    # The picture is served by a proxy that wants a signed-in reader, and the
+    # thing fetching it is an image loader with neither cookie nor bearer — so
+    # the URL has to carry its own permission or it is a 404 in every client.
+    test "and a capability the proxy accepts, because an image loader has none" do
+      account = remote_account(avatar: "pic.avif", avatar_moderation: "approved")
+
+      %{query: query} = account |> Presenter.account() |> Map.fetch!(:avatar) |> URI.parse()
+      token = URI.decode_query(query) |> Map.fetch!(RemoteMediaToken.param())
+
+      assert RemoteMediaToken.avatar?(token, account.id, account.avatar)
+      refute RemoteMediaToken.avatar?(token, account.id, "other.avif")
+      refute RemoteMediaToken.avatar?(token, UUIDv7.generate(), account.avatar)
     end
 
     test "keeps the stand-in while the gate has not cleared it" do

--- a/test/vutuv_web/controllers/mastodon_api/notification_controller_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/notification_controller_test.exs
@@ -207,8 +207,12 @@ defmodule VutuvWeb.MastodonApi.NotificationControllerTest do
       assert favourite["type"] == "favourite"
       assert favourite["account"]["id"] == "remote-" <> account.id
 
-      assert favourite["account"]["avatar"] ==
-               MastodonApi.main_url(RemoteAccount.avatar_url(account))
+      # Plus the capability the picture's proxy wants — a phone app's image
+      # loader sends no cookie, so the URL has to carry its own permission.
+      assert String.starts_with?(
+               favourite["account"]["avatar"],
+               MastodonApi.main_url(RemoteAccount.avatar_url(account)) <> "?"
+             )
 
       refute favourite["account"]["avatar"] == Presenter.fallback_avatar()
     end

--- a/test/vutuv_web/controllers/remote_media_controller_test.exs
+++ b/test/vutuv_web/controllers/remote_media_controller_test.exs
@@ -21,6 +21,7 @@ defmodule VutuvWeb.RemoteMediaControllerTest do
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Fediverse.RemoteImage
   alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.MastodonApi.Presenter
   alias Vutuv.RemoteMedia
 
   setup %{conn: conn} do
@@ -232,5 +233,50 @@ defmodule VutuvWeb.RemoteMediaControllerTest do
 
       assert get(ctx.conn, media_url(stored)).status == 404
     end
+  end
+
+  describe "the URL the Mastodon adapter hands a client" do
+    # The seam #1588 opened: the adapter started naming the cached picture
+    # instead of the installation's icon, and an image loader fetches with a
+    # bare GET — no cookie, no bearer, because that is what every image loader
+    # does. So the picture the API had just named came back 404 and every
+    # account out of the fediverse sat blank in the app.
+    test "loads without a session, because that is how an image loader asks", ctx do
+      stored = avatar(ctx.account)
+
+      assert get(ctx.out, adapter_path(stored)).status == 200
+    end
+
+    test "is still refused without one", ctx do
+      stored = avatar(ctx.account)
+
+      assert get(ctx.out, media_url(stored)).status == 404
+      assert get(ctx.out, media_url(stored) <> "?t=not-a-token").status == 404
+    end
+
+    test "stops answering once the gate takes the picture back", ctx do
+      stored = avatar(ctx.account)
+      path = adapter_path(stored)
+
+      Repo.update!(change(stored, avatar_moderation: "pending"))
+
+      assert get(ctx.out, path).status == 404
+    end
+
+    test "does not open another account's picture", ctx do
+      other = avatar(other_account())
+      borrowed = ctx.account |> avatar() |> capability()
+
+      assert get(ctx.out, media_url(other) <> "?" <> borrowed).status == 404
+    end
+  end
+
+  # The avatar URL as a client receives it, reduced to what ConnTest requests.
+  defp adapter_path(%RemoteAccount{} = account),
+    do: media_url(account) <> "?" <> capability(account)
+
+  defp capability(%RemoteAccount{} = account) do
+    %URI{query: query} = account |> Presenter.account() |> Map.fetch!(:avatar) |> URI.parse()
+    query
   end
 end


### PR DESCRIPTION
**Closes #1618.**

**Änderung:** `VutuvWeb.RemoteMediaToken` — eine signierte, ablaufende Capability, die genau ein Konto und genau dessen aktuell gespeicherte Datei benennt. `Presenter.account/2` hängt sie an die Bild-URL, `RemoteMediaController.avatar/2` nimmt sie statt der Sitzung. KI-Gate und Datei-Whitelist werden weiter pro Anfrage gefragt; die Website nutzt unverändert ihre Sitzung.

**Zwei Details:** `signed_at` ist auf den UTC-Tag gerundet, damit ein Client den ganzen Tag dieselbe URL bekommt und sein Bild-Cache greift. Und die Sitzungsprüfung steht zweimal in der `with`-Kette: als Vorfilter vor dem Datenbanklesen und echt danach.

**Bewusst ausgelassen:** nur Avatare — der Adapter füllt für `%RemotePost{}` und `%Note{}` nie `media_attachments`, auf `post_image/2` wäre das toter Code (Notiz im Moduldoc). Ein fremdes Profil hat weiter kein Titelbild: wir cachen `icon`, nie `image`.

Regressionstest gegen den ungefixten Code kalibriert (404 statt 200). Reiner JSON-Endpunkt, daher kein Screenshot.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*
