### PR TITLE
Stop the message thread jumping to the bottom on every keystroke

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -331,7 +331,7 @@ const MarkdownEditor = {
 // loaded on demand by the proxy above.
 // TagInput is the pill box on every tag field (see the sweep below, which
 // serves the same component on classic pages). LocalTime localizes timestamps
-// (see above). ScrollBottom keeps a chat thread pinned to its newest message.
+// (see above). ScrollBottom follows a chat thread's newest message.
 const Hooks = {
   MarkdownEditor,
   TagInput,
@@ -354,12 +354,66 @@ const Hooks = {
       revealPreviewClamp(this.el)
     },
   },
+  // A chat thread follows its newest message — but only for a reader who is
+  // sitting at the bottom of it. Every keystroke in the composer runs
+  // phx-change ("typing") and every patch morphs this container, so an
+  // unconditional scrollTop = scrollHeight yanked the thread down on each
+  // letter: answering a message you had scrolled up to read was impossible.
+  //
+  // The position must be remembered from OUTSIDE the patch. Reading it in
+  // beforeUpdate looks right and is not: while LiveView re-orders a stream's
+  // children (which is how "Load older messages" prepends its page), the
+  // container's own numbers are momentarily clamped to the top, so a delta
+  // taken there lands the reader a screen too high. Scroll events, in
+  // contrast, are dispatched between frames and never mid-patch — so remember()
+  // runs on every scroll (our own writes included) and always sees settled
+  // geometry.
+  //
+  // What is remembered is the first bubble's offset inside the visible box,
+  // not a scroll height: only growth ABOVE the viewport may move scrollTop,
+  // while a new message arriving below must leave the reader where they are.
+  // Sending is the exception — the server pushes "chat:sent" so your own
+  // message still takes you along.
   ScrollBottom: {
     mounted() {
-      this.el.scrollTop = this.el.scrollHeight
+      this.toBottom()
+      this.remember()
+      this.el.addEventListener("scroll", () => this.remember(), { passive: true })
+      // The scroll event our own toBottom() causes only arrives at the next
+      // frame, and the echo's patch beats it, so pin synchronously here.
+      this.handleEvent("chat:sent", () => {
+        this.pinned = true
+        this.toBottom()
+      })
     },
     updated() {
+      if (this.pinned) return this.toBottom()
+      const anchor = this.anchorId && document.getElementById(this.anchorId)
+      if (anchor) this.el.scrollTop += this.relOf(anchor) - this.anchorRel
+    },
+    remember() {
+      this.pinned = this.atBottom()
+      // A pinned thread never reads the anchor, and sitting at the bottom is
+      // the common case, so don't measure one — the scroll event that ends the
+      // pin records it.
+      if (this.pinned) return
+      const anchor = this.el.firstElementChild
+      this.anchorId = anchor && anchor.id
+      this.anchorRel = this.relOf(anchor)
+    },
+    toBottom() {
       this.el.scrollTop = this.el.scrollHeight
+    },
+    // How far a bubble sits below the top of the visible box. Painted
+    // rectangles rather than offsetTop, so the reading stays right whatever
+    // the browser's own scroll anchoring did during the patch.
+    relOf(el) {
+      return el ? el.getBoundingClientRect().top - this.el.getBoundingClientRect().top : 0
+    },
+    // A few pixels of slack: sub-pixel layout leaves "the bottom" a hair short
+    // of the exact number, and a reader that close is still reading along.
+    atBottom() {
+      return this.el.scrollHeight - this.el.scrollTop - this.el.clientHeight < 24
     },
   },
   // Browser-tab title indicator, so a backgrounded tab still shows new activity.

--- a/lib/vutuv_web/live/message_live/index.ex
+++ b/lib/vutuv_web/live/message_live/index.ex
@@ -219,8 +219,13 @@ defmodule VutuvWeb.MessageLive.Index do
         # sessions (including this one) render it the same way — its handler
         # runs the one refresh_conversation, so none is needed here (this
         # process is subscribed; local PubSub delivery is guaranteed).
+        # The ScrollBottom hook only follows the newest message for a reader
+        # who is at the bottom of the thread, so tell it that this member just
+        # sent one: answering something you scrolled up to read must still land
+        # you at your own message. This reply reaches the client before the
+        # echo's patch, which then keeps the pinned position.
         {:ok, %Message{}} ->
-          {:noreply, assign_form(socket)}
+          {:noreply, socket |> assign_form() |> push_event("chat:sent", %{})}
 
         # Declined conversation: drop silently — for the sender everything
         # looks exactly like an unanswered request.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.338.0",
+      version: "7.338.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/message_live_test.exs
+++ b/test/vutuv_web/live/message_live_test.exs
@@ -205,6 +205,33 @@ defmodule VutuvWeb.MessageLiveTest do
       assert seed.() =~ ~s(data-mde-seed="2")
     end
 
+    test "typing scrolls nothing, sending pins the thread to the bottom", %{conn: conn} do
+      {conn, me} = create_and_login_user(conn)
+      conversation = insert_conversation_between(me, insert_activated_user())
+
+      {:ok, view, _} = live(conn, ~p"/messages/#{conversation.id}")
+
+      # The thread follows its newest message only while the reader sits at the
+      # bottom of it (ScrollBottom in app.js). phx-change fires on every
+      # keystroke, so a draft must never push the thread anywhere — that was the
+      # bug: writing an answer yanked the thread down letter by letter.
+      view
+      |> element("#message-form")
+      |> render_change(%{message: %{body: "still writing"}})
+
+      refute_push_event(view, "chat:sent", %{})
+
+      # A send is the one moment the sender does want to be taken along.
+      view
+      |> form("#message-form", message: %{body: "sent it"})
+      |> render_submit()
+
+      assert_push_event(view, "chat:sent", %{})
+
+      # Let the sender's own echo broadcast finish before the test exits.
+      _ = :sys.get_state(view.pid)
+    end
+
     test "a deleted message disappears live from open threads", %{conn: conn} do
       {conn, me} = create_and_login_user(conn)
       {_other_conn, other} = login_other_user()


### PR DESCRIPTION
**Symptom:** on `/messages/:id`, every keystroke in the composer threw the thread back to the newest message. Scrolling up to read something and answering it was impossible.

**Cause:** the composer's `phx-change="typing"` fires per keystroke, and every patch morphs the stream container, where `ScrollBottom` (`assets/js/app.js`) set `scrollTop = scrollHeight` unconditionally.

**Change:** the hook follows the newest message only while the reader is at the bottom, and otherwise holds the first bubble's position. It remembers that from a `scroll` listener rather than `beforeUpdate` — mid-patch the container reports a scroll clamped to 0 while LiveView re-orders the stream, so a delta measured there lands a screen too high. `handle_event("send", …)` pushes `chat:sent`, so sending still takes you to your own message.

Measured in Chrome against a 43-message thread: typing while parked at 600px stays at 600px (was: 2435, the end); "Load older" prepends 1144px and moves scroll by exactly that, anchor drift 0; an incoming message follows when pinned and does not move when scrolled up.

Both shots: parked mid-thread, one draft typed.

| before | after |
| --- | --- |
| <img src="https://raw.githubusercontent.com/wintermeyer/vutuv/shots/pr-1638/before.jpg" width="440"> | <img src="https://raw.githubusercontent.com/wintermeyer/vutuv/shots/pr-1638/after.jpg" width="440"> |

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_0153rSztuVigFReeqMKiciJ9
