### PR TITLE
Paint Like/Repost/Bookmark on press instead of waiting for the server

### DIFF
--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -26,6 +26,7 @@ defmodule VutuvWeb.PostComponents do
   import VutuvWeb.UI
   import VutuvWeb.UserHelpers, only: [full_name: 1]
 
+  alias Phoenix.LiveView.JS
   alias Vutuv.Accounts.User
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.Handle
@@ -4684,7 +4685,8 @@ defmodule VutuvWeb.PostComponents do
         kind="repost"
         active?={@engagement.reposted?}
         count={@counts.reposts}
-        label={if @engagement.reposted?, do: gettext("Undo repost"), else: gettext("Repost")}
+        on_label={gettext("Undo repost")}
+        off_label={gettext("Repost")}
         active_class="text-brand-600 dark:text-brand-300"
         disabled={@engagement.restricted?}
         disabled_title={gettext("Only public posts can be reposted.")}
@@ -4698,8 +4700,10 @@ defmodule VutuvWeb.PostComponents do
         kind="bookmark"
         active?={@engagement.bookmarked?}
         count={@engagement.bookmarks}
-        label={if @engagement.bookmarked?, do: gettext("Remove bookmark"), else: gettext("Bookmark")}
+        on_label={gettext("Remove bookmark")}
+        off_label={gettext("Bookmark")}
         active_class="text-brand-600 dark:text-brand-300"
+        filled?
       >
         <:icon><.icon_bookmark filled?={@engagement.bookmarked?} /></:icon>
       </.action_button>
@@ -4932,8 +4936,10 @@ defmodule VutuvWeb.PostComponents do
       kind="like"
       active?={@liked?}
       count={@count}
-      label={if @liked?, do: gettext("Unlike"), else: gettext("Like")}
+      on_label={gettext("Unlike")}
+      off_label={gettext("Like")}
       active_class="text-accent"
+      filled?
     >
       <:icon><.icon_heart filled?={@liked?} /></:icon>
     </.action_button>
@@ -4994,23 +5000,34 @@ defmodule VutuvWeb.PostComponents do
     """
   end
 
+  # The idle tint, paired with each control's `active_class`. One place, because
+  # the flip below toggles the pair as a unit.
+  @idle_action_class "text-slate-600 dark:text-slate-400"
+
   attr(:id, :string, required: true)
   attr(:target, :any, default: nil)
   attr(:kind, :string, required: true)
   attr(:active?, :boolean, required: true)
   attr(:count, :integer, required: true)
-  attr(:label, :string, required: true)
+  attr(:on_label, :string, required: true, doc: "what the control says while pressed")
+  attr(:off_label, :string, required: true, doc: "and while not")
   attr(:active_class, :string, required: true)
+  attr(:filled?, :boolean, default: false, doc: "the glyph fills while active (heart, bookmark)")
   attr(:disabled, :boolean, default: false)
   attr(:disabled_title, :string, default: nil)
   slot(:icon, required: true)
 
   defp action_button(assigns) do
+    assigns =
+      assigns
+      |> assign(:label, if(assigns.active?, do: assigns.on_label, else: assigns.off_label))
+      |> assign(:idle_class, @idle_action_class)
+
     ~H"""
     <button
       type="button"
       id={@id}
-      phx-click="toggle"
+      phx-click={toggle_js(@active_class, @on_label, @off_label, @filled?)}
       phx-target={@target}
       phx-value-kind={@kind}
       disabled={@disabled}
@@ -5023,14 +5040,83 @@ defmodule VutuvWeb.PostComponents do
         !@disabled && "hover:bg-slate-100 dark:hover:bg-slate-800",
         # components.css colors bare `a, button` brand-600, which beats the
         # wrapper's inherited slate — so the state color sits on the button.
-        if(@active?, do: @active_class, else: "text-slate-600 dark:text-slate-400")
+        if(@active?, do: @active_class, else: @idle_class)
       ]}
     >
       {render_slot(@icon)}
-      <%!-- Always mounted (invisible at zero) so an arriving first count
-            doesn't shift the neighbouring buttons under the pointer. --%>
-      <.count_pill count={@count} kind={@kind} />
+      <.toggle_count count={@count} kind={@kind} active?={@active?} />
     </button>
+    """
+  end
+
+  # The optimistic flip. A press used to leave the button untouched until the
+  # server had written the row and pushed a diff back — one round trip, which on
+  # a slow line reads as a control that does not work. So the press paints the
+  # new state on the spot and *also* pushes, and the answer confirms what the
+  # member already sees. LiveView's own recipe ("Syncing changes and optimistic
+  # UIs"); no hook, because the JS commands are DOM-patch aware.
+  #
+  # The rule that makes it safe: **every value toggled here is a function of the
+  # absolute state** (pressed / not pressed), never of the state at click time.
+  # LiveView stashes each class and attribute op on the element and re-applies
+  # it after every patch, and nothing ever expires it (`DOM.putSticky` /
+  # `applyStickyOperations`; `deleteSticky` has no caller). An op phrased as
+  # "flip whatever is there" would therefore fight the server's own correct
+  # re-render for the rest of the element's life — a count stuck one too low
+  # once somebody else's like arrives over PubSub. Phrased absolutely, the stash
+  # and the server agree the moment the answer lands.
+  #
+  # What is left is the trade we took on purpose: where the server *disagrees* —
+  # a refused act, a toggle from the member's other tab — the button keeps
+  # showing the press until the next press or a reload.
+  defp toggle_js(active_class, on_label, off_label, filled?) do
+    JS.push("toggle")
+    |> JS.toggle_class("#{active_class} #{@idle_action_class}")
+    |> JS.toggle_attribute({"aria-pressed", "true", "false"})
+    |> JS.toggle_attribute({"aria-label", on_label, off_label})
+    |> JS.toggle_attribute({"title", on_label, off_label})
+    |> JS.toggle_class("hidden", to: {:inner, "[data-count-off]"})
+    |> JS.toggle_class("hidden", to: {:inner, "[data-count-on]"})
+    |> fill_glyph(filled?)
+  end
+
+  defp fill_glyph(js, true),
+    do: JS.toggle_attribute(js, {"fill", "currentColor", "none"}, to: {:inner, "svg"})
+
+  defp fill_glyph(js, false), do: js
+
+  # Both steps of the count, pre-rendered: what it reads while the control is
+  # off, and what it reads while on. The press shows the other one, which is why
+  # the client never has to know that 1000 is written "1K" — `compact_count/1`
+  # is locale-aware and stays on the server, where it belongs.
+  #
+  # The spans are keyed by the *absolute* state, not by "current" and
+  # "alternative", so the stashed class op above lines up with what the server
+  # renders next (see `toggle_js/4`). `data-count` marks the step the server is
+  # showing, so the agent-facing marker never reads twice.
+  attr(:count, :integer, required: true)
+  attr(:kind, :string, required: true)
+  attr(:active?, :boolean, required: true)
+
+  defp toggle_count(assigns) do
+    assigns =
+      assigns
+      |> assign(:off, if(assigns.active?, do: assigns.count - 1, else: assigns.count))
+      |> assign(:on, if(assigns.active?, do: assigns.count, else: assigns.count + 1))
+
+    ~H"""
+    <%!-- Always mounted (invisible at zero) so an arriving first count
+          doesn't shift the neighbouring buttons under the pointer. --%>
+    <span
+      data-count-off
+      class={["font-medium tabular-nums", @active? && "hidden", @off == 0 && "invisible"]}
+      data-count={!@active? && @off > 0 && @kind}
+    >{compact_count(@off)}</span>
+    <span
+      data-count-on
+      class={["font-medium tabular-nums", !@active? && "hidden"]}
+      data-count={@active? && @on > 0 && @kind}
+    >{compact_count(@on)}</span>
     """
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.337.3",
+      version: "7.338.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/post_actions_live_test.exs
+++ b/test/vutuv_web/live/post_actions_live_test.exs
@@ -21,6 +21,49 @@ defmodule VutuvWeb.PostActionsLiveTest do
 
   defp other_user(attrs \\ []), do: insert(:user, Keyword.merge([email_confirmed?: true], attrs))
 
+  # A lone bar rendered from a hand-built engagement, so a test can name counts
+  # no query would produce.
+  defp isolated_bar(post, viewer, engagement) do
+    live_isolated(build_conn(), VutuvWeb.PostLive.Actions,
+      session: %{
+        "post_id" => post.id,
+        "user_id" => viewer.id,
+        "id" => "post-actions-#{post.id}",
+        "locale" => "en",
+        "engagement" => engagement
+      }
+    )
+  end
+
+  # The opening tag's `class=` value alone.
+  defp class_attr(html) do
+    [_, classes] = Regex.run(~r/<[^>]*\sclass="([^"]*)"/, html)
+    classes
+  end
+
+  # The class list of one of a control's two pre-rendered count steps.
+  defp count_class(html, step) do
+    [_, classes] = Regex.run(~r/data-count-#{step}(?:="")?\s+class="([^"]*)"/, html)
+    classes
+  end
+
+  defp engagement(author, post, attrs) do
+    Enum.into(attrs, %{
+      likes: 0,
+      bookmarks: 0,
+      reposts: 0,
+      replies: 0,
+      fediverse_likes: 0,
+      fediverse_reposts: 0,
+      liked?: false,
+      bookmarked?: false,
+      reposted?: false,
+      restricted?: false,
+      author_id: author.id,
+      id: post.id
+    })
+  end
+
   # The bar is part of the feed's own DOM now, so the feed view itself drives it
   # (the button's `phx-target` routes the click to its component).
   defp feed_actions(conn, _post) do
@@ -177,13 +220,16 @@ defmodule VutuvWeb.PostActionsLiveTest do
       post = create_post!(friend, %{body: "state colors"})
       %{view: actions} = feed_actions(conn, post)
 
+      # The button's own `class=` attribute, not the whole tag: the optimistic
+      # flip names both tints inside `phx-click` (it toggles the pair), so a
+      # bare substring match would find slate on an active button.
       like = "#post-actions-post-#{post.id}-like"
-      assert actions |> element(like) |> render() =~ "text-slate-600"
+      assert actions |> element(like) |> render() |> class_attr() =~ "text-slate-600"
 
       actions |> element(like) |> render_click()
-      html = actions |> element(like) |> render()
-      assert html =~ "text-accent"
-      refute html =~ "text-slate-600"
+      classes = actions |> element(like) |> render() |> class_attr()
+      assert classes =~ "text-accent"
+      refute classes =~ "text-slate-600"
 
       # The untouched buttons keep the muted state color.
       assert actions |> element("#post-actions-post-#{post.id}-repost") |> render() =~
@@ -207,7 +253,12 @@ defmodule VutuvWeb.PostActionsLiveTest do
       actions |> element(like) |> render_click()
       html = actions |> element(like) |> render()
       assert html =~ ~s(data-count="like")
-      refute html =~ "invisible"
+
+      # The shown step is the "1"; the zero it came from stays mounted behind
+      # it (hidden, and still holding its space) so an unlike shows a stable
+      # row again without waiting for the server.
+      refute count_class(html, "on") =~ "invisible"
+      assert count_class(html, "off") =~ "invisible"
     end
 
     # The four controls spread across the full column width (X-style) rather
@@ -385,11 +436,11 @@ defmodule VutuvWeb.PostActionsLiveTest do
           }
         )
 
-      assert html =~ ~s(phx-click="toggle")
+      assert html =~ ~s(phx-value-kind="like")
 
       {:ok, _} = Posts.delete_post(post)
       _ = :sys.get_state(bar.pid)
-      refute render(bar) =~ ~s(phx-click="toggle")
+      refute render(bar) =~ ~s(phx-value-kind="like")
     end
   end
 
@@ -612,6 +663,59 @@ defmodule VutuvWeb.PostActionsLiveTest do
         )
 
       assert html =~ ~r/data-count="like">\s*1\s*</
+    end
+  end
+
+  describe "the optimistic flip" do
+    # A press used to be a dead button for a whole round trip: the heart only
+    # filled once the server had written the like and pushed a diff back, which
+    # on a slow line reads as a control that does not work. The press now paints
+    # the new state on the spot and the server's answer merely confirms it.
+    test "the press carries the client-side flip beside the push" do
+      author = other_user()
+      reader = other_user()
+      post = create_post!(author, %{body: "flip"})
+
+      {:ok, bar, _html} = isolated_bar(post, reader, engagement(author, post, []))
+
+      button = bar |> element("#post-actions-#{post.id}-like") |> render()
+
+      # The push is still the first op — the write is not optional — and the
+      # paint rides with it rather than waiting for the diff.
+      assert button =~ "push"
+      assert button =~ "toggle_class"
+      assert button =~ "toggle_attr"
+      # The tint pair and the pressed state both flip client-side.
+      assert button =~ "text-accent"
+      assert button =~ "aria-pressed"
+    end
+
+    test "both count steps are pre-rendered, so the swap needs no client-side formatter" do
+      author = other_user()
+      reader = other_user()
+      post = create_post!(author, %{body: "counted"})
+
+      {:ok, _bar, html} = isolated_bar(post, reader, engagement(author, post, likes: 999))
+
+      # 999 → "1K" is `compact_count/1`'s work and it is locale-aware, so the
+      # client must never re-derive it. The server ships both steps; the press
+      # only swaps which of the two is shown.
+      assert html =~ ~r/data-count="like">\s*999\s*</
+      assert html =~ ~r/data-count-on[^>]*>\s*1K\s*</
+    end
+
+    test "data-count marks the step the server is showing, not the one behind it" do
+      author = other_user()
+      reader = other_user()
+      post = create_post!(author, %{body: "marked"})
+
+      {:ok, _bar, html} =
+        isolated_bar(post, reader, engagement(author, post, likes: 1, liked?: true))
+
+      # The shown step carries the marker; the step behind it (0, what an
+      # unlike would show) must not, or every agent-facing count reads twice.
+      assert html =~ ~r/data-count="like">\s*1\s*</
+      refute html =~ ~r/data-count="like">\s*0\s*</
     end
   end
 end


### PR DESCRIPTION
**Symptom:** on a slow line every Like / Repost / Bookmark press left the button unchanged for a full round trip, which reads as a dead control.

**Change:** `VutuvWeb.PostComponents.action_button/1` paints the new state on press and pushes alongside it, via LiveView's own JS commands (no hook). Both count steps ship pre-rendered (`data-count-off` / `data-count-on`), so `compact_count/1` stays server-side and locale-aware.

**Watch out:** LiveView stashes each JS class/attribute op per element and never expires it (`deleteSticky` has no caller), so every toggled value must be a function of the absolute state, or it fights the server's own re-render forever.

**Your call:** where the server disagrees (refused act, toggle from another tab) the button keeps the press until the next press or a reload. The fediverse card's bar is untouched, it has a real refusal path.

Hot deploy, v7.338.0. Below: one press with the LiveView socket disconnected, so nothing but the client could have moved the bar.

<img src="https://raw.githubusercontent.com/wintermeyer/vutuv/shots/pr-1637/idle.png" width="440">
<img src="https://raw.githubusercontent.com/wintermeyer/vutuv/shots/pr-1637/optimistic.png" width="440">

*An AI agent wrote this text in my name. I know that is problematic.*
