### PR TITLE
The post body travels too (v7.342.9)

### DIFF
--- a/lib/vutuv/mastodon_api/presenter.ex
+++ b/lib/vutuv/mastodon_api/presenter.ex
@@ -302,7 +302,11 @@ defmodule Vutuv.MastodonApi.Presenter do
   defp status(%Post{} = post, context) do
     author = Posts.author(post)
     engagement = context.engagements[post.id]
-    content = post.body |> Markdown.render_post(loaded_images(post)) |> safe_html()
+    # The reader every picture on this post is named for, or nil where it needs
+    # no credential — which is every public post. Decided once: the body's
+    # inline copies and the attachments must reach the same file the same way.
+    photo_viewer = if restricted?(post, engagement), do: context.viewer
+    content = content_html(post, photo_viewer)
 
     fields =
       %{
@@ -312,7 +316,7 @@ defmodule Vutuv.MastodonApi.Presenter do
         url: MastodonApi.main_url(Posts.path(post)),
         uri: MastodonApi.main_url(Posts.path(post)),
         account: account(author),
-        media_attachments: media_attachments(post, engagement, context),
+        media_attachments: media_attachments(post, photo_viewer),
         visibility: visibility(post, engagement),
         language: post.language,
         edited_at: edited_at(post),
@@ -329,7 +333,7 @@ defmodule Vutuv.MastodonApi.Presenter do
     base_status(%{
       id: status_id(post),
       created_at: timestamp(post.published_at),
-      content: Markdown.render_remote(post.content_text || ""),
+      content: remote_content_html(post.content_text),
       url: post.origin_url || post.object_uri,
       uri: post.object_uri,
       account: account(post.remote_account),
@@ -348,7 +352,7 @@ defmodule Vutuv.MastodonApi.Presenter do
     base_status(%{
       id: status_id(note),
       created_at: timestamp(note.received_at),
-      content: Markdown.render_remote(note.content_text || ""),
+      content: remote_content_html(note.content_text),
       url: Note.origin(note),
       uri: note.object_uri,
       account: note_account(note),
@@ -809,23 +813,49 @@ defmodule Vutuv.MastodonApi.Presenter do
   @doc "Whether the scan has finished with this picture, either way."
   def media_ready?(%PostImage{} = image), do: ImageScans.released?(image.moderation)
 
-  # An unloaded association is truthy, so `post.images || []` survived the `||`
-  # and then failed `render_post/3`'s `is_list` guard, whose catch-all answers
-  # an empty body — a status with **no text at all**, silently. Every caller
-  # inside this adapter preloads, but `Vutuv.Search` does not, and the search
-  # endpoint duly served blank posts. A missing preload may cost the inline
-  # pictures; it must never cost the words.
-  defp loaded_images(%Post{images: images}) when is_list(images), do: images
-  defp loaded_images(_not_loaded), do: []
+  # **A body is served away from home too, so its own URLs have to travel**
+  # (issue #1647). The attachments were fixed first, but a client renders
+  # `content` as HTML and every URL the website's renderer writes into it is
+  # root-relative — an inline photo, an `@mention`, a `#hashtag` — so none of
+  # them resolves in an app, on a public post as much as a restricted one. The
+  # pictures take the same capability their attachments take, and the whole
+  # fragment is then absolutized against the main domain, the way the RSS item
+  # and the federated Note already are.
+  #
+  # `released_images/1` and not every loaded picture, the same set the
+  # attachments name: a client has no placecard for one still in the AI gate,
+  # so inlining it would only be a second broken image — and it would be handed
+  # a capability the proxy is going to refuse anyway. It is also what keeps a
+  # missing preload from costing the **words**: it answers `[]` for an unloaded
+  # association where `post.images || []` would hand `render_post/3` a
+  # `NotLoaded`, fail its `is_list` guard and silently render a status with no
+  # text at all (`Vutuv.Search` does not preload, and the search endpoint duly
+  # served blank posts once).
+  defp content_html(post, photo_viewer) do
+    post.body
+    |> Markdown.render_post(Posts.released_images(post),
+      image_query: &capability(&1, photo_viewer)
+    )
+    |> safe_html()
+    |> Markdown.absolutize_html(main_base())
+  end
 
-  defp media_attachments(post, engagement, context) do
-    # The capability is minted only where a bare image loader would otherwise be
-    # turned away: a post its author narrowed. A public post's photo stays a
-    # plain URL — it needs no credential, and a bearer URL that buys nothing is
-    # one more thing that can be shared. One per photo, since the token names
-    # the picture it opens.
-    viewer = if restricted?(post, engagement), do: context.viewer
+  # The same for a cached post or reply. It carries no picture of ours, but
+  # `render_remote/1` still writes our `#hashtag` and local-`@mention` links
+  # root-relative, and those resolve in an app no better than an image URL does.
+  defp remote_content_html(text),
+    do: text |> Kernel.||("") |> Markdown.render_remote() |> Markdown.absolutize_html(main_base())
 
+  # Every URL a client is handed points at the main domain, never at the API
+  # subdomain it is talking to: that is where the pictures and the profiles are.
+  defp main_base, do: MastodonApi.main_url("")
+
+  # The capability is minted only where a bare image loader would otherwise be
+  # turned away: a post its author narrowed. A public post's photo stays a plain
+  # URL — it needs no credential, and a bearer URL that buys nothing is one more
+  # thing that can be shared. One per photo, since the token names the picture
+  # it opens.
+  defp media_attachments(post, viewer) do
     post |> Posts.released_images() |> Enum.map(&post_attachment(&1, capability(&1, viewer)))
   end
 
@@ -868,15 +898,10 @@ defmodule Vutuv.MastodonApi.Presenter do
   # One version's URL, carrying the capability where there is one. `PostImage.url/2`
   # may already end in the crop buster's own `?v=…`, so the capability is appended
   # to that query rather than replacing it.
-  defp image_url(%PostImage{} = image, version, nil),
-    do: MastodonApi.main_url(PostImage.url(image, version))
-
   defp image_url(%PostImage{} = image, version, query) do
     image
     |> PostImage.url(version)
-    |> URI.parse()
-    |> URI.append_query(query)
-    |> to_string()
+    |> Markdown.append_query(query)
     |> MastodonApi.main_url()
   end
 

--- a/lib/vutuv_web/markdown.ex
+++ b/lib/vutuv_web/markdown.ex
@@ -125,11 +125,21 @@ defmodule VutuvWeb.Markdown do
   `mark_verified_author_links/2`. Omit it and nothing is marked, which is
   also what an installation with `:verify_user_links` off gets: no member
   has a verified link there, so the list is always empty.
+
+  `:image_query` (opts) is a `(image -> query | nil)` appended to each inline
+  picture's URL, for a caller serving this HTML where the reader brings no
+  session: the Mastodon adapter passes the same `VutuvWeb.RemoteMediaToken`
+  capability it puts on the attachments (issue #1647). Omit it and the
+  canonical URL stands, which is what the website wants — there the session
+  answers. It does **not** absolutize; a caller rendering into a standalone
+  context runs `absolutize_html/3` over the result, as RSS and the federated
+  Note do.
   """
   def render_post(text, images, opts \\ [])
 
   def render_post(text, images, opts) when is_binary(text) and is_list(images) do
-    {prepared, replacements} = extract_inline_images(text, images)
+    {prepared, replacements} =
+      extract_inline_images(text, images, Keyword.get(opts, :image_query))
 
     prepared
     |> render_pipeline(breaks: false)
@@ -898,15 +908,39 @@ defmodule VutuvWeb.Markdown do
   end
 
   @doc """
+  Appends `query` to a URL that may already have one, or hands it back unchanged
+  for a `nil` query.
+
+  Its reason to exist is the one URL in this application that arrives with a
+  query already on it: a cropped picture carries the cache-buster
+  `?v=<hash>` (`Vutuv.Posts.PostImage.url/2`), and a capability appended by
+  overwriting rather than joining would drop the buster and serve a year-cached
+  copy of the old frame. Shared with `Vutuv.MastodonApi.Presenter`, which puts
+  the same capability on the attachment URLs beside the body's.
+  """
+  def append_query(url, nil), do: url
+
+  def append_query(url, query),
+    do: url |> URI.parse() |> URI.append_query(query) |> to_string()
+
+  @doc """
   Rewrites root-relative `/path` URLs in rendered HTML to absolute `base/path`,
   for a standalone context (an RSS/JSON feed, a downloaded CV, a federated
   note). The negative lookahead leaves a protocol-relative `//host` URL alone:
   it already resolves, and prefixing it would corrupt it into `base//host`.
   `attrs` picks which URL attributes to rewrite (both `src` and `href` by
   default; the CV passes just `["href"]`). Shared by VutuvWeb.Feeds,
-  VutuvWeb.Fediverse.Docs and VutuvWeb.CV.Html so the tricky guard lives once.
+  VutuvWeb.Fediverse.Docs, VutuvWeb.CV.Html and the Mastodon adapter so the
+  tricky guard lives once.
+
+  A trailing slash on `base` is trimmed here rather than at each call site: this
+  appends its own, and `https://host//path` is a **protocol-relative** URL
+  naming a host called `path` — every picture in the document would quietly
+  point at somebody else's server. Callers spell the base three different ways,
+  so only one of them can guard it, and that is this one.
   """
   def absolutize_html(html, base, attrs \\ ["src", "href"]) do
+    base = String.trim_trailing(base, "/")
     String.replace(html, ~r{(#{Enum.join(attrs, "|")})="/(?!/)}, "\\1=\"#{base}/")
   end
 
@@ -1198,7 +1232,7 @@ defmodule VutuvWeb.Markdown do
   # Swaps every allowed `![alt](url)` for a plain-text marker and returns the
   # replacement <img> HTML per marker. The marker carries a per-render nonce,
   # so an author cannot type a literal marker that collides with a real one.
-  defp extract_inline_images(text, images) do
+  defp extract_inline_images(text, images, image_query) do
     allowed = allowed_srcs(images)
     nonce = marker_nonce()
 
@@ -1216,9 +1250,10 @@ defmodule VutuvWeb.Markdown do
 
         {image, canonical_src} ->
           marker = "VUTUVIMG#{nonce}N#{length(replacements)}END"
+          src = append_query(canonical_src, image_query && image_query.(image))
 
           {String.replace(text, full, marker, global: false),
-           [{marker, inline_img_html(canonical_src, alt, image, alignment)} | replacements]}
+           [{marker, inline_img_html(src, alt, image, alignment)} | replacements]}
       end
     end)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.342.10",
+      version: "7.342.11",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/controllers/api_v2/api_v2_test.exs
+++ b/test/vutuv_web/controllers/api_v2/api_v2_test.exs
@@ -152,9 +152,19 @@ defmodule VutuvWeb.ApiV2Test do
     # So the window is checked around the requests rather than asserted into. A
     # roll means the run was meaningless, not that the limiter is broken, and one
     # retry is enough: the three requests take milliseconds and cannot straddle
-    # two boundaries in a row. The retry needs no fresh token, because the rolled
-    # window gives the same key a clean bucket.
+    # two boundaries in a row.
+    #
+    # **The retry has to empty the bucket first, and that is the whole point of
+    # this line.** A roll leaves the requests made *after* it sitting in the new
+    # bucket — the very bucket the next attempt starts counting in — so with a
+    # limit of two, a roll between the first and second request left two hits
+    # behind and the retry's own first request was refused with a 429. The test
+    # then failed asserting `conn1.status == 200`, which reads as the limiter
+    # letting nothing through rather than as the retry poisoning itself. Seen on
+    # 2026-08-04 and again on 2026-08-24, both times on a branch that touches
+    # nothing in this path. The token may stay the same; only its count must go.
     defp three_requests(conn, plaintext, attempt \\ 1) do
+      Vutuv.RateLimiter.reset()
       before = current_window()
       conn1 = conn |> authed(plaintext) |> get("/api/2.0/me")
       build_conn() |> authed(plaintext) |> get("/api/2.0/me")

--- a/test/vutuv_web/controllers/mastodon_api/media_attachments_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/media_attachments_test.exs
@@ -22,7 +22,9 @@ defmodule VutuvWeb.MastodonApi.MediaAttachmentsTest do
   import Vutuv.MastodonHelpers
 
   alias Vutuv.Fediverse.RemoteImage
+  alias Vutuv.MastodonApi
   alias Vutuv.Posts
+  alias Vutuv.Posts.PostImage
   alias Vutuv.RemoteMedia
   alias Vutuv.Repo
 
@@ -81,10 +83,34 @@ defmodule VutuvWeb.MastodonApi.MediaAttachmentsTest do
     {:ok, _} = Image.write(img, src)
     {:ok, image} = Posts.create_pending_image(author, src, "photo.jpg")
 
-    {:ok, post} =
-      Posts.create_post(author, Map.merge(%{body: "Mit Foto", image_ids: [image.id]}, attrs))
+    # A body that references the photo inline, the way the composer writes one.
+    # Built here because it needs the image's URL, which only exists now.
+    body =
+      if attrs[:inline],
+        do: "Seht her:\n\n![Ein Foto](#{PostImage.url(image, "large")})",
+        else: "Mit Foto"
+
+    attrs = Map.merge(%{body: body, image_ids: [image.id]}, Map.delete(attrs, :inline))
+    {:ok, post} = Posts.create_post(author, attrs)
 
     {post, image}
+  end
+
+  defp content(conn, post) do
+    conn |> get("/api/v1/statuses/#{post.id}") |> json_response(200) |> Map.fetch!("content")
+  end
+
+  # The src as a client parses it: an attribute value is HTML, so a URL joining
+  # two query parameters arrives as `?v=…&amp;t=…` and only reads back as two
+  # parameters once the entities are decoded. Asserting on the raw attribute
+  # would pass on an uncropped photo and quietly fetch `amp;t` on a cropped one.
+  defp inline_src(html) do
+    case Regex.run(~r/<img[^>]*\bsrc="([^"]+)"/, html) do
+      # Only `&` can occur in one of our image URLs, and decoding it last is the
+      # rule that keeps a literal `&amp;amp;` from collapsing twice.
+      [_, src] -> String.replace(src, "&amp;", "&")
+      nil -> flunk("no inline <img> in: #{html}")
+    end
   end
 
   # The status as a client reads it, and then its picture as that client's image
@@ -211,6 +237,88 @@ defmodule VutuvWeb.MastodonApi.MediaAttachmentsTest do
     # loader brings when it has no capability.
     test "the bare URL alone is still refused", ctx do
       assert fetch("/post_images/#{ctx.image.token}/large.avif").status == 404
+    end
+  end
+
+  # Issue #1647: `media_attachments` was fixed first, but a client renders
+  # `content` as HTML, and every URL the website's renderer writes into it is
+  # root-relative — so the same photo referenced inline in the body stayed a
+  # broken image even where its attachment loaded.
+  describe "a photo referenced inline in the body" do
+    test "is an absolute URL that loads, on a public post", %{conn: conn, tmp: tmp} do
+      author = insert(:activated_user)
+      {post, image} = local_photo_post(author, tmp, %{inline: true})
+
+      conn = mastodon_conn(conn, mastodon_token(insert(:activated_user), ["read"]))
+      src = conn |> content(post) |> inline_src()
+
+      assert src == MastodonApi.main_url(PostImage.url(image, "large"))
+      assert fetch(src).status == 200
+    end
+
+    test "carries the capability on a restricted post, and loads with it", %{
+      conn: conn,
+      tmp: tmp
+    } do
+      author = insert(:activated_user)
+      reader = insert(:activated_user)
+      follow!(reader, author)
+
+      {post, image} =
+        local_photo_post(author, tmp, %{inline: true, denials: [%{"wildcard" => "non_followers"}]})
+
+      # Cropped, so the URL already carries the cache-buster the capability has
+      # to be joined to rather than replace — the case `append_query/2` exists
+      # for, and the one a bare `?t=` would silently break.
+      Repo.update!(Ecto.Changeset.change(image, crop: "0,0,32,32"))
+
+      conn = mastodon_conn(conn, mastodon_token(reader, ["read"]))
+      src = conn |> content(post) |> inline_src()
+
+      query = URI.decode_query(URI.parse(src).query)
+      assert Map.has_key?(query, "t")
+      assert Map.has_key?(query, "v")
+      assert fetch(src).status == 200
+    end
+
+    # `render_remote/1` writes our hashtag and local-mention links root-relative
+    # as well, so the two remote status heads had the same bug.
+    test "and a cached remote post's own links are absolute", %{conn: conn} do
+      tag = insert(:tag)
+      insert(:user_tag, user: insert(:activated_user), tag: tag)
+
+      post =
+        cached_post(remote_account(), content_text: "Von woanders zum ##{tag.slug}")
+
+      conn = mastodon_conn(conn, mastodon_token(federating_member(), ["read"]))
+
+      html =
+        conn
+        |> get("/api/v1/statuses/remote-#{post.id}")
+        |> json_response(200)
+        |> Map.fetch!("content")
+
+      assert html =~ ~s(href="#{MastodonApi.main_url("/tags/" <> tag.slug)}")
+      refute html =~ ~s(href="/)
+    end
+
+    # The body's other root-relative URLs are the same bug: a client cannot
+    # resolve them either.
+    test "and the body's mentions and hashtags are absolute too", %{conn: conn} do
+      author = insert(:activated_user)
+      named = insert(:activated_user, username: unique_username("inline"))
+      tag = insert(:tag)
+      insert(:user_tag, user: named, tag: tag)
+
+      {:ok, post} =
+        Posts.create_post(author, %{body: "Hallo @#{named.username} zum ##{tag.slug}"})
+
+      conn = mastodon_conn(conn, mastodon_token(insert(:activated_user), ["read"]))
+      html = content(conn, post)
+
+      assert html =~ ~s(href="#{MastodonApi.main_url("/" <> named.username)}")
+      assert html =~ ~s(href="#{MastodonApi.main_url("/tags/" <> tag.slug)}")
+      refute html =~ ~s(href="/)
     end
   end
 


### PR DESCRIPTION
**Symptom.** An image referenced inline in a post's Markdown body reached a Mastodon client as `<img src="/post_images/…">` — root-relative, no credential — so it was a broken image in every client, on public posts as much as restricted ones. The same renderer writes `@mention` and `#hashtag` links root-relative too, in all three status kinds.

**What changed.** `Markdown.render_post/3` takes an `:image_query`, and the adapter passes the same `RemoteMediaToken` capability it already puts on `media_attachments`; every rendered fragment then goes through the existing `absolutize_html/3`, the way the RSS item and the federated Note already did. The cached-post and cached-reply heads get the same treatment — their hashtag and local-mention links were relative as well.

Two smaller things fall out: `content` now names the same pictures the attachments do (`released_images/1`, so an image still in the AI gate is no longer inlined), and `absolutize_html/3` trims a trailing slash off its own base — `base <> "//host"` is protocol-relative and would have pointed every picture at somebody else's server.

Also de-flaked the rate-limit test in `api_v2_test.exs` (it blocked this push): on a window roll, the abandoned attempt's requests kept counting in the new bucket, so the retry refused its own first request with a 429.

Closes #1647.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01Hu13sFQATdNUxiNGivBq2g
