### PR TITLE
Keep the feed's unseen dot across a LiveView rejoin

### DIFF
--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -434,6 +434,34 @@ over there, and the tab reloads from the top anyway. The socket's
 `:unseen_sources` is never stored — it means "since you have been looking at
 this page", so a fresh mount starting clean is the honest state.
 
+**A rejoin runs that same mount and is not a fresh page.** Socket state goes
+with the socket, so the dot went with it: a locked phone, a background tab
+whose heartbeat the browser throttled past the transport timeout, a wifi
+handover and every deploy reconnect without reloading anything, which read as
+the dot expiring by itself a couple of minutes after it appeared. A
+**connected** mount therefore derives it back (`restore_unseen/2`): does the
+tab the reader is not on hold anything at or after the last moment they had it
+on screen (`Posts.feed_source_since?/3`, the boolean half of
+`newest_source_entry/3`)? That moment is the later of
+
+* **when the document was loaded** — `feed_opened_at`, put into the signed
+  `live_render` session by `NewsfeedController`. That map is minted once per
+  document and replayed verbatim on every rejoin, so it dates the one thing a
+  socket that died and came back cannot date itself; and
+* **when they last moved tabs** — `users.feed_source_at`, stamped beside
+  `feed_source` by `remember_feed_filter/3`. Which tab is being left is an
+  argument rather than a rule at the call site, because only that side knows
+  it and the answer decides whether the clock moves at all: pressing the tab
+  already open moves nobody, and a stamp there would swallow a dot still
+  rightly standing on the other one.
+
+A real page load still starts clean (its own `opened_at` is now, and nothing is
+newer than now), and a document from the previous release carries no stamp and
+keeps the old behaviour, so the N-1 deploy window has no half-state. A first
+connect skips the question altogether (`@restore_grace`, 5 s): the socket joins
+a second or two after the render, so the answer is false by construction and
+the five source queries would be waste on the busiest page in the app.
+
 The two halves reach it differently, and the difference is what each write
 knows about the reader:
 

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -320,6 +320,11 @@ defmodule Vutuv.Accounts.User do
     # changeset. Only the opening value: while the feed is open the LiveView's
     # own assign is the truth.
     field(:feed_source, :string)
+    # When that tab was last chosen. Stamped by the same writer, and read at
+    # mount as the anchor for the feed's unseen dot: a rejoining document has
+    # to date "since you were last looking at the other tab" from somewhere
+    # outside the socket it just lost.
+    field(:feed_source_at, :naive_datetime)
     # The reader's post-display preferences (same settings page, applied to
     # every post this member reads: feed, profile Beiträge, permalink). The
     # line counts drive the CSS line-clamp on the preview body, desktop and

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -2644,22 +2644,34 @@ defmodule Vutuv.Posts do
   def remembered_feed_filter(%User{feed_source: source}), do: normalize_feed_filter(source)
 
   @doc """
-  Remembers `filter` as `user`'s feed tab for the next visit.
+  Remembers `filter` as `user`'s feed tab for the next visit, `leaving` being
+  the tab they are coming from.
 
-  A narrow `update_all` on the one column rather than a changeset: a socket's
-  `%User{}` was loaded at mount and can be hours old by the time a tab is
-  clicked, so writing the whole struct back would undo whatever else changed
-  meanwhile — from another device, or from a settings page in the next tab.
-  For the same reason it does not first ask whether the value differs; that
-  question cannot be answered from a struct that may be stale, and the write
-  is one row by primary key. Last click wins, which is what a "last chosen"
-  value means.
+  A narrow `update_all` rather than a changeset: a socket's `%User{}` was
+  loaded at mount and can be hours old by the time a tab is clicked, so writing
+  the whole struct back would undo whatever else changed meanwhile — from
+  another device, or from a settings page in the next tab. For the same reason
+  it does not first ask whether the stored value differs; that question cannot
+  be answered from a struct that may be stale. Last click wins, which is what a
+  "last chosen" value means.
+
+  `feed_source_at` is the exception, and `leaving` is why it is an argument
+  rather than a comment at the call site: it dates the reader's *move*, which
+  `VutuvWeb.PostLive.Feed.restore_unseen/2` reads as "you were still looking at
+  the tab you just left until now". A press on the tab already open moves
+  nobody, so stamping it there would swallow a dot still rightly standing on
+  the other one. Only the caller knows which tab is on screen, so only the
+  caller can say — but it has to say, not remember to.
   """
-  def remember_feed_filter(%User{} = user, filter) do
+  def remember_feed_filter(%User{} = user, filter, leaving) do
     stored = if filter in [:vutuv, :fediverse], do: to_string(filter)
 
-    {1, nil} =
-      Repo.update_all(from(u in User, where: u.id == ^user.id), set: [feed_source: stored])
+    set =
+      if leaving == filter,
+        do: [feed_source: stored],
+        else: [feed_source: stored, feed_source_at: NaiveDateTime.utc_now(:second)]
+
+    {1, nil} = Repo.update_all(from(u in User, where: u.id == ^user.id), set: set)
 
     :ok
   end
@@ -2704,6 +2716,21 @@ defmodule Vutuv.Posts do
     viewer
     |> feed_sources(:fediverse)
     |> Enum.any?(fn fetch -> fetch.(1, nil) != [] end)
+  end
+
+  @doc """
+  Whether the tab `source` holds anything for `viewer` stamped at or after
+  `since` — the boolean half of `newest_source_entry/3` below, and all a mount
+  restoring the dot has to know (`VutuvWeb.PostLive.Feed.restore_unseen/2`).
+
+  It skips that one's decorate pass, and `Enum.any?/2` stops at the first
+  source that answers rather than asking all of them.
+  """
+  def feed_source_since?(%User{} = viewer, source, %NaiveDateTime{} = since)
+      when source in [:vutuv, :fediverse] do
+    viewer
+    |> feed_sources(source)
+    |> Enum.any?(&(newest_row(&1, since) != []))
   end
 
   @doc """

--- a/lib/vutuv_web/controllers/controller_helpers.ex
+++ b/lib/vutuv_web/controllers/controller_helpers.ex
@@ -135,6 +135,13 @@ defmodule VutuvWeb.ControllerHelpers do
   resolved locale and request path. A LiveView mounted outside the
   `live_session` must be handed these explicitly (the profile/CV/board/feed
   pattern); pages layer their own extra keys on top with `Map.put/3`.
+
+  Worth knowing before you layer one on: this map is signed once per **document**
+  and replayed verbatim on every socket rejoin, which makes it the one
+  server-minted thing that can date a document a reconnecting LiveView is
+  patching into. `VutuvWeb.NewsfeedController`'s `feed_opened_at` is that (see
+  `VutuvWeb.PostLive.Feed.restore_unseen/2`). It is not a place for anything
+  that changes while the page is open — a rejoin would hand back the stale one.
   """
   def live_render_session(%Conn{} = conn) do
     %{

--- a/lib/vutuv_web/controllers/newsfeed_controller.ex
+++ b/lib/vutuv_web/controllers/newsfeed_controller.ex
@@ -24,6 +24,7 @@ defmodule VutuvWeb.NewsfeedController do
   alias VutuvWeb.AgentDocs.FeedDoc
   alias VutuvWeb.ApiV2
   alias VutuvWeb.ControllerHelpers
+  alias VutuvWeb.PostLive.Feed
 
   # Mirrors VutuvWeb.PostLive.Feed's @page_size, so the doc's first page matches
   # what the HTML page loads.
@@ -45,7 +46,12 @@ defmodule VutuvWeb.NewsfeedController do
     conn
     |> AgentDocs.put_html_alternates()
     |> put_layout(html: false)
-    |> live_render(VutuvWeb.PostLive.Feed, session: ControllerHelpers.live_render_session(conn))
+    |> live_render(Feed,
+      # Stamped with the moment this document was rendered, which is what lets
+      # a feed whose socket died and came back tell an arrival it already
+      # showed from one that landed while it was away (`Feed.restore_unseen/2`).
+      session: Feed.stamp_document(ControllerHelpers.live_render_session(conn))
+    )
   end
 
   defp send_feed_doc(conn, format, params) do

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -70,6 +70,15 @@ defmodule VutuvWeb.PostLive.Feed do
   @newcomer_pool 30
   @tags_per_newcomer 3
   @suggestions_refresh :timer.minutes(5)
+
+  # How old a document has to be before a connected mount asks whether the dot
+  # on the other tab needs restoring — see `restore_unseen/2`.
+  @restore_grace 5
+
+  # Where that document's own age is kept. This module reads it, so this module
+  # writes it too (`stamp_document/2`) rather than leaving the spelling in the
+  # controller for the two to drift apart.
+  @opened_at_key "feed_opened_at"
   # "Suggested posts" rail: how many discovery posts to show at once.
   @discover_posts 5
 
@@ -84,7 +93,7 @@ defmodule VutuvWeb.PostLive.Feed do
     socket = InitAssigns.assign_embedded(socket, session)
 
     if user = socket.assigns.current_user do
-      {:ok, mount_feed(socket, user)}
+      {:ok, mount_feed(socket, user, session)}
     else
       {:ok,
        socket
@@ -93,7 +102,21 @@ defmodule VutuvWeb.PostLive.Feed do
     end
   end
 
-  defp mount_feed(socket, user) do
+  @doc """
+  Stamps a `live_render` session map with the moment its **document** was
+  rendered — what `restore_unseen/2` dates the unseen dot from.
+
+  Called by `VutuvWeb.NewsfeedController`, which owns `/feed`. It belongs here
+  because this module is what reads the key back, and because the property that
+  makes it work is a property of that map: it is signed once per document and
+  replayed verbatim on every socket rejoin, so it dates the one thing a socket
+  that died and came back cannot date itself. `at` is for tests, which have to
+  place a document in the past to have a rejoin worth testing.
+  """
+  def stamp_document(session, at \\ NaiveDateTime.utc_now(:second)),
+    do: Map.put(session, @opened_at_key, NaiveDateTime.to_iso8601(at))
+
+  defp mount_feed(socket, user, session) do
     # Can this browser draw the tab ticker at all? A deploy does not reload an
     # open feed — the socket reconnects to the new release and patches into a
     # document downloaded hours ago — so the question is not which release that
@@ -121,10 +144,13 @@ defmodule VutuvWeb.PostLive.Feed do
       # The dead render stashed its computed page seconds ago
       # (VutuvWeb.Live.MountHandoff); take it and skip re-running the same
       # queries. Any miss (expired, consumed, a reconnect) recomputes.
-      case MountHandoff.take(user.id, {:feed, remembered}) do
-        {:ok, payload} -> apply_feed_payload(socket, payload)
-        :error -> apply_feed_payload(socket, feed_payload(user, remembered))
-      end
+      socket =
+        case MountHandoff.take(user.id, {:feed, remembered}) do
+          {:ok, payload} -> apply_feed_payload(socket, payload)
+          :error -> apply_feed_payload(socket, feed_payload(user, remembered))
+        end
+
+      restore_unseen(socket, opened_at(session))
     else
       payload = feed_payload(user, remembered)
       MountHandoff.stash(user.id, {:feed, remembered}, payload)
@@ -209,8 +235,10 @@ defmodule VutuvWeb.PostLive.Feed do
     |> assign(:source_tabs?, payload.source_tabs?)
     # The named sources holding something this reader has not seen (issue
     # #1503), each one a dot on its tab. Socket state on purpose and never
-    # stored: it means "since you have been looking at this page", so a mount
-    # starting clean is the honest state, not a lost one.
+    # stored: it means "since you have been looking at this page", so a fresh
+    # document starting clean is the honest state, not a lost one. A **rejoin**
+    # is a mount too and is not a fresh document, so a connected mount derives
+    # the dot back — see `restore_unseen/2`.
     |> assign(:unseen_sources, MapSet.new())
     # The transient half of that (issue #1668): what landed over there, quoted
     # beside its tab for a few seconds. nil = no window open. `ticker_quiet_until`
@@ -598,7 +626,9 @@ defmodule VutuvWeb.PostLive.Feed do
     # `load_source_filter/2`, which the arrival of the member's own post also
     # calls to pull the feed back to "All". That fallback is the code's doing,
     # not theirs, and must not overwrite the tab they chose.
-    Posts.remember_feed_filter(socket.assigns.current_user, filter)
+    # It is handed the tab being left as well, because that is what dates the
+    # move for `restore_unseen/2` and only this side knows it.
+    Posts.remember_feed_filter(socket.assigns.current_user, filter, socket.assigns.feed_filter)
 
     {:noreply, load_source_filter(socket, filter)}
   end
@@ -966,10 +996,10 @@ defmodule VutuvWeb.PostLive.Feed do
   # before the query: "All" has no other tab, a member without the tab bar has
   # nowhere to show one, and a tab already dotted has nothing to learn.
   defp dot_other_tab(socket, at) do
-    source = other_source(socket.assigns.feed_filter)
+    source = dottable_source(socket)
 
     cond do
-      is_nil(source) or not socket.assigns.source_tabs? ->
+      is_nil(source) ->
         socket
 
       # A window already open for this tab only needs the *fact* that another
@@ -989,6 +1019,13 @@ defmodule VutuvWeb.PostLive.Feed do
       true ->
         socket
     end
+  end
+
+  # The tab a dot could go on, or nil: the one the reader is not looking at —
+  # "All" is both of them at once, so nothing ever landed elsewhere — and only
+  # where there is a tab bar to put one in.
+  defp dottable_source(socket) do
+    if socket.assigns.source_tabs?, do: other_source(socket.assigns.feed_filter)
   end
 
   # The other named tab — nil on "All", which is both of them at once.
@@ -1087,6 +1124,69 @@ defmodule VutuvWeb.PostLive.Feed do
 
   defp mark_unseen(socket, source),
     do: update(socket, :unseen_sources, &MapSet.put(&1, source))
+
+  # The dot the reader had before the socket blinked.
+  #
+  # `unseen_sources` is socket state, so a mount starts it empty — and a
+  # LiveView **rejoin is a mount**. A rejoin is also invisible: nothing
+  # reloads, the socket simply re-joins and the tabs come back without the dot,
+  # which reads as the dot expiring by itself a couple of minutes after it
+  # appeared. A locked phone, a backgrounded tab whose heartbeat the browser
+  # throttled past the socket timeout, a wifi handover and every deploy all do
+  # it, and none of them mean the reader stopped looking at this page.
+  #
+  # So on a connected mount the dot is *derived* rather than carried: does the
+  # tab the reader is not on hold anything newer than the last moment they had
+  # it on screen? That moment is the later of
+  #
+  #   * when this **document** was loaded — `feed_opened_at` rides the signed
+  #     `live_render` session, which is minted once by NewsfeedController and
+  #     replayed verbatim on every rejoin, so it survives exactly what the
+  #     socket does not; and
+  #   * when they last **moved tabs** (`users.feed_source_at`, stamped beside
+  #     the tab it names).
+  #
+  # A genuine page load therefore still starts clean, which is the behaviour
+  # #1503 chose: its own `opened_at` is now, and nothing is newer than now.
+  # A document from the previous release carries no stamp and simply keeps the
+  # old behaviour, so the N-1 deploy window has no half-state.
+  #
+  # Which is also why a first connect skips the question entirely
+  # (`@restore_grace`): the socket joins a second or two after the HTTP render,
+  # so the answer is false by construction, and asking it costs five source
+  # queries on the busiest page in the app. The sliver that buys — an arrival
+  # between the render and `Activity.subscribe/1` — was never covered by
+  # anything anyway.
+  defp restore_unseen(socket, nil), do: socket
+
+  defp restore_unseen(socket, opened_at) do
+    user = socket.assigns.current_user
+    source = dottable_source(socket)
+
+    if source && document_aged?(opened_at) &&
+         Posts.feed_source_since?(user, source, later_of(opened_at, user.feed_source_at)) do
+      mark_unseen(socket, source)
+    else
+      socket
+    end
+  end
+
+  # Old enough that this mount can be a rejoin rather than the document's own
+  # first connect.
+  defp document_aged?(opened_at),
+    do: NaiveDateTime.diff(NaiveDateTime.utc_now(:second), opened_at) >= @restore_grace
+
+  defp opened_at(session) do
+    with stamp when is_binary(stamp) <- session[@opened_at_key],
+         {:ok, at} <- NaiveDateTime.from_iso8601(stamp) do
+      at
+    else
+      _ -> nil
+    end
+  end
+
+  defp later_of(at, nil), do: at
+  defp later_of(at, other), do: Enum.max([at, other], NaiveDateTime)
 
   ## ── The tab ticker (issue #1668) ──
   #

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.353.0",
+      version: "7.354.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260825103427_add_feed_source_at_to_users.exs
+++ b/priv/repo/migrations/20260825103427_add_feed_source_at_to_users.exs
@@ -1,0 +1,22 @@
+defmodule Vutuv.Repo.Migrations.AddFeedSourceAtToUsers do
+  use Ecto.Migration
+
+  @moduledoc """
+  When the member last moved between the feed's source tabs — the second half
+  of `feed_source`, and the anchor a reconnecting feed dates its unseen dot
+  from (`VutuvWeb.PostLive.Feed.restore_unseen/2`).
+
+  The dot on the tab you are not on lived only in the socket, so every LiveView
+  rejoin — a locked phone, a throttled background tab, a wifi handover, a
+  deploy — dropped it without the page reloading, which read as the dot
+  expiring on its own after a couple of minutes. Written only by
+  `Vutuv.Posts.remember_feed_filter/2`, beside the tab it names, and NULL for
+  everyone who has never pressed one. N-1 safe: a pure nullable addition.
+  """
+
+  def change do
+    alter table(:users) do
+      add(:feed_source_at, :naive_datetime)
+    end
+  end
+end

--- a/test/vutuv_web/live/feed_source_tabs_test.exs
+++ b/test/vutuv_web/live/feed_source_tabs_test.exs
@@ -14,6 +14,7 @@ defmodule VutuvWeb.FeedSourceTabsTest do
   use VutuvWeb.ConnCase
 
   import Phoenix.LiveViewTest
+  import Vutuv.PostsHelpers, only: [backdate_post!: 2]
 
   alias Vutuv.Accounts.User
   alias Vutuv.Fediverse
@@ -23,7 +24,9 @@ defmodule VutuvWeb.FeedSourceTabsTest do
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Fediverse.RemotePost
   alias Vutuv.Posts
+  alias Vutuv.Sessions
   alias Vutuv.Social
+  alias VutuvWeb.PostLive.Feed
 
   # An account out there that nobody here follows.
   defp remote_account(handle) do
@@ -309,7 +312,7 @@ defmodule VutuvWeb.FeedSourceTabsTest do
       # an empty timeline with no way back.
       {conn, user} = create_and_login_user(conn)
       {_author, _post} = followed_post(user, "written here on vutuv")
-      Posts.remember_feed_filter(user, :fediverse)
+      Posts.remember_feed_filter(user, :fediverse, :all)
 
       {:ok, view, _html} = live(conn, ~p"/feed")
 
@@ -351,7 +354,7 @@ defmodule VutuvWeb.FeedSourceTabsTest do
       assert html_response(conn, 200) =~ "written here on vutuv"
 
       # …and the tab changes before this socket connects.
-      Posts.remember_feed_filter(user, :fediverse)
+      Posts.remember_feed_filter(user, :fediverse, :all)
 
       {:ok, view, _html} = live(conn)
 
@@ -632,6 +635,117 @@ defmodule VutuvWeb.FeedSourceTabsTest do
 
       refute dotted?(view, "fediverse")
       refute dotted?(view, "all")
+    end
+
+    # ── Across a rejoin (the dot that "expired after a couple of minutes") ──
+    #
+    # A rejoin re-mounts with the SAME signed session the document was rendered
+    # with, `feed_opened_at` and all, which is what restores the dot socket
+    # state cannot carry (`PostLive.Feed.restore_unseen/2`). So a rejoin here is
+    # `live_isolated/3` twice on one session map.
+
+    # A reader whose feed has both halves, a member they follow here, and that
+    # member's post — the arrival that belongs on the tab they are not on.
+    defp rejoin_fixture(conn) do
+      {_conn, user} = create_and_login_user(conn)
+      {author, older} = followed_post(user, "an older post")
+      # Well behind everything else: it is the tab's existing content, and a
+      # test asking "is anything NEWER than this document" has to be able to
+      # answer no.
+      backdate_post!(older, 300)
+      cached_post(remote_account(user, "them"), "written out there")
+      {:ok, post} = Posts.create_post(author, %{body: "arriving live"})
+
+      # Placed half a minute back, for two reasons that both come from second
+      # precision: a test whose post, document and tab press all happen in one
+      # second decides ties rather than rules, and a document has to be older
+      # than `@restore_grace` before a mount asks the question at all.
+      {user, backdate_post!(post, 30)}
+    end
+
+    # The state a document arrives with: the tab this member moved to, and when.
+    defp opened_on(user, filter, at) do
+      Repo.update!(
+        Ecto.Changeset.change(user, feed_source: to_string(filter), feed_source_at: at)
+      )
+    end
+
+    # The session `live_render` mints for a /feed document (NewsfeedController).
+    # Bound once per test and mounted twice, because replaying the one map is
+    # exactly what a rejoin does.
+    defp feed_session(user, opened_at) do
+      {token, _session} = Sessions.start_session(user, build_conn(), alert: false)
+
+      %{"session_token" => token, "locale" => "en", "request_path" => "/feed"}
+      |> Feed.stamp_document(opened_at)
+    end
+
+    # `live_isolated/3` mounts outside any real request, so the socket session it
+    # captures is empty — and the feed's post cards render CSRF `<.link
+    # method=…>` items, which raise without the token a browser session carries.
+    # `dump_state/0` mints exactly the value the cookie session would hold.
+    defp mount_document(session) do
+      conn =
+        Plug.Test.init_test_session(build_conn(), %{
+          "_csrf_token" => Plug.CSRFProtection.dump_state()
+        })
+
+      {:ok, view, _html} = live_isolated(conn, Feed, session: session)
+      view
+    end
+
+    test "a rejoin brings back a dot the reader never cleared", %{conn: conn} do
+      {user, post} = rejoin_fixture(conn)
+
+      # The document was opened on the Fediverse tab a second before that post
+      # landed, so it landed while the reader was looking at this page.
+      opened_at = NaiveDateTime.add(post.inserted_at, -1)
+      opened_on(user, :fediverse, opened_at)
+
+      assert dotted?(mount_document(feed_session(user, opened_at)), "vutuv")
+    end
+
+    test "a fresh page load still starts clean", %{conn: conn} do
+      {user, post} = rejoin_fixture(conn)
+
+      # Loaded after that post, so the post is not news: it sits on the tab it
+      # belongs to, above the fold, waiting to be read. #1503's dot means "while
+      # you were looking", not "since you last read everything".
+      opened_at = NaiveDateTime.add(post.inserted_at, 1)
+      opened_on(user, :fediverse, opened_at)
+
+      refute dotted?(mount_document(feed_session(user, opened_at)), "vutuv")
+    end
+
+    test "a tab the reader visited since stays clean across a rejoin", %{conn: conn} do
+      {user, post} = rejoin_fixture(conn)
+
+      # Opened before the post landed — but they moved tabs afterwards, and
+      # moving TO the Fediverse tab means they were sitting on the vutuv one
+      # until then, so they have seen it.
+      opened_at = NaiveDateTime.add(post.inserted_at, -1)
+      opened_on(user, :fediverse, NaiveDateTime.add(post.inserted_at, 1))
+
+      refute dotted?(mount_document(feed_session(user, opened_at)), "vutuv")
+    end
+
+    test "pressing the tab already open does not swallow the other tab's dot", %{conn: conn} do
+      {user, post} = rejoin_fixture(conn)
+      opened_at = NaiveDateTime.add(post.inserted_at, -1)
+      opened_on(user, :fediverse, opened_at)
+      session = feed_session(user, opened_at)
+
+      view = mount_document(session)
+      assert dotted?(view, "vutuv")
+
+      # A press on the tab that is already open moves nobody: the reader has
+      # still not been to the vutuv tab, so the dot must survive the press — and
+      # the rejoin after it, which is where a clock stamped on that press would
+      # quietly have swallowed it.
+      render_click(view, "filter-source", %{"type" => "fediverse"})
+      assert dotted?(view, "vutuv")
+
+      assert dotted?(mount_document(session), "vutuv")
     end
 
     test "the All tab is never dotted while it is the open one", %{conn: conn} do


### PR DESCRIPTION
**Symptom:** the coral "something landed on the other tab" dot on `/feed` goes away by itself a couple of minutes after it appears.

`:unseen_sources` lived only in socket assigns, and a LiveView rejoin re-runs `mount/3`. A rejoin is invisible — a locked phone, a background tab throttled past the heartbeat, a wifi handover, a deploy — so nothing reloads and the tabs just come back plain.

`VutuvWeb.PostLive.Feed.restore_unseen/2` now derives the dot back on a connected mount: does the tab you are not on hold anything newer than the later of when the document was loaded (`feed_opened_at`, stamped into the signed `live_render` session, which every rejoin replays) and when you last moved tabs (new nullable `users.feed_source_at`)? A real page load still starts clean, and a first connect skips the query entirely.

Migration is a plain nullable addition, N-1 safe. Four tests in `feed_source_tabs_test.exs`, each calibrated red against the unfixed code.

*An AI agent wrote this text in my name. I know that is problematic.*
