### PR TITLE
Document how a language is added, once

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -15,6 +15,7 @@ installing and operating vutuv in [Running your own vutuv](../ADMINS.md).
 | [fediverse.md](fediverse.md) | follow-only ActivityPub federation: WebFinger, actors, the inbox, signed deliveries |
 | [posts-and-feed.md](posts-and-feed.md) | posts, deny-based audiences, the `/feed` timeline, likes/bookmarks/reposts, reply threads, post images |
 | [translations.md](translations.md) | declared post languages, on-demand Ollama translation, the cache + job queue, what never translates |
+| [i18n.md](i18n.md) | the interface languages: how a request gets its locale, the Gettext catalogs and their extract/merge traps, per-locale email bodies, locale-sensitive formatting, and how to add a language |
 | [search.md](search.md) | the search page, query operators, post full-text search |
 | [messages.md](messages.md) | 1:1 direct messages, message requests, unread-email nudges |
 | [profiles.md](profiles.md) | what a profile shows: owner vs. public view, the job-title line, education, section ordering, contact details & maps, the Mastodon/Bluesky card |

--- a/docs/architecture/i18n.md
+++ b/docs/architecture/i18n.md
@@ -1,0 +1,210 @@
+# Interface languages
+
+vutuv's interface ships in **English (`en`) and German (`de`)**. This document
+is about that interface: the chrome, the flashes, the error pages and the
+transactional mail. What members *write* is a different subsystem with its own
+rules — see [translations.md](translations.md).
+
+Adding a third language touches Gettext catalogs, two email template trees, a
+CLDR backend and a handful of places that still spell the two locales out by
+hand. The checklist at the bottom lists them; the sections above say why.
+
+## Where a request gets its language
+
+`VutuvWeb.Plug.Locale` resolves it once per request, in this order:
+
+1. the signed-in member's `users.locale`, if set;
+2. otherwise the first `Accept-Language` entry whose **base subtag** the
+   installation serves (`de-AT` counts as `de`);
+3. otherwise `en`.
+
+The answer goes into Gettext for the request process and into the session,
+because a LiveView runs in a process the plug never touched and would
+otherwise render English chrome under a German page (`VutuvWeb.LiveLocale`,
+`VutuvWeb.Live.InitAssigns`). The same plug resolves the two other "where the
+reader is" questions, the date shape (`Vutuv.DateRegions`) and the time zone
+(`Vutuv.ViewerClock`).
+
+Agent formats ignore all of it. `VutuvWeb.AgentDocs` renders `.md`/`.txt`/
+`.json`/`.xml` in English unless the URL asks otherwise with `?lang=`, so one
+URL always answers with the same bytes whether or not anybody is signed in.
+`?lang=` does **not** work on HTML pages: a browser gets what it asked for in
+its header.
+
+## The locale list, and where it lives
+
+```elixir
+config :vutuv, VutuvWeb.Endpoint,
+  locales: ~w(en de)
+```
+
+in `config/config.exs` **and** `config/prod.exs`. Note that it sits inside the
+endpoint block rather than as a top-level `:vutuv` key.
+`Application.get_env(:vutuv, :locales, default)` compiles, runs, answers the
+default, and is wrong — silently. It cost a day when the pre-translation sweep
+read it that way (#1570) and it is still wrong in
+`lib/vutuv/jobs/job_posting.ex`, where the hardcoded default happens to match
+the config. Read it like everyone else does:
+
+```elixir
+{:ok, config} = Application.fetch_env(:vutuv, VutuvWeb.Endpoint)
+config[:locales]
+```
+
+Five readers then follow the config on their own: `Plug.Locale`, NodeInfo's
+`langs` (`Vutuv.NodeInfo`), the Mastodon API's `/api/v2/instance`,
+`Vutuv.Translations` (see below), and `page_locale_render_test.exs`, which
+loops the configured locales so a new language is covered by public-page render
+tests the moment it is added.
+
+Beware the second source of truth beside it: `Gettext.known_locales/1` reports
+whatever PO directories exist under `priv/gettext`. `AgentDocs` keys off that,
+everything else off `:locales`. A half-added language therefore shows up in the
+agent formats before it shows up in the UI.
+
+## Surface 1: the Gettext catalogs
+
+Everything on screen resolves against `priv/gettext/<locale>/LC_MESSAGES/`:
+`default.po` for the interface and `errors.po` for changeset messages. Flash
+messages are ordinary `gettext/1` calls, so they are covered by `default.po`
+and need nothing of their own. So is the text JavaScript puts on screen: the
+hooks read their wording from `data-label-*` attributes the server rendered,
+and no user-facing string is spelled out in `assets/js`.
+
+A missing `msgstr` falls back to the msgid, which is English. An incomplete
+catalog is therefore a cosmetic problem and never an outage — the opposite of
+the email templates below.
+
+### The extract/merge traps
+
+`mix gettext.extract --merge` is the most dangerous command in this subsystem,
+in three separate ways:
+
+- **It fuzzy-fills.** A brand-new msgid does not arrive empty; it arrives
+  holding the translation of whatever existing string the tool thought looked
+  similar. Real examples from one run: `"Now"` became **"Nein"** (no),
+  `"Not yours yet."` became "Noch keine Reposts.". Each is flagged `fuzzy` and
+  nothing fails the build, so confident nonsense ships while every English test
+  stays green. After every merge, read `git diff priv/gettext` and treat every
+  fuzzy entry as untranslated.
+- **Grep for `", fuzzy"`, not `"#, fuzzy"`.** The flag line reads
+  `#, elixir-autogen, elixir-format, fuzzy`, so the obvious pattern matches
+  nothing and reports a clean file.
+- **An empty-looking `msgstr ""` followed by indented lines is a multi-line
+  translation**, not a missing one. Writing into it appends a second copy that
+  gettext concatenates into one doubled sentence. That is how the logged-out
+  landing page came to 500 for every German visitor while `curl /` looked fine.
+
+And one trap grep cannot see at all: **a msgid is a key, not a phrase.**
+`gettext("Following")` is translated "Folge ich" (*I* follow), written for a
+member's own list; reusing it under an organization's navigation made the page
+claim the reader follows those accounts. When the same English word is spoken
+by a different voice, give it its own msgid.
+
+## Surface 2: emails
+
+Mail does not go through Gettext for its body. Every message has **two body
+files per locale**:
+
+| | |
+|---|---|
+| `lib/vutuv_web/templates/email/<name>_<locale>.text.eex` | the `text/plain` part |
+| `lib/vutuv_web/templates/email_body/<name>_<locale>.html.heex` | the `text/html` alternative |
+
+Subjects *are* Gettext, rendered inside `Gettext.with_locale/3` for the
+recipient. `test/vutuv/notifications/email_html_drift_test.exs` fails the build
+if one half of a pair is missing.
+
+Three things are not templates and are easy to miss:
+
+- `_signature_<locale>.text.eex` on the text side has no HTML twin. The HTML
+  signature is a pair of function clauses in `VutuvWeb.EmailComponents`
+  (`signature_line1/1`, `signature_line2/1`), so a new language is an Elixir
+  edit there.
+- `_footer.text.eex` is shared by every locale and is **English prose**. It
+  names the operator and is the same in every message.
+- The salutation every body opens with is `email_greeting/1` in
+  `VutuvWeb.UserHelpers`, one clause per locale, falling through to `"Hi"`.
+  German greets with surname and honorific because the UI says *Sie*; each
+  language decides that for itself.
+- Four mails are deliberately German-only, because they go to the operator and
+  never to a member: `account_deleted_notice`, `ad_booking`, `daily_report`,
+  `organization_operator_notice`. The two admin moderation mails are *not* in
+  that group; they follow the admin's own locale.
+
+**Ordering matters, and getting it wrong is an outage.** `Emailer.get_locale/1`
+falls back to `en` only for locales that are *not* in `:locales`. The moment a
+locale is in the config, `VutuvWeb.EmailText.render/2` looks for
+`<name>_<locale>.text` and raises on the missing atom. Config and templates
+ship in the **same deploy**, always.
+
+`EmailText` builds one function per file at compile time, so *editing* a
+template recompiles the module but *adding* one would not, and CI caches
+`_build`. `__mix_recompile__?/0` closes that hole (#1086); still, verify a new
+template with `mix compile` on an already-built tree, never only after
+`--force`.
+
+## Surface 3: things that are formatted, not translated
+
+A language is not only words. These read the locale and would quietly produce
+English output for a third one:
+
+- **`VutuvWeb.UI.delimited_count/1`** groups thousands with `.` for `de` and
+  `,` for everything else. That binary split is wrong for most of Europe:
+  Spanish and Italian group like German, French uses a narrow no-break space.
+  A number formatted with the wrong rules is *misread*, not untidy.
+- **Decimal separators** are spelled out the same way in
+  `views/qualification_html.ex`, `views/job_reference_html.ex` and
+  `views/admin/newsletter_html.ex`.
+- **`VutuvWeb.UI`'s relative day labels** — "Yesterday"/"Gestern" is an `if`,
+  not a Gettext string.
+- **`Vutuv.Countries`** carries 253 ISO 3166-1 codes with an English and a
+  German name each. A third language means a third column, or taking the names
+  from `Cldr.Territory`, which the CLDR backend already loads.
+- **`Vutuv.DateRegions`** already maps the common language subtags to a date
+  shape, Italian and Spanish included, so it usually needs nothing.
+- **`Vutuv.Cldr`** compiles in only the configured locales. ex_cldr bundles
+  `en` and `und` and **downloads the rest at compile time**, which once let a
+  GitHub incident block a production build. Compile once with network access
+  and commit the generated `priv/cldr/locales/<locale>.json`, or
+  `Vutuv.CldrLocaleBundleTest` fails the build (#1545).
+
+## What a new locale costs at runtime
+
+With `TRANSLATE_POSTS=true`, `Vutuv.Translations` pre-translates every local
+post into every locale the installation serves, so adding one queues a machine
+translation per post through Ollama. Nothing to write, but the config line has
+a GPU bill attached.
+
+## What is deliberately not translated
+
+- **The legal pages.** Impressum, Datenschutzerklärung and Nutzungsbedingungen
+  are database rows edited at `/admin/legal`, one body per slug with no locale
+  column. They stay in the language the operator wrote them.
+- **Operator mail**, as above.
+- **Member content.** Posts are translated on demand by a model, never by us;
+  that is [translations.md](translations.md).
+
+## Adding a language
+
+1. `config/config.exs` and `config/prod.exs`: add the code to `locales:` in the
+   endpoint block.
+2. `lib/vutuv/cldr.ex`: add it to `locales:`, compile once online, commit
+   `priv/cldr/locales/<locale>.json`.
+3. `mix gettext.merge priv/gettext --locale <locale>`, then translate
+   `default.po` and `errors.po` and clear every fuzzy flag.
+4. Both email bodies for every member-facing mail, plus
+   `_signature_<locale>.text.eex`, the two `EmailComponents` clauses and an
+   `email_greeting/1` clause.
+5. `priv/help/{markdown,mastodon}_<locale>.md` — read with `File.read!` at
+   compile time, so a missing file breaks the **build**, not a request.
+6. Widen the hardcoded pairs: the language picker
+   (`templates/settings/preferences.html.heex`), `delimited_count/1` and the
+   decimal separators, the relative day labels,
+   `Vutuv.Newsletters.NewsletterGroup` (its `@locales` decides who a Rundbrief
+   can target), `@language_names` in `VutuvWeb.AgentDocs` (the endonym), and
+   `Vutuv.Countries`.
+7. Verify in a browser, not only in the suite: the Swoosh test adapter never
+   renders a real mail, and `Phoenix.ConnTest` defaults to English. Walk login,
+   posting and following with `Accept-Language: <locale>`, trigger a flash and a
+   404, and read both parts of the login PIN mail in `/sent_emails`.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.350.0",
+      version: "7.350.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
`#788` (French), `#789` (Spanish) and the new `#1677` (Italian) each carried the same ~900-word implementation guide in their body, and it had drifted badly: the catalogs grew from 1,012 to 3,933 messages, every mail gained a second (HTML) body, and the legal pages moved into the database.

This adds `docs/architecture/i18n.md` as the one place that guide lives, linked from the architecture index. Docs only — hot deploy, v7.350.2.

Writing it surfaced two real defects, described in the doc but **not** fixed here:

- `lib/vutuv/jobs/job_posting.ex:237` reads `:locales` as a top-level `:vutuv` key, so it always gets the hardcoded default. Harmless today, wrong the moment a third locale exists.
- `VutuvWeb.UI.delimited_count/1` splits `de` against everything else. Spanish and Italian group like German, French uses a narrow no-break space — all three would print English separators.

Both are on the language issues; I will fix them there.

*An AI agent wrote this text in my name. I know that is problematic.*