### PR TITLE
A test button for browser notifications

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -578,6 +578,14 @@ const Hooks = {
       this.onPermission = () => this.applyPrompt()
       window.addEventListener("vutuv:notify-permission", this.onPermission)
 
+      // "Send a test notification" on /settings/notifications. That page is a
+      // classic controller page with no socket of its own, so it asks through
+      // this hook - the same relay the permission event uses - and the round
+      // trip is the point: a test raised locally in JS would prove nothing
+      // about the path a real notification takes.
+      this.onTest = () => this.pushEvent("notify:test", {})
+      window.addEventListener("vutuv:notify-test", this.onTest)
+
       // Read once. `updated()` runs on every shell patch - a people-counter
       // tick, a presence diff, the hourly clock - and this value changes only
       // through dismiss() below.
@@ -600,6 +608,7 @@ const Hooks = {
     destroyed() {
       this.el.removeEventListener("click", this.onClick)
       window.removeEventListener("vutuv:notify-permission", this.onPermission)
+      window.removeEventListener("vutuv:notify-test", this.onTest)
     },
     // Re-applied on every patch rather than only when something changed: the
     // server re-renders the `hidden` attribute each time, and this is what
@@ -614,10 +623,12 @@ const Hooks = {
       this.dismissed = true
       this.applyPrompt()
     },
-    show({ tag, title, body, icon, url }) {
+    show({ tag, title, body, icon, url, test }) {
       if (notifyPermission() !== "granted") return
-      // Looking at vutuv means the badge and the bell already said it.
-      if (!document.hidden && document.hasFocus()) return
+      // Looking at vutuv means the badge and the bell already said it - except
+      // for the test, which the member asked for while plainly looking at the
+      // page, and which would otherwise be a button that does nothing.
+      if (!test && !document.hidden && document.hasFocus()) return
 
       let notification
       try {
@@ -628,9 +639,13 @@ const Hooks = {
           // popup and four open vutuv tabs raise one between them (the browser
           // collapses same-tag notifications across an origin). A replacement
           // is silent, so only the first of a burst makes a sound - which is
-          // the whole reason `renotify` stays off.
+          // the whole reason `renotify` stays off for news.
+          //
+          // The test is the one case that wants the opposite: pressing it a
+          // second time (after turning Do Not Disturb off, say) has to announce
+          // itself again, or a silent replacement reads as "still broken".
           tag: `vutuv-${tag}`,
-          renotify: false,
+          renotify: !!test,
         })
       } catch (_e) {
         // Some browsers refuse the constructor outright (a service worker is
@@ -643,6 +658,11 @@ const Hooks = {
         notification.close()
         if (url) window.location.href = url
       }
+
+      // Only ever fired for a test: it is what tells the settings card that a
+      // popup really was constructed, so the card can stop waiting instead of
+      // leaving the member to guess whether anything happened.
+      if (test) window.dispatchEvent(new CustomEvent("vutuv:notify-shown"))
     },
   },
   // The admin member browser (VutuvWeb.Admin.UserLive) pages in place over the
@@ -1858,6 +1878,21 @@ function wireBrowserNotifications(status) {
   const box = status.closest("form").querySelector('input[type="checkbox"]')
   const lines = [...status.querySelectorAll("[data-notify-state]")]
 
+  // The verdict under the test button. It ships empty and hidden; the two
+  // sentences ride the element as data- strings, because the server is the
+  // only side that knows the reader's language (the lightbox arrangement).
+  const note = status.querySelector("[data-notify-test-result]")
+  let waiting = null
+
+  const settle = (message) => {
+    if (waiting) clearTimeout(waiting)
+    waiting = null
+    if (note) {
+      note.textContent = message || ""
+      note.hidden = !message
+    }
+  }
+
   // All four lines ship rendered and switched off by the plain `hidden`
   // attribute (the issue #880 trap: a display utility would out-cascade it);
   // exactly the one that applies is revealed, and none of them while the
@@ -1867,6 +1902,9 @@ function wireBrowserNotifications(status) {
     lines.forEach((line) => {
       line.hidden = !box.checked || line.dataset.notifyState !== state
     })
+    // The verdict below belongs to the granted line, so it goes with it:
+    // unticking the box must not leave a stale "Sent." standing on its own.
+    if (!box.checked || state !== "granted") settle("")
   }
 
   // Ticking the box IS the user gesture, so ask right there rather than after
@@ -1875,6 +1913,29 @@ function wireBrowserNotifications(status) {
   box.addEventListener("change", () => {
     if (box.checked) requestNotifyPermission()
     else apply()
+  })
+
+  // "Send a test notification". It goes the whole way round - through the
+  // shell's socket to the server and back - so it answers the question the
+  // status line above cannot: will something actually appear on THIS machine.
+  // Permission granted is only the last link; the socket has to be up and the
+  // operating system has to draw the thing.
+  //
+  // Which is why the button waits for an answer rather than assuming one. The
+  // hook says `vutuv:notify-shown` the moment it really constructs a popup; if
+  // nothing comes back in a few seconds the member is told so, instead of being
+  // left to decide for themselves whether a popup they may simply have missed
+  // was ever raised.
+  window.addEventListener("vutuv:notify-shown", () => settle(note && note.dataset.sent))
+
+  // Wired per instance rather than at the document level like Allow above,
+  // because unlike Allow this button has state to keep: the timer and the
+  // verdict line belong to this card.
+  status.addEventListener("click", (event) => {
+    if (!event.target.closest("[data-notify-test]")) return
+    settle("")
+    window.dispatchEvent(new CustomEvent("vutuv:notify-test"))
+    waiting = setTimeout(() => settle(note && note.dataset.silent), 4000)
   })
 
   window.addEventListener("vutuv:notify-permission", apply)

--- a/docs/architecture/realtime.md
+++ b/docs/architecture/realtime.md
@@ -403,6 +403,17 @@ and reports what this browser answered — never asked / will show them /
 blocking them / cannot show them — because the stored setting alone cannot say
 whether this machine will show anything.
 
+The card also offers **Send a test notification**, and it deliberately makes
+the round trip — shell socket, server, hook — rather than raising one locally in
+JS. Permission granted is only the last link in the chain, so a local popup
+would answer a question nobody asked. Its payload carries `test: true`, which is
+what lets the hook show it although the member is plainly looking at the page;
+without that the away-gate would swallow every press and the button would do
+nothing. It also skips the standing-preference gate, because the useful moment
+to press it is right after ticking the box and before saving. The button waits
+for the hook's `vutuv:notify-shown` and says so if nothing comes back, so a
+silent system is told apart from a silent socket.
+
 Each stream carries one `tag` (`vutuv-activity`, `vutuv-messages`), so a burst
 of ten likes replaces itself into a single popup and four open vutuv tabs raise
 one between them; a replacement is silent, so only the first of a burst makes a

--- a/docs/architecture/settings-and-account.md
+++ b/docs/architecture/settings-and-account.md
@@ -94,7 +94,8 @@ while they are looking at something else. The one switch here that defaults to
 **off** — it is the only one that puts something over what somebody is doing,
 and switching it on is also what makes their browsers ask for permission. The
 card reports what *this* browser answered beside the stored setting, because
-the setting travels with the account and the permission does not. See the
+the setting travels with the account and the permission does not, and offers a
+test notification once that browser has granted permission. See the
 browser-notifications section in [realtime.md](realtime.md).
 
 **CV updates** (`cv_update_notifications?`, default on) and **Thread replies**

--- a/lib/vutuv_web/live/shell_live.ex
+++ b/lib/vutuv_web/live/shell_live.ex
@@ -542,6 +542,37 @@ defmodule VutuvWeb.ShellLive do
   # feature - a popup over whatever somebody is doing is the loudest thing this
   # app can do, so nobody who did not ask is ever prompted, let alone notified.
   # The gate lives in one clause, so a third stream cannot be added without it.
+  # "Send a test notification", from the card on /settings/notifications. The
+  # status line there can say this browser granted permission and still be
+  # wrong about the thing the member actually cares about, because permission
+  # is only the last of several links: the socket has to be up, the server has
+  # to reach this tab, and the operating system has to draw something. So the
+  # test travels the **whole** path a real notification takes rather than being
+  # raised locally in JS, which would answer a question nobody asked.
+  #
+  # Two deliberate exceptions to how every other push behaves. It skips
+  # `push_notify/2`'s standing-preference gate, because the member asked for
+  # this one by name a moment ago - including, usefully, right after ticking
+  # the box and before saving. And it carries `test: true`, which is what lets
+  # the hook show it although the member is plainly looking at the page; the
+  # away-gate is right for news and would make this button do nothing at all.
+  @impl true
+  def handle_event("notify:test", _params, %{assigns: %{user_id: nil}} = socket),
+    do: {:noreply, socket}
+
+  def handle_event("notify:test", _params, socket) do
+    {:noreply,
+     push_event(socket, "notify:show", %{
+       # Its own tag, so a test never replaces a real notification waiting in
+       # the tray - and a second press replaces the first test, not a message.
+       tag: "test",
+       title: gettext("Test notification"),
+       body: gettext("This is what vutuv looks like when something arrives."),
+       url: ~p"/settings/notifications",
+       test: true
+     })}
+  end
+
   defp push_notify(%{assigns: %{browser_notifications?: false}} = socket, _payload), do: socket
 
   defp push_notify(socket, payload), do: push_event(socket, "notify:show", payload)

--- a/lib/vutuv_web/templates/settings/notifications.html.heex
+++ b/lib/vutuv_web/templates/settings/notifications.html.heex
@@ -166,7 +166,33 @@ heading. --%>
               {gettext("Ask now")}
             </button>
           </p>
-          <p hidden data-notify-state="granted">{gettext("This browser will show them.")}</p>
+          <%!-- Only the granted state offers the test: it is the one state
+                where a popup can appear at all, and a button that cannot work
+                is worse than no button. It travels the whole path a real
+                notification takes (shell socket, server, hook), so it answers
+                what the sentence beside it cannot - permission is only the
+                last link. The verdict line ships empty and hidden; app.js
+                fills it from the two data- strings, because the server is the
+                only side that knows the reader's language. --%>
+          <p hidden data-notify-state="granted">
+            {gettext("This browser will show them.")}
+            <button
+              type="button"
+              data-notify-test
+              class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+            >
+              {gettext("Send a test notification")}
+            </button>
+          </p>
+          <p
+            hidden
+            data-notify-test-result
+            data-sent={gettext("Sent. If nothing appeared, your system is holding it back. Check Do Not Disturb and your notification settings.")}
+            data-silent={gettext("No answer. Please reload the page and try again.")}
+            class="mt-1"
+            role="status"
+          >
+          </p>
           <p hidden data-notify-state="denied">
             {gettext(
               "This browser is blocking notifications for vutuv. Allow them for this site in your browser settings; the switch above stays on and every other browser you use is unaffected."

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.343.3",
+      version: "7.343.4",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -443,8 +443,8 @@ msgstr "Einloggen"
 msgid "Log Out"
 msgstr "Ausloggen"
 
-#: lib/vutuv_web/live/shell_live.ex:993
-#: lib/vutuv_web/live/shell_live.ex:1050
+#: lib/vutuv_web/live/shell_live.ex:1024
+#: lib/vutuv_web/live/shell_live.ex:1081
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -644,8 +644,8 @@ msgstr "Speichern"
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:48
 #: lib/vutuv_web/live/search_live.ex:569
-#: lib/vutuv_web/live/shell_live.ex:858
-#: lib/vutuv_web/live/shell_live.ex:1033
+#: lib/vutuv_web/live/shell_live.ex:889
+#: lib/vutuv_web/live/shell_live.ex:1064
 #: lib/vutuv_web/live/tag_live/timeline.ex:266
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
@@ -1189,7 +1189,7 @@ msgstr "Lokalisierung hinzufügen"
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:965
+#: lib/vutuv_web/live/shell_live.ex:996
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1631,7 +1631,7 @@ msgstr "Adressen von %{name}"
 msgid "Admin control panel"
 msgstr "Admin-Bereich"
 
-#: lib/vutuv_web/live/shell_live.ex:1036
+#: lib/vutuv_web/live/shell_live.ex:1067
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "Mitteilungen"
@@ -1748,7 +1748,7 @@ msgstr ""
 " von jemandem, den Sie kennen oder interessant finden, und klicken Sie auf "
 "Folgen!"
 
-#: lib/vutuv_web/live/shell_live.ex:984
+#: lib/vutuv_web/live/shell_live.ex:1015
 #: lib/vutuv_web/views/settings_html.ex:376
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1777,14 +1777,14 @@ msgstr "Nachricht"
 
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:876
-#: lib/vutuv_web/live/shell_live.ex:1035
+#: lib/vutuv_web/live/shell_live.ex:907
+#: lib/vutuv_web/live/shell_live.ex:1066
 #: lib/vutuv_web/templates/layout/app.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr "Nachrichten"
 
-#: lib/vutuv_web/live/shell_live.ex:760
+#: lib/vutuv_web/live/shell_live.ex:791
 #: lib/vutuv_web/templates/layout/app.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Network"
@@ -1810,7 +1810,7 @@ msgstr "Noch nichts Neues."
 #: lib/vutuv_web/components/ui.ex:4162
 #: lib/vutuv_web/live/notification_live/index.ex:132
 #: lib/vutuv_web/live/notification_live/index.ex:360
-#: lib/vutuv_web/live/shell_live.ex:888
+#: lib/vutuv_web/live/shell_live.ex:919
 #: lib/vutuv_web/templates/layout/app.html.heex:173
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -2167,8 +2167,8 @@ msgstr "Beitrag bearbeiten"
 #: lib/vutuv_web/live/organization_live/feed.ex:98
 #: lib/vutuv_web/live/post_live/feed.ex:191
 #: lib/vutuv_web/live/post_live/feed.ex:1203
-#: lib/vutuv_web/live/shell_live.ex:738
-#: lib/vutuv_web/live/shell_live.ex:1031
+#: lib/vutuv_web/live/shell_live.ex:769
+#: lib/vutuv_web/live/shell_live.ex:1062
 #: lib/vutuv_web/templates/layout/app.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2343,7 +2343,7 @@ msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
 
 #: lib/vutuv_web/components/ui.ex:4451
-#: lib/vutuv_web/live/shell_live.ex:931
+#: lib/vutuv_web/live/shell_live.ex:962
 #: lib/vutuv_web/templates/post/index.html.heex:17
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:323
@@ -2433,8 +2433,8 @@ msgstr "Lesezeichen setzen"
 #: lib/vutuv_web/agent_docs/markdown.ex:1108
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
-#: lib/vutuv_web/live/shell_live.ex:868
-#: lib/vutuv_web/live/shell_live.ex:936
+#: lib/vutuv_web/live/shell_live.ex:899
+#: lib/vutuv_web/live/shell_live.ex:967
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2455,7 +2455,7 @@ msgstr "Gefällt mir"
 #: lib/vutuv_web/live/notification_live/index.ex:1005
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
-#: lib/vutuv_web/live/shell_live.ex:939
+#: lib/vutuv_web/live/shell_live.ex:970
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -3223,8 +3223,8 @@ msgid "Private message"
 msgstr "Private Nachricht"
 
 #: lib/vutuv_web/components/ui.ex:4094
-#: lib/vutuv_web/live/shell_live.ex:752
-#: lib/vutuv_web/live/shell_live.ex:1040
+#: lib/vutuv_web/live/shell_live.ex:783
+#: lib/vutuv_web/live/shell_live.ex:1071
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -5539,7 +5539,7 @@ msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
 msgid "Content under review"
 msgstr "Inhalte in Prüfung"
 
-#: lib/vutuv_web/live/shell_live.ex:918
+#: lib/vutuv_web/live/shell_live.ex:949
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr "Kontomenü"
@@ -5561,7 +5561,7 @@ msgstr "Menüs und Dialoge schließen"
 msgid "General"
 msgstr "Allgemeines"
 
-#: lib/vutuv_web/live/shell_live.ex:975
+#: lib/vutuv_web/live/shell_live.ex:1006
 #: lib/vutuv_web/templates/layout/app.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5580,7 +5580,7 @@ msgstr "Navigation"
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:303
-#: lib/vutuv_web/live/shell_live.ex:955
+#: lib/vutuv_web/live/shell_live.ex:986
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5634,8 +5634,8 @@ msgstr "Nächster Beitrag im Feed"
 msgid "Previous post in the feed"
 msgstr "Vorheriger Beitrag im Feed"
 
-#: lib/vutuv_web/live/shell_live.ex:727
-#: lib/vutuv_web/live/shell_live.ex:1021
+#: lib/vutuv_web/live/shell_live.ex:758
+#: lib/vutuv_web/live/shell_live.ex:1052
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr "Hauptnavigation"
@@ -5880,12 +5880,12 @@ msgstr "Apps & API-Zugang"
 msgid "Endorsements"
 msgstr "Empfehlungen"
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:191
+#: lib/vutuv_web/templates/settings/notifications.html.heex:217
 #, elixir-autogen, elixir-format
 msgid "Endorsements and new followers"
 msgstr "Empfehlungen und neue Follower"
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:185
+#: lib/vutuv_web/templates/settings/notifications.html.heex:211
 #, elixir-autogen, elixir-format
 msgid "In-app notifications"
 msgstr "Benachrichtigungen in der App"
@@ -5900,12 +5900,12 @@ msgstr "Neue Follower"
 msgid "Notification settings"
 msgstr "Benachrichtigungseinstellungen"
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:199
+#: lib/vutuv_web/templates/settings/notifications.html.heex:225
 #, elixir-autogen, elixir-format
 msgid "Open your notifications"
 msgstr "Benachrichtigungen öffnen"
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:192
+#: lib/vutuv_web/templates/settings/notifications.html.heex:218
 #, elixir-autogen, elixir-format
 msgid "Replies to and likes on your posts"
 msgstr "Antworten und Likes zu Ihren Beiträgen"
@@ -5920,7 +5920,7 @@ msgstr "Sicherheit"
 msgid "Search engines & AI"
 msgstr "Suchmaschinen & KI"
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:187
+#: lib/vutuv_web/templates/settings/notifications.html.heex:213
 #, elixir-autogen, elixir-format
 msgid "These are always on. You see them under the bell at the top of every page, in real time."
 msgstr ""
@@ -6902,7 +6902,7 @@ msgstr "Stummschalten"
 msgid "Muted. Their posts no longer appear in your feed."
 msgstr "Stummgeschaltet. Die Beiträge erscheinen nicht mehr in Ihrem Feed."
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:190
+#: lib/vutuv_web/templates/settings/notifications.html.heex:216
 #, elixir-autogen, elixir-format
 msgid "New messages and new connections"
 msgstr "Neue Nachrichten und neue Vernetzungen"
@@ -12474,7 +12474,7 @@ msgstr "Organisation wieder freigegeben."
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:946
+#: lib/vutuv_web/live/shell_live.ex:977
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:100
@@ -12816,7 +12816,7 @@ msgstr "Stellenbezeichnung"
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:768
+#: lib/vutuv_web/live/shell_live.ex:799
 #: lib/vutuv_web/templates/layout/app.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -20734,7 +20734,7 @@ msgstr "Sie dürfen nicht mehr im Namen dieser Organisation schreiben."
 msgid "A post in an organization's name is always public."
 msgstr "Ein Beitrag im Namen einer Organisation ist immer öffentlich."
 
-#: lib/vutuv_web/live/shell_live.ex:685
+#: lib/vutuv_web/live/shell_live.ex:716
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr "Seite öffnen"
@@ -20754,7 +20754,7 @@ msgstr "Beendet, im Namen einer Organisation zu schreiben"
 msgid "Write as %{name} for now"
 msgstr "Vorerst als %{name} schreiben"
 
-#: lib/vutuv_web/live/shell_live.ex:695
+#: lib/vutuv_web/live/shell_live.ex:726
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr "Wieder als ich selbst schreiben"
@@ -20764,7 +20764,7 @@ msgstr "Wieder als ich selbst schreiben"
 msgid "You are writing as %{name} now."
 msgstr "Sie schreiben jetzt als %{name}."
 
-#: lib/vutuv_web/live/shell_live.ex:671
+#: lib/vutuv_web/live/shell_live.ex:702
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr "Sie schreiben als %{name}."
@@ -22281,7 +22281,7 @@ msgstr "%{handle} nicht mehr folgen? Die Beiträge verschwinden aus Ihrem Feed."
 msgid "Unfollowed. Their posts leave your feed."
 msgstr "Nicht mehr gefolgt. Die Beiträge verschwinden aus Ihrem Feed."
 
-#: lib/vutuv_web/live/shell_live.ex:641
+#: lib/vutuv_web/live/shell_live.ex:672
 #, elixir-autogen, elixir-format
 msgid "Allow"
 msgstr "Erlauben"
@@ -22296,12 +22296,12 @@ msgstr "Jetzt fragen"
 msgid "Browser notifications"
 msgstr "Browser-Benachrichtigungen"
 
-#: lib/vutuv_web/live/shell_live.ex:583
+#: lib/vutuv_web/live/shell_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "New message"
 msgstr "Neue Nachricht"
 
-#: lib/vutuv_web/live/shell_live.ex:648
+#: lib/vutuv_web/live/shell_live.ex:679
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr "Jetzt nicht"
@@ -22316,7 +22316,7 @@ msgstr "Nur solange vutuv irgendwo offen ist und Sie gerade etwas anderes ansehe
 msgid "Show me browser notifications"
 msgstr "Browser-Benachrichtigungen anzeigen"
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:176
+#: lib/vutuv_web/templates/settings/notifications.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "This browser cannot show notifications. Your other browsers are unaffected."
 msgstr "Dieser Browser kann keine Benachrichtigungen anzeigen. Ihre anderen Browser sind davon nicht betroffen."
@@ -22326,12 +22326,12 @@ msgstr "Dieser Browser kann keine Benachrichtigungen anzeigen. Ihre anderen Brow
 msgid "This browser has not been asked yet."
 msgstr "Dieser Browser wurde noch nicht gefragt."
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:171
+#: lib/vutuv_web/templates/settings/notifications.html.heex:197
 #, elixir-autogen, elixir-format
 msgid "This browser is blocking notifications for vutuv. Allow them for this site in your browser settings; the switch above stays on and every other browser you use is unaffected."
 msgstr "Dieser Browser blockiert Benachrichtigungen von vutuv. Erlauben Sie sie für diese Seite in den Einstellungen Ihres Browsers. Der Schalter oben bleibt an, und jeder andere Browser, den Sie nutzen, ist davon nicht betroffen."
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:169
+#: lib/vutuv_web/templates/settings/notifications.html.heex:178
 #, elixir-autogen, elixir-format
 msgid "This browser will show them."
 msgstr "Dieser Browser zeigt sie an."
@@ -22341,7 +22341,7 @@ msgstr "Dieser Browser zeigt sie an."
 msgid "When something arrives while you have vutuv open in a tab you are not looking at, your browser can show it as a notification. Off unless you switch it on."
 msgstr "Wenn etwas eintrifft, während vutuv in einem Tab offen ist, den Sie gerade nicht ansehen, kann Ihr Browser es als Benachrichtigung anzeigen. Aus, solange Sie es nicht einschalten."
 
-#: lib/vutuv_web/live/shell_live.ex:638
+#: lib/vutuv_web/live/shell_live.ex:669
 #, elixir-autogen, elixir-format
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr "Sie haben Browser-Benachrichtigungen eingeschaltet. Dieser Browser wurde noch nicht um Erlaubnis gebeten."
@@ -22365,3 +22365,28 @@ msgstr "Aus dem Fediverse folgen"
 #, elixir-autogen, elixir-format
 msgid "Posts and members on vutuv about %{tag}."
 msgstr "Beiträge und Mitglieder auf vutuv zum Thema %{tag}."
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:191
+#, elixir-autogen, elixir-format
+msgid "No answer. Please reload the page and try again."
+msgstr "Keine Antwort. Bitte laden Sie die Seite neu und versuchen Sie es noch einmal."
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:184
+#, elixir-autogen, elixir-format
+msgid "Send a test notification"
+msgstr "Test-Benachrichtigung senden"
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:190
+#, elixir-autogen, elixir-format
+msgid "Sent. If nothing appeared, your system is holding it back. Check Do Not Disturb and your notification settings."
+msgstr "Gesendet. Wenn nichts erschienen ist, hält Ihr System sie zurück. Prüfen Sie „Nicht stören“ und Ihre Benachrichtigungseinstellungen."
+
+#: lib/vutuv_web/live/shell_live.ex:569
+#, elixir-autogen, elixir-format
+msgid "Test notification"
+msgstr "Test-Benachrichtigung"
+
+#: lib/vutuv_web/live/shell_live.ex:570
+#, elixir-autogen, elixir-format
+msgid "This is what vutuv looks like when something arrives."
+msgstr "So sieht es aus, wenn auf vutuv etwas für Sie eintrifft."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -443,8 +443,8 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:993
-#: lib/vutuv_web/live/shell_live.ex:1050
+#: lib/vutuv_web/live/shell_live.ex:1024
+#: lib/vutuv_web/live/shell_live.ex:1081
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -644,8 +644,8 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:48
 #: lib/vutuv_web/live/search_live.ex:569
-#: lib/vutuv_web/live/shell_live.ex:858
-#: lib/vutuv_web/live/shell_live.ex:1033
+#: lib/vutuv_web/live/shell_live.ex:889
+#: lib/vutuv_web/live/shell_live.ex:1064
 #: lib/vutuv_web/live/tag_live/timeline.ex:266
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
@@ -1165,7 +1165,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:965
+#: lib/vutuv_web/live/shell_live.ex:996
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1599,7 +1599,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1036
+#: lib/vutuv_web/live/shell_live.ex:1067
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1713,7 +1713,7 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:984
+#: lib/vutuv_web/live/shell_live.ex:1015
 #: lib/vutuv_web/views/settings_html.ex:376
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1742,14 +1742,14 @@ msgstr ""
 
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:876
-#: lib/vutuv_web/live/shell_live.ex:1035
+#: lib/vutuv_web/live/shell_live.ex:907
+#: lib/vutuv_web/live/shell_live.ex:1066
 #: lib/vutuv_web/templates/layout/app.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:760
+#: lib/vutuv_web/live/shell_live.ex:791
 #: lib/vutuv_web/templates/layout/app.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Network"
@@ -1775,7 +1775,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:4162
 #: lib/vutuv_web/live/notification_live/index.ex:132
 #: lib/vutuv_web/live/notification_live/index.ex:360
-#: lib/vutuv_web/live/shell_live.ex:888
+#: lib/vutuv_web/live/shell_live.ex:919
 #: lib/vutuv_web/templates/layout/app.html.heex:173
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -2124,8 +2124,8 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/feed.ex:98
 #: lib/vutuv_web/live/post_live/feed.ex:191
 #: lib/vutuv_web/live/post_live/feed.ex:1203
-#: lib/vutuv_web/live/shell_live.ex:738
-#: lib/vutuv_web/live/shell_live.ex:1031
+#: lib/vutuv_web/live/shell_live.ex:769
+#: lib/vutuv_web/live/shell_live.ex:1062
 #: lib/vutuv_web/templates/layout/app.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2296,7 +2296,7 @@ msgid "Upload failed."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4451
-#: lib/vutuv_web/live/shell_live.ex:931
+#: lib/vutuv_web/live/shell_live.ex:962
 #: lib/vutuv_web/templates/post/index.html.heex:17
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:323
@@ -2386,8 +2386,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1108
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
-#: lib/vutuv_web/live/shell_live.ex:868
-#: lib/vutuv_web/live/shell_live.ex:936
+#: lib/vutuv_web/live/shell_live.ex:899
+#: lib/vutuv_web/live/shell_live.ex:967
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2408,7 +2408,7 @@ msgstr ""
 #: lib/vutuv_web/live/notification_live/index.ex:1005
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
-#: lib/vutuv_web/live/shell_live.ex:939
+#: lib/vutuv_web/live/shell_live.ex:970
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -3152,8 +3152,8 @@ msgid "Private message"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4094
-#: lib/vutuv_web/live/shell_live.ex:752
-#: lib/vutuv_web/live/shell_live.ex:1040
+#: lib/vutuv_web/live/shell_live.ex:783
+#: lib/vutuv_web/live/shell_live.ex:1071
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -5316,7 +5316,7 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:918
+#: lib/vutuv_web/live/shell_live.ex:949
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
@@ -5338,7 +5338,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:975
+#: lib/vutuv_web/live/shell_live.ex:1006
 #: lib/vutuv_web/templates/layout/app.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5357,7 +5357,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:303
-#: lib/vutuv_web/live/shell_live.ex:955
+#: lib/vutuv_web/live/shell_live.ex:986
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5411,8 +5411,8 @@ msgstr ""
 msgid "Previous post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:727
-#: lib/vutuv_web/live/shell_live.ex:1021
+#: lib/vutuv_web/live/shell_live.ex:758
+#: lib/vutuv_web/live/shell_live.ex:1052
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -5654,12 +5654,12 @@ msgstr ""
 msgid "Endorsements"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:191
+#: lib/vutuv_web/templates/settings/notifications.html.heex:217
 #, elixir-autogen, elixir-format
 msgid "Endorsements and new followers"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:185
+#: lib/vutuv_web/templates/settings/notifications.html.heex:211
 #, elixir-autogen, elixir-format
 msgid "In-app notifications"
 msgstr ""
@@ -5674,12 +5674,12 @@ msgstr ""
 msgid "Notification settings"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:199
+#: lib/vutuv_web/templates/settings/notifications.html.heex:225
 #, elixir-autogen, elixir-format
 msgid "Open your notifications"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:192
+#: lib/vutuv_web/templates/settings/notifications.html.heex:218
 #, elixir-autogen, elixir-format
 msgid "Replies to and likes on your posts"
 msgstr ""
@@ -5694,7 +5694,7 @@ msgstr ""
 msgid "Search engines & AI"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:187
+#: lib/vutuv_web/templates/settings/notifications.html.heex:213
 #, elixir-autogen, elixir-format
 msgid "These are always on. You see them under the bell at the top of every page, in real time."
 msgstr ""
@@ -6625,7 +6625,7 @@ msgstr ""
 msgid "Muted. Their posts no longer appear in your feed."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:190
+#: lib/vutuv_web/templates/settings/notifications.html.heex:216
 #, elixir-autogen, elixir-format
 msgid "New messages and new connections"
 msgstr ""
@@ -11835,7 +11835,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:946
+#: lib/vutuv_web/live/shell_live.ex:977
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:100
@@ -12164,7 +12164,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:768
+#: lib/vutuv_web/live/shell_live.ex:799
 #: lib/vutuv_web/templates/layout/app.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -19968,7 +19968,7 @@ msgstr ""
 msgid "A post in an organization's name is always public."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:685
+#: lib/vutuv_web/live/shell_live.ex:716
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr ""
@@ -19988,7 +19988,7 @@ msgstr ""
 msgid "Write as %{name} for now"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:695
+#: lib/vutuv_web/live/shell_live.ex:726
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr ""
@@ -19998,7 +19998,7 @@ msgstr ""
 msgid "You are writing as %{name} now."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:671
+#: lib/vutuv_web/live/shell_live.ex:702
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr ""
@@ -21491,7 +21491,7 @@ msgstr ""
 msgid "Unfollowed. Their posts leave your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:641
+#: lib/vutuv_web/live/shell_live.ex:672
 #, elixir-autogen, elixir-format
 msgid "Allow"
 msgstr ""
@@ -21506,12 +21506,12 @@ msgstr ""
 msgid "Browser notifications"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:583
+#: lib/vutuv_web/live/shell_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "New message"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:648
+#: lib/vutuv_web/live/shell_live.ex:679
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr ""
@@ -21526,7 +21526,7 @@ msgstr ""
 msgid "Show me browser notifications"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:176
+#: lib/vutuv_web/templates/settings/notifications.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "This browser cannot show notifications. Your other browsers are unaffected."
 msgstr ""
@@ -21536,12 +21536,12 @@ msgstr ""
 msgid "This browser has not been asked yet."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:171
+#: lib/vutuv_web/templates/settings/notifications.html.heex:197
 #, elixir-autogen, elixir-format
 msgid "This browser is blocking notifications for vutuv. Allow them for this site in your browser settings; the switch above stays on and every other browser you use is unaffected."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:169
+#: lib/vutuv_web/templates/settings/notifications.html.heex:178
 #, elixir-autogen, elixir-format
 msgid "This browser will show them."
 msgstr ""
@@ -21551,7 +21551,7 @@ msgstr ""
 msgid "When something arrives while you have vutuv open in a tab you are not looking at, your browser can show it as a notification. Off unless you switch it on."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:638
+#: lib/vutuv_web/live/shell_live.ex:669
 #, elixir-autogen, elixir-format
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
@@ -21574,4 +21574,29 @@ msgstr ""
 #: lib/vutuv_web/controllers/tag_controller.ex:174
 #, elixir-autogen, elixir-format
 msgid "Posts and members on vutuv about %{tag}."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:191
+#, elixir-autogen, elixir-format
+msgid "No answer. Please reload the page and try again."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:184
+#, elixir-autogen, elixir-format
+msgid "Send a test notification"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:190
+#, elixir-autogen, elixir-format
+msgid "Sent. If nothing appeared, your system is holding it back. Check Do Not Disturb and your notification settings."
+msgstr ""
+
+#: lib/vutuv_web/live/shell_live.ex:569
+#, elixir-autogen, elixir-format
+msgid "Test notification"
+msgstr ""
+
+#: lib/vutuv_web/live/shell_live.ex:570
+#, elixir-autogen, elixir-format
+msgid "This is what vutuv looks like when something arrives."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -441,8 +441,8 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:993
-#: lib/vutuv_web/live/shell_live.ex:1050
+#: lib/vutuv_web/live/shell_live.ex:1024
+#: lib/vutuv_web/live/shell_live.ex:1081
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -642,8 +642,8 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:48
 #: lib/vutuv_web/live/search_live.ex:569
-#: lib/vutuv_web/live/shell_live.ex:858
-#: lib/vutuv_web/live/shell_live.ex:1033
+#: lib/vutuv_web/live/shell_live.ex:889
+#: lib/vutuv_web/live/shell_live.ex:1064
 #: lib/vutuv_web/live/tag_live/timeline.ex:266
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
@@ -1163,7 +1163,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:965
+#: lib/vutuv_web/live/shell_live.ex:996
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1597,7 +1597,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1036
+#: lib/vutuv_web/live/shell_live.ex:1067
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1711,7 +1711,7 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:984
+#: lib/vutuv_web/live/shell_live.ex:1015
 #: lib/vutuv_web/views/settings_html.ex:376
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1740,14 +1740,14 @@ msgstr ""
 
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:876
-#: lib/vutuv_web/live/shell_live.ex:1035
+#: lib/vutuv_web/live/shell_live.ex:907
+#: lib/vutuv_web/live/shell_live.ex:1066
 #: lib/vutuv_web/templates/layout/app.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:760
+#: lib/vutuv_web/live/shell_live.ex:791
 #: lib/vutuv_web/templates/layout/app.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Network"
@@ -1773,7 +1773,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:4162
 #: lib/vutuv_web/live/notification_live/index.ex:132
 #: lib/vutuv_web/live/notification_live/index.ex:360
-#: lib/vutuv_web/live/shell_live.ex:888
+#: lib/vutuv_web/live/shell_live.ex:919
 #: lib/vutuv_web/templates/layout/app.html.heex:173
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -2122,8 +2122,8 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/feed.ex:98
 #: lib/vutuv_web/live/post_live/feed.ex:191
 #: lib/vutuv_web/live/post_live/feed.ex:1203
-#: lib/vutuv_web/live/shell_live.ex:738
-#: lib/vutuv_web/live/shell_live.ex:1031
+#: lib/vutuv_web/live/shell_live.ex:769
+#: lib/vutuv_web/live/shell_live.ex:1062
 #: lib/vutuv_web/templates/layout/app.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2294,7 +2294,7 @@ msgid "Upload failed."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4451
-#: lib/vutuv_web/live/shell_live.ex:931
+#: lib/vutuv_web/live/shell_live.ex:962
 #: lib/vutuv_web/templates/post/index.html.heex:17
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:323
@@ -2384,8 +2384,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1108
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
-#: lib/vutuv_web/live/shell_live.ex:868
-#: lib/vutuv_web/live/shell_live.ex:936
+#: lib/vutuv_web/live/shell_live.ex:899
+#: lib/vutuv_web/live/shell_live.ex:967
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2406,7 +2406,7 @@ msgstr ""
 #: lib/vutuv_web/live/notification_live/index.ex:1005
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
-#: lib/vutuv_web/live/shell_live.ex:939
+#: lib/vutuv_web/live/shell_live.ex:970
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -3150,8 +3150,8 @@ msgid "Private message"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4094
-#: lib/vutuv_web/live/shell_live.ex:752
-#: lib/vutuv_web/live/shell_live.ex:1040
+#: lib/vutuv_web/live/shell_live.ex:783
+#: lib/vutuv_web/live/shell_live.ex:1071
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -5314,7 +5314,7 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:918
+#: lib/vutuv_web/live/shell_live.ex:949
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
@@ -5336,7 +5336,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:975
+#: lib/vutuv_web/live/shell_live.ex:1006
 #: lib/vutuv_web/templates/layout/app.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5355,7 +5355,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:303
-#: lib/vutuv_web/live/shell_live.ex:955
+#: lib/vutuv_web/live/shell_live.ex:986
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5409,8 +5409,8 @@ msgstr ""
 msgid "Previous post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:727
-#: lib/vutuv_web/live/shell_live.ex:1021
+#: lib/vutuv_web/live/shell_live.ex:758
+#: lib/vutuv_web/live/shell_live.ex:1052
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -5652,12 +5652,12 @@ msgstr ""
 msgid "Endorsements"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:191
+#: lib/vutuv_web/templates/settings/notifications.html.heex:217
 #, elixir-autogen, elixir-format
 msgid "Endorsements and new followers"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:185
+#: lib/vutuv_web/templates/settings/notifications.html.heex:211
 #, elixir-autogen, elixir-format
 msgid "In-app notifications"
 msgstr ""
@@ -5672,12 +5672,12 @@ msgstr ""
 msgid "Notification settings"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:199
+#: lib/vutuv_web/templates/settings/notifications.html.heex:225
 #, elixir-autogen, elixir-format
 msgid "Open your notifications"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:192
+#: lib/vutuv_web/templates/settings/notifications.html.heex:218
 #, elixir-autogen, elixir-format
 msgid "Replies to and likes on your posts"
 msgstr ""
@@ -5692,7 +5692,7 @@ msgstr ""
 msgid "Search engines & AI"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:187
+#: lib/vutuv_web/templates/settings/notifications.html.heex:213
 #, elixir-autogen, elixir-format
 msgid "These are always on. You see them under the bell at the top of every page, in real time."
 msgstr ""
@@ -6623,7 +6623,7 @@ msgstr ""
 msgid "Muted. Their posts no longer appear in your feed."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:190
+#: lib/vutuv_web/templates/settings/notifications.html.heex:216
 #, elixir-autogen, elixir-format
 msgid "New messages and new connections"
 msgstr ""
@@ -11833,7 +11833,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:946
+#: lib/vutuv_web/live/shell_live.ex:977
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:100
@@ -12162,7 +12162,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:768
+#: lib/vutuv_web/live/shell_live.ex:799
 #: lib/vutuv_web/templates/layout/app.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -19966,7 +19966,7 @@ msgstr ""
 msgid "A post in an organization's name is always public."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:685
+#: lib/vutuv_web/live/shell_live.ex:716
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Open the page"
 msgstr ""
@@ -19986,7 +19986,7 @@ msgstr ""
 msgid "Write as %{name} for now"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:695
+#: lib/vutuv_web/live/shell_live.ex:726
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr ""
@@ -19996,7 +19996,7 @@ msgstr ""
 msgid "You are writing as %{name} now."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:671
+#: lib/vutuv_web/live/shell_live.ex:702
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr ""
@@ -21489,7 +21489,7 @@ msgstr ""
 msgid "Unfollowed. Their posts leave your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:641
+#: lib/vutuv_web/live/shell_live.ex:672
 #, elixir-autogen, elixir-format
 msgid "Allow"
 msgstr ""
@@ -21504,12 +21504,12 @@ msgstr ""
 msgid "Browser notifications"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:583
+#: lib/vutuv_web/live/shell_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "New message"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:648
+#: lib/vutuv_web/live/shell_live.ex:679
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr ""
@@ -21524,7 +21524,7 @@ msgstr ""
 msgid "Show me browser notifications"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:176
+#: lib/vutuv_web/templates/settings/notifications.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "This browser cannot show notifications. Your other browsers are unaffected."
 msgstr ""
@@ -21534,12 +21534,12 @@ msgstr ""
 msgid "This browser has not been asked yet."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:171
+#: lib/vutuv_web/templates/settings/notifications.html.heex:197
 #, elixir-autogen, elixir-format
 msgid "This browser is blocking notifications for vutuv. Allow them for this site in your browser settings; the switch above stays on and every other browser you use is unaffected."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:169
+#: lib/vutuv_web/templates/settings/notifications.html.heex:178
 #, elixir-autogen, elixir-format
 msgid "This browser will show them."
 msgstr ""
@@ -21549,7 +21549,7 @@ msgstr ""
 msgid "When something arrives while you have vutuv open in a tab you are not looking at, your browser can show it as a notification. Off unless you switch it on."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:638
+#: lib/vutuv_web/live/shell_live.ex:669
 #, elixir-autogen, elixir-format
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
@@ -21572,4 +21572,29 @@ msgstr ""
 #: lib/vutuv_web/controllers/tag_controller.ex:174
 #, elixir-autogen, elixir-format
 msgid "Posts and members on vutuv about %{tag}."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:191
+#, elixir-autogen, elixir-format
+msgid "No answer. Please reload the page and try again."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:184
+#, elixir-autogen, elixir-format
+msgid "Send a test notification"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:190
+#, elixir-autogen, elixir-format
+msgid "Sent. If nothing appeared, your system is holding it back. Check Do Not Disturb and your notification settings."
+msgstr ""
+
+#: lib/vutuv_web/live/shell_live.ex:569
+#, elixir-autogen, elixir-format
+msgid "Test notification"
+msgstr ""
+
+#: lib/vutuv_web/live/shell_live.ex:570
+#, elixir-autogen, elixir-format
+msgid "This is what vutuv looks like when something arrives."
 msgstr ""

--- a/test/vutuv_web/controllers/settings_controller_test.exs
+++ b/test/vutuv_web/controllers/settings_controller_test.exs
@@ -717,6 +717,33 @@ defmodule VutuvWeb.SettingsControllerTest do
       assert html =~ "Jetzt fragen"
       assert html =~ "Dieser Browser wurde noch nicht gefragt."
       assert html =~ "Dieser Browser zeigt sie an."
+      # "Test notification" came back from the fuzzy fill as "Benachrichtigungen
+      # zu Diskussionen"; a short label is the likeliest to be filled with
+      # nonsense and the least likely to be noticed.
+      assert html =~ "Test-Benachrichtigung senden"
+      assert html =~ "Keine Antwort. Bitte laden Sie die Seite neu"
+    end
+
+    test "the card offers a test notification on the granted line only (issue #1249)",
+         %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+      html = conn |> get(~p"/settings/notifications") |> html_response(200)
+
+      assert html =~ "data-notify-test"
+      # Its verdict ships empty and hidden, with both sentences on the element:
+      # the server is the only side that knows the reader's language.
+      assert html =~ "data-notify-test-result"
+      assert html =~ "data-sent="
+      assert html =~ "data-silent="
+
+      # The button belongs to the one state where a popup can appear at all. A
+      # blocked browser must not be offered a test that cannot work.
+      [_, granted_onwards] = String.split(html, ~s(data-notify-state="granted"), parts: 2)
+
+      [granted_line, _rest] =
+        String.split(granted_onwards, ~s(data-notify-state="denied"), parts: 2)
+
+      assert granted_line =~ "data-notify-test"
     end
 
     test "saving the switch tells the member's other open tabs (issue #1249)", %{conn: conn} do

--- a/test/vutuv_web/live/shell_live_browser_notifications_test.exs
+++ b/test/vutuv_web/live/shell_live_browser_notifications_test.exs
@@ -157,6 +157,43 @@ defmodule VutuvWeb.ShellLiveBrowserNotificationsTest do
     end
   end
 
+  describe "the test notification" do
+    test "travels the same path a real one does", %{conn: conn} do
+      user = insert(:user, browser_notifications?: true)
+      view = mount_shell(conn, user)
+
+      render_hook(view, "notify:test", %{})
+
+      # `test: true` is what lets the hook show it although the member is
+      # plainly looking at the settings page; without it the away-gate would
+      # swallow every press and the button would do nothing at all.
+      assert_push_event(view, "notify:show", %{tag: "test", test: true, title: title})
+      assert title == "Test notification"
+    end
+
+    test "is sent even before the switch has been saved", %{conn: conn} do
+      # Ticking the box asks this browser for permission on the spot, so the
+      # useful moment to press "test" is right then - with the preference still
+      # off in the database. Every automatic push is gated on it; this one is
+      # not, because the member asked for it by name.
+      user = insert(:user)
+      refute user.browser_notifications?
+
+      view = mount_shell(conn, user)
+      render_hook(view, "notify:test", %{})
+
+      assert_push_event(view, "notify:show", %{tag: "test"})
+    end
+
+    test "reaches nobody who is not logged in", %{conn: conn} do
+      {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: %{})
+
+      render_hook(view, "notify:test", %{})
+
+      refute_push_event(view, "notify:show", %{})
+    end
+  end
+
   describe "the per-browser permission prompt" do
     test "renders for a member who switched the feature on", %{conn: conn} do
       user = insert(:user, browser_notifications?: true)


### PR DESCRIPTION
Follow-up to #1249, on your ask.

**Symptom.** The card on `/settings/notifications` can say *Dieser Browser zeigt sie an* and still be wrong about the only thing that matters: whether anything actually appears on this machine. Permission is the last link in the chain, not the whole of it.

**What changed.** The granted status line gains **Test-Benachrichtigung senden**. It makes the full round trip (shell socket, `ShellLive.handle_event("notify:test", …)`, back through the `WebNotify` hook), so a dead socket or a suppressed popup shows up as one, where a locally raised `new Notification` would have proven nothing.

Two deliberate exceptions to how every other push behaves. It skips the standing-preference gate, because the useful moment to press it is right after ticking the box and before saving. And its payload carries `test: true`, which lets the hook show it although the member is plainly looking at the page; the away-gate is right for news and would make this button do nothing at all. It also sets `renotify`, so pressing again after turning Do Not Disturb off announces itself instead of silently replacing the first one.

The button waits for the hook to confirm a popup was really constructed and says so if nothing comes back in four seconds, so a silent system is told apart from a silent socket.

**Where to look:** `/settings/notifications`, on the line under the checkbox, once this browser has granted permission.

Driven in Chrome over CDP: 9 checks, including the popup appearing while the tab is focused and the verdict clearing when the switch goes off.

*An AI agent wrote this text in my name. I know that is problematic.*