### PR TITLE
Author post feeds carry 100 items instead of 20

### DIFF
--- a/docs/architecture/agents-and-seo.md
+++ b/docs/architecture/agents-and-seo.md
@@ -110,7 +110,9 @@ below the bar answers with `X-Robots-Tag: noindex` from `TagController`, so
 the ~10K thin one-member/empty tag pages stopped piling up in Search Console
 as "crawled - currently not indexed"), RSS 2.0 feeds with full post content
 (`/:slug/posts/feed.xml` per member, `/posts/feed.xml` site-wide,
-`VutuvWeb.Feeds`; the member feed carries **original posts only** — reposts
+`VutuvWeb.Feeds`; an author feed (a member's or a page's) carries the newest
+**100** posts, the site-wide firehose the newest 20, since an archive somebody
+subscribed to owes them more history than a firehose everyone polls; the member feed carries **original posts only** — reposts
 are engagement rows and never `Post` rows, and replies are filtered by the
 archive's `:posts` predicate in `Vutuv.Posts.recent_public_posts/2` — while
 the site-wide firehose deliberately keeps replies; besides the invisible

--- a/lib/vutuv_web/controllers/feed_controller.ex
+++ b/lib/vutuv_web/controllers/feed_controller.ex
@@ -17,12 +17,17 @@ defmodule VutuvWeb.FeedController do
   alias VutuvWeb.ContentPolicy
   alias VutuvWeb.Feeds
 
-  @feed_limit 20
+  # An author feed is an archive somebody subscribed to once and then keeps, so
+  # it carries a tail long enough that a reader joining today gets more than the
+  # last fortnight. The site-wide firehose is the other case: everyone polls it,
+  # and what it owes a reader is freshness rather than history.
+  @author_feed_limit 100
+  @site_feed_limit 20
 
   def user(conn, %{"slug" => slug}) do
     case Vutuv.Repo.get_by(Vutuv.Accounts.User, username: slug) do
       %{email_confirmed?: true} = author ->
-        posts = Posts.recent_public_posts(author, limit: @feed_limit)
+        posts = Posts.recent_public_posts(author, limit: @author_feed_limit)
         send_feed(conn, Feeds.render_user_feed(author, posts), author.noindex?, author.noai?)
 
       _unknown_or_unactivated ->
@@ -47,7 +52,7 @@ defmodule VutuvWeb.FeedController do
     organization = Vutuv.Organizations.get_organization_by_slug(slug)
 
     if organization && Vutuv.Organizations.public_visible?(organization) do
-      posts = Posts.organization_posts_page(organization, nil, limit: @feed_limit).entries
+      posts = Posts.organization_posts_page(organization, nil, limit: @author_feed_limit).entries
 
       send_feed(
         conn,
@@ -65,7 +70,7 @@ defmodule VutuvWeb.FeedController do
   # The site-wide feed only aggregates members who opted out of nothing
   # (Posts.recent_public_posts/2), so it carries the permissive signals.
   def site(conn, _params) do
-    posts = Posts.recent_public_posts(:all, limit: @feed_limit)
+    posts = Posts.recent_public_posts(:all, limit: @site_feed_limit)
     send_feed(conn, Feeds.render_site_feed(posts), false, false)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.343.4",
+      version: "7.343.5",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/controllers/feed_controller_test.exs
+++ b/test/vutuv_web/controllers/feed_controller_test.exs
@@ -139,6 +139,21 @@ defmodule VutuvWeb.FeedControllerTest do
       refute body =~ reply.id
     end
 
+    # A subscriber wants the member's archive, not just the last fortnight, so
+    # the author feeds carry a long tail — but an unbounded feed grows with the
+    # account forever, so it stops at the newest @author_feed_limit posts.
+    test "carries the newest 100 posts and stops there", %{author: author} do
+      posts = for i <- 1..101, do: insert(:post, user: author, body: "Post #{i}")
+      [oldest | _] = posts
+      newest = List.last(posts)
+
+      body = build_conn() |> get("/feed_author/posts/feed.xml") |> response(200)
+
+      assert length(String.split(body, "<item>")) - 1 == 100
+      assert body =~ newest.id
+      refute body =~ oldest.id
+    end
+
     test "an unknown or unactivated member 404s" do
       insert(:user, username: "sleepy_member")
 


### PR DESCRIPTION
**Symptom:** `vutuv.de/wintermeyer/posts.xml` (a 301 to `/wintermeyer/posts/feed.xml`) served only the newest 20 posts, so subscribing to a member gave you the last fortnight rather than their archive.

**Change:** `VutuvWeb.FeedController` splits its one `@feed_limit` in two. An author feed — a member's and a page's, since they are the same surface — carries the newest **100** posts; the site-wide firehose `/posts/feed.xml` stays at 20, because everyone polls it and it owes them freshness, not history. `docs/architecture/agents-and-seo.md` records both numbers.

Cost on production: a member feed grows from ~21 KB to roughly 105 KB per fetch, cached 300 s. Say the word if you'd rather have 50.

Hot deploy, v7.343.5. Test: 101 posts in, 100 items out, oldest absent (calibrated red at 20 against the old code). `mix precommit` green; feed driven locally against the dev copy.

*An AI agent wrote this text in my name. I know that is problematic.*