### PR TITLE
Accept the Mastodon scopes we have no API for, instead of refusing the login

### DIFF
--- a/docs/architecture/mastodon-api.md
+++ b/docs/architecture/mastodon-api.md
@@ -234,6 +234,15 @@ historically made it optional; native vutuv OAuth apps still require S256.
 Mastodon access tokens follow the client ecosystem's non-expiring convention
 and are revocable from Connected apps or through `/oauth/revoke`.
 
+A client cannot know which optional halves of the protocol an installation
+implements, so a scope word vutuv recognises but has no API behind — the whole
+`admin:*` family, `profile`, `crypto` — is **accepted at registration and then
+dropped**, and never reaches `registered_scopes`, the consent screen or a token.
+Refusing them ended a login at its first request: Tokodon asks for `admin:read
+admin:write` on every login path, not only a moderator's, so `POST
+/api/v1/apps` answered 422 and the member never saw a consent screen (issue
+#1632). A word in neither list stays `invalid_scope`.
+
 Every token has one fixed identity: the member or one organization selected on
 the consent screen. Blocking is available only for a personal identity against
 another local member because that is the block relationship vutuv currently

--- a/lib/vutuv/mastodon_api/scopes.ex
+++ b/lib/vutuv/mastodon_api/scopes.ex
@@ -16,20 +16,47 @@ defmodule Vutuv.MastodonApi.Scopes do
     follow push
   )
 
+  @doc """
+  Every scope this adapter can honour — what `/api/v1/apps` stores and what the
+  discovery document advertises. `admin:*` is not among them, see
+  `parse_registration/1`.
+  """
   def all, do: @scopes
+
+  # Mastodon scope words this adapter recognises but has no API behind: there is
+  # no Mastodon admin API here, and `profile`/`crypto` name surfaces vutuv does
+  # not serve. Accepted, because a client cannot know which optional halves of
+  # the protocol an installation implements — then dropped, because granting a
+  # word no route reads would put "administer this site" on the consent screen
+  # in exchange for nothing. Refusing them ended a Tokodon login at its first
+  # request: it asks for `admin:read admin:write` on every login path, not only
+  # a moderator's, so the 422 came before any consent screen (issue #1632). A
+  # word in neither list stays a 422 — a misspelt `write:statuse` must not
+  # quietly mint a token that cannot post.
+  @tolerated ~w(profile crypto)
 
   def parse_registration(nil), do: {:ok, ["read"]}
   def parse_registration(""), do: {:ok, ["read"]}
 
   def parse_registration(value) when is_binary(value) do
-    scopes = value |> String.split(" ", trim: true) |> Enum.uniq()
+    {granted, rest} =
+      value
+      |> String.split(" ", trim: true)
+      |> Enum.uniq()
+      |> Enum.split_with(&(&1 in @scopes))
 
-    if scopes != [] and Enum.all?(scopes, &(&1 in @scopes)),
-      do: {:ok, scopes},
+    if granted != [] and Enum.all?(rest, &tolerated?/1),
+      do: {:ok, granted},
       else: {:error, :invalid_scope}
   end
 
   def parse_registration(_other), do: {:error, :invalid_scope}
+
+  defp tolerated?("admin:read"), do: true
+  defp tolerated?("admin:write"), do: true
+  defp tolerated?("admin:read:" <> child), do: child != ""
+  defp tolerated?("admin:write:" <> child), do: child != ""
+  defp tolerated?(scope), do: scope in @tolerated
 
   def authorize(value, registered_scopes) do
     with {:ok, requested} <- parse_registration(value),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.337.2",
+      version: "7.337.3",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/mastodon_api/scopes_test.exs
+++ b/test/vutuv/mastodon_api/scopes_test.exs
@@ -25,4 +25,37 @@ defmodule Vutuv.MastodonApi.ScopesTest do
     assert {:ok, ["read:accounts"]} = Scopes.authorize("read:accounts", ["read"])
     assert {:error, :invalid_scope} = Scopes.authorize("write:statuses", ["read"])
   end
+
+  describe "scopes this adapter has no API for" do
+    test "are accepted and dropped rather than refused" do
+      # Tokodon's every login path asks for these, moderator or not (#1632).
+      assert {:ok, ["read", "write", "follow", "push"]} =
+               Scopes.parse_registration("read write follow push admin:read admin:write")
+
+      assert {:ok, ["read"]} = Scopes.parse_registration("read admin:read:accounts")
+      assert {:ok, ["read"]} = Scopes.parse_registration("read profile crypto")
+    end
+
+    test "still cannot be reached through the authorization step" do
+      # Dropping has to happen on both halves or they disagree: the app is
+      # registered with the narrowed set, so an authorization asking for the
+      # wide one would fail the subset check.
+      assert {:ok, ["read", "write"]} =
+               Scopes.authorize("read write admin:write", ["read", "write"])
+    end
+
+    test "are not in the vocabulary and imply nothing" do
+      refute "admin:read" in Scopes.all()
+      refute Scopes.granted?(["read", "write", "admin:read"], "admin:read:accounts")
+    end
+
+    test "cannot be the only thing a client asks for" do
+      assert {:error, :invalid_scope} = Scopes.parse_registration("admin:read admin:write")
+    end
+  end
+
+  test "a misspelt scope is still refused" do
+    assert {:error, :invalid_scope} = Scopes.parse_registration("read write:statuse")
+    assert {:error, :invalid_scope} = Scopes.parse_registration("read admin:reed")
+  end
 end

--- a/test/vutuv_web/controllers/mastodon_api/oauth_controller_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/oauth_controller_test.exs
@@ -93,13 +93,29 @@ defmodule VutuvWeb.MastodonApi.OauthControllerTest do
     test "rejects unknown scopes and unsafe redirect schemes", %{conn: conn} do
       assert %{"error" => _message} =
                conn
-               |> register(%{"scopes" => "admin:write"})
+               |> register(%{"scopes" => "write:statuse"})
                |> json_response(422)
 
       assert %{"error" => _message} =
                build_conn()
                |> register(%{"redirect_uris" => ["javascript:alert(1)"]})
                |> json_response(422)
+    end
+
+    # Tokodon asks for `admin:read admin:write` on every login path, not only a
+    # moderator's, so refusing the word ended the login at its first request and
+    # no consent screen ever appeared (#1632). Dropped, not granted: no route
+    # here reads one, and there is no Mastodon admin API to hand over.
+    test "keeps a client that asks for scopes this adapter does not have", %{conn: conn} do
+      response =
+        conn
+        |> register(%{"scopes" => "read write follow push admin:read admin:write"})
+        |> json_response(200)
+
+      assert response["scopes"] == ["read", "write", "follow", "push"]
+
+      app = Repo.get_by!(App, client_id: response["client_id"])
+      assert app.registered_scopes == ["read", "write", "follow", "push"]
     end
   end
 
@@ -244,6 +260,72 @@ defmodule VutuvWeb.MastodonApi.OauthControllerTest do
              |> put_req_header("authorization", "Bearer " <> token_response["access_token"])
              |> get("/api/2.0/me")
              |> response(403)
+    end
+
+    # Tokodon's three real requests, with the scope string it really sends.
+    # Registration was the step that 422ed (#1632), but the same string comes
+    # back on the authorize URL, so the drop has to survive the whole flow or
+    # the consent screen refuses it instead.
+    test "signs in a client asking for scopes this adapter does not have", %{conn: conn} do
+      redirect = "tokodon://oauth"
+      scope = "read write follow push admin:read admin:write"
+
+      credentials =
+        conn
+        |> register(%{
+          "client_name" => "Tokodon",
+          "redirect_uris" => redirect,
+          "scopes" => scope,
+          "website" => "https://apps.kde.org/tokodon"
+        })
+        |> json_response(200)
+
+      {conn, user} = create_and_login_user(fresh_conn())
+      allow_mastodon_clients(user)
+
+      authorize_params = %{
+        "response_type" => "code",
+        "client_id" => credentials["client_id"],
+        "redirect_uri" => redirect,
+        "scope" => scope
+      }
+
+      conn = get(conn, "/oauth/authorize?#{URI.encode_query(authorize_params)}")
+      assert html_response(conn, 200) =~ "Tokodon"
+
+      conn =
+        submit_with_csrf(
+          conn,
+          "/oauth/authorize",
+          Map.put(authorize_params, "decision", "allow")
+        )
+
+      # The custom scheme is what the consent form has to be allowed to reach.
+      assert %{query: query, scheme: "tokodon"} = URI.parse(redirected_to(conn))
+      %{"code" => code} = URI.decode_query(query)
+
+      token =
+        build_conn()
+        |> on_mastodon_host()
+        |> post("/oauth/token", %{
+          "grant_type" => "authorization_code",
+          "client_id" => credentials["client_id"],
+          "client_secret" => credentials["client_secret"],
+          "redirect_uri" => redirect,
+          "code" => code
+        })
+        |> json_response(200)
+
+      assert token["scope"] == "read write follow push"
+
+      account =
+        build_conn()
+        |> on_mastodon_host()
+        |> put_req_header("authorization", "Bearer " <> token["access_token"])
+        |> get("/api/v1/accounts/verify_credentials")
+        |> json_response(200)
+
+      assert account["id"] == user.id
     end
 
     test "cannot authorize a scope the client did not register", %{conn: conn} do


### PR DESCRIPTION
**Symptom** Tokodon cannot log in to vutuv.de: `POST /api/v1/apps` answers 422 and the member never reaches a consent screen (#1632).

**Cause** Tokodon sends `scopes=read write follow push admin:read admin:write` on *every* login path, not only a moderator's (`ServersPage.qml` passes `addAdminScope = true` to `registerTokodon`). `Vutuv.MastodonApi.Scopes.parse_registration/1` refused the two admin words outright.

**Change** Scope words we recognise but have no API behind — the `admin:*` family, `profile`, `crypto` — are accepted and then dropped, so they never reach `registered_scopes`, the consent screen or a token. A word in neither list still gets a 422. Same narrowing at `/oauth/authorize`, or the two halves would disagree.

No visual surface changed; a test replays Tokodon's three real requests end to end.

*An AI agent wrote this text in my name. I know that is problematic.*
