### PR TITLE
Three guards measure work, not the wall clock (v7.342.4)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.342.1",
+      version: "7.342.4",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/support/work_counter.ex
+++ b/test/support/work_counter.ex
@@ -1,0 +1,44 @@
+defmodule Vutuv.WorkCounter do
+  @moduledoc """
+  Counts the *work* a function does, in BEAM reductions:
+
+      {work, html} = count_reductions(fn -> Markdown.render(body) end)
+      assert work < 5_000_000
+
+  The shape mirrors `:timer.tc/1` on purpose, because it replaces it at the
+  handful of call sites that guard an algorithm against going quadratic — a
+  ReDoS bump-along, an autolink scan over a pathological token, a zip whose
+  entries all point at one stream.
+
+  Those guards asked the wall clock, and the wall clock answers a different
+  question. `mix test` runs twenty cases in parallel, so the render in
+  `markdown_test.exs` — 3 ms of actual work — was once measured at 1.16 s
+  purely because the scheduler had other tenants, and its `< 1s` bound failed
+  a push on a busy laptop while passing on an idle CI box. Raising such a bound
+  buys time, it does not fix the instrument: what these tests want to know is
+  how much work the input causes, and that is what a reduction counts.
+
+  So the count is stable across a loaded machine and an idle one, and it still
+  sees the thing being guarded. Reductions track NIF work too: a catastrophic
+  `:re` backtrack charges about 1.25 million of them, so a regex guard is
+  measurable this way as well.
+
+  Two limits worth knowing. Reductions are charged per **process**, so work a
+  function hands off to a `Task` is invisible here (every current caller is
+  in-process — check before adding one that is not). And the count drifts a
+  little with the Elixir/OTP version and with library upgrades, so a threshold
+  wants an order of magnitude of headroom rather than a tight fit. The guards
+  have it: each one separates a linear cost from a quadratic one, and every
+  bound in the tree was calibrated by measuring both sides.
+  """
+
+  @doc """
+  Runs `fun` and returns `{reductions, result}`.
+  """
+  def count_reductions(fun) do
+    {:reductions, before} = Process.info(self(), :reductions)
+    result = fun.()
+    {:reductions, afterwards} = Process.info(self(), :reductions)
+    {afterwards - before, result}
+  end
+end

--- a/test/vutuv/imports/linked_in_test.exs
+++ b/test/vutuv/imports/linked_in_test.exs
@@ -5,6 +5,8 @@ defmodule Vutuv.Imports.LinkedInTest do
   """
   use ExUnit.Case, async: true
 
+  import Vutuv.WorkCounter
+
   alias Vutuv.Imports.LinkedIn
 
   # A real Profile.csv header + row from an actual export (note the bracketed
@@ -454,13 +456,18 @@ defmodule Vutuv.Imports.LinkedInTest do
     test "rejects an archive whose entries share one offset, promptly" do
       archive = shared_offset_zip(500)
 
-      {micros, result} = :timer.tc(fn -> LinkedIn.parse(archive) end)
+      {work, result} = count_reductions(fn -> LinkedIn.parse(archive) end)
 
       # Overlapping data regions are not a normal archive: rejected outright,
       # before the shared stream is inflated even once.
       assert {:error, :invalid_archive} = result
-      # No gigabytes inflated: rejection is a cheap header/interval check.
-      assert micros < 1_000_000
+
+      # No gigabytes inflated: rejection is a cheap header/interval check, and
+      # the bound counts work rather than wall-clock time so a loaded machine
+      # cannot fail it. The rejection costs about 73_000 reductions; inflating
+      # the shared 300 KB stream once costs 31_638, so the naive path this
+      # guards against — 500 of them — would charge some 15_800_000.
+      assert work < 2_000_000, "expected a header check, took #{work} reductions"
     end
 
     # The two-entry form of the same defect: entry b's data region is patched to

--- a/test/vutuv/web_address_test.exs
+++ b/test/vutuv/web_address_test.exs
@@ -1,6 +1,8 @@
 defmodule Vutuv.WebAddressTest do
   use ExUnit.Case, async: true
 
+  import Vutuv.WorkCounter
+
   alias Vutuv.WebAddress
 
   doctest Vutuv.WebAddress
@@ -85,17 +87,23 @@ defmodule Vutuv.WebAddressTest do
       assert WebAddress.link_only?(over_limit) == false
     end
 
-    test "a ~1 MB free-text payload returns false fast, not after an O(n²) scan" do
+    test "a ~1 MB free-text payload returns false without scanning it" do
       # The pathological ReDoS input the finding describes: length-unvalidated
       # free text ending in a slash. Without the guard each of the nine
       # unanchored patterns bump-alongs at O(n²) over ~1 MB; with it the byte
-      # cap returns instantly. Assert both the result and that it is fast.
+      # cap returns instantly. Assert both the result and that it did no work.
+      #
+      # Measured in reductions rather than microseconds so a busy machine
+      # cannot fail it: the capped call costs 65 of them, while removing the
+      # cap does not finish inside the 60 s test timeout at all. 50_000 leaves
+      # the short-circuit three orders of magnitude of room and is still far
+      # below what one pass over a megabyte would charge.
       giant = String.duplicate("a", 1_000_000) <> "/"
 
-      {micros, result} = :timer.tc(fn -> WebAddress.link_only?(giant) end)
+      {work, result} = count_reductions(fn -> WebAddress.link_only?(giant) end)
 
       assert result == false
-      assert micros < 100_000, "expected a fast short-circuit, took #{micros}µs"
+      assert work < 50_000, "expected a short-circuit, took #{work} reductions"
     end
 
     test "a storable multi-byte link-only value is still caught, not clipped by the byte cap" do

--- a/test/vutuv_web/markdown_test.exs
+++ b/test/vutuv_web/markdown_test.exs
@@ -1,6 +1,8 @@
 defmodule VutuvWeb.MarkdownTest do
   use ExUnit.Case, async: true
 
+  import Vutuv.WorkCounter
+
   alias VutuvWeb.Markdown
 
   defp render(text), do: text |> Markdown.render() |> Phoenix.HTML.safe_to_string()
@@ -69,16 +71,22 @@ defmodule VutuvWeb.MarkdownTest do
 
   # Findings F1/F9: `http://a` followed by a long unbroken run of trailing
   # punctuation is matched as one token by `[^\s<>]+`. It must be emitted
-  # verbatim (over the length cap → not autolinked) and, either way, render in a
-  # fraction of a second rather than driving a quadratic loop.
-  test "leaves a pathological over-long autolink candidate as literal text, fast" do
+  # verbatim (over the length cap → not autolinked) and, either way, cost work
+  # linear in the input rather than driving a quadratic loop.
+  #
+  # The bound is in reductions, not wall-clock microseconds: this render costs
+  # about 388_000 of them, a quadratic pass over the same input costs
+  # 25_165_094, and the cap sits between the two with an order of magnitude to
+  # spare on either side. The old `< 1s` measured the machine instead — twenty
+  # parallel cases stretched those 3 ms to 1.16 s and failed the push gate.
+  test "leaves a pathological over-long autolink candidate as literal text, cheaply" do
     body = "http://a" <> String.duplicate(".", 20_000)
 
-    {micros, html} = :timer.tc(fn -> render(body) end)
+    {work, html} = count_reductions(fn -> render(body) end)
 
     refute html =~ "<a "
     assert html =~ "http://a"
-    assert micros < 1_000_000
+    assert work < 5_000_000, "expected a linear scan, took #{work} reductions"
   end
 
   test "still autolinks a normal long-ish URL under the cap" do


### PR DESCRIPTION
**Symptom:** `markdown_test.exs` asserts a pathological autolink render takes `< 1s`. The render costs 3 ms of actual work, but measured beside twenty parallel cases it hit 1.16 s and failed the pre-push gate on #1629 — a red build that said nothing about the code.

**Change:** the three guards against quadratic behaviour now count BEAM reductions instead of wall-clock microseconds, through a new `Vutuv.WorkCounter.count_reductions/1` (test support, mirrors `:timer.tc/1`). Reductions are the scheduler's own unit of work, so a loaded laptop and an idle CI box agree, and they still track NIF work — a catastrophic `:re` backtrack charges ~1.25M of them.

**Every bound is measured on both sides,** not guessed:

| Test | correct | the regression it guards | bound |
|---|---|---|---|
| `markdown_test.exs` autolink | 387,750 | 25,165,094 (quadratic pass, same input) | 5,000,000 |
| `web_address_test.exs` ReDoS | 65 | never finishes in the 60 s timeout | 50,000 |
| `linked_in_test.exs` shared offset | 73,181 | ~15,819,000 (500 × one inflation) | 2,000,000 |

I removed each removable guard once and watched the test go red. No `lib/` change. **Deploy:** hot, no migration.

*An AI agent wrote this text in my name. I know that is problematic.*
