### PR TITLE
Feed: drop the unread dot on the All tab

### DIFF
--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -427,7 +427,9 @@ came from), or they would be stranded on a tab they cannot leave.
 **A tab you are not on says something landed there** (issue #1503) — a coral
 dot beside its label (`post_filter_tabs/1`'s `unseen`), cleared by going there
 (`load_source_filter/2` → `clear_unseen/2`; "All" clears both, a named tab only
-itself). A dot and no count: what the reader needs is that there is something
+itself). Only the two named tabs ever dot (`unseen_tabs/1`): "All" holds the
+same posts, so a dot there was true and read as a third place with news of its
+own. A dot and no count: what the reader needs is that there is something
 over there, and the tab reloads from the top anyway. The socket's
 `:unseen_sources` is never stored — it means "since you have been looking at
 this page", so a fresh mount starting clean is the honest state.

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -991,14 +991,10 @@ defmodule VutuvWeb.PostLive.Feed do
   defp other_source(_all), do: nil
 
   # The tab values carrying a dot: the named sources holding something unseen,
-  # plus "All", which shows whatever they hold. The component drops the dot on
+  # and only those. "All" holds the same posts, so a dot there was true and read
+  # as a third place with news of its own. The component drops the dot on
   # whichever tab is active, so this never has to know which one that is.
-  defp unseen_tabs(sources) do
-    case Enum.map(sources, &to_string/1) do
-      [] -> []
-      named -> ["all" | named]
-    end
-  end
+  defp unseen_tabs(sources), do: Enum.map(sources, &to_string/1)
 
   # Swap in the post's now-screenshot-carrying copy and re-stream the entry in
   # place (update_only, so an off-page id is a harmless no-op). The entry's other

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.347.2",
+      version: "7.347.3",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/feed_source_tabs_test.exs
+++ b/test/vutuv_web/live/feed_source_tabs_test.exs
@@ -484,7 +484,7 @@ defmodule VutuvWeb.FeedSourceTabsTest do
       }
     end
 
-    test "a vutuv post arriving on the Fediverse tab dots vutuv and All", %{conn: conn} do
+    test "a vutuv post arriving on the Fediverse tab dots vutuv, never All", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
       {author, _post} = followed_post(user, "an older post")
       cached_post(remote_account(user, "them"), "written out there")
@@ -495,8 +495,8 @@ defmodule VutuvWeb.FeedSourceTabsTest do
       {:ok, _fresh} = Posts.create_post(author, %{body: "arriving live"})
 
       assert dotted?(view, "vutuv")
-      # "All" would show it too, so it says so.
-      assert dotted?(view, "all")
+      # "All" never carries a dot, true as one would be.
+      refute dotted?(view, "all")
       # You are looking at this one, so nothing on it can be unseen.
       refute dotted?(view, "fediverse")
     end
@@ -514,8 +514,6 @@ defmodule VutuvWeb.FeedSourceTabsTest do
       render_click(view, "filter-source", %{"type" => "vutuv"})
 
       assert timeline(view) =~ "arriving live"
-      # Gone from "All" as well: the only thing it was standing for is read.
-      refute dotted?(view, "all")
 
       render_click(view, "filter-source", %{"type" => "fediverse"})
       refute dotted?(view, "vutuv")
@@ -556,12 +554,12 @@ defmodule VutuvWeb.FeedSourceTabsTest do
       assert :ok = Fediverse.record_remote_post(remote_note(account), account.actor_uri)
 
       assert dotted?(view, "fediverse")
-      assert dotted?(view, "all")
+      refute dotted?(view, "all")
       refute dotted?(view, "vutuv")
 
       render_click(view, "filter-source", %{"type" => "fediverse"})
       assert timeline(view) =~ "frisch von drüben"
-      refute dotted?(view, "all")
+      refute dotted?(view, "fediverse")
     end
 
     test "a post the reader's own follow does not open dots nothing", %{conn: conn} do


### PR DESCRIPTION
On `/feed`, an arrival on the tab you are not reading dotted three tabs: the source it landed on **and** "Alle". That is true — "Alle" shows the same post — but three marked tabs read as three places with news of their own when there is only one.

`unseen_tabs/1` in `VutuvWeb.PostLive.Feed` now returns only the named sources. Clearing is unchanged: sitting on "Alle" streams every arrival straight into the "new posts" pill, so nothing can be unseen there anyway.

Tests in `feed_source_tabs_test.exs` flipped to assert "Alle" never dots; the shared `post_filter_tabs/1` component is untouched. `mix precommit` green.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01MkxtjXUsUHPMPEAfEDMrwC