### PR TITLE
Keep the feed's unseen dot until the reader visits that tab

### DIFF
--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -430,37 +430,36 @@ dot beside its label (`post_filter_tabs/1`'s `unseen`), cleared by going there
 itself). Only the two named tabs ever dot (`unseen_tabs/1`): "All" holds the
 same posts, so a dot there was true and read as a third place with news of its
 own. A dot and no count: what the reader needs is that there is something
-over there, and the tab reloads from the top anyway. The socket's
-`:unseen_sources` is never stored — it means "since you have been looking at
-this page", so a fresh mount starting clean is the honest state.
+over there, and the tab reloads from the top anyway.
 
-**A rejoin runs that same mount and is not a fresh page.** Socket state goes
-with the socket, so the dot went with it: a locked phone, a background tab
-whose heartbeat the browser throttled past the transport timeout, a wifi
-handover and every deploy reconnect without reloading anything, which read as
-the dot expiring by itself a couple of minutes after it appeared. A
-**connected** mount therefore derives it back (`restore_unseen/2`): does the
-tab the reader is not on hold anything at or after the last moment they had it
-on screen (`Posts.feed_source_since?/3`, the boolean half of
-`newest_source_entry/3`)? That moment is the later of
+**The dot is derived at every mount, not carried by the socket.** It began as
+socket state meaning "since you have been looking at this page", and that is
+how long it lasted: opening a notification and coming back to /feed showed a
+clean tab bar over a post the reader had never seen. So did a reload, a second
+visit, and every LiveView **rejoin** — a mount with no page load at all, which
+is how a locked phone, a throttled background tab, a wifi handover or a deploy
+took the dot with them. None of those is somebody reading the post.
 
-* **when the document was loaded** — `feed_opened_at`, put into the signed
-  `live_render` session by `NewsfeedController`. That map is minted once per
-  document and replayed verbatim on every rejoin, so it dates the one thing a
-  socket that died and came back cannot date itself; and
-* **when they last moved tabs** — `users.feed_source_at`, stamped beside
-  `feed_source` by `remember_feed_filter/3`. Which tab is being left is an
-  argument rather than a rule at the call site, because only that side knows
-  it and the answer decides whether the clock moves at all: pressing the tab
-  already open moves nobody, and a stamp there would swallow a dot still
-  rightly standing on the other one.
+`unseen_at_mount/3` therefore asks, on the dead render: does the tab the reader
+is not on hold anything at or after the last moment they had it on screen
+(`Posts.feed_source_since?/3`, the boolean half of `newest_source_entry/3`)?
+That moment is `users.feed_source_at`, stamped beside `feed_source` by
+`remember_feed_filter/3`. Moving *to* a tab means the one being left was in
+front of them until then, and moving away again is what ends it, so the other
+tab's clock stands still exactly while it is off screen. Which tab is being
+left is an argument rather than a rule at the call site, because only that side
+knows it and the answer decides whether the clock moves at all: pressing the
+tab already open moves nobody, and a stamp there would swallow a dot still
+rightly standing on the other one. Going to a tab still clears its dot
+(`clear_unseen/2`) — and now that same press dates the next one.
 
-A real page load still starts clean (its own `opened_at` is now, and nothing is
-newer than now), and a document from the previous release carries no stamp and
-keeps the old behaviour, so the N-1 deploy window has no half-state. A first
-connect skips the question altogether (`@restore_grace`, 5 s): the socket joins
-a second or two after the render, so the answer is false by construction and
-the five source queries would be waste on the busiest page in the app.
+A member with no stamp gets no dot rather than a guessed one (a row last
+written before the column existed; their first tab press heals it, and a
+one-off backfill gave everyone else the deploy moment). The answer rides the
+handoff like the rest of the payload, so it is in the first paint and the
+connected mount does not ask again. Members on "All" and members without a tab
+bar pay nothing; for the rest it is an `Enum.any?/2` over the other tab's
+sources, one `LIMIT 1` each, beside the seven the page itself runs.
 
 The two halves reach it differently, and the difference is what each write
 knows about the reader:

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -321,9 +321,10 @@ defmodule Vutuv.Accounts.User do
     # own assign is the truth.
     field(:feed_source, :string)
     # When that tab was last chosen. Stamped by the same writer, and read at
-    # mount as the anchor for the feed's unseen dot: a rejoining document has
-    # to date "since you were last looking at the other tab" from somewhere
-    # outside the socket it just lost.
+    # every feed mount as the anchor for the unseen dot: moving to one tab
+    # dates the moment the reader stopped looking at the other, and that is
+    # what "unseen" is measured against — the socket it used to live in is
+    # gone the moment they open another page.
     field(:feed_source_at, :naive_datetime)
     # The reader's post-display preferences (same settings page, applied to
     # every post this member reads: feed, profile Beiträge, permalink). The

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -2657,7 +2657,7 @@ defmodule Vutuv.Posts do
 
   `feed_source_at` is the exception, and `leaving` is why it is an argument
   rather than a comment at the call site: it dates the reader's *move*, which
-  `VutuvWeb.PostLive.Feed.restore_unseen/2` reads as "you were still looking at
+  `VutuvWeb.PostLive.Feed.unseen_at_mount/3` reads as "you were still looking at
   the tab you just left until now". A press on the tab already open moves
   nobody, so stamping it there would swallow a dot still rightly standing on
   the other one. Only the caller knows which tab is on screen, so only the
@@ -2721,7 +2721,7 @@ defmodule Vutuv.Posts do
   @doc """
   Whether the tab `source` holds anything for `viewer` stamped at or after
   `since` — the boolean half of `newest_source_entry/3` below, and all a mount
-  restoring the dot has to know (`VutuvWeb.PostLive.Feed.restore_unseen/2`).
+  deriving the dot has to know (`VutuvWeb.PostLive.Feed.unseen_at_mount/3`).
 
   It skips that one's decorate pass, and `Enum.any?/2` stops at the first
   source that answers rather than asking all of them.

--- a/lib/vutuv_web/controllers/controller_helpers.ex
+++ b/lib/vutuv_web/controllers/controller_helpers.ex
@@ -137,11 +137,9 @@ defmodule VutuvWeb.ControllerHelpers do
   pattern); pages layer their own extra keys on top with `Map.put/3`.
 
   Worth knowing before you layer one on: this map is signed once per **document**
-  and replayed verbatim on every socket rejoin, which makes it the one
-  server-minted thing that can date a document a reconnecting LiveView is
-  patching into. `VutuvWeb.NewsfeedController`'s `feed_opened_at` is that (see
-  `VutuvWeb.PostLive.Feed.restore_unseen/2`). It is not a place for anything
-  that changes while the page is open — a rejoin would hand back the stale one.
+  and replayed verbatim on every socket rejoin, so it is not a place for
+  anything that changes while the page is open — a rejoin would hand back the
+  value the page was born with.
   """
   def live_render_session(%Conn{} = conn) do
     %{

--- a/lib/vutuv_web/controllers/newsfeed_controller.ex
+++ b/lib/vutuv_web/controllers/newsfeed_controller.ex
@@ -46,12 +46,7 @@ defmodule VutuvWeb.NewsfeedController do
     conn
     |> AgentDocs.put_html_alternates()
     |> put_layout(html: false)
-    |> live_render(Feed,
-      # Stamped with the moment this document was rendered, which is what lets
-      # a feed whose socket died and came back tell an arrival it already
-      # showed from one that landed while it was away (`Feed.restore_unseen/2`).
-      session: Feed.stamp_document(ControllerHelpers.live_render_session(conn))
-    )
+    |> live_render(Feed, session: ControllerHelpers.live_render_session(conn))
   end
 
   defp send_feed_doc(conn, format, params) do

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -70,15 +70,6 @@ defmodule VutuvWeb.PostLive.Feed do
   @newcomer_pool 30
   @tags_per_newcomer 3
   @suggestions_refresh :timer.minutes(5)
-
-  # How old a document has to be before a connected mount asks whether the dot
-  # on the other tab needs restoring — see `restore_unseen/2`.
-  @restore_grace 5
-
-  # Where that document's own age is kept. This module reads it, so this module
-  # writes it too (`stamp_document/2`) rather than leaving the spelling in the
-  # controller for the two to drift apart.
-  @opened_at_key "feed_opened_at"
   # "Suggested posts" rail: how many discovery posts to show at once.
   @discover_posts 5
 
@@ -93,7 +84,7 @@ defmodule VutuvWeb.PostLive.Feed do
     socket = InitAssigns.assign_embedded(socket, session)
 
     if user = socket.assigns.current_user do
-      {:ok, mount_feed(socket, user, session)}
+      {:ok, mount_feed(socket, user)}
     else
       {:ok,
        socket
@@ -102,21 +93,7 @@ defmodule VutuvWeb.PostLive.Feed do
     end
   end
 
-  @doc """
-  Stamps a `live_render` session map with the moment its **document** was
-  rendered — what `restore_unseen/2` dates the unseen dot from.
-
-  Called by `VutuvWeb.NewsfeedController`, which owns `/feed`. It belongs here
-  because this module is what reads the key back, and because the property that
-  makes it work is a property of that map: it is signed once per document and
-  replayed verbatim on every socket rejoin, so it dates the one thing a socket
-  that died and came back cannot date itself. `at` is for tests, which have to
-  place a document in the past to have a rejoin worth testing.
-  """
-  def stamp_document(session, at \\ NaiveDateTime.utc_now(:second)),
-    do: Map.put(session, @opened_at_key, NaiveDateTime.to_iso8601(at))
-
-  defp mount_feed(socket, user, session) do
+  defp mount_feed(socket, user) do
     # Can this browser draw the tab ticker at all? A deploy does not reload an
     # open feed — the socket reconnects to the new release and patches into a
     # document downloaded hours ago — so the question is not which release that
@@ -144,13 +121,10 @@ defmodule VutuvWeb.PostLive.Feed do
       # The dead render stashed its computed page seconds ago
       # (VutuvWeb.Live.MountHandoff); take it and skip re-running the same
       # queries. Any miss (expired, consumed, a reconnect) recomputes.
-      socket =
-        case MountHandoff.take(user.id, {:feed, remembered}) do
-          {:ok, payload} -> apply_feed_payload(socket, payload)
-          :error -> apply_feed_payload(socket, feed_payload(user, remembered))
-        end
-
-      restore_unseen(socket, opened_at(session))
+      case MountHandoff.take(user.id, {:feed, remembered}) do
+        {:ok, payload} -> apply_feed_payload(socket, payload)
+        :error -> apply_feed_payload(socket, feed_payload(user, remembered))
+      end
     else
       payload = feed_payload(user, remembered)
       MountHandoff.stash(user.id, {:feed, remembered}, payload)
@@ -194,6 +168,8 @@ defmodule VutuvWeb.PostLive.Feed do
       # it is a fact about their whole timeline, not about the open tab, so
       # switching tabs must not recompute it.
       source_tabs?: source_tabs?,
+      # The dot on the tab they are not on, as this page opens (issue #1503).
+      unseen_sources: unseen_at_mount(user, filter, source_tabs?),
       # The desktop discovery rail renders WITH the page: it was lazy-loaded
       # for one release (v7.200.3) and the pop-in read as slowness, so it is
       # eager again — computed here once, riding the handoff to the connected
@@ -234,12 +210,11 @@ defmodule VutuvWeb.PostLive.Feed do
     |> assign(:feed_filter, payload.filter)
     |> assign(:source_tabs?, payload.source_tabs?)
     # The named sources holding something this reader has not seen (issue
-    # #1503), each one a dot on its tab. Socket state on purpose and never
-    # stored: it means "since you have been looking at this page", so a fresh
-    # document starting clean is the honest state, not a lost one. A **rejoin**
-    # is a mount too and is not a fresh document, so a connected mount derives
-    # the dot back — see `restore_unseen/2`.
-    |> assign(:unseen_sources, MapSet.new())
+    # #1503), each one a dot on its tab. The socket carries it from here on,
+    # but it does not *begin* here: the mount derives it from the last time
+    # they had the other tab on screen (`unseen_at_mount/3`), because an unread
+    # post is unread on the next page as well.
+    |> assign(:unseen_sources, payload.unseen_sources)
     # The transient half of that (issue #1668): what landed over there, quoted
     # beside its tab for a few seconds. nil = no window open. `ticker_quiet_until`
     # is the short silence after one closes, so a burst on a bad line cannot
@@ -627,7 +602,7 @@ defmodule VutuvWeb.PostLive.Feed do
     # calls to pull the feed back to "All". That fallback is the code's doing,
     # not theirs, and must not overwrite the tab they chose.
     # It is handed the tab being left as well, because that is what dates the
-    # move for `restore_unseen/2` and only this side knows it.
+    # move for `unseen_at_mount/3` and only this side knows it.
     Posts.remember_feed_filter(socket.assigns.current_user, filter, socket.assigns.feed_filter)
 
     {:noreply, load_source_filter(socket, filter)}
@@ -1023,10 +998,13 @@ defmodule VutuvWeb.PostLive.Feed do
 
   # The tab a dot could go on, or nil: the one the reader is not looking at —
   # "All" is both of them at once, so nothing ever landed elsewhere — and only
-  # where there is a tab bar to put one in.
-  defp dottable_source(socket) do
-    if socket.assigns.source_tabs?, do: other_source(socket.assigns.feed_filter)
-  end
+  # where there is a tab bar to put one in. Taken apart from the socket because
+  # `unseen_at_mount/3` asks the same question before there is one.
+  defp dottable_source(socket),
+    do: dottable_source(socket.assigns.feed_filter, socket.assigns.source_tabs?)
+
+  defp dottable_source(filter, true), do: other_source(filter)
+  defp dottable_source(_filter, false), do: nil
 
   # The other named tab — nil on "All", which is both of them at once.
   defp other_source(:vutuv), do: :fediverse
@@ -1125,68 +1103,39 @@ defmodule VutuvWeb.PostLive.Feed do
   defp mark_unseen(socket, source),
     do: update(socket, :unseen_sources, &MapSet.put(&1, source))
 
-  # The dot the reader had before the socket blinked.
+  # The dot a mount opens with — the whole of what carries it from one look at
+  # the feed to the next.
   #
-  # `unseen_sources` is socket state, so a mount starts it empty — and a
-  # LiveView **rejoin is a mount**. A rejoin is also invisible: nothing
-  # reloads, the socket simply re-joins and the tabs come back without the dot,
-  # which reads as the dot expiring by itself a couple of minutes after it
-  # appeared. A locked phone, a backgrounded tab whose heartbeat the browser
-  # throttled past the socket timeout, a wifi handover and every deploy all do
-  # it, and none of them mean the reader stopped looking at this page.
+  # `unseen_sources` is socket state and a mount is a new socket, so the dot
+  # used to last exactly as long as the page: opening a notification and coming
+  # back showed a clean tab bar over a post nobody had read. So did a reload, a
+  # second visit, and every LiveView **rejoin** — a mount with no page load at
+  # all, which is how a locked phone, a throttled background tab, a wifi
+  # handover and every deploy took it. None of that is somebody reading a post.
   #
-  # So on a connected mount the dot is *derived* rather than carried: does the
-  # tab the reader is not on hold anything newer than the last moment they had
-  # it on screen? That moment is the later of
+  # So the dot is *derived* rather than carried: does the tab they are not on
+  # hold anything at or after the last moment they had it on screen? That
+  # moment is `users.feed_source_at`, stamped when they move tabs
+  # (`Posts.remember_feed_filter/3`) — moving *to* one tab dates the moment
+  # they stopped looking at the other, and that clock then stands still exactly
+  # while the tab is off screen. Going there still clears the dot
+  # (`clear_unseen/2`), and now the same press dates the next one.
   #
-  #   * when this **document** was loaded — `feed_opened_at` rides the signed
-  #     `live_render` session, which is minted once by NewsfeedController and
-  #     replayed verbatim on every rejoin, so it survives exactly what the
-  #     socket does not; and
-  #   * when they last **moved tabs** (`users.feed_source_at`, stamped beside
-  #     the tab it names).
+  # No stamp, no dot, rather than a guessed one: that is a member last written
+  # by the release before the column, and their first tab press heals it.
   #
-  # A genuine page load therefore still starts clean, which is the behaviour
-  # #1503 chose: its own `opened_at` is now, and nothing is newer than now.
-  # A document from the previous release carries no stamp and simply keeps the
-  # old behaviour, so the N-1 deploy window has no half-state.
-  #
-  # Which is also why a first connect skips the question entirely
-  # (`@restore_grace`): the socket joins a second or two after the HTTP render,
-  # so the answer is false by construction, and asking it costs five source
-  # queries on the busiest page in the app. The sliver that buys — an arrival
-  # between the render and `Activity.subscribe/1` — was never covered by
-  # anything anyway.
-  defp restore_unseen(socket, nil), do: socket
+  # It runs on the **dead** render, so the dot is in the first paint and the
+  # connected mount takes it off the handoff with everything else. "All" and a
+  # member without a tab bar pay nothing; the rest pay an `Enum.any?/2` over
+  # the other tab's sources, a LIMIT 1 each, beside the seven the page runs.
+  defp unseen_at_mount(user, filter, source_tabs?) do
+    source = dottable_source(filter, source_tabs?)
+    since = user.feed_source_at
 
-  defp restore_unseen(socket, opened_at) do
-    user = socket.assigns.current_user
-    source = dottable_source(socket)
-
-    if source && document_aged?(opened_at) &&
-         Posts.feed_source_since?(user, source, later_of(opened_at, user.feed_source_at)) do
-      mark_unseen(socket, source)
-    else
-      socket
-    end
+    if source && since && Posts.feed_source_since?(user, source, since),
+      do: MapSet.new([source]),
+      else: MapSet.new()
   end
-
-  # Old enough that this mount can be a rejoin rather than the document's own
-  # first connect.
-  defp document_aged?(opened_at),
-    do: NaiveDateTime.diff(NaiveDateTime.utc_now(:second), opened_at) >= @restore_grace
-
-  defp opened_at(session) do
-    with stamp when is_binary(stamp) <- session[@opened_at_key],
-         {:ok, at} <- NaiveDateTime.from_iso8601(stamp) do
-      at
-    else
-      _ -> nil
-    end
-  end
-
-  defp later_of(at, nil), do: at
-  defp later_of(at, other), do: Enum.max([at, other], NaiveDateTime)
 
   ## ── The tab ticker (issue #1668) ──
   #

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.355.1",
+      version: "7.355.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260825123006_backfill_feed_source_at.exs
+++ b/priv/repo/migrations/20260825123006_backfill_feed_source_at.exs
@@ -1,0 +1,32 @@
+defmodule Vutuv.Repo.Migrations.BackfillFeedSourceAt do
+  use Ecto.Migration
+
+  @moduledoc """
+  Gives every member who already chose a feed source tab an anchor for the
+  unseen dot (`VutuvWeb.PostLive.Feed.unseen_at_mount/3`).
+
+  The dot on the tab you are not on is derived at each mount from
+  `feed_source_at` — the last moment that tab was on screen. The column landed
+  one release ago and is written only when a tab is pressed, so nearly every
+  member who chose one months back has a NULL there and would get no dot until
+  they happened to press a tab again. `NOW()` reads as "everything up to the
+  deploy counts as seen", which is the conservative half: it withholds a dot,
+  it never invents one. Members still on "All" keep their NULL — they see both
+  halves, so nothing can land elsewhere.
+
+  N-1 safe: the previous release reads the column too, and a later stamp only
+  makes it show fewer dots.
+  """
+
+  def up do
+    execute("""
+    UPDATE users
+       SET feed_source_at = (NOW() AT TIME ZONE 'utc')
+     WHERE feed_source IS NOT NULL
+       AND feed_source_at IS NULL
+    """)
+  end
+
+  # Nothing to undo: the column's own migration drops it.
+  def down, do: :ok
+end

--- a/test/vutuv_web/live/feed_source_tabs_test.exs
+++ b/test/vutuv_web/live/feed_source_tabs_test.exs
@@ -24,9 +24,7 @@ defmodule VutuvWeb.FeedSourceTabsTest do
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Fediverse.RemotePost
   alias Vutuv.Posts
-  alias Vutuv.Sessions
   alias Vutuv.Social
-  alias VutuvWeb.PostLive.Feed
 
   # An account out there that nobody here follows.
   defp remote_account(handle) do
@@ -637,115 +635,116 @@ defmodule VutuvWeb.FeedSourceTabsTest do
       refute dotted?(view, "all")
     end
 
-    # ── Across a rejoin (the dot that "expired after a couple of minutes") ──
+    # ── Across a page load (the dot that vanished on the way back) ──
     #
-    # A rejoin re-mounts with the SAME signed session the document was rendered
-    # with, `feed_opened_at` and all, which is what restores the dot socket
-    # state cannot carry (`PostLive.Feed.restore_unseen/2`). So a rejoin here is
-    # `live_isolated/3` twice on one session map.
+    # The dot is not state a mount inherits — every mount derives it from the
+    # last moment the reader had the other tab on screen (`users.feed_source_at`,
+    # `unseen_at_mount/3`). So it comes back on the next visit to /feed, and a
+    # rejoin — a mount with no page load at all — takes the same path.
 
     # A reader whose feed has both halves, a member they follow here, and that
     # member's post — the arrival that belongs on the tab they are not on.
-    defp rejoin_fixture(conn) do
-      {_conn, user} = create_and_login_user(conn)
+    defp unseen_fixture(conn) do
+      {conn, user} = create_and_login_user(conn)
       {author, older} = followed_post(user, "an older post")
       # Well behind everything else: it is the tab's existing content, and a
-      # test asking "is anything NEWER than this document" has to be able to
-      # answer no.
+      # test asking "is anything newer than the reader's last look" has to be
+      # able to answer no.
       backdate_post!(older, 300)
       cached_post(remote_account(user, "them"), "written out there")
       {:ok, post} = Posts.create_post(author, %{body: "arriving live"})
 
-      # Placed half a minute back, for two reasons that both come from second
-      # precision: a test whose post, document and tab press all happen in one
-      # second decides ties rather than rules, and a document has to be older
-      # than `@restore_grace` before a mount asks the question at all.
-      {user, backdate_post!(post, 30)}
+      # Placed half a minute back: at second precision, a test whose post and
+      # tab press happen inside one second decides ties rather than rules.
+      {conn, user, backdate_post!(post, 30)}
     end
 
-    # The state a document arrives with: the tab this member moved to, and when.
+    # The tab this member moved to, and when.
     defp opened_on(user, filter, at) do
       Repo.update!(
         Ecto.Changeset.change(user, feed_source: to_string(filter), feed_source_at: at)
       )
     end
 
-    # The session `live_render` mints for a /feed document (NewsfeedController).
-    # Bound once per test and mounted twice, because replaying the one map is
-    # exactly what a rejoin does.
-    defp feed_session(user, opened_at) do
-      {token, _session} = Sessions.start_session(user, build_conn(), alert: false)
-
-      %{"session_token" => token, "locale" => "en", "request_path" => "/feed"}
-      |> Feed.stamp_document(opened_at)
-    end
-
-    # `live_isolated/3` mounts outside any real request, so the socket session it
-    # captures is empty — and the feed's post cards render CSRF `<.link
-    # method=…>` items, which raise without the token a browser session carries.
-    # `dump_state/0` mints exactly the value the cookie session would hold.
-    defp mount_document(session) do
-      conn =
-        Plug.Test.init_test_session(build_conn(), %{
-          "_csrf_token" => Plug.CSRFProtection.dump_state()
-        })
-
-      {:ok, view, _html} = live_isolated(conn, Feed, session: session)
+    defp load_feed(conn) do
+      {:ok, view, _html} = live(conn, ~p"/feed")
       view
     end
 
-    test "a rejoin brings back a dot the reader never cleared", %{conn: conn} do
-      {user, post} = rejoin_fixture(conn)
+    test "the next page load brings back a dot the reader never cleared", %{conn: conn} do
+      {conn, user, post} = unseen_fixture(conn)
 
-      # The document was opened on the Fediverse tab a second before that post
-      # landed, so it landed while the reader was looking at this page.
-      opened_at = NaiveDateTime.add(post.inserted_at, -1)
-      opened_on(user, :fediverse, opened_at)
+      # They moved to the Fediverse tab a second before that vutuv post landed,
+      # so they have not been to the vutuv tab since it did — and a trip to
+      # another page and back does not make it read.
+      opened_on(user, :fediverse, NaiveDateTime.add(post.inserted_at, -1))
 
-      assert dotted?(mount_document(feed_session(user, opened_at)), "vutuv")
+      assert dotted?(load_feed(conn), "vutuv")
     end
 
-    test "a fresh page load still starts clean", %{conn: conn} do
-      {user, post} = rejoin_fixture(conn)
+    test "the Fediverse tab is dotted the same way", %{conn: conn} do
+      # The dot is not a fediverse feature and its clock is not a local one:
+      # the same question is asked of whichever tab the reader is not on, so
+      # this is the mirror of the test above, reader and arrival swapped.
+      {conn, user} = create_and_login_user(conn)
+      {_author, older} = followed_post(user, "an older post")
+      backdate_post!(older, 300)
 
-      # Loaded after that post, so the post is not news: it sits on the tab it
-      # belongs to, above the fold, waiting to be read. #1503's dot means "while
-      # you were looking", not "since you last read everything".
-      opened_at = NaiveDateTime.add(post.inserted_at, 1)
-      opened_on(user, :fediverse, opened_at)
+      landed = DateTime.add(DateTime.utc_now(:second), -30)
 
-      refute dotted?(mount_document(feed_session(user, opened_at)), "vutuv")
+      remote =
+        user
+        |> remote_account("them")
+        |> cached_post("written out there")
+        |> Ecto.Changeset.change(published_at: landed)
+        |> Repo.update!()
+
+      at = DateTime.to_naive(remote.published_at)
+
+      # They moved to the vutuv tab a second before that post landed out there.
+      opened_on(user, :vutuv, NaiveDateTime.add(at, -1))
+      assert dotted?(load_feed(conn), "fediverse")
+
+      # And would not be dotted had they been back since.
+      opened_on(user, :vutuv, NaiveDateTime.add(at, 1))
+      refute dotted?(load_feed(conn), "fediverse")
     end
 
-    test "a tab the reader visited since stays clean across a rejoin", %{conn: conn} do
-      {user, post} = rejoin_fixture(conn)
+    test "a tab the reader has been to since stays clean", %{conn: conn} do
+      {conn, user, post} = unseen_fixture(conn)
 
-      # Opened before the post landed — but they moved tabs afterwards, and
-      # moving TO the Fediverse tab means they were sitting on the vutuv one
-      # until then, so they have seen it.
-      opened_at = NaiveDateTime.add(post.inserted_at, -1)
+      # Moving TO the Fediverse tab after the post landed means they were
+      # sitting on the vutuv one until then, so they have seen it.
       opened_on(user, :fediverse, NaiveDateTime.add(post.inserted_at, 1))
 
-      refute dotted?(mount_document(feed_session(user, opened_at)), "vutuv")
+      refute dotted?(load_feed(conn), "vutuv")
+    end
+
+    test "a member whose tab clock was never stamped gets no dot", %{conn: conn} do
+      # A row last written by a release that had no `feed_source_at` column:
+      # nothing dates their last look, so nothing can be called unseen. It
+      # heals on their first tab press.
+      {conn, user, _post} = unseen_fixture(conn)
+      opened_on(user, :fediverse, nil)
+
+      refute dotted?(load_feed(conn), "vutuv")
     end
 
     test "pressing the tab already open does not swallow the other tab's dot", %{conn: conn} do
-      {user, post} = rejoin_fixture(conn)
-      opened_at = NaiveDateTime.add(post.inserted_at, -1)
-      opened_on(user, :fediverse, opened_at)
-      session = feed_session(user, opened_at)
+      {conn, user, post} = unseen_fixture(conn)
+      opened_on(user, :fediverse, NaiveDateTime.add(post.inserted_at, -1))
 
-      view = mount_document(session)
+      view = load_feed(conn)
       assert dotted?(view, "vutuv")
 
       # A press on the tab that is already open moves nobody: the reader has
       # still not been to the vutuv tab, so the dot must survive the press — and
-      # the rejoin after it, which is where a clock stamped on that press would
-      # quietly have swallowed it.
+      # the page load after it, which is where a clock stamped on that press
+      # would quietly have swallowed it.
       render_click(view, "filter-source", %{"type" => "fediverse"})
       assert dotted?(view, "vutuv")
 
-      assert dotted?(mount_document(session), "vutuv")
+      assert dotted?(load_feed(conn), "vutuv")
     end
 
     test "the All tab is never dotted while it is the open one", %{conn: conn} do


### PR DESCRIPTION
**Symptom:** on `/feed` with a coral dot on Fediverse, opening `/notifications` and coming back showed a clean tab bar — over a post the reader had never seen. Any page load did it, not just that one.

The dot lived in the socket, so it lasted exactly as long as the document. `VutuvWeb.PostLive.Feed.unseen_at_mount/3` now derives it on every mount instead: does the tab you are not on hold anything since the last moment you had it on screen (`users.feed_source_at`, stamped when you switch tabs)? Going to the tab still clears it, and now the same press dates the next one.

That makes v7.354.2's document stamp redundant — a rejoin and a real page load take the same path — so `Feed.stamp_document/2` and its session key go with it. Net −87 lines.

**Cold deploy** (v7.355.2): a one-off backfill gives members who chose a tab before that column existed the deploy moment as their anchor. N-1 safe.

The new test is calibrated: with the derivation off, it goes red.

*An AI agent wrote this text in my name. I know that is problematic.*
