### PR TITLE
Ask the browser for the ticker's capability, not its asset age

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1085,7 +1085,13 @@ const NAV_PRESSING = "data-nav-pressing"
 const KEEP_OPEN = "data-keep-open"
 
 const liveSocket = new LiveSocket("/live", Socket, {
-  params: { _csrf_token: csrfToken() },
+  // `feed_ticker` is a capability, not a setting: the feed's tab ticker brings
+  // its own stylesheet and its own hook, and a document loaded before v7.347.0
+  // has neither — a deploy reloads no open tab, it only reconnects the socket
+  // into hours-old markup. Only a bundle that ships the hook can send this key,
+  // so the claim proves itself, and it stays true however many deploys behind
+  // the document is. Retire it together with the FeedTicker hook.
+  params: { _csrf_token: csrfToken(), feed_ticker: true },
   hooks: Hooks,
   dom: {
     // Both navs live inside ShellLive, so a patch that has nothing to do with

--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -491,16 +491,28 @@ Five rules keep it from becoming a nuisance, and each one has a test:
   the branch for the tab the reader *is* on, so the teaser asks
   `filtered_pattern/3` itself and falls back to the bare dot. The bar is the
   one place a member cannot scroll past it.
-* **Not into a browser left over from the previous release.** A deploy does
-  not reload an open feed: the socket reconnects to the new release and
-  patches into a document downloaded hours ago. Everything else the feed
-  streams is markup whose CSS that browser already has — the ticker is new
-  markup with a stylesheet and a hook of its own, so on the v7.347.0 deploy
-  the quote drew as an unstyled 200-character paragraph across the tab bar
-  that no clock ever took away. `mount_feed/2` reads `static_changed?/1` once
-  (connect params exist only during mount, and it answers only because
-  `root.html.heex` marks both assets `phx-track-static`); a stale client keeps
-  the dot and skips the quote until the next full page load.
+* **Not into a browser whose bundle predates the ticker.** A deploy does not
+  reload an open feed: the socket reconnects to the new release and patches
+  into a document downloaded hours ago. Everything else the feed streams is
+  markup whose CSS that browser already has — the ticker is new markup with a
+  stylesheet and a hook of its own, so on the v7.347.0 deploy the quote drew
+  as an unstyled 200-character paragraph across the tab bar that no clock ever
+  took away. Such a browser keeps the dot and skips the quote.
+
+  **The bundle answers for itself.** `app.js` sends `feed_ticker: true` in the
+  LiveSocket params and `mount_feed/2` reads it once (connect params exist only
+  during mount) into `ticker_capable?`. Only a bundle carrying the hook can
+  send the key, so the claim proves itself — and it stays true however far
+  behind the running release that bundle is.
+
+  v7.347.1 asked `static_changed?/1` instead, which answers the wider question
+  "is anything in this document older than the running release?". That is the
+  right question for the deploy that *introduces* a component and the wrong one
+  ever after: it is true following every asset deploy, so from the second one
+  on it refused browsers that had been carrying the ticker all along. v7.348.0
+  was that second deploy, and the ticker read as broken in every open feed
+  until a reload (fixed in v7.351.1). `phx-track-static` stays in
+  `root.html.heex` as the seam for the next component's first release.
 
 Only ever one tab at a time: `other_source/1` is nil on "All" and the two named
 tabs partition the feed, so a third source would be the first thing to need a

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -94,12 +94,14 @@ defmodule VutuvWeb.PostLive.Feed do
   end
 
   defp mount_feed(socket, user) do
-    # Is this browser still running the previous release's CSS and JS? A deploy
-    # does not reload an open feed — the socket reconnects to the new release
-    # and patches into a document downloaded hours ago — and `static_changed?/1`
-    # is the only way to know (`phx-track-static` in the root layout feeds it).
+    # Can this browser draw the tab ticker at all? A deploy does not reload an
+    # open feed — the socket reconnects to the new release and patches into a
+    # document downloaded hours ago — so the question is not which release that
+    # document came from but what it is able to render. The bundle answers it
+    # itself: `feed_ticker` is a LiveSocket param (assets/js/app.js), so only a
+    # bundle carrying the stylesheet and the hook can claim the capability.
     # Read here because connect params exist only during mount.
-    socket = assign(socket, :stale_client?, static_changed?(socket))
+    socket = assign(socket, :ticker_capable?, ticker_capable?(socket))
 
     # The tab they left on (issue #1499). It opens the page *and* keys the
     # handoff below: the stash holds one entry per member, so two devices
@@ -1170,17 +1172,33 @@ defmodule VutuvWeb.PostLive.Feed do
   # browser can render a quote at all.
   #
   # That last one is the deploy case, and it is the one thing on this page that
-  # a stale browser cannot survive. Everything else the feed patches in is
+  # an old document cannot survive. Everything else the feed patches in is
   # markup whose CSS that browser already has; the ticker is new markup with a
   # stylesheet and a hook of its own, so on a feed left open across the v7.347.0
   # deploy the quote drew as an unstyled 200-character paragraph across the tab
   # bar that no clock ever took away (the `FeedTicker` hook was not in that
-  # bundle either). A stale client keeps the dot, which is markup from #1503 and
+  # bundle either). Such a browser keeps the dot, which is markup from #1503 and
   # renders fine, and skips the quote until the next full page load.
   defp ticker_due?(socket) do
     socket.assigns.source_tabs? and is_nil(socket.assigns.tab_ticker) and
-      not socket.assigns.stale_client? and
+      socket.assigns.ticker_capable? and
       Prefs.get(socket.assigns.current_user, :feed_tab_ticker?) and not quiet?(socket)
+  end
+
+  # v7.347.1 asked `static_changed?/1` here, which answers the wider question
+  # "is anything in this document older than the running release?" — true after
+  # *every* asset deploy, so from the second one on it refused browsers that had
+  # been carrying the ticker all along. v7.348.0 was that second deploy, and the
+  # feature read as broken until a reload. A capability the bundle asserts about
+  # itself cannot go stale that way: it travels with the hook, and a bundle old
+  # enough to lack the hook has no way to send it.
+  #
+  # Retire this param together with the `FeedTicker` hook.
+  defp ticker_capable?(socket) do
+    case get_connect_params(socket) do
+      %{"feed_ticker" => true} -> true
+      _ -> false
+    end
   end
 
   defp quiet?(socket) do

--- a/lib/vutuv_web/templates/layout/root.html.heex
+++ b/lib/vutuv_web/templates/layout/root.html.heex
@@ -86,9 +86,15 @@
     its markup into a document whose stylesheet and hooks are whatever the
     browser downloaded hours ago. The client reports these two hrefs on join
     and `static_changed?/1` compares them against the digest manifest, which is
-    what lets a page skip markup that would arrive unstyled and unhooked (see
-    the feed's tab ticker). Without the annotation the client sends nothing and
-    every such check answers "unchanged". --%>
+    what lets the deploy that INTRODUCES a component skip markup that would
+    arrive unstyled and unhooked. Without the annotation the client sends
+    nothing and every such check answers "unchanged".
+
+    It is the right question for exactly one deploy. Afterwards every bundle
+    carries the component, while this check keeps answering "changed" after any
+    asset deploy at all — so a component that outlives its first release asks
+    the browser for the capability by name instead (`feed_ticker` in the
+    LiveSocket params, see the feed's tab ticker). --%>
     <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
     <script defer phx-track-static src={~p"/assets/app.js"}></script>
   </head>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.350.3",
+      version: "7.351.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/feed_tab_ticker_test.exs
+++ b/test/vutuv_web/live/feed_tab_ticker_test.exs
@@ -7,7 +7,7 @@ defmodule VutuvWeb.FeedTabTickerTest do
   the rules that keep it from becoming a nuisance: one quote per window, a
   count instead of a second quote, a window that ends on its own (and not by a
   later patch putting it back), a silence afterwards — and no quote at all into
-  a browser still running the previous release's stylesheet and hooks.
+  a browser whose bundle predates the ticker's own stylesheet and hook.
 
   Not async: one test sets `:feed_ticker_cooldown_ms`, which is application env
   — process state the SQL sandbox does not roll back, and every open feed reads
@@ -116,23 +116,30 @@ defmodule VutuvWeb.FeedTabTickerTest do
 
   # The reader on one named tab, with the other one populated so the tab bar
   # exists at all (`Posts.fediverse_feed_available?/1` asks the sources).
-  # `connect_params` is what the browser sends on join — the stale-assets test
-  # below puts a `_track_static` in there.
-  defp reader_on(conn, tab, connect_params \\ %{}) do
+  # `connect_params` is what the browser sends on join, and the default is a
+  # current bundle: `feed_ticker` is the capability the quote asks for, so a
+  # browser that omits it is exactly what an old bundle looks like (the
+  # describe below).
+  defp reader_on(conn, tab, connect_params \\ %{"feed_ticker" => true}) do
     {conn, user} = create_and_login_user(conn)
     {_author, _post} = followed_post(user, "an older post")
     account = remote_account(user, "them")
     cached_post(account, "written out there")
 
-    # `get/2` recycles a conn that has already been sent, and recycling drops
-    # `private` — connect params included. Recycling here, before they are put,
-    # is what gets them as far as the join.
-    {:ok, view, _html} =
-      conn |> recycle() |> put_connect_params(connect_params) |> live(~p"/feed")
-
+    view = live_feed(conn, connect_params)
     render_click(view, "filter-source", %{"type" => tab})
 
     %{view: view, user: user, account: account}
+  end
+
+  # `get/2` recycles a conn that has already been sent, and recycling drops
+  # `private` — connect params included. Recycling here, before they are put,
+  # is what gets them as far as the join.
+  defp live_feed(conn, connect_params \\ %{"feed_ticker" => true}) do
+    {:ok, view, _html} =
+      conn |> recycle() |> put_connect_params(connect_params) |> live(~p"/feed")
+
+    view
   end
 
   # The quote's own markup, or nil when no window is open. Floki is not a
@@ -287,7 +294,7 @@ defmodule VutuvWeb.FeedTabTickerTest do
       account = remote_account(user, "them")
       cached_post(account, "written out there")
 
-      {:ok, view, _html} = live(conn, ~p"/feed")
+      view = live_feed(conn)
       render_click(view, "filter-source", %{"type" => "fediverse"})
 
       {:ok, _post} = Posts.create_post(author, %{body: "etwas Neues"})
@@ -304,7 +311,7 @@ defmodule VutuvWeb.FeedTabTickerTest do
       account = remote_account(user, "them")
       cached_post(account, "written out there")
 
-      {:ok, view, _html} = live(conn, ~p"/feed")
+      view = live_feed(conn)
       render_click(view, "filter-source", %{"type" => "fediverse"})
       {:ok, _post} = Posts.create_post(author, %{body: "etwas Neues"})
 
@@ -327,7 +334,7 @@ defmodule VutuvWeb.FeedTabTickerTest do
       account = remote_account(user, "them")
       cached_post(account, "written out there")
 
-      {:ok, view, _html} = live(conn, ~p"/feed")
+      view = live_feed(conn)
       render_click(view, "filter-source", %{"type" => "fediverse"})
 
       {:ok, _post} = Posts.create_post(author, %{body: "Alles über Krypto und so"})
@@ -338,7 +345,7 @@ defmodule VutuvWeb.FeedTabTickerTest do
     end
   end
 
-  describe "a browser left over from the previous release" do
+  describe "a browser whose bundle predates the ticker" do
     # What v7.347.0 looked like on a feed that had been open since before the
     # deploy: the socket reconnects to the new release and patches the quote
     # into a document whose stylesheet has never heard of `.filter-tab-ticker`
@@ -346,24 +353,10 @@ defmodule VutuvWeb.FeedTabTickerTest do
     # unstyled 200-character paragraph across the tab bar, and no clock ever
     # took it away. Everything else on that page is older than the browser's
     # copy and survives the patch; the ticker is the half that cannot.
-    setup do
-      # `static_changed?/1` compares what the client reports against the
-      # digest manifest, which only exists in a release. Two entries that
-      # cannot match, so the comparison has something to answer with.
-      Phoenix.Config.put(VutuvWeb.Endpoint, :cache_static_manifest_latest, %{
-        "assets/app.css" => "assets/app-nowdeployed.css"
-      })
-
-      on_exit(fn ->
-        Phoenix.Config.put(VutuvWeb.Endpoint, :cache_static_manifest_latest, nil)
-      end)
-    end
-
     test "gets the dot and no quote", %{conn: conn} do
-      %{view: view, user: user} =
-        reader_on(conn, "fediverse", %{
-          "_track_static" => ["http://localhost/assets/app-fromthelastrelease.css"]
-        })
+      # No `feed_ticker` key at all: a bundle built before the hook existed
+      # cannot send one, which is precisely what makes the claim trustworthy.
+      %{view: view, user: user} = reader_on(conn, "fediverse", %{})
 
       author = followed_author(user)
       {:ok, _post} = Posts.create_post(author, %{body: "etwas Neues"})
@@ -372,14 +365,10 @@ defmodule VutuvWeb.FeedTabTickerTest do
       assert dotted?(view, "vutuv")
     end
 
-    test "while the browser on this release still gets both", %{conn: conn} do
-      # The other half of the gate: with assets the server recognises, the
-      # window opens as before. Without this the test above would pass on a
-      # ticker that is simply broken.
-      %{view: view, user: user} =
-        reader_on(conn, "fediverse", %{
-          "_track_static" => ["http://localhost/assets/app-nowdeployed.css"]
-        })
+    test "while a bundle that carries it still gets both", %{conn: conn} do
+      # The other half of the gate. Without this the test above would pass on
+      # a ticker that is simply broken.
+      %{view: view, user: user} = reader_on(conn, "fediverse", %{"feed_ticker" => true})
 
       author = followed_author(user)
       {:ok, _post} = Posts.create_post(author, %{body: "etwas Neues"})
@@ -387,13 +376,57 @@ defmodule VutuvWeb.FeedTabTickerTest do
       assert ticker(view)
       assert dotted?(view, "vutuv")
     end
+
+    test "however many asset deploys old that bundle is", %{conn: conn} do
+      # The regression that made this file worth changing (v7.348.0). The gate
+      # used to ask `static_changed?/1`, i.e. "is any asset in this document
+      # older than the running release?" — true after *every* asset deploy, so
+      # from the second one on it refused browsers that had been carrying the
+      # ticker all along, and the feature read as broken until a page reload.
+      # This client reports a stylesheet the manifest does not know AND the
+      # capability: it is behind, and it can still draw the quote.
+      Phoenix.Config.put(VutuvWeb.Endpoint, :cache_static_manifest_latest, %{
+        "assets/app.css" => "assets/app-nowdeployed.css"
+      })
+
+      on_exit(fn ->
+        Phoenix.Config.put(VutuvWeb.Endpoint, :cache_static_manifest_latest, nil)
+      end)
+
+      %{view: view, user: user} =
+        reader_on(conn, "fediverse", %{
+          "feed_ticker" => true,
+          "_track_static" => ["http://localhost/assets/app-fromthelastrelease.css"]
+        })
+
+      author = followed_author(user)
+      {:ok, _post} = Posts.create_post(author, %{body: "etwas Neues"})
+
+      assert ticker(view)
+    end
   end
 
-  describe "the layout the gate reads" do
-    test "marks both assets, or the client reports nothing to compare", %{conn: conn} do
-      # `phx-track-static` is the whole input to `static_changed?/1`: without
-      # it the client sends no manifest, the comparison answers "unchanged"
-      # for every browser, and the gate above is dead code.
+  describe "the capability the gate reads" do
+    test "is declared by the bundle that carries the hook" do
+      # The one half a LiveView test cannot reach: `put_connect_params/2` hands
+      # the server whatever this file says, so every test above would keep
+      # passing if `app.js` never sent the key and the ticker were dead in the
+      # browser. Assert the source, the way `mobile_tab_bar_css_test.exs` does.
+      app_js = File.read!("assets/js/app.js")
+
+      assert app_js =~ ~r/params:\s*\{[^}]*feed_ticker:\s*true/,
+             "the LiveSocket params in assets/js/app.js must send `feed_ticker: true`"
+
+      assert app_js =~ "FeedTicker:",
+             "retire the `feed_ticker` param together with the FeedTicker hook"
+    end
+
+    test "and the layout still marks both assets", %{conn: conn} do
+      # `phx-track-static` no longer feeds the ticker, but it is the standing
+      # seam for the next component that ships its own CSS and hook: the deploy
+      # that *introduces* one still has to keep it away from an old document,
+      # and without the annotation `static_changed?/1` answers "unchanged" for
+      # every browser.
       html = conn |> get(~p"/login") |> html_response(200)
 
       assert html =~ ~r/<link[^>]+phx-track-static[^>]*href="[^"]*app[^"]*\.css/


### PR DESCRIPTION
**Symptom** The feed's tab ticker stopped quoting new posts this morning. Any `/feed` open across the v7.348.0 deploy kept the dot and lost the quote, for the life of that tab, until a full reload.

**Cause** The v7.347.1 gate asks `static_changed?/1`, i.e. "is anything in this document older than the running release?" Right for the deploy that *introduces* a component, wrong for every one after it: every bundle since v7.347.0 carries the ticker's stylesheet and hook, yet the check goes true again on each asset deploy.

**Change** `app.js` sends `feed_ticker: true` in the LiveSocket params; `PostLive.Feed.ticker_capable?/1` reads it at mount. Only a bundle shipping the hook can send the key, so the claim proves itself however far behind the document is. `phx-track-static` stays as the seam for the next component's first release.

**Test** A browser that is behind *and* capable, calibrated red against the old gate.

Entry point: `/feed`, the source tab bar.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01TbpD4hoMz6u9sKbZaSS7E1