### PR TITLE
Eine Antwort im Mastodon-Client zeigt wieder ihren Elternbeitrag

### DIFF
--- a/docs/architecture/mastodon-api.md
+++ b/docs/architecture/mastodon-api.md
@@ -324,6 +324,23 @@ a direct read, and a cached reply is named only while it is public: a reply
 addressed to one member cannot be answered at all, so a private one here was
 narrowed afterwards and its id would answer 404 to everybody but that member.
 
+**A status itself names its parent too, not only `/context`** (issue #1622):
+`in_reply_to_id`/`in_reply_to_account_id` used to fill only for a local reply, so
+a client received `null` on every answer that crossed the border and drew it as
+a standalone post. `Presenter.status/2` now fills the same three border-crossing
+shapes `/context` already walks — a cached reply (`%Note{}`) names the local
+post it answers, a followed account's self-reply names its cached parent
+(scoped to the same account, `own_thread?/2`'s own rule), and a vutuv reply into
+another network names the cached post its `remote_reply_ref` continues. Both
+surfaces share one rule: a parent is named only when `viewer` may actually read
+it (`Posts.note_parent_posts/2`'s `scope_visible/2` for the local case,
+`RemotePost.open?/1` or an accepted follow for a cached one) — an id that
+answers 404 for the reader holding it is worse than none, and naming a
+followers-only parent's id at all would leak that it exists to a reader who
+cannot fetch it. Batched for a whole page (`Presenter.page_context/2`'s
+`note_parents`/`remote_parents`/`followed_remote_ids`), not a query per row —
+the same shape `answered_notes/1` and `list_remote_images/1` already use.
+
 ### Photos
 
 `POST /api/v1/media` and `POST /api/v2/media` (multipart, the file in `file`,

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -1457,6 +1457,35 @@ defmodule Vutuv.Fediverse do
   end
 
   @doc """
+  The same set as `followed_remote_account_ids/2`, narrowed to follows in the
+  `"accepted"` state — the one a **visibility gate** may trust, unlike the
+  menu-branch use above (Mute/Unfollow apply to a still-`"requested"` follow
+  too, so that one deliberately does not filter on state). Mirrors the
+  single-row gate `remote_post_readable?/2`'s own `f.state == "accepted"`
+  condition (`VutuvWeb.MastodonApi.StatusController`).
+
+  Without this, `Vutuv.MastodonApi.Presenter` naming a followers-only cached
+  post's `in_reply_to_id` (issue #1622) would trust a follow request that was
+  never accepted — a followers-only account can leave one `"requested"`
+  indefinitely (see `Vutuv.Fediverse.Follow`'s moduledoc) — and leak that the
+  post exists to a reader who is not actually a follower.
+  """
+  def accepted_remote_account_ids(party, account_ids) do
+    case account_ids |> Enum.filter(&is_binary/1) |> Enum.uniq() do
+      [] ->
+        MapSet.new()
+
+      ids ->
+        from(f in Follow,
+          where: party_is(f, party) and f.remote_account_id in ^ids and f.state == "accepted",
+          select: f.remote_account_id
+        )
+        |> Repo.all()
+        |> MapSet.new()
+    end
+  end
+
+  @doc """
   Mutes (or unmutes) the member's follow of one remote account.
 
   The same meaning a local follow's mute has: the subscription stays, its posts

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -3005,6 +3005,27 @@ defmodule Vutuv.Fediverse do
     )
   end
 
+  @doc """
+  The same lookup as `remote_parent_post/1`, batched for a whole page of
+  `%RemotePost{}` items (issue #1622's Mastodon-adapter case, which — unlike
+  `/context`'s one-post-at-a-time walk — renders many self-replies at once and
+  cannot afford a query per row).
+
+  `pairs` is a list of `{in_reply_to_uri, remote_account_id}`, exactly what
+  `own_thread?/2` gates a stored reply's parent by — so the result keys the
+  same way, and a caller with no candidate pairs pays no query.
+  """
+  def remote_parent_posts([]), do: %{}
+
+  def remote_parent_posts(pairs) when is_list(pairs) do
+    uris = pairs |> Enum.map(&elem(&1, 0)) |> Enum.uniq()
+    account_ids = pairs |> Enum.map(&elem(&1, 1)) |> Enum.uniq()
+
+    from(p in RemotePost, where: p.object_uri in ^uris and p.remote_account_id in ^account_ids)
+    |> Repo.all()
+    |> Map.new(&{{&1.object_uri, &1.remote_account_id}, &1})
+  end
+
   @doc "One cached remote post with its account and screenshot, or nil."
   def get_remote_post(id) do
     UUIDv7.with_cast(id, &Repo.get(RemotePost, &1))

--- a/lib/vutuv/mastodon_api/presenter.ex
+++ b/lib/vutuv/mastodon_api/presenter.ex
@@ -19,6 +19,7 @@ defmodule Vutuv.MastodonApi.Presenter do
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostImage
+  alias Vutuv.Posts.PostRemoteReply
   alias Vutuv.Profiles.Url
   alias Vutuv.Profiles.VerifiedLinks
   alias Vutuv.RemoteMedia
@@ -136,6 +137,17 @@ defmodule Vutuv.MastodonApi.Presenter do
   defp page_context(items, viewer) do
     post_ids = items |> Enum.map(&engaged_post_id/1) |> Enum.reject(&is_nil/1)
     remote_ids = items |> Enum.map(&remote_post_id/1) |> Enum.reject(&is_nil/1)
+    note_parent_ids = items |> Enum.map(&note_parent_post_id/1) |> Enum.reject(&is_nil/1)
+    self_reply_pairs = items |> Enum.map(&self_reply_pair/1) |> Enum.reject(&is_nil/1)
+    reply_ref_parents = items |> Enum.map(&reply_ref_parent/1) |> Enum.reject(&is_nil/1)
+
+    remote_parents = Fediverse.remote_parent_posts(self_reply_pairs)
+
+    followed_remote_ids =
+      (Map.values(remote_parents) ++ reply_ref_parents)
+      |> Enum.map(& &1.remote_account_id)
+      |> Enum.uniq()
+      |> followed_remote_ids(viewer)
 
     %{
       viewer: viewer,
@@ -146,9 +158,29 @@ defmodule Vutuv.MastodonApi.Presenter do
       # The photographs on the cached posts this page shows (issue #1626).
       # `:images` is never preloaded on a `%RemotePost{}` — every surface in this
       # codebase batches them by id, and so does this one.
-      remote_images: Fediverse.list_remote_images(remote_ids)
+      remote_images: Fediverse.list_remote_images(remote_ids),
+      # The local post each cached reply answers (issue #1622), batched and
+      # already scoped to what `viewer` may see (`Posts.note_parent_posts/2`).
+      note_parents: Posts.note_parent_posts(note_parent_ids, viewer),
+      # The cached parent of a followed account's self-reply, batched the same
+      # way (`Fediverse.remote_parent_posts/1`) — visibility is checked at
+      # render time against `followed_remote_ids` below, since two different
+      # callers here (a self-reply's own parent, a vutuv answer's
+      # `remote_reply_ref`) both read this same audience gate.
+      remote_parents: remote_parents,
+      followed_remote_ids: followed_remote_ids
     }
   end
+
+  # `viewer` is never a party `Fediverse.followed_remote_account_ids/2` can
+  # take when nobody is signed in — `Vutuv.Identity.Query.party_is/2` has no
+  # `nil` clause and raises — and an anonymous reader follows nothing anyway,
+  # so every restricted parent is simply unreadable for them.
+  defp followed_remote_ids([], _viewer), do: MapSet.new()
+  defp followed_remote_ids(_account_ids, nil), do: MapSet.new()
+
+  defp followed_remote_ids(account_ids, viewer),
+    do: Fediverse.followed_remote_account_ids(viewer, account_ids)
 
   # What a single status rendered outside `statuses/2` gets. Built by the same
   # function rather than spelled out again, so a sixth batch cannot be added to
@@ -209,6 +241,53 @@ defmodule Vutuv.MastodonApi.Presenter do
     do: id
 
   defp remote_post_id(_other), do: nil
+
+  # The local post id a cached reply's `Note.post_id` names, for the
+  # `note_parents` batch — same map-vs-struct shape as every other extractor
+  # here.
+  defp note_parent_post_id(%Note{post_id: id}) when is_binary(id), do: id
+
+  defp note_parent_post_id(%{note: %Note{post_id: id}} = entry)
+       when not is_struct(entry) and is_binary(id),
+       do: id
+
+  defp note_parent_post_id(_other), do: nil
+
+  # The `{in_reply_to_uri, remote_account_id}` pair `own_thread?/2` gated a
+  # cached post's own parent by, for the `remote_parents` batch.
+  defp self_reply_pair(%RemotePost{in_reply_to_uri: uri, remote_account_id: account_id})
+       when is_binary(uri),
+       do: {uri, account_id}
+
+  defp self_reply_pair(
+         %{remote_post: %RemotePost{in_reply_to_uri: uri, remote_account_id: account_id}} =
+           entry
+       )
+       when not is_struct(entry) and is_binary(uri),
+       do: {uri, account_id}
+
+  defp self_reply_pair(_other), do: nil
+
+  # The cached post a vutuv reply's `remote_reply_ref` continues (issue #1165),
+  # read off the preload rather than queried — `Posts.render_preloads/0`
+  # already carries it on every `%Post{}` this adapter renders, so collecting
+  # it here costs no query; only its audience needs a batch (`followed_remote_ids`).
+  defp reply_ref_parent(%Post{
+         remote_reply_ref: %PostRemoteReply{remote_post: %RemotePost{} = parent}
+       }),
+       do: parent
+
+  defp reply_ref_parent(
+         %{
+           post: %Post{
+             remote_reply_ref: %PostRemoteReply{remote_post: %RemotePost{} = parent}
+           }
+         } = entry
+       )
+       when not is_struct(entry),
+       do: parent
+
+  defp reply_ref_parent(_other), do: nil
 
   defp rendered_status(%Post{} = post, context), do: status(post, context)
 
@@ -323,24 +402,28 @@ defmodule Vutuv.MastodonApi.Presenter do
         tags: status_tags(post),
         mentions: status_mentions(post, context.mentions[post.id])
       }
-      |> Map.merge(reply_fields(post, context.answered[post.id]))
+      |> Map.merge(reply_fields(post, context.answered[post.id], context))
       |> Map.merge(engagement_fields(engagement))
 
     base_status(fields)
   end
 
   defp status(%RemotePost{} = post, context) do
-    base_status(%{
-      id: status_id(post),
-      created_at: timestamp(post.published_at),
-      content: remote_content_html(post.content_text),
-      url: post.origin_url || post.object_uri,
-      uri: post.object_uri,
-      account: account(post.remote_account),
-      media_attachments: remote_attachments(post, context),
-      sensitive: post.sensitive,
-      spoiler_text: post.summary || ""
-    })
+    fields =
+      %{
+        id: status_id(post),
+        created_at: timestamp(post.published_at),
+        content: remote_content_html(post.content_text),
+        url: post.origin_url || post.object_uri,
+        uri: post.object_uri,
+        account: account(post.remote_account),
+        media_attachments: remote_attachments(post, context),
+        sensitive: post.sensitive,
+        spoiler_text: post.summary || ""
+      }
+      |> Map.merge(remote_post_reply_fields(post, context))
+
+    base_status(fields)
   end
 
   # A cached **reply** carries no pictures at all: there is no note-image table
@@ -348,19 +431,23 @@ defmodule Vutuv.MastodonApi.Presenter do
   # picture is not copied here (`Vutuv.Fediverse.Note`). So this head has nothing
   # to name, and an empty `media_attachments` is the true answer rather than an
   # unfinished one.
-  defp status(%Note{} = note, _context) do
-    base_status(%{
-      id: status_id(note),
-      created_at: timestamp(note.received_at),
-      content: remote_content_html(note.content_text),
-      url: Note.origin(note),
-      uri: note.object_uri,
-      account: note_account(note),
-      sensitive: Note.warned?(note),
-      spoiler_text: note.summary || "",
-      favourites_count: note.likes_count || 0,
-      reblogs_count: note.shares_count || 0
-    })
+  defp status(%Note{} = note, context) do
+    fields =
+      %{
+        id: status_id(note),
+        created_at: timestamp(note.received_at),
+        content: remote_content_html(note.content_text),
+        url: Note.origin(note),
+        uri: note.object_uri,
+        account: note_account(note),
+        sensitive: Note.warned?(note),
+        spoiler_text: note.summary || "",
+        favourites_count: note.likes_count || 0,
+        reblogs_count: note.shares_count || 0
+      }
+      |> Map.merge(note_reply_fields(note, context))
+
+    base_status(fields)
   end
 
   @doc """
@@ -774,10 +861,10 @@ defmodule Vutuv.MastodonApi.Presenter do
   #
   # Either way the id named is one this client can fetch, and nothing is named
   # that we hold no row for — an id no client can resolve is worse than none.
-  defp reply_fields(_post, %Note{} = note),
+  defp reply_fields(_post, %Note{} = note, _context),
     do: %{in_reply_to_id: status_id(note), in_reply_to_account_id: note_account_id(note)}
 
-  defp reply_fields(post, _no_cached_reply) do
+  defp reply_fields(post, _no_cached_reply, context) do
     case Posts.reply_ref_state(post) do
       {:parent, %Post{} = parent} ->
         %{
@@ -785,10 +872,82 @@ defmodule Vutuv.MastodonApi.Presenter do
           in_reply_to_account_id: account_id(Posts.author(parent))
         }
 
-      _not_a_live_parent ->
+      _not_a_live_local_parent ->
+        # Not a local reply — but it may answer a followed account's post on
+        # another network (issue #1165), which threads under the cached copy of
+        # that post, a status the same client can fetch (`remote-<id>`). The
+        # #1070 shape (an answer that is *also* a local reply) already resolved
+        # to its local parent above, so only the top-level case reaches here;
+        # `remote_reply_ref` is preloaded with its `remote_post` and account.
+        remote_reply_fields(post, context)
+    end
+  end
+
+  # **Gated the same way `StatusController.status_visible?/2` gates the
+  # single-status case** — a followers-only cached post named here must be one
+  # `context.followed_remote_ids` actually holds, or a client would be handed
+  # an id that answers 404 (or worse, silently confirms a restricted post
+  # exists) to every reader but the ones this installation itself follows that
+  # account for. `open?/1` covers the common case with no set membership check
+  # at all.
+  defp remote_reply_fields(
+         %Post{remote_reply_ref: %PostRemoteReply{remote_post: %RemotePost{} = parent}},
+         context
+       ) do
+    if readable_remote_parent?(parent, context) do
+      %{
+        in_reply_to_id: "remote-" <> parent.id,
+        in_reply_to_account_id: "remote-" <> parent.remote_account_id
+      }
+    else
+      %{}
+    end
+  end
+
+  defp remote_reply_fields(_post, _context), do: %{}
+
+  # Names the local post a cached reply answers, read off `context.note_parents`
+  # (`Posts.note_parent_posts/2` — batched for the whole page and already
+  # scoped to what `context.viewer` may see, the note's own visibility being no
+  # proof that its narrower parent still is). The account id is the post
+  # author's, which `author_id/1` already is (a member or a page), so no
+  # account struct is built; `%{}` (both nil) when the post is gone or not
+  # visible to this viewer.
+  defp note_reply_fields(note, context) do
+    case Map.get(context.note_parents, note.post_id) do
+      %Post{} = parent ->
+        %{in_reply_to_id: parent.id, in_reply_to_account_id: Posts.author_id(parent)}
+
+      nil ->
         %{}
     end
   end
+
+  # Names the cached parent post a stored reply continues, read off
+  # `context.remote_parents` (`Fediverse.remote_parent_posts/1` — batched for
+  # the whole page rather than a query per row) and gated on audience the same
+  # way `remote_reply_fields/2` above is. `%{}` when the parent is not (or no
+  # longer) held, or is one `context.viewer` may not read: an id no client can
+  # resolve or is refused for is worse than none (the issue's own rule).
+  defp remote_post_reply_fields(
+         %RemotePost{in_reply_to_uri: uri, remote_account_id: account_id},
+         context
+       ) do
+    case Map.get(context.remote_parents, {uri, account_id}) do
+      %RemotePost{} = parent ->
+        if readable_remote_parent?(parent, context) do
+          %{in_reply_to_id: "remote-" <> parent.id, in_reply_to_account_id: "remote-" <> account_id}
+        else
+          %{}
+        end
+
+      nil ->
+        %{}
+    end
+  end
+
+  defp readable_remote_parent?(%RemotePost{} = parent, context),
+    do: RemotePost.open?(parent) or MapSet.member?(context.followed_remote_ids, parent.remote_account_id)
 
   @doc """
   One freshly uploaded picture, for the media endpoints.

--- a/lib/vutuv/mastodon_api/presenter.ex
+++ b/lib/vutuv/mastodon_api/presenter.ex
@@ -936,7 +936,10 @@ defmodule Vutuv.MastodonApi.Presenter do
     case Map.get(context.remote_parents, {uri, account_id}) do
       %RemotePost{} = parent ->
         if readable_remote_parent?(parent, context) do
-          %{in_reply_to_id: "remote-" <> parent.id, in_reply_to_account_id: "remote-" <> account_id}
+          %{
+            in_reply_to_id: "remote-" <> parent.id,
+            in_reply_to_account_id: "remote-" <> account_id
+          }
         else
           %{}
         end
@@ -947,7 +950,9 @@ defmodule Vutuv.MastodonApi.Presenter do
   end
 
   defp readable_remote_parent?(%RemotePost{} = parent, context),
-    do: RemotePost.open?(parent) or MapSet.member?(context.followed_remote_ids, parent.remote_account_id)
+    do:
+      RemotePost.open?(parent) or
+        MapSet.member?(context.followed_remote_ids, parent.remote_account_id)
 
   @doc """
   One freshly uploaded picture, for the media endpoints.

--- a/lib/vutuv/mastodon_api/presenter.ex
+++ b/lib/vutuv/mastodon_api/presenter.ex
@@ -172,15 +172,22 @@ defmodule Vutuv.MastodonApi.Presenter do
     }
   end
 
-  # `viewer` is never a party `Fediverse.followed_remote_account_ids/2` can
+  # `viewer` is never a party `Fediverse.accepted_remote_account_ids/2` can
   # take when nobody is signed in — `Vutuv.Identity.Query.party_is/2` has no
   # `nil` clause and raises — and an anonymous reader follows nothing anyway,
   # so every restricted parent is simply unreadable for them.
+  #
+  # **`accepted_remote_account_ids/2`, not `followed_remote_account_ids/2`.**
+  # This set gates whether a followers-only parent's id may be named at all
+  # (`readable_remote_parent?/2` below), so a follow merely `"requested"` — one
+  # a slow-to-accept account can leave pending indefinitely — must not count;
+  # the plain "followed" set is right for the card menu's Mute/Unfollow offer,
+  # which applies to a pending request too, but wrong here.
   defp followed_remote_ids([], _viewer), do: MapSet.new()
   defp followed_remote_ids(_account_ids, nil), do: MapSet.new()
 
   defp followed_remote_ids(account_ids, viewer),
-    do: Fediverse.followed_remote_account_ids(viewer, account_ids)
+    do: Fediverse.accepted_remote_account_ids(viewer, account_ids)
 
   # What a single status rendered outside `statuses/2` gets. Built by the same
   # function rather than spelled out again, so a sixth batch cannot be added to
@@ -896,8 +903,8 @@ defmodule Vutuv.MastodonApi.Presenter do
        ) do
     if readable_remote_parent?(parent, context) do
       %{
-        in_reply_to_id: "remote-" <> parent.id,
-        in_reply_to_account_id: "remote-" <> parent.remote_account_id
+        in_reply_to_id: status_id(parent),
+        in_reply_to_account_id: account_id(parent.remote_account)
       }
     else
       %{}
@@ -937,7 +944,12 @@ defmodule Vutuv.MastodonApi.Presenter do
       %RemotePost{} = parent ->
         if readable_remote_parent?(parent, context) do
           %{
-            in_reply_to_id: "remote-" <> parent.id,
+            in_reply_to_id: status_id(parent),
+            # Not `account_id(parent.remote_account)`: `remote_parent_posts/1`
+            # deliberately does not preload it (this map is batched for a whole
+            # page), and the raw column already is the id `account_id/1` would
+            # build from the struct — so this stays hand-built rather than
+            # paying an extra query per page just to call the shared minter.
             in_reply_to_account_id: "remote-" <> account_id
           }
         else

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -1139,9 +1139,7 @@ defmodule Vutuv.Posts do
   `visible_to?/2`. Composable: `from(p in Post) |> scope_visible(viewer)`.
   """
   def scope_visible(query, nil) do
-    from(p in query,
-      where: fragment("NOT EXISTS (SELECT 1 FROM post_denials d WHERE d.post_id = ?)", p.id)
-    )
+    from(p in query, where: ^no_denials())
     |> scope_unfrozen(nil)
   end
 
@@ -1150,11 +1148,7 @@ defmodule Vutuv.Posts do
   # sees exactly what an anonymous reader sees, plus its own posts while
   # moderation holds them — the way an author sees theirs.
   def scope_visible(query, %Organization{id: organization_id} = viewer) do
-    from(p in query,
-      where:
-        p.organization_id == ^organization_id or
-          fragment("NOT EXISTS (SELECT 1 FROM post_denials d WHERE d.post_id = ?)", p.id)
-    )
+    from(p in query, where: p.organization_id == ^organization_id or ^no_denials())
     |> scope_unfrozen(viewer)
   end
 
@@ -1198,6 +1192,17 @@ defmodule Vutuv.Posts do
     )
     |> scope_unfrozen(viewer)
   end
+
+  # "This post carries no audience restriction at all" — the anonymous-reader
+  # rule (any denial, of any wildcard, hides the post) and the organization
+  # viewer's own rule (a page cannot be named by a denial either, so it reduces
+  # to the same test). One fragment so the two clauses cannot drift apart.
+  defp no_denials,
+    do:
+      dynamic(
+        [p],
+        fragment("NOT EXISTS (SELECT 1 FROM post_denials d WHERE d.post_id = ?)", p.id)
+      )
 
   # The moderation arm of scope_visible/2: frozen posts and posts whose author's
   # account is hidden (frozen / suspended / deactivated) vanish from every list,

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -1145,6 +1145,19 @@ defmodule Vutuv.Posts do
     |> scope_unfrozen(nil)
   end
 
+  # A page as the VIEWER (issue #1336, mirroring `visible_to?/2`'s own
+  # Organization clauses): it is not a member, so no denial can name it and it
+  # sees exactly what an anonymous reader sees, plus its own posts while
+  # moderation holds them — the way an author sees theirs.
+  def scope_visible(query, %Organization{id: organization_id} = viewer) do
+    from(p in query,
+      where:
+        p.organization_id == ^organization_id or
+          fragment("NOT EXISTS (SELECT 1 FROM post_denials d WHERE d.post_id = ?)", p.id)
+    )
+    |> scope_unfrozen(viewer)
+  end
+
   def scope_visible(query, %User{id: viewer_id} = viewer) do
     from(p in query,
       where:
@@ -1197,8 +1210,14 @@ defmodule Vutuv.Posts do
 
     filter =
       case viewer do
-        %User{id: viewer_id} -> dynamic([p], p.user_id == ^viewer_id or ^passes)
-        nil -> passes
+        %User{id: viewer_id} ->
+          dynamic([p], p.user_id == ^viewer_id or ^passes)
+
+        %Organization{id: organization_id} ->
+          dynamic([p], p.organization_id == ^organization_id or ^passes)
+
+        nil ->
+          passes
       end
 
     where(query, ^filter)
@@ -4972,7 +4991,7 @@ defmodule Vutuv.Posts do
   is worse than none. A bare primary-key scan, no preload — the caller reads
   only `id` and `author_id/1` (both plain columns).
   """
-  def note_parent_posts([]), do: %{}
+  def note_parent_posts([], _viewer), do: %{}
 
   def note_parent_posts(post_ids, viewer) when is_list(post_ids) do
     from(p in Post, where: p.id in ^post_ids)

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -4960,6 +4960,27 @@ defmodule Vutuv.Posts do
 
   def reply_ref_state(_post), do: nil
 
+  @doc """
+  The local post each of `post_ids` (`Note.post_id`) names, scoped to what
+  `viewer` may see — one query for a whole page rather than a `Repo.get` per
+  cached reply, and gated the same way `StatusController.context_payload/2`
+  gates the single-note case (`status_visible?/2`): a note's own visibility
+  (a public reply) says nothing about the local post it answers, which its
+  author can since have narrowed. The Mastodon adapter reads this to name a
+  cached reply's `in_reply_to_id` — a parent `viewer` may not see is left out
+  of the map entirely, because an id no client can resolve or is refused for
+  is worse than none. A bare primary-key scan, no preload — the caller reads
+  only `id` and `author_id/1` (both plain columns).
+  """
+  def note_parent_posts([]), do: %{}
+
+  def note_parent_posts(post_ids, viewer) when is_list(post_ids) do
+    from(p in Post, where: p.id in ^post_ids)
+    |> scope_visible(viewer)
+    |> Repo.all()
+    |> Map.new(&{&1.id, &1})
+  end
+
   defp preload_post(nil), do: nil
   defp preload_post(%Post{} = post), do: Repo.preload(post, post_preloads(), force: true)
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.342.13",
+      version: "7.342.14",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/controllers/mastodon_api/status_parent_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/status_parent_test.exs
@@ -1,0 +1,139 @@
+defmodule VutuvWeb.MastodonApi.StatusParentTest do
+  @moduledoc """
+  A status a Mastodon client reads must carry `in_reply_to_id` so the client can
+  thread the reply under the post it answers (issue #1622). The website shows
+  the parent on all four shapes below; before this the API said `null` on the
+  three that cross a network boundary, so a reply looked like a standalone post.
+
+  The rule: name the parent only when it is a status the same client could fetch
+  — a local post id, or a `remote-<id>` we hold. A parent we hold no row for
+  stays `null`, because an id no client can resolve is worse than none.
+  """
+  use VutuvWeb.ConnCase, async: true
+
+  import Vutuv.MastodonHelpers
+
+  alias Vutuv.Fediverse.Follow
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.Posts
+  alias Vutuv.Posts.PostRemoteReply
+
+  defp show(conn, token, id) do
+    conn
+    |> mastodon_conn(token)
+    |> get("/api/v1/statuses/#{id}")
+    |> json_response(200)
+  end
+
+  defp remote_account(handle) do
+    actor = "https://social.example/users/#{handle}"
+
+    Repo.insert!(%RemoteAccount{
+      actor_uri: actor,
+      host: "social.example",
+      handle: handle,
+      name: String.capitalize(handle),
+      inbox_uri: actor <> "/inbox"
+    })
+  end
+
+  defp cached_post(account, overrides \\ %{}) do
+    now = DateTime.utc_now(:second)
+
+    Repo.insert!(
+      struct(
+        %RemotePost{
+          remote_account_id: account.id,
+          object_uri: "https://social.example/p/#{System.unique_integer([:positive])}",
+          origin_url: "https://social.example/@them/1",
+          content_text: "Ein Gedanke von drüben.",
+          audience: "public",
+          kind: "note",
+          published_at: now,
+          received_at: now,
+          expires_at: DateTime.add(now, 86_400)
+        },
+        overrides
+      )
+    )
+  end
+
+  test "a local reply names its local parent", %{conn: conn} do
+    author = insert(:activated_user)
+    {:ok, parent} = Posts.create_post(author, %{body: "Die Ausgangsfrage"})
+    {:ok, reply} = Posts.create_reply(author, parent, %{body: "Die Antwort"})
+
+    token = mastodon_token(insert(:activated_user), ["read"])
+    status = show(conn, token, reply.id)
+
+    assert status["in_reply_to_id"] == parent.id
+    assert status["in_reply_to_account_id"] == author.id
+  end
+
+  test "a cached remote reply names the member's post it answers", %{conn: conn} do
+    member = insert(:activated_user)
+    {:ok, parent} = Posts.create_post(member, %{body: "Womit die Frage begann"})
+    note = insert(:note, post: parent)
+
+    token = mastodon_token(insert(:activated_user), ["read"])
+    status = show(conn, token, "remote-note-" <> note.id)
+
+    assert status["in_reply_to_id"] == parent.id
+    assert status["in_reply_to_account_id"] == member.id
+  end
+
+  test "a followed account's self-reply names its cached parent, same account",
+       %{conn: conn} do
+    account = remote_account("alice")
+    parent = cached_post(account)
+    reply = cached_post(account, %{in_reply_to_uri: parent.object_uri})
+
+    token = mastodon_token(insert(:activated_user), ["read"])
+    status = show(conn, token, "remote-" <> reply.id)
+
+    assert status["in_reply_to_id"] == "remote-" <> parent.id
+    assert status["in_reply_to_account_id"] == "remote-" <> account.id
+  end
+
+  test "a cached reply whose parent we never held stays orphaned", %{conn: conn} do
+    account = remote_account("bob")
+    reply = cached_post(account, %{in_reply_to_uri: "https://social.example/p/never-held"})
+
+    token = mastodon_token(insert(:activated_user), ["read"])
+    status = show(conn, token, "remote-" <> reply.id)
+
+    assert status["in_reply_to_id"] == nil
+    assert status["in_reply_to_account_id"] == nil
+  end
+
+  test "a vutuv answer to a followed account's post names the cached post", %{conn: conn} do
+    author = insert(:activated_user)
+    account = remote_account("carol")
+    remote_post = cached_post(account)
+
+    Repo.insert!(%Follow{
+      user_id: author.id,
+      remote_account_id: account.id,
+      state: "accepted",
+      follow_activity_id: "https://vutuv.test/#{author.id}/actor#f/#{account.id}"
+    })
+
+    {:ok, post} = Posts.create_post(author, %{body: "Meine Antwort nach drüben"})
+
+    Repo.insert!(%PostRemoteReply{
+      post_id: post.id,
+      remote_post_id: remote_post.id,
+      in_reply_to_uri: remote_post.object_uri,
+      actor_uri: account.actor_uri,
+      inbox_uri: account.inbox_uri,
+      handle: "carol@social.example"
+    })
+
+    token = mastodon_token(insert(:activated_user), ["read"])
+    status = show(conn, token, post.id)
+
+    assert status["in_reply_to_id"] == "remote-" <> remote_post.id
+    assert status["in_reply_to_account_id"] == "remote-" <> account.id
+  end
+end

--- a/test/vutuv_web/controllers/mastodon_api/status_parent_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/status_parent_test.exs
@@ -61,6 +61,27 @@ defmodule VutuvWeb.MastodonApi.StatusParentTest do
     assert status["in_reply_to_account_id"] == "remote-" <> account.id
   end
 
+  test "a followers-only parent stays hidden while the follow is only requested",
+       %{conn: conn} do
+    viewer = insert(:activated_user)
+    account = remote_account(handle: "dora")
+    parent = cached_post(account, audience: "followers")
+    reply = cached_post(account, in_reply_to_uri: parent.object_uri)
+
+    Repo.insert!(%Follow{
+      user_id: viewer.id,
+      remote_account_id: account.id,
+      state: "requested",
+      follow_activity_id: "https://vutuv.test/#{viewer.id}/actor#f/#{account.id}"
+    })
+
+    token = mastodon_token(viewer, ["read"])
+    status = show(conn, token, "remote-" <> reply.id)
+
+    assert status["in_reply_to_id"] == nil
+    assert status["in_reply_to_account_id"] == nil
+  end
+
   test "a cached reply whose parent we never held stays orphaned", %{conn: conn} do
     account = remote_account(handle: "bob")
     reply = cached_post(account, in_reply_to_uri: "https://social.example/p/never-held")

--- a/test/vutuv_web/controllers/mastodon_api/status_parent_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/status_parent_test.exs
@@ -14,8 +14,6 @@ defmodule VutuvWeb.MastodonApi.StatusParentTest do
   import Vutuv.MastodonHelpers
 
   alias Vutuv.Fediverse.Follow
-  alias Vutuv.Fediverse.RemoteAccount
-  alias Vutuv.Fediverse.RemotePost
   alias Vutuv.Posts
   alias Vutuv.Posts.PostRemoteReply
 
@@ -24,39 +22,6 @@ defmodule VutuvWeb.MastodonApi.StatusParentTest do
     |> mastodon_conn(token)
     |> get("/api/v1/statuses/#{id}")
     |> json_response(200)
-  end
-
-  defp remote_account(handle) do
-    actor = "https://social.example/users/#{handle}"
-
-    Repo.insert!(%RemoteAccount{
-      actor_uri: actor,
-      host: "social.example",
-      handle: handle,
-      name: String.capitalize(handle),
-      inbox_uri: actor <> "/inbox"
-    })
-  end
-
-  defp cached_post(account, overrides \\ %{}) do
-    now = DateTime.utc_now(:second)
-
-    Repo.insert!(
-      struct(
-        %RemotePost{
-          remote_account_id: account.id,
-          object_uri: "https://social.example/p/#{System.unique_integer([:positive])}",
-          origin_url: "https://social.example/@them/1",
-          content_text: "Ein Gedanke von drüben.",
-          audience: "public",
-          kind: "note",
-          published_at: now,
-          received_at: now,
-          expires_at: DateTime.add(now, 86_400)
-        },
-        overrides
-      )
-    )
   end
 
   test "a local reply names its local parent", %{conn: conn} do
@@ -85,9 +50,9 @@ defmodule VutuvWeb.MastodonApi.StatusParentTest do
 
   test "a followed account's self-reply names its cached parent, same account",
        %{conn: conn} do
-    account = remote_account("alice")
+    account = remote_account(handle: "alice")
     parent = cached_post(account)
-    reply = cached_post(account, %{in_reply_to_uri: parent.object_uri})
+    reply = cached_post(account, in_reply_to_uri: parent.object_uri)
 
     token = mastodon_token(insert(:activated_user), ["read"])
     status = show(conn, token, "remote-" <> reply.id)
@@ -97,8 +62,8 @@ defmodule VutuvWeb.MastodonApi.StatusParentTest do
   end
 
   test "a cached reply whose parent we never held stays orphaned", %{conn: conn} do
-    account = remote_account("bob")
-    reply = cached_post(account, %{in_reply_to_uri: "https://social.example/p/never-held"})
+    account = remote_account(handle: "bob")
+    reply = cached_post(account, in_reply_to_uri: "https://social.example/p/never-held")
 
     token = mastodon_token(insert(:activated_user), ["read"])
     status = show(conn, token, "remote-" <> reply.id)
@@ -109,7 +74,7 @@ defmodule VutuvWeb.MastodonApi.StatusParentTest do
 
   test "a vutuv answer to a followed account's post names the cached post", %{conn: conn} do
     author = insert(:activated_user)
-    account = remote_account("carol")
+    account = remote_account(handle: "carol")
     remote_post = cached_post(account)
 
     Repo.insert!(%Follow{


### PR DESCRIPTION
**Symptom:** Eine Antwort, die über eine Netzwerkgrenze geht, kam im Mastodon-Client ohne Elternbeitrag an — `in_reply_to_id` war `null`, also sah die Antwort wie ein eigenständiger Beitrag aus. Die Website zeigt den Elternbeitrag längst.

**Änderung:** In `Vutuv.MastodonApi.Presenter` drei Fälle gefüllt, jeder so, wie die Website ihn schon auflöst:

- gecachte Fremdnetz-Antwort (`%Note{}`) → der lokale Beitrag, den sie beantwortet
- Selbstantwort eines gefolgten Kontos (`%RemotePost{}`) → dessen gecachter Elternbeitrag (`own_thread?/2` garantiert dasselbe Konto)
- vutuv-Antwort auf einen Fremdnetz-Beitrag (`remote_reply_ref`) → der gecachte Fremdbeitrag

Benannt wird nur ein Elternbeitrag, den derselbe Client abrufen kann (lokale id oder ein gehaltenes `remote-<id>`); sonst bleibt es bei `null` — eine nicht auflösbare id ist schlechter als keine.

Reine JSON-API, keine sichtbare Oberfläche zum Zeigen. Neuer Endpunkt-Test deckt alle vier Fälle ab.

Closes #1622.
