### PR TITLE
Act on a reshare's id as an act, not as the post underneath

### DIFF
--- a/docs/architecture/mastodon-api.md
+++ b/docs/architecture/mastodon-api.md
@@ -290,19 +290,32 @@ report path (`POST /api/v1/reports` with `status_ids`) had the same gap and asks
 it too now; a cached remote object stays unreportable, because a report opens a
 case against something published here.
 
-**A reshare resolves to the post underneath for reads, and the writes are
-deliberately still refused.** The equivalence that makes a read correct makes a
-write dangerous, and in two ways. Resolving a `DELETE` on `repost-<uuid>` to the
-post would let the author of a post somebody boosted delete their own post by
-tapping delete on the boost. And routing it to the existing `:unreblog` action
-instead is not the fix either: `Vutuv.Posts.unrepost_post/2` takes an actor and a
-post and finds *the caller's* reshare of it, so a delete addressed at somebody
-else's row would quietly undo your own. Doing it properly means resolving the
-reshare **row** and checking who owns it, and the row is a different schema per
-prefix — `Vutuv.Posts.PostRepost`, `Vutuv.Fediverse.PostRepost`,
-`Vutuv.Fediverse.NoteRepost`, and `Vutuv.Fediverse.PostBoost`, which belongs to a
-remote account and can never be the caller's. Until that lands, `update`,
-`delete` and `source` keep answering 404 for a reshare id.
+**A reshare resolves to the post underneath for reads — and for a delete it does
+not, because a delete cannot be taken back.** Resolving a `DELETE` on
+`repost-<uuid>` to the post would let the author of a post somebody boosted take
+the original down by tapping delete on that boost, and routing it to the existing
+`:unreblog` action instead is no better: `Vutuv.Posts.unrepost_post/2` takes an
+actor and a post and finds *the caller's* reshare of it, so a delete addressed at
+somebody else's row would quietly undo your own. So `Statuses.own_reshare/2`
+reads the reshare **row** — a different schema per prefix,
+`Vutuv.Posts.PostRepost`, `Vutuv.Fediverse.PostRepost` and
+`Vutuv.Fediverse.NoteRepost` — and answers one of three things: `{:ok, reshare}`
+when the row is the caller's own act, `:not_mine` when it is somebody else's, and
+`:not_a_reshare` when the id names no reshare at all. `DELETE` undoes the first,
+404s the second and falls through to the ordinary post delete for the third. The
+middle answer is the whole safeguard: collapse it into a plain "no" and a foreign
+reshare's id reaches the post lookup again. A `boost-<uuid>` is always `:not_mine`
+— that row belongs to an account on another server, so there is nothing in it a
+member or a page here may undo.
+
+**`update` and `source` do follow a reshare id through**, gated on owning the
+post that comes back: a reshare carries no text of its own, so editing one can
+only mean editing what it passed on, and a reshare of somebody else's post
+answers 404 as it always did. One consequence worth knowing: a `repost-<uuid>`
+now answers an edit with the *reason* it is refused — a reshare made here closes
+the edit window (`Vutuv.Posts` counts it as engagement), so the reply is the 422
+naming that rule instead of the old "Record not found". A `boost-<uuid>` does
+not close it, since that count is of reshares made here.
 
 **Who reacted is asked of a local post only.** `favourited_by` and
 `reblogged_by` answer the empty list for a cached remote object rather than the

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -3025,15 +3025,13 @@ defmodule Vutuv.Fediverse do
   what comes back.
   """
   def get_reposted_remote_post(id) do
-    with %PostRepost{remote_post_id: post_id} <- UUIDv7.with_cast(id, &Repo.get(PostRepost, &1)) do
+    with %PostRepost{remote_post_id: post_id} <- get_remote_post_repost(id) do
       get_remote_post(post_id)
     end
   end
 
   def get_reposted_note(id) do
-    with %NoteRepost{note_id: note_id} <- UUIDv7.with_cast(id, &Repo.get(NoteRepost, &1)) do
-      get_note(note_id)
-    end
+    with %NoteRepost{note_id: note_id} <- get_note_repost(id), do: get_note(note_id)
   end
 
   def get_boosted_object(id) do
@@ -3043,6 +3041,19 @@ defmodule Vutuv.Fediverse do
       _no_such_boost -> nil
     end
   end
+
+  @doc """
+  The reshare **rows** those same ids name, or `nil` — the act rather than what
+  it passed on, for a caller that has to know *whose* reshare it is before
+  undoing one (`VutuvWeb.MastodonApi.Statuses`). Unscoped like the lookups
+  above: the caller compares the row's owner with the identity it is acting as.
+
+  There is no twin for `fediverse_post_boosts` — that row belongs to an account
+  on another server and can never be the caller's act.
+  """
+  def get_remote_post_repost(id), do: UUIDv7.with_cast(id, &Repo.get(PostRepost, &1))
+
+  def get_note_repost(id), do: UUIDv7.with_cast(id, &Repo.get(NoteRepost, &1))
 
   @doc """
   Somebody reports a cached post as not appropriate. **Deletes it immediately**

--- a/lib/vutuv/mastodon_api/presenter.ex
+++ b/lib/vutuv/mastodon_api/presenter.ex
@@ -195,6 +195,27 @@ defmodule Vutuv.MastodonApi.Presenter do
   """
   def one_status(item, viewer), do: item |> List.wrap() |> statuses(viewer) |> hd()
 
+  @doc """
+  One reshare a caller assembled for itself, as a status.
+
+  Every other reshare here arrives as a feed entry from the source that built it
+  (`Vutuv.Posts`, `Vutuv.Fediverse`). This is for the one caller with no feed
+  entry to hand over: `VutuvWeb.MastodonApi.StatusController.delete/2` answering
+  an undo with the reshare the client addressed, which by then is a row it is
+  about to remove. It lives here so the entry shape keeps one owner instead of
+  being hand-built in a controller.
+
+  `reshare` is `%{kind:, object:, at:}` as
+  `VutuvWeb.MastodonApi.Statuses.own_reshare/2` answers it — `kind` is the key
+  the object rides under — and `actor` is both the resharer and the viewer,
+  since that function only ever hands back the caller's own act.
+  """
+  def reshared_status(id, %{kind: kind, object: object, at: at}, actor) do
+    %{id: id, reposted_by: actor, at: at}
+    |> Map.put(kind, object)
+    |> one_status(actor)
+  end
+
   # The map clauses are for feed-entry maps only: a `%Note{}` also carries a
   # `post` association, so without the guard a Note whose `:post` happens to be
   # preloaded would render as its parent post instead of itself.

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -1440,10 +1440,16 @@ defmodule Vutuv.Posts do
   visibility question of the post it gets.
   """
   def get_reposted_post(id) do
-    with %PostRepost{post_id: post_id} <- UUIDv7.with_cast(id, &Repo.get(PostRepost, &1)) do
-      get_post(post_id)
-    end
+    with %PostRepost{post_id: post_id} <- get_post_repost(id), do: get_post(post_id)
   end
+
+  @doc """
+  The repost **row** an id names, or `nil` — the act rather than what it passed
+  on, for a caller that has to know *whose* reshare it is before undoing one
+  (`VutuvWeb.MastodonApi.Statuses`). Unscoped like its twin above: the caller
+  compares the row's owner with the identity it is acting as.
+  """
+  def get_post_repost(id), do: UUIDv7.with_cast(id, &Repo.get(PostRepost, &1))
 
   @doc "Whether any reposts of this post exist (the audience lock)."
   def has_reposts?(%Post{id: id}), do: has_reposts?(id)

--- a/lib/vutuv_web/controllers/mastodon_api/status_controller.ex
+++ b/lib/vutuv_web/controllers/mastodon_api/status_controller.ex
@@ -140,12 +140,30 @@ defmodule VutuvWeb.MastodonApi.StatusController do
 
   def update(conn, _params), do: validation_error(conn, "Status text is required.")
 
-  # Mastodon answers a delete with the status it just removed, so it is rendered
-  # before the row is gone. A failed delete used to raise on the `{:ok, _}`
-  # match, which reaches a client as a 500 with an HTML body it cannot parse —
-  # for the one call where it most needs to know whether the post is still
-  # there. It gets JSON either way now.
+  @doc """
+  Removes the status an id names — and the id decides *what* that is.
+
+  A bare post id deletes the post. A reshare's id undoes that one reshare and
+  leaves what it carried standing, because the id names an act rather than a text
+  and a delete cannot be taken back;
+  `VutuvWeb.MastodonApi.Statuses.own_reshare/2` hands the row over only when it
+  is the caller's own, so every other reshare id answers 404.
+
+  Mastodon answers a delete with the status it just removed, so it is rendered
+  before the row is gone. A failed delete used to raise on the `{:ok, _}` match,
+  which reaches a client as a 500 with an HTML body it cannot parse — for the one
+  call where it most needs to know whether the post is still there. It gets JSON
+  either way now.
+  """
   def delete(conn, %{"id" => id}) do
+    case Statuses.own_reshare(conn, id) do
+      {:ok, reshare} -> undo_own_reshare(conn, id, reshare)
+      :not_mine -> not_found(conn)
+      :not_a_reshare -> delete_own_post(conn, id)
+    end
+  end
+
+  defp delete_own_post(conn, id) do
     case own_post(conn, id) do
       %Post{} = post ->
         rendered = Presenter.one_status(post, viewer(conn))
@@ -157,6 +175,19 @@ defmodule VutuvWeb.MastodonApi.StatusController do
 
       nil ->
         not_found(conn)
+    end
+  end
+
+  # The undo goes through the same `:unreblog` dispatch the action endpoints use,
+  # so the member / page split and the three object kinds are answered in one
+  # place. It is rendered first: the answer is the reshare the client addressed,
+  # and the row is about to be gone.
+  defp undo_own_reshare(conn, id, reshare) do
+    rendered = Presenter.reshared_status(id, reshare, viewer(conn))
+
+    case apply_status_action(conn, reshare.object, :unreblog) do
+      {:error, reason} -> validation_error(conn, action_error(reason))
+      _undone -> json(conn, rendered)
     end
   end
 
@@ -419,8 +450,14 @@ defmodule VutuvWeb.MastodonApi.StatusController do
 
   defp viewer(conn), do: Statuses.viewer(conn)
 
+  # The caller's own post behind whatever id names it, a reshare's included. A
+  # reshare carries no text of its own, so an edit or a source read addressed at
+  # one can only mean the post underneath, and the ownership match is what keeps
+  # that honest: a reshare of somebody else's post resolves to somebody else's
+  # post and answers 404 exactly as it did before. `delete/2` is the one write
+  # that does not come through here; see `VutuvWeb.MastodonApi.Statuses`.
   defp own_post(conn, id) do
-    case {conn.assigns.current_organization, conn.assigns.current_user.id, Posts.get_post(id)} do
+    case {conn.assigns.current_organization, conn.assigns.current_user.id, Statuses.resolve(id)} do
       {nil, user_id, %Post{organization_id: nil, user_id: user_id} = post} ->
         post
 

--- a/lib/vutuv_web/mastodon_api/statuses.ex
+++ b/lib/vutuv_web/mastodon_api/statuses.ex
@@ -16,26 +16,37 @@ defmodule VutuvWeb.MastodonApi.Statuses do
   **A reshare resolves to what it passed on**, which is what Mastodon does with
   a reblog id: reading a reshare is reading the post underneath.
 
-  That equivalence holds for **reads only**, and the writes are deliberately not
-  routed through here yet. A `DELETE` on `repost-<uuid>` must undo that one
-  reshare, and the object this hands back cannot say whose reshare it was:
-  `Vutuv.Posts.unrepost_post/2` would find *the caller's* reshare of the same
-  post, so a delete addressed at somebody else's row would quietly undo your own.
-  Answering that properly needs the reshare **row**, and the row is a different
-  schema per prefix (`Vutuv.Posts.PostRepost`, `Vutuv.Fediverse.PostRepost`,
-  `Vutuv.Fediverse.NoteRepost`, and `Vutuv.Fediverse.PostBoost`, which belongs to
-  a remote account and can never be the caller's). Until that lands, `update`,
-  `delete` and `source` keep refusing a reshare id.
+  **A delete does not follow it through, because a delete cannot be taken back.**
+  `resolve/1` answers the post, whose author is not the resharer, so a `DELETE`
+  routed through it would take the original down on the say-so of an id that
+  named somebody else's act. `own_reshare/2` reads the reshare **row** instead —
+  a different schema per prefix (`Vutuv.Posts.PostRepost`,
+  `Vutuv.Fediverse.PostRepost`, `Vutuv.Fediverse.NoteRepost`) — and hands it over
+  only when the row is the caller's own. That check is also what makes the undo
+  safe at all: `Vutuv.Posts.unrepost_post/2` takes an actor and a post and drops
+  *the caller's* reshare of it, so without it a delete addressed at somebody
+  else's row would quietly undo your own.
 
-  A third home for the same vocabulary is `VutuvWeb.MastodonApi.Pagination`'s
-  `@id_prefixes`, which strips these words to get at the uuid underneath.
+  `update` and `source` do follow the id through, gated on owning the post that
+  comes back: a reshare carries no text of its own, so editing one can only mean
+  editing what it passed on, and a reshare of a post that is not yours answers
+  404 as it always did.
+
+  The vocabulary is spelled twice here — `resolve/1` reads it for the object,
+  `own_reshare/2` for the row — and a third time in
+  `VutuvWeb.MastodonApi.Pagination`'s `@id_prefixes`, which strips these words to
+  get at the uuid underneath. So `own_reshare/2` **fails closed**: a word it has
+  not learned is a reshare it cannot undo, never a post the caller may delete.
   """
 
+  alias Vutuv.Accounts.User
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.Note
   alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.Organizations.Organization
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
+  alias Vutuv.UUIDv7
 
   @doc """
   The object a status id names, or `nil` when it names nothing.
@@ -80,6 +91,83 @@ defmodule VutuvWeb.MastodonApi.Statuses do
 
   @doc "The member or page acting on this request."
   def viewer(conn), do: conn.assigns.current_organization || conn.assigns.current_user
+
+  @doc """
+  The reshare `id` names, in three answers a write has to tell apart:
+  `{:ok, reshare}` when it is the caller's own act, `:not_mine` when the id names
+  a reshare that is not, and `:not_a_reshare` when it names no reshare at all.
+
+  The middle answer is the one that has to exist. Collapsing it into "no" would
+  send a foreign reshare's id on to whatever handles an ordinary status id — and
+  that resolves to the post underneath, which is how a delete aimed at somebody
+  else's reshare reaches an original its author never asked about. So
+  `:not_a_reshare` is only ever the answer for an id this module can *name*: a
+  plain uuid, or one of the two `remote-` prefixes that name an object rather
+  than an act. Anything else fails closed.
+
+  A reshare is `%{kind:, object:, at:}` — what was passed on, when, and which of
+  the three reshare tables it came from. `kind` is the key
+  `Vutuv.MastodonApi.Presenter` reads that object under in a timeline entry
+  (`:post`, `:note`, `:remote_post`), so `Presenter.reshared_status/3` can render
+  the reshare back without asking a second time what shape it is.
+
+  Ownership rather than visibility, because this answers a write: a reshare of a
+  post the caller may read is still not theirs to undo.
+  """
+  def own_reshare(conn, "remote-reply-repost-" <> id),
+    do: own_repost(conn, Fediverse.get_note_repost(id), :note_id, :note, &Fediverse.get_note/1)
+
+  def own_reshare(conn, "remote-repost-" <> id), do: own_remote_post_repost(conn, id)
+  def own_reshare(conn, "remote_repost-" <> id), do: own_remote_post_repost(conn, id)
+
+  def own_reshare(conn, "repost-" <> id),
+    do: own_repost(conn, Posts.get_post_repost(id), :post_id, :post, &Posts.get_post/1)
+
+  # `fediverse_post_boosts` belongs to an account on another server, so there is
+  # no row here a member or a page could own — but the id still names a reshare,
+  # and saying so is what keeps it away from the post it carries.
+  def own_reshare(_conn, "boost-" <> _uuid), do: :not_mine
+
+  # These two name an object, not an act, so the ordinary lookup is right for
+  # them: it answers a cached reply or a cached post, which is nobody's here to
+  # delete and therefore 404s on its own.
+  def own_reshare(_conn, "remote-note-" <> _uuid), do: :not_a_reshare
+  def own_reshare(_conn, "remote-" <> _uuid), do: :not_a_reshare
+
+  def own_reshare(_conn, id),
+    do: if(UUIDv7.cast_or_nil(id), do: :not_a_reshare, else: :not_mine)
+
+  defp own_remote_post_repost(conn, id) do
+    own_repost(
+      conn,
+      Fediverse.get_remote_post_repost(id),
+      :remote_post_id,
+      :remote_post,
+      &Fediverse.get_remote_post/1
+    )
+  end
+
+  # One shape for the three tables a reshare made here can live in: read the row,
+  # ask whose act it is, then read what it passed on. `at` is the row's own time,
+  # which is when the thing was handed on and therefore the timestamp the reshare
+  # wears as a status.
+  defp own_repost(conn, row, object_key, kind, load) do
+    with %{^object_key => object_id} <- row,
+         true <- own_row?(viewer(conn), row),
+         object when not is_nil(object) <- load.(object_id) do
+      {:ok, %{kind: kind, object: object, at: row.inserted_at}}
+    else
+      _not_my_reshare -> :not_mine
+    end
+  end
+
+  # Whose act a reshare row is. A post here can be passed on by a member or by a
+  # page (issue #1336), so `post_reposts` carries both columns and exactly one is
+  # set; the two fediverse tables only ever carry a member's, and their rows
+  # simply miss the `organization_id` key rather than holding a nil.
+  defp own_row?(%User{id: id}, %{user_id: id}), do: true
+  defp own_row?(%Organization{id: id}, %{organization_id: id}), do: true
+  defp own_row?(_viewer, _row), do: false
 
   defp note_visible?(%{assigns: %{current_organization: nil, current_user: user}}, note),
     do: Fediverse.note_readable?(note, user)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.348.0",
+      version: "7.348.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/support/mastodon_helpers.ex
+++ b/test/support/mastodon_helpers.ex
@@ -18,10 +18,12 @@ defmodule Vutuv.MastodonHelpers do
   alias Ecto.Changeset
   alias Vutuv.Accounts.User
   alias Vutuv.ApiAuth
+  alias Vutuv.Fediverse.PostBoost
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Fediverse.RemotePost
   alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
+  alias Vutuv.Posts.Post
   alias Vutuv.Repo
   alias VutuvWeb.RemoteMediaToken
 
@@ -176,6 +178,20 @@ defmodule Vutuv.MastodonHelpers do
       expires_at: DateTime.add(now, 86_400)
     })
     |> Repo.preload(:remote_account)
+  end
+
+  @doc """
+  That account passing one of **our** posts on — the row an inbound `Announce`
+  writes when the thing announced is a member's own (`post_id` set,
+  `remote_post_id` nil).
+  """
+  def boost(%RemoteAccount{} = account, %Post{} = post) do
+    Repo.insert!(%PostBoost{
+      remote_account_id: account.id,
+      post_id: post.id,
+      activity_id: "https://social.example/activities/#{unique_suffix()}",
+      announced_at: DateTime.utc_now(:second)
+    })
   end
 
   defp unique_suffix, do: System.unique_integer([:positive])

--- a/test/vutuv_web/controllers/mastodon_api/reshare_status_ids_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/reshare_status_ids_test.exs
@@ -7,8 +7,10 @@ defmodule VutuvWeb.MastodonApi.ReshareStatusIdsTest do
   a reshare's likers row answered 404 for the very id the timeline had just
   handed over — and reporting such a status failed the same way.
 
-  The writes (`update`, `delete`, `source`) deliberately still refuse a reshare
-  id; see `VutuvWeb.MastodonApi.Statuses` for what undoing one properly needs.
+  The writes split, because a delete cannot be taken back: `update` and `source`
+  follow a reshare id through to the post it passed on and answer only for the
+  caller's own, while `delete` acts on the reshare **row** and undoes it — never
+  the post underneath, whoever wrote that.
 
   async: false — `mastodon_token/2` flips the member's client permission.
   """
@@ -16,9 +18,15 @@ defmodule VutuvWeb.MastodonApi.ReshareStatusIdsTest do
 
   import Vutuv.MastodonHelpers
 
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.PostBoost
+  alias Vutuv.Fediverse.PostRepost, as: RemotePostRepost
+  alias Vutuv.Fediverse.RemotePost
   alias Vutuv.Posts
   alias Vutuv.Posts.PostRepost
+  alias Vutuv.RateLimiter
   alias Vutuv.Repo
+  alias VutuvWeb.MastodonApi.Statuses
 
   setup do
     author = insert(:activated_user)
@@ -27,9 +35,7 @@ defmodule VutuvWeb.MastodonApi.ReshareStatusIdsTest do
 
     {:ok, post} = Posts.create_post(author, %{body: "Weitergereicht"})
     :ok = Posts.like_post(liker, post)
-    Posts.repost_post(resharer, post)
-
-    repost = Repo.get_by!(PostRepost, post_id: post.id, user_id: resharer.id)
+    repost = repost_row(resharer, post)
 
     %{
       author: author,
@@ -127,25 +133,157 @@ defmodule VutuvWeb.MastodonApi.ReshareStatusIdsTest do
     end
   end
 
-  describe "writes addressed at a reshare's id" do
-    test "an edit is refused, and the post keeps its words", ctx do
-      build_conn()
-      |> api(ctx.resharer, ["read", "write"])
-      |> put("/api/v1/statuses/#{ctx.reshare_id}", %{"status" => "Übernommen"})
+  describe "an edit or a source read addressed at a reshare's id" do
+    test "reaches the post underneath when it is the caller's own", ctx do
+      # A boost from another server, because it is the one reshare that does not
+      # itself close the edit window: `has_reposts?/1` counts only reshares made
+      # here, so a `repost-` id always resolves to a post nobody may edit any
+      # more (the test below).
+      {:ok, mine} = Posts.create_post(ctx.author, %{body: "Meins"})
+      boost = boost(remote_account(), mine)
 
+      build_conn()
+      |> api(ctx.author, ["read", "write"])
+      |> put("/api/v1/statuses/boost-#{boost.id}", %{"status" => "Überarbeitet"})
+      |> json_response(200)
+
+      assert Posts.get_post(mine.id).body == "Überarbeitet"
+    end
+
+    test "says why an edit is refused instead of claiming the status is gone", ctx do
+      # The reshare that made this id exist is also what closed the edit window,
+      # so the answer is the rule rather than the old bare 404.
+      repost = repost_row(ctx.author, ctx.post)
+
+      %{"error" => error} =
+        build_conn()
+        |> api(ctx.author, ["read", "write"])
+        |> put("/api/v1/statuses/repost-#{repost.id}", %{"status" => "Überarbeitet"})
+        |> json_response(422)
+
+      assert error =~ "can no longer be edited"
       assert Posts.get_post(ctx.post.id).body == "Weitergereicht"
     end
 
-    test "a delete never reaches the post underneath", ctx do
+    test "source answers that post's Markdown", ctx do
+      repost = repost_row(ctx.author, ctx.post)
+
+      source =
+        build_conn()
+        |> api(ctx.author, ["read"])
+        |> get("/api/v1/statuses/repost-#{repost.id}/source")
+        |> json_response(200)
+
+      assert source["id"] == ctx.post.id
+      assert source["text"] == "Weitergereicht"
+    end
+
+    test "answers 404 for somebody else's post, which keeps its words", ctx do
+      build_conn()
+      |> api(ctx.resharer, ["read", "write"])
+      |> put("/api/v1/statuses/#{ctx.reshare_id}", %{"status" => "Übernommen"})
+      |> json_response(404)
+
+      assert Posts.get_post(ctx.post.id).body == "Weitergereicht"
+    end
+  end
+
+  describe "a delete addressed at a reshare's id" do
+    test "undoes my own reshare and leaves the post standing", ctx do
+      status =
+        build_conn()
+        |> api(ctx.resharer, ["read", "write"])
+        |> delete("/api/v1/statuses/#{ctx.reshare_id}")
+        |> json_response(200)
+
+      # Mastodon answers a delete with the status the client addressed, so what
+      # comes back is the reshare — carrying the post it passed on.
+      assert status["id"] == ctx.reshare_id
+      assert status["reblog"]["id"] == ctx.post.id
+
+      refute Repo.get_by(PostRepost, post_id: ctx.post.id, user_id: ctx.resharer.id)
+      assert Posts.get_post(ctx.post.id)
+    end
+
+    test "undoes my reshare of my own post rather than deleting the post", ctx do
+      # The one id that names two things the caller owns. It names the act.
+      repost = repost_row(ctx.author, ctx.post)
+
+      build_conn()
+      |> api(ctx.author, ["read", "write"])
+      |> delete("/api/v1/statuses/repost-#{repost.id}")
+      |> json_response(200)
+
+      refute Repo.get(PostRepost, repost.id)
+      assert Posts.get_post(ctx.post.id)
+    end
+
+    test "never reaches the post underneath somebody else's reshare", ctx do
       # The case worth being careful about: the author owns the post this id
       # resolves to, so a delete routed through the read resolver would take the
-      # original down instead of the reshare.
+      # original down instead of the reshare — and `unrepost_post/2` finds the
+      # *caller's* reshare, so routing it to the undo would have been wrong too.
       build_conn()
       |> api(ctx.author, ["read", "write"])
       |> delete("/api/v1/statuses/#{ctx.reshare_id}")
+      |> json_response(404)
 
       assert Posts.get_post(ctx.post.id)
       assert Repo.get_by(PostRepost, post_id: ctx.post.id, user_id: ctx.resharer.id)
     end
+
+    test "undoes my reshare of a post from another network" do
+      RateLimiter.reset()
+      sharer = federating_member()
+      remote = cached_post(remote_account())
+
+      {:ok, :reposted} = Fediverse.repost_remote_post(sharer, remote)
+      repost = Repo.get_by!(RemotePostRepost, remote_post_id: remote.id, user_id: sharer.id)
+
+      status =
+        build_conn()
+        |> api(sharer, ["read", "write"])
+        |> delete("/api/v1/statuses/remote-repost-#{repost.id}")
+        |> json_response(200)
+
+      assert status["id"] == "remote-repost-#{repost.id}"
+      refute Repo.get(RemotePostRepost, repost.id)
+      assert Repo.get(RemotePost, remote.id)
+    end
+
+    test "a boost from another server is nobody here's to undo", ctx do
+      # `fediverse_post_boosts` belongs to a remote account, so no member and no
+      # page can ever own the row that id names.
+      boost = boost(remote_account(), ctx.post)
+
+      build_conn()
+      |> api(ctx.author, ["read", "write"])
+      |> delete("/api/v1/statuses/boost-#{boost.id}")
+      |> json_response(404)
+
+      assert Repo.get(PostBoost, boost.id)
+      assert Posts.get_post(ctx.post.id)
+    end
+  end
+
+  describe "an id word this module has not learned" do
+    test "fails closed instead of reaching the post lookup" do
+      # The safeguard rests on `resolve/1` and `own_reshare/2` knowing the same
+      # words, and they are two lists in one file. The day one grows a prefix the
+      # other does not, this default decides: `:not_a_reshare` would hand that id
+      # to the ordinary post lookup, which resolves a reshare to the post
+      # underneath — the deletion the whole split exists to prevent.
+      conn = build_conn()
+
+      assert Statuses.own_reshare(conn, "quote-#{Vutuv.UUIDv7.generate()}") == :not_mine
+      assert Statuses.own_reshare(conn, Vutuv.UUIDv7.generate()) == :not_a_reshare
+    end
+  end
+
+  # `user` passes `post` on, and the row that records it — the thing a reshare's
+  # id names.
+  defp repost_row(user, post) do
+    Posts.repost_post(user, post)
+    Repo.get_by!(PostRepost, post_id: post.id, user_id: user.id)
   end
 end


### PR DESCRIPTION
Closes #1596.

**Symptom:** `PUT`/`DELETE /api/v1/statuses/:id` and `GET …/source` answered 404 for every reshare id the timeline hands out (`repost-<uuid>`, `boost-<uuid>`, the `remote-` family).

**What changed**, in `VutuvWeb.MastodonApi.Statuses` and `StatusController`:

- `update` and `source` follow the id through to the post it passed on, gated on the caller owning that post. A reshare carries no text of its own, so editing one can only mean editing what it carried.
- `delete` does **not** follow it through, because a delete cannot be taken back. `Statuses.own_reshare/2` reads the reshare *row* and undoes it only when the row is the caller's own act; a `boost-` row belongs to a remote account and is nobody's here.
- That function answers three things, not two: `:not_mine` exists so a foreign reshare's id can be refused instead of falling back to the post lookup. Its default fails closed.

**Your call:** the semantics above are the decision you asked for on the issue. Everything else follows from them.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_015TBTbfXVqUfzKGdZMFaSbv
