### PR TITLE
Tag pages: own title, honest description, CollectionPage markup

### DIFF
--- a/lib/vutuv/tags/tag.ex
+++ b/lib/vutuv/tags/tag.ex
@@ -329,6 +329,19 @@ defmodule Vutuv.Tags.Tag do
   defp follow_alias(%__MODULE__{merged_into_id: id} = tag), do: Repo.get(__MODULE__, id) || tag
 
   @doc """
+  What to call this tag on screen: the name its first writer gave it, falling
+  back to the slug for a struct built without one (the column is NOT NULL, but
+  it does allow a blank).
+
+  One owner, because the answer now reaches further than a heading: it is the
+  page's `<h1>`, its `<title>` and `og:title`, and the topic named in its meta
+  description, and a page whose title says one thing while its heading says
+  another is a page a search engine has to guess about.
+  """
+  def display_name(%__MODULE__{name: name}) when is_binary(name) and name != "", do: name
+  def display_name(%__MODULE__{slug: slug}), do: slug
+
+  @doc """
   The topic a tag stands for: itself, or the tag it is an alternative name for.
 
   Takes a loaded `%Tag{}` and answers without a query when the association is

--- a/lib/vutuv_web/controllers/tag_controller.ex
+++ b/lib/vutuv_web/controllers/tag_controller.ex
@@ -13,6 +13,7 @@ defmodule VutuvWeb.TagController do
   alias VutuvWeb.AgentDocs.ListDocs
   alias VutuvWeb.ContentPolicy
   alias VutuvWeb.Fediverse.Docs
+  alias VutuvWeb.UserHelpers
 
   # Not the shared `ResolveSlug` plug: an alternative name for a topic keeps its
   # own slug (issue #1338), and that URL must lead to the topic rather than 404
@@ -29,7 +30,11 @@ defmodule VutuvWeb.TagController do
       |> Pages.paginate(conn.params, tags_count)
       |> Repo.all()
 
-    render(conn, "index.html", tags: tags, tags_count: tags_count)
+    render(conn, "index.html",
+      tags: tags,
+      tags_count: tags_count,
+      page_title: gettext("Tags")
+    )
   end
 
   # Resolves the `:slug` param: a topic is assigned and rendered; an alternative
@@ -96,8 +101,10 @@ defmodule VutuvWeb.TagController do
     # Console as "crawled - currently not indexed". It stays served and
     # linkable, but carries noindex (on every format) so crawlers drop it
     # deliberately; the sitemap advertises only the tags above the bar.
+    indexable? = Tags.indexable_tag?(tag)
+
     conn =
-      if Tags.indexable_tag?(tag),
+      if indexable?,
         do: conn,
         else: ContentPolicy.put_robots_header(conn, true, false)
 
@@ -120,11 +127,22 @@ defmodule VutuvWeb.TagController do
           # shared link may carry, since an off-router LiveView cannot read the
           # query string for itself.
           timeline_session: timeline_session(conn, tag),
-          meta_description: gettext("Members on vutuv tagged %{tag}.", tag: tag.name || tag.slug)
+          # `#Deutschland - vutuv`, and the same string as `og:title`. Every
+          # tag page used to fall through to the bare site name, so the whole
+          # `/tags/*` corpus shared one title — the strongest on-page signal
+          # there is, spent on nothing, and a shared link previewed as "vutuv".
+          # The hashtag form is what makes it a topic rather than a person: a
+          # member may hold `/deutschland` as their handle, and two pages
+          # titled "Deutschland" would be competing with each other.
+          page_title: "#" <> Tag.display_name(tag),
+          meta_description: meta_description(tag),
+          # Markup mirrors the page (the profile's rule): a tag page the
+          # crawlers are told to drop describes no collection to them either.
+          indexable?: indexable?
         ),
       doc: fn ->
         recommended = Tag.recommended_users(tag)
-        work_info_by_id = VutuvWeb.UserHelpers.work_information_map(recommended, 45)
+        work_info_by_id = UserHelpers.work_information_map(recommended, 45)
         jobs = Jobs.list_tag_postings(tag, nil)
         timeline = timeline_doc(tag, conn.params)
 
@@ -138,6 +156,24 @@ defmodule VutuvWeb.TagController do
         )
       end
     )
+  end
+
+  # What a search result and a link preview say under the title. An admin who
+  # wrote a description for this topic wrote the better sentence, so it wins;
+  # otherwise say what the page actually holds. The old copy ("Members on vutuv
+  # tagged X") predates issue #946, after which the page leads with the posts
+  # carrying the tag and most tag pages have no endorsed members at all — so it
+  # promised a search visitor a list of people that often was not there.
+  #
+  # Capped at 160 characters, past which a search-result snippet is cut anyway;
+  # `headline_text/2` is the app's one "make this one plain line and shorten it"
+  # helper, so a description written with a bit of Markdown in the admin form
+  # arrives here as prose rather than as literal asterisks.
+  defp meta_description(%Tag{} = tag) do
+    case UserHelpers.headline_text(tag.description, 160) do
+      "" -> gettext("Posts and members on vutuv about %{tag}.", tag: Tag.display_name(tag))
+      text -> text
+    end
   end
 
   # The controls a link can carry, handed to the LiveView as strings — it

--- a/lib/vutuv_web/templates/tag/index.html.heex
+++ b/lib/vutuv_web/templates/tag/index.html.heex
@@ -3,7 +3,7 @@
 <div class="card-list">
   <section class="card">
     <div class="flex flex-wrap gap-2">
-      <.chip :for={tag <- @tags} navigate={~p"/tags/#{tag}"}>{tag.name || tag.slug}</.chip>
+      <.chip :for={tag <- @tags} navigate={~p"/tags/#{tag}"}>{Tag.display_name(tag)}</.chip>
     </div>
     <.pager params={@conn.params} total={@tags_count} />
   </section>

--- a/lib/vutuv_web/templates/tag/show.html.heex
+++ b/lib/vutuv_web/templates/tag/show.html.heex
@@ -8,7 +8,7 @@ card stretch edge to edge with a huge line length and dead space. --%>
   below it. Exactly one <h1> on the page (no sr-only crumbs h1). --%>
   <div class="profile-header items-start">
     <div class="profile-header__info min-w-0">
-      <h1>{@tag.name || @tag.slug}</h1>
+      <h1>{Tag.display_name(@tag)}</h1>
       <%!-- The page's meta line: how many people follow this topic and, where
       the installation federates, the topic's own address out there — which is
       the one thing a visitor arriving from Mastodon came for, and the only part
@@ -38,6 +38,11 @@ card stretch edge to edge with a huge line length and dead space. --%>
     {gen_breadcrumbs([{gettext("Tags"), ~p"/tags"}, gettext("Show")])}
   </div>
   <JsonLd.script data={JsonLd.breadcrumb_trail([{gettext("Tags"), ~p"/tags"}, gettext("Show")])} />
+  <%!-- What this page collects, and the topic it collects it about. Only on a
+  page the crawlers are allowed to keep — markup that describes a collection to
+  a crawler we just asked to drop the page contradicts itself (the profile's
+  rule). The description is the same string the `<head>` carries. --%>
+  <JsonLd.script :if={@indexable?} data={JsonLd.collection_page(@tag, @meta_description)} />
 
   <%!-- The rest of what a visitor from another server needs: the sentence that
   explains what following a tag over there gets them, and the form that sends

--- a/lib/vutuv_web/views/json_ld.ex
+++ b/lib/vutuv_web/views/json_ld.ex
@@ -34,6 +34,7 @@ defmodule VutuvWeb.JsonLd do
   alias Vutuv.Posts.PostImage
   alias Vutuv.Posts.PostReview
   alias Vutuv.Profiles.SocialMediaAccount
+  alias Vutuv.Tags.Tag
   alias Vutuv.Tags.UserTag
   alias VutuvWeb.AgentDocs
   alias VutuvWeb.AgentDocs.ProfileDoc
@@ -363,6 +364,42 @@ defmodule VutuvWeb.JsonLd do
   defp job_skills(%JobPosting{} = posting) do
     (Jobs.tags_of(posting, :required) ++ Jobs.tags_of(posting, :nice_to_have))
     |> Enum.map(& &1.name)
+  end
+
+  @doc """
+  A tag page as schema.org CollectionPage: what this page collects, and the
+  topic it collects it about.
+
+  A tag page is not an entity, it is a gathering of posts and members around a
+  subject, and `CollectionPage` is the type that says so — which also stops a
+  crawler reading the page's `<h1>` as the name of a *thing* called
+  "Deutschland". The subject itself rides in `about` as a bare `Thing`: naming
+  it is honest (that word is what the page is about) while claiming any more
+  specific type would be a guess, since nothing in a tag row says whether
+  "Deutschland" is a place, "Elixir" a programming language and "Bach" a person.
+
+  `description` is deliberately the same string the page's `<meta
+  name="description">` carries, so the markup cannot describe the page
+  differently from the head.
+
+  Gate at the call site: only emit for an indexable page (`Tags.indexable_tag?/1`),
+  the same rule the profile follows — markup that describes a collection to a
+  crawler we have just asked to drop the page contradicts itself.
+  """
+  def collection_page(tag, description) do
+    url = AgentDocs.abs_url("/tags/#{tag.slug}")
+    name = Tag.display_name(tag)
+
+    compact(%{
+      "@context" => "https://schema.org",
+      "@type" => "CollectionPage",
+      "@id" => url,
+      "url" => url,
+      "name" => name,
+      "description" => description,
+      "about" => %{"@type" => "Thing", "name" => name},
+      "isPartOf" => %{"@type" => "WebSite", "url" => VutuvWeb.Endpoint.url(), "name" => "vutuv"}
+    })
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.343.2",
+      version: "7.343.3",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -1405,6 +1405,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/agent_docs/text.ex:516
 #: lib/vutuv_web/agent_docs/text.ex:753
 #: lib/vutuv_web/components/ui.ex:4125
+#: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
 #: lib/vutuv_web/cv/docx.ex:174
@@ -10969,11 +10970,6 @@ msgstr ""
 "Verwalten Sie Ihr vutuv-Konto: Profil, Privatsphäre, Benachrichtigungen und "
 "Anmeldung."
 
-#: lib/vutuv_web/controllers/tag_controller.ex:123
-#, elixir-autogen, elixir-format
-msgid "Members on vutuv tagged %{tag}."
-msgstr "Mitglieder auf vutuv mit dem Tag %{tag}."
-
 #: lib/vutuv_web/open_graph.ex:159
 #, elixir-autogen, elixir-format
 msgid "Set up an authenticator app (TOTP) for your vutuv login."
@@ -13322,7 +13318,7 @@ msgid "All countries"
 msgstr "Alle Länder"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:503
-#: lib/vutuv_web/templates/tag/show.html.heex:92
+#: lib/vutuv_web/templates/tag/show.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr "Alle Stellen mit diesem Tag"
@@ -13398,7 +13394,7 @@ msgstr "Keine passenden Stellen. Passen Sie die Filter an."
 #: lib/vutuv_web/agent_docs/text.ex:521
 #: lib/vutuv_web/agent_docs/text.ex:533
 #: lib/vutuv_web/live/organization_live/show.ex:676
-#: lib/vutuv_web/templates/tag/show.html.heex:86
+#: lib/vutuv_web/templates/tag/show.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "Open positions"
 msgstr "Offene Stellen"
@@ -22360,7 +22356,12 @@ msgstr "e-mail email mail abbestellen abmelden newsletter glocke benachrichtigun
 msgid "%{formatted} active"
 msgstr "%{formatted} aktiv"
 
-#: lib/vutuv_web/templates/tag/show.html.heex:58
+#: lib/vutuv_web/templates/tag/show.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "Follow from the Fediverse"
 msgstr "Aus dem Fediverse folgen"
+
+#: lib/vutuv_web/controllers/tag_controller.ex:174
+#, elixir-autogen, elixir-format
+msgid "Posts and members on vutuv about %{tag}."
+msgstr "Beiträge und Mitglieder auf vutuv zum Thema %{tag}."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1378,6 +1378,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:516
 #: lib/vutuv_web/agent_docs/text.ex:753
 #: lib/vutuv_web/components/ui.ex:4125
+#: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
 #: lib/vutuv_web/cv/docx.ex:174
@@ -10427,11 +10428,6 @@ msgstr ""
 msgid "Manage your vutuv account: profile, privacy, notifications and sign-in."
 msgstr ""
 
-#: lib/vutuv_web/controllers/tag_controller.ex:123
-#, elixir-autogen, elixir-format
-msgid "Members on vutuv tagged %{tag}."
-msgstr ""
-
 #: lib/vutuv_web/open_graph.ex:159
 #, elixir-autogen, elixir-format
 msgid "Set up an authenticator app (TOTP) for your vutuv login."
@@ -12670,7 +12666,7 @@ msgid "All countries"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:503
-#: lib/vutuv_web/templates/tag/show.html.heex:92
+#: lib/vutuv_web/templates/tag/show.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr ""
@@ -12746,7 +12742,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:521
 #: lib/vutuv_web/agent_docs/text.ex:533
 #: lib/vutuv_web/live/organization_live/show.ex:676
-#: lib/vutuv_web/templates/tag/show.html.heex:86
+#: lib/vutuv_web/templates/tag/show.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "Open positions"
 msgstr ""
@@ -21570,7 +21566,12 @@ msgstr ""
 msgid "%{formatted} active"
 msgstr ""
 
-#: lib/vutuv_web/templates/tag/show.html.heex:58
+#: lib/vutuv_web/templates/tag/show.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "Follow from the Fediverse"
+msgstr ""
+
+#: lib/vutuv_web/controllers/tag_controller.ex:174
+#, elixir-autogen, elixir-format
+msgid "Posts and members on vutuv about %{tag}."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1376,6 +1376,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:516
 #: lib/vutuv_web/agent_docs/text.ex:753
 #: lib/vutuv_web/components/ui.ex:4125
+#: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
 #: lib/vutuv_web/cv/docx.ex:174
@@ -10425,11 +10426,6 @@ msgstr ""
 msgid "Manage your vutuv account: profile, privacy, notifications and sign-in."
 msgstr ""
 
-#: lib/vutuv_web/controllers/tag_controller.ex:123
-#, elixir-autogen, elixir-format
-msgid "Members on vutuv tagged %{tag}."
-msgstr ""
-
 #: lib/vutuv_web/open_graph.ex:159
 #, elixir-autogen, elixir-format
 msgid "Set up an authenticator app (TOTP) for your vutuv login."
@@ -12668,7 +12664,7 @@ msgid "All countries"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:503
-#: lib/vutuv_web/templates/tag/show.html.heex:92
+#: lib/vutuv_web/templates/tag/show.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr ""
@@ -12744,7 +12740,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:521
 #: lib/vutuv_web/agent_docs/text.ex:533
 #: lib/vutuv_web/live/organization_live/show.ex:676
-#: lib/vutuv_web/templates/tag/show.html.heex:86
+#: lib/vutuv_web/templates/tag/show.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "Open positions"
 msgstr ""
@@ -21568,7 +21564,12 @@ msgstr ""
 msgid "%{formatted} active"
 msgstr ""
 
-#: lib/vutuv_web/templates/tag/show.html.heex:58
+#: lib/vutuv_web/templates/tag/show.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "Follow from the Fediverse"
+msgstr ""
+
+#: lib/vutuv_web/controllers/tag_controller.ex:174
+#, elixir-autogen, elixir-format
+msgid "Posts and members on vutuv about %{tag}."
 msgstr ""

--- a/test/vutuv_web/controllers/tag_controller_test.exs
+++ b/test/vutuv_web/controllers/tag_controller_test.exs
@@ -1,7 +1,29 @@
 defmodule VutuvWeb.TagControllerTest do
   use VutuvWeb.ConnCase, async: true
 
+  alias Vutuv.Tags
+  alias Vutuv.Tags.Tag
   alias VutuvWeb.Fediverse.Docs
+
+  defp meta_description(html) do
+    [_, content] = Regex.run(~r/<meta name="description" content="([^"]*)"/, html)
+    content
+  end
+
+  defp og_tag(html, property) do
+    case Regex.run(~r/<meta property="#{property}" content="([^"]*)"/, html) do
+      [_, content] -> content
+      _ -> nil
+    end
+  end
+
+  # The CollectionPage block, or nil when the page emits none.
+  defp collection_page(html) do
+    ~r{<script type="application/ld\+json">\s*(.*?)\s*</script>}s
+    |> Regex.scan(html, capture: :all_but_first)
+    |> Enum.map(fn [json] -> Jason.decode!(json) end)
+    |> Enum.find(&(&1["@type"] == "CollectionPage"))
+  end
 
   # The public tag pages resolve the `:slug` param to a `Tags.Tag` before every
   # action. An unknown slug must render a clean 404 and *halt* (a missing tag
@@ -187,6 +209,88 @@ defmodule VutuvWeb.TagControllerTest do
         |> html_response(200)
 
       assert html =~ "Aus dem Fediverse folgen"
+    end
+  end
+
+  # What a search result and a shared link say about a tag page. The title used
+  # to be the bare site name on every one of them, and the description promised
+  # a list of members that most tag pages do not have.
+  describe "search-engine and link-preview metadata" do
+    test "the description says what the page holds", %{conn: conn} do
+      tag = insert(:tag, name: "Elchtest", slug: "elchtest")
+
+      html = conn |> get(~p"/tags/#{tag}") |> html_response(200)
+
+      assert meta_description(html) == "Posts and members on vutuv about Elchtest."
+    end
+
+    test "a description written in the admin form wins", %{conn: conn} do
+      insert(:tag, name: "Beam", slug: "beam", description: "The Erlang virtual machine.")
+
+      html = conn |> get(~p"/tags/beam") |> html_response(200)
+
+      assert meta_description(html) == "The Erlang virtual machine."
+    end
+
+    test "a long description is cut on a word boundary", %{conn: conn} do
+      insert(:tag, name: "Lang", slug: "lang", description: String.duplicate("Wort ", 60))
+
+      description = conn |> get(~p"/tags/lang") |> html_response(200) |> meta_description()
+
+      assert String.length(description) <= 160
+      assert String.ends_with?(description, "...")
+    end
+
+    test "og:title and og:description carry the same strings as the head", %{conn: conn} do
+      tag = insert(:tag, name: "Elchtest", slug: "elchtest")
+
+      html = conn |> get(~p"/tags/#{tag}") |> html_response(200)
+
+      # og:title is the page title without the " - vutuv" suffix the browser tab
+      # carries — the site name is already og:site_name.
+      assert og_tag(html, "og:title") == "#Elchtest"
+      assert og_tag(html, "og:description") == meta_description(html)
+    end
+
+    test "an indexable tag page describes its collection", %{conn: conn} do
+      tag = insert(:tag)
+
+      for _ <- 1..Tags.min_indexable_members() do
+        insert(:user_tag, user: insert(:activated_user), tag: tag)
+      end
+
+      block = conn |> get(~p"/tags/#{tag}") |> html_response(200) |> collection_page()
+
+      assert block["name"] == Tag.display_name(tag)
+      assert block["url"] =~ "/tags/#{tag.slug}"
+      assert block["description"] =~ Tag.display_name(tag)
+      # The topic itself, named but not typed: nothing in a tag row says whether
+      # it is a place, a language or a person.
+      assert block["about"] == %{"@type" => "Thing", "name" => Tag.display_name(tag)}
+    end
+
+    test "a thin tag page carries no collection markup", %{conn: conn} do
+      # Markup mirrors the page: this one already answers noindex, so telling a
+      # crawler about a collection here would contradict it.
+      tag = insert(:tag)
+      insert(:user_tag, user: insert(:activated_user), tag: tag)
+
+      conn = get(conn, ~p"/tags/#{tag}")
+
+      assert get_resp_header(conn, "x-robots-tag") == ["noindex"]
+      assert conn |> html_response(200) |> collection_page() == nil
+    end
+
+    test "the German page describes itself in German", %{conn: conn} do
+      tag = insert(:tag, name: "Elchtest", slug: "elchtest")
+
+      html =
+        conn
+        |> put_req_header("accept-language", "de-DE,de")
+        |> get(~p"/tags/#{tag}")
+        |> html_response(200)
+
+      assert meta_description(html) == "Beiträge und Mitglieder auf vutuv zum Thema Elchtest."
     end
   end
 

--- a/test/vutuv_web/open_graph_test.exs
+++ b/test/vutuv_web/open_graph_test.exs
@@ -75,7 +75,10 @@ defmodule VutuvWeb.OpenGraphTest do
 
       description = conn |> get(~p"/tags/elixir") |> html_response(200) |> og("og:description")
 
-      assert description == "Members on vutuv tagged Elixir."
+      # Not "members tagged Elixir": since issue #946 the page leads with the
+      # posts carrying the tag, and most tag pages have no endorsed members at
+      # all, so the old copy promised a search visitor a list that wasn't there.
+      assert description == "Posts and members on vutuv about Elixir."
     end
 
     test "each settings page describes what it manages", %{conn: conn} do

--- a/test/vutuv_web/page_title_test.exs
+++ b/test/vutuv_web/page_title_test.exs
@@ -31,6 +31,19 @@ defmodule VutuvWeb.PageTitleTest do
              "Tina Titel · #{Date.to_iso8601(post.published_on)} - vutuv"
   end
 
+  # Every /tags/* page used to fall through to the bare site name, so the whole
+  # corpus shared one title (and one og:title). The hashtag form also keeps a
+  # topic page from colliding with the profile of a member holding that handle.
+  test "a tag page names its topic as a hashtag", %{conn: conn} do
+    insert(:tag, name: "Deutschland", slug: "deutschland")
+
+    assert conn |> get("/tags/deutschland") |> title() == "#Deutschland - vutuv"
+  end
+
+  test "the tag directory names itself", %{conn: conn} do
+    assert conn |> get("/tags") |> title() == "Tags - vutuv"
+  end
+
   test "a LiveView's page_title reaches the dead render too", %{conn: conn} do
     {conn, _user} = create_and_login_user(conn)
 


### PR DESCRIPTION
**Symptom** Every page under `/tags` had `<title>vutuv</title>`. Neither `TagController.show` nor `:index` set `page_title`, and `og:title` inherits it — so the whole corpus shared one title and one link-preview heading. The meta description promised "Members on vutuv tagged X", which since #946 misdescribes a page that leads with posts and usually has no endorsed members.

**Changed**

- `page_title`: `#<Tag>` on the show page (hashtag form, so a topic page cannot collide with the profile of a member holding that handle), `Tags` on `/tags`.
- `meta_description`: an admin-written tag description wins (one plain line via `headline_text/2`, capped at 160), else "Posts and members on vutuv about X."
- `JsonLd.collection_page/2` — schema.org `CollectionPage` with the topic as a bare `about: Thing`, emitted only when `Tags.indexable_tag?/1`, so the markup never contradicts the `noindex` header.
- `Tag.display_name/1` is now the single owner of "what to call this tag".

**Not changed** `og:image` is still the generic brand card; a per-tag card would need a new image endpoint. Say if you want one.

Hot deploy, v7.343.3. Verified against a dev server (`/tags/deutschland`, `Accept-Language: de`).

*An AI agent wrote this text in my name. I know that is problematic.*