### PR TITLE
Photos reach the Mastodon client (v7.342.8)

### DIFF
--- a/docs/architecture/mastodon-api.md
+++ b/docs/architecture/mastodon-api.md
@@ -219,12 +219,42 @@ request, so it widens no picture. It does widen who may fetch one: it is a
 bearer URL naming no member and no device, so a logout, a suspension or a
 revoked app do not close a URL already handed out, and it answers until it
 expires. That is the trade, and it is sized to what is behind the door — one
-cached copy of a public avatar. The post-attachment route keeps the session,
-because its pictures carry a post's audience. Its `signed_at` is pinned to the
-UTC day so a client is handed the same URL all day and its image cache keeps
-working; a per-render timestamp would re-download every face in the timeline on
-every refresh, and a longer bucket would lengthen that bearer window for a
-saving measured in kilobytes.
+cached copy of a public avatar. Its `signed_at` is pinned to the UTC day so a
+client is handed the same URL all day and its image cache keeps working; a
+per-render timestamp would re-download every face in the timeline on every
+refresh, and a longer bucket would lengthen that bearer window for a saving
+measured in kilobytes.
+
+**A photograph is not an avatar, so its capability names the member** (issues
+#1626 and #1627). Two pictures reached a client broken for the same reason and
+neither could take the avatar's shape, because both carry a *post's* audience: a
+photo post from another network arrived as text only (both remote status heads
+built on `base_status/1`, which defaults `media_attachments: []`, and neither
+filled it), and a photo on a *restricted* vutuv post arrived as a broken image
+(the URL was named all along, and against the nil viewer an image loader is,
+`Posts.visible_to?/2` is false for any post carrying a denial). Both are named
+now, and each URL carries a capability holding the id of the member the adapter
+rendered the status for; the proxy resolves that member — refusing one a
+suspension or a deactivation has closed, the way the session plug and the bearer
+check do — and asks the picture's own audience question of them
+(`Posts.image_visible_to?/2`, `Fediverse.remote_image_visible?/2`) on every
+request. A capability opens the sizes a client renders and nothing else: the
+full-resolution `original.orig` download, the `og.jpg` link preview and the
+author-only crop workbench stay session-only, since the version segment is not
+part of what the token pins. So narrowing the post,
+or taking a reader out of its audience, shuts every URL already handed out,
+which the avatar's bearer shape could not do. The cost is one `users` row per
+image request on that path; a signed-in browser never pays it.
+
+Two limits worth knowing. A **public** post's photo is named without a
+capability — it needs no credential, and a bearer URL that buys nothing is one
+more thing that can be shared. And a page identity gets none either: both
+audience predicates answer a `%User{}` and nothing else, so a capability naming
+a page would be one the proxy could never honour, and a client acting as a page
+sees today's plain URLs (right for every public picture, still broken for the
+rest). A cached *reply* carries no pictures at all — there is no note-image
+table and the inbox stores none — so its empty `media_attachments` is the
+answer, not a gap.
 
 The three counts are `Vutuv.MastodonApi.AccountCounts`, one query per figure for
 a whole page rather than three per row — ours are real aggregates where

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -2906,6 +2906,8 @@ defmodule Vutuv.Fediverse do
   and nothing else, and such a post with its picture silently missing is not a
   quiet card, it is a broken one.
   """
+  def list_remote_images([]), do: %{}
+
   def list_remote_images(post_ids) do
     from(i in RemoteImage,
       where: i.remote_post_id in ^post_ids,

--- a/lib/vutuv/mastodon_api/presenter.ex
+++ b/lib/vutuv/mastodon_api/presenter.ex
@@ -8,6 +8,7 @@ defmodule Vutuv.MastodonApi.Presenter do
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.Note
   alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemoteImage
   alias Vutuv.Fediverse.RemotePost
   alias Vutuv.Identity
   alias Vutuv.MastodonApi
@@ -20,6 +21,7 @@ defmodule Vutuv.MastodonApi.Presenter do
   alias Vutuv.Posts.PostImage
   alias Vutuv.Profiles.Url
   alias Vutuv.Profiles.VerifiedLinks
+  alias Vutuv.RemoteMedia
   alias Vutuv.Tags.Tag
   alias Vutuv.UUIDv7
   alias VutuvWeb.Markdown
@@ -121,18 +123,38 @@ defmodule Vutuv.MastodonApi.Presenter do
   counts travel with the record.
   """
   def statuses(items, viewer) when is_list(items) do
-    post_ids = items |> Enum.map(&engaged_post_id/1) |> Enum.reject(&is_nil/1)
-
-    engagements = Posts.post_engagement_map(post_ids, viewer)
-    mentions = Posts.mention_map(post_ids)
-    # Which cached fediverse reply each post answers, if any (issue #1641) —
-    # one query for the page, read by `reply_fields/2`.
-    answered = Fediverse.answered_notes(post_ids)
+    context = page_context(items, viewer)
 
     items
-    |> Enum.map(&rendered_status(&1, engagements, mentions, answered))
+    |> Enum.map(&rendered_status(&1, context))
     |> fill_account_counts(viewer)
   end
+
+  # Everything a page reads **once** and every status on it then reads from.
+  # Growing this map is how a new per-status fact arrives here; growing
+  # `status/3`'s parameter list is not, which is what it already looked like.
+  defp page_context(items, viewer) do
+    post_ids = items |> Enum.map(&engaged_post_id/1) |> Enum.reject(&is_nil/1)
+    remote_ids = items |> Enum.map(&remote_post_id/1) |> Enum.reject(&is_nil/1)
+
+    %{
+      viewer: viewer,
+      engagements: Posts.post_engagement_map(post_ids, viewer),
+      mentions: Posts.mention_map(post_ids),
+      # Which cached fediverse reply each post answers, if any (issue #1641).
+      answered: Fediverse.answered_notes(post_ids),
+      # The photographs on the cached posts this page shows (issue #1626).
+      # `:images` is never preloaded on a `%RemotePost{}` — every surface in this
+      # codebase batches them by id, and so does this one.
+      remote_images: Fediverse.list_remote_images(remote_ids)
+    }
+  end
+
+  # What a single status rendered outside `statuses/2` gets. Built by the same
+  # function rather than spelled out again, so a sixth batch cannot be added to
+  # one shape and forgotten in the other; every batch short-circuits on an empty
+  # id list, so it costs no query.
+  defp no_page, do: page_context([], nil)
 
   # The figures on every account this page embeds, written in after the fact
   # rather than threaded through `status/2`: a status reaches its author through
@@ -180,18 +202,20 @@ defmodule Vutuv.MastodonApi.Presenter do
   defp engaged_post_id(%{post: %Post{id: id}} = entry) when not is_struct(entry), do: id
   defp engaged_post_id(_other), do: nil
 
-  defp rendered_status(%Post{} = post, engagements, mentions, answered),
-    do: status(post, engagements[post.id], mentions[post.id], answered[post.id])
+  # The same, for the cached posts whose photographs the page has to look up.
+  defp remote_post_id(%RemotePost{id: id}), do: id
 
-  defp rendered_status(%{post: %Post{} = post} = entry, engagements, mentions, answered)
-       when not is_struct(entry),
-       do:
-         reshared(
-           entry,
-           status(post, engagements[post.id], mentions[post.id], answered[post.id])
-         )
+  defp remote_post_id(%{remote_post: %RemotePost{id: id}} = entry) when not is_struct(entry),
+    do: id
 
-  defp rendered_status(other, _engagements, _mentions, _answered), do: status_from_entry(other)
+  defp remote_post_id(_other), do: nil
+
+  defp rendered_status(%Post{} = post, context), do: status(post, context)
+
+  defp rendered_status(%{post: %Post{} = post} = entry, context) when not is_struct(entry),
+    do: reshared(entry, status(post, context))
+
+  defp rendered_status(other, context), do: status_from_entry(other, context)
 
   # A reshare in Mastodon's shape: an outer status by whoever passed the post
   # on, carrying the post itself under `reblog`.
@@ -272,10 +296,12 @@ defmodule Vutuv.MastodonApi.Presenter do
   def account_id(%Organization{id: id}), do: id
   def account_id(%RemoteAccount{id: id}), do: "remote-" <> id
 
-  def status(post, engagement \\ nil, mentions \\ nil, answered \\ nil)
-
-  def status(%Post{} = post, engagement, mentions, answered) do
+  # One status. `context` carries everything the page read once (`page_context/2`);
+  # a caller outside `statuses/2` gets the empty one and every lookup simply
+  # misses.
+  defp status(%Post{} = post, context) do
     author = Posts.author(post)
+    engagement = context.engagements[post.id]
     content = post.body |> Markdown.render_post(loaded_images(post)) |> safe_html()
 
     fields =
@@ -286,20 +312,20 @@ defmodule Vutuv.MastodonApi.Presenter do
         url: MastodonApi.main_url(Posts.path(post)),
         uri: MastodonApi.main_url(Posts.path(post)),
         account: account(author),
-        media_attachments: media_attachments(post),
+        media_attachments: media_attachments(post, engagement, context),
         visibility: visibility(post, engagement),
         language: post.language,
         edited_at: edited_at(post),
         tags: status_tags(post),
-        mentions: status_mentions(post, mentions)
+        mentions: status_mentions(post, context.mentions[post.id])
       }
-      |> Map.merge(reply_fields(post, answered))
+      |> Map.merge(reply_fields(post, context.answered[post.id]))
       |> Map.merge(engagement_fields(engagement))
 
     base_status(fields)
   end
 
-  def status(%RemotePost{} = post, _engagement, _mentions, _answered) do
+  defp status(%RemotePost{} = post, context) do
     base_status(%{
       id: status_id(post),
       created_at: timestamp(post.published_at),
@@ -307,12 +333,18 @@ defmodule Vutuv.MastodonApi.Presenter do
       url: post.origin_url || post.object_uri,
       uri: post.object_uri,
       account: account(post.remote_account),
+      media_attachments: remote_attachments(post, context),
       sensitive: post.sensitive,
       spoiler_text: post.summary || ""
     })
   end
 
-  def status(%Note{} = note, _engagement, _mentions, _answered) do
+  # A cached **reply** carries no pictures at all: there is no note-image table
+  # and the inbox stores none, on the reply cards' own stance that a stranger's
+  # picture is not copied here (`Vutuv.Fediverse.Note`). So this head has nothing
+  # to name, and an empty `media_attachments` is the true answer rather than an
+  # unfinished one.
+  defp status(%Note{} = note, _context) do
     base_status(%{
       id: status_id(note),
       created_at: timestamp(note.received_at),
@@ -334,7 +366,8 @@ defmodule Vutuv.MastodonApi.Presenter do
   It is also what the timeline endpoints read the pagination boundary out of, so
   the id it answers for a reshare has to be the reshare's own.
   """
-  def status_from_entry(entry), do: reshared(entry, inner_status_from_entry(entry))
+  def status_from_entry(entry, context \\ no_page()),
+    do: reshared(entry, inner_status_from_entry(entry, context))
 
   # **A row from another network also arrives on its own, not only wrapped in a
   # feed entry.** The map clauses below read the merged feed's entry maps, and
@@ -351,13 +384,15 @@ defmodule Vutuv.MastodonApi.Presenter do
   # The struct clauses come first on purpose: a `%Note{}` also carries a `post`
   # association, so with the map clauses ahead a Note whose `:post` happens to
   # be preloaded would render as its parent post instead of itself.
-  defp inner_status_from_entry(%RemotePost{} = post), do: status(post)
-  defp inner_status_from_entry(%Note{} = note), do: status(note)
-  defp inner_status_from_entry(%Post{} = post), do: status(post)
+  defp inner_status_from_entry(%RemotePost{} = post, context), do: status(post, context)
+  defp inner_status_from_entry(%Note{} = note, context), do: status(note, context)
+  defp inner_status_from_entry(%Post{} = post, context), do: status(post, context)
 
-  defp inner_status_from_entry(%{remote_post: %RemotePost{} = post}), do: status(post)
-  defp inner_status_from_entry(%{note: %Note{} = note}), do: status(note)
-  defp inner_status_from_entry(%{post: %Post{} = post}), do: status(post)
+  defp inner_status_from_entry(%{remote_post: %RemotePost{} = post}, context),
+    do: status(post, context)
+
+  defp inner_status_from_entry(%{note: %Note{} = note}, context), do: status(note, context)
+  defp inner_status_from_entry(%{post: %Post{} = post}, context), do: status(post, context)
 
   defp count_fields(nil), do: %{}
 
@@ -715,8 +750,12 @@ defmodule Vutuv.MastodonApi.Presenter do
   # it is the value that tells a client the post is **not** for redistribution,
   # so it stops offering boost on something its author narrowed. Calling every
   # post `public` told clients the opposite.
-  defp visibility(_post, %{restricted?: restricted?}), do: audience(restricted?)
-  defp visibility(post, _no_engagement), do: audience(Posts.restricted?(post))
+  defp visibility(post, engagement), do: audience(restricted?(post, engagement))
+
+  # Read off the batched engagement where the page has one, so a timeline pays
+  # no query per post for what it already knows.
+  defp restricted?(_post, %{restricted?: restricted?}), do: restricted?
+  defp restricted?(post, _no_engagement), do: Posts.restricted?(post)
 
   defp audience(true), do: "private"
   defp audience(_open), do: "public"
@@ -756,8 +795,11 @@ defmodule Vutuv.MastodonApi.Presenter do
   is rendered exactly that way rather than handing out a link to something no
   reader may see yet.
   """
-  def media_attachment(%PostImage{} = image) do
-    attachment = post_attachment(image)
+  def media_attachment(%PostImage{} = image, viewer) do
+    # A pending upload belongs to its uploader alone, so its URLs are as
+    # credential-bound as a restricted post's (issue #1627) — and the loader
+    # fetching the preview is the same session-less one.
+    attachment = post_attachment(image, capability(image, viewer))
 
     if ImageScans.released?(image.moderation),
       do: attachment,
@@ -776,17 +818,31 @@ defmodule Vutuv.MastodonApi.Presenter do
   defp loaded_images(%Post{images: images}) when is_list(images), do: images
   defp loaded_images(_not_loaded), do: []
 
-  defp media_attachments(post) do
-    post |> Posts.released_images() |> Enum.map(&post_attachment/1)
+  defp media_attachments(post, engagement, context) do
+    # The capability is minted only where a bare image loader would otherwise be
+    # turned away: a post its author narrowed. A public post's photo stays a
+    # plain URL — it needs no credential, and a bearer URL that buys nothing is
+    # one more thing that can be shared. One per photo, since the token names
+    # the picture it opens.
+    viewer = if restricted?(post, engagement), do: context.viewer
+
+    post |> Posts.released_images() |> Enum.map(&post_attachment(&1, capability(&1, viewer)))
   end
 
-  defp post_attachment(%PostImage{} = image) do
+  defp post_attachment(%PostImage{} = image, query) do
+    attachment(image, image_url(image, "large", query), image_url(image, "feed", query))
+  end
+
+  # Mastodon's attachment entity, and the one place its shape is written: the
+  # two kinds of picture here differ in where their bytes come from, never in
+  # what a client is told about them.
+  defp attachment(image, url, preview_url, remote_url \\ nil) do
     %{
       id: image.id,
       type: "image",
-      url: image_url(image, "large"),
-      preview_url: image_url(image, "feed"),
-      remote_url: nil,
+      url: url,
+      preview_url: preview_url,
+      remote_url: remote_url,
       preview_remote_url: nil,
       text_url: nil,
       meta: %{original: %{width: image.width, height: image.height}},
@@ -795,8 +851,60 @@ defmodule Vutuv.MastodonApi.Presenter do
     }
   end
 
-  defp image_url(%PostImage{} = image, version),
+  # `nil` for anything but a member: `Vutuv.Posts.image_visible_to?/2` and
+  # `Vutuv.Fediverse.remote_image_visible?/2` both answer a `%User{}` and
+  # nothing else, so a capability naming a page identity would be one the proxy
+  # could never honour. Those readers keep today's plain URL, which is right for
+  # every public picture and a broken one for the rest — a narrower gap than
+  # handing out a credential that does not work.
+  defp capability(%PostImage{token: token}, %User{id: user_id}),
+    do: RemoteMediaToken.post_image_query(token, user_id)
+
+  defp capability(%RemoteImage{} = image, %User{id: user_id}),
+    do: RemoteMediaToken.remote_image_query(image.id, image.file, user_id)
+
+  defp capability(_image, _viewer), do: nil
+
+  # One version's URL, carrying the capability where there is one. `PostImage.url/2`
+  # may already end in the crop buster's own `?v=…`, so the capability is appended
+  # to that query rather than replacing it.
+  defp image_url(%PostImage{} = image, version, nil),
     do: MastodonApi.main_url(PostImage.url(image, version))
+
+  defp image_url(%PostImage{} = image, version, query) do
+    image
+    |> PostImage.url(version)
+    |> URI.parse()
+    |> URI.append_query(query)
+    |> to_string()
+    |> MastodonApi.main_url()
+  end
+
+  # The photographs on a post from another network (issue #1626). They exist,
+  # they are cached and the website renders them — the adapter simply never
+  # named them, so the same post showed its picture in a browser and none in an
+  # app. Every URL is the authorizing proxy's, never the origin's: the AI gate,
+  # the stored-file whitelist and the post's audience are all re-asked there. A
+  # client that follows `remote_url` instead reaches the origin server directly,
+  # which is its decision to make and not one we make for the reader.
+  defp remote_attachments(%RemotePost{} = post, context) do
+    context.remote_images
+    |> Map.get(post.id, [])
+    |> Enum.filter(&RemoteImage.released?/1)
+    |> Enum.map(&remote_attachment(&1, context.viewer))
+  end
+
+  defp remote_attachment(%RemoteImage{} = image, viewer) do
+    # One stored version, so the preview and the picture are the same file — a
+    # derived copy is all this installation keeps of somebody else's photograph.
+    url =
+      MastodonApi.main_url(
+        RemoteMedia.post_image_url(image.id, image.file),
+        capability(image, viewer)
+      )
+
+    attachment(image, url, url, image.source_uri)
+  end
 
   defp safe_html(value), do: value |> Safe.to_iodata() |> IO.iodata_to_binary()
 

--- a/lib/vutuv_web/controllers/mastodon_api/account_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/account_controller.ex
@@ -139,9 +139,14 @@ defmodule VutuvWeb.MastodonApi.AccountController do
           subject = conn.assigns.current_organization || conn.assigns.current_user
           {posts, _more?} = Fediverse.account_posts(account, subject)
 
+          # Through `statuses/2` like every other source here, not a bare
+          # `status/1` per row: that is what batches the photographs these posts
+          # carry (issue #1626). It costs nothing extra — the batches it runs
+          # short-circuit on a page holding no local post.
           posts
           |> Pagination.window(page, & &1.id)
-          |> Enum.map(fn post -> Presenter.status(%{post | remote_account: account}) end)
+          |> Enum.map(&%{&1 | remote_account: account})
+          |> Presenter.statuses(viewer(conn))
 
         _missing_or_unsupported ->
           []

--- a/lib/vutuv_web/controllers/mastodon_api/media_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/media_controller.ex
@@ -44,7 +44,10 @@ defmodule VutuvWeb.MastodonApi.MediaController do
     case own_media(conn, id) do
       %PostImage{} = image ->
         status = if Presenter.media_ready?(image), do: 200, else: 206
-        conn |> put_status(status) |> json(Presenter.media_attachment(image))
+
+        conn
+        |> put_status(status)
+        |> json(Presenter.media_attachment(image, conn.assigns.current_user))
 
       nil ->
         not_found(conn)
@@ -54,7 +57,13 @@ defmodule VutuvWeb.MastodonApi.MediaController do
   def update(conn, %{"id" => id} = params) do
     case own_media(conn, id) do
       %PostImage{} = image ->
-        json(conn, Presenter.media_attachment(describe(image, params["description"])))
+        json(
+          conn,
+          Presenter.media_attachment(
+            describe(image, params["description"]),
+            conn.assigns.current_user
+          )
+        )
 
       nil ->
         not_found(conn)
@@ -93,7 +102,9 @@ defmodule VutuvWeb.MastodonApi.MediaController do
       image = describe(image, params["description"])
       status = if Presenter.media_ready?(image), do: 200, else: ready_status
 
-      conn |> put_status(status) |> json(Presenter.media_attachment(image))
+      conn
+      |> put_status(status)
+      |> json(Presenter.media_attachment(image, conn.assigns.current_user))
     else
       {:error, :rate_limited} ->
         conn |> put_status(429) |> json(%{error: "Too many uploads"})

--- a/lib/vutuv_web/controllers/post_image_controller.ex
+++ b/lib/vutuv_web/controllers/post_image_controller.ex
@@ -16,23 +16,68 @@ defmodule VutuvWeb.PostImageController do
   (issue #1104), and it is closed unless the photo's author opened it for that
   photo. It is 404 by default, like everything else here — an unopened
   download and a nonexistent one look identical from outside.
+
+  **Two ways to say who is asking, one question asked of the answer** (issue
+  #1627). A browser brings the session. A phone app's image loader brings
+  neither cookie nor bearer — no header we could ask for would arrive — so
+  against the nil viewer it is, `Posts.visible_to?/2` was false for any post
+  carrying a denial and every photo on a restricted post was a broken image in
+  every client. So the Mastodon adapter mints a `VutuvWeb.RemoteMediaToken`
+  capability naming the member it rendered the status for, and that member is
+  the viewer here. The audience question itself is untouched and is still asked
+  per request: the capability says who is at the door, never that the door is
+  open, so narrowing the post shuts every URL already handed out.
   """
 
   use VutuvWeb, :controller
 
+  alias Vutuv.Accounts.User
   alias Vutuv.Posts
   alias Vutuv.Posts.PostImage
   alias VutuvWeb.ImageProxy
+  alias VutuvWeb.RemoteMediaToken
 
-  def show(conn, %{"token" => token, "version" => version_file}) do
+  def show(conn, %{"token" => token, "version" => version_file} = params) do
     with version when not is_nil(version) <- parse_version(version_file),
          image when not is_nil(image) <- Posts.get_image_by_token(token),
-         true <- Posts.image_visible_to?(image, conn.assigns[:current_user]) do
+         {source, viewer} <- reader(conn, params, token),
+         true <- source != :capability or served_version?(version),
+         true <- Posts.image_visible_to?(image, viewer) do
       serve(conn, image, version)
     else
       _ -> ImageProxy.not_found(conn)
     end
   end
+
+  # Who is asking, and how they said so. One viewer, so the audience question is
+  # asked exactly once — `image_visible_to?/2` looks the post up when it is not
+  # preloaded, and asking twice would pay for that twice. A signed-in browser
+  # never reaches the capability branch, and a request bringing nothing is the
+  # anonymous reader this proxy has always served public pictures to.
+  defp reader(conn, params, image_token) do
+    with nil <- conn.assigns[:current_user],
+         %User{} = member <-
+           params[RemoteMediaToken.param()]
+           |> RemoteMediaToken.post_image_viewer(image_token)
+           |> RemoteMediaToken.holder() do
+      {:capability, member}
+    else
+      %User{} = member -> {:session, member}
+      _nothing_brought -> {:anonymous, nil}
+    end
+  end
+
+  # **A capability opens the sizes a client renders, and only those.** The
+  # version segment is not in the signed subject — one capability opens the
+  # photo, not one file of it — so without this rule the three *derived* routes
+  # below come along with it, and `original.orig` is not a size: it is the
+  # full-resolution file, one swapped path segment away from any media URL that
+  # leaked. The adapter names none of the three, so closing them to a capability
+  # costs a client nothing.
+  #
+  # Only to a capability, though: `og.jpg` exists for link scrapers, which
+  # arrive anonymously and must go on being served a public post's preview.
+  defp served_version?(version), do: version in PostImage.versions()
 
   # "og.jpg" is the link-preview JPEG (og:image), derived on the fly rather
   # than stored; "original.orig" is the author-enabled full-resolution

--- a/lib/vutuv_web/controllers/remote_media_controller.ex
+++ b/lib/vutuv_web/controllers/remote_media_controller.ex
@@ -32,20 +32,24 @@ defmodule VutuvWeb.RemoteMediaController do
   is not an access control — it is a URL, and URLs get shared, logged and
   pasted. The check is in the action rather than in a router pipeline so it
   cannot be lost by a route moving scope: the routes sit in the plain
-  `:browser` scope, where nothing else would ask. `post_image/2` takes a
-  `%User{}` and nothing else; `avatar/2` takes one of two claims.
+  `:browser` scope, where nothing else would ask. Each action takes one of two
+  claims, and both resolve to a `%User{}` before any picture moves.
 
-  **The avatar's second claim is a signed capability.** A session is how a
-  *browser* proves it is a member, and the Mastodon adapter's readers are phone
-  apps whose image loader sends neither the cookie nor the bearer token the API
-  call beside it used. So the avatar action takes a
-  `VutuvWeb.RemoteMediaToken` as the equivalent claim — unforgeable, expiring,
-  and naming exactly the account and stored file it opens. Everything else on
-  the way in is unchanged and re-asked per request, so it widens *what* may be
-  seen by nothing; without it, v7.330.0 named every remote picture in an API
-  response at a URL no client could fetch. It does widen *who*, and the module
-  says how far. `post_image/2` has no such door because the adapter names no
-  remote attachment — see `VutuvWeb.RemoteMediaToken`.
+  **The second claim is a signed capability.** A session is how a *browser*
+  proves it is a member, and the Mastodon adapter's readers are phone apps whose
+  image loader sends neither the cookie nor the bearer token the API call beside
+  it used. So both actions take a `VutuvWeb.RemoteMediaToken` as the equivalent
+  claim — unforgeable, expiring, and naming exactly the stored file it opens.
+  Everything else on the way in is unchanged and re-asked per request, so it
+  widens *what* may be seen by nothing; without it, v7.330.0 named every remote
+  picture in an API response at a URL no client could fetch.
+
+  The two claims differ in what they carry, because the two pictures differ in
+  what they are. An avatar has no audience of its own, so its capability names
+  only the account and the file. A **photograph** carries the audience of the
+  post it hangs on (issue #1626), so its capability names the **member** the
+  adapter rendered it for, and `remote_image_visible?/2` is asked that member's
+  own question here like any other reader's.
 
   Both actions open on `Vutuv.Fediverse.enabled?/0`: switching federation off
   has to close the proxy too, or the pictures it cached go on being served
@@ -62,12 +66,20 @@ defmodule VutuvWeb.RemoteMediaController do
   alias VutuvWeb.ImageProxy
   alias VutuvWeb.RemoteMediaToken
 
-  def post_image(conn, %{"id" => id, "version" => version_file}) do
+  # Ordered by what each step costs, the way `avatar/2` below is: an anonymous
+  # caller bringing nothing unforgeable is turned away by the signature check
+  # before it can spend a query, and which member the capability names can only
+  # be settled once the row says which file this picture currently is.
+  def post_image(conn, %{"id" => id, "version" => version_file} = params) do
+    member? = match?(%User{}, conn.assigns[:current_user])
+    token = params[RemoteMediaToken.param()]
+
     with true <- Fediverse.enabled?(),
-         %User{} = viewer <- conn.assigns[:current_user],
+         true <- member? or RemoteMediaToken.authentic?(token),
          %RemoteImage{} = image <- Fediverse.get_remote_image(id),
          true <- RemoteImage.released?(image),
          version when not is_nil(version) <- parse_version(version_file, image.file),
+         %User{} = viewer <- reader(conn, token, image),
          true <- Fediverse.remote_image_visible?(image, viewer) do
       serve(conn, version,
         accel: &RemoteMedia.post_image_accel_path(image.id, &1),
@@ -76,6 +88,13 @@ defmodule VutuvWeb.RemoteMediaController do
     else
       _ -> ImageProxy.not_found(conn)
     end
+  end
+
+  defp reader(conn, token, %RemoteImage{} = image) do
+    conn.assigns[:current_user] ||
+      token
+      |> RemoteMediaToken.remote_image_viewer(image.id, image.file)
+      |> RemoteMediaToken.holder()
   end
 
   # An avatar has no per-post audience: it is the picture of an account

--- a/lib/vutuv_web/mastodon_api/streaming_socket.ex
+++ b/lib/vutuv_web/mastodon_api/streaming_socket.ex
@@ -20,6 +20,12 @@ defmodule VutuvWeb.MastodonApi.StreamingSocket do
   withdrawal *mid-connection*; the stream carries no private content of its own
   (every payload is a status the member may already read), so the exposure is
   the connection's lifetime, not the token's.
+
+  One thing a payload does carry past that lifetime is a picture's capability
+  (`VutuvWeb.RemoteMediaToken`), which outlives the socket by days. It is bound
+  to the member and re-checked against their standing and the picture's audience
+  on every image request, so a withdrawal reaches it there even though it cannot
+  reach it here.
   """
 
   @behaviour Phoenix.Socket.Transport

--- a/lib/vutuv_web/remote_media_token.ex
+++ b/lib/vutuv_web/remote_media_token.ex
@@ -18,9 +18,10 @@ defmodule VutuvWeb.RemoteMediaToken do
   only ever leaves the building inside an authenticated API response (every
   Mastodon route that renders an account sits behind `Plugs.MastodonApiAuth`;
   the few unauthenticated ones render no `%RemoteAccount{}`). And it widens
-  nothing else — the AI gate and the stored-file whitelist are re-asked on
-  every request, so a picture the gate takes back or a file that gets rotated
-  stops answering with the capability still in hand.
+  nothing else — the AI gate, the stored-file whitelist and (for a photograph) the
+  post's own audience are re-asked on every request, so a picture the gate takes
+  back, a file that gets rotated and a post whose audience narrows all stop
+  answering with the capability still in hand.
 
   **What it does widen is *who*, and it is a bearer URL: say so rather than
   claiming otherwise.** It names no member, no device and no access token, so
@@ -31,9 +32,9 @@ defmodule VutuvWeb.RemoteMediaToken do
   `Vutuv.MastodonApi.Presenter.account/2` is handed a row, never a viewer. The
   trade is deliberate and it is sized to what is behind the door — one cached
   copy of a public avatar that its own server serves to anybody who asks, held
-  here only because a member follows them. Do not reach for this shape for
-  anything a member would call private; `post_image/2`, whose pictures carry a
-  post's audience, keeps the session and must go on keeping it.
+  here only because a member follows them. Do not reach for *this* shape for
+  anything a member would call private — the photograph tags below carry a
+  post's audience and are bound to a member for exactly that reason.
 
   `signed_at` is pinned to the UTC day rather than to the moment, so a client
   is handed the same URL all day and its image cache keeps working. A
@@ -43,21 +44,30 @@ defmodule VutuvWeb.RemoteMediaToken do
   client may still be showing a cached timeline from, so the pinning can never
   hand out a capability that is already stale.
 
-  **Avatars only — and that is where the work stopped, not where the problem
-  ends.** Read the scope as two open gaps rather than as a boundary. The
-  proxy's other route serves a cached post's attachments and
-  `Vutuv.MastodonApi.Presenter.status/2` leaves `media_attachments` empty for a
-  `%RemotePost{}` and a `%Note{}`, so a capability there would be dead code
-  today — but only because a photo post from another network reaches a client
-  with no photo at all (issue #1626), and fixing that brings the identical 404
-  straight back. And the adapter *does* name local post photos, at
-  `/post_images/…`, which asks `Posts.image_visible_to?/2`: fine for a public
-  post, false for a restricted one against the nil viewer an image loader is,
-  so those are broken images in every client right now (issue #1627). The
-  subject is a tagged tuple so each of those is a second tag and a second pair
-  of heads here, not a second module.
+  **A photograph is not an avatar, so its capability names the member it was
+  minted for** (issues #1626 and #1627). The two picture tags added here open
+  files that carry a *post's* audience — a member's photo on a post they
+  narrowed, a photograph on a followers-only post cached from another network —
+  and the bearer trade above is not sized for those. So each of them carries the
+  id of the member the adapter rendered it for, and the proxy re-asks that
+  member's own audience question (`Vutuv.Posts.image_visible_to?/2`,
+  `Vutuv.Fediverse.remote_image_visible?/2`) on every request. A URL that leaves
+  the member's hands still opens the picture — it is a URL — but the moment the
+  author narrows the post, or takes the reader out of the audience, it stops
+  answering for everybody holding it. The avatar tag keeps its simpler shape
+  because it is sized for a public picture; do not copy *it* for anything else.
+
+  What that costs is one `users` row per image request on the capability path,
+  which is what the paragraph above said it would; the session path never pays
+  it. And it *is* a standing check, not only an audience one: `holder/1` asks
+  `Vutuv.Moderation.login_block/1` the way the session plug and the bearer
+  check do, so a suspension closes a photograph capability the same day it
+  closes everything else. Three tags, then, one clock and one salt.
   """
 
+  alias Vutuv.Accounts
+  alias Vutuv.Accounts.User
+  alias Vutuv.Moderation
   alias VutuvWeb.Endpoint
 
   @salt "remote media capability"
@@ -78,10 +88,8 @@ defmodule VutuvWeb.RemoteMediaToken do
   passes nothing and gets `bucket/0`.
   """
   def avatar_query(account_id, file, signed_at \\ bucket())
-      when is_binary(account_id) and is_binary(file) do
-    token = Phoenix.Token.sign(Endpoint, @salt, {:avatar, account_id, file}, signed_at: signed_at)
-    URI.encode_query(%{param() => token})
-  end
+      when is_binary(account_id) and is_binary(file),
+      do: sign_query({:avatar, account_id, file}, signed_at)
 
   @doc "How long a capability stays good, in seconds."
   def max_age, do: @max_age
@@ -98,10 +106,12 @@ defmodule VutuvWeb.RemoteMediaToken do
   the real check: only the row knows which file the account holds now.
   """
   def authentic?(token) when is_binary(token) do
-    match?(
-      {:ok, {:avatar, _account_id, _file}},
-      Phoenix.Token.verify(Endpoint, @salt, token, max_age: @max_age)
-    )
+    case verify(token) do
+      {:ok, {:avatar, _account_id, _file}} -> true
+      {:ok, {:post_image, _image_token, _user_id}} -> true
+      {:ok, {:remote_image, _image_id, _file, _user_id}} -> true
+      _not_ours -> false
+    end
   end
 
   def authentic?(_token), do: false
@@ -114,7 +124,7 @@ defmodule VutuvWeb.RemoteMediaToken do
   """
   def avatar?(token, account_id, file)
       when is_binary(token) and is_binary(account_id) and is_binary(file) do
-    case Phoenix.Token.verify(Endpoint, @salt, token, max_age: @max_age) do
+    case verify(token) do
       {:ok, {:avatar, ^account_id, ^file}} -> true
       _other -> false
     end
@@ -122,6 +132,86 @@ defmodule VutuvWeb.RemoteMediaToken do
 
   # nil is the ordinary case on the website, where the session answers instead.
   def avatar?(_token, _account_id, _file), do: false
+
+  @doc """
+  The capability for one **local** post photo, as the query string the adapter
+  appends to every version's URL.
+
+  Keyed on the image's own URL token rather than on a version, so the one
+  capability opens the sizes a client asks for; which member it opens them *as*
+  is the whole point, and `post_image_viewer/2` reads that back.
+  """
+  def post_image_query(image_token, user_id, signed_at \\ bucket())
+      when is_binary(image_token) and is_binary(user_id),
+      do: sign_query({:post_image, image_token, user_id}, signed_at)
+
+  @doc """
+  The id of the member `token` was minted for on exactly this post photo, or
+  `nil`. The caller asks that member's own audience question — the capability
+  says who is at the door, never that the door is open.
+  """
+  def post_image_viewer(token, image_token)
+      when is_binary(token) and is_binary(image_token) do
+    case verify(token) do
+      {:ok, {:post_image, ^image_token, user_id}} -> user_id
+      _other -> nil
+    end
+  end
+
+  def post_image_viewer(_token, _image_token), do: nil
+
+  @doc """
+  The same for a photograph cached from another network, pinned to the stored
+  file the way `avatar_query/3` is: a picture the gate rejects and re-fetches
+  stops answering at its old URL.
+  """
+  def remote_image_query(image_id, file, user_id, signed_at \\ bucket())
+      when is_binary(image_id) and is_binary(file) and is_binary(user_id),
+      do: sign_query({:remote_image, image_id, file, user_id}, signed_at)
+
+  @doc "The member `token` was minted for on exactly this cached photograph, or `nil`."
+  def remote_image_viewer(token, image_id, file)
+      when is_binary(token) and is_binary(image_id) and is_binary(file) do
+    case verify(token) do
+      {:ok, {:remote_image, ^image_id, ^file, user_id}} -> user_id
+      _other -> nil
+    end
+  end
+
+  def remote_image_viewer(_token, _image_id, _file), do: nil
+
+  @doc """
+  The member a `*_viewer` answer names, or `nil` — including for the `nil` those
+  functions return, so a caller reads as
+  `session_member || holder(post_image_viewer(...))`.
+
+  Here rather than in each proxy because it is the second half of one sentence:
+  a photograph's capability says who is knocking, and this is who that is. The
+  proxy then asks *its* picture's own audience question of them.
+
+  **It asks `Moderation.login_block/1` first, which is what keeps the answer
+  honest.** The other two doors into this application already do — the session
+  plug drops a suspended member's session and `Vutuv.ApiAuth` refuses their
+  bearer — and a capability that skipped it would be the one credential a
+  suspension does not reach: a member suspended over the very people whose
+  restricted photographs they hold URLs for would go on loading them until the
+  URL expired. The row is in hand by then, so the check is free.
+  """
+  def holder(user_id) when is_binary(user_id) do
+    case Accounts.get_user(user_id) do
+      %User{} = member -> if is_nil(Moderation.login_block(member)), do: member
+      nil -> nil
+    end
+  end
+
+  def holder(_no_capability), do: nil
+
+  defp sign_query(subject, signed_at) do
+    token = Phoenix.Token.sign(Endpoint, @salt, subject, signed_at: signed_at)
+    URI.encode_query(%{param() => token})
+  end
+
+  defp verify(token), do: Phoenix.Token.verify(Endpoint, @salt, token, max_age: @max_age)
 
   # The start of the current UTC day, in the seconds `Phoenix.Token` wants.
   defp bucket, do: div(System.os_time(:second), @bucket) * @bucket

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.342.7",
+      version: "7.342.8",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/controllers/mastodon_api/media_attachments_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/media_attachments_test.exs
@@ -1,0 +1,237 @@
+defmodule VutuvWeb.MastodonApi.MediaAttachmentsTest do
+  @moduledoc """
+  The photographs a Mastodon client is handed — issues #1626 and #1627.
+
+  Two halves of one complaint: a photo post from another network arrived as text
+  only, and a photo on a *restricted* vutuv post arrived as a broken image. Both
+  because a status is read by the app while its pictures are fetched by the
+  platform's image loader, which sends neither the session cookie nor the bearer
+  token the API call beside it used.
+
+  So every test here does the same two things: read the status through the API,
+  then fetch the URL it names **on a bare conn**, the way that loader would.
+  Asserting the URL alone would have passed all along.
+
+  Calibrated against the un-fixed adapter: drop `remote_attachments/2` or the
+  capability out of `Vutuv.MastodonApi.Presenter` and the matching test goes red.
+
+  `async: false` because it drives the rate-limited API endpoints.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Vutuv.MastodonHelpers
+
+  alias Vutuv.Fediverse.RemoteImage
+  alias Vutuv.Posts
+  alias Vutuv.RemoteMedia
+  alias Vutuv.Repo
+
+  setup do
+    Vutuv.RateLimiter.reset()
+
+    tmp = Path.join(System.tmp_dir!(), "vutuv_media_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp)
+    prev = Application.fetch_env(:vutuv, :uploads_dir_prefix)
+    Application.put_env(:vutuv, :uploads_dir_prefix, tmp)
+
+    on_exit(fn ->
+      File.rm_rf(tmp)
+
+      case prev do
+        {:ok, was} -> Application.put_env(:vutuv, :uploads_dir_prefix, was)
+        :error -> Application.delete_env(:vutuv, :uploads_dir_prefix)
+      end
+    end)
+
+    {:ok, tmp: tmp}
+  end
+
+  defp jpeg_bytes do
+    {:ok, image} = Image.new(8, 8, color: [10, 20, 30])
+    {:ok, bytes} = Image.write(image, :memory, suffix: ".jpg")
+    bytes
+  end
+
+  # A photograph on a cached post, written straight to disk: what is under test
+  # is whether the adapter names it, not how it got here.
+  defp remote_picture(post, attrs \\ %{}) do
+    row =
+      Repo.insert!(
+        struct(
+          %RemoteImage{
+            remote_post_id: post.id,
+            source_uri: "https://social.example/media/#{System.unique_integer([:positive])}.jpg",
+            position: 0,
+            alt: "Ein Bild von woanders.",
+            width: 800,
+            height: 600,
+            moderation: "approved"
+          },
+          attrs
+        )
+      )
+
+    {:ok, %{file: file}} = RemoteMedia.store_post_image(jpeg_bytes(), row.id)
+    Repo.update!(Ecto.Changeset.change(row, file: file))
+  end
+
+  defp local_photo_post(author, tmp, attrs) do
+    src = Path.join(tmp, "src-#{System.unique_integer([:positive])}.jpg")
+    {:ok, img} = Image.new(64, 64, color: [10, 200, 100])
+    {:ok, _} = Image.write(img, src)
+    {:ok, image} = Posts.create_pending_image(author, src, "photo.jpg")
+
+    {:ok, post} =
+      Posts.create_post(author, Map.merge(%{body: "Mit Foto", image_ids: [image.id]}, attrs))
+
+    {post, image}
+  end
+
+  # The status as a client reads it, and then its picture as that client's image
+  # loader fetches it — a bare conn, no cookie, no bearer.
+  defp attachment(conn, path) do
+    [attachment] =
+      conn
+      |> get(path)
+      |> json_response(200)
+      |> Map.fetch!("media_attachments")
+
+    attachment
+  end
+
+  defp fetch(url) do
+    %URI{path: path, query: query} = URI.parse(url)
+    get(build_conn(), path <> if(query, do: "?" <> query, else: ""))
+  end
+
+  describe "a photo post from another network" do
+    setup %{conn: conn} do
+      reader = federating_member()
+      post = cached_post(remote_account(), content_text: "Seht mal.")
+      image = remote_picture(post)
+
+      {:ok, conn: mastodon_conn(conn, mastodon_token(reader, ["read"])), post: post, image: image}
+    end
+
+    # Issue #1626: both remote heads built on `base_status/1`, which defaults
+    # `media_attachments: []`, and neither filled it — so the same post showed
+    # its picture in a browser and none in an app.
+    test "carries its photograph, and that URL loads for the client", ctx do
+      attachment = attachment(ctx.conn, "/api/v1/statuses/remote-#{ctx.post.id}")
+
+      assert attachment["type"] == "image"
+      assert attachment["description"] == "Ein Bild von woanders."
+      assert attachment["meta"]["original"] == %{"width" => 800, "height" => 600}
+      assert fetch(attachment["url"]).status == 200
+    end
+
+    # Mastodon's `remote_url` is the origin's own copy, which is the one thing
+    # a client may legitimately fetch past our proxy.
+    test "names the origin's own copy beside ours", ctx do
+      attachment = attachment(ctx.conn, "/api/v1/statuses/remote-#{ctx.post.id}")
+
+      assert attachment["remote_url"] == ctx.image.source_uri
+      refute attachment["url"] == ctx.image.source_uri
+    end
+
+    test "the same photograph reaches the timeline", ctx do
+      [status] = ctx.conn |> get("/api/v1/timelines/public?remote=true") |> json_response(200)
+
+      assert [%{"url" => url}] = status["media_attachments"]
+      assert fetch(url).status == 200
+    end
+
+    test "a picture the AI gate has not cleared is not named at all", ctx do
+      Repo.update!(Ecto.Changeset.change(ctx.image, moderation: "pending"))
+
+      status = ctx.conn |> get("/api/v1/statuses/remote-#{ctx.post.id}") |> json_response(200)
+
+      assert status["media_attachments"] == []
+    end
+  end
+
+  # A cached *reply* carries no pictures anywhere in this codebase — there is no
+  # note-image table and the inbox stores none. Pinned so the empty list reads as
+  # the answer it is rather than as the gap #1626 described.
+  describe "a cached reply from another network" do
+    test "names no photograph, because none is ever stored for one", %{conn: conn} do
+      author = federating_member()
+      {:ok, post} = Posts.create_post(author, %{body: "Die Wurzel"})
+      note = insert(:note, post: post)
+
+      conn = mastodon_conn(conn, mastodon_token(insert(:activated_user), ["read"]))
+      status = conn |> get("/api/v1/statuses/remote-note-#{note.id}") |> json_response(200)
+
+      assert status["media_attachments"] == []
+    end
+  end
+
+  describe "a photo on a restricted vutuv post" do
+    setup %{conn: conn, tmp: tmp} do
+      author = insert(:activated_user)
+      reader = insert(:activated_user)
+      follow!(reader, author)
+
+      {post, image} =
+        local_photo_post(author, tmp, %{denials: [%{"wildcard" => "non_followers"}]})
+
+      {:ok,
+       conn: mastodon_conn(conn, mastodon_token(reader, ["read"])),
+       author: author,
+       reader: reader,
+       post: post,
+       image: image}
+    end
+
+    # Issue #1627: the URL was named all along and answered 404, because the
+    # loader is a nil viewer and `visible_to?/2` is false for a post carrying a
+    # denial.
+    test "loads for the reader the status was rendered for", ctx do
+      attachment = attachment(ctx.conn, "/api/v1/statuses/#{ctx.post.id}")
+
+      assert fetch(attachment["url"]).status == 200
+      assert fetch(attachment["preview_url"]).status == 200
+    end
+
+    # What keeps the capability from being a key to the file: it names a member,
+    # and the audience is asked again of that member per request.
+    test "and stops loading once that reader leaves the audience", ctx do
+      attachment = attachment(ctx.conn, "/api/v1/statuses/#{ctx.post.id}")
+
+      Repo.delete_all(
+        from(f in Vutuv.Social.Follow,
+          where: f.follower_id == ^ctx.reader.id and f.followee_id == ^ctx.author.id
+        )
+      )
+
+      assert fetch(attachment["url"]).status == 404
+    end
+
+    # The plain URL is what the old adapter named, and it is still what a bare
+    # loader brings when it has no capability.
+    test "the bare URL alone is still refused", ctx do
+      assert fetch("/post_images/#{ctx.image.token}/large.avif").status == 404
+    end
+  end
+
+  describe "a photo on a public vutuv post" do
+    setup %{conn: conn, tmp: tmp} do
+      author = insert(:activated_user)
+      {post, image} = local_photo_post(author, tmp, %{})
+
+      {:ok,
+       conn: mastodon_conn(conn, mastodon_token(insert(:activated_user), ["read"])),
+       post: post,
+       image: image}
+    end
+
+    # A public photo needs no credential, so it is not given one: a bearer URL
+    # that buys nothing is one more thing that can be shared.
+    test "is named without a capability and loads anyway", ctx do
+      attachment = attachment(ctx.conn, "/api/v1/statuses/#{ctx.post.id}")
+
+      assert URI.parse(attachment["url"]).query == nil
+      assert fetch(attachment["url"]).status == 200
+    end
+  end
+end

--- a/test/vutuv_web/controllers/post_image_controller_test.exs
+++ b/test/vutuv_web/controllers/post_image_controller_test.exs
@@ -11,6 +11,7 @@ defmodule VutuvWeb.PostImageControllerTest do
   alias Vix.Vips.MutableImage
   alias Vutuv.Posts
   alias Vutuv.Repo
+  alias VutuvWeb.RemoteMediaToken
 
   @other_login_attrs %{
     "emails" => %{"0" => %{"value" => "other@example.com"}},
@@ -451,4 +452,139 @@ defmodule VutuvWeb.PostImageControllerTest do
                ["/internal_post_images/#{image.token}/large.avif"]
     end
   end
+
+  # Issue #1627: a phone app's image loader sends neither cookie nor bearer, so
+  # against the nil viewer it is, every photo on a *restricted* post was a
+  # broken image in every Mastodon client. The adapter now names it with a
+  # capability that says which member it was rendered for.
+  describe "a restricted post's photo, fetched the way an image loader fetches" do
+    setup %{tmp: tmp} do
+      author = insert(:user, email_confirmed?: true)
+
+      # `non_followers`, not `logged_out`: the point is a post closed to a
+      # *member*, which is what makes the capability's own member matter.
+      {post, image} =
+        post_with_image!(author, tmp, %{denials: [%{"wildcard" => "non_followers"}]})
+
+      %{author: author, post: post, image: image, path: "/post_images/#{image.token}/feed.avif"}
+    end
+
+    test "is refused when the request brings nothing at all", ctx do
+      assert get(build_conn(), ctx.path).status == 404
+    end
+
+    test "is served when the capability names a member who may read the post", ctx do
+      assert get(build_conn(), ctx.path <> "?" <> capability(ctx.image, ctx.author)).status == 200
+    end
+
+    # The whole reason the capability names a member rather than only the
+    # picture: it is not a key to the file, it is a way of saying who is
+    # knocking, and the audience question is asked again on every request.
+    test "stops answering the moment the author closes the post to that member", ctx do
+      stranger = insert(:user, email_confirmed?: true)
+      query = capability(ctx.image, stranger)
+
+      assert get(build_conn(), ctx.path <> "?" <> query).status == 404
+    end
+
+    # A member who was in the audience and is taken out of it: the URL they were
+    # handed has to stop working, which is exactly what a plain bearer
+    # capability could not do.
+    test "and once the reader is taken out of the audience", ctx do
+      reader = insert(:user, email_confirmed?: true)
+      follow = insert(:follow, follower: reader, followee: ctx.author)
+      query = capability(ctx.image, reader)
+
+      assert get(build_conn(), ctx.path <> "?" <> query).status == 200
+
+      Repo.delete!(follow)
+
+      assert get(build_conn(), ctx.path <> "?" <> query).status == 404
+    end
+
+    test "does not open another photo", ctx do
+      {_other_post, other} =
+        post_with_image!(ctx.author, ctx.tmp, %{denials: [%{"wildcard" => "non_followers"}]})
+
+      borrowed = capability(ctx.image, ctx.author)
+
+      assert get(build_conn(), "/post_images/#{other.token}/feed.avif?" <> borrowed).status == 404
+    end
+
+    test "is refused once it has expired", ctx do
+      stale =
+        RemoteMediaToken.post_image_query(
+          ctx.image.token,
+          ctx.author.id,
+          System.os_time(:second) - RemoteMediaToken.max_age() - 60
+        )
+
+      assert get(build_conn(), ctx.path <> "?" <> stale).status == 404
+    end
+
+    # The other end of the window: an expiry test alone stays green when
+    # `max_age:` is dropped from the verify, because signing bakes one in.
+    test "still opens the photo a day inside the window", ctx do
+      fresh =
+        RemoteMediaToken.post_image_query(
+          ctx.image.token,
+          ctx.author.id,
+          System.os_time(:second) - RemoteMediaToken.max_age() + 86_400
+        )
+
+      assert get(build_conn(), ctx.path <> "?" <> fresh).status == 200
+    end
+
+    test "a made-up capability is refused", ctx do
+      assert get(build_conn(), ctx.path <> "?t=not-a-token").status == 404
+    end
+
+    # The signed subject names the photo, not one file of it, so without an
+    # explicit rule the derived routes come along with the sizes — and
+    # `original.orig` is the full-resolution file, one swapped path segment away
+    # from any media URL that leaked.
+    test "does not open the full-resolution download", ctx do
+      Repo.update!(change(ctx.image, download_original: true))
+      query = capability(ctx.image, ctx.author)
+
+      assert get(build_conn(), "/post_images/#{ctx.image.token}/original.orig?" <> query).status ==
+               404
+    end
+
+    test "nor the link-preview JPEG, nor the author's uncropped workbench", ctx do
+      query = capability(ctx.image, ctx.author)
+
+      assert get(build_conn(), "/post_images/#{ctx.image.token}/og.jpg?" <> query).status == 404
+
+      assert get(build_conn(), "/post_images/#{ctx.image.token}/source.avif?" <> query).status ==
+               404
+    end
+
+    # Every other door drops a suspended member (the session plug, the bearer
+    # check); a capability that did not would be the one credential a suspension
+    # cannot reach.
+    test "stops answering once the member it names is suspended", ctx do
+      query = capability(ctx.image, ctx.author)
+      assert get(build_conn(), ctx.path <> "?" <> query).status == 200
+
+      Repo.update!(
+        change(ctx.author,
+          suspended_until: NaiveDateTime.add(NaiveDateTime.utc_now(:second), 86_400)
+        )
+      )
+
+      assert get(build_conn(), ctx.path <> "?" <> query).status == 404
+    end
+
+    test "and once they deactivate their account", ctx do
+      query = capability(ctx.image, ctx.author)
+
+      Repo.update!(change(ctx.author, deactivated_at: NaiveDateTime.utc_now(:second)))
+
+      assert get(build_conn(), ctx.path <> "?" <> query).status == 404
+    end
+  end
+
+  defp capability(image, user),
+    do: RemoteMediaToken.post_image_query(image.token, user.id)
 end

--- a/test/vutuv_web/controllers/remote_media_controller_test.exs
+++ b/test/vutuv_web/controllers/remote_media_controller_test.exs
@@ -297,6 +297,124 @@ defmodule VutuvWeb.RemoteMediaControllerTest do
     end
   end
 
+  # Issue #1626: the adapter names a cached photograph now, and the same
+  # session-less image loader fetches it. Unlike the avatar's, this capability
+  # names the member it was minted for, because the picture carries the
+  # audience of the post it hangs on.
+  describe "the photograph URL the Mastodon adapter hands a client" do
+    test "loads without a session", ctx do
+      image = picture(remote_post(ctx.account))
+
+      assert get(ctx.out, photo_path(image, ctx.user)).status == 200
+    end
+
+    test "is refused when the request brings nothing at all", ctx do
+      image = picture(remote_post(ctx.account))
+
+      assert get(ctx.out, media_url(image)).status == 404
+    end
+
+    test "is refused when the query carries something that is not one", ctx do
+      image = picture(remote_post(ctx.account))
+
+      assert get(ctx.out, media_url(image) <> "?t=not-a-token").status == 404
+    end
+
+    # The capability says who is knocking; the post's audience is asked again
+    # here, of that member, on every request.
+    test "does not open a followers-only post to a member with no follow", ctx do
+      image = picture(remote_post(ctx.account, "followers"))
+
+      assert get(ctx.out, photo_path(image, ctx.user)).status == 404
+    end
+
+    test "opens one to a member whose follow was accepted", ctx do
+      image = picture(remote_post(ctx.account, "followers"))
+      follow(ctx.user, ctx.account, "accepted")
+
+      assert get(ctx.out, photo_path(image, ctx.user)).status == 200
+    end
+
+    test "stops answering when the author narrows the post afterwards", ctx do
+      post = remote_post(ctx.account)
+      image = picture(post)
+      path = photo_path(image, ctx.user)
+
+      assert get(ctx.out, path).status == 200
+
+      Repo.update!(change(post, audience: "followers"))
+
+      assert get(ctx.out, path).status == 404
+    end
+
+    test "stops answering once the gate takes the picture back", ctx do
+      image = picture(remote_post(ctx.account))
+      path = photo_path(image, ctx.user)
+
+      Repo.update!(change(image, moderation: "pending"))
+
+      assert get(ctx.out, path).status == 404
+    end
+
+    test "does not open another photograph", ctx do
+      image = picture(remote_post(ctx.account))
+      other = picture(remote_post(ctx.account))
+      %URI{query: borrowed} = URI.parse(photo_path(image, ctx.user))
+
+      assert get(ctx.out, media_url(other) <> "?" <> borrowed).status == 404
+    end
+
+    test "is refused once it has expired", ctx do
+      image = picture(remote_post(ctx.account))
+
+      stale =
+        RemoteMediaToken.remote_image_query(
+          image.id,
+          image.file,
+          ctx.user.id,
+          System.os_time(:second) - RemoteMediaToken.max_age() - 60
+        )
+
+      assert get(ctx.out, media_url(image) <> "?" <> stale).status == 404
+    end
+
+    # The other end of the window: signing bakes a `max_age` in, so an expiry
+    # test alone stays green when `verify/4` loses its own.
+    test "still opens the photograph a day inside the window", ctx do
+      image = picture(remote_post(ctx.account))
+
+      fresh =
+        RemoteMediaToken.remote_image_query(
+          image.id,
+          image.file,
+          ctx.user.id,
+          System.os_time(:second) - RemoteMediaToken.max_age() + 86_400
+        )
+
+      assert get(ctx.out, media_url(image) <> "?" <> fresh).status == 200
+    end
+
+    test "stops answering once the member it names is suspended", ctx do
+      image = picture(remote_post(ctx.account))
+      path = photo_path(image, ctx.user)
+
+      assert get(ctx.out, path).status == 200
+
+      Repo.update!(
+        change(ctx.user,
+          suspended_until: NaiveDateTime.add(NaiveDateTime.utc_now(:second), 86_400)
+        )
+      )
+
+      assert get(ctx.out, path).status == 404
+    end
+  end
+
+  defp photo_path(image, user),
+    do:
+      media_url(image) <>
+        "?" <> RemoteMediaToken.remote_image_query(image.id, image.file, user.id)
+
   # The avatar URL as a client receives it, reduced to what ConnTest requests.
   defp adapter_path(%RemoteAccount{} = account),
     do: media_url(account) <> "?" <> capability(account)


### PR DESCRIPTION
**Symptom.** In a Mastodon client, a photo post from another network arrived as text only, and a photo on a *restricted* vutuv post was a broken image. Both because the app reads the status while the platform's image loader fetches the picture — with no cookie and no bearer.

**What changed.** `Presenter.status/2`'s `%RemotePost{}` head now names its cached photographs (batched per page, like every other surface here), and both kinds of photo URL carry a signed `RemoteMediaToken` capability. Unlike the avatar's, it names the **member** the status was rendered for: the proxy resolves them, refuses one a suspension has closed, and asks the picture's own audience question again on every request — so narrowing a post shuts every URL already handed out. Public photos get no capability, and a capability opens only the sizes a client renders (`original.orig`, `og.jpg` and the crop workbench stay session-only).

Not fixed here: inline body images in a status's `content` are still relative, credential-less URLs.

Closes #1626, closes #1627.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01Hu13sFQATdNUxiNGivBq2g
