### PR TITLE
Browser notifications when vutuv is open but not in front (#1249)

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -332,6 +332,68 @@ const MarkdownEditor = {
 // TagInput is the pill box on every tag field (see the sweep below, which
 // serves the same component on classic pages). LocalTime localizes timestamps
 // (see above). ScrollBottom follows a chat thread's newest message.
+// Browser notifications (issue #1249). Shared by the `WebNotify` hook (the
+// prompt in the shell) and the card on /settings/notifications, because both
+// answer the same question about the same browser.
+//
+// The account stores whether the member wants notifications; only the browser
+// knows whether it will actually show one, and that answer belongs to one
+// browser profile - which is why a member who switches the feature on at their
+// desk still has to say yes on their laptop.
+//
+// `Notification.permission` is "default" (never asked), "granted" or "denied";
+// a browser with no Notifications API at all is a fourth case, and reading it
+// as "denied" would tell somebody to go fix a browser setting that does not
+// exist.
+const NOTIFY_PROMPT_KEY = "vutuv:notify-prompt-dismissed"
+
+function notifyPermission() {
+  return "Notification" in window ? Notification.permission : "unsupported"
+}
+
+// Both sides wrap the store: a private window, or a browser set to block site
+// data, throws on access. Forgetting a dismissal simply offers the prompt
+// again, which is the right way to fail.
+function notifyPromptDismissed() {
+  try {
+    return window.localStorage.getItem(NOTIFY_PROMPT_KEY) === "1"
+  } catch (_e) {
+    return false
+  }
+}
+
+function setNotifyPromptDismissed(dismissed) {
+  try {
+    if (dismissed) window.localStorage.setItem(NOTIFY_PROMPT_KEY, "1")
+    else window.localStorage.removeItem(NOTIFY_PROMPT_KEY)
+  } catch (_e) {}
+}
+
+// Must run inside a real click: Firefox and Safari refuse the request without
+// a user gesture, and Chrome quietly downgrades a page-load prompt. Whatever
+// the answer - including a refusal, and including a browser with no API at all
+// - it ends in one `vutuv:notify-permission` event, which is how both the
+// prompt and the settings card re-read the state without knowing about each
+// other. Both the promise and the legacy callback form are handled.
+function requestNotifyPermission() {
+  const finish = () => window.dispatchEvent(new CustomEvent("vutuv:notify-permission"))
+
+  if (!("Notification" in window)) return finish()
+
+  try {
+    const result = Notification.requestPermission(finish)
+    if (result && typeof result.then === "function") result.then(finish, finish)
+  } catch (_e) {
+    finish()
+  }
+}
+
+// One delegated listener for both surfaces: the shell's prompt bar and the
+// settings card offer the same button, and neither needs its own copy.
+document.addEventListener("click", (event) => {
+  if (event.target.closest("[data-notify-allow]")) requestNotifyPermission()
+})
+
 const Hooks = {
   MarkdownEditor,
   TagInput,
@@ -483,6 +545,104 @@ const Hooks = {
     destroyed() {
       document.removeEventListener("visibilitychange", this.onVisibility)
       if (this.observer) this.observer.disconnect()
+    },
+  },
+  // Browser notifications (issue #1249): a popup for activity that arrives while
+  // the member is not looking at vutuv. ShellLive pushes a finished, translated
+  // line as "notify:show" whenever the member switched the feature on; this hook
+  // owns the two questions the server cannot answer.
+  //
+  // (1) Is the member looking at vutuv right now? `document.hidden` alone is too
+  // narrow: it is false for a vutuv tab that is frontmost in a window sitting
+  // behind the editor somebody is actually working in, which is the case the
+  // issue is about. So "away" is hidden OR unfocused.
+  //
+  // (2) Did THIS browser grant permission? The switch lives on the account and
+  // follows the member to every machine; the permission belongs to one browser
+  // profile and has to be asked for from a real click - Firefox and Safari
+  // refuse `requestPermission()` without a user gesture, so an automatic prompt
+  // on page load would be denied outright. Hence the server-rendered prompt
+  // inside this element, shown only where the browser has never been asked.
+  WebNotify: {
+    mounted() {
+      this.handleEvent("notify:show", (payload) => this.show(payload))
+
+      // Delegated, so it survives the patches that replace the prompt node.
+      // Allow is handled by the document-level listener above, which the
+      // settings card shares.
+      this.onClick = (event) => {
+        if (event.target.closest("[data-notify-dismiss]")) this.dismiss()
+      }
+      this.el.addEventListener("click", this.onClick)
+
+      this.onPermission = () => this.applyPrompt()
+      window.addEventListener("vutuv:notify-permission", this.onPermission)
+
+      // Read once. `updated()` runs on every shell patch - a people-counter
+      // tick, a presence diff, the hourly clock - and this value changes only
+      // through dismiss() below.
+      this.dismissed = notifyPromptDismissed()
+      this.enabled = this.el.dataset.enabled
+      this.applyPrompt()
+    },
+    updated() {
+      // Switching the feature back on is a fresh ask: somebody who dismissed
+      // the prompt months ago and has now deliberately turned it on again
+      // should be offered it, not left with a switch that does nothing here.
+      const enabled = this.el.dataset.enabled
+      if (enabled === "true" && this.enabled === "false") {
+        setNotifyPromptDismissed(false)
+        this.dismissed = false
+      }
+      this.enabled = enabled
+      this.applyPrompt()
+    },
+    destroyed() {
+      this.el.removeEventListener("click", this.onClick)
+      window.removeEventListener("vutuv:notify-permission", this.onPermission)
+    },
+    // Re-applied on every patch rather than only when something changed: the
+    // server re-renders the `hidden` attribute each time, and this is what
+    // takes it off again.
+    applyPrompt() {
+      const prompt = this.el.querySelector("[data-notify-prompt]")
+      if (!prompt) return
+      prompt.hidden = notifyPermission() !== "default" || this.dismissed
+    },
+    dismiss() {
+      setNotifyPromptDismissed(true)
+      this.dismissed = true
+      this.applyPrompt()
+    },
+    show({ tag, title, body, icon, url }) {
+      if (notifyPermission() !== "granted") return
+      // Looking at vutuv means the badge and the bell already said it.
+      if (!document.hidden && document.hasFocus()) return
+
+      let notification
+      try {
+        notification = new Notification(title, {
+          body: body || undefined,
+          icon: icon || undefined,
+          // One tag per stream, so a burst of ten replaces itself into one
+          // popup and four open vutuv tabs raise one between them (the browser
+          // collapses same-tag notifications across an origin). A replacement
+          // is silent, so only the first of a burst makes a sound - which is
+          // the whole reason `renotify` stays off.
+          tag: `vutuv-${tag}`,
+          renotify: false,
+        })
+      } catch (_e) {
+        // Some browsers refuse the constructor outright (a service worker is
+        // required on Android Chrome). Nothing to do but stay quiet.
+        return
+      }
+
+      notification.onclick = () => {
+        window.focus()
+        notification.close()
+        if (url) window.location.href = url
+      }
     },
   },
   // The admin member browser (VutuvWeb.Admin.UserLive) pages in place over the
@@ -1675,6 +1835,41 @@ function setupSettingsFilter() {
   document.querySelectorAll("[data-settings-filter]").forEach(wireSettingsFilter)
 }
 onReady(setupSettingsFilter)
+
+// The status block on /settings/notifications: what THIS browser answers,
+// beside the switch that stores what the member wants.
+function wireBrowserNotifications(status) {
+  if (!once(status, "browserNotifications")) return
+  const box = status.closest("form").querySelector('input[type="checkbox"]')
+  const lines = [...status.querySelectorAll("[data-notify-state]")]
+
+  // All four lines ship rendered and switched off by the plain `hidden`
+  // attribute (the issue #880 trap: a display utility would out-cascade it);
+  // exactly the one that applies is revealed, and none of them while the
+  // switch is off, where what this browser thinks does not matter yet.
+  const apply = () => {
+    const state = notifyPermission()
+    lines.forEach((line) => {
+      line.hidden = !box.checked || line.dataset.notifyState !== state
+    })
+  }
+
+  // Ticking the box IS the user gesture, so ask right there rather than after
+  // the save: a member who saves and never sees a prompt has no way to tell
+  // that the switch did not take effect on this machine.
+  box.addEventListener("change", () => {
+    if (box.checked) requestNotifyPermission()
+    else apply()
+  })
+
+  window.addEventListener("vutuv:notify-permission", apply)
+  apply()
+}
+
+function setupBrowserNotifications() {
+  document.querySelectorAll("[data-browser-notifications]").forEach(wireBrowserNotifications)
+}
+onReady(setupBrowserNotifications)
 
 // Live character counter for a length-capped text field (the profile Tagline,
 // see user/edit.html.heex). A [data-char-counter] wrapper with data-max holds a

--- a/docs/architecture/realtime.md
+++ b/docs/architecture/realtime.md
@@ -347,6 +347,69 @@ exactly at that moment. A NULL means no note, which is what every account
 predating the feature keeps — the derived feed is otherwise retroactive, and a
 welcome years after the fact would be nonsense.
 
+### Browser notifications (issue #1249)
+
+A member can have vutuv open in a tab they are not looking at. The tab title
+already carries the unread count; with **Browser notifications** switched on in
+`/settings/notifications`, the same events also raise a real notification
+through the browser's Notifications API.
+
+The switch (`users.browser_notifications?`) is the one in-app notification
+setting that defaults to **off**. Every other one is an opt-out, because it
+only decides what a member finds when they come back; this one puts something
+over whatever they are doing in another window, and switching it on is also
+what makes a browser ask for permission. Off by default therefore means nobody
+who did not ask is ever prompted.
+
+`ShellLive` is what pushes them. It is on every page and already holds the
+member's `"user:<id>"` subscription, so it sees the same `{:new_notification,
+…}` and `{:new_message, …}` that move the badges, and it sends the browser a
+**finished, translated line** (`notify:show`) rather than a payload for the
+client to word: only the server knows the reader's locale, and the page under
+the bell must not say one thing while the popup says another. Both surfaces
+therefore share `VutuvWeb.NotificationLine` — extracting it is what surfaced
+that four everyday kinds (like, follower, connection, endorsement) were spelled
+only in the notifications page's *grouping* code, so a single one of them fell
+back to the untranslated English the event was stored with. Invisible there
+(its rows always take the grouped branch), very visible in a popup, which is
+one event by definition.
+
+That module owns the **destination** too (`notification_target/2`), which is
+the half easiest to leave behind: clicking the popup opens the post, the case
+or the profile it named, and only a kind with no page of its own falls back to
+`/notifications`. A popup is raised precisely when the member is not looking at
+vutuv, so a list to hunt through is the one place that costs most. The third
+per-kind wording, `VutuvWeb.NotificationDigestText`, stays separate on purpose
+(a digest mail names the actor inline and by `@handle`) — a new kind is spelled
+in both, and each moduledoc says so.
+
+The `WebNotify` hook in `app.js` owns the two questions the server cannot
+answer.
+
+**Is the member looking at vutuv?** `document.hidden` alone is too narrow: it
+is false for a vutuv tab that is frontmost in a window sitting behind the
+editor somebody is actually working in, which is the case the issue is about.
+So the test is `document.hidden || !document.hasFocus()`.
+
+**Did this browser grant permission?** The switch lives on the account and
+follows the member to every machine; the permission belongs to one browser
+profile and does not travel at all. So a member who switches the feature on at
+their desk and later opens vutuv on a laptop gets a one-line prompt in the
+shell offering to ask that browser, dismissible per browser (`localStorage`).
+It cannot be a prompt on page load: Firefox and Safari refuse
+`requestPermission()` without a user gesture, and Chrome downgrades one. The
+settings card asks the moment the box is ticked (that click *is* the gesture)
+and reports what this browser answered — never asked / will show them /
+blocking them / cannot show them — because the stored setting alone cannot say
+whether this machine will show anything.
+
+Each stream carries one `tag` (`vutuv-activity`, `vutuv-messages`), so a burst
+of ten likes replaces itself into a single popup and four open vutuv tabs raise
+one between them; a replacement is silent, so only the first of a burst makes a
+sound. A message notification names neither sender nor text — the broadcast
+carries neither, and a direct message is the last thing that should be legible
+over somebody's shoulder.
+
 ## The dead-render → socket-mount handoff (profile + feed)
 
 Every LiveView visit computes its data twice: once for the HTML the visitor

--- a/docs/architecture/settings-and-account.md
+++ b/docs/architecture/settings-and-account.md
@@ -84,14 +84,28 @@ so an empty field means "inherit the site default" rather than "never shorten".
 
 ### Notifications (`/settings/notifications`)
 
-Three cards. **Email notifications**: one positive flag per type (unread
-messages plus its frequency/delay pair, endorsements, new followers, the
-newsletter), each with a one-click unsubscribe in the mail itself — see
-[email.md](email.md). **CV updates**: the one in-app notification kind a member
-can switch off (`cv_update_notifications?`, default on), because it is the only
-one triggered by someone else's housekeeping rather than by something done to
-them — see the CV updates section in [realtime.md](realtime.md). **In-app
-notifications**: a read-only explainer of the rest, which are always on.
+**Email notifications**: one positive flag per type (unread messages plus its
+frequency/delay pair, endorsements, new followers, the newsletter), each with a
+one-click unsubscribe in the mail itself — see [email.md](email.md).
+
+**Browser notifications** (`browser_notifications?`, issue #1249): whether the
+member's open tabs may raise a real browser notification when something arrives
+while they are looking at something else. The one switch here that defaults to
+**off** — it is the only one that puts something over what somebody is doing,
+and switching it on is also what makes their browsers ask for permission. The
+card reports what *this* browser answered beside the stored setting, because
+the setting travels with the account and the permission does not. See the
+browser-notifications section in [realtime.md](realtime.md).
+
+**CV updates** (`cv_update_notifications?`, default on) and **Thread replies**
+(`thread_notifications?`, default on): the two in-app kinds a member can switch
+off — the first because it is triggered by someone else's housekeeping rather
+than by anything done to them, the second because a busy thread gets loud while
+direct answers to your own post stay on. See the CV updates section in
+[realtime.md](realtime.md).
+
+**In-app notifications**: a read-only explainer of the rest, which are always
+on.
 
 ### Automatic post deletion (`/settings/auto_post_deletion`)
 

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -215,6 +215,14 @@ defmodule Vutuv.Accounts.User do
     # the unread count (derived, not stored) and the live push stops too. Direct
     # answers to your own post (the "reply" kind) are unaffected and stay on.
     field(:thread_notifications?, :boolean, default: true)
+    # Whether the member's open tabs may raise a **browser** notification (the
+    # Notifications API, issue #1249) when something arrives while they are not
+    # looking at vutuv. Opt-IN (default false), unlike the two switches above: a
+    # popup over whatever they are doing is the loudest thing vutuv can do, and
+    # flipping this on is also what makes their browsers ask for permission, so
+    # nobody who did not ask for it is ever prompted. The switch is the
+    # member's, the permission is each browser's — see VutuvWeb.ShellLive.
+    field(:browser_notifications?, :boolean, default: false)
     # Whether this member's avatar shows the real-time "online" green dot while
     # they have the site open. Default on; opting out (Privacy settings) means
     # VutuvWeb.Presence never tracks them, so they show as online to no one.
@@ -498,7 +506,7 @@ defmodule Vutuv.Accounts.User do
   # :email_confirmed? is NOT here either: it flips only via the login-PIN path
   # (Accounts.activate_user/1, its own narrow cast) — castable, it would let a
   # registration self-activate without ever proving control of an email.
-  @optional_fields ~w(noindex? noai? notification_emails? dm_email_each_message? dm_email_delay_minutes email_on_endorsement? email_on_follower? email_on_reference_check? newsletter_emails? saved_search_emails? cv_update_notifications? thread_notifications? show_online_status? show_mastodon_feed? mastodon_clients? show_code_stats? fediverse_followers? fediverse_reactions? fediverse_replies? also_known_as_input map_google? map_openstreetmap? map_apple? default_map_service post_lines_desktop post_lines_mobile post_hyphenate_desktop post_hyphenate_mobile notification_post_lines like_attribution? headline employment_status employment_status_visibility desired_salary_min desired_salary_currency desired_salary_period desired_salary_visibility desired_workplace_types first_name last_name middle_name nickname honorific_prefix honorific_suffix name_pronunciation gender birthdate birthdate_visibility locale date_region time_zone tag_list auto_post_deletion? auto_post_deletion_after_days auto_post_deletion_keep_photos? auto_post_deletion_keep_answered? auto_post_deletion_keep_bookmarked? auto_post_deletion_delete_replies? auto_post_deletion_min_likes auto_post_deletion_min_bookmarks auto_post_deletion_min_reposts feed_foreign_posts feed_languages)a
+  @optional_fields ~w(noindex? noai? notification_emails? dm_email_each_message? dm_email_delay_minutes email_on_endorsement? email_on_follower? email_on_reference_check? newsletter_emails? saved_search_emails? cv_update_notifications? thread_notifications? browser_notifications? show_online_status? show_mastodon_feed? mastodon_clients? show_code_stats? fediverse_followers? fediverse_reactions? fediverse_replies? also_known_as_input map_google? map_openstreetmap? map_apple? default_map_service post_lines_desktop post_lines_mobile post_hyphenate_desktop post_hyphenate_mobile notification_post_lines like_attribution? headline employment_status employment_status_visibility desired_salary_min desired_salary_currency desired_salary_period desired_salary_visibility desired_workplace_types first_name last_name middle_name nickname honorific_prefix honorific_suffix name_pronunciation gender birthdate birthdate_visibility locale date_region time_zone tag_list auto_post_deletion? auto_post_deletion_after_days auto_post_deletion_keep_photos? auto_post_deletion_keep_answered? auto_post_deletion_keep_bookmarked? auto_post_deletion_delete_replies? auto_post_deletion_min_likes auto_post_deletion_min_bookmarks auto_post_deletion_min_reposts feed_foreign_posts feed_languages)a
 
   # The ages the automatic post deletion offers (issue #1255), in days. A fixed
   # list rather than a free number field on purpose: this setting deletes

--- a/lib/vutuv_web/components/ui.ex
+++ b/lib/vutuv_web/components/ui.ex
@@ -4145,7 +4145,10 @@ defmodule VutuvWeb.UI do
        [
          row(:notifications, gettext("Notifications"), ~p"/settings/notifications",
            hint: gettext("Which emails we send, and what the bell tells you"),
-           terms: gettext("email mail unsubscribe newsletter bell alert quiet fewer")
+           terms:
+             gettext(
+               "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
+             )
          ),
          row(:filters, gettext("Muted words & tags"), ~p"/settings/filters",
            hint: gettext("Keep posts out of your feed"),

--- a/lib/vutuv_web/controllers/settings_controller.ex
+++ b/lib/vutuv_web/controllers/settings_controller.ex
@@ -567,7 +567,19 @@ defmodule VutuvWeb.SettingsController do
       "notifications.html",
       ~p"/settings/notifications",
       gettext("Notification settings saved."),
-      event: "notifications_changed"
+      event: "notifications_changed",
+      # The browser-notification switch is the member's and travels with the
+      # account, so their other open tabs - on this machine and on every other
+      # one - learn about it here rather than on their next reload. A tab whose
+      # browser has never been asked for permission then shows the shell's
+      # prompt (issue #1249); a tab that was switched off simply stops being
+      # pushed to.
+      on_success: fn saved ->
+        Vutuv.Activity.broadcast(
+          saved.id,
+          {:browser_notifications_pref, saved.browser_notifications?}
+        )
+      end
     )
   end
 

--- a/lib/vutuv_web/live/notification_live/index.ex
+++ b/lib/vutuv_web/live/notification_live/index.ex
@@ -57,6 +57,18 @@ defmodule VutuvWeb.NotificationLive.Index do
 
   import VutuvWeb.UserHTML, only: [user_row: 1]
 
+  # What a notification says and where it leads, shared with the browser
+  # notification ShellLive raises for the same event (issue #1249).
+  import VutuvWeb.NotificationLine,
+    only: [
+      cv_entry_label: 1,
+      cv_entry_path: 2,
+      fediverse_reaction_text: 2,
+      notification_target: 2,
+      notification_text: 1,
+      thread_text: 1
+    ]
+
   # Like the feed and messages: not a page for anonymous visitors —
   # redirect to /login instead of rendering an empty 200.
   on_mount({VutuvWeb.Live.InitAssigns, :require_login})
@@ -1073,23 +1085,20 @@ defmodule VutuvWeb.NotificationLive.Index do
 
   # ── The sentence ──
 
-  # The grouped sentence tail after the actor names. English needs no
-  # singular/plural split for "liked your post."; German does for the
-  # follower/connection verbs, hence the count-branched msgids.
+  # The grouped sentence tail after the actor names. Only the forms that differ
+  # from the single-actor one are spelled here - German conjugates the
+  # follower/connection verbs across the count where English does not, hence
+  # the count-branched msgids. Everything else falls through to
+  # VutuvWeb.NotificationText, which the browser notification shares, so one
+  # event cannot read differently in the two places (issue #1249).
   defp group_text(%{kind: "follower", actor_count: count}) when count > 1,
     do: gettext("are now following you.")
-
-  defp group_text(%{kind: "follower"}), do: gettext("started following you.")
 
   defp group_text(%{kind: "connection", actor_count: count}) when count > 1,
     do: gettext("are now connected with you.")
 
-  defp group_text(%{kind: "connection"}), do: gettext("is now connected with you.")
-
-  defp group_text(%{kind: "like"}), do: gettext("liked your post.")
-
   defp group_text(%{kind: "endorsement", tags: [tag]}),
-    do: gettext("endorsed you for %{tag}.", tag: tag)
+    do: notification_text(%{kind: "endorsement", tag: tag})
 
   defp group_text(%{kind: "endorsement", tags: [_ | _] = tags}),
     do: gettext("endorsed you for %{tags}.", tags: join_names(tags))
@@ -1101,44 +1110,6 @@ defmodule VutuvWeb.NotificationLive.Index do
 
   defp group_text(%{item: item}), do: notification_text(item)
 
-  # German conjugates the verb across the actor count (hat/haben) where English
-  # does not, so both branches go through ngettext even when the two English
-  # forms read the same — the same trick `thread_text/1` uses.
-  defp fediverse_reaction_text("announce", count) do
-    ngettext(
-      "shared your post on another network.",
-      "shared your post on another network.",
-      count
-    )
-  end
-
-  defp fediverse_reaction_text("like", count) do
-    ngettext(
-      "liked your post on another network.",
-      "liked your post on another network.",
-      count
-    )
-  end
-
-  defp fediverse_reaction_text(_kind, count) do
-    ngettext(
-      "reacted to your post from another network.",
-      "reacted to your post from another network.",
-      count
-    )
-  end
-
-  # The English tail is number-blind ("A and B replied in..."), but German
-  # conjugates the verb (hat/haben), so the actor count goes through ngettext
-  # even though both English forms read the same.
-  defp thread_text(count) do
-    ngettext(
-      "replied in a thread you posted in.",
-      "replied in a thread you posted in.",
-      count
-    )
-  end
-
   # "Elixir, Phoenix and Rails" - all but the last joined by commas, the last
   # by the localized joining word.
   defp join_names([single]), do: single
@@ -1147,80 +1118,6 @@ defmodule VutuvWeb.NotificationLive.Index do
     {front, [last]} = Enum.split(names, -1)
     Enum.join(front, ", ") <> " " <> gettext("and") <> " " <> last
   end
-
-  # Where clicking the event text leads. Events about one of the viewer's
-  # posts open that post's thread; an endorsement the viewer's tags;
-  # everything else the actor's profile. Moderation events lead to the
-  # owner's case page (and carry no actor).
-  defp notification_target(%{kind: "moderation"} = n, viewer) do
-    if is_binary(n[:case_id]) and viewer != nil, do: ~p"/moderation/cases/#{n.case_id}"
-  end
-
-  # An organization-role grant opens the organization page it was granted on.
-  defp notification_target(%{kind: "organization_role"} = n, _viewer) do
-    if is_binary(n[:organization_slug]), do: ~p"/organizations/#{n.organization_slug}"
-  end
-
-  # A removed avatar/cover leads to the photos form (upload a new one), a
-  # removed qualification proof to the credentials editor; other rejected
-  # images have no page left to open.
-  defp notification_target(%{kind: "image_rejected"} = n, viewer) do
-    cond do
-      viewer == nil -> nil
-      n[:image_kind] in ["avatar", "cover"] -> ~p"/settings/profile"
-      n[:image_kind] == "qualification_document" -> ~p"/settings/qualifications"
-      n[:image_kind] == "job_reference_document" -> ~p"/settings/job_references"
-      true -> nil
-    end
-  end
-
-  # The username note carries its own two links inside the sentence
-  # (username_line/1), so the row itself must not be one.
-  defp notification_target(%{kind: "username"}, _viewer), do: nil
-
-  # Straight to the report the member has been waiting for.
-  defp notification_target(%{kind: "reference_check"} = n, viewer) do
-    if viewer && is_binary(n[:job_reference_id]),
-      do: ~p"/settings/job_references/#{n.job_reference_id}/check"
-  end
-
-  # A CV update (issue #980) opens the entry itself when the group holds
-  # exactly one; a bigger group leads to the author's profile, where all of
-  # them sit (the entries are listed and individually linked under the line).
-  defp notification_target(%{kind: "cv_update"} = n, _viewer) do
-    case n[:entries] do
-      [entry] -> cv_entry_path(n, entry)
-      _ -> actor_target(n)
-    end
-  end
-
-  # A mention opens the post that named the reader, and a thread event the new
-  # reply — both belong to the *actor*, not to the reader, unlike reply/like
-  # below. The row carries that permalink ready-made (`Vutuv.Activity`, built
-  # through `Posts.path/2`): assembling it here from `actor_param` linked a
-  # page's mention into the member namespace, where nothing answers.
-  defp notification_target(%{kind: kind} = n, _viewer) when kind in ["mention", "thread"] do
-    n[:post_path] || actor_target(n)
-  end
-
-  defp notification_target(n, viewer) do
-    primary_target(n, viewer) || actor_target(n)
-  end
-
-  # A reply from another network (issue #1069) opens the reader's **own** post,
-  # where the reply card sits among the rest of the conversation — deliberately
-  # not the remote original, which the card itself links to. The reader stays on
-  # vutuv unless they choose otherwise, and a private reply (issue #1071) has no
-  # public page to open anyway.
-  defp primary_target(%{kind: kind} = n, viewer)
-       when kind in ["reply", "like", "fediverse_reply", "fediverse_reaction"] do
-    if is_binary(n[:post_id]) and viewer != nil, do: ~p"/#{viewer}/posts/#{n.post_id}"
-  end
-
-  defp primary_target(%{kind: "endorsement"}, viewer) when viewer != nil,
-    do: ~p"/#{viewer}/tags"
-
-  defp primary_target(_n, _viewer), do: nil
 
   # Where the quoted remote reply itself goes: the same conversation the row's
   # sentence opens, plus the anchor of this note (`Fediverse.reply_anchor/1`),
@@ -1236,18 +1133,6 @@ defmodule VutuvWeb.NotificationLive.Index do
     end
   end
 
-  # A member's param is their handle and lives at the root; a page's is a slug
-  # that lives under /organizations/:slug (issue #1336). Building this from the
-  # param alone would point into the member namespace, at a word somebody else
-  # may hold — so the row's own `actor_kind` decides, and a row without one
-  # reads as the member it was.
-  defp actor_target(%{actor_kind: "organization", actor_param: slug}) when is_binary(slug),
-    do: ~p"/organizations/#{slug}"
-
-  defp actor_target(n) do
-    if is_binary(n[:actor_param]), do: ~p"/#{n.actor_param}"
-  end
-
   # The same decision for the grouped-actor shape, whose keys are `kind` /
   # `param` rather than the row's `actor_*`. One function per shape, both
   # branching on the kind, so neither can be the one that forgets.
@@ -1255,160 +1140,6 @@ defmodule VutuvWeb.NotificationLive.Index do
     do: ~p"/organizations/#{slug}"
 
   defp actor_path(%{param: param}), do: ~p"/#{param}"
-
-  # The event text for the ungrouped kinds, rendered from the kind (not
-  # stored) so it translates with the viewer's locale. Unknown kinds fall
-  # back to the pushed text.
-  # The only row here with no actor in front of it, so it is a whole sentence
-  # rather than a verb phrase. It names the Zeugnis, because a member with
-  # several of them is otherwise told only that "a" review is ready, and it
-  # names the grade when the report stated one — that is the fact they have
-  # been waiting minutes for, and burying it one click deeper would be a tease.
-  defp notification_text(%{kind: "reference_check"} = n) do
-    case {n[:title], n[:grade]} do
-      {title, grade} when is_binary(title) and is_binary(grade) ->
-        gettext("The review of “%{title}” is ready: %{grade}.", title: title, grade: grade)
-
-      {title, _none} when is_binary(title) ->
-        gettext("The review of “%{title}” is ready.", title: title)
-
-      _untitled ->
-        gettext("Your employment reference has been reviewed.")
-    end
-  end
-
-  defp notification_text(%{kind: "reply"}), do: gettext("replied to your post.")
-
-  defp notification_text(%{kind: "mention"}), do: gettext("mentioned you in a post.")
-
-  defp notification_text(%{kind: "fediverse_reply"}),
-    do: gettext("replied to your post from another network.")
-
-  # Live-pushed reactions land here (no group context yet): one actor. The verb
-  # is the whole point of the news, so `fediverse_reaction_text/2` owns both
-  # sentences and this and the grouped row share them.
-  defp notification_text(%{kind: "fediverse_reaction"} = n),
-    do: fediverse_reaction_text(n[:reaction_kind], 1)
-
-  # Live-pushed thread events land here (no group context yet): one actor.
-  defp notification_text(%{kind: "thread"}), do: thread_text(1)
-
-  defp notification_text(%{kind: "organization_role"} = n) do
-    case n[:role] do
-      "owner" ->
-        gettext("made you an owner of %{organization}.", organization: n.organization_name)
-
-      "admin" ->
-        gettext("made you an admin of %{organization}.", organization: n.organization_name)
-
-      "recruiter" ->
-        gettext("made you a recruiter for %{organization}.", organization: n.organization_name)
-
-      _ ->
-        gettext("gave you a role at %{organization}.", organization: n.organization_name)
-    end
-  end
-
-  # Moderation items carry no actor (reports are anonymous); the text alone
-  # tells the owner what happened and links to the case page.
-  defp notification_text(%{kind: "moderation"} = n) do
-    case n[:status] do
-      "upheld" -> gettext("A report about your content was confirmed.")
-      "rejected" -> gettext("A report about your content was dismissed; it is visible again.")
-      "resolved_edited" -> gettext("You revised reported content; the case is closed.")
-      "resolved_deleted" -> gettext("You deleted reported content; the case is closed.")
-      _ -> gettext("Your content was reported and is hidden while the report is handled.")
-    end
-  end
-
-  # The AI image scan removed an image. No actor (it was the machine); the
-  # what-was-removed wording shares its single source with the email
-  # (VutuvWeb.UserHelpers.image_kind_label/2). The line says outright that a
-  # machine decided and can be wrong — a bare "your image was removed" reads
-  # as a person's judgement on the member.
-  defp notification_text(%{kind: "image_rejected"} = n) do
-    what = UserHelpers.image_kind_label(n[:image_kind], Gettext.get_locale(VutuvWeb.Gettext))
-
-    gettext(
-      "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree.",
-      what: what
-    )
-  end
-
-  # Reporter protection: the actor is the *reported* member, rendered as
-  # @handle by the actor line; the text explains the both-ways pause and
-  # that an unfounded ruling undoes it.
-  defp notification_text(%{kind: "report_protection"} = n) do
-    case n[:status] do
-      "restored" ->
-        gettext(
-          "Our admins found your report unfounded; the paused connection between you two is restored."
-        )
-
-      _ ->
-        gettext(
-          "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
-        )
-    end
-  end
-
-  # A handle change: show the old and new handle so the reader sees exactly
-  # what was rewritten in their posts (before/after).
-  defp notification_text(%{kind: "handle_change"} = n) do
-    gettext("changed their handle from @%{old} to @%{new}.",
-      old: n.old_handle,
-      new: n.new_handle
-    )
-  end
-
-  # New CV entries the author chose to announce (issue #980). A lone entry
-  # gets the section-specific wording, so a reader can tell a job from a
-  # degree without opening it; a group of them is counted and listed below.
-  defp notification_text(%{kind: "cv_update", entries: [entry]}) do
-    case entry.section do
-      "educations" ->
-        gettext("added a new education entry to their CV: %{entry}",
-          entry: cv_entry_label(entry)
-        )
-
-      "qualifications" ->
-        gettext("added a new certificate to their CV: %{entry}", entry: cv_entry_label(entry))
-
-      _ ->
-        gettext("added a new position to their CV: %{entry}", entry: cv_entry_label(entry))
-    end
-  end
-
-  defp notification_text(%{kind: "cv_update"} = n) do
-    gettext("added %{count} new entries to their CV:",
-      count: compact_count(n[:entry_count] || 0)
-    )
-  end
-
-  defp notification_text(n), do: n[:text]
-
-  # "Head of Bridges · Span AG": what the entry is, then where. Either half
-  # can be missing, so the separator only appears when both are there.
-  defp cv_entry_label(entry) do
-    [entry.title, entry.subtitle]
-    |> Enum.reject(&(&1 in [nil, ""]))
-    |> Enum.join(" · ")
-  end
-
-  # One entry's own page under the author's profile.
-  defp cv_entry_path(n, entry) do
-    with slug when is_binary(slug) <- n[:actor_param],
-         param when is_binary(param) <- entry.param do
-      case entry.section do
-        "work_experiences" -> ~p"/#{slug}/work_experiences/#{param}"
-        "educations" -> ~p"/#{slug}/educations/#{param}"
-        "qualifications" -> ~p"/#{slug}/qualifications/#{param}"
-        _ -> ~p"/#{slug}"
-      end
-    else
-      _ -> nil
-    end
-  end
 
   # How many of a group's entries are not in the shown list.
   defp cv_entries_more(n), do: (n[:entry_count] || 0) - length(n[:entries] || [])

--- a/lib/vutuv_web/live/shell_live.ex
+++ b/lib/vutuv_web/live/shell_live.ex
@@ -23,6 +23,7 @@ defmodule VutuvWeb.ShellLive do
 
   import VutuvWeb.UI,
     only: [
+      button: 1,
       compact_count: 1,
       count_badge: 1,
       delimited_count: 1,
@@ -42,6 +43,7 @@ defmodule VutuvWeb.ShellLive do
   alias Vutuv.PeopleCounter
   alias Vutuv.Social
   alias VutuvWeb.Live.InitAssigns
+  alias VutuvWeb.NotificationLine
   alias VutuvWeb.Presence
 
   @impl true
@@ -160,6 +162,7 @@ defmodule VutuvWeb.ShellLive do
     |> assign(:user_avatar, Vutuv.Avatar.user_url(user, :thumb))
     |> assign(:user_admin?, user.admin?)
     |> assign_shell_defaults(path)
+    |> assign(:browser_notifications?, user.browser_notifications?)
     |> maybe_start_counts(user, path)
     |> maybe_start_new_members()
     |> maybe_start_presence(user_id, user.show_online_status?)
@@ -176,6 +179,10 @@ defmodule VutuvWeb.ShellLive do
   defp assign_shell_defaults(socket, path) do
     socket
     |> assign(:self_online?, false)
+    # Whether this member asked for browser notifications (issue #1249). False
+    # for the anonymous shell and for the throwaway dead render, which raises
+    # none anyway — the real value arrives with the authenticated mount.
+    |> assign(:browser_notifications?, false)
     |> assign(:presence_hidden_ids, MapSet.new())
     |> assign(:messages_count, 0)
     |> assign(:notifications_count, 0)
@@ -320,8 +327,8 @@ defmodule VutuvWeb.ShellLive do
   # silent-decrement signal (broadcast by Vutuv.Social), and recomputing on
   # :new_notification too keeps the increment honest.
   @impl true
-  def handle_info({:new_notification, _n}, socket),
-    do: {:noreply, recount_notifications(socket)}
+  def handle_info({:new_notification, n}, socket),
+    do: {:noreply, socket |> recount_notifications() |> push_browser_notification(n)}
 
   def handle_info(:notifications_changed, socket),
     do: {:noreply, recount_notifications(socket)}
@@ -336,7 +343,7 @@ defmodule VutuvWeb.ShellLive do
   # adds nothing, and reading one conversation says nothing about the others —
   # so both recompute the count instead of adjusting it.
   def handle_info({:new_message, _m}, socket),
-    do: {:noreply, recount_messages(socket)}
+    do: {:noreply, socket |> recount_messages() |> push_message_notification()}
 
   def handle_info(:messages_read, socket),
     do: {:noreply, recount_messages(socket)}
@@ -371,6 +378,14 @@ defmodule VutuvWeb.ShellLive do
 
     {:noreply, socket |> assign(:self_online?, show_online?) |> push_online()}
   end
+
+  # The member flipped "Show me browser notifications" (here or in another tab).
+  # Their other open tabs learn about it without a reload, the same way the
+  # online-status switch reaches them — and a tab that has just been switched ON
+  # asks this browser for permission, which is the whole point of the broadcast:
+  # the switch is the member's, the permission is each browser's.
+  def handle_info({:browser_notifications_pref, enabled?}, socket),
+    do: {:noreply, assign(socket, :browser_notifications?, enabled?)}
 
   # The live people total moved — a sign-up confirmed, an account was deleted,
   # or the counter reconciled one of its two halves against the database. Every
@@ -512,6 +527,64 @@ defmodule VutuvWeb.ShellLive do
     end
   end
 
+  # -- Browser notifications (issue #1249) ----------------------------------
+  #
+  # The shell is on every page and already holds this member's activity
+  # subscription, so it is the one place that knows something arrived while
+  # they were somewhere else. It hands the WebNotify hook a finished line; the
+  # hook decides whether the member is actually looking at vutuv and whether
+  # this browser granted permission. Two reasons the wording is built here and
+  # not in JS: only the server knows the reader's locale, and the page under the
+  # bell must not say one thing while the popup says another - hence the shared
+  # VutuvWeb.NotificationLine, which owns the destination too.
+  #
+  # Off unless the member switched it on. That is the whole design of the
+  # feature - a popup over whatever somebody is doing is the loudest thing this
+  # app can do, so nobody who did not ask is ever prompted, let alone notified.
+  # The gate lives in one clause, so a third stream cannot be added without it.
+  defp push_notify(%{assigns: %{browser_notifications?: false}} = socket, _payload), do: socket
+
+  defp push_notify(socket, payload), do: push_event(socket, "notify:show", payload)
+
+  defp push_browser_notification(socket, notification) do
+    {title, body} = NotificationLine.title_and_body(notification)
+
+    push_notify(socket, %{
+      # One tag for the whole activity stream, so a burst of ten likes replaces
+      # itself into a single popup instead of stacking ten - and so a member
+      # with four vutuv tabs open gets one notification rather than four (the
+      # browser collapses same-tag notifications across every page of an
+      # origin). A replacement is silent in every browser, so only the first one
+      # of a burst makes a sound.
+      tag: "activity",
+      title: title,
+      body: body,
+      icon: notification[:actor_avatar],
+      # Where the row under the bell would take them - the post, the case, the
+      # profile. A popup is raised precisely when the member is NOT looking at
+      # vutuv, so the notifications list is the one place that makes them hunt
+      # for what they were just told about. It stays the fallback for a kind
+      # with no page of its own.
+      url:
+        NotificationLine.notification_target(notification, socket.assigns.user_param) ||
+          ~p"/notifications"
+    })
+  end
+
+  defp push_message_notification(socket) do
+    push_notify(socket, %{
+      # Its own tag: a waiting answer and a new like are different errands, and
+      # collapsing them into one popup would let a like bury a message.
+      tag: "messages",
+      # Deliberately no sender and no preview. The broadcast carries neither
+      # (Vutuv.Chat sends the conversation id alone), and a direct message is
+      # the last thing that should be legible over somebody's shoulder or on a
+      # shared screen.
+      title: gettext("New message"),
+      url: ~p"/messages"
+    })
+  end
+
   # The initials tile shares VutuvWeb.UI.name_initials/1 with <.avatar>.
 
   @impl true
@@ -530,6 +603,53 @@ defmodule VutuvWeb.ShellLive do
       Fed by push_badge/1 + the {:new_post} handler; phx-update="ignore" because
       the hook owns document.title, not this node. --%>
       <div :if={@user_id} id="tab-badge" phx-hook="TabBadge" phx-update="ignore" class="hidden"></div>
+      <%!-- Browser notifications (issue #1249). The hook raises the popups
+      ShellLive pushes as "notify:show", and owns the two questions the server
+      cannot answer: is this member looking at vutuv right now, and did THIS
+      browser grant permission. It is rendered for every logged-in member, on
+      or off, so flipping the switch in another tab needs no reload - the
+      server simply stops pushing.
+
+      No phx-update="ignore": the prompt below is server-rendered (only the
+      server knows the reader's language), so LiveView owns these children and
+      the hook re-applies its decision in updated/0.
+
+      The prompt is the answer to "I switched this on at my desk, why is my
+      laptop silent?". The switch is the member's and travels with the account;
+      the permission belongs to each browser and can only be asked for from a
+      real click, which Firefox and Safari refuse to fake on page load. So a
+      browser that has never been asked shows one line with the way to say yes.
+      It ships carrying the plain `hidden` attribute and no display utility (the
+      issue #880 trap - a utility would out-cascade it), and the hook takes it
+      off only where it applies: permission still "default", and not dismissed
+      in this browser before. --%>
+      <div :if={@user_id} id="web-notify" phx-hook="WebNotify" data-enabled={to_string(@browser_notifications?)}>
+        <div
+          :if={@browser_notifications?}
+          hidden
+          data-notify-prompt
+          class="border-b border-brand-100 bg-brand-50 dark:border-brand-900/60 dark:bg-brand-900/30"
+        >
+          <div class={[
+            "mx-auto flex max-w-6xl flex-wrap items-center gap-x-3 gap-y-2 py-2 text-sm",
+            gutter_class()
+          ]}>
+            <span class="text-slate-700 dark:text-slate-200">
+              {gettext("You switched browser notifications on. This browser has not been asked for permission yet.")}
+            </span>
+            <.button type="button" data-notify-allow class="min-h-10">
+              {gettext("Allow")}
+            </.button>
+            <button
+              type="button"
+              data-notify-dismiss
+              class="ml-auto min-h-10 rounded-lg px-3 text-sm font-semibold text-slate-600 hover:bg-brand-100 dark:text-slate-300 dark:hover:bg-brand-900/60"
+            >
+              {gettext("Not now")}
+            </button>
+          </div>
+        </div>
+      </div>
       <%!-- Writing as an organization (issue #1335). The characteristic failure
       of this mode everywhere it exists is somebody posting something personal
       from the brand account, and a discreet badge does not prevent it — so the

--- a/lib/vutuv_web/notification_line.ex
+++ b/lib/vutuv_web/notification_line.ex
@@ -1,0 +1,358 @@
+defmodule VutuvWeb.NotificationLine do
+  @moduledoc """
+  What one notification says, and where it leads.
+
+  A notification is derived with an English `:text` and a `:kind`; the wording
+  is rendered from the **kind** so it follows whoever is reading, not whoever
+  triggered it. Most kinds read as a verb phrase that follows the actor's name
+  ("replied to your post."); the few with no actor - moderation, a rejected
+  image, a finished reference check - are whole sentences.
+
+  Two surfaces share it, which is why it lives here rather than in either:
+  `VutuvWeb.NotificationLive.Index` (the page under the bell) and
+  `VutuvWeb.ShellLive`, which puts the same line into a **browser**
+  notification (issue #1249). A second copy would drift the moment a kind is
+  added, and the popup would quietly go back to the untranslated English
+  `:text` fallback.
+
+  `notification_target/2` lives here for the same reason and is the half that
+  is easiest to leave behind: a popup is raised precisely when the member is
+  *not* looking at vutuv, so dropping them on the notifications list to hunt
+  for the thing they were just told about is the one place that costs most.
+  One function owns where a notification leads, so a new kind is answered once.
+
+  The third per-kind wording is `VutuvWeb.NotificationDigestText`, which stays
+  its own module on purpose: a digest mail names the actor inline and by
+  `@handle`, quotes nothing, and survives having no clause for a kind. When you
+  add a kind, spell it in both.
+  """
+  use Gettext, backend: VutuvWeb.Gettext
+
+  use Phoenix.VerifiedRoutes,
+    endpoint: VutuvWeb.Endpoint,
+    router: VutuvWeb.Router,
+    statics: ~w(assets fonts images favicon.ico)
+
+  import VutuvWeb.UI, only: [compact_count: 1]
+
+  alias VutuvWeb.UserHelpers
+
+  # The event text for the ungrouped kinds, rendered from the kind (not
+  # stored) so it translates with the viewer's locale. Unknown kinds fall
+  # back to the pushed text.
+  # The only row here with no actor in front of it, so it is a whole sentence
+  # rather than a verb phrase. It names the Zeugnis, because a member with
+  # several of them is otherwise told only that "a" review is ready, and it
+  # names the grade when the report stated one — that is the fact they have
+  # been waiting minutes for, and burying it one click deeper would be a tease.
+  def notification_text(%{kind: "reference_check"} = n) do
+    case {n[:title], n[:grade]} do
+      {title, grade} when is_binary(title) and is_binary(grade) ->
+        gettext("The review of “%{title}” is ready: %{grade}.", title: title, grade: grade)
+
+      {title, _none} when is_binary(title) ->
+        gettext("The review of “%{title}” is ready.", title: title)
+
+      _untitled ->
+        gettext("Your employment reference has been reviewed.")
+    end
+  end
+
+  def notification_text(%{kind: "reply"}), do: gettext("replied to your post.")
+
+  # The four everyday kinds. They used to be spelled only in the notifications
+  # page's grouping code, where a row can stand for several actors, so a single
+  # one of them fell through to the untranslated English `:text` the event was
+  # stored with - invisible on that page (its groups always take the grouped
+  # branch) and very visible in a browser notification, which is one event by
+  # definition. The grouped multi-actor forms stay where they are; the
+  # single-actor ones live here and both pages share them.
+  def notification_text(%{kind: "like"}), do: gettext("liked your post.")
+
+  def notification_text(%{kind: "follower"}), do: gettext("started following you.")
+
+  def notification_text(%{kind: "connection"}), do: gettext("is now connected with you.")
+
+  # The live-pushed endorsement names one tag (`:tag`); the page's grouped row
+  # merges an endorser's several into a `:tags` list and keeps its own clause.
+  def notification_text(%{kind: "endorsement", tag: tag}) when is_binary(tag),
+    do: gettext("endorsed you for %{tag}.", tag: tag)
+
+  def notification_text(%{kind: "mention"}), do: gettext("mentioned you in a post.")
+
+  def notification_text(%{kind: "fediverse_reply"}),
+    do: gettext("replied to your post from another network.")
+
+  # Live-pushed reactions land here (no group context yet): one actor. The verb
+  # is the whole point of the news, so `fediverse_reaction_text/2` owns both
+  # sentences and this and the grouped row share them.
+  def notification_text(%{kind: "fediverse_reaction"} = n),
+    do: fediverse_reaction_text(n[:reaction_kind], 1)
+
+  # Live-pushed thread events land here (no group context yet): one actor.
+  def notification_text(%{kind: "thread"}), do: thread_text(1)
+
+  def notification_text(%{kind: "organization_role"} = n) do
+    case n[:role] do
+      "owner" ->
+        gettext("made you an owner of %{organization}.", organization: n.organization_name)
+
+      "admin" ->
+        gettext("made you an admin of %{organization}.", organization: n.organization_name)
+
+      "recruiter" ->
+        gettext("made you a recruiter for %{organization}.", organization: n.organization_name)
+
+      _ ->
+        gettext("gave you a role at %{organization}.", organization: n.organization_name)
+    end
+  end
+
+  # Moderation items carry no actor (reports are anonymous); the text alone
+  # tells the owner what happened and links to the case page.
+  def notification_text(%{kind: "moderation"} = n) do
+    case n[:status] do
+      "upheld" -> gettext("A report about your content was confirmed.")
+      "rejected" -> gettext("A report about your content was dismissed; it is visible again.")
+      "resolved_edited" -> gettext("You revised reported content; the case is closed.")
+      "resolved_deleted" -> gettext("You deleted reported content; the case is closed.")
+      _ -> gettext("Your content was reported and is hidden while the report is handled.")
+    end
+  end
+
+  # The AI image scan removed an image. No actor (it was the machine); the
+  # what-was-removed wording shares its single source with the email
+  # (VutuvWeb.UserHelpers.image_kind_label/2). The line says outright that a
+  # machine decided and can be wrong — a bare "your image was removed" reads
+  # as a person's judgement on the member.
+  def notification_text(%{kind: "image_rejected"} = n) do
+    what = UserHelpers.image_kind_label(n[:image_kind], Gettext.get_locale(VutuvWeb.Gettext))
+
+    gettext(
+      "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree.",
+      what: what
+    )
+  end
+
+  # Reporter protection: the actor is the *reported* member, rendered as
+  # @handle by the actor line; the text explains the both-ways pause and
+  # that an unfounded ruling undoes it.
+  def notification_text(%{kind: "report_protection"} = n) do
+    case n[:status] do
+      "restored" ->
+        gettext(
+          "Our admins found your report unfounded; the paused connection between you two is restored."
+        )
+
+      _ ->
+        gettext(
+          "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
+        )
+    end
+  end
+
+  # A handle change: show the old and new handle so the reader sees exactly
+  # what was rewritten in their posts (before/after).
+  def notification_text(%{kind: "handle_change"} = n) do
+    gettext("changed their handle from @%{old} to @%{new}.",
+      old: n.old_handle,
+      new: n.new_handle
+    )
+  end
+
+  # New CV entries the author chose to announce (issue #980). A lone entry
+  # gets the section-specific wording, so a reader can tell a job from a
+  # degree without opening it; a group of them is counted and listed below.
+  def notification_text(%{kind: "cv_update", entries: [entry]}) do
+    case entry.section do
+      "educations" ->
+        gettext("added a new education entry to their CV: %{entry}",
+          entry: cv_entry_label(entry)
+        )
+
+      "qualifications" ->
+        gettext("added a new certificate to their CV: %{entry}", entry: cv_entry_label(entry))
+
+      _ ->
+        gettext("added a new position to their CV: %{entry}", entry: cv_entry_label(entry))
+    end
+  end
+
+  def notification_text(%{kind: "cv_update"} = n) do
+    gettext("added %{count} new entries to their CV:",
+      count: compact_count(n[:entry_count] || 0)
+    )
+  end
+
+  # A kind with no clause above still reads as something, and reads it in the
+  # member's language. The stored `:text` comes first because it is a real
+  # sentence and says more; it is English, so where a kind is missing entirely
+  # the generic line is the honest floor. `VutuvWeb.NotificationDigestText`
+  # makes the same promise for the digest mail.
+  def notification_text(n), do: n[:text] || gettext("Something new happened on your account.")
+
+  @doc """
+  The popup's two halves: an actor's name over their verb phrase.
+
+  Most kinds read as a phrase that follows a name ("Anna Klein" / "replied to
+  your post."), which is how the row under the bell reads. The kinds with no
+  actor - a moderation ruling, a removed image, a finished reference check -
+  are whole sentences already, so the sentence IS the title and there is no
+  body: a placeholder name over one line would say less, not more.
+  """
+  def title_and_body(notification) do
+    text = notification_text(notification)
+
+    case notification[:actor_name] do
+      name when is_binary(name) and name != "" -> {name, text}
+      _actorless -> {text, nil}
+    end
+  end
+
+  # German conjugates the verb across the actor count (hat/haben) where English
+  # does not, so both branches go through ngettext even when the two English
+  # forms read the same — the same trick `thread_text/1` uses.
+  def fediverse_reaction_text("announce", count) do
+    ngettext(
+      "shared your post on another network.",
+      "shared your post on another network.",
+      count
+    )
+  end
+
+  def fediverse_reaction_text("like", count) do
+    ngettext(
+      "liked your post on another network.",
+      "liked your post on another network.",
+      count
+    )
+  end
+
+  def fediverse_reaction_text(_kind, count) do
+    ngettext(
+      "reacted to your post from another network.",
+      "reacted to your post from another network.",
+      count
+    )
+  end
+
+  # The English tail is number-blind ("A and B replied in..."), but German
+  # conjugates the verb (hat/haben), so the actor count goes through ngettext
+  # even though both English forms read the same.
+  def thread_text(count) do
+    ngettext(
+      "replied in a thread you posted in.",
+      "replied in a thread you posted in.",
+      count
+    )
+  end
+
+  # "Head of Bridges · Span AG": what the entry is, then where. Either half
+  # can be missing, so the separator only appears when both are there.
+  def cv_entry_label(entry) do
+    [entry.title, entry.subtitle]
+    |> Enum.reject(&(&1 in [nil, ""]))
+    |> Enum.join(" · ")
+  end
+
+  # Where clicking the event text leads. Events about one of the viewer's
+  # posts open that post's thread; an endorsement the viewer's tags;
+  # everything else the actor's profile. Moderation events lead to the
+  # owner's case page (and carry no actor).
+  def notification_target(%{kind: "moderation"} = n, viewer) do
+    if is_binary(n[:case_id]) and viewer != nil, do: ~p"/moderation/cases/#{n.case_id}"
+  end
+
+  # An organization-role grant opens the organization page it was granted on.
+  def notification_target(%{kind: "organization_role"} = n, _viewer) do
+    if is_binary(n[:organization_slug]), do: ~p"/organizations/#{n.organization_slug}"
+  end
+
+  # A removed avatar/cover leads to the photos form (upload a new one), a
+  # removed qualification proof to the credentials editor; other rejected
+  # images have no page left to open.
+  def notification_target(%{kind: "image_rejected"} = n, viewer) do
+    cond do
+      viewer == nil -> nil
+      n[:image_kind] in ["avatar", "cover"] -> ~p"/settings/profile"
+      n[:image_kind] == "qualification_document" -> ~p"/settings/qualifications"
+      n[:image_kind] == "job_reference_document" -> ~p"/settings/job_references"
+      true -> nil
+    end
+  end
+
+  # The username note carries its own two links inside the sentence
+  # (username_line/1), so the row itself must not be one.
+  def notification_target(%{kind: "username"}, _viewer), do: nil
+
+  # Straight to the report the member has been waiting for.
+  def notification_target(%{kind: "reference_check"} = n, viewer) do
+    if viewer && is_binary(n[:job_reference_id]),
+      do: ~p"/settings/job_references/#{n.job_reference_id}/check"
+  end
+
+  # A CV update (issue #980) opens the entry itself when the group holds
+  # exactly one; a bigger group leads to the author's profile, where all of
+  # them sit (the entries are listed and individually linked under the line).
+  def notification_target(%{kind: "cv_update"} = n, _viewer) do
+    case n[:entries] do
+      [entry] -> cv_entry_path(n, entry)
+      _ -> actor_target(n)
+    end
+  end
+
+  # A mention opens the post that named the reader, and a thread event the new
+  # reply — both belong to the *actor*, not to the reader, unlike reply/like
+  # below. The row carries that permalink ready-made (`Vutuv.Activity`, built
+  # through `Posts.path/2`): assembling it here from `actor_param` linked a
+  # page's mention into the member namespace, where nothing answers.
+  def notification_target(%{kind: kind} = n, _viewer) when kind in ["mention", "thread"] do
+    n[:post_path] || actor_target(n)
+  end
+
+  def notification_target(n, viewer) do
+    primary_target(n, viewer) || actor_target(n)
+  end
+
+  # A reply from another network (issue #1069) opens the reader's **own** post,
+  # where the reply card sits among the rest of the conversation — deliberately
+  # not the remote original, which the card itself links to. The reader stays on
+  # vutuv unless they choose otherwise, and a private reply (issue #1071) has no
+  # public page to open anyway.
+  def primary_target(%{kind: kind} = n, viewer)
+      when kind in ["reply", "like", "fediverse_reply", "fediverse_reaction"] do
+    if is_binary(n[:post_id]) and viewer != nil, do: ~p"/#{viewer}/posts/#{n.post_id}"
+  end
+
+  def primary_target(%{kind: "endorsement"}, viewer) when viewer != nil,
+    do: ~p"/#{viewer}/tags"
+
+  def primary_target(_n, _viewer), do: nil
+
+  # A member's param is their handle and lives at the root; a page's is a slug
+  # that lives under /organizations/:slug (issue #1336). Building this from the
+  # param alone would point into the member namespace, at a word somebody else
+  # may hold — so the row's own `actor_kind` decides, and a row without one
+  # reads as the member it was.
+  def actor_target(%{actor_kind: "organization", actor_param: slug}) when is_binary(slug),
+    do: ~p"/organizations/#{slug}"
+
+  def actor_target(n) do
+    if is_binary(n[:actor_param]), do: ~p"/#{n.actor_param}"
+  end
+
+  # One entry's own page under the author's profile.
+  def cv_entry_path(n, entry) do
+    with slug when is_binary(slug) <- n[:actor_param],
+         param when is_binary(param) <- entry.param do
+      case entry.section do
+        "work_experiences" -> ~p"/#{slug}/work_experiences/#{param}"
+        "educations" -> ~p"/#{slug}/educations/#{param}"
+        "qualifications" -> ~p"/#{slug}/qualifications/#{param}"
+        _ -> ~p"/#{slug}"
+      end
+    else
+      _ -> nil
+    end
+  end
+end

--- a/lib/vutuv_web/templates/settings/notifications.html.heex
+++ b/lib/vutuv_web/templates/settings/notifications.html.heex
@@ -122,6 +122,63 @@ heading. --%>
       }
     />
 
+    <%!-- Browser notifications (issue #1249): the one switch in this app that
+          is OFF by default, because it is the only one that puts something over
+          whatever the member is doing in another window. Switching it on is also
+          what makes a browser ask for permission, so nobody who left it alone is
+          ever prompted.
+
+          Two states have to be told apart here and only the browser knows the
+          second: the account says "yes, I want these", each browser says whether
+          it will actually show one. So the card carries a status line per
+          permission state, all four shipped and switched off by the plain
+          `hidden` attribute (never a display utility - the issue #880 trap),
+          with app.js revealing the one that applies. The form also asks for
+          permission the moment the box is ticked, because that click is a user
+          gesture and Firefox and Safari refuse the request without one. --%>
+    <.toggle_form_card
+      changeset={@changeset}
+      field={:browser_notifications?}
+      form_id="browser-notifications-form"
+      action={~p"/settings/notifications"}
+      title={gettext("Browser notifications")}
+      intro={
+        gettext(
+          "When something arrives while you have vutuv open in a tab you are not looking at, your browser can show it as a notification. Off unless you switch it on."
+        )
+      }
+      label={gettext("Show me browser notifications")}
+      hint={
+        gettext(
+          "Only while vutuv is open somewhere and you are looking at something else. Every browser you use asks you once."
+        )
+      }
+    >
+      <:footnote>
+        <div data-browser-notifications class="ml-7 text-sm text-slate-600 dark:text-slate-400">
+          <p hidden data-notify-state="default">
+            {gettext("This browser has not been asked yet.")}
+            <button
+              type="button"
+              data-notify-allow
+              class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+            >
+              {gettext("Ask now")}
+            </button>
+          </p>
+          <p hidden data-notify-state="granted">{gettext("This browser will show them.")}</p>
+          <p hidden data-notify-state="denied">
+            {gettext(
+              "This browser is blocking notifications for vutuv. Allow them for this site in your browser settings; the switch above stays on and every other browser you use is unaffected."
+            )}
+          </p>
+          <p hidden data-notify-state="unsupported">
+            {gettext("This browser cannot show notifications. Your other browsers are unaffected.")}
+          </p>
+        </div>
+      </:footnote>
+    </.toggle_form_card>
+
     <%!-- The remaining in-app notifications are not configurable (they are the
           product), so this card just explains them and links to the bell. --%>
     <.card>

--- a/lib/vutuv_web/views/notification_digest_text.ex
+++ b/lib/vutuv_web/views/notification_digest_text.ex
@@ -17,6 +17,12 @@ defmodule VutuvWeb.NotificationDigestText do
   A kind with no clause here still produces a line — a dull, true one — so a
   kind added tomorrow reaches the inbox rather than crashing the sweep or
   arriving blank.
+
+  The other per-kind wording is `VutuvWeb.NotificationLine`, which the
+  notifications page and the browser notification share. A new kind has to be
+  spelled in both, and neither can be inferred from the other — this one names
+  the actor inline and by `@handle`, that one hands a name and a verb phrase to
+  a caller that puts them together.
   """
 
   use Gettext, backend: VutuvWeb.Gettext

--- a/lib/vutuv_web/views/settings_html.ex
+++ b/lib/vutuv_web/views/settings_html.ex
@@ -264,6 +264,13 @@ defmodule VutuvWeb.SettingsHTML do
   attr(:label, :string, required: true)
   attr(:hint, :string, required: true)
 
+  # Rendered between the toggle and the Save button. One caller: the browser-
+  # notification switch, whose card has to report what the BROWSER thinks on top
+  # of what the account stores (issue #1249) - the setting alone cannot say
+  # whether this machine will actually show anything. It belongs inside the
+  # form, which is what lets its JS reach the checkbox it reports on.
+  slot(:footnote)
+
   def toggle_form_card(assigns) do
     ~H"""
     <.card>
@@ -275,6 +282,8 @@ defmodule VutuvWeb.SettingsHTML do
           <:checkbox><%= checkbox f, @field, class: checkbox_class() %></:checkbox>
           {@hint}
         </.setting_toggle>
+
+        {render_slot(@footnote)}
 
         <div class="pt-1">
           <.button type="submit">{gettext("Save")}</.button>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.342.18",
+      version: "7.343.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -15,8 +15,8 @@ msgstr "Language: de\n"
 msgid "About us"
 msgstr "Impressum"
 
-#: lib/vutuv_web/components/ui.ex:3861
 #: lib/vutuv_web/components/ui.ex:3866
+#: lib/vutuv_web/components/ui.ex:3871
 #: lib/vutuv_web/live/admin/screenshot_live.ex:255
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:718
 #: lib/vutuv_web/live/organization_live/domains.ex:272
@@ -38,7 +38,7 @@ msgstr "Eintrag hinzufügen"
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1461
+#: lib/vutuv_web/templates/user/show.html.heex:1464
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -62,7 +62,7 @@ msgstr "Eine Adresse wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:68
 #: lib/vutuv_web/agent_docs/text.ex:65
-#: lib/vutuv_web/components/ui.ex:4119
+#: lib/vutuv_web/components/ui.ex:4124
 #: lib/vutuv_web/controllers/address_controller.ex:23
 #: lib/vutuv_web/controllers/address_controller.ex:38
 #: lib/vutuv_web/controllers/address_controller.ex:85
@@ -80,8 +80,8 @@ msgstr "Adressen"
 msgid "Already a member? Sign in here."
 msgstr "Schon ein Mitglied? Einloggen."
 
-#: lib/vutuv_web/components/ui.ex:3656
-#: lib/vutuv_web/components/ui.ex:3750
+#: lib/vutuv_web/components/ui.ex:3661
+#: lib/vutuv_web/components/ui.ex:3755
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:698
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:830
@@ -103,13 +103,13 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/agent_docs/markdown.ex:603
 #: lib/vutuv_web/agent_docs/text.ex:568
 #: lib/vutuv_web/agent_docs/text.ex:569
-#: lib/vutuv_web/templates/user/show.html.heex:1093
+#: lib/vutuv_web/templates/user/show.html.heex:1096
 #, elixir-autogen
 msgid "Birthday"
 msgstr "Geburtstag"
 
 #: lib/vutuv_web/components/saved_search_components.ex:110
-#: lib/vutuv_web/components/ui.ex:3650
+#: lib/vutuv_web/components/ui.ex:3655
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
@@ -152,7 +152,7 @@ msgstr "Wählen Sie einen Typ aus"
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1131
+#: lib/vutuv_web/templates/user/show.html.heex:1134
 #, elixir-autogen
 msgid "Contact"
 msgstr "Kontakt"
@@ -161,8 +161,8 @@ msgstr "Kontakt"
 msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
-#: lib/vutuv_web/components/post_components.ex:2872
-#: lib/vutuv_web/components/ui.ex:3753
+#: lib/vutuv_web/components/post_components.ex:2969
+#: lib/vutuv_web/components/ui.ex:3758
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
@@ -210,8 +210,8 @@ msgstr "Inaktivieren"
 msgid "Download"
 msgstr "Download"
 
-#: lib/vutuv_web/components/post_components.ex:2837
-#: lib/vutuv_web/components/ui.ex:3744
+#: lib/vutuv_web/components/post_components.ex:2934
+#: lib/vutuv_web/components/ui.ex:3749
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
@@ -224,7 +224,7 @@ msgstr "Download"
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:1116
+#: lib/vutuv_web/templates/user/show.html.heex:1119
 #, elixir-autogen
 msgid "Edit"
 msgstr "Ändern"
@@ -285,11 +285,11 @@ msgstr "E-Mail-Adresse eingeben"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:35
-#: lib/vutuv_web/components/ui.ex:4083
+#: lib/vutuv_web/components/ui.ex:4088
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:624
+#: lib/vutuv_web/templates/user/show.html.heex:627
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -315,7 +315,7 @@ msgstr "Vorname"
 #: lib/vutuv_web/agent_docs/text.ex:589
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
-#: lib/vutuv_web/live/notification_live/index.ex:968
+#: lib/vutuv_web/live/notification_live/index.ex:980
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:27
@@ -326,18 +326,18 @@ msgstr "Follower"
 #: lib/vutuv_web/agent_docs/markdown.ex:624
 #: lib/vutuv_web/agent_docs/text.ex:590
 #: lib/vutuv_web/components/fediverse_components.ex:313
-#: lib/vutuv_web/components/ui.ex:2224
-#: lib/vutuv_web/components/ui.ex:2249
-#: lib/vutuv_web/components/ui.ex:2252
-#: lib/vutuv_web/components/ui.ex:2259
-#: lib/vutuv_web/components/ui.ex:2262
-#: lib/vutuv_web/components/ui.ex:2320
+#: lib/vutuv_web/components/ui.ex:2229
+#: lib/vutuv_web/components/ui.ex:2254
+#: lib/vutuv_web/components/ui.ex:2257
+#: lib/vutuv_web/components/ui.ex:2264
+#: lib/vutuv_web/components/ui.ex:2267
+#: lib/vutuv_web/components/ui.ex:2325
 #: lib/vutuv_web/controllers/followee_controller.ex:29
 #: lib/vutuv_web/live/import_connections_live.ex:469
 #: lib/vutuv_web/live/organization_live/show.ex:471
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:970
+#: lib/vutuv_web/templates/user/show.html.heex:973
 #, elixir-autogen
 msgid "Following"
 msgstr "Folge ich"
@@ -443,8 +443,8 @@ msgstr "Einloggen"
 msgid "Log Out"
 msgstr "Ausloggen"
 
-#: lib/vutuv_web/live/shell_live.ex:853
-#: lib/vutuv_web/live/shell_live.ex:909
+#: lib/vutuv_web/live/shell_live.ex:973
+#: lib/vutuv_web/live/shell_live.ex:1029
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -457,7 +457,7 @@ msgstr "Einloggen"
 msgid "Middle Name"
 msgstr "Zweiter Vorname"
 
-#: lib/vutuv_web/live/notification_live/index.ex:893
+#: lib/vutuv_web/live/notification_live/index.ex:905
 #, elixir-autogen
 msgid "More"
 msgstr "Mehr"
@@ -474,8 +474,8 @@ msgstr "Mehr"
 msgid "Name"
 msgstr "Name"
 
-#: lib/vutuv_web/components/post_components.ex:539
-#: lib/vutuv_web/live/notification_live/index.ex:647
+#: lib/vutuv_web/components/post_components.ex:542
+#: lib/vutuv_web/live/notification_live/index.ex:659
 #: lib/vutuv_web/live/organization_live/activity.ex:127
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
@@ -614,7 +614,7 @@ msgstr "Provider"
 msgid "Public"
 msgstr "Öffentlich"
 
-#: lib/vutuv_web/components/ui.ex:3649
+#: lib/vutuv_web/components/ui.ex:3654
 #: lib/vutuv_web/live/organization_live/edit.ex:345
 #: lib/vutuv_web/live/post_live/composer.ex:1867
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -631,7 +631,7 @@ msgstr "Öffentlich"
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:462
-#: lib/vutuv_web/views/settings_html.ex:280
+#: lib/vutuv_web/views/settings_html.ex:289
 #, elixir-autogen
 msgid "Save"
 msgstr "Speichern"
@@ -644,9 +644,9 @@ msgstr "Speichern"
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:48
 #: lib/vutuv_web/live/search_live.ex:569
-#: lib/vutuv_web/live/shell_live.ex:721
-#: lib/vutuv_web/live/shell_live.ex:892
-#: lib/vutuv_web/live/tag_live/timeline.ex:237
+#: lib/vutuv_web/live/shell_live.ex:841
+#: lib/vutuv_web/live/shell_live.ex:1012
+#: lib/vutuv_web/live/tag_live/timeline.ex:240
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:30
@@ -655,7 +655,7 @@ msgstr "Speichern"
 msgid "Search"
 msgstr "Suche"
 
-#: lib/vutuv_web/components/post_components.ex:1475
+#: lib/vutuv_web/components/post_components.ex:1478
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -691,13 +691,13 @@ msgstr "Slug"
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1245
+#: lib/vutuv_web/templates/user/show.html.heex:1248
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr "Profile"
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1247
+#: lib/vutuv_web/templates/user/show.html.heex:1250
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr "Profil hinzufügen"
@@ -797,12 +797,12 @@ msgstr "Profil aktualisiert."
 msgid "User verified successfully."
 msgstr "User wurde verifiziert."
 
-#: lib/vutuv_web/components/ui.ex:4079
+#: lib/vutuv_web/components/ui.ex:4084
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
-#: lib/vutuv_web/live/notification_live/index.ex:1047
+#: lib/vutuv_web/live/notification_live/index.ex:1059
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -848,20 +848,20 @@ msgstr "Benutzername"
 msgid "Users"
 msgstr "Benutzer"
 
-#: lib/vutuv_web/components/ui.ex:1070
+#: lib/vutuv_web/components/ui.ex:1071
 #: lib/vutuv_web/templates/user/show.html.heex:346
 #, elixir-autogen
 msgid "vCard"
 msgstr "vCard"
 
-#: lib/vutuv_web/components/ui.ex:3814
-#: lib/vutuv_web/templates/user/show.html.heex:964
-#: lib/vutuv_web/templates/user/show.html.heex:987
+#: lib/vutuv_web/components/ui.ex:3819
+#: lib/vutuv_web/templates/user/show.html.heex:967
+#: lib/vutuv_web/templates/user/show.html.heex:990
 #, elixir-autogen
 msgid "View All"
 msgstr "Alle anzeigen"
 
-#: lib/vutuv_web/components/ui.ex:4173
+#: lib/vutuv_web/components/ui.ex:4181
 #: lib/vutuv_web/controllers/settings_controller.ex:169
 #: lib/vutuv_web/live/job_posting_live/form.ex:756
 #: lib/vutuv_web/live/organization_live/edit.ex:304
@@ -937,7 +937,7 @@ msgid "You follow back %{name}."
 msgstr "Sie folgen %{name} jetzt zurück."
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:82
+#: lib/vutuv_web/live/post_live/feed.ex:86
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1063,7 +1063,7 @@ msgstr "Diese Seite ist für Sie gesperrt."
 msgid "An error occurred"
 msgstr "Es gab einen Fehler."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1082
+#: lib/vutuv_web/templates/user/show.html.heex:1085
 #, elixir-autogen
 msgid "General Info"
 msgstr "Allgemeines"
@@ -1189,7 +1189,7 @@ msgstr "Lokalisierung hinzufügen"
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:825
+#: lib/vutuv_web/live/shell_live.ex:945
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1232,7 +1232,7 @@ msgstr "Alle Tag-URLs"
 
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:618
+#: lib/vutuv_web/templates/user/show.html.heex:621
 #, elixir-autogen
 msgid "All tags"
 msgstr "Alle Tags"
@@ -1404,7 +1404,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:516
 #: lib/vutuv_web/agent_docs/text.ex:753
-#: lib/vutuv_web/components/ui.ex:4104
+#: lib/vutuv_web/components/ui.ex:4109
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
 #: lib/vutuv_web/cv/docx.ex:174
@@ -1430,7 +1430,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:23
 #: lib/vutuv_web/templates/tag/show.html.heex:25
-#: lib/vutuv_web/templates/user/show.html.heex:588
+#: lib/vutuv_web/templates/user/show.html.heex:591
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
@@ -1630,7 +1630,7 @@ msgstr "Adressen von %{name}"
 msgid "Admin control panel"
 msgstr "Admin-Bereich"
 
-#: lib/vutuv_web/live/shell_live.ex:895
+#: lib/vutuv_web/live/shell_live.ex:1015
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "Mitteilungen"
@@ -1649,8 +1649,8 @@ msgstr "Zur Startseite"
 msgid "Check your inbox"
 msgstr "Schauen Sie in Ihr Postfach"
 
-#: lib/vutuv_web/components/ui.ex:315
-#: lib/vutuv_web/components/ui.ex:2560
+#: lib/vutuv_web/components/ui.ex:316
+#: lib/vutuv_web/components/ui.ex:2565
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
@@ -1704,24 +1704,24 @@ msgstr "Mein Konto löschen"
 msgid "Edit profile"
 msgstr "Profil bearbeiten"
 
-#: lib/vutuv_web/components/ui.ex:1578
-#: lib/vutuv_web/components/ui.ex:1587
-#: lib/vutuv_web/components/ui.ex:2051
+#: lib/vutuv_web/components/ui.ex:1583
+#: lib/vutuv_web/components/ui.ex:1592
+#: lib/vutuv_web/components/ui.ex:2056
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr "Empfehlen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:199
-#: lib/vutuv_web/components/ui.ex:2189
-#: lib/vutuv_web/components/ui.ex:2189
-#: lib/vutuv_web/components/ui.ex:2206
-#: lib/vutuv_web/components/ui.ex:2215
-#: lib/vutuv_web/components/ui.ex:2231
-#: lib/vutuv_web/components/ui.ex:2268
-#: lib/vutuv_web/components/ui.ex:2271
-#: lib/vutuv_web/components/ui.ex:2278
-#: lib/vutuv_web/components/ui.ex:2281
-#: lib/vutuv_web/components/ui.ex:2354
+#: lib/vutuv_web/components/ui.ex:2194
+#: lib/vutuv_web/components/ui.ex:2194
+#: lib/vutuv_web/components/ui.ex:2211
+#: lib/vutuv_web/components/ui.ex:2220
+#: lib/vutuv_web/components/ui.ex:2236
+#: lib/vutuv_web/components/ui.ex:2273
+#: lib/vutuv_web/components/ui.ex:2276
+#: lib/vutuv_web/components/ui.ex:2283
+#: lib/vutuv_web/components/ui.ex:2286
+#: lib/vutuv_web/components/ui.ex:2359
 #: lib/vutuv_web/live/fediverse_account_live.ex:387
 #: lib/vutuv_web/live/fediverse_following_live.ex:331
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:317
@@ -1729,7 +1729,7 @@ msgstr "Empfehlen"
 #: lib/vutuv_web/live/organization_live/following.ex:407
 #: lib/vutuv_web/live/organization_live/show.ex:440
 #: lib/vutuv_web/live/organization_live/show.ex:469
-#: lib/vutuv_web/templates/user/show.html.heex:1285
+#: lib/vutuv_web/templates/user/show.html.heex:1288
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr "Folgen"
@@ -1747,8 +1747,8 @@ msgstr ""
 " von jemandem, den Sie kennen oder interessant finden, und klicken Sie auf "
 "Folgen!"
 
-#: lib/vutuv_web/live/shell_live.ex:844
-#: lib/vutuv_web/views/settings_html.ex:367
+#: lib/vutuv_web/live/shell_live.ex:964
+#: lib/vutuv_web/views/settings_html.ex:376
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr "Ausloggen"
@@ -1759,7 +1759,7 @@ msgstr "Ausloggen"
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
 #: lib/vutuv_web/live/admin/user_delete_live.ex:143
 #: lib/vutuv_web/live/admin/user_live.ex:154
-#: lib/vutuv_web/live/message_live/index.ex:533
+#: lib/vutuv_web/live/message_live/index.ex:538
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:32
 #: lib/vutuv_web/templates/admin/account/index.html.heex:55
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:28
@@ -1775,22 +1775,22 @@ msgid "Message"
 msgstr "Nachricht"
 
 #: lib/vutuv_web/live/message_live/index.ex:49
-#: lib/vutuv_web/live/message_live/index.ex:629
-#: lib/vutuv_web/live/shell_live.ex:737
-#: lib/vutuv_web/live/shell_live.ex:894
+#: lib/vutuv_web/live/message_live/index.ex:634
+#: lib/vutuv_web/live/shell_live.ex:857
+#: lib/vutuv_web/live/shell_live.ex:1014
 #: lib/vutuv_web/templates/layout/app.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr "Nachrichten"
 
-#: lib/vutuv_web/live/shell_live.ex:629
+#: lib/vutuv_web/live/shell_live.ex:749
 #: lib/vutuv_web/templates/layout/app.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Network"
 msgstr "Netzwerk"
 
-#: lib/vutuv_web/components/post_components.ex:436
-#: lib/vutuv_web/components/ui.ex:3863
+#: lib/vutuv_web/components/post_components.ex:439
+#: lib/vutuv_web/components/ui.ex:3868
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:705
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:742
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:793
@@ -1800,16 +1800,16 @@ msgstr "Netzwerk"
 msgid "Nothing here yet."
 msgstr "Hier gibt es noch nichts."
 
-#: lib/vutuv_web/live/notification_live/index.ex:377
+#: lib/vutuv_web/live/notification_live/index.ex:389
 #, elixir-autogen, elixir-format
 msgid "Nothing new yet."
 msgstr "Noch nichts Neues."
 
 #: lib/vutuv/api_auth/scopes.ex:85
-#: lib/vutuv_web/components/ui.ex:4141
-#: lib/vutuv_web/live/notification_live/index.ex:114
-#: lib/vutuv_web/live/notification_live/index.ex:338
-#: lib/vutuv_web/live/shell_live.ex:748
+#: lib/vutuv_web/components/ui.ex:4146
+#: lib/vutuv_web/live/notification_live/index.ex:126
+#: lib/vutuv_web/live/notification_live/index.ex:350
+#: lib/vutuv_web/live/shell_live.ex:868
 #: lib/vutuv_web/templates/layout/app.html.heex:173
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -1831,7 +1831,7 @@ msgid "Pardon us! Something went wrong."
 msgstr "Entschuldigung! Etwas ist schiefgelaufen."
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:130
-#: lib/vutuv_web/live/message_live/index.ex:884
+#: lib/vutuv_web/live/message_live/index.ex:889
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Send"
@@ -1906,14 +1906,14 @@ msgstr ""
 "Wir haben eine PIN an Ihre neue E-Mail-Adresse geschickt. Geben Sie sie "
 "unten ein, um die Adresse zu bestätigen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1455
+#: lib/vutuv_web/live/post_live/feed.ex:1471
 #: lib/vutuv_web/views/user_html.ex:213
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr "Vorgeschlagene Profile"
 
-#: lib/vutuv_web/live/message_live/index.ex:873
-#: lib/vutuv_web/live/message_live/index.ex:874
+#: lib/vutuv_web/live/message_live/index.ex:878
+#: lib/vutuv_web/live/message_live/index.ex:879
 #, elixir-autogen, elixir-format
 msgid "Write a message…"
 msgstr "Nachricht schreiben…"
@@ -1943,30 +1943,30 @@ msgstr "folgt"
 msgid "submit a bug report"
 msgstr "einen Fehlerbericht erstellen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1069
+#: lib/vutuv_web/notification_line.ex:79
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr "hat Sie für %{tag} empfohlen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1064
+#: lib/vutuv_web/notification_line.ex:74
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr "ist jetzt mit Ihnen vernetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1059
+#: lib/vutuv_web/notification_line.ex:72
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr "folgt Ihnen jetzt."
 
-#: lib/vutuv_web/components/ui.ex:3203
-#: lib/vutuv_web/components/ui.ex:3354
+#: lib/vutuv_web/components/ui.ex:3208
+#: lib/vutuv_web/components/ui.ex:3359
 #: lib/vutuv_web/live/import_connections_live.ex:638
 #: lib/vutuv_web/live/organization_live/index.ex:122
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr "Seitennavigation"
 
-#: lib/vutuv_web/components/ui.ex:3888
+#: lib/vutuv_web/components/ui.ex:3893
 #: lib/vutuv_web/live/organization_live/activity.ex:150
 #: lib/vutuv_web/live/organization_live/feed.ex:142
 #: lib/vutuv_web/live/organization_live/show.ex:637
@@ -1981,13 +1981,13 @@ msgstr ""
 "Die Adresse selbst kann nicht geändert werden. Um eine andere zu verwenden, "
 "legen Sie sie als neue E-Mail-Adresse an und löschen Sie diese hier."
 
-#: lib/vutuv_web/components/ui.ex:3659
+#: lib/vutuv_web/components/ui.ex:3664
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr "Eintrag löschen"
 
-#: lib/vutuv_web/components/ui.ex:1281
-#: lib/vutuv_web/components/ui.ex:1291
+#: lib/vutuv_web/components/ui.ex:1282
+#: lib/vutuv_web/components/ui.ex:1292
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr "Optionen"
@@ -2026,12 +2026,12 @@ msgstr "Titelbild hinzufügen"
 msgid "Add cover photo"
 msgstr "Titelbild hinzufügen"
 
-#: lib/vutuv_web/components/ui.ex:2864
+#: lib/vutuv_web/components/ui.ex:2869
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr "April"
 
-#: lib/vutuv_web/components/ui.ex:2868
+#: lib/vutuv_web/components/ui.ex:2873
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr "August"
@@ -2056,37 +2056,37 @@ msgstr "Titelbild"
 msgid "Cover photo of %{name}"
 msgstr "Titelbild von %{name}"
 
-#: lib/vutuv_web/components/ui.ex:2872
+#: lib/vutuv_web/components/ui.ex:2877
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr "Dezember"
 
-#: lib/vutuv_web/components/ui.ex:2862
+#: lib/vutuv_web/components/ui.ex:2867
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr "Februar"
 
-#: lib/vutuv_web/components/ui.ex:2861
+#: lib/vutuv_web/components/ui.ex:2866
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr "Januar"
 
-#: lib/vutuv_web/components/ui.ex:2867
+#: lib/vutuv_web/components/ui.ex:2872
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr "Juli"
 
-#: lib/vutuv_web/components/ui.ex:2866
+#: lib/vutuv_web/components/ui.ex:2871
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr "Juni"
 
-#: lib/vutuv_web/components/ui.ex:2863
+#: lib/vutuv_web/components/ui.ex:2868
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr "März"
 
-#: lib/vutuv_web/components/ui.ex:2865
+#: lib/vutuv_web/components/ui.ex:2870
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr "Mai"
@@ -2101,17 +2101,17 @@ msgstr "Mitglied seit %{month} %{year}"
 msgid "Member since %{year}"
 msgstr "Mitglied seit %{year}"
 
-#: lib/vutuv_web/components/ui.ex:2871
+#: lib/vutuv_web/components/ui.ex:2876
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr "November"
 
-#: lib/vutuv_web/components/ui.ex:2870
+#: lib/vutuv_web/components/ui.ex:2875
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr "Oktober"
 
-#: lib/vutuv_web/components/ui.ex:2869
+#: lib/vutuv_web/components/ui.ex:2874
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr "September"
@@ -2149,7 +2149,7 @@ msgstr "Upload abbrechen"
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
-#: lib/vutuv_web/components/post_components.ex:2869
+#: lib/vutuv_web/components/post_components.ex:2966
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2164,10 +2164,10 @@ msgstr "Beitrag bearbeiten"
 #: lib/vutuv_web/components/organization_components.ex:274
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:98
-#: lib/vutuv_web/live/post_live/feed.ex:187
-#: lib/vutuv_web/live/post_live/feed.ex:1187
-#: lib/vutuv_web/live/shell_live.ex:609
-#: lib/vutuv_web/live/shell_live.ex:890
+#: lib/vutuv_web/live/post_live/feed.ex:191
+#: lib/vutuv_web/live/post_live/feed.ex:1203
+#: lib/vutuv_web/live/shell_live.ex:729
+#: lib/vutuv_web/live/shell_live.ex:1010
 #: lib/vutuv_web/templates/layout/app.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2193,8 +2193,8 @@ msgstr "Vor einer bestimmten Person verbergen…"
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
 
-#: lib/vutuv_web/components/post_components.ex:2823
-#: lib/vutuv_web/components/post_components.ex:2825
+#: lib/vutuv_web/components/post_components.ex:2920
+#: lib/vutuv_web/components/post_components.ex:2922
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
@@ -2210,7 +2210,7 @@ msgstr "Nicht eingeloggte Besucher"
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1394
+#: lib/vutuv_web/live/post_live/feed.ex:1410
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2251,7 +2251,7 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/gettext_extraction_anchors.ex:91
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
-#: lib/vutuv_web/live/notification_live/index.ex:891
+#: lib/vutuv_web/live/notification_live/index.ex:903
 #: lib/vutuv_web/live/organization_live/show.ex:564
 #: lib/vutuv_web/live/post_live/saved.ex:520
 #: lib/vutuv_web/live/search_live.ex:281
@@ -2262,13 +2262,13 @@ msgstr "Beitrag erfolgreich gelöscht."
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:3293
-#: lib/vutuv_web/components/post_components.ex:3297
+#: lib/vutuv_web/components/post_components.ex:3390
+#: lib/vutuv_web/components/post_components.ex:3394
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:3294
+#: lib/vutuv_web/components/post_components.ex:3391
 #: lib/vutuv_web/live/fediverse_account_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2276,7 +2276,7 @@ msgstr "Weniger anzeigen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:342
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:1097
+#: lib/vutuv_web/components/post_components.ex:1100
 #: lib/vutuv_web/live/admin/screenshot_live.ex:327
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:700
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
@@ -2287,7 +2287,7 @@ msgstr "Weniger anzeigen"
 #: lib/vutuv_web/live/post_live/saved.ex:650
 #: lib/vutuv_web/live/post_live/saved.ex:678
 #: lib/vutuv_web/templates/connection/index.html.heex:40
-#: lib/vutuv_web/views/settings_html.ex:413
+#: lib/vutuv_web/views/settings_html.ex:422
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Entfernen"
@@ -2304,7 +2304,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1298
+#: lib/vutuv_web/live/post_live/feed.ex:1314
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2341,11 +2341,11 @@ msgstr "Zu viele Dateien."
 msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
 
-#: lib/vutuv_web/components/ui.ex:4427
-#: lib/vutuv_web/live/shell_live.ex:791
+#: lib/vutuv_web/components/ui.ex:4435
+#: lib/vutuv_web/live/shell_live.ex:911
 #: lib/vutuv_web/templates/post/index.html.heex:17
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
-#: lib/vutuv_web/views/settings_html.ex:314
+#: lib/vutuv_web/views/settings_html.ex:323
 #, elixir-autogen, elixir-format
 msgid "View profile"
 msgstr "Profil ansehen"
@@ -2360,33 +2360,33 @@ msgstr "Was gibt's Neues?"
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
 
-#: lib/vutuv_web/components/post_components.ex:2820
+#: lib/vutuv_web/components/post_components.ex:2917
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:4613
+#: lib/vutuv_web/components/post_components.ex:4710
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:4617
+#: lib/vutuv_web/components/post_components.ex:4714
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:4615
+#: lib/vutuv_web/components/post_components.ex:4712
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:4616
+#: lib/vutuv_web/components/post_components.ex:4713
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
 
 #: lib/vutuv_web/views/post_html.ex:19
-#: lib/vutuv_web/views/settings_html.ex:492
+#: lib/vutuv_web/views/settings_html.ex:501
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr "unbekannt"
@@ -2411,7 +2411,7 @@ msgstr "Dateityp wird nicht unterstützt (erlaubt: %{types})."
 msgid "Posts by %{name}"
 msgstr "Beiträge von %{name}"
 
-#: lib/vutuv_web/templates/user/show.html.heex:578
+#: lib/vutuv_web/templates/user/show.html.heex:581
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr "Alle %{count} Beiträge ansehen"
@@ -2421,9 +2421,9 @@ msgstr "Alle %{count} Beiträge ansehen"
 msgid "All posts"
 msgstr "Alle Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:1664
-#: lib/vutuv_web/components/post_components.ex:4701
-#: lib/vutuv_web/components/ui.ex:3278
+#: lib/vutuv_web/components/post_components.ex:1693
+#: lib/vutuv_web/components/post_components.ex:4806
+#: lib/vutuv_web/components/ui.ex:3283
 #: lib/vutuv_web/views/user_html.ex:440
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2432,29 +2432,29 @@ msgstr "Lesezeichen setzen"
 #: lib/vutuv_web/agent_docs/markdown.ex:1108
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
-#: lib/vutuv_web/live/shell_live.ex:730
-#: lib/vutuv_web/live/shell_live.ex:796
+#: lib/vutuv_web/live/shell_live.ex:850
+#: lib/vutuv_web/live/shell_live.ex:916
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/vutuv_web/components/post_components.ex:1628
-#: lib/vutuv_web/components/post_components.ex:4935
-#: lib/vutuv_web/components/ui.ex:3264
-#: lib/vutuv_web/live/notification_live/index.ex:1037
+#: lib/vutuv_web/components/post_components.ex:1646
+#: lib/vutuv_web/components/post_components.ex:5042
+#: lib/vutuv_web/components/ui.ex:3269
+#: lib/vutuv_web/live/notification_live/index.ex:1049
 #: lib/vutuv_web/views/user_html.ex:450
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1107
-#: lib/vutuv_web/components/post_components.ex:4944
-#: lib/vutuv_web/live/notification_live/index.ex:970
+#: lib/vutuv_web/components/post_components.ex:5052
+#: lib/vutuv_web/live/notification_live/index.ex:982
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
-#: lib/vutuv_web/live/shell_live.ex:799
+#: lib/vutuv_web/live/shell_live.ex:919
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2472,39 +2472,40 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:4690
+#: lib/vutuv_web/components/post_components.ex:4794
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
-#: lib/vutuv_web/components/post_components.ex:1664
-#: lib/vutuv_web/components/post_components.ex:4701
+#: lib/vutuv_web/components/post_components.ex:1692
+#: lib/vutuv_web/components/post_components.ex:4805
 #: lib/vutuv_web/live/post_live/saved.ex:806
 #: lib/vutuv_web/views/user_html.ex:440
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
-#: lib/vutuv_web/components/post_components.ex:1652
-#: lib/vutuv_web/components/post_components.ex:4687
+#: lib/vutuv_web/components/post_components.ex:1674
+#: lib/vutuv_web/components/post_components.ex:4791
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
-#: lib/vutuv_web/components/post_components.ex:1842
-#: lib/vutuv_web/components/post_components.ex:3875
+#: lib/vutuv_web/components/post_components.ex:1939
+#: lib/vutuv_web/components/post_components.ex:3972
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:1652
-#: lib/vutuv_web/components/post_components.ex:4687
+#: lib/vutuv_web/components/post_components.ex:1673
+#: lib/vutuv_web/components/post_components.ex:4790
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
-#: lib/vutuv_web/components/post_components.ex:4935
+#: lib/vutuv_web/components/post_components.ex:1645
+#: lib/vutuv_web/components/post_components.ex:5041
 #: lib/vutuv_web/live/post_live/saved.ex:805
 #: lib/vutuv_web/views/user_html.ex:450
 #, elixir-autogen, elixir-format
@@ -2512,14 +2513,14 @@ msgid "Unlike"
 msgstr "Gefällt mir entfernen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:343
-#: lib/vutuv_web/components/post_components.ex:2127
-#: lib/vutuv_web/components/ui.ex:2184
-#: lib/vutuv_web/components/ui.ex:2184
-#: lib/vutuv_web/components/ui.ex:2321
+#: lib/vutuv_web/components/post_components.ex:2224
+#: lib/vutuv_web/components/ui.ex:2189
+#: lib/vutuv_web/components/ui.ex:2189
+#: lib/vutuv_web/components/ui.ex:2326
 #: lib/vutuv_web/live/organization_live/following.ex:378
 #: lib/vutuv_web/live/organization_live/following.ex:453
 #: lib/vutuv_web/live/organization_live/show.ex:474
-#: lib/vutuv_web/live/post_live/feed.ex:1444
+#: lib/vutuv_web/live/post_live/feed.ex:1460
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2531,27 +2532,27 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:4988
+#: lib/vutuv_web/components/post_components.ex:5096
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
 
-#: lib/vutuv_web/components/post_components.ex:394
-#: lib/vutuv_web/live/notification_live/index.ex:971
+#: lib/vutuv_web/components/post_components.ex:397
+#: lib/vutuv_web/live/notification_live/index.ex:983
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:1639
-#: lib/vutuv_web/components/post_components.ex:4971
-#: lib/vutuv_web/components/post_components.ex:4972
-#: lib/vutuv_web/live/notification_live/index.ex:1034
+#: lib/vutuv_web/components/post_components.ex:1659
+#: lib/vutuv_web/components/post_components.ex:5079
+#: lib/vutuv_web/components/post_components.ex:5080
+#: lib/vutuv_web/live/notification_live/index.ex:1046
 #: lib/vutuv_web/live/post_live/reply.ex:43
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:2787
+#: lib/vutuv_web/components/post_components.ex:2884
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
@@ -2567,12 +2568,12 @@ msgstr "Solange es geteilte Beiträge oder Antworten gibt, lässt sich der Empf�
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beiträge oder Antworten gibt, bleibt er öffentlich; löschen können Sie ihn weiterhin."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1257
+#: lib/vutuv_web/notification_line.ex:61
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
 
-#: lib/vutuv_web/components/post_components.ex:2323
+#: lib/vutuv_web/components/post_components.ex:2420
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:60
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:57
@@ -2580,59 +2581,59 @@ msgstr "hat auf Ihren Beitrag geantwortet."
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
 
-#: lib/vutuv_web/components/post_components.ex:2761
+#: lib/vutuv_web/components/post_components.ex:2858
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:2752
-#: lib/vutuv_web/components/post_components.ex:2779
-#: lib/vutuv_web/components/post_components.ex:2782
+#: lib/vutuv_web/components/post_components.ex:2849
+#: lib/vutuv_web/components/post_components.ex:2876
+#: lib/vutuv_web/components/post_components.ex:2879
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
 
-#: lib/vutuv_web/live/message_live/index.ex:608
+#: lib/vutuv_web/live/message_live/index.ex:613
 #, elixir-autogen, elixir-format
 msgid "%{names} are typing…"
 msgstr "%{names} schreiben…"
 
-#: lib/vutuv_web/live/message_live/index.ex:607
+#: lib/vutuv_web/live/message_live/index.ex:612
 #, elixir-autogen, elixir-format
 msgid "%{name} is typing…"
 msgstr "%{name} schreibt…"
 
-#: lib/vutuv_web/live/message_live/index.ex:896
+#: lib/vutuv_web/live/message_live/index.ex:901
 #, elixir-autogen, elixir-format
 msgid "@%{slug} has not accepted your message request yet."
 msgstr "@%{slug} hat Ihre Nachrichtenanfrage noch nicht angenommen."
 
-#: lib/vutuv_web/live/message_live/index.ex:848
+#: lib/vutuv_web/live/message_live/index.ex:853
 #, elixir-autogen, elixir-format
 msgid "@%{slug} wants to message you."
 msgstr "@%{slug} möchte Ihnen Nachrichten schicken."
 
-#: lib/vutuv_web/live/message_live/index.ex:591
+#: lib/vutuv_web/live/message_live/index.ex:596
 #, elixir-autogen, elixir-format
 msgid "Accept"
 msgstr "Annehmen"
 
-#: lib/vutuv_web/live/message_live/index.ex:711
+#: lib/vutuv_web/live/message_live/index.ex:716
 #, elixir-autogen, elixir-format
 msgid "Back to conversations"
 msgstr "Zurück zu den Unterhaltungen"
 
-#: lib/vutuv_web/live/message_live/index.ex:598
+#: lib/vutuv_web/live/message_live/index.ex:603
 #, elixir-autogen, elixir-format
 msgid "Decline"
 msgstr "Ablehnen"
 
-#: lib/vutuv_web/live/message_live/index.ex:529
+#: lib/vutuv_web/live/message_live/index.ex:534
 #, elixir-autogen, elixir-format
 msgid "Deleted account"
 msgstr "Gelöschtes Konto"
 
-#: lib/vutuv_web/live/message_live/index.ex:757
+#: lib/vutuv_web/live/message_live/index.ex:762
 #, elixir-autogen, elixir-format
 msgid "Load older messages"
 msgstr "Ältere Nachrichten laden"
@@ -2643,23 +2644,23 @@ msgstr "Ältere Nachrichten laden"
 msgid "Member not found."
 msgstr "Mitglied nicht gefunden."
 
-#: lib/vutuv_web/live/message_live/index.ex:690
+#: lib/vutuv_web/live/message_live/index.ex:695
 #, elixir-autogen, elixir-format
 msgid "No conversations yet."
 msgstr "Noch keine Unterhaltungen."
 
-#: lib/vutuv_web/components/ui.ex:2684
-#: lib/vutuv_web/live/message_live/index.ex:733
+#: lib/vutuv_web/components/ui.ex:2689
+#: lib/vutuv_web/live/message_live/index.ex:738
 #, elixir-autogen, elixir-format
 msgid "Online"
 msgstr "Online"
 
-#: lib/vutuv_web/live/message_live/index.ex:639
+#: lib/vutuv_web/live/message_live/index.ex:644
 #, elixir-autogen, elixir-format
 msgid "Requests"
 msgstr "Anfragen"
 
-#: lib/vutuv_web/live/message_live/index.ex:905
+#: lib/vutuv_web/live/message_live/index.ex:910
 #, elixir-autogen, elixir-format
 msgid "Select a conversation."
 msgstr "Wählen Sie eine Unterhaltung aus."
@@ -2669,7 +2670,7 @@ msgstr "Wählen Sie eine Unterhaltung aus."
 msgid "This member cannot receive messages."
 msgstr "Dieses Mitglied kann keine Nachrichten empfangen."
 
-#: lib/vutuv_web/live/message_live/index.ex:234
+#: lib/vutuv_web/live/message_live/index.ex:239
 #, elixir-autogen, elixir-format
 msgid "This message could not be sent."
 msgstr "Diese Nachricht konnte nicht gesendet werden."
@@ -2737,7 +2738,7 @@ msgstr "Eine neue PIN ist unterwegs zu Ihrer E-Mail-Adresse."
 msgid "Okay, let's start over."
 msgstr "Alles klar, fangen wir neu an."
 
-#: lib/vutuv_web/components/ui.ex:731
+#: lib/vutuv_web/components/ui.ex:732
 #, elixir-autogen, elixir-format
 msgid "Resend PIN"
 msgstr "PIN erneut senden"
@@ -2748,71 +2749,71 @@ msgstr "PIN erneut senden"
 msgid "Too many PIN requests. Please try again later."
 msgstr "Zu viele PIN-Anfragen. Bitte versuchen Sie es später erneut."
 
-#: lib/vutuv_web/components/ui.ex:752
+#: lib/vutuv_web/components/ui.ex:753
 #, elixir-autogen, elixir-format
 msgid "Use a different email address"
 msgstr "Andere E-Mail-Adresse verwenden"
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
 #: lib/vutuv_web/templates/url/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:900
+#: lib/vutuv_web/templates/user/show.html.heex:903
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr "Link hinzufügen"
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1205
+#: lib/vutuv_web/templates/user/show.html.heex:1208
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr "Telefonnummer hinzufügen"
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1463
+#: lib/vutuv_web/templates/user/show.html.heex:1466
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr "Adresse hinzufügen"
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1133
+#: lib/vutuv_web/templates/user/show.html.heex:1136
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr "E-Mail-Adresse hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1084
+#: lib/vutuv_web/templates/user/show.html.heex:1087
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr "Persönliche Angaben hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:627
+#: lib/vutuv_web/templates/user/show.html.heex:630
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #: lib/vutuv_web/templates/work_experience/new.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Add work experience"
 msgstr "Berufserfahrung hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:488
+#: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
 msgstr "Ersten Beitrag schreiben"
 
-#: lib/vutuv_web/components/ui.ex:3442
-#: lib/vutuv_web/components/ui.ex:3816
+#: lib/vutuv_web/components/ui.ex:3447
+#: lib/vutuv_web/components/ui.ex:3821
 #: lib/vutuv_web/templates/settings/apps.html.heex:22
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #: lib/vutuv_web/templates/settings/organizations.html.heex:104
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:216
-#: lib/vutuv_web/templates/user/show.html.heex:618
+#: lib/vutuv_web/templates/user/show.html.heex:621
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr "Verwalten"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1225
-#: lib/vutuv_web/templates/user/show.html.heex:488
+#: lib/vutuv_web/live/post_live/feed.ex:1241
+#: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write a post"
 msgstr "Beitrag schreiben"
@@ -2842,13 +2843,13 @@ msgstr[1] "+%{formatted} weitere Tags"
 #: lib/vutuv_web/agent_docs/markdown.ex:625
 #: lib/vutuv_web/agent_docs/text.ex:591
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:969
+#: lib/vutuv_web/live/notification_live/index.ex:981
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
 msgstr "Vernetzungen"
 
-#: lib/vutuv_web/components/ui.ex:1061
+#: lib/vutuv_web/components/ui.ex:1062
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr "Markdown"
@@ -2858,7 +2859,7 @@ msgstr "Markdown"
 msgid "No connections yet."
 msgstr "Noch keine Vernetzungen."
 
-#: lib/vutuv_web/components/ui.ex:1077
+#: lib/vutuv_web/components/ui.ex:1078
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr "Andere Formate"
@@ -2868,7 +2869,7 @@ msgstr "Andere Formate"
 msgid "People who aren't my connections"
 msgstr "Personen, mit denen ich nicht vernetzt bin"
 
-#: lib/vutuv_web/components/ui.ex:1062
+#: lib/vutuv_web/components/ui.ex:1063
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr "Nur Text"
@@ -2886,35 +2887,35 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:4614
+#: lib/vutuv_web/components/post_components.ex:4711
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
 
-#: lib/vutuv_web/live/message_live/index.ex:691
+#: lib/vutuv_web/live/message_live/index.ex:696
 #, elixir-autogen, elixir-format
 msgid "Open someone's profile to message them."
 msgstr "Öffnen Sie ein Profil, um jemandem zu schreiben."
 
 #: lib/vutuv_web/components/organization_components.ex:268
-#: lib/vutuv_web/live/notification_live/index.ex:1049
+#: lib/vutuv_web/live/notification_live/index.ex:1061
 #: lib/vutuv_web/live/organization_live/activity.ex:103
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr "Aktivität"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1040
+#: lib/vutuv_web/live/notification_live/index.ex:1052
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr "Vernetzung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1033
+#: lib/vutuv_web/live/notification_live/index.ex:1045
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr "Empfehlung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1032
-#: lib/vutuv_web/templates/user/show.html.heex:948
+#: lib/vutuv_web/live/notification_live/index.ex:1044
+#: lib/vutuv_web/templates/user/show.html.heex:951
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -2926,7 +2927,7 @@ msgstr[1] "Follower"
 msgid "Welcome to vutuv, %{name}!"
 msgstr "Willkommen bei vutuv, %{name}!"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1066
+#: lib/vutuv_web/notification_line.ex:70
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr "gefällt Ihr Beitrag."
@@ -2958,12 +2959,12 @@ msgstr "(gelöschtes Konto)"
 msgid "(no text)"
 msgstr "(kein Text)"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1293
+#: lib/vutuv_web/notification_line.ex:115
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr "Eine Meldung zu Ihrem Inhalt wurde bestätigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1294
+#: lib/vutuv_web/notification_line.ex:116
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr "Eine Meldung zu Ihrem Inhalt wurde verworfen; er ist wieder sichtbar."
@@ -3066,7 +3067,7 @@ msgstr ""
 msgid "Hidden. You can settle this yourself - see below."
 msgstr "Verborgen. Sie können das selbst klären, siehe unten."
 
-#: lib/vutuv_web/live/message_live/index.ex:786
+#: lib/vutuv_web/live/message_live/index.ex:791
 #, elixir-autogen, elixir-format
 msgid "Hidden: reported, under review"
 msgstr "Verborgen: gemeldet, wird geprüft"
@@ -3078,7 +3079,7 @@ msgstr "Familienfreundlich bleiben"
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:1041
+#: lib/vutuv_web/live/notification_live/index.ex:1053
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3161,13 +3162,13 @@ msgstr "Nichts zu sehen, keiner Ihrer Inhalte ist derzeit gemeldet."
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1173
-#: lib/vutuv_web/templates/user/show.html.heex:1174
+#: lib/vutuv_web/templates/user/show.html.heex:1176
+#: lib/vutuv_web/templates/user/show.html.heex:1177
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:2728
+#: lib/vutuv_web/components/post_components.ex:2825
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solange eine Meldung zu diesem Beitrag bearbeitet wird, sehen nur Sie ihn."
@@ -3220,9 +3221,9 @@ msgstr ""
 msgid "Private message"
 msgstr "Private Nachricht"
 
-#: lib/vutuv_web/components/ui.ex:4073
-#: lib/vutuv_web/live/shell_live.ex:622
-#: lib/vutuv_web/live/shell_live.ex:899
+#: lib/vutuv_web/components/ui.ex:4078
+#: lib/vutuv_web/live/shell_live.ex:742
+#: lib/vutuv_web/live/shell_live.ex:1019
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -3246,9 +3247,9 @@ msgstr "Abgelehnt"
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 
-#: lib/vutuv_web/components/post_components.ex:1107
-#: lib/vutuv_web/components/post_components.ex:2139
-#: lib/vutuv_web/components/post_components.ex:2892
+#: lib/vutuv_web/components/post_components.ex:1110
+#: lib/vutuv_web/components/post_components.ex:2236
+#: lib/vutuv_web/components/post_components.ex:2989
 #: lib/vutuv_web/live/organization_live/show.ex:547
 #: lib/vutuv_web/templates/user/show.html.heex:222
 #, elixir-autogen, elixir-format
@@ -3276,8 +3277,8 @@ msgstr "Meldung abgelehnt; der Inhalt ist wieder sichtbar."
 msgid "Report this content"
 msgstr "Diesen Inhalt melden"
 
-#: lib/vutuv_web/live/message_live/index.ex:804
-#: lib/vutuv_web/live/message_live/index.ex:805
+#: lib/vutuv_web/live/message_live/index.ex:809
+#: lib/vutuv_web/live/message_live/index.ex:810
 #, elixir-autogen, elixir-format
 msgid "Report this message"
 msgstr "Diese Nachricht melden"
@@ -3334,7 +3335,7 @@ msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 "Meldungen sind anonym; wir verraten nie, wer gemeldet hat. Unsere Regeln:"
 
-#: lib/vutuv_web/components/ui.ex:3178
+#: lib/vutuv_web/components/ui.ex:3183
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:773
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -3538,12 +3539,12 @@ msgstr "Sie haben das bereits gemeldet. Unser Team kümmert sich darum."
 msgid "You cannot report your own content."
 msgstr "Eigene Inhalte können Sie nicht melden."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1296
+#: lib/vutuv_web/notification_line.ex:118
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr "Sie haben gemeldeten Inhalt gelöscht; der Fall ist abgeschlossen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1295
+#: lib/vutuv_web/notification_line.ex:117
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr "Sie haben gemeldeten Inhalt überarbeitet; der Fall ist abgeschlossen."
@@ -3553,7 +3554,7 @@ msgstr "Sie haben gemeldeten Inhalt überarbeitet; der Fall ist abgeschlossen."
 msgid "Your content was reported"
 msgstr "Ihr Inhalt wurde gemeldet"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1297
+#: lib/vutuv_web/notification_line.ex:119
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3748,7 +3749,7 @@ msgstr "Verlauf"
 msgid "Open the profile"
 msgstr "Profil öffnen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1321
+#: lib/vutuv_web/notification_line.ex:143
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3775,7 +3776,7 @@ msgstr "Besitzer hat den Inhalt bearbeitet"
 msgid "Report filed"
 msgstr "Meldung eingegangen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1043
+#: lib/vutuv_web/live/notification_live/index.ex:1055
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr "Schutz nach Meldung"
@@ -3857,7 +3858,7 @@ msgstr "Bestätigt"
 msgid "Waiting for the owner"
 msgstr "Wartet auf den Besitzer"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1326
+#: lib/vutuv_web/notification_line.ex:148
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -4663,7 +4664,7 @@ msgstr ""
 "beide Richtungen unterbunden. Eine Aufhebung der Blockierung stellt das "
 "Entfernte nicht wieder her."
 
-#: lib/vutuv_web/components/ui.ex:4177
+#: lib/vutuv_web/components/ui.ex:4185
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -4712,12 +4713,12 @@ msgstr "Sie haben niemanden blockiert."
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1399
+#: lib/vutuv_web/live/post_live/feed.ex:1415
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
 
-#: lib/vutuv_web/live/message_live/index.ex:694
+#: lib/vutuv_web/live/message_live/index.ex:699
 #, elixir-autogen, elixir-format
 msgid "Find members"
 msgstr "Mitglieder finden"
@@ -4726,7 +4727,7 @@ msgstr "Mitglieder finden"
 #: lib/vutuv_web/live/organization_live/following.ex:299
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:970
+#: lib/vutuv_web/templates/user/show.html.heex:973
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr "Folgt"
@@ -4771,8 +4772,8 @@ msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
 #: lib/vutuv_web/agent_docs/markdown.ex:436
 #: lib/vutuv_web/agent_docs/text.ex:457
 #: lib/vutuv_web/components/saved_search_components.ex:57
-#: lib/vutuv_web/components/ui.ex:551
-#: lib/vutuv_web/live/notification_live/index.ex:892
+#: lib/vutuv_web/components/ui.ex:552
+#: lib/vutuv_web/live/notification_live/index.ex:904
 #: lib/vutuv_web/live/organization_live/show.ex:647
 #: lib/vutuv_web/live/post_live/saved.ex:523
 #: lib/vutuv_web/live/search_live.ex:279
@@ -4793,12 +4794,12 @@ msgstr ""
 msgid "Similar names"
 msgstr "Ähnliche Namen"
 
-#: lib/vutuv_web/components/post_components.ex:391
-#: lib/vutuv_web/components/post_components.ex:410
+#: lib/vutuv_web/components/post_components.ex:394
+#: lib/vutuv_web/components/post_components.ex:413
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
-#: lib/vutuv_web/live/notification_live/index.ex:890
+#: lib/vutuv_web/live/notification_live/index.ex:902
 #: lib/vutuv_web/live/search_live.ex:278
 #: lib/vutuv_web/views/qualification_html.ex:103
 #, elixir-autogen, elixir-format
@@ -4848,7 +4849,7 @@ msgstr "sucht nur in Vornamen (nachname: für Nachnamen)"
 #: lib/vutuv_web/live/job_board_live.ex:388
 #: lib/vutuv_web/live/tag_new_live.ex:48
 #: lib/vutuv_web/live/user_profile_live.ex:1331
-#: lib/vutuv_web/templates/user/show.html.heex:591
+#: lib/vutuv_web/templates/user/show.html.heex:594
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr "Tags hinzufügen"
@@ -5105,7 +5106,7 @@ msgstr "API-Anwendungen"
 #: lib/vutuv_web/live/admin/api_app_live.ex:98
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:181
 #: lib/vutuv_web/views/settings_html.ex:77
-#: lib/vutuv_web/views/settings_html.ex:358
+#: lib/vutuv_web/views/settings_html.ex:367
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr "Aktiv"
@@ -5491,7 +5492,7 @@ msgstr "API-Token (%{date})"
 msgid "API documentation"
 msgstr "API-Dokumentation"
 
-#: lib/vutuv_web/components/ui.ex:4237
+#: lib/vutuv_web/components/ui.ex:4245
 #: lib/vutuv_web/controllers/settings_controller.ex:155
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5542,7 +5543,7 @@ msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
 msgid "Content under review"
 msgstr "Inhalte in Prüfung"
 
-#: lib/vutuv_web/live/shell_live.ex:778
+#: lib/vutuv_web/live/shell_live.ex:898
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr "Kontomenü"
@@ -5564,7 +5565,7 @@ msgstr "Menüs und Dialoge schließen"
 msgid "General"
 msgstr "Allgemeines"
 
-#: lib/vutuv_web/live/shell_live.ex:835
+#: lib/vutuv_web/live/shell_live.ex:955
 #: lib/vutuv_web/templates/layout/app.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5575,15 +5576,15 @@ msgstr "Tastaturkürzel"
 msgid "Navigation"
 msgstr "Navigation"
 
-#: lib/vutuv_web/components/ui.ex:4334
-#: lib/vutuv_web/components/ui.ex:4339
-#: lib/vutuv_web/components/ui.ex:4418
-#: lib/vutuv_web/components/ui.ex:4482
+#: lib/vutuv_web/components/ui.ex:4342
+#: lib/vutuv_web/components/ui.ex:4347
+#: lib/vutuv_web/components/ui.ex:4426
+#: lib/vutuv_web/components/ui.ex:4490
 #: lib/vutuv_web/controllers/settings_controller.ex:62
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:303
-#: lib/vutuv_web/live/shell_live.ex:815
+#: lib/vutuv_web/live/shell_live.ex:935
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5591,7 +5592,7 @@ msgstr "Navigation"
 #: lib/vutuv_web/templates/login_code/index.html.heex:4
 #: lib/vutuv_web/templates/totp/new.html.heex:4
 #: lib/vutuv_web/templates/username/confirm.html.heex:23
-#: lib/vutuv_web/views/settings_html.ex:309
+#: lib/vutuv_web/views/settings_html.ex:318
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr "Einstellungen"
@@ -5637,8 +5638,8 @@ msgstr "Nächster Beitrag im Feed"
 msgid "Previous post in the feed"
 msgstr "Vorheriger Beitrag im Feed"
 
-#: lib/vutuv_web/live/shell_live.ex:602
-#: lib/vutuv_web/live/shell_live.ex:881
+#: lib/vutuv_web/live/shell_live.ex:722
+#: lib/vutuv_web/live/shell_live.ex:1001
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr "Hauptnavigation"
@@ -5648,11 +5649,11 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:2957
-#: lib/vutuv_web/components/post_components.ex:3011
-#: lib/vutuv_web/components/post_components.ex:3430
-#: lib/vutuv_web/live/notification_live/index.ex:691
-#: lib/vutuv_web/live/post_live/feed.ex:1517
+#: lib/vutuv_web/components/post_components.ex:3054
+#: lib/vutuv_web/components/post_components.ex:3108
+#: lib/vutuv_web/components/post_components.ex:3527
+#: lib/vutuv_web/live/notification_live/index.ex:703
+#: lib/vutuv_web/live/post_live/feed.ex:1533
 #: lib/vutuv_web/views/user_html.ex:113
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5697,7 +5698,7 @@ msgstr "Art der E-Mail-Adresse"
 msgid "About you"
 msgstr "Über Sie"
 
-#: lib/vutuv_web/components/ui.ex:4197
+#: lib/vutuv_web/components/ui.ex:4205
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:289
@@ -5719,7 +5720,7 @@ msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 "Laden Sie alles herunter, was vutuv über Sie speichert, als eine Datei."
 
-#: lib/vutuv_web/components/ui.ex:4111
+#: lib/vutuv_web/components/ui.ex:4116
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5753,7 +5754,7 @@ msgstr "Persönliche Tokens für die vutuv-API."
 msgid "Photos"
 msgstr "Fotos"
 
-#: lib/vutuv_web/components/ui.ex:4171
+#: lib/vutuv_web/components/ui.ex:4179
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/templates/page/index.html.heex:174
 #, elixir-autogen, elixir-format
@@ -5780,7 +5781,7 @@ msgstr "Ansehen"
 msgid "Your name"
 msgstr "Ihr Name"
 
-#: lib/vutuv_web/live/notification_live/index.ex:520
+#: lib/vutuv_web/live/notification_live/index.ex:532
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr "Ihr Beitrag"
@@ -5868,14 +5869,14 @@ msgstr "@%{slug} folgt Ihnen jetzt auf vutuv"
 msgid "Apps"
 msgstr "Apps"
 
-#: lib/vutuv_web/components/ui.ex:4230
+#: lib/vutuv_web/components/ui.ex:4238
 #: lib/vutuv_web/controllers/settings_controller.ex:179
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
 msgstr "Apps & API-Zugang"
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:127
-#: lib/vutuv_web/live/notification_live/index.ex:972
+#: lib/vutuv_web/live/notification_live/index.ex:984
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:17
@@ -5883,12 +5884,12 @@ msgstr "Apps & API-Zugang"
 msgid "Endorsements"
 msgstr "Empfehlungen"
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:134
+#: lib/vutuv_web/templates/settings/notifications.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "Endorsements and new followers"
 msgstr "Empfehlungen und neue Follower"
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:128
+#: lib/vutuv_web/templates/settings/notifications.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "In-app notifications"
 msgstr "Benachrichtigungen in der App"
@@ -5903,12 +5904,12 @@ msgstr "Neue Follower"
 msgid "Notification settings"
 msgstr "Benachrichtigungseinstellungen"
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:142
+#: lib/vutuv_web/templates/settings/notifications.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "Open your notifications"
 msgstr "Benachrichtigungen öffnen"
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:135
+#: lib/vutuv_web/templates/settings/notifications.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Replies to and likes on your posts"
 msgstr "Antworten und Likes zu Ihren Beiträgen"
@@ -5923,7 +5924,7 @@ msgstr "Sicherheit"
 msgid "Search engines & AI"
 msgstr "Suchmaschinen & KI"
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:130
+#: lib/vutuv_web/templates/settings/notifications.html.heex:187
 #, elixir-autogen, elixir-format
 msgid "These are always on. You see them under the bell at the top of every page, in real time."
 msgstr ""
@@ -5955,7 +5956,7 @@ msgstr "Wenn jemand beginnt, Ihnen zu folgen."
 msgid "@handle"
 msgstr "@handle"
 
-#: lib/vutuv_web/live/message_live/index.ex:749
+#: lib/vutuv_web/live/message_live/index.ex:754
 #, elixir-autogen, elixir-format
 msgid "Block @%{slug}"
 msgstr "@%{slug} blockieren"
@@ -6023,7 +6024,7 @@ msgid "Name (A-Z)"
 msgstr "Name (A-Z)"
 
 #: lib/vutuv_web/live/post_live/saved.ex:491
-#: lib/vutuv_web/live/tag_live/timeline.ex:325
+#: lib/vutuv_web/live/tag_live/timeline.ex:328
 #, elixir-autogen, elixir-format
 msgid "Newest first"
 msgstr "Neueste zuerst"
@@ -6049,7 +6050,7 @@ msgid "Nothing here yet. People you like show up here."
 msgstr "Hier ist noch nichts. Personen, die Ihnen gefallen, erscheinen hier."
 
 #: lib/vutuv_web/live/post_live/saved.ex:492
-#: lib/vutuv_web/live/tag_live/timeline.ex:326
+#: lib/vutuv_web/live/tag_live/timeline.ex:329
 #, elixir-autogen, elixir-format
 msgid "Oldest first"
 msgstr "Älteste zuerst"
@@ -6071,34 +6072,34 @@ msgid "Search saved items"
 msgstr "Gespeicherte durchsuchen"
 
 #: lib/vutuv_web/live/post_live/saved.ex:554
-#: lib/vutuv_web/live/tag_live/timeline.ex:253
+#: lib/vutuv_web/live/tag_live/timeline.ex:256
 #, elixir-autogen, elixir-format
 msgid "Sort"
 msgstr "Sortieren"
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/views/settings_html.ex:501
+#: lib/vutuv_web/views/settings_html.ex:510
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] "vor %{count} Tag"
 msgstr[1] "vor %{count} Tagen"
 
-#: lib/vutuv_web/views/settings_html.ex:500
+#: lib/vutuv_web/views/settings_html.ex:509
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] "vor %{count} Stunde"
 msgstr[1] "vor %{count} Stunden"
 
-#: lib/vutuv_web/views/settings_html.ex:499
+#: lib/vutuv_web/views/settings_html.ex:508
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
 msgstr[0] "vor %{count} Minute"
 msgstr[1] "vor %{count} Minuten"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:900
+#: lib/vutuv_web/controllers/settings_controller.ex:912
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr "Alle anderen Geräte wurden abgemeldet."
@@ -6108,7 +6109,7 @@ msgstr "Alle anderen Geräte wurden abgemeldet."
 msgid "Another session was already active on your account."
 msgstr "Auf Ihrem Konto war bereits eine andere Sitzung aktiv."
 
-#: lib/vutuv_web/views/settings_html.ex:347
+#: lib/vutuv_web/views/settings_html.ex:356
 #, elixir-autogen, elixir-format
 msgid "Last active"
 msgstr "Zuletzt aktiv"
@@ -6123,7 +6124,7 @@ msgstr "Alle anderen Geräte abmelden"
 msgid "Log out of every device except this one?"
 msgstr "Von allen Geräten außer diesem abmelden?"
 
-#: lib/vutuv_web/views/settings_html.ex:364
+#: lib/vutuv_web/views/settings_html.ex:373
 #, elixir-autogen, elixir-format
 msgid "Log this device out of your account?"
 msgstr "Dieses Gerät von Ihrem Konto abmelden?"
@@ -6138,7 +6139,7 @@ msgstr "Neue Anmeldung bei Ihrem vutuv-Konto"
 msgid "Signed-in devices"
 msgstr "Angemeldete Geräte"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:887
+#: lib/vutuv_web/controllers/settings_controller.ex:899
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr "Dieses Gerät wurde abgemeldet."
@@ -6148,7 +6149,7 @@ msgstr "Dieses Gerät wurde abgemeldet."
 msgid "The location looks different from where you usually sign in."
 msgstr "Der Ort weicht von dem ab, von dem Sie sich üblicherweise anmelden."
 
-#: lib/vutuv_web/views/settings_html.ex:348
+#: lib/vutuv_web/views/settings_html.ex:357
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr "Dieses Gerät"
@@ -6160,7 +6161,7 @@ msgstr ""
 "Das ist die erste Anmeldung, die wir von diesem Gerät oder Browser gesehen "
 "haben."
 
-#: lib/vutuv_web/views/settings_html.ex:498
+#: lib/vutuv_web/views/settings_html.ex:507
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr "gerade eben"
@@ -6198,7 +6199,7 @@ msgstr "Passkey hinzufügen"
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
 #: lib/vutuv_web/live/admin/screenshot_live.ex:309
 #: lib/vutuv_web/live/fediverse_following_live.ex:291
-#: lib/vutuv_web/views/settings_html.ex:399
+#: lib/vutuv_web/views/settings_html.ex:408
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr "Hinzugefügt"
@@ -6209,7 +6210,7 @@ msgid "Could not add the passkey. Please try again."
 msgstr ""
 "Der Passkey konnte nicht hinzugefügt werden. Bitte versuchen Sie es erneut."
 
-#: lib/vutuv_web/views/settings_html.ex:402
+#: lib/vutuv_web/views/settings_html.ex:411
 #, elixir-autogen, elixir-format
 msgid "Last used"
 msgstr "Zuletzt verwendet"
@@ -6219,7 +6220,7 @@ msgstr "Zuletzt verwendet"
 msgid "Name (optional)"
 msgstr "Name (optional)"
 
-#: lib/vutuv_web/views/settings_html.ex:396
+#: lib/vutuv_web/views/settings_html.ex:405
 #, elixir-autogen, elixir-format
 msgid "Passkey"
 msgstr "Passkey"
@@ -6239,7 +6240,7 @@ msgstr "Passkey entfernt."
 msgid "Passkeys"
 msgstr "Passkeys"
 
-#: lib/vutuv_web/views/settings_html.ex:410
+#: lib/vutuv_web/views/settings_html.ex:419
 #, elixir-autogen, elixir-format
 msgid "Remove this passkey?"
 msgstr "Diesen Passkey entfernen?"
@@ -6312,17 +6313,17 @@ msgstr "Kurzbeschreibung hinzufügen"
 msgid "Tagline"
 msgstr "Kurzbeschreibung"
 
-#: lib/vutuv_web/components/ui.ex:331
+#: lib/vutuv_web/components/ui.ex:332
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:898
+#: lib/vutuv_web/templates/user/show.html.heex:901
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
 msgstr[0] "Link"
 msgstr[1] "Links"
 
-#: lib/vutuv_web/templates/user/show.html.heex:462
+#: lib/vutuv_web/templates/user/show.html.heex:465
 #, elixir-autogen, elixir-format
 msgctxt "profile"
 msgid "Post"
@@ -6336,7 +6337,7 @@ msgstr[1] "Beiträge"
 msgid "After choosing a file you can reposition and zoom it."
 msgstr "Nach der Auswahl einer Datei können Sie sie verschieben und zoomen."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1514
+#: lib/vutuv_web/templates/user/show.html.heex:1517
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr "Auch auf"
@@ -6382,8 +6383,8 @@ msgstr "Foto verwenden"
 msgid "Zoom"
 msgstr "Zoom"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1099
-#: lib/vutuv_web/templates/user/show.html.heex:1109
+#: lib/vutuv_web/templates/user/show.html.heex:1102
+#: lib/vutuv_web/templates/user/show.html.heex:1112
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6425,12 +6426,12 @@ msgstr "Tagesbericht für %{day}"
 msgid "Jump to a day"
 msgstr "Zu einem Tag springen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1221
+#: lib/vutuv_web/templates/user/show.html.heex:1224
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr "E-Mails verwalten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1232
+#: lib/vutuv_web/templates/user/show.html.heex:1235
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr "Telefon verwalten"
@@ -6466,14 +6467,14 @@ msgid "Previous day"
 msgstr "Vorheriger Tag"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1107
-#: lib/vutuv_web/components/post_components.ex:393
+#: lib/vutuv_web/components/post_components.ex:396
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reposts"
 msgstr "Reposts"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1230
+#: lib/vutuv_web/templates/user/show.html.heex:1233
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr "Alle Telefonnummern anzeigen"
@@ -6500,9 +6501,9 @@ msgstr "Nach unten"
 msgid "Move up"
 msgstr "Nach oben"
 
-#: lib/vutuv_web/components/ui.ex:1578
-#: lib/vutuv_web/components/ui.ex:1587
-#: lib/vutuv_web/components/ui.ex:2052
+#: lib/vutuv_web/components/ui.ex:1583
+#: lib/vutuv_web/components/ui.ex:1592
+#: lib/vutuv_web/components/ui.ex:2057
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr "Empfehlung zurücknehmen"
@@ -6513,7 +6514,7 @@ msgstr "Empfehlung zurücknehmen"
 msgid "Default map"
 msgstr "Standardkarte"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:750
+#: lib/vutuv_web/controllers/settings_controller.ex:762
 #, elixir-autogen, elixir-format
 msgid "Map preferences saved."
 msgstr "Karteneinstellungen gespeichert."
@@ -6529,9 +6530,9 @@ msgstr "Anzuzeigende Kartendienste"
 msgid "Maps"
 msgstr "Karten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1500
-#: lib/vutuv_web/templates/user/show.html.heex:1508
-#: lib/vutuv_web/templates/user/show.html.heex:1520
+#: lib/vutuv_web/templates/user/show.html.heex:1503
+#: lib/vutuv_web/templates/user/show.html.heex:1511
+#: lib/vutuv_web/templates/user/show.html.heex:1523
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr "In %{name} öffnen"
@@ -6567,11 +6568,11 @@ msgstr "Mitglieder, die %{name} für %{tag} empfohlen haben"
 msgid "No endorsements yet."
 msgstr "Noch keine Empfehlungen."
 
-#: lib/vutuv_web/components/ui.ex:2005
-#: lib/vutuv_web/live/notification_live/index.ex:625
-#: lib/vutuv_web/live/notification_live/index.ex:640
-#: lib/vutuv_web/live/notification_live/index.ex:778
-#: lib/vutuv_web/live/notification_live/index.ex:780
+#: lib/vutuv_web/components/ui.ex:2010
+#: lib/vutuv_web/live/notification_live/index.ex:637
+#: lib/vutuv_web/live/notification_live/index.ex:652
+#: lib/vutuv_web/live/notification_live/index.ex:790
+#: lib/vutuv_web/live/notification_live/index.ex:792
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr "und %{count} weitere"
@@ -6887,9 +6888,9 @@ msgstr ""
 "Schalten Sie einen Schalter aus, geht der passende Opt-out auf den Seiten "
 "und Antworten über Sie mit. Mit beiden aus zum Beispiel:"
 
-#: lib/vutuv_web/components/post_components.ex:2107
-#: lib/vutuv_web/components/post_components.ex:2889
-#: lib/vutuv_web/components/ui.ex:2509
+#: lib/vutuv_web/components/post_components.ex:2204
+#: lib/vutuv_web/components/post_components.ex:2986
+#: lib/vutuv_web/components/ui.ex:2514
 #: lib/vutuv_web/live/fediverse_account_live.ex:381
 #: lib/vutuv_web/live/organization_live/following.ex:371
 #: lib/vutuv_web/live/organization_live/following.ex:446
@@ -6905,7 +6906,7 @@ msgstr "Stummschalten"
 msgid "Muted. Their posts no longer appear in your feed."
 msgstr "Stummgeschaltet. Die Beiträge erscheinen nicht mehr in Ihrem Feed."
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:133
+#: lib/vutuv_web/templates/settings/notifications.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "New messages and new connections"
 msgstr "Neue Nachrichten und neue Vernetzungen"
@@ -6915,8 +6916,8 @@ msgstr "Neue Nachrichten und neue Vernetzungen"
 msgid "Remove this connection? You will stop following them."
 msgstr "Diese Vernetzung entfernen? Sie folgen der Person dann nicht mehr."
 
-#: lib/vutuv_web/components/post_components.ex:2889
-#: lib/vutuv_web/components/ui.ex:2508
+#: lib/vutuv_web/components/post_components.ex:2986
+#: lib/vutuv_web/components/ui.ex:2513
 #: lib/vutuv_web/live/fediverse_account_live.ex:379
 #: lib/vutuv_web/live/organization_live/following.ex:371
 #: lib/vutuv_web/live/organization_live/following.ex:446
@@ -6948,33 +6949,33 @@ msgstr "Zum Profil, um zu folgen"
 msgid "Professional"
 msgstr "Beruflich"
 
-#: lib/vutuv_web/components/ui.ex:2479
+#: lib/vutuv_web/components/ui.ex:2484
 #, elixir-autogen, elixir-format
 msgid "Doesn't follow you"
 msgstr "Folgt Ihnen nicht"
 
-#: lib/vutuv_web/components/ui.ex:2473
+#: lib/vutuv_web/components/ui.ex:2478
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr "Folgt Ihnen"
 
-#: lib/vutuv_web/components/ui.ex:2463
+#: lib/vutuv_web/components/ui.ex:2468
 #, elixir-autogen, elixir-format
 msgid "This member doesn't follow you"
 msgstr "Dieses Mitglied folgt Ihnen nicht"
 
-#: lib/vutuv_web/components/ui.ex:2414
-#: lib/vutuv_web/components/ui.ex:2463
+#: lib/vutuv_web/components/ui.ex:2419
+#: lib/vutuv_web/components/ui.ex:2468
 #, elixir-autogen, elixir-format
 msgid "This member follows you"
 msgstr "Dieses Mitglied folgt Ihnen"
 
-#: lib/vutuv_web/components/ui.ex:2412
+#: lib/vutuv_web/components/ui.ex:2417
 #, elixir-autogen, elixir-format
 msgid "You follow each other"
 msgstr "Sie folgen einander"
 
-#: lib/vutuv_web/components/ui.ex:2413
+#: lib/vutuv_web/components/ui.ex:2418
 #, elixir-autogen, elixir-format
 msgid "You follow this member"
 msgstr "Sie folgen diesem Mitglied"
@@ -7562,13 +7563,13 @@ msgstr "Ihre Mitglieder werden zu dieser hinzugefügt (Vereinigung)."
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr "Seite %{page} von %{pages}, %{total} gesamt"
 
-#: lib/vutuv_web/components/ui.ex:3216
+#: lib/vutuv_web/components/ui.ex:3221
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Zurück"
 
-#: lib/vutuv_web/components/ui.ex:3232
+#: lib/vutuv_web/components/ui.ex:3237
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7649,7 +7650,7 @@ msgid "applies to the whole list, not just this page"
 msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:4846
+#: lib/vutuv_web/components/post_components.ex:4952
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8078,13 +8079,13 @@ msgstr "Neue Mitglieder"
 #: lib/vutuv_web/components/job_components.ex:219
 #: lib/vutuv_web/live/admin/dashboard_live.ex:287
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:457
-#: lib/vutuv_web/live/notification_live/index.ex:919
+#: lib/vutuv_web/live/notification_live/index.ex:931
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr "Heute"
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:291
-#: lib/vutuv_web/live/notification_live/index.ex:922
+#: lib/vutuv_web/live/notification_live/index.ex:934
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr "Gestern"
@@ -8268,7 +8269,7 @@ msgstr "Prüfung ausstehend"
 #: lib/vutuv_web/live/admin/activity_live.ex:231
 #: lib/vutuv_web/live/admin/user_live.ex:184
 #: lib/vutuv_web/live/job_board_live.ex:257
-#: lib/vutuv_web/live/tag_live/timeline.ex:283
+#: lib/vutuv_web/live/tag_live/timeline.ex:286
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr "Filter zurücksetzen"
@@ -8381,7 +8382,7 @@ msgstr "PIN abgelaufen"
 msgid "PIN registered"
 msgstr "PIN-registriert"
 
-#: lib/vutuv_web/components/ui.ex:3219
+#: lib/vutuv_web/components/ui.ex:3224
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr "Seite %{page} von %{pages}"
@@ -8508,7 +8509,7 @@ msgstr[1] "%{count} Berufserfahrungen"
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
 #: lib/vutuv_web/templates/education/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:684
+#: lib/vutuv_web/templates/user/show.html.heex:687
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr "Ausbildung hinzufügen"
@@ -8520,7 +8521,7 @@ msgstr "Abschluss"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:42
 #: lib/vutuv_web/agent_docs/text.ex:39
-#: lib/vutuv_web/components/ui.ex:4087
+#: lib/vutuv_web/components/ui.ex:4092
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8532,7 +8533,7 @@ msgstr "Abschluss"
 #: lib/vutuv_web/templates/education/new.html.heex:4
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
-#: lib/vutuv_web/templates/user/show.html.heex:681
+#: lib/vutuv_web/templates/user/show.html.heex:684
 #: lib/vutuv_web/views/import_html.ex:70
 #: lib/vutuv_web/views/job_reference_html.ex:265
 #, elixir-autogen, elixir-format
@@ -8580,7 +8581,7 @@ msgstr ""
 " was Sie nicht übernehmen möchten. Einträge, die bereits in Ihrem Profil "
 "stehen, sind für Sie abgewählt."
 
-#: lib/vutuv_web/components/ui.ex:4218
+#: lib/vutuv_web/components/ui.ex:4226
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Import"
@@ -8609,7 +8610,7 @@ msgstr "%{items} importiert."
 msgid "Nothing new to import."
 msgstr "Nichts Neues zu importieren."
 
-#: lib/vutuv_web/components/ui.ex:4115
+#: lib/vutuv_web/components/ui.ex:4120
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8706,7 +8707,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr "Zu viele Importe. Bitte versuchen Sie es in Kürze erneut."
 
-#: lib/vutuv_web/components/ui.ex:3488
+#: lib/vutuv_web/components/ui.ex:3493
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8720,7 +8721,7 @@ msgid "Loading posts"
 msgstr "Beiträge werden geladen"
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:140
-#: lib/vutuv_web/templates/user/show.html.heex:1367
+#: lib/vutuv_web/templates/user/show.html.heex:1370
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr "Social-Media-Beiträge"
@@ -8800,13 +8801,13 @@ msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 "Ziehen Sie Ihre ZIP-Datei hierher oder klicken Sie, um eine auszuwählen."
 
-#: lib/vutuv_web/components/ui.ex:4075
+#: lib/vutuv_web/components/ui.ex:4080
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr "Basisdaten & Fotos"
 
-#: lib/vutuv_web/components/ui.ex:4208
+#: lib/vutuv_web/components/ui.ex:4216
 #: lib/vutuv_web/controllers/settings_controller.ex:123
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8818,7 +8819,7 @@ msgstr "Sprache & Anzeige"
 msgid "More profile sections"
 msgstr "Weitere Profil-Bereiche"
 
-#: lib/vutuv_web/components/ui.ex:4199
+#: lib/vutuv_web/components/ui.ex:4207
 #: lib/vutuv_web/controllers/settings_controller.ex:106
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8828,7 +8829,7 @@ msgstr "Weitere Profil-Bereiche"
 msgid "Sign-in & security"
 msgstr "Anmeldung & Sicherheit"
 
-#: lib/vutuv_web/components/ui.ex:4222
+#: lib/vutuv_web/components/ui.ex:4230
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8855,13 +8856,13 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr "Geben Sie zur Bestätigung Ihren Benutzernamen ein:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1484
-#: lib/vutuv_web/live/post_live/feed.ex:1485
+#: lib/vutuv_web/live/post_live/feed.ex:1500
+#: lib/vutuv_web/live/post_live/feed.ex:1501
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr "Andere Beiträge anzeigen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1479
+#: lib/vutuv_web/live/post_live/feed.ex:1495
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr "Vorgeschlagene Beiträge"
@@ -8961,7 +8962,7 @@ msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
 "Die Seite %{letter} des Mitgliederverzeichnisses, sortiert nach Nachnamen."
 
-#: lib/vutuv_web/components/ui.ex:1079
+#: lib/vutuv_web/components/ui.ex:1080
 #, elixir-autogen, elixir-format
 msgid "This profile is not offered as a Markdown, text, JSON or XML export."
 msgstr ""
@@ -9069,7 +9070,7 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/agent_docs/text.ex:580
 #: lib/vutuv_web/agent_docs/text.ex:584
 #: lib/vutuv_web/components/organization_components.ex:285
-#: lib/vutuv_web/components/ui.ex:4189
+#: lib/vutuv_web/components/ui.ex:4197
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:355
 #: lib/vutuv_web/controllers/settings_controller.ex:422
@@ -9083,8 +9084,8 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:1012
-#: lib/vutuv_web/templates/user/show.html.heex:1272
+#: lib/vutuv_web/templates/user/show.html.heex:1015
+#: lib/vutuv_web/templates/user/show.html.heex:1275
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr "Fediverse"
@@ -9233,12 +9234,12 @@ msgstr ""
 "Ihres Browsers (Strg+P oder Cmd+P) und wählen Sie \"Als PDF speichern\", um "
 "eine PDF-Datei zu erhalten."
 
-#: lib/vutuv_web/components/ui.ex:1187
+#: lib/vutuv_web/components/ui.ex:1188
 #, elixir-autogen, elixir-format
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:3878
+#: lib/vutuv_web/components/post_components.ex:3975
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9271,7 +9272,7 @@ msgstr "Jeder Download enthält genau die ausgewählten Teile."
 msgid "Header"
 msgstr "Kopfzeile"
 
-#: lib/vutuv_web/components/ui.ex:1197
+#: lib/vutuv_web/components/ui.ex:1198
 #: lib/vutuv_web/templates/export/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Open CV"
@@ -9309,7 +9310,7 @@ msgstr ""
 "Besuchers enthält nur, was er dort ohnehin sehen kann, und private E-Mail-"
 "Adressen erscheinen nur in Ihrem eigenen."
 
-#: lib/vutuv_web/components/ui.ex:1189
+#: lib/vutuv_web/components/ui.ex:1190
 #, elixir-autogen, elixir-format
 msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
@@ -9484,8 +9485,8 @@ msgstr "Dieses Tag kann nur von einem Admin entfernt werden."
 msgid "Yes"
 msgstr "Ja"
 
-#: lib/vutuv_web/components/ui.ex:1622
-#: lib/vutuv_web/components/ui.ex:1623
+#: lib/vutuv_web/components/ui.ex:1627
+#: lib/vutuv_web/components/ui.ex:1628
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:65
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9515,7 +9516,7 @@ msgstr "A2 (Grundkenntnisse)"
 
 #: lib/vutuv_web/templates/language/manage.html.heex:8
 #: lib/vutuv_web/templates/language/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:746
+#: lib/vutuv_web/templates/user/show.html.heex:749
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr "Sprache hinzufügen"
@@ -9739,7 +9740,7 @@ msgstr "Sprache erfolgreich aktualisiert."
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:4
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:743
+#: lib/vutuv_web/templates/user/show.html.heex:746
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr "Sprachen"
@@ -9926,7 +9927,7 @@ msgstr "Yoruba"
 msgid "Employment status"
 msgstr "Beschäftigungsstatus"
 
-#: lib/vutuv/accounts/user.ex:1146
+#: lib/vutuv/accounts/user.ex:1154
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9937,7 +9938,7 @@ msgstr "Auf Jobsuche"
 msgid "Not open to work"
 msgstr "Nicht offen für Angebote"
 
-#: lib/vutuv/accounts/user.ex:1143
+#: lib/vutuv/accounts/user.ex:1151
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -10030,7 +10031,7 @@ msgstr[0] "%{count} Zertifikat oder Lizenz"
 msgstr[1] "%{count} Zertifikate oder Lizenzen"
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:852
+#: lib/vutuv_web/templates/user/show.html.heex:855
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr "Zertifikat oder Lizenz hinzufügen"
@@ -10063,7 +10064,7 @@ msgstr "Zertifikate"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:46
 #: lib/vutuv_web/agent_docs/text.ex:43
-#: lib/vutuv_web/components/ui.ex:4091
+#: lib/vutuv_web/components/ui.ex:4096
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:132
@@ -10078,7 +10079,7 @@ msgstr "Zertifikate"
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:849
+#: lib/vutuv_web/templates/user/show.html.heex:852
 #: lib/vutuv_web/views/import_html.ex:71
 #: lib/vutuv_web/views/job_reference_html.ex:266
 #, elixir-autogen, elixir-format
@@ -10202,8 +10203,8 @@ msgstr "Bevorzugt"
 msgid "Preferred contact language"
 msgstr "Bevorzugte Kontaktsprache"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1195
-#: lib/vutuv_web/templates/user/show.html.heex:1196
+#: lib/vutuv_web/templates/user/show.html.heex:1198
+#: lib/vutuv_web/templates/user/show.html.heex:1199
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr "+%{code} ist die Ländervorwahl von %{region}"
@@ -10264,13 +10265,13 @@ msgstr "Dauerhafter Profillink"
 msgid "Dismiss"
 msgstr "Schließen"
 
-#: lib/vutuv_web/components/ui.ex:2962
+#: lib/vutuv_web/components/ui.ex:2967
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr "Kopiert"
 
-#: lib/vutuv_web/components/ui.ex:2961
-#: lib/vutuv_web/components/ui.ex:2965
+#: lib/vutuv_web/components/ui.ex:2966
+#: lib/vutuv_web/components/ui.ex:2970
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr "Kopieren"
@@ -10464,12 +10465,12 @@ msgstr ""
 msgid "Authenticator app turned off."
 msgstr "Authenticator-App ausgeschaltet."
 
-#: lib/vutuv_web/components/ui.ex:325
+#: lib/vutuv_web/components/ui.ex:326
 #, elixir-autogen, elixir-format
 msgid "Bold"
 msgstr "Fett"
 
-#: lib/vutuv_web/components/ui.ex:421
+#: lib/vutuv_web/components/ui.ex:422
 #, elixir-autogen, elixir-format
 msgid "Bullet list"
 msgstr "Aufzählung"
@@ -10481,7 +10482,7 @@ msgstr ""
 "Sie können den Code nicht scannen? Geben Sie stattdessen diesen Schlüssel in"
 " Ihrer App ein:"
 
-#: lib/vutuv_web/components/ui.ex:413
+#: lib/vutuv_web/components/ui.ex:414
 #, elixir-autogen, elixir-format
 msgid "Code block"
 msgstr "Codeblock"
@@ -10497,17 +10498,17 @@ msgid "Delete your code list? All its codes stop working immediately."
 msgstr ""
 "Kennwortliste löschen? Alle Codes darauf funktionieren sofort nicht mehr."
 
-#: lib/vutuv_web/components/ui.ex:435
+#: lib/vutuv_web/components/ui.ex:436
 #, elixir-autogen, elixir-format
 msgid "Divider"
 msgstr "Trennlinie"
 
-#: lib/vutuv_web/components/ui.ex:323
+#: lib/vutuv_web/components/ui.ex:324
 #, elixir-autogen, elixir-format
 msgid "Formatting"
 msgstr "Formatierung"
 
-#: lib/vutuv_web/components/ui.ex:447
+#: lib/vutuv_web/components/ui.ex:448
 #, elixir-autogen, elixir-format
 msgid "Full screen"
 msgstr "Vollbild"
@@ -10522,32 +10523,32 @@ msgstr "Neue Liste erstellen"
 msgid "Generate code list"
 msgstr "Kennwortliste erstellen"
 
-#: lib/vutuv_web/components/ui.ex:401
+#: lib/vutuv_web/components/ui.ex:402
 #, elixir-autogen, elixir-format
 msgid "Heading 1"
 msgstr "Überschrift 1"
 
-#: lib/vutuv_web/components/ui.ex:404
+#: lib/vutuv_web/components/ui.ex:405
 #, elixir-autogen, elixir-format
 msgid "Heading 2"
 msgstr "Überschrift 2"
 
-#: lib/vutuv_web/components/ui.ex:407
+#: lib/vutuv_web/components/ui.ex:408
 #, elixir-autogen, elixir-format
 msgid "Heading 3"
 msgstr "Überschrift 3"
 
-#: lib/vutuv_web/components/ui.ex:393
+#: lib/vutuv_web/components/ui.ex:394
 #, elixir-autogen, elixir-format
 msgid "Inline code"
 msgstr "Inline-Code"
 
-#: lib/vutuv_web/components/ui.ex:328
+#: lib/vutuv_web/components/ui.ex:329
 #, elixir-autogen, elixir-format
 msgid "Italic"
 msgstr "Kursiv"
 
-#: lib/vutuv_web/components/ui.ex:312
+#: lib/vutuv_web/components/ui.ex:313
 #, elixir-autogen, elixir-format
 msgid "Link URL"
 msgstr "Link-URL"
@@ -10557,8 +10558,8 @@ msgstr "Link-URL"
 msgid "Login codes"
 msgstr "Anmelde-Codes"
 
-#: lib/vutuv_web/components/ui.ex:373
 #: lib/vutuv_web/components/ui.ex:374
+#: lib/vutuv_web/components/ui.ex:375
 #, elixir-autogen, elixir-format
 msgid "More formatting"
 msgstr "Mehr Formatierung"
@@ -10569,7 +10570,7 @@ msgstr "Mehr Formatierung"
 msgid "Not set up."
 msgstr "Nicht eingerichtet."
 
-#: lib/vutuv_web/components/ui.ex:424
+#: lib/vutuv_web/components/ui.ex:425
 #, elixir-autogen, elixir-format
 msgid "Numbered list"
 msgstr "Nummerierte Liste"
@@ -10586,7 +10587,7 @@ msgstr ""
 "Drucken Sie diese Seite aus oder schreiben Sie die Codes ab. "
 "Durchgestrichene Codes wurden bereits verwendet."
 
-#: lib/vutuv_web/components/ui.ex:410
+#: lib/vutuv_web/components/ui.ex:411
 #, elixir-autogen, elixir-format
 msgid "Quote"
 msgstr "Zitat"
@@ -10611,12 +10612,12 @@ msgstr ""
 msgid "Set up"
 msgstr "Einrichten"
 
-#: lib/vutuv_web/components/ui.ex:390
+#: lib/vutuv_web/components/ui.ex:391
 #, elixir-autogen, elixir-format
 msgid "Strikethrough"
 msgstr "Durchgestrichen"
 
-#: lib/vutuv_web/components/ui.ex:432
+#: lib/vutuv_web/components/ui.ex:433
 #, elixir-autogen, elixir-format
 msgid "Table"
 msgstr "Tabelle"
@@ -10633,7 +10634,7 @@ msgstr ""
 msgid "To finish, enter the code your app shows now"
 msgstr "Geben Sie zum Abschluss den Code ein, den Ihre App jetzt anzeigt"
 
-#: lib/vutuv_web/components/ui.ex:444
+#: lib/vutuv_web/components/ui.ex:445
 #, elixir-autogen, elixir-format
 msgid "Toggle Markdown source"
 msgstr "Markdown-Quelltext umschalten"
@@ -10772,7 +10773,7 @@ msgstr[1] "%{formatted} Sterne"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:63
 #: lib/vutuv_web/agent_docs/text.ex:60
-#: lib/vutuv_web/templates/user/show.html.heex:1341
+#: lib/vutuv_web/templates/user/show.html.heex:1344
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr "Code"
@@ -11101,7 +11102,7 @@ msgstr ""
 "Längere Beiträge erhalten einen „Weiterlesen“-Link. Mit 0 (oder leer) wird "
 "nie gekürzt."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:764
+#: lib/vutuv_web/controllers/settings_controller.ex:776
 #, elixir-autogen, elixir-format
 msgid "Post display settings saved."
 msgstr "Anzeige-Einstellungen für Beiträge gespeichert."
@@ -11160,7 +11161,7 @@ msgstr ""
 msgid "Installation default (%{value})"
 msgstr "Standard der Installation (%{value})"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:796
+#: lib/vutuv_web/controllers/settings_controller.ex:808
 #, elixir-autogen, elixir-format
 msgid "Map preferences reset to the site defaults."
 msgstr "Karteneinstellungen auf die Standardwerte zurückgesetzt."
@@ -11179,7 +11180,7 @@ msgstr ""
 "Eigener Wert; leeren Sie das Feld, um zum Standard der Installation "
 "zurückzukehren."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:792
+#: lib/vutuv_web/controllers/settings_controller.ex:804
 #, elixir-autogen, elixir-format
 msgid "Post display settings reset to the site defaults."
 msgstr ""
@@ -11419,19 +11420,19 @@ msgstr ""
 " Konto anlegen kann. Wählen Sie „Niemand“, um den Status zu speichern, ohne "
 "ihn anzuzeigen."
 
-#: lib/vutuv/accounts/user.ex:1184
+#: lib/vutuv/accounts/user.ex:1192
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Alle, auch nicht angemeldete Besucher"
 
-#: lib/vutuv/accounts/user.ex:1189
+#: lib/vutuv/accounts/user.ex:1197
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Niemand"
 
-#: lib/vutuv/accounts/user.ex:1187
+#: lib/vutuv/accounts/user.ex:1195
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:761
 #, elixir-autogen, elixir-format
@@ -12185,7 +12186,7 @@ msgstr ""
 "Der Linktext ist beliebig. Ein verstecktes <link rel=\"me\"> im Seitenkopf "
 "funktioniert ebenfalls."
 
-#: lib/vutuv_web/components/ui.ex:943
+#: lib/vutuv_web/components/ui.ex:944
 #: lib/vutuv_web/live/section_reorder_live.ex:195
 #, elixir-autogen, elixir-format
 msgid "Verified webpage"
@@ -12463,7 +12464,7 @@ msgstr "Organisationsseite"
 msgid "Organization pages"
 msgstr "Organisationsseiten"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1044
+#: lib/vutuv_web/live/notification_live/index.ex:1056
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr "Organisationsrolle"
@@ -12476,12 +12477,12 @@ msgstr "Organisation wieder freigegeben."
 #: lib/vutuv_web/agent_docs/markdown.ex:419
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:394
-#: lib/vutuv_web/components/ui.ex:4226
+#: lib/vutuv_web/components/ui.ex:4234
 #: lib/vutuv_web/controllers/settings_controller.ex:211
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:806
+#: lib/vutuv_web/live/shell_live.ex:926
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:100
@@ -12580,22 +12581,22 @@ msgstr "Ihre Organisationsseite ist verifiziert und jetzt live."
 msgid "Your organization page was updated."
 msgstr "Ihre Organisationsseite wurde aktualisiert."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1285
+#: lib/vutuv_web/notification_line.ex:107
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr "hat Ihnen eine Rolle bei %{organization} gegeben."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1282
+#: lib/vutuv_web/notification_line.ex:104
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr "hat Sie zum Recruiter für %{organization} gemacht."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1279
+#: lib/vutuv_web/notification_line.ex:101
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr "hat Sie zum Administrator von %{organization} gemacht."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1276
+#: lib/vutuv_web/notification_line.ex:98
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr "hat Sie zum Besitzer von %{organization} gemacht."
@@ -12775,7 +12776,7 @@ msgid "Everyone (public)"
 msgstr "Alle (öffentlich)"
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:647
-#: lib/vutuv_web/live/tag_live/timeline.ex:264
+#: lib/vutuv_web/live/tag_live/timeline.ex:267
 #: lib/vutuv_web/templates/education/form_content.html.heex:41
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:63
 #, elixir-autogen, elixir-format
@@ -12797,7 +12798,7 @@ msgstr "Hervorgehobene Tags passen zu Ihrem Profil."
 msgid "How to apply"
 msgstr "So bewerben Sie sich"
 
-#: lib/vutuv/accounts/user.ex:1158
+#: lib/vutuv/accounts/user.ex:1166
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12823,7 +12824,7 @@ msgstr "Stellenbezeichnung"
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:636
+#: lib/vutuv_web/live/shell_live.ex:756
 #: lib/vutuv_web/templates/layout/app.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -12916,7 +12917,7 @@ msgstr "Hier ist noch nichts. Jobs, die Ihnen gefallen, erscheinen hier."
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) für KI-Agenten anbieten."
 
-#: lib/vutuv/accounts/user.ex:1157
+#: lib/vutuv/accounts/user.ex:1165
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12998,7 +12999,7 @@ msgstr "Anzeige nicht gefunden."
 msgid "Publish"
 msgstr "Veröffentlichen"
 
-#: lib/vutuv/accounts/user.ex:1159
+#: lib/vutuv/accounts/user.ex:1167
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:564
 #: lib/vutuv_web/agent_docs/markdown.ex:458
@@ -13627,7 +13628,7 @@ msgstr[1] "%{count} neue Treffer für Ihre gespeicherten Suchen"
 msgid "Alert frequency"
 msgstr "Häufigkeit der Benachrichtigung"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:678
+#: lib/vutuv_web/controllers/settings_controller.ex:690
 #, elixir-autogen, elixir-format
 msgid "Alert updated."
 msgstr "Benachrichtigung aktualisiert."
@@ -13700,13 +13701,13 @@ msgstr ""
 msgid "Save search"
 msgstr "Suche speichern"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:696
+#: lib/vutuv_web/controllers/settings_controller.ex:708
 #, elixir-autogen, elixir-format
 msgid "Saved search deleted."
 msgstr "Gespeicherte Suche gelöscht."
 
-#: lib/vutuv_web/components/ui.ex:4166
-#: lib/vutuv_web/controllers/settings_controller.ex:588
+#: lib/vutuv_web/components/ui.ex:4174
+#: lib/vutuv_web/controllers/settings_controller.ex:600
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
 #, elixir-autogen, elixir-format
@@ -13725,10 +13726,10 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "E-Mail-Benachrichtigungen für Ihre gespeicherte Suche „%{label}“ stoppen?"
 
-#: lib/vutuv_web/components/post_components.ex:2282
+#: lib/vutuv_web/components/post_components.ex:2379
 #: lib/vutuv_web/components/saved_search_components.ex:43
-#: lib/vutuv_web/controllers/settings_controller.ex:683
-#: lib/vutuv_web/controllers/settings_controller.ex:701
+#: lib/vutuv_web/controllers/settings_controller.ex:695
+#: lib/vutuv_web/controllers/settings_controller.ex:713
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:387
 #: lib/vutuv_web/live/organization_live/following.ex:277
 #: lib/vutuv_web/live/organization_live/following.ex:284
@@ -13986,7 +13987,7 @@ msgstr "%{pending} Bild(er) in der Warteschlange; %{rejected} in den letzten 7 T
 msgid "Image awaiting review, visible only to you"
 msgstr "Bild wird geprüft, nur für Sie sichtbar"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1042
+#: lib/vutuv_web/live/notification_live/index.ex:1054
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -14027,7 +14028,7 @@ msgstr "Screenshot entfernt."
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr "Dieser Screenshot wurde automatisch aus dem Link in Ihrem Beitrag erstellt. Falls er unbrauchbar ist (zum Beispiel weil ein Cookie-Banner die Seite verdeckt), können Sie ihn entfernen."
 
-#: lib/vutuv/accounts/user.ex:1202
+#: lib/vutuv/accounts/user.ex:1210
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -14038,19 +14039,19 @@ msgstr "Nur das Alter, ohne das Datum"
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr "Wählen Sie, wie viel von Ihrem Geburtstag Ihr Profil zeigt. „Nur das Alter“ verbirgt das genaue Datum, „Tag und Monat“ verbirgt das Jahr (und Ihr Alter), und „Nicht anzeigen“ speichert ihn weiterhin, hält ihn aber von Ihrem Profil fern."
 
-#: lib/vutuv/accounts/user.ex:1205
+#: lib/vutuv/accounts/user.ex:1213
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Tag und Monat, ohne das Jahr"
 
-#: lib/vutuv/accounts/user.ex:1208
+#: lib/vutuv/accounts/user.ex:1216
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Geburtstag nicht anzeigen"
 
-#: lib/vutuv/accounts/user.ex:1199
+#: lib/vutuv/accounts/user.ex:1207
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -14073,7 +14074,7 @@ msgstr[1] "%{formatted} Beiträge erwähnen aktuell %{handle} und werden beim Um
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr "Beim Ändern werden alle Erwähnungen Ihres alten Handles in Beiträgen automatisch auf den neuen umgeschrieben und die Verfasser dieser Beiträge benachrichtigt. Ihre alte Profiladresse funktioniert dann nicht mehr."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1045
+#: lib/vutuv_web/live/notification_live/index.ex:1057
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr "Handle-Änderung"
@@ -14085,32 +14086,32 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] "Wir haben %{formatted} Beitrag aktualisiert, der Ihren alten Handle erwähnt hat, und dessen Verfasser benachrichtigt."
 msgstr[1] "Wir haben %{formatted} Beiträge aktualisiert, die Ihren alten Handle erwähnt haben, und deren Verfasser benachrichtigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1335
+#: lib/vutuv_web/notification_line.ex:157
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr "hat den Handle von @%{old} auf @%{new} geändert."
 
-#: lib/vutuv_web/components/ui.ex:358
+#: lib/vutuv_web/components/ui.ex:359
 #, elixir-autogen, elixir-format
 msgid "Center"
 msgstr "Zentriert"
 
-#: lib/vutuv_web/components/ui.ex:355
+#: lib/vutuv_web/components/ui.ex:356
 #, elixir-autogen, elixir-format
 msgid "Float left"
 msgstr "Linksbündig (Text umfließt)"
 
-#: lib/vutuv_web/components/ui.ex:361
+#: lib/vutuv_web/components/ui.ex:362
 #, elixir-autogen, elixir-format
 msgid "Float right"
 msgstr "Rechtsbündig (Text umfließt)"
 
-#: lib/vutuv_web/components/ui.ex:352
+#: lib/vutuv_web/components/ui.ex:353
 #, elixir-autogen, elixir-format
 msgid "Full width"
 msgstr "Volle Breite"
 
-#: lib/vutuv_web/components/ui.ex:340
+#: lib/vutuv_web/components/ui.ex:341
 #, elixir-autogen, elixir-format
 msgid "Insert image"
 msgstr "Bild einfügen"
@@ -14122,7 +14123,7 @@ msgstr "In den Text einfügen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:227
 #: lib/vutuv_web/agent_docs/text.ex:212
-#: lib/vutuv_web/live/tag_live/timeline.ex:210
+#: lib/vutuv_web/live/tag_live/timeline.ex:213
 #, elixir-autogen, elixir-format
 msgid "Posts with this tag"
 msgstr "Beiträge mit diesem Tag"
@@ -14149,22 +14150,22 @@ msgstr "Mobil (privat)"
 msgid "Work mobile"
 msgstr "Mobil (Arbeit)"
 
-#: lib/vutuv_web/components/post_components.ex:433
+#: lib/vutuv_web/components/post_components.ex:436
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr "Noch keine Beiträge."
 
-#: lib/vutuv_web/components/post_components.ex:435
+#: lib/vutuv_web/components/post_components.ex:438
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr "Noch keine Antworten."
 
-#: lib/vutuv_web/components/post_components.ex:434
+#: lib/vutuv_web/components/post_components.ex:437
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr "Noch keine Reposts."
 
-#: lib/vutuv_web/components/post_components.ex:392
+#: lib/vutuv_web/components/post_components.ex:395
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr "Eigene Beiträge"
@@ -14177,16 +14178,16 @@ msgstr ""
 "Personen tauchen in Ihren Vorschlägen auf. Einem Tag folgen Sie auf seiner "
 "Seite."
 
-#: lib/vutuv_web/components/ui.ex:4149
-#: lib/vutuv_web/controllers/settings_controller.ex:602
-#: lib/vutuv_web/live/post_live/feed.ex:1430
+#: lib/vutuv_web/components/ui.ex:4157
+#: lib/vutuv_web/controllers/settings_controller.ex:614
+#: lib/vutuv_web/live/post_live/feed.ex:1446
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr "Tags, denen Sie folgen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1445
+#: lib/vutuv_web/live/post_live/feed.ex:1461
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr "#%{tag} entfolgen"
@@ -14230,7 +14231,7 @@ msgstr "Signal und WhatsApp akzeptieren eine Telefonnummer oder einen Benutzerna
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1307
+#: lib/vutuv_web/templates/user/show.html.heex:1310
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr "Messenger hinzufügen"
@@ -14259,7 +14260,7 @@ msgstr "Messenger wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:60
 #: lib/vutuv_web/agent_docs/text.ex:57
-#: lib/vutuv_web/components/ui.ex:4134
+#: lib/vutuv_web/components/ui.ex:4139
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -14267,7 +14268,7 @@ msgstr "Messenger wurde geändert."
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1305
+#: lib/vutuv_web/templates/user/show.html.heex:1308
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr "Messenger"
@@ -14287,34 +14288,34 @@ msgstr "Messenger von %{name}"
 msgid "Select a messenger"
 msgstr "Messenger auswählen"
 
-#: lib/vutuv_web/components/ui.ex:3574
+#: lib/vutuv_web/components/ui.ex:3579
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] "Meinen Follower darüber informieren"
 msgstr[1] "Meine %{formatted} Follower darüber informieren"
 
-#: lib/vutuv_web/components/ui.ex:3584
+#: lib/vutuv_web/components/ui.ex:3589
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr "Die Benachrichtigung enthält einen Link zu diesem Eintrag. Es wird keine E-Mail verschickt, und das passiert nur bei neuen Einträgen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1046
+#: lib/vutuv_web/live/notification_live/index.ex:1058
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr "Lebenslauf-Update"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1355
+#: lib/vutuv_web/notification_line.ex:177
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr "hat eine neue Station im Lebenslauf: %{entry}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1347
+#: lib/vutuv_web/notification_line.ex:169
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr "hat eine neue Ausbildung im Lebenslauf: %{entry}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1352
+#: lib/vutuv_web/notification_line.ex:174
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr "hat ein neues Zertifikat im Lebenslauf: %{entry}"
@@ -14339,39 +14340,39 @@ msgstr "Über neue Lebenslauf-Einträge von Personen informieren, denen ich folg
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch immer."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1360
+#: lib/vutuv_web/notification_line.ex:182
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:4476
+#: lib/vutuv_web/components/post_components.ex:4573
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1196
-#: lib/vutuv_web/components/post_components.ex:4433
+#: lib/vutuv_web/components/post_components.ex:4530
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:4477
+#: lib/vutuv_web/components/post_components.ex:4574
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:4479
+#: lib/vutuv_web/components/post_components.ex:4576
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:4475
+#: lib/vutuv_web/components/post_components.ex:4572
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1196
-#: lib/vutuv_web/components/post_components.ex:4432
+#: lib/vutuv_web/components/post_components.ex:4529
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Filmbesprechung"
@@ -14382,12 +14383,12 @@ msgstr "Filmbesprechung"
 msgid "Look up"
 msgstr "Nachschlagen"
 
-#: lib/vutuv_web/components/post_components.ex:4474
+#: lib/vutuv_web/components/post_components.ex:4571
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
 
-#: lib/vutuv_web/components/post_components.ex:4478
+#: lib/vutuv_web/components/post_components.ex:4575
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14407,7 +14408,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:4515
+#: lib/vutuv_web/components/post_components.ex:4612
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14415,27 +14416,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:4545
+#: lib/vutuv_web/components/post_components.ex:4642
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:4546
+#: lib/vutuv_web/components/post_components.ex:4643
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:4544
+#: lib/vutuv_web/components/post_components.ex:4641
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:4504
+#: lib/vutuv_web/components/post_components.ex:4601
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:4551
+#: lib/vutuv_web/components/post_components.ex:4648
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14465,72 +14466,72 @@ msgstr "Mit Qualifikation:"
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:4318
+#: lib/vutuv_web/components/post_components.ex:4415
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
 
-#: lib/vutuv_web/live/notification_live/index.ex:911
+#: lib/vutuv_web/live/notification_live/index.ex:923
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] "%{formatted} neue Mitteilung"
 msgstr[1] "%{formatted} neue Mitteilungen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:925
+#: lib/vutuv_web/live/notification_live/index.ex:937
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr "%{day}. %{month} %{year}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:393
+#: lib/vutuv_web/live/notification_live/index.ex:405
 #, elixir-autogen, elixir-format
 msgid "Follow back"
 msgstr "Zurückfolgen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:408
+#: lib/vutuv_web/live/notification_live/index.ex:420
 #, elixir-autogen, elixir-format
 msgid "Last 30 days"
 msgstr "Letzte 30 Tage"
 
-#: lib/vutuv_web/live/notification_live/index.ex:877
-#: lib/vutuv_web/live/notification_live/index.ex:1125
+#: lib/vutuv_web/live/notification_live/index.ex:889
+#: lib/vutuv_web/live/notification_live/index.ex:1096
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr "und"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1062
+#: lib/vutuv_web/live/notification_live/index.ex:1075
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr "sind jetzt mit Ihnen vernetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1057
+#: lib/vutuv_web/live/notification_live/index.ex:1072
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr "folgen Ihnen jetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1072
+#: lib/vutuv_web/live/notification_live/index.ex:1081
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:4309
+#: lib/vutuv_web/components/post_components.ex:4406
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
 
-#: lib/vutuv_web/components/ui.ex:1756
+#: lib/vutuv_web/components/ui.ex:1761
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr "Empfohlen von %{name}"
 
-#: lib/vutuv_web/components/ui.ex:1760
+#: lib/vutuv_web/components/ui.ex:1765
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] "Empfohlen von %{name} und %{formatted} weiteren"
 msgstr[1] "Empfohlen von %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/live/shell_live.ex:438
+#: lib/vutuv_web/live/shell_live.ex:453
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -14759,7 +14760,7 @@ msgstr "Verfügbarkeit"
 msgid "An automated check removed an image from your vutuv account"
 msgstr "Eine automatische Prüfung hat ein Bild aus Ihrem vutuv-Konto entfernt"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1309
+#: lib/vutuv_web/notification_line.ex:131
 #, elixir-autogen, elixir-format
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
@@ -14767,12 +14768,12 @@ msgstr ""
 "familienfreundlich genug für ein Arbeitsumfeld. Sie kann sich irren, "
 "antworten Sie in dem Fall einfach auf unsere E-Mail."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1035
+#: lib/vutuv_web/live/notification_live/index.ex:1047
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr "Thread-Antwort"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1112
+#: lib/vutuv_web/notification_line.ex:243
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -14795,12 +14796,12 @@ msgstr "Unterhaltung"
 msgid "Only part of this long conversation is shown."
 msgstr "Von dieser langen Unterhaltung wird nur ein Teil angezeigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1036
+#: lib/vutuv_web/live/notification_live/index.ex:1048
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr "Erwähnung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1259
+#: lib/vutuv_web/notification_line.ex:81
 #, elixir-autogen, elixir-format
 msgid "mentioned you in a post."
 msgstr "hat Sie in einem Beitrag erwähnt."
@@ -14907,14 +14908,14 @@ msgstr "Konto zum Einfrieren suchen"
 msgid "See all frozen accounts"
 msgstr "Alle eingefrorenen Konten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2555
+#: lib/vutuv_web/components/post_components.ex:2652
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "%{formatted} früheren Beitrag anzeigen"
 msgstr[1] "%{formatted} frühere Beiträge anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2578
+#: lib/vutuv_web/components/post_components.ex:2675
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14941,7 +14942,7 @@ msgstr "Dieses Profil ist zurzeit nicht verfügbar."
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das Konto zu finden, das eingefroren werden soll."
 
-#: lib/vutuv_web/components/post_components.ex:4943
+#: lib/vutuv_web/components/post_components.ex:5051
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Der eigene Beitrag lässt sich nicht mit „Gefällt mir“ markieren."
@@ -15073,7 +15074,7 @@ msgstr[1] "%{formatted} Empfehlungen"
 msgid "All endorsers"
 msgstr "Alle Empfehlenden"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:627
+#: lib/vutuv_web/controllers/settings_controller.ex:639
 #, elixir-autogen, elixir-format
 msgid "Filter added. Matching posts are now hidden from your feed."
 msgstr "Filter hinzugefügt. Passende Beiträge sind jetzt in Ihrem Feed ausgeblendet."
@@ -15083,12 +15084,12 @@ msgstr "Filter hinzugefügt. Passende Beiträge sind jetzt in Ihrem Feed ausgebl
 msgid "Filter by a tag"
 msgstr "Nach einem Tag filtern"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:657
+#: lib/vutuv_web/controllers/settings_controller.ex:669
 #, elixir-autogen, elixir-format
 msgid "Filter removed."
 msgstr "Filter entfernt."
 
-#: lib/vutuv_web/live/post_live/feed.ex:385
+#: lib/vutuv_web/live/post_live/feed.ex:389
 #, elixir-autogen, elixir-format
 msgid "Hidden: matches your filter"
 msgstr "Ausgeblendet: passt zu Ihrem Filter"
@@ -15103,8 +15104,8 @@ msgstr "Blenden Sie Beiträge aus Ihrem Feed aus, die ein Tag tragen oder ein Wo
 msgid "Match whole words only (word/phrase)"
 msgstr "Nur ganze Wörter treffen (Wort/Phrase)"
 
-#: lib/vutuv_web/components/ui.ex:4145
-#: lib/vutuv_web/controllers/settings_controller.ex:668
+#: lib/vutuv_web/components/ui.ex:4153
+#: lib/vutuv_web/controllers/settings_controller.ex:680
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
 #, elixir-autogen, elixir-format
@@ -15123,7 +15124,7 @@ msgstr ""
 "Wählen Sie unten einen Abschluss oder eine Schule, um ihn statt eines "
 "Jobtitels oben in Ihrem Profil anzuzeigen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:394
+#: lib/vutuv_web/live/post_live/feed.ex:398
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr "Trotzdem anzeigen"
@@ -15153,7 +15154,7 @@ msgstr "Diese Ausbildung wird jetzt oben in Ihrem Profil angezeigt."
 msgid "Thread replies"
 msgstr "Thread-Antworten"
 
-#: lib/vutuv_web/live/notification_live/index.ex:603
+#: lib/vutuv_web/live/notification_live/index.ex:615
 #, elixir-autogen, elixir-format
 msgid "Turn off thread notifications"
 msgstr "Thread-Benachrichtigungen abschalten"
@@ -15199,12 +15200,12 @@ msgstr "Sie dürfen den Benutzernamen dieser Organisation nicht ändern."
 msgid "You have not muted anything yet."
 msgstr "Sie haben noch nichts stummgeschaltet."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:635
+#: lib/vutuv_web/controllers/settings_controller.ex:647
 #, elixir-autogen, elixir-format
 msgid "You have reached the maximum of %{count} filters."
 msgstr "Sie haben das Maximum von %{count} Filtern erreicht."
 
-#: lib/vutuv_web/live/notification_live/index.ex:598
+#: lib/vutuv_web/live/notification_live/index.ex:610
 #, elixir-autogen, elixir-format
 msgid "You wrote in this thread."
 msgstr "Sie haben in diesem Thread geschrieben."
@@ -15660,7 +15661,7 @@ msgstr "Wir senden dorthin eine PIN, um zu bestätigen, dass die Adresse Ihnen g
 msgid "ZIP or postal code"
 msgstr "Postleitzahl"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:271
+#: lib/vutuv_web/live/tag_live/timeline.ex:274
 #: lib/vutuv_web/templates/education/form_content.html.heex:59
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:81
 #, elixir-autogen, elixir-format
@@ -15682,7 +15683,7 @@ msgstr "Anwendung bearbeiten"
 msgid "Book an ad"
 msgstr "Anzeige buchen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1016
+#: lib/vutuv_web/templates/user/show.html.heex:1019
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr "%{name} hat dieses Fediverse-Konto umgezogen. Folgen Sie stattdessen der neuen Adresse:"
@@ -15738,257 +15739,252 @@ msgstr "Ihr Server"
 msgid "moved to %{address}"
 msgstr "umgezogen nach %{address}"
 
-#: lib/vutuv_web/components/ui.ex:4076
+#: lib/vutuv_web/components/ui.ex:4081
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr "Name, Foto, Titelbild, Kurzbeschreibung"
 
-#: lib/vutuv_web/components/ui.ex:4081
+#: lib/vutuv_web/components/ui.ex:4086
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr "handle spitzname nutzername umbenennen slug profiladresse url erwähnung"
 
-#: lib/vutuv_web/components/ui.ex:4084
+#: lib/vutuv_web/components/ui.ex:4089
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr "Die Stationen in Ihrem Lebenslauf"
 
-#: lib/vutuv_web/components/ui.ex:4085
+#: lib/vutuv_web/components/ui.ex:4090
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr "lebenslauf cv karriere beruf arbeitgeber position stelle job firma"
 
-#: lib/vutuv_web/components/ui.ex:4088
+#: lib/vutuv_web/components/ui.ex:4093
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr "Schulen, Hochschulen, Abschlüsse"
 
-#: lib/vutuv_web/components/ui.ex:4089
+#: lib/vutuv_web/components/ui.ex:4094
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr "lebenslauf studium schule universität hochschule abschluss ausbildung"
 
-#: lib/vutuv_web/components/ui.ex:4092
+#: lib/vutuv_web/components/ui.ex:4097
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr "Nachweise, mit Belegdokumenten"
 
-#: lib/vutuv_web/components/ui.ex:4093
+#: lib/vutuv_web/components/ui.ex:4098
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr "zertifikat lizenz urkunde diplom nachweis beleg auszeichnung dokument"
 
-#: lib/vutuv_web/components/ui.ex:4100
+#: lib/vutuv_web/components/ui.ex:4105
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr "Sprachkenntnisse"
 
-#: lib/vutuv_web/components/ui.ex:4101
+#: lib/vutuv_web/components/ui.ex:4106
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr "Die Sprachen, die Sie sprechen"
 
-#: lib/vutuv_web/components/ui.ex:4102
+#: lib/vutuv_web/components/ui.ex:4107
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr "sprache sprachen sprechen fließend muttersprache verhandlungssicher"
 
-#: lib/vutuv_web/components/ui.ex:4105
+#: lib/vutuv_web/components/ui.ex:4110
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr "Die Themen, für die Sie bekannt sind"
 
-#: lib/vutuv_web/components/ui.ex:4106
+#: lib/vutuv_web/components/ui.ex:4111
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr "fähigkeit kenntnis thema stichwort schlagwort expertise empfehlung"
 
-#: lib/vutuv_web/components/ui.ex:4227
+#: lib/vutuv_web/components/ui.ex:4235
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr "Organisationsseiten, die Sie verwalten"
 
-#: lib/vutuv_web/components/ui.ex:4228
+#: lib/vutuv_web/components/ui.ex:4236
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr "firma unternehmen arbeitgeber betrieb organisation seite"
 
-#: lib/vutuv_web/components/ui.ex:4109
+#: lib/vutuv_web/components/ui.ex:4114
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr "Kontaktdaten"
 
-#: lib/vutuv_web/components/ui.ex:4112
+#: lib/vutuv_web/components/ui.ex:4117
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr "Wo wir Sie erreichen, und welche Adresse öffentlich ist"
 
-#: lib/vutuv_web/components/ui.ex:4113
+#: lib/vutuv_web/components/ui.ex:4118
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr "mail e-mail email adresse hauptadresse primär"
 
-#: lib/vutuv_web/components/ui.ex:4116
+#: lib/vutuv_web/components/ui.ex:4121
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr "Festnetz, Mobil, Fax"
 
-#: lib/vutuv_web/components/ui.ex:4117
+#: lib/vutuv_web/components/ui.ex:4122
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr "telefon handy mobil festnetz fax nummer rufnummer"
 
-#: lib/vutuv_web/components/ui.ex:4120
+#: lib/vutuv_web/components/ui.ex:4125
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr "Postanschriften auf Ihrem Profil"
 
-#: lib/vutuv_web/components/ui.ex:4121
+#: lib/vutuv_web/components/ui.ex:4126
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr "straße stadt ort postleitzahl plz land anschrift karte"
 
-#: lib/vutuv_web/components/ui.ex:4123
+#: lib/vutuv_web/components/ui.ex:4128
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr "Webseiten & Links"
 
-#: lib/vutuv_web/components/ui.ex:4124
+#: lib/vutuv_web/components/ui.ex:4129
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr "Ihre Homepage und weitere Links"
 
-#: lib/vutuv_web/components/ui.ex:4125
+#: lib/vutuv_web/components/ui.ex:4130
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr "url webseite website homepage blog link verifizieren bestätigen rel=me"
 
-#: lib/vutuv_web/components/ui.ex:4127
+#: lib/vutuv_web/components/ui.ex:4132
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr "Social-Media-Profile"
 
-#: lib/vutuv_web/components/ui.ex:4128
+#: lib/vutuv_web/components/ui.ex:4133
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr "Mastodon, Bluesky, GitHub und die anderen"
 
-#: lib/vutuv_web/components/ui.ex:4130
+#: lib/vutuv_web/components/ui.ex:4135
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr "mastodon bluesky github gitlab codeberg linkedin x twitter instagram soziale netzwerke"
 
-#: lib/vutuv_web/components/ui.ex:4135
+#: lib/vutuv_web/components/ui.ex:4140
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr "Signal, Threema, Matrix und die anderen"
 
-#: lib/vutuv_web/components/ui.ex:4136
+#: lib/vutuv_web/components/ui.ex:4141
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr "signal threema matrix xmpp telegram whatsapp chat messenger nachrichten"
 
-#: lib/vutuv_web/components/ui.ex:4139
+#: lib/vutuv_web/components/ui.ex:4144
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr "Mitteilungen & Feed"
 
-#: lib/vutuv_web/components/ui.ex:4142
+#: lib/vutuv_web/components/ui.ex:4147
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr "Welche E-Mails wir schicken, und was die Glocke meldet"
 
-#: lib/vutuv_web/components/ui.ex:4143
-#, elixir-autogen, elixir-format
-msgid "email mail unsubscribe newsletter bell alert quiet fewer"
-msgstr "e-mail email mail abbestellen abmelden newsletter glocke benachrichtigung weniger ruhe"
-
-#: lib/vutuv_web/components/ui.ex:4146
+#: lib/vutuv_web/components/ui.ex:4154
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr "Beiträge aus Ihrem Feed heraushalten"
 
-#: lib/vutuv_web/components/ui.ex:4147
+#: lib/vutuv_web/components/ui.ex:4155
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr "stummschalten ausblenden verbergen filter wort begriff tag feed blockieren"
 
-#: lib/vutuv_web/components/ui.ex:4150
+#: lib/vutuv_web/components/ui.ex:4158
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr "Themen, deren Beiträge in Ihrem Feed landen"
 
-#: lib/vutuv_web/components/ui.ex:4151
+#: lib/vutuv_web/components/ui.ex:4159
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr "tag thema abonnieren folgen feed"
 
-#: lib/vutuv_web/components/ui.ex:4167
+#: lib/vutuv_web/components/ui.ex:4175
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr "Job- und Personensuchen, die Ihnen neue Treffer mailen"
 
-#: lib/vutuv_web/components/ui.ex:4168
+#: lib/vutuv_web/components/ui.ex:4176
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr "job stelle stellenangebot suchauftrag suche alarm benachrichtigung merkliste"
 
-#: lib/vutuv_web/components/ui.ex:4174
+#: lib/vutuv_web/components/ui.ex:4182
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr "Suchmaschinen, KI, Online-Status"
 
-#: lib/vutuv_web/components/ui.ex:4175
+#: lib/vutuv_web/components/ui.ex:4183
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr "privatsphäre datenschutz google suchmaschine ki ai llm crawler noindex online punkt öffentlich sichtbar"
 
-#: lib/vutuv_web/components/ui.ex:4178
+#: lib/vutuv_web/components/ui.ex:4186
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr "Personen, die nicht mit Ihnen interagieren können"
 
-#: lib/vutuv_web/components/ui.ex:4179
+#: lib/vutuv_web/components/ui.ex:4187
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr "blockieren sperren bannen stummschalten melden missbrauch belästigung"
 
-#: lib/vutuv_web/components/ui.ex:4200
+#: lib/vutuv_web/components/ui.ex:4208
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr "Passkeys, angemeldete Geräte, Anmeldecodes"
 
-#: lib/vutuv_web/components/ui.ex:4201
+#: lib/vutuv_web/components/ui.ex:4209
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr "passwort kennwort anmelden abmelden login logout sitzung gerät passkey totp 2fa pin sicherheit"
 
-#: lib/vutuv_web/components/ui.ex:4219
+#: lib/vutuv_web/components/ui.ex:4227
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr "Ihre Daten von LinkedIn übernehmen"
 
-#: lib/vutuv_web/components/ui.ex:4220
+#: lib/vutuv_web/components/ui.ex:4228
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr "linkedin hochladen zip übernehmen importieren umzug"
 
-#: lib/vutuv_web/components/ui.ex:4223
+#: lib/vutuv_web/components/ui.ex:4231
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr "Alles herunterladen, was wir über Sie speichern"
 
-#: lib/vutuv_web/components/ui.ex:4224
+#: lib/vutuv_web/components/ui.ex:4232
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr "herunterladen download dsgvo gdpr daten sicherung json lebenslauf auskunft"
 
-#: lib/vutuv_web/components/ui.ex:4238
+#: lib/vutuv_web/components/ui.ex:4246
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr "Ihr Konto und alles darauf entfernen"
 
-#: lib/vutuv_web/components/ui.ex:4239
+#: lib/vutuv_web/components/ui.ex:4247
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr "löschen entfernen schließen kündigen beenden verlassen"
@@ -16066,7 +16062,7 @@ msgstr "Verstanden, abschalten"
 msgid "I understand, take part"
 msgstr "Verstanden, teilnehmen"
 
-#: lib/vutuv_web/views/settings_html.ex:480
+#: lib/vutuv_web/views/settings_html.ex:489
 #, elixir-autogen, elixir-format
 msgid "Most of them, not all: we cannot check whether they do it, and anything that was re-shared, archived or indexed elsewhere stays out of reach. If you take part again later, people there have to follow you anew."
 msgstr ""
@@ -16074,7 +16070,7 @@ msgstr ""
 "anderswo geteilt, archiviert oder indexiert wurde, bleibt außer Reichweite. "
 "Wenn Sie später wieder teilnehmen, müssen Ihnen die Leute dort erneut folgen."
 
-#: lib/vutuv_web/views/settings_html.ex:475
+#: lib/vutuv_web/views/settings_html.ex:484
 #, elixir-autogen, elixir-format
 msgid "No new posts go out, and your followers from other networks are removed here. The next time those servers look you up they learn that this account is gone, and most of them then delete their copies of your posts."
 msgstr ""
@@ -16083,25 +16079,25 @@ msgstr ""
 "erfahren sie, dass dieses Konto nicht mehr existiert, und die meisten löschen "
 "daraufhin ihre Kopien Ihrer Beiträge."
 
-#: lib/vutuv_web/views/settings_html.ex:456
+#: lib/vutuv_web/views/settings_html.ex:465
 #, elixir-autogen, elixir-format
 msgid "Once a post has left vutuv, it is out of our hands"
 msgstr ""
 "Was einmal von vutuv aus verschickt wurde, können wir nicht zurückholen"
 
-#: lib/vutuv_web/views/settings_html.ex:458
+#: lib/vutuv_web/views/settings_html.ex:467
 #, elixir-autogen, elixir-format
 msgid "Switching off does not delete what is already out there"
 msgstr "Abschalten löscht nicht, was bereits draußen ist"
 
-#: lib/vutuv_web/views/settings_html.ex:469
+#: lib/vutuv_web/views/settings_html.ex:478
 #, elixir-autogen, elixir-format
 msgid "Switching this off again later stops new posts from going out. It cannot bring back what has already been delivered."
 msgstr ""
 "Wenn Sie das später wieder abschalten, gehen keine neuen Beiträge mehr "
 "hinaus. Bereits zugestellte Beiträge holt das nicht zurück."
 
-#: lib/vutuv_web/views/settings_html.ex:464
+#: lib/vutuv_web/views/settings_html.ex:473
 #, elixir-autogen, elixir-format
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
@@ -16110,21 +16106,21 @@ msgstr ""
 "wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
-#: lib/vutuv_web/components/post_components.ex:4891
+#: lib/vutuv_web/components/post_components.ex:4997
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:4895
+#: lib/vutuv_web/components/post_components.ex:5001
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Like"
 msgstr[1] "%{formatted} Likes"
 
-#: lib/vutuv_web/components/post_components.ex:4899
+#: lib/vutuv_web/components/post_components.ex:5005
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -16132,7 +16128,7 @@ msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1145
-#: lib/vutuv_web/components/post_components.ex:4850
+#: lib/vutuv_web/components/post_components.ex:4956
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Bereits in den Zahlen oben enthalten."
@@ -16148,14 +16144,14 @@ msgstr "Antworten, die dort draußen geschrieben werden, erscheinen unter Ihrem 
 msgid "Content warning"
 msgstr "Inhaltswarnung"
 
-#: lib/vutuv_web/components/post_components.ex:1219
-#: lib/vutuv_web/components/post_components.ex:1784
+#: lib/vutuv_web/components/post_components.ex:1222
+#: lib/vutuv_web/components/post_components.ex:1881
 #: lib/vutuv_web/live/fediverse_account_live.ex:294
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr "Aus einem anderen Netzwerk"
 
-#: lib/vutuv_web/components/post_components.ex:1095
+#: lib/vutuv_web/components/post_components.ex:1098
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr "Diese Antwort aus Ihrem Beitrag entfernen?"
@@ -16174,7 +16170,7 @@ msgstr "Vom Mitglied entfernt"
 msgid "Replies from other networks"
 msgstr "Antworten aus anderen Netzwerken"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1038
+#: lib/vutuv_web/live/notification_live/index.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Reply from another network"
 msgstr "Antwort aus einem anderen Netzwerk"
@@ -16184,7 +16180,7 @@ msgstr "Antwort aus einem anderen Netzwerk"
 msgid "Reply removed."
 msgstr "Antwort entfernt."
 
-#: lib/vutuv_web/components/post_components.ex:1104
+#: lib/vutuv_web/components/post_components.ex:1107
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
@@ -16194,8 +16190,8 @@ msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
 msgid "Reported as not appropriate"
 msgstr "Als unangemessen gemeldet"
 
-#: lib/vutuv_web/components/post_components.ex:1118
-#: lib/vutuv_web/live/notification_live/index.ex:545
+#: lib/vutuv_web/components/post_components.ex:1121
+#: lib/vutuv_web/live/notification_live/index.ex:557
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
 msgstr "Nur an Sie gesendet, für niemanden sonst sichtbar"
@@ -16226,9 +16222,9 @@ msgid "That reply is not yours to remove."
 msgstr "Diese Antwort können Sie nicht entfernen."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1329
-#: lib/vutuv_web/components/post_components.ex:1150
-#: lib/vutuv_web/components/post_components.ex:1350
-#: lib/vutuv_web/components/post_components.ex:2202
+#: lib/vutuv_web/components/post_components.ex:1153
+#: lib/vutuv_web/components/post_components.ex:1353
+#: lib/vutuv_web/components/post_components.ex:2299
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr "Original ansehen"
@@ -16246,7 +16242,7 @@ msgstr "Was"
 msgid "You have reported a lot today. Please try again tomorrow."
 msgstr "Sie haben heute schon viel gemeldet. Bitte versuchen Sie es morgen wieder."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1262
+#: lib/vutuv_web/notification_line.ex:84
 #, elixir-autogen, elixir-format
 msgid "replied to your post from another network."
 msgstr "hat aus einem anderen Netzwerk auf Ihren Beitrag geantwortet."
@@ -16460,7 +16456,7 @@ msgstr "API-Token erstellt"
 msgid "Access token revoked"
 msgstr "API-Token widerrufen"
 
-#: lib/vutuv_web/components/ui.ex:4203
+#: lib/vutuv_web/components/ui.ex:4211
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -16675,7 +16671,7 @@ msgstr "Hier ist noch nichts. Wenn Sie sich das nächste Mal anmelden oder eine 
 #: lib/vutuv_web/live/account_activity_live.ex:198
 #: lib/vutuv_web/live/admin/activity_live.ex:237
 #: lib/vutuv_web/live/fediverse_following_live.ex:378
-#: lib/vutuv_web/live/tag_live/timeline.ex:343
+#: lib/vutuv_web/live/tag_live/timeline.ex:346
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr "Dazu passt nichts. Versuchen Sie eine kürzere Suche oder setzen Sie die Filter zurück."
@@ -16807,7 +16803,7 @@ msgstr "Was sich an einem Konto geändert hat, wann, von wo und wie es bestätig
 msgid "What changed on your account, and exactly when."
 msgstr "Was sich an Ihrem Konto geändert hat, und wann genau."
 
-#: lib/vutuv_web/components/ui.ex:4204
+#: lib/vutuv_web/components/ui.ex:4212
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr "Was sich an Ihrem Konto geändert hat, und wann"
@@ -16843,7 +16839,7 @@ msgstr "durch den Betreiber"
 msgid "from a signed-in session"
 msgstr "aus einer angemeldeten Sitzung"
 
-#: lib/vutuv_web/components/ui.ex:4206
+#: lib/vutuv_web/components/ui.ex:4214
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr "protokoll verlauf historie chronik audit sicherheit war ich das wer hat wann geaendert geändert log"
@@ -16895,22 +16891,22 @@ msgstr "Was sich an welchem Konto geändert hat, wann, von welchem Gerät und wi
 msgid "device or detail"
 msgstr "Gerät oder Detail"
 
-#: lib/vutuv_web/components/post_components.ex:2740
+#: lib/vutuv_web/components/post_components.ex:2837
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Angehefteter Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:2856
+#: lib/vutuv_web/components/post_components.ex:2953
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "An Profil anheften"
 
-#: lib/vutuv_web/components/post_components.ex:2864
+#: lib/vutuv_web/components/post_components.ex:2961
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Vom Profil lösen"
 
-#: lib/vutuv_web/components/post_components.ex:2850
+#: lib/vutuv_web/components/post_components.ex:2947
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr "Es lässt sich nur ein Beitrag an Ihr Profil anheften. Diesen anheften und den anderen lösen?"
@@ -17002,7 +16998,7 @@ msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1257
 #: lib/vutuv_web/agent_docs/text.ex:792
-#: lib/vutuv_web/components/ui.ex:2563
+#: lib/vutuv_web/components/ui.ex:2568
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr "Original herunterladen"
@@ -17032,7 +17028,7 @@ msgstr "Volle Auflösung, direkt aus dem Beitrag."
 msgid "Just the picture"
 msgstr "Nur das Bild"
 
-#: lib/vutuv_web/components/ui.ex:2562
+#: lib/vutuv_web/components/ui.ex:2567
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr "Nächstes Foto"
@@ -17042,17 +17038,17 @@ msgstr "Nächstes Foto"
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
 
-#: lib/vutuv_web/components/post_components.ex:2335
+#: lib/vutuv_web/components/post_components.ex:2432
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Fediverse-Einstellungen öffnen"
 
-#: lib/vutuv_web/components/post_components.ex:3559
+#: lib/vutuv_web/components/post_components.ex:3656
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} von %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:3070
+#: lib/vutuv_web/components/post_components.ex:3167
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
@@ -17065,12 +17061,12 @@ msgstr "Foto-Einstellungen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1290
 #: lib/vutuv_web/agent_docs/text.ex:779
-#: lib/vutuv_web/components/post_components.ex:3776
+#: lib/vutuv_web/components/post_components.ex:3873
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Fotos:"
 
-#: lib/vutuv_web/components/ui.ex:2561
+#: lib/vutuv_web/components/ui.ex:2566
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr "Vorheriges Foto"
@@ -17091,7 +17087,7 @@ msgstr "Dieselben Bildpunkte, sonst nichts: Ort und Seriennummern entfernt, Qual
 msgid "Show camera settings"
 msgstr "Kameradaten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2388
+#: lib/vutuv_web/components/post_components.ex:2485
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr "Dieser Server ist auf dieser Seite gesperrt, deshalb kann keine Antwort dorthin gesendet werden."
@@ -17111,7 +17107,7 @@ msgstr "Dieses Dateiformat lässt sich nur unverändert weitergeben. Entfernen S
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr "Dieses Foto enthält den Ort, an dem es aufgenommen wurde. Wer die exakte Datei herunterlädt, kann ihn auslesen."
 
-#: lib/vutuv_web/components/post_components.ex:2379
+#: lib/vutuv_web/components/post_components.ex:2476
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht öffentlich beantworten."
@@ -17121,12 +17117,12 @@ msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht �
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr "Diese Antwort wurde in einem anderen Netzwerk geschrieben. Sie zu beantworten heißt, Ihre Worte in dieses Netzwerk zu senden, und das tut vutuv nur für Mitglieder, die die Fediverse-Teilnahme eingeschaltet haben."
 
-#: lib/vutuv_web/components/post_components.ex:2397
+#: lib/vutuv_web/components/post_components.ex:2494
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Diese Seite nimmt nicht am Fediverse teil."
 
-#: lib/vutuv_web/components/post_components.ex:2331
+#: lib/vutuv_web/components/post_components.ex:2428
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Fediverse-Teilnahme einschalten, um zu antworten"
@@ -17141,7 +17137,7 @@ msgstr "Wer diese Fotos weiterverwenden darf"
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke geschickt. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:2392
+#: lib/vutuv_web/components/post_components.ex:2489
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshalb werden von hier aus keine Antworten mehr gesendet."
@@ -17151,7 +17147,7 @@ msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshal
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr "Ihre Fediverse-Einstellungen erlauben es derzeit nicht, eine Antwort zu senden."
 
-#: lib/vutuv_web/components/post_components.ex:2345
+#: lib/vutuv_web/components/post_components.ex:2442
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr "Ihre Antwort geht an %{handle} auf dem eigenen Server und an Ihre Fediverse-Follower. Auf vutuv ist sie ebenfalls ein öffentlicher Beitrag."
@@ -17172,8 +17168,8 @@ msgstr "Fotos hinzufügen"
 msgid "Licence"
 msgstr "Lizenz"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1234
-#: lib/vutuv_web/live/post_live/feed.ex:1235
+#: lib/vutuv_web/live/post_live/feed.ex:1250
+#: lib/vutuv_web/live/post_live/feed.ex:1251
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr "Fotos posten"
@@ -17238,13 +17234,13 @@ msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exak
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1163
-#: lib/vutuv_web/components/post_components.ex:4888
+#: lib/vutuv_web/components/post_components.ex:4994
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1161
-#: lib/vutuv_web/components/post_components.ex:4885
+#: lib/vutuv_web/components/post_components.ex:4991
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} hat das geteilt"
@@ -17254,12 +17250,12 @@ msgstr "%{handle} hat das geteilt"
 msgid "Fediverse reactions"
 msgstr "Fediverse-Reaktionen"
 
-#: lib/vutuv_web/components/post_components.ex:4777
+#: lib/vutuv_web/components/post_components.ex:4883
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1039
+#: lib/vutuv_web/live/notification_live/index.ex:1051
 #, elixir-autogen, elixir-format
 msgid "Reaction from another network"
 msgstr "Reaktion aus einem anderen Netzwerk"
@@ -17279,21 +17275,21 @@ msgstr ""
 "Mehr speichern wir über diese Menschen nicht: keinen Namen, kein Bild, "
 "keinen Text. Ausschalten löscht, was dafür gespeichert ist."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1093
+#: lib/vutuv_web/notification_line.ex:224
 #, elixir-autogen, elixir-format
 msgid "liked your post on another network."
 msgid_plural "liked your post on another network."
 msgstr[0] "gefällt Ihr Beitrag in einem anderen Netzwerk."
 msgstr[1] "gefällt Ihr Beitrag in einem anderen Netzwerk."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1101
+#: lib/vutuv_web/notification_line.ex:232
 #, elixir-autogen, elixir-format
 msgid "reacted to your post from another network."
 msgid_plural "reacted to your post from another network."
 msgstr[0] "hat aus einem anderen Netzwerk auf Ihren Beitrag reagiert."
 msgstr[1] "haben aus einem anderen Netzwerk auf Ihren Beitrag reagiert."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1085
+#: lib/vutuv_web/notification_line.ex:216
 #, elixir-autogen, elixir-format
 msgid "shared your post on another network."
 msgid_plural "shared your post on another network."
@@ -17379,7 +17375,7 @@ msgstr "Ein Konto in einem anderen Netzwerk"
 msgid "Cancel request"
 msgstr "Anfrage zurückziehen"
 
-#: lib/vutuv_web/components/ui.ex:4190
+#: lib/vutuv_web/components/ui.ex:4198
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr "Konten auf Mastodon folgen, und von dort gefolgt werden"
@@ -17583,7 +17579,7 @@ msgstr "Sie haben Ihre Fediverse-Follower auf ein anderes Konto umgeleitet, desh
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr "Ihr Konto ist derzeit gesperrt, deshalb geht nichts von Ihnen an andere Netzwerke und Sie können dort niemandem folgen. Das endet von selbst, sobald die Sperre abläuft."
 
-#: lib/vutuv_web/components/ui.ex:4192
+#: lib/vutuv_web/components/ui.ex:4200
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr "mastodon activitypub foederation federation follower folgen folge umzug migration entferntes konto"
@@ -17603,7 +17599,7 @@ msgstr "Von hier aus wird %{follows} Konten in anderen Netzwerken gefolgt, davon
 msgid "Cached posts"
 msgstr "Zwischengespeicherte Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:2148
+#: lib/vutuv_web/components/post_components.ex:2245
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr "Nur für die Follower dieses Kontos"
@@ -17613,7 +17609,7 @@ msgstr "Nur für die Follower dieses Kontos"
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Danke. Unsere Kopie wurde sofort gelöscht."
 
-#: lib/vutuv_web/components/post_components.ex:2201
+#: lib/vutuv_web/components/post_components.ex:2298
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Beim Original abstimmen"
@@ -17633,12 +17629,12 @@ msgstr "Zwischengespeicherter Beitrag gemeldet, hier für alle entfernt"
 msgid "Content from other networks taken down by members"
 msgstr "Von Mitgliedern entfernte Inhalte aus anderen Netzwerken"
 
-#: lib/vutuv_web/components/post_components.ex:1478
+#: lib/vutuv_web/components/post_components.ex:1481
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr "Verbergen"
 
-#: lib/vutuv_web/components/post_components.ex:2166
+#: lib/vutuv_web/components/post_components.ex:2263
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Von der verfassenden Person als sensibel markiert"
@@ -17654,7 +17650,7 @@ msgstr "Stummgeschaltet. Sie folgen dem Konto weiterhin; die Beiträge verschwin
 msgid "Nobody has removed or reported anything yet."
 msgstr "Bisher hat niemand etwas entfernt oder gemeldet."
 
-#: lib/vutuv_web/components/post_components.ex:2134
+#: lib/vutuv_web/components/post_components.ex:2231
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr "Diesen Beitrag als unangemessen melden? Unsere Kopie wird sofort für alle auf diesem vutuv gelöscht."
@@ -17876,27 +17872,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] "(ein Bild)"
 msgstr[1] "(%{count} Bilder)"
 
-#: lib/vutuv_web/components/post_components.ex:1887
+#: lib/vutuv_web/components/post_components.ex:1984
 #, elixir-autogen, elixir-format
 msgid "A picture is on its way."
 msgstr "Ein Bild ist unterwegs."
 
-#: lib/vutuv_web/components/post_components.ex:1916
+#: lib/vutuv_web/components/post_components.ex:2013
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr "Wieder verdecken"
 
-#: lib/vutuv_web/components/post_components.ex:1911
+#: lib/vutuv_web/components/post_components.ex:2008
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr "Heikles Motiv. Bild anzeigen."
 
-#: lib/vutuv_web/components/post_components.ex:2238
+#: lib/vutuv_web/components/post_components.ex:2335
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Das sind viele Likes in einer Stunde. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:2244
+#: lib/vutuv_web/components/post_components.ex:2341
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Diesen Beitrag gibt es hier nicht mehr."
@@ -17906,7 +17902,7 @@ msgstr "Diesen Beitrag gibt es hier nicht mehr."
 msgid "Back to the feed"
 msgstr "Zurück zum Feed"
 
-#: lib/vutuv_web/components/post_components.ex:2383
+#: lib/vutuv_web/components/post_components.ex:2480
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17921,7 +17917,7 @@ msgstr ""
 "beantworten heißt, Ihre Worte in dieses Netzwerk zu senden, und das tut vutuv "
 "nur für Mitglieder, die die Fediverse-Teilnahme eingeschaltet haben."
 
-#: lib/vutuv_web/live/post_live/remote_actions_component.ex:155
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:167
 #, elixir-autogen, elixir-format
 msgid "Reposted. Your followers see it now."
 msgstr "Repostet. Ihre Follower sehen es jetzt."
@@ -18100,7 +18096,7 @@ msgstr "Ihr Benutzername ist hier Ihre öffentliche Identität. Er ändert sich 
 msgid "Your username is your public identity here. It changes only once you confirm with your passkey or a valid code below."
 msgstr "Ihr Benutzername ist hier Ihre öffentliche Identität. Er ändert sich erst, wenn Sie unten mit Ihrem Passkey oder einem gültigen Code bestätigen."
 
-#: lib/vutuv_web/components/ui.ex:497
+#: lib/vutuv_web/components/ui.ex:498
 #, elixir-autogen, elixir-format
 msgid "Markdown help"
 msgstr "Markdown-Hilfe"
@@ -18115,53 +18111,53 @@ msgstr "Auf dieser Seite"
 msgid "Read this page as Markdown"
 msgstr "Diese Seite als Markdown lesen"
 
-#: lib/vutuv_web/components/ui.ex:554
+#: lib/vutuv_web/components/ui.ex:555
 #, elixir-autogen, elixir-format
 msgid "Activities"
 msgstr "Aktivitäten"
 
-#: lib/vutuv_web/components/ui.ex:552
+#: lib/vutuv_web/components/ui.ex:553
 #, elixir-autogen, elixir-format
 msgid "Animals & nature"
 msgstr "Tiere & Natur"
 
-#: lib/vutuv_web/components/ui.ex:313
-#: lib/vutuv_web/components/ui.ex:337
+#: lib/vutuv_web/components/ui.ex:314
+#: lib/vutuv_web/components/ui.ex:338
 #, elixir-autogen, elixir-format
 msgid "Emoji"
 msgstr "Emoji"
 
-#: lib/vutuv_web/components/ui.ex:553
+#: lib/vutuv_web/components/ui.ex:554
 #, elixir-autogen, elixir-format
 msgid "Food & drink"
 msgstr "Essen & Trinken"
 
-#: lib/vutuv_web/components/ui.ex:316
+#: lib/vutuv_web/components/ui.ex:317
 #, elixir-autogen, elixir-format
 msgid "No emoji found."
 msgstr "Keine Emoji gefunden."
 
-#: lib/vutuv_web/components/ui.ex:556
+#: lib/vutuv_web/components/ui.ex:557
 #, elixir-autogen, elixir-format
 msgid "Objects"
 msgstr "Objekte"
 
-#: lib/vutuv_web/components/ui.ex:314
+#: lib/vutuv_web/components/ui.ex:315
 #, elixir-autogen, elixir-format
 msgid "Search emoji"
 msgstr "Emoji suchen"
 
-#: lib/vutuv_web/components/ui.ex:550
+#: lib/vutuv_web/components/ui.ex:551
 #, elixir-autogen, elixir-format
 msgid "Smileys"
 msgstr "Smileys"
 
-#: lib/vutuv_web/components/ui.ex:557
+#: lib/vutuv_web/components/ui.ex:558
 #, elixir-autogen, elixir-format
 msgid "Symbols"
 msgstr "Symbole"
 
-#: lib/vutuv_web/components/ui.ex:555
+#: lib/vutuv_web/components/ui.ex:556
 #, elixir-autogen, elixir-format
 msgid "Travel & places"
 msgstr "Reisen & Orte"
@@ -18172,7 +18168,7 @@ msgid "Address of the post"
 msgstr "Adresse des Beitrags"
 
 #: lib/vutuv_web/components/fediverse_components.ex:504
-#: lib/vutuv_web/live/post_live/remote_actions_component.ex:247
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:262
 #, elixir-autogen, elixir-format
 msgid "Fediverse settings"
 msgstr "Fediverse-Einstellungen"
@@ -18619,57 +18615,57 @@ msgstr "Seiten, von denen nie ein Screenshot entsteht, weil ein Browser ohne Anz
 msgid "Screenshot blocklist"
 msgstr "Screenshot-Blockliste"
 
-#: lib/vutuv_web/components/post_components.ex:425
+#: lib/vutuv_web/components/post_components.ex:428
 #, elixir-autogen, elixir-format
 msgid "Nothing from the fediverse yet. Follow accounts out there to fill this tab."
 msgstr ""
 "Noch nichts aus dem Fediverse. Folgen Sie Konten dort draußen, um diesen Tab "
 "zu füllen."
 
-#: lib/vutuv_web/components/post_components.ex:422
+#: lib/vutuv_web/components/post_components.ex:425
 #, elixir-autogen, elixir-format
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
 "Noch nichts von vutuv. Folgen Sie Menschen hier, um diesen Tab zu füllen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:575
+#: lib/vutuv_web/live/notification_live/index.ex:587
 #, elixir-autogen, elixir-format
 msgid "View the conversation"
 msgstr "Unterhaltung ansehen"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:213
+#: lib/vutuv_web/live/tag_live/timeline.ex:216
 #, elixir-autogen, elixir-format
 msgid "%{formatted} post"
 msgid_plural "%{formatted} posts"
 msgstr[0] "%{formatted} Beitrag"
 msgstr[1] "%{formatted} Beiträge"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:327
+#: lib/vutuv_web/live/tag_live/timeline.ex:330
 #, elixir-autogen, elixir-format
 msgid "Most liked"
 msgstr "Meiste Likes"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:351
+#: lib/vutuv_web/live/tag_live/timeline.ex:354
 #, elixir-autogen, elixir-format
 msgid "No posts carry this tag yet."
 msgstr "Zu diesem Tag gibt es noch keine Beiträge."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:349
+#: lib/vutuv_web/live/tag_live/timeline.ex:352
 #, elixir-autogen, elixir-format
 msgid "No posts from other networks carry this tag yet."
 msgstr "Aus anderen Netzwerken gibt es zu diesem Tag noch keine Beiträge."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:346
+#: lib/vutuv_web/live/tag_live/timeline.ex:349
 #, elixir-autogen, elixir-format
 msgid "No posts on vutuv carry this tag yet."
 msgstr "Auf vutuv gibt es zu diesem Tag noch keine Beiträge."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:246
+#: lib/vutuv_web/live/tag_live/timeline.ex:249
 #, elixir-autogen, elixir-format
 msgid "word in a post"
 msgstr "Wort in einem Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:2241
+#: lib/vutuv_web/components/post_components.ex:2338
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr "Diese Antwort gibt es hier nicht mehr."
@@ -18710,8 +18706,8 @@ msgstr "Mehr von %{name}"
 msgid "This is vutuv's copy of a post published on %{host}. It is kept while somebody here follows its author."
 msgstr "Das ist die Kopie, die vutuv von einem auf %{host} veröffentlichten Beitrag hat. Sie bleibt erhalten, solange hier jemand diesem Konto folgt."
 
-#: lib/vutuv_web/components/ui.ex:1130
 #: lib/vutuv_web/components/ui.ex:1131
+#: lib/vutuv_web/components/ui.ex:1132
 #, elixir-autogen, elixir-format
 msgid "Subscribe to this feed in your RSS reader"
 msgstr "Diesen Feed in Ihrem RSS-Reader abonnieren"
@@ -18972,19 +18968,19 @@ msgstr "Auf der Seite eines Beitrags stehen direkt unter der Zahl die Mitglieder
 msgid "Liked by"
 msgstr "Gefällt diesen Mitgliedern"
 
-#: lib/vutuv_web/components/post_components.ex:4033
+#: lib/vutuv_web/components/post_components.ex:4130
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Gefällt %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:4035
+#: lib/vutuv_web/components/post_components.ex:4132
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Gefällt %{name} und %{formatted} weiteren"
 msgstr[1] "Gefällt %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/components/post_components.ex:4046
+#: lib/vutuv_web/components/post_components.ex:4143
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr "Nur Sie sehen hier alle: Einige dieser Mitglieder werden anderen Lesern nicht genannt."
@@ -19004,7 +19000,7 @@ msgstr "Meinen Namen bei Beiträgen zeigen, die mir gefallen"
 msgid "When off, other members no longer see you among the likes of a post. The author of the post still does: we named you in the notification they got when you liked it. Either way the post keeps the same number of likes."
 msgstr "Wenn aus, sehen andere Mitglieder Sie nicht mehr bei den Likes eines Beitrags. Die Autorin oder der Autor des Beitrags sieht es weiterhin: In der Benachrichtigung von damals haben wir Sie namentlich genannt. Der Beitrag hat in beiden Fällen gleich viele Likes."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:834
+#: lib/vutuv_web/controllers/settings_controller.ex:846
 #, elixir-autogen, elixir-format
 msgid "Your likes follow the site default again."
 msgstr "Ihre Likes folgen wieder dem Standardwert der Website."
@@ -19019,7 +19015,7 @@ msgstr "%{address} (nur diese Seite)"
 msgid "%{address} (whole website)"
 msgstr "%{address} (ganze Website)"
 
-#: lib/vutuv_web/markdown.ex:327
+#: lib/vutuv_web/markdown.ex:337
 #, elixir-autogen, elixir-format
 msgid "Verified webpage of the author (%{address})"
 msgstr "Verifizierte Webseite der Autorin oder des Autors (%{address})"
@@ -19046,7 +19042,7 @@ msgstr "Für dieses Zeugnis läuft bereits eine Prüfung."
 #: lib/vutuv_web/controllers/job_reference_controller.ex:144
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:18
 #: lib/vutuv_web/templates/job_reference/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:786
+#: lib/vutuv_web/templates/user/show.html.heex:789
 #, elixir-autogen, elixir-format
 msgid "Add an employment reference"
 msgstr "Arbeitszeugnis hinzufügen"
@@ -19111,7 +19107,7 @@ msgstr "Arbeitszeugnis gespeichert."
 msgid "Employment reference updated."
 msgstr "Arbeitszeugnis aktualisiert."
 
-#: lib/vutuv_web/components/ui.ex:4095
+#: lib/vutuv_web/components/ui.ex:4100
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -19121,7 +19117,7 @@ msgstr "Arbeitszeugnis aktualisiert."
 #: lib/vutuv_web/templates/job_reference/new.html.heex:4
 #: lib/vutuv_web/templates/job_reference/show.html.heex:12
 #: lib/vutuv_web/templates/job_reference/view.html.heex:11
-#: lib/vutuv_web/templates/user/show.html.heex:783
+#: lib/vutuv_web/templates/user/show.html.heex:786
 #, elixir-autogen, elixir-format
 msgid "Employment references"
 msgstr "Arbeitszeugnisse"
@@ -19305,7 +19301,7 @@ msgstr "In der Warteschlange, Ihres ist als Nächstes dran."
 msgid "You changed the text after this review. It describes the earlier version."
 msgstr "Sie haben den Text nach dieser Prüfung geändert. Sie beschreibt die frühere Fassung."
 
-#: lib/vutuv_web/components/ui.ex:4096
+#: lib/vutuv_web/components/ui.ex:4101
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr "Ihre Arbeitszeugnisse, privat bis Sie sie veröffentlichen"
@@ -19316,7 +19312,7 @@ msgstr "Ihre Arbeitszeugnisse, privat bis Sie sie veröffentlichen"
 msgid "Zwischenzeugnis"
 msgstr "Zwischenzeugnis"
 
-#: lib/vutuv_web/components/ui.ex:4098
+#: lib/vutuv_web/components/ui.ex:4103
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr "arbeitszeugnis zeugnis referenz beurteilung arbeitgeber bewertung prüfung"
@@ -19504,7 +19500,7 @@ msgstr "Arbeitszeugnis geändert"
 msgid "Employment reference deleted"
 msgstr "Arbeitszeugnis gelöscht"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1048
+#: lib/vutuv_web/live/notification_live/index.ex:1060
 #, elixir-autogen, elixir-format
 msgid "Employment reference review"
 msgstr "Zeugnisprüfung"
@@ -19529,14 +19525,14 @@ msgstr "Ausstellungsdatum"
 msgid "Reviewing your reference. This usually takes about %{duration}."
 msgstr "Ihr Zeugnis wird geprüft. Das dauert erfahrungsgemäß etwa %{duration}."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1250
-#: lib/vutuv_web/views/notification_digest_text.ex:84
+#: lib/vutuv_web/notification_line.ex:54
+#: lib/vutuv_web/views/notification_digest_text.ex:90
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready."
 msgstr "Die Prüfung von „%{title}“ ist fertig."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1247
-#: lib/vutuv_web/views/notification_digest_text.ex:81
+#: lib/vutuv_web/notification_line.ex:51
+#: lib/vutuv_web/views/notification_digest_text.ex:87
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready: %{grade}."
 msgstr "Die Prüfung von „%{title}“ ist fertig: %{grade}."
@@ -19551,7 +19547,7 @@ msgstr "Erfahrungsgemäß etwa %{duration}."
 msgid "When the review of one of your employment references is finished. It takes minutes, so you can close the page and wait for the email."
 msgstr "Wenn die Prüfung eines Ihrer Arbeitszeugnisse fertig ist. Das dauert einige Minuten, Sie können die Seite also schließen und auf die E-Mail warten."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1253
+#: lib/vutuv_web/notification_line.ex:57
 #, elixir-autogen, elixir-format
 msgid "Your employment reference has been reviewed."
 msgstr "Ihr Arbeitszeugnis wurde geprüft."
@@ -19638,72 +19634,72 @@ msgid_plural "%{count} new notifications on vutuv"
 msgstr[0] "%{count} neue Mitteilung auf vutuv"
 msgstr[1] "%{count} neue Mitteilungen auf vutuv"
 
-#: lib/vutuv_web/views/notification_digest_text.ex:59
+#: lib/vutuv_web/views/notification_digest_text.ex:65
 #, elixir-autogen, elixir-format
 msgid "%{who} added something to their CV."
 msgstr "%{who} hat den Lebenslauf ergänzt."
 
-#: lib/vutuv_web/views/notification_digest_text.ex:41
+#: lib/vutuv_web/views/notification_digest_text.ex:47
 #, elixir-autogen, elixir-format
 msgid "%{who} answered in a conversation you are part of."
 msgstr "%{who} hat in einem Gespräch geantwortet, an dem Sie beteiligt sind."
 
-#: lib/vutuv_web/views/notification_digest_text.ex:35
+#: lib/vutuv_web/views/notification_digest_text.ex:41
 #, elixir-autogen, elixir-format
 msgid "%{who} endorsed one of your tags."
 msgstr "%{who} hat Sie für einen Ihrer Tags empfohlen."
 
-#: lib/vutuv_web/views/notification_digest_text.ex:32
+#: lib/vutuv_web/views/notification_digest_text.ex:38
 #, elixir-autogen, elixir-format
 msgid "%{who} endorsed you for %{tag}."
 msgstr "%{who} hat Sie für %{tag} empfohlen."
 
-#: lib/vutuv_web/views/notification_digest_text.ex:47
+#: lib/vutuv_web/views/notification_digest_text.ex:53
 #, elixir-autogen, elixir-format
 msgid "%{who} liked your post."
 msgstr "%{who} gefällt Ihr Beitrag."
 
-#: lib/vutuv_web/views/notification_digest_text.ex:44
+#: lib/vutuv_web/views/notification_digest_text.ex:50
 #, elixir-autogen, elixir-format
 msgid "%{who} mentioned you in a post."
 msgstr "%{who} hat Sie in einem Beitrag erwähnt."
 
-#: lib/vutuv_web/views/notification_digest_text.ex:53
+#: lib/vutuv_web/views/notification_digest_text.ex:59
 #, elixir-autogen, elixir-format
 msgid "%{who} reacted to your post from another network."
 msgstr "%{who} hat aus einem anderen Netzwerk auf Ihren Beitrag reagiert."
 
-#: lib/vutuv_web/views/notification_digest_text.ex:50
+#: lib/vutuv_web/views/notification_digest_text.ex:56
 #, elixir-autogen, elixir-format
 msgid "%{who} replied to your post from another network."
 msgstr "%{who} hat aus einem anderen Netzwerk auf Ihren Beitrag geantwortet."
 
-#: lib/vutuv_web/views/notification_digest_text.ex:38
+#: lib/vutuv_web/views/notification_digest_text.ex:44
 #, elixir-autogen, elixir-format
 msgid "%{who} replied to your post."
 msgstr "%{who} hat auf Ihren Beitrag geantwortet."
 
-#: lib/vutuv_web/views/notification_digest_text.ex:26
+#: lib/vutuv_web/views/notification_digest_text.ex:32
 #, elixir-autogen, elixir-format
 msgid "%{who} started following you."
 msgstr "%{who} folgt Ihnen jetzt."
 
-#: lib/vutuv_web/views/notification_digest_text.ex:63
+#: lib/vutuv_web/views/notification_digest_text.ex:69
 #, elixir-autogen, elixir-format
 msgid "@%{old} is now @%{new}."
 msgstr "@%{old} heißt jetzt @%{new}."
 
-#: lib/vutuv_web/views/notification_digest_text.ex:66
+#: lib/vutuv_web/views/notification_digest_text.ex:72
 #, elixir-autogen, elixir-format
 msgid "A moderation case on your account was updated."
 msgstr "Ein Moderationsfall zu Ihrem Konto wurde aktualisiert."
 
-#: lib/vutuv_web/views/notification_digest_text.ex:72
+#: lib/vutuv_web/views/notification_digest_text.ex:78
 #, elixir-autogen, elixir-format
 msgid "A report you are involved in changed something on your account."
 msgstr "Eine Meldung, an der Sie beteiligt sind, hat etwas an Ihrem Konto verändert."
 
-#: lib/vutuv_web/views/notification_digest_text.ex:87
+#: lib/vutuv_web/views/notification_digest_text.ex:93
 #, elixir-autogen, elixir-format
 msgid "An employment reference of yours has been reviewed."
 msgstr "Eines Ihrer Arbeitszeugnisse wurde geprüft."
@@ -19714,17 +19710,18 @@ msgstr "Eines Ihrer Arbeitszeugnisse wurde geprüft."
 msgid "GitHub account @Klotzkette"
 msgstr "GitHub-Account @Klotzkette"
 
-#: lib/vutuv_web/views/notification_digest_text.ex:69
+#: lib/vutuv_web/views/notification_digest_text.ex:75
 #, elixir-autogen, elixir-format
 msgid "One of your images was removed by the image review."
 msgstr "Eines Ihrer Bilder wurde von der Bildprüfung entfernt."
 
-#: lib/vutuv_web/views/notification_digest_text.ex:100
+#: lib/vutuv_web/views/notification_digest_text.ex:106
 #, elixir-autogen, elixir-format
 msgid "Somebody"
 msgstr "Jemand"
 
-#: lib/vutuv_web/views/notification_digest_text.ex:90
+#: lib/vutuv_web/notification_line.ex:192
+#: lib/vutuv_web/views/notification_digest_text.ex:96
 #, elixir-autogen, elixir-format
 msgid "Something new happened on your account."
 msgstr "Es gibt Neues zu Ihrem Konto."
@@ -19734,17 +19731,17 @@ msgstr "Es gibt Neues zu Ihrem Konto."
 msgid "Which wording counts as which grade is not our own invention. We follow the Arbeitszeugnis-Prüfer, a set of instructions published under the MIT and Apache 2.0 licences by the lawyer Tom Braegelmann ({account}). You can read every rule the model is given:"
 msgstr "Welche Formulierung welcher Note entspricht, haben wir uns nicht ausgedacht. Wir folgen dem Arbeitszeugnis-Prüfer, einer Anleitung, die Rechtsanwalt Tom Braegelmann ({account}) unter der MIT- und der Apache-2.0-Lizenz veröffentlicht hat. Sie können jede Regel nachlesen, die das Modell bekommt:"
 
-#: lib/vutuv_web/views/notification_digest_text.ex:29
+#: lib/vutuv_web/views/notification_digest_text.ex:35
 #, elixir-autogen, elixir-format
 msgid "You and %{who} are now connected."
 msgstr "Sie und %{who} sind jetzt vernetzt."
 
-#: lib/vutuv_web/views/notification_digest_text.ex:56
+#: lib/vutuv_web/views/notification_digest_text.ex:62
 #, elixir-autogen, elixir-format
 msgid "You were given a role at %{organization}."
 msgstr "Sie haben eine Rolle bei %{organization} bekommen."
 
-#: lib/vutuv_web/views/notification_digest_text.ex:75
+#: lib/vutuv_web/views/notification_digest_text.ex:81
 #, elixir-autogen, elixir-format
 msgid "Your vutuv username is ready."
 msgstr "Ihr vutuv-Benutzername steht fest."
@@ -19754,7 +19751,7 @@ msgstr "Ihr vutuv-Benutzername steht fest."
 msgid "by the lawyer Tom Braegelmann"
 msgstr "von Rechtsanwalt Tom Braegelmann"
 
-#: lib/vutuv_web/templates/user/show.html.heex:827
+#: lib/vutuv_web/templates/user/show.html.heex:830
 #, elixir-autogen, elixir-format
 msgid "Documents:"
 msgstr "Belegt:"
@@ -19924,19 +19921,19 @@ msgstr "6-stellige PIN"
 msgid "Enter the PIN from the email"
 msgstr "PIN aus der E-Mail eingeben"
 
-#: lib/vutuv_web/components/ui.ex:723
+#: lib/vutuv_web/components/ui.ex:724
 #, elixir-autogen, elixir-format
 msgid "If you have added other addresses to your vutuv account, try logging in with one of those instead."
 msgstr ""
 "Wenn Sie Ihrem vutuv-Konto weitere Adressen hinzugefügt haben, melden Sie "
 "sich stattdessen mit einer davon an."
 
-#: lib/vutuv_web/components/ui.ex:751
+#: lib/vutuv_web/components/ui.ex:752
 #, elixir-autogen, elixir-format
 msgid "Cancel registration"
 msgstr "Registrierung abbrechen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:844
+#: lib/vutuv_web/live/notification_live/index.ex:856
 #, elixir-autogen, elixir-format
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
@@ -19949,24 +19946,24 @@ msgstr ""
 msgid "Follow other members"
 msgstr "Anderen Mitgliedern folgen"
 
-#: lib/vutuv_web/components/ui.ex:706
+#: lib/vutuv_web/components/ui.ex:707
 #, elixir-autogen, elixir-format
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 "Kommt keine PIN an? Ist die E-Mail-Adresse {email} korrekt? Haben Sie einmal "
 "in Ihren Spam-Ordner geschaut?"
 
-#: lib/vutuv/accounts/user.ex:1305
+#: lib/vutuv/accounts/user.ex:1313
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/vutuv/accounts/user.ex:1303
+#: lib/vutuv/accounts/user.ex:1311
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr "Weiblich"
 
-#: lib/vutuv/accounts/user.ex:1304
+#: lib/vutuv/accounts/user.ex:1312
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Männlich"
@@ -19978,7 +19975,7 @@ msgstr ""
 "Anteile bezogen auf die %{answered} Mitglieder mit Angabe. %{unanswered} ohne "
 "Angabe."
 
-#: lib/vutuv_web/components/ui.ex:4077
+#: lib/vutuv_web/components/ui.ex:4082
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr "avatar profilbild portrait foto bild geburtstag geburtsdatum geschlecht über mich"
@@ -20074,7 +20071,7 @@ msgstr "Ebenfalls löschen"
 msgid "Always keep"
 msgstr "Immer behalten"
 
-#: lib/vutuv_web/components/ui.ex:4183
+#: lib/vutuv_web/components/ui.ex:4191
 #: lib/vutuv_web/controllers/settings_controller.ex:245
 #: lib/vutuv_web/controllers/settings_controller.ex:324
 #: lib/vutuv_web/controllers/settings_controller.ex:336
@@ -20171,7 +20168,7 @@ msgstr "Fotobeiträge behalten"
 msgid "Keep posts that did well"
 msgstr "Beiträge behalten, die gut liefen"
 
-#: lib/vutuv_web/components/ui.ex:4185
+#: lib/vutuv_web/components/ui.ex:4193
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr "Ihre Beiträge nach einer selbst gewählten Zeit auslaufen lassen"
@@ -20280,7 +20277,7 @@ msgstr "Sie können vorher alles herunterladen, was Sie hier haben:"
 msgid "Your rule"
 msgstr "Ihre Regel"
 
-#: lib/vutuv_web/components/ui.ex:4187
+#: lib/vutuv_web/components/ui.ex:4195
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr "löschen entfernen beiträge alter alt ablaufen verfallen automatisch aufräumen aufbewahrung"
@@ -20654,7 +20651,7 @@ msgstr "Suchen Sie so oft Sie möchten und nehmen Sie dazu, was gehört. Abkürz
 msgid "Start over"
 msgstr "Von vorn beginnen"
 
-#: lib/vutuv_web/components/post_components.ex:2271
+#: lib/vutuv_web/components/post_components.ex:2368
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr "Ein Herz oder ein Repost geht zurück in das Netzwerk, aus dem dieser Beitrag stammt. Ihr Konto nimmt derzeit nicht am Fediverse teil. Einschalten können Sie das in den {settings}."
@@ -20745,7 +20742,7 @@ msgstr "Sie dürfen nicht mehr im Namen dieser Organisation schreiben."
 msgid "A post in an organization's name is always public."
 msgstr "Ein Beitrag im Namen einer Organisation ist immer öffentlich."
 
-#: lib/vutuv_web/live/shell_live.ex:565
+#: lib/vutuv_web/live/shell_live.ex:685
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr "Seite öffnen"
@@ -20765,7 +20762,7 @@ msgstr "Beendet, im Namen einer Organisation zu schreiben"
 msgid "Write as %{name} for now"
 msgstr "Vorerst als %{name} schreiben"
 
-#: lib/vutuv_web/live/shell_live.ex:575
+#: lib/vutuv_web/live/shell_live.ex:695
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr "Wieder als ich selbst schreiben"
@@ -20775,7 +20772,7 @@ msgstr "Wieder als ich selbst schreiben"
 msgid "You are writing as %{name} now."
 msgstr "Sie schreiben jetzt als %{name}."
 
-#: lib/vutuv_web/live/shell_live.ex:551
+#: lib/vutuv_web/live/shell_live.ex:671
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr "Sie schreiben als %{name}."
@@ -21087,22 +21084,22 @@ msgstr "Neu registrieren"
 msgid "The PIN has expired."
 msgstr "Die PIN ist abgelaufen."
 
-#: lib/vutuv_web/components/ui.ex:827
+#: lib/vutuv_web/components/ui.ex:828
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more minute."
 msgstr "Die PIN ist noch eine Minute gültig."
 
-#: lib/vutuv_web/components/ui.ex:829
+#: lib/vutuv_web/components/ui.ex:830
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more second."
 msgstr "Die PIN ist noch eine Sekunde gültig."
 
-#: lib/vutuv_web/components/ui.ex:828
+#: lib/vutuv_web/components/ui.ex:829
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more minutes."
 msgstr "Die PIN ist noch {n} Minuten gültig."
 
-#: lib/vutuv_web/components/ui.ex:830
+#: lib/vutuv_web/components/ui.ex:831
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more seconds."
 msgstr "Die PIN ist noch {n} Sekunden gültig."
@@ -21139,21 +21136,21 @@ msgstr "Sie folgen #%{tag} hier bereits."
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr "Sie sind selbst auf diesem vutuv. Sie folgen #%{tag} jetzt direkt hier."
 
-#: lib/vutuv_web/live/shell_live.ex:468
+#: lib/vutuv_web/live/shell_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "%{formatted} person"
 msgid_plural "%{formatted} people"
 msgstr[0] "%{formatted} Person"
 msgstr[1] "%{formatted} Personen"
 
-#: lib/vutuv_web/live/shell_live.ex:455
+#: lib/vutuv_web/live/shell_live.ex:470
 #, elixir-autogen, elixir-format
 msgid "person"
 msgid_plural "people"
 msgstr[0] "Person"
 msgstr[1] "Personen"
 
-#: lib/vutuv_web/live/shell_live.ex:490
+#: lib/vutuv_web/live/shell_live.ex:505
 #, elixir-autogen, elixir-format
 msgid "%{members} vutuv members plus %{fediverse} Fediverse account that follows them"
 msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that follow them"
@@ -21570,37 +21567,37 @@ msgstr "Sprache des Beitrags"
 msgid "The language this post is written in"
 msgstr "Die Sprache, in der dieser Beitrag geschrieben ist"
 
-#: lib/vutuv_web/components/post_components.ex:3942
+#: lib/vutuv_web/components/post_components.ex:4039
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Original anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:3963
+#: lib/vutuv_web/components/post_components.ex:4060
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Übersetzen"
 
-#: lib/vutuv_web/components/post_components.ex:3972
+#: lib/vutuv_web/components/post_components.ex:4069
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Übersetzt"
 
-#: lib/vutuv_web/components/post_components.ex:3975
+#: lib/vutuv_web/components/post_components.ex:4072
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Übersetzt aus %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:3952
+#: lib/vutuv_web/components/post_components.ex:4049
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Wird übersetzt …"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:823
+#: lib/vutuv_web/controllers/settings_controller.ex:835
 #, elixir-autogen, elixir-format
 msgid "Feed language settings reset to the site defaults."
 msgstr "Feed-Spracheinstellungen auf die Website-Vorgaben zurückgesetzt."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:812
+#: lib/vutuv_web/controllers/settings_controller.ex:824
 #, elixir-autogen, elixir-format
 msgid "Feed language settings saved."
 msgstr "Feed-Spracheinstellungen gespeichert."
@@ -21640,7 +21637,7 @@ msgstr "Was Ihr Feed mit Beiträgen außerhalb Ihrer gewählten Sprachen macht: 
 msgid "Date & time"
 msgstr "Datum & Uhrzeit"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:736
+#: lib/vutuv_web/controllers/settings_controller.ex:748
 #, elixir-autogen, elixir-format
 msgid "Date and time settings reset to the site defaults."
 msgstr "Datum und Uhrzeit folgen wieder den Voreinstellungen der Website."
@@ -21655,7 +21652,7 @@ msgstr "Datumsformat"
 msgid "Germany, Austria, Switzerland"
 msgstr "Deutschland, Österreich, Schweiz"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:730
+#: lib/vutuv_web/controllers/settings_controller.ex:742
 #, elixir-autogen, elixir-format
 msgid "Language and region saved."
 msgstr "Sprache und Region gespeichert."
@@ -21695,7 +21692,7 @@ msgstr "Ihr Browser meldet: {zone}"
 msgid "ISO 8601 (Sweden, Japan, China)"
 msgstr "ISO 8601 (Schweden, Japan, China)"
 
-#: lib/vutuv_web/components/ui.ex:4210
+#: lib/vutuv_web/components/ui.ex:4218
 #, elixir-autogen, elixir-format
 msgid "Interface language, date format and time zone, feed languages, maps, how posts are shortened"
 msgstr "Sprache der Oberfläche, Datumsformat und Zeitzone, Feed-Sprachen, Karten, wie Beiträge gekürzt werden"
@@ -21705,7 +21702,7 @@ msgstr "Sprache der Oberfläche, Datumsformat und Zeitzone, Feed-Sprachen, Karte
 msgid "Language & display settings changed"
 msgstr "Sprache & Anzeige geändert"
 
-#: lib/vutuv_web/components/ui.ex:4214
+#: lib/vutuv_web/components/ui.ex:4222
 #, elixir-autogen, elixir-format
 msgid "german english locale translation translate map font length hyphenation feed languages hide foreign übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
 msgstr "deutsch englisch locale übersetzung übersetzen karte schrift länge silbentrennung feed sprachen ausblenden fremdsprache zeitzone timezone zone utc datum date uhrzeit uhr format datumsformat 24 stunden"
@@ -21745,19 +21742,19 @@ msgstr "Wir haben den Link in Ihrem Profil noch nicht gefunden. Bitte versuchen 
 msgid "Your username, or paste the address of your profile page."
 msgstr "Ihr Benutzername – oder fügen Sie die Adresse Ihrer Profilseite ein."
 
-#: lib/vutuv_web/components/post_components.ex:3742
+#: lib/vutuv_web/components/post_components.ex:3839
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] "Unsere KI prüft es gerade. Sobald die Prüfung durch ist, erscheint das Foto von selbst."
 msgstr[1] "Unsere KI prüft sie gerade, %{done} von %{total} sind durch. Sobald die letzte durch ist, erscheinen die Fotos von selbst."
 
-#: lib/vutuv_web/components/post_components.ex:3739
+#: lib/vutuv_web/components/post_components.ex:3836
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr "Ihr Beitrag ist veröffentlicht, das Foto noch nicht."
 
-#: lib/vutuv_web/components/post_components.ex:3079
+#: lib/vutuv_web/components/post_components.ex:3176
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -21825,7 +21822,7 @@ msgstr "Damit können Sie sich von einer Mastodon-kompatiblen App aus bei diesem
 msgid "Mastodon app access changed"
 msgstr "Mastodon-App-Zugriff geändert"
 
-#: lib/vutuv_web/components/ui.ex:4231
+#: lib/vutuv_web/components/ui.ex:4239
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr "Mastodon-Apps, verbundene Apps und Zugriffstoken"
@@ -21871,7 +21868,7 @@ msgstr "Wer etwas geschrieben hat, wird weiter festgehalten, das Team kann also 
 msgid "Your account is then %{handle}."
 msgstr "Dein Konto heißt dann %{handle}."
 
-#: lib/vutuv_web/components/ui.ex:4233
+#: lib/vutuv_web/components/ui.ex:4241
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr "api token oauth entwickler verbunden drittanbieter schnittstelle mastodon app handy telefon client ivory tusky ice cubes anmelden"
@@ -21907,7 +21904,7 @@ msgstr "Bekannte aus LinkedIn finden"
 msgid "Find your LinkedIn contacts"
 msgstr "Ihre LinkedIn-Kontakte finden"
 
-#: lib/vutuv_web/components/ui.ex:4158
+#: lib/vutuv_web/components/ui.ex:4166
 #: lib/vutuv_web/live/import_connections_live.ex:64
 #: lib/vutuv_web/templates/import/new.html.heex:37
 #, elixir-autogen, elixir-format
@@ -22014,7 +22011,7 @@ msgstr "Nach Namen suchen"
 msgid "See which of them are already on vutuv"
 msgstr "Sehen Sie, wer davon schon auf vutuv ist"
 
-#: lib/vutuv_web/components/ui.ex:4160
+#: lib/vutuv_web/components/ui.ex:4168
 #, elixir-autogen, elixir-format
 msgid "See which of your LinkedIn contacts are already on vutuv"
 msgstr "Sehen, wer aus Ihren LinkedIn-Kontakten schon auf vutuv ist"
@@ -22086,7 +22083,7 @@ msgstr "Ihre Kontakte auf vutuv"
 msgid "Your export also lists your LinkedIn contacts."
 msgstr "Ihr Export enthält auch Ihre LinkedIn-Kontakte."
 
-#: lib/vutuv_web/components/ui.ex:4162
+#: lib/vutuv_web/components/ui.ex:4170
 #, elixir-autogen, elixir-format
 msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
 msgstr "linkedin kontakte verbindungen adressbuch bekannte kollegen finden folgen zip import netzwerk"
@@ -22282,7 +22279,7 @@ msgstr "Land suchen"
 msgid "This page is following the most accounts we allow (%{max})."
 msgstr "Diese Seite folgt bereits so vielen Konten, wie hier erlaubt sind (%{max})."
 
-#: lib/vutuv_web/components/post_components.ex:2122
+#: lib/vutuv_web/components/post_components.ex:2219
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr "%{handle} nicht mehr folgen? Die Beiträge verschwinden aus Ihrem Feed."
@@ -22291,3 +22288,73 @@ msgstr "%{handle} nicht mehr folgen? Die Beiträge verschwinden aus Ihrem Feed."
 #, elixir-autogen, elixir-format
 msgid "Unfollowed. Their posts leave your feed."
 msgstr "Nicht mehr gefolgt. Die Beiträge verschwinden aus Ihrem Feed."
+
+#: lib/vutuv_web/live/shell_live.ex:641
+#, elixir-autogen, elixir-format
+msgid "Allow"
+msgstr "Erlauben"
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:166
+#, elixir-autogen, elixir-format
+msgid "Ask now"
+msgstr "Jetzt fragen"
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:144
+#, elixir-autogen, elixir-format
+msgid "Browser notifications"
+msgstr "Browser-Benachrichtigungen"
+
+#: lib/vutuv_web/live/shell_live.ex:583
+#, elixir-autogen, elixir-format
+msgid "New message"
+msgstr "Neue Nachricht"
+
+#: lib/vutuv_web/live/shell_live.ex:648
+#, elixir-autogen, elixir-format
+msgid "Not now"
+msgstr "Jetzt nicht"
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:152
+#, elixir-autogen, elixir-format
+msgid "Only while vutuv is open somewhere and you are looking at something else. Every browser you use asks you once."
+msgstr "Nur solange vutuv irgendwo offen ist und Sie gerade etwas anderes ansehen. Jeder Browser, den Sie nutzen, fragt Sie einmal."
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:150
+#, elixir-autogen, elixir-format
+msgid "Show me browser notifications"
+msgstr "Browser-Benachrichtigungen anzeigen"
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:176
+#, elixir-autogen, elixir-format
+msgid "This browser cannot show notifications. Your other browsers are unaffected."
+msgstr "Dieser Browser kann keine Benachrichtigungen anzeigen. Ihre anderen Browser sind davon nicht betroffen."
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:160
+#, elixir-autogen, elixir-format
+msgid "This browser has not been asked yet."
+msgstr "Dieser Browser wurde noch nicht gefragt."
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:171
+#, elixir-autogen, elixir-format
+msgid "This browser is blocking notifications for vutuv. Allow them for this site in your browser settings; the switch above stays on and every other browser you use is unaffected."
+msgstr "Dieser Browser blockiert Benachrichtigungen von vutuv. Erlauben Sie sie für diese Seite in den Einstellungen Ihres Browsers. Der Schalter oben bleibt an, und jeder andere Browser, den Sie nutzen, ist davon nicht betroffen."
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:169
+#, elixir-autogen, elixir-format
+msgid "This browser will show them."
+msgstr "Dieser Browser zeigt sie an."
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:146
+#, elixir-autogen, elixir-format
+msgid "When something arrives while you have vutuv open in a tab you are not looking at, your browser can show it as a notification. Off unless you switch it on."
+msgstr "Wenn etwas eintrifft, während vutuv in einem Tab offen ist, den Sie gerade nicht ansehen, kann Ihr Browser es als Benachrichtigung anzeigen. Aus, solange Sie es nicht einschalten."
+
+#: lib/vutuv_web/live/shell_live.ex:638
+#, elixir-autogen, elixir-format
+msgid "You switched browser notifications on. This browser has not been asked for permission yet."
+msgstr "Sie haben Browser-Benachrichtigungen eingeschaltet. Dieser Browser wurde noch nicht um Erlaubnis gebeten."
+
+#: lib/vutuv_web/components/ui.ex:4149
+#, elixir-autogen, elixir-format
+msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
+msgstr "e-mail email mail abbestellen abmelden newsletter glocke benachrichtigung weniger ruhe browser desktop popup push hinweis mitteilung"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -17,8 +17,8 @@ msgstr ""
 msgid "About us"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3861
 #: lib/vutuv_web/components/ui.ex:3866
+#: lib/vutuv_web/components/ui.ex:3871
 #: lib/vutuv_web/live/admin/screenshot_live.ex:255
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:718
 #: lib/vutuv_web/live/organization_live/domains.ex:272
@@ -40,7 +40,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1461
+#: lib/vutuv_web/templates/user/show.html.heex:1464
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -64,7 +64,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:68
 #: lib/vutuv_web/agent_docs/text.ex:65
-#: lib/vutuv_web/components/ui.ex:4119
+#: lib/vutuv_web/components/ui.ex:4124
 #: lib/vutuv_web/controllers/address_controller.ex:23
 #: lib/vutuv_web/controllers/address_controller.ex:38
 #: lib/vutuv_web/controllers/address_controller.ex:85
@@ -82,8 +82,8 @@ msgstr ""
 msgid "Already a member? Sign in here."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3656
-#: lib/vutuv_web/components/ui.ex:3750
+#: lib/vutuv_web/components/ui.ex:3661
+#: lib/vutuv_web/components/ui.ex:3755
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:698
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:830
@@ -105,13 +105,13 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:603
 #: lib/vutuv_web/agent_docs/text.ex:568
 #: lib/vutuv_web/agent_docs/text.ex:569
-#: lib/vutuv_web/templates/user/show.html.heex:1093
+#: lib/vutuv_web/templates/user/show.html.heex:1096
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:110
-#: lib/vutuv_web/components/ui.ex:3650
+#: lib/vutuv_web/components/ui.ex:3655
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
@@ -152,7 +152,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1131
+#: lib/vutuv_web/templates/user/show.html.heex:1134
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -161,8 +161,8 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2872
-#: lib/vutuv_web/components/ui.ex:3753
+#: lib/vutuv_web/components/post_components.ex:2969
+#: lib/vutuv_web/components/ui.ex:3758
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
@@ -210,8 +210,8 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2837
-#: lib/vutuv_web/components/ui.ex:3744
+#: lib/vutuv_web/components/post_components.ex:2934
+#: lib/vutuv_web/components/ui.ex:3749
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
@@ -224,7 +224,7 @@ msgstr ""
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:1116
+#: lib/vutuv_web/templates/user/show.html.heex:1119
 #, elixir-autogen
 msgid "Edit"
 msgstr ""
@@ -285,11 +285,11 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:35
-#: lib/vutuv_web/components/ui.ex:4083
+#: lib/vutuv_web/components/ui.ex:4088
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:624
+#: lib/vutuv_web/templates/user/show.html.heex:627
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -315,7 +315,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:589
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
-#: lib/vutuv_web/live/notification_live/index.ex:968
+#: lib/vutuv_web/live/notification_live/index.ex:980
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:27
@@ -326,18 +326,18 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:624
 #: lib/vutuv_web/agent_docs/text.ex:590
 #: lib/vutuv_web/components/fediverse_components.ex:313
-#: lib/vutuv_web/components/ui.ex:2224
-#: lib/vutuv_web/components/ui.ex:2249
-#: lib/vutuv_web/components/ui.ex:2252
-#: lib/vutuv_web/components/ui.ex:2259
-#: lib/vutuv_web/components/ui.ex:2262
-#: lib/vutuv_web/components/ui.ex:2320
+#: lib/vutuv_web/components/ui.ex:2229
+#: lib/vutuv_web/components/ui.ex:2254
+#: lib/vutuv_web/components/ui.ex:2257
+#: lib/vutuv_web/components/ui.ex:2264
+#: lib/vutuv_web/components/ui.ex:2267
+#: lib/vutuv_web/components/ui.ex:2325
 #: lib/vutuv_web/controllers/followee_controller.ex:29
 #: lib/vutuv_web/live/import_connections_live.ex:469
 #: lib/vutuv_web/live/organization_live/show.ex:471
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:970
+#: lib/vutuv_web/templates/user/show.html.heex:973
 #, elixir-autogen
 msgid "Following"
 msgstr ""
@@ -443,8 +443,8 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:853
-#: lib/vutuv_web/live/shell_live.ex:909
+#: lib/vutuv_web/live/shell_live.ex:973
+#: lib/vutuv_web/live/shell_live.ex:1029
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -457,7 +457,7 @@ msgstr ""
 msgid "Middle Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:893
+#: lib/vutuv_web/live/notification_live/index.ex:905
 #, elixir-autogen
 msgid "More"
 msgstr ""
@@ -474,8 +474,8 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:539
-#: lib/vutuv_web/live/notification_live/index.ex:647
+#: lib/vutuv_web/components/post_components.ex:542
+#: lib/vutuv_web/live/notification_live/index.ex:659
 #: lib/vutuv_web/live/organization_live/activity.ex:127
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
@@ -614,7 +614,7 @@ msgstr ""
 msgid "Public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3649
+#: lib/vutuv_web/components/ui.ex:3654
 #: lib/vutuv_web/live/organization_live/edit.ex:345
 #: lib/vutuv_web/live/post_live/composer.ex:1867
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -631,7 +631,7 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:462
-#: lib/vutuv_web/views/settings_html.ex:280
+#: lib/vutuv_web/views/settings_html.ex:289
 #, elixir-autogen
 msgid "Save"
 msgstr ""
@@ -644,9 +644,9 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:48
 #: lib/vutuv_web/live/search_live.ex:569
-#: lib/vutuv_web/live/shell_live.ex:721
-#: lib/vutuv_web/live/shell_live.ex:892
-#: lib/vutuv_web/live/tag_live/timeline.ex:237
+#: lib/vutuv_web/live/shell_live.ex:841
+#: lib/vutuv_web/live/shell_live.ex:1012
+#: lib/vutuv_web/live/tag_live/timeline.ex:240
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:30
@@ -655,7 +655,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1475
+#: lib/vutuv_web/components/post_components.ex:1478
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -691,13 +691,13 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1245
+#: lib/vutuv_web/templates/user/show.html.heex:1248
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1247
+#: lib/vutuv_web/templates/user/show.html.heex:1250
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -793,12 +793,12 @@ msgstr ""
 msgid "User verified successfully."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4079
+#: lib/vutuv_web/components/ui.ex:4084
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
-#: lib/vutuv_web/live/notification_live/index.ex:1047
+#: lib/vutuv_web/live/notification_live/index.ex:1059
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -844,20 +844,20 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1070
+#: lib/vutuv_web/components/ui.ex:1071
 #: lib/vutuv_web/templates/user/show.html.heex:346
 #, elixir-autogen
 msgid "vCard"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3814
-#: lib/vutuv_web/templates/user/show.html.heex:964
-#: lib/vutuv_web/templates/user/show.html.heex:987
+#: lib/vutuv_web/components/ui.ex:3819
+#: lib/vutuv_web/templates/user/show.html.heex:967
+#: lib/vutuv_web/templates/user/show.html.heex:990
 #, elixir-autogen
 msgid "View All"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4173
+#: lib/vutuv_web/components/ui.ex:4181
 #: lib/vutuv_web/controllers/settings_controller.ex:169
 #: lib/vutuv_web/live/job_posting_live/form.ex:756
 #: lib/vutuv_web/live/organization_live/edit.ex:304
@@ -927,7 +927,7 @@ msgid "You follow back %{name}."
 msgstr ""
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:82
+#: lib/vutuv_web/live/post_live/feed.ex:86
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1042,7 +1042,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1082
+#: lib/vutuv_web/templates/user/show.html.heex:1085
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1165,7 +1165,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:825
+#: lib/vutuv_web/live/shell_live.ex:945
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1208,7 +1208,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:618
+#: lib/vutuv_web/templates/user/show.html.heex:621
 #, elixir-autogen
 msgid "All tags"
 msgstr ""
@@ -1377,7 +1377,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:516
 #: lib/vutuv_web/agent_docs/text.ex:753
-#: lib/vutuv_web/components/ui.ex:4104
+#: lib/vutuv_web/components/ui.ex:4109
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
 #: lib/vutuv_web/cv/docx.ex:174
@@ -1403,7 +1403,7 @@ msgstr ""
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:23
 #: lib/vutuv_web/templates/tag/show.html.heex:25
-#: lib/vutuv_web/templates/user/show.html.heex:588
+#: lib/vutuv_web/templates/user/show.html.heex:591
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
@@ -1598,7 +1598,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:895
+#: lib/vutuv_web/live/shell_live.ex:1015
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1617,8 +1617,8 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:315
-#: lib/vutuv_web/components/ui.ex:2560
+#: lib/vutuv_web/components/ui.ex:316
+#: lib/vutuv_web/components/ui.ex:2565
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
@@ -1672,24 +1672,24 @@ msgstr ""
 msgid "Edit profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1578
-#: lib/vutuv_web/components/ui.ex:1587
-#: lib/vutuv_web/components/ui.ex:2051
+#: lib/vutuv_web/components/ui.ex:1583
+#: lib/vutuv_web/components/ui.ex:1592
+#: lib/vutuv_web/components/ui.ex:2056
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:199
-#: lib/vutuv_web/components/ui.ex:2189
-#: lib/vutuv_web/components/ui.ex:2189
-#: lib/vutuv_web/components/ui.ex:2206
-#: lib/vutuv_web/components/ui.ex:2215
-#: lib/vutuv_web/components/ui.ex:2231
-#: lib/vutuv_web/components/ui.ex:2268
-#: lib/vutuv_web/components/ui.ex:2271
-#: lib/vutuv_web/components/ui.ex:2278
-#: lib/vutuv_web/components/ui.ex:2281
-#: lib/vutuv_web/components/ui.ex:2354
+#: lib/vutuv_web/components/ui.ex:2194
+#: lib/vutuv_web/components/ui.ex:2194
+#: lib/vutuv_web/components/ui.ex:2211
+#: lib/vutuv_web/components/ui.ex:2220
+#: lib/vutuv_web/components/ui.ex:2236
+#: lib/vutuv_web/components/ui.ex:2273
+#: lib/vutuv_web/components/ui.ex:2276
+#: lib/vutuv_web/components/ui.ex:2283
+#: lib/vutuv_web/components/ui.ex:2286
+#: lib/vutuv_web/components/ui.ex:2359
 #: lib/vutuv_web/live/fediverse_account_live.ex:387
 #: lib/vutuv_web/live/fediverse_following_live.ex:331
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:317
@@ -1697,7 +1697,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:407
 #: lib/vutuv_web/live/organization_live/show.ex:440
 #: lib/vutuv_web/live/organization_live/show.ex:469
-#: lib/vutuv_web/templates/user/show.html.heex:1285
+#: lib/vutuv_web/templates/user/show.html.heex:1288
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr ""
@@ -1712,8 +1712,8 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:844
-#: lib/vutuv_web/views/settings_html.ex:367
+#: lib/vutuv_web/live/shell_live.ex:964
+#: lib/vutuv_web/views/settings_html.ex:376
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr ""
@@ -1724,7 +1724,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
 #: lib/vutuv_web/live/admin/user_delete_live.ex:143
 #: lib/vutuv_web/live/admin/user_live.ex:154
-#: lib/vutuv_web/live/message_live/index.ex:533
+#: lib/vutuv_web/live/message_live/index.ex:538
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:32
 #: lib/vutuv_web/templates/admin/account/index.html.heex:55
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:28
@@ -1740,22 +1740,22 @@ msgid "Message"
 msgstr ""
 
 #: lib/vutuv_web/live/message_live/index.ex:49
-#: lib/vutuv_web/live/message_live/index.ex:629
-#: lib/vutuv_web/live/shell_live.ex:737
-#: lib/vutuv_web/live/shell_live.ex:894
+#: lib/vutuv_web/live/message_live/index.ex:634
+#: lib/vutuv_web/live/shell_live.ex:857
+#: lib/vutuv_web/live/shell_live.ex:1014
 #: lib/vutuv_web/templates/layout/app.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:629
+#: lib/vutuv_web/live/shell_live.ex:749
 #: lib/vutuv_web/templates/layout/app.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:436
-#: lib/vutuv_web/components/ui.ex:3863
+#: lib/vutuv_web/components/post_components.ex:439
+#: lib/vutuv_web/components/ui.ex:3868
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:705
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:742
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:793
@@ -1765,16 +1765,16 @@ msgstr ""
 msgid "Nothing here yet."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:377
+#: lib/vutuv_web/live/notification_live/index.ex:389
 #, elixir-autogen, elixir-format
 msgid "Nothing new yet."
 msgstr ""
 
 #: lib/vutuv/api_auth/scopes.ex:85
-#: lib/vutuv_web/components/ui.ex:4141
-#: lib/vutuv_web/live/notification_live/index.ex:114
-#: lib/vutuv_web/live/notification_live/index.ex:338
-#: lib/vutuv_web/live/shell_live.ex:748
+#: lib/vutuv_web/components/ui.ex:4146
+#: lib/vutuv_web/live/notification_live/index.ex:126
+#: lib/vutuv_web/live/notification_live/index.ex:350
+#: lib/vutuv_web/live/shell_live.ex:868
 #: lib/vutuv_web/templates/layout/app.html.heex:173
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -1796,7 +1796,7 @@ msgid "Pardon us! Something went wrong."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:130
-#: lib/vutuv_web/live/message_live/index.ex:884
+#: lib/vutuv_web/live/message_live/index.ex:889
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Send"
@@ -1865,14 +1865,14 @@ msgstr ""
 msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1455
+#: lib/vutuv_web/live/post_live/feed.ex:1471
 #: lib/vutuv_web/views/user_html.ex:213
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:873
-#: lib/vutuv_web/live/message_live/index.ex:874
+#: lib/vutuv_web/live/message_live/index.ex:878
+#: lib/vutuv_web/live/message_live/index.ex:879
 #, elixir-autogen, elixir-format
 msgid "Write a message…"
 msgstr ""
@@ -1902,30 +1902,30 @@ msgstr ""
 msgid "submit a bug report"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1069
+#: lib/vutuv_web/notification_line.ex:79
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1064
+#: lib/vutuv_web/notification_line.ex:74
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1059
+#: lib/vutuv_web/notification_line.ex:72
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3203
-#: lib/vutuv_web/components/ui.ex:3354
+#: lib/vutuv_web/components/ui.ex:3208
+#: lib/vutuv_web/components/ui.ex:3359
 #: lib/vutuv_web/live/import_connections_live.ex:638
 #: lib/vutuv_web/live/organization_live/index.ex:122
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3888
+#: lib/vutuv_web/components/ui.ex:3893
 #: lib/vutuv_web/live/organization_live/activity.ex:150
 #: lib/vutuv_web/live/organization_live/feed.ex:142
 #: lib/vutuv_web/live/organization_live/show.ex:637
@@ -1938,13 +1938,13 @@ msgstr ""
 msgid "The address itself cannot be changed. To use a different one, add it as a new email address and delete this one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3659
+#: lib/vutuv_web/components/ui.ex:3664
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1281
-#: lib/vutuv_web/components/ui.ex:1291
+#: lib/vutuv_web/components/ui.ex:1282
+#: lib/vutuv_web/components/ui.ex:1292
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr ""
@@ -1983,12 +1983,12 @@ msgstr ""
 msgid "Add cover photo"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2864
+#: lib/vutuv_web/components/ui.ex:2869
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2868
+#: lib/vutuv_web/components/ui.ex:2873
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr ""
@@ -2013,37 +2013,37 @@ msgstr ""
 msgid "Cover photo of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2872
+#: lib/vutuv_web/components/ui.ex:2877
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2862
+#: lib/vutuv_web/components/ui.ex:2867
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2861
+#: lib/vutuv_web/components/ui.ex:2866
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2867
+#: lib/vutuv_web/components/ui.ex:2872
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2866
+#: lib/vutuv_web/components/ui.ex:2871
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2863
+#: lib/vutuv_web/components/ui.ex:2868
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2865
+#: lib/vutuv_web/components/ui.ex:2870
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr ""
@@ -2058,17 +2058,17 @@ msgstr ""
 msgid "Member since %{year}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2871
+#: lib/vutuv_web/components/ui.ex:2876
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2870
+#: lib/vutuv_web/components/ui.ex:2875
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2869
+#: lib/vutuv_web/components/ui.ex:2874
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr ""
@@ -2106,7 +2106,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2869
+#: lib/vutuv_web/components/post_components.ex:2966
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2121,10 +2121,10 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:274
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:98
-#: lib/vutuv_web/live/post_live/feed.ex:187
-#: lib/vutuv_web/live/post_live/feed.ex:1187
-#: lib/vutuv_web/live/shell_live.ex:609
-#: lib/vutuv_web/live/shell_live.ex:890
+#: lib/vutuv_web/live/post_live/feed.ex:191
+#: lib/vutuv_web/live/post_live/feed.ex:1203
+#: lib/vutuv_web/live/shell_live.ex:729
+#: lib/vutuv_web/live/shell_live.ex:1010
 #: lib/vutuv_web/templates/layout/app.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2150,8 +2150,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2823
-#: lib/vutuv_web/components/post_components.ex:2825
+#: lib/vutuv_web/components/post_components.ex:2920
+#: lib/vutuv_web/components/post_components.ex:2922
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2167,7 +2167,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1394
+#: lib/vutuv_web/live/post_live/feed.ex:1410
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2206,7 +2206,7 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:91
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
-#: lib/vutuv_web/live/notification_live/index.ex:891
+#: lib/vutuv_web/live/notification_live/index.ex:903
 #: lib/vutuv_web/live/organization_live/show.ex:564
 #: lib/vutuv_web/live/post_live/saved.ex:520
 #: lib/vutuv_web/live/search_live.ex:281
@@ -2217,13 +2217,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3293
-#: lib/vutuv_web/components/post_components.ex:3297
+#: lib/vutuv_web/components/post_components.ex:3390
+#: lib/vutuv_web/components/post_components.ex:3394
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3294
+#: lib/vutuv_web/components/post_components.ex:3391
 #: lib/vutuv_web/live/fediverse_account_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2231,7 +2231,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:342
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:1097
+#: lib/vutuv_web/components/post_components.ex:1100
 #: lib/vutuv_web/live/admin/screenshot_live.ex:327
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:700
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
@@ -2242,7 +2242,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:650
 #: lib/vutuv_web/live/post_live/saved.ex:678
 #: lib/vutuv_web/templates/connection/index.html.heex:40
-#: lib/vutuv_web/views/settings_html.ex:413
+#: lib/vutuv_web/views/settings_html.ex:422
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
@@ -2257,7 +2257,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1298
+#: lib/vutuv_web/live/post_live/feed.ex:1314
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2294,11 +2294,11 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4427
-#: lib/vutuv_web/live/shell_live.ex:791
+#: lib/vutuv_web/components/ui.ex:4435
+#: lib/vutuv_web/live/shell_live.ex:911
 #: lib/vutuv_web/templates/post/index.html.heex:17
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
-#: lib/vutuv_web/views/settings_html.ex:314
+#: lib/vutuv_web/views/settings_html.ex:323
 #, elixir-autogen, elixir-format
 msgid "View profile"
 msgstr ""
@@ -2313,33 +2313,33 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2820
+#: lib/vutuv_web/components/post_components.ex:2917
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4613
+#: lib/vutuv_web/components/post_components.ex:4710
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4617
+#: lib/vutuv_web/components/post_components.ex:4714
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4615
+#: lib/vutuv_web/components/post_components.ex:4712
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4616
+#: lib/vutuv_web/components/post_components.ex:4713
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
 
 #: lib/vutuv_web/views/post_html.ex:19
-#: lib/vutuv_web/views/settings_html.ex:492
+#: lib/vutuv_web/views/settings_html.ex:501
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr ""
@@ -2364,7 +2364,7 @@ msgstr ""
 msgid "Posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:578
+#: lib/vutuv_web/templates/user/show.html.heex:581
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr ""
@@ -2374,9 +2374,9 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1664
-#: lib/vutuv_web/components/post_components.ex:4701
-#: lib/vutuv_web/components/ui.ex:3278
+#: lib/vutuv_web/components/post_components.ex:1693
+#: lib/vutuv_web/components/post_components.ex:4806
+#: lib/vutuv_web/components/ui.ex:3283
 #: lib/vutuv_web/views/user_html.ex:440
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2385,29 +2385,29 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1108
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
-#: lib/vutuv_web/live/shell_live.ex:730
-#: lib/vutuv_web/live/shell_live.ex:796
+#: lib/vutuv_web/live/shell_live.ex:850
+#: lib/vutuv_web/live/shell_live.ex:916
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1628
-#: lib/vutuv_web/components/post_components.ex:4935
-#: lib/vutuv_web/components/ui.ex:3264
-#: lib/vutuv_web/live/notification_live/index.ex:1037
+#: lib/vutuv_web/components/post_components.ex:1646
+#: lib/vutuv_web/components/post_components.ex:5042
+#: lib/vutuv_web/components/ui.ex:3269
+#: lib/vutuv_web/live/notification_live/index.ex:1049
 #: lib/vutuv_web/views/user_html.ex:450
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1107
-#: lib/vutuv_web/components/post_components.ex:4944
-#: lib/vutuv_web/live/notification_live/index.ex:970
+#: lib/vutuv_web/components/post_components.ex:5052
+#: lib/vutuv_web/live/notification_live/index.ex:982
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
-#: lib/vutuv_web/live/shell_live.ex:799
+#: lib/vutuv_web/live/shell_live.ex:919
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2425,39 +2425,40 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4690
+#: lib/vutuv_web/components/post_components.ex:4794
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1664
-#: lib/vutuv_web/components/post_components.ex:4701
+#: lib/vutuv_web/components/post_components.ex:1692
+#: lib/vutuv_web/components/post_components.ex:4805
 #: lib/vutuv_web/live/post_live/saved.ex:806
 #: lib/vutuv_web/views/user_html.ex:440
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1652
-#: lib/vutuv_web/components/post_components.ex:4687
+#: lib/vutuv_web/components/post_components.ex:1674
+#: lib/vutuv_web/components/post_components.ex:4791
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1842
-#: lib/vutuv_web/components/post_components.ex:3875
+#: lib/vutuv_web/components/post_components.ex:1939
+#: lib/vutuv_web/components/post_components.ex:3972
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1652
-#: lib/vutuv_web/components/post_components.ex:4687
+#: lib/vutuv_web/components/post_components.ex:1673
+#: lib/vutuv_web/components/post_components.ex:4790
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4935
+#: lib/vutuv_web/components/post_components.ex:1645
+#: lib/vutuv_web/components/post_components.ex:5041
 #: lib/vutuv_web/live/post_live/saved.ex:805
 #: lib/vutuv_web/views/user_html.ex:450
 #, elixir-autogen, elixir-format
@@ -2465,14 +2466,14 @@ msgid "Unlike"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:343
-#: lib/vutuv_web/components/post_components.ex:2127
-#: lib/vutuv_web/components/ui.ex:2184
-#: lib/vutuv_web/components/ui.ex:2184
-#: lib/vutuv_web/components/ui.ex:2321
+#: lib/vutuv_web/components/post_components.ex:2224
+#: lib/vutuv_web/components/ui.ex:2189
+#: lib/vutuv_web/components/ui.ex:2189
+#: lib/vutuv_web/components/ui.ex:2326
 #: lib/vutuv_web/live/organization_live/following.ex:378
 #: lib/vutuv_web/live/organization_live/following.ex:453
 #: lib/vutuv_web/live/organization_live/show.ex:474
-#: lib/vutuv_web/live/post_live/feed.ex:1444
+#: lib/vutuv_web/live/post_live/feed.ex:1460
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2484,27 +2485,27 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4988
+#: lib/vutuv_web/components/post_components.ex:5096
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:394
-#: lib/vutuv_web/live/notification_live/index.ex:971
+#: lib/vutuv_web/components/post_components.ex:397
+#: lib/vutuv_web/live/notification_live/index.ex:983
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1639
-#: lib/vutuv_web/components/post_components.ex:4971
-#: lib/vutuv_web/components/post_components.ex:4972
-#: lib/vutuv_web/live/notification_live/index.ex:1034
+#: lib/vutuv_web/components/post_components.ex:1659
+#: lib/vutuv_web/components/post_components.ex:5079
+#: lib/vutuv_web/components/post_components.ex:5080
+#: lib/vutuv_web/live/notification_live/index.ex:1046
 #: lib/vutuv_web/live/post_live/reply.ex:43
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2787
+#: lib/vutuv_web/components/post_components.ex:2884
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2520,12 +2521,12 @@ msgstr ""
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1257
+#: lib/vutuv_web/notification_line.ex:61
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2323
+#: lib/vutuv_web/components/post_components.ex:2420
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:60
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:57
@@ -2533,59 +2534,59 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2761
+#: lib/vutuv_web/components/post_components.ex:2858
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2752
-#: lib/vutuv_web/components/post_components.ex:2779
-#: lib/vutuv_web/components/post_components.ex:2782
+#: lib/vutuv_web/components/post_components.ex:2849
+#: lib/vutuv_web/components/post_components.ex:2876
+#: lib/vutuv_web/components/post_components.ex:2879
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:608
+#: lib/vutuv_web/live/message_live/index.ex:613
 #, elixir-autogen, elixir-format
 msgid "%{names} are typing…"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:607
+#: lib/vutuv_web/live/message_live/index.ex:612
 #, elixir-autogen, elixir-format
 msgid "%{name} is typing…"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:896
+#: lib/vutuv_web/live/message_live/index.ex:901
 #, elixir-autogen, elixir-format
 msgid "@%{slug} has not accepted your message request yet."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:848
+#: lib/vutuv_web/live/message_live/index.ex:853
 #, elixir-autogen, elixir-format
 msgid "@%{slug} wants to message you."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:591
+#: lib/vutuv_web/live/message_live/index.ex:596
 #, elixir-autogen, elixir-format
 msgid "Accept"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:711
+#: lib/vutuv_web/live/message_live/index.ex:716
 #, elixir-autogen, elixir-format
 msgid "Back to conversations"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:598
+#: lib/vutuv_web/live/message_live/index.ex:603
 #, elixir-autogen, elixir-format
 msgid "Decline"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:529
+#: lib/vutuv_web/live/message_live/index.ex:534
 #, elixir-autogen, elixir-format
 msgid "Deleted account"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:757
+#: lib/vutuv_web/live/message_live/index.ex:762
 #, elixir-autogen, elixir-format
 msgid "Load older messages"
 msgstr ""
@@ -2596,23 +2597,23 @@ msgstr ""
 msgid "Member not found."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:690
+#: lib/vutuv_web/live/message_live/index.ex:695
 #, elixir-autogen, elixir-format
 msgid "No conversations yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2684
-#: lib/vutuv_web/live/message_live/index.ex:733
+#: lib/vutuv_web/components/ui.ex:2689
+#: lib/vutuv_web/live/message_live/index.ex:738
 #, elixir-autogen, elixir-format
 msgid "Online"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:639
+#: lib/vutuv_web/live/message_live/index.ex:644
 #, elixir-autogen, elixir-format
 msgid "Requests"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:905
+#: lib/vutuv_web/live/message_live/index.ex:910
 #, elixir-autogen, elixir-format
 msgid "Select a conversation."
 msgstr ""
@@ -2622,7 +2623,7 @@ msgstr ""
 msgid "This member cannot receive messages."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:234
+#: lib/vutuv_web/live/message_live/index.ex:239
 #, elixir-autogen, elixir-format
 msgid "This message could not be sent."
 msgstr ""
@@ -2688,7 +2689,7 @@ msgstr ""
 msgid "Okay, let's start over."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:731
+#: lib/vutuv_web/components/ui.ex:732
 #, elixir-autogen, elixir-format
 msgid "Resend PIN"
 msgstr ""
@@ -2699,71 +2700,71 @@ msgstr ""
 msgid "Too many PIN requests. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:752
+#: lib/vutuv_web/components/ui.ex:753
 #, elixir-autogen, elixir-format
 msgid "Use a different email address"
 msgstr ""
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
 #: lib/vutuv_web/templates/url/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:900
+#: lib/vutuv_web/templates/user/show.html.heex:903
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1205
+#: lib/vutuv_web/templates/user/show.html.heex:1208
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1463
+#: lib/vutuv_web/templates/user/show.html.heex:1466
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1133
+#: lib/vutuv_web/templates/user/show.html.heex:1136
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1084
+#: lib/vutuv_web/templates/user/show.html.heex:1087
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:627
+#: lib/vutuv_web/templates/user/show.html.heex:630
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #: lib/vutuv_web/templates/work_experience/new.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Add work experience"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:488
+#: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3442
-#: lib/vutuv_web/components/ui.ex:3816
+#: lib/vutuv_web/components/ui.ex:3447
+#: lib/vutuv_web/components/ui.ex:3821
 #: lib/vutuv_web/templates/settings/apps.html.heex:22
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #: lib/vutuv_web/templates/settings/organizations.html.heex:104
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:216
-#: lib/vutuv_web/templates/user/show.html.heex:618
+#: lib/vutuv_web/templates/user/show.html.heex:621
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1225
-#: lib/vutuv_web/templates/user/show.html.heex:488
+#: lib/vutuv_web/live/post_live/feed.ex:1241
+#: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write a post"
 msgstr ""
@@ -2793,13 +2794,13 @@ msgstr[1] ""
 #: lib/vutuv_web/agent_docs/markdown.ex:625
 #: lib/vutuv_web/agent_docs/text.ex:591
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:969
+#: lib/vutuv_web/live/notification_live/index.ex:981
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1061
+#: lib/vutuv_web/components/ui.ex:1062
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr ""
@@ -2809,7 +2810,7 @@ msgstr ""
 msgid "No connections yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1077
+#: lib/vutuv_web/components/ui.ex:1078
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr ""
@@ -2819,7 +2820,7 @@ msgstr ""
 msgid "People who aren't my connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1062
+#: lib/vutuv_web/components/ui.ex:1063
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr ""
@@ -2837,35 +2838,35 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4614
+#: lib/vutuv_web/components/post_components.ex:4711
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:691
+#: lib/vutuv_web/live/message_live/index.ex:696
 #, elixir-autogen, elixir-format
 msgid "Open someone's profile to message them."
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:268
-#: lib/vutuv_web/live/notification_live/index.ex:1049
+#: lib/vutuv_web/live/notification_live/index.ex:1061
 #: lib/vutuv_web/live/organization_live/activity.ex:103
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1040
+#: lib/vutuv_web/live/notification_live/index.ex:1052
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1033
+#: lib/vutuv_web/live/notification_live/index.ex:1045
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1032
-#: lib/vutuv_web/templates/user/show.html.heex:948
+#: lib/vutuv_web/live/notification_live/index.ex:1044
+#: lib/vutuv_web/templates/user/show.html.heex:951
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -2877,7 +2878,7 @@ msgstr[1] ""
 msgid "Welcome to vutuv, %{name}!"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1066
+#: lib/vutuv_web/notification_line.ex:70
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr ""
@@ -2909,12 +2910,12 @@ msgstr ""
 msgid "(no text)"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1293
+#: lib/vutuv_web/notification_line.ex:115
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1294
+#: lib/vutuv_web/notification_line.ex:116
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr ""
@@ -3008,7 +3009,7 @@ msgstr ""
 msgid "Hidden. You can settle this yourself - see below."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:786
+#: lib/vutuv_web/live/message_live/index.ex:791
 #, elixir-autogen, elixir-format
 msgid "Hidden: reported, under review"
 msgstr ""
@@ -3020,7 +3021,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:1041
+#: lib/vutuv_web/live/notification_live/index.ex:1053
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3094,13 +3095,13 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1173
-#: lib/vutuv_web/templates/user/show.html.heex:1174
+#: lib/vutuv_web/templates/user/show.html.heex:1176
+#: lib/vutuv_web/templates/user/show.html.heex:1177
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2728
+#: lib/vutuv_web/components/post_components.ex:2825
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3149,9 +3150,9 @@ msgstr ""
 msgid "Private message"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4073
-#: lib/vutuv_web/live/shell_live.ex:622
-#: lib/vutuv_web/live/shell_live.ex:899
+#: lib/vutuv_web/components/ui.ex:4078
+#: lib/vutuv_web/live/shell_live.ex:742
+#: lib/vutuv_web/live/shell_live.ex:1019
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -3175,9 +3176,9 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1107
-#: lib/vutuv_web/components/post_components.ex:2139
-#: lib/vutuv_web/components/post_components.ex:2892
+#: lib/vutuv_web/components/post_components.ex:1110
+#: lib/vutuv_web/components/post_components.ex:2236
+#: lib/vutuv_web/components/post_components.ex:2989
 #: lib/vutuv_web/live/organization_live/show.ex:547
 #: lib/vutuv_web/templates/user/show.html.heex:222
 #, elixir-autogen, elixir-format
@@ -3205,8 +3206,8 @@ msgstr ""
 msgid "Report this content"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:804
-#: lib/vutuv_web/live/message_live/index.ex:805
+#: lib/vutuv_web/live/message_live/index.ex:809
+#: lib/vutuv_web/live/message_live/index.ex:810
 #, elixir-autogen, elixir-format
 msgid "Report this message"
 msgstr ""
@@ -3260,7 +3261,7 @@ msgstr ""
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3178
+#: lib/vutuv_web/components/ui.ex:3183
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:773
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -3444,12 +3445,12 @@ msgstr ""
 msgid "You cannot report your own content."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1296
+#: lib/vutuv_web/notification_line.ex:118
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1295
+#: lib/vutuv_web/notification_line.ex:117
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr ""
@@ -3459,7 +3460,7 @@ msgstr ""
 msgid "Your content was reported"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1297
+#: lib/vutuv_web/notification_line.ex:119
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3643,7 +3644,7 @@ msgstr ""
 msgid "Open the profile"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1321
+#: lib/vutuv_web/notification_line.ex:143
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3668,7 +3669,7 @@ msgstr ""
 msgid "Report filed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1043
+#: lib/vutuv_web/live/notification_live/index.ex:1055
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr ""
@@ -3743,7 +3744,7 @@ msgstr ""
 msgid "Waiting for the owner"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1326
+#: lib/vutuv_web/notification_line.ex:148
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -4501,7 +4502,7 @@ msgstr ""
 msgid "Block @%{slug}? This removes any follows and connection between you, closes your conversation, and prevents all interaction in both directions. Unblocking will not restore what was removed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4177
+#: lib/vutuv_web/components/ui.ex:4185
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -4543,12 +4544,12 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1399
+#: lib/vutuv_web/live/post_live/feed.ex:1415
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:694
+#: lib/vutuv_web/live/message_live/index.ex:699
 #, elixir-autogen, elixir-format
 msgid "Find members"
 msgstr ""
@@ -4557,7 +4558,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:299
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:970
+#: lib/vutuv_web/templates/user/show.html.heex:973
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -4600,8 +4601,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:436
 #: lib/vutuv_web/agent_docs/text.ex:457
 #: lib/vutuv_web/components/saved_search_components.ex:57
-#: lib/vutuv_web/components/ui.ex:551
-#: lib/vutuv_web/live/notification_live/index.ex:892
+#: lib/vutuv_web/components/ui.ex:552
+#: lib/vutuv_web/live/notification_live/index.ex:904
 #: lib/vutuv_web/live/organization_live/show.ex:647
 #: lib/vutuv_web/live/post_live/saved.ex:523
 #: lib/vutuv_web/live/search_live.ex:279
@@ -4620,12 +4621,12 @@ msgstr ""
 msgid "Similar names"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:391
-#: lib/vutuv_web/components/post_components.ex:410
+#: lib/vutuv_web/components/post_components.ex:394
+#: lib/vutuv_web/components/post_components.ex:413
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
-#: lib/vutuv_web/live/notification_live/index.ex:890
+#: lib/vutuv_web/live/notification_live/index.ex:902
 #: lib/vutuv_web/live/search_live.ex:278
 #: lib/vutuv_web/views/qualification_html.ex:103
 #, elixir-autogen, elixir-format
@@ -4675,7 +4676,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:388
 #: lib/vutuv_web/live/tag_new_live.ex:48
 #: lib/vutuv_web/live/user_profile_live.ex:1331
-#: lib/vutuv_web/templates/user/show.html.heex:591
+#: lib/vutuv_web/templates/user/show.html.heex:594
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr ""
@@ -4915,7 +4916,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/api_app_live.ex:98
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:181
 #: lib/vutuv_web/views/settings_html.ex:77
-#: lib/vutuv_web/views/settings_html.ex:358
+#: lib/vutuv_web/views/settings_html.ex:367
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
@@ -5273,7 +5274,7 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4237
+#: lib/vutuv_web/components/ui.ex:4245
 #: lib/vutuv_web/controllers/settings_controller.ex:155
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5319,7 +5320,7 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:778
+#: lib/vutuv_web/live/shell_live.ex:898
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
@@ -5341,7 +5342,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:835
+#: lib/vutuv_web/live/shell_live.ex:955
 #: lib/vutuv_web/templates/layout/app.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5352,15 +5353,15 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4334
-#: lib/vutuv_web/components/ui.ex:4339
-#: lib/vutuv_web/components/ui.ex:4418
-#: lib/vutuv_web/components/ui.ex:4482
+#: lib/vutuv_web/components/ui.ex:4342
+#: lib/vutuv_web/components/ui.ex:4347
+#: lib/vutuv_web/components/ui.ex:4426
+#: lib/vutuv_web/components/ui.ex:4490
 #: lib/vutuv_web/controllers/settings_controller.ex:62
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:303
-#: lib/vutuv_web/live/shell_live.ex:815
+#: lib/vutuv_web/live/shell_live.ex:935
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5368,7 +5369,7 @@ msgstr ""
 #: lib/vutuv_web/templates/login_code/index.html.heex:4
 #: lib/vutuv_web/templates/totp/new.html.heex:4
 #: lib/vutuv_web/templates/username/confirm.html.heex:23
-#: lib/vutuv_web/views/settings_html.ex:309
+#: lib/vutuv_web/views/settings_html.ex:318
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -5414,8 +5415,8 @@ msgstr ""
 msgid "Previous post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:602
-#: lib/vutuv_web/live/shell_live.ex:881
+#: lib/vutuv_web/live/shell_live.ex:722
+#: lib/vutuv_web/live/shell_live.ex:1001
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -5425,11 +5426,11 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2957
-#: lib/vutuv_web/components/post_components.ex:3011
-#: lib/vutuv_web/components/post_components.ex:3430
-#: lib/vutuv_web/live/notification_live/index.ex:691
-#: lib/vutuv_web/live/post_live/feed.ex:1517
+#: lib/vutuv_web/components/post_components.ex:3054
+#: lib/vutuv_web/components/post_components.ex:3108
+#: lib/vutuv_web/components/post_components.ex:3527
+#: lib/vutuv_web/live/notification_live/index.ex:703
+#: lib/vutuv_web/live/post_live/feed.ex:1533
 #: lib/vutuv_web/views/user_html.ex:113
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5474,7 +5475,7 @@ msgstr ""
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4197
+#: lib/vutuv_web/components/ui.ex:4205
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:289
@@ -5495,7 +5496,7 @@ msgstr ""
 msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4111
+#: lib/vutuv_web/components/ui.ex:4116
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5529,7 +5530,7 @@ msgstr ""
 msgid "Photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4171
+#: lib/vutuv_web/components/ui.ex:4179
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/templates/page/index.html.heex:174
 #, elixir-autogen, elixir-format
@@ -5556,7 +5557,7 @@ msgstr ""
 msgid "Your name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:520
+#: lib/vutuv_web/live/notification_live/index.ex:532
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr ""
@@ -5642,14 +5643,14 @@ msgstr ""
 msgid "Apps"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4230
+#: lib/vutuv_web/components/ui.ex:4238
 #: lib/vutuv_web/controllers/settings_controller.ex:179
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:127
-#: lib/vutuv_web/live/notification_live/index.ex:972
+#: lib/vutuv_web/live/notification_live/index.ex:984
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:17
@@ -5657,12 +5658,12 @@ msgstr ""
 msgid "Endorsements"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:134
+#: lib/vutuv_web/templates/settings/notifications.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "Endorsements and new followers"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:128
+#: lib/vutuv_web/templates/settings/notifications.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "In-app notifications"
 msgstr ""
@@ -5677,12 +5678,12 @@ msgstr ""
 msgid "Notification settings"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:142
+#: lib/vutuv_web/templates/settings/notifications.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "Open your notifications"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:135
+#: lib/vutuv_web/templates/settings/notifications.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Replies to and likes on your posts"
 msgstr ""
@@ -5697,7 +5698,7 @@ msgstr ""
 msgid "Search engines & AI"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:130
+#: lib/vutuv_web/templates/settings/notifications.html.heex:187
 #, elixir-autogen, elixir-format
 msgid "These are always on. You see them under the bell at the top of every page, in real time."
 msgstr ""
@@ -5727,7 +5728,7 @@ msgstr ""
 msgid "@handle"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:749
+#: lib/vutuv_web/live/message_live/index.ex:754
 #, elixir-autogen, elixir-format
 msgid "Block @%{slug}"
 msgstr ""
@@ -5793,7 +5794,7 @@ msgid "Name (A-Z)"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:491
-#: lib/vutuv_web/live/tag_live/timeline.ex:325
+#: lib/vutuv_web/live/tag_live/timeline.ex:328
 #, elixir-autogen, elixir-format
 msgid "Newest first"
 msgstr ""
@@ -5819,7 +5820,7 @@ msgid "Nothing here yet. People you like show up here."
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:492
-#: lib/vutuv_web/live/tag_live/timeline.ex:326
+#: lib/vutuv_web/live/tag_live/timeline.ex:329
 #, elixir-autogen, elixir-format
 msgid "Oldest first"
 msgstr ""
@@ -5841,34 +5842,34 @@ msgid "Search saved items"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:554
-#: lib/vutuv_web/live/tag_live/timeline.ex:253
+#: lib/vutuv_web/live/tag_live/timeline.ex:256
 #, elixir-autogen, elixir-format
 msgid "Sort"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/views/settings_html.ex:501
+#: lib/vutuv_web/views/settings_html.ex:510
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:500
+#: lib/vutuv_web/views/settings_html.ex:509
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:499
+#: lib/vutuv_web/views/settings_html.ex:508
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:900
+#: lib/vutuv_web/controllers/settings_controller.ex:912
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr ""
@@ -5878,7 +5879,7 @@ msgstr ""
 msgid "Another session was already active on your account."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:347
+#: lib/vutuv_web/views/settings_html.ex:356
 #, elixir-autogen, elixir-format
 msgid "Last active"
 msgstr ""
@@ -5893,7 +5894,7 @@ msgstr ""
 msgid "Log out of every device except this one?"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:364
+#: lib/vutuv_web/views/settings_html.ex:373
 #, elixir-autogen, elixir-format
 msgid "Log this device out of your account?"
 msgstr ""
@@ -5908,7 +5909,7 @@ msgstr ""
 msgid "Signed-in devices"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:887
+#: lib/vutuv_web/controllers/settings_controller.ex:899
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr ""
@@ -5918,7 +5919,7 @@ msgstr ""
 msgid "The location looks different from where you usually sign in."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:348
+#: lib/vutuv_web/views/settings_html.ex:357
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr ""
@@ -5928,7 +5929,7 @@ msgstr ""
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:498
+#: lib/vutuv_web/views/settings_html.ex:507
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr ""
@@ -5962,7 +5963,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
 #: lib/vutuv_web/live/admin/screenshot_live.ex:309
 #: lib/vutuv_web/live/fediverse_following_live.ex:291
-#: lib/vutuv_web/views/settings_html.ex:399
+#: lib/vutuv_web/views/settings_html.ex:408
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr ""
@@ -5972,7 +5973,7 @@ msgstr ""
 msgid "Could not add the passkey. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:402
+#: lib/vutuv_web/views/settings_html.ex:411
 #, elixir-autogen, elixir-format
 msgid "Last used"
 msgstr ""
@@ -5982,7 +5983,7 @@ msgstr ""
 msgid "Name (optional)"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:396
+#: lib/vutuv_web/views/settings_html.ex:405
 #, elixir-autogen, elixir-format
 msgid "Passkey"
 msgstr ""
@@ -6002,7 +6003,7 @@ msgstr ""
 msgid "Passkeys"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:410
+#: lib/vutuv_web/views/settings_html.ex:419
 #, elixir-autogen, elixir-format
 msgid "Remove this passkey?"
 msgstr ""
@@ -6070,17 +6071,17 @@ msgstr ""
 msgid "Tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:331
+#: lib/vutuv_web/components/ui.ex:332
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:898
+#: lib/vutuv_web/templates/user/show.html.heex:901
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:462
+#: lib/vutuv_web/templates/user/show.html.heex:465
 #, elixir-autogen, elixir-format
 msgctxt "profile"
 msgid "Post"
@@ -6094,7 +6095,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1514
+#: lib/vutuv_web/templates/user/show.html.heex:1517
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6138,8 +6139,8 @@ msgstr ""
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1099
-#: lib/vutuv_web/templates/user/show.html.heex:1109
+#: lib/vutuv_web/templates/user/show.html.heex:1102
+#: lib/vutuv_web/templates/user/show.html.heex:1112
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6179,12 +6180,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1221
+#: lib/vutuv_web/templates/user/show.html.heex:1224
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1232
+#: lib/vutuv_web/templates/user/show.html.heex:1235
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6220,14 +6221,14 @@ msgid "Previous day"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1107
-#: lib/vutuv_web/components/post_components.ex:393
+#: lib/vutuv_web/components/post_components.ex:396
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1230
+#: lib/vutuv_web/templates/user/show.html.heex:1233
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
@@ -6252,9 +6253,9 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1578
-#: lib/vutuv_web/components/ui.ex:1587
-#: lib/vutuv_web/components/ui.ex:2052
+#: lib/vutuv_web/components/ui.ex:1583
+#: lib/vutuv_web/components/ui.ex:1592
+#: lib/vutuv_web/components/ui.ex:2057
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr ""
@@ -6265,7 +6266,7 @@ msgstr ""
 msgid "Default map"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:750
+#: lib/vutuv_web/controllers/settings_controller.ex:762
 #, elixir-autogen, elixir-format
 msgid "Map preferences saved."
 msgstr ""
@@ -6281,9 +6282,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1500
-#: lib/vutuv_web/templates/user/show.html.heex:1508
-#: lib/vutuv_web/templates/user/show.html.heex:1520
+#: lib/vutuv_web/templates/user/show.html.heex:1503
+#: lib/vutuv_web/templates/user/show.html.heex:1511
+#: lib/vutuv_web/templates/user/show.html.heex:1523
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -6315,11 +6316,11 @@ msgstr ""
 msgid "No endorsements yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2005
-#: lib/vutuv_web/live/notification_live/index.ex:625
-#: lib/vutuv_web/live/notification_live/index.ex:640
-#: lib/vutuv_web/live/notification_live/index.ex:778
-#: lib/vutuv_web/live/notification_live/index.ex:780
+#: lib/vutuv_web/components/ui.ex:2010
+#: lib/vutuv_web/live/notification_live/index.ex:637
+#: lib/vutuv_web/live/notification_live/index.ex:652
+#: lib/vutuv_web/live/notification_live/index.ex:790
+#: lib/vutuv_web/live/notification_live/index.ex:792
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr ""
@@ -6610,9 +6611,9 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2107
-#: lib/vutuv_web/components/post_components.ex:2889
-#: lib/vutuv_web/components/ui.ex:2509
+#: lib/vutuv_web/components/post_components.ex:2204
+#: lib/vutuv_web/components/post_components.ex:2986
+#: lib/vutuv_web/components/ui.ex:2514
 #: lib/vutuv_web/live/fediverse_account_live.ex:381
 #: lib/vutuv_web/live/organization_live/following.ex:371
 #: lib/vutuv_web/live/organization_live/following.ex:446
@@ -6628,7 +6629,7 @@ msgstr ""
 msgid "Muted. Their posts no longer appear in your feed."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:133
+#: lib/vutuv_web/templates/settings/notifications.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "New messages and new connections"
 msgstr ""
@@ -6638,8 +6639,8 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2889
-#: lib/vutuv_web/components/ui.ex:2508
+#: lib/vutuv_web/components/post_components.ex:2986
+#: lib/vutuv_web/components/ui.ex:2513
 #: lib/vutuv_web/live/fediverse_account_live.ex:379
 #: lib/vutuv_web/live/organization_live/following.ex:371
 #: lib/vutuv_web/live/organization_live/following.ex:446
@@ -6670,33 +6671,33 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2479
+#: lib/vutuv_web/components/ui.ex:2484
 #, elixir-autogen, elixir-format
 msgid "Doesn't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2473
+#: lib/vutuv_web/components/ui.ex:2478
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2463
+#: lib/vutuv_web/components/ui.ex:2468
 #, elixir-autogen, elixir-format
 msgid "This member doesn't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2414
-#: lib/vutuv_web/components/ui.ex:2463
+#: lib/vutuv_web/components/ui.ex:2419
+#: lib/vutuv_web/components/ui.ex:2468
 #, elixir-autogen, elixir-format
 msgid "This member follows you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2412
+#: lib/vutuv_web/components/ui.ex:2417
 #, elixir-autogen, elixir-format
 msgid "You follow each other"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2413
+#: lib/vutuv_web/components/ui.ex:2418
 #, elixir-autogen, elixir-format
 msgid "You follow this member"
 msgstr ""
@@ -7262,13 +7263,13 @@ msgstr ""
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3216
+#: lib/vutuv_web/components/ui.ex:3221
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3232
+#: lib/vutuv_web/components/ui.ex:3237
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7347,7 +7348,7 @@ msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:4846
+#: lib/vutuv_web/components/post_components.ex:4952
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -7741,13 +7742,13 @@ msgstr ""
 #: lib/vutuv_web/components/job_components.ex:219
 #: lib/vutuv_web/live/admin/dashboard_live.ex:287
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:457
-#: lib/vutuv_web/live/notification_live/index.ex:919
+#: lib/vutuv_web/live/notification_live/index.ex:931
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:291
-#: lib/vutuv_web/live/notification_live/index.ex:922
+#: lib/vutuv_web/live/notification_live/index.ex:934
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr ""
@@ -7917,7 +7918,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/activity_live.ex:231
 #: lib/vutuv_web/live/admin/user_live.ex:184
 #: lib/vutuv_web/live/job_board_live.ex:257
-#: lib/vutuv_web/live/tag_live/timeline.ex:283
+#: lib/vutuv_web/live/tag_live/timeline.ex:286
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr ""
@@ -8021,7 +8022,7 @@ msgstr ""
 msgid "PIN registered"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3219
+#: lib/vutuv_web/components/ui.ex:3224
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr ""
@@ -8139,7 +8140,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
 #: lib/vutuv_web/templates/education/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:684
+#: lib/vutuv_web/templates/user/show.html.heex:687
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr ""
@@ -8151,7 +8152,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:42
 #: lib/vutuv_web/agent_docs/text.ex:39
-#: lib/vutuv_web/components/ui.ex:4087
+#: lib/vutuv_web/components/ui.ex:4092
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8163,7 +8164,7 @@ msgstr ""
 #: lib/vutuv_web/templates/education/new.html.heex:4
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
-#: lib/vutuv_web/templates/user/show.html.heex:681
+#: lib/vutuv_web/templates/user/show.html.heex:684
 #: lib/vutuv_web/views/import_html.ex:70
 #: lib/vutuv_web/views/job_reference_html.ex:265
 #, elixir-autogen, elixir-format
@@ -8206,7 +8207,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4218
+#: lib/vutuv_web/components/ui.ex:4226
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8235,7 +8236,7 @@ msgstr ""
 msgid "Nothing new to import."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4115
+#: lib/vutuv_web/components/ui.ex:4120
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8329,7 +8330,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3488
+#: lib/vutuv_web/components/ui.ex:3493
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8343,7 +8344,7 @@ msgid "Loading posts"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:140
-#: lib/vutuv_web/templates/user/show.html.heex:1367
+#: lib/vutuv_web/templates/user/show.html.heex:1370
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8404,13 +8405,13 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4075
+#: lib/vutuv_web/components/ui.ex:4080
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4208
+#: lib/vutuv_web/components/ui.ex:4216
 #: lib/vutuv_web/controllers/settings_controller.ex:123
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8422,7 +8423,7 @@ msgstr ""
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4199
+#: lib/vutuv_web/components/ui.ex:4207
 #: lib/vutuv_web/controllers/settings_controller.ex:106
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8432,7 +8433,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4222
+#: lib/vutuv_web/components/ui.ex:4230
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8454,13 +8455,13 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1484
-#: lib/vutuv_web/live/post_live/feed.ex:1485
+#: lib/vutuv_web/live/post_live/feed.ex:1500
+#: lib/vutuv_web/live/post_live/feed.ex:1501
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1479
+#: lib/vutuv_web/live/post_live/feed.ex:1495
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr ""
@@ -8552,7 +8553,7 @@ msgstr[1] ""
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1079
+#: lib/vutuv_web/components/ui.ex:1080
 #, elixir-autogen, elixir-format
 msgid "This profile is not offered as a Markdown, text, JSON or XML export."
 msgstr ""
@@ -8648,7 +8649,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:580
 #: lib/vutuv_web/agent_docs/text.ex:584
 #: lib/vutuv_web/components/organization_components.ex:285
-#: lib/vutuv_web/components/ui.ex:4189
+#: lib/vutuv_web/components/ui.ex:4197
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:355
 #: lib/vutuv_web/controllers/settings_controller.ex:422
@@ -8662,8 +8663,8 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:1012
-#: lib/vutuv_web/templates/user/show.html.heex:1272
+#: lib/vutuv_web/templates/user/show.html.heex:1015
+#: lib/vutuv_web/templates/user/show.html.heex:1275
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr ""
@@ -8800,12 +8801,12 @@ msgstr ""
 msgid "This is the print view of this CV. Use your browser's print dialog (Ctrl+P or Cmd+P) and choose \"Save as PDF\" to get a PDF file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1187
+#: lib/vutuv_web/components/ui.ex:1188
 #, elixir-autogen, elixir-format
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3878
+#: lib/vutuv_web/components/post_components.ex:3975
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -8838,7 +8839,7 @@ msgstr ""
 msgid "Header"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1197
+#: lib/vutuv_web/components/ui.ex:1198
 #: lib/vutuv_web/templates/export/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Open CV"
@@ -8870,7 +8871,7 @@ msgstr ""
 msgid "The CV is public, on your profile: a visitor's download contains only what they can see there anyway, and private email addresses appear only in your own."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1189
+#: lib/vutuv_web/components/ui.ex:1190
 #, elixir-autogen, elixir-format
 msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
@@ -9024,8 +9025,8 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1622
-#: lib/vutuv_web/components/ui.ex:1623
+#: lib/vutuv_web/components/ui.ex:1627
+#: lib/vutuv_web/components/ui.ex:1628
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:65
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9055,7 +9056,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/language/manage.html.heex:8
 #: lib/vutuv_web/templates/language/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:746
+#: lib/vutuv_web/templates/user/show.html.heex:749
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr ""
@@ -9279,7 +9280,7 @@ msgstr ""
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:4
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:743
+#: lib/vutuv_web/templates/user/show.html.heex:746
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr ""
@@ -9466,7 +9467,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1146
+#: lib/vutuv/accounts/user.ex:1154
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9477,7 +9478,7 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1143
+#: lib/vutuv/accounts/user.ex:1151
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -9559,7 +9560,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:852
+#: lib/vutuv_web/templates/user/show.html.heex:855
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr ""
@@ -9592,7 +9593,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:46
 #: lib/vutuv_web/agent_docs/text.ex:43
-#: lib/vutuv_web/components/ui.ex:4091
+#: lib/vutuv_web/components/ui.ex:4096
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:132
@@ -9607,7 +9608,7 @@ msgstr ""
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:849
+#: lib/vutuv_web/templates/user/show.html.heex:852
 #: lib/vutuv_web/views/import_html.ex:71
 #: lib/vutuv_web/views/job_reference_html.ex:266
 #, elixir-autogen, elixir-format
@@ -9726,8 +9727,8 @@ msgstr ""
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1195
-#: lib/vutuv_web/templates/user/show.html.heex:1196
+#: lib/vutuv_web/templates/user/show.html.heex:1198
+#: lib/vutuv_web/templates/user/show.html.heex:1199
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -9786,13 +9787,13 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2962
+#: lib/vutuv_web/components/ui.ex:2967
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2961
-#: lib/vutuv_web/components/ui.ex:2965
+#: lib/vutuv_web/components/ui.ex:2966
+#: lib/vutuv_web/components/ui.ex:2970
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr ""
@@ -9966,12 +9967,12 @@ msgstr ""
 msgid "Authenticator app turned off."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:325
+#: lib/vutuv_web/components/ui.ex:326
 #, elixir-autogen, elixir-format
 msgid "Bold"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:421
+#: lib/vutuv_web/components/ui.ex:422
 #, elixir-autogen, elixir-format
 msgid "Bullet list"
 msgstr ""
@@ -9981,7 +9982,7 @@ msgstr ""
 msgid "Can't scan the code? Enter this key in your app instead:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:413
+#: lib/vutuv_web/components/ui.ex:414
 #, elixir-autogen, elixir-format
 msgid "Code block"
 msgstr ""
@@ -9996,17 +9997,17 @@ msgstr ""
 msgid "Delete your code list? All its codes stop working immediately."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:435
+#: lib/vutuv_web/components/ui.ex:436
 #, elixir-autogen, elixir-format
 msgid "Divider"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:323
+#: lib/vutuv_web/components/ui.ex:324
 #, elixir-autogen, elixir-format
 msgid "Formatting"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:447
+#: lib/vutuv_web/components/ui.ex:448
 #, elixir-autogen, elixir-format
 msgid "Full screen"
 msgstr ""
@@ -10021,32 +10022,32 @@ msgstr ""
 msgid "Generate code list"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:401
+#: lib/vutuv_web/components/ui.ex:402
 #, elixir-autogen, elixir-format
 msgid "Heading 1"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:404
+#: lib/vutuv_web/components/ui.ex:405
 #, elixir-autogen, elixir-format
 msgid "Heading 2"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:407
+#: lib/vutuv_web/components/ui.ex:408
 #, elixir-autogen, elixir-format
 msgid "Heading 3"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:393
+#: lib/vutuv_web/components/ui.ex:394
 #, elixir-autogen, elixir-format
 msgid "Inline code"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:328
+#: lib/vutuv_web/components/ui.ex:329
 #, elixir-autogen, elixir-format
 msgid "Italic"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:312
+#: lib/vutuv_web/components/ui.ex:313
 #, elixir-autogen, elixir-format
 msgid "Link URL"
 msgstr ""
@@ -10056,8 +10057,8 @@ msgstr ""
 msgid "Login codes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:373
 #: lib/vutuv_web/components/ui.ex:374
+#: lib/vutuv_web/components/ui.ex:375
 #, elixir-autogen, elixir-format
 msgid "More formatting"
 msgstr ""
@@ -10068,7 +10069,7 @@ msgstr ""
 msgid "Not set up."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:424
+#: lib/vutuv_web/components/ui.ex:425
 #, elixir-autogen, elixir-format
 msgid "Numbered list"
 msgstr ""
@@ -10083,7 +10084,7 @@ msgstr ""
 msgid "Print this page or write the codes down. Crossed-out codes have been used."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:410
+#: lib/vutuv_web/components/ui.ex:411
 #, elixir-autogen, elixir-format
 msgid "Quote"
 msgstr ""
@@ -10104,12 +10105,12 @@ msgstr ""
 msgid "Set up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:390
+#: lib/vutuv_web/components/ui.ex:391
 #, elixir-autogen, elixir-format
 msgid "Strikethrough"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:432
+#: lib/vutuv_web/components/ui.ex:433
 #, elixir-autogen, elixir-format
 msgid "Table"
 msgstr ""
@@ -10124,7 +10125,7 @@ msgstr ""
 msgid "To finish, enter the code your app shows now"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:444
+#: lib/vutuv_web/components/ui.ex:445
 #, elixir-autogen, elixir-format
 msgid "Toggle Markdown source"
 msgstr ""
@@ -10249,7 +10250,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:63
 #: lib/vutuv_web/agent_docs/text.ex:60
-#: lib/vutuv_web/templates/user/show.html.heex:1341
+#: lib/vutuv_web/templates/user/show.html.heex:1344
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -10551,7 +10552,7 @@ msgstr ""
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:764
+#: lib/vutuv_web/controllers/settings_controller.ex:776
 #, elixir-autogen, elixir-format
 msgid "Post display settings saved."
 msgstr ""
@@ -10600,7 +10601,7 @@ msgstr ""
 msgid "Installation default (%{value})"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:796
+#: lib/vutuv_web/controllers/settings_controller.ex:808
 #, elixir-autogen, elixir-format
 msgid "Map preferences reset to the site defaults."
 msgstr ""
@@ -10615,7 +10616,7 @@ msgstr ""
 msgid "Own value; blank the field to go back to the installation default."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:792
+#: lib/vutuv_web/controllers/settings_controller.ex:804
 #, elixir-autogen, elixir-format
 msgid "Post display settings reset to the site defaults."
 msgstr ""
@@ -10835,19 +10836,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1184
+#: lib/vutuv/accounts/user.ex:1192
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1189
+#: lib/vutuv/accounts/user.ex:1197
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1187
+#: lib/vutuv/accounts/user.ex:1195
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:761
 #, elixir-autogen, elixir-format
@@ -11569,7 +11570,7 @@ msgstr ""
 msgid "The link text can be anything. A hidden <link rel=\"me\"> in the page head works too."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:943
+#: lib/vutuv_web/components/ui.ex:944
 #: lib/vutuv_web/live/section_reorder_live.ex:195
 #, elixir-autogen, elixir-format
 msgid "Verified webpage"
@@ -11824,7 +11825,7 @@ msgstr ""
 msgid "Organization pages"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1044
+#: lib/vutuv_web/live/notification_live/index.ex:1056
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr ""
@@ -11837,12 +11838,12 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:419
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:394
-#: lib/vutuv_web/components/ui.ex:4226
+#: lib/vutuv_web/components/ui.ex:4234
 #: lib/vutuv_web/controllers/settings_controller.ex:211
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:806
+#: lib/vutuv_web/live/shell_live.ex:926
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:100
@@ -11933,22 +11934,22 @@ msgstr ""
 msgid "Your organization page was updated."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1285
+#: lib/vutuv_web/notification_line.ex:107
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1282
+#: lib/vutuv_web/notification_line.ex:104
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1279
+#: lib/vutuv_web/notification_line.ex:101
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1276
+#: lib/vutuv_web/notification_line.ex:98
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr ""
@@ -12123,7 +12124,7 @@ msgid "Everyone (public)"
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:647
-#: lib/vutuv_web/live/tag_live/timeline.ex:264
+#: lib/vutuv_web/live/tag_live/timeline.ex:267
 #: lib/vutuv_web/templates/education/form_content.html.heex:41
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:63
 #, elixir-autogen, elixir-format
@@ -12145,7 +12146,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1158
+#: lib/vutuv/accounts/user.ex:1166
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12171,7 +12172,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:636
+#: lib/vutuv_web/live/shell_live.ex:756
 #: lib/vutuv_web/templates/layout/app.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -12264,7 +12265,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1157
+#: lib/vutuv/accounts/user.ex:1165
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12346,7 +12347,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1159
+#: lib/vutuv/accounts/user.ex:1167
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:564
 #: lib/vutuv_web/agent_docs/markdown.ex:458
@@ -12975,7 +12976,7 @@ msgstr[1] ""
 msgid "Alert frequency"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:678
+#: lib/vutuv_web/controllers/settings_controller.ex:690
 #, elixir-autogen, elixir-format
 msgid "Alert updated."
 msgstr ""
@@ -13043,13 +13044,13 @@ msgstr ""
 msgid "Save search"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:696
+#: lib/vutuv_web/controllers/settings_controller.ex:708
 #, elixir-autogen, elixir-format
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4166
-#: lib/vutuv_web/controllers/settings_controller.ex:588
+#: lib/vutuv_web/components/ui.ex:4174
+#: lib/vutuv_web/controllers/settings_controller.ex:600
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
 #, elixir-autogen, elixir-format
@@ -13067,10 +13068,10 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2282
+#: lib/vutuv_web/components/post_components.ex:2379
 #: lib/vutuv_web/components/saved_search_components.ex:43
-#: lib/vutuv_web/controllers/settings_controller.ex:683
-#: lib/vutuv_web/controllers/settings_controller.ex:701
+#: lib/vutuv_web/controllers/settings_controller.ex:695
+#: lib/vutuv_web/controllers/settings_controller.ex:713
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:387
 #: lib/vutuv_web/live/organization_live/following.ex:277
 #: lib/vutuv_web/live/organization_live/following.ex:284
@@ -13320,7 +13321,7 @@ msgstr ""
 msgid "Image awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1042
+#: lib/vutuv_web/live/notification_live/index.ex:1054
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13361,7 +13362,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1202
+#: lib/vutuv/accounts/user.ex:1210
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13372,19 +13373,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1205
+#: lib/vutuv/accounts/user.ex:1213
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1208
+#: lib/vutuv/accounts/user.ex:1216
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1199
+#: lib/vutuv/accounts/user.ex:1207
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13407,7 +13408,7 @@ msgstr[1] ""
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1045
+#: lib/vutuv_web/live/notification_live/index.ex:1057
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr ""
@@ -13419,32 +13420,32 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1335
+#: lib/vutuv_web/notification_line.ex:157
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:358
+#: lib/vutuv_web/components/ui.ex:359
 #, elixir-autogen, elixir-format
 msgid "Center"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:355
+#: lib/vutuv_web/components/ui.ex:356
 #, elixir-autogen, elixir-format
 msgid "Float left"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:361
+#: lib/vutuv_web/components/ui.ex:362
 #, elixir-autogen, elixir-format
 msgid "Float right"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:352
+#: lib/vutuv_web/components/ui.ex:353
 #, elixir-autogen, elixir-format
 msgid "Full width"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:340
+#: lib/vutuv_web/components/ui.ex:341
 #, elixir-autogen, elixir-format
 msgid "Insert image"
 msgstr ""
@@ -13456,7 +13457,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:227
 #: lib/vutuv_web/agent_docs/text.ex:212
-#: lib/vutuv_web/live/tag_live/timeline.ex:210
+#: lib/vutuv_web/live/tag_live/timeline.ex:213
 #, elixir-autogen, elixir-format
 msgid "Posts with this tag"
 msgstr ""
@@ -13481,22 +13482,22 @@ msgstr ""
 msgid "Work mobile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:433
+#: lib/vutuv_web/components/post_components.ex:436
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:435
+#: lib/vutuv_web/components/post_components.ex:438
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:434
+#: lib/vutuv_web/components/post_components.ex:437
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:392
+#: lib/vutuv_web/components/post_components.ex:395
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr ""
@@ -13506,16 +13507,16 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4149
-#: lib/vutuv_web/controllers/settings_controller.ex:602
-#: lib/vutuv_web/live/post_live/feed.ex:1430
+#: lib/vutuv_web/components/ui.ex:4157
+#: lib/vutuv_web/controllers/settings_controller.ex:614
+#: lib/vutuv_web/live/post_live/feed.ex:1446
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1445
+#: lib/vutuv_web/live/post_live/feed.ex:1461
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr ""
@@ -13557,7 +13558,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1307
+#: lib/vutuv_web/templates/user/show.html.heex:1310
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
@@ -13586,7 +13587,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:60
 #: lib/vutuv_web/agent_docs/text.ex:57
-#: lib/vutuv_web/components/ui.ex:4134
+#: lib/vutuv_web/components/ui.ex:4139
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -13594,7 +13595,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1305
+#: lib/vutuv_web/templates/user/show.html.heex:1308
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
@@ -13614,34 +13615,34 @@ msgstr ""
 msgid "Select a messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3574
+#: lib/vutuv_web/components/ui.ex:3579
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3584
+#: lib/vutuv_web/components/ui.ex:3589
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1046
+#: lib/vutuv_web/live/notification_live/index.ex:1058
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1355
+#: lib/vutuv_web/notification_line.ex:177
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1347
+#: lib/vutuv_web/notification_line.ex:169
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1352
+#: lib/vutuv_web/notification_line.ex:174
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr ""
@@ -13666,39 +13667,39 @@ msgstr ""
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1360
+#: lib/vutuv_web/notification_line.ex:182
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4476
+#: lib/vutuv_web/components/post_components.ex:4573
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1196
-#: lib/vutuv_web/components/post_components.ex:4433
+#: lib/vutuv_web/components/post_components.ex:4530
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4477
+#: lib/vutuv_web/components/post_components.ex:4574
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4479
+#: lib/vutuv_web/components/post_components.ex:4576
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4475
+#: lib/vutuv_web/components/post_components.ex:4572
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1196
-#: lib/vutuv_web/components/post_components.ex:4432
+#: lib/vutuv_web/components/post_components.ex:4529
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13709,12 +13710,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4474
+#: lib/vutuv_web/components/post_components.ex:4571
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4478
+#: lib/vutuv_web/components/post_components.ex:4575
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13734,7 +13735,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4515
+#: lib/vutuv_web/components/post_components.ex:4612
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13742,27 +13743,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4545
+#: lib/vutuv_web/components/post_components.ex:4642
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4546
+#: lib/vutuv_web/components/post_components.ex:4643
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4544
+#: lib/vutuv_web/components/post_components.ex:4641
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4504
+#: lib/vutuv_web/components/post_components.ex:4601
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4551
+#: lib/vutuv_web/components/post_components.ex:4648
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13792,72 +13793,72 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4318
+#: lib/vutuv_web/components/post_components.ex:4415
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:911
+#: lib/vutuv_web/live/notification_live/index.ex:923
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:925
+#: lib/vutuv_web/live/notification_live/index.ex:937
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:393
+#: lib/vutuv_web/live/notification_live/index.ex:405
 #, elixir-autogen, elixir-format
 msgid "Follow back"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:408
+#: lib/vutuv_web/live/notification_live/index.ex:420
 #, elixir-autogen, elixir-format
 msgid "Last 30 days"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:877
-#: lib/vutuv_web/live/notification_live/index.ex:1125
+#: lib/vutuv_web/live/notification_live/index.ex:889
+#: lib/vutuv_web/live/notification_live/index.ex:1096
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1062
+#: lib/vutuv_web/live/notification_live/index.ex:1075
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1057
+#: lib/vutuv_web/live/notification_live/index.ex:1072
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1072
+#: lib/vutuv_web/live/notification_live/index.ex:1081
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4309
+#: lib/vutuv_web/components/post_components.ex:4406
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1756
+#: lib/vutuv_web/components/ui.ex:1761
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1760
+#: lib/vutuv_web/components/ui.ex:1765
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:438
+#: lib/vutuv_web/live/shell_live.ex:453
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -14074,17 +14075,17 @@ msgstr ""
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1309
+#: lib/vutuv_web/notification_line.ex:131
 #, elixir-autogen, elixir-format
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1035
+#: lib/vutuv_web/live/notification_live/index.ex:1047
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1112
+#: lib/vutuv_web/notification_line.ex:243
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -14107,12 +14108,12 @@ msgstr ""
 msgid "Only part of this long conversation is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1036
+#: lib/vutuv_web/live/notification_live/index.ex:1048
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1259
+#: lib/vutuv_web/notification_line.ex:81
 #, elixir-autogen, elixir-format
 msgid "mentioned you in a post."
 msgstr ""
@@ -14212,14 +14213,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2555
+#: lib/vutuv_web/components/post_components.ex:2652
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2578
+#: lib/vutuv_web/components/post_components.ex:2675
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14246,7 +14247,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4943
+#: lib/vutuv_web/components/post_components.ex:5051
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14378,7 +14379,7 @@ msgstr[1] ""
 msgid "All endorsers"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:627
+#: lib/vutuv_web/controllers/settings_controller.ex:639
 #, elixir-autogen, elixir-format
 msgid "Filter added. Matching posts are now hidden from your feed."
 msgstr ""
@@ -14388,12 +14389,12 @@ msgstr ""
 msgid "Filter by a tag"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:657
+#: lib/vutuv_web/controllers/settings_controller.ex:669
 #, elixir-autogen, elixir-format
 msgid "Filter removed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:385
+#: lib/vutuv_web/live/post_live/feed.ex:389
 #, elixir-autogen, elixir-format
 msgid "Hidden: matches your filter"
 msgstr ""
@@ -14408,8 +14409,8 @@ msgstr ""
 msgid "Match whole words only (word/phrase)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4145
-#: lib/vutuv_web/controllers/settings_controller.ex:668
+#: lib/vutuv_web/components/ui.ex:4153
+#: lib/vutuv_web/controllers/settings_controller.ex:680
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
 #, elixir-autogen, elixir-format
@@ -14426,7 +14427,7 @@ msgstr ""
 msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:394
+#: lib/vutuv_web/live/post_live/feed.ex:398
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr ""
@@ -14456,7 +14457,7 @@ msgstr ""
 msgid "Thread replies"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:603
+#: lib/vutuv_web/live/notification_live/index.ex:615
 #, elixir-autogen, elixir-format
 msgid "Turn off thread notifications"
 msgstr ""
@@ -14502,12 +14503,12 @@ msgstr ""
 msgid "You have not muted anything yet."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:635
+#: lib/vutuv_web/controllers/settings_controller.ex:647
 #, elixir-autogen, elixir-format
 msgid "You have reached the maximum of %{count} filters."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:598
+#: lib/vutuv_web/live/notification_live/index.ex:610
 #, elixir-autogen, elixir-format
 msgid "You wrote in this thread."
 msgstr ""
@@ -14963,7 +14964,7 @@ msgstr ""
 msgid "ZIP or postal code"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:271
+#: lib/vutuv_web/live/tag_live/timeline.ex:274
 #: lib/vutuv_web/templates/education/form_content.html.heex:59
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:81
 #, elixir-autogen, elixir-format
@@ -14985,7 +14986,7 @@ msgstr ""
 msgid "Book an ad"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1016
+#: lib/vutuv_web/templates/user/show.html.heex:1019
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr ""
@@ -15041,257 +15042,252 @@ msgstr ""
 msgid "moved to %{address}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4076
+#: lib/vutuv_web/components/ui.ex:4081
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4081
+#: lib/vutuv_web/components/ui.ex:4086
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4084
+#: lib/vutuv_web/components/ui.ex:4089
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4085
+#: lib/vutuv_web/components/ui.ex:4090
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4088
+#: lib/vutuv_web/components/ui.ex:4093
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4089
+#: lib/vutuv_web/components/ui.ex:4094
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4092
+#: lib/vutuv_web/components/ui.ex:4097
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4093
+#: lib/vutuv_web/components/ui.ex:4098
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4100
+#: lib/vutuv_web/components/ui.ex:4105
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4101
+#: lib/vutuv_web/components/ui.ex:4106
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4102
+#: lib/vutuv_web/components/ui.ex:4107
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4105
+#: lib/vutuv_web/components/ui.ex:4110
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4106
+#: lib/vutuv_web/components/ui.ex:4111
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4227
+#: lib/vutuv_web/components/ui.ex:4235
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4228
+#: lib/vutuv_web/components/ui.ex:4236
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4109
+#: lib/vutuv_web/components/ui.ex:4114
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4112
+#: lib/vutuv_web/components/ui.ex:4117
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4113
+#: lib/vutuv_web/components/ui.ex:4118
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4116
+#: lib/vutuv_web/components/ui.ex:4121
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4117
+#: lib/vutuv_web/components/ui.ex:4122
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4120
+#: lib/vutuv_web/components/ui.ex:4125
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4121
+#: lib/vutuv_web/components/ui.ex:4126
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4123
+#: lib/vutuv_web/components/ui.ex:4128
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4124
+#: lib/vutuv_web/components/ui.ex:4129
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4125
+#: lib/vutuv_web/components/ui.ex:4130
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4127
+#: lib/vutuv_web/components/ui.ex:4132
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4128
+#: lib/vutuv_web/components/ui.ex:4133
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4130
+#: lib/vutuv_web/components/ui.ex:4135
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4135
+#: lib/vutuv_web/components/ui.ex:4140
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4136
+#: lib/vutuv_web/components/ui.ex:4141
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4139
+#: lib/vutuv_web/components/ui.ex:4144
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4142
+#: lib/vutuv_web/components/ui.ex:4147
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4143
-#, elixir-autogen, elixir-format
-msgid "email mail unsubscribe newsletter bell alert quiet fewer"
-msgstr ""
-
-#: lib/vutuv_web/components/ui.ex:4146
+#: lib/vutuv_web/components/ui.ex:4154
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4147
+#: lib/vutuv_web/components/ui.ex:4155
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4150
+#: lib/vutuv_web/components/ui.ex:4158
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4151
+#: lib/vutuv_web/components/ui.ex:4159
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4167
+#: lib/vutuv_web/components/ui.ex:4175
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4168
+#: lib/vutuv_web/components/ui.ex:4176
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4174
+#: lib/vutuv_web/components/ui.ex:4182
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4175
+#: lib/vutuv_web/components/ui.ex:4183
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4178
+#: lib/vutuv_web/components/ui.ex:4186
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4179
+#: lib/vutuv_web/components/ui.ex:4187
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4200
+#: lib/vutuv_web/components/ui.ex:4208
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4201
+#: lib/vutuv_web/components/ui.ex:4209
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4219
+#: lib/vutuv_web/components/ui.ex:4227
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4220
+#: lib/vutuv_web/components/ui.ex:4228
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4223
+#: lib/vutuv_web/components/ui.ex:4231
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4224
+#: lib/vutuv_web/components/ui.ex:4232
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4238
+#: lib/vutuv_web/components/ui.ex:4246
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4239
+#: lib/vutuv_web/components/ui.ex:4247
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr ""
@@ -15369,51 +15365,51 @@ msgstr ""
 msgid "I understand, take part"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:480
+#: lib/vutuv_web/views/settings_html.ex:489
 #, elixir-autogen, elixir-format
 msgid "Most of them, not all: we cannot check whether they do it, and anything that was re-shared, archived or indexed elsewhere stays out of reach. If you take part again later, people there have to follow you anew."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:475
+#: lib/vutuv_web/views/settings_html.ex:484
 #, elixir-autogen, elixir-format
 msgid "No new posts go out, and your followers from other networks are removed here. The next time those servers look you up they learn that this account is gone, and most of them then delete their copies of your posts."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:456
+#: lib/vutuv_web/views/settings_html.ex:465
 #, elixir-autogen, elixir-format
 msgid "Once a post has left vutuv, it is out of our hands"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:458
+#: lib/vutuv_web/views/settings_html.ex:467
 #, elixir-autogen, elixir-format
 msgid "Switching off does not delete what is already out there"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:469
+#: lib/vutuv_web/views/settings_html.ex:478
 #, elixir-autogen, elixir-format
 msgid "Switching this off again later stops new posts from going out. It cannot bring back what has already been delivered."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:464
+#: lib/vutuv_web/views/settings_html.ex:473
 #, elixir-autogen, elixir-format
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4891
+#: lib/vutuv_web/components/post_components.ex:4997
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4895
+#: lib/vutuv_web/components/post_components.ex:5001
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4899
+#: lib/vutuv_web/components/post_components.ex:5005
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15421,7 +15417,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1145
-#: lib/vutuv_web/components/post_components.ex:4850
+#: lib/vutuv_web/components/post_components.ex:4956
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15437,14 +15433,14 @@ msgstr ""
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1219
-#: lib/vutuv_web/components/post_components.ex:1784
+#: lib/vutuv_web/components/post_components.ex:1222
+#: lib/vutuv_web/components/post_components.ex:1881
 #: lib/vutuv_web/live/fediverse_account_live.ex:294
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1095
+#: lib/vutuv_web/components/post_components.ex:1098
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15463,7 +15459,7 @@ msgstr ""
 msgid "Replies from other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1038
+#: lib/vutuv_web/live/notification_live/index.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Reply from another network"
 msgstr ""
@@ -15473,7 +15469,7 @@ msgstr ""
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1104
+#: lib/vutuv_web/components/post_components.ex:1107
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15483,8 +15479,8 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1118
-#: lib/vutuv_web/live/notification_live/index.ex:545
+#: lib/vutuv_web/components/post_components.ex:1121
+#: lib/vutuv_web/live/notification_live/index.ex:557
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
 msgstr ""
@@ -15515,9 +15511,9 @@ msgid "That reply is not yours to remove."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1329
-#: lib/vutuv_web/components/post_components.ex:1150
-#: lib/vutuv_web/components/post_components.ex:1350
-#: lib/vutuv_web/components/post_components.ex:2202
+#: lib/vutuv_web/components/post_components.ex:1153
+#: lib/vutuv_web/components/post_components.ex:1353
+#: lib/vutuv_web/components/post_components.ex:2299
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -15535,7 +15531,7 @@ msgstr ""
 msgid "You have reported a lot today. Please try again tomorrow."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1262
+#: lib/vutuv_web/notification_line.ex:84
 #, elixir-autogen, elixir-format
 msgid "replied to your post from another network."
 msgstr ""
@@ -15745,7 +15741,7 @@ msgstr ""
 msgid "Access token revoked"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4203
+#: lib/vutuv_web/components/ui.ex:4211
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -15960,7 +15956,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:198
 #: lib/vutuv_web/live/admin/activity_live.ex:237
 #: lib/vutuv_web/live/fediverse_following_live.ex:378
-#: lib/vutuv_web/live/tag_live/timeline.ex:343
+#: lib/vutuv_web/live/tag_live/timeline.ex:346
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr ""
@@ -16092,7 +16088,7 @@ msgstr ""
 msgid "What changed on your account, and exactly when."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4204
+#: lib/vutuv_web/components/ui.ex:4212
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr ""
@@ -16128,7 +16124,7 @@ msgstr ""
 msgid "from a signed-in session"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4206
+#: lib/vutuv_web/components/ui.ex:4214
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
@@ -16180,22 +16176,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2740
+#: lib/vutuv_web/components/post_components.ex:2837
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2856
+#: lib/vutuv_web/components/post_components.ex:2953
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2864
+#: lib/vutuv_web/components/post_components.ex:2961
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2850
+#: lib/vutuv_web/components/post_components.ex:2947
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16281,7 +16277,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1257
 #: lib/vutuv_web/agent_docs/text.ex:792
-#: lib/vutuv_web/components/ui.ex:2563
+#: lib/vutuv_web/components/ui.ex:2568
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
@@ -16311,7 +16307,7 @@ msgstr ""
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2562
+#: lib/vutuv_web/components/ui.ex:2567
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
@@ -16321,17 +16317,17 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2335
+#: lib/vutuv_web/components/post_components.ex:2432
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3559
+#: lib/vutuv_web/components/post_components.ex:3656
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3070
+#: lib/vutuv_web/components/post_components.ex:3167
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16344,12 +16340,12 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1290
 #: lib/vutuv_web/agent_docs/text.ex:779
-#: lib/vutuv_web/components/post_components.ex:3776
+#: lib/vutuv_web/components/post_components.ex:3873
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2561
+#: lib/vutuv_web/components/ui.ex:2566
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr ""
@@ -16370,7 +16366,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2388
+#: lib/vutuv_web/components/post_components.ex:2485
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16390,7 +16386,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2379
+#: lib/vutuv_web/components/post_components.ex:2476
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16400,12 +16396,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2397
+#: lib/vutuv_web/components/post_components.ex:2494
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2331
+#: lib/vutuv_web/components/post_components.ex:2428
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16420,7 +16416,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2392
+#: lib/vutuv_web/components/post_components.ex:2489
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16430,7 +16426,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2345
+#: lib/vutuv_web/components/post_components.ex:2442
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16451,8 +16447,8 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1234
-#: lib/vutuv_web/live/post_live/feed.ex:1235
+#: lib/vutuv_web/live/post_live/feed.ex:1250
+#: lib/vutuv_web/live/post_live/feed.ex:1251
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr ""
@@ -16517,13 +16513,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1163
-#: lib/vutuv_web/components/post_components.ex:4888
+#: lib/vutuv_web/components/post_components.ex:4994
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1161
-#: lib/vutuv_web/components/post_components.ex:4885
+#: lib/vutuv_web/components/post_components.ex:4991
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr ""
@@ -16533,12 +16529,12 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4777
+#: lib/vutuv_web/components/post_components.ex:4883
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1039
+#: lib/vutuv_web/live/notification_live/index.ex:1051
 #, elixir-autogen, elixir-format
 msgid "Reaction from another network"
 msgstr ""
@@ -16553,21 +16549,21 @@ msgstr ""
 msgid "Show under each of your posts who out there liked or shared it, by their account address on their own server, linked to that account. Visible to everyone who sees the post. We keep nothing else about these people: no name, no picture, no text. Switching it off deletes what is stored for it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1093
+#: lib/vutuv_web/notification_line.ex:224
 #, elixir-autogen, elixir-format
 msgid "liked your post on another network."
 msgid_plural "liked your post on another network."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1101
+#: lib/vutuv_web/notification_line.ex:232
 #, elixir-autogen, elixir-format
 msgid "reacted to your post from another network."
 msgid_plural "reacted to your post from another network."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1085
+#: lib/vutuv_web/notification_line.ex:216
 #, elixir-autogen, elixir-format
 msgid "shared your post on another network."
 msgid_plural "shared your post on another network."
@@ -16649,7 +16645,7 @@ msgstr ""
 msgid "Cancel request"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4190
+#: lib/vutuv_web/components/ui.ex:4198
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr ""
@@ -16853,7 +16849,7 @@ msgstr ""
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4192
+#: lib/vutuv_web/components/ui.ex:4200
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
@@ -16873,7 +16869,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2148
+#: lib/vutuv_web/components/post_components.ex:2245
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
@@ -16883,7 +16879,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2201
+#: lib/vutuv_web/components/post_components.ex:2298
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16903,12 +16899,12 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1478
+#: lib/vutuv_web/components/post_components.ex:1481
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2166
+#: lib/vutuv_web/components/post_components.ex:2263
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr ""
@@ -16924,7 +16920,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2134
+#: lib/vutuv_web/components/post_components.ex:2231
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -17146,27 +17142,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1887
+#: lib/vutuv_web/components/post_components.ex:1984
 #, elixir-autogen, elixir-format
 msgid "A picture is on its way."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1916
+#: lib/vutuv_web/components/post_components.ex:2013
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1911
+#: lib/vutuv_web/components/post_components.ex:2008
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2238
+#: lib/vutuv_web/components/post_components.ex:2335
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2244
+#: lib/vutuv_web/components/post_components.ex:2341
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr ""
@@ -17176,7 +17172,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2383
+#: lib/vutuv_web/components/post_components.ex:2480
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17186,7 +17182,7 @@ msgstr ""
 msgid "This post was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/remote_actions_component.ex:155
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:167
 #, elixir-autogen, elixir-format
 msgid "Reposted. Your followers see it now."
 msgstr ""
@@ -17357,7 +17353,7 @@ msgstr ""
 msgid "Your username is your public identity here. It changes only once you confirm with your passkey or a valid code below."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:497
+#: lib/vutuv_web/components/ui.ex:498
 #, elixir-autogen, elixir-format
 msgid "Markdown help"
 msgstr ""
@@ -17372,53 +17368,53 @@ msgstr ""
 msgid "Read this page as Markdown"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:554
+#: lib/vutuv_web/components/ui.ex:555
 #, elixir-autogen, elixir-format
 msgid "Activities"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:552
+#: lib/vutuv_web/components/ui.ex:553
 #, elixir-autogen, elixir-format
 msgid "Animals & nature"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:313
-#: lib/vutuv_web/components/ui.ex:337
+#: lib/vutuv_web/components/ui.ex:314
+#: lib/vutuv_web/components/ui.ex:338
 #, elixir-autogen, elixir-format
 msgid "Emoji"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:553
+#: lib/vutuv_web/components/ui.ex:554
 #, elixir-autogen, elixir-format
 msgid "Food & drink"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:316
+#: lib/vutuv_web/components/ui.ex:317
 #, elixir-autogen, elixir-format
 msgid "No emoji found."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:556
+#: lib/vutuv_web/components/ui.ex:557
 #, elixir-autogen, elixir-format
 msgid "Objects"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:314
+#: lib/vutuv_web/components/ui.ex:315
 #, elixir-autogen, elixir-format
 msgid "Search emoji"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:550
+#: lib/vutuv_web/components/ui.ex:551
 #, elixir-autogen, elixir-format
 msgid "Smileys"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:557
+#: lib/vutuv_web/components/ui.ex:558
 #, elixir-autogen, elixir-format
 msgid "Symbols"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:555
+#: lib/vutuv_web/components/ui.ex:556
 #, elixir-autogen, elixir-format
 msgid "Travel & places"
 msgstr ""
@@ -17429,7 +17425,7 @@ msgid "Address of the post"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:504
-#: lib/vutuv_web/live/post_live/remote_actions_component.ex:247
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:262
 #, elixir-autogen, elixir-format
 msgid "Fediverse settings"
 msgstr ""
@@ -17876,54 +17872,54 @@ msgstr ""
 msgid "Screenshot blocklist"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:425
+#: lib/vutuv_web/components/post_components.ex:428
 #, elixir-autogen, elixir-format
 msgid "Nothing from the fediverse yet. Follow accounts out there to fill this tab."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:422
+#: lib/vutuv_web/components/post_components.ex:425
 #, elixir-autogen, elixir-format
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:575
+#: lib/vutuv_web/live/notification_live/index.ex:587
 #, elixir-autogen, elixir-format
 msgid "View the conversation"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:213
+#: lib/vutuv_web/live/tag_live/timeline.ex:216
 #, elixir-autogen, elixir-format
 msgid "%{formatted} post"
 msgid_plural "%{formatted} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:327
+#: lib/vutuv_web/live/tag_live/timeline.ex:330
 #, elixir-autogen, elixir-format
 msgid "Most liked"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:351
+#: lib/vutuv_web/live/tag_live/timeline.ex:354
 #, elixir-autogen, elixir-format
 msgid "No posts carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:349
+#: lib/vutuv_web/live/tag_live/timeline.ex:352
 #, elixir-autogen, elixir-format
 msgid "No posts from other networks carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:346
+#: lib/vutuv_web/live/tag_live/timeline.ex:349
 #, elixir-autogen, elixir-format
 msgid "No posts on vutuv carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:246
+#: lib/vutuv_web/live/tag_live/timeline.ex:249
 #, elixir-autogen, elixir-format
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2241
+#: lib/vutuv_web/components/post_components.ex:2338
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -17964,8 +17960,8 @@ msgstr ""
 msgid "This is vutuv's copy of a post published on %{host}. It is kept while somebody here follows its author."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1130
 #: lib/vutuv_web/components/ui.ex:1131
+#: lib/vutuv_web/components/ui.ex:1132
 #, elixir-autogen, elixir-format
 msgid "Subscribe to this feed in your RSS reader"
 msgstr ""
@@ -18226,19 +18222,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4033
+#: lib/vutuv_web/components/post_components.ex:4130
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4035
+#: lib/vutuv_web/components/post_components.ex:4132
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4046
+#: lib/vutuv_web/components/post_components.ex:4143
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -18258,7 +18254,7 @@ msgstr ""
 msgid "When off, other members no longer see you among the likes of a post. The author of the post still does: we named you in the notification they got when you liked it. Either way the post keeps the same number of likes."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:834
+#: lib/vutuv_web/controllers/settings_controller.ex:846
 #, elixir-autogen, elixir-format
 msgid "Your likes follow the site default again."
 msgstr ""
@@ -18273,7 +18269,7 @@ msgstr ""
 msgid "%{address} (whole website)"
 msgstr ""
 
-#: lib/vutuv_web/markdown.ex:327
+#: lib/vutuv_web/markdown.ex:337
 #, elixir-autogen, elixir-format
 msgid "Verified webpage of the author (%{address})"
 msgstr ""
@@ -18298,7 +18294,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/job_reference_controller.ex:144
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:18
 #: lib/vutuv_web/templates/job_reference/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:786
+#: lib/vutuv_web/templates/user/show.html.heex:789
 #, elixir-autogen, elixir-format
 msgid "Add an employment reference"
 msgstr ""
@@ -18363,7 +18359,7 @@ msgstr ""
 msgid "Employment reference updated."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4095
+#: lib/vutuv_web/components/ui.ex:4100
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -18373,7 +18369,7 @@ msgstr ""
 #: lib/vutuv_web/templates/job_reference/new.html.heex:4
 #: lib/vutuv_web/templates/job_reference/show.html.heex:12
 #: lib/vutuv_web/templates/job_reference/view.html.heex:11
-#: lib/vutuv_web/templates/user/show.html.heex:783
+#: lib/vutuv_web/templates/user/show.html.heex:786
 #, elixir-autogen, elixir-format
 msgid "Employment references"
 msgstr ""
@@ -18557,7 +18553,7 @@ msgstr ""
 msgid "You changed the text after this review. It describes the earlier version."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4096
+#: lib/vutuv_web/components/ui.ex:4101
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr ""
@@ -18568,7 +18564,7 @@ msgstr ""
 msgid "Zwischenzeugnis"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4098
+#: lib/vutuv_web/components/ui.ex:4103
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr ""
@@ -18756,7 +18752,7 @@ msgstr ""
 msgid "Employment reference deleted"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1048
+#: lib/vutuv_web/live/notification_live/index.ex:1060
 #, elixir-autogen, elixir-format
 msgid "Employment reference review"
 msgstr ""
@@ -18781,14 +18777,14 @@ msgstr ""
 msgid "Reviewing your reference. This usually takes about %{duration}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1250
-#: lib/vutuv_web/views/notification_digest_text.ex:84
+#: lib/vutuv_web/notification_line.ex:54
+#: lib/vutuv_web/views/notification_digest_text.ex:90
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1247
-#: lib/vutuv_web/views/notification_digest_text.ex:81
+#: lib/vutuv_web/notification_line.ex:51
+#: lib/vutuv_web/views/notification_digest_text.ex:87
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready: %{grade}."
 msgstr ""
@@ -18803,7 +18799,7 @@ msgstr ""
 msgid "When the review of one of your employment references is finished. It takes minutes, so you can close the page and wait for the email."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1253
+#: lib/vutuv_web/notification_line.ex:57
 #, elixir-autogen, elixir-format
 msgid "Your employment reference has been reviewed."
 msgstr ""
@@ -18890,72 +18886,72 @@ msgid_plural "%{count} new notifications on vutuv"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:59
+#: lib/vutuv_web/views/notification_digest_text.ex:65
 #, elixir-autogen, elixir-format
 msgid "%{who} added something to their CV."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:41
+#: lib/vutuv_web/views/notification_digest_text.ex:47
 #, elixir-autogen, elixir-format
 msgid "%{who} answered in a conversation you are part of."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:35
+#: lib/vutuv_web/views/notification_digest_text.ex:41
 #, elixir-autogen, elixir-format
 msgid "%{who} endorsed one of your tags."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:32
+#: lib/vutuv_web/views/notification_digest_text.ex:38
 #, elixir-autogen, elixir-format
 msgid "%{who} endorsed you for %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:47
+#: lib/vutuv_web/views/notification_digest_text.ex:53
 #, elixir-autogen, elixir-format
 msgid "%{who} liked your post."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:44
+#: lib/vutuv_web/views/notification_digest_text.ex:50
 #, elixir-autogen, elixir-format
 msgid "%{who} mentioned you in a post."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:53
+#: lib/vutuv_web/views/notification_digest_text.ex:59
 #, elixir-autogen, elixir-format
 msgid "%{who} reacted to your post from another network."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:50
+#: lib/vutuv_web/views/notification_digest_text.ex:56
 #, elixir-autogen, elixir-format
 msgid "%{who} replied to your post from another network."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:38
+#: lib/vutuv_web/views/notification_digest_text.ex:44
 #, elixir-autogen, elixir-format
 msgid "%{who} replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:26
+#: lib/vutuv_web/views/notification_digest_text.ex:32
 #, elixir-autogen, elixir-format
 msgid "%{who} started following you."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:63
+#: lib/vutuv_web/views/notification_digest_text.ex:69
 #, elixir-autogen, elixir-format
 msgid "@%{old} is now @%{new}."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:66
+#: lib/vutuv_web/views/notification_digest_text.ex:72
 #, elixir-autogen, elixir-format
 msgid "A moderation case on your account was updated."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:72
+#: lib/vutuv_web/views/notification_digest_text.ex:78
 #, elixir-autogen, elixir-format
 msgid "A report you are involved in changed something on your account."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:87
+#: lib/vutuv_web/views/notification_digest_text.ex:93
 #, elixir-autogen, elixir-format
 msgid "An employment reference of yours has been reviewed."
 msgstr ""
@@ -18966,17 +18962,18 @@ msgstr ""
 msgid "GitHub account @Klotzkette"
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:69
+#: lib/vutuv_web/views/notification_digest_text.ex:75
 #, elixir-autogen, elixir-format
 msgid "One of your images was removed by the image review."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:100
+#: lib/vutuv_web/views/notification_digest_text.ex:106
 #, elixir-autogen, elixir-format
 msgid "Somebody"
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:90
+#: lib/vutuv_web/notification_line.ex:192
+#: lib/vutuv_web/views/notification_digest_text.ex:96
 #, elixir-autogen, elixir-format
 msgid "Something new happened on your account."
 msgstr ""
@@ -18986,17 +18983,17 @@ msgstr ""
 msgid "Which wording counts as which grade is not our own invention. We follow the Arbeitszeugnis-Prüfer, a set of instructions published under the MIT and Apache 2.0 licences by the lawyer Tom Braegelmann ({account}). You can read every rule the model is given:"
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:29
+#: lib/vutuv_web/views/notification_digest_text.ex:35
 #, elixir-autogen, elixir-format
 msgid "You and %{who} are now connected."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:56
+#: lib/vutuv_web/views/notification_digest_text.ex:62
 #, elixir-autogen, elixir-format
 msgid "You were given a role at %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:75
+#: lib/vutuv_web/views/notification_digest_text.ex:81
 #, elixir-autogen, elixir-format
 msgid "Your vutuv username is ready."
 msgstr ""
@@ -19006,7 +19003,7 @@ msgstr ""
 msgid "by the lawyer Tom Braegelmann"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:827
+#: lib/vutuv_web/templates/user/show.html.heex:830
 #, elixir-autogen, elixir-format
 msgid "Documents:"
 msgstr ""
@@ -19167,17 +19164,17 @@ msgstr ""
 msgid "Enter the PIN from the email"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:723
+#: lib/vutuv_web/components/ui.ex:724
 #, elixir-autogen, elixir-format
 msgid "If you have added other addresses to your vutuv account, try logging in with one of those instead."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:751
+#: lib/vutuv_web/components/ui.ex:752
 #, elixir-autogen, elixir-format
 msgid "Cancel registration"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:844
+#: lib/vutuv_web/live/notification_live/index.ex:856
 #, elixir-autogen, elixir-format
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
@@ -19187,22 +19184,22 @@ msgstr ""
 msgid "Follow other members"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:706
+#: lib/vutuv_web/components/ui.ex:707
 #, elixir-autogen, elixir-format
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1305
+#: lib/vutuv/accounts/user.ex:1313
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1303
+#: lib/vutuv/accounts/user.ex:1311
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1304
+#: lib/vutuv/accounts/user.ex:1312
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -19212,7 +19209,7 @@ msgstr ""
 msgid "Shares are of the %{answered} members who answered. %{unanswered} gave no answer."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4077
+#: lib/vutuv_web/components/ui.ex:4082
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr ""
@@ -19308,7 +19305,7 @@ msgstr ""
 msgid "Always keep"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4183
+#: lib/vutuv_web/components/ui.ex:4191
 #: lib/vutuv_web/controllers/settings_controller.ex:245
 #: lib/vutuv_web/controllers/settings_controller.ex:324
 #: lib/vutuv_web/controllers/settings_controller.ex:336
@@ -19405,7 +19402,7 @@ msgstr ""
 msgid "Keep posts that did well"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4185
+#: lib/vutuv_web/components/ui.ex:4193
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr ""
@@ -19514,7 +19511,7 @@ msgstr ""
 msgid "Your rule"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4187
+#: lib/vutuv_web/components/ui.ex:4195
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
@@ -19888,7 +19885,7 @@ msgstr ""
 msgid "Start over"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2271
+#: lib/vutuv_web/components/post_components.ex:2368
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -19979,7 +19976,7 @@ msgstr ""
 msgid "A post in an organization's name is always public."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:565
+#: lib/vutuv_web/live/shell_live.ex:685
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr ""
@@ -19999,7 +19996,7 @@ msgstr ""
 msgid "Write as %{name} for now"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:575
+#: lib/vutuv_web/live/shell_live.ex:695
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr ""
@@ -20009,7 +20006,7 @@ msgstr ""
 msgid "You are writing as %{name} now."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:551
+#: lib/vutuv_web/live/shell_live.ex:671
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr ""
@@ -20321,22 +20318,22 @@ msgstr ""
 msgid "The PIN has expired."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:827
+#: lib/vutuv_web/components/ui.ex:828
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more minute."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:829
+#: lib/vutuv_web/components/ui.ex:830
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more second."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:828
+#: lib/vutuv_web/components/ui.ex:829
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more minutes."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:830
+#: lib/vutuv_web/components/ui.ex:831
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more seconds."
 msgstr ""
@@ -20373,21 +20370,21 @@ msgstr ""
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:468
+#: lib/vutuv_web/live/shell_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "%{formatted} person"
 msgid_plural "%{formatted} people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:455
+#: lib/vutuv_web/live/shell_live.ex:470
 #, elixir-autogen, elixir-format
 msgid "person"
 msgid_plural "people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:490
+#: lib/vutuv_web/live/shell_live.ex:505
 #, elixir-autogen, elixir-format
 msgid "%{members} vutuv members plus %{fediverse} Fediverse account that follows them"
 msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that follow them"
@@ -20780,37 +20777,37 @@ msgstr ""
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3942
+#: lib/vutuv_web/components/post_components.ex:4039
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3963
+#: lib/vutuv_web/components/post_components.ex:4060
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3972
+#: lib/vutuv_web/components/post_components.ex:4069
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3975
+#: lib/vutuv_web/components/post_components.ex:4072
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3952
+#: lib/vutuv_web/components/post_components.ex:4049
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:823
+#: lib/vutuv_web/controllers/settings_controller.ex:835
 #, elixir-autogen, elixir-format
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:812
+#: lib/vutuv_web/controllers/settings_controller.ex:824
 #, elixir-autogen, elixir-format
 msgid "Feed language settings saved."
 msgstr ""
@@ -20850,7 +20847,7 @@ msgstr ""
 msgid "Date & time"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:736
+#: lib/vutuv_web/controllers/settings_controller.ex:748
 #, elixir-autogen, elixir-format
 msgid "Date and time settings reset to the site defaults."
 msgstr ""
@@ -20865,7 +20862,7 @@ msgstr ""
 msgid "Germany, Austria, Switzerland"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:730
+#: lib/vutuv_web/controllers/settings_controller.ex:742
 #, elixir-autogen, elixir-format
 msgid "Language and region saved."
 msgstr ""
@@ -20905,7 +20902,7 @@ msgstr ""
 msgid "ISO 8601 (Sweden, Japan, China)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4210
+#: lib/vutuv_web/components/ui.ex:4218
 #, elixir-autogen, elixir-format
 msgid "Interface language, date format and time zone, feed languages, maps, how posts are shortened"
 msgstr ""
@@ -20915,7 +20912,7 @@ msgstr ""
 msgid "Language & display settings changed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4214
+#: lib/vutuv_web/components/ui.ex:4222
 #, elixir-autogen, elixir-format
 msgid "german english locale translation translate map font length hyphenation feed languages hide foreign übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
 msgstr ""
@@ -20955,19 +20952,19 @@ msgstr ""
 msgid "Your username, or paste the address of your profile page."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3742
+#: lib/vutuv_web/components/post_components.ex:3839
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3739
+#: lib/vutuv_web/components/post_components.ex:3836
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3079
+#: lib/vutuv_web/components/post_components.ex:3176
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -21035,7 +21032,7 @@ msgstr ""
 msgid "Mastodon app access changed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4231
+#: lib/vutuv_web/components/ui.ex:4239
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr ""
@@ -21081,7 +21078,7 @@ msgstr ""
 msgid "Your account is then %{handle}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4233
+#: lib/vutuv_web/components/ui.ex:4241
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr ""
@@ -21117,7 +21114,7 @@ msgstr ""
 msgid "Find your LinkedIn contacts"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4158
+#: lib/vutuv_web/components/ui.ex:4166
 #: lib/vutuv_web/live/import_connections_live.ex:64
 #: lib/vutuv_web/templates/import/new.html.heex:37
 #, elixir-autogen, elixir-format
@@ -21224,7 +21221,7 @@ msgstr ""
 msgid "See which of them are already on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4160
+#: lib/vutuv_web/components/ui.ex:4168
 #, elixir-autogen, elixir-format
 msgid "See which of your LinkedIn contacts are already on vutuv"
 msgstr ""
@@ -21296,7 +21293,7 @@ msgstr ""
 msgid "Your export also lists your LinkedIn contacts."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4162
+#: lib/vutuv_web/components/ui.ex:4170
 #, elixir-autogen, elixir-format
 msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
 msgstr ""
@@ -21492,7 +21489,7 @@ msgstr ""
 msgid "This page is following the most accounts we allow (%{max})."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2122
+#: lib/vutuv_web/components/post_components.ex:2219
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr ""
@@ -21500,4 +21497,74 @@ msgstr ""
 #: lib/vutuv_web/live/remote_post_actions.ex:89
 #, elixir-autogen, elixir-format
 msgid "Unfollowed. Their posts leave your feed."
+msgstr ""
+
+#: lib/vutuv_web/live/shell_live.ex:641
+#, elixir-autogen, elixir-format
+msgid "Allow"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:166
+#, elixir-autogen, elixir-format
+msgid "Ask now"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:144
+#, elixir-autogen, elixir-format
+msgid "Browser notifications"
+msgstr ""
+
+#: lib/vutuv_web/live/shell_live.ex:583
+#, elixir-autogen, elixir-format
+msgid "New message"
+msgstr ""
+
+#: lib/vutuv_web/live/shell_live.ex:648
+#, elixir-autogen, elixir-format
+msgid "Not now"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:152
+#, elixir-autogen, elixir-format
+msgid "Only while vutuv is open somewhere and you are looking at something else. Every browser you use asks you once."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:150
+#, elixir-autogen, elixir-format
+msgid "Show me browser notifications"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:176
+#, elixir-autogen, elixir-format
+msgid "This browser cannot show notifications. Your other browsers are unaffected."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:160
+#, elixir-autogen, elixir-format
+msgid "This browser has not been asked yet."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:171
+#, elixir-autogen, elixir-format
+msgid "This browser is blocking notifications for vutuv. Allow them for this site in your browser settings; the switch above stays on and every other browser you use is unaffected."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:169
+#, elixir-autogen, elixir-format
+msgid "This browser will show them."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:146
+#, elixir-autogen, elixir-format
+msgid "When something arrives while you have vutuv open in a tab you are not looking at, your browser can show it as a notification. Off unless you switch it on."
+msgstr ""
+
+#: lib/vutuv_web/live/shell_live.ex:638
+#, elixir-autogen, elixir-format
+msgid "You switched browser notifications on. This browser has not been asked for permission yet."
+msgstr ""
+
+#: lib/vutuv_web/components/ui.ex:4149
+#, elixir-autogen, elixir-format
+msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -15,8 +15,8 @@ msgstr "Language: en\n"
 msgid "About us"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3861
 #: lib/vutuv_web/components/ui.ex:3866
+#: lib/vutuv_web/components/ui.ex:3871
 #: lib/vutuv_web/live/admin/screenshot_live.ex:255
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:718
 #: lib/vutuv_web/live/organization_live/domains.ex:272
@@ -38,7 +38,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1461
+#: lib/vutuv_web/templates/user/show.html.heex:1464
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -62,7 +62,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:68
 #: lib/vutuv_web/agent_docs/text.ex:65
-#: lib/vutuv_web/components/ui.ex:4119
+#: lib/vutuv_web/components/ui.ex:4124
 #: lib/vutuv_web/controllers/address_controller.ex:23
 #: lib/vutuv_web/controllers/address_controller.ex:38
 #: lib/vutuv_web/controllers/address_controller.ex:85
@@ -80,8 +80,8 @@ msgstr ""
 msgid "Already a member? Sign in here."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3656
-#: lib/vutuv_web/components/ui.ex:3750
+#: lib/vutuv_web/components/ui.ex:3661
+#: lib/vutuv_web/components/ui.ex:3755
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:698
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:830
@@ -103,13 +103,13 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:603
 #: lib/vutuv_web/agent_docs/text.ex:568
 #: lib/vutuv_web/agent_docs/text.ex:569
-#: lib/vutuv_web/templates/user/show.html.heex:1093
+#: lib/vutuv_web/templates/user/show.html.heex:1096
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:110
-#: lib/vutuv_web/components/ui.ex:3650
+#: lib/vutuv_web/components/ui.ex:3655
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
@@ -150,7 +150,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1131
+#: lib/vutuv_web/templates/user/show.html.heex:1134
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -159,8 +159,8 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2872
-#: lib/vutuv_web/components/ui.ex:3753
+#: lib/vutuv_web/components/post_components.ex:2969
+#: lib/vutuv_web/components/ui.ex:3758
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
@@ -208,8 +208,8 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2837
-#: lib/vutuv_web/components/ui.ex:3744
+#: lib/vutuv_web/components/post_components.ex:2934
+#: lib/vutuv_web/components/ui.ex:3749
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
@@ -222,7 +222,7 @@ msgstr ""
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:1116
+#: lib/vutuv_web/templates/user/show.html.heex:1119
 #, elixir-autogen
 msgid "Edit"
 msgstr ""
@@ -283,11 +283,11 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:35
-#: lib/vutuv_web/components/ui.ex:4083
+#: lib/vutuv_web/components/ui.ex:4088
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:624
+#: lib/vutuv_web/templates/user/show.html.heex:627
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -313,7 +313,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:589
 #: lib/vutuv_web/controllers/follower_controller.ex:29
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
-#: lib/vutuv_web/live/notification_live/index.ex:968
+#: lib/vutuv_web/live/notification_live/index.ex:980
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:27
@@ -324,18 +324,18 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:624
 #: lib/vutuv_web/agent_docs/text.ex:590
 #: lib/vutuv_web/components/fediverse_components.ex:313
-#: lib/vutuv_web/components/ui.ex:2224
-#: lib/vutuv_web/components/ui.ex:2249
-#: lib/vutuv_web/components/ui.ex:2252
-#: lib/vutuv_web/components/ui.ex:2259
-#: lib/vutuv_web/components/ui.ex:2262
-#: lib/vutuv_web/components/ui.ex:2320
+#: lib/vutuv_web/components/ui.ex:2229
+#: lib/vutuv_web/components/ui.ex:2254
+#: lib/vutuv_web/components/ui.ex:2257
+#: lib/vutuv_web/components/ui.ex:2264
+#: lib/vutuv_web/components/ui.ex:2267
+#: lib/vutuv_web/components/ui.ex:2325
 #: lib/vutuv_web/controllers/followee_controller.ex:29
 #: lib/vutuv_web/live/import_connections_live.ex:469
 #: lib/vutuv_web/live/organization_live/show.ex:471
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:970
+#: lib/vutuv_web/templates/user/show.html.heex:973
 #, elixir-autogen
 msgid "Following"
 msgstr ""
@@ -441,8 +441,8 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:853
-#: lib/vutuv_web/live/shell_live.ex:909
+#: lib/vutuv_web/live/shell_live.ex:973
+#: lib/vutuv_web/live/shell_live.ex:1029
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -455,7 +455,7 @@ msgstr ""
 msgid "Middle Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:893
+#: lib/vutuv_web/live/notification_live/index.ex:905
 #, elixir-autogen
 msgid "More"
 msgstr ""
@@ -472,8 +472,8 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:539
-#: lib/vutuv_web/live/notification_live/index.ex:647
+#: lib/vutuv_web/components/post_components.ex:542
+#: lib/vutuv_web/live/notification_live/index.ex:659
 #: lib/vutuv_web/live/organization_live/activity.ex:127
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
@@ -612,7 +612,7 @@ msgstr ""
 msgid "Public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3649
+#: lib/vutuv_web/components/ui.ex:3654
 #: lib/vutuv_web/live/organization_live/edit.ex:345
 #: lib/vutuv_web/live/post_live/composer.ex:1867
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -629,7 +629,7 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:462
-#: lib/vutuv_web/views/settings_html.ex:280
+#: lib/vutuv_web/views/settings_html.ex:289
 #, elixir-autogen
 msgid "Save"
 msgstr ""
@@ -642,9 +642,9 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:48
 #: lib/vutuv_web/live/search_live.ex:569
-#: lib/vutuv_web/live/shell_live.ex:721
-#: lib/vutuv_web/live/shell_live.ex:892
-#: lib/vutuv_web/live/tag_live/timeline.ex:237
+#: lib/vutuv_web/live/shell_live.ex:841
+#: lib/vutuv_web/live/shell_live.ex:1012
+#: lib/vutuv_web/live/tag_live/timeline.ex:240
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:30
@@ -653,7 +653,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1475
+#: lib/vutuv_web/components/post_components.ex:1478
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -689,13 +689,13 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1245
+#: lib/vutuv_web/templates/user/show.html.heex:1248
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1247
+#: lib/vutuv_web/templates/user/show.html.heex:1250
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -791,12 +791,12 @@ msgstr ""
 msgid "User verified successfully."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4079
+#: lib/vutuv_web/components/ui.ex:4084
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:155
-#: lib/vutuv_web/live/notification_live/index.ex:1047
+#: lib/vutuv_web/live/notification_live/index.ex:1059
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -842,20 +842,20 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1070
+#: lib/vutuv_web/components/ui.ex:1071
 #: lib/vutuv_web/templates/user/show.html.heex:346
 #, elixir-autogen
 msgid "vCard"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3814
-#: lib/vutuv_web/templates/user/show.html.heex:964
-#: lib/vutuv_web/templates/user/show.html.heex:987
+#: lib/vutuv_web/components/ui.ex:3819
+#: lib/vutuv_web/templates/user/show.html.heex:967
+#: lib/vutuv_web/templates/user/show.html.heex:990
 #, elixir-autogen
 msgid "View All"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4173
+#: lib/vutuv_web/components/ui.ex:4181
 #: lib/vutuv_web/controllers/settings_controller.ex:169
 #: lib/vutuv_web/live/job_posting_live/form.ex:756
 #: lib/vutuv_web/live/organization_live/edit.ex:304
@@ -925,7 +925,7 @@ msgid "You follow back %{name}."
 msgstr ""
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:82
+#: lib/vutuv_web/live/post_live/feed.ex:86
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1040,7 +1040,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1082
+#: lib/vutuv_web/templates/user/show.html.heex:1085
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1163,7 +1163,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:825
+#: lib/vutuv_web/live/shell_live.ex:945
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1206,7 +1206,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:618
+#: lib/vutuv_web/templates/user/show.html.heex:621
 #, elixir-autogen
 msgid "All tags"
 msgstr ""
@@ -1375,7 +1375,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:516
 #: lib/vutuv_web/agent_docs/text.ex:753
-#: lib/vutuv_web/components/ui.ex:4104
+#: lib/vutuv_web/components/ui.ex:4109
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
 #: lib/vutuv_web/cv/docx.ex:174
@@ -1401,7 +1401,7 @@ msgstr ""
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:23
 #: lib/vutuv_web/templates/tag/show.html.heex:25
-#: lib/vutuv_web/templates/user/show.html.heex:588
+#: lib/vutuv_web/templates/user/show.html.heex:591
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
@@ -1596,7 +1596,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:895
+#: lib/vutuv_web/live/shell_live.ex:1015
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1615,8 +1615,8 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:315
-#: lib/vutuv_web/components/ui.ex:2560
+#: lib/vutuv_web/components/ui.ex:316
+#: lib/vutuv_web/components/ui.ex:2565
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
@@ -1670,24 +1670,24 @@ msgstr ""
 msgid "Edit profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1578
-#: lib/vutuv_web/components/ui.ex:1587
-#: lib/vutuv_web/components/ui.ex:2051
+#: lib/vutuv_web/components/ui.ex:1583
+#: lib/vutuv_web/components/ui.ex:1592
+#: lib/vutuv_web/components/ui.ex:2056
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:199
-#: lib/vutuv_web/components/ui.ex:2189
-#: lib/vutuv_web/components/ui.ex:2189
-#: lib/vutuv_web/components/ui.ex:2206
-#: lib/vutuv_web/components/ui.ex:2215
-#: lib/vutuv_web/components/ui.ex:2231
-#: lib/vutuv_web/components/ui.ex:2268
-#: lib/vutuv_web/components/ui.ex:2271
-#: lib/vutuv_web/components/ui.ex:2278
-#: lib/vutuv_web/components/ui.ex:2281
-#: lib/vutuv_web/components/ui.ex:2354
+#: lib/vutuv_web/components/ui.ex:2194
+#: lib/vutuv_web/components/ui.ex:2194
+#: lib/vutuv_web/components/ui.ex:2211
+#: lib/vutuv_web/components/ui.ex:2220
+#: lib/vutuv_web/components/ui.ex:2236
+#: lib/vutuv_web/components/ui.ex:2273
+#: lib/vutuv_web/components/ui.ex:2276
+#: lib/vutuv_web/components/ui.ex:2283
+#: lib/vutuv_web/components/ui.ex:2286
+#: lib/vutuv_web/components/ui.ex:2359
 #: lib/vutuv_web/live/fediverse_account_live.ex:387
 #: lib/vutuv_web/live/fediverse_following_live.ex:331
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:317
@@ -1695,7 +1695,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:407
 #: lib/vutuv_web/live/organization_live/show.ex:440
 #: lib/vutuv_web/live/organization_live/show.ex:469
-#: lib/vutuv_web/templates/user/show.html.heex:1285
+#: lib/vutuv_web/templates/user/show.html.heex:1288
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr ""
@@ -1710,8 +1710,8 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:844
-#: lib/vutuv_web/views/settings_html.ex:367
+#: lib/vutuv_web/live/shell_live.ex:964
+#: lib/vutuv_web/views/settings_html.ex:376
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr ""
@@ -1722,7 +1722,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
 #: lib/vutuv_web/live/admin/user_delete_live.ex:143
 #: lib/vutuv_web/live/admin/user_live.ex:154
-#: lib/vutuv_web/live/message_live/index.ex:533
+#: lib/vutuv_web/live/message_live/index.ex:538
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:32
 #: lib/vutuv_web/templates/admin/account/index.html.heex:55
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:28
@@ -1738,22 +1738,22 @@ msgid "Message"
 msgstr ""
 
 #: lib/vutuv_web/live/message_live/index.ex:49
-#: lib/vutuv_web/live/message_live/index.ex:629
-#: lib/vutuv_web/live/shell_live.ex:737
-#: lib/vutuv_web/live/shell_live.ex:894
+#: lib/vutuv_web/live/message_live/index.ex:634
+#: lib/vutuv_web/live/shell_live.ex:857
+#: lib/vutuv_web/live/shell_live.ex:1014
 #: lib/vutuv_web/templates/layout/app.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:629
+#: lib/vutuv_web/live/shell_live.ex:749
 #: lib/vutuv_web/templates/layout/app.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:436
-#: lib/vutuv_web/components/ui.ex:3863
+#: lib/vutuv_web/components/post_components.ex:439
+#: lib/vutuv_web/components/ui.ex:3868
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:705
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:742
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:793
@@ -1763,16 +1763,16 @@ msgstr ""
 msgid "Nothing here yet."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:377
+#: lib/vutuv_web/live/notification_live/index.ex:389
 #, elixir-autogen, elixir-format
 msgid "Nothing new yet."
 msgstr ""
 
 #: lib/vutuv/api_auth/scopes.ex:85
-#: lib/vutuv_web/components/ui.ex:4141
-#: lib/vutuv_web/live/notification_live/index.ex:114
-#: lib/vutuv_web/live/notification_live/index.ex:338
-#: lib/vutuv_web/live/shell_live.ex:748
+#: lib/vutuv_web/components/ui.ex:4146
+#: lib/vutuv_web/live/notification_live/index.ex:126
+#: lib/vutuv_web/live/notification_live/index.ex:350
+#: lib/vutuv_web/live/shell_live.ex:868
 #: lib/vutuv_web/templates/layout/app.html.heex:173
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -1794,7 +1794,7 @@ msgid "Pardon us! Something went wrong."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:130
-#: lib/vutuv_web/live/message_live/index.ex:884
+#: lib/vutuv_web/live/message_live/index.ex:889
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Send"
@@ -1863,14 +1863,14 @@ msgstr ""
 msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1455
+#: lib/vutuv_web/live/post_live/feed.ex:1471
 #: lib/vutuv_web/views/user_html.ex:213
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:873
-#: lib/vutuv_web/live/message_live/index.ex:874
+#: lib/vutuv_web/live/message_live/index.ex:878
+#: lib/vutuv_web/live/message_live/index.ex:879
 #, elixir-autogen, elixir-format
 msgid "Write a message…"
 msgstr ""
@@ -1900,30 +1900,30 @@ msgstr ""
 msgid "submit a bug report"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1069
+#: lib/vutuv_web/notification_line.ex:79
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1064
+#: lib/vutuv_web/notification_line.ex:74
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1059
+#: lib/vutuv_web/notification_line.ex:72
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3203
-#: lib/vutuv_web/components/ui.ex:3354
+#: lib/vutuv_web/components/ui.ex:3208
+#: lib/vutuv_web/components/ui.ex:3359
 #: lib/vutuv_web/live/import_connections_live.ex:638
 #: lib/vutuv_web/live/organization_live/index.ex:122
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3888
+#: lib/vutuv_web/components/ui.ex:3893
 #: lib/vutuv_web/live/organization_live/activity.ex:150
 #: lib/vutuv_web/live/organization_live/feed.ex:142
 #: lib/vutuv_web/live/organization_live/show.ex:637
@@ -1936,13 +1936,13 @@ msgstr ""
 msgid "The address itself cannot be changed. To use a different one, add it as a new email address and delete this one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3659
+#: lib/vutuv_web/components/ui.ex:3664
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1281
-#: lib/vutuv_web/components/ui.ex:1291
+#: lib/vutuv_web/components/ui.ex:1282
+#: lib/vutuv_web/components/ui.ex:1292
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr ""
@@ -1981,12 +1981,12 @@ msgstr ""
 msgid "Add cover photo"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2864
+#: lib/vutuv_web/components/ui.ex:2869
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2868
+#: lib/vutuv_web/components/ui.ex:2873
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr ""
@@ -2011,37 +2011,37 @@ msgstr ""
 msgid "Cover photo of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2872
+#: lib/vutuv_web/components/ui.ex:2877
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2862
+#: lib/vutuv_web/components/ui.ex:2867
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2861
+#: lib/vutuv_web/components/ui.ex:2866
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2867
+#: lib/vutuv_web/components/ui.ex:2872
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2866
+#: lib/vutuv_web/components/ui.ex:2871
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2863
+#: lib/vutuv_web/components/ui.ex:2868
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2865
+#: lib/vutuv_web/components/ui.ex:2870
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr ""
@@ -2056,17 +2056,17 @@ msgstr ""
 msgid "Member since %{year}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2871
+#: lib/vutuv_web/components/ui.ex:2876
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2870
+#: lib/vutuv_web/components/ui.ex:2875
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2869
+#: lib/vutuv_web/components/ui.ex:2874
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr ""
@@ -2104,7 +2104,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2869
+#: lib/vutuv_web/components/post_components.ex:2966
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2119,10 +2119,10 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:274
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:98
-#: lib/vutuv_web/live/post_live/feed.ex:187
-#: lib/vutuv_web/live/post_live/feed.ex:1187
-#: lib/vutuv_web/live/shell_live.ex:609
-#: lib/vutuv_web/live/shell_live.ex:890
+#: lib/vutuv_web/live/post_live/feed.ex:191
+#: lib/vutuv_web/live/post_live/feed.ex:1203
+#: lib/vutuv_web/live/shell_live.ex:729
+#: lib/vutuv_web/live/shell_live.ex:1010
 #: lib/vutuv_web/templates/layout/app.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2148,8 +2148,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2823
-#: lib/vutuv_web/components/post_components.ex:2825
+#: lib/vutuv_web/components/post_components.ex:2920
+#: lib/vutuv_web/components/post_components.ex:2922
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2165,7 +2165,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1394
+#: lib/vutuv_web/live/post_live/feed.ex:1410
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2204,7 +2204,7 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:91
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
-#: lib/vutuv_web/live/notification_live/index.ex:891
+#: lib/vutuv_web/live/notification_live/index.ex:903
 #: lib/vutuv_web/live/organization_live/show.ex:564
 #: lib/vutuv_web/live/post_live/saved.ex:520
 #: lib/vutuv_web/live/search_live.ex:281
@@ -2215,13 +2215,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3293
-#: lib/vutuv_web/components/post_components.ex:3297
+#: lib/vutuv_web/components/post_components.ex:3390
+#: lib/vutuv_web/components/post_components.ex:3394
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3294
+#: lib/vutuv_web/components/post_components.ex:3391
 #: lib/vutuv_web/live/fediverse_account_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2229,7 +2229,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:342
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:1097
+#: lib/vutuv_web/components/post_components.ex:1100
 #: lib/vutuv_web/live/admin/screenshot_live.ex:327
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:700
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
@@ -2240,7 +2240,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:650
 #: lib/vutuv_web/live/post_live/saved.ex:678
 #: lib/vutuv_web/templates/connection/index.html.heex:40
-#: lib/vutuv_web/views/settings_html.ex:413
+#: lib/vutuv_web/views/settings_html.ex:422
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
@@ -2255,7 +2255,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1298
+#: lib/vutuv_web/live/post_live/feed.ex:1314
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2292,11 +2292,11 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4427
-#: lib/vutuv_web/live/shell_live.ex:791
+#: lib/vutuv_web/components/ui.ex:4435
+#: lib/vutuv_web/live/shell_live.ex:911
 #: lib/vutuv_web/templates/post/index.html.heex:17
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
-#: lib/vutuv_web/views/settings_html.ex:314
+#: lib/vutuv_web/views/settings_html.ex:323
 #, elixir-autogen, elixir-format
 msgid "View profile"
 msgstr ""
@@ -2311,33 +2311,33 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2820
+#: lib/vutuv_web/components/post_components.ex:2917
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4613
+#: lib/vutuv_web/components/post_components.ex:4710
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4617
+#: lib/vutuv_web/components/post_components.ex:4714
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4615
+#: lib/vutuv_web/components/post_components.ex:4712
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4616
+#: lib/vutuv_web/components/post_components.ex:4713
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
 
 #: lib/vutuv_web/views/post_html.ex:19
-#: lib/vutuv_web/views/settings_html.ex:492
+#: lib/vutuv_web/views/settings_html.ex:501
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr ""
@@ -2362,7 +2362,7 @@ msgstr ""
 msgid "Posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:578
+#: lib/vutuv_web/templates/user/show.html.heex:581
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr ""
@@ -2372,9 +2372,9 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1664
-#: lib/vutuv_web/components/post_components.ex:4701
-#: lib/vutuv_web/components/ui.ex:3278
+#: lib/vutuv_web/components/post_components.ex:1693
+#: lib/vutuv_web/components/post_components.ex:4806
+#: lib/vutuv_web/components/ui.ex:3283
 #: lib/vutuv_web/views/user_html.ex:440
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2383,29 +2383,29 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1108
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
-#: lib/vutuv_web/live/shell_live.ex:730
-#: lib/vutuv_web/live/shell_live.ex:796
+#: lib/vutuv_web/live/shell_live.ex:850
+#: lib/vutuv_web/live/shell_live.ex:916
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1628
-#: lib/vutuv_web/components/post_components.ex:4935
-#: lib/vutuv_web/components/ui.ex:3264
-#: lib/vutuv_web/live/notification_live/index.ex:1037
+#: lib/vutuv_web/components/post_components.ex:1646
+#: lib/vutuv_web/components/post_components.ex:5042
+#: lib/vutuv_web/components/ui.ex:3269
+#: lib/vutuv_web/live/notification_live/index.ex:1049
 #: lib/vutuv_web/views/user_html.ex:450
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1107
-#: lib/vutuv_web/components/post_components.ex:4944
-#: lib/vutuv_web/live/notification_live/index.ex:970
+#: lib/vutuv_web/components/post_components.ex:5052
+#: lib/vutuv_web/live/notification_live/index.ex:982
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
-#: lib/vutuv_web/live/shell_live.ex:799
+#: lib/vutuv_web/live/shell_live.ex:919
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2423,39 +2423,40 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4690
+#: lib/vutuv_web/components/post_components.ex:4794
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1664
-#: lib/vutuv_web/components/post_components.ex:4701
+#: lib/vutuv_web/components/post_components.ex:1692
+#: lib/vutuv_web/components/post_components.ex:4805
 #: lib/vutuv_web/live/post_live/saved.ex:806
 #: lib/vutuv_web/views/user_html.ex:440
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1652
-#: lib/vutuv_web/components/post_components.ex:4687
+#: lib/vutuv_web/components/post_components.ex:1674
+#: lib/vutuv_web/components/post_components.ex:4791
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1842
-#: lib/vutuv_web/components/post_components.ex:3875
+#: lib/vutuv_web/components/post_components.ex:1939
+#: lib/vutuv_web/components/post_components.ex:3972
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1652
-#: lib/vutuv_web/components/post_components.ex:4687
+#: lib/vutuv_web/components/post_components.ex:1673
+#: lib/vutuv_web/components/post_components.ex:4790
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4935
+#: lib/vutuv_web/components/post_components.ex:1645
+#: lib/vutuv_web/components/post_components.ex:5041
 #: lib/vutuv_web/live/post_live/saved.ex:805
 #: lib/vutuv_web/views/user_html.ex:450
 #, elixir-autogen, elixir-format
@@ -2463,14 +2464,14 @@ msgid "Unlike"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:343
-#: lib/vutuv_web/components/post_components.ex:2127
-#: lib/vutuv_web/components/ui.ex:2184
-#: lib/vutuv_web/components/ui.ex:2184
-#: lib/vutuv_web/components/ui.ex:2321
+#: lib/vutuv_web/components/post_components.ex:2224
+#: lib/vutuv_web/components/ui.ex:2189
+#: lib/vutuv_web/components/ui.ex:2189
+#: lib/vutuv_web/components/ui.ex:2326
 #: lib/vutuv_web/live/organization_live/following.ex:378
 #: lib/vutuv_web/live/organization_live/following.ex:453
 #: lib/vutuv_web/live/organization_live/show.ex:474
-#: lib/vutuv_web/live/post_live/feed.ex:1444
+#: lib/vutuv_web/live/post_live/feed.ex:1460
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2482,27 +2483,27 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4988
+#: lib/vutuv_web/components/post_components.ex:5096
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:394
-#: lib/vutuv_web/live/notification_live/index.ex:971
+#: lib/vutuv_web/components/post_components.ex:397
+#: lib/vutuv_web/live/notification_live/index.ex:983
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1639
-#: lib/vutuv_web/components/post_components.ex:4971
-#: lib/vutuv_web/components/post_components.ex:4972
-#: lib/vutuv_web/live/notification_live/index.ex:1034
+#: lib/vutuv_web/components/post_components.ex:1659
+#: lib/vutuv_web/components/post_components.ex:5079
+#: lib/vutuv_web/components/post_components.ex:5080
+#: lib/vutuv_web/live/notification_live/index.ex:1046
 #: lib/vutuv_web/live/post_live/reply.ex:43
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2787
+#: lib/vutuv_web/components/post_components.ex:2884
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2518,12 +2519,12 @@ msgstr ""
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1257
+#: lib/vutuv_web/notification_line.ex:61
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2323
+#: lib/vutuv_web/components/post_components.ex:2420
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:60
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:57
@@ -2531,59 +2532,59 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2761
+#: lib/vutuv_web/components/post_components.ex:2858
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2752
-#: lib/vutuv_web/components/post_components.ex:2779
-#: lib/vutuv_web/components/post_components.ex:2782
+#: lib/vutuv_web/components/post_components.ex:2849
+#: lib/vutuv_web/components/post_components.ex:2876
+#: lib/vutuv_web/components/post_components.ex:2879
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:608
+#: lib/vutuv_web/live/message_live/index.ex:613
 #, elixir-autogen, elixir-format
 msgid "%{names} are typing…"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:607
+#: lib/vutuv_web/live/message_live/index.ex:612
 #, elixir-autogen, elixir-format
 msgid "%{name} is typing…"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:896
+#: lib/vutuv_web/live/message_live/index.ex:901
 #, elixir-autogen, elixir-format
 msgid "@%{slug} has not accepted your message request yet."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:848
+#: lib/vutuv_web/live/message_live/index.ex:853
 #, elixir-autogen, elixir-format
 msgid "@%{slug} wants to message you."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:591
+#: lib/vutuv_web/live/message_live/index.ex:596
 #, elixir-autogen, elixir-format
 msgid "Accept"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:711
+#: lib/vutuv_web/live/message_live/index.ex:716
 #, elixir-autogen, elixir-format
 msgid "Back to conversations"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:598
+#: lib/vutuv_web/live/message_live/index.ex:603
 #, elixir-autogen, elixir-format
 msgid "Decline"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:529
+#: lib/vutuv_web/live/message_live/index.ex:534
 #, elixir-autogen, elixir-format
 msgid "Deleted account"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:757
+#: lib/vutuv_web/live/message_live/index.ex:762
 #, elixir-autogen, elixir-format
 msgid "Load older messages"
 msgstr ""
@@ -2594,23 +2595,23 @@ msgstr ""
 msgid "Member not found."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:690
+#: lib/vutuv_web/live/message_live/index.ex:695
 #, elixir-autogen, elixir-format
 msgid "No conversations yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2684
-#: lib/vutuv_web/live/message_live/index.ex:733
+#: lib/vutuv_web/components/ui.ex:2689
+#: lib/vutuv_web/live/message_live/index.ex:738
 #, elixir-autogen, elixir-format
 msgid "Online"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:639
+#: lib/vutuv_web/live/message_live/index.ex:644
 #, elixir-autogen, elixir-format
 msgid "Requests"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:905
+#: lib/vutuv_web/live/message_live/index.ex:910
 #, elixir-autogen, elixir-format
 msgid "Select a conversation."
 msgstr ""
@@ -2620,7 +2621,7 @@ msgstr ""
 msgid "This member cannot receive messages."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:234
+#: lib/vutuv_web/live/message_live/index.ex:239
 #, elixir-autogen, elixir-format
 msgid "This message could not be sent."
 msgstr ""
@@ -2686,7 +2687,7 @@ msgstr ""
 msgid "Okay, let's start over."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:731
+#: lib/vutuv_web/components/ui.ex:732
 #, elixir-autogen, elixir-format
 msgid "Resend PIN"
 msgstr ""
@@ -2697,71 +2698,71 @@ msgstr ""
 msgid "Too many PIN requests. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:752
+#: lib/vutuv_web/components/ui.ex:753
 #, elixir-autogen, elixir-format
 msgid "Use a different email address"
 msgstr ""
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
 #: lib/vutuv_web/templates/url/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:900
+#: lib/vutuv_web/templates/user/show.html.heex:903
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1205
+#: lib/vutuv_web/templates/user/show.html.heex:1208
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1463
+#: lib/vutuv_web/templates/user/show.html.heex:1466
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1133
+#: lib/vutuv_web/templates/user/show.html.heex:1136
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1084
+#: lib/vutuv_web/templates/user/show.html.heex:1087
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:627
+#: lib/vutuv_web/templates/user/show.html.heex:630
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #: lib/vutuv_web/templates/work_experience/new.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Add work experience"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:488
+#: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3442
-#: lib/vutuv_web/components/ui.ex:3816
+#: lib/vutuv_web/components/ui.ex:3447
+#: lib/vutuv_web/components/ui.ex:3821
 #: lib/vutuv_web/templates/settings/apps.html.heex:22
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #: lib/vutuv_web/templates/settings/organizations.html.heex:104
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:216
-#: lib/vutuv_web/templates/user/show.html.heex:618
+#: lib/vutuv_web/templates/user/show.html.heex:621
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1225
-#: lib/vutuv_web/templates/user/show.html.heex:488
+#: lib/vutuv_web/live/post_live/feed.ex:1241
+#: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write a post"
 msgstr ""
@@ -2791,13 +2792,13 @@ msgstr[1] ""
 #: lib/vutuv_web/agent_docs/markdown.ex:625
 #: lib/vutuv_web/agent_docs/text.ex:591
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:969
+#: lib/vutuv_web/live/notification_live/index.ex:981
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1061
+#: lib/vutuv_web/components/ui.ex:1062
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr ""
@@ -2807,7 +2808,7 @@ msgstr ""
 msgid "No connections yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1077
+#: lib/vutuv_web/components/ui.ex:1078
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr ""
@@ -2817,7 +2818,7 @@ msgstr ""
 msgid "People who aren't my connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1062
+#: lib/vutuv_web/components/ui.ex:1063
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr ""
@@ -2835,35 +2836,35 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4614
+#: lib/vutuv_web/components/post_components.ex:4711
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:691
+#: lib/vutuv_web/live/message_live/index.ex:696
 #, elixir-autogen, elixir-format
 msgid "Open someone's profile to message them."
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:268
-#: lib/vutuv_web/live/notification_live/index.ex:1049
+#: lib/vutuv_web/live/notification_live/index.ex:1061
 #: lib/vutuv_web/live/organization_live/activity.ex:103
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1040
+#: lib/vutuv_web/live/notification_live/index.ex:1052
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1033
+#: lib/vutuv_web/live/notification_live/index.ex:1045
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1032
-#: lib/vutuv_web/templates/user/show.html.heex:948
+#: lib/vutuv_web/live/notification_live/index.ex:1044
+#: lib/vutuv_web/templates/user/show.html.heex:951
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -2875,7 +2876,7 @@ msgstr[1] ""
 msgid "Welcome to vutuv, %{name}!"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1066
+#: lib/vutuv_web/notification_line.ex:70
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr ""
@@ -2907,12 +2908,12 @@ msgstr ""
 msgid "(no text)"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1293
+#: lib/vutuv_web/notification_line.ex:115
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1294
+#: lib/vutuv_web/notification_line.ex:116
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr ""
@@ -3006,7 +3007,7 @@ msgstr ""
 msgid "Hidden. You can settle this yourself - see below."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:786
+#: lib/vutuv_web/live/message_live/index.ex:791
 #, elixir-autogen, elixir-format
 msgid "Hidden: reported, under review"
 msgstr ""
@@ -3018,7 +3019,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:1041
+#: lib/vutuv_web/live/notification_live/index.ex:1053
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3092,13 +3093,13 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1173
-#: lib/vutuv_web/templates/user/show.html.heex:1174
+#: lib/vutuv_web/templates/user/show.html.heex:1176
+#: lib/vutuv_web/templates/user/show.html.heex:1177
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2728
+#: lib/vutuv_web/components/post_components.ex:2825
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3147,9 +3148,9 @@ msgstr ""
 msgid "Private message"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4073
-#: lib/vutuv_web/live/shell_live.ex:622
-#: lib/vutuv_web/live/shell_live.ex:899
+#: lib/vutuv_web/components/ui.ex:4078
+#: lib/vutuv_web/live/shell_live.ex:742
+#: lib/vutuv_web/live/shell_live.ex:1019
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -3173,9 +3174,9 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1107
-#: lib/vutuv_web/components/post_components.ex:2139
-#: lib/vutuv_web/components/post_components.ex:2892
+#: lib/vutuv_web/components/post_components.ex:1110
+#: lib/vutuv_web/components/post_components.ex:2236
+#: lib/vutuv_web/components/post_components.ex:2989
 #: lib/vutuv_web/live/organization_live/show.ex:547
 #: lib/vutuv_web/templates/user/show.html.heex:222
 #, elixir-autogen, elixir-format
@@ -3203,8 +3204,8 @@ msgstr ""
 msgid "Report this content"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:804
-#: lib/vutuv_web/live/message_live/index.ex:805
+#: lib/vutuv_web/live/message_live/index.ex:809
+#: lib/vutuv_web/live/message_live/index.ex:810
 #, elixir-autogen, elixir-format
 msgid "Report this message"
 msgstr ""
@@ -3258,7 +3259,7 @@ msgstr ""
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3178
+#: lib/vutuv_web/components/ui.ex:3183
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:773
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -3442,12 +3443,12 @@ msgstr ""
 msgid "You cannot report your own content."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1296
+#: lib/vutuv_web/notification_line.ex:118
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1295
+#: lib/vutuv_web/notification_line.ex:117
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr ""
@@ -3457,7 +3458,7 @@ msgstr ""
 msgid "Your content was reported"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1297
+#: lib/vutuv_web/notification_line.ex:119
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3641,7 +3642,7 @@ msgstr ""
 msgid "Open the profile"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1321
+#: lib/vutuv_web/notification_line.ex:143
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3666,7 +3667,7 @@ msgstr ""
 msgid "Report filed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1043
+#: lib/vutuv_web/live/notification_live/index.ex:1055
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr ""
@@ -3741,7 +3742,7 @@ msgstr ""
 msgid "Waiting for the owner"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1326
+#: lib/vutuv_web/notification_line.ex:148
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -4499,7 +4500,7 @@ msgstr ""
 msgid "Block @%{slug}? This removes any follows and connection between you, closes your conversation, and prevents all interaction in both directions. Unblocking will not restore what was removed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4177
+#: lib/vutuv_web/components/ui.ex:4185
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -4541,12 +4542,12 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1399
+#: lib/vutuv_web/live/post_live/feed.ex:1415
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:694
+#: lib/vutuv_web/live/message_live/index.ex:699
 #, elixir-autogen, elixir-format
 msgid "Find members"
 msgstr ""
@@ -4555,7 +4556,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:299
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:40
-#: lib/vutuv_web/templates/user/show.html.heex:970
+#: lib/vutuv_web/templates/user/show.html.heex:973
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -4598,8 +4599,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:436
 #: lib/vutuv_web/agent_docs/text.ex:457
 #: lib/vutuv_web/components/saved_search_components.ex:57
-#: lib/vutuv_web/components/ui.ex:551
-#: lib/vutuv_web/live/notification_live/index.ex:892
+#: lib/vutuv_web/components/ui.ex:552
+#: lib/vutuv_web/live/notification_live/index.ex:904
 #: lib/vutuv_web/live/organization_live/show.ex:647
 #: lib/vutuv_web/live/post_live/saved.ex:523
 #: lib/vutuv_web/live/search_live.ex:279
@@ -4618,12 +4619,12 @@ msgstr ""
 msgid "Similar names"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:391
-#: lib/vutuv_web/components/post_components.ex:410
+#: lib/vutuv_web/components/post_components.ex:394
+#: lib/vutuv_web/components/post_components.ex:413
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
-#: lib/vutuv_web/live/notification_live/index.ex:890
+#: lib/vutuv_web/live/notification_live/index.ex:902
 #: lib/vutuv_web/live/search_live.ex:278
 #: lib/vutuv_web/views/qualification_html.ex:103
 #, elixir-autogen, elixir-format
@@ -4673,7 +4674,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:388
 #: lib/vutuv_web/live/tag_new_live.ex:48
 #: lib/vutuv_web/live/user_profile_live.ex:1331
-#: lib/vutuv_web/templates/user/show.html.heex:591
+#: lib/vutuv_web/templates/user/show.html.heex:594
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr ""
@@ -4913,7 +4914,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/api_app_live.ex:98
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:181
 #: lib/vutuv_web/views/settings_html.ex:77
-#: lib/vutuv_web/views/settings_html.ex:358
+#: lib/vutuv_web/views/settings_html.ex:367
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
@@ -5271,7 +5272,7 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4237
+#: lib/vutuv_web/components/ui.ex:4245
 #: lib/vutuv_web/controllers/settings_controller.ex:155
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5317,7 +5318,7 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:778
+#: lib/vutuv_web/live/shell_live.ex:898
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
@@ -5339,7 +5340,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:835
+#: lib/vutuv_web/live/shell_live.ex:955
 #: lib/vutuv_web/templates/layout/app.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5350,15 +5351,15 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4334
-#: lib/vutuv_web/components/ui.ex:4339
-#: lib/vutuv_web/components/ui.ex:4418
-#: lib/vutuv_web/components/ui.ex:4482
+#: lib/vutuv_web/components/ui.ex:4342
+#: lib/vutuv_web/components/ui.ex:4347
+#: lib/vutuv_web/components/ui.ex:4426
+#: lib/vutuv_web/components/ui.ex:4490
 #: lib/vutuv_web/controllers/settings_controller.ex:62
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:303
-#: lib/vutuv_web/live/shell_live.ex:815
+#: lib/vutuv_web/live/shell_live.ex:935
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5366,7 +5367,7 @@ msgstr ""
 #: lib/vutuv_web/templates/login_code/index.html.heex:4
 #: lib/vutuv_web/templates/totp/new.html.heex:4
 #: lib/vutuv_web/templates/username/confirm.html.heex:23
-#: lib/vutuv_web/views/settings_html.ex:309
+#: lib/vutuv_web/views/settings_html.ex:318
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -5412,8 +5413,8 @@ msgstr ""
 msgid "Previous post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:602
-#: lib/vutuv_web/live/shell_live.ex:881
+#: lib/vutuv_web/live/shell_live.ex:722
+#: lib/vutuv_web/live/shell_live.ex:1001
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -5423,11 +5424,11 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2957
-#: lib/vutuv_web/components/post_components.ex:3011
-#: lib/vutuv_web/components/post_components.ex:3430
-#: lib/vutuv_web/live/notification_live/index.ex:691
-#: lib/vutuv_web/live/post_live/feed.ex:1517
+#: lib/vutuv_web/components/post_components.ex:3054
+#: lib/vutuv_web/components/post_components.ex:3108
+#: lib/vutuv_web/components/post_components.ex:3527
+#: lib/vutuv_web/live/notification_live/index.ex:703
+#: lib/vutuv_web/live/post_live/feed.ex:1533
 #: lib/vutuv_web/views/user_html.ex:113
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5472,7 +5473,7 @@ msgstr ""
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4197
+#: lib/vutuv_web/components/ui.ex:4205
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:289
@@ -5493,7 +5494,7 @@ msgstr ""
 msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4111
+#: lib/vutuv_web/components/ui.ex:4116
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5527,7 +5528,7 @@ msgstr ""
 msgid "Photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4171
+#: lib/vutuv_web/components/ui.ex:4179
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/templates/page/index.html.heex:174
 #, elixir-autogen, elixir-format
@@ -5554,7 +5555,7 @@ msgstr ""
 msgid "Your name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:520
+#: lib/vutuv_web/live/notification_live/index.ex:532
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr ""
@@ -5640,14 +5641,14 @@ msgstr ""
 msgid "Apps"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4230
+#: lib/vutuv_web/components/ui.ex:4238
 #: lib/vutuv_web/controllers/settings_controller.ex:179
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:127
-#: lib/vutuv_web/live/notification_live/index.ex:972
+#: lib/vutuv_web/live/notification_live/index.ex:984
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:17
@@ -5655,12 +5656,12 @@ msgstr ""
 msgid "Endorsements"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:134
+#: lib/vutuv_web/templates/settings/notifications.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "Endorsements and new followers"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:128
+#: lib/vutuv_web/templates/settings/notifications.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "In-app notifications"
 msgstr ""
@@ -5675,12 +5676,12 @@ msgstr ""
 msgid "Notification settings"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:142
+#: lib/vutuv_web/templates/settings/notifications.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "Open your notifications"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:135
+#: lib/vutuv_web/templates/settings/notifications.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Replies to and likes on your posts"
 msgstr ""
@@ -5695,7 +5696,7 @@ msgstr ""
 msgid "Search engines & AI"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:130
+#: lib/vutuv_web/templates/settings/notifications.html.heex:187
 #, elixir-autogen, elixir-format
 msgid "These are always on. You see them under the bell at the top of every page, in real time."
 msgstr ""
@@ -5725,7 +5726,7 @@ msgstr ""
 msgid "@handle"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:749
+#: lib/vutuv_web/live/message_live/index.ex:754
 #, elixir-autogen, elixir-format
 msgid "Block @%{slug}"
 msgstr ""
@@ -5791,7 +5792,7 @@ msgid "Name (A-Z)"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:491
-#: lib/vutuv_web/live/tag_live/timeline.ex:325
+#: lib/vutuv_web/live/tag_live/timeline.ex:328
 #, elixir-autogen, elixir-format
 msgid "Newest first"
 msgstr ""
@@ -5817,7 +5818,7 @@ msgid "Nothing here yet. People you like show up here."
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:492
-#: lib/vutuv_web/live/tag_live/timeline.ex:326
+#: lib/vutuv_web/live/tag_live/timeline.ex:329
 #, elixir-autogen, elixir-format
 msgid "Oldest first"
 msgstr ""
@@ -5839,34 +5840,34 @@ msgid "Search saved items"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:554
-#: lib/vutuv_web/live/tag_live/timeline.ex:253
+#: lib/vutuv_web/live/tag_live/timeline.ex:256
 #, elixir-autogen, elixir-format
 msgid "Sort"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/views/settings_html.ex:501
+#: lib/vutuv_web/views/settings_html.ex:510
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:500
+#: lib/vutuv_web/views/settings_html.ex:509
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:499
+#: lib/vutuv_web/views/settings_html.ex:508
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:900
+#: lib/vutuv_web/controllers/settings_controller.ex:912
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr ""
@@ -5876,7 +5877,7 @@ msgstr ""
 msgid "Another session was already active on your account."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:347
+#: lib/vutuv_web/views/settings_html.ex:356
 #, elixir-autogen, elixir-format
 msgid "Last active"
 msgstr ""
@@ -5891,7 +5892,7 @@ msgstr ""
 msgid "Log out of every device except this one?"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:364
+#: lib/vutuv_web/views/settings_html.ex:373
 #, elixir-autogen, elixir-format
 msgid "Log this device out of your account?"
 msgstr ""
@@ -5906,7 +5907,7 @@ msgstr ""
 msgid "Signed-in devices"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:887
+#: lib/vutuv_web/controllers/settings_controller.ex:899
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr ""
@@ -5916,7 +5917,7 @@ msgstr ""
 msgid "The location looks different from where you usually sign in."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:348
+#: lib/vutuv_web/views/settings_html.ex:357
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr ""
@@ -5926,7 +5927,7 @@ msgstr ""
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:498
+#: lib/vutuv_web/views/settings_html.ex:507
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr ""
@@ -5960,7 +5961,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
 #: lib/vutuv_web/live/admin/screenshot_live.ex:309
 #: lib/vutuv_web/live/fediverse_following_live.ex:291
-#: lib/vutuv_web/views/settings_html.ex:399
+#: lib/vutuv_web/views/settings_html.ex:408
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr ""
@@ -5970,7 +5971,7 @@ msgstr ""
 msgid "Could not add the passkey. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:402
+#: lib/vutuv_web/views/settings_html.ex:411
 #, elixir-autogen, elixir-format
 msgid "Last used"
 msgstr ""
@@ -5980,7 +5981,7 @@ msgstr ""
 msgid "Name (optional)"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:396
+#: lib/vutuv_web/views/settings_html.ex:405
 #, elixir-autogen, elixir-format
 msgid "Passkey"
 msgstr ""
@@ -6000,7 +6001,7 @@ msgstr ""
 msgid "Passkeys"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:410
+#: lib/vutuv_web/views/settings_html.ex:419
 #, elixir-autogen, elixir-format
 msgid "Remove this passkey?"
 msgstr ""
@@ -6068,17 +6069,17 @@ msgstr ""
 msgid "Tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:331
+#: lib/vutuv_web/components/ui.ex:332
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:898
+#: lib/vutuv_web/templates/user/show.html.heex:901
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:462
+#: lib/vutuv_web/templates/user/show.html.heex:465
 #, elixir-autogen, elixir-format
 msgctxt "profile"
 msgid "Post"
@@ -6092,7 +6093,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1514
+#: lib/vutuv_web/templates/user/show.html.heex:1517
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6136,8 +6137,8 @@ msgstr ""
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1099
-#: lib/vutuv_web/templates/user/show.html.heex:1109
+#: lib/vutuv_web/templates/user/show.html.heex:1102
+#: lib/vutuv_web/templates/user/show.html.heex:1112
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6177,12 +6178,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1221
+#: lib/vutuv_web/templates/user/show.html.heex:1224
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1232
+#: lib/vutuv_web/templates/user/show.html.heex:1235
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6218,14 +6219,14 @@ msgid "Previous day"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1107
-#: lib/vutuv_web/components/post_components.ex:393
+#: lib/vutuv_web/components/post_components.ex:396
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1230
+#: lib/vutuv_web/templates/user/show.html.heex:1233
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
@@ -6250,9 +6251,9 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1578
-#: lib/vutuv_web/components/ui.ex:1587
-#: lib/vutuv_web/components/ui.ex:2052
+#: lib/vutuv_web/components/ui.ex:1583
+#: lib/vutuv_web/components/ui.ex:1592
+#: lib/vutuv_web/components/ui.ex:2057
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr ""
@@ -6263,7 +6264,7 @@ msgstr ""
 msgid "Default map"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:750
+#: lib/vutuv_web/controllers/settings_controller.ex:762
 #, elixir-autogen, elixir-format
 msgid "Map preferences saved."
 msgstr ""
@@ -6279,9 +6280,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1500
-#: lib/vutuv_web/templates/user/show.html.heex:1508
-#: lib/vutuv_web/templates/user/show.html.heex:1520
+#: lib/vutuv_web/templates/user/show.html.heex:1503
+#: lib/vutuv_web/templates/user/show.html.heex:1511
+#: lib/vutuv_web/templates/user/show.html.heex:1523
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -6313,11 +6314,11 @@ msgstr ""
 msgid "No endorsements yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2005
-#: lib/vutuv_web/live/notification_live/index.ex:625
-#: lib/vutuv_web/live/notification_live/index.ex:640
-#: lib/vutuv_web/live/notification_live/index.ex:778
-#: lib/vutuv_web/live/notification_live/index.ex:780
+#: lib/vutuv_web/components/ui.ex:2010
+#: lib/vutuv_web/live/notification_live/index.ex:637
+#: lib/vutuv_web/live/notification_live/index.ex:652
+#: lib/vutuv_web/live/notification_live/index.ex:790
+#: lib/vutuv_web/live/notification_live/index.ex:792
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr ""
@@ -6608,9 +6609,9 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2107
-#: lib/vutuv_web/components/post_components.ex:2889
-#: lib/vutuv_web/components/ui.ex:2509
+#: lib/vutuv_web/components/post_components.ex:2204
+#: lib/vutuv_web/components/post_components.ex:2986
+#: lib/vutuv_web/components/ui.ex:2514
 #: lib/vutuv_web/live/fediverse_account_live.ex:381
 #: lib/vutuv_web/live/organization_live/following.ex:371
 #: lib/vutuv_web/live/organization_live/following.ex:446
@@ -6626,7 +6627,7 @@ msgstr ""
 msgid "Muted. Their posts no longer appear in your feed."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:133
+#: lib/vutuv_web/templates/settings/notifications.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "New messages and new connections"
 msgstr ""
@@ -6636,8 +6637,8 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2889
-#: lib/vutuv_web/components/ui.ex:2508
+#: lib/vutuv_web/components/post_components.ex:2986
+#: lib/vutuv_web/components/ui.ex:2513
 #: lib/vutuv_web/live/fediverse_account_live.ex:379
 #: lib/vutuv_web/live/organization_live/following.ex:371
 #: lib/vutuv_web/live/organization_live/following.ex:446
@@ -6668,33 +6669,33 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2479
+#: lib/vutuv_web/components/ui.ex:2484
 #, elixir-autogen, elixir-format
 msgid "Doesn't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2473
+#: lib/vutuv_web/components/ui.ex:2478
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2463
+#: lib/vutuv_web/components/ui.ex:2468
 #, elixir-autogen, elixir-format
 msgid "This member doesn't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2414
-#: lib/vutuv_web/components/ui.ex:2463
+#: lib/vutuv_web/components/ui.ex:2419
+#: lib/vutuv_web/components/ui.ex:2468
 #, elixir-autogen, elixir-format
 msgid "This member follows you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2412
+#: lib/vutuv_web/components/ui.ex:2417
 #, elixir-autogen, elixir-format
 msgid "You follow each other"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2413
+#: lib/vutuv_web/components/ui.ex:2418
 #, elixir-autogen, elixir-format
 msgid "You follow this member"
 msgstr ""
@@ -7260,13 +7261,13 @@ msgstr ""
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3216
+#: lib/vutuv_web/components/ui.ex:3221
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3232
+#: lib/vutuv_web/components/ui.ex:3237
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7345,7 +7346,7 @@ msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:4846
+#: lib/vutuv_web/components/post_components.ex:4952
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -7739,13 +7740,13 @@ msgstr ""
 #: lib/vutuv_web/components/job_components.ex:219
 #: lib/vutuv_web/live/admin/dashboard_live.ex:287
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:457
-#: lib/vutuv_web/live/notification_live/index.ex:919
+#: lib/vutuv_web/live/notification_live/index.ex:931
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:291
-#: lib/vutuv_web/live/notification_live/index.ex:922
+#: lib/vutuv_web/live/notification_live/index.ex:934
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr ""
@@ -7915,7 +7916,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/activity_live.ex:231
 #: lib/vutuv_web/live/admin/user_live.ex:184
 #: lib/vutuv_web/live/job_board_live.ex:257
-#: lib/vutuv_web/live/tag_live/timeline.ex:283
+#: lib/vutuv_web/live/tag_live/timeline.ex:286
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr ""
@@ -8019,7 +8020,7 @@ msgstr ""
 msgid "PIN registered"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3219
+#: lib/vutuv_web/components/ui.ex:3224
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr ""
@@ -8137,7 +8138,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
 #: lib/vutuv_web/templates/education/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:684
+#: lib/vutuv_web/templates/user/show.html.heex:687
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr ""
@@ -8149,7 +8150,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:42
 #: lib/vutuv_web/agent_docs/text.ex:39
-#: lib/vutuv_web/components/ui.ex:4087
+#: lib/vutuv_web/components/ui.ex:4092
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8161,7 +8162,7 @@ msgstr ""
 #: lib/vutuv_web/templates/education/new.html.heex:4
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
-#: lib/vutuv_web/templates/user/show.html.heex:681
+#: lib/vutuv_web/templates/user/show.html.heex:684
 #: lib/vutuv_web/views/import_html.ex:70
 #: lib/vutuv_web/views/job_reference_html.ex:265
 #, elixir-autogen, elixir-format
@@ -8204,7 +8205,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4218
+#: lib/vutuv_web/components/ui.ex:4226
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8233,7 +8234,7 @@ msgstr ""
 msgid "Nothing new to import."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4115
+#: lib/vutuv_web/components/ui.ex:4120
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8327,7 +8328,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3488
+#: lib/vutuv_web/components/ui.ex:3493
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8341,7 +8342,7 @@ msgid "Loading posts"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:140
-#: lib/vutuv_web/templates/user/show.html.heex:1367
+#: lib/vutuv_web/templates/user/show.html.heex:1370
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8402,13 +8403,13 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4075
+#: lib/vutuv_web/components/ui.ex:4080
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4208
+#: lib/vutuv_web/components/ui.ex:4216
 #: lib/vutuv_web/controllers/settings_controller.ex:123
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8420,7 +8421,7 @@ msgstr ""
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4199
+#: lib/vutuv_web/components/ui.ex:4207
 #: lib/vutuv_web/controllers/settings_controller.ex:106
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8430,7 +8431,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4222
+#: lib/vutuv_web/components/ui.ex:4230
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8452,13 +8453,13 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1484
-#: lib/vutuv_web/live/post_live/feed.ex:1485
+#: lib/vutuv_web/live/post_live/feed.ex:1500
+#: lib/vutuv_web/live/post_live/feed.ex:1501
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1479
+#: lib/vutuv_web/live/post_live/feed.ex:1495
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr ""
@@ -8550,7 +8551,7 @@ msgstr[1] ""
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1079
+#: lib/vutuv_web/components/ui.ex:1080
 #, elixir-autogen, elixir-format
 msgid "This profile is not offered as a Markdown, text, JSON or XML export."
 msgstr ""
@@ -8646,7 +8647,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:580
 #: lib/vutuv_web/agent_docs/text.ex:584
 #: lib/vutuv_web/components/organization_components.ex:285
-#: lib/vutuv_web/components/ui.ex:4189
+#: lib/vutuv_web/components/ui.ex:4197
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:355
 #: lib/vutuv_web/controllers/settings_controller.ex:422
@@ -8660,8 +8661,8 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:1012
-#: lib/vutuv_web/templates/user/show.html.heex:1272
+#: lib/vutuv_web/templates/user/show.html.heex:1015
+#: lib/vutuv_web/templates/user/show.html.heex:1275
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr ""
@@ -8798,12 +8799,12 @@ msgstr ""
 msgid "This is the print view of this CV. Use your browser's print dialog (Ctrl+P or Cmd+P) and choose \"Save as PDF\" to get a PDF file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1187
+#: lib/vutuv_web/components/ui.ex:1188
 #, elixir-autogen, elixir-format
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3878
+#: lib/vutuv_web/components/post_components.ex:3975
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -8836,7 +8837,7 @@ msgstr ""
 msgid "Header"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1197
+#: lib/vutuv_web/components/ui.ex:1198
 #: lib/vutuv_web/templates/export/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Open CV"
@@ -8868,7 +8869,7 @@ msgstr ""
 msgid "The CV is public, on your profile: a visitor's download contains only what they can see there anyway, and private email addresses appear only in your own."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1189
+#: lib/vutuv_web/components/ui.ex:1190
 #, elixir-autogen, elixir-format
 msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
@@ -9022,8 +9023,8 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1622
-#: lib/vutuv_web/components/ui.ex:1623
+#: lib/vutuv_web/components/ui.ex:1627
+#: lib/vutuv_web/components/ui.ex:1628
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:65
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9053,7 +9054,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/language/manage.html.heex:8
 #: lib/vutuv_web/templates/language/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:746
+#: lib/vutuv_web/templates/user/show.html.heex:749
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr ""
@@ -9277,7 +9278,7 @@ msgstr ""
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:4
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:743
+#: lib/vutuv_web/templates/user/show.html.heex:746
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr ""
@@ -9464,7 +9465,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1146
+#: lib/vutuv/accounts/user.ex:1154
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9475,7 +9476,7 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1143
+#: lib/vutuv/accounts/user.ex:1151
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -9557,7 +9558,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:852
+#: lib/vutuv_web/templates/user/show.html.heex:855
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr ""
@@ -9590,7 +9591,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:46
 #: lib/vutuv_web/agent_docs/text.ex:43
-#: lib/vutuv_web/components/ui.ex:4091
+#: lib/vutuv_web/components/ui.ex:4096
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:132
@@ -9605,7 +9606,7 @@ msgstr ""
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:849
+#: lib/vutuv_web/templates/user/show.html.heex:852
 #: lib/vutuv_web/views/import_html.ex:71
 #: lib/vutuv_web/views/job_reference_html.ex:266
 #, elixir-autogen, elixir-format
@@ -9724,8 +9725,8 @@ msgstr ""
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1195
-#: lib/vutuv_web/templates/user/show.html.heex:1196
+#: lib/vutuv_web/templates/user/show.html.heex:1198
+#: lib/vutuv_web/templates/user/show.html.heex:1199
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -9784,13 +9785,13 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2962
+#: lib/vutuv_web/components/ui.ex:2967
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2961
-#: lib/vutuv_web/components/ui.ex:2965
+#: lib/vutuv_web/components/ui.ex:2966
+#: lib/vutuv_web/components/ui.ex:2970
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr ""
@@ -9964,12 +9965,12 @@ msgstr ""
 msgid "Authenticator app turned off."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:325
+#: lib/vutuv_web/components/ui.ex:326
 #, elixir-autogen, elixir-format
 msgid "Bold"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:421
+#: lib/vutuv_web/components/ui.ex:422
 #, elixir-autogen, elixir-format
 msgid "Bullet list"
 msgstr ""
@@ -9979,7 +9980,7 @@ msgstr ""
 msgid "Can't scan the code? Enter this key in your app instead:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:413
+#: lib/vutuv_web/components/ui.ex:414
 #, elixir-autogen, elixir-format
 msgid "Code block"
 msgstr ""
@@ -9994,17 +9995,17 @@ msgstr ""
 msgid "Delete your code list? All its codes stop working immediately."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:435
+#: lib/vutuv_web/components/ui.ex:436
 #, elixir-autogen, elixir-format
 msgid "Divider"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:323
+#: lib/vutuv_web/components/ui.ex:324
 #, elixir-autogen, elixir-format
 msgid "Formatting"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:447
+#: lib/vutuv_web/components/ui.ex:448
 #, elixir-autogen, elixir-format
 msgid "Full screen"
 msgstr ""
@@ -10019,32 +10020,32 @@ msgstr ""
 msgid "Generate code list"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:401
+#: lib/vutuv_web/components/ui.ex:402
 #, elixir-autogen, elixir-format
 msgid "Heading 1"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:404
+#: lib/vutuv_web/components/ui.ex:405
 #, elixir-autogen, elixir-format
 msgid "Heading 2"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:407
+#: lib/vutuv_web/components/ui.ex:408
 #, elixir-autogen, elixir-format
 msgid "Heading 3"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:393
+#: lib/vutuv_web/components/ui.ex:394
 #, elixir-autogen, elixir-format
 msgid "Inline code"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:328
+#: lib/vutuv_web/components/ui.ex:329
 #, elixir-autogen, elixir-format
 msgid "Italic"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:312
+#: lib/vutuv_web/components/ui.ex:313
 #, elixir-autogen, elixir-format
 msgid "Link URL"
 msgstr ""
@@ -10054,8 +10055,8 @@ msgstr ""
 msgid "Login codes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:373
 #: lib/vutuv_web/components/ui.ex:374
+#: lib/vutuv_web/components/ui.ex:375
 #, elixir-autogen, elixir-format
 msgid "More formatting"
 msgstr ""
@@ -10066,7 +10067,7 @@ msgstr ""
 msgid "Not set up."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:424
+#: lib/vutuv_web/components/ui.ex:425
 #, elixir-autogen, elixir-format
 msgid "Numbered list"
 msgstr ""
@@ -10081,7 +10082,7 @@ msgstr ""
 msgid "Print this page or write the codes down. Crossed-out codes have been used."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:410
+#: lib/vutuv_web/components/ui.ex:411
 #, elixir-autogen, elixir-format
 msgid "Quote"
 msgstr ""
@@ -10102,12 +10103,12 @@ msgstr ""
 msgid "Set up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:390
+#: lib/vutuv_web/components/ui.ex:391
 #, elixir-autogen, elixir-format
 msgid "Strikethrough"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:432
+#: lib/vutuv_web/components/ui.ex:433
 #, elixir-autogen, elixir-format
 msgid "Table"
 msgstr ""
@@ -10122,7 +10123,7 @@ msgstr ""
 msgid "To finish, enter the code your app shows now"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:444
+#: lib/vutuv_web/components/ui.ex:445
 #, elixir-autogen, elixir-format
 msgid "Toggle Markdown source"
 msgstr ""
@@ -10247,7 +10248,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:63
 #: lib/vutuv_web/agent_docs/text.ex:60
-#: lib/vutuv_web/templates/user/show.html.heex:1341
+#: lib/vutuv_web/templates/user/show.html.heex:1344
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -10549,7 +10550,7 @@ msgstr ""
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:764
+#: lib/vutuv_web/controllers/settings_controller.ex:776
 #, elixir-autogen, elixir-format
 msgid "Post display settings saved."
 msgstr ""
@@ -10598,7 +10599,7 @@ msgstr ""
 msgid "Installation default (%{value})"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:796
+#: lib/vutuv_web/controllers/settings_controller.ex:808
 #, elixir-autogen, elixir-format
 msgid "Map preferences reset to the site defaults."
 msgstr ""
@@ -10613,7 +10614,7 @@ msgstr ""
 msgid "Own value; blank the field to go back to the installation default."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:792
+#: lib/vutuv_web/controllers/settings_controller.ex:804
 #, elixir-autogen, elixir-format
 msgid "Post display settings reset to the site defaults."
 msgstr ""
@@ -10833,19 +10834,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1184
+#: lib/vutuv/accounts/user.ex:1192
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1189
+#: lib/vutuv/accounts/user.ex:1197
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1187
+#: lib/vutuv/accounts/user.ex:1195
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:761
 #, elixir-autogen, elixir-format
@@ -11567,7 +11568,7 @@ msgstr ""
 msgid "The link text can be anything. A hidden <link rel=\"me\"> in the page head works too."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:943
+#: lib/vutuv_web/components/ui.ex:944
 #: lib/vutuv_web/live/section_reorder_live.ex:195
 #, elixir-autogen, elixir-format
 msgid "Verified webpage"
@@ -11822,7 +11823,7 @@ msgstr ""
 msgid "Organization pages"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1044
+#: lib/vutuv_web/live/notification_live/index.ex:1056
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr ""
@@ -11835,12 +11836,12 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:419
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:394
-#: lib/vutuv_web/components/ui.ex:4226
+#: lib/vutuv_web/components/ui.ex:4234
 #: lib/vutuv_web/controllers/settings_controller.ex:211
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:806
+#: lib/vutuv_web/live/shell_live.ex:926
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:100
@@ -11931,22 +11932,22 @@ msgstr ""
 msgid "Your organization page was updated."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1285
+#: lib/vutuv_web/notification_line.ex:107
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1282
+#: lib/vutuv_web/notification_line.ex:104
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1279
+#: lib/vutuv_web/notification_line.ex:101
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1276
+#: lib/vutuv_web/notification_line.ex:98
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr ""
@@ -12121,7 +12122,7 @@ msgid "Everyone (public)"
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:647
-#: lib/vutuv_web/live/tag_live/timeline.ex:264
+#: lib/vutuv_web/live/tag_live/timeline.ex:267
 #: lib/vutuv_web/templates/education/form_content.html.heex:41
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:63
 #, elixir-autogen, elixir-format
@@ -12143,7 +12144,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1158
+#: lib/vutuv/accounts/user.ex:1166
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12169,7 +12170,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:636
+#: lib/vutuv_web/live/shell_live.ex:756
 #: lib/vutuv_web/templates/layout/app.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -12262,7 +12263,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1157
+#: lib/vutuv/accounts/user.ex:1165
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12344,7 +12345,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1159
+#: lib/vutuv/accounts/user.ex:1167
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:564
 #: lib/vutuv_web/agent_docs/markdown.ex:458
@@ -12973,7 +12974,7 @@ msgstr[1] ""
 msgid "Alert frequency"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:678
+#: lib/vutuv_web/controllers/settings_controller.ex:690
 #, elixir-autogen, elixir-format
 msgid "Alert updated."
 msgstr ""
@@ -13041,13 +13042,13 @@ msgstr ""
 msgid "Save search"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:696
+#: lib/vutuv_web/controllers/settings_controller.ex:708
 #, elixir-autogen, elixir-format
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4166
-#: lib/vutuv_web/controllers/settings_controller.ex:588
+#: lib/vutuv_web/components/ui.ex:4174
+#: lib/vutuv_web/controllers/settings_controller.ex:600
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
 #, elixir-autogen, elixir-format
@@ -13065,10 +13066,10 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2282
+#: lib/vutuv_web/components/post_components.ex:2379
 #: lib/vutuv_web/components/saved_search_components.ex:43
-#: lib/vutuv_web/controllers/settings_controller.ex:683
-#: lib/vutuv_web/controllers/settings_controller.ex:701
+#: lib/vutuv_web/controllers/settings_controller.ex:695
+#: lib/vutuv_web/controllers/settings_controller.ex:713
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:387
 #: lib/vutuv_web/live/organization_live/following.ex:277
 #: lib/vutuv_web/live/organization_live/following.ex:284
@@ -13318,7 +13319,7 @@ msgstr ""
 msgid "Image awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1042
+#: lib/vutuv_web/live/notification_live/index.ex:1054
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13359,7 +13360,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1202
+#: lib/vutuv/accounts/user.ex:1210
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13370,19 +13371,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1205
+#: lib/vutuv/accounts/user.ex:1213
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1208
+#: lib/vutuv/accounts/user.ex:1216
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1199
+#: lib/vutuv/accounts/user.ex:1207
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13405,7 +13406,7 @@ msgstr[1] ""
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1045
+#: lib/vutuv_web/live/notification_live/index.ex:1057
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr ""
@@ -13417,32 +13418,32 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1335
+#: lib/vutuv_web/notification_line.ex:157
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:358
+#: lib/vutuv_web/components/ui.ex:359
 #, elixir-autogen, elixir-format
 msgid "Center"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:355
+#: lib/vutuv_web/components/ui.ex:356
 #, elixir-autogen, elixir-format
 msgid "Float left"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:361
+#: lib/vutuv_web/components/ui.ex:362
 #, elixir-autogen, elixir-format
 msgid "Float right"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:352
+#: lib/vutuv_web/components/ui.ex:353
 #, elixir-autogen, elixir-format
 msgid "Full width"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:340
+#: lib/vutuv_web/components/ui.ex:341
 #, elixir-autogen, elixir-format
 msgid "Insert image"
 msgstr ""
@@ -13454,7 +13455,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:227
 #: lib/vutuv_web/agent_docs/text.ex:212
-#: lib/vutuv_web/live/tag_live/timeline.ex:210
+#: lib/vutuv_web/live/tag_live/timeline.ex:213
 #, elixir-autogen, elixir-format
 msgid "Posts with this tag"
 msgstr ""
@@ -13479,22 +13480,22 @@ msgstr ""
 msgid "Work mobile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:433
+#: lib/vutuv_web/components/post_components.ex:436
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:435
+#: lib/vutuv_web/components/post_components.ex:438
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:434
+#: lib/vutuv_web/components/post_components.ex:437
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:392
+#: lib/vutuv_web/components/post_components.ex:395
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr ""
@@ -13504,16 +13505,16 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4149
-#: lib/vutuv_web/controllers/settings_controller.ex:602
-#: lib/vutuv_web/live/post_live/feed.ex:1430
+#: lib/vutuv_web/components/ui.ex:4157
+#: lib/vutuv_web/controllers/settings_controller.ex:614
+#: lib/vutuv_web/live/post_live/feed.ex:1446
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1445
+#: lib/vutuv_web/live/post_live/feed.ex:1461
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr ""
@@ -13555,7 +13556,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1307
+#: lib/vutuv_web/templates/user/show.html.heex:1310
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
@@ -13584,7 +13585,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:60
 #: lib/vutuv_web/agent_docs/text.ex:57
-#: lib/vutuv_web/components/ui.ex:4134
+#: lib/vutuv_web/components/ui.ex:4139
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -13592,7 +13593,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1305
+#: lib/vutuv_web/templates/user/show.html.heex:1308
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
@@ -13612,34 +13613,34 @@ msgstr ""
 msgid "Select a messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3574
+#: lib/vutuv_web/components/ui.ex:3579
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3584
+#: lib/vutuv_web/components/ui.ex:3589
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1046
+#: lib/vutuv_web/live/notification_live/index.ex:1058
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1355
+#: lib/vutuv_web/notification_line.ex:177
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1347
+#: lib/vutuv_web/notification_line.ex:169
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1352
+#: lib/vutuv_web/notification_line.ex:174
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr ""
@@ -13664,39 +13665,39 @@ msgstr ""
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1360
+#: lib/vutuv_web/notification_line.ex:182
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4476
+#: lib/vutuv_web/components/post_components.ex:4573
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1196
-#: lib/vutuv_web/components/post_components.ex:4433
+#: lib/vutuv_web/components/post_components.ex:4530
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4477
+#: lib/vutuv_web/components/post_components.ex:4574
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4479
+#: lib/vutuv_web/components/post_components.ex:4576
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4475
+#: lib/vutuv_web/components/post_components.ex:4572
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1196
-#: lib/vutuv_web/components/post_components.ex:4432
+#: lib/vutuv_web/components/post_components.ex:4529
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13707,12 +13708,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4474
+#: lib/vutuv_web/components/post_components.ex:4571
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4478
+#: lib/vutuv_web/components/post_components.ex:4575
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13732,7 +13733,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4515
+#: lib/vutuv_web/components/post_components.ex:4612
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13740,27 +13741,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4545
+#: lib/vutuv_web/components/post_components.ex:4642
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4546
+#: lib/vutuv_web/components/post_components.ex:4643
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4544
+#: lib/vutuv_web/components/post_components.ex:4641
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4504
+#: lib/vutuv_web/components/post_components.ex:4601
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4551
+#: lib/vutuv_web/components/post_components.ex:4648
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13790,72 +13791,72 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4318
+#: lib/vutuv_web/components/post_components.ex:4415
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:911
+#: lib/vutuv_web/live/notification_live/index.ex:923
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:925
+#: lib/vutuv_web/live/notification_live/index.ex:937
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:393
+#: lib/vutuv_web/live/notification_live/index.ex:405
 #, elixir-autogen, elixir-format
 msgid "Follow back"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:408
+#: lib/vutuv_web/live/notification_live/index.ex:420
 #, elixir-autogen, elixir-format
 msgid "Last 30 days"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:877
-#: lib/vutuv_web/live/notification_live/index.ex:1125
+#: lib/vutuv_web/live/notification_live/index.ex:889
+#: lib/vutuv_web/live/notification_live/index.ex:1096
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1062
+#: lib/vutuv_web/live/notification_live/index.ex:1075
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1057
+#: lib/vutuv_web/live/notification_live/index.ex:1072
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1072
+#: lib/vutuv_web/live/notification_live/index.ex:1081
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4309
+#: lib/vutuv_web/components/post_components.ex:4406
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1756
+#: lib/vutuv_web/components/ui.ex:1761
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1760
+#: lib/vutuv_web/components/ui.ex:1765
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:438
+#: lib/vutuv_web/live/shell_live.ex:453
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -14072,17 +14073,17 @@ msgstr ""
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1309
+#: lib/vutuv_web/notification_line.ex:131
 #, elixir-autogen, elixir-format
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1035
+#: lib/vutuv_web/live/notification_live/index.ex:1047
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1112
+#: lib/vutuv_web/notification_line.ex:243
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -14105,12 +14106,12 @@ msgstr ""
 msgid "Only part of this long conversation is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1036
+#: lib/vutuv_web/live/notification_live/index.ex:1048
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1259
+#: lib/vutuv_web/notification_line.ex:81
 #, elixir-autogen, elixir-format
 msgid "mentioned you in a post."
 msgstr ""
@@ -14210,14 +14211,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2555
+#: lib/vutuv_web/components/post_components.ex:2652
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2578
+#: lib/vutuv_web/components/post_components.ex:2675
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14244,7 +14245,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4943
+#: lib/vutuv_web/components/post_components.ex:5051
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14376,7 +14377,7 @@ msgstr[1] ""
 msgid "All endorsers"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:627
+#: lib/vutuv_web/controllers/settings_controller.ex:639
 #, elixir-autogen, elixir-format
 msgid "Filter added. Matching posts are now hidden from your feed."
 msgstr ""
@@ -14386,12 +14387,12 @@ msgstr ""
 msgid "Filter by a tag"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:657
+#: lib/vutuv_web/controllers/settings_controller.ex:669
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Filter removed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:385
+#: lib/vutuv_web/live/post_live/feed.ex:389
 #, elixir-autogen, elixir-format
 msgid "Hidden: matches your filter"
 msgstr ""
@@ -14406,8 +14407,8 @@ msgstr ""
 msgid "Match whole words only (word/phrase)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4145
-#: lib/vutuv_web/controllers/settings_controller.ex:668
+#: lib/vutuv_web/components/ui.ex:4153
+#: lib/vutuv_web/controllers/settings_controller.ex:680
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
 #, elixir-autogen, elixir-format
@@ -14424,7 +14425,7 @@ msgstr ""
 msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:394
+#: lib/vutuv_web/live/post_live/feed.ex:398
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr ""
@@ -14454,7 +14455,7 @@ msgstr ""
 msgid "Thread replies"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:603
+#: lib/vutuv_web/live/notification_live/index.ex:615
 #, elixir-autogen, elixir-format
 msgid "Turn off thread notifications"
 msgstr ""
@@ -14500,12 +14501,12 @@ msgstr ""
 msgid "You have not muted anything yet."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:635
+#: lib/vutuv_web/controllers/settings_controller.ex:647
 #, elixir-autogen, elixir-format
 msgid "You have reached the maximum of %{count} filters."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:598
+#: lib/vutuv_web/live/notification_live/index.ex:610
 #, elixir-autogen, elixir-format
 msgid "You wrote in this thread."
 msgstr ""
@@ -14961,7 +14962,7 @@ msgstr ""
 msgid "ZIP or postal code"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:271
+#: lib/vutuv_web/live/tag_live/timeline.ex:274
 #: lib/vutuv_web/templates/education/form_content.html.heex:59
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:81
 #, elixir-autogen, elixir-format
@@ -14983,7 +14984,7 @@ msgstr ""
 msgid "Book an ad"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1016
+#: lib/vutuv_web/templates/user/show.html.heex:1019
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr ""
@@ -15039,257 +15040,252 @@ msgstr ""
 msgid "moved to %{address}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4076
+#: lib/vutuv_web/components/ui.ex:4081
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4081
+#: lib/vutuv_web/components/ui.ex:4086
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4084
+#: lib/vutuv_web/components/ui.ex:4089
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4085
+#: lib/vutuv_web/components/ui.ex:4090
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4088
+#: lib/vutuv_web/components/ui.ex:4093
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4089
+#: lib/vutuv_web/components/ui.ex:4094
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4092
+#: lib/vutuv_web/components/ui.ex:4097
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4093
+#: lib/vutuv_web/components/ui.ex:4098
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4100
+#: lib/vutuv_web/components/ui.ex:4105
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4101
+#: lib/vutuv_web/components/ui.ex:4106
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4102
+#: lib/vutuv_web/components/ui.ex:4107
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4105
+#: lib/vutuv_web/components/ui.ex:4110
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4106
+#: lib/vutuv_web/components/ui.ex:4111
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4227
+#: lib/vutuv_web/components/ui.ex:4235
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4228
+#: lib/vutuv_web/components/ui.ex:4236
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4109
+#: lib/vutuv_web/components/ui.ex:4114
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4112
+#: lib/vutuv_web/components/ui.ex:4117
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4113
+#: lib/vutuv_web/components/ui.ex:4118
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4116
+#: lib/vutuv_web/components/ui.ex:4121
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4117
+#: lib/vutuv_web/components/ui.ex:4122
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4120
+#: lib/vutuv_web/components/ui.ex:4125
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4121
+#: lib/vutuv_web/components/ui.ex:4126
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4123
+#: lib/vutuv_web/components/ui.ex:4128
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4124
+#: lib/vutuv_web/components/ui.ex:4129
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4125
+#: lib/vutuv_web/components/ui.ex:4130
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4127
+#: lib/vutuv_web/components/ui.ex:4132
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4128
+#: lib/vutuv_web/components/ui.ex:4133
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4130
+#: lib/vutuv_web/components/ui.ex:4135
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4135
+#: lib/vutuv_web/components/ui.ex:4140
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4136
+#: lib/vutuv_web/components/ui.ex:4141
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4139
+#: lib/vutuv_web/components/ui.ex:4144
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4142
+#: lib/vutuv_web/components/ui.ex:4147
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4143
-#, elixir-autogen, elixir-format
-msgid "email mail unsubscribe newsletter bell alert quiet fewer"
-msgstr ""
-
-#: lib/vutuv_web/components/ui.ex:4146
+#: lib/vutuv_web/components/ui.ex:4154
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4147
+#: lib/vutuv_web/components/ui.ex:4155
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4150
+#: lib/vutuv_web/components/ui.ex:4158
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4151
+#: lib/vutuv_web/components/ui.ex:4159
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4167
+#: lib/vutuv_web/components/ui.ex:4175
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4168
+#: lib/vutuv_web/components/ui.ex:4176
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4174
+#: lib/vutuv_web/components/ui.ex:4182
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4175
+#: lib/vutuv_web/components/ui.ex:4183
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4178
+#: lib/vutuv_web/components/ui.ex:4186
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4179
+#: lib/vutuv_web/components/ui.ex:4187
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4200
+#: lib/vutuv_web/components/ui.ex:4208
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4201
+#: lib/vutuv_web/components/ui.ex:4209
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4219
+#: lib/vutuv_web/components/ui.ex:4227
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4220
+#: lib/vutuv_web/components/ui.ex:4228
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4223
+#: lib/vutuv_web/components/ui.ex:4231
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4224
+#: lib/vutuv_web/components/ui.ex:4232
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4238
+#: lib/vutuv_web/components/ui.ex:4246
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4239
+#: lib/vutuv_web/components/ui.ex:4247
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr ""
@@ -15367,51 +15363,51 @@ msgstr ""
 msgid "I understand, take part"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:480
+#: lib/vutuv_web/views/settings_html.ex:489
 #, elixir-autogen, elixir-format
 msgid "Most of them, not all: we cannot check whether they do it, and anything that was re-shared, archived or indexed elsewhere stays out of reach. If you take part again later, people there have to follow you anew."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:475
+#: lib/vutuv_web/views/settings_html.ex:484
 #, elixir-autogen, elixir-format
 msgid "No new posts go out, and your followers from other networks are removed here. The next time those servers look you up they learn that this account is gone, and most of them then delete their copies of your posts."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:456
+#: lib/vutuv_web/views/settings_html.ex:465
 #, elixir-autogen, elixir-format
 msgid "Once a post has left vutuv, it is out of our hands"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:458
+#: lib/vutuv_web/views/settings_html.ex:467
 #, elixir-autogen, elixir-format
 msgid "Switching off does not delete what is already out there"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:469
+#: lib/vutuv_web/views/settings_html.ex:478
 #, elixir-autogen, elixir-format
 msgid "Switching this off again later stops new posts from going out. It cannot bring back what has already been delivered."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:464
+#: lib/vutuv_web/views/settings_html.ex:473
 #, elixir-autogen, elixir-format
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4891
+#: lib/vutuv_web/components/post_components.ex:4997
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4895
+#: lib/vutuv_web/components/post_components.ex:5001
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4899
+#: lib/vutuv_web/components/post_components.ex:5005
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15419,7 +15415,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1145
-#: lib/vutuv_web/components/post_components.ex:4850
+#: lib/vutuv_web/components/post_components.ex:4956
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15435,14 +15431,14 @@ msgstr ""
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1219
-#: lib/vutuv_web/components/post_components.ex:1784
+#: lib/vutuv_web/components/post_components.ex:1222
+#: lib/vutuv_web/components/post_components.ex:1881
 #: lib/vutuv_web/live/fediverse_account_live.ex:294
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1095
+#: lib/vutuv_web/components/post_components.ex:1098
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15461,7 +15457,7 @@ msgstr ""
 msgid "Replies from other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1038
+#: lib/vutuv_web/live/notification_live/index.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Reply from another network"
 msgstr ""
@@ -15471,7 +15467,7 @@ msgstr ""
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1104
+#: lib/vutuv_web/components/post_components.ex:1107
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15481,8 +15477,8 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1118
-#: lib/vutuv_web/live/notification_live/index.ex:545
+#: lib/vutuv_web/components/post_components.ex:1121
+#: lib/vutuv_web/live/notification_live/index.ex:557
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
 msgstr ""
@@ -15513,9 +15509,9 @@ msgid "That reply is not yours to remove."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1329
-#: lib/vutuv_web/components/post_components.ex:1150
-#: lib/vutuv_web/components/post_components.ex:1350
-#: lib/vutuv_web/components/post_components.ex:2202
+#: lib/vutuv_web/components/post_components.ex:1153
+#: lib/vutuv_web/components/post_components.ex:1353
+#: lib/vutuv_web/components/post_components.ex:2299
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -15533,7 +15529,7 @@ msgstr ""
 msgid "You have reported a lot today. Please try again tomorrow."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1262
+#: lib/vutuv_web/notification_line.ex:84
 #, elixir-autogen, elixir-format, fuzzy
 msgid "replied to your post from another network."
 msgstr ""
@@ -15743,7 +15739,7 @@ msgstr ""
 msgid "Access token revoked"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4203
+#: lib/vutuv_web/components/ui.ex:4211
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -15958,7 +15954,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:198
 #: lib/vutuv_web/live/admin/activity_live.ex:237
 #: lib/vutuv_web/live/fediverse_following_live.ex:378
-#: lib/vutuv_web/live/tag_live/timeline.ex:343
+#: lib/vutuv_web/live/tag_live/timeline.ex:346
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr ""
@@ -16090,7 +16086,7 @@ msgstr ""
 msgid "What changed on your account, and exactly when."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4204
+#: lib/vutuv_web/components/ui.ex:4212
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr ""
@@ -16126,7 +16122,7 @@ msgstr ""
 msgid "from a signed-in session"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4206
+#: lib/vutuv_web/components/ui.ex:4214
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
@@ -16178,22 +16174,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2740
+#: lib/vutuv_web/components/post_components.ex:2837
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2856
+#: lib/vutuv_web/components/post_components.ex:2953
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2864
+#: lib/vutuv_web/components/post_components.ex:2961
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2850
+#: lib/vutuv_web/components/post_components.ex:2947
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16279,7 +16275,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1257
 #: lib/vutuv_web/agent_docs/text.ex:792
-#: lib/vutuv_web/components/ui.ex:2563
+#: lib/vutuv_web/components/ui.ex:2568
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
@@ -16309,7 +16305,7 @@ msgstr ""
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2562
+#: lib/vutuv_web/components/ui.ex:2567
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
@@ -16319,17 +16315,17 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2335
+#: lib/vutuv_web/components/post_components.ex:2432
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3559
+#: lib/vutuv_web/components/post_components.ex:3656
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3070
+#: lib/vutuv_web/components/post_components.ex:3167
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16342,12 +16338,12 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1290
 #: lib/vutuv_web/agent_docs/text.ex:779
-#: lib/vutuv_web/components/post_components.ex:3776
+#: lib/vutuv_web/components/post_components.ex:3873
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2561
+#: lib/vutuv_web/components/ui.ex:2566
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Previous photo"
 msgstr ""
@@ -16368,7 +16364,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2388
+#: lib/vutuv_web/components/post_components.ex:2485
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16388,7 +16384,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2379
+#: lib/vutuv_web/components/post_components.ex:2476
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16398,12 +16394,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2397
+#: lib/vutuv_web/components/post_components.ex:2494
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2331
+#: lib/vutuv_web/components/post_components.ex:2428
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16418,7 +16414,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2392
+#: lib/vutuv_web/components/post_components.ex:2489
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16428,7 +16424,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2345
+#: lib/vutuv_web/components/post_components.ex:2442
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16449,8 +16445,8 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1234
-#: lib/vutuv_web/live/post_live/feed.ex:1235
+#: lib/vutuv_web/live/post_live/feed.ex:1250
+#: lib/vutuv_web/live/post_live/feed.ex:1251
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post photos"
 msgstr ""
@@ -16515,13 +16511,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1163
-#: lib/vutuv_web/components/post_components.ex:4888
+#: lib/vutuv_web/components/post_components.ex:4994
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1161
-#: lib/vutuv_web/components/post_components.ex:4885
+#: lib/vutuv_web/components/post_components.ex:4991
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
 msgstr ""
@@ -16531,12 +16527,12 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4777
+#: lib/vutuv_web/components/post_components.ex:4883
 #, elixir-autogen, elixir-format, fuzzy
 msgid "From other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1039
+#: lib/vutuv_web/live/notification_live/index.ex:1051
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Reaction from another network"
 msgstr ""
@@ -16551,21 +16547,21 @@ msgstr ""
 msgid "Show under each of your posts who out there liked or shared it, by their account address on their own server, linked to that account. Visible to everyone who sees the post. We keep nothing else about these people: no name, no picture, no text. Switching it off deletes what is stored for it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1093
+#: lib/vutuv_web/notification_line.ex:224
 #, elixir-autogen, elixir-format
 msgid "liked your post on another network."
 msgid_plural "liked your post on another network."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1101
+#: lib/vutuv_web/notification_line.ex:232
 #, elixir-autogen, elixir-format, fuzzy
 msgid "reacted to your post from another network."
 msgid_plural "reacted to your post from another network."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1085
+#: lib/vutuv_web/notification_line.ex:216
 #, elixir-autogen, elixir-format
 msgid "shared your post on another network."
 msgid_plural "shared your post on another network."
@@ -16647,7 +16643,7 @@ msgstr ""
 msgid "Cancel request"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4190
+#: lib/vutuv_web/components/ui.ex:4198
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr ""
@@ -16851,7 +16847,7 @@ msgstr ""
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4192
+#: lib/vutuv_web/components/ui.ex:4200
 #, elixir-autogen, elixir-format, fuzzy
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
@@ -16871,7 +16867,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2148
+#: lib/vutuv_web/components/post_components.ex:2245
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
@@ -16881,7 +16877,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2201
+#: lib/vutuv_web/components/post_components.ex:2298
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16901,12 +16897,12 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1478
+#: lib/vutuv_web/components/post_components.ex:1481
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2166
+#: lib/vutuv_web/components/post_components.ex:2263
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Marked as sensitive by its author"
 msgstr ""
@@ -16922,7 +16918,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2134
+#: lib/vutuv_web/components/post_components.ex:2231
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -17144,27 +17140,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1887
+#: lib/vutuv_web/components/post_components.ex:1984
 #, elixir-autogen, elixir-format
 msgid "A picture is on its way."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1916
+#: lib/vutuv_web/components/post_components.ex:2013
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1911
+#: lib/vutuv_web/components/post_components.ex:2008
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2238
+#: lib/vutuv_web/components/post_components.ex:2335
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2244
+#: lib/vutuv_web/components/post_components.ex:2341
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That post is not here any more."
 msgstr ""
@@ -17174,7 +17170,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2383
+#: lib/vutuv_web/components/post_components.ex:2480
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17184,7 +17180,7 @@ msgstr ""
 msgid "This post was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/remote_actions_component.ex:155
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:167
 #, elixir-autogen, elixir-format
 msgid "Reposted. Your followers see it now."
 msgstr ""
@@ -17355,7 +17351,7 @@ msgstr ""
 msgid "Your username is your public identity here. It changes only once you confirm with your passkey or a valid code below."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:497
+#: lib/vutuv_web/components/ui.ex:498
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Markdown help"
 msgstr ""
@@ -17370,53 +17366,53 @@ msgstr ""
 msgid "Read this page as Markdown"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:554
+#: lib/vutuv_web/components/ui.ex:555
 #, elixir-autogen, elixir-format
 msgid "Activities"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:552
+#: lib/vutuv_web/components/ui.ex:553
 #, elixir-autogen, elixir-format
 msgid "Animals & nature"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:313
-#: lib/vutuv_web/components/ui.ex:337
+#: lib/vutuv_web/components/ui.ex:314
+#: lib/vutuv_web/components/ui.ex:338
 #, elixir-autogen, elixir-format
 msgid "Emoji"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:553
+#: lib/vutuv_web/components/ui.ex:554
 #, elixir-autogen, elixir-format
 msgid "Food & drink"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:316
+#: lib/vutuv_web/components/ui.ex:317
 #, elixir-autogen, elixir-format
 msgid "No emoji found."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:556
+#: lib/vutuv_web/components/ui.ex:557
 #, elixir-autogen, elixir-format
 msgid "Objects"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:314
+#: lib/vutuv_web/components/ui.ex:315
 #, elixir-autogen, elixir-format
 msgid "Search emoji"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:550
+#: lib/vutuv_web/components/ui.ex:551
 #, elixir-autogen, elixir-format
 msgid "Smileys"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:557
+#: lib/vutuv_web/components/ui.ex:558
 #, elixir-autogen, elixir-format
 msgid "Symbols"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:555
+#: lib/vutuv_web/components/ui.ex:556
 #, elixir-autogen, elixir-format
 msgid "Travel & places"
 msgstr ""
@@ -17427,7 +17423,7 @@ msgid "Address of the post"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:504
-#: lib/vutuv_web/live/post_live/remote_actions_component.ex:247
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:262
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Fediverse settings"
 msgstr ""
@@ -17874,54 +17870,54 @@ msgstr ""
 msgid "Screenshot blocklist"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:425
+#: lib/vutuv_web/components/post_components.ex:428
 #, elixir-autogen, elixir-format
 msgid "Nothing from the fediverse yet. Follow accounts out there to fill this tab."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:422
+#: lib/vutuv_web/components/post_components.ex:425
 #, elixir-autogen, elixir-format
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:575
+#: lib/vutuv_web/live/notification_live/index.ex:587
 #, elixir-autogen, elixir-format
 msgid "View the conversation"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:213
+#: lib/vutuv_web/live/tag_live/timeline.ex:216
 #, elixir-autogen, elixir-format
 msgid "%{formatted} post"
 msgid_plural "%{formatted} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:327
+#: lib/vutuv_web/live/tag_live/timeline.ex:330
 #, elixir-autogen, elixir-format
 msgid "Most liked"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:351
+#: lib/vutuv_web/live/tag_live/timeline.ex:354
 #, elixir-autogen, elixir-format
 msgid "No posts carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:349
+#: lib/vutuv_web/live/tag_live/timeline.ex:352
 #, elixir-autogen, elixir-format
 msgid "No posts from other networks carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:346
+#: lib/vutuv_web/live/tag_live/timeline.ex:349
 #, elixir-autogen, elixir-format
 msgid "No posts on vutuv carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:246
+#: lib/vutuv_web/live/tag_live/timeline.ex:249
 #, elixir-autogen, elixir-format
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2241
+#: lib/vutuv_web/components/post_components.ex:2338
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -17962,8 +17958,8 @@ msgstr ""
 msgid "This is vutuv's copy of a post published on %{host}. It is kept while somebody here follows its author."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1130
 #: lib/vutuv_web/components/ui.ex:1131
+#: lib/vutuv_web/components/ui.ex:1132
 #, elixir-autogen, elixir-format
 msgid "Subscribe to this feed in your RSS reader"
 msgstr ""
@@ -18224,19 +18220,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4033
+#: lib/vutuv_web/components/post_components.ex:4130
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4035
+#: lib/vutuv_web/components/post_components.ex:4132
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4046
+#: lib/vutuv_web/components/post_components.ex:4143
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -18256,7 +18252,7 @@ msgstr ""
 msgid "When off, other members no longer see you among the likes of a post. The author of the post still does: we named you in the notification they got when you liked it. Either way the post keeps the same number of likes."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:834
+#: lib/vutuv_web/controllers/settings_controller.ex:846
 #, elixir-autogen, elixir-format
 msgid "Your likes follow the site default again."
 msgstr ""
@@ -18271,7 +18267,7 @@ msgstr ""
 msgid "%{address} (whole website)"
 msgstr ""
 
-#: lib/vutuv_web/markdown.ex:327
+#: lib/vutuv_web/markdown.ex:337
 #, elixir-autogen, elixir-format
 msgid "Verified webpage of the author (%{address})"
 msgstr ""
@@ -18296,7 +18292,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/job_reference_controller.ex:144
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:18
 #: lib/vutuv_web/templates/job_reference/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:786
+#: lib/vutuv_web/templates/user/show.html.heex:789
 #, elixir-autogen, elixir-format
 msgid "Add an employment reference"
 msgstr ""
@@ -18361,7 +18357,7 @@ msgstr ""
 msgid "Employment reference updated."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4095
+#: lib/vutuv_web/components/ui.ex:4100
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -18371,7 +18367,7 @@ msgstr ""
 #: lib/vutuv_web/templates/job_reference/new.html.heex:4
 #: lib/vutuv_web/templates/job_reference/show.html.heex:12
 #: lib/vutuv_web/templates/job_reference/view.html.heex:11
-#: lib/vutuv_web/templates/user/show.html.heex:783
+#: lib/vutuv_web/templates/user/show.html.heex:786
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Employment references"
 msgstr ""
@@ -18555,7 +18551,7 @@ msgstr ""
 msgid "You changed the text after this review. It describes the earlier version."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4096
+#: lib/vutuv_web/components/ui.ex:4101
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr ""
@@ -18566,7 +18562,7 @@ msgstr ""
 msgid "Zwischenzeugnis"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4098
+#: lib/vutuv_web/components/ui.ex:4103
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr ""
@@ -18754,7 +18750,7 @@ msgstr ""
 msgid "Employment reference deleted"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1048
+#: lib/vutuv_web/live/notification_live/index.ex:1060
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Employment reference review"
 msgstr ""
@@ -18779,14 +18775,14 @@ msgstr ""
 msgid "Reviewing your reference. This usually takes about %{duration}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1250
-#: lib/vutuv_web/views/notification_digest_text.ex:84
+#: lib/vutuv_web/notification_line.ex:54
+#: lib/vutuv_web/views/notification_digest_text.ex:90
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1247
-#: lib/vutuv_web/views/notification_digest_text.ex:81
+#: lib/vutuv_web/notification_line.ex:51
+#: lib/vutuv_web/views/notification_digest_text.ex:87
 #, elixir-autogen, elixir-format
 msgid "The review of “%{title}” is ready: %{grade}."
 msgstr ""
@@ -18801,7 +18797,7 @@ msgstr ""
 msgid "When the review of one of your employment references is finished. It takes minutes, so you can close the page and wait for the email."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1253
+#: lib/vutuv_web/notification_line.ex:57
 #, elixir-autogen, elixir-format
 msgid "Your employment reference has been reviewed."
 msgstr ""
@@ -18888,72 +18884,72 @@ msgid_plural "%{count} new notifications on vutuv"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:59
+#: lib/vutuv_web/views/notification_digest_text.ex:65
 #, elixir-autogen, elixir-format
 msgid "%{who} added something to their CV."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:41
+#: lib/vutuv_web/views/notification_digest_text.ex:47
 #, elixir-autogen, elixir-format
 msgid "%{who} answered in a conversation you are part of."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:35
+#: lib/vutuv_web/views/notification_digest_text.ex:41
 #, elixir-autogen, elixir-format
 msgid "%{who} endorsed one of your tags."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:32
+#: lib/vutuv_web/views/notification_digest_text.ex:38
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{who} endorsed you for %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:47
+#: lib/vutuv_web/views/notification_digest_text.ex:53
 #, elixir-autogen, elixir-format
 msgid "%{who} liked your post."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:44
+#: lib/vutuv_web/views/notification_digest_text.ex:50
 #, elixir-autogen, elixir-format
 msgid "%{who} mentioned you in a post."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:53
+#: lib/vutuv_web/views/notification_digest_text.ex:59
 #, elixir-autogen, elixir-format
 msgid "%{who} reacted to your post from another network."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:50
+#: lib/vutuv_web/views/notification_digest_text.ex:56
 #, elixir-autogen, elixir-format
 msgid "%{who} replied to your post from another network."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:38
+#: lib/vutuv_web/views/notification_digest_text.ex:44
 #, elixir-autogen, elixir-format
 msgid "%{who} replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:26
+#: lib/vutuv_web/views/notification_digest_text.ex:32
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{who} started following you."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:63
+#: lib/vutuv_web/views/notification_digest_text.ex:69
 #, elixir-autogen, elixir-format
 msgid "@%{old} is now @%{new}."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:66
+#: lib/vutuv_web/views/notification_digest_text.ex:72
 #, elixir-autogen, elixir-format
 msgid "A moderation case on your account was updated."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:72
+#: lib/vutuv_web/views/notification_digest_text.ex:78
 #, elixir-autogen, elixir-format
 msgid "A report you are involved in changed something on your account."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:87
+#: lib/vutuv_web/views/notification_digest_text.ex:93
 #, elixir-autogen, elixir-format, fuzzy
 msgid "An employment reference of yours has been reviewed."
 msgstr ""
@@ -18964,17 +18960,18 @@ msgstr ""
 msgid "GitHub account @Klotzkette"
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:69
+#: lib/vutuv_web/views/notification_digest_text.ex:75
 #, elixir-autogen, elixir-format
 msgid "One of your images was removed by the image review."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:100
+#: lib/vutuv_web/views/notification_digest_text.ex:106
 #, elixir-autogen, elixir-format
 msgid "Somebody"
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:90
+#: lib/vutuv_web/notification_line.ex:192
+#: lib/vutuv_web/views/notification_digest_text.ex:96
 #, elixir-autogen, elixir-format
 msgid "Something new happened on your account."
 msgstr ""
@@ -18984,17 +18981,17 @@ msgstr ""
 msgid "Which wording counts as which grade is not our own invention. We follow the Arbeitszeugnis-Prüfer, a set of instructions published under the MIT and Apache 2.0 licences by the lawyer Tom Braegelmann ({account}). You can read every rule the model is given:"
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:29
+#: lib/vutuv_web/views/notification_digest_text.ex:35
 #, elixir-autogen, elixir-format
 msgid "You and %{who} are now connected."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:56
+#: lib/vutuv_web/views/notification_digest_text.ex:62
 #, elixir-autogen, elixir-format
 msgid "You were given a role at %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/views/notification_digest_text.ex:75
+#: lib/vutuv_web/views/notification_digest_text.ex:81
 #, elixir-autogen, elixir-format
 msgid "Your vutuv username is ready."
 msgstr ""
@@ -19004,7 +19001,7 @@ msgstr ""
 msgid "by the lawyer Tom Braegelmann"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:827
+#: lib/vutuv_web/templates/user/show.html.heex:830
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Documents:"
 msgstr ""
@@ -19165,17 +19162,17 @@ msgstr ""
 msgid "Enter the PIN from the email"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:723
+#: lib/vutuv_web/components/ui.ex:724
 #, elixir-autogen, elixir-format
 msgid "If you have added other addresses to your vutuv account, try logging in with one of those instead."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:751
+#: lib/vutuv_web/components/ui.ex:752
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cancel registration"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:844
+#: lib/vutuv_web/live/notification_live/index.ex:856
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
@@ -19185,22 +19182,22 @@ msgstr ""
 msgid "Follow other members"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:706
+#: lib/vutuv_web/components/ui.ex:707
 #, elixir-autogen, elixir-format
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1305
+#: lib/vutuv/accounts/user.ex:1313
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1303
+#: lib/vutuv/accounts/user.ex:1311
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1304
+#: lib/vutuv/accounts/user.ex:1312
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -19210,7 +19207,7 @@ msgstr ""
 msgid "Shares are of the %{answered} members who answered. %{unanswered} gave no answer."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4077
+#: lib/vutuv_web/components/ui.ex:4082
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr ""
@@ -19306,7 +19303,7 @@ msgstr ""
 msgid "Always keep"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4183
+#: lib/vutuv_web/components/ui.ex:4191
 #: lib/vutuv_web/controllers/settings_controller.ex:245
 #: lib/vutuv_web/controllers/settings_controller.ex:324
 #: lib/vutuv_web/controllers/settings_controller.ex:336
@@ -19403,7 +19400,7 @@ msgstr ""
 msgid "Keep posts that did well"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4185
+#: lib/vutuv_web/components/ui.ex:4193
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr ""
@@ -19512,7 +19509,7 @@ msgstr ""
 msgid "Your rule"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4187
+#: lib/vutuv_web/components/ui.ex:4195
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
@@ -19886,7 +19883,7 @@ msgstr ""
 msgid "Start over"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2271
+#: lib/vutuv_web/components/post_components.ex:2368
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -19977,7 +19974,7 @@ msgstr ""
 msgid "A post in an organization's name is always public."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:565
+#: lib/vutuv_web/live/shell_live.ex:685
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Open the page"
 msgstr ""
@@ -19997,7 +19994,7 @@ msgstr ""
 msgid "Write as %{name} for now"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:575
+#: lib/vutuv_web/live/shell_live.ex:695
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr ""
@@ -20007,7 +20004,7 @@ msgstr ""
 msgid "You are writing as %{name} now."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:551
+#: lib/vutuv_web/live/shell_live.ex:671
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr ""
@@ -20319,22 +20316,22 @@ msgstr ""
 msgid "The PIN has expired."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:827
+#: lib/vutuv_web/components/ui.ex:828
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more minute."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:829
+#: lib/vutuv_web/components/ui.ex:830
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for one more second."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:828
+#: lib/vutuv_web/components/ui.ex:829
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more minutes."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:830
+#: lib/vutuv_web/components/ui.ex:831
 #, elixir-autogen, elixir-format
 msgid "The PIN is valid for {n} more seconds."
 msgstr ""
@@ -20371,21 +20368,21 @@ msgstr ""
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:468
+#: lib/vutuv_web/live/shell_live.ex:483
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} person"
 msgid_plural "%{formatted} people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:455
+#: lib/vutuv_web/live/shell_live.ex:470
 #, elixir-autogen, elixir-format, fuzzy
 msgid "person"
 msgid_plural "people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:490
+#: lib/vutuv_web/live/shell_live.ex:505
 #, elixir-autogen, elixir-format
 msgid "%{members} vutuv members plus %{fediverse} Fediverse account that follows them"
 msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that follow them"
@@ -20778,37 +20775,37 @@ msgstr ""
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3942
+#: lib/vutuv_web/components/post_components.ex:4039
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3963
+#: lib/vutuv_web/components/post_components.ex:4060
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3972
+#: lib/vutuv_web/components/post_components.ex:4069
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3975
+#: lib/vutuv_web/components/post_components.ex:4072
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3952
+#: lib/vutuv_web/components/post_components.ex:4049
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:823
+#: lib/vutuv_web/controllers/settings_controller.ex:835
 #, elixir-autogen, elixir-format
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:812
+#: lib/vutuv_web/controllers/settings_controller.ex:824
 #, elixir-autogen, elixir-format
 msgid "Feed language settings saved."
 msgstr ""
@@ -20848,7 +20845,7 @@ msgstr ""
 msgid "Date & time"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:736
+#: lib/vutuv_web/controllers/settings_controller.ex:748
 #, elixir-autogen, elixir-format
 msgid "Date and time settings reset to the site defaults."
 msgstr ""
@@ -20863,7 +20860,7 @@ msgstr ""
 msgid "Germany, Austria, Switzerland"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:730
+#: lib/vutuv_web/controllers/settings_controller.ex:742
 #, elixir-autogen, elixir-format
 msgid "Language and region saved."
 msgstr ""
@@ -20903,7 +20900,7 @@ msgstr ""
 msgid "ISO 8601 (Sweden, Japan, China)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4210
+#: lib/vutuv_web/components/ui.ex:4218
 #, elixir-autogen, elixir-format
 msgid "Interface language, date format and time zone, feed languages, maps, how posts are shortened"
 msgstr ""
@@ -20913,7 +20910,7 @@ msgstr ""
 msgid "Language & display settings changed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4214
+#: lib/vutuv_web/components/ui.ex:4222
 #, elixir-autogen, elixir-format, fuzzy
 msgid "german english locale translation translate map font length hyphenation feed languages hide foreign übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
 msgstr ""
@@ -20953,19 +20950,19 @@ msgstr ""
 msgid "Your username, or paste the address of your profile page."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3742
+#: lib/vutuv_web/components/post_components.ex:3839
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3739
+#: lib/vutuv_web/components/post_components.ex:3836
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3079
+#: lib/vutuv_web/components/post_components.ex:3176
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -21033,7 +21030,7 @@ msgstr ""
 msgid "Mastodon app access changed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4231
+#: lib/vutuv_web/components/ui.ex:4239
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr ""
@@ -21079,7 +21076,7 @@ msgstr ""
 msgid "Your account is then %{handle}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4233
+#: lib/vutuv_web/components/ui.ex:4241
 #, elixir-autogen, elixir-format, fuzzy
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr ""
@@ -21115,7 +21112,7 @@ msgstr ""
 msgid "Find your LinkedIn contacts"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4158
+#: lib/vutuv_web/components/ui.ex:4166
 #: lib/vutuv_web/live/import_connections_live.ex:64
 #: lib/vutuv_web/templates/import/new.html.heex:37
 #, elixir-autogen, elixir-format, fuzzy
@@ -21222,7 +21219,7 @@ msgstr ""
 msgid "See which of them are already on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4160
+#: lib/vutuv_web/components/ui.ex:4168
 #, elixir-autogen, elixir-format
 msgid "See which of your LinkedIn contacts are already on vutuv"
 msgstr ""
@@ -21294,7 +21291,7 @@ msgstr ""
 msgid "Your export also lists your LinkedIn contacts."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4162
+#: lib/vutuv_web/components/ui.ex:4170
 #, elixir-autogen, elixir-format
 msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
 msgstr ""
@@ -21490,7 +21487,7 @@ msgstr ""
 msgid "This page is following the most accounts we allow (%{max})."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2122
+#: lib/vutuv_web/components/post_components.ex:2219
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr ""
@@ -21498,4 +21495,74 @@ msgstr ""
 #: lib/vutuv_web/live/remote_post_actions.ex:89
 #, elixir-autogen, elixir-format
 msgid "Unfollowed. Their posts leave your feed."
+msgstr ""
+
+#: lib/vutuv_web/live/shell_live.ex:641
+#, elixir-autogen, elixir-format
+msgid "Allow"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:166
+#, elixir-autogen, elixir-format
+msgid "Ask now"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:144
+#, elixir-autogen, elixir-format
+msgid "Browser notifications"
+msgstr ""
+
+#: lib/vutuv_web/live/shell_live.ex:583
+#, elixir-autogen, elixir-format
+msgid "New message"
+msgstr ""
+
+#: lib/vutuv_web/live/shell_live.ex:648
+#, elixir-autogen, elixir-format
+msgid "Not now"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:152
+#, elixir-autogen, elixir-format
+msgid "Only while vutuv is open somewhere and you are looking at something else. Every browser you use asks you once."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:150
+#, elixir-autogen, elixir-format
+msgid "Show me browser notifications"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:176
+#, elixir-autogen, elixir-format
+msgid "This browser cannot show notifications. Your other browsers are unaffected."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:160
+#, elixir-autogen, elixir-format
+msgid "This browser has not been asked yet."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:171
+#, elixir-autogen, elixir-format
+msgid "This browser is blocking notifications for vutuv. Allow them for this site in your browser settings; the switch above stays on and every other browser you use is unaffected."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:169
+#, elixir-autogen, elixir-format
+msgid "This browser will show them."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:146
+#, elixir-autogen, elixir-format
+msgid "When something arrives while you have vutuv open in a tab you are not looking at, your browser can show it as a notification. Off unless you switch it on."
+msgstr ""
+
+#: lib/vutuv_web/live/shell_live.ex:638
+#, elixir-autogen, elixir-format
+msgid "You switched browser notifications on. This browser has not been asked for permission yet."
+msgstr ""
+
+#: lib/vutuv_web/components/ui.ex:4149
+#, elixir-autogen, elixir-format
+msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr ""

--- a/priv/repo/migrations/20260824094326_add_browser_notifications.exs
+++ b/priv/repo/migrations/20260824094326_add_browser_notifications.exs
@@ -1,0 +1,21 @@
+defmodule Vutuv.Repo.Migrations.AddBrowserNotifications do
+  use Ecto.Migration
+
+  # Browser notifications (issue #1249): while a member has vutuv open in a tab
+  # they are not looking at, a new notification or message can pop up through
+  # the Notifications API instead of only moving the tab title.
+  #
+  # Default false, unlike the other two in-app switches (`cv_update_notifications?`,
+  # `thread_notifications?`, both opt-outs). This one is an **opt-in** on purpose:
+  # a popup over whatever you are doing is the loudest thing vutuv can do, and
+  # switching it on is also what makes the browser ask for permission — so
+  # nobody who did not ask for it is ever prompted.
+  #
+  # Plain additive column with a default, so the previous release keeps working
+  # untouched during the blue/green window (N-1 safe).
+  def change do
+    alter table(:users) do
+      add(:browser_notifications?, :boolean, null: false, default: false)
+    end
+  end
+end

--- a/test/vutuv_web/controllers/settings_controller_test.exs
+++ b/test/vutuv_web/controllers/settings_controller_test.exs
@@ -664,6 +664,73 @@ defmodule VutuvWeb.SettingsControllerTest do
       assert html =~ "thread_notifications?"
     end
 
+    test "browser notifications are off until the member switches them on (issue #1249)",
+         %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      # Opt-IN, unlike its two neighbours above. Nobody who left it alone is
+      # ever prompted by their browser, which is the whole point of the switch.
+      refute Repo.get(User, user.id).browser_notifications?
+
+      conn = put(conn, ~p"/settings/notifications", user: %{"browser_notifications?" => "true"})
+
+      assert redirected_to(conn) == ~p"/settings/notifications"
+      assert %User{browser_notifications?: true} = Repo.get(User, user.id)
+    end
+
+    test "the browser-notification card reports what THIS browser thinks (issue #1249)",
+         %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+      html = conn |> get(~p"/settings/notifications") |> html_response(200)
+
+      assert html =~ "browser_notifications?"
+      assert html =~ "data-browser-notifications"
+
+      # The account stores the wish; only the browser knows whether it will show
+      # anything, and that answer is per browser profile. All four states ship
+      # rendered and switched off by the plain `hidden` ATTRIBUTE — a display
+      # utility beside it is the issue #880 trap — with app.js revealing the one
+      # that applies.
+      for state <- ~w(default granted denied unsupported) do
+        assert html =~ ~s(data-notify-state="#{state}")
+      end
+
+      refute html =~ ~s(class="hidden" data-notify-state)
+    end
+
+    test "the browser-notification card reads as German for a German member (issue #1249)",
+         %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+
+      html =
+        conn
+        |> recycle()
+        |> Plug.Conn.put_req_header("accept-language", "de-DE,de")
+        |> get(~p"/settings/notifications")
+        |> html_response(200)
+
+      # Named one by one, short labels included: `gettext.extract --merge`
+      # fuzzy-FILLS a new msgid with the translation of whatever it looks
+      # similar to, and a one-word label is the likeliest to be filled with
+      # nonsense and the least likely to be noticed. "Allow" arrived as "Alle".
+      assert html =~ "Browser-Benachrichtigungen anzeigen"
+      assert html =~ "Jetzt fragen"
+      assert html =~ "Dieser Browser wurde noch nicht gefragt."
+      assert html =~ "Dieser Browser zeigt sie an."
+    end
+
+    test "saving the switch tells the member's other open tabs (issue #1249)", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      Vutuv.Activity.subscribe(user.id)
+
+      put(conn, ~p"/settings/notifications", user: %{"browser_notifications?" => "true"})
+
+      # A tab on another machine has to learn about it to ask ITS browser for
+      # permission — the switch travels with the account, the permission does
+      # not travel at all.
+      assert_receive {:browser_notifications_pref, true}
+    end
+
     test "switching thread notifications off persists (issue #1025)", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
 

--- a/test/vutuv_web/live/shell_live_browser_notifications_test.exs
+++ b/test/vutuv_web/live/shell_live_browser_notifications_test.exs
@@ -1,0 +1,196 @@
+defmodule VutuvWeb.ShellLiveBrowserNotificationsTest do
+  @moduledoc """
+  Browser notifications (issue #1249). The shell is on every page and already
+  holds the member's activity subscription, so it is what turns an arriving
+  notification into the `notify:show` event the WebNotify hook raises a popup
+  from.
+
+  What these tests are really about is the **gate**: the feature is opt-in, and
+  a member who never asked for it must never be pushed to — which is also the
+  only thing standing between them and a permission prompt they did not want.
+  So each push assertion has a matching `refute` with the switch off.
+  """
+  use VutuvWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.Activity
+  alias Vutuv.Sessions
+
+  defp session_for(user, extra) do
+    {token, _session} = Sessions.start_session(user, build_conn(), alert: false)
+    Map.merge(%{"session_token" => token}, extra)
+  end
+
+  defp mount_shell(conn, user, session_extra \\ %{}) do
+    {:ok, view, _html} =
+      live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user, session_extra))
+
+    view
+  end
+
+  defp like_notification(actor_name, extra \\ %{}) do
+    Map.merge(
+      %{
+        kind: "like",
+        actor_name: actor_name,
+        actor_param: "anna_klein",
+        actor_avatar: "/avatars/anna/thumb.jpg",
+        text: "liked your post.",
+        at: DateTime.utc_now()
+      },
+      extra
+    )
+  end
+
+  describe "the opt-in gate" do
+    test "a member who switched it on is pushed the arriving notification", %{conn: conn} do
+      user = insert(:user, browser_notifications?: true)
+      view = mount_shell(conn, user)
+
+      Activity.broadcast(user.id, {:new_notification, like_notification("Anna Klein")})
+
+      # The actor's name is the popup's title and their verb phrase its body —
+      # the same two halves the row under the bell reads as.
+      assert_push_event(view, "notify:show", %{
+        tag: "activity",
+        title: "Anna Klein",
+        body: "liked your post.",
+        icon: "/avatars/anna/thumb.jpg"
+      })
+    end
+
+    test "a member who left it off is pushed nothing at all", %{conn: conn} do
+      user = insert(:user)
+      refute user.browser_notifications?
+
+      view = mount_shell(conn, user)
+
+      Activity.broadcast(user.id, {:new_notification, like_notification("Anna Klein")})
+
+      # The badge still moves; only the popup is withheld.
+      assert_push_event(view, "tab:badge", %{})
+      refute_push_event(view, "notify:show", %{})
+    end
+
+    test "a new message is pushed under its own tag, naming neither sender nor text",
+         %{conn: conn} do
+      user = insert(:user, browser_notifications?: true)
+      view = mount_shell(conn, user)
+
+      Activity.broadcast(user.id, {:new_message, %{conversation_id: Vutuv.UUIDv7.generate()}})
+
+      assert_push_event(view, "notify:show", %{tag: "messages", url: "/messages"})
+    end
+
+    test "a new message reaches nobody who left the switch off", %{conn: conn} do
+      user = insert(:user)
+      view = mount_shell(conn, user)
+
+      Activity.broadcast(user.id, {:new_message, %{conversation_id: Vutuv.UUIDv7.generate()}})
+
+      refute_push_event(view, "notify:show", %{})
+    end
+  end
+
+  describe "the wording" do
+    test "an actorless notification puts its whole sentence in the title", %{conn: conn} do
+      user = insert(:user, browser_notifications?: true)
+      view = mount_shell(conn, user)
+
+      Activity.broadcast(
+        user.id,
+        {:new_notification,
+         %{kind: "moderation", status: "upheld", text: "ignored", at: DateTime.utc_now()}}
+      )
+
+      # No name to head the popup with, so the sentence is the title and there
+      # is no body — a placeholder name over one line would say less.
+      assert_push_event(view, "notify:show", %{title: title, body: nil})
+      assert title == "A report about your content was confirmed."
+    end
+
+    test "the line follows the reader's language, not the actor's", %{conn: conn} do
+      user = insert(:user, browser_notifications?: true, locale: "de")
+      # Where the shell reads it from: `VutuvWeb.Plug.Locale` resolves the
+      # member's language per request and stores it in the session, which is
+      # what `LiveLocale.put_viewer/1` re-applies inside the socket. A test that
+      # only set the column would prove nothing about what a member sees.
+      view = mount_shell(conn, user, %{"locale" => "de"})
+
+      Activity.broadcast(user.id, {:new_notification, like_notification("Anna Klein")})
+
+      assert_push_event(view, "notify:show", %{body: body})
+      assert body == "gefällt Ihr Beitrag."
+    end
+  end
+
+  describe "where the popup leads" do
+    test "to the thing it just named, not to the list", %{conn: conn} do
+      user = insert(:user, browser_notifications?: true)
+      post = insert(:post, user: user)
+      view = mount_shell(conn, user)
+
+      Activity.broadcast(
+        user.id,
+        {:new_notification, like_notification("Anna Klein", %{post_id: post.id})}
+      )
+
+      # A popup is raised precisely when the member is NOT looking at vutuv, so
+      # this is the surface where landing on a list to hunt costs most. The
+      # destination comes from the same function the row under the bell uses.
+      assert_push_event(view, "notify:show", %{url: url})
+      assert url == "/#{user.username}/posts/#{post.id}"
+    end
+
+    test "to the notifications list when the kind has no page of its own",
+         %{conn: conn} do
+      user = insert(:user, browser_notifications?: true)
+      view = mount_shell(conn, user)
+
+      Activity.broadcast(
+        user.id,
+        {:new_notification, %{kind: "moderation", status: "upheld", at: DateTime.utc_now()}}
+      )
+
+      assert_push_event(view, "notify:show", %{url: "/notifications"})
+    end
+  end
+
+  describe "the per-browser permission prompt" do
+    test "renders for a member who switched the feature on", %{conn: conn} do
+      user = insert(:user, browser_notifications?: true)
+      view = mount_shell(conn, user)
+
+      assert has_element?(view, "#web-notify[data-enabled=true]")
+      # Shipped hidden by the plain attribute (never a display utility) — the
+      # hook takes it off only where this browser has not been asked yet.
+      assert has_element?(view, "[data-notify-prompt][hidden]")
+      assert has_element?(view, "[data-notify-allow]")
+    end
+
+    test "is absent for a member who left the feature off", %{conn: conn} do
+      user = insert(:user)
+      view = mount_shell(conn, user)
+
+      assert has_element?(view, "#web-notify[data-enabled=false]")
+      refute has_element?(view, "[data-notify-prompt]")
+    end
+
+    test "appears without a reload when another session switches the feature on",
+         %{conn: conn} do
+      user = insert(:user)
+      view = mount_shell(conn, user)
+
+      refute has_element?(view, "[data-notify-prompt]")
+
+      # What SettingsController.update_notifications broadcasts on save. The
+      # switch is the member's and travels with the account, so a tab on
+      # another machine has to learn about it — and then ask its own browser.
+      Activity.broadcast(user.id, {:browser_notifications_pref, true})
+
+      assert has_element?(view, "#web-notify[data-enabled=true]")
+      assert has_element?(view, "[data-notify-prompt]")
+    end
+  end
+end


### PR DESCRIPTION
Closes #1249.

**Symptom.** With vutuv open in a tab you are not looking at, a new reply or message only moved the number in the tab title. Nothing reached you.

**What changed.** `/settings/notifications` gains a **Browser notifications** card (`VutuvWeb.SettingsHTML`, `browser_notifications?`). When it is on, `VutuvWeb.ShellLive` — already on every page and already subscribed to the member's activity — pushes each arriving notification or message to a new `WebNotify` hook in `app.js`, which raises a real browser notification while `document.hidden || !document.hasFocus()`. One `tag` per stream, so a burst and several open tabs collapse into one popup, and a replacement is silent.

Off by default, and the only notification switch here that is. It puts something over whatever you are doing, and switching it on is also what makes a browser ask for permission — so nobody who left it alone is ever prompted.

**Across your machines.** The switch belongs to the account and travels; the permission belongs to one browser and does not. So the shell renders one dismissible line offering to ask a browser that never was, and the card reports what *this* browser answered (never asked / will show them / blocking them / cannot). `requestPermission()` runs from the tick on the checkbox, because Firefox and Safari refuse it without a user gesture.

**Where to look:** `/settings/notifications` for the card; any page while the switch is on and this browser has not been asked for the shell line.

Clicking a popup opens the post, the case or the profile it named: `notification_target/2` moved into the new `VutuvWeb.NotificationLine` beside the wording. Extracting that surfaced four everyday kinds (like, follower, connection, endorsement) spelled only in the grouping code, which fell back to untranslated English.

Driven end to end in Chrome over CDP: 12 checks, including a real popup and silence while the tab is in front.

*An AI agent wrote this text in my name. I know that is problematic.*