### PR TITLE
Keep the feed ticker away from a browser running the previous release

### DIFF
--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -467,7 +467,7 @@ the other tabs fold their labels to zero width and the quote takes the room
 behaves like a phone on a desktop screen); measured on a 356 px bar, that is
 the difference between no room for a quote at all and about twenty characters.
 
-Four rules keep it from becoming a nuisance, and each one has a test:
+Five rules keep it from becoming a nuisance, and each one has a test:
 
 * **One quote per window.** A second arrival inside it cannot replace the
   first (both would stand for less time than it takes to read one) and cannot
@@ -489,6 +489,16 @@ Four rules keep it from becoming a nuisance, and each one has a test:
   the branch for the tab the reader *is* on, so the teaser asks
   `filtered_pattern/3` itself and falls back to the bare dot. The bar is the
   one place a member cannot scroll past it.
+* **Not into a browser left over from the previous release.** A deploy does
+  not reload an open feed: the socket reconnects to the new release and
+  patches into a document downloaded hours ago. Everything else the feed
+  streams is markup whose CSS that browser already has — the ticker is new
+  markup with a stylesheet and a hook of its own, so on the v7.347.0 deploy
+  the quote drew as an unstyled 200-character paragraph across the tab bar
+  that no clock ever took away. `mount_feed/2` reads `static_changed?/1` once
+  (connect params exist only during mount, and it answers only because
+  `root.html.heex` marks both assets `phx-track-static`); a stale client keeps
+  the dot and skips the quote until the next full page load.
 
 Only ever one tab at a time: `other_source/1` is nil on "All" and the two named
 tabs partition the feed, so a third source would be the first thing to need a

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -94,6 +94,13 @@ defmodule VutuvWeb.PostLive.Feed do
   end
 
   defp mount_feed(socket, user) do
+    # Is this browser still running the previous release's CSS and JS? A deploy
+    # does not reload an open feed — the socket reconnects to the new release
+    # and patches into a document downloaded hours ago — and `static_changed?/1`
+    # is the only way to know (`phx-track-static` in the root layout feeds it).
+    # Read here because connect params exist only during mount.
+    socket = assign(socket, :stale_client?, static_changed?(socket))
+
     # The tab they left on (issue #1499). It opens the page *and* keys the
     # handoff below: the stash holds one entry per member, so two devices
     # opening /feed within its 15s TTL would otherwise let one take a page the
@@ -1163,9 +1170,20 @@ defmodule VutuvWeb.PostLive.Feed do
   end
 
   # Whether a fresh window may open: the member wants quotes at all, the tab
-  # bar exists to put one in, and the last window's silence is over.
+  # bar exists to put one in, the last window's silence is over — and the
+  # browser can render a quote at all.
+  #
+  # That last one is the deploy case, and it is the one thing on this page that
+  # a stale browser cannot survive. Everything else the feed patches in is
+  # markup whose CSS that browser already has; the ticker is new markup with a
+  # stylesheet and a hook of its own, so on a feed left open across the v7.347.0
+  # deploy the quote drew as an unstyled 200-character paragraph across the tab
+  # bar that no clock ever took away (the `FeedTicker` hook was not in that
+  # bundle either). A stale client keeps the dot, which is markup from #1503 and
+  # renders fine, and skips the quote until the next full page load.
   defp ticker_due?(socket) do
     socket.assigns.source_tabs? and is_nil(socket.assigns.tab_ticker) and
+      not socket.assigns.stale_client? and
       Prefs.get(socket.assigns.current_user, :feed_tab_ticker?) and not quiet?(socket)
   end
 

--- a/lib/vutuv_web/templates/layout/root.html.heex
+++ b/lib/vutuv_web/templates/layout/root.html.heex
@@ -80,8 +80,17 @@
       type="application/activity+json"
       href={assigns[:activity_json_alternate]}
     />
-    <link rel="stylesheet" href={~p"/assets/app.css"} />
-    <script defer src={~p"/assets/app.js"}></script>
+    <%!-- `phx-track-static` is how a LiveView finds out that the browser it is
+    patching still runs the *previous* release's bundle. A deploy does not
+    reload an open page: the socket reconnects to the new release and patches
+    its markup into a document whose stylesheet and hooks are whatever the
+    browser downloaded hours ago. The client reports these two hrefs on join
+    and `static_changed?/1` compares them against the digest manifest, which is
+    what lets a page skip markup that would arrive unstyled and unhooked (see
+    the feed's tab ticker). Without the annotation the client sends nothing and
+    every such check answers "unchanged". --%>
+    <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
+    <script defer phx-track-static src={~p"/assets/app.js"}></script>
   </head>
   <body class={assigns[:conn] && @conn.assigns[:body_class]}>
     {@inner_content}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.347.0",
+      version: "7.347.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/feed_tab_ticker_test.exs
+++ b/test/vutuv_web/live/feed_tab_ticker_test.exs
@@ -4,9 +4,10 @@ defmodule VutuvWeb.FeedTabTickerTest do
 
   The dot from #1503 says *that* something landed over there; the ticker says
   *what*, for a few seconds. What is worth testing is not that it renders but
-  the four rules that keep it from becoming a nuisance: one quote per window,
-  a count instead of a second quote, a window that ends on its own (and not by
-  a later patch putting it back), and a silence afterwards.
+  the rules that keep it from becoming a nuisance: one quote per window, a
+  count instead of a second quote, a window that ends on its own (and not by a
+  later patch putting it back), a silence afterwards — and no quote at all into
+  a browser still running the previous release's stylesheet and hooks.
 
   Not async: one test sets `:feed_ticker_cooldown_ms`, which is application env
   — process state the SQL sandbox does not roll back, and every open feed reads
@@ -115,13 +116,20 @@ defmodule VutuvWeb.FeedTabTickerTest do
 
   # The reader on one named tab, with the other one populated so the tab bar
   # exists at all (`Posts.fediverse_feed_available?/1` asks the sources).
-  defp reader_on(conn, tab) do
+  # `connect_params` is what the browser sends on join — the stale-assets test
+  # below puts a `_track_static` in there.
+  defp reader_on(conn, tab, connect_params \\ %{}) do
     {conn, user} = create_and_login_user(conn)
     {_author, _post} = followed_post(user, "an older post")
     account = remote_account(user, "them")
     cached_post(account, "written out there")
 
-    {:ok, view, _html} = live(conn, ~p"/feed")
+    # `get/2` recycles a conn that has already been sent, and recycling drops
+    # `private` — connect params included. Recycling here, before they are put,
+    # is what gets them as far as the join.
+    {:ok, view, _html} =
+      conn |> recycle() |> put_connect_params(connect_params) |> live(~p"/feed")
+
     render_click(view, "filter-source", %{"type" => tab})
 
     %{view: view, user: user, account: account}
@@ -327,6 +335,69 @@ defmodule VutuvWeb.FeedTabTickerTest do
       refute ticker(view)
       # Still worth a dot: something did land over there.
       assert dotted?(view, "vutuv")
+    end
+  end
+
+  describe "a browser left over from the previous release" do
+    # What v7.347.0 looked like on a feed that had been open since before the
+    # deploy: the socket reconnects to the new release and patches the quote
+    # into a document whose stylesheet has never heard of `.filter-tab-ticker`
+    # and whose bundle has no `FeedTicker` hook — so the quote drew as an
+    # unstyled 200-character paragraph across the tab bar, and no clock ever
+    # took it away. Everything else on that page is older than the browser's
+    # copy and survives the patch; the ticker is the half that cannot.
+    setup do
+      # `static_changed?/1` compares what the client reports against the
+      # digest manifest, which only exists in a release. Two entries that
+      # cannot match, so the comparison has something to answer with.
+      Phoenix.Config.put(VutuvWeb.Endpoint, :cache_static_manifest_latest, %{
+        "assets/app.css" => "assets/app-nowdeployed.css"
+      })
+
+      on_exit(fn ->
+        Phoenix.Config.put(VutuvWeb.Endpoint, :cache_static_manifest_latest, nil)
+      end)
+    end
+
+    test "gets the dot and no quote", %{conn: conn} do
+      %{view: view, user: user} =
+        reader_on(conn, "fediverse", %{
+          "_track_static" => ["http://localhost/assets/app-fromthelastrelease.css"]
+        })
+
+      author = followed_author(user)
+      {:ok, _post} = Posts.create_post(author, %{body: "etwas Neues"})
+
+      refute ticker(view)
+      assert dotted?(view, "vutuv")
+    end
+
+    test "while the browser on this release still gets both", %{conn: conn} do
+      # The other half of the gate: with assets the server recognises, the
+      # window opens as before. Without this the test above would pass on a
+      # ticker that is simply broken.
+      %{view: view, user: user} =
+        reader_on(conn, "fediverse", %{
+          "_track_static" => ["http://localhost/assets/app-nowdeployed.css"]
+        })
+
+      author = followed_author(user)
+      {:ok, _post} = Posts.create_post(author, %{body: "etwas Neues"})
+
+      assert ticker(view)
+      assert dotted?(view, "vutuv")
+    end
+  end
+
+  describe "the layout the gate reads" do
+    test "marks both assets, or the client reports nothing to compare", %{conn: conn} do
+      # `phx-track-static` is the whole input to `static_changed?/1`: without
+      # it the client sends no manifest, the comparison answers "unchanged"
+      # for every browser, and the gate above is dead code.
+      html = conn |> get(~p"/login") |> html_response(200)
+
+      assert html =~ ~r/<link[^>]+phx-track-static[^>]*href="[^"]*app[^"]*\.css/
+      assert html =~ ~r/<script[^>]+phx-track-static[^>]*src="[^"]*app[^"]*\.js/
     end
   end
 end


### PR DESCRIPTION
**Symptom** On `/feed`, the new tab ticker (v7.347.0) rendered as an unstyled blue paragraph across the tab bar and never went away — but only in tabs that had been open since before the deploy.

**Cause** A deploy does not reload an open page. The socket reconnects to the new release and patches its markup into a document whose `app.css`/`app.js` are the previous release's. Everything else the feed streams looks right there, because its CSS already shipped; the ticker is new markup with its own stylesheet and its own `FeedTicker` hook, so it drew bare and no clock ever ran. Reloading fixes it, which is why it now looks correct.

**Change** `root.html.heex` marks both assets `phx-track-static`, so the client reports them on join. `VutuvWeb.PostLive.Feed.mount_feed/2` reads `static_changed?/1` once (connect params exist only during mount) and `ticker_due?/1` refuses to open a window for such a browser: it keeps the unseen dot, which renders fine, and skips the quote until the next full page load.

Tests: a stale client gets the dot and no quote, a current one gets both, and the layout keeps the annotation the check depends on.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_015FkPnYb5ofJPHphLLxGhvc
