### PR TITLE
Tease a new post's first line in the browser tab

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -418,10 +418,15 @@ function playTickerPreview(box) {
   const quote = box.querySelector("[data-ticker-preview-quote]")
   if (!bar || !tab || !dot || !quote) return
 
-  const form = box.closest(".card")
-  const on = form?.querySelector('input[type="checkbox"][name*="feed_tab_ticker"]')?.checked
+  // Both controls are read from the document, not from an enclosing card: the
+  // kit's <.card> is a pile of utility classes and emits no `card` class at
+  // all, so the `.card` this used to climb to was always null — `on` came back
+  // undefined and the button silently did nothing from the day it shipped
+  // (v7.347.0), which is exactly what an example is supposed to disprove.
+  // Their `name` is server-rendered from the field and unique on this page.
+  const on = document.querySelector('input[type="checkbox"][name*="feed_tab_ticker"]')?.checked
   const seconds =
-    parseInt(form?.querySelector('select[name*="feed_tab_ticker_seconds"]')?.value, 10) || 8
+    parseInt(document.querySelector('select[name*="feed_tab_ticker_seconds"]')?.value, 10) || 8
 
   // Whatever it did last time, back to the resting bar first.
   bar.classList.remove("filter-tabs--ticking")
@@ -455,6 +460,31 @@ document.addEventListener("click", (event) => {
   if (!event.target.closest("[data-ticker-preview-play]")) return
   const box = document.querySelector("[data-ticker-preview]")
   if (box) playTickerPreview(box)
+})
+
+// The browser tab's teaser has the same problem as the ticker above and one
+// twist (issue #1681): its stage is the tab this settings page is sitting in,
+// so the example can simply BE the thing, played in the real tab title through
+// the real hook. Nothing here animates anything — it hands the frames to
+// TabBadge, which owns document.title and would otherwise put the marker back
+// over whatever this wrote.
+document.addEventListener("click", (event) => {
+  const button = event.target.closest("[data-tab-teaser-play]")
+  if (!button) return
+
+  // Read from the document for the reason the ticker preview above records:
+  // there is no `.card` element to climb to.
+  const on = document.querySelector('input[type="checkbox"][name*="browser_tab_teaser"]')?.checked
+  if (!on) return
+
+  let frames = []
+  try {
+    frames = JSON.parse(button.dataset.frames || "[]")
+  } catch (_error) {
+    return
+  }
+
+  window.dispatchEvent(new CustomEvent("vutuv:tab-teaser", { detail: { frames: frames } }))
 })
 
 const Hooks = {
@@ -626,13 +656,33 @@ const Hooks = {
   // The feed dot is intentionally gated on document.hidden (feed posts have no
   // read state) and cleared the moment the member returns to the tab. LiveView's
   // <.live_title> rewrites the title on navigation, which would drop our prefix,
-  // so a MutationObserver on <title> re-applies it after any external change; the
-  // re-apply is idempotent (strip-then-prepend + a no-op guard), so it settles in
-  // one extra cycle and never loops.
+  // so a MutationObserver on <title> watches for a title this hook did not
+  // write, takes it as the new base and re-applies the marker on top; comparing
+  // against our own last write is what keeps that from looping.
+  //
+  // For a few seconds the title also says WHAT arrived (issue #1681): the
+  // author and the first words, paged through the tab one frame per second and
+  // then handed back to the page's own title. Frames rather than a scroll, and
+  // only a few of them, because a hidden tab is where the browser owns the
+  // clock in the strongest sense — timers there are clamped to roughly one per
+  // second, and Chrome drops a chained timer to one per MINUTE once the page
+  // has been hidden for five minutes ("intensive throttling"), which is exactly
+  // the tab this is for. So whatever stands last has to be a line that is still
+  // true a minute later, and the animation stops rather than looping.
+  //
+  // The second asked for below is a floor, not a promise: a hidden tab aligns
+  // timer wake-ups to whole seconds, so a timeout re-armed just after one
+  // misses the next boundary and each frame really stands about two seconds
+  // (measured in headless Chrome 151; the visible settings example runs at the
+  // requested one). ShellLive's window is sized in the measured figure, since
+  // it decides whether a second arrival still reaches a running animation.
   TabBadge: {
     mounted() {
       this.unread = 0
       this.feedPending = false
+      this.teaser = null
+      this.teaserText = null
+      this.baseTitle = this.strip(document.title)
 
       this.handleEvent("tab:badge", ({ unread }) => {
         this.unread = unread || 0
@@ -647,18 +697,42 @@ const Hooks = {
         }
       })
 
-      // Returning to the tab clears the feed dot.
+      this.handleEvent("tab:teaser", ({ id, frames }) => this.startTeaser(id, frames))
+
+      // "Play the example" on /settings/preferences. The member is plainly
+      // looking at this tab, which is the one case the hidden-gate below has to
+      // give way for — the same exemption the test notification takes.
+      this.onPreview = (event) => this.startTeaser(0, event.detail.frames, true)
+      window.addEventListener("vutuv:tab-teaser", this.onPreview)
+
+      // From the second arrival inside one window the server sends a count
+      // instead of a second quote; it becomes the teaser's closing frame.
+      this.handleEvent("tab:teaser_more", ({ id, text }) => {
+        if (this.teaser && this.teaser.id === id) this.teaser.more = text
+      })
+
+      // Returning to the tab clears the feed dot and takes the teaser with it:
+      // a title paging through somebody's post while the member is reading the
+      // page is noise, and the page they are on already shows the arrival.
       this.onVisibility = () => {
-        if (!document.hidden && this.feedPending) {
+        if (!document.hidden) {
           this.feedPending = false
-          this.apply()
+          this.stopTeaser()
         }
+        this.reportVisibility()
       }
       document.addEventListener("visibilitychange", this.onVisibility)
 
       const titleEl = document.querySelector("title")
       if (titleEl) {
-        this.observer = new MutationObserver(() => this.apply())
+        this.observer = new MutationObserver(() => {
+          // Our own writes come back through here too. Anything else is the
+          // page changing its own title (a live navigation), which is the new
+          // base the marker and the teaser sit on top of.
+          if (document.title === this.lastWritten) return
+          this.baseTitle = this.strip(document.title)
+          this.apply()
+        })
         this.observer.observe(titleEl, {
           childList: true,
           characterData: true,
@@ -666,7 +740,13 @@ const Hooks = {
         })
       }
 
+      // The server refuses to spend a feed lookup on a tab that has not said it
+      // is in the background, so this is what turns the teaser on at all.
+      this.reportVisibility()
       this.apply()
+    },
+    reportVisibility() {
+      this.pushEvent("tab:visibility", { hidden: document.hidden })
     },
     // The indicator string: "•(3) ", "(3) ", "• " or "" when nothing is new.
     prefix() {
@@ -675,15 +755,54 @@ const Hooks = {
       const marker = dot + num
       return marker ? `${marker} ` : ""
     },
+    strip(title) {
+      return title.replace(/^\s*•?\s*(\(\d+\)\s*)?/, "")
+    },
+    startTeaser(id, frames, preview) {
+      if ((!document.hidden && !preview) || !frames || frames.length === 0) return
+
+      this.stopTeaser()
+      this.teaser = { id: id, frames: frames, index: 0, more: null }
+      this.teaserStep()
+    },
+    teaserStep() {
+      const teaser = this.teaser
+      if (!teaser) return
+
+      if (teaser.index < teaser.frames.length) {
+        this.teaserText = teaser.frames[teaser.index]
+        teaser.index += 1
+      } else if (teaser.more) {
+        this.teaserText = teaser.more
+        teaser.more = null
+      } else {
+        this.stopTeaser()
+        return
+      }
+
+      this.apply()
+      this.teaserTimer = setTimeout(() => this.teaserStep(), 1000)
+    },
+    stopTeaser() {
+      if (this.teaserTimer) clearTimeout(this.teaserTimer)
+      this.teaserTimer = null
+      this.teaser = null
+      this.teaserText = null
+      this.apply()
+    },
     apply() {
-      // Strip a prefix we added before, then prepend the current one, so the
-      // count/dot can rise, fall or vanish without leaving a stale marker.
-      const base = document.title.replace(/^\s*•?\s*(\(\d+\)\s*)?/, "")
-      const next = this.prefix() + base
-      if (next !== document.title) document.title = next
+      // The marker always leads; behind it stands either a teaser frame or the
+      // page's own title, so a count or a dot can rise, fall or vanish without
+      // leaving a stale marker and without losing the title underneath.
+      const next = this.prefix() + (this.teaserText || this.baseTitle)
+      if (next === document.title) return
+      this.lastWritten = next
+      document.title = next
     },
     destroyed() {
       document.removeEventListener("visibilitychange", this.onVisibility)
+      window.removeEventListener("vutuv:tab-teaser", this.onPreview)
+      if (this.teaserTimer) clearTimeout(this.teaserTimer)
       if (this.observer) this.observer.disconnect()
     },
   },

--- a/config/config.exs
+++ b/config/config.exs
@@ -209,6 +209,16 @@ config :vutuv, :notification_digest_delay_minutes, 30
 # about taste.
 config :vutuv, :feed_ticker_cooldown_ms, 2_000
 
+# The silence after the browser tab's teaser closes (issue #1681), before that
+# socket may spend another feed lookup. Much longer than the one above, and for
+# a different reason: this is not about an animation flickering but about what
+# the whole feature costs. The shell is mounted on every page of every logged-in
+# member, so this figure is the rate limit that turns "a post arrived" into at
+# most one query per open tab per half minute, however busy the network is. A
+# title that rewrote itself every few seconds for an hour would also be its own
+# nuisance. Not a member setting: the switch is the taste, this is the budget.
+config :vutuv, :tab_teaser_cooldown_ms, 30_000
+
 config :vutuv, :reference_checks_enabled, true
 config :vutuv, :reference_check_model, "qwen3.6:27b"
 config :vutuv, :reference_check_model_url, nil

--- a/config/test.exs
+++ b/config/test.exs
@@ -22,6 +22,10 @@ config :vutuv, :composer_draft_debounce_ms, 0
 # second arrival in a test that fires two. Zero here; the test that covers the
 # silence sets its own value.
 config :vutuv, :feed_ticker_cooldown_ms, 0
+# The same for the browser tab's teaser (issue #1681): its silence is half a
+# minute in production and would swallow every second arrival a test fires. The
+# test that covers the silence sets its own value.
+config :vutuv, :tab_teaser_cooldown_ms, 0
 config :vutuv, :sweep_unconfirmed_registrations, false
 # The daily retention sweep of the account-activity log would touch the sandbox
 # from outside; tests call Vutuv.AccountEvents.delete_expired/0 directly.

--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -543,7 +543,10 @@ Five rules keep it from becoming a nuisance, and each one has a test:
 
 Only ever one tab at a time: `other_source/1` is nil on "All" and the two named
 tabs partition the feed, so a third source would be the first thing to need a
-rule for two open windows. Two member preferences (`Vutuv.Prefs`, group
+rule for two open windows. The **browser tab** teases the same arrival in its
+own title while the whole window sits behind something else (issue #1681, see
+[realtime.md](realtime.md)); the quote both surfaces show is
+`VutuvWeb.PostTeaser`, so they cannot drift. Two member preferences (`Vutuv.Prefs`, group
 `:feed_tabs`): `feed_tab_ticker?` (on) and `feed_tab_ticker_seconds` (8, from a
 fixed list of 4–20 on /settings/preferences, where an example plays the
 combination currently selected).

--- a/docs/architecture/realtime.md
+++ b/docs/architecture/realtime.md
@@ -381,6 +381,98 @@ exactly at that moment. A NULL means no note, which is what every account
 predating the feature keeps — the derived feed is otherwise retroactive, and a
 welcome years after the fact would be nonsense.
 
+### The browser tab's teaser (issue #1681)
+
+The tab title has carried two marks for a while: `(3)` for unread messages and
+notifications, and a `•` once a post arrived while the tab was in the
+background. The dot says *that* something landed. For a few seconds the title
+now says **what** — the author and the first words, paged through the tab a
+line at a time, then handed back to the page's own title. It is the feed's
+source-tab ticker one surface further out, and the two share their quote
+(`VutuvWeb.PostTeaser`: who wrote it, how it opens, and the one refusal).
+
+Measured in headless Chrome 151 against a real socket, a backgrounded tab reads:
+
+```
+    0 ms  "Feed - vutuv"
+  200 ms  "• @wintermeyer: Frisch"
+ 2000 ms  "• geflasht, unter zwei"
+ 4000 ms  "• Sekunden bis der Kessel"
+ 6000 ms  "• +1 more post"          (a second post landed at 2.5 s)
+ 8000 ms  "• Feed - vutuv"          (the dot stays until they come back)
+```
+
+**Both sources.** `ShellLive` already receives `{:new_post, …}` on every page,
+and now also takes the `{:remote_feed_arrival, …}` nudge it used to drop
+through its catch-all. That nudge carries no entry, because whether the write
+reaches *this* reader depends on their mutes, follow states, the audience and
+their language filter — so the teaser asks their own sources
+(`Posts.newest_source_entry/3`, the call the feed's ticker makes) and the
+browser-tab dot for a fediverse arrival rides on that answer rather than being
+pushed blind. A vutuv post's dot is unchanged: its fan-out is already scoped to
+the author's followers. `{:new_post, …}` gained an `at` stamp for the lookup,
+the way the fediverse nudge always carried one; a payload from the release
+before this one has none and simply skips the teaser for that deploy window.
+
+**The lookup is the cost, so the window is the budget.** This shell is mounted
+on every page of every logged-in member, so a quote built per arrival would
+turn one post by a well-followed member into thousands of feed queries in the
+same instant. Four rules bound it, and only the first is about taste:
+
+* **Nothing is spent on a tab the member is looking at.** The `TabBadge` hook
+  reports `document.hidden` on connect and on every change (`tab:visibility`),
+  and the server refuses until it hears the tab is in the background. That also
+  keeps the shell off the one page where the feed's own ticker is already
+  saying this — and it is the capability handshake the feed's ticker needed a
+  connect param for (issue #1679): only a bundle carrying this hook can send
+  the event, so a document loaded before this release simply never teases,
+  however many deploys behind it is.
+* **One quote per window.** From the second arrival the quote gives up and
+  becomes a count (`tab:teaser_more`, "+2 more posts") — no query, and the
+  window is not extended, or a busy source would own the tab.
+* **A silence after each window** (`:tab_teaser_cooldown_ms`, 30 s — much
+  longer than the ticker's 2 s, because this one is a rate limit and not an
+  animation). One socket therefore spends at most one lookup per open tab per
+  half minute, however busy the network is.
+* **The silence is armed on every outcome, refusals included.** A quote the
+  reader may not be shown — a muted word, or sources that return nothing — has
+  still spent its query, and a lookup retried on the very next arrival is the
+  one branch with no rate limit at all. It is also worst for exactly the member
+  who muted the word a busy account keeps writing.
+
+**Why frames and not a scrolling marquee.** A hidden tab is where the browser
+owns the clock in the strongest sense: timers are clamped to roughly one per
+second, and Chrome drops a chained timer to one per *minute* once a page has
+been hidden for five minutes ("intensive throttling"), which is precisely the
+tab this is for. So there are about four usable frames, a character scroll
+would spend most of them re-showing words it already showed, and whatever
+stands last has to be a line that is still true a minute later — hence a count
+or the page's own title at the end, never half a sentence.
+
+The hook asks for one second and the trace above shows two: wake-ups in a
+hidden tab are aligned to whole seconds, so a timeout re-armed just after one
+waits for the boundary after next. `ShellLive`'s `@frame_ms` is therefore the
+**measured** figure, not the requested one — it is what decides whether a
+second arrival still reaches a running animation as a count, and sized at the
+requested second the window closed at 3 s while the browser was on frame two.
+The cut itself
+(`PostTeaser.title_frames/1`, ~24 characters at word boundaries, a long URL
+cut hard so it cannot swallow the frames behind it) is done on the server, so
+it is testable without a browser and the wording stays in the reader's locale.
+
+One member preference (`Vutuv.Prefs`, group `:browser_tab`):
+`browser_tab_teaser?`, on, on /settings/preferences under the feed-tabs card.
+The example there plays in the settings page's own tab through the same hook,
+so it is the effect rather than a picture of it. The hint names the cost the
+switch exists for: a tab title also shows up in screenshots, in a window
+switcher and in a screen share.
+
+Both examples on that page read their switch from the **document**, not from an
+enclosing card. The kit's `<.card>` is a pile of utility classes and emits no
+`card` class, so the `.card` the feed-ticker example climbed to was always null
+and its play button had silently done nothing since v7.347.0 — found by driving
+the page in a real browser, which is the only thing that could have found it.
+
 ### Browser notifications (issue #1249)
 
 A member can have vutuv open in a tab they are not looking at. The tab title

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -313,6 +313,11 @@ defmodule Vutuv.Accounts.User do
     # `Vutuv.Prefs.get/2`, never straight off the struct.
     field(:feed_tab_ticker?, :boolean)
     field(:feed_tab_ticker_seconds, :integer)
+    # The same quote one surface further out (issue #1681): while this member's
+    # vutuv tab sits in the background, a new post pages its first line through
+    # the browser tab's title. nil = inherit the installation default; read
+    # through `Vutuv.Prefs.get/2`, never straight off the struct.
+    field(:browser_tab_teaser?, :boolean)
     # The feed's remembered source tab (issue #1499): "vutuv" / "fediverse",
     # nil = All. Not a form field — `Vutuv.Posts.remember_feed_filter/2` writes
     # it from the tab click and `remembered_feed_filter/1` reads it back at
@@ -520,7 +525,7 @@ defmodule Vutuv.Accounts.User do
   # :email_confirmed? is NOT here either: it flips only via the login-PIN path
   # (Accounts.activate_user/1, its own narrow cast) — castable, it would let a
   # registration self-activate without ever proving control of an email.
-  @optional_fields ~w(noindex? noai? notification_emails? dm_email_each_message? dm_email_delay_minutes email_on_endorsement? email_on_follower? email_on_reference_check? newsletter_emails? saved_search_emails? cv_update_notifications? thread_notifications? browser_notifications? show_online_status? show_mastodon_feed? mastodon_clients? show_code_stats? fediverse_followers? fediverse_reactions? fediverse_replies? also_known_as_input map_google? map_openstreetmap? map_apple? default_map_service post_lines_desktop post_lines_mobile post_hyphenate_desktop post_hyphenate_mobile notification_post_lines like_attribution? headline employment_status employment_status_visibility desired_salary_min desired_salary_currency desired_salary_period desired_salary_visibility desired_workplace_types first_name last_name middle_name nickname honorific_prefix honorific_suffix name_pronunciation gender birthdate birthdate_visibility locale date_region time_zone tag_list auto_post_deletion? auto_post_deletion_after_days auto_post_deletion_keep_photos? auto_post_deletion_keep_answered? auto_post_deletion_keep_bookmarked? auto_post_deletion_delete_replies? auto_post_deletion_min_likes auto_post_deletion_min_bookmarks auto_post_deletion_min_reposts feed_foreign_posts feed_languages feed_tab_ticker? feed_tab_ticker_seconds)a
+  @optional_fields ~w(noindex? noai? notification_emails? dm_email_each_message? dm_email_delay_minutes email_on_endorsement? email_on_follower? email_on_reference_check? newsletter_emails? saved_search_emails? cv_update_notifications? thread_notifications? browser_notifications? show_online_status? show_mastodon_feed? mastodon_clients? show_code_stats? fediverse_followers? fediverse_reactions? fediverse_replies? also_known_as_input map_google? map_openstreetmap? map_apple? default_map_service post_lines_desktop post_lines_mobile post_hyphenate_desktop post_hyphenate_mobile notification_post_lines like_attribution? headline employment_status employment_status_visibility desired_salary_min desired_salary_currency desired_salary_period desired_salary_visibility desired_workplace_types first_name last_name middle_name nickname honorific_prefix honorific_suffix name_pronunciation gender birthdate birthdate_visibility locale date_region time_zone tag_list auto_post_deletion? auto_post_deletion_after_days auto_post_deletion_keep_photos? auto_post_deletion_keep_answered? auto_post_deletion_keep_bookmarked? auto_post_deletion_delete_replies? auto_post_deletion_min_likes auto_post_deletion_min_bookmarks auto_post_deletion_min_reposts feed_foreign_posts feed_languages feed_tab_ticker? feed_tab_ticker_seconds browser_tab_teaser?)a
 
   # The ages the automatic post deletion offers (issue #1255), in days. A fixed
   # list rather than a free number field on purpose: this setting deletes

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -5781,11 +5781,17 @@ defmodule Vutuv.Posts do
   defp broadcast_new_post(%Post{user_id: nil}), do: :ok
 
   defp broadcast_new_post(%Post{} = post) do
-    broadcast_to_followers(post.user_id, new_post_event(post.id, post.user_id))
+    broadcast_to_followers(post.user_id, new_post_event(post))
   end
 
-  defp new_post_event(post_id, author_id),
-    do: {:new_post, %{post_id: post_id, author_id: author_id}}
+  # `at` is the stamp this post will carry in the merged feed, the way the
+  # fediverse nudge carries one (issue #1503): it lets a subscriber ask its own
+  # sources for their newest row "at least as new as this" rather than trusting
+  # the fan-out about who may see it. The browser tab's teaser needs exactly
+  # that (issue #1681); every existing matcher takes the map apart by key and
+  # is unaffected.
+  defp new_post_event(%Post{} = post),
+    do: {:new_post, %{post_id: post.id, author_id: post.user_id, at: post.inserted_at}}
 
   @doc """
   Removes a post's auto-captured link screenshot on the author's request (the

--- a/lib/vutuv/prefs.ex
+++ b/lib/vutuv/prefs.ex
@@ -107,6 +107,17 @@ defmodule Vutuv.Prefs do
       max: 20,
       group: :feed_tabs
     },
+    # The same idea one surface further out (issue #1681): while the vutuv tab
+    # sits in the background, a new post pages its first line through the
+    # browser tab's title instead of only putting a dot there. Off leaves the
+    # dot and the page title alone.
+    #
+    # On by default, like the ticker it is modelled on. The switch matters to
+    # the member who screen-shares or presents: the tab title is one of the few
+    # places vutuv writes into the operating system's furniture, so somebody
+    # else's first line can end up in a screenshot, a recording or a window
+    # switcher.
+    %Pref{key: :browser_tab_teaser?, type: :boolean, default: true, group: :browser_tab},
     # How a member's dates and times are written, and which clock they are
     # written on (issue #1502). Two knobs rather than one because they answer
     # different questions — a German-speaking member in Chicago wants German
@@ -187,6 +198,9 @@ defmodule Vutuv.Prefs do
   def label(:feed_tab_ticker_seconds),
     do: Gettext.gettext(VutuvWeb.Gettext, "How long the quote stands")
 
+  def label(:browser_tab_teaser?),
+    do: Gettext.gettext(VutuvWeb.Gettext, "Tease new posts in the browser tab")
+
   def label(:date_region), do: Gettext.gettext(VutuvWeb.Gettext, "Date format")
   def label(:time_zone), do: Gettext.gettext(VutuvWeb.Gettext, "Time zone")
 
@@ -208,6 +222,13 @@ defmodule Vutuv.Prefs do
       Gettext.gettext(
         VutuvWeb.Gettext,
         "When off, a tab holding something new wears its dot and says nothing more."
+      )
+
+  def hint(:browser_tab_teaser?),
+    do:
+      Gettext.gettext(
+        VutuvWeb.Gettext,
+        "Only while you are looking at another tab, and only for a few seconds. The tab title also shows up in screenshots, in your window switcher and in a screen share."
       )
 
   def hint(:feed_tab_ticker_seconds),
@@ -262,6 +283,7 @@ defmodule Vutuv.Prefs do
   def group_label(:post_display), do: Gettext.gettext(VutuvWeb.Gettext, "Posts")
   def group_label(:feed), do: Gettext.gettext(VutuvWeb.Gettext, "Feed")
   def group_label(:feed_tabs), do: Gettext.gettext(VutuvWeb.Gettext, "Feed tabs")
+  def group_label(:browser_tab), do: Gettext.gettext(VutuvWeb.Gettext, "Browser tab")
   def group_label(:privacy), do: Gettext.gettext(VutuvWeb.Gettext, "Privacy")
   def group_label(:region), do: Gettext.gettext(VutuvWeb.Gettext, "Date & time")
   def group_label(:maps), do: Gettext.gettext(VutuvWeb.Gettext, "Maps")

--- a/lib/vutuv_web/controllers/settings_controller.ex
+++ b/lib/vutuv_web/controllers/settings_controller.ex
@@ -826,6 +826,26 @@ defmodule VutuvWeb.SettingsController do
     reset_prefs(conn, :feed_tabs, gettext("Feed tab settings reset to the site defaults."))
   end
 
+  # The browser tab's teaser (issue #1681): whether a post arriving while this
+  # member is looking somewhere else pages its first line through the tab
+  # title. The sibling of the setting above, and on the same page for that
+  # reason — one is what the feed's tabs do, the other what the browser's tab
+  # does.
+  def update_browser_tab(conn, %{"user" => params}) do
+    save(
+      conn,
+      params,
+      "preferences.html",
+      ~p"/settings/preferences",
+      gettext("Browser tab settings saved."),
+      event: "preferences_changed"
+    )
+  end
+
+  def reset_browser_tab(conn, _params) do
+    reset_prefs(conn, :browser_tab, gettext("Browser tab settings reset to the site defaults."))
+  end
+
   # The like-attribution switch (issue #1233) lives on the visibility page
   # rather than under language & display, so its reset lands back there.
   def reset_privacy_prefs(conn, _params) do

--- a/lib/vutuv_web/gettext_extraction_anchors.ex
+++ b/lib/vutuv_web/gettext_extraction_anchors.ex
@@ -90,6 +90,12 @@ defmodule VutuvWeb.GettextExtractionAnchors do
       gettext("Quote what arrives on the other tab"),
       gettext("How long the quote stands"),
       gettext("When off, a tab holding something new wears its dot and says nothing more."),
+      # Vutuv.Prefs — the browser tab's teaser (issue #1681)
+      gettext("Browser tab"),
+      gettext("Tease new posts in the browser tab"),
+      gettext(
+        "Only while you are looking at another tab, and only for a few seconds. The tab title also shows up in screenshots, in your window switcher and in a screen share."
+      ),
       gettext("Between 4 and 20 seconds."),
       gettext("0 means posts are never shortened."),
       gettext("How much of a post a notification quotes before it is cut off."),

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -36,9 +36,6 @@ defmodule VutuvWeb.PostLive.Feed do
   alias Phoenix.LiveView.JS
   alias Vutuv.Activity
   alias Vutuv.ContentFilters
-  alias Vutuv.Fediverse.Handle
-  alias Vutuv.Fediverse.RemoteAccount
-  alias Vutuv.Identity
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias Vutuv.Prefs
@@ -50,6 +47,7 @@ defmodule VutuvWeb.PostLive.Feed do
   alias VutuvWeb.Live.PostTranslations
   alias VutuvWeb.Live.RemotePostActions
   alias VutuvWeb.Markdown
+  alias VutuvWeb.PostTeaser
   alias VutuvWeb.UserHelpers
 
   # The origin's like/repost figures on a card from another network tick
@@ -452,7 +450,7 @@ defmodule VutuvWeb.PostLive.Feed do
   # rail DOM light; the visible cut is the six-line CSS clamp (`line-clamp-6`)
   # on the wrapper, so we drop the truncation flag here.
   defp discover_body(body) do
-    {html, _truncated?} = VutuvWeb.Markdown.render_preview(body, [])
+    {html, _truncated?} = Markdown.render_preview(body, [])
     html
   end
 
@@ -1263,64 +1261,18 @@ defmodule VutuvWeb.PostLive.Feed do
 
   defp ticker_cooldown_ms, do: Application.get_env(:vutuv, :feed_ticker_cooldown_ms, 2_000)
 
-  # Who wrote it and what it opens with. Returns nil for an entry this reader
-  # has muted by content filter: the quote would put the very word they
-  # silenced into the bar, and `decorate/3` — which stamps `:filtered_by` — only
-  # runs on the branch for the tab they *are* on.
+  # Who wrote it and what it opens with — nil for an entry this reader has
+  # muted by content filter, since the quote would put the very word they
+  # silenced into the bar. The browser tab's teaser asks the same three
+  # questions on every page (issue #1681), so `VutuvWeb.PostTeaser` owns them
+  # and the two surfaces cannot drift.
   defp ticker_teaser(socket, entry) do
-    viewer = socket.assigns.current_user
-
-    if filtered_pattern(entry, socket.assigns.content_filters, viewer.id) do
-      nil
-    else
-      %{who: ticker_who(entry), text: ticker_text(entry)}
-    end
+    PostTeaser.quote_for(
+      entry,
+      socket.assigns.content_filters,
+      socket.assigns.current_user.id
+    )
   end
-
-  # The handle without its server (`Handle.short/1`): the tab beside the quote
-  # already says "Fediverse", and the domain would take half the line.
-  defp ticker_who(entry) do
-    cond do
-      Posts.remote_reply_entry?(entry) ->
-        Handle.short(Handle.display(entry.note.handle, entry.note.actor_uri))
-
-      Posts.remote_feed_entry?(entry) ->
-        Handle.short(RemoteAccount.display_handle(entry.remote_post.remote_account))
-
-      true ->
-        case Posts.author(entry.post) do
-          nil -> nil
-          author -> local_who(author)
-        end
-    end
-  end
-
-  # A page that never claimed a root handle has none to show, so it is named.
-  defp local_who(author) do
-    case Identity.handle(author) do
-      handle when is_binary(handle) -> "@" <> handle
-      _ -> Identity.display_name(author)
-    end
-  end
-
-  defp ticker_text(entry) do
-    cond do
-      Posts.remote_reply_entry?(entry) -> one_line(entry.note.content_text)
-      Posts.remote_feed_entry?(entry) -> one_line(entry.remote_post.content_text)
-      true -> one_line(Markdown.to_preview_line(entry.post.body))
-    end
-  end
-
-  # A quote is one line whatever the body did. The cap keeps a long post out of
-  # the payload; where the line is actually cut is the bar's width, in CSS.
-  defp one_line(text) when is_binary(text) do
-    case text |> String.replace(~r/\s+/u, " ") |> String.trim() |> String.slice(0, 200) do
-      "" -> nil
-      line -> line
-    end
-  end
-
-  defp one_line(_text), do: nil
 
   # Naming the tab with a colon rather than a preposition, and one string for
   # both tabs: "new in the Fediverse" and "new on vutuv" do not share a German
@@ -1398,25 +1350,7 @@ defmodule VutuvWeb.PostLive.Feed do
   end
 
   defp mark_one(entry, compiled, viewer_id) do
-    Map.put(entry, :filtered_by, filtered_pattern(entry, compiled, viewer_id))
-  end
-
-  defp filtered_pattern(entry, compiled, viewer_id) do
-    cond do
-      # A cached post from another network (issue #1161) is filtered on its
-      # plain text: the member muted a word because they do not want to read it,
-      # and where it was written changes nothing about that.
-      Posts.remote_feed_entry?(entry) ->
-        ContentFilters.filtered_text(remote_entry_text(entry), compiled)
-
-      # Never the member's own posts. A remote post cannot reach this arm: it has
-      # no author here, so the exemption has nothing to match on.
-      entry.post.user_id == viewer_id ->
-        nil
-
-      true ->
-        ContentFilters.filtered_pattern(entry.post, compiled)
-    end
+    Map.put(entry, :filtered_by, PostTeaser.filtered_pattern(entry, compiled, viewer_id))
   end
 
   # What the reveal set remembers. A vutuv post is keyed by its own id (so the
@@ -1481,13 +1415,6 @@ defmodule VutuvWeb.PostLive.Feed do
   # an assign being flipped: a stream item redraws only when its own entry is
   # handed back, which is also why the state rides the entry. `:flash` is an
   # `{outcome, message}` the act announces itself with when it really happened.
-  # The text a content filter matches on, whichever remote shape the row is.
-  defp remote_entry_text(entry) do
-    if Posts.remote_reply_entry?(entry),
-      do: entry.note.content_text,
-      else: entry.remote_post.content_text
-  end
-
   # "This row is the cached post with that id" — the one predicate the three
   # scans over `:entries` that single a remote post out all read from.
   defp remote_entry?(entry, remote_post_id),

--- a/lib/vutuv_web/live/shell_live.ex
+++ b/lib/vutuv_web/live/shell_live.ex
@@ -37,14 +37,30 @@ defmodule VutuvWeb.ShellLive do
 
   alias Vutuv.Accounts.User
   alias Vutuv.Activity
+  alias Vutuv.ContentFilters
   alias Vutuv.Dashboard
   alias Vutuv.DayClock
   alias Vutuv.Organizations
   alias Vutuv.PeopleCounter
+  alias Vutuv.Posts
+  alias Vutuv.Prefs
   alias Vutuv.Social
   alias VutuvWeb.Live.InitAssigns
   alias VutuvWeb.NotificationLine
+  alias VutuvWeb.PostTeaser
   alias VutuvWeb.Presence
+
+  # How long one browser-tab frame really stands (issue #1681), which is what
+  # the server's window has to be measured in — it is the only thing deciding
+  # whether a second arrival still reaches a running animation as a count.
+  #
+  # The hook asks for a second and the browser gives it two: a hidden tab's
+  # timers are aligned to whole seconds, so a one-second timeout re-armed just
+  # after a wake-up misses the next boundary and waits for the one after.
+  # Measured in headless Chrome 151 against a real socket: frames at 0, 2.0,
+  # 4.0 s and the title handed back at 6.0. Sizing the window at the requested
+  # second instead closed it at 3 s, while the browser was still on frame two.
+  @frame_ms 2_000
 
   @impl true
   def mount(_params, session, socket) do
@@ -163,6 +179,10 @@ defmodule VutuvWeb.ShellLive do
     |> assign(:user_admin?, user.admin?)
     |> assign_shell_defaults(path)
     |> assign(:browser_notifications?, user.browser_notifications?)
+    # The resolved member themselves, for the browser tab's teaser (issue
+    # #1681): it reads their preference and asks their own feed sources what
+    # arrived. Nothing renders from it, so it never reaches the client.
+    |> assign(:current_user, user)
     |> maybe_start_counts(user, path)
     |> maybe_start_new_members()
     |> maybe_start_presence(user_id, user.show_online_status?)
@@ -183,6 +203,16 @@ defmodule VutuvWeb.ShellLive do
     # for the anonymous shell and for the throwaway dead render, which raises
     # none anyway — the real value arrives with the authenticated mount.
     |> assign(:browser_notifications?, false)
+    # The browser tab's teaser (issue #1681). `tab_hidden?` is what the hook
+    # reports and starts false, so nothing is spent on a tab that has not said
+    # it is in the background; `teaser` holds the open window, `teaser_quiet_until`
+    # the silence after it, and `teaser_filters` this member's compiled content
+    # filters once something is actually quoted.
+    |> assign(:current_user, nil)
+    |> assign(:tab_hidden?, false)
+    |> assign(:teaser, nil)
+    |> assign(:teaser_quiet_until, nil)
+    |> assign(:teaser_filters, nil)
     |> assign(:presence_hidden_ids, MapSet.new())
     |> assign(:messages_count, 0)
     |> assign(:notifications_count, 0)
@@ -355,13 +385,33 @@ defmodule VutuvWeb.ShellLive do
   # their own tab. The hook only shows the "new posts" dot while the tab is
   # backgrounded and clears it the moment they return, so feed posts (which have
   # no read state) need no server-side unread tally.
-  def handle_info({:new_post, %{author_id: author_id}}, socket) do
+  #
+  # The dot says *that* something landed; `tab_teaser/3` below says what, for a
+  # few seconds, in the tab's own title (issue #1681).
+  def handle_info({:new_post, %{author_id: author_id} = payload}, socket) do
     socket =
-      if author_id == socket.assigns.user_id,
-        do: socket,
-        else: push_event(socket, "tab:new_post", %{})
+      if author_id == socket.assigns.user_id do
+        socket
+      else
+        {_result, socket} = tab_teaser(socket, :vutuv, payload[:at])
+        push_event(socket, "tab:new_post", %{})
+      end
 
     {:noreply, socket}
+  end
+
+  # Something landed through the fediverse (issue #1503): a followed account
+  # posted or boosted, or somebody here passed a remote post on. The nudge
+  # carries no entry, because whether that write reaches THIS reader depends on
+  # their mutes, their follow states, the audience and their language filter —
+  # so only their own sources can answer, and that is the lookup the teaser
+  # makes anyway. The dot therefore rides on that answer instead of being
+  # pushed blind. Every other subscriber of the member topic ignores this event.
+  def handle_info({:remote_feed_arrival, %{at: at}}, socket) do
+    case tab_teaser(socket, :fediverse, at) do
+      {:opened, socket} -> {:noreply, push_event(socket, "tab:new_post", %{})}
+      {_other, socket} -> {:noreply, socket}
+    end
   end
 
   # A member joined or left site-wide presence: re-push this viewer's (block-
@@ -588,6 +638,139 @@ defmodule VutuvWeb.ShellLive do
   end
 
   def handle_event("notify:seen", _params, socket), do: {:noreply, socket}
+
+  # The TabBadge hook reports whether this browser tab is in the background, on
+  # connect and on every change. The server needs the answer because the teaser
+  # below costs a query: a member sitting in front of the page would pay it for
+  # a title they are not reading, and on /feed the source-tab ticker is already
+  # saying the same thing beside the tabs.
+  #
+  # It doubles as the capability handshake the feed's ticker had to add
+  # separately (issue #1679): a deploy reloads no open tab, it only reconnects
+  # the socket into hours-old markup, and only a bundle carrying this hook can
+  # send this event — so an old document simply never teases, rather than being
+  # asked whether any of its assets are stale. False until the hook speaks.
+  def handle_event("tab:visibility", %{"hidden" => hidden}, socket) do
+    {:noreply, assign(socket, :tab_hidden?, hidden == true)}
+  end
+
+  ## ── The browser tab's teaser (issue #1681) ──
+  #
+  # The dot in the tab title says *that* a post arrived. For a few seconds the
+  # title says what: the author and the first words, paged through the tab one
+  # frame per second, then back to the page's own title. It is the feed's
+  # source-tab ticker (#1668) one surface further out, and it obeys the same
+  # three rules — one quote per window, the browser owns the clock, a silence
+  # after each window — for a fourth reason on top of theirs:
+  #
+  # **The lookup is the cost, so the window is the budget.** This shell is
+  # mounted on every page of every logged-in member and already receives every
+  # arrival, so a quote built per arrival would turn one post by a well-followed
+  # member into thousands of feed queries in the same instant. Instead a socket
+  # spends **one** `Posts.newest_source_entry/3` per window plus cooldown, and
+  # everything landing inside that window is counted rather than looked up
+  # ("+2 more posts"). The work is then bounded by open tabs, not by how busy
+  # the network is.
+  #
+  # The cooldown is armed on **every** outcome, the refusals included. A quote
+  # the reader may not be shown (a muted word, a post their sources do not
+  # return) still spent the query, and a lookup that is retried on the very next
+  # arrival because it found nothing is exactly the shape that has no rate limit
+  # at all — which is worst for the member who muted the word a busy account
+  # keeps writing.
+  defp tab_teaser(socket, source, at) do
+    cond do
+      not teasing?(socket) -> {:off, socket}
+      window_open?(socket) -> {:counted, count_teaser(socket)}
+      quiet?(socket) or is_nil(at) -> {:off, socket}
+      true -> open_teaser(socket, source, at)
+    end
+  end
+
+  # Three cheap refusals before anything is spent: nobody is logged in, the tab
+  # is the one being read, or the member switched the teaser off.
+  defp teasing?(%{assigns: %{current_user: %User{} = user, tab_hidden?: true}}),
+    do: Prefs.get(user, :browser_tab_teaser?)
+
+  defp teasing?(_socket), do: false
+
+  defp window_open?(%{assigns: %{teaser: %{until: until}}}), do: now_ms() < until
+  defp window_open?(_socket), do: false
+
+  defp quiet?(%{assigns: %{teaser_quiet_until: until}}) when is_integer(until),
+    do: now_ms() < until
+
+  defp quiet?(_socket), do: false
+
+  # `at` is the stamp the arrival will carry in the merged feed, so the sources
+  # can be asked for their newest row "at least as new as this". A payload from
+  # the release before this one carries none (the blue/green window), and that
+  # skips the teaser rather than quoting whatever happens to sit on top.
+  defp open_teaser(socket, source, at) do
+    {socket, filters} = teaser_filters(socket)
+    user = socket.assigns.current_user
+
+    frames =
+      case Posts.newest_source_entry(user, source, at) do
+        nil -> []
+        entry -> entry |> PostTeaser.quote_for(filters, user.id) |> PostTeaser.title_frames()
+      end
+
+    push_teaser(socket, frames)
+  end
+
+  defp push_teaser(socket, []), do: {:off, arm_quiet(socket, 0)}
+
+  defp push_teaser(socket, frames) do
+    id = System.unique_integer([:positive])
+    window = length(frames) * @frame_ms
+
+    socket =
+      socket
+      |> assign(:teaser, %{id: id, count: 1, until: now_ms() + window})
+      |> push_event("tab:teaser", %{id: id, frames: frames})
+      |> arm_quiet(window)
+
+    {:opened, socket}
+  end
+
+  # From the second arrival in the window the quote gives up and becomes a
+  # count: two quotes would each stand for less time than it takes to read one,
+  # and a queue of ten would hold the title for a minute and a half. The window
+  # is not extended by it either, or a busy source would own the tab.
+  defp count_teaser(socket) do
+    teaser = %{socket.assigns.teaser | count: socket.assigns.teaser.count + 1}
+
+    socket
+    |> assign(:teaser, teaser)
+    |> push_event("tab:teaser_more", %{id: teaser.id, text: more_line(teaser.count - 1)})
+  end
+
+  # `ngettext/3` binds %{count} to the raw integer and a `count:` binding does
+  # not override it, so the formatted figure travels under its own name.
+  defp more_line(extra) do
+    ngettext("+%{formatted} more post", "+%{formatted} more posts", extra,
+      formatted: compact_count(extra)
+    )
+  end
+
+  # Compiled once per socket, and only when a teaser is actually attempted: the
+  # vast majority of shells never raise one, and the query would otherwise ride
+  # every page load site-wide.
+  defp teaser_filters(%{assigns: %{teaser_filters: nil}} = socket) do
+    compiled = ContentFilters.compile_for(socket.assigns.current_user)
+    {assign(socket, :teaser_filters, compiled), compiled}
+  end
+
+  defp teaser_filters(socket), do: {socket, socket.assigns.teaser_filters}
+
+  defp arm_quiet(socket, window_ms),
+    do: assign(socket, :teaser_quiet_until, now_ms() + window_ms + teaser_cooldown_ms())
+
+  defp teaser_cooldown_ms,
+    do: Application.get_env(:vutuv, :tab_teaser_cooldown_ms, 30_000)
+
+  defp now_ms, do: System.monotonic_time(:millisecond)
 
   defp push_notify(%{assigns: %{browser_notifications?: false}} = socket, _payload), do: socket
 

--- a/lib/vutuv_web/post_teaser.ex
+++ b/lib/vutuv_web/post_teaser.ex
@@ -1,0 +1,199 @@
+defmodule VutuvWeb.PostTeaser do
+  @moduledoc """
+  What an arrival says in one line: who wrote it, how it opens, and whether this
+  reader may be shown it at all.
+
+  Two surfaces quote a post the reader is not looking at, and neither may drift
+  from the other. The feed's source-tab ticker quotes it beside the tab it
+  landed on (issue #1668); the browser tab's title teases it while the whole
+  window sits behind something else (issue #1681). Both ask the same three
+  questions, so all three answers live here instead of twice.
+
+  `title_frames/1` is the browser tab's half and belongs here for the same
+  reason: it cuts the quote the two surfaces share, and where it cuts is a
+  decision about how a tab strip reads, not about the feed.
+  """
+
+  alias Vutuv.ContentFilters
+  alias Vutuv.Fediverse.Handle
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Identity
+  alias Vutuv.Posts
+  alias VutuvWeb.Markdown
+
+  # How wide one browser-tab frame is written. A tab in a window holding a
+  # handful of others shows roughly twenty characters of its title, and the
+  # marker the hook keeps in front ("• (2) ") spends some of those, so a frame
+  # is cut a little above what is certainly visible: the tail of a frame is
+  # truncated, and the words after it arrive in the next one anyway.
+  @frame_width 24
+
+  # How many frames a teaser may run to. Not a taste decision — browsers clamp
+  # timers in a hidden tab to about one per second, and Chrome drops a chained
+  # timer to one per *minute* once the page has been hidden for five minutes
+  # ("intensive throttling", Chrome 88), which is exactly the tab this feature
+  # is for. Measured in headless Chrome 151, a frame asking for a second gets
+  # two, so three frames plus the closing one take about eight seconds of the
+  # window the browser is willing to give. Whatever stands last has to still be
+  # true a minute later.
+  @max_frames 3
+
+  @doc """
+  The quote for one feed entry — `%{who: …, text: …}` — or nil where this
+  reader has muted it.
+
+  nil rather than a redacted line: the member silenced that word, and a teaser
+  is the one place they cannot scroll past it. Both surfaces then fall back to
+  the bare dot, which says *that* something landed without saying what.
+  """
+  def quote_for(entry, compiled, viewer_id) do
+    if filtered_pattern(entry, compiled, viewer_id) do
+      nil
+    else
+      %{who: who(entry), text: text(entry)}
+    end
+  end
+
+  @doc """
+  Which of this reader's content filters hides `entry`, or nil.
+
+  A cached post from another network (issue #1161) is filtered on its plain
+  text: the member muted a word because they do not want to read it, and where
+  it was written changes nothing about that. Never the member's own posts — a
+  remote post cannot reach that arm, having no author here.
+  """
+  def filtered_pattern(entry, compiled, viewer_id) do
+    cond do
+      Posts.remote_feed_entry?(entry) ->
+        ContentFilters.filtered_text(remote_text(entry), compiled)
+
+      entry.post.user_id == viewer_id ->
+        nil
+
+      true ->
+        ContentFilters.filtered_pattern(entry.post, compiled)
+    end
+  end
+
+  @doc """
+  Who wrote it, as a name a reader recognises — or nil.
+
+  The handle without its server (`Handle.short/1`): the surfaces quoting this
+  are short of room, and the domain would take half of it. A page that never
+  claimed a root handle has none to show, so it is named instead.
+  """
+  def who(entry) do
+    cond do
+      Posts.remote_reply_entry?(entry) ->
+        Handle.short(Handle.display(entry.note.handle, entry.note.actor_uri))
+
+      Posts.remote_feed_entry?(entry) ->
+        Handle.short(RemoteAccount.display_handle(entry.remote_post.remote_account))
+
+      true ->
+        case Posts.author(entry.post) do
+          nil -> nil
+          author -> local_who(author)
+        end
+    end
+  end
+
+  @doc """
+  How it opens: one line, whatever the body did — or nil for a post with no
+  text to quote (a photo without a caption).
+  """
+  def text(entry) do
+    cond do
+      Posts.remote_reply_entry?(entry) -> one_line(entry.note.content_text)
+      Posts.remote_feed_entry?(entry) -> one_line(entry.remote_post.content_text)
+      true -> one_line(Markdown.to_preview_line(entry.post.body))
+    end
+  end
+
+  @doc """
+  The quote cut into browser-tab-sized frames, at word boundaries, newest words
+  last. `[]` where there is nothing to say.
+
+  Paging beats scrolling here. Under a budget of about four frames a character
+  scroll spends most of them re-showing words it already showed, while paging
+  puts a fresh line in the tab each second — roughly seventy characters of the
+  post against sixteen. The author leads the first frame and is not repeated:
+  a reader who glances late gets the words, and the tab is the member's own, so
+  the question "who is this from" is the smaller one.
+  """
+  def title_frames(nil), do: []
+
+  def title_frames(%{who: who, text: text}) do
+    case join(who, text) do
+      "" -> []
+      line -> line |> chunks(@frame_width) |> Enum.take(@max_frames)
+    end
+  end
+
+  defp local_who(author) do
+    case Identity.handle(author) do
+      handle when is_binary(handle) -> "@" <> handle
+      _ -> Identity.display_name(author)
+    end
+  end
+
+  defp remote_text(entry) do
+    if Posts.remote_reply_entry?(entry),
+      do: entry.note.content_text,
+      else: entry.remote_post.content_text
+  end
+
+  # A quote is one line whatever the body did. The cap keeps a long post out of
+  # the payload; where the line is actually cut is the surface's own business.
+  defp one_line(text) when is_binary(text) do
+    case text |> String.replace(~r/\s+/u, " ") |> String.trim() |> String.slice(0, 200) do
+      "" -> nil
+      line -> line
+    end
+  end
+
+  defp one_line(_text), do: nil
+
+  defp join(who, text) when is_binary(who) and is_binary(text), do: who <> ": " <> text
+  defp join(who, nil) when is_binary(who), do: who
+  defp join(nil, text) when is_binary(text), do: text
+  defp join(_who, _text), do: ""
+
+  # Greedy word wrap. A word wider than a frame gets a frame of its own, cut
+  # hard — a pasted URL must not swallow the two frames after it as well.
+  defp chunks(line, width) do
+    line
+    |> String.split(~r/\s+/u, trim: true)
+    |> Enum.flat_map(&split_long(&1, width))
+    |> wrap(width, [], [])
+  end
+
+  defp split_long(word, width) do
+    if String.length(word) <= width do
+      [word]
+    else
+      word
+      |> String.graphemes()
+      |> Enum.chunk_every(width)
+      |> Enum.map(&Enum.join/1)
+    end
+  end
+
+  defp wrap([], _width, [], done), do: Enum.reverse(done)
+  defp wrap([], _width, current, done), do: Enum.reverse([finish(current) | done])
+
+  defp wrap([word | rest], width, current, done) do
+    cond do
+      current == [] ->
+        wrap(rest, width, [word], done)
+
+      String.length(finish([word | current])) <= width ->
+        wrap(rest, width, [word | current], done)
+
+      true ->
+        wrap([word | rest], width, [], [finish(current) | done])
+    end
+  end
+
+  defp finish(current), do: current |> Enum.reverse() |> Enum.join(" ")
+end

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -1588,6 +1588,9 @@ defmodule VutuvWeb.Router do
     put("/feed_ticker", SettingsController, :update_feed_ticker)
     patch("/feed_ticker", SettingsController, :update_feed_ticker)
     post("/feed_ticker/reset", SettingsController, :reset_feed_ticker)
+    put("/browser_tab", SettingsController, :update_browser_tab)
+    patch("/browser_tab", SettingsController, :update_browser_tab)
+    post("/browser_tab/reset", SettingsController, :reset_browser_tab)
     # Clear a whole preference group back to nil = "inherit the installation
     # default" (Vutuv.Prefs) — the quiet reset links under the two cards.
     post("/post_display/reset", SettingsController, :reset_post_display)

--- a/lib/vutuv_web/templates/settings/preferences.html.heex
+++ b/lib/vutuv_web/templates/settings/preferences.html.heex
@@ -298,6 +298,70 @@ shortened and hyphenated. Each form posts its own subset and lands back here. --
       </div>
     </.card>
 
+    <%!-- The browser tab's teaser (issue #1681): the same quote one surface
+          further out, in the tab's own title while the member is looking at
+          something else. The dot there is not in question — it stays either
+          way; the switch is only about the words beside it.
+
+          The example plays in this very tab, through the same hook that runs
+          the real thing, so it is not a mock-up of the effect but the effect.
+          It is also the only honest way to show a setting whose stage is
+          somewhere the member cannot be while they are here. --%>
+    <.card>
+      <.section_title>{gettext("Browser tab")}</.section_title>
+      <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+        {gettext(
+          "While you are reading another tab, a new post can page its first words through this tab's title, a line at a time, and then hand the title back."
+        )}
+      </p>
+
+      <.form :let={f} for={@changeset} action={~p"/settings/browser_tab"} class="mt-5 space-y-5">
+        <.form_error changeset={@changeset} />
+
+        <label class="flex items-center gap-3 text-sm text-slate-700 dark:text-slate-300">
+          <%= checkbox f, :browser_tab_teaser?, class: checkbox_class() %>
+          <span>{Vutuv.Prefs.label(:browser_tab_teaser?)}</span>
+        </label>
+        <p class="text-sm text-slate-600 dark:text-slate-400">
+          {Vutuv.Prefs.hint(:browser_tab_teaser?)}
+        </p>
+
+        <div class="pt-1">
+          <.button type="submit">{gettext("Save")}</.button>
+        </div>
+      </.form>
+
+      <div class="mt-5 border-t border-slate-100 pt-4 dark:border-slate-800">
+        <p class="text-sm font-medium text-slate-900 dark:text-white">{gettext("Example")}</p>
+        <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+          {gettext("Watch this tab's title, above.")}
+        </p>
+        <button
+          type="button"
+          data-tab-teaser-play
+          data-frames={Jason.encode!(VutuvWeb.SettingsHTML.tab_teaser_example_frames())}
+          class="mt-3 rounded-lg border border-slate-200 px-3 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+        >
+          {gettext("Play the example")}
+        </button>
+      </div>
+
+      <%!-- Back to inheriting the installation default — see the maps card. --%>
+      <div
+        :if={Vutuv.Prefs.customized_in_group?(@user, :browser_tab)}
+        class="mt-5 border-t border-slate-100 pt-4 dark:border-slate-800"
+      >
+        <.link
+          href={~p"/settings/browser_tab/reset"}
+          method="post"
+          id="reset-browser-tab"
+          class="text-sm font-semibold text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200"
+        >
+          {gettext("Reset to the site defaults")}
+        </.link>
+      </div>
+    </.card>
+
     <%!-- Post display: how posts you read are shortened in the feed and on
           profiles. The line counts drive the CSS clamp on the preview body
           (desktop and mobile separately); 0 or an empty field means no

--- a/lib/vutuv_web/views/settings_html.ex
+++ b/lib/vutuv_web/views/settings_html.ex
@@ -126,6 +126,19 @@ defmodule VutuvWeb.SettingsHTML do
   end
 
   @doc """
+  The frames the browser tab's example plays (issue #1681), cut by the very
+  function that cuts a real arrival — so the example cannot promise a line the
+  tab would never actually show. Shares its sentence with the feed-tab card's
+  example one card above, which is the same post landing on the same evening.
+  """
+  def tab_teaser_example_frames do
+    VutuvWeb.PostTeaser.title_frames(%{
+      who: "@heikeberg",
+      text: gettext("Just flashed the new release, boot is under two seconds now")
+    })
+  end
+
+  @doc """
   One row on the settings subpages' cards: a title, an optional sub-line, and a
   right-aligned text link to where the thing is actually managed. Keeps the
   lists tidy and DRY.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.359.0",
+      version: "7.360.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -444,8 +444,8 @@ msgstr "Einloggen"
 msgid "Log Out"
 msgstr "Ausloggen"
 
-#: lib/vutuv_web/live/shell_live.ex:1024
-#: lib/vutuv_web/live/shell_live.ex:1090
+#: lib/vutuv_web/live/shell_live.ex:1207
+#: lib/vutuv_web/live/shell_live.ex:1273
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -628,11 +628,12 @@ msgstr "Öffentlich"
 #: lib/vutuv_web/templates/settings/preferences.html.heex:84
 #: lib/vutuv_web/templates/settings/preferences.html.heex:157
 #: lib/vutuv_web/templates/settings/preferences.html.heex:242
-#: lib/vutuv_web/templates/settings/preferences.html.heex:399
+#: lib/vutuv_web/templates/settings/preferences.html.heex:330
+#: lib/vutuv_web/templates/settings/preferences.html.heex:463
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:462
-#: lib/vutuv_web/views/settings_html.ex:196
+#: lib/vutuv_web/views/settings_html.ex:209
 #, elixir-autogen
 msgid "Save"
 msgstr "Speichern"
@@ -645,8 +646,8 @@ msgstr "Speichern"
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:48
 #: lib/vutuv_web/live/search_live.ex:569
-#: lib/vutuv_web/live/shell_live.ex:889
-#: lib/vutuv_web/live/shell_live.ex:1073
+#: lib/vutuv_web/live/shell_live.ex:1072
+#: lib/vutuv_web/live/shell_live.ex:1256
 #: lib/vutuv_web/live/tag_live/timeline.ex:283
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
@@ -936,7 +937,7 @@ msgid "You follow back %{name}."
 msgstr "Sie folgen %{name} jetzt zurück."
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:100
+#: lib/vutuv_web/live/post_live/feed.ex:89
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1188,7 +1189,7 @@ msgstr "Lokalisierung hinzufügen"
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:996
+#: lib/vutuv_web/live/shell_live.ex:1179
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1630,7 +1631,7 @@ msgstr "Adressen von %{name}"
 msgid "Admin control panel"
 msgstr "Admin-Bereich"
 
-#: lib/vutuv_web/live/shell_live.ex:1076
+#: lib/vutuv_web/live/shell_live.ex:1259
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "Mitteilungen"
@@ -1747,8 +1748,8 @@ msgstr ""
 " von jemandem, den Sie kennen oder interessant finden, und klicken Sie auf "
 "Folgen!"
 
-#: lib/vutuv_web/live/shell_live.ex:1015
-#: lib/vutuv_web/views/settings_html.ex:283
+#: lib/vutuv_web/live/shell_live.ex:1198
+#: lib/vutuv_web/views/settings_html.ex:296
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr "Ausloggen"
@@ -1776,14 +1777,14 @@ msgstr "Nachricht"
 
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:907
-#: lib/vutuv_web/live/shell_live.ex:1075
+#: lib/vutuv_web/live/shell_live.ex:1090
+#: lib/vutuv_web/live/shell_live.ex:1258
 #: lib/vutuv_web/templates/layout/app.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr "Nachrichten"
 
-#: lib/vutuv_web/live/shell_live.ex:791
+#: lib/vutuv_web/live/shell_live.ex:974
 #: lib/vutuv_web/templates/layout/app.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Network"
@@ -1809,7 +1810,7 @@ msgstr "Noch nichts Neues."
 #: lib/vutuv_web/components/ui.ex:4371
 #: lib/vutuv_web/live/notification_live/index.ex:132
 #: lib/vutuv_web/live/notification_live/index.ex:360
-#: lib/vutuv_web/live/shell_live.ex:919
+#: lib/vutuv_web/live/shell_live.ex:1102
 #: lib/vutuv_web/templates/layout/app.html.heex:173
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -2163,10 +2164,10 @@ msgstr "Beitrag bearbeiten"
 #: lib/vutuv_web/components/organization_components.ex:274
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:98
-#: lib/vutuv_web/live/post_live/feed.ex:231
-#: lib/vutuv_web/live/post_live/feed.ex:1650
-#: lib/vutuv_web/live/shell_live.ex:769
-#: lib/vutuv_web/live/shell_live.ex:1068
+#: lib/vutuv_web/live/post_live/feed.ex:205
+#: lib/vutuv_web/live/post_live/feed.ex:1526
+#: lib/vutuv_web/live/shell_live.ex:952
+#: lib/vutuv_web/live/shell_live.ex:1251
 #: lib/vutuv_web/templates/layout/app.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2209,7 +2210,7 @@ msgstr "Nicht eingeloggte Besucher"
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1858
+#: lib/vutuv_web/live/post_live/feed.ex:1734
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2247,7 +2248,7 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/controllers/post_controller.ex:59
 #: lib/vutuv_web/controllers/post_controller.ex:68
 #: lib/vutuv_web/controllers/user_controller.ex:77
-#: lib/vutuv_web/gettext_extraction_anchors.ex:97
+#: lib/vutuv_web/gettext_extraction_anchors.ex:103
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/live/notification_live/index.ex:926
@@ -2255,7 +2256,7 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/live/post_live/saved.ex:520
 #: lib/vutuv_web/live/search_live.ex:281
 #: lib/vutuv_web/live/search_live.ex:728
-#: lib/vutuv_web/templates/settings/preferences.html.heex:312
+#: lib/vutuv_web/templates/settings/preferences.html.heex:376
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Posts"
@@ -2286,7 +2287,7 @@ msgstr "Weniger anzeigen"
 #: lib/vutuv_web/live/post_live/saved.ex:650
 #: lib/vutuv_web/live/post_live/saved.ex:678
 #: lib/vutuv_web/templates/connection/index.html.heex:40
-#: lib/vutuv_web/views/settings_html.ex:329
+#: lib/vutuv_web/views/settings_html.ex:342
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Entfernen"
@@ -2303,7 +2304,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1762
+#: lib/vutuv_web/live/post_live/feed.ex:1638
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2341,10 +2342,10 @@ msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
 
 #: lib/vutuv_web/components/ui.ex:4671
-#: lib/vutuv_web/live/shell_live.ex:962
+#: lib/vutuv_web/live/shell_live.ex:1145
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
-#: lib/vutuv_web/views/settings_html.ex:230
+#: lib/vutuv_web/views/settings_html.ex:243
 #, elixir-autogen, elixir-format
 msgid "View profile"
 msgstr "Profil ansehen"
@@ -2385,7 +2386,7 @@ msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
 
 #: lib/vutuv_web/views/post_html.ex:19
-#: lib/vutuv_web/views/settings_html.ex:408
+#: lib/vutuv_web/views/settings_html.ex:421
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr "unbekannt"
@@ -2431,8 +2432,8 @@ msgstr "Lesezeichen setzen"
 #: lib/vutuv_web/agent_docs/markdown.ex:1108
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
-#: lib/vutuv_web/live/shell_live.ex:899
-#: lib/vutuv_web/live/shell_live.ex:967
+#: lib/vutuv_web/live/shell_live.ex:1082
+#: lib/vutuv_web/live/shell_live.ex:1150
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2453,7 +2454,7 @@ msgstr "Gefällt mir"
 #: lib/vutuv_web/live/notification_live/index.ex:1005
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
-#: lib/vutuv_web/live/shell_live.ex:970
+#: lib/vutuv_web/live/shell_live.ex:1153
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2519,7 +2520,7 @@ msgstr "Gefällt mir entfernen"
 #: lib/vutuv_web/live/organization_live/following.ex:378
 #: lib/vutuv_web/live/organization_live/following.ex:453
 #: lib/vutuv_web/live/organization_live/show.ex:474
-#: lib/vutuv_web/live/post_live/feed.ex:1907
+#: lib/vutuv_web/live/post_live/feed.ex:1783
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2812,7 +2813,7 @@ msgstr "Ersten Beitrag schreiben"
 msgid "Manage"
 msgstr "Verwalten"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1688
+#: lib/vutuv_web/live/post_live/feed.ex:1564
 #: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2833,7 +2834,7 @@ msgid_plural "%{formatted} connections"
 msgstr[0] "1 Vernetzung"
 msgstr[1] "%{formatted} Vernetzungen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2009
+#: lib/vutuv_web/live/post_live/feed.ex:1885
 #: lib/vutuv_web/templates/user/card_list.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -3223,8 +3224,8 @@ msgid "Private message"
 msgstr "Private Nachricht"
 
 #: lib/vutuv_web/components/ui.ex:4303
-#: lib/vutuv_web/live/shell_live.ex:783
-#: lib/vutuv_web/live/shell_live.ex:1080
+#: lib/vutuv_web/live/shell_live.ex:966
+#: lib/vutuv_web/live/shell_live.ex:1263
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -4714,7 +4715,7 @@ msgstr "Sie haben niemanden blockiert."
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1863
+#: lib/vutuv_web/live/post_live/feed.ex:1739
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
@@ -5103,7 +5104,7 @@ msgstr "API-Anwendungen"
 #: lib/vutuv_web/live/admin/api_app_live.ex:98
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:181
 #: lib/vutuv_web/views/settings_html.ex:75
-#: lib/vutuv_web/views/settings_html.ex:274
+#: lib/vutuv_web/views/settings_html.ex:287
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr "Aktiv"
@@ -5540,7 +5541,7 @@ msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
 msgid "Content under review"
 msgstr "Inhalte in Prüfung"
 
-#: lib/vutuv_web/live/shell_live.ex:949
+#: lib/vutuv_web/live/shell_live.ex:1132
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr "Kontomenü"
@@ -5562,7 +5563,7 @@ msgstr "Menüs und Dialoge schließen"
 msgid "General"
 msgstr "Allgemeines"
 
-#: lib/vutuv_web/live/shell_live.ex:1006
+#: lib/vutuv_web/live/shell_live.ex:1189
 #: lib/vutuv_web/templates/layout/app.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5581,7 +5582,7 @@ msgstr "Navigation"
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:303
-#: lib/vutuv_web/live/shell_live.ex:986
+#: lib/vutuv_web/live/shell_live.ex:1169
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5589,7 +5590,7 @@ msgstr "Navigation"
 #: lib/vutuv_web/templates/login_code/index.html.heex:4
 #: lib/vutuv_web/templates/totp/new.html.heex:4
 #: lib/vutuv_web/templates/username/confirm.html.heex:23
-#: lib/vutuv_web/views/settings_html.ex:225
+#: lib/vutuv_web/views/settings_html.ex:238
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr "Einstellungen"
@@ -5635,8 +5636,8 @@ msgstr "Nächster Beitrag im Feed"
 msgid "Previous post in the feed"
 msgstr "Vorheriger Beitrag im Feed"
 
-#: lib/vutuv_web/live/shell_live.ex:758
-#: lib/vutuv_web/live/shell_live.ex:1052
+#: lib/vutuv_web/live/shell_live.ex:941
+#: lib/vutuv_web/live/shell_live.ex:1235
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr "Hauptnavigation"
@@ -5650,7 +5651,7 @@ msgstr "Fußzeilen-Navigation"
 #: lib/vutuv_web/components/post_components.ex:3201
 #: lib/vutuv_web/components/post_components.ex:3620
 #: lib/vutuv_web/live/notification_live/index.ex:726
-#: lib/vutuv_web/live/post_live/feed.ex:2050
+#: lib/vutuv_web/live/post_live/feed.ex:1926
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -6075,28 +6076,28 @@ msgid "Sort"
 msgstr "Sortieren"
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/views/settings_html.ex:417
+#: lib/vutuv_web/views/settings_html.ex:430
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] "vor %{count} Tag"
 msgstr[1] "vor %{count} Tagen"
 
-#: lib/vutuv_web/views/settings_html.ex:416
+#: lib/vutuv_web/views/settings_html.ex:429
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] "vor %{count} Stunde"
 msgstr[1] "vor %{count} Stunden"
 
-#: lib/vutuv_web/views/settings_html.ex:415
+#: lib/vutuv_web/views/settings_html.ex:428
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
 msgstr[0] "vor %{count} Minute"
 msgstr[1] "vor %{count} Minuten"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:901
+#: lib/vutuv_web/controllers/settings_controller.ex:921
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr "Alle anderen Geräte wurden abgemeldet."
@@ -6106,7 +6107,7 @@ msgstr "Alle anderen Geräte wurden abgemeldet."
 msgid "Another session was already active on your account."
 msgstr "Auf Ihrem Konto war bereits eine andere Sitzung aktiv."
 
-#: lib/vutuv_web/views/settings_html.ex:263
+#: lib/vutuv_web/views/settings_html.ex:276
 #, elixir-autogen, elixir-format
 msgid "Last active"
 msgstr "Zuletzt aktiv"
@@ -6121,7 +6122,7 @@ msgstr "Alle anderen Geräte abmelden"
 msgid "Log out of every device except this one?"
 msgstr "Von allen Geräten außer diesem abmelden?"
 
-#: lib/vutuv_web/views/settings_html.ex:280
+#: lib/vutuv_web/views/settings_html.ex:293
 #, elixir-autogen, elixir-format
 msgid "Log this device out of your account?"
 msgstr "Dieses Gerät von Ihrem Konto abmelden?"
@@ -6136,7 +6137,7 @@ msgstr "Neue Anmeldung bei Ihrem vutuv-Konto"
 msgid "Signed-in devices"
 msgstr "Angemeldete Geräte"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:888
+#: lib/vutuv_web/controllers/settings_controller.ex:908
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr "Dieses Gerät wurde abgemeldet."
@@ -6146,7 +6147,7 @@ msgstr "Dieses Gerät wurde abgemeldet."
 msgid "The location looks different from where you usually sign in."
 msgstr "Der Ort weicht von dem ab, von dem Sie sich üblicherweise anmelden."
 
-#: lib/vutuv_web/views/settings_html.ex:264
+#: lib/vutuv_web/views/settings_html.ex:277
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr "Dieses Gerät"
@@ -6158,7 +6159,7 @@ msgstr ""
 "Das ist die erste Anmeldung, die wir von diesem Gerät oder Browser gesehen "
 "haben."
 
-#: lib/vutuv_web/views/settings_html.ex:414
+#: lib/vutuv_web/views/settings_html.ex:427
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr "gerade eben"
@@ -6196,7 +6197,7 @@ msgstr "Passkey hinzufügen"
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
 #: lib/vutuv_web/live/admin/screenshot_live.ex:309
 #: lib/vutuv_web/live/fediverse_following_live.ex:291
-#: lib/vutuv_web/views/settings_html.ex:315
+#: lib/vutuv_web/views/settings_html.ex:328
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr "Hinzugefügt"
@@ -6207,7 +6208,7 @@ msgid "Could not add the passkey. Please try again."
 msgstr ""
 "Der Passkey konnte nicht hinzugefügt werden. Bitte versuchen Sie es erneut."
 
-#: lib/vutuv_web/views/settings_html.ex:318
+#: lib/vutuv_web/views/settings_html.ex:331
 #, elixir-autogen, elixir-format
 msgid "Last used"
 msgstr "Zuletzt verwendet"
@@ -6217,7 +6218,7 @@ msgstr "Zuletzt verwendet"
 msgid "Name (optional)"
 msgstr "Name (optional)"
 
-#: lib/vutuv_web/views/settings_html.ex:312
+#: lib/vutuv_web/views/settings_html.ex:325
 #, elixir-autogen, elixir-format
 msgid "Passkey"
 msgstr "Passkey"
@@ -6237,7 +6238,7 @@ msgstr "Passkey entfernt."
 msgid "Passkeys"
 msgstr "Passkeys"
 
-#: lib/vutuv_web/views/settings_html.ex:326
+#: lib/vutuv_web/views/settings_html.ex:339
 #, elixir-autogen, elixir-format
 msgid "Remove this passkey?"
 msgstr "Diesen Passkey entfernen?"
@@ -6524,7 +6525,7 @@ msgstr "Karteneinstellungen gespeichert."
 msgid "Map services to show"
 msgstr "Anzuzeigende Kartendienste"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:98
+#: lib/vutuv_web/gettext_extraction_anchors.ex:104
 #: lib/vutuv_web/templates/settings/preferences.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "Maps"
@@ -6537,7 +6538,7 @@ msgstr "Karten"
 msgid "Open in %{name}"
 msgstr "In %{name} öffnen"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:96
+#: lib/vutuv_web/gettext_extraction_anchors.ex:102
 #: lib/vutuv_web/templates/settings/preferences.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "Opens first, as the main button. The others appear as alternatives."
@@ -8251,7 +8252,7 @@ msgid "Admins"
 msgstr "Administratoren"
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:2018
+#: lib/vutuv_web/live/post_live/feed.ex:1894
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr "Alle Mitglieder"
@@ -8858,12 +8859,12 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr "Geben Sie zur Bestätigung Ihren Benutzernamen ein:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2035
+#: lib/vutuv_web/live/post_live/feed.ex:1911
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr "Andere Beiträge anzeigen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2031
+#: lib/vutuv_web/live/post_live/feed.ex:1907
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr "Vorgeschlagene Beiträge"
@@ -9929,7 +9930,7 @@ msgstr "Yoruba"
 msgid "Employment status"
 msgstr "Beschäftigungsstatus"
 
-#: lib/vutuv/accounts/user.ex:1167
+#: lib/vutuv/accounts/user.ex:1173
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9940,7 +9941,7 @@ msgstr "Auf Jobsuche"
 msgid "Not open to work"
 msgstr "Nicht offen für Angebote"
 
-#: lib/vutuv/accounts/user.ex:1164
+#: lib/vutuv/accounts/user.ex:1170
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -11049,14 +11050,14 @@ msgid_plural "You have %{formatted} new messages."
 msgstr[0] "Sie haben %{formatted} neue Nachricht."
 msgstr[1] "Sie haben %{formatted} neue Nachrichten."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:383
+#: lib/vutuv_web/templates/settings/preferences.html.heex:447
 #, elixir-autogen, elixir-format
 msgid "Break long words at syllable points so the text wraps evenly. Helpful in the narrow phone column."
 msgstr ""
 "Trennt lange Wörter an Silbengrenzen, damit der Text gleichmäßig umbricht. "
 "Hilfreich in der schmalen Smartphone-Spalte."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:314
+#: lib/vutuv_web/templates/settings/preferences.html.heex:378
 #, elixir-autogen, elixir-format
 msgid "How posts you read are shortened in your feed and on profiles. These are your own reading preferences."
 msgstr ""
@@ -11064,35 +11065,35 @@ msgstr ""
 "Das sind Ihre eigenen Anzeige-Einstellungen."
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:68
-#: lib/vutuv_web/templates/settings/preferences.html.heex:390
+#: lib/vutuv_web/templates/settings/preferences.html.heex:454
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on desktop"
 msgstr "Silbentrennung am Desktop"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:69
-#: lib/vutuv_web/templates/settings/preferences.html.heex:394
+#: lib/vutuv_web/templates/settings/preferences.html.heex:458
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on mobile"
 msgstr "Silbentrennung auf dem Smartphone"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:380
+#: lib/vutuv_web/templates/settings/preferences.html.heex:444
 #, elixir-autogen, elixir-format
 msgid "Hyphenation"
 msgstr "Silbentrennung"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:66
-#: lib/vutuv_web/templates/settings/preferences.html.heex:337
+#: lib/vutuv_web/templates/settings/preferences.html.heex:401
 #, elixir-autogen, elixir-format
 msgid "Lines on desktop"
 msgstr "Zeilen am Desktop"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:67
-#: lib/vutuv_web/templates/settings/preferences.html.heex:346
+#: lib/vutuv_web/templates/settings/preferences.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "Lines on mobile"
 msgstr "Zeilen auf dem Smartphone"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:332
+#: lib/vutuv_web/templates/settings/preferences.html.heex:396
 #, elixir-autogen, elixir-format
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
@@ -11104,7 +11105,7 @@ msgstr ""
 msgid "Post display settings saved."
 msgstr "Anzeige-Einstellungen für Beiträge gespeichert."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:329
+#: lib/vutuv_web/templates/settings/preferences.html.heex:393
 #, elixir-autogen, elixir-format
 msgid "Shorten a post after"
 msgstr "Beitrag kürzen nach"
@@ -11208,7 +11209,8 @@ msgstr "Einstellungen von %{name}"
 #: lib/vutuv_web/templates/settings/preferences.html.heex:101
 #: lib/vutuv_web/templates/settings/preferences.html.heex:174
 #: lib/vutuv_web/templates/settings/preferences.html.heex:296
-#: lib/vutuv_web/templates/settings/preferences.html.heex:414
+#: lib/vutuv_web/templates/settings/preferences.html.heex:360
+#: lib/vutuv_web/templates/settings/preferences.html.heex:478
 #, elixir-autogen, elixir-format
 msgid "Reset to the site defaults"
 msgstr "Auf die Standardwerte zurücksetzen"
@@ -11242,17 +11244,17 @@ msgstr ""
 "wählt, und was ausgeloggte Besucher sehen. Änderungen gelten sofort; "
 "Mitglieder mit eigenem Wert sind nicht betroffen."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:94
+#: lib/vutuv_web/gettext_extraction_anchors.ex:100
 #, elixir-autogen, elixir-format
 msgid "0 means posts are never shortened."
 msgstr "0 bedeutet: Beiträge werden nie gekürzt."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:100
+#: lib/vutuv_web/gettext_extraction_anchors.ex:106
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr "Aus"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:99
+#: lib/vutuv_web/gettext_extraction_anchors.ex:105
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr "An"
@@ -11418,19 +11420,19 @@ msgstr ""
 " Konto anlegen kann. Wählen Sie „Niemand“, um den Status zu speichern, ohne "
 "ihn anzuzeigen."
 
-#: lib/vutuv/accounts/user.ex:1205
+#: lib/vutuv/accounts/user.ex:1211
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Alle, auch nicht angemeldete Besucher"
 
-#: lib/vutuv/accounts/user.ex:1210
+#: lib/vutuv/accounts/user.ex:1216
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Niemand"
 
-#: lib/vutuv/accounts/user.ex:1208
+#: lib/vutuv/accounts/user.ex:1214
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:761
 #, elixir-autogen, elixir-format
@@ -12480,7 +12482,7 @@ msgstr "Organisation wieder freigegeben."
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:977
+#: lib/vutuv_web/live/shell_live.ex:1160
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:100
@@ -12796,7 +12798,7 @@ msgstr "Hervorgehobene Tags passen zu Ihrem Profil."
 msgid "How to apply"
 msgstr "So bewerben Sie sich"
 
-#: lib/vutuv/accounts/user.ex:1179
+#: lib/vutuv/accounts/user.ex:1185
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12822,7 +12824,7 @@ msgstr "Stellenbezeichnung"
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:799
+#: lib/vutuv_web/live/shell_live.ex:982
 #: lib/vutuv_web/templates/layout/app.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -12915,7 +12917,7 @@ msgstr "Hier ist noch nichts. Jobs, die Ihnen gefallen, erscheinen hier."
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) für KI-Agenten anbieten."
 
-#: lib/vutuv/accounts/user.ex:1178
+#: lib/vutuv/accounts/user.ex:1184
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12997,7 +12999,7 @@ msgstr "Anzeige nicht gefunden."
 msgid "Publish"
 msgstr "Veröffentlichen"
 
-#: lib/vutuv/accounts/user.ex:1180
+#: lib/vutuv/accounts/user.ex:1186
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:564
 #: lib/vutuv_web/agent_docs/markdown.ex:458
@@ -14026,7 +14028,7 @@ msgstr "Screenshot entfernt."
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr "Dieser Screenshot wurde automatisch aus dem Link in Ihrem Beitrag erstellt. Falls er unbrauchbar ist (zum Beispiel weil ein Cookie-Banner die Seite verdeckt), können Sie ihn entfernen."
 
-#: lib/vutuv/accounts/user.ex:1223
+#: lib/vutuv/accounts/user.ex:1229
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -14037,19 +14039,19 @@ msgstr "Nur das Alter, ohne das Datum"
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr "Wählen Sie, wie viel von Ihrem Geburtstag Ihr Profil zeigt. „Nur das Alter“ verbirgt das genaue Datum, „Tag und Monat“ verbirgt das Jahr (und Ihr Alter), und „Nicht anzeigen“ speichert ihn weiterhin, hält ihn aber von Ihrem Profil fern."
 
-#: lib/vutuv/accounts/user.ex:1226
+#: lib/vutuv/accounts/user.ex:1232
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Tag und Monat, ohne das Jahr"
 
-#: lib/vutuv/accounts/user.ex:1229
+#: lib/vutuv/accounts/user.ex:1235
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Geburtstag nicht anzeigen"
 
-#: lib/vutuv/accounts/user.ex:1220
+#: lib/vutuv/accounts/user.ex:1226
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -14178,14 +14180,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4393
 #: lib/vutuv_web/controllers/settings_controller.ex:614
-#: lib/vutuv_web/live/post_live/feed.ex:1893
+#: lib/vutuv_web/live/post_live/feed.ex:1769
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr "Tags, denen Sie folgen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1908
+#: lib/vutuv_web/live/post_live/feed.ex:1784
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr "#%{tag} entfolgen"
@@ -14529,7 +14531,7 @@ msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] "Empfohlen von %{name} und %{formatted} weiteren"
 msgstr[1] "Empfohlen von %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/live/shell_live.ex:453
+#: lib/vutuv_web/live/shell_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -14652,22 +14654,22 @@ msgid "proof document"
 msgstr "Nachweis"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:74
-#: lib/vutuv_web/templates/settings/preferences.html.heex:368
+#: lib/vutuv_web/templates/settings/preferences.html.heex:432
 #, elixir-autogen, elixir-format
 msgid "Lines in notifications"
 msgstr "Zeilen in Benachrichtigungen"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:95
+#: lib/vutuv_web/gettext_extraction_anchors.ex:101
 #, elixir-autogen, elixir-format
 msgid "How much of a post a notification quotes before it is cut off."
 msgstr "Wie viel von einem Beitrag eine Benachrichtigung zitiert, bevor abgeschnitten wird."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:359
+#: lib/vutuv_web/templates/settings/preferences.html.heex:423
 #, elixir-autogen, elixir-format
 msgid "Quoted posts in notifications"
 msgstr "Zitierte Beiträge in Benachrichtigungen"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:362
+#: lib/vutuv_web/templates/settings/preferences.html.heex:426
 #, elixir-autogen, elixir-format
 msgid "Your notifications quote the post someone liked or replied to. Leave the field empty to follow the site default."
 msgstr ""
@@ -15087,7 +15089,7 @@ msgstr "Nach einem Tag filtern"
 msgid "Filter removed."
 msgstr "Filter entfernt."
 
-#: lib/vutuv_web/live/post_live/feed.ex:509
+#: lib/vutuv_web/live/post_live/feed.ex:482
 #, elixir-autogen, elixir-format
 msgid "Hidden: matches your filter"
 msgstr "Ausgeblendet: passt zu Ihrem Filter"
@@ -15122,7 +15124,7 @@ msgstr ""
 "Wählen Sie unten einen Abschluss oder eine Schule, um ihn statt eines "
 "Jobtitels oben in Ihrem Profil anzuzeigen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:518
+#: lib/vutuv_web/live/post_live/feed.ex:491
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr "Trotzdem anzeigen"
@@ -16060,7 +16062,7 @@ msgstr "Verstanden, abschalten"
 msgid "I understand, take part"
 msgstr "Verstanden, teilnehmen"
 
-#: lib/vutuv_web/views/settings_html.ex:396
+#: lib/vutuv_web/views/settings_html.ex:409
 #, elixir-autogen, elixir-format
 msgid "Most of them, not all: we cannot check whether they do it, and anything that was re-shared, archived or indexed elsewhere stays out of reach. If you take part again later, people there have to follow you anew."
 msgstr ""
@@ -16068,7 +16070,7 @@ msgstr ""
 "anderswo geteilt, archiviert oder indexiert wurde, bleibt außer Reichweite. "
 "Wenn Sie später wieder teilnehmen, müssen Ihnen die Leute dort erneut folgen."
 
-#: lib/vutuv_web/views/settings_html.ex:391
+#: lib/vutuv_web/views/settings_html.ex:404
 #, elixir-autogen, elixir-format
 msgid "No new posts go out, and your followers from other networks are removed here. The next time those servers look you up they learn that this account is gone, and most of them then delete their copies of your posts."
 msgstr ""
@@ -16077,25 +16079,25 @@ msgstr ""
 "erfahren sie, dass dieses Konto nicht mehr existiert, und die meisten löschen "
 "daraufhin ihre Kopien Ihrer Beiträge."
 
-#: lib/vutuv_web/views/settings_html.ex:372
+#: lib/vutuv_web/views/settings_html.ex:385
 #, elixir-autogen, elixir-format
 msgid "Once a post has left vutuv, it is out of our hands"
 msgstr ""
 "Was einmal von vutuv aus verschickt wurde, können wir nicht zurückholen"
 
-#: lib/vutuv_web/views/settings_html.ex:374
+#: lib/vutuv_web/views/settings_html.ex:387
 #, elixir-autogen, elixir-format
 msgid "Switching off does not delete what is already out there"
 msgstr "Abschalten löscht nicht, was bereits draußen ist"
 
-#: lib/vutuv_web/views/settings_html.ex:385
+#: lib/vutuv_web/views/settings_html.ex:398
 #, elixir-autogen, elixir-format
 msgid "Switching this off again later stops new posts from going out. It cannot bring back what has already been delivered."
 msgstr ""
 "Wenn Sie das später wieder abschalten, gehen keine neuen Beiträge mehr "
 "hinaus. Bereits zugestellte Beiträge holt das nicht zurück."
 
-#: lib/vutuv_web/views/settings_html.ex:380
+#: lib/vutuv_web/views/settings_html.ex:393
 #, elixir-autogen, elixir-format
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
@@ -17166,8 +17168,8 @@ msgstr "Fotos hinzufügen"
 msgid "Licence"
 msgstr "Lizenz"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1697
-#: lib/vutuv_web/live/post_live/feed.ex:1698
+#: lib/vutuv_web/live/post_live/feed.ex:1573
+#: lib/vutuv_web/live/post_live/feed.ex:1574
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr "Fotos posten"
@@ -18998,7 +19000,7 @@ msgstr "Meinen Namen bei Beiträgen zeigen, die mir gefallen"
 msgid "When off, other members no longer see you among the likes of a post. The author of the post still does: we named you in the notification they got when you liked it. Either way the post keeps the same number of likes."
 msgstr "Wenn aus, sehen andere Mitglieder Sie nicht mehr bei den Likes eines Beitrags. Die Autorin oder der Autor des Beitrags sieht es weiterhin: In der Benachrichtigung von damals haben wir Sie namentlich genannt. Der Beitrag hat in beiden Fällen gleich viele Likes."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:835
+#: lib/vutuv_web/controllers/settings_controller.ex:855
 #, elixir-autogen, elixir-format
 msgid "Your likes follow the site default again."
 msgstr "Ihre Likes folgen wieder dem Standardwert der Website."
@@ -19952,17 +19954,17 @@ msgstr ""
 "Kommt keine PIN an? Ist die E-Mail-Adresse {email} korrekt? Haben Sie einmal "
 "in Ihren Spam-Ordner geschaut?"
 
-#: lib/vutuv/accounts/user.ex:1326
+#: lib/vutuv/accounts/user.ex:1332
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/vutuv/accounts/user.ex:1324
+#: lib/vutuv/accounts/user.ex:1330
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr "Weiblich"
 
-#: lib/vutuv/accounts/user.ex:1325
+#: lib/vutuv/accounts/user.ex:1331
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Männlich"
@@ -20741,7 +20743,7 @@ msgstr "Sie dürfen nicht mehr im Namen dieser Organisation schreiben."
 msgid "A post in an organization's name is always public."
 msgstr "Ein Beitrag im Namen einer Organisation ist immer öffentlich."
 
-#: lib/vutuv_web/live/shell_live.ex:716
+#: lib/vutuv_web/live/shell_live.ex:899
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr "Seite öffnen"
@@ -20761,7 +20763,7 @@ msgstr "Beendet, im Namen einer Organisation zu schreiben"
 msgid "Write as %{name} for now"
 msgstr "Vorerst als %{name} schreiben"
 
-#: lib/vutuv_web/live/shell_live.ex:726
+#: lib/vutuv_web/live/shell_live.ex:909
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr "Wieder als ich selbst schreiben"
@@ -20771,7 +20773,7 @@ msgstr "Wieder als ich selbst schreiben"
 msgid "You are writing as %{name} now."
 msgstr "Sie schreiben jetzt als %{name}."
 
-#: lib/vutuv_web/live/shell_live.ex:702
+#: lib/vutuv_web/live/shell_live.ex:885
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr "Sie schreiben als %{name}."
@@ -21135,21 +21137,21 @@ msgstr "Sie folgen #%{tag} hier bereits."
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr "Sie sind selbst auf diesem vutuv. Sie folgen #%{tag} jetzt direkt hier."
 
-#: lib/vutuv_web/live/shell_live.ex:483
+#: lib/vutuv_web/live/shell_live.ex:533
 #, elixir-autogen, elixir-format
 msgid "%{formatted} person"
 msgid_plural "%{formatted} people"
 msgstr[0] "%{formatted} Person"
 msgstr[1] "%{formatted} Personen"
 
-#: lib/vutuv_web/live/shell_live.ex:470
+#: lib/vutuv_web/live/shell_live.ex:520
 #, elixir-autogen, elixir-format
 msgid "person"
 msgid_plural "people"
 msgstr[0] "Person"
 msgstr[1] "Personen"
 
-#: lib/vutuv_web/live/shell_live.ex:505
+#: lib/vutuv_web/live/shell_live.ex:555
 #, elixir-autogen, elixir-format
 msgid "%{members} vutuv members plus %{fediverse} Fediverse account that follows them"
 msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that follow them"
@@ -21625,7 +21627,7 @@ msgstr "In meine Sprache übersetzen"
 msgid "What your feed does with posts outside your chosen languages: show them as they are, translate them for you, or hide them. Posts that declare no language always show."
 msgstr "Was Ihr Feed mit Beiträgen außerhalb Ihrer gewählten Sprachen macht: im Original zeigen, für Sie übersetzen oder ausblenden. Beiträge ohne Sprachangabe werden immer gezeigt."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:104
+#: lib/vutuv_web/gettext_extraction_anchors.ex:110
 #, elixir-autogen, elixir-format
 msgid "Date & time"
 msgstr "Datum & Uhrzeit"
@@ -21635,12 +21637,12 @@ msgstr "Datum & Uhrzeit"
 msgid "Date and time settings reset to the site defaults."
 msgstr "Datum und Uhrzeit folgen wieder den Voreinstellungen der Website."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:102
+#: lib/vutuv_web/gettext_extraction_anchors.ex:108
 #, elixir-autogen, elixir-format
 msgid "Date format"
 msgstr "Datumsformat"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:112
+#: lib/vutuv_web/gettext_extraction_anchors.ex:118
 #, elixir-autogen, elixir-format
 msgid "Germany, Austria, Switzerland"
 msgstr "Deutschland, Österreich, Schweiz"
@@ -21650,27 +21652,27 @@ msgstr "Deutschland, Österreich, Schweiz"
 msgid "Language and region saved."
 msgstr "Sprache und Region gespeichert."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:108
+#: lib/vutuv_web/gettext_extraction_anchors.ex:114
 #, elixir-autogen, elixir-format
 msgid "Posts, messages and notifications are stamped in this zone. New accounts take it from the browser."
 msgstr "Beiträge, Nachrichten und Benachrichtigungen tragen die Uhrzeit dieser Zeitzone. Neue Konten übernehmen sie vom Browser."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:105
+#: lib/vutuv_web/gettext_extraction_anchors.ex:111
 #, elixir-autogen, elixir-format
 msgid "The order and punctuation of every date you read here, and whether times run on a 12- or 24-hour clock."
 msgstr "Reihenfolge und Trennzeichen aller Datumsangaben, die Sie hier lesen, und ob Uhrzeiten im 12- oder 24-Stunden-Format stehen."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:103
+#: lib/vutuv_web/gettext_extraction_anchors.ex:109
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr "Zeitzone"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:113
+#: lib/vutuv_web/gettext_extraction_anchors.ex:119
 #, elixir-autogen, elixir-format
 msgid "United Kingdom, France, Brazil"
 msgstr "Vereinigtes Königreich, Frankreich, Brasilien"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:114
+#: lib/vutuv_web/gettext_extraction_anchors.ex:120
 #, elixir-autogen, elixir-format
 msgid "United States"
 msgstr "Vereinigte Staaten"
@@ -21680,7 +21682,7 @@ msgstr "Vereinigte Staaten"
 msgid "Your browser says: {zone}"
 msgstr "Ihr Browser meldet: {zone}"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:115
+#: lib/vutuv_web/gettext_extraction_anchors.ex:121
 #, elixir-autogen, elixir-format
 msgid "ISO 8601 (Sweden, Japan, China)"
 msgstr "ISO 8601 (Schweden, Japan, China)"
@@ -21754,7 +21756,7 @@ msgstr "Empfohlen: %{width} × %{height} Pixel (%{ratio})."
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr "Empfohlen: quadratisch, mindestens %{width} × %{height} Pixel."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1950
+#: lib/vutuv_web/live/post_live/feed.ex:1826
 #: lib/vutuv_web/views/user_html.ex:334
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -22258,7 +22260,7 @@ msgstr "%{handle} nicht mehr folgen? Die Beiträge verschwinden aus Ihrem Feed."
 msgid "Unfollowed. Their posts leave your feed."
 msgstr "Nicht mehr gefolgt. Die Beiträge verschwinden aus Ihrem Feed."
 
-#: lib/vutuv_web/live/shell_live.ex:672
+#: lib/vutuv_web/live/shell_live.ex:855
 #, elixir-autogen, elixir-format
 msgid "Allow"
 msgstr "Erlauben"
@@ -22273,12 +22275,12 @@ msgstr "Jetzt fragen"
 msgid "Browser notifications"
 msgstr "Browser-Benachrichtigungen"
 
-#: lib/vutuv_web/live/shell_live.ex:614
+#: lib/vutuv_web/live/shell_live.ex:797
 #, elixir-autogen, elixir-format
 msgid "New message"
 msgstr "Neue Nachricht"
 
-#: lib/vutuv_web/live/shell_live.ex:679
+#: lib/vutuv_web/live/shell_live.ex:862
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr "Jetzt nicht"
@@ -22318,7 +22320,7 @@ msgstr "Dieser Browser zeigt sie an."
 msgid "When something arrives while you have vutuv open in a tab you are not looking at, your browser can show it as a notification. Off unless you switch it on."
 msgstr "Wenn etwas eintrifft, während vutuv in einem Tab offen ist, den Sie gerade nicht ansehen, kann Ihr Browser es als Benachrichtigung anzeigen. Aus, solange Sie es nicht einschalten."
 
-#: lib/vutuv_web/live/shell_live.ex:669
+#: lib/vutuv_web/live/shell_live.ex:852
 #, elixir-autogen, elixir-format
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr "Sie haben Browser-Benachrichtigungen eingeschaltet. Dieser Browser wurde noch nicht um Erlaubnis gebeten."
@@ -22358,12 +22360,12 @@ msgstr "Test-Benachrichtigung senden"
 msgid "Sent. If nothing appeared, your system is holding it back. Check Do Not Disturb and your notification settings."
 msgstr "Gesendet. Wenn nichts erschienen ist, hält Ihr System sie zurück. Prüfen Sie „Nicht stören“ und Ihre Benachrichtigungseinstellungen."
 
-#: lib/vutuv_web/live/shell_live.ex:569
+#: lib/vutuv_web/live/shell_live.ex:619
 #, elixir-autogen, elixir-format
 msgid "Test notification"
 msgstr "Test-Benachrichtigung"
 
-#: lib/vutuv_web/live/shell_live.ex:570
+#: lib/vutuv_web/live/shell_live.ex:620
 #, elixir-autogen, elixir-format
 msgid "This is what vutuv looks like when something arrives."
 msgstr "So sieht es aus, wenn auf vutuv etwas für Sie eintrifft."
@@ -22374,12 +22376,12 @@ msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public po
 msgstr ""
 "Folgen Sie #%{tag} von Mastodon oder einer anderen Fediverse-App aus, dann landen die öffentlichen Beiträge in Ihrer Timeline. Ein vutuv-Konto brauchen Sie dafür nicht."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1932
+#: lib/vutuv_web/live/post_live/feed.ex:1808
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Andere Mitglieder begrüßen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1928
+#: lib/vutuv_web/live/post_live/feed.ex:1804
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr "Neu dabei"
@@ -22425,7 +22427,7 @@ msgstr "Der beste Weg: Folgen Sie %{name} hier. Neue Beiträge landen in Ihrem F
 msgid "With a vutuv account"
 msgstr "Mit einem vutuv-Konto"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1942
+#: lib/vutuv_web/live/post_live/feed.ex:1818
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
@@ -22439,24 +22441,25 @@ msgid_plural "%{formatted} new posts"
 msgstr[0] "%{formatted} neuer Beitrag"
 msgstr[1] "%{formatted} neue Beiträge"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1387
+#: lib/vutuv_web/live/post_live/feed.ex:1288
 #, elixir-autogen, elixir-format
 msgid "%{source}: %{formatted} new post"
 msgid_plural "%{source}: %{formatted} new posts"
 msgstr[0] "%{source}: %{formatted} neuer Beitrag"
 msgstr[1] "%{source}: %{formatted} neue Beiträge"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1384
+#: lib/vutuv_web/live/post_live/feed.ex:1285
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post"
 msgstr "%{source}: neuer Beitrag"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1381
+#: lib/vutuv_web/live/post_live/feed.ex:1282
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post from %{who}"
 msgstr "%{source}: neuer Beitrag von %{who}"
 
 #: lib/vutuv_web/templates/settings/preferences.html.heex:247
+#: lib/vutuv_web/templates/settings/preferences.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "Example"
 msgstr "Beispiel"
@@ -22478,11 +22481,13 @@ msgid "Feed tabs"
 msgstr "Feed-Reiter"
 
 #: lib/vutuv_web/templates/settings/preferences.html.heex:271
+#: lib/vutuv_web/views/settings_html.ex:137
 #, elixir-autogen, elixir-format
 msgid "Just flashed the new release, boot is under two seconds now"
 msgstr "Neue Version geflasht, der Bootvorgang liegt jetzt unter zwei Sekunden"
 
 #: lib/vutuv_web/templates/settings/preferences.html.heex:281
+#: lib/vutuv_web/templates/settings/preferences.html.heex:345
 #, elixir-autogen, elixir-format
 msgid "Play the example"
 msgstr "Beispiel abspielen"
@@ -22492,7 +22497,7 @@ msgstr "Beispiel abspielen"
 msgid "When a post lands on the source tab you are not reading, that tab gets a dot. It can also quote the post for a few seconds, so you can tell whether it is worth switching."
 msgstr "Landet ein Beitrag auf dem Quellen-Reiter, den Sie gerade nicht lesen, bekommt dieser Reiter einen Punkt. Er kann den Beitrag auch ein paar Sekunden lang anreißen, damit Sie sehen, ob sich ein Wechsel lohnt."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:93
+#: lib/vutuv_web/gettext_extraction_anchors.ex:99
 #, elixir-autogen, elixir-format
 msgid "Between 4 and 20 seconds."
 msgstr "Zwischen 4 und 20 Sekunden."
@@ -22642,3 +22647,46 @@ msgstr "In %{language} übersetzen"
 #, elixir-autogen, elixir-format
 msgid "Translated into %{language}."
 msgstr "Wird in %{language} übersetzt."
+
+#: lib/vutuv_web/live/shell_live.ex:736
+#, elixir-autogen, elixir-format
+msgid "+%{formatted} more post"
+msgid_plural "+%{formatted} more posts"
+msgstr[0] "+%{formatted} weiterer Beitrag"
+msgstr[1] "+%{formatted} weitere Beiträge"
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:94
+#: lib/vutuv_web/templates/settings/preferences.html.heex:311
+#, elixir-autogen, elixir-format
+msgid "Browser tab"
+msgstr "Browser-Tab"
+
+#: lib/vutuv_web/controllers/settings_controller.ex:846
+#, elixir-autogen, elixir-format
+msgid "Browser tab settings reset to the site defaults."
+msgstr "Einstellungen für den Browser-Tab auf die Website-Vorgaben zurückgesetzt."
+
+#: lib/vutuv_web/controllers/settings_controller.ex:840
+#, elixir-autogen, elixir-format
+msgid "Browser tab settings saved."
+msgstr "Einstellungen für den Browser-Tab gespeichert."
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:96
+#, elixir-autogen, elixir-format
+msgid "Only while you are looking at another tab, and only for a few seconds. The tab title also shows up in screenshots, in your window switcher and in a screen share."
+msgstr "Nur solange Sie einen anderen Tab ansehen, und nur für ein paar Sekunden. Der Titel eines Tabs erscheint auch in Screenshots, in Ihrer Fensterauswahl und bei einer Bildschirmfreigabe."
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:95
+#, elixir-autogen, elixir-format
+msgid "Tease new posts in the browser tab"
+msgstr "Neue Beiträge im Browser-Tab anreißen"
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:337
+#, elixir-autogen, elixir-format
+msgid "Watch this tab's title, above."
+msgstr "Achten Sie oben auf den Titel dieses Tabs."
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:313
+#, elixir-autogen, elixir-format
+msgid "While you are reading another tab, a new post can page its first words through this tab's title, a line at a time, and then hand the title back."
+msgstr "Während Sie einen anderen Tab lesen, kann ein neuer Beitrag seine ersten Worte durch den Titel dieses Tabs blättern, Zeile für Zeile, und den Titel danach wieder freigeben."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -444,8 +444,8 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1024
-#: lib/vutuv_web/live/shell_live.ex:1090
+#: lib/vutuv_web/live/shell_live.ex:1207
+#: lib/vutuv_web/live/shell_live.ex:1273
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -628,11 +628,12 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/preferences.html.heex:84
 #: lib/vutuv_web/templates/settings/preferences.html.heex:157
 #: lib/vutuv_web/templates/settings/preferences.html.heex:242
-#: lib/vutuv_web/templates/settings/preferences.html.heex:399
+#: lib/vutuv_web/templates/settings/preferences.html.heex:330
+#: lib/vutuv_web/templates/settings/preferences.html.heex:463
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:462
-#: lib/vutuv_web/views/settings_html.ex:196
+#: lib/vutuv_web/views/settings_html.ex:209
 #, elixir-autogen
 msgid "Save"
 msgstr ""
@@ -645,8 +646,8 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:48
 #: lib/vutuv_web/live/search_live.ex:569
-#: lib/vutuv_web/live/shell_live.ex:889
-#: lib/vutuv_web/live/shell_live.ex:1073
+#: lib/vutuv_web/live/shell_live.ex:1072
+#: lib/vutuv_web/live/shell_live.ex:1256
 #: lib/vutuv_web/live/tag_live/timeline.ex:283
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
@@ -926,7 +927,7 @@ msgid "You follow back %{name}."
 msgstr ""
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:100
+#: lib/vutuv_web/live/post_live/feed.ex:89
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1164,7 +1165,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:996
+#: lib/vutuv_web/live/shell_live.ex:1179
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1598,7 +1599,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1076
+#: lib/vutuv_web/live/shell_live.ex:1259
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1712,8 +1713,8 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1015
-#: lib/vutuv_web/views/settings_html.ex:283
+#: lib/vutuv_web/live/shell_live.ex:1198
+#: lib/vutuv_web/views/settings_html.ex:296
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr ""
@@ -1741,14 +1742,14 @@ msgstr ""
 
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:907
-#: lib/vutuv_web/live/shell_live.ex:1075
+#: lib/vutuv_web/live/shell_live.ex:1090
+#: lib/vutuv_web/live/shell_live.ex:1258
 #: lib/vutuv_web/templates/layout/app.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:791
+#: lib/vutuv_web/live/shell_live.ex:974
 #: lib/vutuv_web/templates/layout/app.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Network"
@@ -1774,7 +1775,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:4371
 #: lib/vutuv_web/live/notification_live/index.ex:132
 #: lib/vutuv_web/live/notification_live/index.ex:360
-#: lib/vutuv_web/live/shell_live.ex:919
+#: lib/vutuv_web/live/shell_live.ex:1102
 #: lib/vutuv_web/templates/layout/app.html.heex:173
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -2120,10 +2121,10 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:274
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:98
-#: lib/vutuv_web/live/post_live/feed.ex:231
-#: lib/vutuv_web/live/post_live/feed.ex:1650
-#: lib/vutuv_web/live/shell_live.ex:769
-#: lib/vutuv_web/live/shell_live.ex:1068
+#: lib/vutuv_web/live/post_live/feed.ex:205
+#: lib/vutuv_web/live/post_live/feed.ex:1526
+#: lib/vutuv_web/live/shell_live.ex:952
+#: lib/vutuv_web/live/shell_live.ex:1251
 #: lib/vutuv_web/templates/layout/app.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2166,7 +2167,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1858
+#: lib/vutuv_web/live/post_live/feed.ex:1734
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2202,7 +2203,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/post_controller.ex:59
 #: lib/vutuv_web/controllers/post_controller.ex:68
 #: lib/vutuv_web/controllers/user_controller.ex:77
-#: lib/vutuv_web/gettext_extraction_anchors.ex:97
+#: lib/vutuv_web/gettext_extraction_anchors.ex:103
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/live/notification_live/index.ex:926
@@ -2210,7 +2211,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:520
 #: lib/vutuv_web/live/search_live.ex:281
 #: lib/vutuv_web/live/search_live.ex:728
-#: lib/vutuv_web/templates/settings/preferences.html.heex:312
+#: lib/vutuv_web/templates/settings/preferences.html.heex:376
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Posts"
@@ -2241,7 +2242,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:650
 #: lib/vutuv_web/live/post_live/saved.ex:678
 #: lib/vutuv_web/templates/connection/index.html.heex:40
-#: lib/vutuv_web/views/settings_html.ex:329
+#: lib/vutuv_web/views/settings_html.ex:342
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
@@ -2256,7 +2257,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1762
+#: lib/vutuv_web/live/post_live/feed.ex:1638
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2294,10 +2295,10 @@ msgid "Upload failed."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4671
-#: lib/vutuv_web/live/shell_live.ex:962
+#: lib/vutuv_web/live/shell_live.ex:1145
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
-#: lib/vutuv_web/views/settings_html.ex:230
+#: lib/vutuv_web/views/settings_html.ex:243
 #, elixir-autogen, elixir-format
 msgid "View profile"
 msgstr ""
@@ -2338,7 +2339,7 @@ msgid "people you don't follow"
 msgstr ""
 
 #: lib/vutuv_web/views/post_html.ex:19
-#: lib/vutuv_web/views/settings_html.ex:408
+#: lib/vutuv_web/views/settings_html.ex:421
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr ""
@@ -2384,8 +2385,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1108
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
-#: lib/vutuv_web/live/shell_live.ex:899
-#: lib/vutuv_web/live/shell_live.ex:967
+#: lib/vutuv_web/live/shell_live.ex:1082
+#: lib/vutuv_web/live/shell_live.ex:1150
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2406,7 +2407,7 @@ msgstr ""
 #: lib/vutuv_web/live/notification_live/index.ex:1005
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
-#: lib/vutuv_web/live/shell_live.ex:970
+#: lib/vutuv_web/live/shell_live.ex:1153
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2472,7 +2473,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:378
 #: lib/vutuv_web/live/organization_live/following.ex:453
 #: lib/vutuv_web/live/organization_live/show.ex:474
-#: lib/vutuv_web/live/post_live/feed.ex:1907
+#: lib/vutuv_web/live/post_live/feed.ex:1783
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2763,7 +2764,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1688
+#: lib/vutuv_web/live/post_live/feed.ex:1564
 #: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2784,7 +2785,7 @@ msgid_plural "%{formatted} connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2009
+#: lib/vutuv_web/live/post_live/feed.ex:1885
 #: lib/vutuv_web/templates/user/card_list.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -3152,8 +3153,8 @@ msgid "Private message"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4303
-#: lib/vutuv_web/live/shell_live.ex:783
-#: lib/vutuv_web/live/shell_live.ex:1080
+#: lib/vutuv_web/live/shell_live.ex:966
+#: lib/vutuv_web/live/shell_live.ex:1263
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -4545,7 +4546,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1863
+#: lib/vutuv_web/live/post_live/feed.ex:1739
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -4913,7 +4914,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/api_app_live.ex:98
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:181
 #: lib/vutuv_web/views/settings_html.ex:75
-#: lib/vutuv_web/views/settings_html.ex:274
+#: lib/vutuv_web/views/settings_html.ex:287
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
@@ -5317,7 +5318,7 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:949
+#: lib/vutuv_web/live/shell_live.ex:1132
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
@@ -5339,7 +5340,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1006
+#: lib/vutuv_web/live/shell_live.ex:1189
 #: lib/vutuv_web/templates/layout/app.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5358,7 +5359,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:303
-#: lib/vutuv_web/live/shell_live.ex:986
+#: lib/vutuv_web/live/shell_live.ex:1169
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5366,7 +5367,7 @@ msgstr ""
 #: lib/vutuv_web/templates/login_code/index.html.heex:4
 #: lib/vutuv_web/templates/totp/new.html.heex:4
 #: lib/vutuv_web/templates/username/confirm.html.heex:23
-#: lib/vutuv_web/views/settings_html.ex:225
+#: lib/vutuv_web/views/settings_html.ex:238
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -5412,8 +5413,8 @@ msgstr ""
 msgid "Previous post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:758
-#: lib/vutuv_web/live/shell_live.ex:1052
+#: lib/vutuv_web/live/shell_live.ex:941
+#: lib/vutuv_web/live/shell_live.ex:1235
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -5427,7 +5428,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:3201
 #: lib/vutuv_web/components/post_components.ex:3620
 #: lib/vutuv_web/live/notification_live/index.ex:726
-#: lib/vutuv_web/live/post_live/feed.ex:2050
+#: lib/vutuv_web/live/post_live/feed.ex:1926
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5845,28 +5846,28 @@ msgid "Sort"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/views/settings_html.ex:417
+#: lib/vutuv_web/views/settings_html.ex:430
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:416
+#: lib/vutuv_web/views/settings_html.ex:429
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:415
+#: lib/vutuv_web/views/settings_html.ex:428
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:901
+#: lib/vutuv_web/controllers/settings_controller.ex:921
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr ""
@@ -5876,7 +5877,7 @@ msgstr ""
 msgid "Another session was already active on your account."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:263
+#: lib/vutuv_web/views/settings_html.ex:276
 #, elixir-autogen, elixir-format
 msgid "Last active"
 msgstr ""
@@ -5891,7 +5892,7 @@ msgstr ""
 msgid "Log out of every device except this one?"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:280
+#: lib/vutuv_web/views/settings_html.ex:293
 #, elixir-autogen, elixir-format
 msgid "Log this device out of your account?"
 msgstr ""
@@ -5906,7 +5907,7 @@ msgstr ""
 msgid "Signed-in devices"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:888
+#: lib/vutuv_web/controllers/settings_controller.ex:908
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr ""
@@ -5916,7 +5917,7 @@ msgstr ""
 msgid "The location looks different from where you usually sign in."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:264
+#: lib/vutuv_web/views/settings_html.ex:277
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr ""
@@ -5926,7 +5927,7 @@ msgstr ""
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:414
+#: lib/vutuv_web/views/settings_html.ex:427
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr ""
@@ -5960,7 +5961,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
 #: lib/vutuv_web/live/admin/screenshot_live.ex:309
 #: lib/vutuv_web/live/fediverse_following_live.ex:291
-#: lib/vutuv_web/views/settings_html.ex:315
+#: lib/vutuv_web/views/settings_html.ex:328
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr ""
@@ -5970,7 +5971,7 @@ msgstr ""
 msgid "Could not add the passkey. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:318
+#: lib/vutuv_web/views/settings_html.ex:331
 #, elixir-autogen, elixir-format
 msgid "Last used"
 msgstr ""
@@ -5980,7 +5981,7 @@ msgstr ""
 msgid "Name (optional)"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:312
+#: lib/vutuv_web/views/settings_html.ex:325
 #, elixir-autogen, elixir-format
 msgid "Passkey"
 msgstr ""
@@ -6000,7 +6001,7 @@ msgstr ""
 msgid "Passkeys"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:326
+#: lib/vutuv_web/views/settings_html.ex:339
 #, elixir-autogen, elixir-format
 msgid "Remove this passkey?"
 msgstr ""
@@ -6276,7 +6277,7 @@ msgstr ""
 msgid "Map services to show"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:98
+#: lib/vutuv_web/gettext_extraction_anchors.ex:104
 #: lib/vutuv_web/templates/settings/preferences.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "Maps"
@@ -6289,7 +6290,7 @@ msgstr ""
 msgid "Open in %{name}"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:96
+#: lib/vutuv_web/gettext_extraction_anchors.ex:102
 #: lib/vutuv_web/templates/settings/preferences.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "Opens first, as the main button. The others appear as alternatives."
@@ -7900,7 +7901,7 @@ msgid "Admins"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:2018
+#: lib/vutuv_web/live/post_live/feed.ex:1894
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr ""
@@ -8457,12 +8458,12 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2035
+#: lib/vutuv_web/live/post_live/feed.ex:1911
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2031
+#: lib/vutuv_web/live/post_live/feed.ex:1907
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr ""
@@ -9469,7 +9470,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1167
+#: lib/vutuv/accounts/user.ex:1173
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9480,7 +9481,7 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1164
+#: lib/vutuv/accounts/user.ex:1170
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -10505,46 +10506,46 @@ msgid_plural "You have %{formatted} new messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:383
+#: lib/vutuv_web/templates/settings/preferences.html.heex:447
 #, elixir-autogen, elixir-format
 msgid "Break long words at syllable points so the text wraps evenly. Helpful in the narrow phone column."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:314
+#: lib/vutuv_web/templates/settings/preferences.html.heex:378
 #, elixir-autogen, elixir-format
 msgid "How posts you read are shortened in your feed and on profiles. These are your own reading preferences."
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:68
-#: lib/vutuv_web/templates/settings/preferences.html.heex:390
+#: lib/vutuv_web/templates/settings/preferences.html.heex:454
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on desktop"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:69
-#: lib/vutuv_web/templates/settings/preferences.html.heex:394
+#: lib/vutuv_web/templates/settings/preferences.html.heex:458
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on mobile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:380
+#: lib/vutuv_web/templates/settings/preferences.html.heex:444
 #, elixir-autogen, elixir-format
 msgid "Hyphenation"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:66
-#: lib/vutuv_web/templates/settings/preferences.html.heex:337
+#: lib/vutuv_web/templates/settings/preferences.html.heex:401
 #, elixir-autogen, elixir-format
 msgid "Lines on desktop"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:67
-#: lib/vutuv_web/templates/settings/preferences.html.heex:346
+#: lib/vutuv_web/templates/settings/preferences.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "Lines on mobile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:332
+#: lib/vutuv_web/templates/settings/preferences.html.heex:396
 #, elixir-autogen, elixir-format
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
@@ -10554,7 +10555,7 @@ msgstr ""
 msgid "Post display settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:329
+#: lib/vutuv_web/templates/settings/preferences.html.heex:393
 #, elixir-autogen, elixir-format
 msgid "Shorten a post after"
 msgstr ""
@@ -10643,7 +10644,8 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/preferences.html.heex:101
 #: lib/vutuv_web/templates/settings/preferences.html.heex:174
 #: lib/vutuv_web/templates/settings/preferences.html.heex:296
-#: lib/vutuv_web/templates/settings/preferences.html.heex:414
+#: lib/vutuv_web/templates/settings/preferences.html.heex:360
+#: lib/vutuv_web/templates/settings/preferences.html.heex:478
 #, elixir-autogen, elixir-format
 msgid "Reset to the site defaults"
 msgstr ""
@@ -10674,17 +10676,17 @@ msgstr ""
 msgid "What every member gets until they choose for themselves on their settings pages, and what logged-out visitors see. Changes apply immediately; members who set their own value are not affected."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:94
+#: lib/vutuv_web/gettext_extraction_anchors.ex:100
 #, elixir-autogen, elixir-format
 msgid "0 means posts are never shortened."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:100
+#: lib/vutuv_web/gettext_extraction_anchors.ex:106
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:99
+#: lib/vutuv_web/gettext_extraction_anchors.ex:105
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr ""
@@ -10834,19 +10836,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1205
+#: lib/vutuv/accounts/user.ex:1211
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1210
+#: lib/vutuv/accounts/user.ex:1216
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1208
+#: lib/vutuv/accounts/user.ex:1214
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:761
 #, elixir-autogen, elixir-format
@@ -11841,7 +11843,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:977
+#: lib/vutuv_web/live/shell_live.ex:1160
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:100
@@ -12144,7 +12146,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1179
+#: lib/vutuv/accounts/user.ex:1185
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12170,7 +12172,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:799
+#: lib/vutuv_web/live/shell_live.ex:982
 #: lib/vutuv_web/templates/layout/app.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -12263,7 +12265,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1178
+#: lib/vutuv/accounts/user.ex:1184
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12345,7 +12347,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1180
+#: lib/vutuv/accounts/user.ex:1186
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:564
 #: lib/vutuv_web/agent_docs/markdown.ex:458
@@ -13360,7 +13362,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1223
+#: lib/vutuv/accounts/user.ex:1229
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13371,19 +13373,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1226
+#: lib/vutuv/accounts/user.ex:1232
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1229
+#: lib/vutuv/accounts/user.ex:1235
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1220
+#: lib/vutuv/accounts/user.ex:1226
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13507,14 +13509,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4393
 #: lib/vutuv_web/controllers/settings_controller.ex:614
-#: lib/vutuv_web/live/post_live/feed.ex:1893
+#: lib/vutuv_web/live/post_live/feed.ex:1769
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1908
+#: lib/vutuv_web/live/post_live/feed.ex:1784
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr ""
@@ -13856,7 +13858,7 @@ msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:453
+#: lib/vutuv_web/live/shell_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -13979,22 +13981,22 @@ msgid "proof document"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:74
-#: lib/vutuv_web/templates/settings/preferences.html.heex:368
+#: lib/vutuv_web/templates/settings/preferences.html.heex:432
 #, elixir-autogen, elixir-format
 msgid "Lines in notifications"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:95
+#: lib/vutuv_web/gettext_extraction_anchors.ex:101
 #, elixir-autogen, elixir-format
 msgid "How much of a post a notification quotes before it is cut off."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:359
+#: lib/vutuv_web/templates/settings/preferences.html.heex:423
 #, elixir-autogen, elixir-format
 msgid "Quoted posts in notifications"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:362
+#: lib/vutuv_web/templates/settings/preferences.html.heex:426
 #, elixir-autogen, elixir-format
 msgid "Your notifications quote the post someone liked or replied to. Leave the field empty to follow the site default."
 msgstr ""
@@ -14392,7 +14394,7 @@ msgstr ""
 msgid "Filter removed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:509
+#: lib/vutuv_web/live/post_live/feed.ex:482
 #, elixir-autogen, elixir-format
 msgid "Hidden: matches your filter"
 msgstr ""
@@ -14425,7 +14427,7 @@ msgstr ""
 msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:518
+#: lib/vutuv_web/live/post_live/feed.ex:491
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr ""
@@ -15363,32 +15365,32 @@ msgstr ""
 msgid "I understand, take part"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:396
+#: lib/vutuv_web/views/settings_html.ex:409
 #, elixir-autogen, elixir-format
 msgid "Most of them, not all: we cannot check whether they do it, and anything that was re-shared, archived or indexed elsewhere stays out of reach. If you take part again later, people there have to follow you anew."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:391
+#: lib/vutuv_web/views/settings_html.ex:404
 #, elixir-autogen, elixir-format
 msgid "No new posts go out, and your followers from other networks are removed here. The next time those servers look you up they learn that this account is gone, and most of them then delete their copies of your posts."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:372
+#: lib/vutuv_web/views/settings_html.ex:385
 #, elixir-autogen, elixir-format
 msgid "Once a post has left vutuv, it is out of our hands"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:374
+#: lib/vutuv_web/views/settings_html.ex:387
 #, elixir-autogen, elixir-format
 msgid "Switching off does not delete what is already out there"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:385
+#: lib/vutuv_web/views/settings_html.ex:398
 #, elixir-autogen, elixir-format
 msgid "Switching this off again later stops new posts from going out. It cannot bring back what has already been delivered."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:380
+#: lib/vutuv_web/views/settings_html.ex:393
 #, elixir-autogen, elixir-format
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
@@ -16445,8 +16447,8 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1697
-#: lib/vutuv_web/live/post_live/feed.ex:1698
+#: lib/vutuv_web/live/post_live/feed.ex:1573
+#: lib/vutuv_web/live/post_live/feed.ex:1574
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr ""
@@ -18252,7 +18254,7 @@ msgstr ""
 msgid "When off, other members no longer see you among the likes of a post. The author of the post still does: we named you in the notification they got when you liked it. Either way the post keeps the same number of likes."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:835
+#: lib/vutuv_web/controllers/settings_controller.ex:855
 #, elixir-autogen, elixir-format
 msgid "Your likes follow the site default again."
 msgstr ""
@@ -19188,17 +19190,17 @@ msgstr ""
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1326
+#: lib/vutuv/accounts/user.ex:1332
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1324
+#: lib/vutuv/accounts/user.ex:1330
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1325
+#: lib/vutuv/accounts/user.ex:1331
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -19975,7 +19977,7 @@ msgstr ""
 msgid "A post in an organization's name is always public."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:716
+#: lib/vutuv_web/live/shell_live.ex:899
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr ""
@@ -19995,7 +19997,7 @@ msgstr ""
 msgid "Write as %{name} for now"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:726
+#: lib/vutuv_web/live/shell_live.ex:909
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr ""
@@ -20005,7 +20007,7 @@ msgstr ""
 msgid "You are writing as %{name} now."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:702
+#: lib/vutuv_web/live/shell_live.ex:885
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr ""
@@ -20369,21 +20371,21 @@ msgstr ""
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:483
+#: lib/vutuv_web/live/shell_live.ex:533
 #, elixir-autogen, elixir-format
 msgid "%{formatted} person"
 msgid_plural "%{formatted} people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:470
+#: lib/vutuv_web/live/shell_live.ex:520
 #, elixir-autogen, elixir-format
 msgid "person"
 msgid_plural "people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:505
+#: lib/vutuv_web/live/shell_live.ex:555
 #, elixir-autogen, elixir-format
 msgid "%{members} vutuv members plus %{fediverse} Fediverse account that follows them"
 msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that follow them"
@@ -20835,7 +20837,7 @@ msgstr ""
 msgid "What your feed does with posts outside your chosen languages: show them as they are, translate them for you, or hide them. Posts that declare no language always show."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:104
+#: lib/vutuv_web/gettext_extraction_anchors.ex:110
 #, elixir-autogen, elixir-format
 msgid "Date & time"
 msgstr ""
@@ -20845,12 +20847,12 @@ msgstr ""
 msgid "Date and time settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:102
+#: lib/vutuv_web/gettext_extraction_anchors.ex:108
 #, elixir-autogen, elixir-format
 msgid "Date format"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:112
+#: lib/vutuv_web/gettext_extraction_anchors.ex:118
 #, elixir-autogen, elixir-format
 msgid "Germany, Austria, Switzerland"
 msgstr ""
@@ -20860,27 +20862,27 @@ msgstr ""
 msgid "Language and region saved."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:108
+#: lib/vutuv_web/gettext_extraction_anchors.ex:114
 #, elixir-autogen, elixir-format
 msgid "Posts, messages and notifications are stamped in this zone. New accounts take it from the browser."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:105
+#: lib/vutuv_web/gettext_extraction_anchors.ex:111
 #, elixir-autogen, elixir-format
 msgid "The order and punctuation of every date you read here, and whether times run on a 12- or 24-hour clock."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:103
+#: lib/vutuv_web/gettext_extraction_anchors.ex:109
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:113
+#: lib/vutuv_web/gettext_extraction_anchors.ex:119
 #, elixir-autogen, elixir-format
 msgid "United Kingdom, France, Brazil"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:114
+#: lib/vutuv_web/gettext_extraction_anchors.ex:120
 #, elixir-autogen, elixir-format
 msgid "United States"
 msgstr ""
@@ -20890,7 +20892,7 @@ msgstr ""
 msgid "Your browser says: {zone}"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:115
+#: lib/vutuv_web/gettext_extraction_anchors.ex:121
 #, elixir-autogen, elixir-format
 msgid "ISO 8601 (Sweden, Japan, China)"
 msgstr ""
@@ -20964,7 +20966,7 @@ msgstr ""
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1950
+#: lib/vutuv_web/live/post_live/feed.ex:1826
 #: lib/vutuv_web/views/user_html.ex:334
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -21468,7 +21470,7 @@ msgstr ""
 msgid "Unfollowed. Their posts leave your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:672
+#: lib/vutuv_web/live/shell_live.ex:855
 #, elixir-autogen, elixir-format
 msgid "Allow"
 msgstr ""
@@ -21483,12 +21485,12 @@ msgstr ""
 msgid "Browser notifications"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:614
+#: lib/vutuv_web/live/shell_live.ex:797
 #, elixir-autogen, elixir-format
 msgid "New message"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:679
+#: lib/vutuv_web/live/shell_live.ex:862
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr ""
@@ -21528,7 +21530,7 @@ msgstr ""
 msgid "When something arrives while you have vutuv open in a tab you are not looking at, your browser can show it as a notification. Off unless you switch it on."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:669
+#: lib/vutuv_web/live/shell_live.ex:852
 #, elixir-autogen, elixir-format
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
@@ -21568,12 +21570,12 @@ msgstr ""
 msgid "Sent. If nothing appeared, your system is holding it back. Check Do Not Disturb and your notification settings."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:569
+#: lib/vutuv_web/live/shell_live.ex:619
 #, elixir-autogen, elixir-format
 msgid "Test notification"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:570
+#: lib/vutuv_web/live/shell_live.ex:620
 #, elixir-autogen, elixir-format
 msgid "This is what vutuv looks like when something arrives."
 msgstr ""
@@ -21583,12 +21585,12 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1932
+#: lib/vutuv_web/live/post_live/feed.ex:1808
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1928
+#: lib/vutuv_web/live/post_live/feed.ex:1804
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr ""
@@ -21634,7 +21636,7 @@ msgstr ""
 msgid "With a vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1942
+#: lib/vutuv_web/live/post_live/feed.ex:1818
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
@@ -21646,24 +21648,25 @@ msgid_plural "%{formatted} new posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1387
+#: lib/vutuv_web/live/post_live/feed.ex:1288
 #, elixir-autogen, elixir-format
 msgid "%{source}: %{formatted} new post"
 msgid_plural "%{source}: %{formatted} new posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1384
+#: lib/vutuv_web/live/post_live/feed.ex:1285
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1381
+#: lib/vutuv_web/live/post_live/feed.ex:1282
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post from %{who}"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/preferences.html.heex:247
+#: lib/vutuv_web/templates/settings/preferences.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "Example"
 msgstr ""
@@ -21685,11 +21688,13 @@ msgid "Feed tabs"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/preferences.html.heex:271
+#: lib/vutuv_web/views/settings_html.ex:137
 #, elixir-autogen, elixir-format
 msgid "Just flashed the new release, boot is under two seconds now"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/preferences.html.heex:281
+#: lib/vutuv_web/templates/settings/preferences.html.heex:345
 #, elixir-autogen, elixir-format
 msgid "Play the example"
 msgstr ""
@@ -21699,7 +21704,7 @@ msgstr ""
 msgid "When a post lands on the source tab you are not reading, that tab gets a dot. It can also quote the post for a few seconds, so you can tell whether it is worth switching."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:93
+#: lib/vutuv_web/gettext_extraction_anchors.ex:99
 #, elixir-autogen, elixir-format
 msgid "Between 4 and 20 seconds."
 msgstr ""
@@ -21832,4 +21837,47 @@ msgstr ""
 #: lib/vutuv_web/live/feed_languages_live.ex:437
 #, elixir-autogen, elixir-format
 msgid "Translated into %{language}."
+msgstr ""
+
+#: lib/vutuv_web/live/shell_live.ex:736
+#, elixir-autogen, elixir-format
+msgid "+%{formatted} more post"
+msgid_plural "+%{formatted} more posts"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:94
+#: lib/vutuv_web/templates/settings/preferences.html.heex:311
+#, elixir-autogen, elixir-format
+msgid "Browser tab"
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:846
+#, elixir-autogen, elixir-format
+msgid "Browser tab settings reset to the site defaults."
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:840
+#, elixir-autogen, elixir-format
+msgid "Browser tab settings saved."
+msgstr ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:96
+#, elixir-autogen, elixir-format
+msgid "Only while you are looking at another tab, and only for a few seconds. The tab title also shows up in screenshots, in your window switcher and in a screen share."
+msgstr ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:95
+#, elixir-autogen, elixir-format
+msgid "Tease new posts in the browser tab"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:337
+#, elixir-autogen, elixir-format
+msgid "Watch this tab's title, above."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:313
+#, elixir-autogen, elixir-format
+msgid "While you are reading another tab, a new post can page its first words through this tab's title, a line at a time, and then hand the title back."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -442,8 +442,8 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1024
-#: lib/vutuv_web/live/shell_live.ex:1090
+#: lib/vutuv_web/live/shell_live.ex:1207
+#: lib/vutuv_web/live/shell_live.ex:1273
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -626,11 +626,12 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/preferences.html.heex:84
 #: lib/vutuv_web/templates/settings/preferences.html.heex:157
 #: lib/vutuv_web/templates/settings/preferences.html.heex:242
-#: lib/vutuv_web/templates/settings/preferences.html.heex:399
+#: lib/vutuv_web/templates/settings/preferences.html.heex:330
+#: lib/vutuv_web/templates/settings/preferences.html.heex:463
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:462
-#: lib/vutuv_web/views/settings_html.ex:196
+#: lib/vutuv_web/views/settings_html.ex:209
 #, elixir-autogen
 msgid "Save"
 msgstr ""
@@ -643,8 +644,8 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:48
 #: lib/vutuv_web/live/search_live.ex:569
-#: lib/vutuv_web/live/shell_live.ex:889
-#: lib/vutuv_web/live/shell_live.ex:1073
+#: lib/vutuv_web/live/shell_live.ex:1072
+#: lib/vutuv_web/live/shell_live.ex:1256
 #: lib/vutuv_web/live/tag_live/timeline.ex:283
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
@@ -924,7 +925,7 @@ msgid "You follow back %{name}."
 msgstr ""
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:100
+#: lib/vutuv_web/live/post_live/feed.ex:89
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1162,7 +1163,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:996
+#: lib/vutuv_web/live/shell_live.ex:1179
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1596,7 +1597,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1076
+#: lib/vutuv_web/live/shell_live.ex:1259
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1710,8 +1711,8 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1015
-#: lib/vutuv_web/views/settings_html.ex:283
+#: lib/vutuv_web/live/shell_live.ex:1198
+#: lib/vutuv_web/views/settings_html.ex:296
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr ""
@@ -1739,14 +1740,14 @@ msgstr ""
 
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:907
-#: lib/vutuv_web/live/shell_live.ex:1075
+#: lib/vutuv_web/live/shell_live.ex:1090
+#: lib/vutuv_web/live/shell_live.ex:1258
 #: lib/vutuv_web/templates/layout/app.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:791
+#: lib/vutuv_web/live/shell_live.ex:974
 #: lib/vutuv_web/templates/layout/app.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Network"
@@ -1772,7 +1773,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:4371
 #: lib/vutuv_web/live/notification_live/index.ex:132
 #: lib/vutuv_web/live/notification_live/index.ex:360
-#: lib/vutuv_web/live/shell_live.ex:919
+#: lib/vutuv_web/live/shell_live.ex:1102
 #: lib/vutuv_web/templates/layout/app.html.heex:173
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -2118,10 +2119,10 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:274
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:98
-#: lib/vutuv_web/live/post_live/feed.ex:231
-#: lib/vutuv_web/live/post_live/feed.ex:1650
-#: lib/vutuv_web/live/shell_live.ex:769
-#: lib/vutuv_web/live/shell_live.ex:1068
+#: lib/vutuv_web/live/post_live/feed.ex:205
+#: lib/vutuv_web/live/post_live/feed.ex:1526
+#: lib/vutuv_web/live/shell_live.ex:952
+#: lib/vutuv_web/live/shell_live.ex:1251
 #: lib/vutuv_web/templates/layout/app.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2164,7 +2165,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1858
+#: lib/vutuv_web/live/post_live/feed.ex:1734
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2200,7 +2201,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/post_controller.ex:59
 #: lib/vutuv_web/controllers/post_controller.ex:68
 #: lib/vutuv_web/controllers/user_controller.ex:77
-#: lib/vutuv_web/gettext_extraction_anchors.ex:97
+#: lib/vutuv_web/gettext_extraction_anchors.ex:103
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/live/notification_live/index.ex:926
@@ -2208,7 +2209,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:520
 #: lib/vutuv_web/live/search_live.ex:281
 #: lib/vutuv_web/live/search_live.ex:728
-#: lib/vutuv_web/templates/settings/preferences.html.heex:312
+#: lib/vutuv_web/templates/settings/preferences.html.heex:376
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Posts"
@@ -2239,7 +2240,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:650
 #: lib/vutuv_web/live/post_live/saved.ex:678
 #: lib/vutuv_web/templates/connection/index.html.heex:40
-#: lib/vutuv_web/views/settings_html.ex:329
+#: lib/vutuv_web/views/settings_html.ex:342
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
@@ -2254,7 +2255,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1762
+#: lib/vutuv_web/live/post_live/feed.ex:1638
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2292,10 +2293,10 @@ msgid "Upload failed."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4671
-#: lib/vutuv_web/live/shell_live.ex:962
+#: lib/vutuv_web/live/shell_live.ex:1145
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
-#: lib/vutuv_web/views/settings_html.ex:230
+#: lib/vutuv_web/views/settings_html.ex:243
 #, elixir-autogen, elixir-format
 msgid "View profile"
 msgstr ""
@@ -2336,7 +2337,7 @@ msgid "people you don't follow"
 msgstr ""
 
 #: lib/vutuv_web/views/post_html.ex:19
-#: lib/vutuv_web/views/settings_html.ex:408
+#: lib/vutuv_web/views/settings_html.ex:421
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr ""
@@ -2382,8 +2383,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:1108
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
-#: lib/vutuv_web/live/shell_live.ex:899
-#: lib/vutuv_web/live/shell_live.ex:967
+#: lib/vutuv_web/live/shell_live.ex:1082
+#: lib/vutuv_web/live/shell_live.ex:1150
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2404,7 +2405,7 @@ msgstr ""
 #: lib/vutuv_web/live/notification_live/index.ex:1005
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
-#: lib/vutuv_web/live/shell_live.ex:970
+#: lib/vutuv_web/live/shell_live.ex:1153
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2470,7 +2471,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/following.ex:378
 #: lib/vutuv_web/live/organization_live/following.ex:453
 #: lib/vutuv_web/live/organization_live/show.ex:474
-#: lib/vutuv_web/live/post_live/feed.ex:1907
+#: lib/vutuv_web/live/post_live/feed.ex:1783
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2761,7 +2762,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1688
+#: lib/vutuv_web/live/post_live/feed.ex:1564
 #: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2782,7 +2783,7 @@ msgid_plural "%{formatted} connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2009
+#: lib/vutuv_web/live/post_live/feed.ex:1885
 #: lib/vutuv_web/templates/user/card_list.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -3150,8 +3151,8 @@ msgid "Private message"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4303
-#: lib/vutuv_web/live/shell_live.ex:783
-#: lib/vutuv_web/live/shell_live.ex:1080
+#: lib/vutuv_web/live/shell_live.ex:966
+#: lib/vutuv_web/live/shell_live.ex:1263
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -4543,7 +4544,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1863
+#: lib/vutuv_web/live/post_live/feed.ex:1739
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -4911,7 +4912,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/api_app_live.ex:98
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:181
 #: lib/vutuv_web/views/settings_html.ex:75
-#: lib/vutuv_web/views/settings_html.ex:274
+#: lib/vutuv_web/views/settings_html.ex:287
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
@@ -5315,7 +5316,7 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:949
+#: lib/vutuv_web/live/shell_live.ex:1132
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
@@ -5337,7 +5338,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1006
+#: lib/vutuv_web/live/shell_live.ex:1189
 #: lib/vutuv_web/templates/layout/app.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5356,7 +5357,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:303
-#: lib/vutuv_web/live/shell_live.ex:986
+#: lib/vutuv_web/live/shell_live.ex:1169
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5364,7 +5365,7 @@ msgstr ""
 #: lib/vutuv_web/templates/login_code/index.html.heex:4
 #: lib/vutuv_web/templates/totp/new.html.heex:4
 #: lib/vutuv_web/templates/username/confirm.html.heex:23
-#: lib/vutuv_web/views/settings_html.ex:225
+#: lib/vutuv_web/views/settings_html.ex:238
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -5410,8 +5411,8 @@ msgstr ""
 msgid "Previous post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:758
-#: lib/vutuv_web/live/shell_live.ex:1052
+#: lib/vutuv_web/live/shell_live.ex:941
+#: lib/vutuv_web/live/shell_live.ex:1235
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -5425,7 +5426,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:3201
 #: lib/vutuv_web/components/post_components.ex:3620
 #: lib/vutuv_web/live/notification_live/index.ex:726
-#: lib/vutuv_web/live/post_live/feed.ex:2050
+#: lib/vutuv_web/live/post_live/feed.ex:1926
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5843,28 +5844,28 @@ msgid "Sort"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/views/settings_html.ex:417
+#: lib/vutuv_web/views/settings_html.ex:430
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:416
+#: lib/vutuv_web/views/settings_html.ex:429
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:415
+#: lib/vutuv_web/views/settings_html.ex:428
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:901
+#: lib/vutuv_web/controllers/settings_controller.ex:921
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr ""
@@ -5874,7 +5875,7 @@ msgstr ""
 msgid "Another session was already active on your account."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:263
+#: lib/vutuv_web/views/settings_html.ex:276
 #, elixir-autogen, elixir-format
 msgid "Last active"
 msgstr ""
@@ -5889,7 +5890,7 @@ msgstr ""
 msgid "Log out of every device except this one?"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:280
+#: lib/vutuv_web/views/settings_html.ex:293
 #, elixir-autogen, elixir-format
 msgid "Log this device out of your account?"
 msgstr ""
@@ -5904,7 +5905,7 @@ msgstr ""
 msgid "Signed-in devices"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:888
+#: lib/vutuv_web/controllers/settings_controller.ex:908
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr ""
@@ -5914,7 +5915,7 @@ msgstr ""
 msgid "The location looks different from where you usually sign in."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:264
+#: lib/vutuv_web/views/settings_html.ex:277
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr ""
@@ -5924,7 +5925,7 @@ msgstr ""
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:414
+#: lib/vutuv_web/views/settings_html.ex:427
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr ""
@@ -5958,7 +5959,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
 #: lib/vutuv_web/live/admin/screenshot_live.ex:309
 #: lib/vutuv_web/live/fediverse_following_live.ex:291
-#: lib/vutuv_web/views/settings_html.ex:315
+#: lib/vutuv_web/views/settings_html.ex:328
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr ""
@@ -5968,7 +5969,7 @@ msgstr ""
 msgid "Could not add the passkey. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:318
+#: lib/vutuv_web/views/settings_html.ex:331
 #, elixir-autogen, elixir-format
 msgid "Last used"
 msgstr ""
@@ -5978,7 +5979,7 @@ msgstr ""
 msgid "Name (optional)"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:312
+#: lib/vutuv_web/views/settings_html.ex:325
 #, elixir-autogen, elixir-format
 msgid "Passkey"
 msgstr ""
@@ -5998,7 +5999,7 @@ msgstr ""
 msgid "Passkeys"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:326
+#: lib/vutuv_web/views/settings_html.ex:339
 #, elixir-autogen, elixir-format
 msgid "Remove this passkey?"
 msgstr ""
@@ -6274,7 +6275,7 @@ msgstr ""
 msgid "Map services to show"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:98
+#: lib/vutuv_web/gettext_extraction_anchors.ex:104
 #: lib/vutuv_web/templates/settings/preferences.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "Maps"
@@ -6287,7 +6288,7 @@ msgstr ""
 msgid "Open in %{name}"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:96
+#: lib/vutuv_web/gettext_extraction_anchors.ex:102
 #: lib/vutuv_web/templates/settings/preferences.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "Opens first, as the main button. The others appear as alternatives."
@@ -7898,7 +7899,7 @@ msgid "Admins"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:2018
+#: lib/vutuv_web/live/post_live/feed.ex:1894
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr ""
@@ -8455,12 +8456,12 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2035
+#: lib/vutuv_web/live/post_live/feed.ex:1911
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2031
+#: lib/vutuv_web/live/post_live/feed.ex:1907
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr ""
@@ -9467,7 +9468,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1167
+#: lib/vutuv/accounts/user.ex:1173
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9478,7 +9479,7 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1164
+#: lib/vutuv/accounts/user.ex:1170
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -10503,46 +10504,46 @@ msgid_plural "You have %{formatted} new messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:383
+#: lib/vutuv_web/templates/settings/preferences.html.heex:447
 #, elixir-autogen, elixir-format
 msgid "Break long words at syllable points so the text wraps evenly. Helpful in the narrow phone column."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:314
+#: lib/vutuv_web/templates/settings/preferences.html.heex:378
 #, elixir-autogen, elixir-format
 msgid "How posts you read are shortened in your feed and on profiles. These are your own reading preferences."
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:68
-#: lib/vutuv_web/templates/settings/preferences.html.heex:390
+#: lib/vutuv_web/templates/settings/preferences.html.heex:454
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on desktop"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:69
-#: lib/vutuv_web/templates/settings/preferences.html.heex:394
+#: lib/vutuv_web/templates/settings/preferences.html.heex:458
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on mobile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:380
+#: lib/vutuv_web/templates/settings/preferences.html.heex:444
 #, elixir-autogen, elixir-format
 msgid "Hyphenation"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:66
-#: lib/vutuv_web/templates/settings/preferences.html.heex:337
+#: lib/vutuv_web/templates/settings/preferences.html.heex:401
 #, elixir-autogen, elixir-format
 msgid "Lines on desktop"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:67
-#: lib/vutuv_web/templates/settings/preferences.html.heex:346
+#: lib/vutuv_web/templates/settings/preferences.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "Lines on mobile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:332
+#: lib/vutuv_web/templates/settings/preferences.html.heex:396
 #, elixir-autogen, elixir-format
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
@@ -10552,7 +10553,7 @@ msgstr ""
 msgid "Post display settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:329
+#: lib/vutuv_web/templates/settings/preferences.html.heex:393
 #, elixir-autogen, elixir-format
 msgid "Shorten a post after"
 msgstr ""
@@ -10641,7 +10642,8 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/preferences.html.heex:101
 #: lib/vutuv_web/templates/settings/preferences.html.heex:174
 #: lib/vutuv_web/templates/settings/preferences.html.heex:296
-#: lib/vutuv_web/templates/settings/preferences.html.heex:414
+#: lib/vutuv_web/templates/settings/preferences.html.heex:360
+#: lib/vutuv_web/templates/settings/preferences.html.heex:478
 #, elixir-autogen, elixir-format
 msgid "Reset to the site defaults"
 msgstr ""
@@ -10672,17 +10674,17 @@ msgstr ""
 msgid "What every member gets until they choose for themselves on their settings pages, and what logged-out visitors see. Changes apply immediately; members who set their own value are not affected."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:94
+#: lib/vutuv_web/gettext_extraction_anchors.ex:100
 #, elixir-autogen, elixir-format
 msgid "0 means posts are never shortened."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:100
+#: lib/vutuv_web/gettext_extraction_anchors.ex:106
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:99
+#: lib/vutuv_web/gettext_extraction_anchors.ex:105
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr ""
@@ -10832,19 +10834,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1205
+#: lib/vutuv/accounts/user.ex:1211
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1210
+#: lib/vutuv/accounts/user.ex:1216
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1208
+#: lib/vutuv/accounts/user.ex:1214
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:761
 #, elixir-autogen, elixir-format
@@ -11839,7 +11841,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:977
+#: lib/vutuv_web/live/shell_live.ex:1160
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:100
@@ -12142,7 +12144,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1179
+#: lib/vutuv/accounts/user.ex:1185
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12168,7 +12170,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:799
+#: lib/vutuv_web/live/shell_live.ex:982
 #: lib/vutuv_web/templates/layout/app.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -12261,7 +12263,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1178
+#: lib/vutuv/accounts/user.ex:1184
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12343,7 +12345,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1180
+#: lib/vutuv/accounts/user.ex:1186
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:564
 #: lib/vutuv_web/agent_docs/markdown.ex:458
@@ -13358,7 +13360,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1223
+#: lib/vutuv/accounts/user.ex:1229
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13369,19 +13371,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1226
+#: lib/vutuv/accounts/user.ex:1232
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1229
+#: lib/vutuv/accounts/user.ex:1235
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1220
+#: lib/vutuv/accounts/user.ex:1226
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13505,14 +13507,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4393
 #: lib/vutuv_web/controllers/settings_controller.ex:614
-#: lib/vutuv_web/live/post_live/feed.ex:1893
+#: lib/vutuv_web/live/post_live/feed.ex:1769
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1908
+#: lib/vutuv_web/live/post_live/feed.ex:1784
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr ""
@@ -13854,7 +13856,7 @@ msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:453
+#: lib/vutuv_web/live/shell_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -13977,22 +13979,22 @@ msgid "proof document"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:74
-#: lib/vutuv_web/templates/settings/preferences.html.heex:368
+#: lib/vutuv_web/templates/settings/preferences.html.heex:432
 #, elixir-autogen, elixir-format
 msgid "Lines in notifications"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:95
+#: lib/vutuv_web/gettext_extraction_anchors.ex:101
 #, elixir-autogen, elixir-format
 msgid "How much of a post a notification quotes before it is cut off."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:359
+#: lib/vutuv_web/templates/settings/preferences.html.heex:423
 #, elixir-autogen, elixir-format
 msgid "Quoted posts in notifications"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:362
+#: lib/vutuv_web/templates/settings/preferences.html.heex:426
 #, elixir-autogen, elixir-format
 msgid "Your notifications quote the post someone liked or replied to. Leave the field empty to follow the site default."
 msgstr ""
@@ -14390,7 +14392,7 @@ msgstr ""
 msgid "Filter removed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:509
+#: lib/vutuv_web/live/post_live/feed.ex:482
 #, elixir-autogen, elixir-format
 msgid "Hidden: matches your filter"
 msgstr ""
@@ -14423,7 +14425,7 @@ msgstr ""
 msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:518
+#: lib/vutuv_web/live/post_live/feed.ex:491
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr ""
@@ -15361,32 +15363,32 @@ msgstr ""
 msgid "I understand, take part"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:396
+#: lib/vutuv_web/views/settings_html.ex:409
 #, elixir-autogen, elixir-format
 msgid "Most of them, not all: we cannot check whether they do it, and anything that was re-shared, archived or indexed elsewhere stays out of reach. If you take part again later, people there have to follow you anew."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:391
+#: lib/vutuv_web/views/settings_html.ex:404
 #, elixir-autogen, elixir-format
 msgid "No new posts go out, and your followers from other networks are removed here. The next time those servers look you up they learn that this account is gone, and most of them then delete their copies of your posts."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:372
+#: lib/vutuv_web/views/settings_html.ex:385
 #, elixir-autogen, elixir-format
 msgid "Once a post has left vutuv, it is out of our hands"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:374
+#: lib/vutuv_web/views/settings_html.ex:387
 #, elixir-autogen, elixir-format
 msgid "Switching off does not delete what is already out there"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:385
+#: lib/vutuv_web/views/settings_html.ex:398
 #, elixir-autogen, elixir-format
 msgid "Switching this off again later stops new posts from going out. It cannot bring back what has already been delivered."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:380
+#: lib/vutuv_web/views/settings_html.ex:393
 #, elixir-autogen, elixir-format
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
@@ -16443,8 +16445,8 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1697
-#: lib/vutuv_web/live/post_live/feed.ex:1698
+#: lib/vutuv_web/live/post_live/feed.ex:1573
+#: lib/vutuv_web/live/post_live/feed.ex:1574
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post photos"
 msgstr ""
@@ -18250,7 +18252,7 @@ msgstr ""
 msgid "When off, other members no longer see you among the likes of a post. The author of the post still does: we named you in the notification they got when you liked it. Either way the post keeps the same number of likes."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:835
+#: lib/vutuv_web/controllers/settings_controller.ex:855
 #, elixir-autogen, elixir-format
 msgid "Your likes follow the site default again."
 msgstr ""
@@ -19186,17 +19188,17 @@ msgstr ""
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1326
+#: lib/vutuv/accounts/user.ex:1332
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1324
+#: lib/vutuv/accounts/user.ex:1330
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1325
+#: lib/vutuv/accounts/user.ex:1331
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -19973,7 +19975,7 @@ msgstr ""
 msgid "A post in an organization's name is always public."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:716
+#: lib/vutuv_web/live/shell_live.ex:899
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Open the page"
 msgstr ""
@@ -19993,7 +19995,7 @@ msgstr ""
 msgid "Write as %{name} for now"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:726
+#: lib/vutuv_web/live/shell_live.ex:909
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr ""
@@ -20003,7 +20005,7 @@ msgstr ""
 msgid "You are writing as %{name} now."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:702
+#: lib/vutuv_web/live/shell_live.ex:885
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr ""
@@ -20367,21 +20369,21 @@ msgstr ""
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:483
+#: lib/vutuv_web/live/shell_live.ex:533
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} person"
 msgid_plural "%{formatted} people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:470
+#: lib/vutuv_web/live/shell_live.ex:520
 #, elixir-autogen, elixir-format, fuzzy
 msgid "person"
 msgid_plural "people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/shell_live.ex:505
+#: lib/vutuv_web/live/shell_live.ex:555
 #, elixir-autogen, elixir-format
 msgid "%{members} vutuv members plus %{fediverse} Fediverse account that follows them"
 msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that follow them"
@@ -20833,7 +20835,7 @@ msgstr ""
 msgid "What your feed does with posts outside your chosen languages: show them as they are, translate them for you, or hide them. Posts that declare no language always show."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:104
+#: lib/vutuv_web/gettext_extraction_anchors.ex:110
 #, elixir-autogen, elixir-format
 msgid "Date & time"
 msgstr ""
@@ -20843,12 +20845,12 @@ msgstr ""
 msgid "Date and time settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:102
+#: lib/vutuv_web/gettext_extraction_anchors.ex:108
 #, elixir-autogen, elixir-format
 msgid "Date format"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:112
+#: lib/vutuv_web/gettext_extraction_anchors.ex:118
 #, elixir-autogen, elixir-format
 msgid "Germany, Austria, Switzerland"
 msgstr ""
@@ -20858,27 +20860,27 @@ msgstr ""
 msgid "Language and region saved."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:108
+#: lib/vutuv_web/gettext_extraction_anchors.ex:114
 #, elixir-autogen, elixir-format
 msgid "Posts, messages and notifications are stamped in this zone. New accounts take it from the browser."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:105
+#: lib/vutuv_web/gettext_extraction_anchors.ex:111
 #, elixir-autogen, elixir-format
 msgid "The order and punctuation of every date you read here, and whether times run on a 12- or 24-hour clock."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:103
+#: lib/vutuv_web/gettext_extraction_anchors.ex:109
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:113
+#: lib/vutuv_web/gettext_extraction_anchors.ex:119
 #, elixir-autogen, elixir-format
 msgid "United Kingdom, France, Brazil"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:114
+#: lib/vutuv_web/gettext_extraction_anchors.ex:120
 #, elixir-autogen, elixir-format
 msgid "United States"
 msgstr ""
@@ -20888,7 +20890,7 @@ msgstr ""
 msgid "Your browser says: {zone}"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:115
+#: lib/vutuv_web/gettext_extraction_anchors.ex:121
 #, elixir-autogen, elixir-format, fuzzy
 msgid "ISO 8601 (Sweden, Japan, China)"
 msgstr ""
@@ -20962,7 +20964,7 @@ msgstr ""
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1950
+#: lib/vutuv_web/live/post_live/feed.ex:1826
 #: lib/vutuv_web/views/user_html.ex:334
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -21466,7 +21468,7 @@ msgstr ""
 msgid "Unfollowed. Their posts leave your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:672
+#: lib/vutuv_web/live/shell_live.ex:855
 #, elixir-autogen, elixir-format
 msgid "Allow"
 msgstr ""
@@ -21481,12 +21483,12 @@ msgstr ""
 msgid "Browser notifications"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:614
+#: lib/vutuv_web/live/shell_live.ex:797
 #, elixir-autogen, elixir-format
 msgid "New message"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:679
+#: lib/vutuv_web/live/shell_live.ex:862
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr ""
@@ -21526,7 +21528,7 @@ msgstr ""
 msgid "When something arrives while you have vutuv open in a tab you are not looking at, your browser can show it as a notification. Off unless you switch it on."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:669
+#: lib/vutuv_web/live/shell_live.ex:852
 #, elixir-autogen, elixir-format
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
@@ -21566,12 +21568,12 @@ msgstr ""
 msgid "Sent. If nothing appeared, your system is holding it back. Check Do Not Disturb and your notification settings."
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:569
+#: lib/vutuv_web/live/shell_live.ex:619
 #, elixir-autogen, elixir-format
 msgid "Test notification"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:570
+#: lib/vutuv_web/live/shell_live.ex:620
 #, elixir-autogen, elixir-format
 msgid "This is what vutuv looks like when something arrives."
 msgstr ""
@@ -21581,12 +21583,12 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1932
+#: lib/vutuv_web/live/post_live/feed.ex:1808
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1928
+#: lib/vutuv_web/live/post_live/feed.ex:1804
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr ""
@@ -21632,7 +21634,7 @@ msgstr ""
 msgid "With a vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1942
+#: lib/vutuv_web/live/post_live/feed.ex:1818
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
@@ -21644,24 +21646,25 @@ msgid_plural "%{formatted} new posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1387
+#: lib/vutuv_web/live/post_live/feed.ex:1288
 #, elixir-autogen, elixir-format
 msgid "%{source}: %{formatted} new post"
 msgid_plural "%{source}: %{formatted} new posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1384
+#: lib/vutuv_web/live/post_live/feed.ex:1285
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1381
+#: lib/vutuv_web/live/post_live/feed.ex:1282
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post from %{who}"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/preferences.html.heex:247
+#: lib/vutuv_web/templates/settings/preferences.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "Example"
 msgstr ""
@@ -21683,11 +21686,13 @@ msgid "Feed tabs"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/preferences.html.heex:271
+#: lib/vutuv_web/views/settings_html.ex:137
 #, elixir-autogen, elixir-format
 msgid "Just flashed the new release, boot is under two seconds now"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/preferences.html.heex:281
+#: lib/vutuv_web/templates/settings/preferences.html.heex:345
 #, elixir-autogen, elixir-format
 msgid "Play the example"
 msgstr ""
@@ -21697,7 +21702,7 @@ msgstr ""
 msgid "When a post lands on the source tab you are not reading, that tab gets a dot. It can also quote the post for a few seconds, so you can tell whether it is worth switching."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:93
+#: lib/vutuv_web/gettext_extraction_anchors.ex:99
 #, elixir-autogen, elixir-format
 msgid "Between 4 and 20 seconds."
 msgstr ""
@@ -21830,4 +21835,47 @@ msgstr ""
 #: lib/vutuv_web/live/feed_languages_live.ex:437
 #, elixir-autogen, elixir-format
 msgid "Translated into %{language}."
+msgstr ""
+
+#: lib/vutuv_web/live/shell_live.ex:736
+#, elixir-autogen, elixir-format
+msgid "+%{formatted} more post"
+msgid_plural "+%{formatted} more posts"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:94
+#: lib/vutuv_web/templates/settings/preferences.html.heex:311
+#, elixir-autogen, elixir-format
+msgid "Browser tab"
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:846
+#, elixir-autogen, elixir-format
+msgid "Browser tab settings reset to the site defaults."
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:840
+#, elixir-autogen, elixir-format
+msgid "Browser tab settings saved."
+msgstr ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:96
+#, elixir-autogen, elixir-format
+msgid "Only while you are looking at another tab, and only for a few seconds. The tab title also shows up in screenshots, in your window switcher and in a screen share."
+msgstr ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:95
+#, elixir-autogen, elixir-format
+msgid "Tease new posts in the browser tab"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:337
+#, elixir-autogen, elixir-format
+msgid "Watch this tab's title, above."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:313
+#, elixir-autogen, elixir-format
+msgid "While you are reading another tab, a new post can page its first words through this tab's title, a line at a time, and then hand the title back."
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -446,8 +446,8 @@ msgstr "Accedi"
 msgid "Log Out"
 msgstr "Esci"
 
-#: lib/vutuv_web/live/shell_live.ex:1024
-#: lib/vutuv_web/live/shell_live.ex:1090
+#: lib/vutuv_web/live/shell_live.ex:1207
+#: lib/vutuv_web/live/shell_live.ex:1273
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -630,11 +630,12 @@ msgstr "Pubblico"
 #: lib/vutuv_web/templates/settings/preferences.html.heex:84
 #: lib/vutuv_web/templates/settings/preferences.html.heex:157
 #: lib/vutuv_web/templates/settings/preferences.html.heex:242
-#: lib/vutuv_web/templates/settings/preferences.html.heex:399
+#: lib/vutuv_web/templates/settings/preferences.html.heex:330
+#: lib/vutuv_web/templates/settings/preferences.html.heex:463
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:462
-#: lib/vutuv_web/views/settings_html.ex:196
+#: lib/vutuv_web/views/settings_html.ex:209
 #, elixir-autogen
 msgid "Save"
 msgstr "Salva"
@@ -647,8 +648,8 @@ msgstr "Salva"
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:48
 #: lib/vutuv_web/live/search_live.ex:569
-#: lib/vutuv_web/live/shell_live.ex:889
-#: lib/vutuv_web/live/shell_live.ex:1073
+#: lib/vutuv_web/live/shell_live.ex:1072
+#: lib/vutuv_web/live/shell_live.ex:1256
 #: lib/vutuv_web/live/tag_live/timeline.ex:283
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
@@ -937,7 +938,7 @@ msgid "You follow back %{name}."
 msgstr "Ora segue anche %{name}."
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:100
+#: lib/vutuv_web/live/post_live/feed.ex:89
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1190,7 +1191,7 @@ msgstr "Aggiungi localizzazione"
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:996
+#: lib/vutuv_web/live/shell_live.ex:1179
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1631,7 +1632,7 @@ msgstr "Indirizzi di %{name}"
 msgid "Admin control panel"
 msgstr "Pannello di amministrazione"
 
-#: lib/vutuv_web/live/shell_live.ex:1076
+#: lib/vutuv_web/live/shell_live.ex:1259
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "Avvisi"
@@ -1747,8 +1748,8 @@ msgstr ""
 "Sembra che non segua ancora nessuno. Apra il profilo di una persona che "
 "conosce o che La incuriosisce e prema il pulsante «Segui»."
 
-#: lib/vutuv_web/live/shell_live.ex:1015
-#: lib/vutuv_web/views/settings_html.ex:283
+#: lib/vutuv_web/live/shell_live.ex:1198
+#: lib/vutuv_web/views/settings_html.ex:296
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr "Esci"
@@ -1776,14 +1777,14 @@ msgstr "Messaggio"
 
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:907
-#: lib/vutuv_web/live/shell_live.ex:1075
+#: lib/vutuv_web/live/shell_live.ex:1090
+#: lib/vutuv_web/live/shell_live.ex:1258
 #: lib/vutuv_web/templates/layout/app.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr "Messaggi"
 
-#: lib/vutuv_web/live/shell_live.ex:791
+#: lib/vutuv_web/live/shell_live.ex:974
 #: lib/vutuv_web/templates/layout/app.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Network"
@@ -1809,7 +1810,7 @@ msgstr "Ancora nessuna novità."
 #: lib/vutuv_web/components/ui.ex:4371
 #: lib/vutuv_web/live/notification_live/index.ex:132
 #: lib/vutuv_web/live/notification_live/index.ex:360
-#: lib/vutuv_web/live/shell_live.ex:919
+#: lib/vutuv_web/live/shell_live.ex:1102
 #: lib/vutuv_web/templates/layout/app.html.heex:173
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -2165,10 +2166,10 @@ msgstr "Modifica il post"
 #: lib/vutuv_web/components/organization_components.ex:274
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:98
-#: lib/vutuv_web/live/post_live/feed.ex:231
-#: lib/vutuv_web/live/post_live/feed.ex:1650
-#: lib/vutuv_web/live/shell_live.ex:769
-#: lib/vutuv_web/live/shell_live.ex:1068
+#: lib/vutuv_web/live/post_live/feed.ex:205
+#: lib/vutuv_web/live/post_live/feed.ex:1526
+#: lib/vutuv_web/live/shell_live.ex:952
+#: lib/vutuv_web/live/shell_live.ex:1251
 #: lib/vutuv_web/templates/layout/app.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2211,7 +2212,7 @@ msgstr "Visitatori non connessi"
 msgid "No more than %{max} images per post."
 msgstr "Non più di %{max} immagini per post."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1858
+#: lib/vutuv_web/live/post_live/feed.ex:1734
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2249,7 +2250,7 @@ msgstr "Post eliminato."
 #: lib/vutuv_web/controllers/post_controller.ex:59
 #: lib/vutuv_web/controllers/post_controller.ex:68
 #: lib/vutuv_web/controllers/user_controller.ex:77
-#: lib/vutuv_web/gettext_extraction_anchors.ex:97
+#: lib/vutuv_web/gettext_extraction_anchors.ex:103
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
 #: lib/vutuv_web/live/fediverse_account_live.ex:394
 #: lib/vutuv_web/live/notification_live/index.ex:926
@@ -2257,7 +2258,7 @@ msgstr "Post eliminato."
 #: lib/vutuv_web/live/post_live/saved.ex:520
 #: lib/vutuv_web/live/search_live.ex:281
 #: lib/vutuv_web/live/search_live.ex:728
-#: lib/vutuv_web/templates/settings/preferences.html.heex:312
+#: lib/vutuv_web/templates/settings/preferences.html.heex:376
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Posts"
@@ -2288,7 +2289,7 @@ msgstr "Mostra meno"
 #: lib/vutuv_web/live/post_live/saved.ex:650
 #: lib/vutuv_web/live/post_live/saved.ex:678
 #: lib/vutuv_web/templates/connection/index.html.heex:40
-#: lib/vutuv_web/views/settings_html.ex:329
+#: lib/vutuv_web/views/settings_html.ex:342
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Rimuovi"
@@ -2305,7 +2306,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Salvataggio…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1762
+#: lib/vutuv_web/live/post_live/feed.ex:1638
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2343,10 +2344,10 @@ msgid "Upload failed."
 msgstr "Caricamento non riuscito."
 
 #: lib/vutuv_web/components/ui.ex:4671
-#: lib/vutuv_web/live/shell_live.ex:962
+#: lib/vutuv_web/live/shell_live.ex:1145
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
-#: lib/vutuv_web/views/settings_html.ex:230
+#: lib/vutuv_web/views/settings_html.ex:243
 #, elixir-autogen, elixir-format
 msgid "View profile"
 msgstr "Vedi il profilo"
@@ -2387,7 +2388,7 @@ msgid "people you don't follow"
 msgstr "persone che non segue"
 
 #: lib/vutuv_web/views/post_html.ex:19
-#: lib/vutuv_web/views/settings_html.ex:408
+#: lib/vutuv_web/views/settings_html.ex:421
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr "sconosciuto"
@@ -2433,8 +2434,8 @@ msgstr "Salva"
 #: lib/vutuv_web/agent_docs/markdown.ex:1108
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
-#: lib/vutuv_web/live/shell_live.ex:899
-#: lib/vutuv_web/live/shell_live.ex:967
+#: lib/vutuv_web/live/shell_live.ex:1082
+#: lib/vutuv_web/live/shell_live.ex:1150
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
@@ -2455,7 +2456,7 @@ msgstr "Mi piace"
 #: lib/vutuv_web/live/notification_live/index.ex:1005
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
-#: lib/vutuv_web/live/shell_live.ex:970
+#: lib/vutuv_web/live/shell_live.ex:1153
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:159
 #: lib/vutuv_web/templates/settings/privacy.html.heex:91
 #: lib/vutuv_web/views/admin/report_html.ex:37
@@ -2521,7 +2522,7 @@ msgstr "Togli Mi piace"
 #: lib/vutuv_web/live/organization_live/following.ex:378
 #: lib/vutuv_web/live/organization_live/following.ex:453
 #: lib/vutuv_web/live/organization_live/show.ex:474
-#: lib/vutuv_web/live/post_live/feed.ex:1907
+#: lib/vutuv_web/live/post_live/feed.ex:1783
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2819,7 +2820,7 @@ msgstr "Scriva il Suo primo post"
 msgid "Manage"
 msgstr "Gestisci"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1688
+#: lib/vutuv_web/live/post_live/feed.ex:1564
 #: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2840,7 +2841,7 @@ msgid_plural "%{formatted} connections"
 msgstr[0] "1 collegamento"
 msgstr[1] "%{formatted} collegamenti"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2009
+#: lib/vutuv_web/live/post_live/feed.ex:1885
 #: lib/vutuv_web/templates/user/card_list.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -3232,8 +3233,8 @@ msgid "Private message"
 msgstr "Messaggio privato"
 
 #: lib/vutuv_web/components/ui.ex:4303
-#: lib/vutuv_web/live/shell_live.ex:783
-#: lib/vutuv_web/live/shell_live.ex:1080
+#: lib/vutuv_web/live/shell_live.ex:966
+#: lib/vutuv_web/live/shell_live.ex:1263
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -4725,7 +4726,7 @@ msgstr "Non ha bloccato nessuno."
 msgid "You unblocked @%{slug}."
 msgstr "Ha sbloccato @%{slug}."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1863
+#: lib/vutuv_web/live/post_live/feed.ex:1739
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Scopra persone da seguire"
@@ -5104,7 +5105,7 @@ msgstr "Applicazioni API"
 #: lib/vutuv_web/live/admin/api_app_live.ex:98
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:181
 #: lib/vutuv_web/views/settings_html.ex:75
-#: lib/vutuv_web/views/settings_html.ex:274
+#: lib/vutuv_web/views/settings_html.ex:287
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr "Attiva"
@@ -5537,7 +5538,7 @@ msgstr "Non può più rispondere a questo post."
 msgid "Content under review"
 msgstr "Contenuto in esame"
 
-#: lib/vutuv_web/live/shell_live.ex:949
+#: lib/vutuv_web/live/shell_live.ex:1132
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr "Menu dell'account"
@@ -5559,7 +5560,7 @@ msgstr "Chiudi menu e finestre"
 msgid "General"
 msgstr "Generale"
 
-#: lib/vutuv_web/live/shell_live.ex:1006
+#: lib/vutuv_web/live/shell_live.ex:1189
 #: lib/vutuv_web/templates/layout/app.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5578,7 +5579,7 @@ msgstr "Navigazione"
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
 #: lib/vutuv_web/live/fediverse_following_live.ex:303
-#: lib/vutuv_web/live/shell_live.ex:986
+#: lib/vutuv_web/live/shell_live.ex:1169
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/job_reference/check.html.heex:10
@@ -5586,7 +5587,7 @@ msgstr "Navigazione"
 #: lib/vutuv_web/templates/login_code/index.html.heex:4
 #: lib/vutuv_web/templates/totp/new.html.heex:4
 #: lib/vutuv_web/templates/username/confirm.html.heex:23
-#: lib/vutuv_web/views/settings_html.ex:225
+#: lib/vutuv_web/views/settings_html.ex:238
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr "Impostazioni"
@@ -5632,8 +5633,8 @@ msgstr "Post successivo nel feed"
 msgid "Previous post in the feed"
 msgstr "Post precedente nel feed"
 
-#: lib/vutuv_web/live/shell_live.ex:758
-#: lib/vutuv_web/live/shell_live.ex:1052
+#: lib/vutuv_web/live/shell_live.ex:941
+#: lib/vutuv_web/live/shell_live.ex:1235
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr "Navigazione principale"
@@ -5647,7 +5648,7 @@ msgstr "Navigazione a piè di pagina"
 #: lib/vutuv_web/components/post_components.ex:3201
 #: lib/vutuv_web/components/post_components.ex:3620
 #: lib/vutuv_web/live/notification_live/index.ex:726
-#: lib/vutuv_web/live/post_live/feed.ex:2050
+#: lib/vutuv_web/live/post_live/feed.ex:1926
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -6070,28 +6071,28 @@ msgid "Sort"
 msgstr "Ordina"
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/views/settings_html.ex:417
+#: lib/vutuv_web/views/settings_html.ex:430
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] "%{count} giorno fa"
 msgstr[1] "%{count} giorni fa"
 
-#: lib/vutuv_web/views/settings_html.ex:416
+#: lib/vutuv_web/views/settings_html.ex:429
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] "%{count} ora fa"
 msgstr[1] "%{count} ore fa"
 
-#: lib/vutuv_web/views/settings_html.ex:415
+#: lib/vutuv_web/views/settings_html.ex:428
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
 msgstr[0] "%{count} minuto fa"
 msgstr[1] "%{count} minuti fa"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:901
+#: lib/vutuv_web/controllers/settings_controller.ex:921
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr "Tutti gli altri dispositivi sono stati disconnessi."
@@ -6101,7 +6102,7 @@ msgstr "Tutti gli altri dispositivi sono stati disconnessi."
 msgid "Another session was already active on your account."
 msgstr "Sul Suo account era già attiva un'altra sessione."
 
-#: lib/vutuv_web/views/settings_html.ex:263
+#: lib/vutuv_web/views/settings_html.ex:276
 #, elixir-autogen, elixir-format
 msgid "Last active"
 msgstr "Ultima attività"
@@ -6116,7 +6117,7 @@ msgstr "Disconnetti tutti gli altri dispositivi"
 msgid "Log out of every device except this one?"
 msgstr "Disconnettere ogni dispositivo tranne questo?"
 
-#: lib/vutuv_web/views/settings_html.ex:280
+#: lib/vutuv_web/views/settings_html.ex:293
 #, elixir-autogen, elixir-format
 msgid "Log this device out of your account?"
 msgstr "Disconnettere questo dispositivo dal Suo account?"
@@ -6131,7 +6132,7 @@ msgstr "Nuovo accesso al Suo account vutuv"
 msgid "Signed-in devices"
 msgstr "Dispositivi connessi"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:888
+#: lib/vutuv_web/controllers/settings_controller.ex:908
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr "Quel dispositivo è stato disconnesso."
@@ -6141,7 +6142,7 @@ msgstr "Quel dispositivo è stato disconnesso."
 msgid "The location looks different from where you usually sign in."
 msgstr "La posizione è diversa da quella da cui accede di solito."
 
-#: lib/vutuv_web/views/settings_html.ex:264
+#: lib/vutuv_web/views/settings_html.ex:277
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr "Questo dispositivo"
@@ -6151,7 +6152,7 @@ msgstr "Questo dispositivo"
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr "È il primo accesso che vediamo da questo dispositivo o browser."
 
-#: lib/vutuv_web/views/settings_html.ex:414
+#: lib/vutuv_web/views/settings_html.ex:427
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr "adesso"
@@ -6189,7 +6190,7 @@ msgstr "Aggiungi una passkey"
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
 #: lib/vutuv_web/live/admin/screenshot_live.ex:309
 #: lib/vutuv_web/live/fediverse_following_live.ex:291
-#: lib/vutuv_web/views/settings_html.ex:315
+#: lib/vutuv_web/views/settings_html.ex:328
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr "Aggiunta"
@@ -6199,7 +6200,7 @@ msgstr "Aggiunta"
 msgid "Could not add the passkey. Please try again."
 msgstr "Non è stato possibile aggiungere la passkey. Riprovi."
 
-#: lib/vutuv_web/views/settings_html.ex:318
+#: lib/vutuv_web/views/settings_html.ex:331
 #, elixir-autogen, elixir-format
 msgid "Last used"
 msgstr "Ultimo utilizzo"
@@ -6209,7 +6210,7 @@ msgstr "Ultimo utilizzo"
 msgid "Name (optional)"
 msgstr "Nome (facoltativo)"
 
-#: lib/vutuv_web/views/settings_html.ex:312
+#: lib/vutuv_web/views/settings_html.ex:325
 #, elixir-autogen, elixir-format
 msgid "Passkey"
 msgstr "Passkey"
@@ -6229,7 +6230,7 @@ msgstr "Passkey rimossa."
 msgid "Passkeys"
 msgstr "Passkey"
 
-#: lib/vutuv_web/views/settings_html.ex:326
+#: lib/vutuv_web/views/settings_html.ex:339
 #, elixir-autogen, elixir-format
 msgid "Remove this passkey?"
 msgstr "Rimuovere questa passkey?"
@@ -6514,7 +6515,7 @@ msgstr "Preferenze delle mappe salvate."
 msgid "Map services to show"
 msgstr "Servizi di mappe da mostrare"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:98
+#: lib/vutuv_web/gettext_extraction_anchors.ex:104
 #: lib/vutuv_web/templates/settings/preferences.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "Maps"
@@ -6527,7 +6528,7 @@ msgstr "Mappe"
 msgid "Open in %{name}"
 msgstr "Apri in %{name}"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:96
+#: lib/vutuv_web/gettext_extraction_anchors.ex:102
 #: lib/vutuv_web/templates/settings/preferences.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "Opens first, as the main button. The others appear as alternatives."
@@ -8239,7 +8240,7 @@ msgid "Admins"
 msgstr "Amministratori"
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:2018
+#: lib/vutuv_web/live/post_live/feed.ex:1894
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr "Tutti i membri"
@@ -8839,12 +8840,12 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr "Digiti il Suo nome utente per confermare:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2035
+#: lib/vutuv_web/live/post_live/feed.ex:1911
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr "Mostra altri post"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2031
+#: lib/vutuv_web/live/post_live/feed.ex:1907
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr "Post consigliati"
@@ -9899,7 +9900,7 @@ msgstr "Yoruba"
 msgid "Employment status"
 msgstr "Situazione lavorativa"
 
-#: lib/vutuv/accounts/user.ex:1167
+#: lib/vutuv/accounts/user.ex:1173
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9910,7 +9911,7 @@ msgstr "In cerca di lavoro"
 msgid "Not open to work"
 msgstr "Non in cerca di lavoro"
 
-#: lib/vutuv/accounts/user.ex:1164
+#: lib/vutuv/accounts/user.ex:1170
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -11016,14 +11017,14 @@ msgid_plural "You have %{formatted} new messages."
 msgstr[0] "Ha %{formatted} nuovo messaggio."
 msgstr[1] "Ha %{formatted} nuovi messaggi."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:383
+#: lib/vutuv_web/templates/settings/preferences.html.heex:447
 #, elixir-autogen, elixir-format
 msgid "Break long words at syllable points so the text wraps evenly. Helpful in the narrow phone column."
 msgstr ""
 "Spezza le parole lunghe in corrispondenza delle sillabe, così il testo va a "
 "capo in modo uniforme. Utile nella colonna stretta del telefono."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:314
+#: lib/vutuv_web/templates/settings/preferences.html.heex:378
 #, elixir-autogen, elixir-format
 msgid "How posts you read are shortened in your feed and on profiles. These are your own reading preferences."
 msgstr ""
@@ -11031,35 +11032,35 @@ msgstr ""
 "le Sue preferenze di lettura personali."
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:68
-#: lib/vutuv_web/templates/settings/preferences.html.heex:390
+#: lib/vutuv_web/templates/settings/preferences.html.heex:454
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on desktop"
 msgstr "Sillabazione su computer"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:69
-#: lib/vutuv_web/templates/settings/preferences.html.heex:394
+#: lib/vutuv_web/templates/settings/preferences.html.heex:458
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on mobile"
 msgstr "Sillabazione su telefono"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:380
+#: lib/vutuv_web/templates/settings/preferences.html.heex:444
 #, elixir-autogen, elixir-format
 msgid "Hyphenation"
 msgstr "Sillabazione"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:66
-#: lib/vutuv_web/templates/settings/preferences.html.heex:337
+#: lib/vutuv_web/templates/settings/preferences.html.heex:401
 #, elixir-autogen, elixir-format
 msgid "Lines on desktop"
 msgstr "Righe su computer"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:67
-#: lib/vutuv_web/templates/settings/preferences.html.heex:346
+#: lib/vutuv_web/templates/settings/preferences.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "Lines on mobile"
 msgstr "Righe su telefono"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:332
+#: lib/vutuv_web/templates/settings/preferences.html.heex:396
 #, elixir-autogen, elixir-format
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
@@ -11071,7 +11072,7 @@ msgstr ""
 msgid "Post display settings saved."
 msgstr "Impostazioni di visualizzazione dei post salvate."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:329
+#: lib/vutuv_web/templates/settings/preferences.html.heex:393
 #, elixir-autogen, elixir-format
 msgid "Shorten a post after"
 msgstr "Accorcia un post dopo"
@@ -11174,7 +11175,8 @@ msgstr "Preferenze di %{name}"
 #: lib/vutuv_web/templates/settings/preferences.html.heex:101
 #: lib/vutuv_web/templates/settings/preferences.html.heex:174
 #: lib/vutuv_web/templates/settings/preferences.html.heex:296
-#: lib/vutuv_web/templates/settings/preferences.html.heex:414
+#: lib/vutuv_web/templates/settings/preferences.html.heex:360
+#: lib/vutuv_web/templates/settings/preferences.html.heex:478
 #, elixir-autogen, elixir-format
 msgid "Reset to the site defaults"
 msgstr "Riporta ai valori predefiniti del sito"
@@ -11209,17 +11211,17 @@ msgstr ""
 "valgono subito; i membri che hanno impostato un valore proprio non sono "
 "interessati."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:94
+#: lib/vutuv_web/gettext_extraction_anchors.ex:100
 #, elixir-autogen, elixir-format
 msgid "0 means posts are never shortened."
 msgstr "0 significa che i post non vengono mai accorciati."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:100
+#: lib/vutuv_web/gettext_extraction_anchors.ex:106
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr "Disattivato"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:99
+#: lib/vutuv_web/gettext_extraction_anchors.ex:105
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr "Attivato"
@@ -11385,19 +11387,19 @@ msgstr ""
 "Sua disponibilità ma non può garantirla, perché chiunque può creare un "
 "account. Scelga \"Nessuno\" per conservare lo stato senza mostrarlo."
 
-#: lib/vutuv/accounts/user.ex:1205
+#: lib/vutuv/accounts/user.ex:1211
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Tutti, compresi i visitatori non connessi"
 
-#: lib/vutuv/accounts/user.ex:1210
+#: lib/vutuv/accounts/user.ex:1216
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Nessuno"
 
-#: lib/vutuv/accounts/user.ex:1208
+#: lib/vutuv/accounts/user.ex:1214
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:761
 #, elixir-autogen, elixir-format
@@ -12463,7 +12465,7 @@ msgstr "Organizzazione sbloccata."
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:526
-#: lib/vutuv_web/live/shell_live.ex:977
+#: lib/vutuv_web/live/shell_live.ex:1160
 #: lib/vutuv_web/templates/followee/index.html.heex:14
 #: lib/vutuv_web/templates/follower/index.html.heex:13
 #: lib/vutuv_web/templates/layout/app.html.heex:100
@@ -12782,7 +12784,7 @@ msgstr "I tag evidenziati corrispondono al Suo profilo."
 msgid "How to apply"
 msgstr "Come candidarsi"
 
-#: lib/vutuv/accounts/user.ex:1179
+#: lib/vutuv/accounts/user.ex:1185
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12808,7 +12810,7 @@ msgstr "Titolo della posizione"
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:529
-#: lib/vutuv_web/live/shell_live.ex:799
+#: lib/vutuv_web/live/shell_live.ex:982
 #: lib/vutuv_web/templates/layout/app.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -12904,7 +12906,7 @@ msgstr ""
 "Offri i formati leggibili dalle macchine (.md/.txt/.json/.xml) agli agenti "
 "IA."
 
-#: lib/vutuv/accounts/user.ex:1178
+#: lib/vutuv/accounts/user.ex:1184
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12988,7 +12990,7 @@ msgstr "Annuncio non trovato."
 msgid "Publish"
 msgstr "Pubblica"
 
-#: lib/vutuv/accounts/user.ex:1180
+#: lib/vutuv/accounts/user.ex:1186
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:564
 #: lib/vutuv_web/agent_docs/markdown.ex:458
@@ -14088,7 +14090,7 @@ msgstr ""
 "Se è venuto male (ad esempio con un avviso sui cookie che copre la pagina), "
 "può rimuoverlo."
 
-#: lib/vutuv/accounts/user.ex:1223
+#: lib/vutuv/accounts/user.ex:1229
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -14102,19 +14104,19 @@ msgstr ""
 "la data esatta, \"Giorno e mese\" nasconde l'anno (e la Sua età) e \"Non "
 "mostrare\" lo conserva ma lo tiene fuori dal profilo."
 
-#: lib/vutuv/accounts/user.ex:1226
+#: lib/vutuv/accounts/user.ex:1232
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Giorno e mese, senza l'anno"
 
-#: lib/vutuv/accounts/user.ex:1229
+#: lib/vutuv/accounts/user.ex:1235
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Non mostrare il mio compleanno"
 
-#: lib/vutuv/accounts/user.ex:1220
+#: lib/vutuv/accounts/user.ex:1226
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -14254,14 +14256,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4393
 #: lib/vutuv_web/controllers/settings_controller.ex:614
-#: lib/vutuv_web/live/post_live/feed.ex:1893
+#: lib/vutuv_web/live/post_live/feed.ex:1769
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr "Tag che segue"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1908
+#: lib/vutuv_web/live/post_live/feed.ex:1784
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr "Smetti di seguire #%{tag}"
@@ -14615,7 +14617,7 @@ msgid_plural "Endorsed by %{name} and %{formatted} others"
 msgstr[0] "Confermato da %{name} e da %{formatted} altro"
 msgstr[1] "Confermato da %{name} e da altri %{formatted}"
 
-#: lib/vutuv_web/live/shell_live.ex:453
+#: lib/vutuv_web/live/shell_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
@@ -14742,23 +14744,23 @@ msgid "proof document"
 msgstr "documento di prova"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:74
-#: lib/vutuv_web/templates/settings/preferences.html.heex:368
+#: lib/vutuv_web/templates/settings/preferences.html.heex:432
 #, elixir-autogen, elixir-format
 msgid "Lines in notifications"
 msgstr "Righe nelle notifiche"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:95
+#: lib/vutuv_web/gettext_extraction_anchors.ex:101
 #, elixir-autogen, elixir-format
 msgid "How much of a post a notification quotes before it is cut off."
 msgstr ""
 "Quanta parte di un post viene citata in una notifica prima del taglio."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:359
+#: lib/vutuv_web/templates/settings/preferences.html.heex:423
 #, elixir-autogen, elixir-format
 msgid "Quoted posts in notifications"
 msgstr "Post citati nelle notifiche"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:362
+#: lib/vutuv_web/templates/settings/preferences.html.heex:426
 #, elixir-autogen, elixir-format
 msgid "Your notifications quote the post someone liked or replied to. Leave the field empty to follow the site default."
 msgstr ""
@@ -15205,7 +15207,7 @@ msgstr "Filtra per tag"
 msgid "Filter removed."
 msgstr "Filtro rimosso."
 
-#: lib/vutuv_web/live/post_live/feed.ex:509
+#: lib/vutuv_web/live/post_live/feed.ex:482
 #, elixir-autogen, elixir-format
 msgid "Hidden: matches your filter"
 msgstr "Nascosto: corrisponde a un Suo filtro"
@@ -15244,7 +15246,7 @@ msgstr ""
 "Scelga qui sotto un titolo di studio o un istituto da mostrare in cima al "
 "Suo profilo al posto di una qualifica."
 
-#: lib/vutuv_web/live/post_live/feed.ex:518
+#: lib/vutuv_web/live/post_live/feed.ex:491
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr "Mostra comunque"
@@ -16266,7 +16268,7 @@ msgstr "Ho capito, disattiva"
 msgid "I understand, take part"
 msgstr "Ho capito, partecipa"
 
-#: lib/vutuv_web/views/settings_html.ex:396
+#: lib/vutuv_web/views/settings_html.ex:409
 #, elixir-autogen, elixir-format
 msgid "Most of them, not all: we cannot check whether they do it, and anything that was re-shared, archived or indexed elsewhere stays out of reach. If you take part again later, people there have to follow you anew."
 msgstr ""
@@ -16275,7 +16277,7 @@ msgstr ""
 "portata. Se in futuro partecipa di nuovo, le persone che stanno lì dovranno "
 "seguirla da capo."
 
-#: lib/vutuv_web/views/settings_html.ex:391
+#: lib/vutuv_web/views/settings_html.ex:404
 #, elixir-autogen, elixir-format
 msgid "No new posts go out, and your followers from other networks are removed here. The next time those servers look you up they learn that this account is gone, and most of them then delete their copies of your posts."
 msgstr ""
@@ -16284,24 +16286,24 @@ msgstr ""
 "che questo account non c'è più, e la maggior parte eliminerà le proprie "
 "copie dei Suoi post."
 
-#: lib/vutuv_web/views/settings_html.ex:372
+#: lib/vutuv_web/views/settings_html.ex:385
 #, elixir-autogen, elixir-format
 msgid "Once a post has left vutuv, it is out of our hands"
 msgstr "Quando un post ha lasciato vutuv, non è più nelle nostre mani"
 
-#: lib/vutuv_web/views/settings_html.ex:374
+#: lib/vutuv_web/views/settings_html.ex:387
 #, elixir-autogen, elixir-format
 msgid "Switching off does not delete what is already out there"
 msgstr "Disattivare non elimina ciò che è già fuori"
 
-#: lib/vutuv_web/views/settings_html.ex:385
+#: lib/vutuv_web/views/settings_html.ex:398
 #, elixir-autogen, elixir-format
 msgid "Switching this off again later stops new posts from going out. It cannot bring back what has already been delivered."
 msgstr ""
 "Disattivarlo in seguito impedisce ai nuovi post di uscire. Non può riportare"
 " indietro ciò che è già stato consegnato."
 
-#: lib/vutuv_web/views/settings_html.ex:380
+#: lib/vutuv_web/views/settings_html.ex:393
 #, elixir-autogen, elixir-format
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
@@ -17429,8 +17431,8 @@ msgstr "Aggiungi foto"
 msgid "Licence"
 msgstr "Licenza"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1697
-#: lib/vutuv_web/live/post_live/feed.ex:1698
+#: lib/vutuv_web/live/post_live/feed.ex:1573
+#: lib/vutuv_web/live/post_live/feed.ex:1574
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr "Pubblica foto"
@@ -19487,7 +19489,7 @@ msgstr ""
 "ha ricevuto quando ha messo Mi piace. In ogni caso il post mantiene lo "
 "stesso numero di Mi piace."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:835
+#: lib/vutuv_web/controllers/settings_controller.ex:855
 #, elixir-autogen, elixir-format
 msgid "Your likes follow the site default again."
 msgstr "I Suoi Mi piace tornano a seguire il valore predefinito del sito."
@@ -20520,17 +20522,17 @@ msgstr ""
 "Il PIN non arriva? L'indirizzo e-mail {email} è corretto? Ha controllato la "
 "cartella dello spam?"
 
-#: lib/vutuv/accounts/user.ex:1326
+#: lib/vutuv/accounts/user.ex:1332
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Non binario"
 
-#: lib/vutuv/accounts/user.ex:1324
+#: lib/vutuv/accounts/user.ex:1330
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr "Femminile"
 
-#: lib/vutuv/accounts/user.ex:1325
+#: lib/vutuv/accounts/user.ex:1331
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Maschile"
@@ -21390,7 +21392,7 @@ msgstr "Non può più scrivere a nome di questa organizzazione."
 msgid "A post in an organization's name is always public."
 msgstr "Un post a nome di un'organizzazione è sempre pubblico."
 
-#: lib/vutuv_web/live/shell_live.ex:716
+#: lib/vutuv_web/live/shell_live.ex:899
 #, elixir-autogen, elixir-format
 msgid "Open the page"
 msgstr "Apri la pagina"
@@ -21410,7 +21412,7 @@ msgstr "Ha smesso di scrivere come organizzazione"
 msgid "Write as %{name} for now"
 msgstr "Scrivi come %{name} per ora"
 
-#: lib/vutuv_web/live/shell_live.ex:726
+#: lib/vutuv_web/live/shell_live.ex:909
 #, elixir-autogen, elixir-format
 msgid "Write as myself again"
 msgstr "Torna a scrivere come me stesso"
@@ -21420,7 +21422,7 @@ msgstr "Torna a scrivere come me stesso"
 msgid "You are writing as %{name} now."
 msgstr "Ora sta scrivendo come %{name}."
 
-#: lib/vutuv_web/live/shell_live.ex:702
+#: lib/vutuv_web/live/shell_live.ex:885
 #, elixir-autogen, elixir-format
 msgid "You are writing as %{name}."
 msgstr "Sta scrivendo come %{name}."
@@ -21831,21 +21833,21 @@ msgstr "Segue già #%{tag} qui."
 msgid "You are on this vutuv yourself, so you now follow #%{tag} right here."
 msgstr "Anche Lei è su questo vutuv, quindi ora segue #%{tag} proprio qui."
 
-#: lib/vutuv_web/live/shell_live.ex:483
+#: lib/vutuv_web/live/shell_live.ex:533
 #, elixir-autogen, elixir-format
 msgid "%{formatted} person"
 msgid_plural "%{formatted} people"
 msgstr[0] "%{formatted} persona"
 msgstr[1] "%{formatted} persone"
 
-#: lib/vutuv_web/live/shell_live.ex:470
+#: lib/vutuv_web/live/shell_live.ex:520
 #, elixir-autogen, elixir-format
 msgid "person"
 msgid_plural "people"
 msgstr[0] "persona"
 msgstr[1] "persone"
 
-#: lib/vutuv_web/live/shell_live.ex:505
+#: lib/vutuv_web/live/shell_live.ex:555
 #, elixir-autogen, elixir-format
 msgid "%{members} vutuv members plus %{fediverse} Fediverse account that follows them"
 msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that follow them"
@@ -22344,7 +22346,7 @@ msgstr ""
 "così come sono, tradurglieli o nasconderli. I post che non dichiarano una "
 "lingua vengono sempre mostrati."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:104
+#: lib/vutuv_web/gettext_extraction_anchors.ex:110
 #, elixir-autogen, elixir-format
 msgid "Date & time"
 msgstr "Data e ora"
@@ -22354,12 +22356,12 @@ msgstr "Data e ora"
 msgid "Date and time settings reset to the site defaults."
 msgstr "Impostazioni di data e ora riportate ai valori predefiniti del sito."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:102
+#: lib/vutuv_web/gettext_extraction_anchors.ex:108
 #, elixir-autogen, elixir-format
 msgid "Date format"
 msgstr "Formato della data"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:112
+#: lib/vutuv_web/gettext_extraction_anchors.ex:118
 #, elixir-autogen, elixir-format
 msgid "Germany, Austria, Switzerland"
 msgstr "Germania, Austria, Svizzera"
@@ -22369,31 +22371,31 @@ msgstr "Germania, Austria, Svizzera"
 msgid "Language and region saved."
 msgstr "Lingua e regione salvate."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:108
+#: lib/vutuv_web/gettext_extraction_anchors.ex:114
 #, elixir-autogen, elixir-format
 msgid "Posts, messages and notifications are stamped in this zone. New accounts take it from the browser."
 msgstr ""
 "Post, messaggi e notifiche vengono datati in questo fuso. I nuovi account lo"
 " ricavano dal browser."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:105
+#: lib/vutuv_web/gettext_extraction_anchors.ex:111
 #, elixir-autogen, elixir-format
 msgid "The order and punctuation of every date you read here, and whether times run on a 12- or 24-hour clock."
 msgstr ""
 "L'ordine e la punteggiatura di ogni data che legge qui, e se gli orari usano"
 " il formato a 12 o a 24 ore."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:103
+#: lib/vutuv_web/gettext_extraction_anchors.ex:109
 #, elixir-autogen, elixir-format
 msgid "Time zone"
 msgstr "Fuso orario"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:113
+#: lib/vutuv_web/gettext_extraction_anchors.ex:119
 #, elixir-autogen, elixir-format
 msgid "United Kingdom, France, Brazil"
 msgstr "Regno Unito, Francia, Brasile"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:114
+#: lib/vutuv_web/gettext_extraction_anchors.ex:120
 #, elixir-autogen, elixir-format
 msgid "United States"
 msgstr "Stati Uniti"
@@ -22403,7 +22405,7 @@ msgstr "Stati Uniti"
 msgid "Your browser says: {zone}"
 msgstr "Il Suo browser dice: {zone}"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:115
+#: lib/vutuv_web/gettext_extraction_anchors.ex:121
 #, elixir-autogen, elixir-format
 msgid "ISO 8601 (Sweden, Japan, China)"
 msgstr "ISO 8601 (Svezia, Giappone, Cina)"
@@ -22490,7 +22492,7 @@ msgstr "Consigliato: %{width} × %{height} pixel (%{ratio})."
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr "Consigliato: quadrata, almeno %{width} × %{height} pixel."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1950
+#: lib/vutuv_web/live/post_live/feed.ex:1826
 #: lib/vutuv_web/views/user_html.ex:334
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -23052,7 +23054,7 @@ msgstr "Smettere di seguire %{handle}? I suoi post spariscono dal Suo feed."
 msgid "Unfollowed. Their posts leave your feed."
 msgstr "Non lo segue più. I suoi post spariscono dal Suo feed."
 
-#: lib/vutuv_web/live/shell_live.ex:672
+#: lib/vutuv_web/live/shell_live.ex:855
 #, elixir-autogen, elixir-format
 msgid "Allow"
 msgstr "Consenti"
@@ -23067,12 +23069,12 @@ msgstr "Chiedi ora"
 msgid "Browser notifications"
 msgstr "Notifiche del browser"
 
-#: lib/vutuv_web/live/shell_live.ex:614
+#: lib/vutuv_web/live/shell_live.ex:797
 #, elixir-autogen, elixir-format
 msgid "New message"
 msgstr "Nuovo messaggio"
 
-#: lib/vutuv_web/live/shell_live.ex:679
+#: lib/vutuv_web/live/shell_live.ex:862
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr "Non ora"
@@ -23122,7 +23124,7 @@ msgstr ""
 "guardando, il Suo browser può mostrarlo come notifica. Disattivate finché "
 "non le attiva."
 
-#: lib/vutuv_web/live/shell_live.ex:669
+#: lib/vutuv_web/live/shell_live.ex:852
 #, elixir-autogen, elixir-format
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
@@ -23168,12 +23170,12 @@ msgstr ""
 "Inviata. Se non è comparso nulla, è il Suo sistema a trattenerla. Controlli "
 "la modalità Non disturbare e le impostazioni delle notifiche."
 
-#: lib/vutuv_web/live/shell_live.ex:569
+#: lib/vutuv_web/live/shell_live.ex:619
 #, elixir-autogen, elixir-format
 msgid "Test notification"
 msgstr "Notifica di prova"
 
-#: lib/vutuv_web/live/shell_live.ex:570
+#: lib/vutuv_web/live/shell_live.ex:620
 #, elixir-autogen, elixir-format
 msgid "This is what vutuv looks like when something arrives."
 msgstr "Ecco come si presenta vutuv quando arriva qualcosa."
@@ -23185,12 +23187,12 @@ msgstr ""
 "Segua #%{tag} da Mastodon o da qualsiasi altra app del Fediverso e i suoi "
 "post pubblici arriveranno nella Sua cronologia. Non serve un account vutuv."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1932
+#: lib/vutuv_web/live/post_live/feed.ex:1808
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Saluti gli altri membri"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1928
+#: lib/vutuv_web/live/post_live/feed.ex:1804
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr "Nuovi qui"
@@ -23240,7 +23242,7 @@ msgstr ""
 msgid "With a vutuv account"
 msgstr "Con un account vutuv"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1942
+#: lib/vutuv_web/live/post_live/feed.ex:1818
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr "Alcuni fra i membri più recenti. Seguirli è un bel benvenuto."
@@ -23252,24 +23254,25 @@ msgid_plural "%{formatted} new posts"
 msgstr[0] "%{formatted} nuovo post"
 msgstr[1] "%{formatted} nuovi post"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1387
+#: lib/vutuv_web/live/post_live/feed.ex:1288
 #, elixir-autogen, elixir-format
 msgid "%{source}: %{formatted} new post"
 msgid_plural "%{source}: %{formatted} new posts"
 msgstr[0] "%{source}: %{formatted} nuovo post"
 msgstr[1] "%{source}: %{formatted} nuovi post"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1384
+#: lib/vutuv_web/live/post_live/feed.ex:1285
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post"
 msgstr "%{source}: nuovo post"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1381
+#: lib/vutuv_web/live/post_live/feed.ex:1282
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post from %{who}"
 msgstr "%{source}: nuovo post di %{who}"
 
 #: lib/vutuv_web/templates/settings/preferences.html.heex:247
+#: lib/vutuv_web/templates/settings/preferences.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "Example"
 msgstr "Esempio"
@@ -23292,12 +23295,14 @@ msgid "Feed tabs"
 msgstr "Schede del feed"
 
 #: lib/vutuv_web/templates/settings/preferences.html.heex:271
+#: lib/vutuv_web/views/settings_html.ex:137
 #, elixir-autogen, elixir-format
 msgid "Just flashed the new release, boot is under two seconds now"
 msgstr ""
 "Appena installata la nuova versione, l'avvio ora sta sotto i due secondi"
 
 #: lib/vutuv_web/templates/settings/preferences.html.heex:281
+#: lib/vutuv_web/templates/settings/preferences.html.heex:345
 #, elixir-autogen, elixir-format
 msgid "Play the example"
 msgstr "Riproduci l'esempio"
@@ -23310,7 +23315,7 @@ msgstr ""
 "riceve un pallino. Può anche citare il post per qualche secondo, così "
 "capisce se vale la pena cambiare scheda."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:93
+#: lib/vutuv_web/gettext_extraction_anchors.ex:99
 #, elixir-autogen, elixir-format
 msgid "Between 4 and 20 seconds."
 msgstr "Fra 4 e 20 secondi."
@@ -23446,3 +23451,46 @@ msgstr "Traducili in %{language}"
 #, elixir-autogen, elixir-format
 msgid "Translated into %{language}."
 msgstr "Vengono tradotti in %{language}."
+
+#: lib/vutuv_web/live/shell_live.ex:736
+#, elixir-autogen, elixir-format
+msgid "+%{formatted} more post"
+msgid_plural "+%{formatted} more posts"
+msgstr[0] "+%{formatted} altro post"
+msgstr[1] "+%{formatted} altri post"
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:94
+#: lib/vutuv_web/templates/settings/preferences.html.heex:311
+#, elixir-autogen, elixir-format
+msgid "Browser tab"
+msgstr "Scheda del browser"
+
+#: lib/vutuv_web/controllers/settings_controller.ex:846
+#, elixir-autogen, elixir-format
+msgid "Browser tab settings reset to the site defaults."
+msgstr "Impostazioni della scheda del browser ripristinate ai valori predefiniti del sito."
+
+#: lib/vutuv_web/controllers/settings_controller.ex:840
+#, elixir-autogen, elixir-format
+msgid "Browser tab settings saved."
+msgstr "Impostazioni della scheda del browser salvate."
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:96
+#, elixir-autogen, elixir-format
+msgid "Only while you are looking at another tab, and only for a few seconds. The tab title also shows up in screenshots, in your window switcher and in a screen share."
+msgstr "Solo mentre sta guardando un'altra scheda, e solo per qualche secondo. Il titolo della scheda compare anche negli screenshot, nel selettore di finestre e in una condivisione dello schermo."
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:95
+#, elixir-autogen, elixir-format
+msgid "Tease new posts in the browser tab"
+msgstr "Anticipa i nuovi post nella scheda del browser"
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:337
+#, elixir-autogen, elixir-format
+msgid "Watch this tab's title, above."
+msgstr "Guardi il titolo di questa scheda, qui sopra."
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:313
+#, elixir-autogen, elixir-format
+msgid "While you are reading another tab, a new post can page its first words through this tab's title, a line at a time, and then hand the title back."
+msgstr "Mentre sta leggendo un'altra scheda, un nuovo post può far scorrere le sue prime parole nel titolo di questa scheda, una riga alla volta, per poi restituire il titolo."

--- a/priv/repo/migrations/20260825101216_add_browser_tab_teaser_pref.exs
+++ b/priv/repo/migrations/20260825101216_add_browser_tab_teaser_pref.exs
@@ -1,0 +1,22 @@
+defmodule Vutuv.Repo.Migrations.AddBrowserTabTeaserPref do
+  use Ecto.Migration
+
+  @moduledoc """
+  The browser tab's teaser (issue #1681): while a member's vutuv tab sits in the
+  background, a new post pages its first line through the tab title instead of
+  only putting a dot there. The sibling of the feed's tab ticker (#1668), one
+  surface further out.
+
+  One knob, `Vutuv.Prefs` group `:browser_tab`: `browser_tab_teaser?`. Nullable
+  with **no** DB default, like every other pref column — NULL means "inherit the
+  installation default", and the shipped value (on) lives only in the registry.
+
+  N-1 safe: a pure nullable addition the deployed release never reads.
+  """
+
+  def change do
+    alter table(:users) do
+      add(:browser_tab_teaser?, :boolean)
+    end
+  end
+end

--- a/test/vutuv_web/controllers/settings_prefs_test.exs
+++ b/test/vutuv_web/controllers/settings_prefs_test.exs
@@ -93,6 +93,50 @@ defmodule VutuvWeb.SettingsPrefsTest do
     end
   end
 
+  describe "the browser tab's teaser (issue #1681)" do
+    test "the card saves the switch and offers its own reset", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      html = conn |> get(~p"/settings/preferences") |> html_response(200)
+      assert html =~ ~s(action="/settings/browser_tab")
+      refute html =~ ~s(id="reset-browser-tab")
+
+      conn =
+        put(conn, ~p"/settings/browser_tab", %{"user" => %{"browser_tab_teaser?" => "false"}})
+
+      assert redirected_to(conn) == ~p"/settings/preferences"
+      assert Repo.get!(User, user.id).browser_tab_teaser? == false
+
+      html = conn |> get(~p"/settings/preferences") |> html_response(200)
+      assert html =~ ~s(id="reset-browser-tab")
+
+      conn = post(conn, ~p"/settings/browser_tab/reset")
+      assert redirected_to(conn) == ~p"/settings/preferences"
+      user = Repo.get!(User, user.id)
+      assert user.browser_tab_teaser? == nil
+      # Its own group, so the feed-tab card beside it is untouched.
+      assert user.feed_tab_ticker? == nil
+    end
+
+    test "the card reads in German for a German reader", %{conn: conn} do
+      # A German-only crash or a fuzzy-filled msgid passes every English check,
+      # so the new strings are asserted by name in the language they ship in.
+      {conn, _user} = create_and_login_user(conn)
+
+      html =
+        conn
+        |> recycle()
+        |> put_req_header("accept-language", "de-DE,de")
+        |> get(~p"/settings/preferences")
+        |> html_response(200)
+
+      assert html =~ "Browser-Tab"
+      assert html =~ "Neue Beiträge im Browser-Tab anreißen"
+      assert html =~ "Bildschirmfreigabe"
+      assert html =~ "Achten Sie oben auf den Titel dieses Tabs."
+    end
+  end
+
   describe "rendering for readers" do
     test "an admin-set post default reaches an untouched member's feed markup" do
       with_installation_defaults(%{post_lines_desktop: 12})

--- a/test/vutuv_web/live/browser_tab_teaser_test.exs
+++ b/test/vutuv_web/live/browser_tab_teaser_test.exs
@@ -1,0 +1,249 @@
+defmodule VutuvWeb.BrowserTabTeaserTest do
+  @moduledoc """
+  The teaser in the browser tab's own title (issue #1681).
+
+  The shell is mounted on every page of every logged-in member and already
+  receives every arrival, so what is worth testing is not that a quote renders
+  but the rules that keep the feature from turning one popular post into
+  thousands of feed queries: nothing is spent on a tab the member is looking
+  at, a second arrival inside the window is counted rather than looked up, and
+  the silence afterwards is armed even by the arrivals that produce no quote at
+  all — the case that would otherwise have no rate limit whatsoever.
+
+  Not async: two tests set `:tab_teaser_cooldown_ms`, which is application env —
+  process state the SQL sandbox does not roll back, and every open shell reads
+  it. `config/test.exs` holds it at 0 so the other tests here can fire twice.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.ContentFilters
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Follow
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Posts
+  alias Vutuv.Sessions
+  alias Vutuv.Social
+
+  setup do
+    # `record_remote_post/2` claims the shared inbound cap, which lives in the
+    # RateLimiter's ETS table and outlives a test.
+    Vutuv.RateLimiter.reset()
+    :ok
+  end
+
+  defp put_config(key, value) do
+    original = Application.fetch_env(:vutuv, key)
+    Application.put_env(:vutuv, key, value)
+
+    on_exit(fn ->
+      case original do
+        {:ok, was} -> Application.put_env(:vutuv, key, was)
+        :error -> Application.delete_env(:vutuv, key)
+      end
+    end)
+  end
+
+  # The shell as one of this member's browser tabs. `hidden?` is what the
+  # TabBadge hook reports on connect: the server refuses to spend a lookup
+  # until it hears that the member is looking somewhere else.
+  defp tab(conn, user, hidden? \\ true) do
+    {token, _session} = Sessions.start_session(user, build_conn(), alert: false)
+
+    {:ok, view, _html} =
+      live_isolated(conn, VutuvWeb.ShellLive, session: %{"session_token" => token})
+
+    render_hook(view, "tab:visibility", %{"hidden" => hidden?})
+    view
+  end
+
+  defp followed_author(viewer, attrs \\ []) do
+    author = insert(:user, [email_confirmed?: true] ++ attrs)
+    Social.follow(viewer, author.id)
+    author
+  end
+
+  defp remote_account(user, handle) do
+    actor = "https://social.example/users/#{handle}"
+
+    account =
+      Repo.insert!(%RemoteAccount{
+        actor_uri: actor,
+        host: "social.example",
+        handle: handle,
+        name: String.capitalize(handle),
+        inbox_uri: actor <> "/inbox"
+      })
+
+    Repo.insert!(%Follow{
+      user_id: user.id,
+      remote_account_id: account.id,
+      state: "accepted",
+      follow_activity_id: "https://vutuv.test/#{user.id}/actor#follows/#{handle}"
+    })
+
+    account
+  end
+
+  defp remote_note(account, text) do
+    unique = System.unique_integer([:positive])
+
+    %{
+      "type" => "Create",
+      "actor" => account.actor_uri,
+      "object" => %{
+        "id" => "https://social.example/posts/#{unique}",
+        "type" => "Note",
+        "attributedTo" => account.actor_uri,
+        "content" => "<p>#{text}</p>",
+        "url" => "https://social.example/@#{account.handle}/#{unique}",
+        "published" => DateTime.to_iso8601(DateTime.utc_now(:second)),
+        "to" => ["https://www.w3.org/ns/activitystreams#Public"]
+      }
+    }
+  end
+
+  describe "a post arriving while the member is somewhere else" do
+    test "pages its author and first words through the title", %{conn: conn} do
+      user = insert(:user)
+      view = tab(conn, user)
+      author = followed_author(user, username: "quotable")
+
+      {:ok, _post} =
+        Posts.create_post(author, %{body: "Frisch geflasht, **unter zwei Sekunden**"})
+
+      assert_push_event(view, "tab:teaser", %{frames: [first | _] = frames})
+      assert first =~ "@quotable"
+      # The body arrives as one line of plain text: no Markdown, no asterisks.
+      assert Enum.join(frames, " ") =~ "Frisch geflasht, unter zwei Sekunden"
+      # The dot is a separate promise and is made too.
+      assert_push_event(view, "tab:new_post", %{})
+    end
+
+    test "names a remote author without their server", %{conn: conn} do
+      user = insert(:user)
+      view = tab(conn, user)
+      account = remote_account(user, "them")
+
+      assert :ok =
+               Fediverse.record_remote_post(
+                 remote_note(account, "frisch von drüben"),
+                 account.actor_uri
+               )
+
+      assert_push_event(view, "tab:teaser", %{frames: frames})
+      line = Enum.join(frames, " ")
+      assert line =~ "@them"
+      refute line =~ "social.example"
+      assert line =~ "frisch von drüben"
+
+      # The fediverse nudge carries no entry, so the dot rides on the lookup
+      # that found something for this reader rather than being pushed blind.
+      assert_push_event(view, "tab:new_post", %{})
+    end
+
+    test "your own post never teases your own tab", %{conn: conn} do
+      user = insert(:user, email_confirmed?: true)
+      view = tab(conn, user)
+
+      {:ok, _post} = Posts.create_post(user, %{body: "etwas von mir"})
+
+      refute_push_event(view, "tab:teaser", %{})
+    end
+  end
+
+  describe "what is not spent" do
+    test "a tab the member is reading gets the dot and no teaser", %{conn: conn} do
+      user = insert(:user)
+      view = tab(conn, user, false)
+      author = followed_author(user)
+
+      {:ok, _post} = Posts.create_post(author, %{body: "etwas Neues"})
+
+      assert_push_event(view, "tab:new_post", %{})
+      refute_push_event(view, "tab:teaser", %{})
+    end
+
+    test "a member who switched the teaser off keeps the plain dot", %{conn: conn} do
+      user = insert(:user, browser_tab_teaser?: false)
+      view = tab(conn, user)
+      author = followed_author(user)
+
+      {:ok, _post} = Posts.create_post(author, %{body: "etwas Neues"})
+
+      assert_push_event(view, "tab:new_post", %{})
+      refute_push_event(view, "tab:teaser", %{})
+    end
+
+    test "a muted word is never quoted into the tab", %{conn: conn} do
+      user = insert(:user)
+      {:ok, _filter} = ContentFilters.create_filter(user, %{kind: :keyword, pattern: "Kessel"})
+      view = tab(conn, user)
+      author = followed_author(user)
+
+      {:ok, _post} = Posts.create_post(author, %{body: "Der Kessel läuft wieder"})
+
+      # The tab is the one place a member cannot scroll past it, so the quote
+      # gives up entirely rather than being redacted.
+      refute_push_event(view, "tab:teaser", %{})
+      assert_push_event(view, "tab:new_post", %{})
+    end
+  end
+
+  describe "more than one inside the window" do
+    test "the second arrival is counted, not quoted again", %{conn: conn} do
+      user = insert(:user)
+      view = tab(conn, user)
+      author = followed_author(user)
+
+      {:ok, _first} = Posts.create_post(author, %{body: "der erste Beitrag"})
+      assert_push_event(view, "tab:teaser", %{frames: _})
+
+      {:ok, _second} = Posts.create_post(author, %{body: "und gleich der zweite"})
+
+      assert_push_event(view, "tab:teaser_more", %{text: text})
+      assert text =~ "1"
+      # A second quote would stand for less time than it takes to read one.
+      refute_push_event(view, "tab:teaser", %{})
+    end
+  end
+
+  describe "the silence after a window" do
+    test "an arrival inside it spends no lookup", %{conn: conn} do
+      put_config(:tab_teaser_cooldown_ms, 30_000)
+
+      user = insert(:user)
+      view = tab(conn, user)
+      author = followed_author(user)
+
+      {:ok, _first} = Posts.create_post(author, %{body: "der erste Beitrag"})
+      assert_push_event(view, "tab:teaser", %{frames: _})
+
+      # Past the window this would be a fresh quote; inside the silence that
+      # follows it, the socket does not go back to the database at all.
+      send(view.pid, {:new_post, %{post_id: Vutuv.UUIDv7.generate(), author_id: author.id}})
+      refute_push_event(view, "tab:teaser", %{})
+    end
+
+    test "a quote the reader may not see spends it too", %{conn: conn} do
+      # The refusal is the branch with no rate limit of its own: it looks up,
+      # finds nothing it may show, and would otherwise look up again on the very
+      # next arrival — worst for the member who muted the word a busy account
+      # keeps writing. Remove the `arm_quiet/2` on that branch and the second
+      # post below is quoted.
+      put_config(:tab_teaser_cooldown_ms, 30_000)
+
+      user = insert(:user)
+      {:ok, _filter} = ContentFilters.create_filter(user, %{kind: :keyword, pattern: "Kessel"})
+      view = tab(conn, user)
+      author = followed_author(user)
+
+      {:ok, _muted} = Posts.create_post(author, %{body: "Der Kessel läuft wieder"})
+      refute_push_event(view, "tab:teaser", %{})
+
+      {:ok, _other} = Posts.create_post(author, %{body: "etwas ganz anderes"})
+      refute_push_event(view, "tab:teaser", %{})
+    end
+  end
+end

--- a/test/vutuv_web/post_teaser_test.exs
+++ b/test/vutuv_web/post_teaser_test.exs
@@ -1,0 +1,68 @@
+defmodule VutuvWeb.PostTeaserTest do
+  @moduledoc """
+  How a quote is cut into browser-tab frames (issue #1681).
+
+  The frames are the whole feature on that surface: a hidden tab gives us about
+  four of them before the browser stops advancing the timer, and each one has
+  to be a line somebody can read in the width of a tab. So what is worth
+  pinning is that the author leads, that words are not cut in half, that a
+  pasted URL cannot swallow the frames after it, and that the cap holds.
+  """
+  use ExUnit.Case, async: true
+
+  alias VutuvWeb.PostTeaser
+
+  defp frames(who, text), do: PostTeaser.title_frames(%{who: who, text: text})
+
+  test "the author leads the first frame and is not repeated" do
+    [first | rest] = frames("@quotable", "Frisch geflasht, unter zwei Sekunden")
+
+    assert first =~ "@quotable"
+    refute Enum.any?(rest, &(&1 =~ "@quotable"))
+  end
+
+  test "the frames read back as the line they were cut from" do
+    line = "Frisch geflasht, unter zwei Sekunden"
+
+    assert "@quotable" |> frames(line) |> Enum.join(" ") == "@quotable: " <> line
+  end
+
+  test "no frame is wider than a tab, and words survive whole" do
+    line = "Der Kessel steht seit gestern im Keller und heizt das ganze Haus"
+    cut = frames("@quotable", line)
+
+    words = Enum.flat_map(cut, &String.split(&1, " "))
+
+    assert Enum.all?(cut, &(String.length(&1) <= 24))
+    # What the frames carry is the opening of the line, word for word.
+    assert words == Enum.take(String.split("@quotable: " <> line, " "), length(words))
+  end
+
+  test "a long post stops at the frame cap rather than paging all evening" do
+    # Three, because a hidden tab gives us about four one-second frames before
+    # the browser stops advancing the timer and the fourth has to be the line
+    # that is still true a minute later.
+    long = String.duplicate("Wort ", 200)
+
+    assert length(frames("@quotable", long)) == 3
+  end
+
+  test "a word wider than a frame gets one of its own, cut hard" do
+    url = "https://example.com/" <> String.duplicate("a", 80)
+
+    # Without the hard cut the URL would be one 100-character frame and the two
+    # frames after it would never carry any of the sentence.
+    assert [first, second | _] = frames(nil, url <> " danach kommt noch etwas")
+    assert String.length(first) <= 24
+    assert String.length(second) <= 24
+  end
+
+  test "an author with nothing to quote still says who it was" do
+    assert frames("@quotable", nil) == ["@quotable"]
+  end
+
+  test "nothing to say at all is no teaser" do
+    assert frames(nil, nil) == []
+    assert PostTeaser.title_frames(nil) == []
+  end
+end

--- a/test/vutuv_web/settings_example_buttons_test.exs
+++ b/test/vutuv_web/settings_example_buttons_test.exs
@@ -1,0 +1,55 @@
+defmodule VutuvWeb.SettingsExampleButtonsTest do
+  @moduledoc """
+  The two "Play the example" buttons on /settings/preferences — the feed tab's
+  ticker (issue #1668) and the browser tab's teaser (issue #1681).
+
+  Both are a setting whose effect happens somewhere the member cannot watch, so
+  the example is the whole reason the card is legible. And both read their own
+  switch before playing, which is where the one bug in this file's history came
+  from: they climbed to `.closest(".card")`, and the kit's `<.card>` is a pile
+  of utility classes that emits no `card` class at all. `form` was null, `on`
+  came back `undefined`, and the button silently did nothing from the day it
+  shipped. Nothing failed, because nothing here can fail — a LiveView or
+  controller test never runs `app.js`, and it took driving the page in a real
+  browser to see it.
+
+  So this asserts the two halves of the contract that a browser would check:
+  the page really renders the checkbox each handler looks up, and the handlers
+  really look it up somewhere that exists.
+  """
+  use VutuvWeb.ConnCase, async: true
+
+  @app_js "assets/js/app.js"
+
+  describe "the switch each example reads" do
+    test "is rendered on the page, under the name the handler queries", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+      html = conn |> get(~p"/settings/preferences") |> html_response(200)
+
+      # `name*=` on a checkbox, so the hidden false-companion beside it (same
+      # name, type="hidden") must not be what the handler finds.
+      assert html =~ ~s(name="user[feed_tab_ticker?]" type="checkbox")
+      assert html =~ ~s(name="user[browser_tab_teaser?]" type="checkbox")
+      assert html =~ "data-ticker-preview-play"
+      assert html =~ "data-tab-teaser-play"
+    end
+
+    test "is looked up somewhere that exists" do
+      app_js = File.read!(@app_js)
+
+      refute app_js =~ ~s|closest(".card")|,
+             """
+             A handler in #{@app_js} climbs to `.card`, and no such element is \
+             rendered — the kit's <.card> emits utility classes only, so the \
+             lookup returns null and whatever depends on it silently does \
+             nothing. Query the document for the control's own name instead.\
+             """
+
+      assert app_js =~
+               ~s|document.querySelector('input[type="checkbox"][name*="feed_tab_ticker"]')|
+
+      assert app_js =~
+               ~s|document.querySelector('input[type="checkbox"][name*="browser_tab_teaser"]')|
+    end
+  end
+end


### PR DESCRIPTION
**Symptom:** a new post only puts a bare `•` in the browser tab. **Now:** `VutuvWeb.ShellLive` pages the author and first words through the tab title, then hands it back. Both sources; the quote is shared with the feed's ticker (`VutuvWeb.PostTeaser`). Switch on /settings/preferences, on by default.

**The budget:** the shell is on every page, so a socket spends one `Posts.newest_source_entry/3` per window plus a 30 s cooldown; arrivals inside it are counted ("+2 more posts"), and refusals arm it too. No new broadcasts.

**Driven in headless Chrome:**

```
  200 ms  "• @wintermeyer: Frisch"
 2000 ms  "• geflasht, unter zwei"
 4000 ms  "• Sekunden bis der Kessel"
 6000 ms  "• +1 more post"
 8000 ms  "• Feed - vutuv"
```

Frames stand 2 s, not the 1 s asked for (hidden tabs align wake-ups), so the window is sized on that.

**Fixed beside it:** both example buttons there climbed to `.card`, which the kit card never emits; the older one had been dead since v7.347.0.

*An AI agent wrote this text in my name. I know that is problematic.*
