### PR TITLE
Resolve reshare and remote status ids on the endpoints that still 404ed

### DIFF
--- a/docs/architecture/mastodon-api.md
+++ b/docs/architecture/mastodon-api.md
@@ -276,8 +276,39 @@ wrapper keeps the **entry's** id (`boost-<uuid>`, `repost-<uuid>`), so a boost a
 the post it carries are two rows to a client and the pagination cursor is when
 the post was passed on rather than when it was written;
 `VutuvWeb.MastodonApi.Pagination.bare_id/1` reads the uuid back out of it and
-`StatusController.resolve_status/1` resolves it to the post underneath, the way
-Mastodon resolves a reblog id.
+`VutuvWeb.MastodonApi.Statuses.resolve/1` resolves it to the post underneath, the
+way Mastodon resolves a reblog id.
+
+**That grammar has exactly one owner**, and issue #1596 is what it cost when it
+had two. The resolver started life private to `StatusController`, so
+`/statuses/:id` read a reshare id while `ListController` still resolved with
+`Posts.get_post/1` alone: tapping the likers row of a reshare answered 404 for
+the id the timeline had just handed over. `Statuses.visible/2` is now the single answer to
+"which object is this, and may you read it" — the pairing and not just its
+halves, since spelling the two steps out per controller is what drifted. The
+report path (`POST /api/v1/reports` with `status_ids`) had the same gap and asks
+it too now; a cached remote object stays unreportable, because a report opens a
+case against something published here.
+
+**A reshare resolves to the post underneath for reads, and the writes are
+deliberately still refused.** The equivalence that makes a read correct makes a
+write dangerous, and in two ways. Resolving a `DELETE` on `repost-<uuid>` to the
+post would let the author of a post somebody boosted delete their own post by
+tapping delete on the boost. And routing it to the existing `:unreblog` action
+instead is not the fix either: `Vutuv.Posts.unrepost_post/2` takes an actor and a
+post and finds *the caller's* reshare of it, so a delete addressed at somebody
+else's row would quietly undo your own. Doing it properly means resolving the
+reshare **row** and checking who owns it, and the row is a different schema per
+prefix — `Vutuv.Posts.PostRepost`, `Vutuv.Fediverse.PostRepost`,
+`Vutuv.Fediverse.NoteRepost`, and `Vutuv.Fediverse.PostBoost`, which belongs to a
+remote account and can never be the caller's. Until that lands, `update`,
+`delete` and `source` keep answering 404 for a reshare id.
+
+**Who reacted is asked of a local post only.** `favourited_by` and
+`reblogged_by` answer the empty list for a cached remote object rather than the
+reactions this installation happens to hold: that slice is whatever reached us,
+and presenting it as the origin's answer would be a partial list dressed as a
+whole one.
 
 **A record from another network also arrives on its own, not only wrapped in a
 feed entry**, and for a while nothing rendered it that way:

--- a/lib/vutuv_web/controllers/mastodon_api/list_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/list_controller.ex
@@ -29,6 +29,7 @@ defmodule VutuvWeb.MastodonApi.ListController do
   alias Vutuv.Social
   alias Vutuv.UUIDv7
   alias VutuvWeb.MastodonApi.Pagination
+  alias VutuvWeb.MastodonApi.Statuses
 
   def bookmarks(conn, params), do: engaged(conn, params, &Posts.bookmarked_statuses/2)
   def favourites(conn, params), do: engaged(conn, params, &Posts.liked_statuses/2)
@@ -89,26 +90,25 @@ defmodule VutuvWeb.MastodonApi.ListController do
   # roundabout way of reading a restricted audience.
   defp reactors(conn, id, params, reader) do
     page = Pagination.params(params)
-    viewer = conn.assigns.current_organization || conn.assigns.current_user
 
-    case visible_post(id, viewer) do
+    case Statuses.visible(conn, id) do
       nil ->
         conn |> put_status(404) |> json(%{error: "Record not found"})
 
-      post ->
+      %Post{} = post ->
         accounts =
           post.id
           |> reader.(Pagination.opts(page))
           |> Enum.map(&Presenter.account/1)
 
         respond(conn, accounts, page)
-    end
-  end
 
-  defp visible_post(id, viewer) do
-    case Posts.get_post(id) do
-      %Post{} = post -> if Posts.visible_to?(post, viewer), do: post
-      nil -> nil
+      _cached_remote_object ->
+        # A cached copy of somebody else's status. Who reacted to it is the
+        # origin's answer, not ours, and the reactions this installation holds
+        # are only the slice that happened to reach it — so the honest answer is
+        # the empty list rather than a partial one presented as the whole.
+        respond(conn, [], page)
     end
   end
 

--- a/lib/vutuv_web/controllers/mastodon_api/profile_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/profile_controller.ex
@@ -23,8 +23,9 @@ defmodule VutuvWeb.MastodonApi.ProfileController do
   alias Vutuv.MastodonApi.Presenter
   alias Vutuv.Moderation
   alias Vutuv.Moderation.Report
-  alias Vutuv.Posts
+  alias Vutuv.Posts.Post
   alias Vutuv.UUIDv7
+  alias VutuvWeb.MastodonApi.Statuses
 
   def update_credentials(conn, params) do
     user = conn.assigns.current_user
@@ -95,12 +96,19 @@ defmodule VutuvWeb.MastodonApi.ProfileController do
 
   defp report_target(_conn, _params), do: {:error, :not_found}
 
+  # The same id grammar every other status reader uses (issue #1596): a client
+  # reports the status it is looking at, and the timeline hands it ids like
+  # `repost-<uuid>` and the `remote-` family, all of which `Posts.get_post/1`
+  # alone answered with `:not_found`. A cached remote object stays unreportable
+  # as it was — a report here opens a case against something published on this
+  # installation, and that is what `Vutuv.Moderation` knows how to act on.
   defp reported_status(conn, id) do
-    viewer = conn.assigns.current_user
+    case Statuses.resolve(id) do
+      %Post{} = post ->
+        if Statuses.visible?(conn, post), do: {:ok, post}, else: {:error, :not_allowed}
 
-    case Posts.get_post(id) do
-      nil -> {:error, :not_found}
-      post -> if Posts.visible_to?(post, viewer), do: {:ok, post}, else: {:error, :not_allowed}
+      _no_local_post ->
+        {:error, :not_found}
     end
   end
 

--- a/lib/vutuv_web/controllers/mastodon_api/status_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/status_controller.ex
@@ -11,6 +11,7 @@ defmodule VutuvWeb.MastodonApi.StatusController do
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias Vutuv.Repo
+  alias VutuvWeb.MastodonApi.Statuses
 
   # The empty conversation, in Mastodon's own shape — the honest answer
   # wherever there is nothing local to show.
@@ -41,26 +42,11 @@ defmodule VutuvWeb.MastodonApi.StatusController do
   # tells whoever asks that the object exists, which is the one thing a
   # followers-only cached post must not confirm, so no caller may skip the gate.
   defp with_visible_status(conn, id, fun) do
-    case resolve_status(id) do
-      nil ->
-        not_found(conn)
-
-      object ->
-        if status_visible?(conn, object), do: fun.(object), else: not_found(conn)
+    case Statuses.visible(conn, id) do
+      nil -> not_found(conn)
+      object -> fun.(object)
     end
   end
-
-  # Every id shape the client API mints, in one place. Order matters: the longer
-  # `remote-` prefixes have to be read before the bare one, or a cached reply
-  # would be looked up as a cached post.
-  defp resolve_status("remote-note-" <> id), do: Fediverse.get_note(id)
-  defp resolve_status("remote-reply-repost-" <> id), do: Fediverse.get_reposted_note(id)
-  defp resolve_status("remote-repost-" <> id), do: Fediverse.get_reposted_remote_post(id)
-  defp resolve_status("remote_repost-" <> id), do: Fediverse.get_reposted_remote_post(id)
-  defp resolve_status("remote-" <> id), do: Fediverse.get_remote_post(id)
-  defp resolve_status("boost-" <> id), do: Fediverse.get_boosted_object(id)
-  defp resolve_status("repost-" <> id), do: Posts.get_reposted_post(id)
-  defp resolve_status(id), do: Posts.get_post(id)
 
   def create(conn, %{"status" => body} = params) when is_binary(body) do
     with :ok <- validate_visibility(params["visibility"]),
@@ -209,7 +195,7 @@ defmodule VutuvWeb.MastodonApi.StatusController do
   # local answer to this reply lives in the parent's thread and is read there.
   defp context_payload(conn, %Note{} = note) do
     with %Post{} = parent <- Repo.get(Post, note.post_id),
-         true <- status_visible?(conn, parent) do
+         true <- Statuses.visible?(conn, parent) do
       # Seeded at the parent **inclusive**: the reply is the focus, so the post
       # it hangs under is its youngest ancestor rather than the start of a walk.
       ancestors_above(conn, parent, parent.id)
@@ -288,7 +274,7 @@ defmodule VutuvWeb.MastodonApi.StatusController do
   # that replies while looking at a reshare answers the post rather than being
   # told the status does not exist.
   defp create_reply(user, id, attrs) do
-    case resolve_status(id) do
+    case Statuses.resolve(id) do
       %Note{} = note -> Posts.create_remote_reply(user, note, attrs)
       %RemotePost{} = post -> Posts.create_remote_post_reply(user, post, attrs)
       %Post{} = post -> Posts.create_reply(user, post, attrs)
@@ -431,31 +417,7 @@ defmodule VutuvWeb.MastodonApi.StatusController do
 
   defp action_error(_reason), do: "The status action could not be completed."
 
-  defp note_visible?(%{assigns: %{current_organization: nil, current_user: user}}, note),
-    do: Fediverse.note_readable?(note, user)
-
-  defp note_visible?(_conn, note), do: Note.public?(note)
-
-  defp remote_post_visible?(%{assigns: %{current_organization: nil, current_user: user}}, post),
-    do: Fediverse.remote_post_readable?(post, user)
-
-  defp remote_post_visible?(%{assigns: %{current_organization: organization}}, post) do
-    RemotePost.open?(post) or
-      match?(
-        %{state: "accepted"},
-        Fediverse.remote_follow_for(organization, post.remote_account)
-      )
-  end
-
-  defp status_visible?(conn, %Note{} = note), do: note_visible?(conn, note)
-  defp status_visible?(conn, %RemotePost{} = post), do: remote_post_visible?(conn, post)
-
-  defp status_visible?(conn, %Post{} = post) do
-    subject = conn.assigns.current_organization || conn.assigns.current_user
-    Posts.visible_to?(post, subject)
-  end
-
-  defp viewer(conn), do: conn.assigns.current_organization || conn.assigns.current_user
+  defp viewer(conn), do: Statuses.viewer(conn)
 
   defp own_post(conn, id) do
     case {conn.assigns.current_organization, conn.assigns.current_user.id, Posts.get_post(id)} do
@@ -548,7 +510,7 @@ defmodule VutuvWeb.MastodonApi.StatusController do
     posts
     |> Enum.map(& &1.id)
     |> Fediverse.answered_objects()
-    |> Map.filter(fn {_post_id, object} -> status_visible?(conn, object) end)
+    |> Map.filter(fn {_post_id, object} -> Statuses.visible?(conn, object) end)
   end
 
   # One borrowed node per entry, as `{record, id it answers}`.
@@ -582,7 +544,7 @@ defmodule VutuvWeb.MastodonApi.StatusController do
 
     with %RemotePost{} = parent <- Fediverse.remote_parent_post(post),
          false <- MapSet.member?(seen, parent.id),
-         true <- status_visible?(conn, parent) do
+         true <- Statuses.visible?(conn, parent) do
       remote_ancestors(conn, parent, [parent | acc], seen)
     else
       _end_of_chain -> acc

--- a/lib/vutuv_web/mastodon_api/statuses.ex
+++ b/lib/vutuv_web/mastodon_api/statuses.ex
@@ -1,0 +1,99 @@
+defmodule VutuvWeb.MastodonApi.Statuses do
+  @moduledoc """
+  Turning a status id a client sent into the object it names, and deciding
+  whether the asker may read it.
+
+  One owner for the whole grammar, because more than one controller asks the
+  same question — and issue #1596 is what it costs when they answer it apart.
+  `Vutuv.MastodonApi.Presenter` hands a client `repost-<uuid>`, `boost-<uuid>`
+  and the `remote-` family as status ids in their own right (issue #1588);
+  `VutuvWeb.MastodonApi.StatusController` learned to read them and
+  `VutuvWeb.MastodonApi.ListController` kept resolving with
+  `Vutuv.Posts.get_post/1` alone. So `/statuses/:id` answered a reshare's id
+  while `/statuses/:id/favourited_by` 404ed on the very id the timeline had just
+  handed over.
+
+  **A reshare resolves to what it passed on**, which is what Mastodon does with
+  a reblog id: reading a reshare is reading the post underneath.
+
+  That equivalence holds for **reads only**, and the writes are deliberately not
+  routed through here yet. A `DELETE` on `repost-<uuid>` must undo that one
+  reshare, and the object this hands back cannot say whose reshare it was:
+  `Vutuv.Posts.unrepost_post/2` would find *the caller's* reshare of the same
+  post, so a delete addressed at somebody else's row would quietly undo your own.
+  Answering that properly needs the reshare **row**, and the row is a different
+  schema per prefix (`Vutuv.Posts.PostRepost`, `Vutuv.Fediverse.PostRepost`,
+  `Vutuv.Fediverse.NoteRepost`, and `Vutuv.Fediverse.PostBoost`, which belongs to
+  a remote account and can never be the caller's). Until that lands, `update`,
+  `delete` and `source` keep refusing a reshare id.
+
+  A third home for the same vocabulary is `VutuvWeb.MastodonApi.Pagination`'s
+  `@id_prefixes`, which strips these words to get at the uuid underneath.
+  """
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Note
+  alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.Posts
+  alias Vutuv.Posts.Post
+
+  @doc """
+  The object a status id names, or `nil` when it names nothing.
+
+  Order matters: the longer `remote-` prefixes have to be read before the bare
+  one, or a cached reply would be looked up as a cached post.
+  """
+  def resolve("remote-note-" <> id), do: Fediverse.get_note(id)
+  def resolve("remote-reply-repost-" <> id), do: Fediverse.get_reposted_note(id)
+  def resolve("remote-repost-" <> id), do: Fediverse.get_reposted_remote_post(id)
+  def resolve("remote_repost-" <> id), do: Fediverse.get_reposted_remote_post(id)
+  def resolve("remote-" <> id), do: Fediverse.get_remote_post(id)
+  def resolve("boost-" <> id), do: Fediverse.get_boosted_object(id)
+  def resolve("repost-" <> id), do: Posts.get_reposted_post(id)
+  def resolve(id), do: Posts.get_post(id)
+
+  @doc """
+  The object `id` names **if the asker may read it**, otherwise `nil`.
+
+  The pairing and not just its halves, because the pairing is what drifted:
+  resolving and gating were two steps each controller spelled for itself, and
+  `ListController` got the first one wrong for every id shape but the bare one. A
+  caller that asks this cannot forget either half.
+  """
+  def visible(conn, id) do
+    case resolve(id) do
+      nil -> nil
+      object -> if visible?(conn, object), do: object
+    end
+  end
+
+  @doc """
+  Whether the identity behind `conn` may read this object.
+
+  Answering 200 to any id that merely resolves tells whoever asks that the
+  object exists, which is the one thing a followers-only cached post must not
+  confirm — so no caller may skip this.
+  """
+  def visible?(conn, %Note{} = note), do: note_visible?(conn, note)
+  def visible?(conn, %RemotePost{} = post), do: remote_post_visible?(conn, post)
+  def visible?(conn, %Post{} = post), do: Posts.visible_to?(post, viewer(conn))
+
+  @doc "The member or page acting on this request."
+  def viewer(conn), do: conn.assigns.current_organization || conn.assigns.current_user
+
+  defp note_visible?(%{assigns: %{current_organization: nil, current_user: user}}, note),
+    do: Fediverse.note_readable?(note, user)
+
+  defp note_visible?(_conn, note), do: Note.public?(note)
+
+  defp remote_post_visible?(%{assigns: %{current_organization: nil, current_user: user}}, post),
+    do: Fediverse.remote_post_readable?(post, user)
+
+  defp remote_post_visible?(%{assigns: %{current_organization: organization}}, post) do
+    RemotePost.open?(post) or
+      match?(
+        %{state: "accepted"},
+        Fediverse.remote_follow_for(organization, post.remote_account)
+      )
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.342.14",
+      version: "7.342.16",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/controllers/mastodon_api/reshare_status_ids_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/reshare_status_ids_test.exs
@@ -1,0 +1,151 @@
+defmodule VutuvWeb.MastodonApi.ReshareStatusIdsTest do
+  @moduledoc """
+  A reshare is a status of its own to a Mastodon client (issue #1588), so a
+  client hands `repost-<uuid>` and the `remote-` family back to endpoints that
+  were still resolving ids with `Vutuv.Posts.get_post/1` alone (issue #1596).
+  `/statuses/:id` had learned the grammar and its neighbours had not, so tapping
+  a reshare's likers row answered 404 for the very id the timeline had just
+  handed over — and reporting such a status failed the same way.
+
+  The writes (`update`, `delete`, `source`) deliberately still refuse a reshare
+  id; see `VutuvWeb.MastodonApi.Statuses` for what undoing one properly needs.
+
+  async: false — `mastodon_token/2` flips the member's client permission.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Vutuv.MastodonHelpers
+
+  alias Vutuv.Posts
+  alias Vutuv.Posts.PostRepost
+  alias Vutuv.Repo
+
+  setup do
+    author = insert(:activated_user)
+    resharer = insert(:activated_user)
+    liker = insert(:activated_user)
+
+    {:ok, post} = Posts.create_post(author, %{body: "Weitergereicht"})
+    :ok = Posts.like_post(liker, post)
+    Posts.repost_post(resharer, post)
+
+    repost = Repo.get_by!(PostRepost, post_id: post.id, user_id: resharer.id)
+
+    %{
+      author: author,
+      resharer: resharer,
+      liker: liker,
+      post: post,
+      reshare_id: "repost-#{repost.id}"
+    }
+  end
+
+  defp api(conn, user, scopes), do: mastodon_conn(conn, mastodon_token(user, scopes))
+
+  describe "reads addressed at a reshare's id" do
+    test "favourited_by answers the underlying post's likers", ctx do
+      accounts =
+        build_conn()
+        |> api(ctx.resharer, ["read"])
+        |> get("/api/v1/statuses/#{ctx.reshare_id}/favourited_by")
+        |> json_response(200)
+
+      assert Enum.map(accounts, & &1["id"]) == [ctx.liker.id]
+    end
+
+    test "reblogged_by answers the underlying post's resharers", ctx do
+      accounts =
+        build_conn()
+        |> api(ctx.resharer, ["read"])
+        |> get("/api/v1/statuses/#{ctx.reshare_id}/reblogged_by")
+        |> json_response(200)
+
+      assert Enum.map(accounts, & &1["id"]) == [ctx.resharer.id]
+    end
+
+    test "a cached remote status answers an empty list, not a 404", ctx do
+      # Who reacted to somebody else's status is the origin's answer. What this
+      # installation holds is only the slice that reached it, so the honest
+      # reply is nothing at all — but the id must still resolve.
+      remote = cached_post(remote_account())
+
+      accounts =
+        build_conn()
+        |> api(ctx.resharer, ["read"])
+        |> get("/api/v1/statuses/remote-#{remote.id}/favourited_by")
+        |> json_response(200)
+
+      assert accounts == []
+    end
+
+    test "an id naming nothing is still a 404", ctx do
+      build_conn()
+      |> api(ctx.resharer, ["read"])
+      |> get("/api/v1/statuses/repost-#{Vutuv.UUIDv7.generate()}/favourited_by")
+      |> json_response(404)
+    end
+
+    test "a post the asker may not read still answers 404", ctx do
+      # The gate survived the move to the shared resolver. Deliberately a plain
+      # post and not a reshare of one: a restricted post can never carry a
+      # reshare, because the audience lock refuses to narrow a post once one
+      # exists, so there is no such thing as a reshare id pointing at a post
+      # somebody is denied.
+      stranger = insert(:activated_user)
+
+      {:ok, closed} =
+        Posts.create_post(ctx.author, %{
+          body: "Nicht für alle",
+          denials: [%{"wildcard" => "non_followers"}]
+        })
+
+      build_conn()
+      |> api(stranger, ["read"])
+      |> get("/api/v1/statuses/#{closed.id}/favourited_by")
+      |> json_response(404)
+    end
+  end
+
+  describe "reporting a status by a reshare's id" do
+    test "opens a case against the post underneath", ctx do
+      reporter = insert(:activated_user)
+
+      build_conn()
+      |> api(reporter, ["read", "write"])
+      |> post("/api/v1/reports", %{
+        "account_id" => ctx.author.id,
+        "status_ids" => [ctx.reshare_id]
+      })
+      |> json_response(200)
+
+      # The case names the post underneath, not the reshare row.
+      assert Repo.exists?(
+               from(c in Vutuv.Moderation.Case,
+                 where: c.content_type == "post" and c.content_id == ^ctx.post.id
+               )
+             )
+    end
+  end
+
+  describe "writes addressed at a reshare's id" do
+    test "an edit is refused, and the post keeps its words", ctx do
+      build_conn()
+      |> api(ctx.resharer, ["read", "write"])
+      |> put("/api/v1/statuses/#{ctx.reshare_id}", %{"status" => "Übernommen"})
+
+      assert Posts.get_post(ctx.post.id).body == "Weitergereicht"
+    end
+
+    test "a delete never reaches the post underneath", ctx do
+      # The case worth being careful about: the author owns the post this id
+      # resolves to, so a delete routed through the read resolver would take the
+      # original down instead of the reshare.
+      build_conn()
+      |> api(ctx.author, ["read", "write"])
+      |> delete("/api/v1/statuses/#{ctx.reshare_id}")
+
+      assert Posts.get_post(ctx.post.id)
+      assert Repo.get_by(PostRepost, post_id: ctx.post.id, user_id: ctx.resharer.id)
+    end
+  end
+end


### PR DESCRIPTION
**Symptom:** `GET /api/v1/statuses/repost-<uuid>/favourited_by` → 404, on an id the timeline had just handed the client (#1596). Reporting such a status failed the same way.

**Cause:** `Presenter` mints `repost-`/`boost-`/`remote-` ids, but only `StatusController` could read them. `ListController` and the report path resolved with `Posts.get_post/1` alone.

**Change:** `VutuvWeb.MastodonApi.Statuses` owns the grammar, and `Statuses.visible/2` owns resolve-and-gate as one call — spelling those two steps out per controller is what drifted. A cached remote status now answers `[]` rather than 404; who reacted to it is the origin's answer, not ours.

**What I left out, and why it's your call:** `update`, `delete` and `source` still refuse a reshare id. I built the delete first and it was wrong — `unrepost_post/2` finds *the caller's* reshare of that post, so a delete addressed at someone else's row would quietly undo your own. Doing it right needs the reshare row's owner, and that's four schemas (`Posts.PostRepost`, `Fediverse.PostRepost`, `NoteRepost`, `PostBoost` — which a member can never own). That's the "decide semantics first" the issue asked for.

Hot deploy, v7.342.16.

*An AI agent wrote this text in my name. I know that is problematic.*