### PR TITLE
A conversation that crossed a network border stays one conversation (v7.342.1)

### DIFF
--- a/docs/architecture/mastodon-api.md
+++ b/docs/architecture/mastodon-api.md
@@ -264,6 +264,36 @@ that server, the hour's budget is spent — and all of them used to collapse int
 one sentence naming nothing. They are spelled out per reason now, because a
 member cannot see the rule from inside a phone app.
 
+### A conversation that crossed a border
+
+Three id shapes name a status here: a bare UUID is a vutuv post,
+`remote-<uuid>` a cached post from an account somebody follows, and
+`remote-note-<uuid>` a cached reply written under a member's post. One function
+spells all three (`Presenter.status_id/1`), because a status and anything that
+*names* it — an `in_reply_to_id`, a parent link in `/context` — have to agree or
+a client draws the same answer twice.
+
+Where a conversation crosses the border, both surfaces follow it (issues #1640,
+#1641):
+
+- an answer to a cached reply names that reply, not the post underneath it.
+  `Posts.create_remote_reply/3` files such an answer as an ordinary local reply
+  to the post the reply hangs under (issue #1070), so the local parent is a
+  level too high — a client labelled it "Replying to @member" where it addresses
+  a stranger. The website hangs it under the reply's card for the same reason.
+- `/context` walks the borrowed nodes with the local ones: the cached reply sits
+  between the root post and the answer, an answer written here to a cached post
+  gets that post as its ancestor, and a followed account's self-reply gets the
+  author's own chain above it (`own_thread?/2` is what makes following
+  `in_reply_to_uri` safe — a stored reply's parent is always another cached post
+  by the same account).
+
+Only what this installation serves under an id of its own takes part. Nothing is
+invented from a bare URI, every borrowed node passes the same visibility gate as
+a direct read, and a cached reply is named only while it is public: a reply
+addressed to one member cannot be answered at all, so a private one here was
+narrowed afterwards and its id would answer 404 to everybody but that member.
+
 ### Photos
 
 `POST /api/v1/media` and `POST /api/v2/media` (multipart, the file in `file`,

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -2915,6 +2915,94 @@ defmodule Vutuv.Fediverse do
     |> Enum.group_by(& &1.remote_post_id)
   end
 
+  @doc """
+  The **cached reply** each of `post_ids` answers, keyed by post id (issue
+  #1641). Posts that answer no stored reply are simply absent.
+
+  One query for a whole page rather than one per row, because the caller is the
+  Mastodon adapter's page renderer, which bundles everything else it reads the
+  same way.
+
+  **Deliberately not read off the `:remote_reply_ref` preload.** Half the
+  callers hand over posts straight from a query, and an answer whose parent
+  silently depends on whether somebody remembered a preload is the shape that
+  has bitten this codebase before.
+
+  **Public replies only, and that is the whole gate** — no viewer is needed and
+  none may be assumed. `check_remote_reply/2` refuses to let a member answer a
+  reply that was addressed to them alone, so a private note here can only be one
+  an upstream `Update` narrowed afterwards; naming it would hand a client an id
+  that answers 404 to everybody but the member whose post it hangs under, and
+  the local parent is the honest fallback for all of them.
+  """
+  def answered_notes([]), do: %{}
+
+  def answered_notes(post_ids) when is_list(post_ids) do
+    from(r in PostRemoteReply,
+      join: n in subquery(notes_with_account()),
+      on: n.id == r.note_id,
+      where: r.post_id in ^post_ids and n.audience == "public",
+      select: {r.post_id, n}
+    )
+    |> Repo.all()
+    |> Map.new()
+  end
+
+  @doc """
+  The same, widened to the **cached post** half of the sidecar (issue #1165), so
+  one map answers "what does this post answer out there" for a whole thread.
+
+  The two halves are gated differently and the caller has to know it: a reply
+  comes back public-only (see `answered_notes/1`), while a cached post carries
+  its own audience and is gated by whoever is rendering — the only one that
+  knows the reader and whether they follow that account.
+  """
+  def answered_objects([]), do: %{}
+
+  def answered_objects(post_ids) when is_list(post_ids),
+    do: Map.merge(answered_notes(post_ids), answered_remote_posts(post_ids))
+
+  defp answered_remote_posts(post_ids) do
+    from(r in PostRemoteReply,
+      join: p in RemotePost,
+      on: p.id == r.remote_post_id,
+      join: a in RemoteAccount,
+      on: a.id == p.remote_account_id,
+      where: r.post_id in ^post_ids,
+      select: {r.post_id, %{p | remote_account: a}}
+    )
+    |> Repo.all()
+    |> Map.new()
+  end
+
+  @doc """
+  The cached post `post` continues, or `nil` when we hold no such row.
+
+  A stored remote reply only ever continues a thread of the **same** account,
+  which is `own_thread?/2`'s rule and why both read one query
+  (`same_account_post/2`): a reply is kept solely when its parent is already one
+  of that account's cached posts. So the scope here is not a precaution against
+  a missing row, it is what the column means — and it is what lets the client
+  API name a followed account's self-reply with an id the same client can fetch.
+  """
+  def remote_parent_post(%RemotePost{in_reply_to_uri: uri, remote_account_id: account_id})
+      when is_binary(uri) and is_binary(account_id) do
+    Repo.one(from([p, a] in same_account_post(uri, account_id), select: %{p | remote_account: a}))
+  end
+
+  def remote_parent_post(%RemotePost{}), do: nil
+
+  # "That account's own cached post with this object URI" — the predicate
+  # `own_thread?/2` decides a reply by and `remote_parent_post/1` resolves it
+  # with. One builder, so the invariant the second relies on stays the first's.
+  defp same_account_post(uri, account_id) do
+    from(p in RemotePost,
+      join: a in RemoteAccount,
+      on: a.id == p.remote_account_id,
+      where: p.object_uri == ^uri and p.remote_account_id == ^account_id
+    )
+  end
+
   @doc "One cached remote post with its account and screenshot, or nil."
   def get_remote_post(id) do
     UUIDv7.with_cast(id, &Repo.get(RemotePost, &1))
@@ -3332,13 +3420,8 @@ defmodule Vutuv.Fediverse do
   # The line is deliberate: a followed account's own thread is what a follower
   # subscribed to, while their reply under a stranger's post drags a third
   # party's conversation into our storage for the sake of one half of it.
-  defp own_thread?(%{"inReplyTo" => parent}, %RemoteAccount{} = account) when is_binary(parent) do
-    Repo.exists?(
-      from(p in RemotePost,
-        where: p.object_uri == ^parent and p.remote_account_id == ^account.id
-      )
-    )
-  end
+  defp own_thread?(%{"inReplyTo" => parent}, %RemoteAccount{} = account) when is_binary(parent),
+    do: Repo.exists?(same_account_post(parent, account.id))
 
   defp own_thread?(_object, _account), do: true
 

--- a/lib/vutuv/mastodon_api/presenter.ex
+++ b/lib/vutuv/mastodon_api/presenter.ex
@@ -51,7 +51,7 @@ defmodule Vutuv.MastodonApi.Presenter do
     header = user_cover(user)
 
     base_account(%{
-      id: user.id,
+      id: account_id(user),
       username: user.username,
       acct: user.username,
       display_name: UserHelpers.full_name(user),
@@ -72,7 +72,7 @@ defmodule Vutuv.MastodonApi.Presenter do
     header = organization_image(organization.cover, fallback_header())
 
     base_account(%{
-      id: organization.id,
+      id: account_id(organization),
       username: handle,
       acct: handle,
       display_name: organization.name,
@@ -93,7 +93,7 @@ defmodule Vutuv.MastodonApi.Presenter do
     icon = remote_avatar(account)
 
     base_account(%{
-      id: "remote-" <> account.id,
+      id: account_id(account),
       username: username,
       acct: handle,
       display_name: account.name || username,
@@ -125,9 +125,12 @@ defmodule Vutuv.MastodonApi.Presenter do
 
     engagements = Posts.post_engagement_map(post_ids, viewer)
     mentions = Posts.mention_map(post_ids)
+    # Which cached fediverse reply each post answers, if any (issue #1641) —
+    # one query for the page, read by `reply_fields/2`.
+    answered = Fediverse.answered_notes(post_ids)
 
     items
-    |> Enum.map(&rendered_status(&1, engagements, mentions))
+    |> Enum.map(&rendered_status(&1, engagements, mentions, answered))
     |> fill_account_counts(viewer)
   end
 
@@ -177,14 +180,18 @@ defmodule Vutuv.MastodonApi.Presenter do
   defp engaged_post_id(%{post: %Post{id: id}} = entry) when not is_struct(entry), do: id
   defp engaged_post_id(_other), do: nil
 
-  defp rendered_status(%Post{} = post, engagements, mentions),
-    do: status(post, engagements[post.id], mentions[post.id])
+  defp rendered_status(%Post{} = post, engagements, mentions, answered),
+    do: status(post, engagements[post.id], mentions[post.id], answered[post.id])
 
-  defp rendered_status(%{post: %Post{} = post} = entry, engagements, mentions)
+  defp rendered_status(%{post: %Post{} = post} = entry, engagements, mentions, answered)
        when not is_struct(entry),
-       do: reshared(entry, status(post, engagements[post.id], mentions[post.id]))
+       do:
+         reshared(
+           entry,
+           status(post, engagements[post.id], mentions[post.id], answered[post.id])
+         )
 
-  defp rendered_status(other, _engagements, _mentions), do: status_from_entry(other)
+  defp rendered_status(other, _engagements, _mentions, _answered), do: status_from_entry(other)
 
   # A reshare in Mastodon's shape: an outer status by whoever passed the post
   # on, carrying the post itself under `reblog`.
@@ -242,15 +249,38 @@ defmodule Vutuv.MastodonApi.Presenter do
   defp reshare_time(%{at: at}), do: timestamp(at)
   defp reshare_time(_entry), do: nil
 
-  def status(post, engagement \\ nil, mentions \\ nil)
+  @doc """
+  The id a client is handed for one object — the same string
+  `VutuvWeb.MastodonApi.StatusController` resolves back.
 
-  def status(%Post{} = post, engagement, mentions) do
+  One spelling of the three shapes, so a status and anything that *names* it (a
+  thread's parent link, an `in_reply_to_id`) cannot drift apart.
+  """
+  def status_id(%Post{id: id}), do: id
+  def status_id(%RemotePost{id: id}), do: "remote-" <> id
+  def status_id(%Note{id: id}), do: "remote-note-" <> id
+
+  @doc """
+  The id a client is handed for one account — its twin, and the string
+  `VutuvWeb.MastodonApi.AccountController` resolves back.
+
+  Worth its own function for the same reason: `in_reply_to_account_id` names an
+  account the client is expected to match against one it already holds, so the
+  two must be minted in one place.
+  """
+  def account_id(%User{id: id}), do: id
+  def account_id(%Organization{id: id}), do: id
+  def account_id(%RemoteAccount{id: id}), do: "remote-" <> id
+
+  def status(post, engagement \\ nil, mentions \\ nil, answered \\ nil)
+
+  def status(%Post{} = post, engagement, mentions, answered) do
     author = Posts.author(post)
     content = post.body |> Markdown.render_post(loaded_images(post)) |> safe_html()
 
     fields =
       %{
-        id: post.id,
+        id: status_id(post),
         created_at: timestamp(post.inserted_at),
         content: content,
         url: MastodonApi.main_url(Posts.path(post)),
@@ -263,15 +293,15 @@ defmodule Vutuv.MastodonApi.Presenter do
         tags: status_tags(post),
         mentions: status_mentions(post, mentions)
       }
-      |> Map.merge(reply_fields(post))
+      |> Map.merge(reply_fields(post, answered))
       |> Map.merge(engagement_fields(engagement))
 
     base_status(fields)
   end
 
-  def status(%RemotePost{} = post, _engagement, _mentions) do
+  def status(%RemotePost{} = post, _engagement, _mentions, _answered) do
     base_status(%{
-      id: "remote-" <> post.id,
+      id: status_id(post),
       created_at: timestamp(post.published_at),
       content: Markdown.render_remote(post.content_text || ""),
       url: post.origin_url || post.object_uri,
@@ -282,9 +312,9 @@ defmodule Vutuv.MastodonApi.Presenter do
     })
   end
 
-  def status(%Note{} = note, _engagement, _mentions) do
+  def status(%Note{} = note, _engagement, _mentions, _answered) do
     base_status(%{
-      id: "remote-note-" <> note.id,
+      id: status_id(note),
       created_at: timestamp(note.received_at),
       content: Markdown.render_remote(note.content_text || ""),
       url: Note.origin(note),
@@ -547,15 +577,30 @@ defmodule Vutuv.MastodonApi.Presenter do
 
   defp note_account(note), do: note_fallback_account(note)
 
+  # The id the note's author carries as a status account, without paying for the
+  # account record: the virtual `account_id` the note loader joins in already
+  # says whether we hold one. What a parent link needs, and the only part of
+  # `note_account/1` a *reference* to the note has to agree on.
+  defp note_account_id(%Note{account_id: id}) when is_binary(id),
+    do: account_id(%RemoteAccount{id: id})
+
+  defp note_account_id(%Note{} = note), do: note_author_id(note)
+
+  # The stand-in id for an author we hold no account row for. Derived from the
+  # actor's own URI so the same stranger reads as the same account across a
+  # page, and never as an id `/api/v1/accounts` would resolve.
+  defp note_author_id(%Note{} = note),
+    do:
+      "remote-note-author-" <>
+        (:crypto.hash(:sha256, note.actor_uri) |> Base.url_encode64(padding: false))
+
   defp note_fallback_account(note) do
     handle = Note.display_handle(note) |> String.trim_leading("@")
     username = handle |> String.split("@") |> hd()
     icon = fallback_avatar()
 
-    id = :crypto.hash(:sha256, note.actor_uri) |> Base.url_encode64(padding: false)
-
     base_account(%{
-      id: "remote-note-author-" <> id,
+      id: note_author_id(note),
       username: username,
       acct: handle,
       display_name: note.display_name || username,
@@ -676,10 +721,26 @@ defmodule Vutuv.MastodonApi.Presenter do
   defp audience(true), do: "private"
   defp audience(_open), do: "public"
 
-  defp reply_fields(post) do
+  # **The cached reply wins over the post underneath it** (issue #1641).
+  # `Posts.create_remote_reply/3` files an answer to a reply from another
+  # network as an ordinary local reply to the post that reply hangs under (issue
+  # #1070), so the local parent is a level too high: a client threaded the
+  # answer under the member's own post and labelled it "Replying to @member"
+  # where it addresses a stranger. The website hangs it under the reply's card
+  # for the same reason (`VutuvWeb.PostComponents`).
+  #
+  # Either way the id named is one this client can fetch, and nothing is named
+  # that we hold no row for — an id no client can resolve is worse than none.
+  defp reply_fields(_post, %Note{} = note),
+    do: %{in_reply_to_id: status_id(note), in_reply_to_account_id: note_account_id(note)}
+
+  defp reply_fields(post, _no_cached_reply) do
     case Posts.reply_ref_state(post) do
       {:parent, %Post{} = parent} ->
-        %{in_reply_to_id: parent.id, in_reply_to_account_id: account(Posts.author(parent)).id}
+        %{
+          in_reply_to_id: status_id(parent),
+          in_reply_to_account_id: account_id(Posts.author(parent))
+        }
 
       _not_a_live_parent ->
         %{}

--- a/lib/vutuv_web/controllers/mastodon_api/status_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/status_controller.ex
@@ -16,6 +16,10 @@ defmodule VutuvWeb.MastodonApi.StatusController do
   # wherever there is nothing local to show.
   @empty_context %{ancestors: [], descendants: []}
 
+  # How far up a cached self-thread `/context` follows. A client draws a handful
+  # of ancestors above the status somebody opened, and each step is a query.
+  @max_remote_ancestors 20
+
   @doc """
   One status by the id a client was given.
 
@@ -177,9 +181,14 @@ defmodule VutuvWeb.MastodonApi.StatusController do
 
   `Vutuv.Posts.list_thread/3` already loads the visibility-scoped conversation
   the permalink renders, so the split is done on the parent links it preloads
-  rather than with a second set of queries. Only vutuv posts take part: a reply
-  written on another network is cached without a place in the local reply tree,
-  and inventing one would put words in the wrong conversation.
+  rather than with a second set of queries.
+
+  **A conversation that crossed a network border stays one conversation**
+  (issue #1640). Where a post here answers something we hold a cache of, that
+  cached reply or cached post is a node in the same walk — and a followed
+  account's self-reply gets the author's own thread above it. Only what this
+  installation can serve under an id of its own takes part; nothing is invented
+  from a bare URI, which would name a status no client here could fetch.
   """
   def context(conn, %{"id" => id}) do
     with_visible_status(conn, id, fn object ->
@@ -201,23 +210,36 @@ defmodule VutuvWeb.MastodonApi.StatusController do
   defp context_payload(conn, %Note{} = note) do
     with %Post{} = parent <- Repo.get(Post, note.post_id),
          true <- status_visible?(conn, parent) do
-      viewer = viewer(conn)
-      %{posts: posts} = Posts.list_thread(parent, viewer)
-      parents = Map.new(posts, &{&1.id, parent_id(&1)})
-      by_id = Map.new(posts, &{&1.id, &1})
-      chain = for id <- ancestor_chain(parents, parent.id, []), p = by_id[id], do: p
-      %{ancestors: Presenter.statuses(chain, viewer), descendants: []}
+      # Seeded at the parent **inclusive**: the reply is the focus, so the post
+      # it hangs under is its youngest ancestor rather than the start of a walk.
+      ancestors_above(conn, parent, parent.id)
     else
       _gone_or_closed -> @empty_context
     end
   end
 
-  # A status from another network has no place in the local reply tree, but a
-  # client asks for its context the moment somebody opens it — and a 404 to
-  # that call is an error screen where the post should be. The honest answer is
-  # the empty conversation (the visibility gate has already been asked by
-  # `with_visible_status/3`, like on every other read).
-  defp context_payload(_conn, _remote), do: @empty_context
+  # A cached post is a self-reply whenever its author carried their own thread
+  # on, and `own_thread?/2` is what makes following that safe: a stored reply's
+  # parent is always another cached post by the **same** account, so the chain
+  # above is one we hold and can serve. Descendants stay empty — an answer
+  # written here to a cached post lives in its own thread and is read there.
+  defp context_payload(conn, %RemotePost{} = post) do
+    %{
+      ancestors: Presenter.statuses(remote_ancestors(conn, post), viewer(conn)),
+      descendants: []
+    }
+  end
+
+  # The conversation above `seed`, with no answers below it — `root`'s thread is
+  # what gets loaded, `seed` is where the walk up starts.
+  defp ancestors_above(conn, %Post{} = root, seed) do
+    viewer = viewer(conn)
+    %{posts: posts} = Posts.list_thread(root, viewer)
+    {parents, by_id} = thread_graph(conn, posts)
+    chain = for id <- ancestor_chain(parents, seed, []), p = by_id[id], do: p
+
+    %{ancestors: Presenter.statuses(chain, viewer), descendants: []}
+  end
 
   @doc """
   The status as its author typed it — the Markdown source, not the rendered
@@ -452,8 +474,7 @@ defmodule VutuvWeb.MastodonApi.StatusController do
     viewer = viewer(conn)
     %{posts: posts} = Posts.list_thread(post, viewer)
 
-    parents = Map.new(posts, &{&1.id, parent_id(&1)})
-    by_id = Map.new(posts, &{&1.id, &1})
+    {parents, by_id} = thread_graph(conn, posts)
     ancestors = for id <- ancestor_chain(parents, parents[post.id], []), p = by_id[id], do: p
     descendants = Enum.filter(posts, &below?(parents, &1.id, post.id))
 
@@ -489,7 +510,99 @@ defmodule VutuvWeb.MastodonApi.StatusController do
     end
   end
 
-  defp parent_id(%Post{} = post) do
+  # The conversation as a graph in the ids a client speaks: what each node
+  # answers (`parents`) and the record behind each id (`by_id`). Both halves in
+  # one place, so the walk up and the walk down never have to ask where a status
+  # came from.
+  defp thread_graph(conn, posts) do
+    answered = visible_answered(conn, posts)
+
+    # `uniq_by` because two members can answer the same cached object, and each
+    # borrowed chain is walked a query at a time.
+    borrowed =
+      answered
+      |> Map.values()
+      |> Enum.uniq_by(&Presenter.status_id/1)
+      |> Enum.flat_map(&borrowed_chain(conn, &1))
+
+    parents =
+      posts
+      |> Map.new(&{&1.id, parent_id(&1, answered)})
+      |> Map.merge(
+        Map.new(borrowed, fn {node, parent} -> {Presenter.status_id(node), parent} end)
+      )
+
+    by_id =
+      posts
+      |> Map.new(&{&1.id, &1})
+      |> Map.merge(Map.new(borrowed, fn {node, _parent} -> {Presenter.status_id(node), node} end))
+
+    {parents, by_id}
+  end
+
+  # What these posts answer on other networks, minus whatever this reader may
+  # not see: an account can narrow a single post to its followers, so holding
+  # the cache is not the same as being allowed to read it, and a closed post
+  # must not ride into the conversation on a local answer's id.
+  defp visible_answered(conn, posts) do
+    posts
+    |> Enum.map(& &1.id)
+    |> Fediverse.answered_objects()
+    |> Map.filter(fn {_post_id, object} -> status_visible?(conn, object) end)
+  end
+
+  # One borrowed node per entry, as `{record, id it answers}`.
+  #
+  # A cached reply hangs off a local post, which is the node below it in this
+  # same thread. A cached post brings its author's own chain along, so the
+  # conversation reads the same whether the client opened the answer written
+  # here or the cached post it answers.
+  defp borrowed_chain(_conn, %Note{} = note), do: [{note, note.post_id}]
+
+  defp borrowed_chain(conn, %RemotePost{} = post) do
+    chain = remote_ancestors(conn, post) ++ [post]
+
+    # Each node answers the one before it; the oldest answers nothing we hold.
+    Enum.zip(chain, [nil | Enum.map(chain, &Presenter.status_id/1)])
+  end
+
+  # The cached posts above `post` in its author's own thread, oldest first.
+  # Gated one row at a time, since an account can narrow a single post to its
+  # followers. Two brakes, because a cache of somebody else's data is not ours
+  # to trust: a `seen` set, so a pair of posts naming each other cannot pad the
+  # chain with a loop, and a hard cap, because a client draws a handful of
+  # ancestors and every step here is a query.
+  defp remote_ancestors(conn, post, acc \\ [], seen \\ MapSet.new())
+
+  defp remote_ancestors(_conn, _post, acc, _seen) when length(acc) >= @max_remote_ancestors,
+    do: acc
+
+  defp remote_ancestors(conn, post, acc, seen) do
+    seen = MapSet.put(seen, post.id)
+
+    with %RemotePost{} = parent <- Fediverse.remote_parent_post(post),
+         false <- MapSet.member?(seen, parent.id),
+         true <- status_visible?(conn, parent) do
+      remote_ancestors(conn, parent, [parent | acc], seen)
+    else
+      _end_of_chain -> acc
+    end
+  end
+
+  # What a post answers — the cached reply or cached post it addresses on
+  # another network where it has one, otherwise the local post above it. The
+  # remote side wins because it is the *closer* parent: an answer to a cached
+  # reply is filed as an ordinary local reply to the post that reply hangs under
+  # (issue #1070), so naming the local one hangs it a level too high, which is
+  # exactly what a client then draws (issue #1641).
+  defp parent_id(%Post{} = post, answered) do
+    case answered[post.id] do
+      nil -> local_parent_id(post)
+      object -> Presenter.status_id(object)
+    end
+  end
+
+  defp local_parent_id(%Post{} = post) do
     case Posts.reply_ref_state(post) do
       {:parent, %Post{id: id}} -> id
       _not_a_reply -> nil

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.342.0",
+      version: "7.342.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/support/mastodon_helpers.ex
+++ b/test/support/mastodon_helpers.ex
@@ -18,6 +18,8 @@ defmodule Vutuv.MastodonHelpers do
   alias Ecto.Changeset
   alias Vutuv.Accounts.User
   alias Vutuv.ApiAuth
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemotePost
   alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
   alias Vutuv.Repo
@@ -111,6 +113,72 @@ defmodule Vutuv.MastodonHelpers do
 
   @doc "Puts `conn` on the adapter's host without a token."
   def on_mastodon_host(conn), do: Map.put(conn, :host, mastodon_host())
+
+  @doc """
+  The same conn ready for a second request: `Phoenix.ConnTest` reuses one conn,
+  so recycling clears the previous response while the bearer header and the
+  adapter's host are put back.
+  """
+  def recycle_mastodon(conn) do
+    [header] = Plug.Conn.get_req_header(conn, "authorization")
+
+    conn
+    |> Phoenix.ConnTest.recycle()
+    |> Map.put(:host, mastodon_host())
+    |> Plug.Conn.put_req_header("authorization", header)
+  end
+
+  @doc """
+  A member who may act across the border: an act leaves this site signed with
+  their own key, so every outbound gate refuses somebody who does not federate.
+  Replies are switched on too, which is what lets a stranger's reply be stored
+  under their post in the first place.
+  """
+  def federating_member(attrs \\ []) do
+    user =
+      insert(
+        :activated_user,
+        Keyword.merge([fediverse_followers?: true, fediverse_replies?: true], attrs)
+      )
+
+    {:ok, _actor} = Vutuv.Fediverse.ensure_actor(user)
+    Repo.reload!(user)
+  end
+
+  @doc "An account on another server, the row the inbox writes from an actor document."
+  def remote_account(attrs \\ []) do
+    uri = attrs[:actor_uri] || "https://social.example/users/them#{unique_suffix()}"
+
+    Repo.insert!(%RemoteAccount{
+      actor_uri: uri,
+      host: URI.parse(uri).host,
+      handle: attrs[:handle] || "them",
+      name: attrs[:name] || "Them",
+      inbox_uri: uri <> "/inbox",
+      avatar: attrs[:avatar],
+      avatar_moderation: attrs[:avatar_moderation]
+    })
+  end
+
+  @doc "One of that account's posts, cached here because somebody follows them."
+  def cached_post(%RemoteAccount{} = account, attrs \\ []) do
+    now = DateTime.utc_now(:second)
+
+    Repo.insert!(%RemotePost{
+      remote_account_id: account.id,
+      object_uri: attrs[:object_uri] || "https://social.example/p/#{unique_suffix()}",
+      in_reply_to_uri: attrs[:in_reply_to_uri],
+      content_text: attrs[:content_text] || "Von woanders.",
+      audience: attrs[:audience] || "public",
+      kind: "note",
+      published_at: now,
+      received_at: now,
+      expires_at: DateTime.add(now, 86_400)
+    })
+    |> Repo.preload(:remote_account)
+  end
+
+  defp unique_suffix, do: System.unique_integer([:positive])
 
   @doc """
   The `VutuvWeb.RemoteMediaToken` out of a rendered avatar URL, or nil when the

--- a/test/vutuv_web/controllers/mastodon_api/fediverse_client_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/fediverse_client_test.exs
@@ -23,7 +23,6 @@ defmodule VutuvWeb.MastodonApi.FediverseClientTest do
 
   alias Vutuv.Fediverse.PostBoost
   alias Vutuv.Fediverse.RemoteAccount
-  alias Vutuv.Fediverse.RemotePost
   alias Vutuv.MastodonApi
   alias Vutuv.MastodonApi.Presenter
   alias Vutuv.Posts
@@ -36,46 +35,7 @@ defmodule VutuvWeb.MastodonApi.FediverseClientTest do
     :ok
   end
 
-  defp remote_account(attrs \\ []) do
-    uri = attrs[:actor_uri] || "https://social.example/users/them#{unique()}"
-
-    Repo.insert!(%RemoteAccount{
-      actor_uri: uri,
-      host: URI.parse(uri).host,
-      handle: attrs[:handle] || "them",
-      name: attrs[:name] || "Them",
-      inbox_uri: uri <> "/inbox",
-      avatar: attrs[:avatar],
-      avatar_moderation: attrs[:avatar_moderation]
-    })
-  end
-
-  defp cached_post(account, attrs \\ []) do
-    now = DateTime.utc_now(:second)
-
-    Repo.insert!(%RemotePost{
-      remote_account_id: account.id,
-      object_uri: "https://social.example/p/#{unique()}",
-      content_text: attrs[:content_text] || "Von woanders.",
-      audience: "public",
-      kind: "note",
-      published_at: now,
-      received_at: now,
-      expires_at: DateTime.add(now, 86_400)
-    })
-    |> Repo.preload(:remote_account)
-  end
-
   defp unique, do: System.unique_integer([:positive])
-
-  # A like, boost or reply leaves this site signed with the member's own key, so
-  # the outbound gates refuse an account that does not federate — which is a rule,
-  # not the bug under test here.
-  defp federating_member do
-    user = insert(:activated_user, fediverse_followers?: true)
-    {:ok, _actor} = Vutuv.Fediverse.ensure_actor(user)
-    Repo.reload!(user)
-  end
 
   describe "the Federated tab" do
     test "lists the posts this site has cached instead of failing", %{conn: conn} do
@@ -371,24 +331,13 @@ defmodule VutuvWeb.MastodonApi.FediverseClientTest do
     defp walk(conn, path, max_id, seen, rounds) do
       params = if max_id, do: %{"limit" => "1", "max_id" => max_id}, else: %{"limit" => "1"}
 
-      case conn |> recycle_token() |> get(path, params) |> json_response(200) do
+      case conn |> recycle_mastodon() |> get(path, params) |> json_response(200) do
         [] ->
           seen
 
         [status] ->
           walk(conn, path, status["id"], seen ++ [status["id"]], rounds + 1)
       end
-    end
-
-    # `Phoenix.ConnTest` reuses one conn per request; recycling keeps the bearer
-    # header while clearing the previous response.
-    defp recycle_token(conn) do
-      [header] = Plug.Conn.get_req_header(conn, "authorization")
-
-      conn
-      |> Phoenix.ConnTest.recycle()
-      |> Map.put(:host, conn.host)
-      |> Plug.Conn.put_req_header("authorization", header)
     end
   end
 

--- a/test/vutuv_web/controllers/mastodon_api/thread_parents_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/thread_parents_test.exs
@@ -1,0 +1,226 @@
+defmodule VutuvWeb.MastodonApi.ThreadParentsTest do
+  @moduledoc """
+  What a client is told a status answers, once the conversation crosses a
+  network border — issues #1640 and #1641.
+
+  Two surfaces carry that relation and a client threads from whichever it has:
+  `in_reply_to_id` on the single status, and `ancestors` in its `/context`. For
+  a cached *reply* both are asserted here and they name the same thing. For a
+  cached *post* only `/context` names it: filling `in_reply_to_id` there is
+  issue #1622, in flight as a separate change, so this file pins the half that
+  is done rather than pretending both are.
+
+  Calibrated against the un-fixed adapter: drop the answered-object lookup out
+  of `Vutuv.MastodonApi.Presenter` or out of
+  `VutuvWeb.MastodonApi.StatusController` and the matching test here goes red.
+
+  `async: false` because answering something on another network claims the
+  shared outbound budget.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Vutuv.MastodonHelpers
+
+  alias Vutuv.Posts
+  alias Vutuv.Repo
+
+  # Every test here reads as somebody with no relationship to anybody: the
+  # relation under test is what a stranger's client is told.
+  setup %{conn: conn} do
+    Vutuv.RateLimiter.reset()
+
+    {:ok, conn: mastodon_conn(conn, mastodon_token(insert(:activated_user), ["read"]))}
+  end
+
+  describe "an answer to a cached reply from another network" do
+    setup do
+      author = federating_member()
+      {:ok, root} = Posts.create_post(author, %{body: "Die Wurzel"})
+      note = insert(:note, post: root)
+      {:ok, answer} = Posts.create_remote_reply(author, note, %{"body" => "Danke, freut mich!"})
+
+      {:ok, root: root, note: note, answer: answer}
+    end
+
+    # Issue #1641: `create_remote_reply/3` files the answer as an ordinary local
+    # reply to the post the cached reply hangs under (issue #1070), so without
+    # the fix `in_reply_to_id` is the root post and a client labels the answer
+    # "Replying to @member" where it addresses a stranger.
+    test "names the cached reply, not the post underneath it", %{
+      conn: conn,
+      note: note,
+      answer: answer
+    } do
+      status = conn |> get("/api/v1/statuses/#{answer.id}") |> json_response(200)
+
+      assert status["in_reply_to_id"] == "remote-note-" <> note.id
+    end
+
+    # The id it names has to be one this client can fetch, or the "Replying to"
+    # line leads to an error screen.
+    test "and that id resolves to the reply itself", %{conn: conn, answer: answer} do
+      named =
+        conn
+        |> get("/api/v1/statuses/#{answer.id}")
+        |> json_response(200)
+        |> Map.fetch!("in_reply_to_id")
+
+      parent =
+        conn |> recycle_mastodon() |> get("/api/v1/statuses/#{named}") |> json_response(200)
+
+      assert parent["content"] =~ "Guter Punkt"
+    end
+
+    # The account named beside it is the one the reply's own status carries, so
+    # a client that already holds the reply matches the two up.
+    test "and names the stranger's account rather than the member's", %{
+      conn: conn,
+      note: note,
+      answer: answer
+    } do
+      answer_status = conn |> get("/api/v1/statuses/#{answer.id}") |> json_response(200)
+
+      note_status =
+        conn
+        |> recycle_mastodon()
+        |> get("/api/v1/statuses/remote-note-#{note.id}")
+        |> json_response(200)
+
+      assert answer_status["in_reply_to_account_id"] == note_status["account"]["id"]
+    end
+
+    # Issue #1640: the two surfaces agree. The cached reply sits between the
+    # root post and the answer, oldest first.
+    test "and its context carries the cached reply above it", %{
+      conn: conn,
+      root: root,
+      note: note,
+      answer: answer
+    } do
+      context = conn |> get("/api/v1/statuses/#{answer.id}/context") |> json_response(200)
+
+      assert Enum.map(context["ancestors"], & &1["id"]) == [root.id, "remote-note-" <> note.id]
+    end
+
+    # A reply the sender addressed to the member alone cannot be answered at all
+    # (`check_remote_reply/2`), so a private note here is one an upstream
+    # `Update` narrowed afterwards — and its id answers 404 to everybody but the
+    # member whose post it hangs under. The local parent is the honest fallback.
+    test "but a reply narrowed after the fact is not named", %{
+      conn: conn,
+      root: root,
+      note: note,
+      answer: answer
+    } do
+      Repo.update!(Ecto.Changeset.change(note, audience: "direct"))
+
+      status = conn |> get("/api/v1/statuses/#{answer.id}") |> json_response(200)
+
+      assert status["in_reply_to_id"] == root.id
+    end
+  end
+
+  describe "an ordinary reply" do
+    test "still names the post above it", %{conn: conn} do
+      author = insert(:activated_user)
+      {:ok, root} = Posts.create_post(author, %{body: "Die Wurzel"})
+      {:ok, reply} = Posts.create_reply(author, root, %{body: "Die Antwort"})
+
+      status = conn |> get("/api/v1/statuses/#{reply.id}") |> json_response(200)
+
+      assert status["in_reply_to_id"] == root.id
+    end
+  end
+
+  describe "a self-reply from another network" do
+    setup do
+      account = remote_account()
+      parent = cached_post(account, content_text: "Erster Teil.")
+
+      reply =
+        cached_post(account, content_text: "Zweiter Teil.", in_reply_to_uri: parent.object_uri)
+
+      {:ok, account: account, parent: parent, reply: reply}
+    end
+
+    # Issue #1640: without the fix `/context` answered the empty conversation
+    # for anything from another network, so a followed account's self-reply
+    # stood in the client as an orphan although we serve its parent.
+    test "answers the cached post above it", %{conn: conn, parent: parent, reply: reply} do
+      context = conn |> get("/api/v1/statuses/remote-#{reply.id}/context") |> json_response(200)
+
+      assert Enum.map(context["ancestors"], & &1["id"]) == ["remote-" <> parent.id]
+      assert context["descendants"] == []
+    end
+
+    test "walks the whole chain, oldest first", %{
+      conn: conn,
+      account: account,
+      parent: parent,
+      reply: reply
+    } do
+      third =
+        cached_post(account, content_text: "Dritter Teil.", in_reply_to_uri: reply.object_uri)
+
+      context = conn |> get("/api/v1/statuses/remote-#{third.id}/context") |> json_response(200)
+
+      assert Enum.map(context["ancestors"], & &1["id"]) ==
+               ["remote-" <> parent.id, "remote-" <> reply.id]
+    end
+
+    # Holding the parent is not the same as being allowed to read it: an account
+    # can narrow a single post to its followers, and this reader follows nobody.
+    test "but stops at a parent the reader may not see", %{
+      conn: conn,
+      parent: parent,
+      reply: reply
+    } do
+      Repo.update!(Ecto.Changeset.change(parent, audience: "followers"))
+
+      context = conn |> get("/api/v1/statuses/remote-#{reply.id}/context") |> json_response(200)
+
+      assert context == %{"ancestors" => [], "descendants" => []}
+    end
+
+    # A thread of a different account is not this account's thread — the column
+    # is scoped, so a stranger cannot graft their post above somebody else's.
+    test "and never borrows a post from another account", %{conn: conn, account: account} do
+      stranger = cached_post(remote_account(), content_text: "Fremd.")
+      reply = cached_post(account, content_text: "Antwort.", in_reply_to_uri: stranger.object_uri)
+
+      context = conn |> get("/api/v1/statuses/remote-#{reply.id}/context") |> json_response(200)
+
+      assert context["ancestors"] == []
+    end
+
+    # Two cached posts naming each other is broken data from somebody else's
+    # server, and the walk must end rather than pad the chain with the loop.
+    test "and a chain that points back at itself ends", %{conn: conn, account: account} do
+      first = cached_post(account, content_text: "Eins.")
+      second = cached_post(account, content_text: "Zwei.", in_reply_to_uri: first.object_uri)
+      Repo.update!(Ecto.Changeset.change(first, in_reply_to_uri: second.object_uri))
+
+      context = conn |> get("/api/v1/statuses/remote-#{second.id}/context") |> json_response(200)
+
+      assert Enum.map(context["ancestors"], & &1["id"]) == ["remote-" <> first.id]
+    end
+  end
+
+  describe "an answer written here to a cached post" do
+    # Issue #1640: the answer is a top-level vutuv post (there is nothing local
+    # underneath it), so without the fix its context was empty although the post
+    # it addresses is one we serve.
+    test "carries that cached post as its ancestor", %{conn: conn} do
+      remote = cached_post(remote_account())
+
+      {:ok, answer} =
+        Posts.create_remote_post_reply(federating_member(), remote, %{
+          "body" => "Sehe ich auch so."
+        })
+
+      context = conn |> get("/api/v1/statuses/#{answer.id}/context") |> json_response(200)
+
+      assert Enum.map(context["ancestors"], & &1["id"]) == ["remote-" <> remote.id]
+    end
+  end
+end


### PR DESCRIPTION
**Symptom.** In a Mastodon client, a member's answer to a cached fediverse reply read "Replying to @member" instead of naming the stranger it addresses, and `GET /api/v1/statuses/:id/context` answered the empty conversation for anything from another network.

**What changed.** `Presenter.reply_fields/2` names the cached reply (`remote-note-<id>`) where the `PostRemoteReply` sidecar has one — `create_remote_reply/3` files such an answer as an ordinary local reply to the post underneath (#1070), which is a level too high. `StatusController.thread_graph/2` walks parent chains in client ids, so a borrowed node stands beside the local ones: the cached reply between the root post and the answer, an answer written here under the cached post it addresses, a followed account's self-reply under its author's own chain.

Only ids this installation serves are named, each behind the same visibility gate as a direct read. Filling `in_reply_to_id` for a cached *post* is #1622 (PR #1623), deliberately left out. No screenshot: the changed surface is JSON.

Closes #1640, #1641.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01Hu13sFQATdNUxiNGivBq2g
