### PR TITLE
Trim the newcomer card's meta line and drop the ordering promise

### DIFF
--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -308,9 +308,8 @@ line) with cursor "Load more", a *"Show N new posts"* pill fed by `{:new_post,
 …}` / `{:new_repost, …}` broadcasts, and a desktop-only **"New here"** welcome
 rail: five of the newest members who show a face
 (`Vutuv.Social.newest_members_with_avatar/1`, a pool of 30 ordered by the UUID
-v7 primary key), drawn at random, each with how long they have been here
-(`VutuvWeb.UserHTML.joined_line/1`) and three of their tags picked at random so
-a ↻ shows another side of the same person. It replaced a most-followed
+v7 primary key), drawn at random, each with their job title and three of their
+tags picked at random so a ↻ shows another side of the same person. It replaced a most-followed
 suggestion rail: a ranking shows the same well-connected members to everybody
 and can never reach the person who signed up this morning, who is the one for
 whom being seen decides whether they come back. Following somebody here

--- a/lib/vutuv/social.ex
+++ b/lib/vutuv/social.ex
@@ -988,8 +988,7 @@ defmodule Vutuv.Social do
 
   Same visibility gate as every other people listing (unconfirmed and
   moderation-hidden accounts never surface) and the same narrow listing-row
-  select, plus `inserted_at`: the card says how long each member has been
-  here. The viewer, their blocks and the people they already follow are
+  select. The viewer, their blocks and the people they already follow are
   filtered at the call site, exactly as `most_followed_users/1`'s pool is.
   """
   def newest_members_with_avatar(limit) do
@@ -1000,7 +999,7 @@ defmodule Vutuv.Social do
         where: is_nil(u.avatar_moderation) or u.avatar_moderation == "approved",
         order_by: [desc: u.id],
         limit: ^limit,
-        select: struct(u, ^[:inserted_at | User.listing_fields()])
+        select: struct(u, ^User.listing_fields())
       )
     )
   end

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -32,10 +32,6 @@ defmodule VutuvWeb.PostLive.Feed do
   use VutuvWeb, :live_view
 
   import VutuvWeb.PostComponents
-  # The "New here" rail's per-row "joined 3 days ago" line (the "Other formats"
-  # card and the chip/avatar/follow controls are global VutuvWeb.UI components,
-  # imported already).
-  import VutuvWeb.UserHTML, only: [joined_line: 1]
 
   alias Phoenix.LiveView.JS
   alias Vutuv.Activity
@@ -345,20 +341,12 @@ defmodule VutuvWeb.PostLive.Feed do
 
       %{
         user: user,
-        meta: meta_line(user, Map.get(work_info, user.id, "")),
+        work: Map.get(work_info, user.id, ""),
         tags: sample,
         more: length(tags) - length(sample)
       }
     end)
   end
-
-  # One muted line per row, and the recency leads it: it is the card's whole
-  # claim, so a long job title truncates behind it rather than in front of it.
-  # One line rather than two because the card is five rows deep and its rows
-  # already carry tags — and on the first day, which is when this card shows
-  # somebody, most members have no job filled in at all.
-  defp meta_line(user, ""), do: joined_line(user)
-  defp meta_line(user, work), do: joined_line(user) <> " · " <> work
 
   defp assign_newcomers(socket) do
     socket
@@ -1592,13 +1580,14 @@ defmodule VutuvWeb.PostLive.Feed do
                 label={gettext("Greet other members")}
               />
             </div>
-            <%!-- Deliberately not "these five just joined": on a quiet
-            installation (an intranet vutuv with forty members) the newest
-            member may have been here for months, and this sentence has to stay
-            true there too. Each row's own line says how new that member really
-            is. --%>
+            <%!-- "A few of" carries the whole draw: these are not *the* newest
+            members in order, they are a random handful out of them, and a
+            sentence that says "the most recently joined" promises a ranking the
+            ↻ visibly contradicts. It also stays true on a quiet installation
+            (an intranet vutuv with forty members), where the newest member may
+            have been here for months. --%>
             <p class="mb-4 text-sm text-slate-600 dark:text-slate-400">
-              {gettext("The members who joined most recently. Following them is a warm welcome.")}
+              {gettext("A few of the newest members. Following them is a warm welcome.")}
             </p>
             <ul class="space-y-4">
               <li :for={row <- @newcomers} id={"newcomer-#{row.user.id}"} class="flex items-start gap-3">
@@ -1630,8 +1619,18 @@ defmodule VutuvWeb.PostLive.Feed do
                       live?
                     />
                   </div>
-                  <p class="mb-0 mt-0.5 truncate text-xs text-slate-600 dark:text-slate-400">
-                    {row.meta}
+                  <%!-- The job title, when there is one. It used to lead with
+                  how long the member had been here ("seit 3 Tagen dabei · …"),
+                  which was interesting and cost a third of the row for a fact
+                  the card's own heading already makes — five rows deep, that
+                  bought nothing (Stefan, 2026-08-24). A member with no job
+                  filled in, which most have not on their first days, simply
+                  gets no line rather than an empty one. --%>
+                  <p
+                    :if={row.work != ""}
+                    class="mb-0 mt-0.5 truncate text-xs text-slate-600 dark:text-slate-400"
+                  >
+                    {row.work}
                   </p>
                   <%!-- Three tags, at rail scale, each a link to that topic:
                   enough to be curious about somebody, never their whole

--- a/lib/vutuv_web/views/user_html.ex
+++ b/lib/vutuv_web/views/user_html.ex
@@ -287,39 +287,6 @@ defmodule VutuvWeb.UserHTML do
   def member_since(_user), do: nil
 
   @doc """
-  How long ago the account was created, said the way a person says it — the
-  line under each face in the feed's "New here" card.
-
-  A join date is a point in time, so it is rendered as relative time and never
-  as a raw age: "joined today", "joined yesterday", "joined 5 days ago". Past a
-  month the relative form stops carrying anything ("joined 84 days ago" is
-  arithmetic, not information), so it hands over to `member_since/1`'s calendar
-  wording, which is also what a profile shows.
-
-  The day boundary is the reader's own (`Vutuv.ViewerClock`), exactly like a
-  post stamp: nobody should be told a member joined "yesterday" while their own
-  calendar disagrees. A stamp from the future (clock skew) falls through to the
-  calendar form rather than counting backwards.
-  """
-  def joined_line(%Vutuv.Accounts.User{inserted_at: %NaiveDateTime{} = at} = user) do
-    case Date.diff(ViewerClock.today(), ViewerClock.date(at)) do
-      0 ->
-        gettext("joined today")
-
-      1 ->
-        gettext("joined yesterday")
-
-      days when days in 2..30 ->
-        ngettext("joined %{count} day ago", "joined %{count} days ago", days)
-
-      _older ->
-        member_since(user)
-    end
-  end
-
-  def joined_line(_user), do: nil
-
-  @doc """
   The "Member since" line (calendar icon + label). Rendered in two spots on the
   profile: right-aligned on the counts row, or moved up under the work line
   when the account has no followers and no following. `class` positions it.
@@ -733,7 +700,7 @@ defmodule VutuvWeb.UserHTML do
   """
   def compact_activity_date(%Date{} = date, %Date{} = today) do
     if date.year == today.year do
-      Vutuv.ViewerClock.format(date, :day_month)
+      ViewerClock.format(date, :day_month)
     else
       Integer.to_string(date.year)
     end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.346.0",
+      version: "7.346.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -728,12 +728,12 @@ msgstr "Profil wurde geändert."
 msgid "Profile deleted successfully."
 msgstr "Profil wurde gelöscht."
 
-#: lib/vutuv_web/views/user_html.ex:770
+#: lib/vutuv_web/views/user_html.ex:737
 #, elixir-autogen, elixir-format
 msgid "Social networks"
 msgstr "Soziale Netzwerke"
 
-#: lib/vutuv_web/views/user_html.ex:777
+#: lib/vutuv_web/views/user_html.ex:744
 #, elixir-autogen, elixir-format
 msgid "Code & repositories"
 msgstr "Code & Repositorys"
@@ -936,7 +936,7 @@ msgid "You follow back %{name}."
 msgstr "Sie folgen %{name} jetzt zurück."
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:90
+#: lib/vutuv_web/live/post_live/feed.ex:86
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1880,7 +1880,7 @@ msgstr "Zu viele Versuche. Bitte versuchen Sie es später erneut."
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:27
 #: lib/vutuv_web/templates/social_media_account/verify.html.heex:18
 #: lib/vutuv_web/templates/user/show.html.heex:200
-#: lib/vutuv_web/views/user_html.ex:822
+#: lib/vutuv_web/views/user_html.ex:789
 #, elixir-autogen, elixir-format
 msgid "Verified profile"
 msgstr "Verifiziertes Profil"
@@ -2163,8 +2163,8 @@ msgstr "Beitrag bearbeiten"
 #: lib/vutuv_web/components/organization_components.ex:274
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:98
-#: lib/vutuv_web/live/post_live/feed.ex:195
-#: lib/vutuv_web/live/post_live/feed.ex:1311
+#: lib/vutuv_web/live/post_live/feed.ex:191
+#: lib/vutuv_web/live/post_live/feed.ex:1299
 #: lib/vutuv_web/live/shell_live.ex:769
 #: lib/vutuv_web/live/shell_live.ex:1062
 #: lib/vutuv_web/templates/layout/app.html.heex:171
@@ -2209,7 +2209,7 @@ msgstr "Nicht eingeloggte Besucher"
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1518
+#: lib/vutuv_web/live/post_live/feed.ex:1506
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1422
+#: lib/vutuv_web/live/post_live/feed.ex:1410
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2423,7 +2423,7 @@ msgstr "Alle Beiträge"
 #: lib/vutuv_web/components/post_components.ex:1699
 #: lib/vutuv_web/components/post_components.ex:4812
 #: lib/vutuv_web/components/ui.ex:3498
-#: lib/vutuv_web/views/user_html.ex:486
+#: lib/vutuv_web/views/user_html.ex:453
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr "Lesezeichen setzen"
@@ -2443,7 +2443,7 @@ msgstr "Lesezeichen"
 #: lib/vutuv_web/components/post_components.ex:5048
 #: lib/vutuv_web/components/ui.ex:3484
 #: lib/vutuv_web/live/notification_live/index.ex:1072
-#: lib/vutuv_web/views/user_html.ex:496
+#: lib/vutuv_web/views/user_html.ex:463
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr "Gefällt mir"
@@ -2479,7 +2479,7 @@ msgstr "Nur öffentliche Beiträge können repostet werden."
 #: lib/vutuv_web/components/post_components.ex:1698
 #: lib/vutuv_web/components/post_components.ex:4811
 #: lib/vutuv_web/live/post_live/saved.ex:806
-#: lib/vutuv_web/views/user_html.ex:486
+#: lib/vutuv_web/views/user_html.ex:453
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
@@ -2506,7 +2506,7 @@ msgstr "Repost zurücknehmen"
 #: lib/vutuv_web/components/post_components.ex:1651
 #: lib/vutuv_web/components/post_components.ex:5047
 #: lib/vutuv_web/live/post_live/saved.ex:805
-#: lib/vutuv_web/views/user_html.ex:496
+#: lib/vutuv_web/views/user_html.ex:463
 #, elixir-autogen, elixir-format
 msgid "Unlike"
 msgstr "Gefällt mir entfernen"
@@ -2519,7 +2519,7 @@ msgstr "Gefällt mir entfernen"
 #: lib/vutuv_web/live/organization_live/following.ex:378
 #: lib/vutuv_web/live/organization_live/following.ex:453
 #: lib/vutuv_web/live/organization_live/show.ex:474
-#: lib/vutuv_web/live/post_live/feed.ex:1567
+#: lib/vutuv_web/live/post_live/feed.ex:1555
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2811,7 +2811,7 @@ msgstr "Ersten Beitrag schreiben"
 msgid "Manage"
 msgstr "Verwalten"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1349
+#: lib/vutuv_web/live/post_live/feed.ex:1337
 #: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2832,7 +2832,7 @@ msgid_plural "%{formatted} connections"
 msgstr[0] "1 Vernetzung"
 msgstr[1] "%{formatted} Vernetzungen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1658
+#: lib/vutuv_web/live/post_live/feed.ex:1657
 #: lib/vutuv_web/templates/user/card_list.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -4713,7 +4713,7 @@ msgstr "Sie haben niemanden blockiert."
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1523
+#: lib/vutuv_web/live/post_live/feed.ex:1511
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
@@ -5648,7 +5648,7 @@ msgstr "Fußzeilen-Navigation"
 #: lib/vutuv_web/components/post_components.ex:3114
 #: lib/vutuv_web/components/post_components.ex:3533
 #: lib/vutuv_web/live/notification_live/index.ex:726
-#: lib/vutuv_web/live/post_live/feed.ex:1699
+#: lib/vutuv_web/live/post_live/feed.ex:1698
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5673,7 +5673,7 @@ msgstr "Andere"
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:33
 #: lib/vutuv_web/views/email_html.ex:12
-#: lib/vutuv_web/views/user_html.ex:947
+#: lib/vutuv_web/views/user_html.ex:914
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr "Privat"
@@ -6939,7 +6939,7 @@ msgstr "Folgen Sie einander, um mit %{name} vernetzt zu sein und ihn zu lesen."
 msgid "Go to profile to follow"
 msgstr "Zum Profil, um zu folgen"
 
-#: lib/vutuv_web/views/user_html.ex:946
+#: lib/vutuv_web/views/user_html.ex:913
 #, elixir-autogen, elixir-format
 msgid "Professional"
 msgstr "Beruflich"
@@ -8246,7 +8246,7 @@ msgid "Admins"
 msgstr "Administratoren"
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:1667
+#: lib/vutuv_web/live/post_live/feed.ex:1666
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr "Alle Mitglieder"
@@ -8712,7 +8712,7 @@ msgstr "Zu viele Importe. Bitte versuchen Sie es in Kürze erneut."
 msgid "Please check the fields marked in red."
 msgstr "Bitte prüfen Sie die rot markierten Felder."
 
-#: lib/vutuv_web/views/user_html.ex:831
+#: lib/vutuv_web/views/user_html.ex:798
 #, elixir-autogen, elixir-format
 msgid "Loading posts"
 msgstr "Beiträge werden geladen"
@@ -8853,12 +8853,12 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr "Geben Sie zur Bestätigung Ihren Benutzernamen ein:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1684
+#: lib/vutuv_web/live/post_live/feed.ex:1683
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr "Andere Beiträge anzeigen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1680
+#: lib/vutuv_web/live/post_live/feed.ex:1679
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr "Vorgeschlagene Beiträge"
@@ -10751,15 +10751,15 @@ msgstr[0] "%{count} Stern"
 msgstr[1] "%{count} Sterne"
 
 #: lib/vutuv_web/live/organization_live/show.ex:498
-#: lib/vutuv_web/views/user_html.ex:695
-#: lib/vutuv_web/views/user_html.ex:871
+#: lib/vutuv_web/views/user_html.ex:662
+#: lib/vutuv_web/views/user_html.ex:838
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower"
 msgid_plural "%{formatted} followers"
 msgstr[0] "%{formatted} Follower"
 msgstr[1] "%{formatted} Follower"
 
-#: lib/vutuv_web/views/user_html.ex:688
+#: lib/vutuv_web/views/user_html.ex:655
 #, elixir-autogen, elixir-format
 msgid "%{formatted} star"
 msgid_plural "%{formatted} stars"
@@ -10787,7 +10787,7 @@ msgstr ""
 "dessen öffentliche Statistiken zeigen: Sterne, Repositories, Follower, "
 "Sprachen und letzte Aktivität."
 
-#: lib/vutuv_web/views/user_html.ex:702
+#: lib/vutuv_web/views/user_html.ex:669
 #, elixir-autogen, elixir-format
 msgid "Last active %{date}"
 msgstr "Zuletzt aktiv %{date}"
@@ -10814,7 +10814,7 @@ msgstr "zuletzt aktiv %{date}"
 msgid "since %{date}"
 msgstr "seit %{date}"
 
-#: lib/vutuv_web/views/user_html.ex:618
+#: lib/vutuv_web/views/user_html.ex:585
 #, elixir-autogen, elixir-format
 msgid "since %{year}"
 msgstr "seit %{year}"
@@ -14170,14 +14170,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4372
 #: lib/vutuv_web/controllers/settings_controller.ex:614
-#: lib/vutuv_web/live/post_live/feed.ex:1553
+#: lib/vutuv_web/live/post_live/feed.ex:1541
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr "Tags, denen Sie folgen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1568
+#: lib/vutuv_web/live/post_live/feed.ex:1556
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr "#%{tag} entfolgen"
@@ -15079,7 +15079,7 @@ msgstr "Nach einem Tag filtern"
 msgid "Filter removed."
 msgstr "Filter entfernt."
 
-#: lib/vutuv_web/live/post_live/feed.ex:473
+#: lib/vutuv_web/live/post_live/feed.ex:461
 #, elixir-autogen, elixir-format
 msgid "Hidden: matches your filter"
 msgstr "Ausgeblendet: passt zu Ihrem Filter"
@@ -15114,7 +15114,7 @@ msgstr ""
 "Wählen Sie unten einen Abschluss oder eine Schule, um ihn statt eines "
 "Jobtitels oben in Ihrem Profil anzuzeigen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:482
+#: lib/vutuv_web/live/post_live/feed.ex:470
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr "Trotzdem anzeigen"
@@ -17158,8 +17158,8 @@ msgstr "Fotos hinzufügen"
 msgid "Licence"
 msgstr "Lizenz"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1358
-#: lib/vutuv_web/live/post_live/feed.ex:1359
+#: lib/vutuv_web/live/post_live/feed.ex:1346
+#: lib/vutuv_web/live/post_live/feed.ex:1347
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr "Fotos posten"
@@ -21761,13 +21761,13 @@ msgstr "Empfohlen: %{width} × %{height} Pixel (%{ratio})."
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr "Empfohlen: quadratisch, mindestens %{width} × %{height} Pixel."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1609
-#: lib/vutuv_web/views/user_html.ex:367
+#: lib/vutuv_web/live/post_live/feed.ex:1598
+#: lib/vutuv_web/views/user_html.ex:334
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
 msgstr "Profilbild von %{name}"
 
-#: lib/vutuv_web/views/user_html.ex:370
+#: lib/vutuv_web/views/user_html.ex:337
 #, elixir-autogen, elixir-format
 msgid "Show the profile picture larger"
 msgstr "Profilbild größer anzeigen"
@@ -22396,39 +22396,15 @@ msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public po
 msgstr ""
 "Folgen Sie #%{tag} von Mastodon oder einer anderen Fediverse-App aus, dann landen die öffentlichen Beiträge in Ihrer Timeline. Ein vutuv-Konto brauchen Sie dafür nicht."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1592
+#: lib/vutuv_web/live/post_live/feed.ex:1580
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Andere Mitglieder begrüßen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1588
+#: lib/vutuv_web/live/post_live/feed.ex:1576
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr "Neu dabei"
-
-#: lib/vutuv_web/live/post_live/feed.ex:1601
-#, elixir-autogen, elixir-format
-msgid "The members who joined most recently. Following them is a warm welcome."
-msgstr ""
-"Die zuletzt dazugekommenen Mitglieder. Ihnen zu folgen ist eine herzliche "
-"Begrüßung."
-
-#: lib/vutuv_web/views/user_html.ex:313
-#, elixir-autogen, elixir-format
-msgid "joined %{count} day ago"
-msgid_plural "joined %{count} days ago"
-msgstr[0] "seit %{count} Tag dabei"
-msgstr[1] "seit %{count} Tagen dabei"
-
-#: lib/vutuv_web/views/user_html.ex:307
-#, elixir-autogen, elixir-format
-msgid "joined today"
-msgstr "seit heute dabei"
-
-#: lib/vutuv_web/views/user_html.ex:310
-#, elixir-autogen, elixir-format
-msgid "joined yesterday"
-msgstr "seit gestern dabei"
 
 #: lib/vutuv_web/components/ui.ex:1302
 #, elixir-autogen, elixir-format
@@ -22470,3 +22446,10 @@ msgstr "Der beste Weg: Folgen Sie %{name} hier. Neue Beiträge landen in Ihrem F
 #, elixir-autogen, elixir-format
 msgid "With a vutuv account"
 msgstr "Mit einem vutuv-Konto"
+
+#: lib/vutuv_web/live/post_live/feed.ex:1590
+#, elixir-autogen, elixir-format
+msgid "A few of the newest members. Following them is a warm welcome."
+msgstr ""
+"Ein paar der neuesten Mitglieder. Ihnen zu folgen ist eine herzliche "
+"Begrüßung."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -726,12 +726,12 @@ msgstr ""
 msgid "Profile deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:770
+#: lib/vutuv_web/views/user_html.ex:737
 #, elixir-autogen, elixir-format
 msgid "Social networks"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:777
+#: lib/vutuv_web/views/user_html.ex:744
 #, elixir-autogen, elixir-format
 msgid "Code & repositories"
 msgstr ""
@@ -926,7 +926,7 @@ msgid "You follow back %{name}."
 msgstr ""
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:90
+#: lib/vutuv_web/live/post_live/feed.ex:86
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1845,7 +1845,7 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:27
 #: lib/vutuv_web/templates/social_media_account/verify.html.heex:18
 #: lib/vutuv_web/templates/user/show.html.heex:200
-#: lib/vutuv_web/views/user_html.ex:822
+#: lib/vutuv_web/views/user_html.ex:789
 #, elixir-autogen, elixir-format
 msgid "Verified profile"
 msgstr ""
@@ -2120,8 +2120,8 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:274
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:98
-#: lib/vutuv_web/live/post_live/feed.ex:195
-#: lib/vutuv_web/live/post_live/feed.ex:1311
+#: lib/vutuv_web/live/post_live/feed.ex:191
+#: lib/vutuv_web/live/post_live/feed.ex:1299
 #: lib/vutuv_web/live/shell_live.ex:769
 #: lib/vutuv_web/live/shell_live.ex:1062
 #: lib/vutuv_web/templates/layout/app.html.heex:171
@@ -2166,7 +2166,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1518
+#: lib/vutuv_web/live/post_live/feed.ex:1506
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2256,7 +2256,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1422
+#: lib/vutuv_web/live/post_live/feed.ex:1410
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2376,7 +2376,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1699
 #: lib/vutuv_web/components/post_components.ex:4812
 #: lib/vutuv_web/components/ui.ex:3498
-#: lib/vutuv_web/views/user_html.ex:486
+#: lib/vutuv_web/views/user_html.ex:453
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr ""
@@ -2396,7 +2396,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:5048
 #: lib/vutuv_web/components/ui.ex:3484
 #: lib/vutuv_web/live/notification_live/index.ex:1072
-#: lib/vutuv_web/views/user_html.ex:496
+#: lib/vutuv_web/views/user_html.ex:463
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr ""
@@ -2432,7 +2432,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1698
 #: lib/vutuv_web/components/post_components.ex:4811
 #: lib/vutuv_web/live/post_live/saved.ex:806
-#: lib/vutuv_web/views/user_html.ex:486
+#: lib/vutuv_web/views/user_html.ex:453
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
@@ -2459,7 +2459,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1651
 #: lib/vutuv_web/components/post_components.ex:5047
 #: lib/vutuv_web/live/post_live/saved.ex:805
-#: lib/vutuv_web/views/user_html.ex:496
+#: lib/vutuv_web/views/user_html.ex:463
 #, elixir-autogen, elixir-format
 msgid "Unlike"
 msgstr ""
@@ -2472,7 +2472,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:378
 #: lib/vutuv_web/live/organization_live/following.ex:453
 #: lib/vutuv_web/live/organization_live/show.ex:474
-#: lib/vutuv_web/live/post_live/feed.ex:1567
+#: lib/vutuv_web/live/post_live/feed.ex:1555
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2762,7 +2762,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1349
+#: lib/vutuv_web/live/post_live/feed.ex:1337
 #: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2783,7 +2783,7 @@ msgid_plural "%{formatted} connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1658
+#: lib/vutuv_web/live/post_live/feed.ex:1657
 #: lib/vutuv_web/templates/user/card_list.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -4544,7 +4544,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1523
+#: lib/vutuv_web/live/post_live/feed.ex:1511
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -5425,7 +5425,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:3114
 #: lib/vutuv_web/components/post_components.ex:3533
 #: lib/vutuv_web/live/notification_live/index.ex:726
-#: lib/vutuv_web/live/post_live/feed.ex:1699
+#: lib/vutuv_web/live/post_live/feed.ex:1698
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5450,7 +5450,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:33
 #: lib/vutuv_web/views/email_html.ex:12
-#: lib/vutuv_web/views/user_html.ex:947
+#: lib/vutuv_web/views/user_html.ex:914
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr ""
@@ -6661,7 +6661,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:946
+#: lib/vutuv_web/views/user_html.ex:913
 #, elixir-autogen, elixir-format
 msgid "Professional"
 msgstr ""
@@ -7895,7 +7895,7 @@ msgid "Admins"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:1667
+#: lib/vutuv_web/live/post_live/feed.ex:1666
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr ""
@@ -8335,7 +8335,7 @@ msgstr ""
 msgid "Please check the fields marked in red."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:831
+#: lib/vutuv_web/views/user_html.ex:798
 #, elixir-autogen, elixir-format
 msgid "Loading posts"
 msgstr ""
@@ -8452,12 +8452,12 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1684
+#: lib/vutuv_web/live/post_live/feed.ex:1683
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1680
+#: lib/vutuv_web/live/post_live/feed.ex:1679
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr ""
@@ -10228,15 +10228,15 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/live/organization_live/show.ex:498
-#: lib/vutuv_web/views/user_html.ex:695
-#: lib/vutuv_web/views/user_html.ex:871
+#: lib/vutuv_web/views/user_html.ex:662
+#: lib/vutuv_web/views/user_html.ex:838
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower"
 msgid_plural "%{formatted} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_html.ex:688
+#: lib/vutuv_web/views/user_html.ex:655
 #, elixir-autogen, elixir-format
 msgid "%{formatted} star"
 msgid_plural "%{formatted} stars"
@@ -10261,7 +10261,7 @@ msgstr ""
 msgid "If you list a GitHub, GitLab or Codeberg account, your profile can show its public statistics: stars, repositories, followers, languages and recent activity."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:702
+#: lib/vutuv_web/views/user_html.ex:669
 #, elixir-autogen, elixir-format
 msgid "Last active %{date}"
 msgstr ""
@@ -10286,7 +10286,7 @@ msgstr ""
 msgid "since %{date}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:618
+#: lib/vutuv_web/views/user_html.ex:585
 #, elixir-autogen, elixir-format
 msgid "since %{year}"
 msgstr ""
@@ -13499,14 +13499,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4372
 #: lib/vutuv_web/controllers/settings_controller.ex:614
-#: lib/vutuv_web/live/post_live/feed.ex:1553
+#: lib/vutuv_web/live/post_live/feed.ex:1541
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1568
+#: lib/vutuv_web/live/post_live/feed.ex:1556
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr ""
@@ -14384,7 +14384,7 @@ msgstr ""
 msgid "Filter removed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:473
+#: lib/vutuv_web/live/post_live/feed.ex:461
 #, elixir-autogen, elixir-format
 msgid "Hidden: matches your filter"
 msgstr ""
@@ -14417,7 +14417,7 @@ msgstr ""
 msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:482
+#: lib/vutuv_web/live/post_live/feed.ex:470
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr ""
@@ -16437,8 +16437,8 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1358
-#: lib/vutuv_web/live/post_live/feed.ex:1359
+#: lib/vutuv_web/live/post_live/feed.ex:1346
+#: lib/vutuv_web/live/post_live/feed.ex:1347
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr ""
@@ -20971,13 +20971,13 @@ msgstr ""
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1609
-#: lib/vutuv_web/views/user_html.ex:367
+#: lib/vutuv_web/live/post_live/feed.ex:1598
+#: lib/vutuv_web/views/user_html.ex:334
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:370
+#: lib/vutuv_web/views/user_html.ex:337
 #, elixir-autogen, elixir-format
 msgid "Show the profile picture larger"
 msgstr ""
@@ -21605,36 +21605,14 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1592
+#: lib/vutuv_web/live/post_live/feed.ex:1580
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1588
+#: lib/vutuv_web/live/post_live/feed.ex:1576
 #, elixir-autogen, elixir-format
 msgid "New here"
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/feed.ex:1601
-#, elixir-autogen, elixir-format
-msgid "The members who joined most recently. Following them is a warm welcome."
-msgstr ""
-
-#: lib/vutuv_web/views/user_html.ex:313
-#, elixir-autogen, elixir-format
-msgid "joined %{count} day ago"
-msgid_plural "joined %{count} days ago"
-msgstr[0] ""
-msgstr[1] ""
-
-#: lib/vutuv_web/views/user_html.ex:307
-#, elixir-autogen, elixir-format
-msgid "joined today"
-msgstr ""
-
-#: lib/vutuv_web/views/user_html.ex:310
-#, elixir-autogen, elixir-format
-msgid "joined yesterday"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:1302
@@ -21676,4 +21654,9 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1250
 #, elixir-autogen, elixir-format
 msgid "With a vutuv account"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/feed.ex:1590
+#, elixir-autogen, elixir-format
+msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -724,12 +724,12 @@ msgstr ""
 msgid "Profile deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:770
+#: lib/vutuv_web/views/user_html.ex:737
 #, elixir-autogen, elixir-format
 msgid "Social networks"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:777
+#: lib/vutuv_web/views/user_html.ex:744
 #, elixir-autogen, elixir-format
 msgid "Code & repositories"
 msgstr ""
@@ -924,7 +924,7 @@ msgid "You follow back %{name}."
 msgstr ""
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:90
+#: lib/vutuv_web/live/post_live/feed.ex:86
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1843,7 +1843,7 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:27
 #: lib/vutuv_web/templates/social_media_account/verify.html.heex:18
 #: lib/vutuv_web/templates/user/show.html.heex:200
-#: lib/vutuv_web/views/user_html.ex:822
+#: lib/vutuv_web/views/user_html.ex:789
 #, elixir-autogen, elixir-format
 msgid "Verified profile"
 msgstr ""
@@ -2118,8 +2118,8 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:274
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:98
-#: lib/vutuv_web/live/post_live/feed.ex:195
-#: lib/vutuv_web/live/post_live/feed.ex:1311
+#: lib/vutuv_web/live/post_live/feed.ex:191
+#: lib/vutuv_web/live/post_live/feed.ex:1299
 #: lib/vutuv_web/live/shell_live.ex:769
 #: lib/vutuv_web/live/shell_live.ex:1062
 #: lib/vutuv_web/templates/layout/app.html.heex:171
@@ -2164,7 +2164,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1518
+#: lib/vutuv_web/live/post_live/feed.ex:1506
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2254,7 +2254,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1422
+#: lib/vutuv_web/live/post_live/feed.ex:1410
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2374,7 +2374,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1699
 #: lib/vutuv_web/components/post_components.ex:4812
 #: lib/vutuv_web/components/ui.ex:3498
-#: lib/vutuv_web/views/user_html.ex:486
+#: lib/vutuv_web/views/user_html.ex:453
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr ""
@@ -2394,7 +2394,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:5048
 #: lib/vutuv_web/components/ui.ex:3484
 #: lib/vutuv_web/live/notification_live/index.ex:1072
-#: lib/vutuv_web/views/user_html.ex:496
+#: lib/vutuv_web/views/user_html.ex:463
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr ""
@@ -2430,7 +2430,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1698
 #: lib/vutuv_web/components/post_components.ex:4811
 #: lib/vutuv_web/live/post_live/saved.ex:806
-#: lib/vutuv_web/views/user_html.ex:486
+#: lib/vutuv_web/views/user_html.ex:453
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
@@ -2457,7 +2457,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1651
 #: lib/vutuv_web/components/post_components.ex:5047
 #: lib/vutuv_web/live/post_live/saved.ex:805
-#: lib/vutuv_web/views/user_html.ex:496
+#: lib/vutuv_web/views/user_html.ex:463
 #, elixir-autogen, elixir-format
 msgid "Unlike"
 msgstr ""
@@ -2470,7 +2470,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:378
 #: lib/vutuv_web/live/organization_live/following.ex:453
 #: lib/vutuv_web/live/organization_live/show.ex:474
-#: lib/vutuv_web/live/post_live/feed.ex:1567
+#: lib/vutuv_web/live/post_live/feed.ex:1555
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2760,7 +2760,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1349
+#: lib/vutuv_web/live/post_live/feed.ex:1337
 #: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2781,7 +2781,7 @@ msgid_plural "%{formatted} connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1658
+#: lib/vutuv_web/live/post_live/feed.ex:1657
 #: lib/vutuv_web/templates/user/card_list.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -4542,7 +4542,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1523
+#: lib/vutuv_web/live/post_live/feed.ex:1511
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -5423,7 +5423,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:3114
 #: lib/vutuv_web/components/post_components.ex:3533
 #: lib/vutuv_web/live/notification_live/index.ex:726
-#: lib/vutuv_web/live/post_live/feed.ex:1699
+#: lib/vutuv_web/live/post_live/feed.ex:1698
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5448,7 +5448,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:33
 #: lib/vutuv_web/views/email_html.ex:12
-#: lib/vutuv_web/views/user_html.ex:947
+#: lib/vutuv_web/views/user_html.ex:914
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr ""
@@ -6659,7 +6659,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:946
+#: lib/vutuv_web/views/user_html.ex:913
 #, elixir-autogen, elixir-format
 msgid "Professional"
 msgstr ""
@@ -7893,7 +7893,7 @@ msgid "Admins"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:1667
+#: lib/vutuv_web/live/post_live/feed.ex:1666
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr ""
@@ -8333,7 +8333,7 @@ msgstr ""
 msgid "Please check the fields marked in red."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:831
+#: lib/vutuv_web/views/user_html.ex:798
 #, elixir-autogen, elixir-format
 msgid "Loading posts"
 msgstr ""
@@ -8450,12 +8450,12 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1684
+#: lib/vutuv_web/live/post_live/feed.ex:1683
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1680
+#: lib/vutuv_web/live/post_live/feed.ex:1679
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr ""
@@ -10226,15 +10226,15 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/live/organization_live/show.ex:498
-#: lib/vutuv_web/views/user_html.ex:695
-#: lib/vutuv_web/views/user_html.ex:871
+#: lib/vutuv_web/views/user_html.ex:662
+#: lib/vutuv_web/views/user_html.ex:838
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower"
 msgid_plural "%{formatted} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_html.ex:688
+#: lib/vutuv_web/views/user_html.ex:655
 #, elixir-autogen, elixir-format
 msgid "%{formatted} star"
 msgid_plural "%{formatted} stars"
@@ -10259,7 +10259,7 @@ msgstr ""
 msgid "If you list a GitHub, GitLab or Codeberg account, your profile can show its public statistics: stars, repositories, followers, languages and recent activity."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:702
+#: lib/vutuv_web/views/user_html.ex:669
 #, elixir-autogen, elixir-format
 msgid "Last active %{date}"
 msgstr ""
@@ -10284,7 +10284,7 @@ msgstr ""
 msgid "since %{date}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:618
+#: lib/vutuv_web/views/user_html.ex:585
 #, elixir-autogen, elixir-format
 msgid "since %{year}"
 msgstr ""
@@ -13497,14 +13497,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4372
 #: lib/vutuv_web/controllers/settings_controller.ex:614
-#: lib/vutuv_web/live/post_live/feed.ex:1553
+#: lib/vutuv_web/live/post_live/feed.ex:1541
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1568
+#: lib/vutuv_web/live/post_live/feed.ex:1556
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr ""
@@ -14382,7 +14382,7 @@ msgstr ""
 msgid "Filter removed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:473
+#: lib/vutuv_web/live/post_live/feed.ex:461
 #, elixir-autogen, elixir-format
 msgid "Hidden: matches your filter"
 msgstr ""
@@ -14415,7 +14415,7 @@ msgstr ""
 msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:482
+#: lib/vutuv_web/live/post_live/feed.ex:470
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr ""
@@ -16435,8 +16435,8 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1358
-#: lib/vutuv_web/live/post_live/feed.ex:1359
+#: lib/vutuv_web/live/post_live/feed.ex:1346
+#: lib/vutuv_web/live/post_live/feed.ex:1347
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post photos"
 msgstr ""
@@ -20969,13 +20969,13 @@ msgstr ""
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1609
-#: lib/vutuv_web/views/user_html.ex:367
+#: lib/vutuv_web/live/post_live/feed.ex:1598
+#: lib/vutuv_web/views/user_html.ex:334
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:370
+#: lib/vutuv_web/views/user_html.ex:337
 #, elixir-autogen, elixir-format
 msgid "Show the profile picture larger"
 msgstr ""
@@ -21603,36 +21603,14 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1592
+#: lib/vutuv_web/live/post_live/feed.ex:1580
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1588
+#: lib/vutuv_web/live/post_live/feed.ex:1576
 #, elixir-autogen, elixir-format
 msgid "New here"
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/feed.ex:1601
-#, elixir-autogen, elixir-format
-msgid "The members who joined most recently. Following them is a warm welcome."
-msgstr ""
-
-#: lib/vutuv_web/views/user_html.ex:313
-#, elixir-autogen, elixir-format
-msgid "joined %{count} day ago"
-msgid_plural "joined %{count} days ago"
-msgstr[0] ""
-msgstr[1] ""
-
-#: lib/vutuv_web/views/user_html.ex:307
-#, elixir-autogen, elixir-format
-msgid "joined today"
-msgstr ""
-
-#: lib/vutuv_web/views/user_html.ex:310
-#, elixir-autogen, elixir-format
-msgid "joined yesterday"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:1302
@@ -21674,4 +21652,9 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1250
 #, elixir-autogen, elixir-format
 msgid "With a vutuv account"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/feed.ex:1590
+#, elixir-autogen, elixir-format
+msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""

--- a/test/vutuv_web/live/feed_newcomers_test.exs
+++ b/test/vutuv_web/live/feed_newcomers_test.exs
@@ -155,17 +155,27 @@ defmodule VutuvWeb.PostLive.FeedNewcomersTest do
              )
     end
 
-    test "says how new the member is, in German", %{conn: conn} do
+    test "shows the job title, and nothing where there is none", %{conn: conn} do
+      {conn, _me} = create_and_login_user(conn)
+      employed = newcomer()
+      insert(:work_experience, user: employed, title: "Zugführerin", organization: "DB")
+      jobless = newcomer()
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      html = render(view)
+
+      assert html =~ "Zugführerin"
+      # The row is a name and its tags, not a name and an empty line: the meta
+      # paragraph is absent rather than blank, so a member who has filled
+      # nothing in yet costs the card no height.
+      assert has_element?(view, "#newcomer-#{jobless.id}")
+      refute html =~ "dabei ·"
+    end
+
+    test "says what the card is, in German", %{conn: conn} do
       {conn, me} = create_and_login_user(conn)
       me |> Ecto.Changeset.change(locale: "de") |> Repo.update!()
-
-      _today = newcomer()
-
       newcomer()
-      |> Ecto.Changeset.change(
-        inserted_at: NaiveDateTime.add(NaiveDateTime.utc_now(:second), -1, :day)
-      )
-      |> Repo.update!()
 
       conn = conn |> recycle() |> put_req_header("accept-language", "de-DE,de;q=0.9")
       {:ok, view, _html} = live(conn, ~p"/feed")
@@ -176,9 +186,10 @@ defmodule VutuvWeb.PostLive.FeedNewcomersTest do
       # labels like these are its favourite victims — a German feed would then
       # ship confident nonsense while every English assertion stayed green.
       assert html =~ "Neu dabei"
-      assert html =~ "seit heute dabei"
-      assert html =~ "seit gestern dabei"
+      assert html =~ "Ein paar der neuesten Mitglieder"
       assert html =~ "Ihnen zu folgen ist eine herzliche Begrüßung"
+      # "zuletzt dazugekommen" promised an order the ↻ visibly contradicts.
+      refute html =~ "zuletzt dazugekommen"
     end
   end
 


### PR DESCRIPTION
**Symptom** In the `/feed` rail's "Neu dabei" card, each row's meta line led with "seit 3 Tagen dabei · " before the job title. Interesting, but it ate a third of every row for a fact the card's own heading already makes — five rows deep that bought nothing. The intro also read "Die zuletzt dazugekommenen Mitglieder", promising an order that the ↻ visibly contradicts: the card draws *randomly* from the newest.

**Changed** (`VutuvWeb.PostLive.Feed`, the `#newcomers` card) The meta line is the job title alone, and a member who has not filled one in gets no line at all rather than an empty one. The intro is now "Ein paar der neuesten Mitglieder. Ihnen zu folgen ist eine herzliche Begrüßung."

**Removed with it** `VutuvWeb.UserHTML.joined_line/1` loses its only caller and goes, along with its four msgids; `Social.newest_members_with_avatar/1` no longer selects `inserted_at`.

Hot deploy, v7.345.2. `mix precommit` green.

*An AI agent wrote this text in my name. I know that is problematic.*
