### PR TITLE
Send the picture after the post when the image scan finishes late

### DIFF
--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -8398,6 +8398,13 @@ defmodule Vutuv.Fediverse do
   # Nothing recorded: a post from before the records existed. The current
   # followers and the current Note id are a worse address than the real one, and
   # a much better one than silence.
+  # Whether this post was ever addressed to an inbox. The rows are written at
+  # enqueue time, so this says "we sent it somewhere", never "somebody received
+  # it" — enough for the one question it answers (issue #1585), since a post that
+  # was never enqueued has no remote copy to bring up to date.
+  defp addressed_anywhere?(post_id),
+    do: Repo.exists?(from(d in PostDelivery, where: d.post_id == ^post_id))
+
   defp fallback_targets(%User{} = user, %Post{} = post) do
     case recipients(user, post) do
       [] -> []
@@ -8482,10 +8489,34 @@ defmodule Vutuv.Fediverse do
 
   Nothing to do when a *second* picture on the same post is still pending: the
   post waits for the last one.
+
+  **Nothing queued any more means the scan came back too late** (issue #1585):
+  the ceiling ran out, the `Create` went to the followers carrying no
+  attachment, and its row was deleted on success. Nothing else ever revisits a
+  post, so the picture would never arrive — the release therefore falls back to
+  the `Update` an edit sends. That marks the remote copy as edited although the
+  author changed nothing, which is much the smaller loss of the two.
+
+  It is also the only thing that ever federates a **book review's cover**:
+  `Vutuv.Posts.ReviewCovers` fetches that in a task *after* the post has
+  committed, so the post is long gone by the time there is a cover to hold it
+  for and `Posts.awaiting_image_release?/1` never held it at all.
   """
   def images_settled(post_id) when is_binary(post_id) do
     if enabled?() and not Posts.awaiting_image_release?(post_id) do
-      release_held_deliveries(post_id)
+      # Asked before the release, so the Deliverer draining a row mid-call
+      # cannot read as "nothing was queued" and earn the post a second
+      # delivery. A row that is merely *due* has not been sent either, and it
+      # re-renders with the picture at send time.
+      #
+      # Post-level, so a post still retrying one inbox while the others already
+      # hold the attachment-less copy keeps the old behaviour for those. Closing
+      # that needs the per-inbox reading `revoke_post/1` does.
+      if Repo.exists?(held_deliveries(post_id)) do
+        release_held_deliveries(post_id)
+      else
+        update_delivered_post(post_id)
+      end
     end
 
     :ok
@@ -8493,16 +8524,42 @@ defmodule Vutuv.Fediverse do
 
   def images_settled(_post_id), do: :ok
 
+  # Every queued delivery built from this post, whether or not it is due yet.
+  defp held_deliveries(post_id) do
+    markers = Enum.map(["post_create", "post_update"], &"#{&1}:#{post_id}")
+    from(d in Delivery, where: d.rebuild_from in ^markers)
+  end
+
   defp release_held_deliveries(post_id) do
     now = DateTime.utc_now(:second)
-    markers = Enum.map(["post_create", "post_update"], &"#{&1}:#{post_id}")
 
-    {count, _} =
-      from(d in Delivery, where: d.rebuild_from in ^markers and d.next_attempt_at > ^now)
+    {nudged, _} =
+      post_id
+      |> held_deliveries()
+      |> where([d], d.next_attempt_at > ^now)
       |> Repo.update_all(set: [next_attempt_at: now])
 
-    if count > 0, do: Deliverer.nudge()
-    count
+    if nudged > 0, do: Deliverer.nudge()
+    :ok
+  end
+
+  # A post deleted while the scanner thought about it has nothing to bring up to
+  # date, and `federate_post_update/1` turns one whose audience closed in the
+  # meantime into the revocation instead — both of which are why this goes
+  # through the ordinary edit path rather than enqueueing an Update itself.
+  defp update_delivered_post(post_id) do
+    # `Repo.get/2` and not `Posts.get_post/1`: that one is the page-rendering
+    # loader (10 queries — screenshots, verified links, the author) where
+    # `maybe_federate/3` re-reads the author for itself and preloads exactly
+    # what the Note needs. A bare struct also sends `Posts.restricted?/1` to its
+    # forced-fresh clause, which is the reading we want for an audience that may
+    # have closed while the scanner was thinking.
+    with true <- addressed_anywhere?(post_id),
+         %Post{} = post <- Repo.get(Post, post_id) do
+      federate_post_update(post)
+    end
+
+    :ok
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.342.11",
+      version: "7.342.13",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/fediverse_image_hold_test.exs
+++ b/test/vutuv/fediverse_image_hold_test.exs
@@ -15,9 +15,11 @@ defmodule Vutuv.FediverseImageHoldTest do
 
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.Delivery
+  alias Vutuv.Fediverse.PostDelivery
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.Posts
   alias Vutuv.Posts.PostImage
+  alias Vutuv.ReviewCover
 
   setup do
     user = insert(:activated_user, fediverse_followers?: true)
@@ -61,7 +63,11 @@ defmodule Vutuv.FediverseImageHoldTest do
       release!(image)
       assert :ok == Fediverse.images_settled(post.id)
 
-      assert [%Delivery{next_attempt_at: due}] = Repo.all(Delivery)
+      # Still the one Create, pulled forward and still carrying its marker: it
+      # re-renders with the picture at send time. A second row here would mean
+      # the late-scan Update below had delivered the same post twice.
+      assert [%Delivery{next_attempt_at: due, rebuild_from: marker}] = Repo.all(Delivery)
+      assert marker == "post_create:#{post.id}"
       assert DateTime.compare(due, DateTime.utc_now()) != :gt
     end
 
@@ -128,6 +134,72 @@ defmodule Vutuv.FediverseImageHoldTest do
       # Guards against the hold and the renderer drifting apart: both ask this.
       assert ImageScans.released?("approved")
       refute ImageScans.released?("pending")
+    end
+  end
+
+  describe "a scan that settles after the post already federated (issue #1585)" do
+    test "sends the picture after it with an Update", %{user: user} do
+      post = insert(:post, user: user, body: "Mit Bild")
+      image = pending_image!(post)
+      assert :ok == Fediverse.federate_new_post(post)
+
+      # The hold ran out and the Create went to the follower: the queue row is
+      # deleted on success, and the PostDelivery record of where it went stays.
+      # That is exactly the state issue #1585 was reported from.
+      Repo.delete_all(Delivery)
+      assert Repo.aggregate(PostDelivery, :count) > 0
+
+      release!(image)
+      assert :ok == Fediverse.images_settled(post.id)
+
+      assert [%Delivery{} = delivery] = Repo.all(Delivery)
+      assert delivery.activity_json =~ ~s("type":"Update")
+      # The whole point: the follower that already has the text now gets the
+      # picture. Without the Update it never would - nothing else revisits a
+      # post whose scan came back late.
+      assert delivery.activity_json =~ PostImage.url(image, "large")
+    end
+
+    test "carries a book review's cover, which never federated before", %{user: user} do
+      # A cover is fetched in a task AFTER the post commits, so `cover_status`
+      # is still "pending" here and `awaiting_image_release?/1` never holds the
+      # post — the Create leaves without it and nothing used to follow.
+      post = insert(:post, user: user, body: "Ein Buch")
+      review = insert(:post_review, post: post, cover_status: "pending")
+
+      assert :ok == Fediverse.federate_new_post(post)
+      assert [%Delivery{rebuild_from: nil}] = Repo.all(Delivery)
+      Repo.delete_all(Delivery)
+
+      review
+      |> Ecto.Changeset.change(
+        cover_status: "ready",
+        cover: "cover.avif",
+        cover_moderation: "approved"
+      )
+      |> Repo.update!()
+
+      assert :ok == Fediverse.images_settled(post.id)
+
+      assert [%Delivery{} = delivery] = Repo.all(Delivery)
+      assert delivery.activity_json =~ ~s("type":"Update")
+      assert delivery.activity_json =~ ReviewCover.url(Repo.reload!(review))
+    end
+
+    test "stays silent for a post that never federated" do
+      # No followers, so `federate_new_post/1` enqueued nothing and recorded
+      # nothing. An Update here would be addressed at nobody.
+      lonely = insert(:activated_user, fediverse_followers?: true)
+      {:ok, _actor} = Fediverse.ensure_actor(lonely)
+      post = insert(:post, user: lonely, body: "Mit Bild")
+      image = pending_image!(post)
+
+      assert :skip == Fediverse.federate_new_post(post)
+
+      release!(image)
+      assert :ok == Fediverse.images_settled(post.id)
+
+      assert Repo.all(Delivery) == []
     end
   end
 


### PR DESCRIPTION
**Symptom:** a post with a photo reaches Mastodon without the photo (#1585).

**Cause:** the outgoing `Create` is held up to 90s while the AI scan judges the picture, then goes out regardless. A scan that finishes later finds the queue row already deleted, and nothing else ever revisits a post, so the picture never arrived.

**Change:** with no queued delivery left, `Vutuv.Fediverse.images_settled/1` now sends the `Update` an edit sends.

**Your call:** the remote copy gets marked "edited" although the author changed nothing. I judged that much smaller than a missing picture.

**Bonus:** this is the first thing that ever federates a book review's cover. `ReviewCovers` fetches it in a task after the post commits, so the hold never applied to it.

**Known limit:** post-level. One inbox still retrying while the others hold the attachment-less copy keeps the old behaviour.

Hot deploy, v7.342.13. Closes #1585.

*An AI agent wrote this text in my name. I know that is problematic.*