### PR TITLE
Say the held picture is being checked, not on its way

### DIFF
--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -2063,15 +2063,18 @@ defmodule VutuvWeb.PostComponents do
         <%= if !RemoteImage.released?(image) do %>
           <%!-- Recorded, not shown: still downloading from its own server, or
           still with the AI gate. The tile is what keeps a wordless photo post
-          from rendering as an empty card — a reader must be able to tell "a
-          picture is coming" from "this post is broken". The hourglass is the
-          same glyph a member's own held post wears. --%>
+          from rendering as an empty card, so it has to say which of the two is
+          happening. It says what a member's own held photo says ("Foto wird
+          geprüft"), under the same hourglass, because it is the same wait: the
+          picture is here and we are looking at it before showing it. The older
+          "a picture is on its way" named the download instead, which is over
+          in a second and is never what the reader is waiting for. --%>
           <div
             data-remote-image-pending
             class="flex min-h-24 items-center justify-center gap-2 rounded-lg bg-slate-100 px-3 py-6 text-center text-xs text-slate-600 dark:bg-slate-800 dark:text-slate-400"
           >
             <.hourglass />
-            <span>{gettext("A picture is on its way.")}</span>
+            <span>{gettext("Picture is being checked")}</span>
           </div>
         <% else %>
           <%= if RemoteImage.blurred?(image) do %>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.354.3",
+      version: "7.354.4",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -17865,10 +17865,10 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] "(ein Bild)"
 msgstr[1] "(%{count} Bilder)"
 
-#: lib/vutuv_web/components/post_components.ex:2062
+#: lib/vutuv_web/components/post_components.ex:2075
 #, elixir-autogen, elixir-format
-msgid "A picture is on its way."
-msgstr "Ein Bild ist unterwegs."
+msgid "Picture is being checked"
+msgstr "Bild wird geprüft"
 
 #: lib/vutuv_web/components/post_components.ex:2091
 #, elixir-autogen, elixir-format

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -17135,9 +17135,9 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2062
+#: lib/vutuv_web/components/post_components.ex:2075
 #, elixir-autogen, elixir-format
-msgid "A picture is on its way."
+msgid "Picture is being checked"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2091

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -17133,9 +17133,9 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2062
+#: lib/vutuv_web/components/post_components.ex:2075
 #, elixir-autogen, elixir-format
-msgid "A picture is on its way."
+msgid "Picture is being checked"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2091

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -18934,10 +18934,10 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] "(un'immagine)"
 msgstr[1] "(%{count} immagini)"
 
-#: lib/vutuv_web/components/post_components.ex:2062
+#: lib/vutuv_web/components/post_components.ex:2075
 #, elixir-autogen, elixir-format
-msgid "A picture is on its way."
-msgstr "Un'immagine è in arrivo."
+msgid "Picture is being checked"
+msgstr "L'immagine è in fase di controllo"
 
 #: lib/vutuv_web/components/post_components.ex:2091
 #, elixir-autogen, elixir-format

--- a/test/vutuv_web/components/remote_post_images_test.exs
+++ b/test/vutuv_web/components/remote_post_images_test.exs
@@ -1,0 +1,39 @@
+defmodule VutuvWeb.RemotePostImagesTest do
+  @moduledoc """
+  What a cached post's picture says while it is still held back.
+
+  The tile stands in for a picture that is recorded but not released: the file
+  may still be coming from its own server, and the AI gate has not cleared it.
+  It used to say "a picture is on its way", which named the one half of that
+  wait the reader is not actually waiting for. The wording is asserted by name
+  and in German, because a short string is exactly the kind a `gettext.extract
+  --merge` fuzzy-fills with somebody else's translation.
+  """
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.Fediverse.RemoteImage
+  alias VutuvWeb.PostComponents
+
+  # No file yet and the gate still open: `RemoteImage.released?/1` says no on
+  # either count, which is the whole condition the tile stands for.
+  defp held_picture, do: %RemoteImage{file: nil, moderation: "pending"}
+
+  defp render_tile(images),
+    do: render_component(&PostComponents.remote_post_images/1, images: images)
+
+  test "a held picture says it is being checked, not that it is travelling" do
+    html = render_tile([held_picture()])
+
+    assert html =~ "data-remote-image-pending"
+    assert html =~ "Picture is being checked"
+    refute html =~ "on its way"
+  end
+
+  test "German says what a member's own held photo says" do
+    Gettext.put_locale(VutuvWeb.Gettext, "de")
+
+    assert render_tile([held_picture()]) =~ "Bild wird geprüft"
+  end
+end


### PR DESCRIPTION
A picture on a post from another network, while it is still held back, said "Ein Bild ist unterwegs" ("a picture is on its way"). The picture is already here — the download takes a second, and what the reader actually waits for is our AI image check.

The tile now says **"Bild wird geprüft"**, the same words a member's own held photo already uses (`Foto wird geprüft`), under the same hourglass. English msgid `Picture is being checked`, with de and it translations.

**Where:** `VutuvWeb.PostComponents.remote_post_images/1` — visible on the feed and on a cached post's permalink whenever a fediverse picture is still pending.

A component test asserts both wordings by name; a one-word-ish msgid is exactly the kind `gettext.extract --merge` fuzzy-fills with somebody else's translation.

Noticed on the way: `mix gettext.extract --merge` wants to rewrite `priv/gettext/it/LC_MESSAGES/default.po` wholesale (16 new, 8 fuzzy, ~1,100 lines net). That drift is older than this change, so this PR edits the four catalogs by hand instead of dragging it along.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01W1mgbhkL5UpV2uRByEQM6c
