### PR TITLE
Catch the Italian catalog up with the feed-language page

### DIFF
--- a/docs/architecture/i18n.md
+++ b/docs/architecture/i18n.md
@@ -1,13 +1,13 @@
 # Interface languages
 
-vutuv's interface ships in **English (`en`) and German (`de`)**. This document
-is about that interface: the chrome, the flashes, the error pages and the
-transactional mail. What members *write* is a different subsystem with its own
-rules — see [translations.md](translations.md).
+vutuv's interface ships in **English (`en`), German (`de`) and Italian (`it`)**.
+This document is about that interface: the chrome, the flashes, the error pages
+and the transactional mail. What members *write* is a different subsystem with
+its own rules — see [translations.md](translations.md).
 
-Adding a third language touches Gettext catalogs, two email template trees, a
-CLDR backend and a handful of places that still spell the two locales out by
-hand. The checklist at the bottom lists them; the sections above say why.
+Adding a language touches Gettext catalogs, two email template trees, a CLDR
+backend and a handful of places that still spell the locales out by hand. The
+checklist at the bottom lists them; the sections above say why.
 
 ## Where a request gets its language
 
@@ -35,7 +35,7 @@ its header.
 
 ```elixir
 config :vutuv, VutuvWeb.Endpoint,
-  locales: ~w(en de)
+  locales: ~w(en de it)
 ```
 
 in `config/config.exs` **and** `config/prod.exs`. Note that it sits inside the
@@ -94,6 +94,12 @@ in three separate ways:
   translation**, not a missing one. Writing into it appends a second copy that
   gettext concatenates into one doubled sentence. That is how the logged-out
   landing page came to 500 for every German visitor while `curl /` looked fine.
+
+Both translated catalogs are **complete and fuzzy-free** as of v7.355.1, so a
+`grep -c ", fuzzy" priv/gettext/{de,it}/LC_MESSAGES/default.po` answering
+anything but `0` comes from your own merge rather than from old debt. The `en`
+catalog is different: its entries carry no translation at all (English falls
+back to the msgid), so the flags left on 310 of them mean nothing.
 
 And one trap grep cannot see at all: **a msgid is a key, not a phrase.**
 `gettext("Following")` is translated "Folge ich" (*I* follow), written for a

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.354.4",
+      version: "7.355.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -15,8 +15,8 @@ msgstr "Language: de\n"
 msgid "About us"
 msgstr "Impressum"
 
-#: lib/vutuv_web/components/ui.ex:4081
-#: lib/vutuv_web/components/ui.ex:4086
+#: lib/vutuv_web/components/ui.ex:4091
+#: lib/vutuv_web/components/ui.ex:4096
 #: lib/vutuv_web/live/admin/screenshot_live.ex:255
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:718
 #: lib/vutuv_web/live/organization_live/domains.ex:272
@@ -62,7 +62,7 @@ msgstr "Eine Adresse wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:68
 #: lib/vutuv_web/agent_docs/text.ex:65
-#: lib/vutuv_web/components/ui.ex:4339
+#: lib/vutuv_web/components/ui.ex:4349
 #: lib/vutuv_web/controllers/address_controller.ex:23
 #: lib/vutuv_web/controllers/address_controller.ex:38
 #: lib/vutuv_web/controllers/address_controller.ex:85
@@ -81,8 +81,8 @@ msgstr "Adressen"
 msgid "Already a member? Sign in here."
 msgstr "Schon ein Mitglied? Einloggen."
 
-#: lib/vutuv_web/components/ui.ex:3876
-#: lib/vutuv_web/components/ui.ex:3970
+#: lib/vutuv_web/components/ui.ex:3886
+#: lib/vutuv_web/components/ui.ex:3980
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:698
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:830
@@ -110,7 +110,7 @@ msgid "Birthday"
 msgstr "Geburtstag"
 
 #: lib/vutuv_web/components/saved_search_components.ex:110
-#: lib/vutuv_web/components/ui.ex:3870
+#: lib/vutuv_web/components/ui.ex:3880
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
@@ -162,8 +162,8 @@ msgstr "Kontakt"
 msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
-#: lib/vutuv_web/components/post_components.ex:3047
-#: lib/vutuv_web/components/ui.ex:3973
+#: lib/vutuv_web/components/post_components.ex:3062
+#: lib/vutuv_web/components/ui.ex:3983
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
@@ -211,8 +211,8 @@ msgstr "Inaktivieren"
 msgid "Download"
 msgstr "Download"
 
-#: lib/vutuv_web/components/post_components.ex:3012
-#: lib/vutuv_web/components/ui.ex:3964
+#: lib/vutuv_web/components/post_components.ex:3027
+#: lib/vutuv_web/components/ui.ex:3974
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
@@ -286,7 +286,7 @@ msgstr "E-Mail-Adresse eingeben"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:35
-#: lib/vutuv_web/components/ui.ex:4303
+#: lib/vutuv_web/components/ui.ex:4313
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -445,7 +445,7 @@ msgid "Log Out"
 msgstr "Ausloggen"
 
 #: lib/vutuv_web/live/shell_live.ex:1024
-#: lib/vutuv_web/live/shell_live.ex:1081
+#: lib/vutuv_web/live/shell_live.ex:1090
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -475,7 +475,7 @@ msgstr "Mehr"
 msgid "Name"
 msgstr "Name"
 
-#: lib/vutuv_web/components/post_components.ex:620
+#: lib/vutuv_web/components/post_components.ex:632
 #: lib/vutuv_web/live/notification_live/index.ex:682
 #: lib/vutuv_web/live/organization_live/activity.ex:127
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
@@ -615,7 +615,7 @@ msgstr "Provider"
 msgid "Public"
 msgstr "Öffentlich"
 
-#: lib/vutuv_web/components/ui.ex:3869
+#: lib/vutuv_web/components/ui.ex:3879
 #: lib/vutuv_web/live/organization_live/edit.ex:345
 #: lib/vutuv_web/live/post_live/composer.ex:1867
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -627,13 +627,12 @@ msgstr "Öffentlich"
 #: lib/vutuv_web/templates/settings/notifications.html.heex:79
 #: lib/vutuv_web/templates/settings/preferences.html.heex:84
 #: lib/vutuv_web/templates/settings/preferences.html.heex:157
-#: lib/vutuv_web/templates/settings/preferences.html.heex:228
-#: lib/vutuv_web/templates/settings/preferences.html.heex:292
-#: lib/vutuv_web/templates/settings/preferences.html.heex:449
+#: lib/vutuv_web/templates/settings/preferences.html.heex:242
+#: lib/vutuv_web/templates/settings/preferences.html.heex:399
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:462
-#: lib/vutuv_web/views/settings_html.ex:301
+#: lib/vutuv_web/views/settings_html.ex:196
 #, elixir-autogen
 msgid "Save"
 msgstr "Speichern"
@@ -647,7 +646,7 @@ msgstr "Speichern"
 #: lib/vutuv_web/live/search_live.ex:48
 #: lib/vutuv_web/live/search_live.ex:569
 #: lib/vutuv_web/live/shell_live.ex:889
-#: lib/vutuv_web/live/shell_live.ex:1064
+#: lib/vutuv_web/live/shell_live.ex:1073
 #: lib/vutuv_web/live/tag_live/timeline.ex:283
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
@@ -657,7 +656,7 @@ msgstr "Speichern"
 msgid "Search"
 msgstr "Suche"
 
-#: lib/vutuv_web/components/post_components.ex:1556
+#: lib/vutuv_web/components/post_components.ex:1568
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -797,7 +796,7 @@ msgstr "Profil aktualisiert."
 msgid "User verified successfully."
 msgstr "User wurde verifiziert."
 
-#: lib/vutuv_web/components/ui.ex:4299
+#: lib/vutuv_web/components/ui.ex:4309
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
@@ -854,14 +853,14 @@ msgstr "Benutzer"
 msgid "vCard"
 msgstr "vCard"
 
-#: lib/vutuv_web/components/ui.ex:4034
+#: lib/vutuv_web/components/ui.ex:4044
 #: lib/vutuv_web/templates/user/show.html.heex:967
 #: lib/vutuv_web/templates/user/show.html.heex:990
 #, elixir-autogen
 msgid "View All"
 msgstr "Alle anzeigen"
 
-#: lib/vutuv_web/components/ui.ex:4396
+#: lib/vutuv_web/components/ui.ex:4417
 #: lib/vutuv_web/controllers/settings_controller.ex:169
 #: lib/vutuv_web/live/job_posting_live/form.ex:756
 #: lib/vutuv_web/live/organization_live/edit.ex:304
@@ -937,7 +936,7 @@ msgid "You follow back %{name}."
 msgstr "Sie folgen %{name} jetzt zurück."
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:91
+#: lib/vutuv_web/live/post_live/feed.ex:100
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1404,7 +1403,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:516
 #: lib/vutuv_web/agent_docs/text.ex:753
-#: lib/vutuv_web/components/ui.ex:4324
+#: lib/vutuv_web/components/ui.ex:4334
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1631,7 +1630,7 @@ msgstr "Adressen von %{name}"
 msgid "Admin control panel"
 msgstr "Admin-Bereich"
 
-#: lib/vutuv_web/live/shell_live.ex:1067
+#: lib/vutuv_web/live/shell_live.ex:1076
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "Mitteilungen"
@@ -1749,7 +1748,7 @@ msgstr ""
 "Folgen!"
 
 #: lib/vutuv_web/live/shell_live.ex:1015
-#: lib/vutuv_web/views/settings_html.ex:388
+#: lib/vutuv_web/views/settings_html.ex:283
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr "Ausloggen"
@@ -1778,7 +1777,7 @@ msgstr "Nachricht"
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
 #: lib/vutuv_web/live/shell_live.ex:907
-#: lib/vutuv_web/live/shell_live.ex:1066
+#: lib/vutuv_web/live/shell_live.ex:1075
 #: lib/vutuv_web/templates/layout/app.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Messages"
@@ -1791,7 +1790,7 @@ msgid "Network"
 msgstr "Netzwerk"
 
 #: lib/vutuv_web/components/post_components.ex:439
-#: lib/vutuv_web/components/ui.ex:4083
+#: lib/vutuv_web/components/ui.ex:4093
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:705
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:742
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:793
@@ -1807,7 +1806,7 @@ msgid "Nothing new yet."
 msgstr "Noch nichts Neues."
 
 #: lib/vutuv/api_auth/scopes.ex:85
-#: lib/vutuv_web/components/ui.ex:4361
+#: lib/vutuv_web/components/ui.ex:4371
 #: lib/vutuv_web/live/notification_live/index.ex:132
 #: lib/vutuv_web/live/notification_live/index.ex:360
 #: lib/vutuv_web/live/shell_live.ex:919
@@ -1958,15 +1957,15 @@ msgstr "ist jetzt mit Ihnen vernetzt."
 msgid "started following you."
 msgstr "folgt Ihnen jetzt."
 
-#: lib/vutuv_web/components/ui.ex:3423
-#: lib/vutuv_web/components/ui.ex:3574
+#: lib/vutuv_web/components/ui.ex:3433
+#: lib/vutuv_web/components/ui.ex:3584
 #: lib/vutuv_web/live/import_connections_live.ex:638
 #: lib/vutuv_web/live/organization_live/index.ex:122
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr "Seitennavigation"
 
-#: lib/vutuv_web/components/ui.ex:4108
+#: lib/vutuv_web/components/ui.ex:4118
 #: lib/vutuv_web/live/organization_live/activity.ex:150
 #: lib/vutuv_web/live/organization_live/feed.ex:142
 #: lib/vutuv_web/live/organization_live/show.ex:647
@@ -1981,7 +1980,7 @@ msgstr ""
 "Die Adresse selbst kann nicht geändert werden. Um eine andere zu verwenden, "
 "legen Sie sie als neue E-Mail-Adresse an und löschen Sie diese hier."
 
-#: lib/vutuv_web/components/ui.ex:3879
+#: lib/vutuv_web/components/ui.ex:3889
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr "Eintrag löschen"
@@ -2149,7 +2148,7 @@ msgstr "Upload abbrechen"
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
-#: lib/vutuv_web/components/post_components.ex:3044
+#: lib/vutuv_web/components/post_components.ex:3059
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2164,10 +2163,10 @@ msgstr "Beitrag bearbeiten"
 #: lib/vutuv_web/components/organization_components.ex:274
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:98
-#: lib/vutuv_web/live/post_live/feed.ex:196
-#: lib/vutuv_web/live/post_live/feed.ex:1514
+#: lib/vutuv_web/live/post_live/feed.ex:231
+#: lib/vutuv_web/live/post_live/feed.ex:1650
 #: lib/vutuv_web/live/shell_live.ex:769
-#: lib/vutuv_web/live/shell_live.ex:1062
+#: lib/vutuv_web/live/shell_live.ex:1068
 #: lib/vutuv_web/templates/layout/app.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2193,8 +2192,8 @@ msgstr "Vor einer bestimmten Person verbergen…"
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
 
-#: lib/vutuv_web/components/post_components.ex:2998
-#: lib/vutuv_web/components/post_components.ex:3000
+#: lib/vutuv_web/components/post_components.ex:3013
+#: lib/vutuv_web/components/post_components.ex:3015
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
@@ -2210,7 +2209,7 @@ msgstr "Nicht eingeloggte Besucher"
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1722
+#: lib/vutuv_web/live/post_live/feed.ex:1858
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2256,19 +2255,19 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/live/post_live/saved.ex:520
 #: lib/vutuv_web/live/search_live.ex:281
 #: lib/vutuv_web/live/search_live.ex:728
-#: lib/vutuv_web/templates/settings/preferences.html.heex:362
+#: lib/vutuv_web/templates/settings/preferences.html.heex:312
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:3468
-#: lib/vutuv_web/components/post_components.ex:3472
+#: lib/vutuv_web/components/post_components.ex:3483
+#: lib/vutuv_web/components/post_components.ex:3487
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:3469
+#: lib/vutuv_web/components/post_components.ex:3484
 #: lib/vutuv_web/live/fediverse_account_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2276,7 +2275,7 @@ msgstr "Weniger anzeigen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:376
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:1178
+#: lib/vutuv_web/components/post_components.ex:1190
 #: lib/vutuv_web/live/admin/screenshot_live.ex:327
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:700
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
@@ -2287,7 +2286,7 @@ msgstr "Weniger anzeigen"
 #: lib/vutuv_web/live/post_live/saved.ex:650
 #: lib/vutuv_web/live/post_live/saved.ex:678
 #: lib/vutuv_web/templates/connection/index.html.heex:40
-#: lib/vutuv_web/views/settings_html.ex:434
+#: lib/vutuv_web/views/settings_html.ex:329
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Entfernen"
@@ -2304,7 +2303,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1626
+#: lib/vutuv_web/live/post_live/feed.ex:1762
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2341,11 +2340,11 @@ msgstr "Zu viele Dateien."
 msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
 
-#: lib/vutuv_web/components/ui.ex:4650
+#: lib/vutuv_web/components/ui.ex:4671
 #: lib/vutuv_web/live/shell_live.ex:962
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
-#: lib/vutuv_web/views/settings_html.ex:335
+#: lib/vutuv_web/views/settings_html.ex:230
 #, elixir-autogen, elixir-format
 msgid "View profile"
 msgstr "Profil ansehen"
@@ -2360,33 +2359,33 @@ msgstr "Was gibt's Neues?"
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
 
-#: lib/vutuv_web/components/post_components.ex:2995
+#: lib/vutuv_web/components/post_components.ex:3010
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:4788
+#: lib/vutuv_web/components/post_components.ex:4818
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:4792
+#: lib/vutuv_web/components/post_components.ex:4822
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:4790
+#: lib/vutuv_web/components/post_components.ex:4820
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:4791
+#: lib/vutuv_web/components/post_components.ex:4821
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
 
 #: lib/vutuv_web/views/post_html.ex:19
-#: lib/vutuv_web/views/settings_html.ex:513
+#: lib/vutuv_web/views/settings_html.ex:408
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr "unbekannt"
@@ -2421,9 +2420,9 @@ msgstr "Alle %{count} Beiträge ansehen"
 msgid "All posts"
 msgstr "Alle Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:1771
-#: lib/vutuv_web/components/post_components.ex:4884
-#: lib/vutuv_web/components/ui.ex:3498
+#: lib/vutuv_web/components/post_components.ex:1783
+#: lib/vutuv_web/components/post_components.ex:4914
+#: lib/vutuv_web/components/ui.ex:3508
 #: lib/vutuv_web/views/user_html.ex:453
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2440,9 +2439,9 @@ msgstr "Lesezeichen setzen"
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/vutuv_web/components/post_components.ex:1724
-#: lib/vutuv_web/components/post_components.ex:5120
-#: lib/vutuv_web/components/ui.ex:3484
+#: lib/vutuv_web/components/post_components.ex:1736
+#: lib/vutuv_web/components/post_components.ex:5150
+#: lib/vutuv_web/components/ui.ex:3494
 #: lib/vutuv_web/live/notification_live/index.ex:1072
 #: lib/vutuv_web/views/user_html.ex:463
 #, elixir-autogen, elixir-format
@@ -2450,7 +2449,7 @@ msgid "Like"
 msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1107
-#: lib/vutuv_web/components/post_components.ex:5130
+#: lib/vutuv_web/components/post_components.ex:5160
 #: lib/vutuv_web/live/notification_live/index.ex:1005
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
@@ -2472,40 +2471,40 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:4872
+#: lib/vutuv_web/components/post_components.ex:4902
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
-#: lib/vutuv_web/components/post_components.ex:1770
-#: lib/vutuv_web/components/post_components.ex:4883
+#: lib/vutuv_web/components/post_components.ex:1782
+#: lib/vutuv_web/components/post_components.ex:4913
 #: lib/vutuv_web/live/post_live/saved.ex:806
 #: lib/vutuv_web/views/user_html.ex:453
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
-#: lib/vutuv_web/components/post_components.ex:1752
-#: lib/vutuv_web/components/post_components.ex:4869
+#: lib/vutuv_web/components/post_components.ex:1764
+#: lib/vutuv_web/components/post_components.ex:4899
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
-#: lib/vutuv_web/components/post_components.ex:2017
-#: lib/vutuv_web/components/post_components.ex:4050
+#: lib/vutuv_web/components/post_components.ex:2029
+#: lib/vutuv_web/components/post_components.ex:4065
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:1751
-#: lib/vutuv_web/components/post_components.ex:4868
+#: lib/vutuv_web/components/post_components.ex:1763
+#: lib/vutuv_web/components/post_components.ex:4898
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
-#: lib/vutuv_web/components/post_components.ex:1723
-#: lib/vutuv_web/components/post_components.ex:5119
+#: lib/vutuv_web/components/post_components.ex:1735
+#: lib/vutuv_web/components/post_components.ex:5149
 #: lib/vutuv_web/live/post_live/saved.ex:805
 #: lib/vutuv_web/views/user_html.ex:463
 #, elixir-autogen, elixir-format
@@ -2513,14 +2512,14 @@ msgid "Unlike"
 msgstr "Gefällt mir entfernen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:377
-#: lib/vutuv_web/components/post_components.ex:2302
+#: lib/vutuv_web/components/post_components.ex:2317
 #: lib/vutuv_web/components/ui.ex:2388
 #: lib/vutuv_web/components/ui.ex:2388
 #: lib/vutuv_web/components/ui.ex:2525
 #: lib/vutuv_web/live/organization_live/following.ex:378
 #: lib/vutuv_web/live/organization_live/following.ex:453
 #: lib/vutuv_web/live/organization_live/show.ex:474
-#: lib/vutuv_web/live/post_live/feed.ex:1771
+#: lib/vutuv_web/live/post_live/feed.ex:1907
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2532,7 +2531,7 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:5174
+#: lib/vutuv_web/components/post_components.ex:5204
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
@@ -2543,16 +2542,16 @@ msgstr "Nur öffentliche Beiträge können beantwortet werden."
 msgid "Replies"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:1737
-#: lib/vutuv_web/components/post_components.ex:5157
-#: lib/vutuv_web/components/post_components.ex:5158
+#: lib/vutuv_web/components/post_components.ex:1749
+#: lib/vutuv_web/components/post_components.ex:5187
+#: lib/vutuv_web/components/post_components.ex:5188
 #: lib/vutuv_web/live/notification_live/index.ex:1069
 #: lib/vutuv_web/live/post_live/reply.ex:43
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:2962
+#: lib/vutuv_web/components/post_components.ex:2977
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
@@ -2573,7 +2572,7 @@ msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beitr
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
 
-#: lib/vutuv_web/components/post_components.ex:2498
+#: lib/vutuv_web/components/post_components.ex:2513
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:60
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:57
@@ -2581,14 +2580,14 @@ msgstr "hat auf Ihren Beitrag geantwortet."
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
 
-#: lib/vutuv_web/components/post_components.ex:2936
+#: lib/vutuv_web/components/post_components.ex:2951
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:2927
-#: lib/vutuv_web/components/post_components.ex:2954
-#: lib/vutuv_web/components/post_components.ex:2957
+#: lib/vutuv_web/components/post_components.ex:2942
+#: lib/vutuv_web/components/post_components.ex:2969
+#: lib/vutuv_web/components/post_components.ex:2972
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
@@ -2799,11 +2798,12 @@ msgstr "Berufserfahrung hinzufügen"
 msgid "Write your first post"
 msgstr "Ersten Beitrag schreiben"
 
-#: lib/vutuv_web/components/ui.ex:3662
-#: lib/vutuv_web/components/ui.ex:4036
+#: lib/vutuv_web/components/ui.ex:3672
+#: lib/vutuv_web/components/ui.ex:4046
 #: lib/vutuv_web/templates/settings/apps.html.heex:22
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #: lib/vutuv_web/templates/settings/organizations.html.heex:104
+#: lib/vutuv_web/templates/settings/preferences.html.heex:195
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:216
@@ -2812,7 +2812,7 @@ msgstr "Ersten Beitrag schreiben"
 msgid "Manage"
 msgstr "Verwalten"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1552
+#: lib/vutuv_web/live/post_live/feed.ex:1688
 #: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2833,7 +2833,7 @@ msgid_plural "%{formatted} connections"
 msgstr[0] "1 Vernetzung"
 msgstr[1] "%{formatted} Vernetzungen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1873
+#: lib/vutuv_web/live/post_live/feed.ex:2009
 #: lib/vutuv_web/templates/user/card_list.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -2888,7 +2888,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:4789
+#: lib/vutuv_web/components/post_components.ex:4819
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -3169,7 +3169,7 @@ msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:2903
+#: lib/vutuv_web/components/post_components.ex:2918
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solange eine Meldung zu diesem Beitrag bearbeitet wird, sehen nur Sie ihn."
@@ -3222,9 +3222,9 @@ msgstr ""
 msgid "Private message"
 msgstr "Private Nachricht"
 
-#: lib/vutuv_web/components/ui.ex:4293
+#: lib/vutuv_web/components/ui.ex:4303
 #: lib/vutuv_web/live/shell_live.ex:783
-#: lib/vutuv_web/live/shell_live.ex:1071
+#: lib/vutuv_web/live/shell_live.ex:1080
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -3248,9 +3248,9 @@ msgstr "Abgelehnt"
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 
-#: lib/vutuv_web/components/post_components.ex:1188
-#: lib/vutuv_web/components/post_components.ex:2314
-#: lib/vutuv_web/components/post_components.ex:3067
+#: lib/vutuv_web/components/post_components.ex:1200
+#: lib/vutuv_web/components/post_components.ex:2329
+#: lib/vutuv_web/components/post_components.ex:3082
 #: lib/vutuv_web/live/organization_live/show.ex:547
 #: lib/vutuv_web/templates/user/show.html.heex:222
 #, elixir-autogen, elixir-format
@@ -3336,7 +3336,7 @@ msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 "Meldungen sind anonym; wir verraten nie, wer gemeldet hat. Unsere Regeln:"
 
-#: lib/vutuv_web/components/ui.ex:3398
+#: lib/vutuv_web/components/ui.ex:3408
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:773
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -4665,7 +4665,7 @@ msgstr ""
 "beide Richtungen unterbunden. Eine Aufhebung der Blockierung stellt das "
 "Entfernte nicht wieder her."
 
-#: lib/vutuv_web/components/ui.ex:4400
+#: lib/vutuv_web/components/ui.ex:4421
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -4714,7 +4714,7 @@ msgstr "Sie haben niemanden blockiert."
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1727
+#: lib/vutuv_web/live/post_live/feed.ex:1863
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
@@ -4802,7 +4802,7 @@ msgstr "Ähnliche Namen"
 #: lib/vutuv_web/live/import_connections_live.ex:470
 #: lib/vutuv_web/live/notification_live/index.ex:925
 #: lib/vutuv_web/live/search_live.ex:278
-#: lib/vutuv_web/templates/settings/preferences.html.heex:304
+#: lib/vutuv_web/templates/settings/preferences.html.heex:254
 #: lib/vutuv_web/views/qualification_html.ex:103
 #, elixir-autogen, elixir-format
 msgid "All"
@@ -4850,7 +4850,7 @@ msgstr "sucht nur in Vornamen (nachname: für Nachnamen)"
 
 #: lib/vutuv_web/live/job_board_live.ex:388
 #: lib/vutuv_web/live/tag_new_live.ex:48
-#: lib/vutuv_web/live/user_profile_live.ex:1332
+#: lib/vutuv_web/live/user_profile_live.ex:1336
 #: lib/vutuv_web/templates/user/show.html.heex:594
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
@@ -5102,8 +5102,8 @@ msgstr "API-Anwendungen"
 
 #: lib/vutuv_web/live/admin/api_app_live.ex:98
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:181
-#: lib/vutuv_web/views/settings_html.ex:77
-#: lib/vutuv_web/views/settings_html.ex:379
+#: lib/vutuv_web/views/settings_html.ex:75
+#: lib/vutuv_web/views/settings_html.ex:274
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr "Aktiv"
@@ -5489,7 +5489,7 @@ msgstr "API-Token (%{date})"
 msgid "API documentation"
 msgstr "API-Dokumentation"
 
-#: lib/vutuv_web/components/ui.ex:4460
+#: lib/vutuv_web/components/ui.ex:4481
 #: lib/vutuv_web/controllers/settings_controller.ex:155
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5573,10 +5573,10 @@ msgstr "Tastaturkürzel"
 msgid "Navigation"
 msgstr "Navigation"
 
-#: lib/vutuv_web/components/ui.ex:4557
-#: lib/vutuv_web/components/ui.ex:4562
-#: lib/vutuv_web/components/ui.ex:4641
-#: lib/vutuv_web/components/ui.ex:4705
+#: lib/vutuv_web/components/ui.ex:4578
+#: lib/vutuv_web/components/ui.ex:4583
+#: lib/vutuv_web/components/ui.ex:4662
+#: lib/vutuv_web/components/ui.ex:4726
 #: lib/vutuv_web/controllers/settings_controller.ex:62
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5589,7 +5589,7 @@ msgstr "Navigation"
 #: lib/vutuv_web/templates/login_code/index.html.heex:4
 #: lib/vutuv_web/templates/totp/new.html.heex:4
 #: lib/vutuv_web/templates/username/confirm.html.heex:23
-#: lib/vutuv_web/views/settings_html.ex:330
+#: lib/vutuv_web/views/settings_html.ex:225
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr "Einstellungen"
@@ -5620,7 +5620,7 @@ msgstr "Profil vervollständigen"
 msgid "A few quick steps so people can find and recognize you."
 msgstr "Ein paar schnelle Schritte, damit andere Sie finden und erkennen."
 
-#: lib/vutuv_web/live/user_profile_live.ex:1338
+#: lib/vutuv_web/live/user_profile_live.ex:1342
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr "Profilfoto hinzufügen"
@@ -5646,11 +5646,11 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:3132
-#: lib/vutuv_web/components/post_components.ex:3186
-#: lib/vutuv_web/components/post_components.ex:3605
+#: lib/vutuv_web/components/post_components.ex:3147
+#: lib/vutuv_web/components/post_components.ex:3201
+#: lib/vutuv_web/components/post_components.ex:3620
 #: lib/vutuv_web/live/notification_live/index.ex:726
-#: lib/vutuv_web/live/post_live/feed.ex:1914
+#: lib/vutuv_web/live/post_live/feed.ex:2050
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5695,7 +5695,7 @@ msgstr "Art der E-Mail-Adresse"
 msgid "About you"
 msgstr "Über Sie"
 
-#: lib/vutuv_web/components/ui.ex:4420
+#: lib/vutuv_web/components/ui.ex:4441
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:289
@@ -5717,7 +5717,7 @@ msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 "Laden Sie alles herunter, was vutuv über Sie speichert, als eine Datei."
 
-#: lib/vutuv_web/components/ui.ex:4331
+#: lib/vutuv_web/components/ui.ex:4341
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5751,7 +5751,7 @@ msgstr "Persönliche Tokens für die vutuv-API."
 msgid "Photos"
 msgstr "Fotos"
 
-#: lib/vutuv_web/components/ui.ex:4394
+#: lib/vutuv_web/components/ui.ex:4415
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/templates/page/index.html.heex:174
 #, elixir-autogen, elixir-format
@@ -5866,7 +5866,7 @@ msgstr "@%{slug} folgt Ihnen jetzt auf vutuv"
 msgid "Apps"
 msgstr "Apps"
 
-#: lib/vutuv_web/components/ui.ex:4453
+#: lib/vutuv_web/components/ui.ex:4474
 #: lib/vutuv_web/controllers/settings_controller.ex:179
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -6075,28 +6075,28 @@ msgid "Sort"
 msgstr "Sortieren"
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/views/settings_html.ex:522
+#: lib/vutuv_web/views/settings_html.ex:417
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] "vor %{count} Tag"
 msgstr[1] "vor %{count} Tagen"
 
-#: lib/vutuv_web/views/settings_html.ex:521
+#: lib/vutuv_web/views/settings_html.ex:416
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] "vor %{count} Stunde"
 msgstr[1] "vor %{count} Stunden"
 
-#: lib/vutuv_web/views/settings_html.ex:520
+#: lib/vutuv_web/views/settings_html.ex:415
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
 msgstr[0] "vor %{count} Minute"
 msgstr[1] "vor %{count} Minuten"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:930
+#: lib/vutuv_web/controllers/settings_controller.ex:901
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr "Alle anderen Geräte wurden abgemeldet."
@@ -6106,7 +6106,7 @@ msgstr "Alle anderen Geräte wurden abgemeldet."
 msgid "Another session was already active on your account."
 msgstr "Auf Ihrem Konto war bereits eine andere Sitzung aktiv."
 
-#: lib/vutuv_web/views/settings_html.ex:368
+#: lib/vutuv_web/views/settings_html.ex:263
 #, elixir-autogen, elixir-format
 msgid "Last active"
 msgstr "Zuletzt aktiv"
@@ -6121,7 +6121,7 @@ msgstr "Alle anderen Geräte abmelden"
 msgid "Log out of every device except this one?"
 msgstr "Von allen Geräten außer diesem abmelden?"
 
-#: lib/vutuv_web/views/settings_html.ex:385
+#: lib/vutuv_web/views/settings_html.ex:280
 #, elixir-autogen, elixir-format
 msgid "Log this device out of your account?"
 msgstr "Dieses Gerät von Ihrem Konto abmelden?"
@@ -6136,7 +6136,7 @@ msgstr "Neue Anmeldung bei Ihrem vutuv-Konto"
 msgid "Signed-in devices"
 msgstr "Angemeldete Geräte"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:917
+#: lib/vutuv_web/controllers/settings_controller.ex:888
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr "Dieses Gerät wurde abgemeldet."
@@ -6146,7 +6146,7 @@ msgstr "Dieses Gerät wurde abgemeldet."
 msgid "The location looks different from where you usually sign in."
 msgstr "Der Ort weicht von dem ab, von dem Sie sich üblicherweise anmelden."
 
-#: lib/vutuv_web/views/settings_html.ex:369
+#: lib/vutuv_web/views/settings_html.ex:264
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr "Dieses Gerät"
@@ -6158,7 +6158,7 @@ msgstr ""
 "Das ist die erste Anmeldung, die wir von diesem Gerät oder Browser gesehen "
 "haben."
 
-#: lib/vutuv_web/views/settings_html.ex:519
+#: lib/vutuv_web/views/settings_html.ex:414
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr "gerade eben"
@@ -6196,7 +6196,7 @@ msgstr "Passkey hinzufügen"
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
 #: lib/vutuv_web/live/admin/screenshot_live.ex:309
 #: lib/vutuv_web/live/fediverse_following_live.ex:291
-#: lib/vutuv_web/views/settings_html.ex:420
+#: lib/vutuv_web/views/settings_html.ex:315
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr "Hinzugefügt"
@@ -6207,7 +6207,7 @@ msgid "Could not add the passkey. Please try again."
 msgstr ""
 "Der Passkey konnte nicht hinzugefügt werden. Bitte versuchen Sie es erneut."
 
-#: lib/vutuv_web/views/settings_html.ex:423
+#: lib/vutuv_web/views/settings_html.ex:318
 #, elixir-autogen, elixir-format
 msgid "Last used"
 msgstr "Zuletzt verwendet"
@@ -6217,7 +6217,7 @@ msgstr "Zuletzt verwendet"
 msgid "Name (optional)"
 msgstr "Name (optional)"
 
-#: lib/vutuv_web/views/settings_html.ex:417
+#: lib/vutuv_web/views/settings_html.ex:312
 #, elixir-autogen, elixir-format
 msgid "Passkey"
 msgstr "Passkey"
@@ -6237,7 +6237,7 @@ msgstr "Passkey entfernt."
 msgid "Passkeys"
 msgstr "Passkeys"
 
-#: lib/vutuv_web/views/settings_html.ex:431
+#: lib/vutuv_web/views/settings_html.ex:326
 #, elixir-autogen, elixir-format
 msgid "Remove this passkey?"
 msgstr "Diesen Passkey entfernen?"
@@ -6298,7 +6298,7 @@ msgstr "z. B. MacBook"
 msgid "or"
 msgstr "oder"
 
-#: lib/vutuv_web/live/user_profile_live.ex:1343
+#: lib/vutuv_web/live/user_profile_live.ex:1347
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr "Kurzbeschreibung hinzufügen"
@@ -6476,6 +6476,7 @@ msgstr "Reposts"
 msgid "View all phone numbers"
 msgstr "Alle Telefonnummern anzeigen"
 
+#: lib/vutuv_web/live/feed_languages_live.ex:235
 #: lib/vutuv_web/live/section_reorder_live.ex:127
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder"
@@ -6488,11 +6489,13 @@ msgstr ""
 "Zum Sortieren ziehen oder die Pfeile verwenden. Diese Reihenfolge wird auf "
 "Ihrem Profil angezeigt."
 
+#: lib/vutuv_web/live/feed_languages_live.ex:267
 #: lib/vutuv_web/live/section_reorder_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "Move down"
 msgstr "Nach unten"
 
+#: lib/vutuv_web/live/feed_languages_live.ex:256
 #: lib/vutuv_web/live/section_reorder_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -6885,8 +6888,8 @@ msgstr ""
 "Schalten Sie einen Schalter aus, geht der passende Opt-out auf den Seiten "
 "und Antworten über Sie mit. Mit beiden aus zum Beispiel:"
 
-#: lib/vutuv_web/components/post_components.ex:2282
-#: lib/vutuv_web/components/post_components.ex:3064
+#: lib/vutuv_web/components/post_components.ex:2297
+#: lib/vutuv_web/components/post_components.ex:3079
 #: lib/vutuv_web/components/ui.ex:2713
 #: lib/vutuv_web/live/fediverse_account_live.ex:381
 #: lib/vutuv_web/live/organization_live/following.ex:371
@@ -6913,7 +6916,7 @@ msgstr "Neue Nachrichten und neue Vernetzungen"
 msgid "Remove this connection? You will stop following them."
 msgstr "Diese Vernetzung entfernen? Sie folgen der Person dann nicht mehr."
 
-#: lib/vutuv_web/components/post_components.ex:3064
+#: lib/vutuv_web/components/post_components.ex:3079
 #: lib/vutuv_web/components/ui.ex:2712
 #: lib/vutuv_web/live/fediverse_account_live.ex:379
 #: lib/vutuv_web/live/organization_live/following.ex:371
@@ -7413,7 +7416,7 @@ msgstr "Unterdrückt (unzustellbare Adresse)"
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:816
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:44
 #: lib/vutuv_web/templates/settings/filters.html.heex:22
-#: lib/vutuv_web/views/settings_html.ex:61
+#: lib/vutuv_web/views/settings_html.ex:59
 #, elixir-autogen, elixir-format
 msgid "Tag"
 msgstr "Tag"
@@ -7561,13 +7564,13 @@ msgstr "Ihre Mitglieder werden zu dieser hinzugefügt (Vereinigung)."
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr "Seite %{page} von %{pages}, %{total} gesamt"
 
-#: lib/vutuv_web/components/ui.ex:3436
+#: lib/vutuv_web/components/ui.ex:3446
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Zurück"
 
-#: lib/vutuv_web/components/ui.ex:3452
+#: lib/vutuv_web/components/ui.ex:3462
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7648,7 +7651,7 @@ msgid "applies to the whole list, not just this page"
 msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:5030
+#: lib/vutuv_web/components/post_components.ex:5060
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8162,42 +8165,42 @@ msgstr "Wie oft"
 msgid "Send the email"
 msgstr "E-Mail senden"
 
-#: lib/vutuv_web/views/settings_html.ex:111
+#: lib/vutuv_web/views/settings_html.ex:109
 #, elixir-autogen
 msgid "As soon as possible"
 msgstr "So bald wie möglich"
 
-#: lib/vutuv_web/views/settings_html.ex:112
+#: lib/vutuv_web/views/settings_html.ex:110
 #, elixir-autogen
 msgid "After 5 minutes"
 msgstr "Nach 5 Minuten"
 
-#: lib/vutuv_web/views/settings_html.ex:113
+#: lib/vutuv_web/views/settings_html.ex:111
 #, elixir-autogen
 msgid "After 15 minutes"
 msgstr "Nach 15 Minuten"
 
-#: lib/vutuv_web/views/settings_html.ex:114
+#: lib/vutuv_web/views/settings_html.ex:112
 #, elixir-autogen
 msgid "After 30 minutes"
 msgstr "Nach 30 Minuten"
 
-#: lib/vutuv_web/views/settings_html.ex:115
+#: lib/vutuv_web/views/settings_html.ex:113
 #, elixir-autogen
 msgid "After 1 hour"
 msgstr "Nach 1 Stunde"
 
-#: lib/vutuv_web/views/settings_html.ex:116
+#: lib/vutuv_web/views/settings_html.ex:114
 #, elixir-autogen
 msgid "After 2 hours"
 msgstr "Nach 2 Stunden"
 
-#: lib/vutuv_web/views/settings_html.ex:95
+#: lib/vutuv_web/views/settings_html.ex:93
 #, elixir-autogen
 msgid "Only the first message"
 msgstr "Nur die erste Nachricht"
 
-#: lib/vutuv_web/views/settings_html.ex:96
+#: lib/vutuv_web/views/settings_html.ex:94
 #, elixir-autogen
 msgid "Every message"
 msgstr "Jede Nachricht"
@@ -8248,7 +8251,7 @@ msgid "Admins"
 msgstr "Administratoren"
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:1882
+#: lib/vutuv_web/live/post_live/feed.ex:2018
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr "Alle Mitglieder"
@@ -8381,7 +8384,7 @@ msgstr "PIN abgelaufen"
 msgid "PIN registered"
 msgstr "PIN-registriert"
 
-#: lib/vutuv_web/components/ui.ex:3439
+#: lib/vutuv_web/components/ui.ex:3449
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr "Seite %{page} von %{pages}"
@@ -8520,7 +8523,7 @@ msgstr "Abschluss"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:42
 #: lib/vutuv_web/agent_docs/text.ex:39
-#: lib/vutuv_web/components/ui.ex:4307
+#: lib/vutuv_web/components/ui.ex:4317
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8580,7 +8583,7 @@ msgstr ""
 " was Sie nicht übernehmen möchten. Einträge, die bereits in Ihrem Profil "
 "stehen, sind für Sie abgewählt."
 
-#: lib/vutuv_web/components/ui.ex:4441
+#: lib/vutuv_web/components/ui.ex:4462
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Import"
@@ -8609,7 +8612,7 @@ msgstr "%{items} importiert."
 msgid "Nothing new to import."
 msgstr "Nichts Neues zu importieren."
 
-#: lib/vutuv_web/components/ui.ex:4335
+#: lib/vutuv_web/components/ui.ex:4345
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8706,7 +8709,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr "Zu viele Importe. Bitte versuchen Sie es in Kürze erneut."
 
-#: lib/vutuv_web/components/ui.ex:3708
+#: lib/vutuv_web/components/ui.ex:3718
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8800,13 +8803,13 @@ msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 "Ziehen Sie Ihre ZIP-Datei hierher oder klicken Sie, um eine auszuwählen."
 
-#: lib/vutuv_web/components/ui.ex:4295
+#: lib/vutuv_web/components/ui.ex:4305
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr "Basisdaten & Fotos"
 
-#: lib/vutuv_web/components/ui.ex:4431
+#: lib/vutuv_web/components/ui.ex:4452
 #: lib/vutuv_web/controllers/settings_controller.ex:123
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8818,7 +8821,7 @@ msgstr "Sprache & Anzeige"
 msgid "More profile sections"
 msgstr "Weitere Profil-Bereiche"
 
-#: lib/vutuv_web/components/ui.ex:4422
+#: lib/vutuv_web/components/ui.ex:4443
 #: lib/vutuv_web/controllers/settings_controller.ex:106
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8828,7 +8831,7 @@ msgstr "Weitere Profil-Bereiche"
 msgid "Sign-in & security"
 msgstr "Anmeldung & Sicherheit"
 
-#: lib/vutuv_web/components/ui.ex:4445
+#: lib/vutuv_web/components/ui.ex:4466
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8855,12 +8858,12 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr "Geben Sie zur Bestätigung Ihren Benutzernamen ein:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1899
+#: lib/vutuv_web/live/post_live/feed.ex:2035
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr "Andere Beiträge anzeigen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1895
+#: lib/vutuv_web/live/post_live/feed.ex:2031
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr "Vorgeschlagene Beiträge"
@@ -9069,7 +9072,7 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/agent_docs/text.ex:584
 #: lib/vutuv_web/components/organization_components.ex:285
 #: lib/vutuv_web/components/ui.ex:1282
-#: lib/vutuv_web/components/ui.ex:4412
+#: lib/vutuv_web/components/ui.ex:4433
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:355
 #: lib/vutuv_web/controllers/settings_controller.ex:422
@@ -9236,7 +9239,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:4053
+#: lib/vutuv_web/components/post_components.ex:4068
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9511,6 +9514,7 @@ msgstr "A1 (Anfänger)"
 msgid "A2 (Elementary)"
 msgstr "A2 (Grundkenntnisse)"
 
+#: lib/vutuv_web/live/feed_languages_live.ex:317
 #: lib/vutuv_web/templates/language/manage.html.heex:8
 #: lib/vutuv_web/templates/language/new.html.heex:5
 #: lib/vutuv_web/templates/user/show.html.heex:749
@@ -9684,6 +9688,7 @@ msgid "Irish"
 msgstr "Irisch"
 
 #: lib/vutuv/languages.ex:125
+#: lib/vutuv_web/templates/settings/preferences.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "Italian"
 msgstr "Italienisch"
@@ -9924,7 +9929,7 @@ msgstr "Yoruba"
 msgid "Employment status"
 msgstr "Beschäftigungsstatus"
 
-#: lib/vutuv/accounts/user.ex:1162
+#: lib/vutuv/accounts/user.ex:1167
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9935,7 +9940,7 @@ msgstr "Auf Jobsuche"
 msgid "Not open to work"
 msgstr "Nicht offen für Angebote"
 
-#: lib/vutuv/accounts/user.ex:1159
+#: lib/vutuv/accounts/user.ex:1164
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -10061,7 +10066,7 @@ msgstr "Zertifikate"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:46
 #: lib/vutuv_web/agent_docs/text.ex:43
-#: lib/vutuv_web/components/ui.ex:4311
+#: lib/vutuv_web/components/ui.ex:4321
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:132
@@ -10262,13 +10267,13 @@ msgstr "Dauerhafter Profillink"
 msgid "Dismiss"
 msgstr "Schließen"
 
-#: lib/vutuv_web/components/ui.ex:3182
+#: lib/vutuv_web/components/ui.ex:3185
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr "Kopiert"
 
-#: lib/vutuv_web/components/ui.ex:3181
-#: lib/vutuv_web/components/ui.ex:3185
+#: lib/vutuv_web/components/ui.ex:3184
+#: lib/vutuv_web/components/ui.ex:3188
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr "Kopieren"
@@ -11044,14 +11049,14 @@ msgid_plural "You have %{formatted} new messages."
 msgstr[0] "Sie haben %{formatted} neue Nachricht."
 msgstr[1] "Sie haben %{formatted} neue Nachrichten."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:433
+#: lib/vutuv_web/templates/settings/preferences.html.heex:383
 #, elixir-autogen, elixir-format
 msgid "Break long words at syllable points so the text wraps evenly. Helpful in the narrow phone column."
 msgstr ""
 "Trennt lange Wörter an Silbengrenzen, damit der Text gleichmäßig umbricht. "
 "Hilfreich in der schmalen Smartphone-Spalte."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:364
+#: lib/vutuv_web/templates/settings/preferences.html.heex:314
 #, elixir-autogen, elixir-format
 msgid "How posts you read are shortened in your feed and on profiles. These are your own reading preferences."
 msgstr ""
@@ -11059,35 +11064,35 @@ msgstr ""
 "Das sind Ihre eigenen Anzeige-Einstellungen."
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:68
-#: lib/vutuv_web/templates/settings/preferences.html.heex:440
+#: lib/vutuv_web/templates/settings/preferences.html.heex:390
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on desktop"
 msgstr "Silbentrennung am Desktop"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:69
-#: lib/vutuv_web/templates/settings/preferences.html.heex:444
+#: lib/vutuv_web/templates/settings/preferences.html.heex:394
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on mobile"
 msgstr "Silbentrennung auf dem Smartphone"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:430
+#: lib/vutuv_web/templates/settings/preferences.html.heex:380
 #, elixir-autogen, elixir-format
 msgid "Hyphenation"
 msgstr "Silbentrennung"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:66
-#: lib/vutuv_web/templates/settings/preferences.html.heex:387
+#: lib/vutuv_web/templates/settings/preferences.html.heex:337
 #, elixir-autogen, elixir-format
 msgid "Lines on desktop"
 msgstr "Zeilen am Desktop"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:67
-#: lib/vutuv_web/templates/settings/preferences.html.heex:396
+#: lib/vutuv_web/templates/settings/preferences.html.heex:346
 #, elixir-autogen, elixir-format
 msgid "Lines on mobile"
 msgstr "Zeilen auf dem Smartphone"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:382
+#: lib/vutuv_web/templates/settings/preferences.html.heex:332
 #, elixir-autogen, elixir-format
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
@@ -11099,7 +11104,7 @@ msgstr ""
 msgid "Post display settings saved."
 msgstr "Anzeige-Einstellungen für Beiträge gespeichert."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:379
+#: lib/vutuv_web/templates/settings/preferences.html.heex:329
 #, elixir-autogen, elixir-format
 msgid "Shorten a post after"
 msgstr "Beitrag kürzen nach"
@@ -11199,11 +11204,11 @@ msgstr "Einstellungen"
 msgid "Preferences of %{name}"
 msgstr "Einstellungen von %{name}"
 
+#: lib/vutuv_web/live/feed_languages_live.ex:377
 #: lib/vutuv_web/templates/settings/preferences.html.heex:101
 #: lib/vutuv_web/templates/settings/preferences.html.heex:174
-#: lib/vutuv_web/templates/settings/preferences.html.heex:245
-#: lib/vutuv_web/templates/settings/preferences.html.heex:346
-#: lib/vutuv_web/templates/settings/preferences.html.heex:464
+#: lib/vutuv_web/templates/settings/preferences.html.heex:296
+#: lib/vutuv_web/templates/settings/preferences.html.heex:414
 #, elixir-autogen, elixir-format
 msgid "Reset to the site defaults"
 msgstr "Auf die Standardwerte zurücksetzen"
@@ -11413,19 +11418,19 @@ msgstr ""
 " Konto anlegen kann. Wählen Sie „Niemand“, um den Status zu speichern, ohne "
 "ihn anzuzeigen."
 
-#: lib/vutuv/accounts/user.ex:1200
+#: lib/vutuv/accounts/user.ex:1205
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Alle, auch nicht angemeldete Besucher"
 
-#: lib/vutuv/accounts/user.ex:1205
+#: lib/vutuv/accounts/user.ex:1210
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Niemand"
 
-#: lib/vutuv/accounts/user.ex:1203
+#: lib/vutuv/accounts/user.ex:1208
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:761
 #, elixir-autogen, elixir-format
@@ -12470,7 +12475,7 @@ msgstr "Organisation wieder freigegeben."
 #: lib/vutuv_web/agent_docs/markdown.ex:419
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:394
-#: lib/vutuv_web/components/ui.ex:4449
+#: lib/vutuv_web/components/ui.ex:4470
 #: lib/vutuv_web/controllers/settings_controller.ex:211
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
@@ -12791,7 +12796,7 @@ msgstr "Hervorgehobene Tags passen zu Ihrem Profil."
 msgid "How to apply"
 msgstr "So bewerben Sie sich"
 
-#: lib/vutuv/accounts/user.ex:1174
+#: lib/vutuv/accounts/user.ex:1179
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12910,7 +12915,7 @@ msgstr "Hier ist noch nichts. Jobs, die Ihnen gefallen, erscheinen hier."
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) für KI-Agenten anbieten."
 
-#: lib/vutuv/accounts/user.ex:1173
+#: lib/vutuv/accounts/user.ex:1178
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12992,7 +12997,7 @@ msgstr "Anzeige nicht gefunden."
 msgid "Publish"
 msgstr "Veröffentlichen"
 
-#: lib/vutuv/accounts/user.ex:1175
+#: lib/vutuv/accounts/user.ex:1180
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:564
 #: lib/vutuv_web/agent_docs/markdown.ex:458
@@ -13237,12 +13242,12 @@ msgstr "Vertreten Sie ein Unternehmen, einen Verein oder eine andere Gruppe? Fü
 msgid "Browse all organizations"
 msgstr "Alle Organisationen ansehen"
 
-#: lib/vutuv_web/views/settings_html.ex:74
+#: lib/vutuv_web/views/settings_html.ex:72
 #, elixir-autogen, elixir-format
 msgid "Under review"
 msgstr "In Prüfung"
 
-#: lib/vutuv_web/views/settings_html.ex:76
+#: lib/vutuv_web/views/settings_html.ex:74
 #, elixir-autogen, elixir-format
 msgid "Verification pending"
 msgstr "Verifizierung ausstehend"
@@ -13699,7 +13704,7 @@ msgstr "Suche speichern"
 msgid "Saved search deleted."
 msgstr "Gespeicherte Suche gelöscht."
 
-#: lib/vutuv_web/components/ui.ex:4389
+#: lib/vutuv_web/components/ui.ex:4410
 #: lib/vutuv_web/controllers/settings_controller.ex:600
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -13719,7 +13724,7 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "E-Mail-Benachrichtigungen für Ihre gespeicherte Suche „%{label}“ stoppen?"
 
-#: lib/vutuv_web/components/post_components.ex:2457
+#: lib/vutuv_web/components/post_components.ex:2472
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:695
 #: lib/vutuv_web/controllers/settings_controller.ex:713
@@ -14021,7 +14026,7 @@ msgstr "Screenshot entfernt."
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr "Dieser Screenshot wurde automatisch aus dem Link in Ihrem Beitrag erstellt. Falls er unbrauchbar ist (zum Beispiel weil ein Cookie-Banner die Seite verdeckt), können Sie ihn entfernen."
 
-#: lib/vutuv/accounts/user.ex:1218
+#: lib/vutuv/accounts/user.ex:1223
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -14032,19 +14037,19 @@ msgstr "Nur das Alter, ohne das Datum"
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr "Wählen Sie, wie viel von Ihrem Geburtstag Ihr Profil zeigt. „Nur das Alter“ verbirgt das genaue Datum, „Tag und Monat“ verbirgt das Jahr (und Ihr Alter), und „Nicht anzeigen“ speichert ihn weiterhin, hält ihn aber von Ihrem Profil fern."
 
-#: lib/vutuv/accounts/user.ex:1221
+#: lib/vutuv/accounts/user.ex:1226
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Tag und Monat, ohne das Jahr"
 
-#: lib/vutuv/accounts/user.ex:1224
+#: lib/vutuv/accounts/user.ex:1229
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Geburtstag nicht anzeigen"
 
-#: lib/vutuv/accounts/user.ex:1215
+#: lib/vutuv/accounts/user.ex:1220
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -14171,16 +14176,16 @@ msgstr ""
 "Personen tauchen in Ihren Vorschlägen auf. Einem Tag folgen Sie auf seiner "
 "Seite."
 
-#: lib/vutuv_web/components/ui.ex:4372
+#: lib/vutuv_web/components/ui.ex:4393
 #: lib/vutuv_web/controllers/settings_controller.ex:614
-#: lib/vutuv_web/live/post_live/feed.ex:1757
+#: lib/vutuv_web/live/post_live/feed.ex:1893
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr "Tags, denen Sie folgen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1772
+#: lib/vutuv_web/live/post_live/feed.ex:1908
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr "#%{tag} entfolgen"
@@ -14253,7 +14258,7 @@ msgstr "Messenger wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:60
 #: lib/vutuv_web/agent_docs/text.ex:57
-#: lib/vutuv_web/components/ui.ex:4354
+#: lib/vutuv_web/components/ui.ex:4364
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -14281,14 +14286,14 @@ msgstr "Messenger von %{name}"
 msgid "Select a messenger"
 msgstr "Messenger auswählen"
 
-#: lib/vutuv_web/components/ui.ex:3794
+#: lib/vutuv_web/components/ui.ex:3804
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] "Meinen Follower darüber informieren"
 msgstr[1] "Meine %{formatted} Follower darüber informieren"
 
-#: lib/vutuv_web/components/ui.ex:3804
+#: lib/vutuv_web/components/ui.ex:3814
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr "Die Benachrichtigung enthält einen Link zu diesem Eintrag. Es wird keine E-Mail verschickt, und das passiert nur bei neuen Einträgen."
@@ -14338,34 +14343,34 @@ msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch imm
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:4651
+#: lib/vutuv_web/components/post_components.ex:4681
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1196
-#: lib/vutuv_web/components/post_components.ex:4608
+#: lib/vutuv_web/components/post_components.ex:4638
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:4652
+#: lib/vutuv_web/components/post_components.ex:4682
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:4654
+#: lib/vutuv_web/components/post_components.ex:4684
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:4650
+#: lib/vutuv_web/components/post_components.ex:4680
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1196
-#: lib/vutuv_web/components/post_components.ex:4607
+#: lib/vutuv_web/components/post_components.ex:4637
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Filmbesprechung"
@@ -14376,12 +14381,12 @@ msgstr "Filmbesprechung"
 msgid "Look up"
 msgstr "Nachschlagen"
 
-#: lib/vutuv_web/components/post_components.ex:4649
+#: lib/vutuv_web/components/post_components.ex:4679
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
 
-#: lib/vutuv_web/components/post_components.ex:4653
+#: lib/vutuv_web/components/post_components.ex:4683
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14401,7 +14406,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:4690
+#: lib/vutuv_web/components/post_components.ex:4720
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14409,27 +14414,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:4720
+#: lib/vutuv_web/components/post_components.ex:4750
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:4721
+#: lib/vutuv_web/components/post_components.ex:4751
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:4719
+#: lib/vutuv_web/components/post_components.ex:4749
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:4679
+#: lib/vutuv_web/components/post_components.ex:4709
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:4726
+#: lib/vutuv_web/components/post_components.ex:4756
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14459,7 +14464,7 @@ msgstr "Mit Qualifikation:"
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:4493
+#: lib/vutuv_web/components/post_components.ex:4523
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
@@ -14507,7 +14512,7 @@ msgstr "folgen Ihnen jetzt."
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:4484
+#: lib/vutuv_web/components/post_components.ex:4514
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
@@ -14647,7 +14652,7 @@ msgid "proof document"
 msgstr "Nachweis"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:74
-#: lib/vutuv_web/templates/settings/preferences.html.heex:418
+#: lib/vutuv_web/templates/settings/preferences.html.heex:368
 #, elixir-autogen, elixir-format
 msgid "Lines in notifications"
 msgstr "Zeilen in Benachrichtigungen"
@@ -14657,12 +14662,12 @@ msgstr "Zeilen in Benachrichtigungen"
 msgid "How much of a post a notification quotes before it is cut off."
 msgstr "Wie viel von einem Beitrag eine Benachrichtigung zitiert, bevor abgeschnitten wird."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:409
+#: lib/vutuv_web/templates/settings/preferences.html.heex:359
 #, elixir-autogen, elixir-format
 msgid "Quoted posts in notifications"
 msgstr "Zitierte Beiträge in Benachrichtigungen"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:412
+#: lib/vutuv_web/templates/settings/preferences.html.heex:362
 #, elixir-autogen, elixir-format
 msgid "Your notifications quote the post someone liked or replied to. Leave the field empty to follow the site default."
 msgstr ""
@@ -14881,7 +14886,7 @@ msgstr "Konto einfrieren"
 msgid "No accounts are currently frozen."
 msgstr "Zurzeit sind keine Konten eingefroren."
 
-#: lib/vutuv_web/live/post_live/thread.ex:460
+#: lib/vutuv_web/live/post_live/thread.ex:464
 #, elixir-autogen, elixir-format
 msgid "Read it from the start"
 msgstr "Von Anfang an lesen"
@@ -14901,14 +14906,14 @@ msgstr "Konto zum Einfrieren suchen"
 msgid "See all frozen accounts"
 msgstr "Alle eingefrorenen Konten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2730
+#: lib/vutuv_web/components/post_components.ex:2745
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "%{formatted} früheren Beitrag anzeigen"
 msgstr[1] "%{formatted} frühere Beiträge anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2753
+#: lib/vutuv_web/components/post_components.ex:2768
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14920,7 +14925,7 @@ msgstr[1] "%{formatted} weitere Antworten anzeigen"
 msgid "This page is no longer available."
 msgstr "Diese Seite ist nicht mehr verfügbar."
 
-#: lib/vutuv_web/live/post_live/thread.ex:452
+#: lib/vutuv_web/live/post_live/thread.ex:456
 #, elixir-autogen, elixir-format
 msgid "This post is part of a conversation with %{formatted} posts."
 msgstr "Dieser Beitrag ist Teil einer Unterhaltung mit %{formatted} Beiträgen."
@@ -14935,7 +14940,7 @@ msgstr "Dieses Profil ist zurzeit nicht verfügbar."
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das Konto zu finden, das eingefroren werden soll."
 
-#: lib/vutuv_web/components/post_components.ex:5129
+#: lib/vutuv_web/components/post_components.ex:5159
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Der eigene Beitrag lässt sich nicht mit „Gefällt mir“ markieren."
@@ -15082,7 +15087,7 @@ msgstr "Nach einem Tag filtern"
 msgid "Filter removed."
 msgstr "Filter entfernt."
 
-#: lib/vutuv_web/live/post_live/feed.ex:472
+#: lib/vutuv_web/live/post_live/feed.ex:509
 #, elixir-autogen, elixir-format
 msgid "Hidden: matches your filter"
 msgstr "Ausgeblendet: passt zu Ihrem Filter"
@@ -15097,7 +15102,7 @@ msgstr "Blenden Sie Beiträge aus Ihrem Feed aus, die ein Tag tragen oder ein Wo
 msgid "Match whole words only (word/phrase)"
 msgstr "Nur ganze Wörter treffen (Wort/Phrase)"
 
-#: lib/vutuv_web/components/ui.ex:4368
+#: lib/vutuv_web/components/ui.ex:4378
 #: lib/vutuv_web/controllers/settings_controller.ex:680
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -15117,7 +15122,7 @@ msgstr ""
 "Wählen Sie unten einen Abschluss oder eine Schule, um ihn statt eines "
 "Jobtitels oben in Ihrem Profil anzuzeigen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:481
+#: lib/vutuv_web/live/post_live/feed.ex:518
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr "Trotzdem anzeigen"
@@ -15168,12 +15173,12 @@ msgid "When someone replies anywhere in a thread you have written in, you hear a
 msgstr "Wenn jemand irgendwo in einem Thread antwortet, in dem Sie geschrieben haben, hören Sie es unter der Glocke, damit eine Diskussion alle Beteiligten erreicht. Nie per E-Mail."
 
 #: lib/vutuv_web/templates/settings/filters.html.heex:19
-#: lib/vutuv_web/views/settings_html.ex:62
+#: lib/vutuv_web/views/settings_html.ex:60
 #, elixir-autogen, elixir-format
 msgid "Word or phrase"
 msgstr "Wort oder Phrase"
 
-#: lib/vutuv_web/views/settings_html.ex:65
+#: lib/vutuv_web/views/settings_html.ex:63
 #, elixir-autogen, elixir-format
 msgid "Word or phrase (whole word)"
 msgstr "Wort oder Phrase (ganzes Wort)"
@@ -15732,252 +15737,252 @@ msgstr "Ihr Server"
 msgid "moved to %{address}"
 msgstr "umgezogen nach %{address}"
 
-#: lib/vutuv_web/components/ui.ex:4296
+#: lib/vutuv_web/components/ui.ex:4306
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr "Name, Foto, Titelbild, Kurzbeschreibung"
 
-#: lib/vutuv_web/components/ui.ex:4301
+#: lib/vutuv_web/components/ui.ex:4311
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr "handle spitzname nutzername umbenennen slug profiladresse url erwähnung"
 
-#: lib/vutuv_web/components/ui.ex:4304
+#: lib/vutuv_web/components/ui.ex:4314
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr "Die Stationen in Ihrem Lebenslauf"
 
-#: lib/vutuv_web/components/ui.ex:4305
+#: lib/vutuv_web/components/ui.ex:4315
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr "lebenslauf cv karriere beruf arbeitgeber position stelle job firma"
 
-#: lib/vutuv_web/components/ui.ex:4308
+#: lib/vutuv_web/components/ui.ex:4318
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr "Schulen, Hochschulen, Abschlüsse"
 
-#: lib/vutuv_web/components/ui.ex:4309
+#: lib/vutuv_web/components/ui.ex:4319
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr "lebenslauf studium schule universität hochschule abschluss ausbildung"
 
-#: lib/vutuv_web/components/ui.ex:4312
+#: lib/vutuv_web/components/ui.ex:4322
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr "Nachweise, mit Belegdokumenten"
 
-#: lib/vutuv_web/components/ui.ex:4313
+#: lib/vutuv_web/components/ui.ex:4323
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr "zertifikat lizenz urkunde diplom nachweis beleg auszeichnung dokument"
 
-#: lib/vutuv_web/components/ui.ex:4320
+#: lib/vutuv_web/components/ui.ex:4330
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr "Sprachkenntnisse"
 
-#: lib/vutuv_web/components/ui.ex:4321
+#: lib/vutuv_web/components/ui.ex:4331
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr "Die Sprachen, die Sie sprechen"
 
-#: lib/vutuv_web/components/ui.ex:4322
+#: lib/vutuv_web/components/ui.ex:4332
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr "sprache sprachen sprechen fließend muttersprache verhandlungssicher"
 
-#: lib/vutuv_web/components/ui.ex:4325
+#: lib/vutuv_web/components/ui.ex:4335
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr "Die Themen, für die Sie bekannt sind"
 
-#: lib/vutuv_web/components/ui.ex:4326
+#: lib/vutuv_web/components/ui.ex:4336
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr "fähigkeit kenntnis thema stichwort schlagwort expertise empfehlung"
 
-#: lib/vutuv_web/components/ui.ex:4450
+#: lib/vutuv_web/components/ui.ex:4471
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr "Organisationsseiten, die Sie verwalten"
 
-#: lib/vutuv_web/components/ui.ex:4451
+#: lib/vutuv_web/components/ui.ex:4472
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr "firma unternehmen arbeitgeber betrieb organisation seite"
 
-#: lib/vutuv_web/components/ui.ex:4329
+#: lib/vutuv_web/components/ui.ex:4339
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr "Kontaktdaten"
 
-#: lib/vutuv_web/components/ui.ex:4332
+#: lib/vutuv_web/components/ui.ex:4342
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr "Wo wir Sie erreichen, und welche Adresse öffentlich ist"
 
-#: lib/vutuv_web/components/ui.ex:4333
+#: lib/vutuv_web/components/ui.ex:4343
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr "mail e-mail email adresse hauptadresse primär"
 
-#: lib/vutuv_web/components/ui.ex:4336
+#: lib/vutuv_web/components/ui.ex:4346
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr "Festnetz, Mobil, Fax"
 
-#: lib/vutuv_web/components/ui.ex:4337
+#: lib/vutuv_web/components/ui.ex:4347
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr "telefon handy mobil festnetz fax nummer rufnummer"
 
-#: lib/vutuv_web/components/ui.ex:4340
+#: lib/vutuv_web/components/ui.ex:4350
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr "Postanschriften auf Ihrem Profil"
 
-#: lib/vutuv_web/components/ui.ex:4341
+#: lib/vutuv_web/components/ui.ex:4351
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr "straße stadt ort postleitzahl plz land anschrift karte"
 
-#: lib/vutuv_web/components/ui.ex:4343
+#: lib/vutuv_web/components/ui.ex:4353
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr "Webseiten & Links"
 
-#: lib/vutuv_web/components/ui.ex:4344
+#: lib/vutuv_web/components/ui.ex:4354
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr "Ihre Homepage und weitere Links"
 
-#: lib/vutuv_web/components/ui.ex:4345
+#: lib/vutuv_web/components/ui.ex:4355
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr "url webseite website homepage blog link verifizieren bestätigen rel=me"
 
-#: lib/vutuv_web/components/ui.ex:4347
+#: lib/vutuv_web/components/ui.ex:4357
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr "Social-Media-Profile"
 
-#: lib/vutuv_web/components/ui.ex:4348
+#: lib/vutuv_web/components/ui.ex:4358
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr "Mastodon, Bluesky, GitHub und die anderen"
 
-#: lib/vutuv_web/components/ui.ex:4350
+#: lib/vutuv_web/components/ui.ex:4360
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr "mastodon bluesky github gitlab codeberg linkedin x twitter instagram soziale netzwerke"
 
-#: lib/vutuv_web/components/ui.ex:4355
+#: lib/vutuv_web/components/ui.ex:4365
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr "Signal, Threema, Matrix und die anderen"
 
-#: lib/vutuv_web/components/ui.ex:4356
+#: lib/vutuv_web/components/ui.ex:4366
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr "signal threema matrix xmpp telegram whatsapp chat messenger nachrichten"
 
-#: lib/vutuv_web/components/ui.ex:4359
+#: lib/vutuv_web/components/ui.ex:4369
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr "Mitteilungen & Feed"
 
-#: lib/vutuv_web/components/ui.ex:4362
+#: lib/vutuv_web/components/ui.ex:4372
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr "Welche E-Mails wir schicken, und was die Glocke meldet"
 
-#: lib/vutuv_web/components/ui.ex:4369
+#: lib/vutuv_web/components/ui.ex:4379
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr "Beiträge aus Ihrem Feed heraushalten"
 
-#: lib/vutuv_web/components/ui.ex:4370
+#: lib/vutuv_web/components/ui.ex:4380
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr "stummschalten ausblenden verbergen filter wort begriff tag feed blockieren"
 
-#: lib/vutuv_web/components/ui.ex:4373
+#: lib/vutuv_web/components/ui.ex:4394
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr "Themen, deren Beiträge in Ihrem Feed landen"
 
-#: lib/vutuv_web/components/ui.ex:4374
+#: lib/vutuv_web/components/ui.ex:4395
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr "tag thema abonnieren folgen feed"
 
-#: lib/vutuv_web/components/ui.ex:4390
+#: lib/vutuv_web/components/ui.ex:4411
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr "Job- und Personensuchen, die Ihnen neue Treffer mailen"
 
-#: lib/vutuv_web/components/ui.ex:4391
+#: lib/vutuv_web/components/ui.ex:4412
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr "job stelle stellenangebot suchauftrag suche alarm benachrichtigung merkliste"
 
-#: lib/vutuv_web/components/ui.ex:4397
+#: lib/vutuv_web/components/ui.ex:4418
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr "Suchmaschinen, KI, Online-Status"
 
-#: lib/vutuv_web/components/ui.ex:4398
+#: lib/vutuv_web/components/ui.ex:4419
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr "privatsphäre datenschutz google suchmaschine ki ai llm crawler noindex online punkt öffentlich sichtbar"
 
-#: lib/vutuv_web/components/ui.ex:4401
+#: lib/vutuv_web/components/ui.ex:4422
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr "Personen, die nicht mit Ihnen interagieren können"
 
-#: lib/vutuv_web/components/ui.ex:4402
+#: lib/vutuv_web/components/ui.ex:4423
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr "blockieren sperren bannen stummschalten melden missbrauch belästigung"
 
-#: lib/vutuv_web/components/ui.ex:4423
+#: lib/vutuv_web/components/ui.ex:4444
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr "Passkeys, angemeldete Geräte, Anmeldecodes"
 
-#: lib/vutuv_web/components/ui.ex:4424
+#: lib/vutuv_web/components/ui.ex:4445
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr "passwort kennwort anmelden abmelden login logout sitzung gerät passkey totp 2fa pin sicherheit"
 
-#: lib/vutuv_web/components/ui.ex:4442
+#: lib/vutuv_web/components/ui.ex:4463
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr "Ihre Daten von LinkedIn übernehmen"
 
-#: lib/vutuv_web/components/ui.ex:4443
+#: lib/vutuv_web/components/ui.ex:4464
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr "linkedin hochladen zip übernehmen importieren umzug"
 
-#: lib/vutuv_web/components/ui.ex:4446
+#: lib/vutuv_web/components/ui.ex:4467
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr "Alles herunterladen, was wir über Sie speichern"
 
-#: lib/vutuv_web/components/ui.ex:4447
+#: lib/vutuv_web/components/ui.ex:4468
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr "herunterladen download dsgvo gdpr daten sicherung json lebenslauf auskunft"
 
-#: lib/vutuv_web/components/ui.ex:4461
+#: lib/vutuv_web/components/ui.ex:4482
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr "Ihr Konto und alles darauf entfernen"
 
-#: lib/vutuv_web/components/ui.ex:4462
+#: lib/vutuv_web/components/ui.ex:4483
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr "löschen entfernen schließen kündigen beenden verlassen"
@@ -16055,7 +16060,7 @@ msgstr "Verstanden, abschalten"
 msgid "I understand, take part"
 msgstr "Verstanden, teilnehmen"
 
-#: lib/vutuv_web/views/settings_html.ex:501
+#: lib/vutuv_web/views/settings_html.ex:396
 #, elixir-autogen, elixir-format
 msgid "Most of them, not all: we cannot check whether they do it, and anything that was re-shared, archived or indexed elsewhere stays out of reach. If you take part again later, people there have to follow you anew."
 msgstr ""
@@ -16063,7 +16068,7 @@ msgstr ""
 "anderswo geteilt, archiviert oder indexiert wurde, bleibt außer Reichweite. "
 "Wenn Sie später wieder teilnehmen, müssen Ihnen die Leute dort erneut folgen."
 
-#: lib/vutuv_web/views/settings_html.ex:496
+#: lib/vutuv_web/views/settings_html.ex:391
 #, elixir-autogen, elixir-format
 msgid "No new posts go out, and your followers from other networks are removed here. The next time those servers look you up they learn that this account is gone, and most of them then delete their copies of your posts."
 msgstr ""
@@ -16072,25 +16077,25 @@ msgstr ""
 "erfahren sie, dass dieses Konto nicht mehr existiert, und die meisten löschen "
 "daraufhin ihre Kopien Ihrer Beiträge."
 
-#: lib/vutuv_web/views/settings_html.ex:477
+#: lib/vutuv_web/views/settings_html.ex:372
 #, elixir-autogen, elixir-format
 msgid "Once a post has left vutuv, it is out of our hands"
 msgstr ""
 "Was einmal von vutuv aus verschickt wurde, können wir nicht zurückholen"
 
-#: lib/vutuv_web/views/settings_html.ex:479
+#: lib/vutuv_web/views/settings_html.ex:374
 #, elixir-autogen, elixir-format
 msgid "Switching off does not delete what is already out there"
 msgstr "Abschalten löscht nicht, was bereits draußen ist"
 
-#: lib/vutuv_web/views/settings_html.ex:490
+#: lib/vutuv_web/views/settings_html.ex:385
 #, elixir-autogen, elixir-format
 msgid "Switching this off again later stops new posts from going out. It cannot bring back what has already been delivered."
 msgstr ""
 "Wenn Sie das später wieder abschalten, gehen keine neuen Beiträge mehr "
 "hinaus. Bereits zugestellte Beiträge holt das nicht zurück."
 
-#: lib/vutuv_web/views/settings_html.ex:485
+#: lib/vutuv_web/views/settings_html.ex:380
 #, elixir-autogen, elixir-format
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
@@ -16099,21 +16104,21 @@ msgstr ""
 "wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
-#: lib/vutuv_web/components/post_components.ex:5075
+#: lib/vutuv_web/components/post_components.ex:5105
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:5079
+#: lib/vutuv_web/components/post_components.ex:5109
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Like"
 msgstr[1] "%{formatted} Likes"
 
-#: lib/vutuv_web/components/post_components.ex:5083
+#: lib/vutuv_web/components/post_components.ex:5113
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -16121,7 +16126,7 @@ msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1145
-#: lib/vutuv_web/components/post_components.ex:5034
+#: lib/vutuv_web/components/post_components.ex:5064
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Bereits in den Zahlen oben enthalten."
@@ -16137,14 +16142,14 @@ msgstr "Antworten, die dort draußen geschrieben werden, erscheinen unter Ihrem 
 msgid "Content warning"
 msgstr "Inhaltswarnung"
 
-#: lib/vutuv_web/components/post_components.ex:1300
-#: lib/vutuv_web/components/post_components.ex:1959
+#: lib/vutuv_web/components/post_components.ex:1312
+#: lib/vutuv_web/components/post_components.ex:1971
 #: lib/vutuv_web/live/fediverse_account_live.ex:294
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr "Aus einem anderen Netzwerk"
 
-#: lib/vutuv_web/components/post_components.ex:1176
+#: lib/vutuv_web/components/post_components.ex:1188
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr "Diese Antwort aus Ihrem Beitrag entfernen?"
@@ -16173,7 +16178,7 @@ msgstr "Antwort aus einem anderen Netzwerk"
 msgid "Reply removed."
 msgstr "Antwort entfernt."
 
-#: lib/vutuv_web/components/post_components.ex:1185
+#: lib/vutuv_web/components/post_components.ex:1197
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
@@ -16183,7 +16188,7 @@ msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
 msgid "Reported as not appropriate"
 msgstr "Als unangemessen gemeldet"
 
-#: lib/vutuv_web/components/post_components.ex:1199
+#: lib/vutuv_web/components/post_components.ex:1211
 #: lib/vutuv_web/live/notification_live/index.ex:580
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -16209,15 +16214,15 @@ msgstr "Entfernt"
 msgid "Thank you. The reply was deleted right away."
 msgstr "Danke. Die Antwort wurde sofort gelöscht."
 
-#: lib/vutuv_web/live/post_live/thread.ex:356
+#: lib/vutuv_web/live/post_live/thread.ex:360
 #, elixir-autogen, elixir-format
 msgid "That reply is not yours to remove."
 msgstr "Diese Antwort können Sie nicht entfernen."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1329
-#: lib/vutuv_web/components/post_components.ex:1231
-#: lib/vutuv_web/components/post_components.ex:1431
-#: lib/vutuv_web/components/post_components.ex:2377
+#: lib/vutuv_web/components/post_components.ex:1243
+#: lib/vutuv_web/components/post_components.ex:1443
+#: lib/vutuv_web/components/post_components.ex:2392
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr "Original ansehen"
@@ -16229,7 +16234,7 @@ msgstr "Original ansehen"
 msgid "What"
 msgstr "Was"
 
-#: lib/vutuv_web/live/post_live/thread.ex:352
+#: lib/vutuv_web/live/post_live/thread.ex:356
 #: lib/vutuv_web/live/remote_post_actions.ex:53
 #, elixir-autogen, elixir-format
 msgid "You have reported a lot today. Please try again tomorrow."
@@ -16449,7 +16454,7 @@ msgstr "API-Token erstellt"
 msgid "Access token revoked"
 msgstr "API-Token widerrufen"
 
-#: lib/vutuv_web/components/ui.ex:4426
+#: lib/vutuv_web/components/ui.ex:4447
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -16796,7 +16801,7 @@ msgstr "Was sich an einem Konto geändert hat, wann, von wo und wie es bestätig
 msgid "What changed on your account, and exactly when."
 msgstr "Was sich an Ihrem Konto geändert hat, und wann genau."
 
-#: lib/vutuv_web/components/ui.ex:4427
+#: lib/vutuv_web/components/ui.ex:4448
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr "Was sich an Ihrem Konto geändert hat, und wann"
@@ -16832,7 +16837,7 @@ msgstr "durch den Betreiber"
 msgid "from a signed-in session"
 msgstr "aus einer angemeldeten Sitzung"
 
-#: lib/vutuv_web/components/ui.ex:4429
+#: lib/vutuv_web/components/ui.ex:4450
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr "protokoll verlauf historie chronik audit sicherheit war ich das wer hat wann geaendert geändert log"
@@ -16884,22 +16889,22 @@ msgstr "Was sich an welchem Konto geändert hat, wann, von welchem Gerät und wi
 msgid "device or detail"
 msgstr "Gerät oder Detail"
 
-#: lib/vutuv_web/components/post_components.ex:2915
+#: lib/vutuv_web/components/post_components.ex:2930
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Angehefteter Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:3031
+#: lib/vutuv_web/components/post_components.ex:3046
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "An Profil anheften"
 
-#: lib/vutuv_web/components/post_components.ex:3039
+#: lib/vutuv_web/components/post_components.ex:3054
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Vom Profil lösen"
 
-#: lib/vutuv_web/components/post_components.ex:3025
+#: lib/vutuv_web/components/post_components.ex:3040
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr "Es lässt sich nur ein Beitrag an Ihr Profil anheften. Diesen anheften und den anderen lösen?"
@@ -17031,17 +17036,17 @@ msgstr "Nächstes Foto"
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
 
-#: lib/vutuv_web/components/post_components.ex:2510
+#: lib/vutuv_web/components/post_components.ex:2525
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Fediverse-Einstellungen öffnen"
 
-#: lib/vutuv_web/components/post_components.ex:3734
+#: lib/vutuv_web/components/post_components.ex:3749
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} von %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:3245
+#: lib/vutuv_web/components/post_components.ex:3260
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
@@ -17054,7 +17059,7 @@ msgstr "Foto-Einstellungen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1290
 #: lib/vutuv_web/agent_docs/text.ex:779
-#: lib/vutuv_web/components/post_components.ex:3951
+#: lib/vutuv_web/components/post_components.ex:3966
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Fotos:"
@@ -17080,7 +17085,7 @@ msgstr "Dieselben Bildpunkte, sonst nichts: Ort und Seriennummern entfernt, Qual
 msgid "Show camera settings"
 msgstr "Kameradaten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2563
+#: lib/vutuv_web/components/post_components.ex:2578
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr "Dieser Server ist auf dieser Seite gesperrt, deshalb kann keine Antwort dorthin gesendet werden."
@@ -17100,7 +17105,7 @@ msgstr "Dieses Dateiformat lässt sich nur unverändert weitergeben. Entfernen S
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr "Dieses Foto enthält den Ort, an dem es aufgenommen wurde. Wer die exakte Datei herunterlädt, kann ihn auslesen."
 
-#: lib/vutuv_web/components/post_components.ex:2554
+#: lib/vutuv_web/components/post_components.ex:2569
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht öffentlich beantworten."
@@ -17110,12 +17115,12 @@ msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht �
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr "Diese Antwort wurde in einem anderen Netzwerk geschrieben. Sie zu beantworten heißt, Ihre Worte in dieses Netzwerk zu senden, und das tut vutuv nur für Mitglieder, die die Fediverse-Teilnahme eingeschaltet haben."
 
-#: lib/vutuv_web/components/post_components.ex:2572
+#: lib/vutuv_web/components/post_components.ex:2587
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Diese Seite nimmt nicht am Fediverse teil."
 
-#: lib/vutuv_web/components/post_components.ex:2506
+#: lib/vutuv_web/components/post_components.ex:2521
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Fediverse-Teilnahme einschalten, um zu antworten"
@@ -17130,7 +17135,7 @@ msgstr "Wer diese Fotos weiterverwenden darf"
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke geschickt. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:2567
+#: lib/vutuv_web/components/post_components.ex:2582
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshalb werden von hier aus keine Antworten mehr gesendet."
@@ -17140,7 +17145,7 @@ msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshal
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr "Ihre Fediverse-Einstellungen erlauben es derzeit nicht, eine Antwort zu senden."
 
-#: lib/vutuv_web/components/post_components.ex:2520
+#: lib/vutuv_web/components/post_components.ex:2535
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr "Ihre Antwort geht an %{handle} auf dem eigenen Server und an Ihre Fediverse-Follower. Auf vutuv ist sie ebenfalls ein öffentlicher Beitrag."
@@ -17161,8 +17166,8 @@ msgstr "Fotos hinzufügen"
 msgid "Licence"
 msgstr "Lizenz"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1561
-#: lib/vutuv_web/live/post_live/feed.ex:1562
+#: lib/vutuv_web/live/post_live/feed.ex:1697
+#: lib/vutuv_web/live/post_live/feed.ex:1698
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr "Fotos posten"
@@ -17227,13 +17232,13 @@ msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exak
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1163
-#: lib/vutuv_web/components/post_components.ex:5072
+#: lib/vutuv_web/components/post_components.ex:5102
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1161
-#: lib/vutuv_web/components/post_components.ex:5069
+#: lib/vutuv_web/components/post_components.ex:5099
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} hat das geteilt"
@@ -17243,7 +17248,7 @@ msgstr "%{handle} hat das geteilt"
 msgid "Fediverse reactions"
 msgstr "Fediverse-Reaktionen"
 
-#: lib/vutuv_web/components/post_components.ex:4961
+#: lib/vutuv_web/components/post_components.ex:4991
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
@@ -17368,7 +17373,7 @@ msgstr "Ein Konto in einem anderen Netzwerk"
 msgid "Cancel request"
 msgstr "Anfrage zurückziehen"
 
-#: lib/vutuv_web/components/ui.ex:4413
+#: lib/vutuv_web/components/ui.ex:4434
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr "Konten auf Mastodon folgen, und von dort gefolgt werden"
@@ -17572,7 +17577,7 @@ msgstr "Sie haben Ihre Fediverse-Follower auf ein anderes Konto umgeleitet, desh
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr "Ihr Konto ist derzeit gesperrt, deshalb geht nichts von Ihnen an andere Netzwerke und Sie können dort niemandem folgen. Das endet von selbst, sobald die Sperre abläuft."
 
-#: lib/vutuv_web/components/ui.ex:4415
+#: lib/vutuv_web/components/ui.ex:4436
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr "mastodon activitypub foederation federation follower folgen folge umzug migration entferntes konto"
@@ -17592,7 +17597,7 @@ msgstr "Von hier aus wird %{follows} Konten in anderen Netzwerken gefolgt, davon
 msgid "Cached posts"
 msgstr "Zwischengespeicherte Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:2323
+#: lib/vutuv_web/components/post_components.ex:2338
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr "Nur für die Follower dieses Kontos"
@@ -17602,7 +17607,7 @@ msgstr "Nur für die Follower dieses Kontos"
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Danke. Unsere Kopie wurde sofort gelöscht."
 
-#: lib/vutuv_web/components/post_components.ex:2376
+#: lib/vutuv_web/components/post_components.ex:2391
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Beim Original abstimmen"
@@ -17622,12 +17627,12 @@ msgstr "Zwischengespeicherter Beitrag gemeldet, hier für alle entfernt"
 msgid "Content from other networks taken down by members"
 msgstr "Von Mitgliedern entfernte Inhalte aus anderen Netzwerken"
 
-#: lib/vutuv_web/components/post_components.ex:1559
+#: lib/vutuv_web/components/post_components.ex:1571
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr "Verbergen"
 
-#: lib/vutuv_web/components/post_components.ex:2341
+#: lib/vutuv_web/components/post_components.ex:2356
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Von der verfassenden Person als sensibel markiert"
@@ -17643,7 +17648,7 @@ msgstr "Stummgeschaltet. Sie folgen dem Konto weiterhin; die Beiträge verschwin
 msgid "Nobody has removed or reported anything yet."
 msgstr "Bisher hat niemand etwas entfernt oder gemeldet."
 
-#: lib/vutuv_web/components/post_components.ex:2309
+#: lib/vutuv_web/components/post_components.ex:2324
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr "Diesen Beitrag als unangemessen melden? Unsere Kopie wird sofort für alle auf diesem vutuv gelöscht."
@@ -17865,27 +17870,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] "(ein Bild)"
 msgstr[1] "(%{count} Bilder)"
 
-#: lib/vutuv_web/components/post_components.ex:2075
+#: lib/vutuv_web/components/post_components.ex:2077
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr "Bild wird geprüft"
 
-#: lib/vutuv_web/components/post_components.ex:2091
+#: lib/vutuv_web/components/post_components.ex:2106
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr "Wieder verdecken"
 
-#: lib/vutuv_web/components/post_components.ex:2086
+#: lib/vutuv_web/components/post_components.ex:2101
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr "Heikles Motiv. Bild anzeigen."
 
-#: lib/vutuv_web/components/post_components.ex:2413
+#: lib/vutuv_web/components/post_components.ex:2428
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Das sind viele Likes in einer Stunde. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:2419
+#: lib/vutuv_web/components/post_components.ex:2434
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Diesen Beitrag gibt es hier nicht mehr."
@@ -17895,7 +17900,7 @@ msgstr "Diesen Beitrag gibt es hier nicht mehr."
 msgid "Back to the feed"
 msgstr "Zurück zum Feed"
 
-#: lib/vutuv_web/components/post_components.ex:2558
+#: lib/vutuv_web/components/post_components.ex:2573
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17946,7 +17951,7 @@ msgstr ""
 "Dieser Link zeigt auf einen einzelnen Beitrag. Von hier aus können Sie dem "
 "Konto dahinter folgen: %{account}."
 
-#: lib/vutuv_web/live/user_profile_live.ex:1378
+#: lib/vutuv_web/live/user_profile_live.ex:1382
 #, elixir-autogen, elixir-format
 msgid "You already follow one member."
 msgid_plural "You already follow %{count} members."
@@ -17982,7 +17987,7 @@ msgstr "Zurück zu den Profilen"
 
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:185
 #: lib/vutuv_web/templates/social_media_account/verify.html.heex:51
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Profile verification is disabled on this installation."
 msgstr "Die Profil-Verifizierung ist auf dieser Installation deaktiviert."
 
@@ -18007,13 +18012,13 @@ msgid "This network cannot be verified."
 msgstr "Dieses Netzwerk lässt sich nicht verifizieren."
 
 #: lib/vutuv_web/templates/social_media_account/verify.html.heex:26
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Verified. Run the check again below to refresh it."
 msgstr "Verifiziert. Starten Sie die Prüfung unten erneut, um sie aufzufrischen."
 
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:165
 #: lib/vutuv_web/templates/social_media_account/verify.html.heex:7
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Verify profile"
 msgstr "Profil verifizieren"
 
@@ -18024,7 +18029,7 @@ msgstr "Wir konnten das Netzwerk gerade nicht erreichen. Bitte versuchen Sie es 
 
 #: lib/vutuv_web/agent_docs/markdown.ex:963
 #: lib/vutuv_web/agent_docs/text.ex:627
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "verified profile"
 msgstr "verifiziertes Profil"
 
@@ -18658,7 +18663,7 @@ msgstr "Auf vutuv gibt es zu diesem Tag noch keine Beiträge."
 msgid "word in a post"
 msgstr "Wort in einem Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:2416
+#: lib/vutuv_web/components/post_components.ex:2431
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr "Diese Antwort gibt es hier nicht mehr."
@@ -18961,19 +18966,19 @@ msgstr "Auf der Seite eines Beitrags stehen direkt unter der Zahl die Mitglieder
 msgid "Liked by"
 msgstr "Gefällt diesen Mitgliedern"
 
-#: lib/vutuv_web/components/post_components.ex:4208
+#: lib/vutuv_web/components/post_components.ex:4238
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Gefällt %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:4210
+#: lib/vutuv_web/components/post_components.ex:4240
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Gefällt %{name} und %{formatted} weiteren"
 msgstr[1] "Gefällt %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/components/post_components.ex:4221
+#: lib/vutuv_web/components/post_components.ex:4251
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr "Nur Sie sehen hier alle: Einige dieser Mitglieder werden anderen Lesern nicht genannt."
@@ -18993,7 +18998,7 @@ msgstr "Meinen Namen bei Beiträgen zeigen, die mir gefallen"
 msgid "When off, other members no longer see you among the likes of a post. The author of the post still does: we named you in the notification they got when you liked it. Either way the post keeps the same number of likes."
 msgstr "Wenn aus, sehen andere Mitglieder Sie nicht mehr bei den Likes eines Beitrags. Die Autorin oder der Autor des Beitrags sieht es weiterhin: In der Benachrichtigung von damals haben wir Sie namentlich genannt. Der Beitrag hat in beiden Fällen gleich viele Likes."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:864
+#: lib/vutuv_web/controllers/settings_controller.ex:835
 #, elixir-autogen, elixir-format
 msgid "Your likes follow the site default again."
 msgstr "Ihre Likes folgen wieder dem Standardwert der Website."
@@ -19100,7 +19105,7 @@ msgstr "Arbeitszeugnis gespeichert."
 msgid "Employment reference updated."
 msgstr "Arbeitszeugnis aktualisiert."
 
-#: lib/vutuv_web/components/ui.ex:4315
+#: lib/vutuv_web/components/ui.ex:4325
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -19294,7 +19299,7 @@ msgstr "In der Warteschlange, Ihres ist als Nächstes dran."
 msgid "You changed the text after this review. It describes the earlier version."
 msgstr "Sie haben den Text nach dieser Prüfung geändert. Sie beschreibt die frühere Fassung."
 
-#: lib/vutuv_web/components/ui.ex:4316
+#: lib/vutuv_web/components/ui.ex:4326
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr "Ihre Arbeitszeugnisse, privat bis Sie sie veröffentlichen"
@@ -19305,7 +19310,7 @@ msgstr "Ihre Arbeitszeugnisse, privat bis Sie sie veröffentlichen"
 msgid "Zwischenzeugnis"
 msgstr "Zwischenzeugnis"
 
-#: lib/vutuv_web/components/ui.ex:4318
+#: lib/vutuv_web/components/ui.ex:4328
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr "arbeitszeugnis zeugnis referenz beurteilung arbeitgeber bewertung prüfung"
@@ -19472,7 +19477,7 @@ msgstr[0] "%{count} Minute"
 msgstr[1] "%{count} Minuten"
 
 #: lib/vutuv_web/live/reference_check_live.ex:156
-#: lib/vutuv_web/templates/settings/preferences.html.heex:285
+#: lib/vutuv_web/templates/settings/preferences.html.heex:235
 #, elixir-autogen, elixir-format
 msgid "%{count} second"
 msgid_plural "%{count} seconds"
@@ -19935,7 +19940,7 @@ msgstr ""
 "ändern, und unter {import_url} importieren Sie ein bestehendes "
 "LinkedIn-Profil."
 
-#: lib/vutuv_web/live/user_profile_live.ex:1363
+#: lib/vutuv_web/live/user_profile_live.ex:1367
 #, elixir-autogen, elixir-format
 msgid "Follow other members"
 msgstr "Anderen Mitgliedern folgen"
@@ -19947,17 +19952,17 @@ msgstr ""
 "Kommt keine PIN an? Ist die E-Mail-Adresse {email} korrekt? Haben Sie einmal "
 "in Ihren Spam-Ordner geschaut?"
 
-#: lib/vutuv/accounts/user.ex:1321
+#: lib/vutuv/accounts/user.ex:1326
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/vutuv/accounts/user.ex:1319
+#: lib/vutuv/accounts/user.ex:1324
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr "Weiblich"
 
-#: lib/vutuv/accounts/user.ex:1320
+#: lib/vutuv/accounts/user.ex:1325
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Männlich"
@@ -19969,7 +19974,7 @@ msgstr ""
 "Anteile bezogen auf die %{answered} Mitglieder mit Angabe. %{unanswered} ohne "
 "Angabe."
 
-#: lib/vutuv_web/components/ui.ex:4297
+#: lib/vutuv_web/components/ui.ex:4307
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr "avatar profilbild portrait foto bild geburtstag geburtsdatum geschlecht über mich"
@@ -19984,7 +19989,7 @@ msgstr "%{model} nachschlagen"
 msgid "We use {model}, a freely available language model. Anyone can download it and run the same review themselves, which is also why we are able to run it on our own machines at all."
 msgstr "Wir benutzen {model}, ein frei verfügbares Sprachmodell. Jeder kann es herunterladen und dieselbe Prüfung selbst laufen lassen. Genau deshalb können wir es überhaupt auf unseren eigenen Rechnern betreiben."
 
-#: lib/vutuv_web/views/settings_html.ex:58
+#: lib/vutuv_web/views/settings_html.ex:56
 #, elixir-autogen, elixir-format
 msgid "%{count} day"
 msgid_plural "%{count} days"
@@ -20005,47 +20010,47 @@ msgid_plural "%{formatted} posts"
 msgstr[0] "%{count} Beitrag"
 msgstr[1] "%{formatted} Beiträge"
 
-#: lib/vutuv_web/views/settings_html.ex:49
+#: lib/vutuv_web/views/settings_html.ex:47
 #, elixir-autogen, elixir-format
 msgid "1 day"
 msgstr "1 Tag"
 
-#: lib/vutuv_web/views/settings_html.ex:53
+#: lib/vutuv_web/views/settings_html.ex:51
 #, elixir-autogen, elixir-format
 msgid "1 month"
 msgstr "1 Monat"
 
-#: lib/vutuv_web/views/settings_html.ex:51
+#: lib/vutuv_web/views/settings_html.ex:49
 #, elixir-autogen, elixir-format
 msgid "1 week"
 msgstr "1 Woche"
 
-#: lib/vutuv_web/views/settings_html.ex:56
+#: lib/vutuv_web/views/settings_html.ex:54
 #, elixir-autogen, elixir-format
 msgid "1 year"
 msgstr "1 Jahr"
 
-#: lib/vutuv_web/views/settings_html.ex:52
+#: lib/vutuv_web/views/settings_html.ex:50
 #, elixir-autogen, elixir-format
 msgid "2 weeks"
 msgstr "2 Wochen"
 
-#: lib/vutuv_web/views/settings_html.ex:57
+#: lib/vutuv_web/views/settings_html.ex:55
 #, elixir-autogen, elixir-format
 msgid "2 years"
 msgstr "2 Jahre"
 
-#: lib/vutuv_web/views/settings_html.ex:50
+#: lib/vutuv_web/views/settings_html.ex:48
 #, elixir-autogen, elixir-format
 msgid "3 days"
 msgstr "3 Tage"
 
-#: lib/vutuv_web/views/settings_html.ex:54
+#: lib/vutuv_web/views/settings_html.ex:52
 #, elixir-autogen, elixir-format
 msgid "3 months"
 msgstr "3 Monate"
 
-#: lib/vutuv_web/views/settings_html.ex:55
+#: lib/vutuv_web/views/settings_html.ex:53
 #, elixir-autogen, elixir-format
 msgid "6 months"
 msgstr "6 Monate"
@@ -20065,7 +20070,7 @@ msgstr "Ebenfalls löschen"
 msgid "Always keep"
 msgstr "Immer behalten"
 
-#: lib/vutuv_web/components/ui.ex:4406
+#: lib/vutuv_web/components/ui.ex:4427
 #: lib/vutuv_web/controllers/settings_controller.ex:245
 #: lib/vutuv_web/controllers/settings_controller.ex:324
 #: lib/vutuv_web/controllers/settings_controller.ex:336
@@ -20162,7 +20167,7 @@ msgstr "Fotobeiträge behalten"
 msgid "Keep posts that did well"
 msgstr "Beiträge behalten, die gut liefen"
 
-#: lib/vutuv_web/components/ui.ex:4408
+#: lib/vutuv_web/components/ui.ex:4429
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr "Ihre Beiträge nach einer selbst gewählten Zeit auslaufen lassen"
@@ -20271,7 +20276,7 @@ msgstr "Sie können vorher alles herunterladen, was Sie hier haben:"
 msgid "Your rule"
 msgstr "Ihre Regel"
 
-#: lib/vutuv_web/components/ui.ex:4410
+#: lib/vutuv_web/components/ui.ex:4431
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr "löschen entfernen beiträge alter alt ablaufen verfallen automatisch aufräumen aufbewahrung"
@@ -20645,7 +20650,7 @@ msgstr "Suchen Sie so oft Sie möchten und nehmen Sie dazu, was gehört. Abkürz
 msgid "Start over"
 msgstr "Von vorn beginnen"
 
-#: lib/vutuv_web/components/post_components.ex:2446
+#: lib/vutuv_web/components/post_components.ex:2461
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr "Ein Herz oder ein Repost geht zurück in das Netzwerk, aus dem dieser Beitrag stammt. Ihr Konto nimmt derzeit nicht am Fediverse teil. Einschalten können Sie das in den {settings}."
@@ -21561,50 +21566,44 @@ msgstr "Sprache des Beitrags"
 msgid "The language this post is written in"
 msgstr "Die Sprache, in der dieser Beitrag geschrieben ist"
 
-#: lib/vutuv_web/components/post_components.ex:4117
+#: lib/vutuv_web/components/post_components.ex:4132
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Original anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:4138
+#: lib/vutuv_web/components/post_components.ex:4168
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Übersetzen"
 
-#: lib/vutuv_web/components/post_components.ex:4147
+#: lib/vutuv_web/components/post_components.ex:4177
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Übersetzt"
 
-#: lib/vutuv_web/components/post_components.ex:4150
+#: lib/vutuv_web/components/post_components.ex:4180
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Übersetzt aus %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:4127
+#: lib/vutuv_web/components/post_components.ex:4157
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Wird übersetzt …"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:853
+#: lib/vutuv_web/live/feed_languages_live.ex:129
 #, elixir-autogen, elixir-format
 msgid "Feed language settings reset to the site defaults."
 msgstr "Feed-Spracheinstellungen auf die Website-Vorgaben zurückgesetzt."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:824
-#, elixir-autogen, elixir-format
-msgid "Feed language settings saved."
-msgstr "Feed-Spracheinstellungen gespeichert."
-
-#: lib/vutuv_web/templates/settings/preferences.html.heex:193
+#: lib/vutuv_web/components/post_components.ex:4147
+#: lib/vutuv_web/components/ui.ex:4386
+#: lib/vutuv_web/live/feed_languages_live.ex:65
+#: lib/vutuv_web/live/feed_languages_live.ex:200
+#: lib/vutuv_web/templates/settings/preferences.html.heex:187
 #, elixir-autogen, elixir-format
 msgid "Feed languages"
 msgstr "Feed-Sprachen"
-
-#: lib/vutuv_web/templates/settings/preferences.html.heex:195
-#, elixir-autogen, elixir-format
-msgid "Pick which languages your feed shows, and what happens to posts in other languages. Posts that declare no language always show."
-msgstr "Wählen Sie, welche Sprachen Ihr Feed zeigt und was mit Beiträgen in anderen Sprachen passiert. Beiträge ohne Sprachangabe werden immer gezeigt."
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:83
 #, elixir-autogen, elixir-format
@@ -21686,20 +21685,10 @@ msgstr "Ihr Browser meldet: {zone}"
 msgid "ISO 8601 (Sweden, Japan, China)"
 msgstr "ISO 8601 (Schweden, Japan, China)"
 
-#: lib/vutuv_web/components/ui.ex:4433
-#, elixir-autogen, elixir-format
-msgid "Interface language, date format and time zone, feed languages, maps, how posts are shortened"
-msgstr "Sprache der Oberfläche, Datumsformat und Zeitzone, Feed-Sprachen, Karten, wie Beiträge gekürzt werden"
-
 #: lib/vutuv_web/views/account_event_text.ex:48
 #, elixir-autogen, elixir-format
 msgid "Language & display settings changed"
 msgstr "Sprache & Anzeige geändert"
-
-#: lib/vutuv_web/components/ui.ex:4437
-#, elixir-autogen, elixir-format
-msgid "german english locale translation translate map font length hyphenation feed languages hide foreign übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
-msgstr "deutsch englisch locale übersetzung übersetzen karte schrift länge silbentrennung feed sprachen ausblenden fremdsprache zeitzone timezone zone utc datum date uhrzeit uhr format datumsformat 24 stunden"
 
 #: lib/vutuv_web/templates/social_media_account/verify.html.heex:42
 #, elixir-autogen, elixir-format
@@ -21736,19 +21725,19 @@ msgstr "Wir haben den Link in Ihrem Profil noch nicht gefunden. Bitte versuchen 
 msgid "Your username, or paste the address of your profile page."
 msgstr "Ihr Benutzername – oder fügen Sie die Adresse Ihrer Profilseite ein."
 
-#: lib/vutuv_web/components/post_components.ex:3917
+#: lib/vutuv_web/components/post_components.ex:3932
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] "Unsere KI prüft es gerade. Sobald die Prüfung durch ist, erscheint das Foto von selbst."
 msgstr[1] "Unsere KI prüft sie gerade, %{done} von %{total} sind durch. Sobald die letzte durch ist, erscheinen die Fotos von selbst."
 
-#: lib/vutuv_web/components/post_components.ex:3914
+#: lib/vutuv_web/components/post_components.ex:3929
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr "Ihr Beitrag ist veröffentlicht, das Foto noch nicht."
 
-#: lib/vutuv_web/components/post_components.ex:3254
+#: lib/vutuv_web/components/post_components.ex:3269
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -21765,7 +21754,7 @@ msgstr "Empfohlen: %{width} × %{height} Pixel (%{ratio})."
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr "Empfohlen: quadratisch, mindestens %{width} × %{height} Pixel."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1814
+#: lib/vutuv_web/live/post_live/feed.ex:1950
 #: lib/vutuv_web/views/user_html.ex:334
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -21817,7 +21806,7 @@ msgstr "Damit können Sie sich von einer Mastodon-kompatiblen App aus bei diesem
 msgid "Mastodon app access changed"
 msgstr "Mastodon-App-Zugriff geändert"
 
-#: lib/vutuv_web/components/ui.ex:4454
+#: lib/vutuv_web/components/ui.ex:4475
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr "Mastodon-Apps, verbundene Apps und Zugriffstoken"
@@ -21863,7 +21852,7 @@ msgstr "Wer etwas geschrieben hat, wird weiter festgehalten, das Team kann also 
 msgid "Your account is then %{handle}."
 msgstr "Dein Konto heißt dann %{handle}."
 
-#: lib/vutuv_web/components/ui.ex:4456
+#: lib/vutuv_web/components/ui.ex:4477
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr "api token oauth entwickler verbunden drittanbieter schnittstelle mastodon app handy telefon client ivory tusky ice cubes anmelden"
@@ -21899,7 +21888,7 @@ msgstr "Bekannte aus LinkedIn finden"
 msgid "Find your LinkedIn contacts"
 msgstr "Ihre LinkedIn-Kontakte finden"
 
-#: lib/vutuv_web/components/ui.ex:4381
+#: lib/vutuv_web/components/ui.ex:4402
 #: lib/vutuv_web/live/import_connections_live.ex:64
 #: lib/vutuv_web/templates/import/new.html.heex:37
 #, elixir-autogen, elixir-format
@@ -22006,7 +21995,7 @@ msgstr "Nach Namen suchen"
 msgid "See which of them are already on vutuv"
 msgstr "Sehen Sie, wer davon schon auf vutuv ist"
 
-#: lib/vutuv_web/components/ui.ex:4383
+#: lib/vutuv_web/components/ui.ex:4404
 #, elixir-autogen, elixir-format
 msgid "See which of your LinkedIn contacts are already on vutuv"
 msgstr "Sehen, wer aus Ihren LinkedIn-Kontakten schon auf vutuv ist"
@@ -22078,25 +22067,10 @@ msgstr "Ihre Kontakte auf vutuv"
 msgid "Your export also lists your LinkedIn contacts."
 msgstr "Ihr Export enthält auch Ihre LinkedIn-Kontakte."
 
-#: lib/vutuv_web/components/ui.ex:4385
+#: lib/vutuv_web/components/ui.ex:4406
 #, elixir-autogen, elixir-format
 msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
 msgstr "linkedin kontakte verbindungen adressbuch bekannte kollegen finden folgen zip import netzwerk"
-
-#: lib/vutuv_web/views/settings_html.ex:173
-#, elixir-autogen, elixir-format
-msgid "Add another language"
-msgstr "Weitere Sprache hinzufügen"
-
-#: lib/vutuv_web/templates/settings/preferences.html.heex:208
-#, elixir-autogen, elixir-format
-msgid "Choosing none means: all languages."
-msgstr "Keine Auswahl bedeutet: alle Sprachen."
-
-#: lib/vutuv_web/templates/settings/preferences.html.heex:205
-#, elixir-autogen, elixir-format
-msgid "These languages I read"
-msgstr "Diese Sprachen lese ich"
 
 #: lib/vutuv_web/live/organization_live/activity.ex:91
 #, elixir-autogen, elixir-format
@@ -22274,7 +22248,7 @@ msgstr "Land suchen"
 msgid "This page is following the most accounts we allow (%{max})."
 msgstr "Diese Seite folgt bereits so vielen Konten, wie hier erlaubt sind (%{max})."
 
-#: lib/vutuv_web/components/post_components.ex:2297
+#: lib/vutuv_web/components/post_components.ex:2312
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr "%{handle} nicht mehr folgen? Die Beiträge verschwinden aus Ihrem Feed."
@@ -22349,7 +22323,7 @@ msgstr "Wenn etwas eintrifft, während vutuv in einem Tab offen ist, den Sie ger
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr "Sie haben Browser-Benachrichtigungen eingeschaltet. Dieser Browser wurde noch nicht um Erlaubnis gebeten."
 
-#: lib/vutuv_web/components/ui.ex:4364
+#: lib/vutuv_web/components/ui.ex:4374
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr "e-mail email mail abbestellen abmelden newsletter glocke benachrichtigung weniger ruhe browser desktop popup push hinweis mitteilung"
@@ -22400,12 +22374,12 @@ msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public po
 msgstr ""
 "Folgen Sie #%{tag} von Mastodon oder einer anderen Fediverse-App aus, dann landen die öffentlichen Beiträge in Ihrer Timeline. Ein vutuv-Konto brauchen Sie dafür nicht."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1796
+#: lib/vutuv_web/live/post_live/feed.ex:1932
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Andere Mitglieder begrüßen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1792
+#: lib/vutuv_web/live/post_live/feed.ex:1928
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr "Neu dabei"
@@ -22451,69 +22425,69 @@ msgstr "Der beste Weg: Folgen Sie %{name} hier. Neue Beiträge landen in Ihrem F
 msgid "With a vutuv account"
 msgstr "Mit einem vutuv-Konto"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1806
+#: lib/vutuv_web/live/post_live/feed.ex:1942
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
 "Ein paar der neuesten Mitglieder. Ihnen zu folgen ist eine herzliche "
 "Begrüßung."
 
-#: lib/vutuv_web/components/post_components.ex:593
+#: lib/vutuv_web/components/post_components.ex:605
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new post"
 msgid_plural "%{formatted} new posts"
 msgstr[0] "%{formatted} neuer Beitrag"
 msgstr[1] "%{formatted} neue Beiträge"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1251
+#: lib/vutuv_web/live/post_live/feed.ex:1387
 #, elixir-autogen, elixir-format
 msgid "%{source}: %{formatted} new post"
 msgid_plural "%{source}: %{formatted} new posts"
 msgstr[0] "%{source}: %{formatted} neuer Beitrag"
 msgstr[1] "%{source}: %{formatted} neue Beiträge"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1248
+#: lib/vutuv_web/live/post_live/feed.ex:1384
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post"
 msgstr "%{source}: neuer Beitrag"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1245
+#: lib/vutuv_web/live/post_live/feed.ex:1381
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post from %{who}"
 msgstr "%{source}: neuer Beitrag von %{who}"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:297
+#: lib/vutuv_web/templates/settings/preferences.html.heex:247
 #, elixir-autogen, elixir-format
 msgid "Example"
 msgstr "Beispiel"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:844
+#: lib/vutuv_web/controllers/settings_controller.ex:826
 #, elixir-autogen, elixir-format
 msgid "Feed tab settings reset to the site defaults."
 msgstr "Reiter-Einstellungen auf die Website-Vorgaben zurückgesetzt."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:838
+#: lib/vutuv_web/controllers/settings_controller.ex:820
 #, elixir-autogen, elixir-format
 msgid "Feed tab settings saved."
 msgstr "Reiter-Einstellungen gespeichert."
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:89
-#: lib/vutuv_web/templates/settings/preferences.html.heex:263
+#: lib/vutuv_web/templates/settings/preferences.html.heex:213
 #, elixir-autogen, elixir-format
 msgid "Feed tabs"
 msgstr "Feed-Reiter"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:321
+#: lib/vutuv_web/templates/settings/preferences.html.heex:271
 #, elixir-autogen, elixir-format
 msgid "Just flashed the new release, boot is under two seconds now"
 msgstr "Neue Version geflasht, der Bootvorgang liegt jetzt unter zwei Sekunden"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:331
+#: lib/vutuv_web/templates/settings/preferences.html.heex:281
 #, elixir-autogen, elixir-format
 msgid "Play the example"
 msgstr "Beispiel abspielen"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:265
+#: lib/vutuv_web/templates/settings/preferences.html.heex:215
 #, elixir-autogen, elixir-format
 msgid "When a post lands on the source tab you are not reading, that tab gets a dot. It can also quote the post for a few seconds, so you can tell whether it is worth switching."
 msgstr "Landet ein Beitrag auf dem Quellen-Reiter, den Sie gerade nicht lesen, bekommt dieser Reiter einen Punkt. Er kann den Beitrag auch ein paar Sekunden lang anreißen, damit Sie sehen, ob sich ein Wechsel lohnt."
@@ -22538,7 +22512,7 @@ msgstr "Neues auf dem anderen Reiter anreißen"
 msgid "When off, a tab holding something new wears its dot and says nothing more."
 msgstr "Ausgeschaltet trägt ein Reiter mit Neuem nur seinen Punkt und sagt sonst nichts."
 
-#: lib/vutuv_web/live/feed_languages_live.ex
+#: lib/vutuv_web/live/feed_languages_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Rank the languages you read. Posts in them reach your feed as they were written; you decide below what happens to the rest."
 msgstr ""
@@ -22546,37 +22520,37 @@ msgstr ""
 "erreichen Ihren Feed so, wie sie geschrieben wurden; was mit dem Rest "
 "geschieht, legen Sie unten fest."
 
-#: lib/vutuv_web/live/feed_languages_live.ex:202
+#: lib/vutuv_web/live/feed_languages_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "Languages you read"
 msgstr "Sprachen, die Sie lesen"
 
-#: lib/vutuv_web/live/feed_languages_live.ex
+#: lib/vutuv_web/live/feed_languages_live.ex:218
 #, elixir-autogen, elixir-format
 msgid "No language chosen, so your feed shows all of them."
 msgstr "Keine Sprache gewählt, Ihr Feed zeigt also alle."
 
-#: lib/vutuv_web/live/feed_languages_live.ex
+#: lib/vutuv_web/live/feed_languages_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "First: translations go into this language"
 msgstr "Zuerst: In diese Sprache wird übersetzt"
 
-#: lib/vutuv_web/live/feed_languages_live.ex:265
+#: lib/vutuv_web/live/feed_languages_live.ex:278
 #, elixir-autogen, elixir-format
 msgid "Remove %{language}"
 msgstr "%{language} entfernen"
 
-#: lib/vutuv_web/live/feed_languages_live.ex:277
+#: lib/vutuv_web/live/feed_languages_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "Suggested:"
 msgstr "Vorschläge:"
 
-#: lib/vutuv_web/live/feed_languages_live.ex:312
+#: lib/vutuv_web/live/feed_languages_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "Choose a language"
 msgstr "Sprache auswählen"
 
-#: lib/vutuv_web/live/feed_languages_live.ex
+#: lib/vutuv_web/live/feed_languages_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "This installation has translations switched off, so posts in other languages show as written until an administrator turns them on."
 msgstr ""
@@ -22584,63 +22558,63 @@ msgstr ""
 "anderen Sprachen erscheinen daher so, wie sie geschrieben wurden, bis eine "
 "Administratorin oder ein Administrator sie einschaltet."
 
-#: lib/vutuv_web/live/feed_languages_live.ex:347
+#: lib/vutuv_web/live/feed_languages_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "What your feed does"
 msgstr "Was Ihr Feed macht"
 
-#: lib/vutuv_web/live/feed_languages_live.ex:387
+#: lib/vutuv_web/live/feed_languages_live.ex:403
 #, elixir-autogen, elixir-format
 msgid "Shown as written"
 msgstr "Wird so gezeigt, wie geschrieben"
 
-#: lib/vutuv_web/live/feed_languages_live.ex:395
+#: lib/vutuv_web/live/feed_languages_live.ex:411
 #, elixir-autogen, elixir-format
 msgid "Every language"
 msgstr "Alle Sprachen"
 
-#: lib/vutuv_web/live/feed_languages_live.ex:395
+#: lib/vutuv_web/live/feed_languages_live.ex:411
 #, elixir-autogen, elixir-format
 msgid "Every other language"
 msgstr "Alle anderen Sprachen"
 
-#: lib/vutuv_web/live/feed_languages_live.ex
+#: lib/vutuv_web/live/feed_languages_live.ex:432
 #, elixir-autogen, elixir-format
 msgid "Nothing is hidden: hiding needs at least one language above."
 msgstr ""
 "Es wird nichts ausgeblendet: Dafür brauchen Sie oben mindestens eine "
 "Sprache."
 
-#: lib/vutuv_web/live/feed_languages_live.ex:411
+#: lib/vutuv_web/live/feed_languages_live.ex:434
 #, elixir-autogen, elixir-format
 msgid "Hidden from your feed."
 msgstr "Wird in Ihrem Feed ausgeblendet."
 
-#: lib/vutuv_web/live/feed_languages_live.ex:421
+#: lib/vutuv_web/live/feed_languages_live.ex:440
 #, elixir-autogen, elixir-format
 msgid "Shown in the language it was written in."
 msgstr "Wird in der Sprache gezeigt, in der es geschrieben wurde."
 
-#: lib/vutuv_web/components/ui.ex
+#: lib/vutuv_web/components/ui.ex:4387
 #, elixir-autogen, elixir-format
 msgid "Which languages reach you, and what happens to the rest"
 msgstr "Welche Sprachen Sie erreichen und was mit dem Rest geschieht"
 
-#: lib/vutuv_web/components/ui.ex
+#: lib/vutuv_web/components/ui.ex:4389
 #, elixir-autogen, elixir-format
 msgid "language translate translation german english original hide foreign rank order sprache übersetzen fremdsprache reihenfolge"
 msgstr ""
 "sprache übersetzen übersetzung deutsch englisch original ausblenden "
 "fremdsprache reihenfolge rang feed language translate"
 
-#: lib/vutuv_web/components/ui.ex
+#: lib/vutuv_web/components/ui.ex:4454
 #, elixir-autogen, elixir-format
 msgid "Interface language, date format and time zone, maps, how posts are shortened"
 msgstr ""
 "Anzeigesprache, Datumsformat und Zeitzone, Karten, wie Beiträge gekürzt "
 "werden"
 
-#: lib/vutuv_web/components/ui.ex
+#: lib/vutuv_web/components/ui.ex:4458
 #, elixir-autogen, elixir-format
 msgid "german english locale map font length hyphenation übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
 msgstr ""
@@ -22652,19 +22626,19 @@ msgstr ""
 msgid "Languages your feed shows"
 msgstr "Sprachen, die Ihr Feed zeigt"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex
+#: lib/vutuv_web/templates/settings/preferences.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Rank the languages you read, and say what happens to posts in the others."
 msgstr ""
 "Ordnen Sie die Sprachen, die Sie lesen, und legen Sie fest, was mit "
 "Beiträgen in anderen Sprachen geschieht."
 
-#: lib/vutuv_web/live/feed_languages_live.ex
+#: lib/vutuv_web/live/feed_languages_live.ex:424
 #, elixir-autogen, elixir-format
 msgid "Translate into %{language}"
 msgstr "In %{language} übersetzen"
 
-#: lib/vutuv_web/live/feed_languages_live.ex
+#: lib/vutuv_web/live/feed_languages_live.ex:437
 #, elixir-autogen, elixir-format
 msgid "Translated into %{language}."
 msgstr "Wird in %{language} übersetzt."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -17,8 +17,8 @@ msgstr ""
 msgid "About us"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4081
-#: lib/vutuv_web/components/ui.ex:4086
+#: lib/vutuv_web/components/ui.ex:4091
+#: lib/vutuv_web/components/ui.ex:4096
 #: lib/vutuv_web/live/admin/screenshot_live.ex:255
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:718
 #: lib/vutuv_web/live/organization_live/domains.ex:272
@@ -64,7 +64,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:68
 #: lib/vutuv_web/agent_docs/text.ex:65
-#: lib/vutuv_web/components/ui.ex:4339
+#: lib/vutuv_web/components/ui.ex:4349
 #: lib/vutuv_web/controllers/address_controller.ex:23
 #: lib/vutuv_web/controllers/address_controller.ex:38
 #: lib/vutuv_web/controllers/address_controller.ex:85
@@ -83,8 +83,8 @@ msgstr ""
 msgid "Already a member? Sign in here."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3876
-#: lib/vutuv_web/components/ui.ex:3970
+#: lib/vutuv_web/components/ui.ex:3886
+#: lib/vutuv_web/components/ui.ex:3980
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:698
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:830
@@ -112,7 +112,7 @@ msgid "Birthday"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:110
-#: lib/vutuv_web/components/ui.ex:3870
+#: lib/vutuv_web/components/ui.ex:3880
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
@@ -162,8 +162,8 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3047
-#: lib/vutuv_web/components/ui.ex:3973
+#: lib/vutuv_web/components/post_components.ex:3062
+#: lib/vutuv_web/components/ui.ex:3983
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
@@ -211,8 +211,8 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3012
-#: lib/vutuv_web/components/ui.ex:3964
+#: lib/vutuv_web/components/post_components.ex:3027
+#: lib/vutuv_web/components/ui.ex:3974
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
@@ -286,7 +286,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:35
-#: lib/vutuv_web/components/ui.ex:4303
+#: lib/vutuv_web/components/ui.ex:4313
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -445,7 +445,7 @@ msgid "Log Out"
 msgstr ""
 
 #: lib/vutuv_web/live/shell_live.ex:1024
-#: lib/vutuv_web/live/shell_live.ex:1081
+#: lib/vutuv_web/live/shell_live.ex:1090
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -475,7 +475,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:620
+#: lib/vutuv_web/components/post_components.ex:632
 #: lib/vutuv_web/live/notification_live/index.ex:682
 #: lib/vutuv_web/live/organization_live/activity.ex:127
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
@@ -615,7 +615,7 @@ msgstr ""
 msgid "Public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3869
+#: lib/vutuv_web/components/ui.ex:3879
 #: lib/vutuv_web/live/organization_live/edit.ex:345
 #: lib/vutuv_web/live/post_live/composer.ex:1867
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -627,13 +627,12 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/notifications.html.heex:79
 #: lib/vutuv_web/templates/settings/preferences.html.heex:84
 #: lib/vutuv_web/templates/settings/preferences.html.heex:157
-#: lib/vutuv_web/templates/settings/preferences.html.heex:228
-#: lib/vutuv_web/templates/settings/preferences.html.heex:292
-#: lib/vutuv_web/templates/settings/preferences.html.heex:449
+#: lib/vutuv_web/templates/settings/preferences.html.heex:242
+#: lib/vutuv_web/templates/settings/preferences.html.heex:399
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:462
-#: lib/vutuv_web/views/settings_html.ex:301
+#: lib/vutuv_web/views/settings_html.ex:196
 #, elixir-autogen
 msgid "Save"
 msgstr ""
@@ -647,7 +646,7 @@ msgstr ""
 #: lib/vutuv_web/live/search_live.ex:48
 #: lib/vutuv_web/live/search_live.ex:569
 #: lib/vutuv_web/live/shell_live.ex:889
-#: lib/vutuv_web/live/shell_live.ex:1064
+#: lib/vutuv_web/live/shell_live.ex:1073
 #: lib/vutuv_web/live/tag_live/timeline.ex:283
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
@@ -657,7 +656,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1556
+#: lib/vutuv_web/components/post_components.ex:1568
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -793,7 +792,7 @@ msgstr ""
 msgid "User verified successfully."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4299
+#: lib/vutuv_web/components/ui.ex:4309
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
@@ -850,14 +849,14 @@ msgstr ""
 msgid "vCard"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4034
+#: lib/vutuv_web/components/ui.ex:4044
 #: lib/vutuv_web/templates/user/show.html.heex:967
 #: lib/vutuv_web/templates/user/show.html.heex:990
 #, elixir-autogen
 msgid "View All"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4396
+#: lib/vutuv_web/components/ui.ex:4417
 #: lib/vutuv_web/controllers/settings_controller.ex:169
 #: lib/vutuv_web/live/job_posting_live/form.ex:756
 #: lib/vutuv_web/live/organization_live/edit.ex:304
@@ -927,7 +926,7 @@ msgid "You follow back %{name}."
 msgstr ""
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:91
+#: lib/vutuv_web/live/post_live/feed.ex:100
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1377,7 +1376,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:516
 #: lib/vutuv_web/agent_docs/text.ex:753
-#: lib/vutuv_web/components/ui.ex:4324
+#: lib/vutuv_web/components/ui.ex:4334
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1599,7 +1598,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1067
+#: lib/vutuv_web/live/shell_live.ex:1076
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1714,7 +1713,7 @@ msgid "It doesn't look like you're following anyone yet. Open the profile of som
 msgstr ""
 
 #: lib/vutuv_web/live/shell_live.ex:1015
-#: lib/vutuv_web/views/settings_html.ex:388
+#: lib/vutuv_web/views/settings_html.ex:283
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr ""
@@ -1743,7 +1742,7 @@ msgstr ""
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
 #: lib/vutuv_web/live/shell_live.ex:907
-#: lib/vutuv_web/live/shell_live.ex:1066
+#: lib/vutuv_web/live/shell_live.ex:1075
 #: lib/vutuv_web/templates/layout/app.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Messages"
@@ -1756,7 +1755,7 @@ msgid "Network"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:439
-#: lib/vutuv_web/components/ui.ex:4083
+#: lib/vutuv_web/components/ui.ex:4093
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:705
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:742
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:793
@@ -1772,7 +1771,7 @@ msgid "Nothing new yet."
 msgstr ""
 
 #: lib/vutuv/api_auth/scopes.ex:85
-#: lib/vutuv_web/components/ui.ex:4361
+#: lib/vutuv_web/components/ui.ex:4371
 #: lib/vutuv_web/live/notification_live/index.ex:132
 #: lib/vutuv_web/live/notification_live/index.ex:360
 #: lib/vutuv_web/live/shell_live.ex:919
@@ -1917,15 +1916,15 @@ msgstr ""
 msgid "started following you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3423
-#: lib/vutuv_web/components/ui.ex:3574
+#: lib/vutuv_web/components/ui.ex:3433
+#: lib/vutuv_web/components/ui.ex:3584
 #: lib/vutuv_web/live/import_connections_live.ex:638
 #: lib/vutuv_web/live/organization_live/index.ex:122
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4108
+#: lib/vutuv_web/components/ui.ex:4118
 #: lib/vutuv_web/live/organization_live/activity.ex:150
 #: lib/vutuv_web/live/organization_live/feed.ex:142
 #: lib/vutuv_web/live/organization_live/show.ex:647
@@ -1938,7 +1937,7 @@ msgstr ""
 msgid "The address itself cannot be changed. To use a different one, add it as a new email address and delete this one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3879
+#: lib/vutuv_web/components/ui.ex:3889
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
@@ -2106,7 +2105,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3044
+#: lib/vutuv_web/components/post_components.ex:3059
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2121,10 +2120,10 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:274
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:98
-#: lib/vutuv_web/live/post_live/feed.ex:196
-#: lib/vutuv_web/live/post_live/feed.ex:1514
+#: lib/vutuv_web/live/post_live/feed.ex:231
+#: lib/vutuv_web/live/post_live/feed.ex:1650
 #: lib/vutuv_web/live/shell_live.ex:769
-#: lib/vutuv_web/live/shell_live.ex:1062
+#: lib/vutuv_web/live/shell_live.ex:1068
 #: lib/vutuv_web/templates/layout/app.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2150,8 +2149,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2998
-#: lib/vutuv_web/components/post_components.ex:3000
+#: lib/vutuv_web/components/post_components.ex:3013
+#: lib/vutuv_web/components/post_components.ex:3015
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2167,7 +2166,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1722
+#: lib/vutuv_web/live/post_live/feed.ex:1858
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2211,19 +2210,19 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:520
 #: lib/vutuv_web/live/search_live.ex:281
 #: lib/vutuv_web/live/search_live.ex:728
-#: lib/vutuv_web/templates/settings/preferences.html.heex:362
+#: lib/vutuv_web/templates/settings/preferences.html.heex:312
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3468
-#: lib/vutuv_web/components/post_components.ex:3472
+#: lib/vutuv_web/components/post_components.ex:3483
+#: lib/vutuv_web/components/post_components.ex:3487
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3469
+#: lib/vutuv_web/components/post_components.ex:3484
 #: lib/vutuv_web/live/fediverse_account_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2231,7 +2230,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:376
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:1178
+#: lib/vutuv_web/components/post_components.ex:1190
 #: lib/vutuv_web/live/admin/screenshot_live.ex:327
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:700
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
@@ -2242,7 +2241,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:650
 #: lib/vutuv_web/live/post_live/saved.ex:678
 #: lib/vutuv_web/templates/connection/index.html.heex:40
-#: lib/vutuv_web/views/settings_html.ex:434
+#: lib/vutuv_web/views/settings_html.ex:329
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
@@ -2257,7 +2256,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1626
+#: lib/vutuv_web/live/post_live/feed.ex:1762
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2294,11 +2293,11 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4650
+#: lib/vutuv_web/components/ui.ex:4671
 #: lib/vutuv_web/live/shell_live.ex:962
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
-#: lib/vutuv_web/views/settings_html.ex:335
+#: lib/vutuv_web/views/settings_html.ex:230
 #, elixir-autogen, elixir-format
 msgid "View profile"
 msgstr ""
@@ -2313,33 +2312,33 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2995
+#: lib/vutuv_web/components/post_components.ex:3010
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4788
+#: lib/vutuv_web/components/post_components.ex:4818
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4792
+#: lib/vutuv_web/components/post_components.ex:4822
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4790
+#: lib/vutuv_web/components/post_components.ex:4820
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4791
+#: lib/vutuv_web/components/post_components.ex:4821
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
 
 #: lib/vutuv_web/views/post_html.ex:19
-#: lib/vutuv_web/views/settings_html.ex:513
+#: lib/vutuv_web/views/settings_html.ex:408
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr ""
@@ -2374,9 +2373,9 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1771
-#: lib/vutuv_web/components/post_components.ex:4884
-#: lib/vutuv_web/components/ui.ex:3498
+#: lib/vutuv_web/components/post_components.ex:1783
+#: lib/vutuv_web/components/post_components.ex:4914
+#: lib/vutuv_web/components/ui.ex:3508
 #: lib/vutuv_web/views/user_html.ex:453
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2393,9 +2392,9 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1724
-#: lib/vutuv_web/components/post_components.ex:5120
-#: lib/vutuv_web/components/ui.ex:3484
+#: lib/vutuv_web/components/post_components.ex:1736
+#: lib/vutuv_web/components/post_components.ex:5150
+#: lib/vutuv_web/components/ui.ex:3494
 #: lib/vutuv_web/live/notification_live/index.ex:1072
 #: lib/vutuv_web/views/user_html.ex:463
 #, elixir-autogen, elixir-format
@@ -2403,7 +2402,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1107
-#: lib/vutuv_web/components/post_components.ex:5130
+#: lib/vutuv_web/components/post_components.ex:5160
 #: lib/vutuv_web/live/notification_live/index.ex:1005
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
@@ -2425,40 +2424,40 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4872
+#: lib/vutuv_web/components/post_components.ex:4902
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1770
-#: lib/vutuv_web/components/post_components.ex:4883
+#: lib/vutuv_web/components/post_components.ex:1782
+#: lib/vutuv_web/components/post_components.ex:4913
 #: lib/vutuv_web/live/post_live/saved.ex:806
 #: lib/vutuv_web/views/user_html.ex:453
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1752
-#: lib/vutuv_web/components/post_components.ex:4869
+#: lib/vutuv_web/components/post_components.ex:1764
+#: lib/vutuv_web/components/post_components.ex:4899
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2017
-#: lib/vutuv_web/components/post_components.ex:4050
+#: lib/vutuv_web/components/post_components.ex:2029
+#: lib/vutuv_web/components/post_components.ex:4065
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1751
-#: lib/vutuv_web/components/post_components.ex:4868
+#: lib/vutuv_web/components/post_components.ex:1763
+#: lib/vutuv_web/components/post_components.ex:4898
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1723
-#: lib/vutuv_web/components/post_components.ex:5119
+#: lib/vutuv_web/components/post_components.ex:1735
+#: lib/vutuv_web/components/post_components.ex:5149
 #: lib/vutuv_web/live/post_live/saved.ex:805
 #: lib/vutuv_web/views/user_html.ex:463
 #, elixir-autogen, elixir-format
@@ -2466,14 +2465,14 @@ msgid "Unlike"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:377
-#: lib/vutuv_web/components/post_components.ex:2302
+#: lib/vutuv_web/components/post_components.ex:2317
 #: lib/vutuv_web/components/ui.ex:2388
 #: lib/vutuv_web/components/ui.ex:2388
 #: lib/vutuv_web/components/ui.ex:2525
 #: lib/vutuv_web/live/organization_live/following.ex:378
 #: lib/vutuv_web/live/organization_live/following.ex:453
 #: lib/vutuv_web/live/organization_live/show.ex:474
-#: lib/vutuv_web/live/post_live/feed.ex:1771
+#: lib/vutuv_web/live/post_live/feed.ex:1907
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2485,7 +2484,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5174
+#: lib/vutuv_web/components/post_components.ex:5204
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2496,16 +2495,16 @@ msgstr ""
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1737
-#: lib/vutuv_web/components/post_components.ex:5157
-#: lib/vutuv_web/components/post_components.ex:5158
+#: lib/vutuv_web/components/post_components.ex:1749
+#: lib/vutuv_web/components/post_components.ex:5187
+#: lib/vutuv_web/components/post_components.ex:5188
 #: lib/vutuv_web/live/notification_live/index.ex:1069
 #: lib/vutuv_web/live/post_live/reply.ex:43
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2962
+#: lib/vutuv_web/components/post_components.ex:2977
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2526,7 +2525,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2498
+#: lib/vutuv_web/components/post_components.ex:2513
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:60
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:57
@@ -2534,14 +2533,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2936
+#: lib/vutuv_web/components/post_components.ex:2951
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2927
-#: lib/vutuv_web/components/post_components.ex:2954
-#: lib/vutuv_web/components/post_components.ex:2957
+#: lib/vutuv_web/components/post_components.ex:2942
+#: lib/vutuv_web/components/post_components.ex:2969
+#: lib/vutuv_web/components/post_components.ex:2972
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2750,11 +2749,12 @@ msgstr ""
 msgid "Write your first post"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3662
-#: lib/vutuv_web/components/ui.ex:4036
+#: lib/vutuv_web/components/ui.ex:3672
+#: lib/vutuv_web/components/ui.ex:4046
 #: lib/vutuv_web/templates/settings/apps.html.heex:22
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #: lib/vutuv_web/templates/settings/organizations.html.heex:104
+#: lib/vutuv_web/templates/settings/preferences.html.heex:195
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:216
@@ -2763,7 +2763,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1552
+#: lib/vutuv_web/live/post_live/feed.ex:1688
 #: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2784,7 +2784,7 @@ msgid_plural "%{formatted} connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1873
+#: lib/vutuv_web/live/post_live/feed.ex:2009
 #: lib/vutuv_web/templates/user/card_list.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -2839,7 +2839,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4789
+#: lib/vutuv_web/components/post_components.ex:4819
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3102,7 +3102,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2903
+#: lib/vutuv_web/components/post_components.ex:2918
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3151,9 +3151,9 @@ msgstr ""
 msgid "Private message"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4293
+#: lib/vutuv_web/components/ui.ex:4303
 #: lib/vutuv_web/live/shell_live.ex:783
-#: lib/vutuv_web/live/shell_live.ex:1071
+#: lib/vutuv_web/live/shell_live.ex:1080
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -3177,9 +3177,9 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1188
-#: lib/vutuv_web/components/post_components.ex:2314
-#: lib/vutuv_web/components/post_components.ex:3067
+#: lib/vutuv_web/components/post_components.ex:1200
+#: lib/vutuv_web/components/post_components.ex:2329
+#: lib/vutuv_web/components/post_components.ex:3082
 #: lib/vutuv_web/live/organization_live/show.ex:547
 #: lib/vutuv_web/templates/user/show.html.heex:222
 #, elixir-autogen, elixir-format
@@ -3262,7 +3262,7 @@ msgstr ""
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3398
+#: lib/vutuv_web/components/ui.ex:3408
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:773
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -4503,7 +4503,7 @@ msgstr ""
 msgid "Block @%{slug}? This removes any follows and connection between you, closes your conversation, and prevents all interaction in both directions. Unblocking will not restore what was removed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4400
+#: lib/vutuv_web/components/ui.ex:4421
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -4545,7 +4545,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1727
+#: lib/vutuv_web/live/post_live/feed.ex:1863
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -4629,7 +4629,7 @@ msgstr ""
 #: lib/vutuv_web/live/import_connections_live.ex:470
 #: lib/vutuv_web/live/notification_live/index.ex:925
 #: lib/vutuv_web/live/search_live.ex:278
-#: lib/vutuv_web/templates/settings/preferences.html.heex:304
+#: lib/vutuv_web/templates/settings/preferences.html.heex:254
 #: lib/vutuv_web/views/qualification_html.ex:103
 #, elixir-autogen, elixir-format
 msgid "All"
@@ -4677,7 +4677,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:388
 #: lib/vutuv_web/live/tag_new_live.ex:48
-#: lib/vutuv_web/live/user_profile_live.ex:1332
+#: lib/vutuv_web/live/user_profile_live.ex:1336
 #: lib/vutuv_web/templates/user/show.html.heex:594
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
@@ -4912,8 +4912,8 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/api_app_live.ex:98
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:181
-#: lib/vutuv_web/views/settings_html.ex:77
-#: lib/vutuv_web/views/settings_html.ex:379
+#: lib/vutuv_web/views/settings_html.ex:75
+#: lib/vutuv_web/views/settings_html.ex:274
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
@@ -5271,7 +5271,7 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4460
+#: lib/vutuv_web/components/ui.ex:4481
 #: lib/vutuv_web/controllers/settings_controller.ex:155
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5350,10 +5350,10 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4557
-#: lib/vutuv_web/components/ui.ex:4562
-#: lib/vutuv_web/components/ui.ex:4641
-#: lib/vutuv_web/components/ui.ex:4705
+#: lib/vutuv_web/components/ui.ex:4578
+#: lib/vutuv_web/components/ui.ex:4583
+#: lib/vutuv_web/components/ui.ex:4662
+#: lib/vutuv_web/components/ui.ex:4726
 #: lib/vutuv_web/controllers/settings_controller.ex:62
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5366,7 +5366,7 @@ msgstr ""
 #: lib/vutuv_web/templates/login_code/index.html.heex:4
 #: lib/vutuv_web/templates/totp/new.html.heex:4
 #: lib/vutuv_web/templates/username/confirm.html.heex:23
-#: lib/vutuv_web/views/settings_html.ex:330
+#: lib/vutuv_web/views/settings_html.ex:225
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -5397,7 +5397,7 @@ msgstr ""
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1338
+#: lib/vutuv_web/live/user_profile_live.ex:1342
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr ""
@@ -5423,11 +5423,11 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3132
-#: lib/vutuv_web/components/post_components.ex:3186
-#: lib/vutuv_web/components/post_components.ex:3605
+#: lib/vutuv_web/components/post_components.ex:3147
+#: lib/vutuv_web/components/post_components.ex:3201
+#: lib/vutuv_web/components/post_components.ex:3620
 #: lib/vutuv_web/live/notification_live/index.ex:726
-#: lib/vutuv_web/live/post_live/feed.ex:1914
+#: lib/vutuv_web/live/post_live/feed.ex:2050
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5472,7 +5472,7 @@ msgstr ""
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4420
+#: lib/vutuv_web/components/ui.ex:4441
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:289
@@ -5493,7 +5493,7 @@ msgstr ""
 msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4331
+#: lib/vutuv_web/components/ui.ex:4341
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5527,7 +5527,7 @@ msgstr ""
 msgid "Photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4394
+#: lib/vutuv_web/components/ui.ex:4415
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/templates/page/index.html.heex:174
 #, elixir-autogen, elixir-format
@@ -5640,7 +5640,7 @@ msgstr ""
 msgid "Apps"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4453
+#: lib/vutuv_web/components/ui.ex:4474
 #: lib/vutuv_web/controllers/settings_controller.ex:179
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -5845,28 +5845,28 @@ msgid "Sort"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/views/settings_html.ex:522
+#: lib/vutuv_web/views/settings_html.ex:417
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:521
+#: lib/vutuv_web/views/settings_html.ex:416
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:520
+#: lib/vutuv_web/views/settings_html.ex:415
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:930
+#: lib/vutuv_web/controllers/settings_controller.ex:901
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr ""
@@ -5876,7 +5876,7 @@ msgstr ""
 msgid "Another session was already active on your account."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:368
+#: lib/vutuv_web/views/settings_html.ex:263
 #, elixir-autogen, elixir-format
 msgid "Last active"
 msgstr ""
@@ -5891,7 +5891,7 @@ msgstr ""
 msgid "Log out of every device except this one?"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:385
+#: lib/vutuv_web/views/settings_html.ex:280
 #, elixir-autogen, elixir-format
 msgid "Log this device out of your account?"
 msgstr ""
@@ -5906,7 +5906,7 @@ msgstr ""
 msgid "Signed-in devices"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:917
+#: lib/vutuv_web/controllers/settings_controller.ex:888
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr ""
@@ -5916,7 +5916,7 @@ msgstr ""
 msgid "The location looks different from where you usually sign in."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:369
+#: lib/vutuv_web/views/settings_html.ex:264
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr ""
@@ -5926,7 +5926,7 @@ msgstr ""
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:519
+#: lib/vutuv_web/views/settings_html.ex:414
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr ""
@@ -5960,7 +5960,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
 #: lib/vutuv_web/live/admin/screenshot_live.ex:309
 #: lib/vutuv_web/live/fediverse_following_live.ex:291
-#: lib/vutuv_web/views/settings_html.ex:420
+#: lib/vutuv_web/views/settings_html.ex:315
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr ""
@@ -5970,7 +5970,7 @@ msgstr ""
 msgid "Could not add the passkey. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:423
+#: lib/vutuv_web/views/settings_html.ex:318
 #, elixir-autogen, elixir-format
 msgid "Last used"
 msgstr ""
@@ -5980,7 +5980,7 @@ msgstr ""
 msgid "Name (optional)"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:417
+#: lib/vutuv_web/views/settings_html.ex:312
 #, elixir-autogen, elixir-format
 msgid "Passkey"
 msgstr ""
@@ -6000,7 +6000,7 @@ msgstr ""
 msgid "Passkeys"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:431
+#: lib/vutuv_web/views/settings_html.ex:326
 #, elixir-autogen, elixir-format
 msgid "Remove this passkey?"
 msgstr ""
@@ -6056,7 +6056,7 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1343
+#: lib/vutuv_web/live/user_profile_live.ex:1347
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr ""
@@ -6230,6 +6230,7 @@ msgstr ""
 msgid "View all phone numbers"
 msgstr ""
 
+#: lib/vutuv_web/live/feed_languages_live.ex:235
 #: lib/vutuv_web/live/section_reorder_live.ex:127
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder"
@@ -6240,11 +6241,13 @@ msgstr ""
 msgid "Drag to reorder, or use the arrows. The order is the one shown on your profile."
 msgstr ""
 
+#: lib/vutuv_web/live/feed_languages_live.ex:267
 #: lib/vutuv_web/live/section_reorder_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "Move down"
 msgstr ""
 
+#: lib/vutuv_web/live/feed_languages_live.ex:256
 #: lib/vutuv_web/live/section_reorder_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -6608,8 +6611,8 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2282
-#: lib/vutuv_web/components/post_components.ex:3064
+#: lib/vutuv_web/components/post_components.ex:2297
+#: lib/vutuv_web/components/post_components.ex:3079
 #: lib/vutuv_web/components/ui.ex:2713
 #: lib/vutuv_web/live/fediverse_account_live.ex:381
 #: lib/vutuv_web/live/organization_live/following.ex:371
@@ -6636,7 +6639,7 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3064
+#: lib/vutuv_web/components/post_components.ex:3079
 #: lib/vutuv_web/components/ui.ex:2712
 #: lib/vutuv_web/live/fediverse_account_live.ex:379
 #: lib/vutuv_web/live/organization_live/following.ex:371
@@ -7121,7 +7124,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:816
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:44
 #: lib/vutuv_web/templates/settings/filters.html.heex:22
-#: lib/vutuv_web/views/settings_html.ex:61
+#: lib/vutuv_web/views/settings_html.ex:59
 #, elixir-autogen, elixir-format
 msgid "Tag"
 msgstr ""
@@ -7261,13 +7264,13 @@ msgstr ""
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3436
+#: lib/vutuv_web/components/ui.ex:3446
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3452
+#: lib/vutuv_web/components/ui.ex:3462
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7346,7 +7349,7 @@ msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:5030
+#: lib/vutuv_web/components/post_components.ex:5060
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -7821,42 +7824,42 @@ msgstr ""
 msgid "Send the email"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:111
+#: lib/vutuv_web/views/settings_html.ex:109
 #, elixir-autogen
 msgid "As soon as possible"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:112
+#: lib/vutuv_web/views/settings_html.ex:110
 #, elixir-autogen
 msgid "After 5 minutes"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:113
+#: lib/vutuv_web/views/settings_html.ex:111
 #, elixir-autogen
 msgid "After 15 minutes"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:114
+#: lib/vutuv_web/views/settings_html.ex:112
 #, elixir-autogen
 msgid "After 30 minutes"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:115
+#: lib/vutuv_web/views/settings_html.ex:113
 #, elixir-autogen
 msgid "After 1 hour"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:116
+#: lib/vutuv_web/views/settings_html.ex:114
 #, elixir-autogen
 msgid "After 2 hours"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:95
+#: lib/vutuv_web/views/settings_html.ex:93
 #, elixir-autogen
 msgid "Only the first message"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:96
+#: lib/vutuv_web/views/settings_html.ex:94
 #, elixir-autogen
 msgid "Every message"
 msgstr ""
@@ -7897,7 +7900,7 @@ msgid "Admins"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:1882
+#: lib/vutuv_web/live/post_live/feed.ex:2018
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr ""
@@ -8021,7 +8024,7 @@ msgstr ""
 msgid "PIN registered"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3439
+#: lib/vutuv_web/components/ui.ex:3449
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr ""
@@ -8151,7 +8154,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:42
 #: lib/vutuv_web/agent_docs/text.ex:39
-#: lib/vutuv_web/components/ui.ex:4307
+#: lib/vutuv_web/components/ui.ex:4317
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8206,7 +8209,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4441
+#: lib/vutuv_web/components/ui.ex:4462
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8235,7 +8238,7 @@ msgstr ""
 msgid "Nothing new to import."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4335
+#: lib/vutuv_web/components/ui.ex:4345
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8329,7 +8332,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3708
+#: lib/vutuv_web/components/ui.ex:3718
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8404,13 +8407,13 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4295
+#: lib/vutuv_web/components/ui.ex:4305
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4431
+#: lib/vutuv_web/components/ui.ex:4452
 #: lib/vutuv_web/controllers/settings_controller.ex:123
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8422,7 +8425,7 @@ msgstr ""
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4422
+#: lib/vutuv_web/components/ui.ex:4443
 #: lib/vutuv_web/controllers/settings_controller.ex:106
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8432,7 +8435,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4445
+#: lib/vutuv_web/components/ui.ex:4466
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8454,12 +8457,12 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1899
+#: lib/vutuv_web/live/post_live/feed.ex:2035
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1895
+#: lib/vutuv_web/live/post_live/feed.ex:2031
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr ""
@@ -8648,7 +8651,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:584
 #: lib/vutuv_web/components/organization_components.ex:285
 #: lib/vutuv_web/components/ui.ex:1282
-#: lib/vutuv_web/components/ui.ex:4412
+#: lib/vutuv_web/components/ui.ex:4433
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:355
 #: lib/vutuv_web/controllers/settings_controller.ex:422
@@ -8803,7 +8806,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4053
+#: lib/vutuv_web/components/post_components.ex:4068
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9051,6 +9054,7 @@ msgstr ""
 msgid "A2 (Elementary)"
 msgstr ""
 
+#: lib/vutuv_web/live/feed_languages_live.ex:317
 #: lib/vutuv_web/templates/language/manage.html.heex:8
 #: lib/vutuv_web/templates/language/new.html.heex:5
 #: lib/vutuv_web/templates/user/show.html.heex:749
@@ -9224,6 +9228,7 @@ msgid "Irish"
 msgstr ""
 
 #: lib/vutuv/languages.ex:125
+#: lib/vutuv_web/templates/settings/preferences.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "Italian"
 msgstr ""
@@ -9464,7 +9469,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1162
+#: lib/vutuv/accounts/user.ex:1167
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9475,7 +9480,7 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1159
+#: lib/vutuv/accounts/user.ex:1164
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -9590,7 +9595,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:46
 #: lib/vutuv_web/agent_docs/text.ex:43
-#: lib/vutuv_web/components/ui.ex:4311
+#: lib/vutuv_web/components/ui.ex:4321
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:132
@@ -9784,13 +9789,13 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3182
+#: lib/vutuv_web/components/ui.ex:3185
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3181
-#: lib/vutuv_web/components/ui.ex:3185
+#: lib/vutuv_web/components/ui.ex:3184
+#: lib/vutuv_web/components/ui.ex:3188
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr ""
@@ -10500,46 +10505,46 @@ msgid_plural "You have %{formatted} new messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:433
+#: lib/vutuv_web/templates/settings/preferences.html.heex:383
 #, elixir-autogen, elixir-format
 msgid "Break long words at syllable points so the text wraps evenly. Helpful in the narrow phone column."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:364
+#: lib/vutuv_web/templates/settings/preferences.html.heex:314
 #, elixir-autogen, elixir-format
 msgid "How posts you read are shortened in your feed and on profiles. These are your own reading preferences."
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:68
-#: lib/vutuv_web/templates/settings/preferences.html.heex:440
+#: lib/vutuv_web/templates/settings/preferences.html.heex:390
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on desktop"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:69
-#: lib/vutuv_web/templates/settings/preferences.html.heex:444
+#: lib/vutuv_web/templates/settings/preferences.html.heex:394
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on mobile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:430
+#: lib/vutuv_web/templates/settings/preferences.html.heex:380
 #, elixir-autogen, elixir-format
 msgid "Hyphenation"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:66
-#: lib/vutuv_web/templates/settings/preferences.html.heex:387
+#: lib/vutuv_web/templates/settings/preferences.html.heex:337
 #, elixir-autogen, elixir-format
 msgid "Lines on desktop"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:67
-#: lib/vutuv_web/templates/settings/preferences.html.heex:396
+#: lib/vutuv_web/templates/settings/preferences.html.heex:346
 #, elixir-autogen, elixir-format
 msgid "Lines on mobile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:382
+#: lib/vutuv_web/templates/settings/preferences.html.heex:332
 #, elixir-autogen, elixir-format
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
@@ -10549,7 +10554,7 @@ msgstr ""
 msgid "Post display settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:379
+#: lib/vutuv_web/templates/settings/preferences.html.heex:329
 #, elixir-autogen, elixir-format
 msgid "Shorten a post after"
 msgstr ""
@@ -10634,11 +10639,11 @@ msgstr ""
 msgid "Preferences of %{name}"
 msgstr ""
 
+#: lib/vutuv_web/live/feed_languages_live.ex:377
 #: lib/vutuv_web/templates/settings/preferences.html.heex:101
 #: lib/vutuv_web/templates/settings/preferences.html.heex:174
-#: lib/vutuv_web/templates/settings/preferences.html.heex:245
-#: lib/vutuv_web/templates/settings/preferences.html.heex:346
-#: lib/vutuv_web/templates/settings/preferences.html.heex:464
+#: lib/vutuv_web/templates/settings/preferences.html.heex:296
+#: lib/vutuv_web/templates/settings/preferences.html.heex:414
 #, elixir-autogen, elixir-format
 msgid "Reset to the site defaults"
 msgstr ""
@@ -10829,19 +10834,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1200
+#: lib/vutuv/accounts/user.ex:1205
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1205
+#: lib/vutuv/accounts/user.ex:1210
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1203
+#: lib/vutuv/accounts/user.ex:1208
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:761
 #, elixir-autogen, elixir-format
@@ -11831,7 +11836,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:419
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:394
-#: lib/vutuv_web/components/ui.ex:4449
+#: lib/vutuv_web/components/ui.ex:4470
 #: lib/vutuv_web/controllers/settings_controller.ex:211
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
@@ -12139,7 +12144,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1174
+#: lib/vutuv/accounts/user.ex:1179
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12258,7 +12263,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1173
+#: lib/vutuv/accounts/user.ex:1178
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12340,7 +12345,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1175
+#: lib/vutuv/accounts/user.ex:1180
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:564
 #: lib/vutuv_web/agent_docs/markdown.ex:458
@@ -12585,12 +12590,12 @@ msgstr ""
 msgid "Browse all organizations"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:74
+#: lib/vutuv_web/views/settings_html.ex:72
 #, elixir-autogen, elixir-format
 msgid "Under review"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:76
+#: lib/vutuv_web/views/settings_html.ex:74
 #, elixir-autogen, elixir-format
 msgid "Verification pending"
 msgstr ""
@@ -13042,7 +13047,7 @@ msgstr ""
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4389
+#: lib/vutuv_web/components/ui.ex:4410
 #: lib/vutuv_web/controllers/settings_controller.ex:600
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -13061,7 +13066,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2457
+#: lib/vutuv_web/components/post_components.ex:2472
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:695
 #: lib/vutuv_web/controllers/settings_controller.ex:713
@@ -13355,7 +13360,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1218
+#: lib/vutuv/accounts/user.ex:1223
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13366,19 +13371,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1221
+#: lib/vutuv/accounts/user.ex:1226
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1224
+#: lib/vutuv/accounts/user.ex:1229
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1215
+#: lib/vutuv/accounts/user.ex:1220
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13500,16 +13505,16 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4372
+#: lib/vutuv_web/components/ui.ex:4393
 #: lib/vutuv_web/controllers/settings_controller.ex:614
-#: lib/vutuv_web/live/post_live/feed.ex:1757
+#: lib/vutuv_web/live/post_live/feed.ex:1893
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1772
+#: lib/vutuv_web/live/post_live/feed.ex:1908
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr ""
@@ -13580,7 +13585,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:60
 #: lib/vutuv_web/agent_docs/text.ex:57
-#: lib/vutuv_web/components/ui.ex:4354
+#: lib/vutuv_web/components/ui.ex:4364
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -13608,14 +13613,14 @@ msgstr ""
 msgid "Select a messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3794
+#: lib/vutuv_web/components/ui.ex:3804
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3804
+#: lib/vutuv_web/components/ui.ex:3814
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
@@ -13665,34 +13670,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4651
+#: lib/vutuv_web/components/post_components.ex:4681
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1196
-#: lib/vutuv_web/components/post_components.ex:4608
+#: lib/vutuv_web/components/post_components.ex:4638
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4652
+#: lib/vutuv_web/components/post_components.ex:4682
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4654
+#: lib/vutuv_web/components/post_components.ex:4684
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4650
+#: lib/vutuv_web/components/post_components.ex:4680
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1196
-#: lib/vutuv_web/components/post_components.ex:4607
+#: lib/vutuv_web/components/post_components.ex:4637
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13703,12 +13708,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4649
+#: lib/vutuv_web/components/post_components.ex:4679
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4653
+#: lib/vutuv_web/components/post_components.ex:4683
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13728,7 +13733,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4690
+#: lib/vutuv_web/components/post_components.ex:4720
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13736,27 +13741,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4720
+#: lib/vutuv_web/components/post_components.ex:4750
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4721
+#: lib/vutuv_web/components/post_components.ex:4751
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4719
+#: lib/vutuv_web/components/post_components.ex:4749
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4679
+#: lib/vutuv_web/components/post_components.ex:4709
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4726
+#: lib/vutuv_web/components/post_components.ex:4756
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13786,7 +13791,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4493
+#: lib/vutuv_web/components/post_components.ex:4523
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13834,7 +13839,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4484
+#: lib/vutuv_web/components/post_components.ex:4514
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -13974,7 +13979,7 @@ msgid "proof document"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:74
-#: lib/vutuv_web/templates/settings/preferences.html.heex:418
+#: lib/vutuv_web/templates/settings/preferences.html.heex:368
 #, elixir-autogen, elixir-format
 msgid "Lines in notifications"
 msgstr ""
@@ -13984,12 +13989,12 @@ msgstr ""
 msgid "How much of a post a notification quotes before it is cut off."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:409
+#: lib/vutuv_web/templates/settings/preferences.html.heex:359
 #, elixir-autogen, elixir-format
 msgid "Quoted posts in notifications"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:412
+#: lib/vutuv_web/templates/settings/preferences.html.heex:362
 #, elixir-autogen, elixir-format
 msgid "Your notifications quote the post someone liked or replied to. Leave the field empty to follow the site default."
 msgstr ""
@@ -14186,7 +14191,7 @@ msgstr ""
 msgid "No accounts are currently frozen."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:460
+#: lib/vutuv_web/live/post_live/thread.ex:464
 #, elixir-autogen, elixir-format
 msgid "Read it from the start"
 msgstr ""
@@ -14206,14 +14211,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2730
+#: lib/vutuv_web/components/post_components.ex:2745
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2753
+#: lib/vutuv_web/components/post_components.ex:2768
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14225,7 +14230,7 @@ msgstr[1] ""
 msgid "This page is no longer available."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:452
+#: lib/vutuv_web/live/post_live/thread.ex:456
 #, elixir-autogen, elixir-format
 msgid "This post is part of a conversation with %{formatted} posts."
 msgstr ""
@@ -14240,7 +14245,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5129
+#: lib/vutuv_web/components/post_components.ex:5159
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14387,7 +14392,7 @@ msgstr ""
 msgid "Filter removed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:472
+#: lib/vutuv_web/live/post_live/feed.ex:509
 #, elixir-autogen, elixir-format
 msgid "Hidden: matches your filter"
 msgstr ""
@@ -14402,7 +14407,7 @@ msgstr ""
 msgid "Match whole words only (word/phrase)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4368
+#: lib/vutuv_web/components/ui.ex:4378
 #: lib/vutuv_web/controllers/settings_controller.ex:680
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -14420,7 +14425,7 @@ msgstr ""
 msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:481
+#: lib/vutuv_web/live/post_live/feed.ex:518
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr ""
@@ -14471,12 +14476,12 @@ msgid "When someone replies anywhere in a thread you have written in, you hear a
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/filters.html.heex:19
-#: lib/vutuv_web/views/settings_html.ex:62
+#: lib/vutuv_web/views/settings_html.ex:60
 #, elixir-autogen, elixir-format
 msgid "Word or phrase"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:65
+#: lib/vutuv_web/views/settings_html.ex:63
 #, elixir-autogen, elixir-format
 msgid "Word or phrase (whole word)"
 msgstr ""
@@ -15035,252 +15040,252 @@ msgstr ""
 msgid "moved to %{address}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4296
+#: lib/vutuv_web/components/ui.ex:4306
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4301
+#: lib/vutuv_web/components/ui.ex:4311
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4304
+#: lib/vutuv_web/components/ui.ex:4314
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4305
+#: lib/vutuv_web/components/ui.ex:4315
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4308
+#: lib/vutuv_web/components/ui.ex:4318
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4309
+#: lib/vutuv_web/components/ui.ex:4319
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4312
+#: lib/vutuv_web/components/ui.ex:4322
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4313
+#: lib/vutuv_web/components/ui.ex:4323
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4320
+#: lib/vutuv_web/components/ui.ex:4330
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4321
+#: lib/vutuv_web/components/ui.ex:4331
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4322
+#: lib/vutuv_web/components/ui.ex:4332
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4325
+#: lib/vutuv_web/components/ui.ex:4335
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4326
+#: lib/vutuv_web/components/ui.ex:4336
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4450
+#: lib/vutuv_web/components/ui.ex:4471
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4451
+#: lib/vutuv_web/components/ui.ex:4472
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4329
+#: lib/vutuv_web/components/ui.ex:4339
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4332
+#: lib/vutuv_web/components/ui.ex:4342
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4333
+#: lib/vutuv_web/components/ui.ex:4343
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4336
+#: lib/vutuv_web/components/ui.ex:4346
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4337
+#: lib/vutuv_web/components/ui.ex:4347
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4340
+#: lib/vutuv_web/components/ui.ex:4350
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4341
+#: lib/vutuv_web/components/ui.ex:4351
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4343
+#: lib/vutuv_web/components/ui.ex:4353
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4344
+#: lib/vutuv_web/components/ui.ex:4354
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4345
+#: lib/vutuv_web/components/ui.ex:4355
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4347
+#: lib/vutuv_web/components/ui.ex:4357
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4348
+#: lib/vutuv_web/components/ui.ex:4358
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4350
+#: lib/vutuv_web/components/ui.ex:4360
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4355
+#: lib/vutuv_web/components/ui.ex:4365
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4356
+#: lib/vutuv_web/components/ui.ex:4366
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4359
+#: lib/vutuv_web/components/ui.ex:4369
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4362
+#: lib/vutuv_web/components/ui.ex:4372
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4369
+#: lib/vutuv_web/components/ui.ex:4379
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4370
+#: lib/vutuv_web/components/ui.ex:4380
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4373
+#: lib/vutuv_web/components/ui.ex:4394
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4374
+#: lib/vutuv_web/components/ui.ex:4395
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4390
+#: lib/vutuv_web/components/ui.ex:4411
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4391
+#: lib/vutuv_web/components/ui.ex:4412
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4397
+#: lib/vutuv_web/components/ui.ex:4418
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4398
+#: lib/vutuv_web/components/ui.ex:4419
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4401
+#: lib/vutuv_web/components/ui.ex:4422
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4402
+#: lib/vutuv_web/components/ui.ex:4423
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4423
+#: lib/vutuv_web/components/ui.ex:4444
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4424
+#: lib/vutuv_web/components/ui.ex:4445
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4442
+#: lib/vutuv_web/components/ui.ex:4463
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4443
+#: lib/vutuv_web/components/ui.ex:4464
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4446
+#: lib/vutuv_web/components/ui.ex:4467
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4447
+#: lib/vutuv_web/components/ui.ex:4468
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4461
+#: lib/vutuv_web/components/ui.ex:4482
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4462
+#: lib/vutuv_web/components/ui.ex:4483
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr ""
@@ -15358,51 +15363,51 @@ msgstr ""
 msgid "I understand, take part"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:501
+#: lib/vutuv_web/views/settings_html.ex:396
 #, elixir-autogen, elixir-format
 msgid "Most of them, not all: we cannot check whether they do it, and anything that was re-shared, archived or indexed elsewhere stays out of reach. If you take part again later, people there have to follow you anew."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:496
+#: lib/vutuv_web/views/settings_html.ex:391
 #, elixir-autogen, elixir-format
 msgid "No new posts go out, and your followers from other networks are removed here. The next time those servers look you up they learn that this account is gone, and most of them then delete their copies of your posts."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:477
+#: lib/vutuv_web/views/settings_html.ex:372
 #, elixir-autogen, elixir-format
 msgid "Once a post has left vutuv, it is out of our hands"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:479
+#: lib/vutuv_web/views/settings_html.ex:374
 #, elixir-autogen, elixir-format
 msgid "Switching off does not delete what is already out there"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:490
+#: lib/vutuv_web/views/settings_html.ex:385
 #, elixir-autogen, elixir-format
 msgid "Switching this off again later stops new posts from going out. It cannot bring back what has already been delivered."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:485
+#: lib/vutuv_web/views/settings_html.ex:380
 #, elixir-autogen, elixir-format
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5075
+#: lib/vutuv_web/components/post_components.ex:5105
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5079
+#: lib/vutuv_web/components/post_components.ex:5109
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5083
+#: lib/vutuv_web/components/post_components.ex:5113
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15410,7 +15415,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1145
-#: lib/vutuv_web/components/post_components.ex:5034
+#: lib/vutuv_web/components/post_components.ex:5064
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15426,14 +15431,14 @@ msgstr ""
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1300
-#: lib/vutuv_web/components/post_components.ex:1959
+#: lib/vutuv_web/components/post_components.ex:1312
+#: lib/vutuv_web/components/post_components.ex:1971
 #: lib/vutuv_web/live/fediverse_account_live.ex:294
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1176
+#: lib/vutuv_web/components/post_components.ex:1188
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15462,7 +15467,7 @@ msgstr ""
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1185
+#: lib/vutuv_web/components/post_components.ex:1197
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15472,7 +15477,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1199
+#: lib/vutuv_web/components/post_components.ex:1211
 #: lib/vutuv_web/live/notification_live/index.ex:580
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -15498,15 +15503,15 @@ msgstr ""
 msgid "Thank you. The reply was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:356
+#: lib/vutuv_web/live/post_live/thread.ex:360
 #, elixir-autogen, elixir-format
 msgid "That reply is not yours to remove."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1329
-#: lib/vutuv_web/components/post_components.ex:1231
-#: lib/vutuv_web/components/post_components.ex:1431
-#: lib/vutuv_web/components/post_components.ex:2377
+#: lib/vutuv_web/components/post_components.ex:1243
+#: lib/vutuv_web/components/post_components.ex:1443
+#: lib/vutuv_web/components/post_components.ex:2392
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -15518,7 +15523,7 @@ msgstr ""
 msgid "What"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:352
+#: lib/vutuv_web/live/post_live/thread.ex:356
 #: lib/vutuv_web/live/remote_post_actions.ex:53
 #, elixir-autogen, elixir-format
 msgid "You have reported a lot today. Please try again tomorrow."
@@ -15734,7 +15739,7 @@ msgstr ""
 msgid "Access token revoked"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4426
+#: lib/vutuv_web/components/ui.ex:4447
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -16081,7 +16086,7 @@ msgstr ""
 msgid "What changed on your account, and exactly when."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4427
+#: lib/vutuv_web/components/ui.ex:4448
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr ""
@@ -16117,7 +16122,7 @@ msgstr ""
 msgid "from a signed-in session"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4429
+#: lib/vutuv_web/components/ui.ex:4450
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
@@ -16169,22 +16174,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2915
+#: lib/vutuv_web/components/post_components.ex:2930
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3031
+#: lib/vutuv_web/components/post_components.ex:3046
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3039
+#: lib/vutuv_web/components/post_components.ex:3054
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3025
+#: lib/vutuv_web/components/post_components.ex:3040
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16310,17 +16315,17 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2510
+#: lib/vutuv_web/components/post_components.ex:2525
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3734
+#: lib/vutuv_web/components/post_components.ex:3749
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3245
+#: lib/vutuv_web/components/post_components.ex:3260
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16333,7 +16338,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1290
 #: lib/vutuv_web/agent_docs/text.ex:779
-#: lib/vutuv_web/components/post_components.ex:3951
+#: lib/vutuv_web/components/post_components.ex:3966
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr ""
@@ -16359,7 +16364,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2563
+#: lib/vutuv_web/components/post_components.ex:2578
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16379,7 +16384,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2554
+#: lib/vutuv_web/components/post_components.ex:2569
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16389,12 +16394,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2572
+#: lib/vutuv_web/components/post_components.ex:2587
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2506
+#: lib/vutuv_web/components/post_components.ex:2521
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16409,7 +16414,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2567
+#: lib/vutuv_web/components/post_components.ex:2582
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16419,7 +16424,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2520
+#: lib/vutuv_web/components/post_components.ex:2535
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16440,8 +16445,8 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1561
-#: lib/vutuv_web/live/post_live/feed.ex:1562
+#: lib/vutuv_web/live/post_live/feed.ex:1697
+#: lib/vutuv_web/live/post_live/feed.ex:1698
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr ""
@@ -16506,13 +16511,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1163
-#: lib/vutuv_web/components/post_components.ex:5072
+#: lib/vutuv_web/components/post_components.ex:5102
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1161
-#: lib/vutuv_web/components/post_components.ex:5069
+#: lib/vutuv_web/components/post_components.ex:5099
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr ""
@@ -16522,7 +16527,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4961
+#: lib/vutuv_web/components/post_components.ex:4991
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr ""
@@ -16638,7 +16643,7 @@ msgstr ""
 msgid "Cancel request"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4413
+#: lib/vutuv_web/components/ui.ex:4434
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr ""
@@ -16842,7 +16847,7 @@ msgstr ""
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4415
+#: lib/vutuv_web/components/ui.ex:4436
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
@@ -16862,7 +16867,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2323
+#: lib/vutuv_web/components/post_components.ex:2338
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
@@ -16872,7 +16877,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2376
+#: lib/vutuv_web/components/post_components.ex:2391
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16892,12 +16897,12 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1559
+#: lib/vutuv_web/components/post_components.ex:1571
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2341
+#: lib/vutuv_web/components/post_components.ex:2356
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr ""
@@ -16913,7 +16918,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2309
+#: lib/vutuv_web/components/post_components.ex:2324
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -17135,27 +17140,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2075
+#: lib/vutuv_web/components/post_components.ex:2077
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2091
+#: lib/vutuv_web/components/post_components.ex:2106
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2086
+#: lib/vutuv_web/components/post_components.ex:2101
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2413
+#: lib/vutuv_web/components/post_components.ex:2428
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2419
+#: lib/vutuv_web/components/post_components.ex:2434
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr ""
@@ -17165,7 +17170,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2558
+#: lib/vutuv_web/components/post_components.ex:2573
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17205,7 +17210,7 @@ msgstr ""
 msgid "That link points at a single post. You can follow its author, %{account}, from here."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1378
+#: lib/vutuv_web/live/user_profile_live.ex:1382
 #, elixir-autogen, elixir-format
 msgid "You already follow one member."
 msgid_plural "You already follow %{count} members."
@@ -17912,7 +17917,7 @@ msgstr ""
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2416
+#: lib/vutuv_web/components/post_components.ex:2431
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -18215,19 +18220,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4208
+#: lib/vutuv_web/components/post_components.ex:4238
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4210
+#: lib/vutuv_web/components/post_components.ex:4240
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4221
+#: lib/vutuv_web/components/post_components.ex:4251
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -18247,7 +18252,7 @@ msgstr ""
 msgid "When off, other members no longer see you among the likes of a post. The author of the post still does: we named you in the notification they got when you liked it. Either way the post keeps the same number of likes."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:864
+#: lib/vutuv_web/controllers/settings_controller.ex:835
 #, elixir-autogen, elixir-format
 msgid "Your likes follow the site default again."
 msgstr ""
@@ -18352,7 +18357,7 @@ msgstr ""
 msgid "Employment reference updated."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4315
+#: lib/vutuv_web/components/ui.ex:4325
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -18546,7 +18551,7 @@ msgstr ""
 msgid "You changed the text after this review. It describes the earlier version."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4316
+#: lib/vutuv_web/components/ui.ex:4326
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr ""
@@ -18557,7 +18562,7 @@ msgstr ""
 msgid "Zwischenzeugnis"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4318
+#: lib/vutuv_web/components/ui.ex:4328
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr ""
@@ -18724,7 +18729,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/live/reference_check_live.ex:156
-#: lib/vutuv_web/templates/settings/preferences.html.heex:285
+#: lib/vutuv_web/templates/settings/preferences.html.heex:235
 #, elixir-autogen, elixir-format
 msgid "%{count} second"
 msgid_plural "%{count} seconds"
@@ -19173,7 +19178,7 @@ msgstr ""
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1363
+#: lib/vutuv_web/live/user_profile_live.ex:1367
 #, elixir-autogen, elixir-format
 msgid "Follow other members"
 msgstr ""
@@ -19183,17 +19188,17 @@ msgstr ""
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1321
+#: lib/vutuv/accounts/user.ex:1326
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1319
+#: lib/vutuv/accounts/user.ex:1324
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1320
+#: lib/vutuv/accounts/user.ex:1325
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -19203,7 +19208,7 @@ msgstr ""
 msgid "Shares are of the %{answered} members who answered. %{unanswered} gave no answer."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4297
+#: lib/vutuv_web/components/ui.ex:4307
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr ""
@@ -19218,7 +19223,7 @@ msgstr ""
 msgid "We use {model}, a freely available language model. Anyone can download it and run the same review themselves, which is also why we are able to run it on our own machines at all."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:58
+#: lib/vutuv_web/views/settings_html.ex:56
 #, elixir-autogen, elixir-format
 msgid "%{count} day"
 msgid_plural "%{count} days"
@@ -19239,47 +19244,47 @@ msgid_plural "%{formatted} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:49
+#: lib/vutuv_web/views/settings_html.ex:47
 #, elixir-autogen, elixir-format
 msgid "1 day"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:53
+#: lib/vutuv_web/views/settings_html.ex:51
 #, elixir-autogen, elixir-format
 msgid "1 month"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:51
+#: lib/vutuv_web/views/settings_html.ex:49
 #, elixir-autogen, elixir-format
 msgid "1 week"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:56
+#: lib/vutuv_web/views/settings_html.ex:54
 #, elixir-autogen, elixir-format
 msgid "1 year"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:52
+#: lib/vutuv_web/views/settings_html.ex:50
 #, elixir-autogen, elixir-format
 msgid "2 weeks"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:57
+#: lib/vutuv_web/views/settings_html.ex:55
 #, elixir-autogen, elixir-format
 msgid "2 years"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:50
+#: lib/vutuv_web/views/settings_html.ex:48
 #, elixir-autogen, elixir-format
 msgid "3 days"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:54
+#: lib/vutuv_web/views/settings_html.ex:52
 #, elixir-autogen, elixir-format
 msgid "3 months"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:55
+#: lib/vutuv_web/views/settings_html.ex:53
 #, elixir-autogen, elixir-format
 msgid "6 months"
 msgstr ""
@@ -19299,7 +19304,7 @@ msgstr ""
 msgid "Always keep"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4406
+#: lib/vutuv_web/components/ui.ex:4427
 #: lib/vutuv_web/controllers/settings_controller.ex:245
 #: lib/vutuv_web/controllers/settings_controller.ex:324
 #: lib/vutuv_web/controllers/settings_controller.ex:336
@@ -19396,7 +19401,7 @@ msgstr ""
 msgid "Keep posts that did well"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4408
+#: lib/vutuv_web/components/ui.ex:4429
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr ""
@@ -19505,7 +19510,7 @@ msgstr ""
 msgid "Your rule"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4410
+#: lib/vutuv_web/components/ui.ex:4431
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
@@ -19879,7 +19884,7 @@ msgstr ""
 msgid "Start over"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2446
+#: lib/vutuv_web/components/post_components.ex:2461
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -20771,49 +20776,43 @@ msgstr ""
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4117
+#: lib/vutuv_web/components/post_components.ex:4132
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4138
+#: lib/vutuv_web/components/post_components.ex:4168
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4147
+#: lib/vutuv_web/components/post_components.ex:4177
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4150
+#: lib/vutuv_web/components/post_components.ex:4180
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4127
+#: lib/vutuv_web/components/post_components.ex:4157
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:853
+#: lib/vutuv_web/live/feed_languages_live.ex:129
 #, elixir-autogen, elixir-format
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:824
-#, elixir-autogen, elixir-format
-msgid "Feed language settings saved."
-msgstr ""
-
-#: lib/vutuv_web/templates/settings/preferences.html.heex:193
+#: lib/vutuv_web/components/post_components.ex:4147
+#: lib/vutuv_web/components/ui.ex:4386
+#: lib/vutuv_web/live/feed_languages_live.ex:65
+#: lib/vutuv_web/live/feed_languages_live.ex:200
+#: lib/vutuv_web/templates/settings/preferences.html.heex:187
 #, elixir-autogen, elixir-format
 msgid "Feed languages"
-msgstr ""
-
-#: lib/vutuv_web/templates/settings/preferences.html.heex:195
-#, elixir-autogen, elixir-format
-msgid "Pick which languages your feed shows, and what happens to posts in other languages. Posts that declare no language always show."
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:83
@@ -20896,19 +20895,9 @@ msgstr ""
 msgid "ISO 8601 (Sweden, Japan, China)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4433
-#, elixir-autogen, elixir-format
-msgid "Interface language, date format and time zone, feed languages, maps, how posts are shortened"
-msgstr ""
-
 #: lib/vutuv_web/views/account_event_text.ex:48
 #, elixir-autogen, elixir-format
 msgid "Language & display settings changed"
-msgstr ""
-
-#: lib/vutuv_web/components/ui.ex:4437
-#, elixir-autogen, elixir-format
-msgid "german english locale translation translate map font length hyphenation feed languages hide foreign übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/verify.html.heex:42
@@ -20946,19 +20935,19 @@ msgstr ""
 msgid "Your username, or paste the address of your profile page."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3917
+#: lib/vutuv_web/components/post_components.ex:3932
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3914
+#: lib/vutuv_web/components/post_components.ex:3929
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3254
+#: lib/vutuv_web/components/post_components.ex:3269
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -20975,7 +20964,7 @@ msgstr ""
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1814
+#: lib/vutuv_web/live/post_live/feed.ex:1950
 #: lib/vutuv_web/views/user_html.ex:334
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -21027,7 +21016,7 @@ msgstr ""
 msgid "Mastodon app access changed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4454
+#: lib/vutuv_web/components/ui.ex:4475
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr ""
@@ -21073,7 +21062,7 @@ msgstr ""
 msgid "Your account is then %{handle}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4456
+#: lib/vutuv_web/components/ui.ex:4477
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr ""
@@ -21109,7 +21098,7 @@ msgstr ""
 msgid "Find your LinkedIn contacts"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4381
+#: lib/vutuv_web/components/ui.ex:4402
 #: lib/vutuv_web/live/import_connections_live.ex:64
 #: lib/vutuv_web/templates/import/new.html.heex:37
 #, elixir-autogen, elixir-format
@@ -21216,7 +21205,7 @@ msgstr ""
 msgid "See which of them are already on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4383
+#: lib/vutuv_web/components/ui.ex:4404
 #, elixir-autogen, elixir-format
 msgid "See which of your LinkedIn contacts are already on vutuv"
 msgstr ""
@@ -21288,24 +21277,9 @@ msgstr ""
 msgid "Your export also lists your LinkedIn contacts."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4385
+#: lib/vutuv_web/components/ui.ex:4406
 #, elixir-autogen, elixir-format
 msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
-msgstr ""
-
-#: lib/vutuv_web/views/settings_html.ex:173
-#, elixir-autogen, elixir-format
-msgid "Add another language"
-msgstr ""
-
-#: lib/vutuv_web/templates/settings/preferences.html.heex:208
-#, elixir-autogen, elixir-format
-msgid "Choosing none means: all languages."
-msgstr ""
-
-#: lib/vutuv_web/templates/settings/preferences.html.heex:205
-#, elixir-autogen, elixir-format
-msgid "These languages I read"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/activity.ex:91
@@ -21484,7 +21458,7 @@ msgstr ""
 msgid "This page is following the most accounts we allow (%{max})."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2297
+#: lib/vutuv_web/components/post_components.ex:2312
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr ""
@@ -21559,7 +21533,7 @@ msgstr ""
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4364
+#: lib/vutuv_web/components/ui.ex:4374
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr ""
@@ -21609,12 +21583,12 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1796
+#: lib/vutuv_web/live/post_live/feed.ex:1932
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1792
+#: lib/vutuv_web/live/post_live/feed.ex:1928
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr ""
@@ -21660,67 +21634,67 @@ msgstr ""
 msgid "With a vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1806
+#: lib/vutuv_web/live/post_live/feed.ex:1942
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:593
+#: lib/vutuv_web/components/post_components.ex:605
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new post"
 msgid_plural "%{formatted} new posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1251
+#: lib/vutuv_web/live/post_live/feed.ex:1387
 #, elixir-autogen, elixir-format
 msgid "%{source}: %{formatted} new post"
 msgid_plural "%{source}: %{formatted} new posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1248
+#: lib/vutuv_web/live/post_live/feed.ex:1384
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1245
+#: lib/vutuv_web/live/post_live/feed.ex:1381
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post from %{who}"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:297
+#: lib/vutuv_web/templates/settings/preferences.html.heex:247
 #, elixir-autogen, elixir-format
 msgid "Example"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:844
+#: lib/vutuv_web/controllers/settings_controller.ex:826
 #, elixir-autogen, elixir-format
 msgid "Feed tab settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:838
+#: lib/vutuv_web/controllers/settings_controller.ex:820
 #, elixir-autogen, elixir-format
 msgid "Feed tab settings saved."
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:89
-#: lib/vutuv_web/templates/settings/preferences.html.heex:263
+#: lib/vutuv_web/templates/settings/preferences.html.heex:213
 #, elixir-autogen, elixir-format
 msgid "Feed tabs"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:321
+#: lib/vutuv_web/templates/settings/preferences.html.heex:271
 #, elixir-autogen, elixir-format
 msgid "Just flashed the new release, boot is under two seconds now"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:331
+#: lib/vutuv_web/templates/settings/preferences.html.heex:281
 #, elixir-autogen, elixir-format
 msgid "Play the example"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:265
+#: lib/vutuv_web/templates/settings/preferences.html.heex:215
 #, elixir-autogen, elixir-format
 msgid "When a post lands on the source tab you are not reading, that tab gets a dot. It can also quote the post for a few seconds, so you can tell whether it is worth switching."
 msgstr ""
@@ -21745,97 +21719,97 @@ msgstr ""
 msgid "When off, a tab holding something new wears its dot and says nothing more."
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex
+#: lib/vutuv_web/live/feed_languages_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Rank the languages you read. Posts in them reach your feed as they were written; you decide below what happens to the rest."
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex:202
+#: lib/vutuv_web/live/feed_languages_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "Languages you read"
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex
+#: lib/vutuv_web/live/feed_languages_live.ex:218
 #, elixir-autogen, elixir-format
 msgid "No language chosen, so your feed shows all of them."
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex
+#: lib/vutuv_web/live/feed_languages_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "First: translations go into this language"
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex:265
+#: lib/vutuv_web/live/feed_languages_live.ex:278
 #, elixir-autogen, elixir-format
 msgid "Remove %{language}"
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex:277
+#: lib/vutuv_web/live/feed_languages_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "Suggested:"
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex:312
+#: lib/vutuv_web/live/feed_languages_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "Choose a language"
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex
+#: lib/vutuv_web/live/feed_languages_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "This installation has translations switched off, so posts in other languages show as written until an administrator turns them on."
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex:347
+#: lib/vutuv_web/live/feed_languages_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "What your feed does"
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex:387
+#: lib/vutuv_web/live/feed_languages_live.ex:403
 #, elixir-autogen, elixir-format
 msgid "Shown as written"
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex:395
+#: lib/vutuv_web/live/feed_languages_live.ex:411
 #, elixir-autogen, elixir-format
 msgid "Every language"
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex:395
+#: lib/vutuv_web/live/feed_languages_live.ex:411
 #, elixir-autogen, elixir-format
 msgid "Every other language"
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex
+#: lib/vutuv_web/live/feed_languages_live.ex:432
 #, elixir-autogen, elixir-format
 msgid "Nothing is hidden: hiding needs at least one language above."
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex:411
+#: lib/vutuv_web/live/feed_languages_live.ex:434
 #, elixir-autogen, elixir-format
 msgid "Hidden from your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex:421
+#: lib/vutuv_web/live/feed_languages_live.ex:440
 #, elixir-autogen, elixir-format
 msgid "Shown in the language it was written in."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex
+#: lib/vutuv_web/components/ui.ex:4387
 #, elixir-autogen, elixir-format
 msgid "Which languages reach you, and what happens to the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex
+#: lib/vutuv_web/components/ui.ex:4389
 #, elixir-autogen, elixir-format
 msgid "language translate translation german english original hide foreign rank order sprache übersetzen fremdsprache reihenfolge"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex
+#: lib/vutuv_web/components/ui.ex:4454
 #, elixir-autogen, elixir-format
 msgid "Interface language, date format and time zone, maps, how posts are shortened"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex
+#: lib/vutuv_web/components/ui.ex:4458
 #, elixir-autogen, elixir-format
 msgid "german english locale map font length hyphenation übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
 msgstr ""
@@ -21845,17 +21819,17 @@ msgstr ""
 msgid "Languages your feed shows"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex
+#: lib/vutuv_web/templates/settings/preferences.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Rank the languages you read, and say what happens to posts in the others."
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex
+#: lib/vutuv_web/live/feed_languages_live.ex:424
 #, elixir-autogen, elixir-format
 msgid "Translate into %{language}"
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex
+#: lib/vutuv_web/live/feed_languages_live.ex:437
 #, elixir-autogen, elixir-format
 msgid "Translated into %{language}."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -15,8 +15,8 @@ msgstr "Language: en\n"
 msgid "About us"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4081
-#: lib/vutuv_web/components/ui.ex:4086
+#: lib/vutuv_web/components/ui.ex:4091
+#: lib/vutuv_web/components/ui.ex:4096
 #: lib/vutuv_web/live/admin/screenshot_live.ex:255
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:718
 #: lib/vutuv_web/live/organization_live/domains.ex:272
@@ -62,7 +62,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:68
 #: lib/vutuv_web/agent_docs/text.ex:65
-#: lib/vutuv_web/components/ui.ex:4339
+#: lib/vutuv_web/components/ui.ex:4349
 #: lib/vutuv_web/controllers/address_controller.ex:23
 #: lib/vutuv_web/controllers/address_controller.ex:38
 #: lib/vutuv_web/controllers/address_controller.ex:85
@@ -81,8 +81,8 @@ msgstr ""
 msgid "Already a member? Sign in here."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3876
-#: lib/vutuv_web/components/ui.ex:3970
+#: lib/vutuv_web/components/ui.ex:3886
+#: lib/vutuv_web/components/ui.ex:3980
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:698
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:830
@@ -110,7 +110,7 @@ msgid "Birthday"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:110
-#: lib/vutuv_web/components/ui.ex:3870
+#: lib/vutuv_web/components/ui.ex:3880
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
@@ -160,8 +160,8 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3047
-#: lib/vutuv_web/components/ui.ex:3973
+#: lib/vutuv_web/components/post_components.ex:3062
+#: lib/vutuv_web/components/ui.ex:3983
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
@@ -209,8 +209,8 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3012
-#: lib/vutuv_web/components/ui.ex:3964
+#: lib/vutuv_web/components/post_components.ex:3027
+#: lib/vutuv_web/components/ui.ex:3974
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
@@ -284,7 +284,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:35
-#: lib/vutuv_web/components/ui.ex:4303
+#: lib/vutuv_web/components/ui.ex:4313
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -443,7 +443,7 @@ msgid "Log Out"
 msgstr ""
 
 #: lib/vutuv_web/live/shell_live.ex:1024
-#: lib/vutuv_web/live/shell_live.ex:1081
+#: lib/vutuv_web/live/shell_live.ex:1090
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -473,7 +473,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:620
+#: lib/vutuv_web/components/post_components.ex:632
 #: lib/vutuv_web/live/notification_live/index.ex:682
 #: lib/vutuv_web/live/organization_live/activity.ex:127
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
@@ -613,7 +613,7 @@ msgstr ""
 msgid "Public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3869
+#: lib/vutuv_web/components/ui.ex:3879
 #: lib/vutuv_web/live/organization_live/edit.ex:345
 #: lib/vutuv_web/live/post_live/composer.ex:1867
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -625,13 +625,12 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/notifications.html.heex:79
 #: lib/vutuv_web/templates/settings/preferences.html.heex:84
 #: lib/vutuv_web/templates/settings/preferences.html.heex:157
-#: lib/vutuv_web/templates/settings/preferences.html.heex:228
-#: lib/vutuv_web/templates/settings/preferences.html.heex:292
-#: lib/vutuv_web/templates/settings/preferences.html.heex:449
+#: lib/vutuv_web/templates/settings/preferences.html.heex:242
+#: lib/vutuv_web/templates/settings/preferences.html.heex:399
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:462
-#: lib/vutuv_web/views/settings_html.ex:301
+#: lib/vutuv_web/views/settings_html.ex:196
 #, elixir-autogen
 msgid "Save"
 msgstr ""
@@ -645,7 +644,7 @@ msgstr ""
 #: lib/vutuv_web/live/search_live.ex:48
 #: lib/vutuv_web/live/search_live.ex:569
 #: lib/vutuv_web/live/shell_live.ex:889
-#: lib/vutuv_web/live/shell_live.ex:1064
+#: lib/vutuv_web/live/shell_live.ex:1073
 #: lib/vutuv_web/live/tag_live/timeline.ex:283
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
@@ -655,7 +654,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1556
+#: lib/vutuv_web/components/post_components.ex:1568
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -791,7 +790,7 @@ msgstr ""
 msgid "User verified successfully."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4299
+#: lib/vutuv_web/components/ui.ex:4309
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
@@ -848,14 +847,14 @@ msgstr ""
 msgid "vCard"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4034
+#: lib/vutuv_web/components/ui.ex:4044
 #: lib/vutuv_web/templates/user/show.html.heex:967
 #: lib/vutuv_web/templates/user/show.html.heex:990
 #, elixir-autogen
 msgid "View All"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4396
+#: lib/vutuv_web/components/ui.ex:4417
 #: lib/vutuv_web/controllers/settings_controller.ex:169
 #: lib/vutuv_web/live/job_posting_live/form.ex:756
 #: lib/vutuv_web/live/organization_live/edit.ex:304
@@ -925,7 +924,7 @@ msgid "You follow back %{name}."
 msgstr ""
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:91
+#: lib/vutuv_web/live/post_live/feed.ex:100
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1375,7 +1374,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:516
 #: lib/vutuv_web/agent_docs/text.ex:753
-#: lib/vutuv_web/components/ui.ex:4324
+#: lib/vutuv_web/components/ui.ex:4334
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1597,7 +1596,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:1067
+#: lib/vutuv_web/live/shell_live.ex:1076
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1712,7 +1711,7 @@ msgid "It doesn't look like you're following anyone yet. Open the profile of som
 msgstr ""
 
 #: lib/vutuv_web/live/shell_live.ex:1015
-#: lib/vutuv_web/views/settings_html.ex:388
+#: lib/vutuv_web/views/settings_html.ex:283
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr ""
@@ -1741,7 +1740,7 @@ msgstr ""
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
 #: lib/vutuv_web/live/shell_live.ex:907
-#: lib/vutuv_web/live/shell_live.ex:1066
+#: lib/vutuv_web/live/shell_live.ex:1075
 #: lib/vutuv_web/templates/layout/app.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Messages"
@@ -1754,7 +1753,7 @@ msgid "Network"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:439
-#: lib/vutuv_web/components/ui.ex:4083
+#: lib/vutuv_web/components/ui.ex:4093
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:705
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:742
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:793
@@ -1770,7 +1769,7 @@ msgid "Nothing new yet."
 msgstr ""
 
 #: lib/vutuv/api_auth/scopes.ex:85
-#: lib/vutuv_web/components/ui.ex:4361
+#: lib/vutuv_web/components/ui.ex:4371
 #: lib/vutuv_web/live/notification_live/index.ex:132
 #: lib/vutuv_web/live/notification_live/index.ex:360
 #: lib/vutuv_web/live/shell_live.ex:919
@@ -1915,15 +1914,15 @@ msgstr ""
 msgid "started following you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3423
-#: lib/vutuv_web/components/ui.ex:3574
+#: lib/vutuv_web/components/ui.ex:3433
+#: lib/vutuv_web/components/ui.ex:3584
 #: lib/vutuv_web/live/import_connections_live.ex:638
 #: lib/vutuv_web/live/organization_live/index.ex:122
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4108
+#: lib/vutuv_web/components/ui.ex:4118
 #: lib/vutuv_web/live/organization_live/activity.ex:150
 #: lib/vutuv_web/live/organization_live/feed.ex:142
 #: lib/vutuv_web/live/organization_live/show.ex:647
@@ -1936,7 +1935,7 @@ msgstr ""
 msgid "The address itself cannot be changed. To use a different one, add it as a new email address and delete this one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3879
+#: lib/vutuv_web/components/ui.ex:3889
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
@@ -2104,7 +2103,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3044
+#: lib/vutuv_web/components/post_components.ex:3059
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2119,10 +2118,10 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:274
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:98
-#: lib/vutuv_web/live/post_live/feed.ex:196
-#: lib/vutuv_web/live/post_live/feed.ex:1514
+#: lib/vutuv_web/live/post_live/feed.ex:231
+#: lib/vutuv_web/live/post_live/feed.ex:1650
 #: lib/vutuv_web/live/shell_live.ex:769
-#: lib/vutuv_web/live/shell_live.ex:1062
+#: lib/vutuv_web/live/shell_live.ex:1068
 #: lib/vutuv_web/templates/layout/app.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2148,8 +2147,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2998
-#: lib/vutuv_web/components/post_components.ex:3000
+#: lib/vutuv_web/components/post_components.ex:3013
+#: lib/vutuv_web/components/post_components.ex:3015
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2165,7 +2164,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1722
+#: lib/vutuv_web/live/post_live/feed.ex:1858
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2209,19 +2208,19 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:520
 #: lib/vutuv_web/live/search_live.ex:281
 #: lib/vutuv_web/live/search_live.ex:728
-#: lib/vutuv_web/templates/settings/preferences.html.heex:362
+#: lib/vutuv_web/templates/settings/preferences.html.heex:312
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3468
-#: lib/vutuv_web/components/post_components.ex:3472
+#: lib/vutuv_web/components/post_components.ex:3483
+#: lib/vutuv_web/components/post_components.ex:3487
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3469
+#: lib/vutuv_web/components/post_components.ex:3484
 #: lib/vutuv_web/live/fediverse_account_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2229,7 +2228,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:376
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:1178
+#: lib/vutuv_web/components/post_components.ex:1190
 #: lib/vutuv_web/live/admin/screenshot_live.ex:327
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:700
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
@@ -2240,7 +2239,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:650
 #: lib/vutuv_web/live/post_live/saved.ex:678
 #: lib/vutuv_web/templates/connection/index.html.heex:40
-#: lib/vutuv_web/views/settings_html.ex:434
+#: lib/vutuv_web/views/settings_html.ex:329
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
@@ -2255,7 +2254,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1626
+#: lib/vutuv_web/live/post_live/feed.ex:1762
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2292,11 +2291,11 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4650
+#: lib/vutuv_web/components/ui.ex:4671
 #: lib/vutuv_web/live/shell_live.ex:962
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
-#: lib/vutuv_web/views/settings_html.ex:335
+#: lib/vutuv_web/views/settings_html.ex:230
 #, elixir-autogen, elixir-format
 msgid "View profile"
 msgstr ""
@@ -2311,33 +2310,33 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2995
+#: lib/vutuv_web/components/post_components.ex:3010
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4788
+#: lib/vutuv_web/components/post_components.ex:4818
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4792
+#: lib/vutuv_web/components/post_components.ex:4822
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4790
+#: lib/vutuv_web/components/post_components.ex:4820
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4791
+#: lib/vutuv_web/components/post_components.ex:4821
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
 
 #: lib/vutuv_web/views/post_html.ex:19
-#: lib/vutuv_web/views/settings_html.ex:513
+#: lib/vutuv_web/views/settings_html.ex:408
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr ""
@@ -2372,9 +2371,9 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1771
-#: lib/vutuv_web/components/post_components.ex:4884
-#: lib/vutuv_web/components/ui.ex:3498
+#: lib/vutuv_web/components/post_components.ex:1783
+#: lib/vutuv_web/components/post_components.ex:4914
+#: lib/vutuv_web/components/ui.ex:3508
 #: lib/vutuv_web/views/user_html.ex:453
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2391,9 +2390,9 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1724
-#: lib/vutuv_web/components/post_components.ex:5120
-#: lib/vutuv_web/components/ui.ex:3484
+#: lib/vutuv_web/components/post_components.ex:1736
+#: lib/vutuv_web/components/post_components.ex:5150
+#: lib/vutuv_web/components/ui.ex:3494
 #: lib/vutuv_web/live/notification_live/index.ex:1072
 #: lib/vutuv_web/views/user_html.ex:463
 #, elixir-autogen, elixir-format
@@ -2401,7 +2400,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1107
-#: lib/vutuv_web/components/post_components.ex:5130
+#: lib/vutuv_web/components/post_components.ex:5160
 #: lib/vutuv_web/live/notification_live/index.ex:1005
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
@@ -2423,40 +2422,40 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4872
+#: lib/vutuv_web/components/post_components.ex:4902
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1770
-#: lib/vutuv_web/components/post_components.ex:4883
+#: lib/vutuv_web/components/post_components.ex:1782
+#: lib/vutuv_web/components/post_components.ex:4913
 #: lib/vutuv_web/live/post_live/saved.ex:806
 #: lib/vutuv_web/views/user_html.ex:453
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1752
-#: lib/vutuv_web/components/post_components.ex:4869
+#: lib/vutuv_web/components/post_components.ex:1764
+#: lib/vutuv_web/components/post_components.ex:4899
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2017
-#: lib/vutuv_web/components/post_components.ex:4050
+#: lib/vutuv_web/components/post_components.ex:2029
+#: lib/vutuv_web/components/post_components.ex:4065
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1751
-#: lib/vutuv_web/components/post_components.ex:4868
+#: lib/vutuv_web/components/post_components.ex:1763
+#: lib/vutuv_web/components/post_components.ex:4898
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1723
-#: lib/vutuv_web/components/post_components.ex:5119
+#: lib/vutuv_web/components/post_components.ex:1735
+#: lib/vutuv_web/components/post_components.ex:5149
 #: lib/vutuv_web/live/post_live/saved.ex:805
 #: lib/vutuv_web/views/user_html.ex:463
 #, elixir-autogen, elixir-format
@@ -2464,14 +2463,14 @@ msgid "Unlike"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:377
-#: lib/vutuv_web/components/post_components.ex:2302
+#: lib/vutuv_web/components/post_components.ex:2317
 #: lib/vutuv_web/components/ui.ex:2388
 #: lib/vutuv_web/components/ui.ex:2388
 #: lib/vutuv_web/components/ui.ex:2525
 #: lib/vutuv_web/live/organization_live/following.ex:378
 #: lib/vutuv_web/live/organization_live/following.ex:453
 #: lib/vutuv_web/live/organization_live/show.ex:474
-#: lib/vutuv_web/live/post_live/feed.ex:1771
+#: lib/vutuv_web/live/post_live/feed.ex:1907
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2483,7 +2482,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5174
+#: lib/vutuv_web/components/post_components.ex:5204
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2494,16 +2493,16 @@ msgstr ""
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1737
-#: lib/vutuv_web/components/post_components.ex:5157
-#: lib/vutuv_web/components/post_components.ex:5158
+#: lib/vutuv_web/components/post_components.ex:1749
+#: lib/vutuv_web/components/post_components.ex:5187
+#: lib/vutuv_web/components/post_components.ex:5188
 #: lib/vutuv_web/live/notification_live/index.ex:1069
 #: lib/vutuv_web/live/post_live/reply.ex:43
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2962
+#: lib/vutuv_web/components/post_components.ex:2977
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2524,7 +2523,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2498
+#: lib/vutuv_web/components/post_components.ex:2513
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:60
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:57
@@ -2532,14 +2531,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2936
+#: lib/vutuv_web/components/post_components.ex:2951
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2927
-#: lib/vutuv_web/components/post_components.ex:2954
-#: lib/vutuv_web/components/post_components.ex:2957
+#: lib/vutuv_web/components/post_components.ex:2942
+#: lib/vutuv_web/components/post_components.ex:2969
+#: lib/vutuv_web/components/post_components.ex:2972
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2748,11 +2747,12 @@ msgstr ""
 msgid "Write your first post"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3662
-#: lib/vutuv_web/components/ui.ex:4036
+#: lib/vutuv_web/components/ui.ex:3672
+#: lib/vutuv_web/components/ui.ex:4046
 #: lib/vutuv_web/templates/settings/apps.html.heex:22
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #: lib/vutuv_web/templates/settings/organizations.html.heex:104
+#: lib/vutuv_web/templates/settings/preferences.html.heex:195
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:216
@@ -2761,7 +2761,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1552
+#: lib/vutuv_web/live/post_live/feed.ex:1688
 #: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2782,7 +2782,7 @@ msgid_plural "%{formatted} connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1873
+#: lib/vutuv_web/live/post_live/feed.ex:2009
 #: lib/vutuv_web/templates/user/card_list.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -2837,7 +2837,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4789
+#: lib/vutuv_web/components/post_components.ex:4819
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3100,7 +3100,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2903
+#: lib/vutuv_web/components/post_components.ex:2918
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3149,9 +3149,9 @@ msgstr ""
 msgid "Private message"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4293
+#: lib/vutuv_web/components/ui.ex:4303
 #: lib/vutuv_web/live/shell_live.ex:783
-#: lib/vutuv_web/live/shell_live.ex:1071
+#: lib/vutuv_web/live/shell_live.ex:1080
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -3175,9 +3175,9 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1188
-#: lib/vutuv_web/components/post_components.ex:2314
-#: lib/vutuv_web/components/post_components.ex:3067
+#: lib/vutuv_web/components/post_components.ex:1200
+#: lib/vutuv_web/components/post_components.ex:2329
+#: lib/vutuv_web/components/post_components.ex:3082
 #: lib/vutuv_web/live/organization_live/show.ex:547
 #: lib/vutuv_web/templates/user/show.html.heex:222
 #, elixir-autogen, elixir-format
@@ -3260,7 +3260,7 @@ msgstr ""
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3398
+#: lib/vutuv_web/components/ui.ex:3408
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:773
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -4501,7 +4501,7 @@ msgstr ""
 msgid "Block @%{slug}? This removes any follows and connection between you, closes your conversation, and prevents all interaction in both directions. Unblocking will not restore what was removed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4400
+#: lib/vutuv_web/components/ui.ex:4421
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -4543,7 +4543,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1727
+#: lib/vutuv_web/live/post_live/feed.ex:1863
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -4627,7 +4627,7 @@ msgstr ""
 #: lib/vutuv_web/live/import_connections_live.ex:470
 #: lib/vutuv_web/live/notification_live/index.ex:925
 #: lib/vutuv_web/live/search_live.ex:278
-#: lib/vutuv_web/templates/settings/preferences.html.heex:304
+#: lib/vutuv_web/templates/settings/preferences.html.heex:254
 #: lib/vutuv_web/views/qualification_html.ex:103
 #, elixir-autogen, elixir-format
 msgid "All"
@@ -4675,7 +4675,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:388
 #: lib/vutuv_web/live/tag_new_live.ex:48
-#: lib/vutuv_web/live/user_profile_live.ex:1332
+#: lib/vutuv_web/live/user_profile_live.ex:1336
 #: lib/vutuv_web/templates/user/show.html.heex:594
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
@@ -4910,8 +4910,8 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/api_app_live.ex:98
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:181
-#: lib/vutuv_web/views/settings_html.ex:77
-#: lib/vutuv_web/views/settings_html.ex:379
+#: lib/vutuv_web/views/settings_html.ex:75
+#: lib/vutuv_web/views/settings_html.ex:274
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
@@ -5269,7 +5269,7 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4460
+#: lib/vutuv_web/components/ui.ex:4481
 #: lib/vutuv_web/controllers/settings_controller.ex:155
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5348,10 +5348,10 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4557
-#: lib/vutuv_web/components/ui.ex:4562
-#: lib/vutuv_web/components/ui.ex:4641
-#: lib/vutuv_web/components/ui.ex:4705
+#: lib/vutuv_web/components/ui.ex:4578
+#: lib/vutuv_web/components/ui.ex:4583
+#: lib/vutuv_web/components/ui.ex:4662
+#: lib/vutuv_web/components/ui.ex:4726
 #: lib/vutuv_web/controllers/settings_controller.ex:62
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5364,7 +5364,7 @@ msgstr ""
 #: lib/vutuv_web/templates/login_code/index.html.heex:4
 #: lib/vutuv_web/templates/totp/new.html.heex:4
 #: lib/vutuv_web/templates/username/confirm.html.heex:23
-#: lib/vutuv_web/views/settings_html.ex:330
+#: lib/vutuv_web/views/settings_html.ex:225
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -5395,7 +5395,7 @@ msgstr ""
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1338
+#: lib/vutuv_web/live/user_profile_live.ex:1342
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr ""
@@ -5421,11 +5421,11 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3132
-#: lib/vutuv_web/components/post_components.ex:3186
-#: lib/vutuv_web/components/post_components.ex:3605
+#: lib/vutuv_web/components/post_components.ex:3147
+#: lib/vutuv_web/components/post_components.ex:3201
+#: lib/vutuv_web/components/post_components.ex:3620
 #: lib/vutuv_web/live/notification_live/index.ex:726
-#: lib/vutuv_web/live/post_live/feed.ex:1914
+#: lib/vutuv_web/live/post_live/feed.ex:2050
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5470,7 +5470,7 @@ msgstr ""
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4420
+#: lib/vutuv_web/components/ui.ex:4441
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:289
@@ -5491,7 +5491,7 @@ msgstr ""
 msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4331
+#: lib/vutuv_web/components/ui.ex:4341
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "Photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4394
+#: lib/vutuv_web/components/ui.ex:4415
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/templates/page/index.html.heex:174
 #, elixir-autogen, elixir-format
@@ -5638,7 +5638,7 @@ msgstr ""
 msgid "Apps"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4453
+#: lib/vutuv_web/components/ui.ex:4474
 #: lib/vutuv_web/controllers/settings_controller.ex:179
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -5843,28 +5843,28 @@ msgid "Sort"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/views/settings_html.ex:522
+#: lib/vutuv_web/views/settings_html.ex:417
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:521
+#: lib/vutuv_web/views/settings_html.ex:416
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:520
+#: lib/vutuv_web/views/settings_html.ex:415
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:930
+#: lib/vutuv_web/controllers/settings_controller.ex:901
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr ""
@@ -5874,7 +5874,7 @@ msgstr ""
 msgid "Another session was already active on your account."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:368
+#: lib/vutuv_web/views/settings_html.ex:263
 #, elixir-autogen, elixir-format
 msgid "Last active"
 msgstr ""
@@ -5889,7 +5889,7 @@ msgstr ""
 msgid "Log out of every device except this one?"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:385
+#: lib/vutuv_web/views/settings_html.ex:280
 #, elixir-autogen, elixir-format
 msgid "Log this device out of your account?"
 msgstr ""
@@ -5904,7 +5904,7 @@ msgstr ""
 msgid "Signed-in devices"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:917
+#: lib/vutuv_web/controllers/settings_controller.ex:888
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr ""
@@ -5914,7 +5914,7 @@ msgstr ""
 msgid "The location looks different from where you usually sign in."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:369
+#: lib/vutuv_web/views/settings_html.ex:264
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr ""
@@ -5924,7 +5924,7 @@ msgstr ""
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:519
+#: lib/vutuv_web/views/settings_html.ex:414
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr ""
@@ -5958,7 +5958,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
 #: lib/vutuv_web/live/admin/screenshot_live.ex:309
 #: lib/vutuv_web/live/fediverse_following_live.ex:291
-#: lib/vutuv_web/views/settings_html.ex:420
+#: lib/vutuv_web/views/settings_html.ex:315
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr ""
@@ -5968,7 +5968,7 @@ msgstr ""
 msgid "Could not add the passkey. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:423
+#: lib/vutuv_web/views/settings_html.ex:318
 #, elixir-autogen, elixir-format
 msgid "Last used"
 msgstr ""
@@ -5978,7 +5978,7 @@ msgstr ""
 msgid "Name (optional)"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:417
+#: lib/vutuv_web/views/settings_html.ex:312
 #, elixir-autogen, elixir-format
 msgid "Passkey"
 msgstr ""
@@ -5998,7 +5998,7 @@ msgstr ""
 msgid "Passkeys"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:431
+#: lib/vutuv_web/views/settings_html.ex:326
 #, elixir-autogen, elixir-format
 msgid "Remove this passkey?"
 msgstr ""
@@ -6054,7 +6054,7 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1343
+#: lib/vutuv_web/live/user_profile_live.ex:1347
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr ""
@@ -6228,6 +6228,7 @@ msgstr ""
 msgid "View all phone numbers"
 msgstr ""
 
+#: lib/vutuv_web/live/feed_languages_live.ex:235
 #: lib/vutuv_web/live/section_reorder_live.ex:127
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder"
@@ -6238,11 +6239,13 @@ msgstr ""
 msgid "Drag to reorder, or use the arrows. The order is the one shown on your profile."
 msgstr ""
 
+#: lib/vutuv_web/live/feed_languages_live.ex:267
 #: lib/vutuv_web/live/section_reorder_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "Move down"
 msgstr ""
 
+#: lib/vutuv_web/live/feed_languages_live.ex:256
 #: lib/vutuv_web/live/section_reorder_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -6606,8 +6609,8 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2282
-#: lib/vutuv_web/components/post_components.ex:3064
+#: lib/vutuv_web/components/post_components.ex:2297
+#: lib/vutuv_web/components/post_components.ex:3079
 #: lib/vutuv_web/components/ui.ex:2713
 #: lib/vutuv_web/live/fediverse_account_live.ex:381
 #: lib/vutuv_web/live/organization_live/following.ex:371
@@ -6634,7 +6637,7 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3064
+#: lib/vutuv_web/components/post_components.ex:3079
 #: lib/vutuv_web/components/ui.ex:2712
 #: lib/vutuv_web/live/fediverse_account_live.ex:379
 #: lib/vutuv_web/live/organization_live/following.ex:371
@@ -7119,7 +7122,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:816
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:44
 #: lib/vutuv_web/templates/settings/filters.html.heex:22
-#: lib/vutuv_web/views/settings_html.ex:61
+#: lib/vutuv_web/views/settings_html.ex:59
 #, elixir-autogen, elixir-format
 msgid "Tag"
 msgstr ""
@@ -7259,13 +7262,13 @@ msgstr ""
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3436
+#: lib/vutuv_web/components/ui.ex:3446
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3452
+#: lib/vutuv_web/components/ui.ex:3462
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7344,7 +7347,7 @@ msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:5030
+#: lib/vutuv_web/components/post_components.ex:5060
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -7819,42 +7822,42 @@ msgstr ""
 msgid "Send the email"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:111
+#: lib/vutuv_web/views/settings_html.ex:109
 #, elixir-autogen
 msgid "As soon as possible"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:112
+#: lib/vutuv_web/views/settings_html.ex:110
 #, elixir-autogen
 msgid "After 5 minutes"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:113
+#: lib/vutuv_web/views/settings_html.ex:111
 #, elixir-autogen
 msgid "After 15 minutes"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:114
+#: lib/vutuv_web/views/settings_html.ex:112
 #, elixir-autogen
 msgid "After 30 minutes"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:115
+#: lib/vutuv_web/views/settings_html.ex:113
 #, elixir-autogen
 msgid "After 1 hour"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:116
+#: lib/vutuv_web/views/settings_html.ex:114
 #, elixir-autogen
 msgid "After 2 hours"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:95
+#: lib/vutuv_web/views/settings_html.ex:93
 #, elixir-autogen
 msgid "Only the first message"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:96
+#: lib/vutuv_web/views/settings_html.ex:94
 #, elixir-autogen
 msgid "Every message"
 msgstr ""
@@ -7895,7 +7898,7 @@ msgid "Admins"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:1882
+#: lib/vutuv_web/live/post_live/feed.ex:2018
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr ""
@@ -8019,7 +8022,7 @@ msgstr ""
 msgid "PIN registered"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3439
+#: lib/vutuv_web/components/ui.ex:3449
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr ""
@@ -8149,7 +8152,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:42
 #: lib/vutuv_web/agent_docs/text.ex:39
-#: lib/vutuv_web/components/ui.ex:4307
+#: lib/vutuv_web/components/ui.ex:4317
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8204,7 +8207,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4441
+#: lib/vutuv_web/components/ui.ex:4462
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8233,7 +8236,7 @@ msgstr ""
 msgid "Nothing new to import."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4335
+#: lib/vutuv_web/components/ui.ex:4345
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8327,7 +8330,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3708
+#: lib/vutuv_web/components/ui.ex:3718
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8402,13 +8405,13 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4295
+#: lib/vutuv_web/components/ui.ex:4305
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4431
+#: lib/vutuv_web/components/ui.ex:4452
 #: lib/vutuv_web/controllers/settings_controller.ex:123
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8420,7 +8423,7 @@ msgstr ""
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4422
+#: lib/vutuv_web/components/ui.ex:4443
 #: lib/vutuv_web/controllers/settings_controller.ex:106
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -8430,7 +8433,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4445
+#: lib/vutuv_web/components/ui.ex:4466
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8452,12 +8455,12 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1899
+#: lib/vutuv_web/live/post_live/feed.ex:2035
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1895
+#: lib/vutuv_web/live/post_live/feed.ex:2031
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr ""
@@ -8646,7 +8649,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:584
 #: lib/vutuv_web/components/organization_components.ex:285
 #: lib/vutuv_web/components/ui.ex:1282
-#: lib/vutuv_web/components/ui.ex:4412
+#: lib/vutuv_web/components/ui.ex:4433
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:355
 #: lib/vutuv_web/controllers/settings_controller.ex:422
@@ -8801,7 +8804,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4053
+#: lib/vutuv_web/components/post_components.ex:4068
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9049,6 +9052,7 @@ msgstr ""
 msgid "A2 (Elementary)"
 msgstr ""
 
+#: lib/vutuv_web/live/feed_languages_live.ex:317
 #: lib/vutuv_web/templates/language/manage.html.heex:8
 #: lib/vutuv_web/templates/language/new.html.heex:5
 #: lib/vutuv_web/templates/user/show.html.heex:749
@@ -9222,6 +9226,7 @@ msgid "Irish"
 msgstr ""
 
 #: lib/vutuv/languages.ex:125
+#: lib/vutuv_web/templates/settings/preferences.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "Italian"
 msgstr ""
@@ -9462,7 +9467,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1162
+#: lib/vutuv/accounts/user.ex:1167
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9473,7 +9478,7 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1159
+#: lib/vutuv/accounts/user.ex:1164
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -9588,7 +9593,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:46
 #: lib/vutuv_web/agent_docs/text.ex:43
-#: lib/vutuv_web/components/ui.ex:4311
+#: lib/vutuv_web/components/ui.ex:4321
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:132
@@ -9782,13 +9787,13 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3182
+#: lib/vutuv_web/components/ui.ex:3185
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3181
-#: lib/vutuv_web/components/ui.ex:3185
+#: lib/vutuv_web/components/ui.ex:3184
+#: lib/vutuv_web/components/ui.ex:3188
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr ""
@@ -10498,46 +10503,46 @@ msgid_plural "You have %{formatted} new messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:433
+#: lib/vutuv_web/templates/settings/preferences.html.heex:383
 #, elixir-autogen, elixir-format
 msgid "Break long words at syllable points so the text wraps evenly. Helpful in the narrow phone column."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:364
+#: lib/vutuv_web/templates/settings/preferences.html.heex:314
 #, elixir-autogen, elixir-format
 msgid "How posts you read are shortened in your feed and on profiles. These are your own reading preferences."
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:68
-#: lib/vutuv_web/templates/settings/preferences.html.heex:440
+#: lib/vutuv_web/templates/settings/preferences.html.heex:390
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on desktop"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:69
-#: lib/vutuv_web/templates/settings/preferences.html.heex:444
+#: lib/vutuv_web/templates/settings/preferences.html.heex:394
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on mobile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:430
+#: lib/vutuv_web/templates/settings/preferences.html.heex:380
 #, elixir-autogen, elixir-format
 msgid "Hyphenation"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:66
-#: lib/vutuv_web/templates/settings/preferences.html.heex:387
+#: lib/vutuv_web/templates/settings/preferences.html.heex:337
 #, elixir-autogen, elixir-format
 msgid "Lines on desktop"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:67
-#: lib/vutuv_web/templates/settings/preferences.html.heex:396
+#: lib/vutuv_web/templates/settings/preferences.html.heex:346
 #, elixir-autogen, elixir-format
 msgid "Lines on mobile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:382
+#: lib/vutuv_web/templates/settings/preferences.html.heex:332
 #, elixir-autogen, elixir-format
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
@@ -10547,7 +10552,7 @@ msgstr ""
 msgid "Post display settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:379
+#: lib/vutuv_web/templates/settings/preferences.html.heex:329
 #, elixir-autogen, elixir-format
 msgid "Shorten a post after"
 msgstr ""
@@ -10632,11 +10637,11 @@ msgstr ""
 msgid "Preferences of %{name}"
 msgstr ""
 
+#: lib/vutuv_web/live/feed_languages_live.ex:377
 #: lib/vutuv_web/templates/settings/preferences.html.heex:101
 #: lib/vutuv_web/templates/settings/preferences.html.heex:174
-#: lib/vutuv_web/templates/settings/preferences.html.heex:245
-#: lib/vutuv_web/templates/settings/preferences.html.heex:346
-#: lib/vutuv_web/templates/settings/preferences.html.heex:464
+#: lib/vutuv_web/templates/settings/preferences.html.heex:296
+#: lib/vutuv_web/templates/settings/preferences.html.heex:414
 #, elixir-autogen, elixir-format
 msgid "Reset to the site defaults"
 msgstr ""
@@ -10827,19 +10832,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1200
+#: lib/vutuv/accounts/user.ex:1205
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1205
+#: lib/vutuv/accounts/user.ex:1210
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1203
+#: lib/vutuv/accounts/user.ex:1208
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:761
 #, elixir-autogen, elixir-format
@@ -11829,7 +11834,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:419
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:394
-#: lib/vutuv_web/components/ui.ex:4449
+#: lib/vutuv_web/components/ui.ex:4470
 #: lib/vutuv_web/controllers/settings_controller.ex:211
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
@@ -12137,7 +12142,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1174
+#: lib/vutuv/accounts/user.ex:1179
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12256,7 +12261,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1173
+#: lib/vutuv/accounts/user.ex:1178
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12338,7 +12343,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1175
+#: lib/vutuv/accounts/user.ex:1180
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:564
 #: lib/vutuv_web/agent_docs/markdown.ex:458
@@ -12583,12 +12588,12 @@ msgstr ""
 msgid "Browse all organizations"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:74
+#: lib/vutuv_web/views/settings_html.ex:72
 #, elixir-autogen, elixir-format
 msgid "Under review"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:76
+#: lib/vutuv_web/views/settings_html.ex:74
 #, elixir-autogen, elixir-format
 msgid "Verification pending"
 msgstr ""
@@ -13040,7 +13045,7 @@ msgstr ""
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4389
+#: lib/vutuv_web/components/ui.ex:4410
 #: lib/vutuv_web/controllers/settings_controller.ex:600
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -13059,7 +13064,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2457
+#: lib/vutuv_web/components/post_components.ex:2472
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:695
 #: lib/vutuv_web/controllers/settings_controller.ex:713
@@ -13353,7 +13358,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1218
+#: lib/vutuv/accounts/user.ex:1223
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13364,19 +13369,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1221
+#: lib/vutuv/accounts/user.ex:1226
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1224
+#: lib/vutuv/accounts/user.ex:1229
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1215
+#: lib/vutuv/accounts/user.ex:1220
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13498,16 +13503,16 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4372
+#: lib/vutuv_web/components/ui.ex:4393
 #: lib/vutuv_web/controllers/settings_controller.ex:614
-#: lib/vutuv_web/live/post_live/feed.ex:1757
+#: lib/vutuv_web/live/post_live/feed.ex:1893
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1772
+#: lib/vutuv_web/live/post_live/feed.ex:1908
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr ""
@@ -13578,7 +13583,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:60
 #: lib/vutuv_web/agent_docs/text.ex:57
-#: lib/vutuv_web/components/ui.ex:4354
+#: lib/vutuv_web/components/ui.ex:4364
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -13606,14 +13611,14 @@ msgstr ""
 msgid "Select a messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3794
+#: lib/vutuv_web/components/ui.ex:3804
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:3804
+#: lib/vutuv_web/components/ui.ex:3814
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
@@ -13663,34 +13668,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4651
+#: lib/vutuv_web/components/post_components.ex:4681
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1196
-#: lib/vutuv_web/components/post_components.ex:4608
+#: lib/vutuv_web/components/post_components.ex:4638
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4652
+#: lib/vutuv_web/components/post_components.ex:4682
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4654
+#: lib/vutuv_web/components/post_components.ex:4684
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4650
+#: lib/vutuv_web/components/post_components.ex:4680
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1196
-#: lib/vutuv_web/components/post_components.ex:4607
+#: lib/vutuv_web/components/post_components.ex:4637
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13701,12 +13706,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4649
+#: lib/vutuv_web/components/post_components.ex:4679
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4653
+#: lib/vutuv_web/components/post_components.ex:4683
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13726,7 +13731,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4690
+#: lib/vutuv_web/components/post_components.ex:4720
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13734,27 +13739,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4720
+#: lib/vutuv_web/components/post_components.ex:4750
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4721
+#: lib/vutuv_web/components/post_components.ex:4751
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4719
+#: lib/vutuv_web/components/post_components.ex:4749
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4679
+#: lib/vutuv_web/components/post_components.ex:4709
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4726
+#: lib/vutuv_web/components/post_components.ex:4756
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13784,7 +13789,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4493
+#: lib/vutuv_web/components/post_components.ex:4523
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13832,7 +13837,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4484
+#: lib/vutuv_web/components/post_components.ex:4514
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -13972,7 +13977,7 @@ msgid "proof document"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:74
-#: lib/vutuv_web/templates/settings/preferences.html.heex:418
+#: lib/vutuv_web/templates/settings/preferences.html.heex:368
 #, elixir-autogen, elixir-format
 msgid "Lines in notifications"
 msgstr ""
@@ -13982,12 +13987,12 @@ msgstr ""
 msgid "How much of a post a notification quotes before it is cut off."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:409
+#: lib/vutuv_web/templates/settings/preferences.html.heex:359
 #, elixir-autogen, elixir-format
 msgid "Quoted posts in notifications"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:412
+#: lib/vutuv_web/templates/settings/preferences.html.heex:362
 #, elixir-autogen, elixir-format
 msgid "Your notifications quote the post someone liked or replied to. Leave the field empty to follow the site default."
 msgstr ""
@@ -14184,7 +14189,7 @@ msgstr ""
 msgid "No accounts are currently frozen."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:460
+#: lib/vutuv_web/live/post_live/thread.ex:464
 #, elixir-autogen, elixir-format
 msgid "Read it from the start"
 msgstr ""
@@ -14204,14 +14209,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2730
+#: lib/vutuv_web/components/post_components.ex:2745
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2753
+#: lib/vutuv_web/components/post_components.ex:2768
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14223,7 +14228,7 @@ msgstr[1] ""
 msgid "This page is no longer available."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:452
+#: lib/vutuv_web/live/post_live/thread.ex:456
 #, elixir-autogen, elixir-format
 msgid "This post is part of a conversation with %{formatted} posts."
 msgstr ""
@@ -14238,7 +14243,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5129
+#: lib/vutuv_web/components/post_components.ex:5159
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14385,7 +14390,7 @@ msgstr ""
 msgid "Filter removed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:472
+#: lib/vutuv_web/live/post_live/feed.ex:509
 #, elixir-autogen, elixir-format
 msgid "Hidden: matches your filter"
 msgstr ""
@@ -14400,7 +14405,7 @@ msgstr ""
 msgid "Match whole words only (word/phrase)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4368
+#: lib/vutuv_web/components/ui.ex:4378
 #: lib/vutuv_web/controllers/settings_controller.ex:680
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -14418,7 +14423,7 @@ msgstr ""
 msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:481
+#: lib/vutuv_web/live/post_live/feed.ex:518
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr ""
@@ -14469,12 +14474,12 @@ msgid "When someone replies anywhere in a thread you have written in, you hear a
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/filters.html.heex:19
-#: lib/vutuv_web/views/settings_html.ex:62
+#: lib/vutuv_web/views/settings_html.ex:60
 #, elixir-autogen, elixir-format
 msgid "Word or phrase"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:65
+#: lib/vutuv_web/views/settings_html.ex:63
 #, elixir-autogen, elixir-format
 msgid "Word or phrase (whole word)"
 msgstr ""
@@ -15033,252 +15038,252 @@ msgstr ""
 msgid "moved to %{address}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4296
+#: lib/vutuv_web/components/ui.ex:4306
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4301
+#: lib/vutuv_web/components/ui.ex:4311
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4304
+#: lib/vutuv_web/components/ui.ex:4314
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4305
+#: lib/vutuv_web/components/ui.ex:4315
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4308
+#: lib/vutuv_web/components/ui.ex:4318
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4309
+#: lib/vutuv_web/components/ui.ex:4319
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4312
+#: lib/vutuv_web/components/ui.ex:4322
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4313
+#: lib/vutuv_web/components/ui.ex:4323
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4320
+#: lib/vutuv_web/components/ui.ex:4330
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4321
+#: lib/vutuv_web/components/ui.ex:4331
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4322
+#: lib/vutuv_web/components/ui.ex:4332
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4325
+#: lib/vutuv_web/components/ui.ex:4335
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4326
+#: lib/vutuv_web/components/ui.ex:4336
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4450
+#: lib/vutuv_web/components/ui.ex:4471
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4451
+#: lib/vutuv_web/components/ui.ex:4472
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4329
+#: lib/vutuv_web/components/ui.ex:4339
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4332
+#: lib/vutuv_web/components/ui.ex:4342
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4333
+#: lib/vutuv_web/components/ui.ex:4343
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4336
+#: lib/vutuv_web/components/ui.ex:4346
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4337
+#: lib/vutuv_web/components/ui.ex:4347
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4340
+#: lib/vutuv_web/components/ui.ex:4350
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4341
+#: lib/vutuv_web/components/ui.ex:4351
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4343
+#: lib/vutuv_web/components/ui.ex:4353
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4344
+#: lib/vutuv_web/components/ui.ex:4354
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4345
+#: lib/vutuv_web/components/ui.ex:4355
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4347
+#: lib/vutuv_web/components/ui.ex:4357
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4348
+#: lib/vutuv_web/components/ui.ex:4358
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4350
+#: lib/vutuv_web/components/ui.ex:4360
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4355
+#: lib/vutuv_web/components/ui.ex:4365
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4356
+#: lib/vutuv_web/components/ui.ex:4366
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4359
+#: lib/vutuv_web/components/ui.ex:4369
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4362
+#: lib/vutuv_web/components/ui.ex:4372
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4369
+#: lib/vutuv_web/components/ui.ex:4379
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4370
+#: lib/vutuv_web/components/ui.ex:4380
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4373
+#: lib/vutuv_web/components/ui.ex:4394
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4374
+#: lib/vutuv_web/components/ui.ex:4395
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4390
+#: lib/vutuv_web/components/ui.ex:4411
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4391
+#: lib/vutuv_web/components/ui.ex:4412
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4397
+#: lib/vutuv_web/components/ui.ex:4418
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4398
+#: lib/vutuv_web/components/ui.ex:4419
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4401
+#: lib/vutuv_web/components/ui.ex:4422
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4402
+#: lib/vutuv_web/components/ui.ex:4423
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4423
+#: lib/vutuv_web/components/ui.ex:4444
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4424
+#: lib/vutuv_web/components/ui.ex:4445
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4442
+#: lib/vutuv_web/components/ui.ex:4463
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4443
+#: lib/vutuv_web/components/ui.ex:4464
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4446
+#: lib/vutuv_web/components/ui.ex:4467
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4447
+#: lib/vutuv_web/components/ui.ex:4468
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4461
+#: lib/vutuv_web/components/ui.ex:4482
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4462
+#: lib/vutuv_web/components/ui.ex:4483
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr ""
@@ -15356,51 +15361,51 @@ msgstr ""
 msgid "I understand, take part"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:501
+#: lib/vutuv_web/views/settings_html.ex:396
 #, elixir-autogen, elixir-format
 msgid "Most of them, not all: we cannot check whether they do it, and anything that was re-shared, archived or indexed elsewhere stays out of reach. If you take part again later, people there have to follow you anew."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:496
+#: lib/vutuv_web/views/settings_html.ex:391
 #, elixir-autogen, elixir-format
 msgid "No new posts go out, and your followers from other networks are removed here. The next time those servers look you up they learn that this account is gone, and most of them then delete their copies of your posts."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:477
+#: lib/vutuv_web/views/settings_html.ex:372
 #, elixir-autogen, elixir-format
 msgid "Once a post has left vutuv, it is out of our hands"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:479
+#: lib/vutuv_web/views/settings_html.ex:374
 #, elixir-autogen, elixir-format
 msgid "Switching off does not delete what is already out there"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:490
+#: lib/vutuv_web/views/settings_html.ex:385
 #, elixir-autogen, elixir-format
 msgid "Switching this off again later stops new posts from going out. It cannot bring back what has already been delivered."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:485
+#: lib/vutuv_web/views/settings_html.ex:380
 #, elixir-autogen, elixir-format
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5075
+#: lib/vutuv_web/components/post_components.ex:5105
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5079
+#: lib/vutuv_web/components/post_components.ex:5109
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5083
+#: lib/vutuv_web/components/post_components.ex:5113
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15408,7 +15413,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1145
-#: lib/vutuv_web/components/post_components.ex:5034
+#: lib/vutuv_web/components/post_components.ex:5064
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15424,14 +15429,14 @@ msgstr ""
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1300
-#: lib/vutuv_web/components/post_components.ex:1959
+#: lib/vutuv_web/components/post_components.ex:1312
+#: lib/vutuv_web/components/post_components.ex:1971
 #: lib/vutuv_web/live/fediverse_account_live.ex:294
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1176
+#: lib/vutuv_web/components/post_components.ex:1188
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15460,7 +15465,7 @@ msgstr ""
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1185
+#: lib/vutuv_web/components/post_components.ex:1197
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15470,7 +15475,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1199
+#: lib/vutuv_web/components/post_components.ex:1211
 #: lib/vutuv_web/live/notification_live/index.ex:580
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -15496,15 +15501,15 @@ msgstr ""
 msgid "Thank you. The reply was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:356
+#: lib/vutuv_web/live/post_live/thread.ex:360
 #, elixir-autogen, elixir-format
 msgid "That reply is not yours to remove."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1329
-#: lib/vutuv_web/components/post_components.ex:1231
-#: lib/vutuv_web/components/post_components.ex:1431
-#: lib/vutuv_web/components/post_components.ex:2377
+#: lib/vutuv_web/components/post_components.ex:1243
+#: lib/vutuv_web/components/post_components.ex:1443
+#: lib/vutuv_web/components/post_components.ex:2392
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -15516,7 +15521,7 @@ msgstr ""
 msgid "What"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:352
+#: lib/vutuv_web/live/post_live/thread.ex:356
 #: lib/vutuv_web/live/remote_post_actions.ex:53
 #, elixir-autogen, elixir-format
 msgid "You have reported a lot today. Please try again tomorrow."
@@ -15732,7 +15737,7 @@ msgstr ""
 msgid "Access token revoked"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4426
+#: lib/vutuv_web/components/ui.ex:4447
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -16079,7 +16084,7 @@ msgstr ""
 msgid "What changed on your account, and exactly when."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4427
+#: lib/vutuv_web/components/ui.ex:4448
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr ""
@@ -16115,7 +16120,7 @@ msgstr ""
 msgid "from a signed-in session"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4429
+#: lib/vutuv_web/components/ui.ex:4450
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
@@ -16167,22 +16172,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2915
+#: lib/vutuv_web/components/post_components.ex:2930
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3031
+#: lib/vutuv_web/components/post_components.ex:3046
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3039
+#: lib/vutuv_web/components/post_components.ex:3054
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3025
+#: lib/vutuv_web/components/post_components.ex:3040
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16308,17 +16313,17 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2510
+#: lib/vutuv_web/components/post_components.ex:2525
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3734
+#: lib/vutuv_web/components/post_components.ex:3749
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3245
+#: lib/vutuv_web/components/post_components.ex:3260
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16331,7 +16336,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1290
 #: lib/vutuv_web/agent_docs/text.ex:779
-#: lib/vutuv_web/components/post_components.ex:3951
+#: lib/vutuv_web/components/post_components.ex:3966
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
 msgstr ""
@@ -16357,7 +16362,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2563
+#: lib/vutuv_web/components/post_components.ex:2578
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16377,7 +16382,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2554
+#: lib/vutuv_web/components/post_components.ex:2569
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16387,12 +16392,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2572
+#: lib/vutuv_web/components/post_components.ex:2587
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2506
+#: lib/vutuv_web/components/post_components.ex:2521
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16407,7 +16412,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2567
+#: lib/vutuv_web/components/post_components.ex:2582
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16417,7 +16422,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2520
+#: lib/vutuv_web/components/post_components.ex:2535
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16438,8 +16443,8 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1561
-#: lib/vutuv_web/live/post_live/feed.ex:1562
+#: lib/vutuv_web/live/post_live/feed.ex:1697
+#: lib/vutuv_web/live/post_live/feed.ex:1698
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post photos"
 msgstr ""
@@ -16504,13 +16509,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1163
-#: lib/vutuv_web/components/post_components.ex:5072
+#: lib/vutuv_web/components/post_components.ex:5102
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1161
-#: lib/vutuv_web/components/post_components.ex:5069
+#: lib/vutuv_web/components/post_components.ex:5099
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
 msgstr ""
@@ -16520,7 +16525,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4961
+#: lib/vutuv_web/components/post_components.ex:4991
 #, elixir-autogen, elixir-format, fuzzy
 msgid "From other networks"
 msgstr ""
@@ -16636,7 +16641,7 @@ msgstr ""
 msgid "Cancel request"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4413
+#: lib/vutuv_web/components/ui.ex:4434
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr ""
@@ -16840,7 +16845,7 @@ msgstr ""
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4415
+#: lib/vutuv_web/components/ui.ex:4436
 #, elixir-autogen, elixir-format, fuzzy
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
@@ -16860,7 +16865,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2323
+#: lib/vutuv_web/components/post_components.ex:2338
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
@@ -16870,7 +16875,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2376
+#: lib/vutuv_web/components/post_components.ex:2391
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16890,12 +16895,12 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1559
+#: lib/vutuv_web/components/post_components.ex:1571
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2341
+#: lib/vutuv_web/components/post_components.ex:2356
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Marked as sensitive by its author"
 msgstr ""
@@ -16911,7 +16916,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2309
+#: lib/vutuv_web/components/post_components.ex:2324
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -17133,27 +17138,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2075
+#: lib/vutuv_web/components/post_components.ex:2077
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2091
+#: lib/vutuv_web/components/post_components.ex:2106
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2086
+#: lib/vutuv_web/components/post_components.ex:2101
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2413
+#: lib/vutuv_web/components/post_components.ex:2428
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2419
+#: lib/vutuv_web/components/post_components.ex:2434
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That post is not here any more."
 msgstr ""
@@ -17163,7 +17168,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2558
+#: lib/vutuv_web/components/post_components.ex:2573
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17203,7 +17208,7 @@ msgstr ""
 msgid "That link points at a single post. You can follow its author, %{account}, from here."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1378
+#: lib/vutuv_web/live/user_profile_live.ex:1382
 #, elixir-autogen, elixir-format
 msgid "You already follow one member."
 msgid_plural "You already follow %{count} members."
@@ -17910,7 +17915,7 @@ msgstr ""
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2416
+#: lib/vutuv_web/components/post_components.ex:2431
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -18213,19 +18218,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4208
+#: lib/vutuv_web/components/post_components.ex:4238
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4210
+#: lib/vutuv_web/components/post_components.ex:4240
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4221
+#: lib/vutuv_web/components/post_components.ex:4251
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -18245,7 +18250,7 @@ msgstr ""
 msgid "When off, other members no longer see you among the likes of a post. The author of the post still does: we named you in the notification they got when you liked it. Either way the post keeps the same number of likes."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:864
+#: lib/vutuv_web/controllers/settings_controller.ex:835
 #, elixir-autogen, elixir-format
 msgid "Your likes follow the site default again."
 msgstr ""
@@ -18350,7 +18355,7 @@ msgstr ""
 msgid "Employment reference updated."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4315
+#: lib/vutuv_web/components/ui.ex:4325
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -18544,7 +18549,7 @@ msgstr ""
 msgid "You changed the text after this review. It describes the earlier version."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4316
+#: lib/vutuv_web/components/ui.ex:4326
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr ""
@@ -18555,7 +18560,7 @@ msgstr ""
 msgid "Zwischenzeugnis"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4318
+#: lib/vutuv_web/components/ui.ex:4328
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr ""
@@ -18722,7 +18727,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/live/reference_check_live.ex:156
-#: lib/vutuv_web/templates/settings/preferences.html.heex:285
+#: lib/vutuv_web/templates/settings/preferences.html.heex:235
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} second"
 msgid_plural "%{count} seconds"
@@ -19171,7 +19176,7 @@ msgstr ""
 msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1363
+#: lib/vutuv_web/live/user_profile_live.ex:1367
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follow other members"
 msgstr ""
@@ -19181,17 +19186,17 @@ msgstr ""
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1321
+#: lib/vutuv/accounts/user.ex:1326
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1319
+#: lib/vutuv/accounts/user.ex:1324
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1320
+#: lib/vutuv/accounts/user.ex:1325
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -19201,7 +19206,7 @@ msgstr ""
 msgid "Shares are of the %{answered} members who answered. %{unanswered} gave no answer."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4297
+#: lib/vutuv_web/components/ui.ex:4307
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr ""
@@ -19216,7 +19221,7 @@ msgstr ""
 msgid "We use {model}, a freely available language model. Anyone can download it and run the same review themselves, which is also why we are able to run it on our own machines at all."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:58
+#: lib/vutuv_web/views/settings_html.ex:56
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} day"
 msgid_plural "%{count} days"
@@ -19237,47 +19242,47 @@ msgid_plural "%{formatted} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:49
+#: lib/vutuv_web/views/settings_html.ex:47
 #, elixir-autogen, elixir-format, fuzzy
 msgid "1 day"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:53
+#: lib/vutuv_web/views/settings_html.ex:51
 #, elixir-autogen, elixir-format, fuzzy
 msgid "1 month"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:51
+#: lib/vutuv_web/views/settings_html.ex:49
 #, elixir-autogen, elixir-format, fuzzy
 msgid "1 week"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:56
+#: lib/vutuv_web/views/settings_html.ex:54
 #, elixir-autogen, elixir-format, fuzzy
 msgid "1 year"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:52
+#: lib/vutuv_web/views/settings_html.ex:50
 #, elixir-autogen, elixir-format, fuzzy
 msgid "2 weeks"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:57
+#: lib/vutuv_web/views/settings_html.ex:55
 #, elixir-autogen, elixir-format, fuzzy
 msgid "2 years"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:50
+#: lib/vutuv_web/views/settings_html.ex:48
 #, elixir-autogen, elixir-format, fuzzy
 msgid "3 days"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:54
+#: lib/vutuv_web/views/settings_html.ex:52
 #, elixir-autogen, elixir-format, fuzzy
 msgid "3 months"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:55
+#: lib/vutuv_web/views/settings_html.ex:53
 #, elixir-autogen, elixir-format, fuzzy
 msgid "6 months"
 msgstr ""
@@ -19297,7 +19302,7 @@ msgstr ""
 msgid "Always keep"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4406
+#: lib/vutuv_web/components/ui.ex:4427
 #: lib/vutuv_web/controllers/settings_controller.ex:245
 #: lib/vutuv_web/controllers/settings_controller.ex:324
 #: lib/vutuv_web/controllers/settings_controller.ex:336
@@ -19394,7 +19399,7 @@ msgstr ""
 msgid "Keep posts that did well"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4408
+#: lib/vutuv_web/components/ui.ex:4429
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr ""
@@ -19503,7 +19508,7 @@ msgstr ""
 msgid "Your rule"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4410
+#: lib/vutuv_web/components/ui.ex:4431
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
@@ -19877,7 +19882,7 @@ msgstr ""
 msgid "Start over"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2446
+#: lib/vutuv_web/components/post_components.ex:2461
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -20769,49 +20774,43 @@ msgstr ""
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4117
+#: lib/vutuv_web/components/post_components.ex:4132
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4138
+#: lib/vutuv_web/components/post_components.ex:4168
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4147
+#: lib/vutuv_web/components/post_components.ex:4177
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4150
+#: lib/vutuv_web/components/post_components.ex:4180
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4127
+#: lib/vutuv_web/components/post_components.ex:4157
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:853
+#: lib/vutuv_web/live/feed_languages_live.ex:129
 #, elixir-autogen, elixir-format
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:824
-#, elixir-autogen, elixir-format
-msgid "Feed language settings saved."
-msgstr ""
-
-#: lib/vutuv_web/templates/settings/preferences.html.heex:193
+#: lib/vutuv_web/components/post_components.ex:4147
+#: lib/vutuv_web/components/ui.ex:4386
+#: lib/vutuv_web/live/feed_languages_live.ex:65
+#: lib/vutuv_web/live/feed_languages_live.ex:200
+#: lib/vutuv_web/templates/settings/preferences.html.heex:187
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Feed languages"
-msgstr ""
-
-#: lib/vutuv_web/templates/settings/preferences.html.heex:195
-#, elixir-autogen, elixir-format
-msgid "Pick which languages your feed shows, and what happens to posts in other languages. Posts that declare no language always show."
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:83
@@ -20894,19 +20893,9 @@ msgstr ""
 msgid "ISO 8601 (Sweden, Japan, China)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4433
-#, elixir-autogen, elixir-format
-msgid "Interface language, date format and time zone, feed languages, maps, how posts are shortened"
-msgstr ""
-
 #: lib/vutuv_web/views/account_event_text.ex:48
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Language & display settings changed"
-msgstr ""
-
-#: lib/vutuv_web/components/ui.ex:4437
-#, elixir-autogen, elixir-format, fuzzy
-msgid "german english locale translation translate map font length hyphenation feed languages hide foreign übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/verify.html.heex:42
@@ -20944,19 +20933,19 @@ msgstr ""
 msgid "Your username, or paste the address of your profile page."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3917
+#: lib/vutuv_web/components/post_components.ex:3932
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3914
+#: lib/vutuv_web/components/post_components.ex:3929
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3254
+#: lib/vutuv_web/components/post_components.ex:3269
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -20973,7 +20962,7 @@ msgstr ""
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1814
+#: lib/vutuv_web/live/post_live/feed.ex:1950
 #: lib/vutuv_web/views/user_html.ex:334
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -21025,7 +21014,7 @@ msgstr ""
 msgid "Mastodon app access changed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4454
+#: lib/vutuv_web/components/ui.ex:4475
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr ""
@@ -21071,7 +21060,7 @@ msgstr ""
 msgid "Your account is then %{handle}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4456
+#: lib/vutuv_web/components/ui.ex:4477
 #, elixir-autogen, elixir-format, fuzzy
 msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr ""
@@ -21107,7 +21096,7 @@ msgstr ""
 msgid "Find your LinkedIn contacts"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4381
+#: lib/vutuv_web/components/ui.ex:4402
 #: lib/vutuv_web/live/import_connections_live.ex:64
 #: lib/vutuv_web/templates/import/new.html.heex:37
 #, elixir-autogen, elixir-format, fuzzy
@@ -21214,7 +21203,7 @@ msgstr ""
 msgid "See which of them are already on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4383
+#: lib/vutuv_web/components/ui.ex:4404
 #, elixir-autogen, elixir-format
 msgid "See which of your LinkedIn contacts are already on vutuv"
 msgstr ""
@@ -21286,24 +21275,9 @@ msgstr ""
 msgid "Your export also lists your LinkedIn contacts."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4385
+#: lib/vutuv_web/components/ui.ex:4406
 #, elixir-autogen, elixir-format
 msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
-msgstr ""
-
-#: lib/vutuv_web/views/settings_html.ex:173
-#, elixir-autogen, elixir-format
-msgid "Add another language"
-msgstr ""
-
-#: lib/vutuv_web/templates/settings/preferences.html.heex:208
-#, elixir-autogen, elixir-format
-msgid "Choosing none means: all languages."
-msgstr ""
-
-#: lib/vutuv_web/templates/settings/preferences.html.heex:205
-#, elixir-autogen, elixir-format
-msgid "These languages I read"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/activity.ex:91
@@ -21482,7 +21456,7 @@ msgstr ""
 msgid "This page is following the most accounts we allow (%{max})."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2297
+#: lib/vutuv_web/components/post_components.ex:2312
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr ""
@@ -21557,7 +21531,7 @@ msgstr ""
 msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:4364
+#: lib/vutuv_web/components/ui.ex:4374
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr ""
@@ -21607,12 +21581,12 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1796
+#: lib/vutuv_web/live/post_live/feed.ex:1932
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1792
+#: lib/vutuv_web/live/post_live/feed.ex:1928
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr ""
@@ -21658,67 +21632,67 @@ msgstr ""
 msgid "With a vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1806
+#: lib/vutuv_web/live/post_live/feed.ex:1942
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:593
+#: lib/vutuv_web/components/post_components.ex:605
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} new post"
 msgid_plural "%{formatted} new posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1251
+#: lib/vutuv_web/live/post_live/feed.ex:1387
 #, elixir-autogen, elixir-format
 msgid "%{source}: %{formatted} new post"
 msgid_plural "%{source}: %{formatted} new posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1248
+#: lib/vutuv_web/live/post_live/feed.ex:1384
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1245
+#: lib/vutuv_web/live/post_live/feed.ex:1381
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post from %{who}"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:297
+#: lib/vutuv_web/templates/settings/preferences.html.heex:247
 #, elixir-autogen, elixir-format
 msgid "Example"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:844
+#: lib/vutuv_web/controllers/settings_controller.ex:826
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Feed tab settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:838
+#: lib/vutuv_web/controllers/settings_controller.ex:820
 #, elixir-autogen, elixir-format
 msgid "Feed tab settings saved."
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:89
-#: lib/vutuv_web/templates/settings/preferences.html.heex:263
+#: lib/vutuv_web/templates/settings/preferences.html.heex:213
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Feed tabs"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:321
+#: lib/vutuv_web/templates/settings/preferences.html.heex:271
 #, elixir-autogen, elixir-format
 msgid "Just flashed the new release, boot is under two seconds now"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:331
+#: lib/vutuv_web/templates/settings/preferences.html.heex:281
 #, elixir-autogen, elixir-format
 msgid "Play the example"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:265
+#: lib/vutuv_web/templates/settings/preferences.html.heex:215
 #, elixir-autogen, elixir-format
 msgid "When a post lands on the source tab you are not reading, that tab gets a dot. It can also quote the post for a few seconds, so you can tell whether it is worth switching."
 msgstr ""
@@ -21743,97 +21717,97 @@ msgstr ""
 msgid "When off, a tab holding something new wears its dot and says nothing more."
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex
+#: lib/vutuv_web/live/feed_languages_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Rank the languages you read. Posts in them reach your feed as they were written; you decide below what happens to the rest."
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex:202
+#: lib/vutuv_web/live/feed_languages_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "Languages you read"
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex
+#: lib/vutuv_web/live/feed_languages_live.ex:218
 #, elixir-autogen, elixir-format
 msgid "No language chosen, so your feed shows all of them."
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex
+#: lib/vutuv_web/live/feed_languages_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "First: translations go into this language"
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex:265
+#: lib/vutuv_web/live/feed_languages_live.ex:278
 #, elixir-autogen, elixir-format
 msgid "Remove %{language}"
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex:277
+#: lib/vutuv_web/live/feed_languages_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "Suggested:"
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex:312
+#: lib/vutuv_web/live/feed_languages_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "Choose a language"
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex
+#: lib/vutuv_web/live/feed_languages_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "This installation has translations switched off, so posts in other languages show as written until an administrator turns them on."
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex:347
+#: lib/vutuv_web/live/feed_languages_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "What your feed does"
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex:387
+#: lib/vutuv_web/live/feed_languages_live.ex:403
 #, elixir-autogen, elixir-format
 msgid "Shown as written"
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex:395
+#: lib/vutuv_web/live/feed_languages_live.ex:411
 #, elixir-autogen, elixir-format
 msgid "Every language"
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex:395
+#: lib/vutuv_web/live/feed_languages_live.ex:411
 #, elixir-autogen, elixir-format
 msgid "Every other language"
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex
+#: lib/vutuv_web/live/feed_languages_live.ex:432
 #, elixir-autogen, elixir-format
 msgid "Nothing is hidden: hiding needs at least one language above."
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex:411
+#: lib/vutuv_web/live/feed_languages_live.ex:434
 #, elixir-autogen, elixir-format
 msgid "Hidden from your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex:421
+#: lib/vutuv_web/live/feed_languages_live.ex:440
 #, elixir-autogen, elixir-format
 msgid "Shown in the language it was written in."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex
+#: lib/vutuv_web/components/ui.ex:4387
 #, elixir-autogen, elixir-format
 msgid "Which languages reach you, and what happens to the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex
+#: lib/vutuv_web/components/ui.ex:4389
 #, elixir-autogen, elixir-format
 msgid "language translate translation german english original hide foreign rank order sprache übersetzen fremdsprache reihenfolge"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex
+#: lib/vutuv_web/components/ui.ex:4454
 #, elixir-autogen, elixir-format
 msgid "Interface language, date format and time zone, maps, how posts are shortened"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex
+#: lib/vutuv_web/components/ui.ex:4458
 #, elixir-autogen, elixir-format
 msgid "german english locale map font length hyphenation übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
 msgstr ""
@@ -21843,17 +21817,17 @@ msgstr ""
 msgid "Languages your feed shows"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex
+#: lib/vutuv_web/templates/settings/preferences.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Rank the languages you read, and say what happens to posts in the others."
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex
+#: lib/vutuv_web/live/feed_languages_live.ex:424
 #, elixir-autogen, elixir-format
 msgid "Translate into %{language}"
 msgstr ""
 
-#: lib/vutuv_web/live/feed_languages_live.ex
+#: lib/vutuv_web/live/feed_languages_live.ex:437
 #, elixir-autogen, elixir-format
 msgid "Translated into %{language}."
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -17,7 +17,8 @@ msgstr ""
 msgid "About us"
 msgstr "Note legali"
 
-#: lib/vutuv_web/components/ui.ex:4081 lib/vutuv_web/components/ui.ex:4086
+#: lib/vutuv_web/components/ui.ex:4091
+#: lib/vutuv_web/components/ui.ex:4096
 #: lib/vutuv_web/live/admin/screenshot_live.ex:255
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:718
 #: lib/vutuv_web/live/organization_live/domains.ex:272
@@ -61,8 +62,9 @@ msgstr "Indirizzo eliminato."
 msgid "Address updated successfully."
 msgstr "Indirizzo aggiornato."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:68 lib/vutuv_web/agent_docs/text.ex:65
-#: lib/vutuv_web/components/ui.ex:4339
+#: lib/vutuv_web/agent_docs/markdown.ex:68
+#: lib/vutuv_web/agent_docs/text.ex:65
+#: lib/vutuv_web/components/ui.ex:4349
 #: lib/vutuv_web/controllers/address_controller.ex:23
 #: lib/vutuv_web/controllers/address_controller.ex:38
 #: lib/vutuv_web/controllers/address_controller.ex:85
@@ -81,7 +83,8 @@ msgstr "Indirizzi"
 msgid "Already a member? Sign in here."
 msgstr "È già iscritto? Acceda qui."
 
-#: lib/vutuv_web/components/ui.ex:3876 lib/vutuv_web/components/ui.ex:3970
+#: lib/vutuv_web/components/ui.ex:3886
+#: lib/vutuv_web/components/ui.ex:3980
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:698
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:830
@@ -101,14 +104,15 @@ msgstr "Data di nascita"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:602
 #: lib/vutuv_web/agent_docs/markdown.ex:603
-#: lib/vutuv_web/agent_docs/text.ex:568 lib/vutuv_web/agent_docs/text.ex:569
+#: lib/vutuv_web/agent_docs/text.ex:568
+#: lib/vutuv_web/agent_docs/text.ex:569
 #: lib/vutuv_web/templates/user/show.html.heex:1099
 #, elixir-autogen
 msgid "Birthday"
 msgstr "Compleanno"
 
 #: lib/vutuv_web/components/saved_search_components.ex:110
-#: lib/vutuv_web/components/ui.ex:3870
+#: lib/vutuv_web/components/ui.ex:3880
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
@@ -144,7 +148,8 @@ msgstr "Non è possibile eliminare l'ultimo indirizzo e-mail."
 msgid "Choose One"
 msgstr "Selezioni una voce"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:54 lib/vutuv_web/agent_docs/text.ex:51
+#: lib/vutuv_web/agent_docs/markdown.ex:54
+#: lib/vutuv_web/agent_docs/text.ex:51
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
@@ -157,8 +162,8 @@ msgstr "Contatto"
 msgid "Couldn't follow back to %{name}."
 msgstr "Non è stato possibile ricambiare il follow a %{name}."
 
-#: lib/vutuv_web/components/post_components.ex:3047
-#: lib/vutuv_web/components/ui.ex:3973
+#: lib/vutuv_web/components/post_components.ex:3062
+#: lib/vutuv_web/components/ui.ex:3983
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
@@ -206,8 +211,8 @@ msgstr "Disattiva"
 msgid "Download"
 msgstr "Scarica"
 
-#: lib/vutuv_web/components/post_components.ex:3012
-#: lib/vutuv_web/components/ui.ex:3964
+#: lib/vutuv_web/components/post_components.ex:3027
+#: lib/vutuv_web/components/ui.ex:3974
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
@@ -279,8 +284,9 @@ msgstr "Inglese"
 msgid "Enter your email address"
 msgstr "Inserisca il Suo indirizzo e-mail"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:38 lib/vutuv_web/agent_docs/text.ex:35
-#: lib/vutuv_web/components/ui.ex:4303
+#: lib/vutuv_web/agent_docs/markdown.ex:38
+#: lib/vutuv_web/agent_docs/text.ex:35
+#: lib/vutuv_web/components/ui.ex:4313
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -321,9 +327,12 @@ msgstr "Follower"
 #: lib/vutuv_web/agent_docs/markdown.ex:624
 #: lib/vutuv_web/agent_docs/text.ex:590
 #: lib/vutuv_web/components/fediverse_components.ex:347
-#: lib/vutuv_web/components/ui.ex:2428 lib/vutuv_web/components/ui.ex:2453
-#: lib/vutuv_web/components/ui.ex:2456 lib/vutuv_web/components/ui.ex:2463
-#: lib/vutuv_web/components/ui.ex:2466 lib/vutuv_web/components/ui.ex:2524
+#: lib/vutuv_web/components/ui.ex:2428
+#: lib/vutuv_web/components/ui.ex:2453
+#: lib/vutuv_web/components/ui.ex:2456
+#: lib/vutuv_web/components/ui.ex:2463
+#: lib/vutuv_web/components/ui.ex:2466
+#: lib/vutuv_web/components/ui.ex:2524
 #: lib/vutuv_web/controllers/followee_controller.ex:29
 #: lib/vutuv_web/live/import_connections_live.ex:469
 #: lib/vutuv_web/live/organization_live/show.ex:471
@@ -361,10 +370,7 @@ msgid "Home"
 msgstr "Home"
 
 #: web/templates/followee/index.html.eex:21
-msgid ""
-"It doesn't look like you're following anyone yet. Find someone a profile of "
-"someone you know, or someone you're interested in, and click the follow "
-"button!"
+msgid "It doesn't look like you're following anyone yet. Find someone a profile of someone you know, or someone you're interested in, and click the follow button!"
 msgstr ""
 "Sembra che non segua ancora nessuno. Cerchi il profilo di una persona che "
 "conosce, o che La incuriosisce, e prema il pulsante «Segui»."
@@ -402,12 +408,16 @@ msgstr "Link eliminato."
 msgid "Link updated successfully."
 msgstr "Link aggiornato."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:53 lib/vutuv_web/agent_docs/text.ex:50
+#: lib/vutuv_web/agent_docs/markdown.ex:53
+#: lib/vutuv_web/agent_docs/text.ex:50
 #: lib/vutuv_web/controllers/url_controller.ex:23
 #: lib/vutuv_web/controllers/url_controller.ex:34
-#: lib/vutuv_web/controllers/url_controller.ex:83 lib/vutuv_web/cv/docx.ex:206
-#: lib/vutuv_web/cv/html.ex:202 lib/vutuv_web/cv/latex.ex:164
-#: lib/vutuv_web/cv/odt.ex:176 lib/vutuv_web/live/cv_live.ex:336
+#: lib/vutuv_web/controllers/url_controller.ex:83
+#: lib/vutuv_web/cv/docx.ex:206
+#: lib/vutuv_web/cv/html.ex:202
+#: lib/vutuv_web/cv/latex.ex:164
+#: lib/vutuv_web/cv/odt.ex:176
+#: lib/vutuv_web/live/cv_live.ex:336
 #: lib/vutuv_web/templates/import/new.html.heex:13
 #: lib/vutuv_web/templates/url/edit.html.heex:4
 #: lib/vutuv_web/templates/url/index.html.heex:10
@@ -436,7 +446,8 @@ msgstr "Accedi"
 msgid "Log Out"
 msgstr "Esci"
 
-#: lib/vutuv_web/live/shell_live.ex:1024 lib/vutuv_web/live/shell_live.ex:1081
+#: lib/vutuv_web/live/shell_live.ex:1024
+#: lib/vutuv_web/live/shell_live.ex:1090
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -466,7 +477,7 @@ msgstr "Altro"
 msgid "Name"
 msgstr "Nome"
 
-#: lib/vutuv_web/components/post_components.ex:620
+#: lib/vutuv_web/components/post_components.ex:632
 #: lib/vutuv_web/live/notification_live/index.ex:682
 #: lib/vutuv_web/live/organization_live/activity.ex:127
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
@@ -525,7 +536,8 @@ msgid_plural "Phone Numbers"
 msgstr[0] "Numero di telefono"
 msgstr[1] "Numeri di telefono"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:65 lib/vutuv_web/agent_docs/text.ex:62
+#: lib/vutuv_web/agent_docs/markdown.ex:65
+#: lib/vutuv_web/agent_docs/text.ex:62
 #: lib/vutuv_web/templates/phone_number/index.html.heex:10
 #: lib/vutuv_web/templates/phone_number/show.html.heex:6
 #, elixir-autogen
@@ -605,7 +617,7 @@ msgstr "Piattaforma"
 msgid "Public"
 msgstr "Pubblico"
 
-#: lib/vutuv_web/components/ui.ex:3869
+#: lib/vutuv_web/components/ui.ex:3879
 #: lib/vutuv_web/live/organization_live/edit.ex:345
 #: lib/vutuv_web/live/post_live/composer.ex:1867
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -617,13 +629,12 @@ msgstr "Pubblico"
 #: lib/vutuv_web/templates/settings/notifications.html.heex:79
 #: lib/vutuv_web/templates/settings/preferences.html.heex:84
 #: lib/vutuv_web/templates/settings/preferences.html.heex:157
-#: lib/vutuv_web/templates/settings/preferences.html.heex:228
-#: lib/vutuv_web/templates/settings/preferences.html.heex:292
-#: lib/vutuv_web/templates/settings/preferences.html.heex:449
+#: lib/vutuv_web/templates/settings/preferences.html.heex:242
+#: lib/vutuv_web/templates/settings/preferences.html.heex:399
 #: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:462
-#: lib/vutuv_web/views/settings_html.ex:301
+#: lib/vutuv_web/views/settings_html.ex:196
 #, elixir-autogen
 msgid "Save"
 msgstr "Salva"
@@ -634,8 +645,10 @@ msgstr "Salva"
 #: lib/vutuv_web/live/admin/user_delete_live.ex:118
 #: lib/vutuv_web/live/admin/user_live.ex:219
 #: lib/vutuv_web/live/job_board_live.ex:418
-#: lib/vutuv_web/live/search_live.ex:48 lib/vutuv_web/live/search_live.ex:569
-#: lib/vutuv_web/live/shell_live.ex:889 lib/vutuv_web/live/shell_live.ex:1064
+#: lib/vutuv_web/live/search_live.ex:48
+#: lib/vutuv_web/live/search_live.ex:569
+#: lib/vutuv_web/live/shell_live.ex:889
+#: lib/vutuv_web/live/shell_live.ex:1073
 #: lib/vutuv_web/live/tag_live/timeline.ex:283
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
@@ -645,7 +658,7 @@ msgstr "Salva"
 msgid "Search"
 msgstr "Cerca"
 
-#: lib/vutuv_web/components/post_components.ex:1556
+#: lib/vutuv_web/components/post_components.ex:1568
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -664,11 +677,14 @@ msgstr "Crei un account gratuito"
 msgid "Slug"
 msgstr "Slug"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:56 lib/vutuv_web/agent_docs/text.ex:53
+#: lib/vutuv_web/agent_docs/markdown.ex:56
+#: lib/vutuv_web/agent_docs/text.ex:53
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:25
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:42
-#: lib/vutuv_web/cv/docx.ex:217 lib/vutuv_web/cv/html.ex:223
-#: lib/vutuv_web/cv/latex.ex:179 lib/vutuv_web/cv/odt.ex:185
+#: lib/vutuv_web/cv/docx.ex:217
+#: lib/vutuv_web/cv/html.ex:223
+#: lib/vutuv_web/cv/latex.ex:179
+#: lib/vutuv_web/cv/odt.ex:185
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:749
 #: lib/vutuv_web/live/cv_live.ex:410
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:4
@@ -694,9 +710,7 @@ msgstr "Profili di %{name}"
 
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:78
 #, elixir-autogen, elixir-format
-msgid ""
-"Profile created successfully. BTW: Did you know that the vutuv repo is "
-"hosted on GitHub? https://github.com/wintermeyer/vutuv"
+msgid "Profile created successfully. BTW: Did you know that the vutuv repo is hosted on GitHub? https://github.com/wintermeyer/vutuv"
 msgstr ""
 "Profilo creato. A proposito: sapeva che il codice di vutuv è su GitHub? "
 "https://github.com/wintermeyer/vutuv"
@@ -764,8 +778,7 @@ msgid "URL"
 msgstr "URL"
 
 #: web/controllers/user_controller.ex:43
-msgid ""
-"User %{name} created successfully. An email has been sent with your PIN."
+msgid "User %{name} created successfully. An email has been sent with your PIN."
 msgstr "Utente %{name} creato. Le abbiamo inviato un'e-mail con il PIN."
 
 #: lib/vutuv_web/controllers/user_controller.ex:363
@@ -783,7 +796,7 @@ msgstr "Utente aggiornato."
 msgid "User verified successfully."
 msgstr "Utente verificato."
 
-#: lib/vutuv_web/components/ui.ex:4299
+#: lib/vutuv_web/components/ui.ex:4309
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
@@ -840,14 +853,14 @@ msgstr "Utenti"
 msgid "vCard"
 msgstr "vCard"
 
-#: lib/vutuv_web/components/ui.ex:4034
+#: lib/vutuv_web/components/ui.ex:4044
 #: lib/vutuv_web/templates/user/show.html.heex:967
 #: lib/vutuv_web/templates/user/show.html.heex:990
 #, elixir-autogen
 msgid "View All"
 msgstr "Mostra tutti"
 
-#: lib/vutuv_web/components/ui.ex:4396
+#: lib/vutuv_web/components/ui.ex:4417
 #: lib/vutuv_web/controllers/settings_controller.ex:169
 #: lib/vutuv_web/live/job_posting_live/form.ex:756
 #: lib/vutuv_web/live/organization_live/edit.ex:304
@@ -866,9 +879,7 @@ msgstr "Niente da fare, capitano."
 
 #: lib/vutuv_web/templates/page/index.html.heex:276
 #, elixir-autogen
-msgid ""
-"We reserve the right to stop this service or delete your account anytime "
-"without warning."
+msgid "We reserve the right to stop this service or delete your account anytime without warning."
 msgstr ""
 "Ci riserviamo il diritto di interrompere questo servizio o di eliminare il "
 "Suo account in qualsiasi momento e senza preavviso."
@@ -908,19 +919,14 @@ msgstr "Esperienza lavorativa aggiornata."
 
 #: lib/vutuv_web/controllers/session_controller.ex:194
 #, elixir-autogen, elixir-format
-msgid ""
-"You don't have a passkey yet, so we've emailed you a one-time PIN to sign in"
-" instead."
+msgid "You don't have a passkey yet, so we've emailed you a one-time PIN to sign in instead."
 msgstr ""
 "Non ha ancora una passkey, quindi Le abbiamo inviato per e-mail un PIN "
 "monouso per accedere."
 
 #: lib/vutuv_web/templates/follower/index.html.heex:33
 #, elixir-autogen
-msgid ""
-"You don't have any followers yet! If you want more followers, you could "
-"follow others, invite your friends, or link your Vutuv profile on other "
-"social media websites."
+msgid "You don't have any followers yet! If you want more followers, you could follow others, invite your friends, or link your Vutuv profile on other social media websites."
 msgstr ""
 "Non ha ancora follower. Se ne desidera, può seguire altre persone, invitare "
 "i Suoi contatti o mettere il link del Suo profilo vutuv sugli altri social "
@@ -931,7 +937,7 @@ msgid "You follow back %{name}."
 msgstr "Ora segue anche %{name}."
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:91
+#: lib/vutuv_web/live/post_live/feed.ex:100
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -950,9 +956,7 @@ msgid "our blog"
 msgstr "il nostro blog"
 
 #: web/controllers/user_controller.ex:226
-msgid ""
-"An email has been sent to your email address with instructions on how to "
-"delete your account."
+msgid "An email has been sent to your email address with instructions on how to delete your account."
 msgstr ""
 "Le abbiamo inviato un'e-mail con le istruzioni per eliminare il Suo account."
 
@@ -963,17 +967,13 @@ msgstr "Consentire ad altri di vedere il mio indirizzo e-mail"
 
 #: lib/vutuv_web/templates/page/index.html.heex:262
 #, elixir-autogen, elixir-format
-msgid ""
-"By creating an account you accept our {nutzungsbedingungen} and confirm that"
-" you have read our {datenschutz}."
+msgid "By creating an account you accept our {nutzungsbedingungen} and confirm that you have read our {datenschutz}."
 msgstr ""
 "Creando un account accetta le nostre {nutzungsbedingungen} e conferma di "
 "aver letto la nostra {datenschutz}."
 
 #: web/templates/session/user_login.html.eex:16
-msgid ""
-"An email has been sent with your login link. Once you login, you'll be "
-"logged in for the next 90 days on this device, or until you log out."
+msgid "An email has been sent with your login link. Once you login, you'll be logged in for the next 90 days on this device, or until you log out."
 msgstr ""
 "Le abbiamo inviato un'e-mail con il link di accesso. Dopo l'accesso resterà "
 "connesso su questo dispositivo per 90 giorni, o finché non esce."
@@ -1015,9 +1015,7 @@ msgstr "Questa pagina non esiste"
 
 #: lib/vutuv_web/views/error_html.ex:168
 #, elixir-autogen
-msgid ""
-"Mea culpa: we once sent this exact broken link in a newsletter. We are "
-"sorry!"
+msgid "Mea culpa: we once sent this exact broken link in a newsletter. We are sorry!"
 msgstr ""
 "Mea culpa: questo link errato lo abbiamo inviato noi in una newsletter. Ci "
 "dispiace."
@@ -1029,9 +1027,7 @@ msgstr "La parola"
 
 #: lib/vutuv_web/views/error_html.ex:174
 #, elixir-autogen
-msgid ""
-"in this address is only a placeholder. Replace it with the actual username "
-"of the person whose profile you want to visit."
+msgid "in this address is only a placeholder. Replace it with the actual username of the person whose profile you want to visit."
 msgstr ""
 "in questo indirizzo è solo un segnaposto. Lo sostituisca con il nome utente "
 "della persona di cui vuole vedere il profilo."
@@ -1052,9 +1048,7 @@ msgid "search page"
 msgstr "pagina di ricerca"
 
 #: web/views/error_view.ex:15, web/views/error_view.ex:26
-msgid ""
-"Pardon us! Something went wrong. If you think this is a bug, please "
-"%{link_open}submit a bug report."
+msgid "Pardon us! Something went wrong. If you think this is a bug, please %{link_open}submit a bug report."
 msgstr ""
 "Ci scusi, qualcosa è andato storto. Se pensa che sia un errore del "
 "programma, %{link_open}ce lo segnali."
@@ -1119,10 +1113,7 @@ msgstr "I 1.000 utenti con più follower"
 #: lib/vutuv_web/agent_docs/list_docs.ex:171
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:12
 #, elixir-autogen
-msgid ""
-"We haven't yet figured out the best way to help everyone discover other "
-"interesting vutuv users. So for now, this page simply lists the 1,000 users "
-"with the most followers."
+msgid "We haven't yet figured out the best way to help everyone discover other interesting vutuv users. So for now, this page simply lists the 1,000 users with the most followers."
 msgstr ""
 "Non abbiamo ancora trovato il modo migliore per far scoprire a tutti gli "
 "utenti vutuv più interessanti. Per ora questa pagina elenca semplicemente i "
@@ -1148,7 +1139,8 @@ msgstr "Oggi"
 msgid "Homepage"
 msgstr "Sito web"
 
-#: lib/vutuv/changeset_helpers.ex:18 lib/vutuv/changeset_helpers.ex:26
+#: lib/vutuv/changeset_helpers.ex:18
+#: lib/vutuv/changeset_helpers.ex:26
 #: lib/vutuv/changeset_helpers.ex:39
 #, elixir-autogen
 msgid "Invalid URL"
@@ -1160,13 +1152,12 @@ msgstr "URL non raggiungibile"
 
 #: lib/vutuv_web/live/search_live.ex:301
 #, elixir-autogen
-msgid ""
-"Our search will try to match similar names to your search, so don't worry "
-"about spelling."
+msgid "Our search will try to match similar names to your search, so don't worry about spelling."
 msgstr ""
 "La ricerca trova anche nomi simili, quindi non si preoccupi dell'ortografia."
 
-#: lib/vutuv_web/live/search_live.ex:629 lib/vutuv_web/live/search_live.ex:654
+#: lib/vutuv_web/live/search_live.ex:629
+#: lib/vutuv_web/live/search_live.ex:654
 #, elixir-autogen
 msgid "Search Tips"
 msgstr "Consigli per la ricerca"
@@ -1249,9 +1240,7 @@ msgstr "Tutti i tag"
 
 #: lib/vutuv_web/templates/session/pin_user_login.html.heex:3
 #, elixir-autogen
-msgid ""
-"An email has been sent with your PIN. Once you enter your PIN below, you'll "
-"be logged in for the next 90 days on this device, or until you log out."
+msgid "An email has been sent with your PIN. Once you enter your PIN below, you'll be logged in for the next 90 days on this device, or until you log out."
 msgstr ""
 "Le abbiamo inviato un'e-mail con il PIN. Dopo averlo inserito qui sotto "
 "resterà connesso su questo dispositivo per 90 giorni, o finché non esce."
@@ -1412,18 +1401,25 @@ msgstr "URL dei tag"
 #: lib/vutuv_web/agent_docs/markdown.ex:34
 #: lib/vutuv_web/agent_docs/markdown.ex:495
 #: lib/vutuv_web/agent_docs/markdown.ex:1070
-#: lib/vutuv_web/agent_docs/text.ex:31 lib/vutuv_web/agent_docs/text.ex:516
-#: lib/vutuv_web/agent_docs/text.ex:753 lib/vutuv_web/components/ui.ex:4324
+#: lib/vutuv_web/agent_docs/text.ex:31
+#: lib/vutuv_web/agent_docs/text.ex:516
+#: lib/vutuv_web/agent_docs/text.ex:753
+#: lib/vutuv_web/components/ui.ex:4334
 #: lib/vutuv_web/controllers/tag_controller.ex:36
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
-#: lib/vutuv_web/cv/docx.ex:174 lib/vutuv_web/cv/html.ex:156
-#: lib/vutuv_web/cv/latex.ex:131 lib/vutuv_web/cv/odt.ex:148
+#: lib/vutuv_web/cv/docx.ex:174
+#: lib/vutuv_web/cv/html.ex:156
+#: lib/vutuv_web/cv/latex.ex:131
+#: lib/vutuv_web/cv/odt.ex:148
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:433
-#: lib/vutuv_web/live/cv_live.ex:315 lib/vutuv_web/live/job_board_live.ex:277
+#: lib/vutuv_web/live/cv_live.ex:315
+#: lib/vutuv_web/live/job_board_live.ex:277
 #: lib/vutuv_web/live/job_posting_live/form.ex:705
-#: lib/vutuv_web/live/search_live.ex:280 lib/vutuv_web/live/search_live.ex:714
-#: lib/vutuv_web/live/tag_new_live.ex:36 lib/vutuv_web/live/tag_new_live.ex:47
+#: lib/vutuv_web/live/search_live.ex:280
+#: lib/vutuv_web/live/search_live.ex:714
+#: lib/vutuv_web/live/tag_new_live.ex:36
+#: lib/vutuv_web/live/tag_new_live.ex:47
 #: lib/vutuv_web/live/tag_new_live.ex:54
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:247
 #: lib/vutuv_web/templates/admin/tag/edit.html.heex:5
@@ -1463,10 +1459,7 @@ msgstr "URL"
 
 #: lib/vutuv_web/templates/page/pin_new_registration.html.heex:27
 #, elixir-autogen
-msgid ""
-"Your account has been created, and an email with a PIN has been sent. No "
-"passwords to remember! Once you enter your PIN below, you'll be logged in on"
-" this device for the next 90 days, or until you log out."
+msgid "Your account has been created, and an email with a PIN has been sent. No passwords to remember! Once you enter your PIN below, you'll be logged in on this device for the next 90 days, or until you log out."
 msgstr ""
 "Il Suo account è stato creato e Le abbiamo inviato un'e-mail con un PIN. "
 "Nessuna password da ricordare. Dopo aver inserito il PIN qui sotto resterà "
@@ -1638,13 +1631,15 @@ msgstr "Indirizzi di %{name}"
 msgid "Admin control panel"
 msgstr "Pannello di amministrazione"
 
-#: lib/vutuv_web/live/shell_live.ex:1067
+#: lib/vutuv_web/live/shell_live.ex:1076
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "Avvisi"
 
-#: lib/vutuv_web/views/error_html.ex:62 lib/vutuv_web/views/error_html.ex:110
-#: lib/vutuv_web/views/error_html.ex:147 lib/vutuv_web/views/error_html.ex:194
+#: lib/vutuv_web/views/error_html.ex:62
+#: lib/vutuv_web/views/error_html.ex:110
+#: lib/vutuv_web/views/error_html.ex:147
+#: lib/vutuv_web/views/error_html.ex:194
 #: lib/vutuv_web/views/error_html.ex:216
 #, elixir-autogen, elixir-format
 msgid "Back to the start page"
@@ -1655,7 +1650,8 @@ msgstr "Torna alla pagina iniziale"
 msgid "Check your inbox"
 msgstr "Controlli la Sua casella di posta"
 
-#: lib/vutuv_web/components/ui.ex:317 lib/vutuv_web/components/ui.ex:2764
+#: lib/vutuv_web/components/ui.ex:317
+#: lib/vutuv_web/components/ui.ex:2764
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
@@ -1709,18 +1705,24 @@ msgstr "Elimina il mio account"
 msgid "Edit profile"
 msgstr "Modifica profilo"
 
-#: lib/vutuv_web/components/ui.ex:1782 lib/vutuv_web/components/ui.ex:1791
+#: lib/vutuv_web/components/ui.ex:1782
+#: lib/vutuv_web/components/ui.ex:1791
 #: lib/vutuv_web/components/ui.ex:2255
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr "Conferma"
 
 #: lib/vutuv_web/components/fediverse_components.ex:233
-#: lib/vutuv_web/components/ui.ex:2393 lib/vutuv_web/components/ui.ex:2393
-#: lib/vutuv_web/components/ui.ex:2410 lib/vutuv_web/components/ui.ex:2419
-#: lib/vutuv_web/components/ui.ex:2435 lib/vutuv_web/components/ui.ex:2472
-#: lib/vutuv_web/components/ui.ex:2475 lib/vutuv_web/components/ui.ex:2482
-#: lib/vutuv_web/components/ui.ex:2485 lib/vutuv_web/components/ui.ex:2558
+#: lib/vutuv_web/components/ui.ex:2393
+#: lib/vutuv_web/components/ui.ex:2393
+#: lib/vutuv_web/components/ui.ex:2410
+#: lib/vutuv_web/components/ui.ex:2419
+#: lib/vutuv_web/components/ui.ex:2435
+#: lib/vutuv_web/components/ui.ex:2472
+#: lib/vutuv_web/components/ui.ex:2475
+#: lib/vutuv_web/components/ui.ex:2482
+#: lib/vutuv_web/components/ui.ex:2485
+#: lib/vutuv_web/components/ui.ex:2558
 #: lib/vutuv_web/live/fediverse_account_live.ex:387
 #: lib/vutuv_web/live/fediverse_following_live.ex:331
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:317
@@ -1740,15 +1742,13 @@ msgstr "Se pensa che sia un errore del programma,"
 
 #: lib/vutuv_web/templates/followee/index.html.heex:46
 #, elixir-autogen, elixir-format
-msgid ""
-"It doesn't look like you're following anyone yet. Open the profile of "
-"someone you know or find interesting and click the follow button!"
+msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 "Sembra che non segua ancora nessuno. Apra il profilo di una persona che "
 "conosce o che La incuriosisce e prema il pulsante «Segui»."
 
 #: lib/vutuv_web/live/shell_live.ex:1015
-#: lib/vutuv_web/views/settings_html.ex:388
+#: lib/vutuv_web/views/settings_html.ex:283
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr "Esci"
@@ -1776,7 +1776,8 @@ msgstr "Messaggio"
 
 #: lib/vutuv_web/live/message_live/index.ex:49
 #: lib/vutuv_web/live/message_live/index.ex:634
-#: lib/vutuv_web/live/shell_live.ex:907 lib/vutuv_web/live/shell_live.ex:1066
+#: lib/vutuv_web/live/shell_live.ex:907
+#: lib/vutuv_web/live/shell_live.ex:1075
 #: lib/vutuv_web/templates/layout/app.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Messages"
@@ -1789,7 +1790,7 @@ msgid "Network"
 msgstr "Rete"
 
 #: lib/vutuv_web/components/post_components.ex:439
-#: lib/vutuv_web/components/ui.ex:4083
+#: lib/vutuv_web/components/ui.ex:4093
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:705
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:742
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:793
@@ -1804,7 +1805,8 @@ msgstr "Qui non c'è ancora nulla."
 msgid "Nothing new yet."
 msgstr "Ancora nessuna novità."
 
-#: lib/vutuv/api_auth/scopes.ex:85 lib/vutuv_web/components/ui.ex:4361
+#: lib/vutuv/api_auth/scopes.ex:85
+#: lib/vutuv_web/components/ui.ex:4371
 #: lib/vutuv_web/live/notification_live/index.ex:132
 #: lib/vutuv_web/live/notification_live/index.ex:360
 #: lib/vutuv_web/live/shell_live.ex:919
@@ -1885,27 +1887,21 @@ msgstr "Profilo verificato"
 
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:5
 #, elixir-autogen, elixir-format
-msgid ""
-"WARNING: There is no turning back from this. Your account is deleted as soon"
-" as you submit the PIN."
+msgid "WARNING: There is no turning back from this. Your account is deleted as soon as you submit the PIN."
 msgstr ""
 "ATTENZIONE: non si torna indietro. Il Suo account viene eliminato non appena"
 " invia il PIN."
 
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:4
 #, elixir-autogen, elixir-format
-msgid ""
-"We sent a PIN to your email address. Enter it below to permanently delete "
-"your account."
+msgid "We sent a PIN to your email address. Enter it below to permanently delete your account."
 msgstr ""
 "Abbiamo inviato un PIN al Suo indirizzo e-mail. Lo inserisca qui sotto per "
 "eliminare definitivamente il Suo account."
 
 #: lib/vutuv_web/templates/email/confirm.html.heex:14
 #, elixir-autogen, elixir-format
-msgid ""
-"We sent a PIN to your new email address. Enter it below to confirm the "
-"address."
+msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr ""
 "Abbiamo inviato un PIN al Suo nuovo indirizzo e-mail. Lo inserisca qui sotto"
 " per confermare l'indirizzo."
@@ -1961,14 +1957,15 @@ msgstr "ora è collegato con Lei."
 msgid "started following you."
 msgstr "ha iniziato a seguirla."
 
-#: lib/vutuv_web/components/ui.ex:3423 lib/vutuv_web/components/ui.ex:3574
+#: lib/vutuv_web/components/ui.ex:3433
+#: lib/vutuv_web/components/ui.ex:3584
 #: lib/vutuv_web/live/import_connections_live.ex:638
 #: lib/vutuv_web/live/organization_live/index.ex:122
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr "Paginazione"
 
-#: lib/vutuv_web/components/ui.ex:4108
+#: lib/vutuv_web/components/ui.ex:4118
 #: lib/vutuv_web/live/organization_live/activity.ex:150
 #: lib/vutuv_web/live/organization_live/feed.ex:142
 #: lib/vutuv_web/live/organization_live/show.ex:647
@@ -1978,19 +1975,18 @@ msgstr "Carica altro"
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:10
 #, elixir-autogen, elixir-format
-msgid ""
-"The address itself cannot be changed. To use a different one, add it as a "
-"new email address and delete this one."
+msgid "The address itself cannot be changed. To use a different one, add it as a new email address and delete this one."
 msgstr ""
 "L'indirizzo non può essere modificato. Per usarne un altro, lo aggiunga come"
 " nuovo indirizzo e-mail ed elimini questo."
 
-#: lib/vutuv_web/components/ui.ex:3879
+#: lib/vutuv_web/components/ui.ex:3889
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr "Elimina voce"
 
-#: lib/vutuv_web/components/ui.ex:1465 lib/vutuv_web/components/ui.ex:1475
+#: lib/vutuv_web/components/ui.ex:1465
+#: lib/vutuv_web/components/ui.ex:1475
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr "Opzioni"
@@ -2133,9 +2129,7 @@ msgstr "Aggiungi immagini"
 
 #: lib/vutuv_web/live/post_live/composer.ex:1978
 #, elixir-autogen, elixir-format
-msgid ""
-"As soon as anything is hidden, the post is also invisible to logged-out "
-"visitors and search engines."
+msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
 "Non appena qualcosa viene nascosto, il post diventa invisibile anche ai "
 "visitatori non connessi e ai motori di ricerca."
@@ -2156,7 +2150,7 @@ msgstr "Annulla il caricamento"
 msgid "Delete post"
 msgstr "Elimina il post"
 
-#: lib/vutuv_web/components/post_components.ex:3044
+#: lib/vutuv_web/components/post_components.ex:3059
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2171,9 +2165,10 @@ msgstr "Modifica il post"
 #: lib/vutuv_web/components/organization_components.ex:274
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:98
-#: lib/vutuv_web/live/post_live/feed.ex:196
-#: lib/vutuv_web/live/post_live/feed.ex:1514
-#: lib/vutuv_web/live/shell_live.ex:769 lib/vutuv_web/live/shell_live.ex:1062
+#: lib/vutuv_web/live/post_live/feed.ex:231
+#: lib/vutuv_web/live/post_live/feed.ex:1650
+#: lib/vutuv_web/live/shell_live.ex:769
+#: lib/vutuv_web/live/shell_live.ex:1068
 #: lib/vutuv_web/templates/layout/app.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2199,8 +2194,8 @@ msgstr "Nascondi a una persona specifica…"
 msgid "Hide this post from…"
 msgstr "Nascondi questo post a…"
 
-#: lib/vutuv_web/components/post_components.ex:2998
-#: lib/vutuv_web/components/post_components.ex:3000
+#: lib/vutuv_web/components/post_components.ex:3013
+#: lib/vutuv_web/components/post_components.ex:3015
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Pubblico limitato"
@@ -2216,10 +2211,9 @@ msgstr "Visitatori non connessi"
 msgid "No more than %{max} images per post."
 msgstr "Non più di %{max} immagini per post."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1722
+#: lib/vutuv_web/live/post_live/feed.ex:1858
 #, elixir-autogen, elixir-format
-msgid ""
-"Nothing here yet. Follow people to fill your feed, or write your first post."
+msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 "Qui non c'è ancora nulla. Segua altre persone per riempire il Suo feed, "
 "oppure scriva il Suo primo post."
@@ -2261,20 +2255,21 @@ msgstr "Post eliminato."
 #: lib/vutuv_web/live/notification_live/index.ex:926
 #: lib/vutuv_web/live/organization_live/show.ex:564
 #: lib/vutuv_web/live/post_live/saved.ex:520
-#: lib/vutuv_web/live/search_live.ex:281 lib/vutuv_web/live/search_live.ex:728
-#: lib/vutuv_web/templates/settings/preferences.html.heex:362
+#: lib/vutuv_web/live/search_live.ex:281
+#: lib/vutuv_web/live/search_live.ex:728
+#: lib/vutuv_web/templates/settings/preferences.html.heex:312
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Posts"
 msgstr "Post"
 
-#: lib/vutuv_web/components/post_components.ex:3468
-#: lib/vutuv_web/components/post_components.ex:3472
+#: lib/vutuv_web/components/post_components.ex:3483
+#: lib/vutuv_web/components/post_components.ex:3487
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Leggi tutto"
 
-#: lib/vutuv_web/components/post_components.ex:3469
+#: lib/vutuv_web/components/post_components.ex:3484
 #: lib/vutuv_web/live/fediverse_account_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2282,7 +2277,7 @@ msgstr "Mostra meno"
 
 #: lib/vutuv_web/components/fediverse_components.ex:376
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:1178
+#: lib/vutuv_web/components/post_components.ex:1190
 #: lib/vutuv_web/live/admin/screenshot_live.ex:327
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:700
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
@@ -2293,16 +2288,14 @@ msgstr "Mostra meno"
 #: lib/vutuv_web/live/post_live/saved.ex:650
 #: lib/vutuv_web/live/post_live/saved.ex:678
 #: lib/vutuv_web/templates/connection/index.html.heex:40
-#: lib/vutuv_web/views/settings_html.ex:434
+#: lib/vutuv_web/views/settings_html.ex:329
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Rimuovi"
 
 #: lib/vutuv_web/templates/post/show.html.heex:30
 #, elixir-autogen, elixir-format
-msgid ""
-"Restricted posts are also hidden from logged-out visitors and search "
-"engines."
+msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
 "I post con pubblico limitato sono nascosti anche ai visitatori non connessi "
 "e ai motori di ricerca."
@@ -2312,7 +2305,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Salvataggio…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1626
+#: lib/vutuv_web/live/post_live/feed.ex:1762
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2349,10 +2342,11 @@ msgstr "Troppi file."
 msgid "Upload failed."
 msgstr "Caricamento non riuscito."
 
-#: lib/vutuv_web/components/ui.ex:4650 lib/vutuv_web/live/shell_live.ex:962
+#: lib/vutuv_web/components/ui.ex:4671
+#: lib/vutuv_web/live/shell_live.ex:962
 #: lib/vutuv_web/templates/post/index.html.heex:18
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
-#: lib/vutuv_web/views/settings_html.ex:335
+#: lib/vutuv_web/views/settings_html.ex:230
 #, elixir-autogen, elixir-format
 msgid "View profile"
 msgstr "Vedi il profilo"
@@ -2367,33 +2361,33 @@ msgstr "Che c'è di nuovo?"
 msgid "What's new? Markdown is supported."
 msgstr "Che c'è di nuovo? Markdown è supportato."
 
-#: lib/vutuv_web/components/post_components.ex:2995
+#: lib/vutuv_web/components/post_components.ex:3010
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "modificato"
 
-#: lib/vutuv_web/components/post_components.ex:4788
+#: lib/vutuv_web/components/post_components.ex:4818
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "tutti gli altri"
 
-#: lib/vutuv_web/components/post_components.ex:4792
+#: lib/vutuv_web/components/post_components.ex:4822
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "visitatori non connessi"
 
-#: lib/vutuv_web/components/post_components.ex:4790
+#: lib/vutuv_web/components/post_components.ex:4820
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "persone che non La seguono"
 
-#: lib/vutuv_web/components/post_components.ex:4791
+#: lib/vutuv_web/components/post_components.ex:4821
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "persone che non segue"
 
 #: lib/vutuv_web/views/post_html.ex:19
-#: lib/vutuv_web/views/settings_html.ex:513
+#: lib/vutuv_web/views/settings_html.ex:408
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr "sconosciuto"
@@ -2428,9 +2422,10 @@ msgstr "Vedi tutti i %{count} post"
 msgid "All posts"
 msgstr "Tutti i post"
 
-#: lib/vutuv_web/components/post_components.ex:1771
-#: lib/vutuv_web/components/post_components.ex:4884
-#: lib/vutuv_web/components/ui.ex:3498 lib/vutuv_web/views/user_html.ex:453
+#: lib/vutuv_web/components/post_components.ex:1783
+#: lib/vutuv_web/components/post_components.ex:4914
+#: lib/vutuv_web/components/ui.ex:3508
+#: lib/vutuv_web/views/user_html.ex:453
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr "Salva"
@@ -2438,16 +2433,17 @@ msgstr "Salva"
 #: lib/vutuv_web/agent_docs/markdown.ex:1108
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
-#: lib/vutuv_web/live/shell_live.ex:899 lib/vutuv_web/live/shell_live.ex:967
+#: lib/vutuv_web/live/shell_live.ex:899
+#: lib/vutuv_web/live/shell_live.ex:967
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:172
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr "Salvati"
 
-#: lib/vutuv_web/components/post_components.ex:1724
-#: lib/vutuv_web/components/post_components.ex:5120
-#: lib/vutuv_web/components/ui.ex:3484
+#: lib/vutuv_web/components/post_components.ex:1736
+#: lib/vutuv_web/components/post_components.ex:5150
+#: lib/vutuv_web/components/ui.ex:3494
 #: lib/vutuv_web/live/notification_live/index.ex:1072
 #: lib/vutuv_web/views/user_html.ex:463
 #, elixir-autogen, elixir-format
@@ -2455,7 +2451,7 @@ msgid "Like"
 msgstr "Mi piace"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1107
-#: lib/vutuv_web/components/post_components.ex:5130
+#: lib/vutuv_web/components/post_components.ex:5160
 #: lib/vutuv_web/live/notification_live/index.ex:1005
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
@@ -2477,40 +2473,40 @@ msgstr "Qui non c'è ancora nulla. I post che salva compaiono qui."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Qui non c'è ancora nulla. I post a cui mette Mi piace compaiono qui."
 
-#: lib/vutuv_web/components/post_components.ex:4872
+#: lib/vutuv_web/components/post_components.ex:4902
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Solo i post pubblici possono essere ripubblicati."
 
-#: lib/vutuv_web/components/post_components.ex:1770
-#: lib/vutuv_web/components/post_components.ex:4883
+#: lib/vutuv_web/components/post_components.ex:1782
+#: lib/vutuv_web/components/post_components.ex:4913
 #: lib/vutuv_web/live/post_live/saved.ex:806
 #: lib/vutuv_web/views/user_html.ex:453
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr "Rimuovi dai salvati"
 
-#: lib/vutuv_web/components/post_components.ex:1752
-#: lib/vutuv_web/components/post_components.ex:4869
+#: lib/vutuv_web/components/post_components.ex:1764
+#: lib/vutuv_web/components/post_components.ex:4899
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Ripubblica"
 
-#: lib/vutuv_web/components/post_components.ex:2017
-#: lib/vutuv_web/components/post_components.ex:4050
+#: lib/vutuv_web/components/post_components.ex:2029
+#: lib/vutuv_web/components/post_components.ex:4065
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Ripubblicato da %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:1751
-#: lib/vutuv_web/components/post_components.ex:4868
+#: lib/vutuv_web/components/post_components.ex:1763
+#: lib/vutuv_web/components/post_components.ex:4898
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Annulla la ripubblicazione"
 
-#: lib/vutuv_web/components/post_components.ex:1723
-#: lib/vutuv_web/components/post_components.ex:5119
+#: lib/vutuv_web/components/post_components.ex:1735
+#: lib/vutuv_web/components/post_components.ex:5149
 #: lib/vutuv_web/live/post_live/saved.ex:805
 #: lib/vutuv_web/views/user_html.ex:463
 #, elixir-autogen, elixir-format
@@ -2518,13 +2514,14 @@ msgid "Unlike"
 msgstr "Togli Mi piace"
 
 #: lib/vutuv_web/components/fediverse_components.ex:377
-#: lib/vutuv_web/components/post_components.ex:2302
-#: lib/vutuv_web/components/ui.ex:2388 lib/vutuv_web/components/ui.ex:2388
+#: lib/vutuv_web/components/post_components.ex:2317
+#: lib/vutuv_web/components/ui.ex:2388
+#: lib/vutuv_web/components/ui.ex:2388
 #: lib/vutuv_web/components/ui.ex:2525
 #: lib/vutuv_web/live/organization_live/following.ex:378
 #: lib/vutuv_web/live/organization_live/following.ex:453
 #: lib/vutuv_web/live/organization_live/show.ex:474
-#: lib/vutuv_web/live/post_live/feed.ex:1771
+#: lib/vutuv_web/live/post_live/feed.ex:1907
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2536,7 +2533,7 @@ msgstr "Non seguire più"
 msgid "Welcome to vutuv!"
 msgstr "Benvenuto su vutuv."
 
-#: lib/vutuv_web/components/post_components.ex:5174
+#: lib/vutuv_web/components/post_components.ex:5204
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Solo ai post pubblici si può rispondere."
@@ -2547,16 +2544,16 @@ msgstr "Solo ai post pubblici si può rispondere."
 msgid "Replies"
 msgstr "Risposte"
 
-#: lib/vutuv_web/components/post_components.ex:1737
-#: lib/vutuv_web/components/post_components.ex:5157
-#: lib/vutuv_web/components/post_components.ex:5158
+#: lib/vutuv_web/components/post_components.ex:1749
+#: lib/vutuv_web/components/post_components.ex:5187
+#: lib/vutuv_web/components/post_components.ex:5188
 #: lib/vutuv_web/live/notification_live/index.ex:1069
 #: lib/vutuv_web/live/post_live/reply.ex:43
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Rispondi"
 
-#: lib/vutuv_web/components/post_components.ex:2962
+#: lib/vutuv_web/components/post_components.ex:2977
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Risposta a un post eliminato"
@@ -2571,9 +2568,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/post_live/composer.ex:1985
 #, elixir-autogen, elixir-format
-msgid ""
-"This post has been reposted or answered. Its audience stays public while "
-"reposts or replies exist; you can still delete the post."
+msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
 "Questo post è stato ripubblicato o ha ricevuto risposte. Il suo pubblico "
 "resta pubblico finché esistono ripubblicazioni o risposte; può comunque "
@@ -2584,7 +2579,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr "ha risposto al Suo post."
 
-#: lib/vutuv_web/components/post_components.ex:2498
+#: lib/vutuv_web/components/post_components.ex:2513
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:60
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:57
@@ -2592,14 +2587,14 @@ msgstr "ha risposto al Suo post."
 msgid "Reply to %{handle}"
 msgstr "Rispondi a %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:2936
+#: lib/vutuv_web/components/post_components.ex:2951
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Risposta a un post di %{handle} ora eliminato"
 
-#: lib/vutuv_web/components/post_components.ex:2927
-#: lib/vutuv_web/components/post_components.ex:2954
-#: lib/vutuv_web/components/post_components.ex:2957
+#: lib/vutuv_web/components/post_components.ex:2942
+#: lib/vutuv_web/components/post_components.ex:2969
+#: lib/vutuv_web/components/post_components.ex:2972
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "In risposta a %{handle}"
@@ -2708,9 +2703,7 @@ msgstr "Acceda a vutuv"
 
 #: lib/vutuv_web/templates/session/new.html.heex:3
 #, elixir-autogen, elixir-format
-msgid ""
-"Sign in with your email and we'll send you a one-time PIN. No password to "
-"remember."
+msgid "Sign in with your email and we'll send you a one-time PIN. No password to remember."
 msgstr ""
 "Inserisca il Suo indirizzo e-mail e Le invieremo un PIN monouso. Nessuna "
 "password da ricordare."
@@ -2812,10 +2805,12 @@ msgstr "Aggiungi un'esperienza lavorativa"
 msgid "Write your first post"
 msgstr "Scriva il Suo primo post"
 
-#: lib/vutuv_web/components/ui.ex:3662 lib/vutuv_web/components/ui.ex:4036
+#: lib/vutuv_web/components/ui.ex:3672
+#: lib/vutuv_web/components/ui.ex:4046
 #: lib/vutuv_web/templates/settings/apps.html.heex:22
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #: lib/vutuv_web/templates/settings/organizations.html.heex:104
+#: lib/vutuv_web/templates/settings/preferences.html.heex:195
 #: lib/vutuv_web/templates/settings/privacy.html.heex:179
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:216
@@ -2824,7 +2819,7 @@ msgstr "Scriva il Suo primo post"
 msgid "Manage"
 msgstr "Gestisci"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1552
+#: lib/vutuv_web/live/post_live/feed.ex:1688
 #: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2845,7 +2840,7 @@ msgid_plural "%{formatted} connections"
 msgstr[0] "1 collegamento"
 msgstr[1] "%{formatted} collegamenti"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1873
+#: lib/vutuv_web/live/post_live/feed.ex:2009
 #: lib/vutuv_web/templates/user/card_list.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -2900,7 +2895,7 @@ msgid_plural "connections"
 msgstr[0] "collegamento"
 msgstr[1] "collegamenti"
 
-#: lib/vutuv_web/components/post_components.ex:4789
+#: lib/vutuv_web/components/post_components.ex:4819
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "persone che non sono Suoi collegamenti"
@@ -3024,9 +3019,7 @@ msgstr "Regole della community"
 
 #: lib/vutuv_web/templates/page/community.html.heex:68
 #, elixir-autogen, elixir-format
-msgid ""
-"Confirmed violations follow three steps: a warning, then a one-week "
-"suspension, then permanent deactivation. Strikes expire after twelve months."
+msgid "Confirmed violations follow three steps: a warning, then a one-week suspension, then permanent deactivation. Strikes expire after twelve months."
 msgstr ""
 "Le violazioni confermate seguono tre passi: un avvertimento, poi una "
 "sospensione di una settimana, poi la disattivazione definitiva. I richiami "
@@ -3039,10 +3032,7 @@ msgstr "Contesto della conversazione (il messaggio segnalato per ultimo)"
 
 #: lib/vutuv_web/templates/page/community.html.heex:28
 #, elixir-autogen, elixir-format
-msgid ""
-"Criticize ideas, never people. Demeaning, threatening or repeatedly unwanted"
-" messages get accounts suspended - in public posts and in private messages "
-"alike."
+msgid "Criticize ideas, never people. Demeaning, threatening or repeatedly unwanted messages get accounts suspended - in public posts and in private messages alike."
 msgstr ""
 "Critichi le idee, mai le persone. Messaggi umilianti, minacciosi o "
 "ripetutamente indesiderati portano alla sospensione dell'account, tanto nei "
@@ -3080,8 +3070,7 @@ msgstr "Segnalato"
 
 #: lib/vutuv_web/views/moderation_case_html.ex:17
 #, elixir-autogen, elixir-format
-msgid ""
-"Hidden until one of our admins has ruled. You do not need to do anything."
+msgid "Hidden until one of our admins has ruled. You do not need to do anything."
 msgstr ""
 "Nascosto finché uno dei nostri amministratori non avrà deciso. Non deve fare"
 " nulla."
@@ -3134,9 +3123,7 @@ msgstr "Niente bullismo né molestie"
 
 #: lib/vutuv_web/templates/page/community.html.heex:18
 #, elixir-autogen, elixir-format
-msgid ""
-"No nudity, no graphic violence, no glorification of drugs or self-harm. If "
-"you would not put it on a poster in a schoolyard, do not put it on vutuv."
+msgid "No nudity, no graphic violence, no glorification of drugs or self-harm. If you would not put it on a poster in a schoolyard, do not put it on vutuv."
 msgstr ""
 "Niente nudità, niente violenza esplicita, nessuna esaltazione di droghe o "
 "autolesionismo. Se non lo appenderebbe su un manifesto nel cortile di una "
@@ -3166,9 +3153,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:31
 #, elixir-autogen, elixir-format
-msgid ""
-"Nobody else can see it right now. You have 72 hours to settle this yourself;"
-" after that our admins decide. Three ways out:"
+msgid "Nobody else can see it right now. You have 72 hours to settle this yourself; after that our admins decide. Three ways out:"
 msgstr ""
 "Al momento nessun altro può vederlo. Ha 72 ore per risolvere da solo; poi "
 "decidono i nostri amministratori. Tre vie d'uscita:"
@@ -3194,16 +3179,14 @@ msgstr "Nudità, violenza o altri contenuti che non hanno posto su vutuv."
 msgid "Only visible to you"
 msgstr "Visibile solo a Lei"
 
-#: lib/vutuv_web/components/post_components.ex:2903
+#: lib/vutuv_web/components/post_components.ex:2918
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solo Lei può vedere questo post finché la segnalazione è in corso."
 
 #: lib/vutuv_web/templates/user/show.html.heex:30
 #, elixir-autogen, elixir-format
-msgid ""
-"Only you can see your profile right now - it is hidden while a report is "
-"handled."
+msgid "Only you can see your profile right now - it is hidden while a report is handled."
 msgstr ""
 "Al momento solo Lei può vedere il Suo profilo: è nascosto finché la "
 "segnalazione è in corso."
@@ -3248,8 +3231,9 @@ msgstr ""
 msgid "Private message"
 msgstr "Messaggio privato"
 
-#: lib/vutuv_web/components/ui.ex:4293 lib/vutuv_web/live/shell_live.ex:783
-#: lib/vutuv_web/live/shell_live.ex:1071
+#: lib/vutuv_web/components/ui.ex:4303
+#: lib/vutuv_web/live/shell_live.ex:783
+#: lib/vutuv_web/live/shell_live.ex:1080
 #: lib/vutuv_web/templates/import/new.html.heex:16
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
 #: lib/vutuv_web/views/import_html.ex:76
@@ -3273,9 +3257,9 @@ msgstr "Respinta"
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Lo rimuova. La segnalazione si chiude, senza altre domande."
 
-#: lib/vutuv_web/components/post_components.ex:1188
-#: lib/vutuv_web/components/post_components.ex:2314
-#: lib/vutuv_web/components/post_components.ex:3067
+#: lib/vutuv_web/components/post_components.ex:1200
+#: lib/vutuv_web/components/post_components.ex:2329
+#: lib/vutuv_web/components/post_components.ex:3082
 #: lib/vutuv_web/live/organization_live/show.ex:547
 #: lib/vutuv_web/templates/user/show.html.heex:222
 #, elixir-autogen, elixir-format
@@ -3330,9 +3314,7 @@ msgstr "Contenuto segnalato"
 
 #: lib/vutuv_web/templates/page/community.html.heex:58
 #, elixir-autogen, elixir-format
-msgid ""
-"Reported content is hidden right away while the report is handled. Nobody is"
-" publicly marked."
+msgid "Reported content is hidden right away while the report is handled. Nobody is publicly marked."
 msgstr ""
 "Il contenuto segnalato viene nascosto subito mentre la segnalazione è in "
 "corso. Nessuno viene indicato pubblicamente."
@@ -3364,7 +3346,7 @@ msgstr ""
 "Le segnalazioni sono anonime; non diciamo mai chi ha segnalato. Le nostre "
 "regole:"
 
-#: lib/vutuv_web/components/ui.ex:3398
+#: lib/vutuv_web/components/ui.ex:3408
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:773
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
@@ -3374,11 +3356,7 @@ msgstr "Esamina"
 
 #: lib/vutuv_web/templates/page/community.html.heex:46
 #, elixir-autogen, elixir-format
-msgid ""
-"See something that breaks these rules? Report it - every post, message and "
-"profile has a report option, and reports are anonymous. But reporting is not"
-" a weapon: deliberately false reports count as bullying and earn the "
-"reporter the same strikes."
+msgid "See something that breaks these rules? Report it - every post, message and profile has a report option, and reports are anonymous. But reporting is not a weapon: deliberately false reports count as bullying and earn the reporter the same strikes."
 msgstr ""
 "Vede qualcosa che viola queste regole? Lo segnali: ogni post, messaggio e "
 "profilo ha un'opzione di segnalazione, e le segnalazioni sono anonime. Ma la"
@@ -3458,9 +3436,7 @@ msgstr "Il contenuto in questione"
 
 #: lib/vutuv_web/templates/page/community.html.heex:63
 #, elixir-autogen, elixir-format
-msgid ""
-"The owner is notified and can delete the content, fix it (it becomes visible"
-" again immediately) or stand by it - then our admins decide."
+msgid "The owner is notified and can delete the content, fix it (it becomes visible again immediately) or stand by it - then our admins decide."
 msgstr ""
 "Il proprietario viene avvisato e può eliminare il contenuto, correggerlo "
 "(torna subito visibile) oppure confermarlo: in quel caso decidono i nostri "
@@ -3480,9 +3456,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:349
 #, elixir-autogen, elixir-format
-msgid ""
-"The report is justified. The content stays hidden and the owner gets a "
-"strike (warn, suspend, deactivate)."
+msgid "The report is justified. The content stays hidden and the owner gets a strike (warn, suspend, deactivate)."
 msgstr ""
 "La segnalazione è fondata. Il contenuto resta nascosto e il proprietario "
 "riceve un richiamo (avvertimento, sospensione, disattivazione)."
@@ -3521,8 +3495,7 @@ msgstr "Tipo"
 
 #: lib/vutuv_web/controllers/moderation_case_controller.ex:45
 #, elixir-autogen, elixir-format
-msgid ""
-"Understood. The content stays hidden until one of our admins has ruled."
+msgid "Understood. The content stays hidden until one of our admins has ruled."
 msgstr ""
 "Inteso. Il contenuto resta nascosto finché uno dei nostri amministratori non"
 " avrà deciso."
@@ -3559,9 +3532,7 @@ msgstr "Perché lo segnala?"
 
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:14
 #, elixir-autogen, elixir-format
-msgid ""
-"Worst offenders first. Reporters with abusive reports or three rejections in"
-" a year lose the instant freeze; their reports only flag for review."
+msgid "Worst offenders first. Reporters with abusive reports or three rejections in a year lose the instant freeze; their reports only flag for review."
 msgstr ""
 "Prima i casi peggiori. I segnalanti con segnalazioni abusive o tre "
 "respingimenti in un anno perdono il blocco immediato: le loro segnalazioni "
@@ -3601,9 +3572,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/report/new.html.heex:7
 #, elixir-autogen, elixir-format
-msgid ""
-"Your report is anonymous. If it checks out, the content is hidden right away"
-" and the owner is asked to fix it."
+msgid "Your report is anonymous. If it checks out, the content is hidden right away and the owner is asked to fix it."
 msgstr ""
 "La Sua segnalazione è anonima. Se risulta fondata, il contenuto viene "
 "nascosto subito e al proprietario viene chiesto di correggerlo."
@@ -3621,10 +3590,7 @@ msgstr "no"
 
 #: lib/vutuv_web/templates/page/community.html.heex:7
 #, elixir-autogen, elixir-format
-msgid ""
-"vutuv is a friendly, family-friendly network. Everything you publish here "
-"should be fine for a colleague, your boss and a twelve-year-old to read. "
-"These few rules keep it that way."
+msgid "vutuv is a friendly, family-friendly network. Everything you publish here should be fine for a colleague, your boss and a twelve-year-old to read. These few rules keep it that way."
 msgstr ""
 "vutuv è una rete cordiale e adatta a tutti. Tutto ciò che pubblica qui "
 "dovrebbe poter essere letto da un collega, dal Suo capo e da un dodicenne. "
@@ -3793,9 +3759,7 @@ msgstr "Apri il profilo"
 
 #: lib/vutuv_web/notification_line.ex:143
 #, elixir-autogen, elixir-format
-msgid ""
-"Our admins found your report unfounded; the paused connection between you "
-"two is restored."
+msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
 "I nostri amministratori hanno ritenuto infondata la Sua segnalazione; il "
 "collegamento sospeso tra voi due è ripristinato."
@@ -3842,9 +3806,7 @@ msgstr "Segnalato il %{date}"
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:306
 #, elixir-autogen, elixir-format
-msgid ""
-"Reporter and owner are separated since this report (connection, follows, "
-"messages)."
+msgid "Reporter and owner are separated since this report (connection, follows, messages)."
 msgstr ""
 "Segnalante e proprietario sono separati da questa segnalazione "
 "(collegamento, follow, messaggi)."
@@ -3882,10 +3844,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:365
 #, elixir-autogen, elixir-format
-msgid ""
-"The report is unfounded. The content becomes visible again, any protective "
-"separation is lifted, and the rejection counts against each reporter's "
-"trust."
+msgid "The report is unfounded. The content becomes visible again, any protective separation is lifted, and the rejection counts against each reporter's trust."
 msgstr ""
 "La segnalazione è infondata. Il contenuto torna visibile, ogni separazione "
 "protettiva viene revocata e il respingimento pesa sull'affidabilità di "
@@ -3893,9 +3852,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:203
 #, elixir-autogen, elixir-format
-msgid ""
-"The whole profile was reported. Judge the profile itself - the snapshot "
-"below only preserves the name at report time."
+msgid "The whole profile was reported. Judge the profile itself - the snapshot below only preserves the name at report time."
 msgstr ""
 "È stato segnalato l'intero profilo. Giudichi il profilo stesso: l'istantanea"
 " qui sotto conserva solo il nome al momento della segnalazione."
@@ -3912,9 +3869,7 @@ msgstr "In attesa del proprietario"
 
 #: lib/vutuv_web/notification_line.ex:148
 #, elixir-autogen, elixir-format
-msgid ""
-"Your report paused the connection between you two - no contact in either "
-"direction for now. If our admins find the report unfounded, this is undone."
+msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
 "La Sua segnalazione ha sospeso il collegamento tra voi due: per ora nessun "
 "contatto in nessuna delle due direzioni. Se i nostri amministratori "
@@ -3956,9 +3911,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/report/new.html.heex:12
 #, elixir-autogen, elixir-format
-msgid ""
-"If your report checks out, the content is hidden right away and the owner is"
-" asked to fix it."
+msgid "If your report checks out, the content is hidden right away and the owner is asked to fix it."
 msgstr ""
 "Se la Sua segnalazione risulta fondata, il contenuto viene nascosto subito e"
 " al proprietario viene chiesto di correggerlo."
@@ -3971,11 +3924,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/report/new.html.heex:31
 #, elixir-autogen, elixir-format
-msgid ""
-"To protect you, your connection, follows and messages are paused in both "
-"directions - nobody should have to stay in contact with someone they just "
-"reported. Because of this, @%{handle} may recognize that the report came "
-"from you."
+msgid "To protect you, your connection, follows and messages are paused in both directions - nobody should have to stay in contact with someone they just reported. Because of this, @%{handle} may recognize that the report came from you."
 msgstr ""
 "Per proteggerLa, il collegamento, i follow e i messaggi vengono sospesi in "
 "entrambe le direzioni: nessuno dovrebbe restare in contatto con una persona "
@@ -4037,8 +3986,10 @@ msgstr "%{count} post di %{name}"
 #: lib/vutuv_web/agent_docs/markdown.ex:194
 #: lib/vutuv_web/agent_docs/markdown.ex:208
 #: lib/vutuv_web/agent_docs/markdown.ex:1070
-#: lib/vutuv_web/agent_docs/text.ex:80 lib/vutuv_web/agent_docs/text.ex:179
-#: lib/vutuv_web/agent_docs/text.ex:193 lib/vutuv_web/agent_docs/text.ex:753
+#: lib/vutuv_web/agent_docs/text.ex:80
+#: lib/vutuv_web/agent_docs/text.ex:179
+#: lib/vutuv_web/agent_docs/text.ex:193
+#: lib/vutuv_web/agent_docs/text.ex:753
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr "%{count} in totale"
@@ -4050,7 +4001,8 @@ msgstr "Follower di %{name}"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:111
 #: lib/vutuv_web/agent_docs/markdown.ex:149
-#: lib/vutuv_web/agent_docs/text.ex:106 lib/vutuv_web/agent_docs/text.ex:137
+#: lib/vutuv_web/agent_docs/text.ex:106
+#: lib/vutuv_web/agent_docs/text.ex:137
 #: lib/vutuv_web/live/job_posting_live/form.ex:689
 #, elixir-autogen, elixir-format
 msgid "Images"
@@ -4070,7 +4022,8 @@ msgstr "In risposta a un post eliminato."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1092
 #: lib/vutuv_web/agent_docs/markdown.ex:1306
-#: lib/vutuv_web/agent_docs/text.ex:767 lib/vutuv_web/agent_docs/text.ex:811
+#: lib/vutuv_web/agent_docs/text.ex:767
+#: lib/vutuv_web/agent_docs/text.ex:811
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr "In risposta a un post di %{name}."
@@ -4104,7 +4057,8 @@ msgstr "Archivio dei post di %{name}"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:103
 #: lib/vutuv_web/agent_docs/markdown.ex:143
-#: lib/vutuv_web/agent_docs/text.ex:98 lib/vutuv_web/agent_docs/text.ex:131
+#: lib/vutuv_web/agent_docs/text.ex:98
+#: lib/vutuv_web/agent_docs/text.ex:131
 #: lib/vutuv_web/live/admin/screenshot_live.ex:380
 #: lib/vutuv_web/live/admin/screenshot_live.ex:389
 #: lib/vutuv_web/templates/post/show.html.heex:10
@@ -4112,7 +4066,8 @@ msgstr "Archivio dei post di %{name}"
 msgid "Post by %{name}"
 msgstr "Post di %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:70 lib/vutuv_web/agent_docs/text.ex:67
+#: lib/vutuv_web/agent_docs/markdown.ex:70
+#: lib/vutuv_web/agent_docs/text.ex:67
 #, elixir-autogen, elixir-format
 msgid "Posts (%{count} total)"
 msgstr "Post (%{count} in totale)"
@@ -4200,9 +4155,7 @@ msgstr "Pubblicità su vutuv"
 
 #: lib/vutuv_web/agent_docs/ads_doc.ex:18
 #, elixir-autogen, elixir-format
-msgid ""
-"Appears at most once per hour per visitor and hides itself after two "
-"minutes."
+msgid "Appears at most once per hour per visitor and hides itself after two minutes."
 msgstr ""
 "Compare al massimo una volta all'ora per visitatore e si nasconde da sola "
 "dopo due minuti."
@@ -4296,8 +4249,7 @@ msgstr "Prezzo"
 
 #: lib/vutuv_web/agent_docs/ads_doc.ex:17
 #, elixir-autogen, elixir-format
-msgid ""
-"Shown to every visitor, between the top navigation and the page content."
+msgid "Shown to every visitor, between the top navigation and the page content."
 msgstr ""
 "Mostrata a tutti i visitatori, tra la navigazione in alto e il contenuto "
 "della pagina."
@@ -4309,9 +4261,7 @@ msgstr "Via e numero"
 
 #: lib/vutuv_web/agent_docs/ads_doc.ex:19
 #, elixir-autogen, elixir-format
-msgid ""
-"Text only: Markdown, up to %{max} characters, always clearly labeled as an "
-"ad."
+msgid "Text only: Markdown, up to %{max} characters, always clearly labeled as an ad."
 msgstr ""
 "Solo testo: Markdown, fino a %{max} caratteri, sempre chiaramente indicata "
 "come pubblicità."
@@ -4340,18 +4290,14 @@ msgstr "tutto prenotato"
 
 #: lib/vutuv_web/templates/ad/new.html.heex:126
 #, elixir-autogen, elixir-format
-msgid ""
-"Price: %{price}. Payment by invoice; the day is reserved immediately and the"
-" invoice follows by email."
+msgid "Price: %{price}. Payment by invoice; the day is reserved immediately and the invoice follows by email."
 msgstr ""
 "Prezzo: %{price}. Pagamento tramite fattura; il giorno viene riservato "
 "subito e la fattura arriva per e-mail."
 
 #: lib/vutuv_web/templates/ad/index.html.heex:13
 #, elixir-autogen, elixir-format
-msgid ""
-"vutuv shows a single, text-only ad per calendar day: discreet, between the "
-"navigation and the content, in the style of classic text ads."
+msgid "vutuv shows a single, text-only ad per calendar day: discreet, between the navigation and the content, in the style of classic text ads."
 msgstr ""
 "vutuv mostra una sola pubblicità di solo testo al giorno: discreta, tra la "
 "navigazione e il contenuto, nello stile delle classiche inserzioni testuali."
@@ -4418,18 +4364,14 @@ msgstr "Prenotata da un account poi eliminato"
 
 #: lib/vutuv_web/agent_docs/ads_doc.ex:23
 #, elixir-autogen, elixir-format
-msgid ""
-"Every ad is reviewed and approved before it runs; the earliest bookable day "
-"is three days out."
+msgid "Every ad is reviewed and approved before it runs; the earliest bookable day is three days out."
 msgstr ""
 "Ogni pubblicità viene verificata e approvata prima di andare online; il "
 "primo giorno prenotabile è tra tre giorni."
 
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:13
 #, elixir-autogen, elixir-format
-msgid ""
-"Every ad must be approved before it runs. Check that it is family-friendly "
-"(community guidelines) before approving."
+msgid "Every ad must be approved before it runs. Check that it is family-friendly (community guidelines) before approving."
 msgstr ""
 "Ogni pubblicità va approvata prima di andare online. Prima di approvare, "
 "verifichi che sia adatta a tutti (regole della community)."
@@ -4498,9 +4440,7 @@ msgstr "In attesa di approvazione"
 
 #: lib/vutuv_web/templates/ad/new.html.heex:130
 #, elixir-autogen, elixir-format
-msgid ""
-"We review and approve every ad before it runs, which is why the earliest "
-"bookable day is three days out."
+msgid "We review and approve every ad before it runs, which is why the earliest bookable day is three days out."
 msgstr ""
 "Verifichiamo e approviamo ogni pubblicità prima che vada online: per questo "
 "il primo giorno prenotabile è tra tre giorni."
@@ -4519,9 +4459,7 @@ msgstr "Non ha ancora prenotato una pubblicità."
 
 #: lib/vutuv_web/controllers/ad_controller.ex:66
 #, elixir-autogen, elixir-format
-msgid ""
-"Your ad for %{day} is booked. We will review and approve it shortly; the "
-"invoice follows by email."
+msgid "Your ad for %{day} is booked. We will review and approve it shortly; the invoice follows by email."
 msgstr ""
 "La Sua pubblicità del %{day} è prenotata. La verificheremo e approveremo a "
 "breve; la fattura arriva per e-mail."
@@ -4572,9 +4510,7 @@ msgstr "Lu"
 
 #: lib/vutuv_web/templates/ad/new.html.heex:61
 #, elixir-autogen, elixir-format
-msgid ""
-"One ad per calendar day: pick a free day in the calendar; struck-through "
-"days are already booked."
+msgid "One ad per calendar day: pick a free day in the calendar; struck-through days are already booked."
 msgstr ""
 "Una pubblicità al giorno: scelga un giorno libero nel calendario; i giorni "
 "barrati sono già prenotati."
@@ -4649,9 +4585,7 @@ msgstr "Prenoti ora (vincolante, con fattura)"
 
 #: lib/vutuv_web/templates/ad/preview.html.heex:56
 #, elixir-autogen, elixir-format
-msgid ""
-"Booking is binding; payment by invoice. We review and approve every ad "
-"before it runs."
+msgid "Booking is binding; payment by invoice. We review and approve every ad before it runs."
 msgstr ""
 "La prenotazione è vincolante; pagamento tramite fattura. Verifichiamo e "
 "approviamo ogni pubblicità prima che vada online."
@@ -4678,9 +4612,7 @@ msgstr "Anteprima della Sua pubblicità"
 
 #: lib/vutuv_web/templates/ad/preview.html.heex:10
 #, elixir-autogen, elixir-format
-msgid ""
-"This is exactly how your ad will appear between the navigation and the "
-"content on %{day}."
+msgid "This is exactly how your ad will appear between the navigation and the content on %{day}."
 msgstr ""
 "Ecco esattamente come apparirà la Sua pubblicità tra la navigazione e il "
 "contenuto il %{day}."
@@ -4699,9 +4631,7 @@ msgstr "I PIN di accesso e le altre e-mail essenziali non sono interessati."
 #: lib/vutuv_web/live/section_reorder_live.ex:266
 #: lib/vutuv_web/templates/email/card_list.html.heex:21
 #, elixir-autogen, elixir-format
-msgid ""
-"Mail to this address bounced. Logging in with a PIN sent to it will clear "
-"this warning."
+msgid "Mail to this address bounced. Logging in with a PIN sent to it will clear this warning."
 msgstr ""
 "Un messaggio a questo indirizzo è stato respinto. Accedendo con un PIN "
 "inviato a questo indirizzo l'avviso sparisce."
@@ -4714,8 +4644,7 @@ msgstr "Non recapitabile"
 
 #: lib/vutuv_web/live/search_live.ex:397
 #, elixir-autogen, elixir-format
-msgid ""
-"You can search for a name, email, or tag, or for words in public posts."
+msgid "You can search for a name, email, or tag, or for words in public posts."
 msgstr ""
 "Può cercare un nome, un indirizzo e-mail o un tag, oppure parole nei post "
 "pubblici."
@@ -4743,16 +4672,13 @@ msgstr "Blocca"
 
 #: lib/vutuv_web/block_text.ex:18
 #, elixir-autogen, elixir-format
-msgid ""
-"Block @%{slug}? This removes any follows and connection between you, closes "
-"your conversation, and prevents all interaction in both directions. "
-"Unblocking will not restore what was removed."
+msgid "Block @%{slug}? This removes any follows and connection between you, closes your conversation, and prevents all interaction in both directions. Unblocking will not restore what was removed."
 msgstr ""
 "Bloccare @%{slug}? Questo rimuove ogni follow e collegamento tra voi, chiude"
 " la vostra conversazione e impedisce ogni interazione in entrambe le "
 "direzioni. Sbloccare non ripristina ciò che è stato rimosso."
 
-#: lib/vutuv_web/components/ui.ex:4400
+#: lib/vutuv_web/components/ui.ex:4421
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -4763,10 +4689,7 @@ msgstr "Membri bloccati"
 
 #: lib/vutuv_web/templates/block/index.html.heex:43
 #, elixir-autogen, elixir-format
-msgid ""
-"Blocked members cannot follow you, connect with you, message you, or reply "
-"to your posts - and you cannot interact with them either. Blocking removed "
-"any follows and connection between you; unblocking does not restore them."
+msgid "Blocked members cannot follow you, connect with you, message you, or reply to your posts - and you cannot interact with them either. Blocking removed any follows and connection between you; unblocking does not restore them."
 msgstr ""
 "I membri bloccati non possono seguirLa, collegarsi con Lei, scriverLe o "
 "rispondere ai Suoi post, e nemmeno Lei può interagire con loro. Il blocco ha"
@@ -4802,7 +4725,7 @@ msgstr "Non ha bloccato nessuno."
 msgid "You unblocked @%{slug}."
 msgstr "Ha sbloccato @%{slug}."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1727
+#: lib/vutuv_web/live/post_live/feed.ex:1863
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Scopra persone da seguire"
@@ -4863,7 +4786,8 @@ msgstr "Non è una corrispondenza esatta, ma somiglia alla Sua ricerca."
 #: lib/vutuv_web/live/notification_live/index.ex:927
 #: lib/vutuv_web/live/organization_live/show.ex:657
 #: lib/vutuv_web/live/post_live/saved.ex:523
-#: lib/vutuv_web/live/search_live.ex:279 lib/vutuv_web/live/search_live.ex:670
+#: lib/vutuv_web/live/search_live.ex:279
+#: lib/vutuv_web/live/search_live.ex:670
 #, elixir-autogen, elixir-format
 msgid "People"
 msgstr "Persone"
@@ -4885,7 +4809,7 @@ msgstr "Nomi simili"
 #: lib/vutuv_web/live/import_connections_live.ex:470
 #: lib/vutuv_web/live/notification_live/index.ex:925
 #: lib/vutuv_web/live/search_live.ex:278
-#: lib/vutuv_web/templates/settings/preferences.html.heex:304
+#: lib/vutuv_web/templates/settings/preferences.html.heex:254
 #: lib/vutuv_web/views/qualification_html.ex:103
 #, elixir-autogen, elixir-format
 msgid "All"
@@ -4933,7 +4857,7 @@ msgstr "cerca solo nel nome (cognome: per il cognome)"
 
 #: lib/vutuv_web/live/job_board_live.ex:388
 #: lib/vutuv_web/live/tag_new_live.ex:48
-#: lib/vutuv_web/live/user_profile_live.ex:1332
+#: lib/vutuv_web/live/user_profile_live.ex:1336
 #: lib/vutuv_web/templates/user/show.html.heex:594
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
@@ -4954,8 +4878,7 @@ msgstr "Token di accesso"
 
 #: lib/vutuv_web/templates/access_token/new.html.heex:54
 #, elixir-autogen, elixir-format
-msgid ""
-"An expiry limits the damage if a token leaks. You can always revoke earlier."
+msgid "An expiry limits the damage if a token leaks. You can always revoke earlier."
 msgstr ""
 "Una scadenza limita i danni se un token finisce in mani sbagliate. Può "
 "sempre revocarlo prima."
@@ -5018,16 +4941,14 @@ msgstr "Autorizzazioni"
 
 #: lib/vutuv_web/templates/access_token/index.html.heex:12
 #, elixir-autogen, elixir-format
-msgid ""
-"Personal access tokens let scripts and third-party tools use the vutuv API "
-"as you, limited to the permissions you pick. Revoking a token cuts off its "
-"access immediately. Documentation: "
+msgid "Personal access tokens let scripts and third-party tools use the vutuv API as you, limited to the permissions you pick. Revoking a token cuts off its access immediately. Documentation: "
 msgstr ""
 "I token di accesso personali permettono a script e strumenti di terze parti "
 "di usare l'API di vutuv a Suo nome, con le sole autorizzazioni che sceglie. "
 "Revocare un token interrompe subito il suo accesso. Documentazione:"
 
-#: lib/vutuv/api_auth/scopes.ex:56 lib/vutuv/api_auth/scopes.ex:75
+#: lib/vutuv/api_auth/scopes.ex:56
+#: lib/vutuv/api_auth/scopes.ex:75
 #: lib/vutuv/api_auth/scopes.ex:81
 #, elixir-autogen, elixir-format
 msgid "Read posts visible to you"
@@ -5038,7 +4959,8 @@ msgstr "Leggere i post visibili a Lei"
 msgid "Read your messages"
 msgstr "Leggere i Suoi messaggi"
 
-#: lib/vutuv/api_auth/scopes.ex:44 lib/vutuv/api_auth/scopes.ex:74
+#: lib/vutuv/api_auth/scopes.ex:44
+#: lib/vutuv/api_auth/scopes.ex:74
 #: lib/vutuv/api_auth/scopes.ex:79
 #, elixir-autogen, elixir-format
 msgid "Read your profile, including entries only you can see"
@@ -5056,9 +4978,7 @@ msgstr "Revocare \"%{name}\"? Tutto ciò che lo usa smette subito di funzionare.
 
 #: lib/vutuv_web/templates/access_token/index.html.heex:61
 #, elixir-autogen, elixir-format
-msgid ""
-"Revoke ALL tokens? Every app and script using them stops working "
-"immediately."
+msgid "Revoke ALL tokens? Every app and script using them stops working immediately."
 msgstr ""
 "Revocare TUTTI i token? Ogni app e script che li usa smette subito di "
 "funzionare."
@@ -5083,7 +5003,8 @@ msgstr "Inviare messaggi a Suo nome"
 msgid "The token \"%{name}\" no longer works."
 msgstr "Il token \"%{name}\" non funziona più."
 
-#: lib/vutuv/api_auth/scopes.ex:59 lib/vutuv/api_auth/scopes.ex:82
+#: lib/vutuv/api_auth/scopes.ex:59
+#: lib/vutuv/api_auth/scopes.ex:82
 #: lib/vutuv/api_auth/scopes.ex:83
 #, elixir-autogen, elixir-format
 msgid "Write, edit and delete your posts"
@@ -5163,12 +5084,8 @@ msgstr "%{app} chiede di accedere al Suo account vutuv. Potrebbe:"
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:411
 #, elixir-autogen, elixir-format
-msgid ""
-"%{formatted} registered third-party application. Suspending one cuts off all"
-" of its tokens."
-msgid_plural ""
-"%{formatted} registered third-party applications. Suspending one cuts off "
-"all of its tokens."
+msgid "%{formatted} registered third-party application. Suspending one cuts off all of its tokens."
+msgid_plural "%{formatted} registered third-party applications. Suspending one cuts off all of its tokens."
 msgstr[0] ""
 "%{formatted} applicazione di terze parti registrata. Sospenderla interrompe "
 "tutti i suoi token."
@@ -5186,8 +5103,8 @@ msgstr "Applicazioni API"
 
 #: lib/vutuv_web/live/admin/api_app_live.ex:98
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:181
-#: lib/vutuv_web/views/settings_html.ex:77
-#: lib/vutuv_web/views/settings_html.ex:379
+#: lib/vutuv_web/views/settings_html.ex:75
+#: lib/vutuv_web/views/settings_html.ex:274
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr "Attiva"
@@ -5251,9 +5168,7 @@ msgstr "App collegate"
 
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:18
 #, elixir-autogen, elixir-format
-msgid ""
-"Delete \"%{name}\"? Every member authorization and every token of this "
-"application stops working immediately."
+msgid "Delete \"%{name}\"? Every member authorization and every token of this application stops working immediately."
 msgstr ""
 "Eliminare \"%{name}\"? Ogni autorizzazione dei membri e ogni token di questa"
 " applicazione smette subito di funzionare."
@@ -5305,9 +5220,7 @@ msgstr "Nulla è stato modificato sul Suo account."
 
 #: lib/vutuv_web/templates/dev_app/index.html.heex:9
 #, elixir-autogen, elixir-format
-msgid ""
-"OAuth applications let other members connect your software with their vutuv "
-"account through a consent screen, instead of pasting tokens. Documentation: "
+msgid "OAuth applications let other members connect your software with their vutuv account through a consent screen, instead of pasting tokens. Documentation: "
 msgstr ""
 "Le applicazioni OAuth permettono agli altri membri di collegare il Suo "
 "software al loro account vutuv tramite una schermata di consenso, invece di "
@@ -5315,9 +5228,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/dev_app/form_content.html.heex:33
 #, elixir-autogen, elixir-format
-msgid ""
-"One per line. Exact https:// URLs (http://localhost is allowed for "
-"development). The authorization flow only ever redirects to these."
+msgid "One per line. Exact https:// URLs (http://localhost is allowed for development). The authorization flow only ever redirects to these."
 msgstr ""
 "Uno per riga. URL https:// esatti (http://localhost è ammesso in fase di "
 "sviluppo). Il flusso di autorizzazione reindirizza solo a questi."
@@ -5388,15 +5299,13 @@ msgstr "L'applicazione ha chiesto autorizzazioni sconosciute."
 
 #: lib/vutuv_web/views/oauth_html.ex:8
 #, elixir-autogen, elixir-format
-msgid ""
-"The application is unknown. Its developer needs to check the client_id."
+msgid "The application is unknown. Its developer needs to check the client_id."
 msgstr ""
 "L'applicazione è sconosciuta. Chi la sviluppa deve controllare il client_id."
 
 #: lib/vutuv_web/views/oauth_html.ex:23
 #, elixir-autogen, elixir-format
-msgid ""
-"The application's request is missing the required PKCE challenge (S256)."
+msgid "The application's request is missing the required PKCE challenge (S256)."
 msgstr ""
 "Alla richiesta dell'applicazione manca il challenge PKCE richiesto (S256)."
 
@@ -5412,18 +5321,14 @@ msgstr "Il vecchio client secret ha smesso di funzionare."
 
 #: lib/vutuv_web/views/oauth_html.ex:12
 #, elixir-autogen, elixir-format
-msgid ""
-"The redirect address is not registered for this application. Its developer "
-"needs to register it first."
+msgid "The redirect address is not registered for this application. Its developer needs to register it first."
 msgstr ""
 "L'indirizzo di reindirizzamento non è registrato per questa applicazione. "
 "Chi la sviluppa deve registrarlo prima."
 
 #: lib/vutuv_web/templates/connected_app/index.html.heex:6
 #, elixir-autogen, elixir-format
-msgid ""
-"These applications may use your vutuv account, limited to the permissions "
-"you granted them. Withdrawing access cuts them off immediately."
+msgid "These applications may use your vutuv account, limited to the permissions you granted them. Withdrawing access cuts them off immediately."
 msgstr ""
 "Queste applicazioni possono usare il Suo account vutuv, con le sole "
 "autorizzazioni che ha concesso. Revocare l'accesso le interrompe subito."
@@ -5435,8 +5340,7 @@ msgstr "Questa applicazione è stata sospesa."
 
 #: lib/vutuv_web/templates/dev_app/show.html.heex:13
 #, elixir-autogen, elixir-format
-msgid ""
-"This application was suspended by the operator. Its tokens are refused."
+msgid "This application was suspended by the operator. Its tokens are refused."
 msgstr ""
 "Questa applicazione è stata sospesa da chi gestisce l'installazione. I suoi "
 "token vengono rifiutati."
@@ -5458,9 +5362,7 @@ msgstr "Revocare l'accesso a \"%{name}\"? Smette subito di funzionare."
 
 #: lib/vutuv_web/templates/oauth/authorize.html.heex:29
 #, elixir-autogen, elixir-format
-msgid ""
-"You can withdraw this access at any time under Connected apps in your "
-"settings."
+msgid "You can withdraw this access at any time under Connected apps in your settings."
 msgstr ""
 "Può revocare questo accesso in qualsiasi momento da App collegate nelle Sue "
 "impostazioni."
@@ -5498,9 +5400,7 @@ msgstr "Eliminare questo webhook?"
 
 #: lib/vutuv_web/templates/dev_webhook/new.html.heex:48
 #, elixir-autogen, elixir-format
-msgid ""
-"Deliveries only ever concern members who authorized your application with "
-"the matching permission."
+msgid "Deliveries only ever concern members who authorized your application with the matching permission."
 msgstr ""
 "Le consegne riguardano solo i membri che hanno autorizzato la Sua "
 "applicazione con l'autorizzazione corrispondente."
@@ -5566,9 +5466,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/dev_webhook/new.html.heex:25
 #, elixir-autogen, elixir-format
-msgid ""
-"vutuv POSTs signed JSON envelopes here (see the webhooks documentation). "
-"https:// only; http://localhost is allowed for development."
+msgid "vutuv POSTs signed JSON envelopes here (see the webhooks documentation). https:// only; http://localhost is allowed for development."
 msgstr ""
 "vutuv invia qui buste JSON firmate via POST (veda la documentazione sui "
 "webhook). Solo https://; http://localhost è ammesso in fase di sviluppo."
@@ -5589,7 +5487,7 @@ msgstr "Token API (%{date})"
 msgid "API documentation"
 msgstr "Documentazione dell'API"
 
-#: lib/vutuv_web/components/ui.ex:4460
+#: lib/vutuv_web/components/ui.ex:4481
 #: lib/vutuv_web/controllers/settings_controller.ex:155
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5624,9 +5522,7 @@ msgstr "Questo caso è già stato risolto."
 
 #: lib/vutuv_web/templates/settings/delete_account.html.heex:13
 #, elixir-autogen, elixir-format
-msgid ""
-"This permanently removes your profile, posts, messages and everything else. "
-"We email you a PIN to confirm. It cannot be undone."
+msgid "This permanently removes your profile, posts, messages and everything else. We email you a PIN to confirm. It cannot be undone."
 msgstr ""
 "Questo elimina definitivamente il Suo profilo, i post, i messaggi e tutto il"
 " resto. Le inviamo un PIN per e-mail per confermare. Non si può annullare."
@@ -5674,8 +5570,10 @@ msgstr "Scorciatoie da tastiera"
 msgid "Navigation"
 msgstr "Navigazione"
 
-#: lib/vutuv_web/components/ui.ex:4557 lib/vutuv_web/components/ui.ex:4562
-#: lib/vutuv_web/components/ui.ex:4641 lib/vutuv_web/components/ui.ex:4705
+#: lib/vutuv_web/components/ui.ex:4578
+#: lib/vutuv_web/components/ui.ex:4583
+#: lib/vutuv_web/components/ui.ex:4662
+#: lib/vutuv_web/components/ui.ex:4726
 #: lib/vutuv_web/controllers/settings_controller.ex:62
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:168
@@ -5688,7 +5586,7 @@ msgstr "Navigazione"
 #: lib/vutuv_web/templates/login_code/index.html.heex:4
 #: lib/vutuv_web/templates/totp/new.html.heex:4
 #: lib/vutuv_web/templates/username/confirm.html.heex:23
-#: lib/vutuv_web/views/settings_html.ex:330
+#: lib/vutuv_web/views/settings_html.ex:225
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr "Impostazioni"
@@ -5719,7 +5617,7 @@ msgstr "Completi il Suo profilo"
 msgid "A few quick steps so people can find and recognize you."
 msgstr "Pochi passaggi veloci perché le persone La trovino e La riconoscano."
 
-#: lib/vutuv_web/live/user_profile_live.ex:1338
+#: lib/vutuv_web/live/user_profile_live.ex:1342
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr "Aggiungi una foto del profilo"
@@ -5734,7 +5632,8 @@ msgstr "Post successivo nel feed"
 msgid "Previous post in the feed"
 msgstr "Post precedente nel feed"
 
-#: lib/vutuv_web/live/shell_live.ex:758 lib/vutuv_web/live/shell_live.ex:1052
+#: lib/vutuv_web/live/shell_live.ex:758
+#: lib/vutuv_web/live/shell_live.ex:1052
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr "Navigazione principale"
@@ -5744,11 +5643,11 @@ msgstr "Navigazione principale"
 msgid "Footer navigation"
 msgstr "Navigazione a piè di pagina"
 
-#: lib/vutuv_web/components/post_components.ex:3132
-#: lib/vutuv_web/components/post_components.ex:3186
-#: lib/vutuv_web/components/post_components.ex:3605
+#: lib/vutuv_web/components/post_components.ex:3147
+#: lib/vutuv_web/components/post_components.ex:3201
+#: lib/vutuv_web/components/post_components.ex:3620
 #: lib/vutuv_web/live/notification_live/index.ex:726
-#: lib/vutuv_web/live/post_live/feed.ex:1914
+#: lib/vutuv_web/live/post_live/feed.ex:2050
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5772,7 +5671,8 @@ msgid "Other"
 msgstr "Altro"
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:33
-#: lib/vutuv_web/views/email_html.ex:12 lib/vutuv_web/views/user_html.ex:914
+#: lib/vutuv_web/views/email_html.ex:12
+#: lib/vutuv_web/views/user_html.ex:914
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr "Personale"
@@ -5792,7 +5692,7 @@ msgstr "Tipo di indirizzo e-mail"
 msgid "About you"
 msgstr "Su di Lei"
 
-#: lib/vutuv_web/components/ui.ex:4420
+#: lib/vutuv_web/components/ui.ex:4441
 #: lib/vutuv_web/live/admin/user_live.ex:254
 #: lib/vutuv_web/live/fediverse_followers_live.ex:154
 #: lib/vutuv_web/live/fediverse_following_live.ex:289
@@ -5813,7 +5713,7 @@ msgstr "Modifica"
 msgid "Download everything vutuv stores about you, as one file."
 msgstr "Scarichi in un unico file tutto ciò che vutuv conserva su di Lei."
 
-#: lib/vutuv_web/components/ui.ex:4331
+#: lib/vutuv_web/components/ui.ex:4341
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5847,7 +5747,7 @@ msgstr "Token personali per l'API di vutuv."
 msgid "Photos"
 msgstr "Foto"
 
-#: lib/vutuv_web/components/ui.ex:4394
+#: lib/vutuv_web/components/ui.ex:4415
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/templates/page/index.html.heex:174
 #, elixir-autogen, elixir-format
@@ -5918,9 +5818,7 @@ msgstr "Legga la documentazione dell'API"
 
 #: lib/vutuv_web/templates/settings/preferences.html.heex:22
 #, elixir-autogen, elixir-format
-msgid ""
-"This sets the language of the whole vutuv interface, not your public "
-"profile."
+msgid "This sets the language of the whole vutuv interface, not your public profile."
 msgstr ""
 "Imposta la lingua dell'intera interfaccia di vutuv, non del Suo profilo "
 "pubblico."
@@ -5964,7 +5862,7 @@ msgstr "@%{slug} ha iniziato a seguirla su vutuv"
 msgid "Apps"
 msgstr "App"
 
-#: lib/vutuv_web/components/ui.ex:4453
+#: lib/vutuv_web/components/ui.ex:4474
 #: lib/vutuv_web/controllers/settings_controller.ex:179
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
@@ -6021,9 +5919,7 @@ msgstr "Motori di ricerca e IA"
 
 #: lib/vutuv_web/templates/settings/notifications.html.heex:213
 #, elixir-autogen, elixir-format
-msgid ""
-"These are always on. You see them under the bell at the top of every page, "
-"in real time."
+msgid "These are always on. You see them under the bell at the top of every page, in real time."
 msgstr ""
 "Sono sempre attive. Le vede sotto la campanella in cima a ogni pagina, in "
 "tempo reale."
@@ -6174,28 +6070,28 @@ msgid "Sort"
 msgstr "Ordina"
 
 #: lib/vutuv_web/components/job_components.ex:220
-#: lib/vutuv_web/views/settings_html.ex:522
+#: lib/vutuv_web/views/settings_html.ex:417
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] "%{count} giorno fa"
 msgstr[1] "%{count} giorni fa"
 
-#: lib/vutuv_web/views/settings_html.ex:521
+#: lib/vutuv_web/views/settings_html.ex:416
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] "%{count} ora fa"
 msgstr[1] "%{count} ore fa"
 
-#: lib/vutuv_web/views/settings_html.ex:520
+#: lib/vutuv_web/views/settings_html.ex:415
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
 msgstr[0] "%{count} minuto fa"
 msgstr[1] "%{count} minuti fa"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:930
+#: lib/vutuv_web/controllers/settings_controller.ex:901
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr "Tutti gli altri dispositivi sono stati disconnessi."
@@ -6205,7 +6101,7 @@ msgstr "Tutti gli altri dispositivi sono stati disconnessi."
 msgid "Another session was already active on your account."
 msgstr "Sul Suo account era già attiva un'altra sessione."
 
-#: lib/vutuv_web/views/settings_html.ex:368
+#: lib/vutuv_web/views/settings_html.ex:263
 #, elixir-autogen, elixir-format
 msgid "Last active"
 msgstr "Ultima attività"
@@ -6220,7 +6116,7 @@ msgstr "Disconnetti tutti gli altri dispositivi"
 msgid "Log out of every device except this one?"
 msgstr "Disconnettere ogni dispositivo tranne questo?"
 
-#: lib/vutuv_web/views/settings_html.ex:385
+#: lib/vutuv_web/views/settings_html.ex:280
 #, elixir-autogen, elixir-format
 msgid "Log this device out of your account?"
 msgstr "Disconnettere questo dispositivo dal Suo account?"
@@ -6235,7 +6131,7 @@ msgstr "Nuovo accesso al Suo account vutuv"
 msgid "Signed-in devices"
 msgstr "Dispositivi connessi"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:917
+#: lib/vutuv_web/controllers/settings_controller.ex:888
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr "Quel dispositivo è stato disconnesso."
@@ -6245,7 +6141,7 @@ msgstr "Quel dispositivo è stato disconnesso."
 msgid "The location looks different from where you usually sign in."
 msgstr "La posizione è diversa da quella da cui accede di solito."
 
-#: lib/vutuv_web/views/settings_html.ex:369
+#: lib/vutuv_web/views/settings_html.ex:264
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr "Questo dispositivo"
@@ -6255,15 +6151,14 @@ msgstr "Questo dispositivo"
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr "È il primo accesso che vediamo da questo dispositivo o browser."
 
-#: lib/vutuv_web/views/settings_html.ex:519
+#: lib/vutuv_web/views/settings_html.ex:414
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr "adesso"
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:125
 #, elixir-autogen, elixir-format
-msgid ""
-"A green dot on your avatar tells other members you are online right now."
+msgid "A green dot on your avatar tells other members you are online right now."
 msgstr ""
 "Un pallino verde sulla Sua immagine del profilo indica agli altri membri che"
 " è online in questo momento."
@@ -6281,9 +6176,7 @@ msgstr "Mostrare quando sono online"
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:127
 #, elixir-autogen, elixir-format
-msgid ""
-"When off, no one sees the green dot on your avatar, and you never show as "
-"online."
+msgid "When off, no one sees the green dot on your avatar, and you never show as online."
 msgstr ""
 "Se disattivato, nessuno vede il pallino verde sulla Sua immagine del profilo"
 " e non risulta mai online."
@@ -6296,7 +6189,7 @@ msgstr "Aggiungi una passkey"
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
 #: lib/vutuv_web/live/admin/screenshot_live.ex:309
 #: lib/vutuv_web/live/fediverse_following_live.ex:291
-#: lib/vutuv_web/views/settings_html.ex:420
+#: lib/vutuv_web/views/settings_html.ex:315
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr "Aggiunta"
@@ -6306,7 +6199,7 @@ msgstr "Aggiunta"
 msgid "Could not add the passkey. Please try again."
 msgstr "Non è stato possibile aggiungere la passkey. Riprovi."
 
-#: lib/vutuv_web/views/settings_html.ex:423
+#: lib/vutuv_web/views/settings_html.ex:318
 #, elixir-autogen, elixir-format
 msgid "Last used"
 msgstr "Ultimo utilizzo"
@@ -6316,7 +6209,7 @@ msgstr "Ultimo utilizzo"
 msgid "Name (optional)"
 msgstr "Nome (facoltativo)"
 
-#: lib/vutuv_web/views/settings_html.ex:417
+#: lib/vutuv_web/views/settings_html.ex:312
 #, elixir-autogen, elixir-format
 msgid "Passkey"
 msgstr "Passkey"
@@ -6336,16 +6229,14 @@ msgstr "Passkey rimossa."
 msgid "Passkeys"
 msgstr "Passkey"
 
-#: lib/vutuv_web/views/settings_html.ex:431
+#: lib/vutuv_web/views/settings_html.ex:326
 #, elixir-autogen, elixir-format
 msgid "Remove this passkey?"
 msgstr "Rimuovere questa passkey?"
 
 #: lib/vutuv_web/templates/settings/security.html.heex:102
 #, elixir-autogen, elixir-format
-msgid ""
-"Sign in with Touch ID, Windows Hello or a security key instead of waiting "
-"for an email PIN. Your email PIN stays available as a backup."
+msgid "Sign in with Touch ID, Windows Hello or a security key instead of waiting for an email PIN. Your email PIN stays available as a backup."
 msgstr ""
 "Acceda con Touch ID, Windows Hello o una chiave di sicurezza invece di "
 "aspettare un PIN via e-mail. Il PIN via e-mail resta disponibile come "
@@ -6397,7 +6288,7 @@ msgstr "ad esempio MacBook"
 msgid "or"
 msgstr "oppure"
 
-#: lib/vutuv_web/live/user_profile_live.ex:1343
+#: lib/vutuv_web/live/user_profile_live.ex:1347
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr "Aggiungi una descrizione breve"
@@ -6441,8 +6332,7 @@ msgstr "Anche su"
 #: lib/vutuv_web/templates/user/edit.html.heex:51
 #: lib/vutuv_web/templates/user/edit.html.heex:136
 #, elixir-autogen, elixir-format
-msgid ""
-"Drag to move, use the slider to zoom. The framed area is what others see."
+msgid "Drag to move, use the slider to zoom. The framed area is what others see."
 msgstr ""
 "Trascini per spostare, usi il cursore per ingrandire. L'area nel riquadro è "
 "quella che vedono gli altri."
@@ -6496,9 +6386,7 @@ msgstr "Età"
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:321
 #, elixir-autogen, elixir-format
-msgid ""
-"Confirmed new registrations and the day's posts, reposts, likes and "
-"bookmarks. Time-travel to any past day."
+msgid "Confirmed new registrations and the day's posts, reposts, likes and bookmarks. Time-travel to any past day."
 msgstr ""
 "Nuove registrazioni confermate e post, ripubblicazioni, Mi piace e "
 "salvataggi del giorno. Può spostarsi su qualsiasi giorno passato."
@@ -6578,6 +6466,7 @@ msgstr "Ripubblicazioni"
 msgid "View all phone numbers"
 msgstr "Vedi tutti i numeri di telefono"
 
+#: lib/vutuv_web/live/feed_languages_live.ex:235
 #: lib/vutuv_web/live/section_reorder_live.ex:127
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder"
@@ -6585,24 +6474,25 @@ msgstr "Trascini per riordinare"
 
 #: lib/vutuv_web/live/section_reorder_live.ex:178
 #, elixir-autogen, elixir-format
-msgid ""
-"Drag to reorder, or use the arrows. The order is the one shown on your "
-"profile."
+msgid "Drag to reorder, or use the arrows. The order is the one shown on your profile."
 msgstr ""
 "Trascini per riordinare, oppure usi le frecce. L'ordine è quello mostrato "
 "sul Suo profilo."
 
+#: lib/vutuv_web/live/feed_languages_live.ex:267
 #: lib/vutuv_web/live/section_reorder_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "Move down"
 msgstr "Sposta giù"
 
+#: lib/vutuv_web/live/feed_languages_live.ex:256
 #: lib/vutuv_web/live/section_reorder_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Move up"
 msgstr "Sposta su"
 
-#: lib/vutuv_web/components/ui.ex:1782 lib/vutuv_web/components/ui.ex:1791
+#: lib/vutuv_web/components/ui.ex:1782
+#: lib/vutuv_web/components/ui.ex:1791
 #: lib/vutuv_web/components/ui.ex:2256
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
@@ -6647,9 +6537,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/settings/preferences.html.heex:117
 #, elixir-autogen, elixir-format
-msgid ""
-"Pick which map services to show on addresses, and which one opens by "
-"default."
+msgid "Pick which map services to show on addresses, and which one opens by default."
 msgstr ""
 "Scelga quali servizi di mappe mostrare sugli indirizzi e quale si apre di "
 "default."
@@ -6687,8 +6575,7 @@ msgstr "confermato il %{date}"
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:160
 #, elixir-autogen, elixir-format
 msgid "%{formatted} account is frozen because every email address bounced."
-msgid_plural ""
-"%{formatted} accounts are frozen because every email address bounced."
+msgid_plural "%{formatted} accounts are frozen because every email address bounced."
 msgstr[0] ""
 "%{formatted} account è bloccato perché tutti i suoi indirizzi e-mail sono "
 "stati respinti."
@@ -6746,10 +6633,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/deliverability_live.ex:157
 #, elixir-autogen, elixir-format
-msgid ""
-"Addresses marked undeliverable after a hard bounce. Automatic mail to them "
-"is dropped; login PINs still send. Clearing the mark is normally automatic "
-"on the next successful login PIN."
+msgid "Addresses marked undeliverable after a hard bounce. Automatic mail to them is dropped; login PINs still send. Clearing the mark is normally automatic on the next successful login PIN."
 msgstr ""
 "Indirizzi contrassegnati come non recapitabili dopo un rifiuto definitivo. "
 "Le e-mail automatiche verso di essi vengono scartate; i PIN di accesso "
@@ -6774,10 +6658,7 @@ msgstr "Rimuovi"
 
 #: lib/vutuv_web/live/admin/deliverability_live.ex:106
 #, elixir-autogen, elixir-format
-msgid ""
-"Confirmed members whose every email address bounced, so they can no longer "
-"receive a login PIN. Hidden from other members until an address works again."
-" Thaw to lift the freeze."
+msgid "Confirmed members whose every email address bounced, so they can no longer receive a login PIN. Hidden from other members until an address works again. Thaw to lift the freeze."
 msgstr ""
 "Membri confermati i cui indirizzi e-mail sono stati tutti respinti, e che "
 "quindi non possono più ricevere un PIN di accesso. Restano nascosti agli "
@@ -6851,9 +6732,7 @@ msgstr "Nessun account è bloccato per irraggiungibilità."
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:156
 #, elixir-autogen, elixir-format
-msgid ""
-"No accounts frozen for unreachability. Bounced addresses and the audit trail"
-" are here too."
+msgid "No accounts frozen for unreachability. Bounced addresses and the audit trail are here too."
 msgstr ""
 "Nessun account bloccato per irraggiungibilità. Qui trova anche gli indirizzi"
 " respinti e il registro delle attività."
@@ -6968,9 +6847,7 @@ msgstr "Account sbloccati"
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:65
 #, elixir-autogen, elixir-format
-msgid ""
-"When on, AI assistants and crawlers may read and train on your public "
-"profile. When off, we ask them not to."
+msgid "When on, AI assistants and crawlers may read and train on your public profile. When off, we ask them not to."
 msgstr ""
 "Se attivo, gli assistenti IA e i crawler possono leggere il Suo profilo "
 "pubblico e addestrarsi su di esso. Se disattivo, chiediamo loro di non "
@@ -6978,9 +6855,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:60
 #, elixir-autogen, elixir-format
-msgid ""
-"When on, your public profile can appear in Google and other search engines. "
-"When off, we ask them to leave it out."
+msgid "When on, your public profile can appear in Google and other search engines. When off, we ask them to leave it out."
 msgstr ""
 "Se attivo, il Suo profilo pubblico può comparire su Google e sugli altri "
 "motori di ricerca. Se disattivo, chiediamo loro di escluderlo."
@@ -6992,9 +6867,7 @@ msgstr "Esattamente ciò che inviamo"
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:50
 #, elixir-autogen, elixir-format
-msgid ""
-"Compliant crawlers honor these; they are not a hard block. A noindexed "
-"profile is also kept out of the sitemap and structured data."
+msgid "Compliant crawlers honor these; they are not a hard block. A noindexed profile is also kept out of the sitemap and structured data."
 msgstr ""
 "I crawler che rispettano le regole ne tengono conto; non sono un blocco vero"
 " e proprio. Un profilo escluso dall'indicizzazione resta fuori anche dalla "
@@ -7002,15 +6875,13 @@ msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:43
 #, elixir-autogen, elixir-format
-msgid ""
-"Turn a switch off and the matching opt-out rides along on the pages and "
-"responses about you. With both off, for example:"
+msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 "Se disattiva un'opzione, la relativa esclusione viaggia con le pagine e le "
 "risposte che La riguardano. Con entrambe disattivate, ad esempio:"
 
-#: lib/vutuv_web/components/post_components.ex:2282
-#: lib/vutuv_web/components/post_components.ex:3064
+#: lib/vutuv_web/components/post_components.ex:2297
+#: lib/vutuv_web/components/post_components.ex:3079
 #: lib/vutuv_web/components/ui.ex:2713
 #: lib/vutuv_web/live/fediverse_account_live.ex:381
 #: lib/vutuv_web/live/organization_live/following.ex:371
@@ -7037,7 +6908,7 @@ msgstr "Nuovi messaggi e nuovi collegamenti"
 msgid "Remove this connection? You will stop following them."
 msgstr "Rimuovere questo collegamento? Smetterà di seguire questa persona."
 
-#: lib/vutuv_web/components/post_components.ex:3064
+#: lib/vutuv_web/components/post_components.ex:3079
 #: lib/vutuv_web/components/ui.ex:2712
 #: lib/vutuv_web/live/fediverse_account_live.ex:379
 #: lib/vutuv_web/live/organization_live/following.ex:371
@@ -7084,7 +6955,8 @@ msgstr "La segue"
 msgid "This member doesn't follow you"
 msgstr "Questo membro non La segue"
 
-#: lib/vutuv_web/components/ui.ex:2618 lib/vutuv_web/components/ui.ex:2667
+#: lib/vutuv_web/components/ui.ex:2618
+#: lib/vutuv_web/components/ui.ex:2667
 #, elixir-autogen, elixir-format
 msgid "This member follows you"
 msgstr "Questo membro La segue"
@@ -7161,9 +7033,7 @@ msgstr "Invio massivo"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:576
 #, elixir-autogen, elixir-format
-msgid ""
-"Build a fixed group from filters, then send a newsletter to it. Subtract "
-"another group to do a test run, then send to the rest."
+msgid "Build a fixed group from filters, then send a newsletter to it. Subtract another group to do a test run, then send to the rest."
 msgstr ""
 "Costruisca un gruppo fisso a partire dai filtri, poi gli invii una "
 "newsletter. Sottragga un altro gruppo per fare una prova, poi invii al "
@@ -7176,18 +7046,14 @@ msgstr "Limite di dimensione del gruppo (facoltativo)"
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:228
 #, elixir-autogen, elixir-format
-msgid ""
-"Compose a newsletter, save it as a draft, test it, then send it to all "
-"members."
+msgid "Compose a newsletter, save it as a draft, test it, then send it to all members."
 msgstr ""
 "Scriva una newsletter, la salvi come bozza, la provi e poi la invii a tutti "
 "i membri."
 
 #: lib/vutuv_web/templates/admin/newsletter/index.html.heex:12
 #, elixir-autogen, elixir-format
-msgid ""
-"Compose a newsletter, save it as a draft, test it, then send it to all "
-"members. Right now a broadcast would reach %{count} members."
+msgid "Compose a newsletter, save it as a draft, test it, then send it to all members. Right now a broadcast would reach %{count} members."
 msgstr ""
 "Scriva una newsletter, la salvi come bozza, la provi e poi la invii a tutti "
 "i membri. In questo momento un invio massivo raggiungerebbe %{count} membri."
@@ -7258,9 +7124,7 @@ msgstr "Errore"
 
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:231
 #, elixir-autogen, elixir-format
-msgid ""
-"Every email sent for this newsletter. Filter, search and sort; click a "
-"column to sort."
+msgid "Every email sent for this newsletter. Filter, search and sort; click a column to sort."
 msgstr ""
 "Ogni e-mail inviata per questa newsletter. Può filtrare, cercare e ordinare;"
 " prema su una colonna per ordinare."
@@ -7425,9 +7289,7 @@ msgstr "Scegli a caso i membri entro il limite"
 
 #: lib/vutuv_web/templates/settings/notifications.html.heex:14
 #, elixir-autogen, elixir-format
-msgid ""
-"Pick which emails vutuv may send you. Each email has a one-click "
-"unsubscribe."
+msgid "Pick which emails vutuv may send you. Each email has a one-click unsubscribe."
 msgstr ""
 "Scelga quali e-mail vutuv può inviarLe. Ogni e-mail ha un link di "
 "disiscrizione con un solo clic."
@@ -7492,9 +7354,7 @@ msgstr "Invia la newsletter"
 
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:144
 #, elixir-autogen, elixir-format
-msgid ""
-"Send one copy to any address to check it, using your account data for the "
-"variables. Logged below as a test."
+msgid "Send one copy to any address to check it, using your account data for the variables. Logged below as a test."
 msgstr ""
 "Invii una copia a un indirizzo qualsiasi per controllarla, usando i dati del"
 " Suo account al posto delle variabili. Viene registrata qui sotto come "
@@ -7548,7 +7408,7 @@ msgstr "Soppressa (indirizzo respinto)"
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:816
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:44
 #: lib/vutuv_web/templates/settings/filters.html.heex:22
-#: lib/vutuv_web/views/settings_html.ex:61
+#: lib/vutuv_web/views/settings_html.ex:59
 #, elixir-autogen, elixir-format
 msgid "Tag"
 msgstr "Tag"
@@ -7581,9 +7441,7 @@ msgstr "Non è stato possibile trovare questo gruppo destinatari."
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:918
 #, elixir-autogen, elixir-format
-msgid ""
-"Their members are removed from this one (e.g. exclude the test group to send"
-" to \"the rest\")."
+msgid "Their members are removed from this one (e.g. exclude the test group to send to \"the rest\")."
 msgstr ""
 "I loro membri vengono tolti da questo (ad esempio escluda il gruppo di prova"
 " per inviare \"al resto\")."
@@ -7606,9 +7464,7 @@ msgstr "Variabili che può usare nell'oggetto e nel testo"
 
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:29
 #, elixir-autogen, elixir-format
-msgid ""
-"Write the newsletter in Markdown. Use {{greeting}}, for a personal "
-"salutation."
+msgid "Write the newsletter in Markdown. Use {{greeting}}, for a personal salutation."
 msgstr ""
 "Scriva la newsletter in Markdown. Usi {{greeting}}, per un saluto personale."
 
@@ -7662,9 +7518,7 @@ msgstr "max %{count}"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:674
 #, elixir-autogen, elixir-format
-msgid ""
-"The frozen snapshot saved with this audience. Click a name to open the "
-"profile."
+msgid "The frozen snapshot saved with this audience. Click a name to open the profile."
 msgstr ""
 "L'istantanea congelata salvata con questo gruppo destinatari. Prema su un "
 "nome per aprire il profilo."
@@ -7701,13 +7555,13 @@ msgstr "I loro membri vengono aggiunti a questo (unione)."
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr "pagina %{page} di %{pages}, %{total} in totale"
 
-#: lib/vutuv_web/components/ui.ex:3436
+#: lib/vutuv_web/components/ui.ex:3446
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Precedente"
 
-#: lib/vutuv_web/components/ui.ex:3452
+#: lib/vutuv_web/components/ui.ex:3462
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7727,9 +7581,7 @@ msgstr "Scelga account specifici"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:959
 #, elixir-autogen, elixir-format
-msgid ""
-"Tick to include an account, untick to exclude it. Search by @handle to find "
-"anyone."
+msgid "Tick to include an account, untick to exclude it. Search by @handle to find anyone."
 msgstr ""
 "Spunti per includere un account, tolga la spunta per escluderlo. Cerchi per "
 "@handle per trovare chiunque."
@@ -7790,7 +7642,7 @@ msgid "applies to the whole list, not just this page"
 msgstr "vale per l'intero elenco, non solo per questa pagina"
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:5030
+#: lib/vutuv_web/components/post_components.ex:5060
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -7845,10 +7697,7 @@ msgstr "queste e-mail"
 
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:136
 #, elixir-autogen, elixir-format
-msgid ""
-"Every sent newsletter automatically ends with a one-click unsubscribe link "
-"(and a List-Unsubscribe header); the recipient is removed from future "
-"newsletters with one click, no login."
+msgid "Every sent newsletter automatically ends with a one-click unsubscribe link (and a List-Unsubscribe header); the recipient is removed from future newsletters with one click, no login."
 msgstr ""
 "Ogni newsletter inviata termina automaticamente con un link di disiscrizione"
 " a un clic (e con un'intestazione List-Unsubscribe); il destinatario viene "
@@ -7866,8 +7715,7 @@ msgstr "Scelga un gruppo destinatari, confermi e segua la partenza."
 
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:198
 #, elixir-autogen
-msgid ""
-"Pick an audience, confirm, and watch it go out. This can only be done once."
+msgid "Pick an audience, confirm, and watch it go out. This can only be done once."
 msgstr ""
 "Scelga un gruppo destinatari, confermi e segua la partenza. Si può fare una "
 "volta sola."
@@ -7897,8 +7745,7 @@ msgstr "Invio in corso…"
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:171
 #, elixir-autogen
-msgid ""
-"This updates on its own. You can leave this page; the send keeps running."
+msgid "This updates on its own. You can leave this page; the send keeps running."
 msgstr "Si aggiorna da sola. Può lasciare questa pagina: l'invio prosegue."
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
@@ -7955,10 +7802,8 @@ msgstr[1] "Inviata a %{formatted} membri."
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:202
 #, elixir-autogen
-msgid ""
-"The newsletter will be sent to %{formatted} person. This cannot be undone."
-msgid_plural ""
-"The newsletter will be sent to %{formatted} people. This cannot be undone."
+msgid "The newsletter will be sent to %{formatted} person. This cannot be undone."
+msgid_plural "The newsletter will be sent to %{formatted} people. This cannot be undone."
 msgstr[0] ""
 "La newsletter verrà inviata a %{formatted} persona. L'operazione non si può "
 "annullare."
@@ -8054,27 +7899,21 @@ msgstr "Disattiva un nome utente"
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:288
 #, elixir-autogen, elixir-format
-msgid ""
-"Take an unwanted username away from a member by force-renaming the account."
+msgid "Take an unwanted username away from a member by force-renaming the account."
 msgstr ""
 "Tolga a un membro un nome utente indesiderato rinominandone l'account "
 "d'ufficio."
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:238
 #, elixir-autogen, elixir-format
-msgid ""
-"Build fixed recipient groups from filters (language, country, age, tag) to "
-"target a newsletter."
+msgid "Build fixed recipient groups from filters (language, country, age, tag) to target a newsletter."
 msgstr ""
 "Costruisca gruppi di destinatari fissi a partire dai filtri (lingua, paese, "
 "età, tag) per mirare una newsletter."
 
 #: lib/vutuv_web/templates/admin/username/index.html.heex:8
 #, elixir-autogen, elixir-format
-msgid ""
-"Take an unwanted username away from a member: the account is force-renamed "
-"to a generated handle. The old name is not blocked afterwards - a name bad "
-"enough to ban globally belongs in the moderation tooling."
+msgid "Take an unwanted username away from a member: the account is force-renamed to a generated handle. The old name is not blocked afterwards - a name bad enough to ban globally belongs in the moderation tooling."
 msgstr ""
 "Tolga a un membro un nome utente indesiderato: l'account viene rinominato "
 "d'ufficio con un handle generato. Il vecchio nome non resta bloccato: un "
@@ -8105,9 +7944,7 @@ msgstr "Questa applicazione non esiste più."
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:4
 #, elixir-autogen, elixir-format
-msgid ""
-"Everything that keeps vutuv running, in one place. Cards with open work glow"
-" in coral."
+msgid "Everything that keeps vutuv running, in one place. Cards with open work glow in coral."
 msgstr ""
 "Tutto ciò che tiene in piedi vutuv, in un unico posto. Le schede con lavoro "
 "in sospeso sono evidenziate in corallo."
@@ -8126,9 +7963,7 @@ msgstr "Riscontro"
 
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:48
 #, elixir-autogen, elixir-format
-msgid ""
-"How members engaged with the vutuv.de links in this newsletter. Counts the "
-"HTML email's links; the plain-text version is not tracked."
+msgid "How members engaged with the vutuv.de links in this newsletter. Counts the HTML email's links; the plain-text version is not tracked."
 msgstr ""
 "Come i membri hanno reagito ai link vutuv.de di questa newsletter. Conta i "
 "link dell'e-mail HTML; la versione in solo testo non viene tracciata."
@@ -8167,9 +8002,7 @@ msgstr "Registro completo dei clic"
 
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:116
 #, elixir-autogen, elixir-format
-msgid ""
-"Note: automated email-security scanners can follow links and inflate these "
-"numbers."
+msgid "Note: automated email-security scanners can follow links and inflate these numbers."
 msgstr ""
 "Nota: i controlli automatici di sicurezza della posta possono seguire i link"
 " e gonfiare questi numeri."
@@ -8186,9 +8019,7 @@ msgstr "Clic sui link"
 
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:18
 #, elixir-autogen, elixir-format
-msgid ""
-"Every recorded click on a vutuv.de link in this newsletter, newest first: "
-"who clicked which link, and when."
+msgid "Every recorded click on a vutuv.de link in this newsletter, newest first: who clicked which link, and when."
 msgstr ""
 "Ogni clic registrato su un link vutuv.de di questa newsletter, dal più "
 "recente: chi ha cliccato quale link, e quando."
@@ -8269,9 +8100,7 @@ msgstr "Account specifici"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:749
 #, elixir-autogen, elixir-format
-msgid ""
-"Pick members from filters, or hand-pick specific accounts (e.g. a small "
-"group of testers)."
+msgid "Pick members from filters, or hand-pick specific accounts (e.g. a small group of testers)."
 msgstr ""
 "Scelga i membri con i filtri, oppure selezioni a mano account specifici (ad "
 "esempio un piccolo gruppo di tester)."
@@ -8283,9 +8112,7 @@ msgstr "Account in questo gruppo destinatari"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1049
 #, elixir-autogen, elixir-format
-msgid ""
-"Only these accounts get the newsletter. Search for members below and add "
-"them one by one."
+msgid "Only these accounts get the newsletter. Search for members below and add them one by one."
 msgstr ""
 "Solo questi account ricevono la newsletter. Cerchi i membri qui sotto e li "
 "aggiunga uno per uno."
@@ -8325,51 +8152,49 @@ msgstr "Con che frequenza"
 msgid "Send the email"
 msgstr "Invia l'e-mail"
 
-#: lib/vutuv_web/views/settings_html.ex:111
+#: lib/vutuv_web/views/settings_html.ex:109
 #, elixir-autogen
 msgid "As soon as possible"
 msgstr "Il prima possibile"
 
-#: lib/vutuv_web/views/settings_html.ex:112
+#: lib/vutuv_web/views/settings_html.ex:110
 #, elixir-autogen
 msgid "After 5 minutes"
 msgstr "Dopo 5 minuti"
 
-#: lib/vutuv_web/views/settings_html.ex:113
+#: lib/vutuv_web/views/settings_html.ex:111
 #, elixir-autogen
 msgid "After 15 minutes"
 msgstr "Dopo 15 minuti"
 
-#: lib/vutuv_web/views/settings_html.ex:114
+#: lib/vutuv_web/views/settings_html.ex:112
 #, elixir-autogen
 msgid "After 30 minutes"
 msgstr "Dopo 30 minuti"
 
-#: lib/vutuv_web/views/settings_html.ex:115
+#: lib/vutuv_web/views/settings_html.ex:113
 #, elixir-autogen
 msgid "After 1 hour"
 msgstr "Dopo 1 ora"
 
-#: lib/vutuv_web/views/settings_html.ex:116
+#: lib/vutuv_web/views/settings_html.ex:114
 #, elixir-autogen
 msgid "After 2 hours"
 msgstr "Dopo 2 ore"
 
-#: lib/vutuv_web/views/settings_html.ex:95
+#: lib/vutuv_web/views/settings_html.ex:93
 #, elixir-autogen
 msgid "Only the first message"
 msgstr "Solo il primo messaggio"
 
-#: lib/vutuv_web/views/settings_html.ex:96
+#: lib/vutuv_web/views/settings_html.ex:94
 #, elixir-autogen
 msgid "Every message"
 msgstr "Ogni messaggio"
 
 #: lib/vutuv_web/templates/settings/notifications.html.heex:45
 #, elixir-autogen
-msgid ""
-"We wait a little before emailing, so you can read the message yourself "
-"first. These two settings apply only while unread-message emails are on."
+msgid "We wait a little before emailing, so you can read the message yourself first. These two settings apply only while unread-message emails are on."
 msgstr ""
 "Aspettiamo un poco prima di inviare l'e-mail, così può leggere prima il "
 "messaggio da sé. Queste due impostazioni valgono solo finché le e-mail sui "
@@ -8392,12 +8217,7 @@ msgstr "Il Suo indirizzo IP, come lo vede vutuv:"
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:22
 #, elixir-autogen, elixir-format
-msgid ""
-"vutuv sees your address as %{ip}, a loopback or private-range address. That "
-"means nginx is not passing the X-Forwarded-For header, so per-IP rate "
-"limiting and the security email's IP line do not work (issue #799). Add "
-"\"proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\" to the "
-"nginx site config."
+msgid "vutuv sees your address as %{ip}, a loopback or private-range address. That means nginx is not passing the X-Forwarded-For header, so per-IP rate limiting and the security email's IP line do not work (issue #799). Add \"proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\" to the nginx site config."
 msgstr ""
 "vutuv vede il Suo indirizzo come %{ip}, un indirizzo di loopback o di rete "
 "privata. Significa che nginx non inoltra l'intestazione X-Forwarded-For, "
@@ -8408,8 +8228,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/user_delete_live.ex:78
 #, elixir-autogen, elixir-format
-msgid ""
-"Account @%{username} was deleted. A record was emailed to the operator."
+msgid "Account @%{username} was deleted. A record was emailed to the operator."
 msgstr ""
 "L'account @%{username} è stato eliminato. Una registrazione è stata inviata "
 "per e-mail a chi gestisce l'installazione."
@@ -8420,7 +8239,7 @@ msgid "Admins"
 msgstr "Amministratori"
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:1882
+#: lib/vutuv_web/live/post_live/feed.ex:2018
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr "Tutti i membri"
@@ -8463,11 +8282,7 @@ msgstr "Eliminare questo account?"
 
 #: lib/vutuv_web/live/admin/user_delete_live.ex:111
 #, elixir-autogen, elixir-format
-msgid ""
-"Find a member by name, @handle or email, then delete the account. Deletion "
-"is permanent: it removes the account and everything it owns (posts, phone "
-"numbers, email addresses, tags and more). The member is not emailed; a "
-"record is sent to the operator."
+msgid "Find a member by name, @handle or email, then delete the account. Deletion is permanent: it removes the account and everything it owns (posts, phone numbers, email addresses, tags and more). The member is not emailed; a record is sent to the operator."
 msgstr ""
 "Trovi un membro per nome, @handle o indirizzo e-mail, poi elimini l'account."
 " L'eliminazione è definitiva: rimuove l'account e tutto ciò che gli "
@@ -8477,9 +8292,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:141
 #, elixir-autogen, elixir-format
-msgid ""
-"Find an account by name, @handle or email and delete it, with everything it "
-"owns, behind a confirmation."
+msgid "Find an account by name, @handle or email and delete it, with everything it owns, behind a confirmation."
 msgstr ""
 "Trovi un account per nome, @handle o indirizzo e-mail ed eliminilo, con "
 "tutto ciò che gli appartiene, dopo una conferma."
@@ -8506,7 +8319,8 @@ msgstr "Identità verificata. Il membro è stato avvisato per e-mail."
 msgid "Identity-verified"
 msgstr "Identità verificata"
 
-#: lib/vutuv/accounts.ex:1444 lib/vutuv/accounts.ex:1493
+#: lib/vutuv/accounts.ex:1444
+#: lib/vutuv/accounts.ex:1493
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -8547,7 +8361,8 @@ msgstr "Non confermato"
 msgid "Open the member browser"
 msgstr "Apri l'elenco dei membri"
 
-#: lib/vutuv/accounts.ex:1461 lib/vutuv_web/gettext_extraction_anchors.ex:43
+#: lib/vutuv/accounts.ex:1461
+#: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
 msgstr "PIN scaduto"
@@ -8557,7 +8372,7 @@ msgstr "PIN scaduto"
 msgid "PIN registered"
 msgstr "Registrato con PIN"
 
-#: lib/vutuv_web/components/ui.ex:3439
+#: lib/vutuv_web/components/ui.ex:3449
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr "Pagina %{page} di %{pages}"
@@ -8574,9 +8389,7 @@ msgstr "Cerca ed elimina"
 
 #: lib/vutuv_web/live/admin/user_live.ex:188
 #, elixir-autogen, elixir-format
-msgid ""
-"Search by name, @handle or email, filter and sort. The list updates as you "
-"type, and the default shows PIN-registered members, newest first."
+msgid "Search by name, @handle or email, filter and sort. The list updates as you type, and the default shows PIN-registered members, newest first."
 msgstr ""
 "Cerchi per nome, @handle o indirizzo e-mail, filtri e ordini. L'elenco si "
 "aggiorna mentre digita e per impostazione predefinita mostra i membri "
@@ -8584,10 +8397,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/user_delete_live.ex:198
 #, elixir-autogen, elixir-format
-msgid ""
-"This permanently deletes the account and everything it owns (posts, phone "
-"numbers, email addresses, tags and more). This cannot be undone. The member "
-"is not notified; a record is emailed to the operator."
+msgid "This permanently deletes the account and everything it owns (posts, phone numbers, email addresses, tags and more). This cannot be undone. The member is not notified; a record is emailed to the operator."
 msgstr ""
 "Questo elimina definitivamente l'account e tutto ciò che gli appartiene "
 "(post, numeri di telefono, indirizzi e-mail, tag e altro). L'operazione non "
@@ -8699,8 +8509,9 @@ msgstr "Aggiungi una formazione"
 msgid "Degree"
 msgstr "Titolo di studio"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:42 lib/vutuv_web/agent_docs/text.ex:39
-#: lib/vutuv_web/components/ui.ex:4307
+#: lib/vutuv_web/agent_docs/markdown.ex:42
+#: lib/vutuv_web/agent_docs/text.ex:39
+#: lib/vutuv_web/components/ui.ex:4317
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8741,9 +8552,7 @@ msgstr "Formazione aggiornata."
 
 #: lib/vutuv_web/templates/import/preview.html.heex:98
 #, elixir-autogen, elixir-format
-msgid ""
-"Email addresses are not imported automatically because each one is confirmed"
-" by PIN. Add them yourself if you like:"
+msgid "Email addresses are not imported automatically because each one is confirmed by PIN. Add them yourself if you like:"
 msgstr ""
 "Gli indirizzi e-mail non vengono importati automaticamente perché ciascuno "
 "va confermato con un PIN. Se vuole, li aggiunga a mano:"
@@ -8756,14 +8565,12 @@ msgstr "Ambito di studio"
 
 #: lib/vutuv_web/templates/import/preview.html.heex:26
 #, elixir-autogen, elixir-format
-msgid ""
-"Here is what we found in your export. Uncheck anything you do not want. "
-"Entries already on your profile are unchecked for you."
+msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 "Ecco cosa abbiamo trovato nella Sua esportazione. Tolga la spunta a ciò che "
 "non desidera. Le voci già presenti sul Suo profilo sono già senza spunta."
 
-#: lib/vutuv_web/components/ui.ex:4441
+#: lib/vutuv_web/components/ui.ex:4462
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Importa"
@@ -8792,7 +8599,7 @@ msgstr "Importati: %{items}."
 msgid "Nothing new to import."
 msgstr "Nulla di nuovo da importare."
 
-#: lib/vutuv_web/components/ui.ex:4335
+#: lib/vutuv_web/components/ui.ex:4345
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8888,7 +8695,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr "Troppe importazioni. Riprovi tra poco."
 
-#: lib/vutuv_web/components/ui.ex:3708
+#: lib/vutuv_web/components/ui.ex:3718
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8914,9 +8721,7 @@ msgstr "Prema \"Request archive\"."
 
 #: lib/vutuv_web/templates/import/new.html.heex:81
 #, elixir-autogen, elixir-format
-msgid ""
-"LinkedIn's \"Download my data\" page with \"Download larger data archive\" "
-"selected and the \"Request archive\" button below it."
+msgid "LinkedIn's \"Download my data\" page with \"Download larger data archive\" selected and the \"Request archive\" button below it."
 msgstr ""
 "La pagina \"Download my data\" di LinkedIn con \"Download larger data "
 "archive\" selezionato e il pulsante \"Request archive\" sotto."
@@ -8933,10 +8738,7 @@ msgstr "Selezioni l'archivio più grande, poi prema \"Request archive\"."
 
 #: lib/vutuv_web/templates/import/new.html.heex:46
 #, elixir-autogen, elixir-format
-msgid ""
-"LinkedIn lets you export your own data as a ZIP archive. Open the export "
-"page, request the larger archive, and download the ZIP once LinkedIn has "
-"finished preparing it (this usually takes a few minutes)."
+msgid "LinkedIn lets you export your own data as a ZIP archive. Open the export page, request the larger archive, and download the ZIP once LinkedIn has finished preparing it (this usually takes a few minutes)."
 msgstr ""
 "LinkedIn Le permette di esportare i Suoi dati come archivio ZIP. Apra la "
 "pagina di esportazione, richieda l'archivio più grande e scarichi lo ZIP "
@@ -8944,17 +8746,14 @@ msgstr ""
 
 #: lib/vutuv_web/templates/import/new.html.heex:71
 #, elixir-autogen, elixir-format
-msgid ""
-"LinkedIn prepares your archive. When it is ready (usually after a few "
-"minutes), download the ZIP to your device."
+msgid "LinkedIn prepares your archive. When it is ready (usually after a few minutes), download the ZIP to your device."
 msgstr ""
 "LinkedIn prepara il Suo archivio. Quando è pronto (di solito dopo pochi "
 "minuti), scarichi lo ZIP sul Suo dispositivo."
 
 #: lib/vutuv_web/templates/import/new.html.heex:97
 #, elixir-autogen, elixir-format
-msgid ""
-"Then upload the ZIP file below to see the preview and pick what to add."
+msgid "Then upload the ZIP file below to see the preview and pick what to add."
 msgstr ""
 "Poi carichi qui sotto il file ZIP per vedere l'anteprima e scegliere cosa "
 "aggiungere."
@@ -8966,11 +8765,7 @@ msgstr "Cosa viene importato"
 
 #: lib/vutuv_web/templates/import/new.html.heex:19
 #, elixir-autogen, elixir-format
-msgid ""
-"You decide exactly what to add. In the next step we show you everything we "
-"found and you pick it entry by entry, so you never import anything sight "
-"unseen. Nothing is added until you confirm, and your existing entries are "
-"never overwritten."
+msgid "You decide exactly what to add. In the next step we show you everything we found and you pick it entry by entry, so you never import anything sight unseen. Nothing is added until you confirm, and your existing entries are never overwritten."
 msgstr ""
 "Decide Lei esattamente cosa aggiungere. Nel passo successivo Le mostriamo "
 "tutto ciò che abbiamo trovato e sceglie voce per voce, così non importa mai "
@@ -8979,9 +8774,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/import/new.html.heex:6
 #, elixir-autogen, elixir-format
-msgid ""
-"Import your LinkedIn profile data into your vutuv profile. From your export "
-"we can fill in:"
+msgid "Import your LinkedIn profile data into your vutuv profile. From your export we can fill in:"
 msgstr ""
 "Importi i dati del Suo profilo LinkedIn nel Suo profilo vutuv. Dalla Sua "
 "esportazione possiamo ricavare:"
@@ -8992,13 +8785,13 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr "Trascini qui il Suo file ZIP, oppure prema per sceglierne uno."
 
-#: lib/vutuv_web/components/ui.ex:4295
+#: lib/vutuv_web/components/ui.ex:4305
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr "Dati di base e foto"
 
-#: lib/vutuv_web/components/ui.ex:4431
+#: lib/vutuv_web/components/ui.ex:4452
 #: lib/vutuv_web/controllers/settings_controller.ex:123
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -9010,7 +8803,7 @@ msgstr "Lingua e visualizzazione"
 msgid "More profile sections"
 msgstr "Altre sezioni del profilo"
 
-#: lib/vutuv_web/components/ui.ex:4422
+#: lib/vutuv_web/components/ui.ex:4443
 #: lib/vutuv_web/controllers/settings_controller.ex:106
 #: lib/vutuv_web/live/account_activity_live.ex:306
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
@@ -9020,7 +8813,7 @@ msgstr "Altre sezioni del profilo"
 msgid "Sign-in & security"
 msgstr "Accesso e sicurezza"
 
-#: lib/vutuv_web/components/ui.ex:4445
+#: lib/vutuv_web/components/ui.ex:4466
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -9029,9 +8822,7 @@ msgstr "Esportazione"
 
 #: lib/vutuv_web/templates/export/index.html.heex:36
 #, elixir-autogen, elixir-format
-msgid ""
-"The file is in JSON format and includes your profile, posts, messages and "
-"settings. It contains private data, so store it carefully."
+msgid "The file is in JSON format and includes your profile, posts, messages and settings. It contains private data, so store it carefully."
 msgstr ""
 "Il file è in formato JSON e comprende il Suo profilo, i post, i messaggi e "
 "le impostazioni. Contiene dati privati, quindi lo conservi con cura."
@@ -9048,21 +8839,19 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr "Digiti il Suo nome utente per confermare:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1899
+#: lib/vutuv_web/live/post_live/feed.ex:2035
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr "Mostra altri post"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1895
+#: lib/vutuv_web/live/post_live/feed.ex:2031
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr "Post consigliati"
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:142
 #, elixir-autogen, elixir-format
-msgid ""
-"If you list a Mastodon or Bluesky account, your profile can show your latest"
-" public posts from it."
+msgid "If you list a Mastodon or Bluesky account, your profile can show your latest public posts from it."
 msgstr ""
 "Se indica un account Mastodon o Bluesky, il Suo profilo può mostrarne gli "
 "ultimi post pubblici."
@@ -9159,9 +8948,7 @@ msgstr ""
 
 #: lib/vutuv_web/views/error_html.ex:137
 #, elixir-autogen, elixir-format
-msgid ""
-"Admin rights are granted by the operator of this vutuv instance, from the "
-"server's command line:"
+msgid "Admin rights are granted by the operator of this vutuv instance, from the server's command line:"
 msgstr ""
 "I diritti di amministratore vengono concessi da chi gestisce questa "
 "installazione di vutuv, dalla riga di comando del server:"
@@ -9178,10 +8965,7 @@ msgstr "Modifica le pagine legali"
 
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:9
 #, elixir-autogen, elixir-format
-msgid ""
-"Every installation states its own operator identity here. These pages are "
-"legally required in Germany; a page that is not written yet shows visitors a"
-" neutral placeholder."
+msgid "Every installation states its own operator identity here. These pages are legally required in Germany; a page that is not written yet shows visitors a neutral placeholder."
 msgstr ""
 "Ogni installazione dichiara qui l'identità di chi la gestisce. In Germania "
 "queste pagine sono obbligatorie per legge; una pagina non ancora scritta "
@@ -9194,9 +8978,7 @@ msgstr "Impressum"
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:376
 #, elixir-autogen, elixir-format
-msgid ""
-"Impressum, Datenschutzerklärung and Nutzungsbedingungen: every installation "
-"publishes its own operator identity here."
+msgid "Impressum, Datenschutzerklärung and Nutzungsbedingungen: every installation publishes its own operator identity here."
 msgstr ""
 "Impressum, Datenschutzerklärung e Nutzungsbedingungen: ogni installazione "
 "pubblica qui l'identità di chi la gestisce."
@@ -9217,9 +8999,7 @@ msgstr "Pagine legali"
 
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:28
 #, elixir-autogen, elixir-format
-msgid ""
-"Markdown is supported (headings, bold, lists, links). The page is published "
-"the moment you save it."
+msgid "Markdown is supported (headings, bold, lists, links). The page is published the moment you save it."
 msgstr ""
 "Markdown è supportato (titoli, grassetto, elenchi, link). La pagina viene "
 "pubblicata nel momento in cui la salva."
@@ -9264,9 +9044,11 @@ msgstr "La scriva in Amministrazione › Pagine legali"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:614
 #: lib/vutuv_web/agent_docs/markdown.ex:618
-#: lib/vutuv_web/agent_docs/text.ex:580 lib/vutuv_web/agent_docs/text.ex:584
+#: lib/vutuv_web/agent_docs/text.ex:580
+#: lib/vutuv_web/agent_docs/text.ex:584
 #: lib/vutuv_web/components/organization_components.ex:285
-#: lib/vutuv_web/components/ui.ex:1282 lib/vutuv_web/components/ui.ex:4412
+#: lib/vutuv_web/components/ui.ex:1282
+#: lib/vutuv_web/components/ui.ex:4433
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:355
 #: lib/vutuv_web/controllers/settings_controller.ex:422
@@ -9291,18 +9073,14 @@ msgstr "Si faccia verificare su Mastodon"
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:27
 #, elixir-autogen, elixir-format
-msgid ""
-"Your vutuv profile links every account listed here back with a rel=\"me\" "
-"tag. Mastodon uses exactly that for its link verification: add"
+msgid "Your vutuv profile links every account listed here back with a rel=\"me\" tag. Mastodon uses exactly that for its link verification: add"
 msgstr ""
 "Il Suo profilo vutuv rimanda a ogni account elencato qui con un tag "
 "rel=\"me\". Mastodon usa proprio questo per la verifica dei link: aggiunga"
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:31
 #, elixir-autogen, elixir-format
-msgid ""
-"as a link in your Mastodon profile settings, and Mastodon will show it as "
-"verified with a green check."
+msgid "as a link in your Mastodon profile settings, and Mastodon will show it as verified with a green check."
 msgstr ""
 "come link nelle impostazioni del Suo profilo Mastodon, e Mastodon lo "
 "mostrerà come verificato con una spunta verde."
@@ -9322,7 +9100,8 @@ msgstr "Gestisci gli account social"
 msgid "Your Fediverse handle"
 msgstr "Il Suo handle nel Fediverso"
 
-#: lib/vutuv/accounts.ex:1456 lib/vutuv_web/gettext_extraction_anchors.ex:44
+#: lib/vutuv/accounts.ex:1456
+#: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
 msgstr "Questo PIN è già stato usato."
@@ -9359,9 +9138,7 @@ msgstr "Tirocini"
 
 #: lib/vutuv_web/templates/import/new.html.heex:65
 #, elixir-autogen, elixir-format
-msgid ""
-"On that page, select \"Download larger data archive\" (profile, positions, "
-"volunteering, education, skills)."
+msgid "On that page, select \"Download larger data archive\" (profile, positions, volunteering, education, skills)."
 msgstr ""
 "In quella pagina selezioni \"Download larger data archive\" (profilo, "
 "posizioni, volontariato, formazione, competenze)."
@@ -9382,8 +9159,10 @@ msgstr "Volontariato e hobby"
 msgid "Not available while the search uses a people filter."
 msgstr "Non disponibile mentre la ricerca usa un filtro sulle persone."
 
-#: lib/vutuv_web/cv/html.ex:57 lib/vutuv_web/cv/html.ex:58
-#: lib/vutuv_web/cv/latex.ex:45 lib/vutuv_web/cv/latex.ex:46
+#: lib/vutuv_web/cv/html.ex:57
+#: lib/vutuv_web/cv/html.ex:58
+#: lib/vutuv_web/cv/latex.ex:45
+#: lib/vutuv_web/cv/latex.ex:46
 #: lib/vutuv_web/live/cv_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "CV"
@@ -9423,9 +9202,7 @@ msgstr "Consiglio:"
 
 #: lib/vutuv_web/cv/html.ex:62
 #, elixir-autogen, elixir-format
-msgid ""
-"This is the print view of this CV. Use your browser's print dialog (Ctrl+P "
-"or Cmd+P) and choose \"Save as PDF\" to get a PDF file."
+msgid "This is the print view of this CV. Use your browser's print dialog (Ctrl+P or Cmd+P) and choose \"Save as PDF\" to get a PDF file."
 msgstr ""
 "Questa è la versione di stampa del CV. Usi la finestra di stampa del browser"
 " (Ctrl+P o Cmd+P) e scelga \"Salva come PDF\" per ottenere un file PDF."
@@ -9435,7 +9212,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Download del CV"
 
-#: lib/vutuv_web/components/post_components.ex:4053
+#: lib/vutuv_web/components/post_components.ex:4068
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9482,9 +9259,7 @@ msgstr "Foto"
 
 #: lib/vutuv_web/live/cv_live.ex:222
 #, elixir-autogen, elixir-format
-msgid ""
-"Pick what to include. Untick single entries or whole sections, or anonymize "
-"the CV by hiding the name, photo and contact details."
+msgid "Pick what to include. Untick single entries or whole sections, or anonymize the CV by hiding the name, photo and contact details."
 msgstr ""
 "Scelga cosa includere. Tolga la spunta a singole voci o a intere sezioni, "
 "oppure renda anonimo il CV nascondendo nome, foto e recapiti."
@@ -9501,10 +9276,7 @@ msgstr "Link al profilo"
 
 #: lib/vutuv_web/templates/export/index.html.heex:22
 #, elixir-autogen, elixir-format
-msgid ""
-"The CV is public, on your profile: a visitor's download contains only what "
-"they can see there anyway, and private email addresses appear only in your "
-"own."
+msgid "The CV is public, on your profile: a visitor's download contains only what they can see there anyway, and private email addresses appear only in your own."
 msgstr ""
 "Il CV è pubblico, sul Suo profilo: il download di un visitatore contiene "
 "solo ciò che può già vedere lì, e gli indirizzi e-mail privati compaiono "
@@ -9512,19 +9284,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:1373
 #, elixir-autogen, elixir-format
-msgid ""
-"This profile as a formatted CV for job applications. Open it to pick what to"
-" include, anonymize it, print or download."
+msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
 "Questo profilo come CV impaginato per le candidature. Lo apra per scegliere "
 "cosa includere, renderlo anonimo, stamparlo o scaricarlo."
 
 #: lib/vutuv_web/templates/export/index.html.heex:17
 #, elixir-autogen, elixir-format
-msgid ""
-"Turn your profile into a formatted CV for a job application: pick what to "
-"include, anonymize it, then print (Save as PDF) or download it as Word, "
-"OpenDocument, HTML, LaTeX or JSON Resume."
+msgid "Turn your profile into a formatted CV for a job application: pick what to include, anonymize it, then print (Save as PDF) or download it as Word, OpenDocument, HTML, LaTeX or JSON Resume."
 msgstr ""
 "Trasformi il Suo profilo in un CV impaginato per una candidatura: scelga "
 "cosa includere, lo renda anonimo, poi lo stampi (Salva come PDF) o lo "
@@ -9537,9 +9304,7 @@ msgstr "CV di %{name}"
 
 #: lib/vutuv_web/live/cv_live.ex:49
 #, elixir-autogen, elixir-format
-msgid ""
-"The CV of %{name} on vutuv: work experience, education and skills to view "
-"and download."
+msgid "The CV of %{name} on vutuv: work experience, education and skills to view and download."
 msgstr ""
 "Il CV di %{name} su vutuv: esperienza lavorativa, formazione e competenze da"
 " consultare e scaricare."
@@ -9558,10 +9323,7 @@ msgstr "Altre attività"
 
 #: lib/vutuv_web/live/cv_live.ex:463
 #, elixir-autogen, elixir-format
-msgid ""
-"For a PDF, open the print view and choose \"Save as PDF\" in your browser's "
-"print dialog. Word and OpenDocument are editable; LaTeX is the typesetting "
-"source; JSON Resume is the open %{link} format."
+msgid "For a PDF, open the print view and choose \"Save as PDF\" in your browser's print dialog. Word and OpenDocument are editable; LaTeX is the typesetting source; JSON Resume is the open %{link} format."
 msgstr ""
 "Per un PDF, apra la versione di stampa e scelga \"Salva come PDF\" nella "
 "finestra di stampa del browser. Word e OpenDocument sono modificabili; LaTeX"
@@ -9596,16 +9358,13 @@ msgstr "Mostrata in cima al Suo profilo"
 
 #: lib/vutuv_web/controllers/work_experience_controller.ex:92
 #, elixir-autogen, elixir-format
-msgid ""
-"The job title at the top of your profile is chosen automatically again."
+msgid "The job title at the top of your profile is chosen automatically again."
 msgstr ""
 "La qualifica in cima al Suo profilo torna a essere scelta automaticamente."
 
 #: lib/vutuv_web/templates/work_experience/card_list.html.heex:39
 #, elixir-autogen, elixir-format
-msgid ""
-"The job title at the top of your profile is picked automatically. Right now "
-"it's %{job}. Pick a role below to choose it yourself."
+msgid "The job title at the top of your profile is picked automatically. Right now it's %{job}. Pick a role below to choose it yourself."
 msgstr ""
 "La qualifica in cima al Suo profilo viene scelta automaticamente. Al momento"
 " è %{job}. Scelga un ruolo qui sotto per deciderla Lei."
@@ -9637,10 +9396,7 @@ msgstr "Questo tag è stato assegnato a @%{handle}."
 
 #: lib/vutuv_web/templates/admin/tag/form_content.html.heex:25
 #, elixir-autogen, elixir-format
-msgid ""
-"Members can neither add nor remove this tag; grant it to members on the tag "
-"page. If the tag already has members, they keep it but can no longer remove "
-"it themselves."
+msgid "Members can neither add nor remove this tag; grant it to members on the tag page. If the tag already has members, they keep it but can no longer remove it themselves."
 msgstr ""
 "I membri non possono né aggiungere né rimuovere questo tag; lo assegni loro "
 "dalla pagina del tag. Se il tag ha già dei membri, questi lo mantengono ma "
@@ -9668,9 +9424,7 @@ msgstr "Nessun membro ha ancora questo tag."
 
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:53
 #, elixir-autogen, elixir-format
-msgid ""
-"Only site admins can grant or remove this tag. Removing a member here does "
-"not delete the tag; deleting the tag above removes it from everyone."
+msgid "Only site admins can grant or remove this tag. Removing a member here does not delete the tag; deleting the tag above removes it from everyone."
 msgstr ""
 "Solo gli amministratori del sito possono assegnare o rimuovere questo tag. "
 "Rimuovere qui un membro non elimina il tag; eliminare il tag qui sopra lo "
@@ -9701,7 +9455,8 @@ msgstr "Questo tag può essere rimosso solo da un amministratore del sito."
 msgid "Yes"
 msgstr "Sì"
 
-#: lib/vutuv_web/components/ui.ex:1826 lib/vutuv_web/components/ui.ex:1827
+#: lib/vutuv_web/components/ui.ex:1826
+#: lib/vutuv_web/components/ui.ex:1827
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:65
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9729,6 +9484,7 @@ msgstr "A1 (Principiante)"
 msgid "A2 (Elementary)"
 msgstr "A2 (Elementare)"
 
+#: lib/vutuv_web/live/feed_languages_live.ex:317
 #: lib/vutuv_web/templates/language/manage.html.heex:8
 #: lib/vutuv_web/templates/language/new.html.heex:5
 #: lib/vutuv_web/templates/user/show.html.heex:749
@@ -9902,6 +9658,7 @@ msgid "Irish"
 msgstr "Irlandese"
 
 #: lib/vutuv/languages.ex:125
+#: lib/vutuv_web/templates/settings/preferences.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "Italian"
 msgstr "Italiano"
@@ -9941,11 +9698,14 @@ msgstr "Lingua eliminata."
 msgid "Language updated successfully."
 msgstr "Lingua aggiornata."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:50 lib/vutuv_web/agent_docs/text.ex:47
+#: lib/vutuv_web/agent_docs/markdown.ex:50
+#: lib/vutuv_web/agent_docs/text.ex:47
 #: lib/vutuv_web/controllers/language_controller.ex:32
 #: lib/vutuv_web/controllers/language_controller.ex:47
-#: lib/vutuv_web/cv/docx.ex:192 lib/vutuv_web/cv/html.ex:185
-#: lib/vutuv_web/cv/latex.ex:149 lib/vutuv_web/cv/odt.ex:163
+#: lib/vutuv_web/cv/docx.ex:192
+#: lib/vutuv_web/cv/html.ex:185
+#: lib/vutuv_web/cv/latex.ex:149
+#: lib/vutuv_web/cv/odt.ex:163
 #: lib/vutuv_web/live/cv_live.ex:386
 #: lib/vutuv_web/templates/language/edit.html.heex:4
 #: lib/vutuv_web/templates/language/index.html.heex:10
@@ -10139,7 +9899,7 @@ msgstr "Yoruba"
 msgid "Employment status"
 msgstr "Situazione lavorativa"
 
-#: lib/vutuv/accounts/user.ex:1162
+#: lib/vutuv/accounts/user.ex:1167
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -10150,7 +9910,7 @@ msgstr "In cerca di lavoro"
 msgid "Not open to work"
 msgstr "Non in cerca di lavoro"
 
-#: lib/vutuv/accounts/user.ex:1159
+#: lib/vutuv/accounts/user.ex:1164
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -10158,9 +9918,7 @@ msgstr "Aperto a proposte"
 
 #: lib/vutuv_web/templates/user/edit.html.heex:287
 #, elixir-autogen, elixir-format
-msgid ""
-"Shown as a badge next to your tagline so people can see whether you are open"
-" to opportunities."
+msgid "Shown as a badge next to your tagline so people can see whether you are open to opportunities."
 msgstr ""
 "Mostrata come etichetta accanto alla Sua descrizione breve, così si vede se "
 "è aperto a nuove opportunità."
@@ -10185,10 +9943,7 @@ msgstr "Tag d'onore"
 
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:12
 #, elixir-autogen, elixir-format
-msgid ""
-"Honor tags are official, admin-granted badges (like vutuv_developer for the "
-"core team). Members cannot add or remove them themselves, and they are not "
-"endorsable. Create one below, then add members on its page."
+msgid "Honor tags are official, admin-granted badges (like vutuv_developer for the core team). Members cannot add or remove them themselves, and they are not endorsable. Create one below, then add members on its page."
 msgstr ""
 "I tag d'onore sono riconoscimenti ufficiali assegnati dagli amministratori "
 "(come vutuv_developer per il gruppo di sviluppo). I membri non possono "
@@ -10222,18 +9977,14 @@ msgstr "Ancora nessun tag d'onore. Ne crei uno qui sopra."
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:276
 #, elixir-autogen, elixir-format
-msgid ""
-"Official badges you grant, like vutuv_developer for the core team. See who "
-"holds each and add or remove members."
+msgid "Official badges you grant, like vutuv_developer for the core team. See who holds each and add or remove members."
 msgstr ""
 "Riconoscimenti ufficiali che assegna Lei, come vutuv_developer per il gruppo"
 " di sviluppo. Veda chi ha ciascuno di essi e aggiunga o rimuova membri."
 
 #: lib/vutuv_web/controllers/admin/honor_tag_controller.ex:35
 #, elixir-autogen, elixir-format
-msgid ""
-"The tag “%{name}” already exists and members hold it. Review it here before "
-"making it an honor tag."
+msgid "The tag “%{name}” already exists and members hold it. Review it here before making it an honor tag."
 msgstr ""
 "Il tag “%{name}” esiste già e dei membri lo possiedono. Lo controlli qui "
 "prima di renderlo un tag d'onore."
@@ -10282,13 +10033,16 @@ msgstr "Certificato o abilitazione aggiornato."
 msgid "Certificates"
 msgstr "Certificati"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:46 lib/vutuv_web/agent_docs/text.ex:43
-#: lib/vutuv_web/components/ui.ex:4311
+#: lib/vutuv_web/agent_docs/markdown.ex:46
+#: lib/vutuv_web/agent_docs/text.ex:43
+#: lib/vutuv_web/components/ui.ex:4321
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:132
-#: lib/vutuv_web/cv/docx.ex:183 lib/vutuv_web/cv/html.ex:169
-#: lib/vutuv_web/cv/latex.ex:140 lib/vutuv_web/cv/odt.ex:154
+#: lib/vutuv_web/cv/docx.ex:183
+#: lib/vutuv_web/cv/html.ex:169
+#: lib/vutuv_web/cv/latex.ex:140
+#: lib/vutuv_web/cv/odt.ex:154
 #: lib/vutuv_web/live/cv_live.ex:361
 #: lib/vutuv_web/templates/import/new.html.heex:11
 #: lib/vutuv_web/templates/qualification/edit.html.heex:4
@@ -10363,10 +10117,7 @@ msgstr "Abilitazioni"
 
 #: lib/vutuv_web/templates/import/preview.html.heex:50
 #, elixir-autogen, elixir-format
-msgid ""
-"LinkedIn does not say whether an entry is a certificate or a license, so we "
-"import all of them as certificates. Please review the section afterwards and"
-" switch any that are licenses."
+msgid "LinkedIn does not say whether an entry is a certificate or a license, so we import all of them as certificates. Please review the section afterwards and switch any that are licenses."
 msgstr ""
 "LinkedIn non indica se una voce è un certificato o un'abilitazione, quindi "
 "le importiamo tutte come certificati. Controlli poi la sezione e converta "
@@ -10406,9 +10157,7 @@ msgstr "valido fino al %{date}"
 
 #: lib/vutuv_web/live/section_reorder_live.ex:173
 #, elixir-autogen, elixir-format
-msgid ""
-"Drag to reorder, or use the arrows. The first language is your preferred "
-"contact language."
+msgid "Drag to reorder, or use the arrows. The first language is your preferred contact language."
 msgstr ""
 "Trascini per riordinare, oppure usi le frecce. La prima lingua è la Sua "
 "lingua di contatto preferita."
@@ -10431,8 +10180,10 @@ msgstr "Lingua di contatto preferita"
 msgid "+%{code} is the calling code of %{region}"
 msgstr "+%{code} è il prefisso telefonico di %{region}"
 
-#: lib/vutuv_web/cv/docx.ex:136 lib/vutuv_web/cv/html.ex:83
-#: lib/vutuv_web/cv/latex.ex:69 lib/vutuv_web/cv/odt.ex:109
+#: lib/vutuv_web/cv/docx.ex:136
+#: lib/vutuv_web/cv/html.ex:83
+#: lib/vutuv_web/cv/latex.ex:69
+#: lib/vutuv_web/cv/odt.ex:109
 #: lib/vutuv_web/live/cv_live.ex:153
 #: lib/vutuv_web/views/account_event_text.ex:214
 #, elixir-autogen, elixir-format
@@ -10452,9 +10203,7 @@ msgstr "Rimuovere la Sua data di nascita?"
 
 #: lib/vutuv_web/templates/user/edit.html.heex:506
 #, elixir-autogen, elixir-format
-msgid ""
-"Your date of birth will be removed and your age will no longer be shown on "
-"your profile. You can add it again at any time."
+msgid "Your date of birth will be removed and your age will no longer be shown on your profile. You can add it again at any time."
 msgstr ""
 "La Sua data di nascita verrà rimossa e la Sua età non sarà più mostrata sul "
 "profilo. Può reinserirla in qualsiasi momento."
@@ -10487,12 +10236,13 @@ msgstr "Link permanente al profilo"
 msgid "Dismiss"
 msgstr "Chiudi"
 
-#: lib/vutuv_web/components/ui.ex:3182
+#: lib/vutuv_web/components/ui.ex:3185
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr "Copiato"
 
-#: lib/vutuv_web/components/ui.ex:3181 lib/vutuv_web/components/ui.ex:3185
+#: lib/vutuv_web/components/ui.ex:3184
+#: lib/vutuv_web/components/ui.ex:3188
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr "Copia"
@@ -10551,9 +10301,7 @@ msgstr "Account disattivato e contrassegnato come spam."
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:68
 #, elixir-autogen, elixir-format
-msgid ""
-"Account deactivated and marked as spam. Restore it from the member browser "
-"if this was wrong."
+msgid "Account deactivated and marked as spam. Restore it from the member browser if this was wrong."
 msgstr ""
 "Account disattivato e contrassegnato come spam. Se è stato un errore, lo "
 "ripristini dall'elenco dei membri."
@@ -10601,19 +10349,14 @@ msgstr "Disattiva l'account"
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:415
 #, elixir-autogen, elixir-format
-msgid ""
-"Permanently DELETE @%{slug} and everything they posted? This cannot be "
-"undone."
+msgid "Permanently DELETE @%{slug} and everything they posted? This cannot be undone."
 msgstr ""
 "ELIMINARE definitivamente @%{slug} e tutto ciò che ha pubblicato? "
 "L'operazione non si può annullare."
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:391
 #, elixir-autogen, elixir-format
-msgid ""
-"Remove the account outright, skipping the warning ladder. Deactivating marks"
-" it as spam and is reversible from the member browser; deleting is "
-"permanent."
+msgid "Remove the account outright, skipping the warning ladder. Deactivating marks it as spam and is reversible from the member browser; deleting is permanent."
 msgstr ""
 "Rimuova l'account senza passare per la scala degli avvertimenti. La "
 "disattivazione lo contrassegna come spam ed è reversibile dall'elenco dei "
@@ -10641,9 +10384,7 @@ msgstr "Spam"
 
 #: lib/vutuv_web/controllers/report_controller.ex:105
 #, elixir-autogen, elixir-format
-msgid ""
-"Thank you for your report. Our moderators have been notified and will review"
-" this account."
+msgid "Thank you for your report. Our moderators have been notified and will review this account."
 msgstr ""
 "Grazie per la segnalazione. I nostri moderatori sono stati avvisati ed "
 "esamineranno questo account."
@@ -10661,10 +10402,7 @@ msgstr "eliminato"
 
 #: lib/vutuv_web/controllers/report_controller.ex:115
 #, elixir-autogen, elixir-format
-msgid ""
-"To protect you, the connection between you and the reported member is paused"
-" - no contact in either direction, including messages. If our admins find "
-"the report unfounded, this is undone."
+msgid "To protect you, the connection between you and the reported member is paused - no contact in either direction, including messages. If our admins find the report unfounded, this is undone."
 msgstr ""
 "Per proteggerLa, il collegamento tra Lei e il membro segnalato viene "
 "sospeso: nessun contatto in nessuna delle due direzioni, messaggi compresi. "
@@ -10678,10 +10416,7 @@ msgstr "%{unused} codici su %{total} non ancora usati."
 
 #: lib/vutuv_web/templates/login_code/index.html.heex:13
 #, elixir-autogen, elixir-format
-msgid ""
-"A one-time code list is a printed backup for logging in: each code signs you"
-" in exactly once, typed into the PIN field at login instead of the emailed "
-"PIN."
+msgid "A one-time code list is a printed backup for logging in: each code signs you in exactly once, typed into the PIN field at login instead of the emailed PIN."
 msgstr ""
 "Un elenco di codici monouso è una riserva su carta per accedere: ogni codice"
 " consente esattamente un accesso e va digitato nel campo del PIN al posto "
@@ -10689,9 +10424,7 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/totp_controller.ex:53
 #, elixir-autogen, elixir-format
-msgid ""
-"Authenticator app set up. When you log in, the code from your app now works "
-"in the PIN field."
+msgid "Authenticator app set up. When you log in, the code from your app now works in the PIN field."
 msgstr ""
 "App di autenticazione configurata. Al momento dell'accesso, il codice della "
 "Sua app funziona ora nel campo del PIN."
@@ -10795,7 +10528,8 @@ msgstr "URL del link"
 msgid "Login codes"
 msgstr "Codici di accesso"
 
-#: lib/vutuv_web/components/ui.ex:375 lib/vutuv_web/components/ui.ex:376
+#: lib/vutuv_web/components/ui.ex:375
+#: lib/vutuv_web/components/ui.ex:376
 #, elixir-autogen, elixir-format
 msgid "More formatting"
 msgstr "Altra formattazione"
@@ -10818,8 +10552,7 @@ msgstr "Elenco di codici monouso eliminato."
 
 #: lib/vutuv_web/templates/login_code/index.html.heex:44
 #, elixir-autogen, elixir-format
-msgid ""
-"Print this page or write the codes down. Crossed-out codes have been used."
+msgid "Print this page or write the codes down. Crossed-out codes have been used."
 msgstr ""
 "Stampi questa pagina o annoti i codici. I codici barrati sono già stati "
 "usati."
@@ -10838,10 +10571,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/totp/new.html.heex:13
 #, elixir-autogen, elixir-format
-msgid ""
-"Scan this QR code with an authenticator app (for example FreeOTP, Google "
-"Authenticator or 1Password). The app then shows a fresh 6-digit code every "
-"30 seconds."
+msgid "Scan this QR code with an authenticator app (for example FreeOTP, Google Authenticator or 1Password). The app then shows a fresh 6-digit code every 30 seconds."
 msgstr ""
 "Scansioni questo codice QR con un'app di autenticazione (ad esempio FreeOTP,"
 " Google Authenticator o 1Password). L'app mostrerà poi un nuovo codice di 6 "
@@ -10865,8 +10595,7 @@ msgstr "Tabella"
 
 #: lib/vutuv_web/controllers/totp_controller.ex:67
 #, elixir-autogen, elixir-format
-msgid ""
-"That code didn't match. Please try again with the code your app shows now."
+msgid "That code didn't match. Please try again with the code your app shows now."
 msgstr ""
 "Il codice non corrisponde. Riprovi con il codice che la Sua app mostra "
 "adesso."
@@ -10888,9 +10617,7 @@ msgstr "Disattiva"
 
 #: lib/vutuv_web/templates/settings/security.html.heex:187
 #, elixir-autogen, elixir-format
-msgid ""
-"Turn off the authenticator app? Its codes stop working at login; the emailed"
-" PIN is unaffected."
+msgid "Turn off the authenticator app? Its codes stop working at login; the emailed PIN is unaffected."
 msgstr ""
 "Disattivare l'app di autenticazione? I suoi codici smettono di funzionare "
 "all'accesso; il PIN inviato per e-mail non è interessato."
@@ -10907,9 +10634,7 @@ msgstr "Attivata."
 
 #: lib/vutuv_web/templates/totp/new.html.heex:16
 #, elixir-autogen, elixir-format
-msgid ""
-"When you log in, that code works in the PIN field, so you don't have to wait"
-" for the emailed PIN. The emailed PIN keeps working as before."
+msgid "When you log in, that code works in the PIN field, so you don't have to wait for the emailed PIN. The emailed PIN keeps working as before."
 msgstr ""
 "All'accesso quel codice funziona nel campo del PIN, così non deve aspettare "
 "il PIN via e-mail. Il PIN via e-mail continua a funzionare come prima."
@@ -10937,9 +10662,7 @@ msgstr "usato"
 
 #: lib/vutuv_web/templates/session/pin_user_login.html.heex:21
 #, elixir-autogen, elixir-format
-msgid ""
-"A one-time code (OTP) from your authenticator app or your code list also "
-"works here, instead of the emailed PIN."
+msgid "A one-time code (OTP) from your authenticator app or your code list also works here, instead of the emailed PIN."
 msgstr ""
 "Anche un codice monouso (OTP) dalla Sua app di autenticazione o dal Suo "
 "elenco di codici funziona qui, al posto del PIN inviato per e-mail."
@@ -10962,19 +10685,14 @@ msgstr "Elenco di codici monouso (OTP)"
 
 #: lib/vutuv_web/templates/totp/new.html.heex:31
 #, elixir-autogen, elixir-format
-msgid ""
-"Reading this on the phone that should generate the codes? You can't scan "
-"your own screen. Instead:"
+msgid "Reading this on the phone that should generate the codes? You can't scan your own screen. Instead:"
 msgstr ""
 "Sta leggendo questo sul telefono che dovrebbe generare i codici? Non può "
 "scansionare il proprio schermo. Faccia invece così:"
 
 #: lib/vutuv_web/templates/settings/security.html.heex:168
 #, elixir-autogen, elixir-format
-msgid ""
-"Sign in with a one-time code (OTP) from an authenticator app or from a "
-"printed code list, typed into the normal PIN field. Your emailed PIN always "
-"keeps working."
+msgid "Sign in with a one-time code (OTP) from an authenticator app or from a printed code list, typed into the normal PIN field. Your emailed PIN always keeps working."
 msgstr ""
 "Acceda con un codice monouso (OTP) da un'app di autenticazione o da un "
 "elenco stampato, digitandolo nel normale campo del PIN. Il Suo PIN via "
@@ -11007,7 +10725,8 @@ msgstr[0] "%{count} stella"
 msgstr[1] "%{count} stelle"
 
 #: lib/vutuv_web/live/organization_live/show.ex:498
-#: lib/vutuv_web/views/user_html.ex:662 lib/vutuv_web/views/user_html.ex:838
+#: lib/vutuv_web/views/user_html.ex:662
+#: lib/vutuv_web/views/user_html.ex:838
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower"
 msgid_plural "%{formatted} followers"
@@ -11021,7 +10740,8 @@ msgid_plural "%{formatted} stars"
 msgstr[0] "%{formatted} stella"
 msgstr[1] "%{formatted} stelle"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:63 lib/vutuv_web/agent_docs/text.ex:60
+#: lib/vutuv_web/agent_docs/markdown.ex:63
+#: lib/vutuv_web/agent_docs/text.ex:60
 #: lib/vutuv_web/templates/user/show.html.heex:1348
 #, elixir-autogen, elixir-format
 msgid "Code"
@@ -11035,10 +10755,7 @@ msgstr "Statistiche del codice"
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:161
 #, elixir-autogen, elixir-format
-msgid ""
-"If you list a GitHub, GitLab or Codeberg account, your profile can show its "
-"public statistics: stars, repositories, followers, languages and recent "
-"activity."
+msgid "If you list a GitHub, GitLab or Codeberg account, your profile can show its public statistics: stars, repositories, followers, languages and recent activity."
 msgstr ""
 "Se indica un account GitHub, GitLab o Codeberg, il Suo profilo può mostrarne"
 " le statistiche pubbliche: stelle, repository, follower, linguaggi e "
@@ -11056,8 +10773,7 @@ msgstr "Mostrare le statistiche del codice sul mio profilo"
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:166
 #, elixir-autogen, elixir-format
-msgid ""
-"When off, the Social Media card lists your accounts as plain links only."
+msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
 "Se disattivo, la scheda Social media elenca i Suoi account come semplici "
 "link."
@@ -11079,10 +10795,7 @@ msgstr "dal %{year}"
 
 #: lib/vutuv_web/templates/login_code/index.html.heex:16
 #, elixir-autogen, elixir-format
-msgid ""
-"Keep it somewhere safe, like your wallet. If you lose it, or it falls into "
-"the wrong hands, replace or delete it here: a new list makes every old code "
-"stop working immediately. The emailed PIN always keeps working."
+msgid "Keep it somewhere safe, like your wallet. If you lose it, or it falls into the wrong hands, replace or delete it here: a new list makes every old code stop working immediately. The emailed PIN always keeps working."
 msgstr ""
 "Lo conservi in un posto sicuro, ad esempio nel portafoglio. Se lo perde, o "
 "finisce in mani sbagliate, lo sostituisca o lo elimini qui: un nuovo elenco "
@@ -11121,9 +10834,7 @@ msgstr "Colleghi il Suo profilo vutuv al Fediverso."
 
 #: lib/vutuv_web/open_graph.ex:171
 #, elixir-autogen, elixir-format
-msgid ""
-"Control who can find you on vutuv and what search engines and AI agents may "
-"use."
+msgid "Control who can find you on vutuv and what search engines and AI agents may use."
 msgstr ""
 "Decida chi può trovarla su vutuv e cosa possono usare i motori di ricerca e "
 "gli agenti IA."
@@ -11162,9 +10873,7 @@ msgstr "Importi il Suo profilo da un'esportazione di dati LinkedIn."
 
 #: lib/vutuv_web/open_graph.ex:154
 #, elixir-autogen, elixir-format
-msgid ""
-"Manage how you sign in to vutuv: username, email addresses, devices, "
-"passkeys and login codes."
+msgid "Manage how you sign in to vutuv: username, email addresses, devices, passkeys and login codes."
 msgstr ""
 "Gestisca il modo in cui accede a vutuv: nome utente, indirizzi e-mail, "
 "dispositivi, passkey e codici di accesso."
@@ -11226,8 +10935,7 @@ msgstr "Gestisca l'esperienza lavorativa sul Suo profilo vutuv."
 
 #: lib/vutuv_web/open_graph.ex:223
 #, elixir-autogen, elixir-format
-msgid ""
-"Manage your vutuv account: profile, privacy, notifications and sign-in."
+msgid "Manage your vutuv account: profile, privacy, notifications and sign-in."
 msgstr "Gestisca il Suo account vutuv: profilo, privacy, notifiche e accesso."
 
 #: lib/vutuv_web/open_graph.ex:159
@@ -11267,18 +10975,14 @@ msgstr "Il Suo feed di notizie personale su vutuv."
 
 #: lib/vutuv_web/open_graph.ex:98
 #, elixir-autogen, elixir-format
-msgid ""
-"vutuv is the open business network where professionals connect, share, and "
-"get found. Free to join."
+msgid "vutuv is the open business network where professionals connect, share, and get found. Free to join."
 msgstr ""
 "vutuv è la rete professionale aperta dove ci si collega, si condivide e ci "
 "si fa trovare. L'iscrizione è gratuita."
 
 #: lib/vutuv_web/templates/page/index.html.heex:133
 #, elixir-autogen, elixir-format
-msgid ""
-"At least three tags, separated by commas. A tag may be several words long, "
-"like Ruby on Rails."
+msgid "At least three tags, separated by commas. A tag may be several words long, like Ruby on Rails."
 msgstr ""
 "Almeno tre tag, separati da virgole. Un tag può essere lungo più parole, "
 "come Ruby on Rails."
@@ -11290,9 +10994,7 @@ msgstr "PHP, JavaScript, Ruby on Rails"
 
 #: lib/vutuv_web/live/tag_new_live.ex:56
 #, elixir-autogen, elixir-format
-msgid ""
-"Separate tags with a comma. A tag may be several words long, like Ruby on "
-"Rails."
+msgid "Separate tags with a comma. A tag may be several words long, like Ruby on Rails."
 msgstr ""
 "Separi i tag con una virgola. Un tag può essere lungo più parole, come Ruby "
 "on Rails."
@@ -11314,58 +11016,52 @@ msgid_plural "You have %{formatted} new messages."
 msgstr[0] "Ha %{formatted} nuovo messaggio."
 msgstr[1] "Ha %{formatted} nuovi messaggi."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:433
+#: lib/vutuv_web/templates/settings/preferences.html.heex:383
 #, elixir-autogen, elixir-format
-msgid ""
-"Break long words at syllable points so the text wraps evenly. Helpful in the"
-" narrow phone column."
+msgid "Break long words at syllable points so the text wraps evenly. Helpful in the narrow phone column."
 msgstr ""
 "Spezza le parole lunghe in corrispondenza delle sillabe, così il testo va a "
 "capo in modo uniforme. Utile nella colonna stretta del telefono."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:364
+#: lib/vutuv_web/templates/settings/preferences.html.heex:314
 #, elixir-autogen, elixir-format
-msgid ""
-"How posts you read are shortened in your feed and on profiles. These are "
-"your own reading preferences."
+msgid "How posts you read are shortened in your feed and on profiles. These are your own reading preferences."
 msgstr ""
 "Come vengono accorciati i post che legge, nel Suo feed e sui profili. Sono "
 "le Sue preferenze di lettura personali."
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:68
-#: lib/vutuv_web/templates/settings/preferences.html.heex:440
+#: lib/vutuv_web/templates/settings/preferences.html.heex:390
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on desktop"
 msgstr "Sillabazione su computer"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:69
-#: lib/vutuv_web/templates/settings/preferences.html.heex:444
+#: lib/vutuv_web/templates/settings/preferences.html.heex:394
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on mobile"
 msgstr "Sillabazione su telefono"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:430
+#: lib/vutuv_web/templates/settings/preferences.html.heex:380
 #, elixir-autogen, elixir-format
 msgid "Hyphenation"
 msgstr "Sillabazione"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:66
-#: lib/vutuv_web/templates/settings/preferences.html.heex:387
+#: lib/vutuv_web/templates/settings/preferences.html.heex:337
 #, elixir-autogen, elixir-format
 msgid "Lines on desktop"
 msgstr "Righe su computer"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:67
-#: lib/vutuv_web/templates/settings/preferences.html.heex:396
+#: lib/vutuv_web/templates/settings/preferences.html.heex:346
 #, elixir-autogen, elixir-format
 msgid "Lines on mobile"
 msgstr "Righe su telefono"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:382
+#: lib/vutuv_web/templates/settings/preferences.html.heex:332
 #, elixir-autogen, elixir-format
-msgid ""
-"Longer posts get a “Read more” link. Set 0 (or leave empty) to never "
-"shorten."
+msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
 "I post più lunghi ricevono un link “Leggi tutto”. Imposti 0 (o lasci vuoto) "
 "per non accorciare mai."
@@ -11375,7 +11071,7 @@ msgstr ""
 msgid "Post display settings saved."
 msgstr "Impostazioni di visualizzazione dei post salvate."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:379
+#: lib/vutuv_web/templates/settings/preferences.html.heex:329
 #, elixir-autogen, elixir-format
 msgid "Shorten a post after"
 msgstr "Accorcia un post dopo"
@@ -11406,12 +11102,8 @@ msgstr "Segue il valore predefinito dell'installazione."
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:394
 #, elixir-autogen, elixir-format
-msgid ""
-"How posts and maps behave for everyone who has not chosen for themselves. "
-"%{formatted} default differs from the shipped value."
-msgid_plural ""
-"How posts and maps behave for everyone who has not chosen for themselves. "
-"%{formatted} defaults differ from the shipped values."
+msgid "How posts and maps behave for everyone who has not chosen for themselves. %{formatted} default differs from the shipped value."
+msgid_plural "How posts and maps behave for everyone who has not chosen for themselves. %{formatted} defaults differ from the shipped values."
 msgstr[0] ""
 "Come si comportano post e mappe per tutti coloro che non hanno scelto da sé."
 " %{formatted} valore predefinito è diverso da quello di fabbrica."
@@ -11421,9 +11113,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:390
 #, elixir-autogen, elixir-format
-msgid ""
-"How posts and maps behave for everyone who has not chosen for themselves. "
-"This installation runs on the shipped defaults."
+msgid "How posts and maps behave for everyone who has not chosen for themselves. This installation runs on the shipped defaults."
 msgstr ""
 "Come si comportano post e mappe per tutti coloro che non hanno scelto da sé."
 " Questa installazione usa i valori di fabbrica."
@@ -11480,11 +11170,11 @@ msgstr "Preferenze"
 msgid "Preferences of %{name}"
 msgstr "Preferenze di %{name}"
 
+#: lib/vutuv_web/live/feed_languages_live.ex:377
 #: lib/vutuv_web/templates/settings/preferences.html.heex:101
 #: lib/vutuv_web/templates/settings/preferences.html.heex:174
-#: lib/vutuv_web/templates/settings/preferences.html.heex:245
-#: lib/vutuv_web/templates/settings/preferences.html.heex:346
-#: lib/vutuv_web/templates/settings/preferences.html.heex:464
+#: lib/vutuv_web/templates/settings/preferences.html.heex:296
+#: lib/vutuv_web/templates/settings/preferences.html.heex:414
 #, elixir-autogen, elixir-format
 msgid "Reset to the site defaults"
 msgstr "Riporta ai valori predefiniti del sito"
@@ -11512,10 +11202,7 @@ msgstr "Questo valore non è valido."
 
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:11
 #, elixir-autogen, elixir-format
-msgid ""
-"What every member gets until they choose for themselves on their settings "
-"pages, and what logged-out visitors see. Changes apply immediately; members "
-"who set their own value are not affected."
+msgid "What every member gets until they choose for themselves on their settings pages, and what logged-out visitors see. Changes apply immediately; members who set their own value are not affected."
 msgstr ""
 "Ciò che ogni membro ottiene finché non sceglie da sé nelle proprie "
 "impostazioni, e ciò che vedono i visitatori non connessi. Le modifiche "
@@ -11554,11 +11241,7 @@ msgstr "Mostra OpenStreetMap"
 
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:29
 #, elixir-autogen, elixir-format
-msgid ""
-"These are the member's own settings: change them here only for support. A "
-"field on \"installation default\" follows whatever the defaults page says, "
-"now and in the future; a set value stays until the member (or an admin) "
-"changes it again."
+msgid "These are the member's own settings: change them here only for support. A field on \"installation default\" follows whatever the defaults page says, now and in the future; a set value stays until the member (or an admin) changes it again."
 msgstr ""
 "Queste sono le impostazioni personali del membro: le modifichi qui solo per "
 "assistenza. Un campo su \"valore predefinito dell'installazione\" segue "
@@ -11568,9 +11251,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:197
 #, elixir-autogen, elixir-format
-msgid ""
-"Auto-generated screenshots for single-link posts: watch the capture queue "
-"and browse the gallery of finished shots, each linked to its post."
+msgid "Auto-generated screenshots for single-link posts: watch the capture queue and browse the gallery of finished shots, each linked to its post."
 msgstr ""
 "Screenshot generati automaticamente per i post con un solo link: segua la "
 "coda di acquisizione e sfogli la galleria delle immagini pronte, ciascuna "
@@ -11588,9 +11269,7 @@ msgstr "Acquisizione in corso"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:355
 #, elixir-autogen, elixir-format
-msgid ""
-"Every captured link screenshot, newest first. Each links to the page and its"
-" post."
+msgid "Every captured link screenshot, newest first. Each links to the page and its post."
 msgstr ""
 "Ogni screenshot di link acquisito, dal più recente. Ciascuno rimanda alla "
 "pagina e al relativo post."
@@ -11607,9 +11286,7 @@ msgstr "Galleria"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:405
 #, elixir-autogen, elixir-format
-msgid ""
-"Jobs waiting, in flight, or given up. The worker retries transient failures "
-"with backoff and re-queues anything a restart left mid-capture."
+msgid "Jobs waiting, in flight, or given up. The worker retries transient failures with backoff and re-queues anything a restart left mid-capture."
 msgstr ""
 "Lavori in attesa, in corso o abbandonati. Il worker ritenta gli errori "
 "temporanei con attese crescenti e rimette in coda tutto ciò che un riavvio "
@@ -11702,28 +11379,25 @@ msgstr "Visualizzazioni"
 
 #: lib/vutuv_web/templates/user/edit.html.heex:296
 #, elixir-autogen, elixir-format
-msgid ""
-"\"Signed-in members only\" is the default. It reduces who sees your "
-"availability but cannot guarantee it, since anyone can create an account. "
-"Choose \"No one\" to keep the status saved without showing it."
+msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 "\"Solo i membri connessi\" è l'impostazione predefinita. Riduce chi vede la "
 "Sua disponibilità ma non può garantirla, perché chiunque può creare un "
 "account. Scelga \"Nessuno\" per conservare lo stato senza mostrarlo."
 
-#: lib/vutuv/accounts/user.ex:1200
+#: lib/vutuv/accounts/user.ex:1205
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Tutti, compresi i visitatori non connessi"
 
-#: lib/vutuv/accounts/user.ex:1205
+#: lib/vutuv/accounts/user.ex:1210
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Nessuno"
 
-#: lib/vutuv/accounts/user.ex:1203
+#: lib/vutuv/accounts/user.ex:1208
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:761
 #, elixir-autogen, elixir-format
@@ -11751,10 +11425,7 @@ msgstr "Valuta"
 
 #: lib/vutuv_web/templates/user/edit.html.heex:336
 #, elixir-autogen, elixir-format
-msgid ""
-"Hidden by default, and it still does its job while hidden. \"Signed-in "
-"members only\" adds a quiet line to your profile for members; \"Everyone\" "
-"also shows it to logged-out visitors."
+msgid "Hidden by default, and it still does its job while hidden. \"Signed-in members only\" adds a quiet line to your profile for members; \"Everyone\" also shows it to logged-out visitors."
 msgstr ""
 "Nascosta per impostazione predefinita, e anche da nascosta fa il suo lavoro."
 " \"Solo i membri connessi\" aggiunge al Suo profilo una riga discreta per i "
@@ -11768,9 +11439,7 @@ msgstr "Retribuzione minima desiderata"
 
 #: lib/vutuv_web/templates/user/edit.html.heex:312
 #, elixir-autogen, elixir-format
-msgid ""
-"Optional. Even when hidden, it sharpens your own job search and alerts by "
-"filtering out postings below it. Leave the amount empty to remove it."
+msgid "Optional. Even when hidden, it sharpens your own job search and alerts by filtering out postings below it. Leave the amount empty to remove it."
 msgstr ""
 "Facoltativa. Anche da nascosta affina la Sua ricerca di lavoro e i Suoi "
 "avvisi, escludendo gli annunci al di sotto. Lasci vuoto l'importo per "
@@ -11794,27 +11463,32 @@ msgstr ""
 msgid "Who can see your salary expectation?"
 msgstr "Chi può vedere la Sua retribuzione desiderata?"
 
-#: lib/vutuv/salary.ex:48 lib/vutuv_web/gettext_extraction_anchors.ex:62
+#: lib/vutuv/salary.ex:48
+#: lib/vutuv_web/gettext_extraction_anchors.ex:62
 #, elixir-autogen, elixir-format
 msgid "day"
 msgstr "giorno"
 
-#: lib/vutuv/salary.ex:47 lib/vutuv_web/gettext_extraction_anchors.ex:61
+#: lib/vutuv/salary.ex:47
+#: lib/vutuv_web/gettext_extraction_anchors.ex:61
 #, elixir-autogen, elixir-format
 msgid "hour"
 msgstr "ora"
 
-#: lib/vutuv/salary.ex:50 lib/vutuv_web/gettext_extraction_anchors.ex:64
+#: lib/vutuv/salary.ex:50
+#: lib/vutuv_web/gettext_extraction_anchors.ex:64
 #, elixir-autogen, elixir-format
 msgid "month"
 msgstr "mese"
 
-#: lib/vutuv/salary.ex:49 lib/vutuv_web/gettext_extraction_anchors.ex:63
+#: lib/vutuv/salary.ex:49
+#: lib/vutuv_web/gettext_extraction_anchors.ex:63
 #, elixir-autogen, elixir-format
 msgid "week"
 msgstr "settimana"
 
-#: lib/vutuv/salary.ex:51 lib/vutuv_web/gettext_extraction_anchors.ex:65
+#: lib/vutuv/salary.ex:51
+#: lib/vutuv_web/gettext_extraction_anchors.ex:65
 #, elixir-autogen, elixir-format
 msgid "year"
 msgstr "anno"
@@ -11866,10 +11540,7 @@ msgstr "Elenco di esclusioni per la ricerca di lavoro"
 
 #: lib/vutuv_web/templates/user/edit.html.heex:392
 #, elixir-autogen, elixir-format
-msgid ""
-"Keep your availability broadly visible while making sure your own employer "
-"never sees it. Exclude specific members or email domains, and they never see"
-" your availability or salary expectation, even at \"Everyone\"."
+msgid "Keep your availability broadly visible while making sure your own employer never sees it. Exclude specific members or email domains, and they never see your availability or salary expectation, even at \"Everyone\"."
 msgstr ""
 "Mantenga la Sua disponibilità largamente visibile assicurandosi però che il "
 "Suo datore di lavoro non la veda mai. Escluda membri o domini e-mail "
@@ -11897,11 +11568,7 @@ msgstr "Nessun membro ha questo @handle."
 
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:117
 #, elixir-autogen, elixir-format
-msgid ""
-"People and email domains on this list never see that you are open to work, "
-"or your salary expectation, even when your availability is set to "
-"\"Everyone\". Excluding reduces who can see it but cannot guarantee it: "
-"someone can still look while logged out, or from a private email address."
+msgid "People and email domains on this list never see that you are open to work, or your salary expectation, even when your availability is set to \"Everyone\". Excluding reduces who can see it but cannot guarantee it: someone can still look while logged out, or from a private email address."
 msgstr ""
 "Le persone e i domini e-mail in questo elenco non vedono mai che è aperto a "
 "nuove opportunità, né la Sua retribuzione desiderata, nemmeno quando la Sua "
@@ -11988,9 +11655,7 @@ msgstr "Markdown è supportato"
 
 #: lib/vutuv_web/live/organization_live/edit.ex:334
 #, elixir-autogen, elixir-format
-msgid ""
-"Offer the machine-readable formats (.md/.txt/.json/.xml) and list them for "
-"AI agents."
+msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) and list them for AI agents."
 msgstr ""
 "Offri i formati leggibili dalle macchine (.md/.txt/.json/.xml) ed elencali "
 "per gli agenti IA."
@@ -12115,9 +11780,7 @@ msgstr "Può caricare un solo logo."
 
 #: lib/vutuv_web/live/organization_live/new.ex:149
 #, elixir-autogen, elixir-format
-msgid ""
-"You will publish a record or file to prove control of the domain on the next"
-" step."
+msgid "You will publish a record or file to prove control of the domain on the next step."
 msgstr ""
 "Nel passo successivo pubblicherà un record o un file per dimostrare di "
 "controllare il dominio."
@@ -12266,9 +11929,7 @@ msgstr "Blocca"
 
 #: lib/vutuv_web/live/admin/organization_live.ex:370
 #, elixir-autogen, elixir-format
-msgid ""
-"Freeze this page? It disappears for the public but stays visible to its "
-"owner."
+msgid "Freeze this page? It disappears for the public but stays visible to its owner."
 msgstr ""
 "Bloccare questa pagina? Sparisce per il pubblico ma resta visibile al suo "
 "proprietario."
@@ -12473,9 +12134,7 @@ msgstr "Link verificato. Ora mostra un contrassegno di verifica."
 
 #: lib/vutuv_web/templates/url/verify.html.heex:17
 #, elixir-autogen, elixir-format
-msgid ""
-"Prove this link is your own webpage with one of the methods below. It then "
-"shows a verified mark."
+msgid "Prove this link is your own webpage with one of the methods below. It then shows a verified mark."
 msgstr ""
 "Dimostri con uno dei metodi qui sotto che questo link è una Sua pagina web. "
 "Mostrerà poi un contrassegno di verifica."
@@ -12487,9 +12146,7 @@ msgstr "Pubblichi questo file:"
 
 #: lib/vutuv_web/templates/url/verify.html.heex:39
 #, elixir-autogen, elixir-format
-msgid ""
-"The link text can be anything. A hidden <link rel=\"me\"> in the page head "
-"works too."
+msgid "The link text can be anything. A hidden <link rel=\"me\"> in the page head works too."
 msgstr ""
 "Il testo del link può essere qualsiasi. Va bene anche un <link rel=\"me\"> "
 "nascosto nell'head della pagina."
@@ -12541,8 +12198,7 @@ msgstr "pagina web verificata"
 
 #: lib/vutuv_web/templates/username/form_content.html.heex:21
 #, elixir-autogen, elixir-format
-msgid ""
-"%{min} to %{max} characters: letters (a-z), numbers (0-9) and underscores."
+msgid "%{min} to %{max} characters: letters (a-z), numbers (0-9) and underscores."
 msgstr ""
 "Da %{min} a %{max} caratteri: lettere (a-z), cifre (0-9) e trattini bassi."
 
@@ -12580,12 +12236,8 @@ msgstr "precedente"
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:303
 #, elixir-autogen, elixir-format
-msgid ""
-"%{formatted} alias matches another verified organization and is flagged for "
-"review."
-msgid_plural ""
-"%{formatted} aliases match another verified organization and are flagged for"
-" review."
+msgid "%{formatted} alias matches another verified organization and is flagged for review."
+msgid_plural "%{formatted} aliases match another verified organization and are flagged for review."
 msgstr[0] ""
 "%{formatted} alias coincide con un'altra organizzazione verificata ed è "
 "segnalato per la revisione."
@@ -12595,12 +12247,8 @@ msgstr[1] ""
 
 #: lib/vutuv_web/live/admin/organization_live.ex:199
 #, elixir-autogen, elixir-format
-msgid ""
-"%{count} alias matches another verified organization and is flagged for "
-"review. Open an organization below to see it."
-msgid_plural ""
-"%{count} aliases match another verified organization and are flagged for "
-"review. Open an organization below to see them."
+msgid "%{count} alias matches another verified organization and is flagged for review. Open an organization below to see it."
+msgid_plural "%{count} aliases match another verified organization and are flagged for review. Open an organization below to see them."
 msgstr[0] ""
 "%{count} alias coincide con un'altra organizzazione verificata ed è "
 "segnalato per la revisione. Apra un'organizzazione qui sotto per vederlo."
@@ -12610,55 +12258,42 @@ msgstr[1] ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:359
 #, elixir-autogen, elixir-format
-msgid ""
-"Alternative names, brands or abbreviations this organization is findable "
-"under. A rename keeps the old name here automatically."
+msgid "Alternative names, brands or abbreviations this organization is findable under. A rename keeps the old name here automatically."
 msgstr ""
 "Nomi alternativi, marchi o sigle con cui questa organizzazione si può "
 "trovare. Un cambio di nome conserva qui il nome precedente in automatico."
 
 #: lib/vutuv_web/live/organization_live/domains.ex:180
 #, elixir-autogen, elixir-format
-msgid ""
-"An organization can prove several domains. The primary one shows in the "
-"“Verified via …” badge."
+msgid "An organization can prove several domains. The primary one shows in the “Verified via …” badge."
 msgstr ""
 "Un'organizzazione può dimostrare più domini. Quello principale compare "
 "nell'etichetta “Verificato tramite …”."
 
 #: lib/vutuv_web/live/organization_live/domains.ex:146
 #, elixir-autogen, elixir-format
-msgid ""
-"An organization keeps at least one verified domain, so this one cannot be "
-"removed."
+msgid "An organization keeps at least one verified domain, so this one cannot be removed."
 msgstr ""
 "Un'organizzazione mantiene almeno un dominio verificato, quindi questo non "
 "può essere rimosso."
 
 #: lib/vutuv_web/live/organization_live/roles.ex:152
 #, elixir-autogen, elixir-format
-msgid ""
-"An organization must keep at least one owner, so the last owner cannot be "
-"changed."
+msgid "An organization must keep at least one owner, so the last owner cannot be changed."
 msgstr ""
 "Un'organizzazione deve mantenere almeno un proprietario, quindi l'ultimo "
 "proprietario non può essere modificato."
 
 #: lib/vutuv_web/live/organization_live/new.ex:97
 #, elixir-autogen, elixir-format
-msgid ""
-"Create a verified page for your company, association, school or public "
-"authority."
+msgid "Create a verified page for your company, association, school or public authority."
 msgstr ""
 "Crei una pagina verificata per la Sua azienda, associazione, scuola o ente "
 "pubblico."
 
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:172
 #, elixir-autogen, elixir-format
-msgid ""
-"Any signed-in member whose confirmed email is at this domain, or a subdomain"
-" of it, is excluded. This is the reliable way to hide from your whole "
-"organization."
+msgid "Any signed-in member whose confirmed email is at this domain, or a subdomain of it, is excluded. This is the reliable way to hide from your whole organization."
 msgstr ""
 "Viene escluso ogni membro connesso il cui indirizzo e-mail confermato "
 "appartiene a questo dominio o a un suo sottodominio. È il modo affidabile "
@@ -12680,10 +12315,7 @@ msgstr "Perché chiediamo una verifica"
 
 #: lib/vutuv_web/live/organization_live/new.ex:109
 #, elixir-autogen, elixir-format
-msgid ""
-"So visitors can trust the page. We only publish it once you prove that you "
-"control the organization's web domain, so nobody can put up a page that "
-"pretends to be your organization."
+msgid "So visitors can trust the page. We only publish it once you prove that you control the organization's web domain, so nobody can put up a page that pretends to be your organization."
 msgstr ""
 "Perché i visitatori possano fidarsi della pagina. La pubblichiamo solo dopo "
 "che ha dimostrato di controllare il dominio web dell'organizzazione, così "
@@ -12696,12 +12328,7 @@ msgstr "Potrebbe servirLe l'aiuto di chi amministra il sito"
 
 #: lib/vutuv_web/live/organization_live/new.ex:117
 #, elixir-autogen, elixir-format
-msgid ""
-"The proof is a small technical change to your domain: a DNS entry or a file "
-"on your website. If you don't manage the website yourself, ask the person or"
-" team who does. That is usually your IT department or the company that runs "
-"your website. We show the exact instructions on the next step, so you can "
-"simply pass them on."
+msgid "The proof is a small technical change to your domain: a DNS entry or a file on your website. If you don't manage the website yourself, ask the person or team who does. That is usually your IT department or the company that runs your website. We show the exact instructions on the next step, so you can simply pass them on."
 msgstr ""
 "La prova è una piccola modifica tecnica al Suo dominio: una voce DNS o un "
 "file sul Suo sito web. Se non gestisce Lei il sito, lo chieda a chi se ne "
@@ -12711,10 +12338,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/show.ex:834
 #, elixir-autogen, elixir-format
-msgid ""
-"These steps are technical. If you don't manage %{domain} yourself, copy the "
-"record or file shown below and send it to your IT team or whoever runs your "
-"website. Once they have added it, come back here and press Verify now."
+msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr ""
 "Questi passaggi sono tecnici. Se non gestisce Lei %{domain}, copi il record "
 "o il file mostrato qui sotto e lo invii al Suo reparto IT o a chi gestisce "
@@ -12727,9 +12351,7 @@ msgstr "Elimina questa organizzazione"
 
 #: lib/vutuv_web/live/organization_live/edit.ex:459
 #, elixir-autogen, elixir-format
-msgid ""
-"Deleting this organization page is permanent. Its verified domains and its "
-"@handle are freed and can be claimed again."
+msgid "Deleting this organization page is permanent. Its verified domains and its @handle are freed and can be claimed again."
 msgstr ""
 "L'eliminazione di questa pagina di organizzazione è definitiva. I suoi "
 "domini verificati e il suo @handle tornano liberi e possono essere "
@@ -12835,7 +12457,8 @@ msgstr "Organizzazione sbloccata."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:419
 #: lib/vutuv_web/agent_docs/organization_doc.ex:123
-#: lib/vutuv_web/agent_docs/text.ex:394 lib/vutuv_web/components/ui.ex:4449
+#: lib/vutuv_web/agent_docs/text.ex:394
+#: lib/vutuv_web/components/ui.ex:4470
 #: lib/vutuv_web/controllers/settings_controller.ex:211
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
@@ -12857,8 +12480,7 @@ msgstr "Scelga"
 
 #: lib/vutuv_web/controllers/organization_controller.ex:142
 #, elixir-autogen, elixir-format
-msgid ""
-"Please confirm your email address before claiming an organization page."
+msgid "Please confirm your email address before claiming an organization page."
 msgstr ""
 "Confermi il Suo indirizzo e-mail prima di rivendicare una pagina di "
 "organizzazione."
@@ -12895,9 +12517,7 @@ msgstr "La pagina dell'organizzazione è stata eliminata."
 
 #: lib/vutuv_web/live/organization_live/show.ex:379
 #, elixir-autogen, elixir-format
-msgid ""
-"This organization page was reported and is hidden while it is reviewed. Only"
-" you and the moderators can see it."
+msgid "This organization page was reported and is hidden while it is reviewed. Only you and the moderators can see it."
 msgstr ""
 "Questa pagina di organizzazione è stata segnalata ed è nascosta durante "
 "l'esame. Solo Lei e i moderatori possono vederla."
@@ -12916,9 +12536,7 @@ msgstr "Pagine di organizzazioni verificate su vutuv."
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:301
 #, elixir-autogen, elixir-format
-msgid ""
-"Verified organization pages: domains, team roles, aliases and rename "
-"history. Freeze, archive or delete a page."
+msgid "Verified organization pages: domains, team roles, aliases and rename history. Freeze, archive or delete a page."
 msgstr ""
 "Pagine di organizzazioni verificate: domini, ruoli nel team, alias e "
 "cronologia dei cambi di nome. Blocchi, archivi o elimini una pagina."
@@ -12971,12 +12589,7 @@ msgstr "la_sua_organizzazione"
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:20
 #, elixir-autogen, elixir-format
-msgid ""
-"We can't stop a search engine or AI service from reading a page it can open."
-" What we can do is tell them, in the machine-readable way they look for, "
-"that you don't want your profile listed in search results or used by AI. "
-"Reputable search engines and AI companies follow that request; we can't "
-"force the rest."
+msgid "We can't stop a search engine or AI service from reading a page it can open. What we can do is tell them, in the machine-readable way they look for, that you don't want your profile listed in search results or used by AI. Reputable search engines and AI companies follow that request; we can't force the rest."
 msgstr ""
 "Non possiamo impedire a un motore di ricerca o a un servizio di IA di "
 "leggere una pagina che riesce ad aprire. Quello che possiamo fare è dire "
@@ -13117,7 +12730,8 @@ msgstr "Modifica l'annuncio"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:272
 #: lib/vutuv_web/agent_docs/markdown.ex:480
-#: lib/vutuv_web/agent_docs/text.ex:258 lib/vutuv_web/agent_docs/text.ex:501
+#: lib/vutuv_web/agent_docs/text.ex:258
+#: lib/vutuv_web/agent_docs/text.ex:501
 #: lib/vutuv_web/live/admin/job_live.ex:344
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:17
 #: lib/vutuv_web/views/account_event_text.ex:225
@@ -13132,7 +12746,8 @@ msgstr "Nome del datore di lavoro (facoltativo)"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:273
 #: lib/vutuv_web/agent_docs/markdown.ex:481
-#: lib/vutuv_web/agent_docs/text.ex:259 lib/vutuv_web/agent_docs/text.ex:502
+#: lib/vutuv_web/agent_docs/text.ex:259
+#: lib/vutuv_web/agent_docs/text.ex:502
 #: lib/vutuv_web/live/job_board_live.ex:367
 #: lib/vutuv_web/live/job_posting_live/form.ex:473
 #, elixir-autogen, elixir-format
@@ -13167,7 +12782,8 @@ msgstr "I tag evidenziati corrispondono al Suo profilo."
 msgid "How to apply"
 msgstr "Come candidarsi"
 
-#: lib/vutuv/accounts/user.ex:1174 lib/vutuv/jobs/job_posting.ex:163
+#: lib/vutuv/accounts/user.ex:1179
+#: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
 msgstr "Ibrido"
@@ -13206,7 +12822,8 @@ msgstr "Consenti ai motori di ricerca di indicizzare questo annuncio."
 #: lib/vutuv_web/agent_docs/markdown.ex:455
 #: lib/vutuv_web/agent_docs/markdown.ex:458
 #: lib/vutuv_web/agent_docs/markdown.ex:460
-#: lib/vutuv_web/agent_docs/text.ex:476 lib/vutuv_web/agent_docs/text.ex:479
+#: lib/vutuv_web/agent_docs/text.ex:476
+#: lib/vutuv_web/agent_docs/text.ex:479
 #: lib/vutuv_web/agent_docs/text.ex:481
 #: lib/vutuv_web/live/job_posting_live/form.ex:514
 #, elixir-autogen, elixir-format
@@ -13287,7 +12904,8 @@ msgstr ""
 "Offri i formati leggibili dalle macchine (.md/.txt/.json/.xml) agli agenti "
 "IA."
 
-#: lib/vutuv/accounts/user.ex:1173 lib/vutuv/jobs/job_posting.ex:162
+#: lib/vutuv/accounts/user.ex:1178
+#: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
 msgstr "In sede"
@@ -13347,7 +12965,8 @@ msgstr "CAP"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:277
 #: lib/vutuv_web/agent_docs/markdown.ex:485
-#: lib/vutuv_web/agent_docs/text.ex:263 lib/vutuv_web/agent_docs/text.ex:506
+#: lib/vutuv_web/agent_docs/text.ex:263
+#: lib/vutuv_web/agent_docs/text.ex:506
 #: lib/vutuv_web/live/job_posting_live/show.ex:133
 #, elixir-autogen, elixir-format
 msgid "Posted"
@@ -13369,11 +12988,13 @@ msgstr "Annuncio non trovato."
 msgid "Publish"
 msgstr "Pubblica"
 
-#: lib/vutuv/accounts/user.ex:1175 lib/vutuv/jobs/job_posting.ex:164
+#: lib/vutuv/accounts/user.ex:1180
+#: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:564
 #: lib/vutuv_web/agent_docs/markdown.ex:458
 #: lib/vutuv_web/agent_docs/markdown.ex:460
-#: lib/vutuv_web/agent_docs/text.ex:479 lib/vutuv_web/agent_docs/text.ex:481
+#: lib/vutuv_web/agent_docs/text.ex:479
+#: lib/vutuv_web/agent_docs/text.ex:481
 #: lib/vutuv_web/components/job_components.ex:140
 #: lib/vutuv_web/components/job_components.ex:141
 #, elixir-autogen, elixir-format
@@ -13395,7 +13016,8 @@ msgstr "Richiesto"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:276
 #: lib/vutuv_web/agent_docs/markdown.ex:484
-#: lib/vutuv_web/agent_docs/text.ex:262 lib/vutuv_web/agent_docs/text.ex:505
+#: lib/vutuv_web/agent_docs/text.ex:262
+#: lib/vutuv_web/agent_docs/text.ex:505
 #, elixir-autogen, elixir-format
 msgid "Salary"
 msgstr "Retribuzione"
@@ -13428,9 +13050,7 @@ msgstr "Via (facoltativo)"
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:707
 #, elixir-autogen, elixir-format
-msgid ""
-"Tags match your posting to members. Separate them with commas; a tag may be "
-"several words long, like Ruby on Rails."
+msgid "Tags match your posting to members. Separate them with commas; a tag may be several words long, like Ruby on Rails."
 msgstr ""
 "I tag mettono in relazione il Suo annuncio con i membri. Li separi con "
 "virgole; un tag può essere lungo più parole, come Ruby on Rails."
@@ -13462,9 +13082,7 @@ msgstr "Questa posizione non è più disponibile."
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:440
 #, elixir-autogen, elixir-format
-msgid ""
-"Tip: adding a gender marker like (m/w/d) helps your posting comply with the "
-"AGG. This is a suggestion, not legal advice."
+msgid "Tip: adding a gender marker like (m/w/d) helps your posting comply with the AGG. This is a suggestion, not legal advice."
 msgstr ""
 "Consiglio: aggiungere un'indicazione di genere come (m/f/d) aiuta il Suo "
 "annuncio a rispettare la legge tedesca sulla parità di trattamento (AGG). È "
@@ -13500,7 +13118,8 @@ msgstr "Studente lavoratore"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:274
 #: lib/vutuv_web/agent_docs/markdown.ex:482
-#: lib/vutuv_web/agent_docs/text.ex:260 lib/vutuv_web/agent_docs/text.ex:503
+#: lib/vutuv_web/agent_docs/text.ex:260
+#: lib/vutuv_web/agent_docs/text.ex:503
 #: lib/vutuv_web/live/job_posting_live/form.ex:488
 #, elixir-autogen, elixir-format
 msgid "Workplace"
@@ -13535,9 +13154,7 @@ msgstr "Prova mancante"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:218
 #, elixir-autogen, elixir-format
-msgid ""
-"We could not read this domain's proof on the last check. Restore it and "
-"check again, or the domain loses its verification."
+msgid "We could not read this domain's proof on the last check. Restore it and check again, or the domain loses its verification."
 msgstr ""
 "All'ultimo controllo non siamo riusciti a leggere la prova di questo "
 "dominio. La ripristini e controlli di nuovo, altrimenti il dominio perde la "
@@ -13581,11 +13198,7 @@ msgstr "Che cos'è una pagina di organizzazione?"
 
 #: lib/vutuv_web/templates/settings/organizations.html.heex:13
 #, elixir-autogen, elixir-format
-msgid ""
-"An organization page is a verified profile for a company, association, "
-"school, public authority or any other group, not for a single person. Every "
-"page has a proven web domain, so visitors can trust that it is really run by"
-" that organization."
+msgid "An organization page is a verified profile for a company, association, school, public authority or any other group, not for a single person. Every page has a proven web domain, so visitors can trust that it is really run by that organization."
 msgstr ""
 "Una pagina di organizzazione è un profilo verificato per un'azienda, "
 "un'associazione, una scuola, un ente pubblico o qualsiasi altro gruppo, non "
@@ -13604,9 +13217,7 @@ msgstr "Chi crea una pagina ne diventa proprietario."
 
 #: lib/vutuv_web/templates/settings/organizations.html.heex:30
 #, elixir-autogen, elixir-format
-msgid ""
-"A page can claim a short @handle, so it lives at a memorable address like "
-"%{example}."
+msgid "A page can claim a short @handle, so it lives at a memorable address like %{example}."
 msgstr ""
 "Una pagina può rivendicare un @handle breve, così si trova a un indirizzo "
 "facile da ricordare come %{example}."
@@ -13630,9 +13241,7 @@ msgstr "Aggiungi un'organizzazione"
 
 #: lib/vutuv_web/templates/settings/organizations.html.heex:115
 #, elixir-autogen, elixir-format
-msgid ""
-"Represent a company, association or other group? Add its page and verify the"
-" domain to become its owner."
+msgid "Represent a company, association or other group? Add its page and verify the domain to become its owner."
 msgstr ""
 "Rappresenta un'azienda, un'associazione o un altro gruppo? Ne aggiunga la "
 "pagina e verifichi il dominio per diventarne proprietario."
@@ -13642,22 +13251,19 @@ msgstr ""
 msgid "Browse all organizations"
 msgstr "Sfoglia tutte le organizzazioni"
 
-#: lib/vutuv_web/views/settings_html.ex:74
+#: lib/vutuv_web/views/settings_html.ex:72
 #, elixir-autogen, elixir-format
 msgid "Under review"
 msgstr "In esame"
 
-#: lib/vutuv_web/views/settings_html.ex:76
+#: lib/vutuv_web/views/settings_html.ex:74
 #, elixir-autogen, elixir-format
 msgid "Verification pending"
 msgstr "Verifica in attesa"
 
 #: lib/vutuv_web/live/organization_live/index.ex:63
 #, elixir-autogen, elixir-format
-msgid ""
-"Verified pages for companies, associations, schools, public authorities and "
-"other groups, not for single people. Every page has a proven web domain, so "
-"you know it is really them."
+msgid "Verified pages for companies, associations, schools, public authorities and other groups, not for single people. Every page has a proven web domain, so you know it is really them."
 msgstr ""
 "Pagine verificate per aziende, associazioni, scuole, enti pubblici e altri "
 "gruppi, non per singole persone. Ogni pagina ha un dominio web dimostrato, "
@@ -13665,19 +13271,14 @@ msgstr ""
 
 #: lib/vutuv_web/templates/url/verify.html.heex:92
 #, elixir-autogen, elixir-format
-msgid ""
-"DNS changes can take a while to spread. If it does not verify right away, "
-"wait a few minutes and try again."
+msgid "DNS changes can take a while to spread. If it does not verify right away, wait a few minutes and try again."
 msgstr ""
 "Le modifiche al DNS possono metterci un po' a propagarsi. Se la verifica non"
 " riesce subito, aspetti qualche minuto e riprovi."
 
 #: lib/vutuv_web/templates/url/verify.html.heex:80
 #, elixir-autogen, elixir-format
-msgid ""
-"Getting an error, or is %{host} a CNAME / alias to another address? A TXT "
-"record cannot share a name with a CNAME. Use this name instead, with the "
-"exact same value as above:"
+msgid "Getting an error, or is %{host} a CNAME / alias to another address? A TXT record cannot share a name with a CNAME. Use this name instead, with the exact same value as above:"
 msgstr ""
 "Riceve un errore, oppure %{host} è un CNAME / alias verso un altro "
 "indirizzo? Un record TXT non può condividere il nome con un CNAME. Usi "
@@ -13686,9 +13287,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:322
 #: lib/vutuv_web/live/organization_live/show.ex:880
 #, elixir-autogen, elixir-format
-msgid ""
-"If %{domain} is a CNAME / alias (a TXT record cannot share a name with a "
-"CNAME), put the record on %{name} instead, with the same value."
+msgid "If %{domain} is a CNAME / alias (a TXT record cannot share a name with a CNAME), put the record on %{name} instead, with the same value."
 msgstr ""
 "Se %{domain} è un CNAME / alias (un record TXT non può condividere il nome "
 "con un CNAME), metta il record su %{name}, con lo stesso valore."
@@ -13696,17 +13295,14 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:320
 #: lib/vutuv_web/live/organization_live/show.ex:871
 #, elixir-autogen, elixir-format
-msgid ""
-"In your DNS settings, create a TXT record on the name %{domain} with this "
-"value:"
+msgid "In your DNS settings, create a TXT record on the name %{domain} with this value:"
 msgstr ""
 "Nelle Sue impostazioni DNS, crei un record TXT sul nome %{domain} con questo"
 " valore:"
 
 #: lib/vutuv_web/templates/url/verify.html.heex:48
 #, elixir-autogen, elixir-format
-msgid ""
-"In your DNS settings, create a new TXT record with this name and value:"
+msgid "In your DNS settings, create a new TXT record with this name and value:"
 msgstr ""
 "Nelle Sue impostazioni DNS, crei un nuovo record TXT con questo nome e "
 "questo valore:"
@@ -13825,7 +13421,8 @@ msgstr "Nessuna posizione corrispondente. Provi a modificare i filtri."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:501
 #: lib/vutuv_web/agent_docs/markdown.ex:513
-#: lib/vutuv_web/agent_docs/text.ex:521 lib/vutuv_web/agent_docs/text.ex:533
+#: lib/vutuv_web/agent_docs/text.ex:521
+#: lib/vutuv_web/agent_docs/text.ex:533
 #: lib/vutuv_web/live/organization_live/show.ex:686
 #: lib/vutuv_web/templates/tag/show.html.heex:78
 #, elixir-autogen, elixir-format
@@ -13885,8 +13482,7 @@ msgstr "(nessun datore di lavoro)"
 
 #: lib/vutuv_web/live/admin/job_live.ex:481
 #, elixir-autogen, elixir-format
-msgid ""
-"Close this posting? It ends the listing (a regular ending, not a deletion)."
+msgid "Close this posting? It ends the listing (a regular ending, not a deletion)."
 msgstr ""
 "Chiudere questo annuncio? Ne conclude la pubblicazione (una fine regolare, "
 "non un'eliminazione)."
@@ -13911,9 +13507,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:179
 #, elixir-autogen, elixir-format
-msgid ""
-"Every job posting: search, freeze/unfreeze, close or delete, with the "
-"poster's report history and cold-outreach counter."
+msgid "Every job posting: search, freeze/unfreeze, close or delete, with the poster's report history and cold-outreach counter."
 msgstr ""
 "Ogni annuncio di lavoro: cerchi, blocchi o sblocchi, chiuda o elimini, con "
 "lo storico delle segnalazioni di chi ha pubblicato e il contatore dei "
@@ -13931,9 +13525,7 @@ msgstr "In scadenza (7 giorni)"
 
 #: lib/vutuv_web/live/admin/job_live.ex:462
 #, elixir-autogen, elixir-format
-msgid ""
-"Freeze this posting? It disappears from the public board and its indexing "
-"but stays visible to its poster."
+msgid "Freeze this posting? It disappears from the public board and its indexing but stays visible to its poster."
 msgstr ""
 "Bloccare questo annuncio? Sparisce dalla bacheca pubblica e "
 "dall'indicizzazione ma resta visibile a chi lo ha pubblicato."
@@ -14127,10 +13719,7 @@ msgstr "Meno recenti"
 
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:5
 #, elixir-autogen, elixir-format
-msgid ""
-"Save a search on the job board or on the people search, then let vutuv "
-"e-mail you when a new match appears. Daily searches are checked every day; "
-"weekly ones once a week."
+msgid "Save a search on the job board or on the people search, then let vutuv e-mail you when a new match appears. Daily searches are checked every day; weekly ones once a week."
 msgstr ""
 "Salvi una ricerca sulla bacheca degli annunci o sulla ricerca di persone, e "
 "lasci che vutuv Le scriva quando compare una nuova corrispondenza. Le "
@@ -14148,7 +13737,7 @@ msgstr "Salva la ricerca"
 msgid "Saved search deleted."
 msgstr "Ricerca salvata eliminata."
 
-#: lib/vutuv_web/components/ui.ex:4389
+#: lib/vutuv_web/components/ui.ex:4410
 #: lib/vutuv_web/controllers/settings_controller.ex:600
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -14168,7 +13757,7 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "Interrompere gli avvisi via e-mail per la Sua ricerca salvata \"%{label}\"?"
 
-#: lib/vutuv_web/components/post_components.ex:2457
+#: lib/vutuv_web/components/post_components.ex:2472
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:695
 #: lib/vutuv_web/controllers/settings_controller.ex:713
@@ -14202,9 +13791,7 @@ msgstr "Ha già raggiunto il numero massimo di ricerche salvate."
 
 #: lib/vutuv_web/templates/saved_search_alert/done.html.heex:10
 #, elixir-autogen, elixir-format
-msgid ""
-"You can turn its alerts back on, or delete the search, in your settings at "
-"any time."
+msgid "You can turn its alerts back on, or delete the search, in your settings at any time."
 msgstr ""
 "Può riattivarne gli avvisi, o eliminare la ricerca, dalle Sue impostazioni "
 "in qualsiasi momento."
@@ -14250,9 +13837,7 @@ msgstr "le e-mail di avviso delle ricerche salvate"
 
 #: lib/vutuv_web/templates/saved_search_alert/show.html.heex:10
 #, elixir-autogen, elixir-format
-msgid ""
-"The search itself is kept. Only its e-mails stop, and you can turn them back"
-" on in your settings."
+msgid "The search itself is kept. Only its e-mails stop, and you can turn them back on in your settings."
 msgstr ""
 "La ricerca resta. Si interrompono solo le sue e-mail, e può riattivarle "
 "dalle Sue impostazioni."
@@ -14280,9 +13865,7 @@ msgstr "Un'organizzazione non può escludere sé stessa."
 
 #: lib/vutuv_web/components/job_exclusion_components.ex:113
 #, elixir-autogen, elixir-format
-msgid ""
-"Any signed-in member whose confirmed email is at this domain, or a subdomain"
-" of it, is excluded."
+msgid "Any signed-in member whose confirmed email is at this domain, or a subdomain of it, is excluded."
 msgstr ""
 "Viene escluso ogni membro connesso il cui indirizzo e-mail confermato "
 "appartiene a questo dominio o a un suo sottodominio."
@@ -14294,10 +13877,7 @@ msgstr "Torna all'annuncio"
 
 #: lib/vutuv_web/live/organization_live/exclusions.ex:108
 #, elixir-autogen, elixir-format
-msgid ""
-"Every posting attributed to this organization inherits this standing list, "
-"on top of its own. Use it to keep vacancies away from competitors you never "
-"advertise to."
+msgid "Every posting attributed to this organization inherits this standing list, on top of its own. Use it to keep vacancies away from competitors you never advertise to."
 msgstr ""
 "Ogni annuncio attribuito a questa organizzazione eredita questo elenco "
 "permanente, oltre al proprio. Lo usi per tenere le posizioni aperte lontano "
@@ -14310,9 +13890,7 @@ msgstr "Escludi un'organizzazione"
 
 #: lib/vutuv_web/components/job_exclusion_components.ex:83
 #, elixir-autogen, elixir-format
-msgid ""
-"Excluding an organization also hides the posting from its verified email "
-"domains, its team, and members whose current job is linked to it."
+msgid "Excluding an organization also hides the posting from its verified email domains, its team, and members whose current job is linked to it."
 msgstr ""
 "Escludere un'organizzazione nasconde l'annuncio anche ai suoi domini e-mail "
 "verificati, al suo team e ai membri il cui impiego attuale è collegato a "
@@ -14369,10 +13947,7 @@ msgstr "@handle dell'organizzazione"
 
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:137
 #, elixir-autogen, elixir-format
-msgid ""
-"People and organizations on this list never see this posting: it drops off "
-"their board, their search, its detail page and their job alerts, with no "
-"hint they were singled out."
+msgid "People and organizations on this list never see this posting: it drops off their board, their search, its detail page and their job alerts, with no hint they were singled out."
 msgstr ""
 "Le persone e le organizzazioni in questo elenco non vedono mai questo "
 "annuncio: sparisce dalla loro bacheca, dalla loro ricerca, dalla pagina di "
@@ -14401,19 +13976,14 @@ msgstr "Questo elenco è pieno (max %{count})."
 
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:162
 #, elixir-autogen, elixir-format
-msgid ""
-"This posting also inherits %{count} standing exclusion(s) from %{name}, "
-"managed on its exclusions page."
+msgid "This posting also inherits %{count} standing exclusion(s) from %{name}, managed on its exclusions page."
 msgstr ""
 "Questo annuncio eredita anche %{count} esclusioni permanenti da %{name}, "
 "gestite nella sua pagina delle esclusioni."
 
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:142
 #, elixir-autogen, elixir-format
-msgid ""
-"This posting is public, so excluding only narrows the signed-in audience: "
-"someone can still read it while logged out. To also hide it from logged-out "
-"visitors, set its visibility to “Members only”."
+msgid "This posting is public, so excluding only narrows the signed-in audience: someone can still read it while logged out. To also hide it from logged-out visitors, set its visibility to “Members only”."
 msgstr ""
 "Questo annuncio è pubblico, quindi l'esclusione restringe solo il pubblico "
 "dei membri connessi: qualcuno può comunque leggerlo senza essere connesso. "
@@ -14442,9 +14012,7 @@ msgstr "Esaminato, tutto a posto: rimuovi la segnalazione"
 
 #: lib/vutuv_web/live/organization_live/edit.ex:181
 #, elixir-autogen, elixir-format
-msgid ""
-"This page has job postings, so it cannot be deleted. Ask an admin to archive"
-" it instead."
+msgid "This page has job postings, so it cannot be deleted. Ask an admin to archive it instead."
 msgstr ""
 "Questa pagina ha annunci di lavoro, quindi non può essere eliminata. Chieda "
 "a un amministratore di archiviarla."
@@ -14461,9 +14029,7 @@ msgstr "Questo membro non esiste più."
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:79
 #, elixir-autogen, elixir-format
-msgid ""
-"%{pending} image(s) in the scan queue; %{rejected} rejected in the last 7 "
-"days. A growing queue usually means Ollama is unreachable."
+msgid "%{pending} image(s) in the scan queue; %{rejected} rejected in the last 7 days. A growing queue usually means Ollama is unreachable."
 msgstr ""
 "%{pending} immagini nella coda di analisi; %{rejected} rifiutate negli "
 "ultimi 7 giorni. Una coda che cresce di solito significa che Ollama non è "
@@ -14484,8 +14050,7 @@ msgstr "Esame delle immagini"
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:74
 #, elixir-autogen, elixir-format
-msgid ""
-"No images waiting for the AI scan. %{formatted} rejected in the last 7 days."
+msgid "No images waiting for the AI scan. %{formatted} rejected in the last 7 days."
 msgstr ""
 "Nessuna immagine in attesa dell'analisi IA. %{formatted} rifiutate negli "
 "ultimi 7 giorni."
@@ -14517,16 +14082,13 @@ msgstr "Screenshot rimosso."
 
 #: lib/vutuv_web/live/post_live/edit.ex:114
 #, elixir-autogen, elixir-format
-msgid ""
-"This screenshot was captured automatically from the link in your post. If it"
-" turned out wrong (for example a cookie banner covering the page), you can "
-"remove it."
+msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 "Questo screenshot è stato acquisito automaticamente dal link nel Suo post. "
 "Se è venuto male (ad esempio con un avviso sui cookie che copre la pagina), "
 "può rimuoverlo."
 
-#: lib/vutuv/accounts/user.ex:1218
+#: lib/vutuv/accounts/user.ex:1223
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -14534,28 +14096,25 @@ msgstr "Solo l'età, senza la data"
 
 #: lib/vutuv_web/templates/user/edit.html.heex:451
 #, elixir-autogen, elixir-format
-msgid ""
-"Choose how much of your birthday your profile shows. \"Age only\" hides the "
-"exact date, \"Day and month\" hides the year (and your age), and \"Do not "
-"show\" keeps it saved but off your profile."
+msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 "Scelga quanto del Suo compleanno mostra il profilo. \"Solo l'età\" nasconde "
 "la data esatta, \"Giorno e mese\" nasconde l'anno (e la Sua età) e \"Non "
 "mostrare\" lo conserva ma lo tiene fuori dal profilo."
 
-#: lib/vutuv/accounts/user.ex:1221
+#: lib/vutuv/accounts/user.ex:1226
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Giorno e mese, senza l'anno"
 
-#: lib/vutuv/accounts/user.ex:1224
+#: lib/vutuv/accounts/user.ex:1229
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Non mostrare il mio compleanno"
 
-#: lib/vutuv/accounts/user.ex:1215
+#: lib/vutuv/accounts/user.ex:1220
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -14568,12 +14127,8 @@ msgstr "Mostra il mio compleanno come"
 
 #: lib/vutuv_web/templates/username/new.html.heex:34
 #, elixir-autogen, elixir-format
-msgid ""
-"%{formatted} post currently mentions %{handle} and will be updated when you "
-"rename."
-msgid_plural ""
-"%{formatted} posts currently mention %{handle} and will be updated when you "
-"rename."
+msgid "%{formatted} post currently mentions %{handle} and will be updated when you rename."
+msgid_plural "%{formatted} posts currently mention %{handle} and will be updated when you rename."
 msgstr[0] ""
 "%{formatted} post menziona %{handle} e verrà aggiornato quando cambierà "
 "nome."
@@ -14583,10 +14138,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/templates/username/new.html.heex:26
 #, elixir-autogen, elixir-format
-msgid ""
-"Changing it automatically rewrites every mention of your old handle in posts"
-" to the new one and notifies those posts' authors. Your old profile address "
-"stops working."
+msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr ""
 "Cambiandolo, ogni menzione del Suo vecchio handle nei post viene riscritta "
 "con quello nuovo e gli autori di quei post vengono avvisati. Il Suo vecchio "
@@ -14599,12 +14151,8 @@ msgstr "Cambio di handle"
 
 #: lib/vutuv_web/controllers/username_controller.ex:412
 #, elixir-autogen, elixir-format
-msgid ""
-"We updated %{formatted} post that mentioned your old handle and notified its"
-" author."
-msgid_plural ""
-"We updated %{formatted} posts that mentioned your old handle and notified "
-"their authors."
+msgid "We updated %{formatted} post that mentioned your old handle and notified its author."
+msgid_plural "We updated %{formatted} posts that mentioned your old handle and notified their authors."
 msgstr[0] ""
 "Abbiamo aggiornato %{formatted} post che menzionava il Suo vecchio handle e "
 "ne abbiamo avvisato l'autore."
@@ -14656,9 +14204,7 @@ msgstr "Post con questo tag"
 
 #: lib/vutuv_web/live/search_live.ex:608
 #, elixir-autogen, elixir-format
-msgid ""
-"Your search uses a people-only filter such as city: or status:, so it only "
-"finds people."
+msgid "Your search uses a people-only filter such as city: or status:, so it only finds people."
 msgstr ""
 "La Sua ricerca usa un filtro valido solo per le persone, come città: o "
 "status:, quindi trova solo persone."
@@ -14700,33 +14246,29 @@ msgstr "Post propri"
 
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:5
 #, elixir-autogen, elixir-format
-msgid ""
-"Posts tagged with a tag you follow show up in your feed, and people known "
-"for it appear in your suggestions. Follow a tag from its page."
+msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 "I post contrassegnati con un tag che segue compaiono nel Suo feed, e le "
 "persone note per quel tag compaiono tra i Suoi suggerimenti. Segua un tag "
 "dalla sua pagina."
 
-#: lib/vutuv_web/components/ui.ex:4372
+#: lib/vutuv_web/components/ui.ex:4393
 #: lib/vutuv_web/controllers/settings_controller.ex:614
-#: lib/vutuv_web/live/post_live/feed.ex:1757
+#: lib/vutuv_web/live/post_live/feed.ex:1893
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr "Tag che segue"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1772
+#: lib/vutuv_web/live/post_live/feed.ex:1908
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr "Smetti di seguire #%{tag}"
 
 #: lib/vutuv_web/live/job_board_live.ex:428
 #, elixir-autogen, elixir-format
-msgid ""
-"Looking for a role that goes by several titles? Separate them with a comma "
-"and we show postings that match any of them."
+msgid "Looking for a role that goes by several titles? Separate them with a comma and we show postings that match any of them."
 msgstr ""
 "Cerca un ruolo che ha più titoli diversi? Li separi con una virgola e "
 "mostreremo gli annunci che corrispondono a uno qualsiasi di essi."
@@ -14758,10 +14300,7 @@ msgstr "inizio di parola: trova anche Sviluppatore, Sviluppo"
 
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:15
 #, elixir-autogen, elixir-format
-msgid ""
-"Signal and WhatsApp accept a phone number or a username; the other "
-"messengers use their own id or handle (e.g. an 8-character Threema ID or a "
-"Matrix @you:matrix.org)."
+msgid "Signal and WhatsApp accept a phone number or a username; the other messengers use their own id or handle (e.g. an 8-character Threema ID or a Matrix @you:matrix.org)."
 msgstr ""
 "Signal e WhatsApp accettano un numero di telefono o un nome utente; gli "
 "altri messenger usano un proprio id o handle (ad esempio un ID Threema di 8 "
@@ -14796,8 +14335,9 @@ msgstr "Messenger eliminato."
 msgid "Messenger updated successfully."
 msgstr "Messenger aggiornato."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:60 lib/vutuv_web/agent_docs/text.ex:57
-#: lib/vutuv_web/components/ui.ex:4354
+#: lib/vutuv_web/agent_docs/markdown.ex:60
+#: lib/vutuv_web/agent_docs/text.ex:57
+#: lib/vutuv_web/components/ui.ex:4364
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -14825,18 +14365,16 @@ msgstr "Messenger di %{name}"
 msgid "Select a messenger"
 msgstr "Selezioni un messenger"
 
-#: lib/vutuv_web/components/ui.ex:3794
+#: lib/vutuv_web/components/ui.ex:3804
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] "Avvisa il mio follower"
 msgstr[1] "Avvisa i miei %{formatted} follower"
 
-#: lib/vutuv_web/components/ui.ex:3804
+#: lib/vutuv_web/components/ui.ex:3814
 #, elixir-autogen, elixir-format
-msgid ""
-"They see one notification linking to this entry. No email is sent, and it "
-"only ever happens for a new entry."
+msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
 "Vedono una notifica che rimanda a questa voce. Non viene inviata alcuna "
 "e-mail, e accade solo per una voce nuova."
@@ -14868,9 +14406,7 @@ msgstr "Aggiornamenti del CV"
 
 #: lib/vutuv_web/templates/settings/notifications.html.heex:94
 #, elixir-autogen, elixir-format
-msgid ""
-"When someone you follow adds a new entry to their CV, they can let their "
-"followers know. It shows up under the bell, never by email."
+msgid "When someone you follow adds a new entry to their CV, they can let their followers know. It shows up under the bell, never by email."
 msgstr ""
 "Quando una persona che segue aggiunge una nuova voce al proprio CV, può "
 "avvisarne i follower. Compare sotto la campanella, mai per e-mail."
@@ -14891,34 +14427,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr "ha aggiunto %{count} nuove voci al proprio CV:"
 
-#: lib/vutuv_web/components/post_components.ex:4651
+#: lib/vutuv_web/components/post_components.ex:4681
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Audiolibro"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1196
-#: lib/vutuv_web/components/post_components.ex:4608
+#: lib/vutuv_web/components/post_components.ex:4638
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Recensione di un libro"
 
-#: lib/vutuv_web/components/post_components.ex:4652
+#: lib/vutuv_web/components/post_components.ex:4682
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Cinema"
 
-#: lib/vutuv_web/components/post_components.ex:4654
+#: lib/vutuv_web/components/post_components.ex:4684
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:4650
+#: lib/vutuv_web/components/post_components.ex:4680
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1196
-#: lib/vutuv_web/components/post_components.ex:4607
+#: lib/vutuv_web/components/post_components.ex:4637
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Recensione di un film"
@@ -14929,12 +14465,12 @@ msgstr "Recensione di un film"
 msgid "Look up"
 msgstr "Cerca"
 
-#: lib/vutuv_web/components/post_components.ex:4649
+#: lib/vutuv_web/components/post_components.ex:4679
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Libro cartaceo"
 
-#: lib/vutuv_web/components/post_components.ex:4653
+#: lib/vutuv_web/components/post_components.ex:4683
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14954,7 +14490,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Anno"
 
-#: lib/vutuv_web/components/post_components.ex:4690
+#: lib/vutuv_web/components/post_components.ex:4720
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14962,27 +14498,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} pagina"
 msgstr[1] "%{formatted} pagine"
 
-#: lib/vutuv_web/components/post_components.ex:4720
+#: lib/vutuv_web/components/post_components.ex:4750
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} h"
 
-#: lib/vutuv_web/components/post_components.ex:4721
+#: lib/vutuv_web/components/post_components.ex:4751
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} h %{minutes} min"
 
-#: lib/vutuv_web/components/post_components.ex:4719
+#: lib/vutuv_web/components/post_components.ex:4749
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} min"
 
-#: lib/vutuv_web/components/post_components.ex:4679
+#: lib/vutuv_web/components/post_components.ex:4709
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(edizione cartacea)"
 
-#: lib/vutuv_web/components/post_components.ex:4726
+#: lib/vutuv_web/components/post_components.ex:4756
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "circa %{duration}"
@@ -15014,7 +14550,7 @@ msgstr "Con certificazione:"
 msgid "With qualification: %{name}"
 msgstr "Con certificazione: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:4493
+#: lib/vutuv_web/components/post_components.ex:4523
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Editore:"
@@ -15062,7 +14598,7 @@ msgstr "ora La seguono."
 msgid "endorsed you for %{tags}."
 msgstr "L'ha confermata per %{tags}."
 
-#: lib/vutuv_web/components/post_components.ex:4484
+#: lib/vutuv_web/components/post_components.ex:4514
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "di:"
@@ -15139,11 +14675,7 @@ msgstr "Scarica l'originale (%{label})"
 
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:133
 #, elixir-autogen, elixir-format
-msgid ""
-"I agree that the uploaded file is shown publicly on my profile and can be "
-"viewed and downloaded by anyone. Only upload documents you are allowed and "
-"willing to publish; consider redacting sensitive details (like your address "
-"or ID numbers) first."
+msgid "I agree that the uploaded file is shown publicly on my profile and can be viewed and downloaded by anyone. Only upload documents you are allowed and willing to publish; consider redacting sensitive details (like your address or ID numbers) first."
 msgstr ""
 "Acconsento a che il file caricato sia mostrato pubblicamente sul mio profilo"
 " e possa essere visto e scaricato da chiunque. Carichi solo documenti che "
@@ -15210,7 +14742,7 @@ msgid "proof document"
 msgstr "documento di prova"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:74
-#: lib/vutuv_web/templates/settings/preferences.html.heex:418
+#: lib/vutuv_web/templates/settings/preferences.html.heex:368
 #, elixir-autogen, elixir-format
 msgid "Lines in notifications"
 msgstr "Righe nelle notifiche"
@@ -15221,16 +14753,14 @@ msgid "How much of a post a notification quotes before it is cut off."
 msgstr ""
 "Quanta parte di un post viene citata in una notifica prima del taglio."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:409
+#: lib/vutuv_web/templates/settings/preferences.html.heex:359
 #, elixir-autogen, elixir-format
 msgid "Quoted posts in notifications"
 msgstr "Post citati nelle notifiche"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:412
+#: lib/vutuv_web/templates/settings/preferences.html.heex:362
 #, elixir-autogen, elixir-format
-msgid ""
-"Your notifications quote the post someone liked or replied to. Leave the "
-"field empty to follow the site default."
+msgid "Your notifications quote the post someone liked or replied to. Leave the field empty to follow the site default."
 msgstr ""
 "Le Sue notifiche citano il post a cui qualcuno ha messo Mi piace o ha "
 "risposto. Lasci il campo vuoto per seguire il valore predefinito del sito."
@@ -15242,9 +14772,7 @@ msgstr "Benvenuto"
 
 #: lib/vutuv_web/templates/welcome/show.html.heex:17
 #, elixir-autogen, elixir-format
-msgid ""
-"Two questions before you start. They decide who finds you and which jobs we "
-"show you. Answer as much or as little as you like."
+msgid "Two questions before you start. They decide who finds you and which jobs we show you. Answer as much or as little as you like."
 msgstr ""
 "Due domande prima di iniziare. Decidono chi La trova e quali annunci Le "
 "mostriamo. Risponda quanto vuole."
@@ -15256,9 +14784,7 @@ msgstr "Dove si trova?"
 
 #: lib/vutuv_web/templates/welcome/show.html.heex:42
 #, elixir-autogen, elixir-format
-msgid ""
-"A city alone is enough. It appears on your profile and lets people search "
-"for members near them."
+msgid "A city alone is enough. It appears on your profile and lets people search for members near them."
 msgstr ""
 "Basta la città. Compare sul Suo profilo e permette alle persone di cercare "
 "membri vicino a loro."
@@ -15275,9 +14801,7 @@ msgstr "È in cerca di lavoro?"
 
 #: lib/vutuv_web/templates/welcome/show.html.heex:117
 #, elixir-autogen, elixir-format
-msgid ""
-"Optional, and nobody else sees it. It filters postings below it out of your "
-"own job search."
+msgid "Optional, and nobody else sees it. It filters postings below it out of your own job search."
 msgstr ""
 "Facoltativo, e nessun altro lo vede. Esclude dalla Sua ricerca di lavoro gli"
 " annunci al di sotto."
@@ -15324,10 +14848,7 @@ msgstr "Un controllo automatico ha rimosso un'immagine dal Suo account vutuv"
 
 #: lib/vutuv_web/notification_line.ex:131
 #, elixir-autogen, elixir-format
-msgid ""
-"An AI, not a person, removed %{what}: it judged the image not family-"
-"friendly enough for a work environment. It can be wrong, so reply to our "
-"email if you disagree."
+msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
 "A rimuovere %{what} è stata un'IA, non una persona: ha giudicato l'immagine "
 "non abbastanza adatta a un ambiente di lavoro. Può sbagliare, quindi "
@@ -15347,14 +14868,16 @@ msgstr[1] "ha risposto in una discussione a cui ha partecipato."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:117
 #: lib/vutuv_web/agent_docs/markdown.ex:152
-#: lib/vutuv_web/agent_docs/text.ex:109 lib/vutuv_web/agent_docs/text.ex:140
+#: lib/vutuv_web/agent_docs/text.ex:109
+#: lib/vutuv_web/agent_docs/text.ex:140
 #, elixir-autogen, elixir-format
 msgid "Conversation"
 msgstr "Conversazione"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:120
 #: lib/vutuv_web/agent_docs/markdown.ex:155
-#: lib/vutuv_web/agent_docs/text.ex:112 lib/vutuv_web/agent_docs/text.ex:143
+#: lib/vutuv_web/agent_docs/text.ex:112
+#: lib/vutuv_web/agent_docs/text.ex:143
 #, elixir-autogen, elixir-format
 msgid "Only part of this long conversation is shown."
 msgstr "Di questa lunga conversazione è mostrata solo una parte."
@@ -15372,9 +14895,7 @@ msgstr "L'ha menzionata in un post."
 #: lib/vutuv_web/live/post_live/composer.ex:1049
 #: lib/vutuv_web/live/post_live/edit.ex:57
 #, elixir-autogen, elixir-format
-msgid ""
-"This post can no longer be edited: someone has liked, reposted or answered "
-"it."
+msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr ""
 "Questo post non può più essere modificato: qualcuno gli ha messo Mi piace, "
 "lo ha ripubblicato o gli ha risposto."
@@ -15382,18 +14903,14 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/composer.ex:1052
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
-msgid ""
-"This post can no longer be edited. Posts stay editable for %{minutes} "
-"minutes after publishing."
+msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
 msgstr ""
 "Questo post non può più essere modificato. I post restano modificabili per "
 "%{minutes} minuti dopo la pubblicazione."
 
 #: lib/vutuv_web/live/post_live/edit.ex:98
 #, elixir-autogen, elixir-format
-msgid ""
-"A post stays editable for %{minutes} minutes, and only until someone likes, "
-"reposts or answers it. You can delete it at any time."
+msgid "A post stays editable for %{minutes} minutes, and only until someone likes, reposts or answers it. You can delete it at any time."
 msgstr ""
 "Un post resta modificabile per %{minutes} minuti, e solo finché qualcuno non"
 " gli mette Mi piace, lo ripubblica o gli risponde. Può eliminarlo in "
@@ -15401,12 +14918,8 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:10
 #, elixir-autogen, elixir-format
-msgid ""
-"%{formatted} account is currently in the moderation freezer, newest freeze "
-"first."
-msgid_plural ""
-"%{formatted} accounts are currently in the moderation freezer, newest freeze"
-" first."
+msgid "%{formatted} account is currently in the moderation freezer, newest freeze first."
+msgid_plural "%{formatted} accounts are currently in the moderation freezer, newest freeze first."
 msgstr[0] ""
 "%{formatted} account è attualmente bloccato dalla moderazione, dal blocco "
 "più recente."
@@ -15443,11 +14956,7 @@ msgstr "@%{username} è stato sbloccato."
 
 #: lib/vutuv_web/templates/admin/account/index.html.heex:10
 #, elixir-autogen, elixir-format
-msgid ""
-"Find a member by name, @handle or email, then freeze or unfreeze the "
-"account. A freeze hides the profile and everything it owns from everyone but"
-" the member and admins; it does not block the member from signing in. "
-"Freezing is reversible."
+msgid "Find a member by name, @handle or email, then freeze or unfreeze the account. A freeze hides the profile and everything it owns from everyone but the member and admins; it does not block the member from signing in. Freezing is reversible."
 msgstr ""
 "Trovi un membro per nome, @handle o indirizzo e-mail, poi blocchi o sblocchi"
 " l'account. Un blocco nasconde il profilo e tutto ciò che gli appartiene a "
@@ -15456,10 +14965,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:121
 #, elixir-autogen, elixir-format
-msgid ""
-"Find an account by name, @handle or email and freeze or unfreeze it "
-"directly, without waiting for a report. The frozen-accounts list is here "
-"too."
+msgid "Find an account by name, @handle or email and freeze or unfreeze it directly, without waiting for a report. The frozen-accounts list is here too."
 msgstr ""
 "Trovi un account per nome, @handle o indirizzo e-mail e lo blocchi o "
 "sblocchi direttamente, senza aspettare una segnalazione. Qui trova anche "
@@ -15479,7 +14985,7 @@ msgstr "Blocchi un account"
 msgid "No accounts are currently frozen."
 msgstr "Al momento nessun account è bloccato."
 
-#: lib/vutuv_web/live/post_live/thread.ex:460
+#: lib/vutuv_web/live/post_live/thread.ex:464
 #, elixir-autogen, elixir-format
 msgid "Read it from the start"
 msgstr "Leggila dall'inizio"
@@ -15499,14 +15005,14 @@ msgstr "Cerchi un account da bloccare"
 msgid "See all frozen accounts"
 msgstr "Vedi tutti gli account bloccati"
 
-#: lib/vutuv_web/components/post_components.ex:2730
+#: lib/vutuv_web/components/post_components.ex:2745
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "Mostra %{formatted} post precedente"
 msgstr[1] "Mostra %{formatted} post precedenti"
 
-#: lib/vutuv_web/components/post_components.ex:2753
+#: lib/vutuv_web/components/post_components.ex:2768
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -15518,7 +15024,7 @@ msgstr[1] "Mostra altre %{formatted} risposte"
 msgid "This page is no longer available."
 msgstr "Questa pagina non è più disponibile."
 
-#: lib/vutuv_web/live/post_live/thread.ex:452
+#: lib/vutuv_web/live/post_live/thread.ex:456
 #, elixir-autogen, elixir-format
 msgid "This post is part of a conversation with %{formatted} posts."
 msgstr "Questo post fa parte di una conversazione con %{formatted} post."
@@ -15535,7 +15041,7 @@ msgstr ""
 "Digiti un nome, un @handle o un indirizzo e-mail per trovare un account da "
 "bloccare."
 
-#: lib/vutuv_web/components/post_components.ex:5129
+#: lib/vutuv_web/components/post_components.ex:5159
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Non può mettere Mi piace al Suo stesso post."
@@ -15587,10 +15093,7 @@ msgstr "Annulla il reindirizzamento"
 
 #: lib/vutuv_web/controllers/settings_controller.ex:487
 #, elixir-autogen, elixir-format
-msgid ""
-"Done. Your Fediverse followers have been asked to follow your new account, "
-"and new posts are no longer federated from here. Your vutuv profile is "
-"unchanged."
+msgid "Done. Your Fediverse followers have been asked to follow your new account, and new posts are no longer federated from here. Your vutuv profile is unchanged."
 msgstr ""
 "Fatto. Ai Suoi follower del Fediverso è stato chiesto di seguire il Suo "
 "nuovo account, e i nuovi post non vengono più federati da qui. Il Suo "
@@ -15633,18 +15136,14 @@ msgstr "Reindirizzati il %{date}"
 
 #: lib/vutuv_web/controllers/settings_controller.ex:539
 #, elixir-autogen, elixir-format
-msgid ""
-"That account could not be reached. Check the address, and that the other "
-"server is online."
+msgid "That account could not be reached. Check the address, and that the other server is online."
 msgstr ""
 "Non è stato possibile raggiungere quell'account. Controlli l'indirizzo e che"
 " l'altro server sia online."
 
 #: lib/vutuv_web/controllers/settings_controller.ex:533
 #, elixir-autogen, elixir-format
-msgid ""
-"That account does not list your vutuv profile as an alias yet. Add this "
-"profile's address there first, then try again."
+msgid "That account does not list your vutuv profile as an alias yet. Add this profile's address there first, then try again."
 msgstr ""
 "Quell'account non indica ancora il Suo profilo vutuv come alias. Aggiunga "
 "prima lì l'indirizzo di questo profilo, poi riprovi."
@@ -15657,10 +15156,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:151
 #, elixir-autogen, elixir-format
-msgid ""
-"This tells your Fediverse followers to follow your new account instead, and "
-"stops federating your posts from here. Your vutuv profile is not affected. "
-"Continue?"
+msgid "This tells your Fediverse followers to follow your new account instead, and stops federating your posts from here. Your vutuv profile is not affected. Continue?"
 msgstr ""
 "Questo dice ai Suoi follower del Fediverso di seguire il nuovo account e "
 "interrompe la federazione dei Suoi post da qui. Il Suo profilo vutuv non "
@@ -15709,17 +15205,14 @@ msgstr "Filtra per tag"
 msgid "Filter removed."
 msgstr "Filtro rimosso."
 
-#: lib/vutuv_web/live/post_live/feed.ex:472
+#: lib/vutuv_web/live/post_live/feed.ex:509
 #, elixir-autogen, elixir-format
 msgid "Hidden: matches your filter"
 msgstr "Nascosto: corrisponde a un Suo filtro"
 
 #: lib/vutuv_web/templates/settings/filters.html.heex:5
 #, elixir-autogen, elixir-format
-msgid ""
-"Hide posts from your feed that carry a tag, or that contain a word or "
-"phrase. This list is yours alone: it is never shared, the author is never "
-"told, and a hidden post collapses to a line you can still open."
+msgid "Hide posts from your feed that carry a tag, or that contain a word or phrase. This list is yours alone: it is never shared, the author is never told, and a hidden post collapses to a line you can still open."
 msgstr ""
 "Nasconda dal Suo feed i post che portano un certo tag, o che contengono una "
 "parola o una frase. Questo elenco è solo Suo: non viene mai condiviso, "
@@ -15731,7 +15224,7 @@ msgstr ""
 msgid "Match whole words only (word/phrase)"
 msgstr "Corrispondenza solo su parole intere (parola o frase)"
 
-#: lib/vutuv_web/components/ui.ex:4368
+#: lib/vutuv_web/components/ui.ex:4378
 #: lib/vutuv_web/controllers/settings_controller.ex:680
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -15746,14 +15239,12 @@ msgstr "Nessuno ha ancora confermato %{name} per questo tag."
 
 #: lib/vutuv_web/templates/education/card_list.html.heex:40
 #, elixir-autogen, elixir-format
-msgid ""
-"Pick a degree or school below to show it at the top of your profile instead "
-"of a job title."
+msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
 msgstr ""
 "Scelga qui sotto un titolo di studio o un istituto da mostrare in cima al "
 "Suo profilo al posto di una qualifica."
 
-#: lib/vutuv_web/live/post_live/feed.ex:481
+#: lib/vutuv_web/live/post_live/feed.ex:518
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr "Mostra comunque"
@@ -15797,31 +15288,26 @@ msgstr ""
 
 #: lib/vutuv_web/templates/settings/notifications.html.heex:119
 #, elixir-autogen, elixir-format
-msgid ""
-"When off, you only hear about direct answers to your own posts, never other "
-"replies in the thread."
+msgid "When off, you only hear about direct answers to your own posts, never other replies in the thread."
 msgstr ""
 "Se disattivo, viene avvisato solo delle risposte dirette ai Suoi post, mai "
 "delle altre risposte nella discussione."
 
 #: lib/vutuv_web/templates/settings/notifications.html.heex:113
 #, elixir-autogen, elixir-format
-msgid ""
-"When someone replies anywhere in a thread you have written in, you hear "
-"about it under the bell, so a discussion reaches everyone who took part. "
-"Never by email."
+msgid "When someone replies anywhere in a thread you have written in, you hear about it under the bell, so a discussion reaches everyone who took part. Never by email."
 msgstr ""
 "Quando qualcuno risponde in un punto qualsiasi di una discussione in cui ha "
 "scritto, ne viene avvisato sotto la campanella, così la discussione "
 "raggiunge tutti quelli che vi hanno partecipato. Mai per e-mail."
 
 #: lib/vutuv_web/templates/settings/filters.html.heex:19
-#: lib/vutuv_web/views/settings_html.ex:62
+#: lib/vutuv_web/views/settings_html.ex:60
 #, elixir-autogen, elixir-format
 msgid "Word or phrase"
 msgstr "Parola o frase"
 
-#: lib/vutuv_web/views/settings_html.ex:65
+#: lib/vutuv_web/views/settings_html.ex:63
 #, elixir-autogen, elixir-format
 msgid "Word or phrase (whole word)"
 msgstr "Parola o frase (parola intera)"
@@ -15863,18 +15349,14 @@ msgstr "Inserisca solo il nome del server, ad esempio mastodon.example."
 
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:67
 #, elixir-autogen, elixir-format
-msgid ""
-"%{host} is no longer blocked. What was deleted stays deleted; the server has"
-" to follow again."
+msgid "%{host} is no longer blocked. What was deleted stays deleted; the server has to follow again."
 msgstr ""
 "%{host} non è più bloccato. Ciò che è stato eliminato resta eliminato; il "
 "server deve seguire di nuovo."
 
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:80
 #, elixir-autogen, elixir-format
-msgid ""
-"%{host} is blocked. Removed: %{followers} remote followers and %{deliveries}"
-" queued deliveries."
+msgid "%{host} is blocked. Removed: %{followers} remote followers and %{deliveries} queued deliveries."
 msgstr ""
 "%{host} è bloccato. Rimossi: %{followers} follower remoti e %{deliveries} "
 "consegne in coda."
@@ -15886,20 +15368,14 @@ msgstr "In sintesi"
 
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:16
 #, elixir-autogen, elixir-format
-msgid ""
-"%{members} members federate, %{followers} remote followers between them, "
-"%{queue} activities queued for delivery, %{blocked} servers blocked."
+msgid "%{members} members federate, %{followers} remote followers between them, %{queue} activities queued for delivery, %{blocked} servers blocked."
 msgstr ""
 "%{members} membri federano, %{followers} follower remoti in tutto, %{queue} "
 "attività in coda per la consegna, %{blocked} server bloccati."
 
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:37
 #, elixir-autogen, elixir-format
-msgid ""
-"Anyone can run a server in this network, so a server that talks to us is not"
-" a vetted party. Per hour, one server may store at most %{host_cap} rows "
-"here and one remote account at most %{actor_cap}; anything beyond that is "
-"dropped."
+msgid "Anyone can run a server in this network, so a server that talks to us is not a vetted party. Per hour, one server may store at most %{host_cap} rows here and one remote account at most %{actor_cap}; anything beyond that is dropped."
 msgstr ""
 "In questa rete chiunque può gestire un server, quindi un server che parla "
 "con noi non è una controparte verificata. In un'ora un singolo server può "
@@ -15913,11 +15389,7 @@ msgstr "Blocca un server"
 
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:50
 #, elixir-autogen, elixir-format
-msgid ""
-"Blocking drops everything that server sends before it is even checked, "
-"deletes its followers and its queued deliveries, and stops our members' "
-"posts from going there. Lifting the block later does not bring any of it "
-"back."
+msgid "Blocking drops everything that server sends before it is even checked, deletes its followers and its queued deliveries, and stops our members' posts from going there. Lifting the block later does not bring any of it back."
 msgstr ""
 "Il blocco scarta tutto ciò che quel server invia ancora prima di "
 "controllarlo, elimina i suoi follower e le sue consegne in coda e impedisce "
@@ -15931,8 +15403,7 @@ msgstr "Nome del server"
 
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:66
 #, elixir-autogen, elixir-format
-msgid ""
-"A full address or an @user@server handle works too; we keep the server part."
+msgid "A full address or an @user@server handle works too; we keep the server part."
 msgstr ""
 "Va bene anche un indirizzo completo o un handle @utente@server; noi teniamo "
 "la parte del server."
@@ -15988,9 +15459,7 @@ msgstr "Bloccato da"
 
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:119
 #, elixir-autogen, elixir-format
-msgid ""
-"Unblock %{host}? Nothing that was deleted comes back; the server simply may "
-"talk to us again."
+msgid "Unblock %{host}? Nothing that was deleted comes back; the server simply may talk to us again."
 msgstr ""
 "Sbloccare %{host}? Nulla di ciò che è stato eliminato torna indietro; il "
 "server potrà semplicemente parlare di nuovo con noi."
@@ -16042,10 +15511,7 @@ msgstr "Follower da altre reti"
 
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:17
 #, elixir-autogen, elixir-format
-msgid ""
-"Beside vutuv there are thousands of independent social websites that all "
-"talk to each other. Mastodon is the best known of them. Together they are "
-"called the Fediverse."
+msgid "Beside vutuv there are thousands of independent social websites that all talk to each other. Mastodon is the best known of them. Together they are called the Fediverse."
 msgstr ""
 "Accanto a vutuv esistono migliaia di siti sociali indipendenti che parlano "
 "tutti fra loro. Mastodon è il più noto. Insieme si chiamano Fediverso."
@@ -16081,9 +15547,7 @@ msgstr "Partecipi al Fediverso"
 
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:68
 #, elixir-autogen, elixir-format
-msgid ""
-"Off means your profile cannot be found there and nothing is sent. Posts "
-"already delivered may stay on those servers, beyond our reach."
+msgid "Off means your profile cannot be found there and nothing is sent. Posts already delivered may stay on those servers, beyond our reach."
 msgstr ""
 "Disattivato significa che il Suo profilo non è trovabile lì e che non viene "
 "inviato nulla. I post già consegnati possono restare su quei server, fuori "
@@ -16091,9 +15555,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:117
 #, elixir-autogen, elixir-format
-msgid ""
-"Give this out the way you give out an email address. Anyone on Mastodon and "
-"friends can paste it into their search and follow you from there."
+msgid "Give this out the way you give out an email address. Anyone on Mastodon and friends can paste it into their search and follow you from there."
 msgstr ""
 "Lo distribuisca come distribuirebbe un indirizzo e-mail. Chiunque su "
 "Mastodon e affini può incollarlo nella ricerca e seguirla da lì."
@@ -16101,9 +15563,7 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_followers_live.ex:187
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:138
 #, elixir-autogen, elixir-format
-msgid ""
-"Nobody yet. Post your handle where people can see it, and the first follows "
-"will show up here."
+msgid "Nobody yet. Post your handle where people can see it, and the first follows will show up here."
 msgstr ""
 "Ancora nessuno. Pubblichi il Suo handle dove le persone possono vederlo, e i"
 " primi follow compariranno qui."
@@ -16128,9 +15588,7 @@ msgstr "Sposti il Suo account"
 
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:218
 #, elixir-autogen, elixir-format
-msgid ""
-"Want the checkmark on your Mastodon profile? That works without taking part "
-"here: your vutuv profile links your listed accounts with rel=\"me\"."
+msgid "Want the checkmark on your Mastodon profile? That works without taking part here: your vutuv profile links your listed accounts with rel=\"me\"."
 msgstr ""
 "Vuole la spunta sul Suo profilo Mastodon? Funziona anche senza partecipare "
 "qui: il Suo profilo vutuv collega gli account che ha indicato con "
@@ -16138,10 +15596,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:16
 #, elixir-autogen, elixir-format
-msgid ""
-"Changing which Fediverse account you use? A move keeps your followers: the "
-"other server asks them to follow the new account instead. Both directions "
-"are set up here."
+msgid "Changing which Fediverse account you use? A move keeps your followers: the other server asks them to follow the new account instead. Both directions are set up here."
 msgstr ""
 "Sta cambiando l'account del Fediverso che usa? Uno spostamento Le fa "
 "mantenere i follower: l'altro server chiede loro di seguire il nuovo "
@@ -16149,9 +15604,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:21
 #, elixir-autogen, elixir-format
-msgid ""
-"A move is a redirect, never a deletion. Whichever direction you go, your "
-"vutuv profile stays exactly as it is."
+msgid "A move is a redirect, never a deletion. Whichever direction you go, your vutuv profile stays exactly as it is."
 msgstr ""
 "Uno spostamento è un reindirizzamento, mai un'eliminazione. In qualunque "
 "direzione vada, il Suo profilo vutuv resta esattamente com'è."
@@ -16163,10 +15616,7 @@ msgstr "Spostarsi verso vutuv"
 
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:34
 #, elixir-autogen, elixir-format
-msgid ""
-"List the accounts you are moving away from. The other server only hands your"
-" followers over once it sees its own account named here, so this is the step"
-" that makes a move to vutuv possible. You start the move itself over there."
+msgid "List the accounts you are moving away from. The other server only hands your followers over once it sees its own account named here, so this is the step that makes a move to vutuv possible. You start the move itself over there."
 msgstr ""
 "Elenchi gli account da cui si sta spostando. L'altro server consegna i Suoi "
 "follower solo quando vede il proprio account indicato qui, quindi è questo "
@@ -16180,9 +15630,7 @@ msgstr "Account da cui si sta spostando"
 
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:66
 #, elixir-autogen, elixir-format
-msgid ""
-"One full account address per line, for example %{example}. Leave it empty if"
-" you are not moving to vutuv."
+msgid "One full account address per line, for example %{example}. Leave it empty if you are not moving to vutuv."
 msgstr ""
 "Un indirizzo completo di account per riga, ad esempio %{example}. Lo lasci "
 "vuoto se non si sta spostando verso vutuv."
@@ -16199,10 +15647,7 @@ msgstr "I Suoi follower del Fediverso vengono reindirizzati a:"
 
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:115
 #, elixir-autogen, elixir-format
-msgid ""
-"Send your Fediverse followers to another account. They are asked to follow "
-"it instead, and vutuv stops federating your new posts. Your vutuv profile "
-"stays exactly as it is, and nothing is deleted."
+msgid "Send your Fediverse followers to another account. They are asked to follow it instead, and vutuv stops federating your new posts. Your vutuv profile stays exactly as it is, and nothing is deleted."
 msgstr ""
 "Mandi i Suoi follower del Fediverso a un altro account. Verrà chiesto loro "
 "di seguire quello, e vutuv smette di federare i Suoi nuovi post. Il Suo "
@@ -16352,9 +15797,7 @@ msgstr "Mese"
 
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:98
 #, elixir-autogen, elixir-format
-msgid ""
-"New posts are no longer federated from here, and your actor points visitors "
-"to the new account. Your vutuv profile itself is unchanged."
+msgid "New posts are no longer federated from here, and your actor points visitors to the new account. Your vutuv profile itself is unchanged."
 msgstr ""
 "I nuovi post non vengono più federati da qui, e il Suo actor indirizza i "
 "visitatori al nuovo account. Il Suo profilo vutuv resta invariato."
@@ -16427,9 +15870,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:181
 #, elixir-autogen, elixir-format
-msgid ""
-"Are you on Mastodon or another Fediverse app? Follow %{name} from there and "
-"new public posts arrive in your timeline. No vutuv account needed."
+msgid "Are you on Mastodon or another Fediverse app? Follow %{name} from there and new public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 "È su Mastodon o su un'altra app del Fediverso? Segua %{name} da lì e i nuovi"
 " post pubblici arriveranno nella Sua cronologia. Non serve un account vutuv."
@@ -16446,9 +15887,7 @@ msgstr "@lei@esempio.social"
 
 #: lib/vutuv_web/components/fediverse_components.ex:237
 #, elixir-autogen, elixir-format
-msgid ""
-"Your address is used once, to send you to your own server's follow dialog. "
-"It is never stored here."
+msgid "Your address is used once, to send you to your own server's follow dialog. It is never stored here."
 msgstr ""
 "Il Suo indirizzo viene usato una volta sola, per portarla alla finestra di "
 "follow del Suo server. Non viene mai conservato qui."
@@ -16466,18 +15905,14 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/remote_follow_controller.ex:225
 #, elixir-autogen, elixir-format
-msgid ""
-"%{server} did not offer a follow dialog. Copy the handle above and paste it "
-"into your app's search instead."
+msgid "%{server} did not offer a follow dialog. Copy the handle above and paste it into your app's search instead."
 msgstr ""
 "%{server} non ha offerto una finestra di follow. Copi l'handle qui sopra e "
 "lo incolli nella ricerca della Sua app."
 
 #: lib/vutuv_web/controllers/remote_follow_controller.ex:232
 #, elixir-autogen, elixir-format
-msgid ""
-"%{server} did not answer. Copy the handle above and paste it into your app's"
-" search instead."
+msgid "%{server} did not answer. Copy the handle above and paste it into your app's search instead."
 msgstr ""
 "%{server} non ha risposto. Copi l'handle qui sopra e lo incolli nella "
 "ricerca della Sua app."
@@ -16493,260 +15928,259 @@ msgstr "Il Suo server"
 msgid "moved to %{address}"
 msgstr "spostato a %{address}"
 
-#: lib/vutuv_web/components/ui.ex:4296
+#: lib/vutuv_web/components/ui.ex:4306
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr "Nome, foto, immagine di copertina, descrizione breve"
 
-#: lib/vutuv_web/components/ui.ex:4301
+#: lib/vutuv_web/components/ui.ex:4311
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr "handle soprannome rinomina slug profilo indirizzo url menzione"
 
-#: lib/vutuv_web/components/ui.ex:4304
+#: lib/vutuv_web/components/ui.ex:4314
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr "Gli impieghi e i ruoli nel Suo CV"
 
-#: lib/vutuv_web/components/ui.ex:4305
+#: lib/vutuv_web/components/ui.ex:4315
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr "cv curriculum carriera datore di lavoro posizione qualifica azienda"
 
-#: lib/vutuv_web/components/ui.ex:4308
+#: lib/vutuv_web/components/ui.ex:4318
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr "Scuole, università, titoli di studio"
 
-#: lib/vutuv_web/components/ui.ex:4309
+#: lib/vutuv_web/components/ui.ex:4319
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr "cv curriculum studio studi scuola università laurea titolo"
 
-#: lib/vutuv_web/components/ui.ex:4312
+#: lib/vutuv_web/components/ui.ex:4322
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr "Credenziali, con documenti di prova"
 
-#: lib/vutuv_web/components/ui.ex:4313
+#: lib/vutuv_web/components/ui.ex:4323
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr ""
 "certificato abilitazione diploma credenziale riconoscimento prova documento"
 
-#: lib/vutuv_web/components/ui.ex:4320
+#: lib/vutuv_web/components/ui.ex:4330
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr "Competenze linguistiche"
 
-#: lib/vutuv_web/components/ui.ex:4321
+#: lib/vutuv_web/components/ui.ex:4331
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr "Le lingue che parla"
 
-#: lib/vutuv_web/components/ui.ex:4322
+#: lib/vutuv_web/components/ui.ex:4332
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr "lingua parlare parlata fluente madrelingua"
 
-#: lib/vutuv_web/components/ui.ex:4325
+#: lib/vutuv_web/components/ui.ex:4335
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr "Gli argomenti per cui è conosciuto"
 
-#: lib/vutuv_web/components/ui.ex:4326
+#: lib/vutuv_web/components/ui.ex:4336
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr "competenza argomento parola chiave esperienza conferma"
 
-#: lib/vutuv_web/components/ui.ex:4450
+#: lib/vutuv_web/components/ui.ex:4471
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr "Pagine aziendali che gestisce"
 
-#: lib/vutuv_web/components/ui.ex:4451
+#: lib/vutuv_web/components/ui.ex:4472
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr "azienda datore di lavoro impresa attività organizzazione pagina"
 
-#: lib/vutuv_web/components/ui.ex:4329
+#: lib/vutuv_web/components/ui.ex:4339
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr "Recapiti"
 
-#: lib/vutuv_web/components/ui.ex:4332
+#: lib/vutuv_web/components/ui.ex:4342
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr "Dove La raggiungiamo, e quale indirizzo è pubblico"
 
-#: lib/vutuv_web/components/ui.ex:4333
+#: lib/vutuv_web/components/ui.ex:4343
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr "posta e-mail indirizzo principale"
 
-#: lib/vutuv_web/components/ui.ex:4336
+#: lib/vutuv_web/components/ui.ex:4346
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr "Fisso, cellulare, fax"
 
-#: lib/vutuv_web/components/ui.ex:4337
+#: lib/vutuv_web/components/ui.ex:4347
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr "telefono cellulare fax numero"
 
-#: lib/vutuv_web/components/ui.ex:4340
+#: lib/vutuv_web/components/ui.ex:4350
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr "Indirizzi postali sul Suo profilo"
 
-#: lib/vutuv_web/components/ui.ex:4341
+#: lib/vutuv_web/components/ui.ex:4351
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr "via città cap paese posta mappa"
 
-#: lib/vutuv_web/components/ui.ex:4343
+#: lib/vutuv_web/components/ui.ex:4353
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr "Siti web e link"
 
-#: lib/vutuv_web/components/ui.ex:4344
+#: lib/vutuv_web/components/ui.ex:4354
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr "Il Suo sito e gli altri link"
 
-#: lib/vutuv_web/components/ui.ex:4345
+#: lib/vutuv_web/components/ui.ex:4355
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr "url sito web homepage blog link verifica rel=me"
 
-#: lib/vutuv_web/components/ui.ex:4347
+#: lib/vutuv_web/components/ui.ex:4357
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr "Profili sui social"
 
-#: lib/vutuv_web/components/ui.ex:4348
+#: lib/vutuv_web/components/ui.ex:4358
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr "Mastodon, Bluesky, GitHub e gli altri"
 
-#: lib/vutuv_web/components/ui.ex:4350
+#: lib/vutuv_web/components/ui.ex:4360
 #, elixir-autogen, elixir-format
-msgid ""
-"mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
+msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr ""
 "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 
-#: lib/vutuv_web/components/ui.ex:4355
+#: lib/vutuv_web/components/ui.ex:4365
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr "Signal, Threema, Matrix e gli altri"
 
-#: lib/vutuv_web/components/ui.ex:4356
+#: lib/vutuv_web/components/ui.ex:4366
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr "signal threema matrix xmpp telegram whatsapp chat messenger"
 
-#: lib/vutuv_web/components/ui.ex:4359
+#: lib/vutuv_web/components/ui.ex:4369
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr "Notifiche e feed"
 
-#: lib/vutuv_web/components/ui.ex:4362
+#: lib/vutuv_web/components/ui.ex:4372
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr "Quali e-mail inviamo, e cosa Le dice la campanella"
 
-#: lib/vutuv_web/components/ui.ex:4369
+#: lib/vutuv_web/components/ui.ex:4379
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr "Tenga dei post fuori dal Suo feed"
 
-#: lib/vutuv_web/components/ui.ex:4370
+#: lib/vutuv_web/components/ui.ex:4380
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr "silenzia blocca nascondi filtro parola chiave parola tag feed"
 
-#: lib/vutuv_web/components/ui.ex:4373
+#: lib/vutuv_web/components/ui.ex:4394
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr "Argomenti i cui post arrivano nel Suo feed"
 
-#: lib/vutuv_web/components/ui.ex:4374
+#: lib/vutuv_web/components/ui.ex:4395
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr "tag argomento iscriviti segui feed"
 
-#: lib/vutuv_web/components/ui.ex:4390
+#: lib/vutuv_web/components/ui.ex:4411
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr ""
 "Ricerche di lavoro e di persone che Le inviano per e-mail le nuove "
 "corrispondenze"
 
-#: lib/vutuv_web/components/ui.ex:4391
+#: lib/vutuv_web/components/ui.ex:4412
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr "lavoro avviso ricerca agente osservati"
 
-#: lib/vutuv_web/components/ui.ex:4397
+#: lib/vutuv_web/components/ui.ex:4418
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr "Motori di ricerca, IA, stato online"
 
-#: lib/vutuv_web/components/ui.ex:4398
+#: lib/vutuv_web/components/ui.ex:4419
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr ""
 "privacy google motore di ricerca ia llm crawler noindex online pallino "
 "pubblico"
 
-#: lib/vutuv_web/components/ui.ex:4401
+#: lib/vutuv_web/components/ui.ex:4422
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr "Persone che non possono interagire con Lei"
 
-#: lib/vutuv_web/components/ui.ex:4402
+#: lib/vutuv_web/components/ui.ex:4423
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr "blocca bandisci silenzia segnala abuso molestie stalker"
 
-#: lib/vutuv_web/components/ui.ex:4423
+#: lib/vutuv_web/components/ui.ex:4444
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr "Passkey, dispositivi connessi, codici di accesso"
 
-#: lib/vutuv_web/components/ui.ex:4424
+#: lib/vutuv_web/components/ui.ex:4445
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 "password accesso entrare uscire sessione dispositivo passkey totp 2fa pin"
 
-#: lib/vutuv_web/components/ui.ex:4442
+#: lib/vutuv_web/components/ui.ex:4463
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr "Porti i Suoi dati da LinkedIn"
 
-#: lib/vutuv_web/components/ui.ex:4443
+#: lib/vutuv_web/components/ui.ex:4464
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr "linkedin caricamento zip migrazione trasferimento"
 
-#: lib/vutuv_web/components/ui.ex:4446
+#: lib/vutuv_web/components/ui.ex:4467
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr "Scarichi tutto ciò che conserviamo su di Lei"
 
-#: lib/vutuv_web/components/ui.ex:4447
+#: lib/vutuv_web/components/ui.ex:4468
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr "download gdpr rgpd dati backup json cv"
 
-#: lib/vutuv_web/components/ui.ex:4461
+#: lib/vutuv_web/components/ui.ex:4482
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr "Rimuova il Suo account e tutto ciò che contiene"
 
-#: lib/vutuv_web/components/ui.ex:4462
+#: lib/vutuv_web/components/ui.ex:4483
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr "elimina rimuovi chiudi esci cancella abbandona"
@@ -16786,9 +16220,7 @@ msgstr "Apri"
 
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:18
 #, elixir-autogen, elixir-format
-msgid ""
-"You do not follow any tags yet. Open a tag page and press Follow, for "
-"example"
+msgid "You do not follow any tags yet. Open a tag page and press Follow, for example"
 msgstr ""
 "Non segue ancora alcun tag. Apra la pagina di un tag e prema Segui, ad "
 "esempio"
@@ -16815,10 +16247,7 @@ msgstr "Cambi il Suo nome utente"
 
 #: lib/vutuv_web/templates/username/new.html.heex:85
 #, elixir-autogen, elixir-format
-msgid ""
-"This link always opens your profile, even after you change your username. It"
-" is built from a fixed id, so it never breaks on a rename. For everyday "
-"sharing the short address above is friendlier."
+msgid "This link always opens your profile, even after you change your username. It is built from a fixed id, so it never breaks on a rename. For everyday sharing the short address above is friendlier."
 msgstr ""
 "Questo link apre sempre il Suo profilo, anche dopo che ha cambiato nome "
 "utente. È costruito su un id fisso, quindi non si rompe mai con un cambio di"
@@ -16837,77 +16266,65 @@ msgstr "Ho capito, disattiva"
 msgid "I understand, take part"
 msgstr "Ho capito, partecipa"
 
-#: lib/vutuv_web/views/settings_html.ex:501
+#: lib/vutuv_web/views/settings_html.ex:396
 #, elixir-autogen, elixir-format
-msgid ""
-"Most of them, not all: we cannot check whether they do it, and anything that"
-" was re-shared, archived or indexed elsewhere stays out of reach. If you "
-"take part again later, people there have to follow you anew."
+msgid "Most of them, not all: we cannot check whether they do it, and anything that was re-shared, archived or indexed elsewhere stays out of reach. If you take part again later, people there have to follow you anew."
 msgstr ""
 "La maggior parte, non tutti: non possiamo controllare se lo fanno, e tutto "
 "ciò che è stato ricondiviso, archiviato o indicizzato altrove resta fuori "
 "portata. Se in futuro partecipa di nuovo, le persone che stanno lì dovranno "
 "seguirla da capo."
 
-#: lib/vutuv_web/views/settings_html.ex:496
+#: lib/vutuv_web/views/settings_html.ex:391
 #, elixir-autogen, elixir-format
-msgid ""
-"No new posts go out, and your followers from other networks are removed "
-"here. The next time those servers look you up they learn that this account "
-"is gone, and most of them then delete their copies of your posts."
+msgid "No new posts go out, and your followers from other networks are removed here. The next time those servers look you up they learn that this account is gone, and most of them then delete their copies of your posts."
 msgstr ""
 "Non esce più alcun nuovo post, e i Suoi follower da altre reti vengono "
 "rimossi qui. La prossima volta che quei server La cercheranno, scopriranno "
 "che questo account non c'è più, e la maggior parte eliminerà le proprie "
 "copie dei Suoi post."
 
-#: lib/vutuv_web/views/settings_html.ex:477
+#: lib/vutuv_web/views/settings_html.ex:372
 #, elixir-autogen, elixir-format
 msgid "Once a post has left vutuv, it is out of our hands"
 msgstr "Quando un post ha lasciato vutuv, non è più nelle nostre mani"
 
-#: lib/vutuv_web/views/settings_html.ex:479
+#: lib/vutuv_web/views/settings_html.ex:374
 #, elixir-autogen, elixir-format
 msgid "Switching off does not delete what is already out there"
 msgstr "Disattivare non elimina ciò che è già fuori"
 
-#: lib/vutuv_web/views/settings_html.ex:490
+#: lib/vutuv_web/views/settings_html.ex:385
 #, elixir-autogen, elixir-format
-msgid ""
-"Switching this off again later stops new posts from going out. It cannot "
-"bring back what has already been delivered."
+msgid "Switching this off again later stops new posts from going out. It cannot bring back what has already been delivered."
 msgstr ""
 "Disattivarlo in seguito impedisce ai nuovi post di uscire. Non può riportare"
 " indietro ciò che è già stato consegnato."
 
-#: lib/vutuv_web/views/settings_html.ex:485
+#: lib/vutuv_web/views/settings_html.ex:380
 #, elixir-autogen, elixir-format
-msgid ""
-"Your public posts are copied to other servers. Once a copy is there we "
-"cannot delete it, we cannot change it, and we cannot see where it travels "
-"next. Editing or deleting a post on vutuv is only a request to those "
-"servers, and not every server honours it."
+msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 "I Suoi post pubblici vengono copiati su altri server. Una volta che una "
 "copia è lì, non possiamo eliminarla, non possiamo modificarla e non possiamo"
 " vedere dove va a finire. Modificare o eliminare un post su vutuv è solo una"
 " richiesta rivolta a quei server, e non tutti la rispettano."
 
-#: lib/vutuv_web/components/post_components.ex:5075
+#: lib/vutuv_web/components/post_components.ex:5105
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} risposta"
 msgstr[1] "%{formatted} risposte"
 
-#: lib/vutuv_web/components/post_components.ex:5079
+#: lib/vutuv_web/components/post_components.ex:5109
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Mi piace"
 msgstr[1] "%{formatted} Mi piace"
 
-#: lib/vutuv_web/components/post_components.ex:5083
+#: lib/vutuv_web/components/post_components.ex:5113
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -16915,18 +16332,14 @@ msgstr[0] "%{formatted} ripubblicazione"
 msgstr[1] "%{formatted} ripubblicazioni"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1145
-#: lib/vutuv_web/components/post_components.ex:5034
+#: lib/vutuv_web/components/post_components.ex:5064
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Già conteggiate nei numeri qui sopra."
 
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:99
 #, elixir-autogen, elixir-format
-msgid ""
-"Answers people write out there appear under your post, marked as coming from"
-" another network. We keep a copy for up to six months and check now and then"
-" whether it is still published; if the author deletes it, ours goes too. You"
-" can remove any single reply, and switching this off deletes all of them."
+msgid "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
 msgstr ""
 "Le risposte che le persone scrivono là fuori compaiono sotto il Suo post, "
 "contrassegnate come provenienti da un'altra rete. Ne conserviamo una copia "
@@ -16940,14 +16353,14 @@ msgstr ""
 msgid "Content warning"
 msgstr "Avviso sul contenuto"
 
-#: lib/vutuv_web/components/post_components.ex:1300
-#: lib/vutuv_web/components/post_components.ex:1959
+#: lib/vutuv_web/components/post_components.ex:1312
+#: lib/vutuv_web/components/post_components.ex:1971
 #: lib/vutuv_web/live/fediverse_account_live.ex:294
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr "Da un'altra rete"
 
-#: lib/vutuv_web/components/post_components.ex:1176
+#: lib/vutuv_web/components/post_components.ex:1188
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr "Rimuovere questa risposta dal Suo post?"
@@ -16960,7 +16373,8 @@ msgstr "Rimossa dal membro"
 #: lib/vutuv_web/agent_docs/markdown.ex:126
 #: lib/vutuv_web/agent_docs/markdown.ex:157
 #: lib/vutuv_web/agent_docs/markdown.ex:1144
-#: lib/vutuv_web/agent_docs/text.ex:117 lib/vutuv_web/agent_docs/text.ex:145
+#: lib/vutuv_web/agent_docs/text.ex:117
+#: lib/vutuv_web/agent_docs/text.ex:145
 #, elixir-autogen, elixir-format
 msgid "Replies from other networks"
 msgstr "Risposte da altre reti"
@@ -16975,7 +16389,7 @@ msgstr "Risposta da un'altra rete"
 msgid "Reply removed."
 msgstr "Risposta rimossa."
 
-#: lib/vutuv_web/components/post_components.ex:1185
+#: lib/vutuv_web/components/post_components.ex:1197
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -16986,7 +16400,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr "Segnalata come non appropriata"
 
-#: lib/vutuv_web/components/post_components.ex:1199
+#: lib/vutuv_web/components/post_components.ex:1211
 #: lib/vutuv_web/live/notification_live/index.ex:580
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -17012,15 +16426,15 @@ msgstr "Rimossa"
 msgid "Thank you. The reply was deleted right away."
 msgstr "Grazie. La risposta è stata eliminata subito."
 
-#: lib/vutuv_web/live/post_live/thread.ex:356
+#: lib/vutuv_web/live/post_live/thread.ex:360
 #, elixir-autogen, elixir-format
 msgid "That reply is not yours to remove."
 msgstr "Questa risposta non spetta a Lei rimuoverla."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1329
-#: lib/vutuv_web/components/post_components.ex:1231
-#: lib/vutuv_web/components/post_components.ex:1431
-#: lib/vutuv_web/components/post_components.ex:2377
+#: lib/vutuv_web/components/post_components.ex:1243
+#: lib/vutuv_web/components/post_components.ex:1443
+#: lib/vutuv_web/components/post_components.ex:2392
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr "Vedi l'originale"
@@ -17032,7 +16446,7 @@ msgstr "Vedi l'originale"
 msgid "What"
 msgstr "Cosa"
 
-#: lib/vutuv_web/live/post_live/thread.ex:352
+#: lib/vutuv_web/live/post_live/thread.ex:356
 #: lib/vutuv_web/live/remote_post_actions.ex:53
 #, elixir-autogen, elixir-format
 msgid "You have reported a lot today. Please try again tomorrow."
@@ -17091,10 +16505,7 @@ msgstr "Mostrati %{first}-%{last} di %{total}."
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:180
 #, elixir-autogen, elixir-format
-msgid ""
-"Everyone on another network who follows your vutuv posts. Only you see this "
-"list: the followers collection your profile publishes carries the number, "
-"never the names."
+msgid "Everyone on another network who follows your vutuv posts. Only you see this list: the followers collection your profile publishes carries the number, never the names."
 msgstr ""
 "Tutti quelli che su un'altra rete seguono i Suoi post vutuv. Questo elenco "
 "lo vede solo Lei: la raccolta dei follower che il Suo profilo pubblica "
@@ -17102,10 +16513,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:260
 #, elixir-autogen, elixir-format
-msgid ""
-"Accounts that no longer exist on their own server drop off this list by "
-"themselves. Names and handles are the ones their server last told us, so a "
-"renamed account updates here on its own too."
+msgid "Accounts that no longer exist on their own server drop off this list by themselves. Names and handles are the ones their server last told us, so a renamed account updates here on its own too."
 msgstr ""
 "Gli account che non esistono più sul proprio server spariscono da questo "
 "elenco da soli. Nomi e handle sono quelli che il loro server ci ha "
@@ -17267,7 +16675,7 @@ msgstr "Token di accesso creato"
 msgid "Access token revoked"
 msgstr "Token di accesso revocato"
 
-#: lib/vutuv_web/components/ui.ex:4426
+#: lib/vutuv_web/components/ui.ex:4447
 #: lib/vutuv_web/live/account_activity_live.ex:42
 #: lib/vutuv_web/live/account_activity_live.ex:114
 #: lib/vutuv_web/live/account_activity_live.ex:115
@@ -17380,10 +16788,7 @@ msgstr "E-mail sulle conferme"
 
 #: lib/vutuv_web/live/account_activity_live.ex:124
 #, elixir-autogen, elixir-format
-msgid ""
-"Every change to your account: what changed, exactly when, from which device,"
-" and how it was confirmed. If a line surprises you, follow the link at the "
-"end of it."
+msgid "Every change to your account: what changed, exactly when, from which device, and how it was confirmed. If a line surprises you, follow the link at the end of it."
 msgstr ""
 "Ogni modifica al Suo account: cosa è cambiato, esattamente quando, da quale "
 "dispositivo e come è stato confermato. Se una riga La sorprende, segua il "
@@ -17484,9 +16889,7 @@ msgstr "Non è stato Lei?"
 
 #: lib/vutuv_web/live/account_activity_live.ex:131
 #, elixir-autogen, elixir-format
-msgid ""
-"Nothing here yet. The next time you sign in or change a setting, it will be "
-"listed here."
+msgid "Nothing here yet. The next time you sign in or change a setting, it will be listed here."
 msgstr ""
 "Qui non c'è ancora nulla. La prossima volta che accede o cambia "
 "un'impostazione, comparirà qui."
@@ -17567,9 +16970,7 @@ msgstr "Mostra solo questo membro"
 
 #: lib/vutuv_web/live/account_activity_live.ex:292
 #, elixir-autogen, elixir-format
-msgid ""
-"Sign every other device out, then check which passkeys, codes and email "
-"addresses your account has. All of it is on the sign-in & security page."
+msgid "Sign every other device out, then check which passkeys, codes and email addresses your account has. All of it is on the sign-in & security page."
 msgstr ""
 "Disconnetta tutti gli altri dispositivi, poi controlli quali passkey, codici"
 " e indirizzi e-mail ha il Suo account. È tutto nella pagina Accesso e "
@@ -17624,9 +17025,7 @@ msgstr "È stato Lei?"
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:106
 #, elixir-autogen, elixir-format
-msgid ""
-"What changed on an account, when, from where and how it was confirmed - the "
-"answer to \"I didn't do anything!\". Opening it is recorded in your own log."
+msgid "What changed on an account, when, from where and how it was confirmed - the answer to \"I didn't do anything!\". Opening it is recorded in your own log."
 msgstr ""
 "Cosa è cambiato su un account, quando, da dove e come è stato confermato: la"
 " risposta a \"Ma io non ho fatto niente!\". L'apertura viene registrata nel "
@@ -17637,7 +17036,7 @@ msgstr ""
 msgid "What changed on your account, and exactly when."
 msgstr "Cosa è cambiato sul Suo account, ed esattamente quando."
 
-#: lib/vutuv_web/components/ui.ex:4427
+#: lib/vutuv_web/components/ui.ex:4448
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr "Cosa è cambiato sul Suo account, e quando"
@@ -17673,7 +17072,7 @@ msgstr "da chi gestisce il sito"
 msgid "from a signed-in session"
 msgstr "da una sessione connessa"
 
-#: lib/vutuv_web/components/ui.ex:4429
+#: lib/vutuv_web/components/ui.ex:4450
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
@@ -17718,10 +17117,7 @@ msgstr "Dispositivo"
 
 #: lib/vutuv_web/live/admin/activity_live.ex:159
 #, elixir-autogen, elixir-format
-msgid ""
-"What changed on which account, when, from which device and how it was "
-"confirmed - the same log every member sees for themselves. Opening it is "
-"recorded in your own activity log."
+msgid "What changed on which account, when, from which device and how it was confirmed - the same log every member sees for themselves. Opening it is recorded in your own activity log."
 msgstr ""
 "Cosa è cambiato su quale account, quando, da quale dispositivo e come è "
 "stato confermato: lo stesso registro che ogni membro vede per sé. L'apertura"
@@ -17733,26 +17129,24 @@ msgstr ""
 msgid "device or detail"
 msgstr "dispositivo o dettaglio"
 
-#: lib/vutuv_web/components/post_components.ex:2915
+#: lib/vutuv_web/components/post_components.ex:2930
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Post fissato"
 
-#: lib/vutuv_web/components/post_components.ex:3031
+#: lib/vutuv_web/components/post_components.ex:3046
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "Fissa sul profilo"
 
-#: lib/vutuv_web/components/post_components.ex:3039
+#: lib/vutuv_web/components/post_components.ex:3054
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Togli dal profilo"
 
-#: lib/vutuv_web/components/post_components.ex:3025
+#: lib/vutuv_web/components/post_components.ex:3040
 #, elixir-autogen, elixir-format
-msgid ""
-"Only one post can be pinned to your profile. Pin this one and release the "
-"other?"
+msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
 "Si può fissare un solo post sul profilo. Fissare questo e liberare l'altro?"
 
@@ -17763,9 +17157,7 @@ msgstr "Fissato in cima al Suo profilo."
 
 #: lib/vutuv_web/controllers/post_controller.ex:252
 #, elixir-autogen, elixir-format
-msgid ""
-"Pinned to the top of your profile. The post pinned before it is a normal "
-"post again."
+msgid "Pinned to the top of your profile. The post pinned before it is a normal post again."
 msgstr ""
 "Fissato in cima al Suo profilo. Il post fissato prima torna a essere un post"
 " normale."
@@ -17796,11 +17188,7 @@ msgstr "ad esempio [STÈ-fan VÌN-ter-mai-er]"
 
 #: lib/vutuv_web/templates/user/edit.html.heex:231
 #, elixir-autogen, elixir-format
-msgid ""
-"Optional. Write your name the way it sounds, so someone calling you for the "
-"first time gets it right. It shows in square brackets under your name on "
-"your profile, the way a transcription is written, and the brackets are added"
-" for you. Leave it empty and nothing is shown."
+msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
 "Facoltativo. Scriva il Suo nome come suona, così chi La chiama per la prima "
 "volta lo pronuncia bene. Compare tra parentesi quadre sotto il Suo nome sul "
@@ -17848,7 +17236,8 @@ msgid "Describe the photo for people who can't see it"
 msgstr "Descriva la foto per chi non può vederla"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1257
-#: lib/vutuv_web/agent_docs/text.ex:792 lib/vutuv_web/components/ui.ex:2767
+#: lib/vutuv_web/agent_docs/text.ex:792
+#: lib/vutuv_web/components/ui.ex:2767
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr "Scarica l'originale"
@@ -17890,17 +17279,17 @@ msgstr "Foto successiva"
 msgid "No image description yet"
 msgstr "Ancora nessuna descrizione dell'immagine"
 
-#: lib/vutuv_web/components/post_components.ex:2510
+#: lib/vutuv_web/components/post_components.ex:2525
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Apri le impostazioni del Fediverso"
 
-#: lib/vutuv_web/components/post_components.ex:3734
+#: lib/vutuv_web/components/post_components.ex:3749
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} di %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:3245
+#: lib/vutuv_web/components/post_components.ex:3260
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "La foto è in fase di controllo"
@@ -17913,7 +17302,7 @@ msgstr "Opzioni della foto"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1290
 #: lib/vutuv_web/agent_docs/text.ex:779
-#: lib/vutuv_web/components/post_components.ex:3951
+#: lib/vutuv_web/components/post_components.ex:3966
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Foto:"
@@ -17931,9 +17320,7 @@ msgstr "Rimuovi la foto"
 
 #: lib/vutuv_web/live/post_live/composer.ex:2353
 #, elixir-autogen, elixir-format
-msgid ""
-"Same pixels, nothing else: location and serial numbers removed, quality "
-"untouched."
+msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr ""
 "Gli stessi pixel e nient'altro: posizione e numeri di serie rimossi, qualità"
 " intatta."
@@ -17943,7 +17330,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr "Mostra le impostazioni della fotocamera"
 
-#: lib/vutuv_web/components/post_components.ex:2563
+#: lib/vutuv_web/components/post_components.ex:2578
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -17957,23 +17344,19 @@ msgstr "Il file esattamente come l'ho caricato"
 
 #: lib/vutuv_web/live/post_live/composer.ex:2408
 #, elixir-autogen, elixir-format
-msgid ""
-"This file format can only be handed out as it is. Remove the photo if that "
-"is not what you want."
+msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr ""
 "Questo formato di file può essere consegnato solo così com'è. Rimuova la "
 "foto se non è ciò che desidera."
 
 #: lib/vutuv_web/live/post_live/composer.ex:2400
 #, elixir-autogen, elixir-format
-msgid ""
-"This photo carries the location it was taken at. Anyone who downloads the "
-"exact file can read it."
+msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 "Questa foto porta con sé il luogo in cui è stata scattata. Chiunque scarichi"
 " il file esatto può leggerlo."
 
-#: lib/vutuv_web/components/post_components.ex:2554
+#: lib/vutuv_web/components/post_components.ex:2569
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -17982,21 +17365,18 @@ msgstr ""
 
 #: lib/vutuv_web/live/post_live/remote_reply.ex:86
 #, elixir-autogen, elixir-format
-msgid ""
-"This reply was written on another network. Answering it means sending your "
-"words to that network, which vutuv only does for members who have switched "
-"Fediverse participation on."
+msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 "Questa risposta è stata scritta su un'altra rete. Rispondere significa "
 "inviare le Sue parole a quella rete, cosa che vutuv fa solo per i membri che"
 " hanno attivato la partecipazione al Fediverso."
 
-#: lib/vutuv_web/components/post_components.ex:2572
+#: lib/vutuv_web/components/post_components.ex:2587
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Questo sito non partecipa al Fediverso."
 
-#: lib/vutuv_web/components/post_components.ex:2506
+#: lib/vutuv_web/components/post_components.ex:2521
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Attivi la partecipazione al Fediverso per rispondere"
@@ -18008,17 +17388,13 @@ msgstr "Chi può riutilizzare queste foto"
 
 #: lib/vutuv_web/live/post_live/composer.ex:1069
 #, elixir-autogen, elixir-format
-msgid ""
-"You have sent a lot of answers to other networks in the past hour. Please "
-"try again later."
+msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 "Nell'ultima ora ha inviato molte risposte ad altre reti. Riprovi più tardi."
 
-#: lib/vutuv_web/components/post_components.ex:2567
+#: lib/vutuv_web/components/post_components.ex:2582
 #, elixir-autogen, elixir-format
-msgid ""
-"You moved your Fediverse account to another server, so answers are no longer"
-" sent from here."
+msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
 "Ha spostato il Suo account del Fediverso su un altro server, quindi da qui "
 "non vengono più inviate risposte."
@@ -18030,11 +17406,9 @@ msgstr ""
 "Al momento le Sue impostazioni del Fediverso non consentono di inviare una "
 "risposta."
 
-#: lib/vutuv_web/components/post_components.ex:2520
+#: lib/vutuv_web/components/post_components.ex:2535
 #, elixir-autogen, elixir-format
-msgid ""
-"Your answer goes to %{handle} on their own server and to your Fediverse "
-"followers. It is a public post on vutuv as well."
+msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
 "La Sua risposta arriva a %{handle} sul suo server e ai Suoi follower del "
 "Fediverso. Su vutuv è anche un post pubblico."
@@ -18055,8 +17429,8 @@ msgstr "Aggiungi foto"
 msgid "Licence"
 msgstr "Licenza"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1561
-#: lib/vutuv_web/live/post_live/feed.ex:1562
+#: lib/vutuv_web/live/post_live/feed.ex:1697
+#: lib/vutuv_web/live/post_live/feed.ex:1698
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr "Pubblica foto"
@@ -18085,8 +17459,7 @@ msgstr "Ripreso da dove aveva lasciato."
 
 #: lib/vutuv_web/live/post_live/composer.ex:1767
 #, elixir-autogen, elixir-format
-msgid ""
-"A file whose format cannot be cleaned is handed out exactly as uploaded."
+msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr ""
 "Un file il cui formato non può essere ripulito viene consegnato esattamente "
 "come caricato."
@@ -18118,12 +17491,8 @@ msgstr "Cosa può salvare un visitatore"
 
 #: lib/vutuv_web/live/post_live/composer.ex:1756
 #, elixir-autogen, elixir-format
-msgid ""
-"This photo carries the location it was taken at, and the exact file hands it"
-" over."
-msgid_plural ""
-"Some of these photos carry the location they were taken at, and the exact "
-"file hands it over."
+msgid "This photo carries the location it was taken at, and the exact file hands it over."
+msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
 msgstr[0] ""
 "Questa foto porta con sé il luogo in cui è stata scattata, e il file esatto "
 "lo rivela."
@@ -18132,13 +17501,13 @@ msgstr[1] ""
 "il file esatto lo rivela."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1163
-#: lib/vutuv_web/components/post_components.ex:5072
+#: lib/vutuv_web/components/post_components.ex:5102
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "A %{handle} è piaciuto"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1161
-#: lib/vutuv_web/components/post_components.ex:5069
+#: lib/vutuv_web/components/post_components.ex:5099
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} lo ha condiviso"
@@ -18148,7 +17517,7 @@ msgstr "%{handle} lo ha condiviso"
 msgid "Fediverse reactions"
 msgstr "Reazioni dal Fediverso"
 
-#: lib/vutuv_web/components/post_components.ex:4961
+#: lib/vutuv_web/components/post_components.ex:4991
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Da altre reti"
@@ -18165,11 +17534,7 @@ msgstr "Mostra le reazioni da altre reti"
 
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:84
 #, elixir-autogen, elixir-format
-msgid ""
-"Show under each of your posts who out there liked or shared it, by their "
-"account address on their own server, linked to that account. Visible to "
-"everyone who sees the post. We keep nothing else about these people: no "
-"name, no picture, no text. Switching it off deletes what is stored for it."
+msgid "Show under each of your posts who out there liked or shared it, by their account address on their own server, linked to that account. Visible to everyone who sees the post. We keep nothing else about these people: no name, no picture, no text. Switching it off deletes what is stored for it."
 msgstr ""
 "Mostri sotto ciascuno dei Suoi post chi là fuori gli ha messo Mi piace o lo "
 "ha condiviso, con l'indirizzo del suo account sul proprio server, collegato "
@@ -18235,11 +17600,7 @@ msgstr "Rimozioni che non sono andate a buon fine"
 
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:222
 #, elixir-autogen, elixir-format
-msgid ""
-"These withdrawal requests were retried eight times over about four hours and"
-" then dropped. We cannot make another server delete anything, but a server "
-"showing up here repeatedly is either broken or ignoring us, and can be "
-"blocked above."
+msgid "These withdrawal requests were retried eight times over about four hours and then dropped. We cannot make another server delete anything, but a server showing up here repeatedly is either broken or ignoring us, and can be blocked above."
 msgstr ""
 "Queste richieste di ritiro sono state ritentate otto volte nell'arco di "
 "circa quattro ore e poi abbandonate. Non possiamo costringere un altro "
@@ -18281,7 +17642,7 @@ msgstr "Un account su un'altra rete"
 msgid "Cancel request"
 msgstr "Annulla la richiesta"
 
-#: lib/vutuv_web/components/ui.ex:4413
+#: lib/vutuv_web/components/ui.ex:4434
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr "Segua account su Mastodon, e si faccia seguire da lì"
@@ -18305,14 +17666,13 @@ msgstr "Segui questo account"
 
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:161
 #, elixir-autogen, elixir-format
-msgid ""
-"It works the other way round too: paste somebody's address from Mastodon and"
-" friends, and you follow them from here."
+msgid "It works the other way round too: paste somebody's address from Mastodon and friends, and you follow them from here."
 msgstr ""
 "Funziona anche al contrario: incolli l'indirizzo di qualcuno da Mastodon e "
 "affini, e lo segue da qui."
 
-#: lib/vutuv/api_auth/scopes.ex:84 lib/vutuv/api_auth/scopes.ex:87
+#: lib/vutuv/api_auth/scopes.ex:84
+#: lib/vutuv/api_auth/scopes.ex:87
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:182
 #, elixir-autogen, elixir-format
 msgid "Manage who you follow"
@@ -18320,9 +17680,7 @@ msgstr "Gestisca chi segue"
 
 #: lib/vutuv_web/live/fediverse_following_live.ex:318
 #, elixir-autogen, elixir-format
-msgid ""
-"Mastodon and the other networks work like email: an address is enough. Paste"
-" one here and vutuv asks that server to let you follow the account."
+msgid "Mastodon and the other networks work like email: an address is enough. Paste one here and vutuv asks that server to let you follow the account."
 msgstr ""
 "Mastodon e le altre reti funzionano come la posta elettronica: basta un "
 "indirizzo. Ne incolli uno qui e vutuv chiederà a quel server di lasciarLe "
@@ -18366,9 +17724,7 @@ msgstr "Smettere di seguire %{account}?"
 
 #: lib/vutuv_web/components/fediverse_components.ex:402
 #, elixir-autogen, elixir-format
-msgid ""
-"That account could not be loaded from its server. Try again in a little "
-"while."
+msgid "That account could not be loaded from its server. Try again in a little while."
 msgstr ""
 "Non è stato possibile caricare quell'account dal suo server. Riprovi tra "
 "poco."
@@ -18380,18 +17736,14 @@ msgstr "Non ha funzionato. Controlli l'indirizzo e riprovi."
 
 #: lib/vutuv_web/components/fediverse_components.ex:391
 #, elixir-autogen, elixir-format
-msgid ""
-"That does not look like an address on another network. They look like "
-"@name@server."
+msgid "That does not look like an address on another network. They look like @name@server."
 msgstr ""
 "Questo non sembra un indirizzo su un'altra rete. Hanno la forma "
 "@nome@server."
 
 #: lib/vutuv_web/live/search_live.ex:460
 #, elixir-autogen, elixir-format
-msgid ""
-"That is an address on Mastodon or one of the other networks, so nobody here "
-"carries it. You can follow it from vutuv."
+msgid "That is an address on Mastodon or one of the other networks, so nobody here carries it. You can follow it from vutuv."
 msgstr ""
 "Questo è un indirizzo su Mastodon o su una delle altre reti, quindi qui non "
 "lo ha nessuno. Può seguirlo da vutuv."
@@ -18406,9 +17758,7 @@ msgstr ""
 #: lib/vutuv_web/components/fediverse_components.ex:396
 #: lib/vutuv_web/components/fediverse_components.ex:475
 #, elixir-autogen, elixir-format
-msgid ""
-"That server did not answer. Check the address, and that the server is "
-"online."
+msgid "That server did not answer. Check the address, and that the server is online."
 msgstr ""
 "Quel server non ha risposto. Controlli l'indirizzo e che il server sia "
 "online."
@@ -18425,10 +17775,7 @@ msgstr "L'indirizzo che si è portato dietro è conservato qui:"
 
 #: lib/vutuv_web/live/fediverse_following_live.ex:464
 #, elixir-autogen, elixir-format
-msgid ""
-"The other server decides. Most accounts accept straight away; one that "
-"checks its followers by hand stays on \"Requested\" until somebody there "
-"says yes."
+msgid "The other server decides. Most accounts accept straight away; one that checks its followers by hand stays on \"Requested\" until somebody there says yes."
 msgstr ""
 "Decide l'altro server. La maggior parte degli account accetta subito; uno "
 "che controlla i propri follower a mano resta su \"Richiesto\" finché "
@@ -18436,9 +17783,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:290
 #, elixir-autogen, elixir-format
-msgid ""
-"This vutuv does not exchange anything with other networks, so there is "
-"nothing to follow from here. That is an operator setting, not yours."
+msgid "This vutuv does not exchange anything with other networks, so there is nothing to follow from here. That is an operator setting, not yours."
 msgstr ""
 "Questo vutuv non scambia nulla con altre reti, quindi da qui non c'è nulla "
 "da seguire. È un'impostazione di chi gestisce il sito, non Sua."
@@ -18450,9 +17795,7 @@ msgstr "Questo vutuv non scambia nulla con quel server."
 
 #: lib/vutuv_web/components/fediverse_components.ex:312
 #, elixir-autogen, elixir-format
-msgid ""
-"To follow an account out there you need a Fediverse identity of your own: "
-"the request is signed in your name, so the other server knows who is asking."
+msgid "To follow an account out there you need a Fediverse identity of your own: the request is signed in your name, so the other server knows who is asking."
 msgstr ""
 "Per seguire un account là fuori Le serve una Sua identità nel Fediverso: la "
 "richiesta viene firmata a Suo nome, così l'altro server sa chi la sta "
@@ -18471,9 +17814,7 @@ msgstr "Cosa significa seguire là fuori"
 
 #: lib/vutuv_web/live/fediverse_following_live.ex:469
 #, elixir-autogen, elixir-format
-msgid ""
-"Who you follow is yours alone. Your profile publishes how many accounts you "
-"follow out there, never which ones."
+msgid "Who you follow is yours alone. Your profile publishes how many accounts you follow out there, never which ones."
 msgstr ""
 "Chi segue riguarda solo Lei. Il Suo profilo pubblica quanti account segue là"
 " fuori, mai quali."
@@ -18500,10 +17841,7 @@ msgstr "Sta seguendo il numero massimo di account che consentiamo (%{max})."
 
 #: lib/vutuv_web/components/fediverse_components.ex:430
 #, elixir-autogen, elixir-format
-msgid ""
-"You are not taking part in the Fediverse at the moment, so there is no "
-"identity to sign the request with. Open the Fediverse settings to switch it "
-"on."
+msgid "You are not taking part in the Fediverse at the moment, so there is no identity to sign the request with. Open the Fediverse settings to switch it on."
 msgstr ""
 "Al momento non partecipa al Fediverso, quindi non c'è un'identità con cui "
 "firmare la richiesta. Apra le impostazioni del Fediverso per attivarla."
@@ -18522,37 +17860,28 @@ msgstr[1] "Segue %{formatted} account su altre reti"
 
 #: lib/vutuv_web/components/fediverse_components.ex:436
 #, elixir-autogen, elixir-format
-msgid ""
-"You have sent a lot of follow requests in the last hour. Please try again "
-"later."
+msgid "You have sent a lot of follow requests in the last hour. Please try again later."
 msgstr ""
 "Nell'ultima ora ha inviato molte richieste di follow. Riprovi più tardi."
 
 #: lib/vutuv_web/components/fediverse_components.ex:446
 #, elixir-autogen, elixir-format
-msgid ""
-"You redirected your Fediverse followers to another account, so this account "
-"no longer acts out there."
+msgid "You redirected your Fediverse followers to another account, so this account no longer acts out there."
 msgstr ""
 "Ha reindirizzato i Suoi follower del Fediverso a un altro account, quindi "
 "questo account non agisce più là fuori."
 
 #: lib/vutuv_web/components/fediverse_components.ex:279
 #, elixir-autogen, elixir-format
-msgid ""
-"Your account is on hold at the moment, so nothing of yours goes out to other"
-" networks and you cannot follow anybody there. This lifts by itself once the"
-" hold ends."
+msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr ""
 "Al momento il Suo account è sospeso, quindi nulla di Suo esce verso altre "
 "reti e non può seguire nessuno lì. La sospensione decade da sé quando "
 "termina."
 
-#: lib/vutuv_web/components/ui.ex:4415
+#: lib/vutuv_web/components/ui.ex:4436
 #, elixir-autogen, elixir-format
-msgid ""
-"mastodon activitypub federation follower following follow move migrate "
-"remote account"
+msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
 "mastodon activitypub federazione follower seguiti segui spostamento "
 "migrazione account remoto"
@@ -18564,9 +17893,7 @@ msgstr "Account seguiti"
 
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:30
 #, elixir-autogen, elixir-format
-msgid ""
-"%{follows} accounts on other networks are followed from here, with %{posts} "
-"of their posts cached."
+msgid "%{follows} accounts on other networks are followed from here, with %{posts} of their posts cached."
 msgstr ""
 "Da qui vengono seguiti %{follows} account su altre reti, con %{posts} dei "
 "loro post in cache."
@@ -18576,7 +17903,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr "Post in cache"
 
-#: lib/vutuv_web/components/post_components.ex:2323
+#: lib/vutuv_web/components/post_components.ex:2338
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr "Solo per i follower di questo account"
@@ -18586,20 +17913,14 @@ msgstr "Solo per i follower di questo account"
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Grazie. La nostra copia è stata eliminata subito."
 
-#: lib/vutuv_web/components/post_components.ex:2376
+#: lib/vutuv_web/components/post_components.ex:2391
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Vota sull'originale"
 
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:181
 #, elixir-autogen, elixir-format
-msgid ""
-"A report deletes our copy right away, with no queue to work through. This is"
-" the trail, so a server that keeps showing up here can be blocked above. It "
-"holds no text and no links, only which server and which account (as a short "
-"digest). The What column says whether a reply under one member's post was "
-"taken down or a cached post, which is shared by everybody following its "
-"author."
+msgid "A report deletes our copy right away, with no queue to work through. This is the trail, so a server that keeps showing up here can be blocked above. It holds no text and no links, only which server and which account (as a short digest). The What column says whether a reply under one member's post was taken down or a cached post, which is shared by everybody following its author."
 msgstr ""
 "Una segnalazione elimina subito la nostra copia, senza code da smaltire. "
 "Questo è il tracciato, così un server che continua a comparire qui può "
@@ -18618,12 +17939,12 @@ msgstr "Post in cache segnalato, rimosso per tutti qui"
 msgid "Content from other networks taken down by members"
 msgstr "Contenuti da altre reti rimossi dai membri"
 
-#: lib/vutuv_web/components/post_components.ex:1559
+#: lib/vutuv_web/components/post_components.ex:1571
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr "Nascondi"
 
-#: lib/vutuv_web/components/post_components.ex:2341
+#: lib/vutuv_web/components/post_components.ex:2356
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Contrassegnato come sensibile dal suo autore"
@@ -18639,21 +17960,16 @@ msgstr "Silenziato. Continua a seguirlo; i suoi post spariscono dal Suo feed."
 msgid "Nobody has removed or reported anything yet."
 msgstr "Nessuno ha ancora rimosso o segnalato nulla."
 
-#: lib/vutuv_web/components/post_components.ex:2309
+#: lib/vutuv_web/components/post_components.ex:2324
 #, elixir-autogen, elixir-format
-msgid ""
-"Report this post as not appropriate? Our copy is deleted for everyone on "
-"this vutuv right away."
+msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
 "Segnalare questo post come non appropriato? La nostra copia viene eliminata "
 "subito per tutti su questo vutuv."
 
 #: lib/vutuv_web/live/fediverse_following_live.ex:480
 #, elixir-autogen, elixir-format
-msgid ""
-"To show their posts we keep a copy here for up to six months. If the author "
-"deletes or edits something, ours follows; and when you stop following an "
-"account, its posts are deleted here at once."
+msgid "To show their posts we keep a copy here for up to six months. If the author deletes or edits something, ours follows; and when you stop following an account, its posts are deleted here at once."
 msgstr ""
 "Per mostrare i loro post ne conserviamo qui una copia per un massimo di sei "
 "mesi. Se l'autore elimina o modifica qualcosa, la nostra copia lo segue; e "
@@ -18662,9 +17978,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/fediverse_following_live.ex:364
 #, elixir-autogen, elixir-format
-msgid ""
-"You do not follow anybody out there yet. Once you do, what they post appears"
-" in your feed among everything else."
+msgid "You do not follow anybody out there yet. Once you do, what they post appears in your feed among everything else."
 msgstr ""
 "Non segue ancora nessuno là fuori. Quando lo farà, ciò che pubblicano "
 "comparirà nel Suo feed insieme a tutto il resto."
@@ -18697,9 +18011,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:247
 #, elixir-autogen, elixir-format
-msgid ""
-"Nothing here. vutuv only keeps an account's posts while somebody here "
-"follows it, and this page never fetches any."
+msgid "Nothing here. vutuv only keeps an account's posts while somebody here follows it, and this page never fetches any."
 msgstr ""
 "Qui non c'è nulla. vutuv conserva i post di un account solo finché qualcuno "
 "qui lo segue, e questa pagina non ne scarica mai."
@@ -18731,18 +18043,14 @@ msgstr "Veda il suo profilo completo su %{host}"
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:256
 #, elixir-autogen, elixir-format
-msgid ""
-"Waiting for that server to accept your follow. Posts they addressed to their"
-" followers appear once it does."
+msgid "Waiting for that server to accept your follow. Posts they addressed to their followers appear once it does."
 msgstr ""
 "In attesa che quel server accetti il Suo follow. I post rivolti ai suoi "
 "follower compariranno quando lo avrà fatto."
 
 #: lib/vutuv_web/components/fediverse_components.ex:301
 #, elixir-autogen, elixir-format
-msgid ""
-"You redirected your Fediverse followers to another account, so this one no "
-"longer follows anybody out there."
+msgid "You redirected your Fediverse followers to another account, so this one no longer follows anybody out there."
 msgstr ""
 "Ha reindirizzato i Suoi follower del Fediverso a un altro account, quindi "
 "questo non segue più nessuno là fuori."
@@ -18765,18 +18073,14 @@ msgstr "“Stanco di LinkedIn? Allora entri e si metta comodo.”"
 
 #: lib/vutuv_web/views/admin/experiment_html.ex:52
 #, elixir-autogen, elixir-format
-msgid ""
-"%{variant} is ahead, but a lead this size turns up by chance %{p} of the "
-"time. Keep the test running."
+msgid "%{variant} is ahead, but a lead this size turns up by chance %{p} of the time. Keep the test running."
 msgstr ""
 "%{variant} è in vantaggio, ma un margine di queste dimensioni compare per "
 "caso nel %{p} dei casi. Lasci il test in corso."
 
 #: lib/vutuv_web/views/admin/experiment_html.ex:60
 #, elixir-autogen, elixir-format
-msgid ""
-"%{variant} wins. A lead this size turns up by chance only %{p} of the time, "
-"so the difference is real."
+msgid "%{variant} wins. A lead this size turns up by chance only %{p} of the time, so the difference is real."
 msgstr ""
 "Vince %{variant}. Un margine di queste dimensioni compare per caso solo nel "
 "%{p} dei casi, quindi la differenza è reale."
@@ -18798,12 +18102,7 @@ msgstr "Membri confermati:"
 
 #: lib/vutuv_web/templates/admin/experiment/index.html.heex:83
 #, elixir-autogen, elixir-format
-msgid ""
-"Crawlers that ignore cookies count as views, which drags both rates down by "
-"roughly the same amount. That is why the verdict above is read from how the "
-"sign-ups split between the two variants, not from the rates themselves: a "
-"random 50/50 assignment makes an uneven split the signal, and no amount of "
-"bot traffic can tilt it."
+msgid "Crawlers that ignore cookies count as views, which drags both rates down by roughly the same amount. That is why the verdict above is read from how the sign-ups split between the two variants, not from the rates themselves: a random 50/50 assignment makes an uneven split the signal, and no amount of bot traffic can tilt it."
 msgstr ""
 "I crawler che ignorano i cookie contano come visualizzazioni, il che abbassa"
 " entrambi i tassi più o meno della stessa quantità. Per questo il verdetto "
@@ -18821,11 +18120,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/experiment/index.html.heex:14
 #, elixir-autogen, elixir-format
-msgid ""
-"Every logged-out visitor to the start page is shown one of two founder "
-"quotes at random and keeps it for their session. Counted per variant: the "
-"visitors who saw it, the sign-up forms that created an account, and the PINs"
-" that turned such an account into a real member."
+msgid "Every logged-out visitor to the start page is shown one of two founder quotes at random and keeps it for their session. Counted per variant: the visitors who saw it, the sign-up forms that created an account, and the PINs that turned such an account into a real member."
 msgstr ""
 "A ogni visitatore non connesso della pagina iniziale viene mostrata a caso "
 "una di due citazioni del fondatore, che resta la stessa per tutta la "
@@ -18888,9 +18183,7 @@ msgstr "Iscrizioni:"
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:333
 #, elixir-autogen, elixir-format
-msgid ""
-"The start page shows one of two founder quotes at random. Views, sign-ups "
-"and confirmed members per variant, and whether the difference is real yet."
+msgid "The start page shows one of two founder quotes at random. Views, sign-ups and confirmed members per variant, and whether the difference is real yet."
 msgstr ""
 "La pagina iniziale mostra a caso una di due citazioni del fondatore. "
 "Visualizzazioni, iscrizioni e membri confermati per variante, e se la "
@@ -18898,10 +18191,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/experiment/index.html.heex:24
 #, elixir-autogen, elixir-format
-msgid ""
-"The test is switched off on this installation (LANDING_HEADLINE_EXPERIMENT),"
-" so every visitor sees the same headline and nothing new is counted. The "
-"figures below are whatever was collected while it ran."
+msgid "The test is switched off on this installation (LANDING_HEADLINE_EXPERIMENT), so every visitor sees the same headline and nothing new is counted. The figures below are whatever was collected while it ran."
 msgstr ""
 "Su questa installazione il test è disattivato (LANDING_HEADLINE_EXPERIMENT),"
 " quindi ogni visitatore vede lo stesso titolo e non viene conteggiato nulla "
@@ -18909,9 +18199,7 @@ msgstr ""
 
 #: lib/vutuv_web/views/admin/experiment_html.ex:38
 #, elixir-autogen, elixir-format
-msgid ""
-"Too early to say: %{count} of at least %{min} outcomes. Anything read out of"
-" the numbers below now is noise."
+msgid "Too early to say: %{count} of at least %{min} outcomes. Anything read out of the numbers below now is noise."
 msgstr ""
 "Troppo presto per dirlo: %{count} esiti su almeno %{min}. Qualsiasi cosa si "
 "legga adesso nei numeri qui sotto è rumore."
@@ -18934,27 +18222,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] "(un'immagine)"
 msgstr[1] "(%{count} immagini)"
 
-#: lib/vutuv_web/components/post_components.ex:2075
+#: lib/vutuv_web/components/post_components.ex:2077
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr "L'immagine è in fase di controllo"
 
-#: lib/vutuv_web/components/post_components.ex:2091
+#: lib/vutuv_web/components/post_components.ex:2106
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr "Coprila di nuovo"
 
-#: lib/vutuv_web/components/post_components.ex:2086
+#: lib/vutuv_web/components/post_components.ex:2101
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr "Contenuto sensibile. Mostra l'immagine."
 
-#: lib/vutuv_web/components/post_components.ex:2413
+#: lib/vutuv_web/components/post_components.ex:2428
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Sono molti Mi piace in un'ora. Riprovi più tardi."
 
-#: lib/vutuv_web/components/post_components.ex:2419
+#: lib/vutuv_web/components/post_components.ex:2434
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Quel post non è più qui."
@@ -18964,21 +18252,16 @@ msgstr "Quel post non è più qui."
 msgid "Back to the feed"
 msgstr "Torna al feed"
 
-#: lib/vutuv_web/components/post_components.ex:2558
+#: lib/vutuv_web/components/post_components.ex:2573
 #, elixir-autogen, elixir-format
-msgid ""
-"This post was published to that account's followers only, so it cannot be "
-"answered with a public post here."
+msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
 "Questo post è stato pubblicato solo per i follower di quell'account, quindi "
 "non gli si può rispondere con un post pubblico qui."
 
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:101
 #, elixir-autogen, elixir-format
-msgid ""
-"This post was written on another network. Answering it means sending your "
-"words to that network, which vutuv only does for members who have switched "
-"Fediverse participation on."
+msgid "This post was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 "Questo post è stato scritto su un'altra rete. Rispondere significa inviare "
 "le Sue parole a quella rete, cosa che vutuv fa solo per i membri che hanno "
@@ -18996,18 +18279,14 @@ msgstr "Spostato"
 
 #: lib/vutuv_web/live/fediverse_following_live.ex:267
 #, elixir-autogen, elixir-format
-msgid ""
-"%{account} moved to another server. Your subscription already went with them"
-" — remove this old entry?"
+msgid "%{account} moved to another server. Your subscription already went with them — remove this old entry?"
 msgstr ""
 "%{account} si è spostato su un altro server. Il Suo abbonamento lo ha già "
 "seguito: rimuovere questa vecchia voce?"
 
 #: lib/vutuv_web/controllers/authorize_interaction_controller.ex:50
 #, elixir-autogen, elixir-format
-msgid ""
-"Please sign in first, then you can follow that account from your vutuv "
-"account."
+msgid "Please sign in first, then you can follow that account from your vutuv account."
 msgstr "Prima acceda, poi potrà seguire quell'account dal Suo account vutuv."
 
 #: lib/vutuv_web/controllers/authorize_interaction_controller.ex:73
@@ -19017,14 +18296,12 @@ msgstr "Quel link non indica un account del Fediverso che possiamo leggere."
 
 #: lib/vutuv_web/controllers/authorize_interaction_controller.ex:120
 #, elixir-autogen, elixir-format
-msgid ""
-"That link points at a single post. You can follow its author, %{account}, "
-"from here."
+msgid "That link points at a single post. You can follow its author, %{account}, from here."
 msgstr ""
 "Quel link punta a un singolo post. Da qui può seguire il suo autore, "
 "%{account}."
 
-#: lib/vutuv_web/live/user_profile_live.ex:1378
+#: lib/vutuv_web/live/user_profile_live.ex:1382
 #, elixir-autogen, elixir-format
 msgid "You already follow one member."
 msgid_plural "You already follow %{count} members."
@@ -19033,8 +18310,7 @@ msgstr[1] "Segue già %{count} membri."
 
 #: lib/vutuv_web/views/user_html.ex:228
 #, elixir-autogen, elixir-format
-msgid ""
-"Your feed shows the posts of members you follow. Follow a few to fill it."
+msgid "Your feed shows the posts of members you follow. Follow a few to fill it."
 msgstr ""
 "Il Suo feed mostra i post dei membri che segue. Ne segua qualcuno per "
 "riempirlo."
@@ -19051,9 +18327,7 @@ msgstr "Rimuovi il tag %{name}"
 
 #: lib/vutuv_web/views/social_media_account_html.ex:24
 #, elixir-autogen, elixir-format
-msgid ""
-"Add this address to your Bluesky profile description (your bio), then run "
-"the check:"
+msgid "Add this address to your Bluesky profile description (your bio), then run the check:"
 msgstr ""
 "Aggiunga questo indirizzo alla descrizione del Suo profilo Bluesky (la Sua "
 "bio), poi avvii il controllo:"
@@ -19076,9 +18350,7 @@ msgstr "Profilo verificato. Ora mostra un contrassegno di verifica."
 
 #: lib/vutuv_web/templates/social_media_account/verify.html.heex:32
 #, elixir-autogen, elixir-format
-msgid ""
-"Prove this profile is yours by linking back to vutuv from it. It then shows "
-"a verified mark."
+msgid "Prove this profile is yours by linking back to vutuv from it. It then shows a verified mark."
 msgstr ""
 "Dimostri che questo profilo è Suo mettendovi un link di ritorno a vutuv. "
 "Mostrerà poi un contrassegno di verifica."
@@ -19149,10 +18421,7 @@ msgstr "Adesso"
 
 #: lib/vutuv_web/templates/username/confirm.html.heex:83
 #, elixir-autogen, elixir-format
-msgid ""
-"Once you confirm, your current profile address stops working, and anyone can"
-" claim the handle you leave behind. Mentions of your old handle in posts are"
-" rewritten to the new one."
+msgid "Once you confirm, your current profile address stops working, and anyone can claim the handle you leave behind. Mentions of your old handle in posts are rewritten to the new one."
 msgstr ""
 "Dopo la conferma, l'attuale indirizzo del Suo profilo smette di funzionare e"
 " chiunque può rivendicare l'handle che lascia libero. Le menzioni del Suo "
@@ -19160,18 +18429,14 @@ msgstr ""
 
 #: lib/vutuv_web/views/username_html.ex:28
 #, elixir-autogen, elixir-format
-msgid ""
-"You are still @%{handle}. The new name only takes effect once you confirm "
-"below."
+msgid "You are still @%{handle}. The new name only takes effect once you confirm below."
 msgstr ""
 "È ancora @%{handle}. Il nuovo nome ha effetto solo dopo che avrà confermato "
 "qui sotto."
 
 #: lib/vutuv_web/views/username_html.ex:21
 #, elixir-autogen, elixir-format
-msgid ""
-"You are still @%{handle}. The new name only takes effect once you confirm "
-"with the PIN below."
+msgid "You are still @%{handle}. The new name only takes effect once you confirm with the PIN below."
 msgstr ""
 "È ancora @%{handle}. Il nuovo nome ha effetto solo dopo che avrà confermato "
 "con il PIN qui sotto."
@@ -19183,18 +18448,14 @@ msgstr "L'indirizzo del Suo profilo, invariato."
 
 #: lib/vutuv_web/views/username_html.ex:50
 #, elixir-autogen, elixir-format
-msgid ""
-"Your username is your public identity here. It changes only once you enter a"
-" valid code below."
+msgid "Your username is your public identity here. It changes only once you enter a valid code below."
 msgstr ""
 "Il Suo nome utente è la Sua identità pubblica qui. Cambia solo dopo che avrà"
 " inserito un codice valido qui sotto."
 
 #: lib/vutuv_web/views/username_html.ex:44
 #, elixir-autogen, elixir-format
-msgid ""
-"Your username is your public identity here. It changes only once you confirm"
-" with your passkey or a valid code below."
+msgid "Your username is your public identity here. It changes only once you confirm with your passkey or a valid code below."
 msgstr ""
 "Il Suo nome utente è la Sua identità pubblica qui. Cambia solo dopo che avrà"
 " confermato con la Sua passkey o con un codice valido qui sotto."
@@ -19224,7 +18485,8 @@ msgstr "Attività"
 msgid "Animals & nature"
 msgstr "Animali e natura"
 
-#: lib/vutuv_web/components/ui.ex:315 lib/vutuv_web/components/ui.ex:339
+#: lib/vutuv_web/components/ui.ex:315
+#: lib/vutuv_web/components/ui.ex:339
 #, elixir-autogen, elixir-format
 msgid "Emoji"
 msgstr "Emoji"
@@ -19277,18 +18539,14 @@ msgstr "Impostazioni del Fediverso"
 
 #: lib/vutuv_web/components/fediverse_components.ex:515
 #, elixir-autogen, elixir-format
-msgid ""
-"Fetching a post asks its server for it in your name, signed with your own "
-"key, so there is no such thing as an anonymous lookup here."
+msgid "Fetching a post asks its server for it in your name, signed with your own key, so there is no such thing as an anonymous lookup here."
 msgstr ""
 "Scaricare un post significa chiederlo al suo server a Suo nome, firmato con "
 "la Sua chiave: qui una ricerca anonima non esiste."
 
 #: lib/vutuv_web/components/fediverse_components.ex:482
 #, elixir-autogen, elixir-format
-msgid ""
-"Its author published this post to their followers alone, so vutuv does not "
-"keep a copy of it."
+msgid "Its author published this post to their followers alone, so vutuv does not keep a copy of it."
 msgstr ""
 "Il suo autore ha pubblicato questo post solo per i propri follower, quindi "
 "vutuv non ne conserva una copia."
@@ -19312,10 +18570,7 @@ msgstr "Cerca un account invece di un singolo post?"
 
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:199
 #, elixir-autogen, elixir-format
-msgid ""
-"Paste the address of a post on Mastodon and friends. vutuv fetches it, shows"
-" it here, and you can answer, like or repost it as if it had arrived on its "
-"own."
+msgid "Paste the address of a post on Mastodon and friends. vutuv fetches it, shows it here, and you can answer, like or repost it as if it had arrived on its own."
 msgstr ""
 "Incolli l'indirizzo di un post su Mastodon e affini. vutuv lo scarica, lo "
 "mostra qui e Lei può rispondere, mettere Mi piace o ripubblicarlo come se "
@@ -19328,9 +18583,7 @@ msgstr "Ha letto qualcosa là fuori a cui vuole rispondere da qui?"
 
 #: lib/vutuv_web/components/fediverse_components.ex:467
 #, elixir-autogen, elixir-format
-msgid ""
-"That does not look like a link to a post. Copy the address of the post "
-"itself, for example https://server/@name/12345."
+msgid "That does not look like a link to a post. Copy the address of the post itself, for example https://server/@name/12345."
 msgstr ""
 "Questo non sembra un link a un post. Copi l'indirizzo del post stesso, ad "
 "esempio https://server/@nome/12345."
@@ -19357,9 +18610,7 @@ msgstr "Questo account non agisce più là fuori"
 
 #: lib/vutuv_web/components/fediverse_components.ex:527
 #, elixir-autogen, elixir-format
-msgid ""
-"This vutuv does not exchange anything with other networks. That is an "
-"operator setting, not yours."
+msgid "This vutuv does not exchange anything with other networks. That is an operator setting, not yours."
 msgstr ""
 "Questo vutuv non scambia nulla con altre reti. È un'impostazione di chi "
 "gestisce il sito, non Sua."
@@ -19386,25 +18637,19 @@ msgstr "Chi lo ha scritto"
 
 #: lib/vutuv_web/components/fediverse_components.ex:487
 #, elixir-autogen, elixir-format
-msgid ""
-"You have looked a lot of posts up in the last hour. Please try again later."
+msgid "You have looked a lot of posts up in the last hour. Please try again later."
 msgstr "Nell'ultima ora ha cercato molti post. Riprovi più tardi."
 
 #: lib/vutuv_web/components/fediverse_components.ex:521
 #, elixir-autogen, elixir-format
-msgid ""
-"You redirected your Fediverse followers to another account, so nothing is "
-"fetched or sent from this one any more."
+msgid "You redirected your Fediverse followers to another account, so nothing is fetched or sent from this one any more."
 msgstr ""
 "Ha reindirizzato i Suoi follower del Fediverso a un altro account, quindi da"
 " questo non viene più scaricato né inviato nulla."
 
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:340
 #, elixir-autogen, elixir-format
-msgid ""
-"vutuv keeps a copy of a post you look up for the same six months every other"
-" post from another network gets, and its author's server is asked nothing "
-"else."
+msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr ""
 "vutuv conserva una copia di un post che cerca per gli stessi sei mesi "
 "previsti per ogni altro post da un'altra rete, e al server del suo autore "
@@ -19484,8 +18729,7 @@ msgstr "Mosaico"
 
 #: lib/vutuv_web/live/post_live/composer.ex:1396
 #, elixir-autogen, elixir-format
-msgid ""
-"Pick a shape, then drag and zoom. The framed part is what the post shows."
+msgid "Pick a shape, then drag and zoom. The framed part is what the post shows."
 msgstr ""
 "Scelga una forma, poi trascini e ingrandisca. La parte nel riquadro è quella"
 " che il post mostra."
@@ -19518,9 +18762,7 @@ msgstr "Non è stato possibile ritagliare la foto."
 
 #: lib/vutuv_web/live/post_live/composer.ex:2387
 #, elixir-autogen, elixir-format
-msgid ""
-"This photo is cropped: downloads hand out the cropped picture, and the "
-"untouched upload stays private."
+msgid "This photo is cropped: downloads hand out the cropped picture, and the untouched upload stays private."
 msgstr ""
 "Questa foto è ritagliata: i download consegnano l'immagine ritagliata, e il "
 "caricamento intatto resta privato."
@@ -19557,9 +18799,7 @@ msgstr "Invia il post o il messaggio che sta scrivendo"
 
 #: lib/vutuv_web/templates/layout/app.html.heex:241
 #, elixir-autogen, elixir-format
-msgid ""
-"The single-key shortcuts pause while you type, and are off on phones and "
-"tablets."
+msgid "The single-key shortcuts pause while you type, and are off on phones and tablets."
 msgstr ""
 "Le scorciatoie a tasto singolo si sospendono mentre digita, e sono "
 "disattivate su telefoni e tablet."
@@ -19583,9 +18823,7 @@ msgstr ""
 
 #: lib/vutuv_web/views/error_html.ex:56
 #, elixir-autogen, elixir-format
-msgid ""
-"The most helpful detail in such a report is the exact time of the error. "
-"Right now it is %{time}."
+msgid "The most helpful detail in such a report is the exact time of the error. Right now it is %{time}."
 msgstr ""
 "Il dettaglio più utile in una segnalazione del genere è l'ora esatta "
 "dell'errore. In questo momento sono le %{time}."
@@ -19602,9 +18840,7 @@ msgstr "Quell'indirizzo è su questo vutuv, ma non indica alcun membro qui."
 
 #: lib/vutuv_web/controllers/remote_follow_controller.ex:216
 #, elixir-autogen, elixir-format
-msgid ""
-"That address is on this vutuv. Sign in and use the Follow button on this "
-"profile."
+msgid "That address is on this vutuv. Sign in and use the Follow button on this profile."
 msgstr ""
 "Quell'indirizzo è su questo vutuv. Acceda e usi il pulsante Segui su questo "
 "profilo."
@@ -19626,8 +18862,7 @@ msgstr "Segue già @%{handle} qui."
 
 #: lib/vutuv_web/controllers/remote_follow_controller.ex:151
 #, elixir-autogen, elixir-format
-msgid ""
-"You are on this vutuv yourself, so you now follow @%{handle} right here."
+msgid "You are on this vutuv yourself, so you now follow @%{handle} right here."
 msgstr "Anche Lei è su questo vutuv, quindi ora segue @%{handle} proprio qui."
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:119
@@ -19647,11 +18882,7 @@ msgstr "* sta per esattamente un segmento di percorso"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:337
 #, elixir-autogen, elixir-format
-msgid ""
-"Adding an entry stops new captures, but a page captured before it stays on "
-"the profile or post that shows it, because nothing re-captures a link whose "
-"URL has not changed. This removes every stored screenshot of a page that is "
-"on the list today."
+msgid "Adding an entry stops new captures, but a page captured before it stays on the profile or post that shows it, because nothing re-captures a link whose URL has not changed. This removes every stored screenshot of a page that is on the list today."
 msgstr ""
 "Aggiungere una voce ferma le nuove acquisizioni, ma una pagina acquisita "
 "prima resta sul profilo o sul post che la mostra, perché nulla riacquisisce "
@@ -19687,12 +18918,7 @@ msgstr "Non bloccata: questa pagina viene acquisita normalmente."
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:217
 #, elixir-autogen, elixir-format
-msgid ""
-"Pages this installation never screenshots. Some sites answer a headless "
-"capture with a cookie banner, a login wall or a bot check, so the picture "
-"shows the dialog instead of the page. Nothing else changes for a listed "
-"link: a post shows the plain link, and a profile link shows the site's name "
-"in place of a thumbnail."
+msgid "Pages this installation never screenshots. Some sites answer a headless capture with a cookie banner, a login wall or a bot check, so the picture shows the dialog instead of the page. Nothing else changes for a listed link: a post shows the plain link, and a profile link shows the site's name in place of a thumbnail."
 msgstr ""
 "Pagine di cui questa installazione non fa mai screenshot. Alcuni siti "
 "rispondono a un'acquisizione automatica con un avviso sui cookie, una "
@@ -19784,10 +19010,7 @@ msgstr "Modifica l'elenco dei bloccati"
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:214
 #, elixir-autogen, elixir-format
-msgid ""
-"Pages never to screenshot, because a headless capture only ever gets their "
-"cookie banner or login wall. Add a domain or a single URL, and the links "
-"stay plain instead."
+msgid "Pages never to screenshot, because a headless capture only ever gets their cookie banner or login wall. Add a domain or a single URL, and the links stay plain instead."
 msgstr ""
 "Pagine di cui non fare mai screenshot, perché un'acquisizione automatica ne "
 "coglie sempre e solo l'avviso sui cookie o la richiesta di accesso. Aggiunga"
@@ -19800,8 +19023,7 @@ msgstr "Elenco dei bloccati per gli screenshot"
 
 #: lib/vutuv_web/components/post_components.ex:428
 #, elixir-autogen, elixir-format
-msgid ""
-"Nothing from the fediverse yet. Follow accounts out there to fill this tab."
+msgid "Nothing from the fediverse yet. Follow accounts out there to fill this tab."
 msgstr ""
 "Ancora nulla dal Fediverso. Segua account là fuori per riempire questa "
 "scheda."
@@ -19848,7 +19070,7 @@ msgstr "Nessun post su vutuv porta ancora questo tag."
 msgid "word in a post"
 msgstr "parola in un post"
 
-#: lib/vutuv_web/components/post_components.ex:2416
+#: lib/vutuv_web/components/post_components.ex:2431
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr "Quella risposta non è più qui."
@@ -19860,9 +19082,7 @@ msgstr "Nulla di salvato da altre reti corrisponde."
 
 #: lib/vutuv_web/live/post_live/saved.ex:485
 #, elixir-autogen, elixir-format
-msgid ""
-"Nothing saved from other networks yet. The bookmark on a post or reply from "
-"another network keeps it here."
+msgid "Nothing saved from other networks yet. The bookmark on a post or reply from another network keeps it here."
 msgstr ""
 "Ancora nulla di salvato da altre reti. Il salvataggio di un post o di una "
 "risposta da un'altra rete lo conserva qui."
@@ -19890,59 +19110,48 @@ msgstr "Altro da %{name}"
 
 #: lib/vutuv_web/live/fediverse_post_live.ex:121
 #, elixir-autogen, elixir-format
-msgid ""
-"This is vutuv's copy of a post published on %{host}. It is kept while "
-"somebody here follows its author."
+msgid "This is vutuv's copy of a post published on %{host}. It is kept while somebody here follows its author."
 msgstr ""
 "Questa è la copia vutuv di un post pubblicato su %{host}. Viene conservata "
 "finché qualcuno qui segue il suo autore."
 
-#: lib/vutuv_web/components/ui.ex:1133 lib/vutuv_web/components/ui.ex:1134
+#: lib/vutuv_web/components/ui.ex:1133
+#: lib/vutuv_web/components/ui.ex:1134
 #, elixir-autogen, elixir-format
 msgid "Subscribe to this feed in your RSS reader"
 msgstr "Si iscriva a questo feed nel Suo lettore RSS"
 
 #: lib/vutuv_web/views/page_html.ex:508
 #, elixir-autogen, elixir-format
-msgid ""
-"A CV with positions, education, certificates including proof, spoken "
-"languages and tags other members endorse you for."
+msgid "A CV with positions, education, certificates including proof, spoken languages and tags other members endorse you for."
 msgstr ""
 "Un CV con posizioni, formazione, certificati con tanto di prova, lingue "
 "parlate e tag per cui altri membri La confermano."
 
 #: lib/vutuv_web/templates/page/index.html.heex:418
 #, elixir-autogen, elixir-format
-msgid ""
-"A business network that is free, does not lock your data in, and is yours to"
-" run yourself if you want to."
+msgid "A business network that is free, does not lock your data in, and is yours to run yourself if you want to."
 msgstr ""
 "Una rete professionale gratuita, che non tiene prigionieri i Suoi dati e "
 "che, se vuole, può gestire Lei stesso."
 
 #: lib/vutuv_web/views/page_html.ex:523
 #, elixir-autogen, elixir-format
-msgid ""
-"A job board with radius search and saved searches that email you when "
-"something matches."
+msgid "A job board with radius search and saved searches that email you when something matches."
 msgstr ""
 "Una bacheca di annunci con ricerca per raggio e ricerche salvate che Le "
 "scrivono quando qualcosa corrisponde."
 
 #: lib/vutuv_web/views/page_html.ex:514
 #, elixir-autogen, elixir-format
-msgid ""
-"A permanent public address, readable without an account and downloadable as "
-"a vCard."
+msgid "A permanent public address, readable without an account and downloadable as a vCard."
 msgstr ""
 "Un indirizzo pubblico permanente, leggibile senza account e scaricabile come"
 " vCard."
 
 #: lib/vutuv_web/views/page_html.ex:511
 #, elixir-autogen, elixir-format
-msgid ""
-"CV download as PDF, Word, OpenDocument, LaTeX or JSON Resume, and you pick "
-"what goes in before you download it."
+msgid "CV download as PDF, Word, OpenDocument, LaTeX or JSON Resume, and you pick what goes in before you download it."
 msgstr ""
 "Download del CV in PDF, Word, OpenDocument, LaTeX o JSON Resume, e sceglie "
 "Lei cosa includere prima di scaricarlo."
@@ -19954,9 +19163,7 @@ msgstr "Documentazione per sviluppatori"
 
 #: lib/vutuv_web/templates/page/index.html.heex:431
 #, elixir-autogen, elixir-format
-msgid ""
-"Every public page here is also served as Markdown, plain text, JSON and XML "
-"under the same address. No scraping, no API key, no account."
+msgid "Every public page here is also served as Markdown, plain text, JSON and XML under the same address. No scraping, no API key, no account."
 msgstr ""
 "Qui ogni pagina pubblica è servita anche in Markdown, testo semplice, JSON e"
 " XML allo stesso indirizzo. Niente scraping, niente chiave API, niente "
@@ -19974,18 +19181,14 @@ msgstr "Aperto per impostazione predefinita"
 
 #: lib/vutuv_web/views/page_html.ex:539
 #, elixir-autogen, elixir-format
-msgid ""
-"Open source under the MIT license, and you can run your own installation on "
-"the internet or in your own intranet."
+msgid "Open source under the MIT license, and you can run your own installation on the internet or in your own intranet."
 msgstr ""
 "Open source con licenza MIT, e può gestire una Sua installazione su internet"
 " o nella Sua intranet."
 
 #: lib/vutuv_web/views/page_html.ex:526
 #, elixir-autogen, elixir-format
-msgid ""
-"Organization pages that only exist once somebody has proven control of the "
-"organization's domain."
+msgid "Organization pages that only exist once somebody has proven control of the organization's domain."
 msgstr ""
 "Pagine di organizzazione che esistono solo dopo che qualcuno ha dimostrato "
 "di controllare il dominio dell'organizzazione."
@@ -20014,9 +19217,7 @@ msgstr "Lo gestisca Lei"
 
 #: lib/vutuv_web/views/page_html.ex:536
 #, elixir-autogen, elixir-format
-msgid ""
-"Sign in without a password, by emailed PIN, passkey, authenticator app or a "
-"printed list of codes."
+msgid "Sign in without a password, by emailed PIN, passkey, authenticator app or a printed list of codes."
 msgstr ""
 "Acceda senza password, con un PIN via e-mail, una passkey, un'app di "
 "autenticazione o un elenco di codici stampato."
@@ -20049,10 +19250,7 @@ msgstr "La Sua indipendenza"
 
 #: lib/vutuv_web/templates/page/index.html.heex:456
 #, elixir-autogen, elixir-format
-msgid ""
-"vutuv is open source under the MIT license. Run it for a company, an "
-"association or a school, on the internet or air-gapped inside your own "
-"network."
+msgid "vutuv is open source under the MIT license. Run it for a company, an association or a school, on the internet or air-gapped inside your own network."
 msgstr ""
 "vutuv è open source con licenza MIT. Lo faccia girare per un'azienda, "
 "un'associazione o una scuola, su internet o isolato dentro la Sua rete."
@@ -20064,10 +19262,7 @@ msgstr "Uno sguardo dentro"
 
 #: lib/vutuv_web/views/page_html.ex:185
 #, elixir-autogen, elixir-format
-msgid ""
-"A vutuv profile: cover picture, photo, name, tagline and job title, follower"
-" counts and the first posts, with contact details and social media profiles "
-"in a column on the right."
+msgid "A vutuv profile: cover picture, photo, name, tagline and job title, follower counts and the first posts, with contact details and social media profiles in a column on the right."
 msgstr ""
 "Un profilo vutuv: immagine di copertina, foto, nome, descrizione breve e "
 "qualifica, numero di follower e i primi post, con recapiti e profili social "
@@ -20080,10 +19275,7 @@ msgstr "Sfogli profili veri"
 
 #: lib/vutuv_web/views/page_html.ex:207
 #, elixir-autogen, elixir-format
-msgid ""
-"The lower part of the profile: spoken languages with levels, web links each "
-"shown as a preview image with a verification mark, and a panel offering the "
-"CV for download."
+msgid "The lower part of the profile: spoken languages with levels, web links each shown as a preview image with a verification mark, and a panel offering the CV for download."
 msgstr ""
 "La parte bassa del profilo: lingue parlate con i relativi livelli, link web "
 "mostrati ciascuno come immagine di anteprima con un contrassegno di "
@@ -20091,9 +19283,7 @@ msgstr ""
 
 #: lib/vutuv_web/views/page_html.ex:197
 #, elixir-autogen, elixir-format
-msgid ""
-"The same profile further down: tags, each with the number of members who "
-"endorse it, and a CV as a timeline of positions with employer and duration."
+msgid "The same profile further down: tags, each with the number of members who endorse it, and a CV as a timeline of positions with employer and duration."
 msgstr ""
 "Lo stesso profilo più in basso: i tag, ciascuno con il numero di membri che "
 "lo confermano, e un CV come sequenza di posizioni con datore di lavoro e "
@@ -20106,19 +19296,14 @@ msgstr "Lo provi:"
 
 #: lib/vutuv_web/templates/page/index.html.heex:447
 #, elixir-autogen, elixir-format
-msgid ""
-"Plus a sitemap, JSON-LD and a REST API with OAuth 2 and personal access "
-"tokens."
+msgid "Plus a sitemap, JSON-LD and a REST API with OAuth 2 and personal access tokens."
 msgstr ""
 "In più una sitemap, JSON-LD e un'API REST con OAuth 2 e token di accesso "
 "personali."
 
 #: lib/vutuv_web/templates/page/index.html.heex:302
 #, elixir-autogen, elixir-format
-msgid ""
-"Work experience, education, certificates, languages, links and tags others "
-"endorse you for. Anyone can read a profile, entirely without a vutuv "
-"account. Unlike LinkedIn, where you hit a login wall in short order."
+msgid "Work experience, education, certificates, languages, links and tags others endorse you for. Anyone can read a profile, entirely without a vutuv account. Unlike LinkedIn, where you hit a login wall in short order."
 msgstr ""
 "Esperienza lavorativa, formazione, certificati, lingue, link e tag per cui "
 "altri La confermano. Chiunque può leggere un profilo, senza alcun account "
@@ -20132,10 +19317,7 @@ msgstr "Parlare con le persone"
 
 #: lib/vutuv_web/views/page_html.ex:236
 #, elixir-autogen, elixir-format
-msgid ""
-"The settings page for followed Fediverse accounts: a field to enter an "
-"address like @name@server, and a table of accounts already followed with "
-"their server and an unfollow link."
+msgid "The settings page for followed Fediverse accounts: a field to enter an address like @name@server, and a table of accounts already followed with their server and an unfollow link."
 msgstr ""
 "La pagina delle impostazioni per gli account seguiti nel Fediverso: un campo"
 " per inserire un indirizzo come @nome@server e una tabella degli account già"
@@ -20143,10 +19325,7 @@ msgstr ""
 
 #: lib/vutuv_web/views/page_html.ex:226
 #, elixir-autogen, elixir-format
-msgid ""
-"The vutuv feed with the Fediverse tab selected: posts by news accounts on "
-"ard.social, mastodon.social and bonn.social, each with the server it came "
-"from, and heart, reply and repost counts underneath."
+msgid "The vutuv feed with the Fediverse tab selected: posts by news accounts on ard.social, mastodon.social and bonn.social, each with the server it came from, and heart, reply and repost counts underneath."
 msgstr ""
 "Il feed di vutuv con la scheda Fediverso selezionata: post di account di "
 "notizie su ard.social, mastodon.social e bonn.social, ciascuno con il server"
@@ -20154,9 +19333,7 @@ msgstr ""
 
 #: lib/vutuv_web/views/page_html.ex:477
 #, elixir-autogen, elixir-format
-msgid ""
-"The Fediverse: let people follow you from Mastodon, and your public posts "
-"show up there. You choose at sign-up, and can change it later."
+msgid "The Fediverse: let people follow you from Mastodon, and your public posts show up there. You choose at sign-up, and can change it later."
 msgstr ""
 "Il Fediverso: si faccia seguire da Mastodon, e i Suoi post pubblici "
 "compariranno lì. Sceglie al momento dell'iscrizione, e può cambiare idea in "
@@ -20169,15 +19346,7 @@ msgstr "Post, messaggi e con essi il Fediverso"
 
 #: lib/vutuv_web/templates/page/index.html.heex:405
 #, elixir-autogen, elixir-format
-msgid ""
-"Write a post, react with a heart, a repost or a reply, or message somebody "
-"privately. And you are not stuck among vutuv members: vutuv is part of the "
-"Fediverse, the union of independent networks that Mastodon belongs to as "
-"well. Follow an account over there and its posts arrive in your feed; the "
-"other way round, people there can follow you and see your public posts. Both"
-" directions, and entirely your choice: at sign-up you decide whether to use "
-"vutuv with or without the Fediverse, and you can change that at any time in "
-"the settings."
+msgid "Write a post, react with a heart, a repost or a reply, or message somebody privately. And you are not stuck among vutuv members: vutuv is part of the Fediverse, the union of independent networks that Mastodon belongs to as well. Follow an account over there and its posts arrive in your feed; the other way round, people there can follow you and see your public posts. Both directions, and entirely your choice: at sign-up you decide whether to use vutuv with or without the Fediverse, and you can change that at any time in the settings."
 msgstr ""
 "Scriva un post, reagisca con un cuore, una ripubblicazione o una risposta, "
 "oppure scriva a qualcuno in privato. E non è chiuso fra i soli membri di "
@@ -20190,10 +19359,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/page/index.html.heex:518
 #, elixir-autogen, elixir-format
-msgid ""
-"Download everything you have here at any time, in a machine-readable file. "
-"Not on request, not after a waiting period: from your settings, whenever you"
-" like."
+msgid "Download everything you have here at any time, in a machine-readable file. Not on request, not after a waiting period: from your settings, whenever you like."
 msgstr ""
 "Scarichi in qualsiasi momento tutto ciò che ha qui, in un file leggibile "
 "dalle macchine. Non su richiesta, non dopo un periodo di attesa: dalle Sue "
@@ -20211,10 +19377,7 @@ msgstr "Nessun cookie di terze parti"
 
 #: lib/vutuv_web/templates/page/index.html.heex:499
 #, elixir-autogen, elixir-format
-msgid ""
-"On our own servers in %{place}, not in somebody else's cloud. We do not hand"
-" your profile to a third party, and there is no tracking network reading "
-"along."
+msgid "On our own servers in %{place}, not in somebody else's cloud. We do not hand your profile to a third party, and there is no tracking network reading along."
 msgstr ""
 "Sui nostri server in %{place}, non nella nuvola di qualcun altro. Non "
 "consegniamo il Suo profilo a terzi, e non c'è alcuna rete di tracciamento "
@@ -20232,9 +19395,7 @@ msgstr "I Suoi dati"
 
 #: lib/vutuv_web/templates/page/index.html.heex:509
 #, elixir-autogen, elixir-format
-msgid ""
-"vutuv sets one cookie, the one that keeps you signed in. No advertising "
-"network, no analytics service, nothing loaded from anybody else's server."
+msgid "vutuv sets one cookie, the one that keeps you signed in. No advertising network, no analytics service, nothing loaded from anybody else's server."
 msgstr ""
 "vutuv imposta un solo cookie, quello che La tiene connesso. Nessuna rete "
 "pubblicitaria, nessun servizio di statistiche, nulla caricato dal server di "
@@ -20252,10 +19413,7 @@ msgstr "Open source"
 
 #: lib/vutuv_web/templates/page/index.html.heex:543
 #, elixir-autogen, elixir-format
-msgid ""
-"You can check at any time how exactly vutuv works. The whole source code is "
-"public under the MIT license, so everything said above about your data can "
-"be read rather than taken on trust."
+msgid "You can check at any time how exactly vutuv works. The whole source code is public under the MIT license, so everything said above about your data can be read rather than taken on trust."
 msgstr ""
 "Può verificare in qualsiasi momento come funziona esattamente vutuv. "
 "L'intero codice sorgente è pubblico con licenza MIT, quindi tutto quello che"
@@ -20269,9 +19427,7 @@ msgstr "I Suoi dati restano Suoi"
 
 #: lib/vutuv_web/templates/page/index.html.heex:532
 #, elixir-autogen, elixir-format
-msgid ""
-"Delete your account yourself, without writing to anybody. No questions "
-"asked, and you are welcome back any time."
+msgid "Delete your account yourself, without writing to anybody. No questions asked, and you are welcome back any time."
 msgstr ""
 "Elimini il Suo account da sé, senza scrivere a nessuno. Nessuna domanda, e "
 "può tornare quando vuole."
@@ -20283,9 +19439,7 @@ msgstr "Al massimo %{max} tag. Ne rimuova uno per aggiungerne un altro."
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:93
 #, elixir-autogen, elixir-format
-msgid ""
-"A post's page shows the members who liked it, right under the count. This is"
-" whether you are one of the faces."
+msgid "A post's page shows the members who liked it, right under the count. This is whether you are one of the faces."
 msgstr ""
 "La pagina di un post mostra i membri a cui è piaciuto, subito sotto il "
 "contatore. Questa impostazione decide se Lei è tra quei volti."
@@ -20295,23 +19449,21 @@ msgstr ""
 msgid "Liked by"
 msgstr "Piace a"
 
-#: lib/vutuv_web/components/post_components.ex:4208
+#: lib/vutuv_web/components/post_components.ex:4238
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Piace a %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:4210
+#: lib/vutuv_web/components/post_components.ex:4240
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Piace a %{name} e a %{formatted} altro"
 msgstr[1] "Piace a %{name} e ad altri %{formatted}"
 
-#: lib/vutuv_web/components/post_components.ex:4221
+#: lib/vutuv_web/components/post_components.ex:4251
 #, elixir-autogen, elixir-format
-msgid ""
-"Only you see everyone here: some of these members are not named to other "
-"readers."
+msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
 "Solo Lei li vede tutti qui: alcuni di questi membri non vengono nominati "
 "agli altri lettori."
@@ -20328,17 +19480,14 @@ msgstr "Mostra il mio nome sui post a cui metto Mi piace"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:76
 #, elixir-autogen, elixir-format
-msgid ""
-"When off, other members no longer see you among the likes of a post. The "
-"author of the post still does: we named you in the notification they got "
-"when you liked it. Either way the post keeps the same number of likes."
+msgid "When off, other members no longer see you among the likes of a post. The author of the post still does: we named you in the notification they got when you liked it. Either way the post keeps the same number of likes."
 msgstr ""
 "Se disattivo, gli altri membri non La vedono più tra i Mi piace di un post. "
 "L'autore del post continua a vederla: L'abbiamo nominata nella notifica che "
 "ha ricevuto quando ha messo Mi piace. In ogni caso il post mantiene lo "
 "stesso numero di Mi piace."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:864
+#: lib/vutuv_web/controllers/settings_controller.ex:835
 #, elixir-autogen, elixir-format
 msgid "Your likes follow the site default again."
 msgstr "I Suoi Mi piace tornano a seguire il valore predefinito del sito."
@@ -20385,10 +19534,7 @@ msgstr "Aggiungi un attestato di lavoro"
 
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:302
 #, elixir-autogen, elixir-format
-msgid ""
-"Anyone can then read and download it, including search engines. Black out "
-"anything you do not want to share (your address, your date of birth, "
-"signatures) before uploading."
+msgid "Anyone can then read and download it, including search engines. Black out anything you do not want to share (your address, your date of birth, signatures) before uploading."
 msgstr ""
 "Chiunque potrà poi leggerlo e scaricarlo, motori di ricerca compresi. Prima "
 "di caricarlo, oscuri tutto ciò che non vuole condividere (il Suo indirizzo, "
@@ -20449,7 +19595,7 @@ msgstr "Attestato di lavoro salvato."
 msgid "Employment reference updated."
 msgstr "Attestato di lavoro aggiornato."
 
-#: lib/vutuv_web/components/ui.ex:4315
+#: lib/vutuv_web/components/ui.ex:4325
 #: lib/vutuv_web/controllers/job_reference_controller.ex:57
 #: lib/vutuv_web/controllers/job_reference_controller.ex:95
 #: lib/vutuv_web/templates/job_reference/check.html.heex:11
@@ -20572,9 +19718,7 @@ msgstr "L'analisi con l'IA non è disponibile su questa installazione."
 
 #: lib/vutuv_web/live/reference_check_live.ex:195
 #, elixir-autogen, elixir-format
-msgid ""
-"The AI review reads German employment law and is therefore offered for "
-"German Arbeitszeugnisse only."
+msgid "The AI review reads German employment law and is therefore offered for German Arbeitszeugnisse only."
 msgstr ""
 "L'analisi con l'IA si basa sul diritto del lavoro tedesco ed è quindi "
 "offerta solo per gli Arbeitszeugnisse tedeschi."
@@ -20630,9 +19774,7 @@ msgstr "Riprova"
 
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:10
 #, elixir-autogen, elixir-format
-msgid ""
-"Upload your Arbeitszeugnisse, attach them to your CV, and have them "
-"reviewed. Nothing is public until you say so."
+msgid "Upload your Arbeitszeugnisse, attach them to your CV, and have them reviewed. Nothing is public until you say so."
 msgstr ""
 "Carichi i Suoi Arbeitszeugnisse, li alleghi al Suo CV e li faccia "
 "analizzare. Nulla è pubblico finché non lo decide Lei."
@@ -20651,13 +19793,12 @@ msgstr "In attesa: la Sua è la prossima."
 
 #: lib/vutuv_web/templates/job_reference/check.html.heex:66
 #, elixir-autogen, elixir-format
-msgid ""
-"You changed the text after this review. It describes the earlier version."
+msgid "You changed the text after this review. It describes the earlier version."
 msgstr ""
 "Ha modificato il testo dopo questa analisi. L'analisi descrive la versione "
 "precedente."
 
-#: lib/vutuv_web/components/ui.ex:4316
+#: lib/vutuv_web/components/ui.ex:4326
 #, elixir-autogen, elixir-format
 msgid "Your Arbeitszeugnisse, private unless you publish them"
 msgstr "I Suoi Arbeitszeugnisse, privati finché non li pubblica"
@@ -20668,7 +19809,7 @@ msgstr "I Suoi Arbeitszeugnisse, privati finché non li pubblica"
 msgid "Zwischenzeugnis"
 msgstr "Zwischenzeugnis"
 
-#: lib/vutuv_web/components/ui.ex:4318
+#: lib/vutuv_web/components/ui.ex:4328
 #, elixir-autogen, elixir-format
 msgid "arbeitszeugnis reference letter testimonial employer evaluation review"
 msgstr ""
@@ -20682,9 +19823,7 @@ msgstr "ad esempio Zeugnis Muster GmbH 2019–2026"
 
 #: lib/vutuv_web/templates/job_reference/check.html.heex:116
 #, elixir-autogen, elixir-format
-msgid ""
-"For a binding assessment please ask a lawyer, ideally a Fachanwalt für "
-"Arbeitsrecht."
+msgid "For a binding assessment please ask a lawyer, ideally a Fachanwalt für Arbeitsrecht."
 msgstr ""
 "Per una valutazione vincolante si rivolga a un avvocato, preferibilmente un "
 "Fachanwalt für Arbeitsrecht (specialista in diritto del lavoro tedesco)."
@@ -20702,9 +19841,7 @@ msgstr "Questo non è un parere legale."
 
 #: lib/vutuv_web/templates/job_reference/check.html.heex:113
 #, elixir-autogen, elixir-format
-msgid ""
-"We do not assess your case. What you see is an automated reading of the "
-"wording of your document, produced on our own servers by a language model."
+msgid "We do not assess your case. What you see is an automated reading of the wording of your document, produced on our own servers by a language model."
 msgstr ""
 "Non valutiamo il Suo caso. Quello che vede è una lettura automatica del "
 "testo del Suo documento, prodotta sui nostri server da un modello "
@@ -20759,8 +19896,7 @@ msgstr "Controlli il testo"
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:116
 #: lib/vutuv_web/templates/job_reference/view.html.heex:104
 #, elixir-autogen, elixir-format
-msgid ""
-"Delete this reference, its document and its review? This cannot be undone."
+msgid "Delete this reference, its document and its review? This cannot be undone."
 msgstr ""
 "Eliminare questo attestato, il suo documento e la sua analisi? L'operazione "
 "non si può annullare."
@@ -20793,9 +19929,7 @@ msgstr "Ha modificato il testo dopo questa analisi."
 
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:231
 #, elixir-autogen, elixir-format
-msgid ""
-"A language model reads wording and can be wrong. For a binding assessment "
-"ask a lawyer, ideally a Fachanwalt für Arbeitsrecht."
+msgid "A language model reads wording and can be wrong. For a binding assessment ask a lawyer, ideally a Fachanwalt für Arbeitsrecht."
 msgstr ""
 "Un modello linguistico legge il testo e può sbagliare. Per una valutazione "
 "vincolante si rivolga a un avvocato, preferibilmente un Fachanwalt für "
@@ -20813,19 +19947,14 @@ msgstr "Non è un parere legale."
 
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:153
 #, elixir-autogen, elixir-format
-msgid ""
-"It is not sent to ChatGPT, to Google or to any other company. There is no "
-"account and no interface anywhere else through which it could travel."
+msgid "It is not sent to ChatGPT, to Google or to any other company. There is no account and no interface anywhere else through which it could travel."
 msgstr ""
 "Non viene inviato a ChatGPT, a Google né ad alcun'altra azienda. Non esiste "
 "alcun account né alcuna interfaccia altrove attraverso cui potrebbe passare."
 
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:220
 #, elixir-autogen, elixir-format
-msgid ""
-"Nobody else can open a review, and publishing a reference on your profile "
-"never publishes its review. What a machine read into your Zeugnis is "
-"nobody's business but yours."
+msgid "Nobody else can open a review, and publishing a reference on your profile never publishes its review. What a machine read into your Zeugnis is nobody's business but yours."
 msgstr ""
 "Nessun altro può aprire un'analisi, e pubblicare un attestato sul Suo "
 "profilo non ne pubblica mai l'analisi. Quello che una macchina ha letto nel "
@@ -20865,7 +19994,7 @@ msgstr[0] "%{count} minuto"
 msgstr[1] "%{count} minuti"
 
 #: lib/vutuv_web/live/reference_check_live.ex:156
-#: lib/vutuv_web/templates/settings/preferences.html.heex:285
+#: lib/vutuv_web/templates/settings/preferences.html.heex:235
 #, elixir-autogen, elixir-format
 msgid "%{count} second"
 msgid_plural "%{count} seconds"
@@ -20932,9 +20061,7 @@ msgstr "Di solito circa %{duration}."
 
 #: lib/vutuv_web/templates/settings/notifications.html.heex:68
 #, elixir-autogen, elixir-format
-msgid ""
-"When the review of one of your employment references is finished. It takes "
-"minutes, so you can close the page and wait for the email."
+msgid "When the review of one of your employment references is finished. It takes minutes, so you can close the page and wait for the email."
 msgstr ""
 "Quando l'analisi di uno dei Suoi attestati di lavoro è terminata. Ci "
 "vogliono alcuni minuti, quindi può chiudere la pagina e aspettare l'e-mail."
@@ -20971,10 +20098,7 @@ msgstr "Il rapporto completo"
 
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:239
 #, elixir-autogen, elixir-format
-msgid ""
-"This is the text of your document and cannot be edited: the review grades "
-"this exact wording. If it was read wrongly, delete this reference and upload"
-" it again."
+msgid "This is the text of your document and cannot be edited: the review grades this exact wording. If it was read wrongly, delete this reference and upload it again."
 msgstr ""
 "Questo è il testo del Suo documento e non è modificabile: l'analisi valuta "
 "esattamente questa formulazione. Se è stato letto male, elimini l'attestato "
@@ -20982,10 +20106,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:83
 #, elixir-autogen, elixir-format
-msgid ""
-"A reference belongs to the person it is about. If this one is somebody "
-"else's, ask them first: without their explicit agreement you may not upload "
-"it here or have it reviewed."
+msgid "A reference belongs to the person it is about. If this one is somebody else's, ask them first: without their explicit agreement you may not upload it here or have it reviewed."
 msgstr ""
 "Un attestato appartiene alla persona di cui parla. Se questo è di qualcun "
 "altro, glielo chieda prima: senza il suo consenso esplicito non può "
@@ -21003,11 +20124,7 @@ msgstr "Decifri questo attestato"
 
 #: lib/vutuv_web/live/reference_check_live.ex:237
 #, elixir-autogen, elixir-format
-msgid ""
-"German references are graded in code, so friendly words can carry a poor "
-"mark. We read the wording against German employment-reference law and tell "
-"you which grade is in it, what each assessing phrase really says, and what "
-"is missing, contradictory or formally wrong."
+msgid "German references are graded in code, so friendly words can carry a poor mark. We read the wording against German employment-reference law and tell you which grade is in it, what each assessing phrase really says, and what is missing, contradictory or formally wrong."
 msgstr ""
 "Gli attestati tedeschi sono valutati in codice, quindi parole cordiali "
 "possono nascondere un voto scarso. Leggiamo il testo alla luce del diritto "
@@ -21022,9 +20139,7 @@ msgstr "L'esito lo vede solo Lei."
 
 #: lib/vutuv_web/live/reference_check_live.ex:389
 #, elixir-autogen, elixir-format
-msgid ""
-"You can leave this page. The result lands in your notifications, and we "
-"email it to you if you are no longer here by then."
+msgid "You can leave this page. The result lands in your notifications, and we email it to you if you are no longer here by then."
 msgstr ""
 "Può lasciare questa pagina. L'esito arriva nelle Sue notifiche, e Glielo "
 "inviamo per e-mail se nel frattempo non è più qui."
@@ -21041,9 +20156,7 @@ msgstr "Serve solo se non ha un file da caricare."
 
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:58
 #, elixir-autogen, elixir-format
-msgid ""
-"Upload the PDF or the scan. We read the text out of it, and the review "
-"always reads that text, never the file itself."
+msgid "Upload the PDF or the scan. We read the text out of it, and the review always reads that text, never the file itself."
 msgstr ""
 "Carichi il PDF o la scansione. Ne estraiamo il testo, e l'analisi legge "
 "sempre quel testo, mai il file stesso."
@@ -21150,11 +20263,7 @@ msgstr "È successo qualcosa di nuovo sul Suo account."
 
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:192
 #, elixir-autogen, elixir-format
-msgid ""
-"Which wording counts as which grade is not our own invention. We follow the "
-"Arbeitszeugnis-Prüfer, a set of instructions published under the MIT and "
-"Apache 2.0 licences by the lawyer Tom Braegelmann ({account}). You can read "
-"every rule the model is given:"
+msgid "Which wording counts as which grade is not our own invention. We follow the Arbeitszeugnis-Prüfer, a set of instructions published under the MIT and Apache 2.0 licences by the lawyer Tom Braegelmann ({account}). You can read every rule the model is given:"
 msgstr ""
 "Quale formula corrisponde a quale voto non l'abbiamo inventato noi. Seguiamo"
 " l'Arbeitszeugnis-Prüfer, una serie di istruzioni pubblicate con licenza MIT"
@@ -21212,18 +20321,14 @@ msgstr "Apri questo attestato"
 
 #: lib/vutuv_web/views/job_reference_html.ex:382
 #, elixir-autogen, elixir-format
-msgid ""
-"You have used your %{limit} reviews for the last %{window}. The next one is "
-"possible again in about %{wait}."
+msgid "You have used your %{limit} reviews for the last %{window}. The next one is possible again in about %{wait}."
 msgstr ""
 "Ha usato le Sue %{limit} analisi nell'arco di %{window}. La prossima sarà di"
 " nuovo possibile fra circa %{wait}."
 
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:156
 #, elixir-autogen, elixir-format
-msgid ""
-"Choosing a new file below replaces this one; the text is kept either way. "
-"The file itself can only go together with the whole reference."
+msgid "Choosing a new file below replaces this one; the text is kept either way. The file itself can only go together with the whole reference."
 msgstr ""
 "Scegliendo un nuovo file qui sotto, questo viene sostituito; in ogni caso il"
 " testo resta. Il file in sé può sparire solo insieme all'intero attestato."
@@ -21250,9 +20355,7 @@ msgstr "Il Suo attestato resta sui nostri server in %{country}."
 
 #: lib/vutuv_web/views/job_reference_html.ex:376
 #, elixir-autogen, elixir-format
-msgid ""
-"You have reached your limit of %{limit} reviews. Please try again in "
-"%{window}."
+msgid "You have reached your limit of %{limit} reviews. Please try again in %{window}."
 msgstr ""
 "Ha raggiunto il Suo limite di %{limit} analisi. Riprovi fra %{window}."
 
@@ -21263,9 +20366,7 @@ msgstr "Attestato di lavoro"
 
 #: lib/vutuv_web/views/page_html.ex:493
 #, elixir-autogen, elixir-format
-msgid ""
-"Employment references: upload them, keep them private, and have the wording "
-"read and graded on our own servers."
+msgid "Employment references: upload them, keep them private, and have the wording read and graded on our own servers."
 msgstr ""
 "Attestati di lavoro: li carichi, li tenga privati e faccia leggere e "
 "valutare il loro testo sui nostri server."
@@ -21277,10 +20378,7 @@ msgstr "Candidature"
 
 #: lib/vutuv_web/views/page_html.ex:257
 #, elixir-autogen, elixir-format
-msgid ""
-"The CV builder: a checklist of everything that could go into the CV, with "
-"name, photo, tagline and contact details, and beside it a panel offering the"
-" download as PDF, Word, OpenDocument, LaTeX or JSON Resume."
+msgid "The CV builder: a checklist of everything that could go into the CV, with name, photo, tagline and contact details, and beside it a panel offering the download as PDF, Word, OpenDocument, LaTeX or JSON Resume."
 msgstr ""
 "Il generatore di CV: un elenco di spunte con tutto ciò che può entrare nel "
 "CV, con nome, foto, descrizione breve e recapiti, e accanto un riquadro che "
@@ -21288,10 +20386,7 @@ msgstr ""
 
 #: lib/vutuv_web/views/page_html.ex:267
 #, elixir-autogen, elixir-format
-msgid ""
-"The finished CV ready to print: name, tagline and contact details at the "
-"top, below them the positions held with employer and period, and further "
-"down the tags and the spoken languages."
+msgid "The finished CV ready to print: name, tagline and contact details at the top, below them the positions held with employer and period, and further down the tags and the spoken languages."
 msgstr ""
 "Il CV finito pronto per la stampa: in alto nome, descrizione breve e "
 "recapiti, sotto le posizioni ricoperte con datore di lavoro e periodo, e più"
@@ -21299,19 +20394,14 @@ msgstr ""
 
 #: lib/vutuv_web/templates/page/index.html.heex:382
 #, elixir-autogen, elixir-format
-msgid ""
-"The review is a text analysis, not legal advice, and it covers German "
-"employment references."
+msgid "The review is a text analysis, not legal advice, and it covers German employment references."
 msgstr ""
 "L'analisi è un esame del testo, non un parere legale, e riguarda gli "
 "attestati di lavoro tedeschi."
 
 #: lib/vutuv_web/views/page_html.ex:298
 #, elixir-autogen, elixir-format
-msgid ""
-"The review of a single employment reference: the overall grade on a red "
-"panel, then a report naming the kind of reference, the grade range, a "
-"traffic-light tally of its wordings and the main criticism."
+msgid "The review of a single employment reference: the overall grade on a red panel, then a report naming the kind of reference, the grade range, a traffic-light tally of its wordings and the main criticism."
 msgstr ""
 "L'analisi di un singolo attestato di lavoro: il voto complessivo su un "
 "riquadro rosso, poi un rapporto che indica il tipo di attestato, la fascia "
@@ -21319,10 +20409,7 @@ msgstr ""
 
 #: lib/vutuv_web/views/page_html.ex:288
 #, elixir-autogen, elixir-format
-msgid ""
-"The uploaded employment references, each marked private: one graded 1 (very "
-"good) on a green panel, one graded 4 to 5 (poor to unsatisfactory) on a red "
-"one, each with a link to its full report."
+msgid "The uploaded employment references, each marked private: one graded 1 (very good) on a green panel, one graded 4 to 5 (poor to unsatisfactory) on a red one, each with a link to its full report."
 msgstr ""
 "Gli attestati di lavoro caricati, ciascuno contrassegnato come privato: uno "
 "con voto 1 (ottimo) su un riquadro verde, uno con voto da 4 a 5 (scarso o "
@@ -21330,11 +20417,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/page/index.html.heex:365
 #, elixir-autogen, elixir-format
-msgid ""
-"Upload your employment references and have them read sentence by sentence: a"
-" grade, a traffic light, and the explanation of how a recruiter reads that "
-"wording. It takes a few minutes, then the report is there. Nothing becomes "
-"public before you release it."
+msgid "Upload your employment references and have them read sentence by sentence: a grade, a traffic light, and the explanation of how a recruiter reads that wording. It takes a few minutes, then the report is there. Nothing becomes public before you release it."
 msgstr ""
 "Carichi i Suoi attestati di lavoro e li faccia leggere frase per frase: un "
 "voto, un semaforo e la spiegazione di come un selezionatore legge quella "
@@ -21348,11 +20431,7 @@ msgstr "Cosa dice davvero il Suo attestato di lavoro"
 
 #: lib/vutuv_web/templates/page/index.html.heex:342
 #, elixir-autogen, elixir-format
-msgid ""
-"What your profile already says becomes a CV. You tick what should go in, "
-"then download it as PDF, Word, OpenDocument, LaTeX or JSON Resume. "
-"Anonymously as well, if you would rather show what you can do before you "
-"show who you are."
+msgid "What your profile already says becomes a CV. You tick what should go in, then download it as PDF, Word, OpenDocument, LaTeX or JSON Resume. Anonymously as well, if you would rather show what you can do before you show who you are."
 msgstr ""
 "Ciò che il Suo profilo già dice diventa un CV. Spunta cosa deve entrarci, "
 "poi lo scarica in PDF, Word, OpenDocument, LaTeX o JSON Resume. Anche in "
@@ -21380,11 +20459,7 @@ msgstr "Appellativo"
 
 #: lib/vutuv_web/controllers/user_controller.ex:275
 #, elixir-autogen, elixir-format
-msgid ""
-"Your verified badge was removed because you changed your name or date of "
-"birth. We re-check identity against those details so members can trust "
-"verified profiles and nobody can set up a fake verified account. An admin "
-"can verify you again anytime."
+msgid "Your verified badge was removed because you changed your name or date of birth. We re-check identity against those details so members can trust verified profiles and nobody can set up a fake verified account. An admin can verify you again anytime."
 msgstr ""
 "Il Suo contrassegno di verifica è stato rimosso perché ha modificato il nome"
 " o la data di nascita. Ricontrolliamo l'identità su questi dati perché i "
@@ -21394,11 +20469,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/page/index.html.heex:232
 #, elixir-autogen, elixir-format
-msgid ""
-"Your public posts then also appear on {mastodon} and other independent "
-"networks, where people can follow you. Replies and reposts come back under "
-"your posts, with the account's address, and are kept for up to six months. "
-"You can switch it off at any time."
+msgid "Your public posts then also appear on {mastodon} and other independent networks, where people can follow you. Replies and reposts come back under your posts, with the account's address, and are kept for up to six months. You can switch it off at any time."
 msgstr ""
 "I Suoi post pubblici compariranno allora anche su {mastodon} e su altre reti"
 " indipendenti, dove le persone possono seguirla. Risposte e ripubblicazioni "
@@ -21420,9 +20491,7 @@ msgstr "Inserisca il PIN che trova nell'e-mail"
 
 #: lib/vutuv_web/components/ui.ex:725
 #, elixir-autogen, elixir-format
-msgid ""
-"If you have added other addresses to your vutuv account, try logging in with"
-" one of those instead."
+msgid "If you have added other addresses to your vutuv account, try logging in with one of those instead."
 msgstr ""
 "Se ha aggiunto altri indirizzi al Suo account vutuv, provi ad accedere con "
 "uno di quelli."
@@ -21434,52 +20503,46 @@ msgstr "Annulla la registrazione"
 
 #: lib/vutuv_web/live/notification_live/index.ex:879
 #, elixir-autogen, elixir-format
-msgid ""
-"Welcome to vutuv! You can change your username {handle} at {url}, and at "
-"{import_url} you can import an existing LinkedIn profile."
+msgid "Welcome to vutuv! You can change your username {handle} at {url}, and at {import_url} you can import an existing LinkedIn profile."
 msgstr ""
 "Benvenuto su vutuv. Può cambiare il Suo nome utente {handle} su {url}, e su "
 "{import_url} può importare un profilo LinkedIn esistente."
 
-#: lib/vutuv_web/live/user_profile_live.ex:1363
+#: lib/vutuv_web/live/user_profile_live.ex:1367
 #, elixir-autogen, elixir-format
 msgid "Follow other members"
 msgstr "Segua altri membri"
 
 #: lib/vutuv_web/components/ui.ex:708
 #, elixir-autogen, elixir-format
-msgid ""
-"PIN not arriving? Is the email address {email} correct? Have you checked "
-"your spam folder?"
+msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 "Il PIN non arriva? L'indirizzo e-mail {email} è corretto? Ha controllato la "
 "cartella dello spam?"
 
-#: lib/vutuv/accounts/user.ex:1321
+#: lib/vutuv/accounts/user.ex:1326
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Non binario"
 
-#: lib/vutuv/accounts/user.ex:1319
+#: lib/vutuv/accounts/user.ex:1324
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr "Femminile"
 
-#: lib/vutuv/accounts/user.ex:1320
+#: lib/vutuv/accounts/user.ex:1325
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Maschile"
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:209
 #, elixir-autogen, elixir-format
-msgid ""
-"Shares are of the %{answered} members who answered. %{unanswered} gave no "
-"answer."
+msgid "Shares are of the %{answered} members who answered. %{unanswered} gave no answer."
 msgstr ""
 "Le percentuali si riferiscono ai %{answered} membri che hanno risposto. "
 "%{unanswered} non hanno risposto."
 
-#: lib/vutuv_web/components/ui.ex:4297
+#: lib/vutuv_web/components/ui.ex:4307
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr "immagine profilo ritratto foto compleanno genere su di me"
@@ -21491,16 +20554,13 @@ msgstr "Cerchi %{model}"
 
 #: lib/vutuv_web/templates/job_reference/manage.html.heex:170
 #, elixir-autogen, elixir-format
-msgid ""
-"We use {model}, a freely available language model. Anyone can download it "
-"and run the same review themselves, which is also why we are able to run it "
-"on our own machines at all."
+msgid "We use {model}, a freely available language model. Anyone can download it and run the same review themselves, which is also why we are able to run it on our own machines at all."
 msgstr ""
 "Usiamo {model}, un modello linguistico liberamente disponibile. Chiunque può"
 " scaricarlo ed eseguire da sé la stessa analisi, ed è anche il motivo per "
 "cui possiamo farlo girare sulle nostre macchine."
 
-#: lib/vutuv_web/views/settings_html.ex:58
+#: lib/vutuv_web/views/settings_html.ex:56
 #, elixir-autogen, elixir-format
 msgid "%{count} day"
 msgid_plural "%{count} days"
@@ -21521,57 +20581,54 @@ msgid_plural "%{formatted} posts"
 msgstr[0] "%{count} post"
 msgstr[1] "%{formatted} post"
 
-#: lib/vutuv_web/views/settings_html.ex:49
+#: lib/vutuv_web/views/settings_html.ex:47
 #, elixir-autogen, elixir-format
 msgid "1 day"
 msgstr "1 giorno"
 
-#: lib/vutuv_web/views/settings_html.ex:53
+#: lib/vutuv_web/views/settings_html.ex:51
 #, elixir-autogen, elixir-format
 msgid "1 month"
 msgstr "1 mese"
 
-#: lib/vutuv_web/views/settings_html.ex:51
+#: lib/vutuv_web/views/settings_html.ex:49
 #, elixir-autogen, elixir-format
 msgid "1 week"
 msgstr "1 settimana"
 
-#: lib/vutuv_web/views/settings_html.ex:56
+#: lib/vutuv_web/views/settings_html.ex:54
 #, elixir-autogen, elixir-format
 msgid "1 year"
 msgstr "1 anno"
 
-#: lib/vutuv_web/views/settings_html.ex:52
+#: lib/vutuv_web/views/settings_html.ex:50
 #, elixir-autogen, elixir-format
 msgid "2 weeks"
 msgstr "2 settimane"
 
-#: lib/vutuv_web/views/settings_html.ex:57
+#: lib/vutuv_web/views/settings_html.ex:55
 #, elixir-autogen, elixir-format
 msgid "2 years"
 msgstr "2 anni"
 
-#: lib/vutuv_web/views/settings_html.ex:50
+#: lib/vutuv_web/views/settings_html.ex:48
 #, elixir-autogen, elixir-format
 msgid "3 days"
 msgstr "3 giorni"
 
-#: lib/vutuv_web/views/settings_html.ex:54
+#: lib/vutuv_web/views/settings_html.ex:52
 #, elixir-autogen, elixir-format
 msgid "3 months"
 msgstr "3 mesi"
 
-#: lib/vutuv_web/views/settings_html.ex:55
+#: lib/vutuv_web/views/settings_html.ex:53
 #, elixir-autogen, elixir-format
 msgid "6 months"
 msgstr "6 mesi"
 
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:150
 #, elixir-autogen, elixir-format
-msgid ""
-"A post that reached one of these numbers is kept. Leave a field at 0 to "
-"switch it off. Likes and reposts include the ones from other networks, the "
-"same numbers you see on the post itself."
+msgid "A post that reached one of these numbers is kept. Leave a field at 0 to switch it off. Likes and reposts include the ones from other networks, the same numbers you see on the post itself."
 msgstr ""
 "Un post che ha raggiunto uno di questi numeri viene conservato. Lasci un "
 "campo a 0 per disattivarlo. Mi piace e ripubblicazioni comprendono quelli da"
@@ -21587,7 +20644,7 @@ msgstr "Elimina anche"
 msgid "Always keep"
 msgstr "Conserva sempre"
 
-#: lib/vutuv_web/components/ui.ex:4406
+#: lib/vutuv_web/components/ui.ex:4427
 #: lib/vutuv_web/controllers/settings_controller.ex:245
 #: lib/vutuv_web/controllers/settings_controller.ex:324
 #: lib/vutuv_web/controllers/settings_controller.ex:336
@@ -21609,19 +20666,14 @@ msgstr "Soglia dei salvataggi"
 
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:124
 #, elixir-autogen, elixir-format
-msgid ""
-"Bookmark one of your own posts and this rule steps over it. That is how you "
-"keep a single post."
+msgid "Bookmark one of your own posts and this rule steps over it. That is how you keep a single post."
 msgstr ""
 "Salvi un Suo post e questa regola lo salterà. È così che si conserva un "
 "singolo post."
 
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:59
 #, elixir-autogen, elixir-format
-msgid ""
-"Copies people made themselves are out of reach entirely: a screenshot, a "
-"quote, a search engine's cache. Deleting a post here removes it from vutuv; "
-"it does not recall it from the internet."
+msgid "Copies people made themselves are out of reach entirely: a screenshot, a quote, a search engine's cache. Deleting a post here removes it from vutuv; it does not recall it from the internet."
 msgstr ""
 "Le copie che le persone si sono fatte da sé sono del tutto fuori portata: "
 "uno screenshot, una citazione, la cache di un motore di ricerca. Eliminare "
@@ -21661,29 +20713,21 @@ msgstr "Elimina anche le risposte"
 
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:31
 #, elixir-autogen, elixir-format
-msgid ""
-"Deleting a post cannot be undone. Your pinned post and any post a moderator "
-"is currently looking at are always kept."
+msgid "Deleting a post cannot be undone. Your pinned post and any post a moderator is currently looking at are always kept."
 msgstr ""
 "L'eliminazione di un post non si può annullare. Il Suo post fissato e ogni "
 "post attualmente all'esame di un moderatore vengono sempre conservati."
 
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:117
 #, elixir-autogen, elixir-format
-msgid ""
-"Deleting a post that started a conversation leaves the replies without their"
-" beginning."
+msgid "Deleting a post that started a conversation leaves the replies without their beginning."
 msgstr ""
 "Eliminare un post che ha avviato una conversazione lascia le risposte senza "
 "il loro inizio."
 
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:54
 #, elixir-autogen, elixir-format
-msgid ""
-"If a post of yours reached other networks (Mastodon and the rest), we ask "
-"every server that received it to delete its copy. We cannot make them. A "
-"server that is switched off, that no longer talks to us, or that simply "
-"ignores the request keeps what it has."
+msgid "If a post of yours reached other networks (Mastodon and the rest), we ask every server that received it to delete its copy. We cannot make them. A server that is switched off, that no longer talks to us, or that simply ignores the request keeps what it has."
 msgstr ""
 "Se un Suo post ha raggiunto altre reti (Mastodon e le altre), chiediamo a "
 "ogni server che lo ha ricevuto di eliminare la propria copia. Non possiamo "
@@ -21710,7 +20754,7 @@ msgstr "Conserva i post con foto"
 msgid "Keep posts that did well"
 msgstr "Conserva i post andati bene"
 
-#: lib/vutuv_web/components/ui.ex:4408
+#: lib/vutuv_web/components/ui.ex:4429
 #, elixir-autogen, elixir-format
 msgid "Let your posts age out after a time you set"
 msgstr "Lasci scadere i Suoi post dopo un tempo che decide Lei"
@@ -21734,9 +20778,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:137
 #, elixir-autogen, elixir-format
-msgid ""
-"Off by default: a reply is one turn in a conversation that is not only "
-"yours."
+msgid "Off by default: a reply is one turn in a conversation that is not only yours."
 msgstr ""
 "Disattivata per impostazione predefinita: una risposta è un turno in una "
 "conversazione che non è solo Sua."
@@ -21780,11 +20822,8 @@ msgstr "Soglia delle ripubblicazioni"
 
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:246
 #, elixir-autogen, elixir-format
-msgid ""
-"Saving this rule deletes %{count} post straight away. It cannot be undone."
-msgid_plural ""
-"Saving this rule deletes %{formatted} posts straight away. This cannot be "
-"undone."
+msgid "Saving this rule deletes %{count} post straight away. It cannot be undone."
+msgid_plural "Saving this rule deletes %{formatted} posts straight away. This cannot be undone."
 msgstr[0] ""
 "Salvando questa regola viene eliminato subito %{count} post. L'operazione "
 "non si può annullare."
@@ -21806,9 +20845,7 @@ msgstr[1] "Impostazioni salvate. %{formatted} post sono stati eliminati."
 
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:255
 #, elixir-autogen, elixir-format
-msgid ""
-"We will ask other networks to delete their copies as well, but we cannot "
-"make them."
+msgid "We will ask other networks to delete their copies as well, but we cannot make them."
 msgstr ""
 "Chiederemo anche alle altre reti di eliminare le loro copie, ma non possiamo"
 " obbligarle."
@@ -21825,9 +20862,7 @@ msgstr "Cosa non possiamo promettere"
 
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:26
 #, elixir-autogen, elixir-format
-msgid ""
-"With this on, your own posts are deleted once they pass the age you pick. It"
-" runs once a day and only ever touches your posts, never anyone else's."
+msgid "With this on, your own posts are deleted once they pass the age you pick. It runs once a day and only ever touches your posts, never anyone else's."
 msgstr ""
 "Con questa opzione attiva, i Suoi post vengono eliminati quando superano "
 "l'età che sceglie. Viene eseguita una volta al giorno e tocca solo i Suoi "
@@ -21843,10 +20878,9 @@ msgstr "Prima può scaricare tutto ciò che ha qui:"
 msgid "Your rule"
 msgstr "La Sua regola"
 
-#: lib/vutuv_web/components/ui.ex:4410
+#: lib/vutuv_web/components/ui.ex:4431
 #, elixir-autogen, elixir-format
-msgid ""
-"delete remove erase posts age old expire automatic cleanup retention purge"
+msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr ""
 "elimina rimuovi cancella post età vecchi scadenza automatico pulizia "
 "conservazione"
@@ -21858,10 +20892,7 @@ msgstr "%{a} e %{b} sono registrati come argomenti diversi."
 
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:651
 #, elixir-autogen, elixir-format
-msgid ""
-"A dropped row belongs to somebody who already carries the surviving tag, so "
-"they end up carrying the topic once. Endorsements move to the row that "
-"stays."
+msgid "A dropped row belongs to somebody who already carries the surviving tag, so they end up carrying the topic once. Endorsements move to the row that stays."
 msgstr ""
 "Una riga scartata appartiene a qualcuno che porta già il tag superstite, "
 "quindi finisce per portare l'argomento una volta sola. Le conferme si "
@@ -21904,9 +20935,7 @@ msgstr "Scartato come duplicato"
 
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:712
 #, elixir-autogen, elixir-format
-msgid ""
-"For a name nobody has typed yet, so it never becomes a page of its own. A "
-"name that is already a tag has to be merged instead."
+msgid "For a name nobody has typed yet, so it never becomes a page of its own. A name that is already a tag has to be merged instead."
 msgstr ""
 "Per un nome che nessuno ha ancora digitato, così non diventa mai una pagina "
 "a sé. Un nome che è già un tag va invece unito."
@@ -21968,9 +20997,7 @@ msgstr "Cerchi per nome o slug"
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:263
 #, elixir-autogen, elixir-format
-msgid ""
-"Several tags for one topic become one page: see what a merge would move, do "
-"it, and take it back if it was wrong."
+msgid "Several tags for one topic become one page: see what a merge would move, do it, and take it back if it was wrong."
 msgstr ""
 "Più tag per uno stesso argomento diventano una sola pagina: veda cosa "
 "sposterebbe un'unione, la esegua e la annulli se era sbagliata."
@@ -21987,8 +21014,7 @@ msgstr "Quell'unione era già stata annullata."
 
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:380
 #, elixir-autogen, elixir-format
-msgid ""
-"That name is already a tag. Merge it instead, so its entries come along."
+msgid "That name is already a tag. Merge it instead, so its entries come along."
 msgstr ""
 "Questo nome è già un tag. Lo unisca invece, così le sue voci lo seguono."
 
@@ -22009,8 +21035,7 @@ msgstr "L'unione è stata annullata."
 
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:368
 #, elixir-autogen, elixir-format
-msgid ""
-"The surviving tag is itself an alternative name. Pick its topic instead."
+msgid "The surviving tag is itself an alternative name. Pick its topic instead."
 msgstr ""
 "Il tag superstite è a sua volta un nome alternativo. Scelga invece il suo "
 "argomento."
@@ -22022,9 +21047,7 @@ msgstr "Questi sono argomenti diversi"
 
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:375
 #, elixir-autogen, elixir-format
-msgid ""
-"These names differ only in characters the slug drops (like + or #), which is"
-" how C, C++ and C# tell each other apart. They are not merged."
+msgid "These names differ only in characters the slug drops (like + or #), which is how C, C++ and C# tell each other apart. They are not merged."
 msgstr ""
 "Questi nomi differiscono solo per caratteri che lo slug elimina (come + o "
 "#), che è il modo in cui C, C++ e C# si distinguono fra loro. Non vengono "
@@ -22088,9 +21111,7 @@ msgstr "I tag d'onore vengono assegnati, non digitati. Non vengono mai uniti."
 
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:202
 #, elixir-autogen, elixir-format
-msgid ""
-"%{written} proposals, %{judged} of them judged by the model. %{dropped} more"
-" were found than the queue holds."
+msgid "%{written} proposals, %{judged} of them judged by the model. %{dropped} more were found than the queue holds."
 msgstr ""
 "%{written} proposte, di cui %{judged} valutate dal modello. Ne sono state "
 "trovate %{dropped} in più di quante ne contenga la coda."
@@ -22112,10 +21133,7 @@ msgstr "Coppia"
 
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:728
 #, elixir-autogen, elixir-format
-msgid ""
-"Pairs of tags that might be one topic, found by rule and, where a local "
-"model is available, judged by it. Nothing here has happened yet: opening one"
-" loads it above, where you see what a merge would move before confirming."
+msgid "Pairs of tags that might be one topic, found by rule and, where a local model is available, judged by it. Nothing here has happened yet: opening one loads it above, where you see what a merge would move before confirming."
 msgstr ""
 "Coppie di tag che potrebbero essere un unico argomento, trovate per regola "
 "e, dove è disponibile un modello locale, valutate da esso. Qui non è ancora "
@@ -22161,11 +21179,7 @@ msgstr "lo stesso nome, scritto in modo diverso"
 
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:474
 #, elixir-autogen, elixir-format
-msgid ""
-"\"rubyonrails\" was absorbed: nobody loses a tag, the name goes on working, "
-"and it is listed on the remaining page as an alternative name. Anyone typing"
-" it from now on gets the one page. Every merge can be undone at the bottom "
-"of this page."
+msgid "\"rubyonrails\" was absorbed: nobody loses a tag, the name goes on working, and it is listed on the remaining page as an alternative name. Anyone typing it from now on gets the one page. Every merge can be undone at the bottom of this page."
 msgstr ""
 "\"rubyonrails\" è stato assorbito: nessuno perde un tag, il nome continua a "
 "funzionare ed è elencato sulla pagina rimasta come nome alternativo. Da ora "
@@ -22191,10 +21205,7 @@ msgstr "Nessun tag corrisponde."
 
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:442
 #, elixir-autogen, elixir-format
-msgid ""
-"One topic sometimes ends up under several tags, so its members and its posts"
-" are split over two pages that never show each other. Merging puts them on "
-"one page."
+msgid "One topic sometimes ends up under several tags, so its members and its posts are split over two pages that never show each other. Merging puts them on one page."
 msgstr ""
 "A volte un argomento finisce sotto più tag, così i suoi membri e i suoi post"
 " si dividono su due pagine che non si mostrano mai a vicenda. L'unione li "
@@ -22219,12 +21230,8 @@ msgstr[1] "%{count} tag sono ora nomi alternativi per %{canonical}."
 
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:606
 #, elixir-autogen, elixir-format
-msgid ""
-"%{names} becomes an alternative name for %{canonical} and %{urls} redirects "
-"to /tags/%{slug}."
-msgid_plural ""
-"%{names} become alternative names for %{canonical}, and their addresses "
-"redirect to /tags/%{slug}."
+msgid "%{names} becomes an alternative name for %{canonical} and %{urls} redirects to /tags/%{slug}."
+msgid_plural "%{names} become alternative names for %{canonical}, and their addresses redirect to /tags/%{slug}."
 msgstr[0] ""
 "%{names} diventa un nome alternativo per %{canonical} e %{urls} rimanda a "
 "/tags/%{slug}."
@@ -22244,9 +21251,7 @@ msgstr "Non c'entra"
 
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:539
 #, elixir-autogen, elixir-format
-msgid ""
-"It keeps its page and its address; every other one becomes an alternative "
-"name pointing at it."
+msgid "It keeps its page and its address; every other one becomes an alternative name pointing at it."
 msgstr ""
 "Mantiene la sua pagina e il suo indirizzo; ogni altro diventa un nome "
 "alternativo che punta a esso."
@@ -22275,9 +21280,7 @@ msgstr "Scelga quello che resta"
 
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:492
 #, elixir-autogen, elixir-format
-msgid ""
-"Search as often as you like and add what belongs. Abbreviations will not "
-"turn up under the full name, so look for them separately."
+msgid "Search as often as you like and add what belongs. Abbreviations will not turn up under the full name, so look for them separately."
 msgstr ""
 "Cerchi quante volte vuole e aggiunga ciò che c'entra. Le sigle non compaiono"
 " cercando il nome per esteso, quindi le cerchi a parte."
@@ -22287,12 +21290,9 @@ msgstr ""
 msgid "Start over"
 msgstr "Ricomincia"
 
-#: lib/vutuv_web/components/post_components.ex:2446
+#: lib/vutuv_web/components/post_components.ex:2461
 #, elixir-autogen, elixir-format
-msgid ""
-"A like or a repost is sent back to the network this post came from, and your"
-" account does not take part in the Fediverse at the moment. You can switch "
-"it on in the {settings}."
+msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
 "Un Mi piace o una ripubblicazione viene rimandato alla rete da cui proviene "
 "questo post, e al momento il Suo account non partecipa al Fediverso. Può "
@@ -22310,9 +21310,7 @@ msgstr "Modifica la pagina e pubblica annunci di lavoro."
 
 #: lib/vutuv_web/live/organization_live/roles.ex:171
 #, elixir-autogen, elixir-format
-msgid ""
-"Give members their roles on this page. Someone can hold several at once, and"
-" every role is granted on its own."
+msgid "Give members their roles on this page. Someone can hold several at once, and every role is granted on its own."
 msgstr ""
 "Assegni ai membri i loro ruoli su questa pagina. Una persona può averne più "
 "di uno, e ogni ruolo viene concesso a sé."
@@ -22349,10 +21347,7 @@ msgstr "Scrive post a nome dell'organizzazione."
 
 #: lib/vutuv_web/templates/settings/organizations.html.heex:26
 #, elixir-autogen, elixir-format
-msgid ""
-"The owner gives other members their roles on the page, and can hand "
-"ownership over to someone else at any time. Someone can hold several roles, "
-"and writing in the organization's name is always granted on its own."
+msgid "The owner gives other members their roles on the page, and can hand ownership over to someone else at any time. Someone can hold several roles, and writing in the organization's name is always granted on its own."
 msgstr ""
 "Il proprietario assegna agli altri membri i loro ruoli sulla pagina e può "
 "cedere la proprietà a qualcun altro in qualsiasi momento. Una persona può "
@@ -22462,9 +21457,7 @@ msgstr "Non è ancora successo nulla."
 
 #: lib/vutuv_web/live/organization_live/activity.ex:105
 #, elixir-autogen, elixir-format
-msgid ""
-"What happened to this page. Everyone on the team sees the same list, and "
-"opening it marks it read for all of you."
+msgid "What happened to this page. Everyone on the team sees the same list, and opening it marks it read for all of you."
 msgstr ""
 "Cosa è successo a questa pagina. Tutti nel team vedono lo stesso elenco, e "
 "aprirlo lo segna come letto per tutti voi."
@@ -22503,18 +21496,14 @@ msgstr "Membri e organizzazioni"
 
 #: lib/vutuv_web/live/organization_live/feed.ex:104
 #, elixir-autogen, elixir-format
-msgid ""
-"Nothing here yet. This page does not follow anyone, or nobody it follows has"
-" published."
+msgid "Nothing here yet. This page does not follow anyone, or nobody it follows has published."
 msgstr ""
 "Qui non c'è ancora nulla. Questa pagina non segue nessuno, oppure nessuno di"
 " quelli che segue ha pubblicato."
 
 #: lib/vutuv_web/live/organization_live/following.ex:301
 #, elixir-autogen, elixir-format
-msgid ""
-"The members, organizations and topics this page follows. Everything here "
-"shapes its feed, and only the team can see this list."
+msgid "The members, organizations and topics this page follows. Everything here shapes its feed, and only the team can see this list."
 msgstr ""
 "I membri, le organizzazioni e gli argomenti che questa pagina segue. Tutto "
 "ciò che sta qui determina il suo feed, e questo elenco lo vede solo il team."
@@ -22542,9 +21531,7 @@ msgstr "Smetti di seguire %{tag}"
 
 #: lib/vutuv_web/live/organization_live/feed.ex:100
 #, elixir-autogen, elixir-format
-msgid ""
-"What the members and organizations this page follows have published. Liking "
-"or saving something here is done from your own account, not the page's."
+msgid "What the members and organizations this page follows have published. Liking or saving something here is done from your own account, not the page's."
 msgstr ""
 "Ciò che hanno pubblicato i membri e le organizzazioni che questa pagina "
 "segue. Mettere Mi piace o salvare qualcosa qui avviene dal Suo account, non "
@@ -22567,9 +21554,7 @@ msgstr "Impostazioni della pagina"
 
 #: lib/vutuv_web/live/organization_live/fediverse.ex:147
 #, elixir-autogen, elixir-format
-msgid ""
-"Switching this off stops new posts from leaving. Copies another server "
-"already holds can only be asked to delete them, never made to."
+msgid "Switching this off stops new posts from leaving. Copies another server already holds can only be asked to delete them, never made to."
 msgstr ""
 "Disattivarlo impedisce ai nuovi post di uscire. Alle copie che un altro "
 "server già possiede si può solo chiedere di eliminarle, mai imporlo."
@@ -22628,9 +21613,7 @@ msgstr "Questa pagina non può ricevere messaggi."
 #: lib/vutuv_web/controllers/remote_follow_controller.ex:208
 #: lib/vutuv_web/controllers/remote_follow_controller.ex:212
 #, elixir-autogen, elixir-format
-msgid ""
-"That address is on this vutuv. Sign in and use the Follow button on this "
-"page."
+msgid "That address is on this vutuv. Sign in and use the Follow button on this page."
 msgstr ""
 "Quell'indirizzo è su questo vutuv. Acceda e usi il pulsante Segui su questa "
 "pagina."
@@ -22654,10 +21637,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/fediverse.ex:101
 #, elixir-autogen, elixir-format
-msgid ""
-"Other networks address this page as @name@%{host}, the way they address a "
-"member. So it needs a short @name of its own first. Claim one in the page "
-"settings, then come back."
+msgid "Other networks address this page as @name@%{host}, the way they address a member. So it needs a short @name of its own first. Claim one in the page settings, then come back."
 msgstr ""
 "Le altre reti si rivolgono a questa pagina come @nome@%{host}, allo stesso "
 "modo in cui si rivolgono a un membro. Le serve quindi prima un @nome breve "
@@ -22667,9 +21647,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/new.ex:211
 #: lib/vutuv_web/live/organization_live/show.ex:755
 #, elixir-autogen, elixir-format
-msgid ""
-"People who have no vutuv account can follow this page and read its posts, in"
-" networks like Mastodon."
+msgid "People who have no vutuv account can follow this page and read its posts, in networks like Mastodon."
 msgstr ""
 "Le persone che non hanno un account vutuv possono seguire questa pagina e "
 "leggerne i post, su reti come Mastodon."
@@ -22691,31 +21669,26 @@ msgstr "Attivalo"
 
 #: lib/vutuv_web/live/organization_live/show.ex:760
 #, elixir-autogen, elixir-format
-msgid ""
-"The page gets an address of its own for that, written like an email address."
+msgid "The page gets an address of its own for that, written like an email address."
 msgstr ""
 "Per questo la pagina riceve un indirizzo tutto suo, scritto come un "
 "indirizzo e-mail."
 
 #: lib/vutuv_web/live/organization_live/fediverse.ex:126
 #, elixir-autogen, elixir-format
-msgid ""
-"This page is not visible on other networks. Nothing of it leaves vutuv."
+msgid "This page is not visible on other networks. Nothing of it leaves vutuv."
 msgstr ""
 "Questa pagina non è visibile su altre reti. Nulla di essa lascia vutuv."
 
 #: lib/vutuv_web/live/organization_live/fediverse.ex:122
 #, elixir-autogen, elixir-format
-msgid ""
-"This page is visible on other networks. %{count} accounts there follow it."
+msgid "This page is visible on other networks. %{count} accounts there follow it."
 msgstr ""
 "Questa pagina è visibile su altre reti. Lì la seguono %{count} account."
 
 #: lib/vutuv_web/live/organization_live/fediverse.ex:172
 #, elixir-autogen, elixir-format
-msgid ""
-"This page was visible on other networks before. Servers that still hold "
-"copies keep them until they act on a deletion request."
+msgid "This page was visible on other networks before. Servers that still hold copies keep them until they act on a deletion request."
 msgstr ""
 "Questa pagina era visibile su altre reti in passato. I server che ne "
 "conservano ancora copie le mantengono finché non danno seguito a una "
@@ -22723,17 +21696,13 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/fediverse.ex:91
 #, elixir-autogen, elixir-format
-msgid ""
-"This vutuv exchanges nothing with other networks, so nothing here has any "
-"effect."
+msgid "This vutuv exchanges nothing with other networks, so nothing here has any effect."
 msgstr ""
 "Questo vutuv non scambia nulla con altre reti, quindi qui nulla ha effetto."
 
 #: lib/vutuv_web/live/organization_live/edit.ex:412
 #, elixir-autogen, elixir-format
-msgid ""
-"Claim a short @name so this organization has an address of its own, like a "
-"member. Letters, numbers and underscores, %{min} to %{max} characters."
+msgid "Claim a short @name so this organization has an address of its own, like a member. Letters, numbers and underscores, %{min} to %{max} characters."
 msgstr ""
 "Rivendichi un @nome breve, così questa organizzazione ha un indirizzo tutto "
 "suo, come un membro. Lettere, numeri e trattini bassi, da %{min} a %{max} "
@@ -22758,9 +21727,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/organization_live/fediverse_followers.ex:240
 #, elixir-autogen, elixir-format
-msgid ""
-"Accounts that no longer exist on their own server drop off this list by "
-"themselves. Names and handles are the ones their server last told us."
+msgid "Accounts that no longer exist on their own server drop off this list by themselves. Names and handles are the ones their server last told us."
 msgstr ""
 "Gli account che non esistono più sul proprio server spariscono da questo "
 "elenco da soli. Nomi e handle sono quelli che il loro server ci ha "
@@ -22773,9 +21740,7 @@ msgstr "Torna alla pagina del Fediverso"
 
 #: lib/vutuv_web/live/organization_live/fediverse_followers.ex:165
 #, elixir-autogen, elixir-format
-msgid ""
-"Everyone on another network who follows this page. Only you see this list: "
-"what the page publishes out there is the number, never the names."
+msgid "Everyone on another network who follows this page. Only you see this list: what the page publishes out there is the number, never the names."
 msgstr ""
 "Tutti quelli che su un'altra rete seguono questa pagina. Questo elenco lo "
 "vede solo Lei: quello che la pagina pubblica là fuori è il numero, mai i "
@@ -22788,9 +21753,7 @@ msgstr "Follower – %{name}"
 
 #: lib/vutuv_web/live/organization_live/fediverse_followers.ex:172
 #, elixir-autogen, elixir-format
-msgid ""
-"Nobody yet. Post the page's address where people can see it, and the first "
-"follows will show up here."
+msgid "Nobody yet. Post the page's address where people can see it, and the first follows will show up here."
 msgstr ""
 "Ancora nessuno. Pubblichi l'indirizzo della pagina dove le persone possono "
 "vederlo, e i primi follow compariranno qui."
@@ -22832,21 +21795,15 @@ msgstr "Il PIN è valido per altri {n} secondi."
 
 #: lib/vutuv_web/templates/page/pin_new_registration.html.heex:87
 #, elixir-autogen, elixir-format
-msgid ""
-"You can sign up again right away with the same email address, and we will "
-"send you a new PIN."
+msgid "You can sign up again right away with the same email address, and we will send you a new PIN."
 msgstr ""
 "Può iscriversi di nuovo subito con lo stesso indirizzo e-mail, e Le "
 "invieremo un nuovo PIN."
 
 #: lib/vutuv_web/templates/page/pin_new_registration.html.heex:49
 #, elixir-autogen, elixir-format
-msgid ""
-"Your sign-up was never confirmed, so we delete it automatically in about one"
-" minute."
-msgid_plural ""
-"Your sign-up was never confirmed, so we delete it automatically in about "
-"%{count} minutes."
+msgid "Your sign-up was never confirmed, so we delete it automatically in about one minute."
+msgid_plural "Your sign-up was never confirmed, so we delete it automatically in about %{count} minutes."
 msgstr[0] ""
 "La Sua iscrizione non è mai stata confermata, quindi la eliminiamo "
 "automaticamente fra circa un minuto."
@@ -22890,12 +21847,8 @@ msgstr[1] "persone"
 
 #: lib/vutuv_web/live/shell_live.ex:505
 #, elixir-autogen, elixir-format
-msgid ""
-"%{members} vutuv members plus %{fediverse} Fediverse account that follows "
-"them"
-msgid_plural ""
-"%{members} vutuv members plus %{fediverse} Fediverse accounts that follow "
-"them"
+msgid "%{members} vutuv members plus %{fediverse} Fediverse account that follows them"
+msgid_plural "%{members} vutuv members plus %{fediverse} Fediverse accounts that follow them"
 msgstr[0] ""
 "%{members} membri vutuv più %{fediverse} account del Fediverso che li segue"
 msgstr[1] ""
@@ -22904,19 +21857,14 @@ msgstr[1] ""
 
 #: lib/vutuv_web/templates/directory/index.html.heex:14
 #, elixir-autogen, elixir-format
-msgid ""
-"%{count} vutuv members whose profiles are open to search engines, filed "
-"alphabetically by last name."
+msgid "%{count} vutuv members whose profiles are open to search engines, filed alphabetically by last name."
 msgstr ""
 "%{count} membri vutuv i cui profili sono aperti ai motori di ricerca, "
 "ordinati alfabeticamente per cognome."
 
 #: lib/vutuv_web/agent_docs/list_docs.ex:205
 #, elixir-autogen, elixir-format
-msgid ""
-"%{listed} vutuv members are listed here, grouped by the first letter of "
-"their last name; anyone who does not open their profile to search engines is"
-" not among them."
+msgid "%{listed} vutuv members are listed here, grouped by the first letter of their last name; anyone who does not open their profile to search engines is not among them."
 msgstr ""
 "Qui sono elencati %{listed} membri vutuv, raggruppati per la prima lettera "
 "del cognome; chi non apre il proprio profilo ai motori di ricerca non è fra "
@@ -22934,10 +21882,7 @@ msgstr "Apri la chat"
 
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:18
 #, elixir-autogen, elixir-format
-msgid ""
-"Signal also takes its contact link (https://signal.me/#…). It names neither "
-"your phone number nor your username, and you can reset it in Signal at any "
-"time."
+msgid "Signal also takes its contact link (https://signal.me/#…). It names neither your phone number nor your username, and you can reset it in Signal at any time."
 msgstr ""
 "Signal accetta anche il proprio link di contatto (https://signal.me/#…). Non"
 " indica né il Suo numero di telefono né il Suo nome utente, e può azzerarlo "
@@ -22965,10 +21910,7 @@ msgstr "Acceda per scaricare questo post"
 
 #: lib/vutuv_web/live/search_live.ex:512
 #, elixir-autogen, elixir-format
-msgid ""
-"That is a link to somewhere else, not something anybody here wrote. vutuv "
-"can fetch the post behind it so you can read it, answer it, like it or "
-"repost it from here."
+msgid "That is a link to somewhere else, not something anybody here wrote. vutuv can fetch the post behind it so you can read it, answer it, like it or repost it from here."
 msgstr ""
 "Questo è un link verso un altro posto, non qualcosa scritto da qualcuno qui."
 " vutuv può scaricare il post che c'è dietro, così può leggerlo, "
@@ -22981,8 +21923,7 @@ msgstr "un indirizzo su un'altra rete: vutuv Le propone di seguirlo"
 
 #: lib/vutuv_web/live/search_live.ex:371
 #, elixir-autogen, elixir-format
-msgid ""
-"the address of a post out there: vutuv fetches it so you can answer it here"
+msgid "the address of a post out there: vutuv fetches it so you can answer it here"
 msgstr ""
 "l'indirizzo di un post là fuori: vutuv lo scarica così può rispondergli da "
 "qui"
@@ -23014,10 +21955,7 @@ msgstr "gravatar.com non ha alcuna immagine per il Suo indirizzo e-mail."
 
 #: lib/vutuv_web/templates/user/edit.html.heex:89
 #, elixir-autogen, elixir-format
-msgid ""
-"Only when you press this: we ask gravatar.com whether there is a picture for"
-" your email address, sending a hash of the address rather than the address "
-"itself. Nothing leaves this server otherwise."
+msgid "Only when you press this: we ask gravatar.com whether there is a picture for your email address, sending a hash of the address rather than the address itself. Nothing leaves this server otherwise."
 msgstr ""
 "Solo quando preme questo pulsante: chiediamo a gravatar.com se esiste "
 "un'immagine per il Suo indirizzo e-mail, inviando un hash dell'indirizzo e "
@@ -23030,10 +21968,7 @@ msgstr "La ricerca su gravatar.com è disattivata su questa installazione."
 
 #: lib/vutuv_web/components/organization_components.ex:55
 #, elixir-autogen, elixir-format
-msgid ""
-"A new entry can take a while to reach everyone. We keep checking %{domain} "
-"by ourselves and send you an email as soon as it works, so you can close "
-"this page."
+msgid "A new entry can take a while to reach everyone. We keep checking %{domain} by ourselves and send you an email as soon as it works, so you can close this page."
 msgstr ""
 "Una voce nuova può metterci un po' ad arrivare a tutti. Continuiamo a "
 "controllare %{domain} da soli e Le inviamo un'e-mail non appena funziona, "
@@ -23077,9 +22012,7 @@ msgstr "Non ancora trovato"
 
 #: lib/vutuv_web/components/verification_components.ex:80
 #, elixir-autogen, elixir-format
-msgid ""
-"We asked the name servers of your domain directly, for %{names}, and looked "
-"for this value:"
+msgid "We asked the name servers of your domain directly, for %{names}, and looked for this value:"
 msgstr ""
 "Abbiamo interrogato direttamente i name server del Suo dominio, per "
 "%{names}, cercando questo valore:"
@@ -23158,8 +22091,7 @@ msgstr "App compatibili con Mastodon"
 
 #: lib/vutuv_web/templates/oauth/authorize.html.heex:70
 #, elixir-autogen, elixir-format
-msgid ""
-"Mastodon client access is disabled for every identity available to you."
+msgid "Mastodon client access is disabled for every identity available to you."
 msgstr ""
 "L'accesso dei client Mastodon è disattivato per ogni identità a Sua "
 "disposizione."
@@ -23181,9 +22113,7 @@ msgstr "Segui un account locale"
 
 #: lib/vutuv_web/live/organization_live/following.ex:307
 #, elixir-autogen, elixir-format
-msgid ""
-"Enter a member handle or organization handle. This follow belongs to the "
-"organization, not to your personal account."
+msgid "Enter a member handle or organization handle. This follow belongs to the organization, not to your personal account."
 msgstr ""
 "Inserisca l'handle di un membro o di un'organizzazione. Questo follow "
 "appartiene all'organizzazione, non al Suo account personale."
@@ -23229,12 +22159,8 @@ msgstr[1] "%{count} voci non è stato possibile aggiungerle."
 
 #: lib/vutuv_web/controllers/import_controller.ex:253
 #, elixir-autogen, elixir-format
-msgid ""
-"%{count} social account could not be added because another member has "
-"already claimed it."
-msgid_plural ""
-"%{count} social accounts could not be added because another member has "
-"already claimed them."
+msgid "%{count} social account could not be added because another member has already claimed it."
+msgid_plural "%{count} social accounts could not be added because another member has already claimed them."
 msgstr[0] ""
 "%{count} account social non è stato possibile aggiungerlo perché un altro "
 "membro lo ha già rivendicato."
@@ -23264,9 +22190,7 @@ msgstr "Pronto per l'importazione"
 
 #: lib/vutuv_web/templates/import/preview.html.heex:13
 #, elixir-autogen, elixir-format
-msgid ""
-"Review the entries below and confirm your selection to add them to your "
-"profile."
+msgid "Review the entries below and confirm your selection to add them to your profile."
 msgstr ""
 "Controlli le voci qui sotto e confermi la Sua selezione per aggiungerle al "
 "Suo profilo."
@@ -23285,11 +22209,7 @@ msgstr[1] "Saltate %{count} voci già presenti sul Suo profilo."
 
 #: lib/vutuv_web/templates/import/preview.html.heex:20
 #, elixir-autogen, elixir-format
-msgid ""
-"You can analyse the same or a newer LinkedIn archive again at any time. "
-"Nothing is duplicated and nothing is overwritten. Entries you already have "
-"are not updated either: they keep the description and dates they have on "
-"vutuv, even when your archive holds newer ones."
+msgid "You can analyse the same or a newer LinkedIn archive again at any time. Nothing is duplicated and nothing is overwritten. Entries you already have are not updated either: they keep the description and dates they have on vutuv, even when your archive holds newer ones."
 msgstr ""
 "Può analizzare di nuovo lo stesso archivio LinkedIn o uno più recente in "
 "qualsiasi momento. Nulla viene duplicato e nulla viene sovrascritto. Nemmeno"
@@ -23299,12 +22219,8 @@ msgstr ""
 #: lib/vutuv_web/controllers/import_controller.ex:272
 #: lib/vutuv_web/views/user_helpers.ex:219
 #, elixir-autogen, elixir-format
-msgid ""
-"%{count} tag did not fit: your profile holds at most %{max}. Remove some and"
-" try again."
-msgid_plural ""
-"%{count} tags did not fit: your profile holds at most %{max}. Remove some "
-"and try again."
+msgid "%{count} tag did not fit: your profile holds at most %{max}. Remove some and try again."
+msgid_plural "%{count} tags did not fit: your profile holds at most %{max}. Remove some and try again."
 msgstr[0] ""
 "%{count} tag non ci stava: il Suo profilo ne contiene al massimo %{max}. Ne "
 "rimuova qualcuno e riprovi."
@@ -23365,55 +22281,45 @@ msgstr "Lingua del post"
 msgid "The language this post is written in"
 msgstr "La lingua in cui è scritto questo post"
 
-#: lib/vutuv_web/components/post_components.ex:4117
+#: lib/vutuv_web/components/post_components.ex:4132
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Mostra l'originale"
 
-#: lib/vutuv_web/components/post_components.ex:4138
+#: lib/vutuv_web/components/post_components.ex:4168
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Traduci"
 
-#: lib/vutuv_web/components/post_components.ex:4147
+#: lib/vutuv_web/components/post_components.ex:4177
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Tradotto"
 
-#: lib/vutuv_web/components/post_components.ex:4150
+#: lib/vutuv_web/components/post_components.ex:4180
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Tradotto da %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:4127
+#: lib/vutuv_web/components/post_components.ex:4157
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Traduzione in corso…"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:853
+#: lib/vutuv_web/live/feed_languages_live.ex:129
 #, elixir-autogen, elixir-format
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 "Impostazioni delle lingue del feed riportate ai valori predefiniti del sito."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:824
-#, elixir-autogen, elixir-format
-msgid "Feed language settings saved."
-msgstr "Impostazioni delle lingue del feed salvate."
-
-#: lib/vutuv_web/templates/settings/preferences.html.heex:193
+#: lib/vutuv_web/components/post_components.ex:4147
+#: lib/vutuv_web/components/ui.ex:4386
+#: lib/vutuv_web/live/feed_languages_live.ex:65
+#: lib/vutuv_web/live/feed_languages_live.ex:200
+#: lib/vutuv_web/templates/settings/preferences.html.heex:187
 #, elixir-autogen, elixir-format
 msgid "Feed languages"
 msgstr "Lingue del feed"
-
-#: lib/vutuv_web/templates/settings/preferences.html.heex:195
-#, elixir-autogen, elixir-format
-msgid ""
-"Pick which languages your feed shows, and what happens to posts in other "
-"languages. Posts that declare no language always show."
-msgstr ""
-"Scelga quali lingue mostra il Suo feed, e cosa succede ai post in altre "
-"lingue. I post che non dichiarano una lingua vengono sempre mostrati."
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:83
 #, elixir-autogen, elixir-format
@@ -23432,10 +22338,7 @@ msgstr "Traducili nella mia lingua"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:84
 #, elixir-autogen, elixir-format
-msgid ""
-"What your feed does with posts outside your chosen languages: show them as "
-"they are, translate them for you, or hide them. Posts that declare no "
-"language always show."
+msgid "What your feed does with posts outside your chosen languages: show them as they are, translate them for you, or hide them. Posts that declare no language always show."
 msgstr ""
 "Cosa fa il Suo feed con i post fuori dalle lingue che ha scelto: mostrarli "
 "così come sono, tradurglieli o nasconderli. I post che non dichiarano una "
@@ -23468,18 +22371,14 @@ msgstr "Lingua e regione salvate."
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:108
 #, elixir-autogen, elixir-format
-msgid ""
-"Posts, messages and notifications are stamped in this zone. New accounts "
-"take it from the browser."
+msgid "Posts, messages and notifications are stamped in this zone. New accounts take it from the browser."
 msgstr ""
 "Post, messaggi e notifiche vengono datati in questo fuso. I nuovi account lo"
 " ricavano dal browser."
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:105
 #, elixir-autogen, elixir-format
-msgid ""
-"The order and punctuation of every date you read here, and whether times run"
-" on a 12- or 24-hour clock."
+msgid "The order and punctuation of every date you read here, and whether times run on a 12- or 24-hour clock."
 msgstr ""
 "L'ordine e la punteggiatura di ogni data che legge qui, e se gli orari usano"
 " il formato a 12 o a 24 ore."
@@ -23509,45 +22408,21 @@ msgstr "Il Suo browser dice: {zone}"
 msgid "ISO 8601 (Sweden, Japan, China)"
 msgstr "ISO 8601 (Svezia, Giappone, Cina)"
 
-#: lib/vutuv_web/components/ui.ex:4433
-#, elixir-autogen, elixir-format
-msgid ""
-"Interface language, date format and time zone, feed languages, maps, how "
-"posts are shortened"
-msgstr ""
-"Lingua dell'interfaccia, formato della data e fuso orario, lingue del feed, "
-"mappe, come vengono accorciati i post"
-
 #: lib/vutuv_web/views/account_event_text.ex:48
 #, elixir-autogen, elixir-format
 msgid "Language & display settings changed"
 msgstr "Impostazioni di lingua e visualizzazione modificate"
 
-#: lib/vutuv_web/components/ui.ex:4437
-#, elixir-autogen, elixir-format
-msgid ""
-"german english locale translation translate map font length hyphenation feed"
-" languages hide foreign übersetzen sprache zeitzone timezone time zone utc "
-"datum date uhrzeit clock 24 hour datumsformat"
-msgstr ""
-"tedesco inglese italiano lingua traduzione tradurre mappa carattere "
-"lunghezza sillabazione lingue del feed nascondi straniere fuso orario utc "
-"data ora orologio 24 ore formato della data"
-
 #: lib/vutuv_web/templates/social_media_account/verify.html.heex:42
 #, elixir-autogen, elixir-format
-msgid ""
-"%{provider} profiles cannot be verified yet: the network offers no field we "
-"could check."
+msgid "%{provider} profiles cannot be verified yet: the network offers no field we could check."
 msgstr ""
 "I profili %{provider} non si possono ancora verificare: la rete non offre "
 "alcun campo che potremmo controllare."
 
 #: lib/vutuv_web/views/social_media_account_html.ex:19
 #, elixir-autogen, elixir-format
-msgid ""
-"Add this address to your %{provider} profile, in the website field or your "
-"description, then run the check:"
+msgid "Add this address to your %{provider} profile, in the website field or your description, then run the check:"
 msgstr ""
 "Aggiunga questo indirizzo al Suo profilo %{provider}, nel campo del sito web"
 " o nella descrizione, poi avvii il controllo:"
@@ -23564,9 +22439,7 @@ msgstr "Sulla Sua istanza Gitea o Forgejo: nome@git.esempio.com"
 
 #: lib/vutuv_web/templates/social_media_account/verify.html.heex:64
 #, elixir-autogen, elixir-format
-msgid ""
-"The rest of the field can say whatever you like. We only look for this "
-"address."
+msgid "The rest of the field can say whatever you like. We only look for this address."
 msgstr ""
 "Il resto del campo può dire quello che vuole. Noi cerchiamo solo questo "
 "indirizzo."
@@ -23582,14 +22455,10 @@ msgid "Your username, or paste the address of your profile page."
 msgstr ""
 "Il Suo nome utente, oppure incolli l'indirizzo della Sua pagina di profilo."
 
-#: lib/vutuv_web/components/post_components.ex:3917
+#: lib/vutuv_web/components/post_components.ex:3932
 #, elixir-autogen, elixir-format
-msgid ""
-"Our AI is still checking it. As soon as it is through, the photo appears by "
-"itself."
-msgid_plural ""
-"Our AI is still checking them, %{done} of %{total} done. As soon as the last"
-" one is through, the photos appear by themselves."
+msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
+msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] ""
 "La nostra IA la sta ancora controllando. Appena avrà finito, la foto "
 "comparirà da sé."
@@ -23597,17 +22466,15 @@ msgstr[1] ""
 "La nostra IA le sta ancora controllando, %{done} su %{total} fatte. Appena "
 "avrà finito con l'ultima, le foto compariranno da sé."
 
-#: lib/vutuv_web/components/post_components.ex:3914
+#: lib/vutuv_web/components/post_components.ex:3929
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr "Il Suo post è pubblicato, la foto non c'è ancora."
 
-#: lib/vutuv_web/components/post_components.ex:3254
+#: lib/vutuv_web/components/post_components.ex:3269
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
-msgid_plural ""
-"Our AI is looking at them. They appear here by themselves once they are "
-"through."
+msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
 msgstr[0] ""
 "La nostra IA la sta esaminando. Comparirà qui da sé quando avrà finito."
 msgstr[1] ""
@@ -23623,7 +22490,7 @@ msgstr "Consigliato: %{width} × %{height} pixel (%{ratio})."
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr "Consigliato: quadrata, almeno %{width} × %{height} pixel."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1814
+#: lib/vutuv_web/live/post_live/feed.ex:1950
 #: lib/vutuv_web/views/user_html.ex:334
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -23636,10 +22503,7 @@ msgstr "Mostra l'immagine del profilo più grande"
 
 #: lib/vutuv_web/live/organization_live/apps.ex:183
 #, elixir-autogen, elixir-format
-msgid ""
-"The page's Editorial team can use this organization as a separate identity "
-"in a compatible phone app, with the same rights they already have here. "
-"Those rights are checked again on every request."
+msgid "The page's Editorial team can use this organization as a separate identity in a compatible phone app, with the same rights they already have here. Those rights are checked again on every request."
 msgstr ""
 "La redazione della pagina può usare questa organizzazione come identità "
 "separata in un'app per telefono compatibile, con gli stessi diritti che ha "
@@ -23652,18 +22516,14 @@ msgstr "Impostazioni delle app salvate."
 
 #: lib/vutuv_web/live/organization_live/apps.ex:169
 #, elixir-autogen, elixir-format
-msgid ""
-"Apps built for Mastodon can write in this page's name, read its feed and "
-"notify its team."
+msgid "Apps built for Mastodon can write in this page's name, read its feed and notify its team."
 msgstr ""
 "Le app pensate per Mastodon possono scrivere a nome di questa pagina, "
 "leggerne il feed e avvisarne il team."
 
 #: lib/vutuv_web/templates/settings/apps.html.heex:44
 #, elixir-autogen, elixir-format
-msgid ""
-"Apps built for Mastodon — Ivory, Tusky, Ice Cubes and the rest — can read "
-"your feed, post, and notify you. Off unless you turn it on."
+msgid "Apps built for Mastodon — Ivory, Tusky, Ice Cubes and the rest — can read your feed, post, and notify you. Off unless you turn it on."
 msgstr ""
 "Le app pensate per Mastodon (Ivory, Tusky, Ice Cubes e le altre) possono "
 "leggere il Suo feed, pubblicare e avvisarla. Disattivate finché non le "
@@ -23682,10 +22542,7 @@ msgstr "Come configurare un'app"
 
 #: lib/vutuv_web/templates/settings/apps.html.heex:58
 #, elixir-autogen, elixir-format
-msgid ""
-"Lets you sign in to this account from a Mastodon-compatible app. Switching "
-"it off immediately stops apps you already signed in from reaching this "
-"account."
+msgid "Lets you sign in to this account from a Mastodon-compatible app. Switching it off immediately stops apps you already signed in from reaching this account."
 msgstr ""
 "Le permette di accedere a questo account da un'app compatibile con Mastodon."
 " Disattivandolo, le app da cui ha già effettuato l'accesso smettono subito "
@@ -23696,25 +22553,21 @@ msgstr ""
 msgid "Mastodon app access changed"
 msgstr "Accesso delle app Mastodon modificato"
 
-#: lib/vutuv_web/components/ui.ex:4454
+#: lib/vutuv_web/components/ui.ex:4475
 #, elixir-autogen, elixir-format
 msgid "Mastodon apps, connected apps and access tokens"
 msgstr "App Mastodon, app collegate e token di accesso"
 
 #: lib/vutuv_web/live/organization_live/apps.ex:312
 #, elixir-autogen, elixir-format
-msgid ""
-"Sign in with your own account, then pick %{name} on the approval screen."
+msgid "Sign in with your own account, then pick %{name} on the approval screen."
 msgstr ""
 "Acceda con il Suo account, poi scelga %{name} nella schermata di "
 "approvazione."
 
 #: lib/vutuv_web/live/organization_live/apps.ex:317
 #, elixir-autogen, elixir-format
-msgid ""
-"Sign in with your own account, then pick this page on the approval screen. A"
-" short @name is not needed for that, only for being followed from another "
-"server."
+msgid "Sign in with your own account, then pick this page on the approval screen. A short @name is not needed for that, only for being followed from another server."
 msgstr ""
 "Acceda con il Suo account, poi scelga questa pagina nella schermata di "
 "approvazione. Per questo non serve un @nome breve, che serve solo per farsi "
@@ -23745,10 +22598,7 @@ msgstr "Attiva l'accesso delle app"
 
 #: lib/vutuv_web/live/organization_live/apps.ex:188
 #, elixir-autogen, elixir-format
-msgid ""
-"Whoever posted stays recorded, so the team can always tell who wrote what — "
-"and an app signed in as this page cannot block anybody, because blocking is "
-"between two people."
+msgid "Whoever posted stays recorded, so the team can always tell who wrote what — and an app signed in as this page cannot block anybody, because blocking is between two people."
 msgstr ""
 "Resta sempre registrato chi ha pubblicato, così il team può sapere chi ha "
 "scritto cosa; e un'app collegata come questa pagina non può bloccare "
@@ -23759,11 +22609,9 @@ msgstr ""
 msgid "Your account is then %{handle}."
 msgstr "Il Suo account è allora %{handle}."
 
-#: lib/vutuv_web/components/ui.ex:4456
+#: lib/vutuv_web/components/ui.ex:4477
 #, elixir-autogen, elixir-format
-msgid ""
-"api token oauth developer connected third party mastodon app phone client "
-"ivory tusky ice cubes sign in"
+msgid "api token oauth developer connected third party mastodon app phone client ivory tusky ice cubes sign in"
 msgstr ""
 "api token oauth sviluppatore collegate terze parti mastodon app telefono "
 "client ivory tusky ice cubes accesso"
@@ -23799,7 +22647,7 @@ msgstr "Trovi le persone che conosce da LinkedIn"
 msgid "Find your LinkedIn contacts"
 msgstr "Trovi i Suoi contatti LinkedIn"
 
-#: lib/vutuv_web/components/ui.ex:4381
+#: lib/vutuv_web/components/ui.ex:4402
 #: lib/vutuv_web/live/import_connections_live.ex:64
 #: lib/vutuv_web/templates/import/new.html.heex:37
 #, elixir-autogen, elixir-format
@@ -23848,10 +22696,7 @@ msgstr "Nessuno di nuovo da seguire: li segue già tutti."
 
 #: lib/vutuv_web/live/import_connections_live.ex:435
 #, elixir-autogen, elixir-format
-msgid ""
-"None of your contacts is here yet. Or they are, but keep their address "
-"private and have not linked their LinkedIn profile. Nothing was stored, and "
-"you can try again with a newer archive at any time."
+msgid "None of your contacts is here yet. Or they are, but keep their address private and have not linked their LinkedIn profile. Nothing was stored, and you can try again with a newer archive at any time."
 msgstr ""
 "Nessuno dei Suoi contatti è ancora qui. Oppure c'è, ma tiene privato il "
 "proprio indirizzo e non ha collegato il proprio profilo LinkedIn. Non è "
@@ -23870,9 +22715,7 @@ msgstr "Al Suo profilo non viene aggiunto nulla."
 
 #: lib/vutuv_web/live/import_connections_live.ex:322
 #, elixir-autogen, elixir-format
-msgid ""
-"Nothing is stored: we read the file, show you the result, and keep neither "
-"your contacts nor the list."
+msgid "Nothing is stored: we read the file, show you the result, and keep neither your contacts nor the list."
 msgstr ""
 "Non viene memorizzato nulla: leggiamo il file, Le mostriamo il risultato e "
 "non conserviamo né i Suoi contatti né l'elenco."
@@ -23880,8 +22723,7 @@ msgstr ""
 #: lib/vutuv_web/live/import_connections_live.ex:442
 #, elixir-autogen, elixir-format
 msgid "One of your LinkedIn contacts is already a vutuv member."
-msgid_plural ""
-"%{formatted} of your LinkedIn contacts are already vutuv members."
+msgid_plural "%{formatted} of your LinkedIn contacts are already vutuv members."
 msgstr[0] "Uno dei Suoi contatti LinkedIn è già membro di vutuv."
 msgstr[1] "%{formatted} dei Suoi contatti LinkedIn sono già membri di vutuv."
 
@@ -23918,7 +22760,7 @@ msgstr "Cerchi per nome"
 msgid "See which of them are already on vutuv"
 msgstr "Veda quali di loro sono già su vutuv"
 
-#: lib/vutuv_web/components/ui.ex:4383
+#: lib/vutuv_web/components/ui.ex:4404
 #, elixir-autogen, elixir-format
 msgid "See which of your LinkedIn contacts are already on vutuv"
 msgstr "Veda quali dei Suoi contatti LinkedIn sono già su vutuv"
@@ -23947,20 +22789,14 @@ msgstr "Non è stato possibile leggere il file."
 
 #: lib/vutuv_web/templates/import/new.html.heex:29
 #, elixir-autogen, elixir-format
-msgid ""
-"The same file also lists your LinkedIn contacts. We can show you which of "
-"them are already on vutuv, without importing or inviting anyone."
+msgid "The same file also lists your LinkedIn contacts. We can show you which of them are already on vutuv, without importing or inviting anyone."
 msgstr ""
 "Lo stesso file elenca anche i Suoi contatti LinkedIn. Possiamo mostrarLe "
 "quali di loro sono già su vutuv, senza importare né invitare nessuno."
 
 #: lib/vutuv_web/live/import_connections_live.ex:329
 #, elixir-autogen, elixir-format
-msgid ""
-"We only recognise someone by an email address they published here, or by the"
-" LinkedIn profile they linked from their vutuv profile. We never guess by "
-"name, so you will not be offered a stranger who happens to share a name with"
-" someone you know."
+msgid "We only recognise someone by an email address they published here, or by the LinkedIn profile they linked from their vutuv profile. We never guess by name, so you will not be offered a stranger who happens to share a name with someone you know."
 msgstr ""
 "Riconosciamo qualcuno solo tramite un indirizzo e-mail che ha pubblicato "
 "qui, o tramite il profilo LinkedIn che ha collegato dal proprio profilo "
@@ -23992,10 +22828,7 @@ msgstr[1] "Ora segue %{formatted} membri in più."
 
 #: lib/vutuv_web/live/import_connections_live.ex:311
 #, elixir-autogen, elixir-format
-msgid ""
-"Your LinkedIn data export lists your contacts. We read that list, look for "
-"the people among them who are already vutuv members, and show you who they "
-"are. You decide who to follow."
+msgid "Your LinkedIn data export lists your contacts. We read that list, look for the people among them who are already vutuv members, and show you who they are. You decide who to follow."
 msgstr ""
 "L'esportazione dei Suoi dati LinkedIn elenca i Suoi contatti. Leggiamo "
 "quell'elenco, cerchiamo fra loro le persone che sono già membri di vutuv e "
@@ -24011,29 +22844,12 @@ msgstr "I Suoi contatti su vutuv"
 msgid "Your export also lists your LinkedIn contacts."
 msgstr "La Sua esportazione elenca anche i Suoi contatti LinkedIn."
 
-#: lib/vutuv_web/components/ui.ex:4385
+#: lib/vutuv_web/components/ui.ex:4406
 #, elixir-autogen, elixir-format
-msgid ""
-"linkedin contacts connections address book find people know colleagues "
-"follow zip kontakte bekannte kollegen finden"
+msgid "linkedin contacts connections address book find people know colleagues follow zip kontakte bekannte kollegen finden"
 msgstr ""
 "linkedin contatti collegamenti rubrica trovare persone conoscenti colleghi "
 "seguire zip"
-
-#: lib/vutuv_web/views/settings_html.ex:173
-#, elixir-autogen, elixir-format
-msgid "Add another language"
-msgstr "Aggiungi un'altra lingua"
-
-#: lib/vutuv_web/templates/settings/preferences.html.heex:208
-#, elixir-autogen, elixir-format
-msgid "Choosing none means: all languages."
-msgstr "Non sceglierne nessuna significa: tutte le lingue."
-
-#: lib/vutuv_web/templates/settings/preferences.html.heex:205
-#, elixir-autogen, elixir-format
-msgid "These languages I read"
-msgstr "Le lingue che leggo"
 
 #: lib/vutuv_web/live/organization_live/activity.ex:91
 #, elixir-autogen, elixir-format
@@ -24042,9 +22858,7 @@ msgstr "%{name} ha risposto a un post."
 
 #: lib/vutuv_web/views/oauth_html.ex:27
 #, elixir-autogen, elixir-format
-msgid ""
-"This application asked to be connected too many times in a row. Please wait "
-"a moment and try again."
+msgid "This application asked to be connected too many times in a row. Please wait a moment and try again."
 msgstr ""
 "Questa applicazione ha chiesto di collegarsi troppe volte di seguito. "
 "Aspetti un momento e riprovi."
@@ -24066,10 +22880,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/live/organization_live/apps.ex:220
 #, elixir-autogen, elixir-format
-msgid ""
-"Each row is one app signed in as this page, issued by the team member named "
-"on it. Withdrawing one stops that app immediately; the member keeps their "
-"own account."
+msgid "Each row is one app signed in as this page, issued by the team member named on it. Withdrawing one stops that app immediately; the member keeps their own account."
 msgstr ""
 "Ogni riga è un'app collegata come questa pagina, rilasciata dal membro del "
 "team indicato accanto. Revocarne una ferma subito quell'app; il membro "
@@ -24119,12 +22930,8 @@ msgstr "L'app non può più agire per questa pagina."
 
 #: lib/vutuv_web/live/organization_live/apps.ex:201
 #, elixir-autogen, elixir-format
-msgid ""
-"Turn app access off? The one app token issued for this page is withdrawn and"
-" stops working immediately."
-msgid_plural ""
-"Turn app access off? All %{count} app tokens issued for this page are "
-"withdrawn and stop working immediately."
+msgid "Turn app access off? The one app token issued for this page is withdrawn and stops working immediately."
+msgid_plural "Turn app access off? All %{count} app tokens issued for this page are withdrawn and stop working immediately."
 msgstr[0] ""
 "Disattivare l'accesso delle app? L'unico token rilasciato per questa pagina "
 "viene revocato e smette subito di funzionare."
@@ -24235,7 +23042,7 @@ msgstr ""
 "Questa pagina sta seguendo il numero massimo di account che consentiamo "
 "(%{max})."
 
-#: lib/vutuv_web/components/post_components.ex:2297
+#: lib/vutuv_web/components/post_components.ex:2312
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr "Smettere di seguire %{handle}? I suoi post spariscono dal Suo feed."
@@ -24272,9 +23079,7 @@ msgstr "Non ora"
 
 #: lib/vutuv_web/templates/settings/notifications.html.heex:152
 #, elixir-autogen, elixir-format
-msgid ""
-"Only while vutuv is open somewhere and you are looking at something else. "
-"Every browser you use asks you once."
+msgid "Only while vutuv is open somewhere and you are looking at something else. Every browser you use asks you once."
 msgstr ""
 "Solo mentre vutuv è aperto da qualche parte e Lei sta guardando altro. Ogni "
 "browser che usa Glielo chiede una volta."
@@ -24286,8 +23091,7 @@ msgstr "Mostrami le notifiche del browser"
 
 #: lib/vutuv_web/templates/settings/notifications.html.heex:202
 #, elixir-autogen, elixir-format
-msgid ""
-"This browser cannot show notifications. Your other browsers are unaffected."
+msgid "This browser cannot show notifications. Your other browsers are unaffected."
 msgstr ""
 "Questo browser non può mostrare notifiche. Gli altri Suoi browser non sono "
 "interessati."
@@ -24299,10 +23103,7 @@ msgstr "A questo browser non è ancora stato chiesto."
 
 #: lib/vutuv_web/templates/settings/notifications.html.heex:197
 #, elixir-autogen, elixir-format
-msgid ""
-"This browser is blocking notifications for vutuv. Allow them for this site "
-"in your browser settings; the switch above stays on and every other browser "
-"you use is unaffected."
+msgid "This browser is blocking notifications for vutuv. Allow them for this site in your browser settings; the switch above stays on and every other browser you use is unaffected."
 msgstr ""
 "Questo browser sta bloccando le notifiche per vutuv. Le consenta per questo "
 "sito nelle impostazioni del browser; l'interruttore qui sopra resta attivo e"
@@ -24315,10 +23116,7 @@ msgstr "Questo browser le mostrerà."
 
 #: lib/vutuv_web/templates/settings/notifications.html.heex:146
 #, elixir-autogen, elixir-format
-msgid ""
-"When something arrives while you have vutuv open in a tab you are not "
-"looking at, your browser can show it as a notification. Off unless you "
-"switch it on."
+msgid "When something arrives while you have vutuv open in a tab you are not looking at, your browser can show it as a notification. Off unless you switch it on."
 msgstr ""
 "Quando arriva qualcosa mentre ha vutuv aperto in una scheda che non sta "
 "guardando, il Suo browser può mostrarlo come notifica. Disattivate finché "
@@ -24326,18 +23124,14 @@ msgstr ""
 
 #: lib/vutuv_web/live/shell_live.ex:669
 #, elixir-autogen, elixir-format
-msgid ""
-"You switched browser notifications on. This browser has not been asked for "
-"permission yet."
+msgid "You switched browser notifications on. This browser has not been asked for permission yet."
 msgstr ""
 "Ha attivato le notifiche del browser. A questo browser non è ancora stato "
 "chiesto il permesso."
 
-#: lib/vutuv_web/components/ui.ex:4364
+#: lib/vutuv_web/components/ui.ex:4374
 #, elixir-autogen, elixir-format
-msgid ""
-"email mail unsubscribe newsletter bell alert quiet fewer browser desktop "
-"popup push benachrichtigung"
+msgid "email mail unsubscribe newsletter bell alert quiet fewer browser desktop popup push benachrichtigung"
 msgstr ""
 "e-mail posta disiscrizione newsletter campanella avviso silenzio meno "
 "browser desktop popup push notifica"
@@ -24369,9 +23163,7 @@ msgstr "Invia una notifica di prova"
 
 #: lib/vutuv_web/templates/settings/notifications.html.heex:190
 #, elixir-autogen, elixir-format
-msgid ""
-"Sent. If nothing appeared, your system is holding it back. Check Do Not "
-"Disturb and your notification settings."
+msgid "Sent. If nothing appeared, your system is holding it back. Check Do Not Disturb and your notification settings."
 msgstr ""
 "Inviata. Se non è comparso nulla, è il Suo sistema a trattenerla. Controlli "
 "la modalità Non disturbare e le impostazioni delle notifiche."
@@ -24388,19 +23180,17 @@ msgstr "Ecco come si presenta vutuv quando arriva qualcosa."
 
 #: lib/vutuv_web/views/tag_html.ex:103
 #, elixir-autogen, elixir-format
-msgid ""
-"Follow #%{tag} from Mastodon or any other Fediverse app and its public posts"
-" arrive in your timeline. No vutuv account needed."
+msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 "Segua #%{tag} da Mastodon o da qualsiasi altra app del Fediverso e i suoi "
 "post pubblici arriveranno nella Sua cronologia. Non serve un account vutuv."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1796
+#: lib/vutuv_web/live/post_live/feed.ex:1932
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Saluti gli altri membri"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1792
+#: lib/vutuv_web/live/post_live/feed.ex:1928
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr "Nuovi qui"
@@ -24417,7 +23207,8 @@ msgstr ""
 msgid "Or with an RSS reader"
 msgstr "Oppure con un lettore RSS"
 
-#: lib/vutuv_web/components/ui.ex:1178 lib/vutuv_web/components/ui.ex:1247
+#: lib/vutuv_web/components/ui.ex:1178
+#: lib/vutuv_web/components/ui.ex:1247
 #, elixir-autogen, elixir-format
 msgid "Subscribe"
 msgstr "Iscriviti"
@@ -24439,9 +23230,7 @@ msgstr "Non ha un account vutuv? Funzionano anche questi modi:"
 
 #: lib/vutuv_web/components/ui.ex:1252
 #, elixir-autogen, elixir-format
-msgid ""
-"The best way: follow %{name} here. New posts land in your feed, and you can "
-"reply and join in."
+msgid "The best way: follow %{name} here. New posts land in your feed, and you can reply and join in."
 msgstr ""
 "Il modo migliore: segua %{name} qui. I nuovi post arrivano nel Suo feed, e "
 "può rispondere e partecipare."
@@ -24451,74 +23240,71 @@ msgstr ""
 msgid "With a vutuv account"
 msgstr "Con un account vutuv"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1806
+#: lib/vutuv_web/live/post_live/feed.ex:1942
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr "Alcuni fra i membri più recenti. Seguirli è un bel benvenuto."
 
-#: lib/vutuv_web/components/post_components.ex:593
+#: lib/vutuv_web/components/post_components.ex:605
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new post"
 msgid_plural "%{formatted} new posts"
 msgstr[0] "%{formatted} nuovo post"
 msgstr[1] "%{formatted} nuovi post"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1251
+#: lib/vutuv_web/live/post_live/feed.ex:1387
 #, elixir-autogen, elixir-format
 msgid "%{source}: %{formatted} new post"
 msgid_plural "%{source}: %{formatted} new posts"
 msgstr[0] "%{source}: %{formatted} nuovo post"
 msgstr[1] "%{source}: %{formatted} nuovi post"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1248
+#: lib/vutuv_web/live/post_live/feed.ex:1384
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post"
 msgstr "%{source}: nuovo post"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1245
+#: lib/vutuv_web/live/post_live/feed.ex:1381
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post from %{who}"
 msgstr "%{source}: nuovo post di %{who}"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:297
+#: lib/vutuv_web/templates/settings/preferences.html.heex:247
 #, elixir-autogen, elixir-format
 msgid "Example"
 msgstr "Esempio"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:844
+#: lib/vutuv_web/controllers/settings_controller.ex:826
 #, elixir-autogen, elixir-format
 msgid "Feed tab settings reset to the site defaults."
 msgstr ""
 "Impostazioni delle schede del feed riportate ai valori predefiniti del sito."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:838
+#: lib/vutuv_web/controllers/settings_controller.ex:820
 #, elixir-autogen, elixir-format
 msgid "Feed tab settings saved."
 msgstr "Impostazioni delle schede del feed salvate."
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:89
-#: lib/vutuv_web/templates/settings/preferences.html.heex:263
+#: lib/vutuv_web/templates/settings/preferences.html.heex:213
 #, elixir-autogen, elixir-format
 msgid "Feed tabs"
 msgstr "Schede del feed"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:321
+#: lib/vutuv_web/templates/settings/preferences.html.heex:271
 #, elixir-autogen, elixir-format
 msgid "Just flashed the new release, boot is under two seconds now"
 msgstr ""
 "Appena installata la nuova versione, l'avvio ora sta sotto i due secondi"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:331
+#: lib/vutuv_web/templates/settings/preferences.html.heex:281
 #, elixir-autogen, elixir-format
 msgid "Play the example"
 msgstr "Riproduci l'esempio"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:265
+#: lib/vutuv_web/templates/settings/preferences.html.heex:215
 #, elixir-autogen, elixir-format
-msgid ""
-"When a post lands on the source tab you are not reading, that tab gets a "
-"dot. It can also quote the post for a few seconds, so you can tell whether "
-"it is worth switching."
+msgid "When a post lands on the source tab you are not reading, that tab gets a dot. It can also quote the post for a few seconds, so you can tell whether it is worth switching."
 msgstr ""
 "Quando un post arriva sulla scheda che non sta leggendo, quella scheda "
 "riceve un pallino. Può anche citare il post per qualche secondo, così "
@@ -24541,8 +23327,122 @@ msgstr "Cita ciò che arriva sull'altra scheda"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:92
 #, elixir-autogen, elixir-format
-msgid ""
-"When off, a tab holding something new wears its dot and says nothing more."
+msgid "When off, a tab holding something new wears its dot and says nothing more."
 msgstr ""
 "Se disattivato, una scheda con qualcosa di nuovo porta il suo pallino e non "
 "dice altro."
+
+#: lib/vutuv_web/live/feed_languages_live.ex:208
+#, elixir-autogen, elixir-format
+msgid "Rank the languages you read. Posts in them reach your feed as they were written; you decide below what happens to the rest."
+msgstr "Ordini le lingue che legge. I post in queste lingue arrivano nel Suo feed così come sono stati scritti; cosa succede al resto lo decide qui sotto."
+
+#: lib/vutuv_web/live/feed_languages_live.ex:215
+#, elixir-autogen, elixir-format
+msgid "Languages you read"
+msgstr "Lingue che legge"
+
+#: lib/vutuv_web/live/feed_languages_live.ex:218
+#, elixir-autogen, elixir-format
+msgid "No language chosen, so your feed shows all of them."
+msgstr "Nessuna lingua scelta: il Suo feed le mostra tutte."
+
+#: lib/vutuv_web/live/feed_languages_live.ex:243
+#, elixir-autogen, elixir-format
+msgid "First: translations go into this language"
+msgstr "Prima: si traduce in questa lingua"
+
+#: lib/vutuv_web/live/feed_languages_live.ex:278
+#, elixir-autogen, elixir-format
+msgid "Remove %{language}"
+msgstr "Rimuovi %{language}"
+
+#: lib/vutuv_web/live/feed_languages_live.ex:290
+#, elixir-autogen, elixir-format
+msgid "Suggested:"
+msgstr "Suggerite:"
+
+#: lib/vutuv_web/live/feed_languages_live.ex:325
+#, elixir-autogen, elixir-format
+msgid "Choose a language"
+msgstr "Scegli una lingua"
+
+#: lib/vutuv_web/live/feed_languages_live.ex:356
+#, elixir-autogen, elixir-format
+msgid "This installation has translations switched off, so posts in other languages show as written until an administrator turns them on."
+msgstr "Su questa installazione le traduzioni sono disattivate: i post in altre lingue vengono quindi mostrati così come sono stati scritti finché un amministratore non le attiva."
+
+#: lib/vutuv_web/live/feed_languages_live.ex:363
+#, elixir-autogen, elixir-format
+msgid "What your feed does"
+msgstr "Cosa fa il Suo feed"
+
+#: lib/vutuv_web/live/feed_languages_live.ex:403
+#, elixir-autogen, elixir-format
+msgid "Shown as written"
+msgstr "Mostrati così come sono scritti"
+
+#: lib/vutuv_web/live/feed_languages_live.ex:411
+#, elixir-autogen, elixir-format
+msgid "Every language"
+msgstr "Tutte le lingue"
+
+#: lib/vutuv_web/live/feed_languages_live.ex:411
+#, elixir-autogen, elixir-format
+msgid "Every other language"
+msgstr "Tutte le altre lingue"
+
+#: lib/vutuv_web/live/feed_languages_live.ex:432
+#, elixir-autogen, elixir-format
+msgid "Nothing is hidden: hiding needs at least one language above."
+msgstr "Non viene nascosto nulla: per nascondere serve almeno una lingua qui sopra."
+
+#: lib/vutuv_web/live/feed_languages_live.ex:434
+#, elixir-autogen, elixir-format
+msgid "Hidden from your feed."
+msgstr "Vengono nascosti dal Suo feed."
+
+#: lib/vutuv_web/live/feed_languages_live.ex:440
+#, elixir-autogen, elixir-format
+msgid "Shown in the language it was written in."
+msgstr "Vengono mostrati nella lingua in cui sono stati scritti."
+
+#: lib/vutuv_web/components/ui.ex:4387
+#, elixir-autogen, elixir-format
+msgid "Which languages reach you, and what happens to the rest"
+msgstr "Quali lingue arrivano fino a Lei e cosa succede al resto"
+
+#: lib/vutuv_web/components/ui.ex:4389
+#, elixir-autogen, elixir-format
+msgid "language translate translation german english original hide foreign rank order sprache übersetzen fremdsprache reihenfolge"
+msgstr "lingua tradurre traduzione italiano tedesco inglese originale nascondere lingua straniera ordine priorità feed language translate sprache"
+
+#: lib/vutuv_web/components/ui.ex:4454
+#, elixir-autogen, elixir-format
+msgid "Interface language, date format and time zone, maps, how posts are shortened"
+msgstr "Lingua dell'interfaccia, formato della data e fuso orario, mappe, come vengono accorciati i post"
+
+#: lib/vutuv_web/components/ui.ex:4458
+#, elixir-autogen, elixir-format
+msgid "german english locale map font length hyphenation übersetzen sprache zeitzone timezone time zone utc datum date uhrzeit clock 24 hour datumsformat"
+msgstr "italiano tedesco inglese lingua mappa carattere lunghezza sillabazione fuso orario timezone utc data ora orologio 24 ore formato della data"
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:190
+#, elixir-autogen, elixir-format
+msgid "Languages your feed shows"
+msgstr "Lingue che il Suo feed mostra"
+
+#: lib/vutuv_web/templates/settings/preferences.html.heex:192
+#, elixir-autogen, elixir-format
+msgid "Rank the languages you read, and say what happens to posts in the others."
+msgstr "Ordini le lingue che legge e stabilisca cosa succede ai post nelle altre."
+
+#: lib/vutuv_web/live/feed_languages_live.ex:424
+#, elixir-autogen, elixir-format
+msgid "Translate into %{language}"
+msgstr "Traducili in %{language}"
+
+#: lib/vutuv_web/live/feed_languages_live.ex:437
+#, elixir-autogen, elixir-format
+msgid "Translated into %{language}."
+msgstr "Vengono tradotti in %{language}."

--- a/priv/gettext/it/LC_MESSAGES/errors.po
+++ b/priv/gettext/it/LC_MESSAGES/errors.po
@@ -152,12 +152,8 @@ msgstr "Contiene un paese non valido"
 msgid "is already used in a post, so it can't be claimed"
 msgstr "È già usato in un post e quindi non è più rivendicabile"
 
-msgid ""
-"The handle %{handles} does not exist. Remove the mention or check the "
-"spelling."
-msgid_plural ""
-"The handle %{handles} does not exist. Remove the mention or check the "
-"spelling."
+msgid "The handle %{handles} does not exist. Remove the mention or check the spelling."
+msgid_plural "The handle %{handles} does not exist. Remove the mention or check the spelling."
 msgstr[0] ""
 "L'handle %{handles} non esiste. Rimuova la menzione o controlli "
 "l'ortografia."
@@ -176,17 +172,13 @@ msgstr "Alla recensione manca il titolo dell'opera"
 
 #: lib/vutuv_web/views/error_helpers.ex:99
 #, elixir-autogen, elixir-format
-msgid ""
-"PDF uploads are not available on this installation. Please upload an image "
-"instead."
+msgid "PDF uploads are not available on this installation. Please upload an image instead."
 msgstr ""
 "Su questa installazione non si possono caricare PDF. Carichi un'immagine."
 
 #: lib/vutuv_web/views/error_helpers.ex:94
 #, elixir-autogen, elixir-format
-msgid ""
-"Please confirm that the file may be shown publicly. Without your consent "
-"nothing is uploaded."
+msgid "Please confirm that the file may be shown publicly. Without your consent nothing is uploaded."
 msgstr ""
 "Confermi che il file può essere mostrato pubblicamente. Senza il Suo "
 "consenso non viene caricato nulla."
@@ -213,8 +205,7 @@ msgstr "Non può essere solo un link. Si descriva in poche parole."
 
 #: lib/vutuv_web/views/error_helpers.ex:111
 #, elixir-autogen, elixir-format
-msgid ""
-"\"%{tag}\" is a web address, not a tag. Please describe yourself with words."
+msgid "\"%{tag}\" is a web address, not a tag. Please describe yourself with words."
 msgstr "\"%{tag}\" è un indirizzo web, non un tag. Si descriva a parole."
 
 #: lib/vutuv_web/views/error_helpers.ex:118
@@ -254,8 +245,7 @@ msgstr "Inserisca il Suo link Signal: inizia con https://signal.me/#"
 
 #: lib/vutuv_web/views/error_helpers.ex:123
 #, elixir-autogen, elixir-format
-msgid ""
-"We allow at most %{max} accounts per post. Please remove some mentions."
+msgid "We allow at most %{max} accounts per post. Please remove some mentions."
 msgstr ""
 "Sono ammessi al massimo %{max} account per post. Rimuova qualche menzione."
 
@@ -280,8 +270,7 @@ msgstr ""
 
 #: lib/vutuv_web/views/error_helpers.ex:139
 #, elixir-autogen, elixir-format
-msgid ""
-"Enter your GitLab username, e.g. gitlab.com/username (not a /-/u/ ID link)"
+msgid "Enter your GitLab username, e.g. gitlab.com/username (not a /-/u/ ID link)"
 msgstr ""
 "Inserisca il Suo nome utente GitLab, ad esempio gitlab.com/nomeutente (non "
 "un link ID /-/u/)"
@@ -321,7 +310,6 @@ msgstr "Per ora troppi controlli. Riprovi più tardi."
 
 #: lib/vutuv_web/views/error_helpers.ex:155
 #, elixir-autogen, elixir-format
-msgid ""
-"We could not find this account on that instance. Please check the address."
+msgid "We could not find this account on that instance. Please check the address."
 msgstr ""
 "Non abbiamo trovato questo account su quell'istanza. Controlli l'indirizzo."


### PR DESCRIPTION
`mix gettext.extract --merge` had 23 pending changes for the Italian catalog, all from the feed-languages page (#1672), which shipped after Italian did: 15 msgids with no translation and 8 the merge fuzzy-filled with something else's words — `Suggested:` as "Post consigliati", `Every language` as "Modifica la lingua", `Hidden from your feed.` as "Nascosto a:".

**Where:** `/settings/feed_languages` and the settings hub tile, in Italian.

All 23 are now written by hand in the formal register the rest of the catalog uses, and verified resolving at runtime. Four German entries lost a fuzzy flag they should never have kept: their translations were checked line by line and are correct, so `grep -c ", fuzzy"` is now 0 for both translated catalogs — the number is worth something again.

The line count is wrapping, not content: the Italian catalog was the only one wrapped at 80 columns, and the merge rewrites it like the others. That is why the next merge will be quiet.

`docs/architecture/i18n.md` still said the interface ships in two languages; it now says three, and records the fuzzy-free baseline.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01W1mgbhkL5UpV2uRByEQM6c
