### PR TITLE
Ein Bildlader bringt keine Sitzung mit, also trägt die URL ihre Erlaubnis (v7.334.5)

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -1588,12 +1588,19 @@ conflated:
 chokepoints ("we have the file **and** the gate cleared it"), read both at
 render time and again in `VutuvWeb.RemoteMediaController` — the authorizing
 proxy at `/system/remote_media/…`, which re-checks per request that the reader
-is signed in, that the post's own audience reaches them, that the gate cleared
+belongs here, that the post's own audience reaches them, that the gate cleared
 the picture, and that the URL's version segment names the exact fingerprinted
 file we currently store. Everything else is a 404, and every response carries
 `X-Robots-Tag: noindex, noimageindex`: this is somebody else's photograph, and
 it must never surface as ours in an image search. An unguessable URL is not an
 access control.
+
+"Belongs here" is a session for a browser, and on the avatar route also a
+`VutuvWeb.RemoteMediaToken` in `t` — the capability the Mastodon adapter appends
+because a phone app's image loader sends neither the cookie nor the bearer token
+the API call beside it used. It is unforgeable, it expires, and it names one
+account's one stored file, so it opens nothing else and stops opening that one
+the moment the file is replaced.
 
 A post can now be a **photograph and nothing else**, which used to be dropped
 for having no text. Its `content_text` is then the empty string — emphatically

--- a/docs/architecture/mastodon-api.md
+++ b/docs/architecture/mastodon-api.md
@@ -127,13 +127,29 @@ and cover, and the cached picture of an account on another network
 (`RemoteAccount.avatar_url/1`, the one chokepoint that answers `nil` unless the
 gate cleared it). An account with no cover gets a plain brand banner
 (`/images/header-placeholder.png`) rather than the installation's square icon,
-which is what a client used to draw across the top of every profile. The
-**notification actor** goes through the same chokepoint (issue #1598): an
-activity item for somebody on another network carries only their handle and
-actor URI, so `Notifications.accounts/1` — the one loader both the REST list
-and the streaming socket render through — resolves the cached `RemoteAccount`
-by that URI (`Fediverse.remote_accounts_by_uris/1`, batched per page) and only
-an actor nobody here stored falls back to the hand-built placeholder account.
+which is what a client used to draw across the top of every profile. A remote
+account has no banner at all — we cache an actor's `icon`, never its `image` —
+so it always gets that one. The **notification actor** goes through the same
+chokepoint (issue #1598): an activity item for somebody on another network
+carries only their handle and actor URI, so `Notifications.accounts/1` — the one
+loader both the REST list and the streaming socket render through — resolves the
+cached `RemoteAccount` by that URI (`Fediverse.remote_accounts_by_uris/1`,
+batched per page) and only an actor nobody here stored falls back to the
+hand-built placeholder account.
+
+**A cached remote picture needs a capability, because an image loader carries
+no credentials.** `/system/remote_media/…` asks for a signed-in reader, and a
+phone app fetches an image with a bare `GET`: no cookie, no bearer, whatever
+the API call beside it used. So naming the real picture (v7.330.0) named it at
+a URL the client could not fetch, and every account out of the fediverse went
+blank — its profile, its posts, and from v7.332.6 its notifications too. The
+adapter appends `VutuvWeb.RemoteMediaToken` — signed, expiring, and naming
+exactly the account and stored file it opens — and the proxy takes it in place
+of the session. The AI gate and the stored-file whitelist are still re-asked per
+request, so it widens nothing. Its `signed_at` is pinned to the UTC day so a
+client is handed the same URL all day and its image cache keeps working; a
+per-render timestamp would re-download every face in the timeline on every
+refresh.
 
 The three counts are `Vutuv.MastodonApi.AccountCounts`, one query per figure for
 a whole page rather than three per row — ours are real aggregates where

--- a/docs/architecture/mastodon-api.md
+++ b/docs/architecture/mastodon-api.md
@@ -146,10 +146,16 @@ blank — its profile, its posts, and from v7.332.6 its notifications too. The
 adapter appends `VutuvWeb.RemoteMediaToken` — signed, expiring, and naming
 exactly the account and stored file it opens — and the proxy takes it in place
 of the session. The AI gate and the stored-file whitelist are still re-asked per
-request, so it widens nothing. Its `signed_at` is pinned to the UTC day so a
-client is handed the same URL all day and its image cache keeps working; a
-per-render timestamp would re-download every face in the timeline on every
-refresh.
+request, so it widens no picture. It does widen who may fetch one: it is a
+bearer URL naming no member and no device, so a logout, a suspension or a
+revoked app do not close a URL already handed out, and it answers until it
+expires. That is the trade, and it is sized to what is behind the door — one
+cached copy of a public avatar. The post-attachment route keeps the session,
+because its pictures carry a post's audience. Its `signed_at` is pinned to the
+UTC day so a client is handed the same URL all day and its image cache keeps
+working; a per-render timestamp would re-download every face in the timeline on
+every refresh, and a longer bucket would lengthen that bearer window for a
+saving measured in kilobytes.
 
 The three counts are `Vutuv.MastodonApi.AccountCounts`, one query per figure for
 a whole page rather than three per row — ours are real aggregates where

--- a/lib/vutuv/mastodon_api.ex
+++ b/lib/vutuv/mastodon_api.ex
@@ -95,8 +95,14 @@ defmodule Vutuv.MastodonApi do
   """
   def operator_handle, do: Application.get_env(:vutuv, :operator_handle)
 
-  def main_url(path), do: absolute_url(local_domain(), path)
-  def api_url(path), do: absolute_url(api_host(), path)
+  @doc """
+  An absolute URL on the main host. `query` is passed separately because
+  `absolute_url/3` builds the URI from parts — a query folded into `path`
+  would be escaped into the path rather than kept as one.
+  """
+  def main_url(path, query \\ nil), do: absolute_url(local_domain(), path, query)
+
+  def api_url(path), do: absolute_url(api_host(), path, nil)
 
   @doc """
   The streaming endpoint as a client must dial it: the `ws(s)` form of
@@ -113,8 +119,8 @@ defmodule Vutuv.MastodonApi do
     |> String.replace_prefix("http://", "ws://")
   end
 
-  defp absolute_url(host, path) do
+  defp absolute_url(host, path, query) do
     uri = URI.parse(Endpoint.url())
-    URI.to_string(%{uri | host: host, path: path, query: nil, fragment: nil})
+    URI.to_string(%{uri | host: host, path: path, query: query, fragment: nil})
   end
 end

--- a/lib/vutuv/mastodon_api.ex
+++ b/lib/vutuv/mastodon_api.ex
@@ -96,13 +96,17 @@ defmodule Vutuv.MastodonApi do
   def operator_handle, do: Application.get_env(:vutuv, :operator_handle)
 
   @doc """
-  An absolute URL on the main host. `query` is passed separately because
-  `absolute_url/3` builds the URI from parts — a query folded into `path`
-  would be escaped into the path rather than kept as one.
+  An absolute URL on the main host, optionally with a query string.
+
+  The URI is built from parts, and `URI.to_string/1` escapes nothing, so a
+  query folded into `path` also comes out intact — `PostImage.url/2` has always
+  arrived that way, carrying its crop buster. What must not happen is both at
+  once: a `path` already ending in `?v=…` plus a `query` yields `…?v=1?t=…`,
+  which names nothing. Nothing enforces that, so pass the query here.
   """
   def main_url(path, query \\ nil), do: absolute_url(local_domain(), path, query)
 
-  def api_url(path), do: absolute_url(api_host(), path, nil)
+  def api_url(path), do: absolute_url(api_host(), path)
 
   @doc """
   The streaming endpoint as a client must dial it: the `ws(s)` form of
@@ -119,7 +123,7 @@ defmodule Vutuv.MastodonApi do
     |> String.replace_prefix("http://", "ws://")
   end
 
-  defp absolute_url(host, path, query) do
+  defp absolute_url(host, path, query \\ nil) do
     uri = URI.parse(Endpoint.url())
     URI.to_string(%{uri | host: host, path: path, query: query, fragment: nil})
   end

--- a/lib/vutuv/mastodon_api/presenter.ex
+++ b/lib/vutuv/mastodon_api/presenter.ex
@@ -20,6 +20,7 @@ defmodule Vutuv.MastodonApi.Presenter do
   alias Vutuv.Posts.PostImage
   alias Vutuv.UUIDv7
   alias VutuvWeb.Markdown
+  alias VutuvWeb.RemoteMediaToken
   alias VutuvWeb.UserHelpers
 
   def identity_name(%User{} = user),
@@ -470,10 +471,20 @@ defmodule Vutuv.MastodonApi.Presenter do
   # rendered the vutuv logo beside every remote author. `avatar_url/1` is the
   # one chokepoint that answers nil unless the AI gate cleared the file, so a
   # picture we may not show still falls back rather than leaking.
+  #
+  # The capability rides along because the proxy that serves these bytes asks
+  # for a signed-in reader, and the thing fetching this URL is an image loader
+  # with no cookie and no bearer — which is why naming the real picture, on its
+  # own, only turned every remote face into a 404. See
+  # `VutuvWeb.RemoteMediaToken`; the website keeps using the bare path and its
+  # session.
   defp remote_avatar(%RemoteAccount{} = account) do
     case RemoteAccount.avatar_url(account) do
-      path when is_binary(path) -> MastodonApi.main_url(path)
-      nil -> fallback_avatar()
+      path when is_binary(path) ->
+        MastodonApi.main_url(path, RemoteMediaToken.avatar_query(account.id, account.avatar))
+
+      nil ->
+        fallback_avatar()
     end
   end
 

--- a/lib/vutuv_web/controllers/remote_media_controller.ex
+++ b/lib/vutuv_web/controllers/remote_media_controller.ex
@@ -34,6 +34,21 @@ defmodule VutuvWeb.RemoteMediaController do
   cannot be lost by a route moving scope, and it is the same `%User{}` gate on
   both actions: the routes sit in the plain `:browser` scope, where nothing
   else would ask.
+
+  **Or a signed capability, on the avatar.** A session is how a *browser*
+  proves it is a member, and the Mastodon adapter's readers are phone apps
+  whose image loader sends neither the cookie nor the bearer token the API call
+  beside it used. So the avatar action takes a `VutuvWeb.RemoteMediaToken` as
+  the equivalent claim — unforgeable, expiring, and naming exactly the account
+  and stored file it opens. Everything else on the way in is unchanged and
+  re-asked per request, so it widens what may be seen by nothing; without it,
+  v7.330.0 named every remote picture in an API response at a URL no client
+  could fetch. `post_image/2` has no such door because the adapter names no
+  remote attachment — see `VutuvWeb.RemoteMediaToken`.
+
+  Both actions open on `Vutuv.Fediverse.enabled?/0`: switching federation off
+  has to close the proxy too, or the pictures it cached go on being served
+  after the feature that justified them is gone.
   """
 
   use VutuvWeb, :controller
@@ -44,9 +59,11 @@ defmodule VutuvWeb.RemoteMediaController do
   alias Vutuv.Fediverse.RemoteImage
   alias Vutuv.RemoteMedia
   alias VutuvWeb.ImageProxy
+  alias VutuvWeb.RemoteMediaToken
 
   def post_image(conn, %{"id" => id, "version" => version_file}) do
-    with %User{} = viewer <- viewer(conn),
+    with true <- Fediverse.enabled?(),
+         %User{} = viewer <- conn.assigns[:current_user],
          %RemoteImage{} = image <- Fediverse.get_remote_image(id),
          true <- RemoteImage.released?(image),
          version when not is_nil(version) <- parse_version(version_file, image.file),
@@ -62,11 +79,22 @@ defmodule VutuvWeb.RemoteMediaController do
 
   # An avatar has no per-post audience: it is the picture of an account
   # somebody here follows, shown wherever that account is named. So the check
-  # is the gate plus a signed-in reader.
-  def avatar(conn, %{"id" => id, "version" => version_file}) do
-    with %User{} <- viewer(conn),
+  # is the gate plus a reader who belongs here — a session, or the capability
+  # the API hands its clients.
+  #
+  # `signed_in?/1` is asked twice on purpose. The second time is the real
+  # check, and it needs the row, because a capability names the file the row
+  # currently holds. The first is a pre-filter: this route answers without a
+  # session, and a caller who brings neither claim must not be able to make us
+  # read the database at all.
+  def avatar(conn, %{"id" => id, "version" => version_file} = params) do
+    token = params[RemoteMediaToken.param()]
+
+    with true <- Fediverse.enabled?(),
+         true <- signed_in?(conn) or is_binary(token),
          %RemoteAccount{} = account <- Fediverse.get_remote_account(id),
          true <- RemoteAccount.avatar_ready?(account),
+         true <- signed_in?(conn) or RemoteMediaToken.avatar?(token, account.id, account.avatar),
          version when not is_nil(version) <- parse_version(version_file, account.avatar) do
       serve(conn, version,
         accel: &RemoteMedia.avatar_accel_path(account.id, &1),
@@ -77,12 +105,7 @@ defmodule VutuvWeb.RemoteMediaController do
     end
   end
 
-  # A signed-in reader, and only while the installation federates at all:
-  # switching federation off has to close the proxy too, or the pictures it
-  # cached go on being served after the feature that justified them is gone.
-  defp viewer(conn) do
-    if Fediverse.enabled?(), do: conn.assigns[:current_user]
-  end
+  defp signed_in?(conn), do: match?(%User{}, conn.assigns[:current_user])
 
   defp serve(conn, version, accel: accel, path: path) do
     conn

--- a/lib/vutuv_web/controllers/remote_media_controller.ex
+++ b/lib/vutuv_web/controllers/remote_media_controller.ex
@@ -31,19 +31,20 @@ defmodule VutuvWeb.RemoteMediaController do
   follows their author; none of it is a public surface, and an unguessable URL
   is not an access control — it is a URL, and URLs get shared, logged and
   pasted. The check is in the action rather than in a router pipeline so it
-  cannot be lost by a route moving scope, and it is the same `%User{}` gate on
-  both actions: the routes sit in the plain `:browser` scope, where nothing
-  else would ask.
+  cannot be lost by a route moving scope: the routes sit in the plain
+  `:browser` scope, where nothing else would ask. `post_image/2` takes a
+  `%User{}` and nothing else; `avatar/2` takes one of two claims.
 
-  **Or a signed capability, on the avatar.** A session is how a *browser*
-  proves it is a member, and the Mastodon adapter's readers are phone apps
-  whose image loader sends neither the cookie nor the bearer token the API call
-  beside it used. So the avatar action takes a `VutuvWeb.RemoteMediaToken` as
-  the equivalent claim — unforgeable, expiring, and naming exactly the account
-  and stored file it opens. Everything else on the way in is unchanged and
-  re-asked per request, so it widens what may be seen by nothing; without it,
-  v7.330.0 named every remote picture in an API response at a URL no client
-  could fetch. `post_image/2` has no such door because the adapter names no
+  **The avatar's second claim is a signed capability.** A session is how a
+  *browser* proves it is a member, and the Mastodon adapter's readers are phone
+  apps whose image loader sends neither the cookie nor the bearer token the API
+  call beside it used. So the avatar action takes a
+  `VutuvWeb.RemoteMediaToken` as the equivalent claim — unforgeable, expiring,
+  and naming exactly the account and stored file it opens. Everything else on
+  the way in is unchanged and re-asked per request, so it widens *what* may be
+  seen by nothing; without it, v7.330.0 named every remote picture in an API
+  response at a URL no client could fetch. It does widen *who*, and the module
+  says how far. `post_image/2` has no such door because the adapter names no
   remote attachment — see `VutuvWeb.RemoteMediaToken`.
 
   Both actions open on `Vutuv.Fediverse.enabled?/0`: switching federation off
@@ -82,19 +83,22 @@ defmodule VutuvWeb.RemoteMediaController do
   # is the gate plus a reader who belongs here — a session, or the capability
   # the API hands its clients.
   #
-  # `signed_in?/1` is asked twice on purpose. The second time is the real
-  # check, and it needs the row, because a capability names the file the row
-  # currently holds. The first is a pre-filter: this route answers without a
-  # session, and a caller who brings neither claim must not be able to make us
-  # read the database at all.
+  # The capability is asked about twice because the two halves of its answer
+  # have different costs. Whether we minted it and it is still good is a
+  # signature check over the token alone (`authentic?/1`), so it goes ABOVE the
+  # lookup and keeps an anonymous caller from spending a query — this route
+  # used to refuse them for free and must go on doing so. Which file it opens
+  # can only be settled against the row, because a rotated picture has to stop
+  # answering, so that half stays below.
   def avatar(conn, %{"id" => id, "version" => version_file} = params) do
+    member? = match?(%User{}, conn.assigns[:current_user])
     token = params[RemoteMediaToken.param()]
 
     with true <- Fediverse.enabled?(),
-         true <- signed_in?(conn) or is_binary(token),
+         true <- member? or RemoteMediaToken.authentic?(token),
          %RemoteAccount{} = account <- Fediverse.get_remote_account(id),
          true <- RemoteAccount.avatar_ready?(account),
-         true <- signed_in?(conn) or RemoteMediaToken.avatar?(token, account.id, account.avatar),
+         true <- member? or RemoteMediaToken.avatar?(token, account.id, account.avatar),
          version when not is_nil(version) <- parse_version(version_file, account.avatar) do
       serve(conn, version,
         accel: &RemoteMedia.avatar_accel_path(account.id, &1),
@@ -104,8 +108,6 @@ defmodule VutuvWeb.RemoteMediaController do
       _ -> ImageProxy.not_found(conn)
     end
   end
-
-  defp signed_in?(conn), do: match?(%User{}, conn.assigns[:current_user])
 
   defp serve(conn, version, accel: accel, path: path) do
     conn

--- a/lib/vutuv_web/remote_media_token.ex
+++ b/lib/vutuv_web/remote_media_token.ex
@@ -1,0 +1,76 @@
+defmodule VutuvWeb.RemoteMediaToken do
+  @moduledoc """
+  The capability that lets an **API client** load a picture cached from another
+  network — the second door into `VutuvWeb.RemoteMediaController`, beside the
+  signed-in reader it already knew.
+
+  A phone app fetches an image with a bare `GET`. Its image loader carries
+  neither the session cookie nor the OAuth token the API call itself used, and
+  no header we could ask for would arrive — that is how every image loader on
+  every platform works. So from v7.330.0, when the Mastodon adapter started
+  naming the cached picture instead of the installation's icon, every account
+  out of the fediverse came back 404 and sat blank in the app. The adapter now
+  mints a capability for exactly that picture and the proxy takes it instead of
+  a session.
+
+  This is **not** the "unguessable URL" the proxy's moduledoc rightly refuses:
+  it is unforgeable, it expires, it names one account's one stored file, and it
+  only ever leaves the building inside an authenticated API response. And it
+  widens nothing else — the AI gate and the stored-file whitelist are re-asked
+  on every request, so a picture the gate takes back or a file that gets
+  rotated stops answering with the capability still in hand.
+
+  `signed_at` is pinned to the UTC day rather than to the moment, so a client
+  is handed the same URL all day and its image cache keeps working. A
+  per-render timestamp would re-mint every avatar URL on every timeline
+  refresh, and a client caches by URL — every face in the timeline would be
+  downloaded again each time. `@max_age` is a day longer than the window a
+  client may still be showing a cached timeline from, so the pinning can never
+  hand out a capability that is already stale.
+
+  **Avatars only, and that is a decision rather than an oversight.** The proxy's
+  other route serves a cached post's attachments, and the adapter never names
+  one: `Vutuv.MastodonApi.Presenter.status/2` leaves `media_attachments` at the
+  empty default for a `%RemotePost{}` and a `%Note{}`, so a capability there
+  would be dead code today. The subject is a tagged tuple, so the day that
+  changes is a second tag and a second pair of heads here — not a second module.
+  """
+
+  alias VutuvWeb.Endpoint
+
+  @salt "remote media capability"
+  @bucket 60 * 60 * 24
+  @max_age 60 * 60 * 24 * 8
+
+  @doc "The query-parameter name a capability travels in."
+  def param, do: "t"
+
+  @doc """
+  The capability for one account's currently stored avatar, as the query string
+  the adapter appends to the picture's URL.
+  """
+  def avatar_query(account_id, file) when is_binary(account_id) and is_binary(file) do
+    token = Phoenix.Token.sign(Endpoint, @salt, {:avatar, account_id, file}, signed_at: bucket())
+    URI.encode_query(%{param() => token})
+  end
+
+  @doc """
+  Whether `token` opens exactly this account's exactly this file. Anything else
+  — a made-up string, an expired one, one minted for another account or for the
+  picture this row used to hold — is false, which the proxy answers as 404 like
+  every other refusal it makes.
+  """
+  def avatar?(token, account_id, file)
+      when is_binary(token) and is_binary(account_id) and is_binary(file) do
+    case Phoenix.Token.verify(Endpoint, @salt, token, max_age: @max_age) do
+      {:ok, {:avatar, ^account_id, ^file}} -> true
+      _other -> false
+    end
+  end
+
+  # nil is the ordinary case on the website, where the session answers instead.
+  def avatar?(_token, _account_id, _file), do: false
+
+  # The start of the current UTC day, in the seconds `Phoenix.Token` wants.
+  defp bucket, do: div(System.os_time(:second), @bucket) * @bucket
+end

--- a/lib/vutuv_web/remote_media_token.ex
+++ b/lib/vutuv_web/remote_media_token.ex
@@ -15,10 +15,25 @@ defmodule VutuvWeb.RemoteMediaToken do
 
   This is **not** the "unguessable URL" the proxy's moduledoc rightly refuses:
   it is unforgeable, it expires, it names one account's one stored file, and it
-  only ever leaves the building inside an authenticated API response. And it
-  widens nothing else — the AI gate and the stored-file whitelist are re-asked
-  on every request, so a picture the gate takes back or a file that gets
-  rotated stops answering with the capability still in hand.
+  only ever leaves the building inside an authenticated API response (every
+  Mastodon route that renders an account sits behind `Plugs.MastodonApiAuth`;
+  the few unauthenticated ones render no `%RemoteAccount{}`). And it widens
+  nothing else — the AI gate and the stored-file whitelist are re-asked on
+  every request, so a picture the gate takes back or a file that gets rotated
+  stops answering with the capability still in hand.
+
+  **What it does widen is *who*, and it is a bearer URL: say so rather than
+  claiming otherwise.** It names no member, no device and no access token, so
+  nothing that ends a member's access ends its own — a remote logout, a
+  suspension, a revoked OAuth app all leave a URL already handed out answering
+  until it expires. Closing that would mean naming a session inside the token
+  and looking it up per image request, which the adapter cannot do anyway:
+  `Vutuv.MastodonApi.Presenter.account/2` is handed a row, never a viewer. The
+  trade is deliberate and it is sized to what is behind the door — one cached
+  copy of a public avatar that its own server serves to anybody who asks, held
+  here only because a member follows them. Do not reach for this shape for
+  anything a member would call private; `post_image/2`, whose pictures carry a
+  post's audience, keeps the session and must go on keeping it.
 
   `signed_at` is pinned to the UTC day rather than to the moment, so a client
   is handed the same URL all day and its image cache keeps working. A
@@ -28,12 +43,19 @@ defmodule VutuvWeb.RemoteMediaToken do
   client may still be showing a cached timeline from, so the pinning can never
   hand out a capability that is already stale.
 
-  **Avatars only, and that is a decision rather than an oversight.** The proxy's
-  other route serves a cached post's attachments, and the adapter never names
-  one: `Vutuv.MastodonApi.Presenter.status/2` leaves `media_attachments` at the
-  empty default for a `%RemotePost{}` and a `%Note{}`, so a capability there
-  would be dead code today. The subject is a tagged tuple, so the day that
-  changes is a second tag and a second pair of heads here — not a second module.
+  **Avatars only — and that is where the work stopped, not where the problem
+  ends.** Read the scope as two open gaps rather than as a boundary. The
+  proxy's other route serves a cached post's attachments and
+  `Vutuv.MastodonApi.Presenter.status/2` leaves `media_attachments` empty for a
+  `%RemotePost{}` and a `%Note{}`, so a capability there would be dead code
+  today — but only because a photo post from another network reaches a client
+  with no photo at all (issue #1626), and fixing that brings the identical 404
+  straight back. And the adapter *does* name local post photos, at
+  `/post_images/…`, which asks `Posts.image_visible_to?/2`: fine for a public
+  post, false for a restricted one against the nil viewer an image loader is,
+  so those are broken images in every client right now (issue #1627). The
+  subject is a tagged tuple so each of those is a second tag and a second pair
+  of heads here, not a second module.
   """
 
   alias VutuvWeb.Endpoint
@@ -48,11 +70,41 @@ defmodule VutuvWeb.RemoteMediaToken do
   @doc """
   The capability for one account's currently stored avatar, as the query string
   the adapter appends to the picture's URL.
+
+  `signed_at` is the injectable clock: expiry is the one property that makes
+  this a capability rather than an unguessable URL, and a test that cannot mint
+  an old capability cannot prove the expiry is wired up at all — nor tell a
+  `max_age` that is enforced from one that was quietly dropped. Production
+  passes nothing and gets `bucket/0`.
   """
-  def avatar_query(account_id, file) when is_binary(account_id) and is_binary(file) do
-    token = Phoenix.Token.sign(Endpoint, @salt, {:avatar, account_id, file}, signed_at: bucket())
+  def avatar_query(account_id, file, signed_at \\ bucket())
+      when is_binary(account_id) and is_binary(file) do
+    token = Phoenix.Token.sign(Endpoint, @salt, {:avatar, account_id, file}, signed_at: signed_at)
     URI.encode_query(%{param() => token})
   end
+
+  @doc "How long a capability stays good, in seconds."
+  def max_age, do: @max_age
+
+  @doc """
+  Whether `token` is a capability this installation minted and has not expired
+  — without saying which picture it opens.
+
+  This is the half of the answer that needs no database row, and it exists so
+  the proxy can turn away a caller who brings nothing unforgeable *before*
+  looking an account up. A check on the token's shape could not do that (any
+  non-empty string has the shape), so without this an anonymous request would
+  cost a query, which the signed-in-only route never did. `avatar?/3` is still
+  the real check: only the row knows which file the account holds now.
+  """
+  def authentic?(token) when is_binary(token) do
+    match?(
+      {:ok, {:avatar, _account_id, _file}},
+      Phoenix.Token.verify(Endpoint, @salt, token, max_age: @max_age)
+    )
+  end
+
+  def authentic?(_token), do: false
 
   @doc """
   Whether `token` opens exactly this account's exactly this file. Anything else

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.334.3",
+      version: "7.334.5",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/support/mastodon_helpers.ex
+++ b/test/support/mastodon_helpers.ex
@@ -21,6 +21,7 @@ defmodule Vutuv.MastodonHelpers do
   alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
   alias Vutuv.Repo
+  alias VutuvWeb.RemoteMediaToken
 
   @doc "Turns an identity's Mastodon-app switch on, as its owner would."
   def allow_mastodon_clients(%User{} = user),
@@ -110,4 +111,20 @@ defmodule Vutuv.MastodonHelpers do
 
   @doc "Puts `conn` on the adapter's host without a token."
   def on_mastodon_host(conn), do: Map.put(conn, :host, mastodon_host())
+
+  @doc """
+  The `VutuvWeb.RemoteMediaToken` out of a rendered avatar URL, or nil when the
+  URL carries none.
+
+  Every assertion about a remote face wants this **beside**
+  `String.starts_with?(url, path <> "?")`, which on its own proves only that
+  something follows the picture's path: what makes the URL work is that the
+  proxy accepts the capability in it, and a query the proxy would refuse starts
+  with exactly the same characters.
+  """
+  def avatar_capability(url) when is_binary(url) do
+    %URI{query: query} = URI.parse(url)
+
+    (query || "") |> URI.decode_query() |> Map.get(RemoteMediaToken.param())
+  end
 end

--- a/test/vutuv/mastodon_api/notifications_test.exs
+++ b/test/vutuv/mastodon_api/notifications_test.exs
@@ -46,7 +46,13 @@ defmodule Vutuv.MastodonApi.NotificationsTest do
     account = Notifications.account(item(actor_uri))
 
     assert account.id == "remote-" <> stored.id
-    assert account.avatar == MastodonApi.main_url(RemoteAccount.avatar_url(stored))
+    # The URL carries the proxy's capability beside the path — an image loader
+    # brings no session of its own.
+    assert String.starts_with?(
+             account.avatar,
+             MastodonApi.main_url(RemoteAccount.avatar_url(stored)) <> "?"
+           )
+
     refute account.avatar == Presenter.fallback_avatar()
   end
 

--- a/test/vutuv/mastodon_api/notifications_test.exs
+++ b/test/vutuv/mastodon_api/notifications_test.exs
@@ -9,10 +9,13 @@ defmodule Vutuv.MastodonApi.NotificationsTest do
   """
   use Vutuv.DataCase, async: true
 
+  import Vutuv.MastodonHelpers, only: [avatar_capability: 1]
+
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.MastodonApi
   alias Vutuv.MastodonApi.Notifications
   alias Vutuv.MastodonApi.Presenter
+  alias VutuvWeb.RemoteMediaToken
 
   defp stored_account(actor_uri) do
     Repo.insert!(%RemoteAccount{
@@ -46,12 +49,16 @@ defmodule Vutuv.MastodonApi.NotificationsTest do
     account = Notifications.account(item(actor_uri))
 
     assert account.id == "remote-" <> stored.id
-    # The URL carries the proxy's capability beside the path — an image loader
-    # brings no session of its own.
+    # The path names the picture, and the query carries a capability the proxy
+    # accepts for exactly it — an image loader brings no session of its own.
     assert String.starts_with?(
              account.avatar,
              MastodonApi.main_url(RemoteAccount.avatar_url(stored)) <> "?"
            )
+
+    assert account.avatar
+           |> avatar_capability()
+           |> RemoteMediaToken.avatar?(stored.id, stored.avatar)
 
     refute account.avatar == Presenter.fallback_avatar()
   end

--- a/test/vutuv_web/controllers/mastodon_api/fediverse_client_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/fediverse_client_test.exs
@@ -28,6 +28,8 @@ defmodule VutuvWeb.MastodonApi.FediverseClientTest do
   alias Vutuv.MastodonApi.Presenter
   alias Vutuv.Posts
   alias Vutuv.Repo
+  alias Vutuv.UUIDv7
+  alias VutuvWeb.RemoteMediaToken
 
   setup do
     Vutuv.RateLimiter.reset()
@@ -182,10 +184,25 @@ defmodule VutuvWeb.MastodonApi.FediverseClientTest do
       account = remote_account(avatar: "pic.avif", avatar_moderation: "approved")
 
       rendered = Presenter.account(account)
+      picture = MastodonApi.main_url(RemoteAccount.avatar_url(account))
 
-      assert rendered.avatar == MastodonApi.main_url(RemoteAccount.avatar_url(account))
+      assert String.starts_with?(rendered.avatar, picture <> "?")
       assert rendered.avatar_static == rendered.avatar
       refute rendered.avatar == Presenter.fallback_avatar()
+    end
+
+    # The picture is served by a proxy that wants a signed-in reader, and the
+    # thing fetching it is an image loader with neither cookie nor bearer — so
+    # the URL has to carry its own permission or it is a 404 in every client.
+    test "and a capability the proxy accepts, because an image loader has none" do
+      account = remote_account(avatar: "pic.avif", avatar_moderation: "approved")
+
+      %{query: query} = account |> Presenter.account() |> Map.fetch!(:avatar) |> URI.parse()
+      token = URI.decode_query(query) |> Map.fetch!(RemoteMediaToken.param())
+
+      assert RemoteMediaToken.avatar?(token, account.id, account.avatar)
+      refute RemoteMediaToken.avatar?(token, account.id, "other.avif")
+      refute RemoteMediaToken.avatar?(token, UUIDv7.generate(), account.avatar)
     end
 
     test "keeps the stand-in while the gate has not cleared it" do

--- a/test/vutuv_web/controllers/mastodon_api/fediverse_client_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/fediverse_client_test.exs
@@ -197,8 +197,7 @@ defmodule VutuvWeb.MastodonApi.FediverseClientTest do
     test "and a capability the proxy accepts, because an image loader has none" do
       account = remote_account(avatar: "pic.avif", avatar_moderation: "approved")
 
-      %{query: query} = account |> Presenter.account() |> Map.fetch!(:avatar) |> URI.parse()
-      token = URI.decode_query(query) |> Map.fetch!(RemoteMediaToken.param())
+      token = account |> Presenter.account() |> Map.fetch!(:avatar) |> avatar_capability()
 
       assert RemoteMediaToken.avatar?(token, account.id, account.avatar)
       refute RemoteMediaToken.avatar?(token, account.id, "other.avif")

--- a/test/vutuv_web/controllers/mastodon_api/notification_controller_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/notification_controller_test.exs
@@ -207,8 +207,12 @@ defmodule VutuvWeb.MastodonApi.NotificationControllerTest do
       assert favourite["type"] == "favourite"
       assert favourite["account"]["id"] == "remote-" <> account.id
 
-      assert favourite["account"]["avatar"] ==
-               MastodonApi.main_url(RemoteAccount.avatar_url(account))
+      # Plus the capability the picture's proxy wants — a phone app's image
+      # loader sends no cookie, so the URL has to carry its own permission.
+      assert String.starts_with?(
+               favourite["account"]["avatar"],
+               MastodonApi.main_url(RemoteAccount.avatar_url(account)) <> "?"
+             )
 
       refute favourite["account"]["avatar"] == Presenter.fallback_avatar()
     end

--- a/test/vutuv_web/controllers/mastodon_api/notification_controller_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/notification_controller_test.exs
@@ -15,6 +15,7 @@ defmodule VutuvWeb.MastodonApi.NotificationControllerTest do
   alias Vutuv.Posts
   alias Vutuv.Repo
   alias Vutuv.Social
+  alias VutuvWeb.RemoteMediaToken
 
   test "a like and a follow arrive as favourite and follow", %{conn: conn} do
     member = insert(:activated_user)
@@ -213,6 +214,10 @@ defmodule VutuvWeb.MastodonApi.NotificationControllerTest do
                favourite["account"]["avatar"],
                MastodonApi.main_url(RemoteAccount.avatar_url(account)) <> "?"
              )
+
+      assert favourite["account"]["avatar"]
+             |> avatar_capability()
+             |> RemoteMediaToken.avatar?(account.id, account.avatar)
 
       refute favourite["account"]["avatar"] == Presenter.fallback_avatar()
     end

--- a/test/vutuv_web/controllers/remote_media_controller_test.exs
+++ b/test/vutuv_web/controllers/remote_media_controller_test.exs
@@ -21,6 +21,7 @@ defmodule VutuvWeb.RemoteMediaControllerTest do
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Fediverse.RemoteImage
   alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.MastodonApi.Presenter
   alias Vutuv.RemoteMedia
 
   setup %{conn: conn} do
@@ -232,5 +233,50 @@ defmodule VutuvWeb.RemoteMediaControllerTest do
 
       assert get(ctx.conn, media_url(stored)).status == 404
     end
+  end
+
+  describe "the URL the Mastodon adapter hands a client" do
+    # The seam #1588 opened: the adapter started naming the cached picture
+    # instead of the installation's icon, and an image loader fetches with a
+    # bare GET — no cookie, no bearer, because that is what every image loader
+    # does. So the picture the API had just named came back 404 and every
+    # account out of the fediverse sat blank in the app.
+    test "loads without a session, because that is how an image loader asks", ctx do
+      stored = avatar(ctx.account)
+
+      assert get(ctx.out, adapter_path(stored)).status == 200
+    end
+
+    test "is still refused without one", ctx do
+      stored = avatar(ctx.account)
+
+      assert get(ctx.out, media_url(stored)).status == 404
+      assert get(ctx.out, media_url(stored) <> "?t=not-a-token").status == 404
+    end
+
+    test "stops answering once the gate takes the picture back", ctx do
+      stored = avatar(ctx.account)
+      path = adapter_path(stored)
+
+      Repo.update!(change(stored, avatar_moderation: "pending"))
+
+      assert get(ctx.out, path).status == 404
+    end
+
+    test "does not open another account's picture", ctx do
+      other = avatar(other_account())
+      borrowed = ctx.account |> avatar() |> capability()
+
+      assert get(ctx.out, media_url(other) <> "?" <> borrowed).status == 404
+    end
+  end
+
+  # The avatar URL as a client receives it, reduced to what ConnTest requests.
+  defp adapter_path(%RemoteAccount{} = account),
+    do: media_url(account) <> "?" <> capability(account)
+
+  defp capability(%RemoteAccount{} = account) do
+    %URI{query: query} = account |> Presenter.account() |> Map.fetch!(:avatar) |> URI.parse()
+    query
   end
 end

--- a/test/vutuv_web/controllers/remote_media_controller_test.exs
+++ b/test/vutuv_web/controllers/remote_media_controller_test.exs
@@ -15,6 +15,8 @@ defmodule VutuvWeb.RemoteMediaControllerTest do
   """
   use VutuvWeb.ConnCase, async: true
 
+  import Vutuv.MastodonHelpers, only: [avatar_capability: 1]
+
   alias Vutuv.Fediverse.Follow
   alias Vutuv.Fediverse.PostBoost
   alias Vutuv.Fediverse.PostRepost
@@ -23,6 +25,7 @@ defmodule VutuvWeb.RemoteMediaControllerTest do
   alias Vutuv.Fediverse.RemotePost
   alias Vutuv.MastodonApi.Presenter
   alias Vutuv.RemoteMedia
+  alias VutuvWeb.RemoteMediaToken
 
   setup %{conn: conn} do
     {conn, user} = create_and_login_user(Plug.Test.init_test_session(conn, %{}))
@@ -247,11 +250,34 @@ defmodule VutuvWeb.RemoteMediaControllerTest do
       assert get(ctx.out, adapter_path(stored)).status == 200
     end
 
-    test "is still refused without one", ctx do
+    test "is refused when the query carries something that is not one", ctx do
       stored = avatar(ctx.account)
 
-      assert get(ctx.out, media_url(stored)).status == 404
       assert get(ctx.out, media_url(stored) <> "?t=not-a-token").status == 404
+    end
+
+    # Expiry is the whole difference between a capability and the unguessable
+    # URL the proxy's moduledoc refuses, so both ends of the window are pinned.
+    test "stops opening the picture once it has expired", ctx do
+      stored = avatar(ctx.account)
+      stale = minted_ago(stored, RemoteMediaToken.max_age() + 86_400)
+
+      refute RemoteMediaToken.avatar?(avatar_capability("?" <> stale), stored.id, stored.avatar)
+      assert get(ctx.out, media_url(stored) <> "?" <> stale).status == 404
+    end
+
+    # The other end, and the one a reader would report: a client may still be
+    # showing a timeline it cached days ago, and those URLs have to keep
+    # working. It is also the only guard on `verify/4`'s `max_age:` option —
+    # drop it and Plug.Crypto falls back to the ONE DAY it bakes in at signing
+    # time, which is *stricter*, so no expiry test can catch that. Every
+    # capability older than a day would 404 and every face would go blank
+    # again, which is the bug this whole module exists to fix.
+    test "still opens it a day inside the window", ctx do
+      stored = avatar(ctx.account)
+      old = minted_ago(stored, RemoteMediaToken.max_age() - 86_400)
+
+      assert get(ctx.out, media_url(stored) <> "?" <> old).status == 200
     end
 
     test "stops answering once the gate takes the picture back", ctx do
@@ -279,4 +305,9 @@ defmodule VutuvWeb.RemoteMediaControllerTest do
     %URI{query: query} = account |> Presenter.account() |> Map.fetch!(:avatar) |> URI.parse()
     query
   end
+
+  # A capability as it would have been minted `seconds` ago — the injectable
+  # clock, so the expiry tests never wait and never read the real one.
+  defp minted_ago(%RemoteAccount{id: id, avatar: file}, seconds),
+    do: RemoteMediaToken.avatar_query(id, file, System.os_time(:second) - seconds)
 end

--- a/test/vutuv_web/controllers/remote_media_federation_disabled_test.exs
+++ b/test/vutuv_web/controllers/remote_media_federation_disabled_test.exs
@@ -1,0 +1,80 @@
+defmodule VutuvWeb.RemoteMediaFederationDisabledTest do
+  @moduledoc """
+  Switching federation off closes the picture proxy, on **both** of its doors.
+
+  The signed-in door has been closed since the proxy shipped. The capability
+  the Mastodon adapter hands its clients (`VutuvWeb.RemoteMediaToken`) is the
+  new one, and it is the one worth a test of its own: it is checked after the
+  database read, so a rearrangement of `avatar/2`'s `with` chain could leave a
+  valid capability opening cached pictures of accounts on a network this
+  installation no longer talks to.
+
+  Key flipped here, and who else reads it: `:fediverse_enabled`, through
+  `Vutuv.Fediverse.enabled?/0` — the tag timeline, the feed source tabs, the
+  sign-up form and `Vutuv.Fediverse.federated?/1` all consult it.
+
+  async: false for exactly that reason, like `VutuvWeb.LandingConfigurationTest`:
+  the flag is global application state the SQL sandbox does not roll back, so
+  this must not run beside anything that reads it. It lives in its own file
+  rather than making the whole of `VutuvWeb.RemoteMediaControllerTest` sync.
+  """
+  use VutuvWeb.ConnCase
+
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.RemoteMedia
+  alias VutuvWeb.RemoteMediaToken
+
+  setup do
+    account =
+      Repo.insert!(%RemoteAccount{
+        actor_uri: "https://social.example/users/them#{System.unique_integer([:positive])}",
+        host: "social.example",
+        handle: "them",
+        inbox_uri: "https://social.example/inbox"
+      })
+
+    {:ok, %{file: file}} = RemoteMedia.store_avatar(jpeg_bytes(), account.id)
+    account = Repo.update!(change(account, avatar: file, avatar_moderation: "approved"))
+
+    %{account: account, url: adapter_url(account), out: build_conn()}
+  end
+
+  test "the capability opens the picture while the installation federates", ctx do
+    assert get(ctx.out, ctx.url).status == 200
+  end
+
+  test "and stops opening it once federation is switched off", ctx do
+    put_config(:fediverse_enabled, false)
+
+    assert get(ctx.out, ctx.url).status == 404
+  end
+
+  # The avatar URL as an API client receives it. Minted straight from the
+  # capability rather than round-tripped through `Presenter.account/1`: that
+  # the adapter really appends this is `VutuvWeb.MastodonApi.FediverseClientTest`'s
+  # subject, and what is under test here is only the switch.
+  defp adapter_url(%RemoteAccount{id: id, avatar: file}),
+    do: RemoteMedia.avatar_url(id, file) <> "?" <> RemoteMediaToken.avatar_query(id, file)
+
+  # `put_env(key, get_env(key))` cannot restore: `get_env` answers nil both for
+  # "absent" and for "present as nil", and a nil `:fediverse_enabled` makes
+  # every `and` on `enabled?/0` raise instead of falling through to its `true`
+  # default. `fetch_env/2` tells the two cases apart.
+  defp put_config(key, value) do
+    original = Application.fetch_env(:vutuv, key)
+    Application.put_env(:vutuv, key, value)
+
+    on_exit(fn ->
+      case original do
+        {:ok, was} -> Application.put_env(:vutuv, key, was)
+        :error -> Application.delete_env(:vutuv, key)
+      end
+    end)
+  end
+
+  defp jpeg_bytes do
+    {:ok, image} = Image.new(8, 8, color: [10, 20, 30])
+    {:ok, bytes} = Image.write(image, :memory, suffix: ".jpg")
+    bytes
+  end
+end


### PR DESCRIPTION
**Closes #1618. Supersedes #1621** (@jpawlowski's Arbeit, Commit unverändert übernommen — sein Branch kollidierte mit `main` und ließ sich aus meinem Worktree nicht rebasen).

**Symptom:** jedes Gesicht aus dem Fediverse blieb in einer Mastodon-App leer — Profil, Beiträge und seit v7.332.6 auch die Benachrichtigungen. Der Bildlader eines Telefons schickt weder Cookie noch Bearer, die URL zeigte aber auf einen Proxy, der eine Sitzung verlangt.

**Änderung:** `VutuvWeb.RemoteMediaToken` — eine signierte, ablaufende Capability für genau ein Konto und genau dessen gespeicherte Datei. `Presenter.account/2` hängt sie an, `RemoteMediaController.avatar/2` nimmt sie statt der Sitzung. KI-Gate und Datei-Whitelist werden weiter pro Anfrage gefragt.

**Was ich nach dem Review geändert habe:** das Moduldoc sagt jetzt, dass die URL ein Inhaber-Papier ist (kein Logout und keine Sperre schließt eine ausgelieferte URL); der Vorfilter prüft die Signatur statt der Form; zwei Tests nageln die Frist von beiden Seiten fest, gegen den ungefixten Stand kalibriert.

**Zu entscheiden:** die Frist steht bei 8 Tagen. Kürzer ist sicherer, riskiert aber wieder leere Gesichter in einer länger gecachten Timeline.

Reiner JSON-Endpunkt, daher kein Screenshot. Beim Aufräumen gefunden: #1626, #1627.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben. Ich weiß, dass das problematisch ist.*
