### PR TITLE
Clicking a browser notification takes one off the bell count

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -763,7 +763,7 @@ const Hooks = {
       this.dismissed = true
       this.applyPrompt()
     },
-    show({ tag, title, body, icon, url, test }) {
+    show({ tag, title, body, icon, url, test, ack }) {
       if (notifyPermission() !== "granted") return
       // Looking at vutuv means the badge and the bell already said it - except
       // for the test, which the member asked for while plainly looking at the
@@ -796,13 +796,35 @@ const Hooks = {
       notification.onclick = () => {
         window.focus()
         notification.close()
-        if (url) window.location.href = url
+        this.acknowledge(ack, () => {
+          if (url) window.location.href = url
+        })
       }
 
       // Only ever fired for a test: it is what tells the settings card that a
       // popup really was constructed, so the card can stop waiting instead of
       // leaving the member to guess whether anything happened.
       if (test) window.dispatchEvent(new CustomEvent("vutuv:notify-shown"))
+    },
+    // Clicking a popup means the member has seen that one event, so the bell
+    // should drop it and keep the rest. The server needs to hear that BEFORE
+    // the tab navigates: assigning `location.href` tears the socket down, and
+    // a push in flight would go with it. So navigation waits for the server's
+    // reply - and for a socket that is slow or already gone, a short timer
+    // takes them to the page anyway. Whichever comes first wins; `done` is
+    // what keeps the member from being sent twice.
+    acknowledge(ack, then) {
+      if (!ack) return then()
+
+      let done = false
+      const go = () => {
+        if (done) return
+        done = true
+        then()
+      }
+
+      this.pushEvent("notify:seen", ack, go)
+      window.setTimeout(go, 700)
     },
   },
   // The admin member browser (VutuvWeb.Admin.UserLive) pages in place over the

--- a/docs/architecture/realtime.md
+++ b/docs/architecture/realtime.md
@@ -184,9 +184,9 @@ a single post never produces two notifications for the same reader.
 `post_mentions` and `handle_change_notifications` are the two event tables
 written for a feed kind rather than read from one that already existed.
 
-### Read state: one marker plus per-post exceptions
+### Read state: one marker plus two kinds of exception
 
-Derived-feed-wise, read state is stored in exactly two places.
+Derived-feed-wise, read state is stored in exactly three places.
 
 `users.notifications_read_at` is the **marker**: everything up to here has been
 seen. `Activity.mark_notifications_read/1` bumps it when the member opens
@@ -223,6 +223,40 @@ the feed itself do not, so the row stays listed and the pager's total is
 unchanged — /notifications remains the log of what happened, it just stops
 calling that row new. The page marks those rows with one extra query per page
 (`Activity.seen_post_ids/2`), so the list and the badge tell one story.
+
+`notification_dismissals` holds the **per-event exceptions**, written by
+`Activity.mark_notification_seen/3` when a member clicks the browser
+notification that announced one event. A popup carries a single event and is
+only ever raised while the member is somewhere else, so clicking it says "I
+have seen this" about that event and about nothing else waiting on the bell —
+which the marker cannot express, because moving it would swallow everything
+older too. The badge therefore drops by one.
+
+A row names its event by `kind` plus `source_id`, the id of the row the feed
+derives that event from: the follow, the like, the endorsement, the image scan.
+That pair is also the feed item's own id (`Activity.event_id/2`), which is what
+lets the notifications page render the dismissed row as read from the same two
+columns.
+
+Which shape a kind's exclusion takes is a **registry** entry, beside its
+read-marker arm, its feed source and its counts: `dismiss: [{"like", :id}]` and
+`unless_dismissed/4` is applied once, in `total_count/4`, rather than inside
+seventeen count queries. `:id` covers all but one, because a count query counts
+rows of the table it is named after and that table is its first binding — the
+assumption `since/2` already makes; the connection pair is two rows and names
+itself by the later of them (`:later_follow`). `cv_update` declares `nil`: a
+sitting is several CV rows grouped in Elixir under a synthesised id, so there is
+no row for SQL to exclude. `Activity.dismissable_kinds/0` reads straight off
+those entries, so a kind cannot store dismissals the tally would then ignore.
+
+The live push has to name the same row the tally counts, and the two are written
+in different modules from different arguments, so `Vutuv.Activity.notify_*`
+carries a `:source_id`, `notify/2` stamps the derived `event_id/2` on the push
+(an event arriving twice then replaces its row instead of stacking another), and
+`notification_dismissal_test.exs` asserts per kind that the push and the derived
+item name the same row. Opening /notifications deletes the member's dismissals:
+the marker now covers them, so the table only ever holds the exceptions that
+still matter.
 
 ### The notifications page (2026-07 redesign)
 
@@ -377,7 +411,13 @@ one event by definition.
 That module owns the **destination** too (`notification_target/2`), which is
 the half easiest to leave behind: clicking the popup opens the post, the case
 or the profile it named, and only a kind with no page of its own falls back to
-`/notifications`. A popup is raised precisely when the member is not looking at
+`/notifications`. The click also **puts that one event to rest**: the push
+carries an `ack` (`Activity.dismiss_ref/1`), the hook sends it back as
+`notify:seen`, and the shell records a per-event dismissal — see "Read state"
+above. Navigation waits for the server's reply, because assigning
+`location.href` tears the socket down and a push in flight would go with it; a
+700 ms timer takes the member to the page anyway when the socket is slow or
+already gone. A popup is raised precisely when the member is not looking at
 vutuv, so a list to hunt through is the one place that costs most. The third
 per-kind wording, `VutuvWeb.NotificationDigestText`, stays separate on purpose
 (a digest mail names the actor inline and by `@handle`) — a new kind is spelled

--- a/lib/vutuv/activity.ex
+++ b/lib/vutuv/activity.ex
@@ -30,12 +30,18 @@ defmodule Vutuv.Activity do
       that post, so what the feed has to say about it is old news even though
       the marker still sits behind it. Only the unread tally consults them —
       the page keeps listing those events, it just stops calling them new.
+    * `notification_dismissals` holds the **per-event** exceptions written by
+      `mark_notification_seen/3`: the member clicked the browser notification
+      that announced this one event, so it is read and the rest of the bell is
+      not. Both the tally and the notifications page consult them, keyed on the
+      `event_id/2` pair the feed already gives every item.
   """
   import Ecto.Query
   import Vutuv.Identity.Query, only: [join_party: 3, shown_party: 2]
 
   alias Vutuv.Accounts.HandleChangeNotification
   alias Vutuv.Accounts.User
+  alias Vutuv.Activity.NotificationDismissal
   alias Vutuv.Activity.NotificationPostRead
   alias Vutuv.Engagement
   alias Vutuv.Fediverse.Note
@@ -83,6 +89,12 @@ defmodule Vutuv.Activity do
       from(u in User, where: u.id == ^user_id),
       set: [notifications_read_at: read_marker(user_id)]
     )
+
+    # The marker now covers everything the per-event dismissals were holding
+    # out of the tally, so they have nothing left to say. Dropping them keeps
+    # the table to the handful of exceptions that still matter, rather than a
+    # row per browser notification a member ever clicked.
+    Repo.delete_all(from(d in NotificationDismissal, where: d.user_id == ^user_id))
 
     broadcast(user_id, :notifications_read)
   end
@@ -317,6 +329,121 @@ defmodule Vutuv.Activity do
   def subject_post_id(%{kind: "mention"} = item), do: Map.get(item, :post_id)
   def subject_post_id(_item), do: nil
 
+  @doc """
+  Record that `user_id` has seen the single event named by `kind` and
+  `source_id`, so it stops counting as unread.
+
+  Written when the member clicks the **browser notification** that announced
+  it (issue #1249 shipped the popup; this is the half that makes clicking one
+  mean something). A popup carries exactly one event, so the click is a
+  statement about that event and about nothing else waiting on the bell —
+  which is why this writes a per-event exception instead of moving the read
+  marker, and why the badge drops by one rather than to zero.
+
+  `kind` is a notification kind (`kinds/0`) or the pseudo-kind
+  `"report_protection_restored"`; `source_id` the id of the row the feed
+  derives the event from. Unknown kinds and non-UUID ids are ignored rather
+  than stored, since both arrive from the browser. Idempotent — a second click
+  on the same popup changes nothing and stays silent, the same way a repeated
+  `mark_post_seen/2` does.
+
+  The badge is not decremented here: `:notifications_changed` tells the shell
+  to recount from the source, so the tally and the feed can never drift.
+  """
+  def mark_notification_seen(user_id, kind, source_id)
+      when is_binary(user_id) and is_binary(kind) and is_binary(source_id) do
+    with true <- kind in dismissable_kinds(),
+         {:ok, id} <- Vutuv.UUIDv7.cast(source_id),
+         {:inserted, _row} <-
+           Engagement.insert_if_new(
+             NotificationDismissal,
+             %{user_id: user_id, kind: kind, source_id: id},
+             [:user_id, :kind, :source_id]
+           ) do
+      broadcast(user_id, :notifications_changed)
+    else
+      _ -> :ok
+    end
+  end
+
+  # Total on purpose: the three arguments come off the wire, so a nil or a
+  # number is an ordinary thing to be handed, not a bug to crash the socket on.
+  def mark_notification_seen(_user_id, _kind, _source_id), do: :ok
+
+  @doc """
+  How a live-pushed notification names itself to `mark_notification_seen/3`:
+  `%{kind: kind, source_id: id}`, or nil for an event the tally cannot single
+  out again.
+
+  The browser notification carries this back when the member clicks it, so the
+  kind vocabulary stays here rather than being spelled again in the shell.
+  """
+  def dismiss_ref(%{kind: kind} = notification) do
+    kind = dismiss_kind(kind, notification)
+    source_id = notification[:source_id]
+
+    if kind in dismissable_kinds() and is_binary(source_id),
+      do: %{kind: kind, source_id: source_id}
+  end
+
+  def dismiss_ref(_notification), do: nil
+
+  # The severance row behind `report_protection` produces two events at
+  # different times, so the pair (kind, source_id) needs the family to tell
+  # them apart — dismissing "your report severed this" must not also dismiss
+  # "and a rejected case restored it" months later.
+  defp dismiss_kind("report_protection", %{status: "restored"}), do: "report_protection_restored"
+  defp dismiss_kind(kind, _notification), do: kind
+
+  @doc """
+  The id one feed item carries: its kind (or pseudo-kind) and the id of the row
+  it derives from, which is also what a dismissal stores. Every `*_items/3`
+  builder composes its `:id` through here, so the two can only agree.
+  """
+  def event_id(kind, source_id), do: "#{id_prefix(kind)}-#{source_id}"
+
+  # The prefixes predate the kind strings and differ from them in spelling
+  # (dashes, not underscores); they are part of the identity of a rendered row,
+  # so they are kept as they were rather than normalised.
+  defp id_prefix("organization_role"), do: "organization-role"
+  defp id_prefix("image_rejected"), do: "image-rejected"
+  defp id_prefix("report_protection"), do: "report-protection"
+  defp id_prefix("report_protection_restored"), do: "report-protection-restored"
+  defp id_prefix("handle_change"), do: "handle-change"
+  defp id_prefix("reference_check"), do: "reference-check"
+  defp id_prefix("cv_update"), do: "cv-update"
+  defp id_prefix(kind), do: kind
+
+  @doc """
+  The kinds a dismissal can name, read straight off the registry's `dismiss`
+  entries — every kind with a single source row behind it, which is all of them
+  but `cv_update`, plus the second name `report_protection` needs for its
+  restore half. A kind cannot end up storing dismissals the tally then ignores,
+  because both answers come from the same declaration.
+  """
+  def dismissable_kinds do
+    for spec <- kind_specs(Vutuv.UUIDv7.generate()),
+        {kind, _shape} <- spec.dismiss,
+        do: kind
+  end
+
+  @doc """
+  Which of the member's notifications are individually dismissed
+  (`mark_notification_seen/3`), as a `MapSet` of `event_id/2` strings — the
+  same ids the feed items carry, so a page can render those rows as read. One
+  query, and empty for a logged-out visitor.
+  """
+  def dismissed_event_ids(nil), do: MapSet.new()
+
+  def dismissed_event_ids(user_id) do
+    from(d in NotificationDismissal,
+      where: d.user_id == ^user_id,
+      select: {d.kind, d.source_id}
+    )
+    |> Repo.all()
+    |> MapSet.new(fn {kind, source_id} -> event_id(kind, source_id) end)
+  end
+
   @doc "Tell a user's shell their messages were just read (clears the badge)."
   def mark_messages_read(party), do: broadcast(party, :messages_read)
 
@@ -324,6 +451,8 @@ defmodule Vutuv.Activity do
   def notify(nil, _notification), do: :ok
 
   def notify(user_id, %{} = notification) do
+    notification = with_event_id(notification)
+
     # The one place a notification is announced, which is why the Web Push
     # fan-out hangs here rather than at each of the twenty callers: a push
     # cannot then drift out of step with what the website shows.
@@ -331,12 +460,23 @@ defmodule Vutuv.Activity do
     broadcast(user_id, {:new_notification, notification})
   end
 
+  # A live push and the feed row it will become are the same event, so they get
+  # the same id — which is what lets an open notifications page replace the row
+  # rather than stack a second one, and what `dismiss_ref/1` hands back when the
+  # member clicks the popup. Kinds that already carry an id (the CV sitting,
+  # whose id is a group and not a row) keep it.
+  defp with_event_id(%{kind: kind, source_id: source_id} = notification)
+       when is_binary(source_id),
+       do: Map.put_new(notification, :id, event_id(kind, source_id))
+
+  defp with_event_id(notification), do: notification
+
   @doc """
   Convenience: a "started following you" notification for the followee. Carries
   the actor's name, route param, and avatar so the notifications page can link
   to the follower's profile and show their picture.
   """
-  def notify_new_follower(followee_id, follower) do
+  def notify_new_follower(followee_id, follower, follow_id \\ nil) do
     Vutuv.Webhooks.emit(followee_id, "follower.created", %{
       "follower" => actor_param(follower)
     })
@@ -346,6 +486,7 @@ defmodule Vutuv.Activity do
       Map.merge(actor_fields(follower), %{
         kind: "follower",
         text: "started following you.",
+        source_id: follow_id,
         at: DateTime.utc_now()
       })
     )
@@ -360,12 +501,19 @@ defmodule Vutuv.Activity do
   toast at grant time. The actor is the granting member, rendered as a linked
   `@handle`.
   """
-  def notify_organization_role(user_id, granter, %Organization{} = organization, role) do
+  def notify_organization_role(
+        user_id,
+        granter,
+        %Organization{} = organization,
+        role,
+        role_id \\ nil
+      ) do
     notify(
       user_id,
       Map.merge(actor_fields(granter), %{
         kind: "organization_role",
         role: role,
+        source_id: role_id,
         organization_name: organization.name,
         organization_slug: organization.slug,
         at: DateTime.utc_now()
@@ -386,6 +534,7 @@ defmodule Vutuv.Activity do
       notification.recipient_id,
       Map.merge(actor_fields(actor), %{
         kind: "handle_change",
+        source_id: notification.id,
         old_handle: notification.old_handle,
         new_handle: notification.new_handle,
         post_ids: notification.post_ids,
@@ -429,8 +578,8 @@ defmodule Vutuv.Activity do
     grade = Check.grade_span(check)
 
     notify(user_id, %{
-      id: "reference-check-#{check.id}",
       kind: "reference_check",
+      source_id: check.id,
       at: check.finished_at || DateTime.utc_now(),
       job_reference_id: reference.id,
       title: reference.title,
@@ -441,7 +590,7 @@ defmodule Vutuv.Activity do
   end
 
   @doc ~S(Convenience: an "endorsed you for <tag>" notification for the tag's owner.)
-  def notify_endorsement(owner_id, endorser, tag_name) do
+  def notify_endorsement(owner_id, endorser, tag_name, endorsement_id \\ nil) do
     Vutuv.Webhooks.emit(owner_id, "endorsement.created", %{
       "endorser" => actor_param(endorser),
       "tag" => tag_name
@@ -452,6 +601,7 @@ defmodule Vutuv.Activity do
       Map.merge(actor_fields(endorser), %{
         kind: "endorsement",
         tag: tag_name,
+        source_id: endorsement_id,
         text: "endorsed you for #{tag_name}.",
         at: DateTime.utc_now()
       })
@@ -465,7 +615,13 @@ defmodule Vutuv.Activity do
   author. `post_id` is the parent post, so the notification can link to the
   thread the reply landed in.
   """
-  def notify_reply(parent_author_id, replier, parent_post_id \\ nil, reply_post_id \\ nil) do
+  def notify_reply(
+        parent_author_id,
+        replier,
+        parent_post_id \\ nil,
+        reply_post_id \\ nil,
+        reply_ref_id \\ nil
+      ) do
     Vutuv.Webhooks.emit(parent_author_id, "post.replied", %{
       "by" => actor_param(replier),
       "post_id" => parent_post_id
@@ -480,6 +636,8 @@ defmodule Vutuv.Activity do
         post_id: parent_post_id,
         # …and the reply itself, so the row can quote both.
         reply_post_id: reply_post_id,
+        # The `post_replies` row the feed counts — what a dismissal names.
+        source_id: reply_ref_id,
         at: DateTime.utc_now()
       })
     )
@@ -492,7 +650,7 @@ defmodule Vutuv.Activity do
   `reply_post_id` is the new reply, so the row can quote and link it;
   `root_post_id` keys the notification page's per-thread grouping.
   """
-  def notify_thread_reply(user_id, replier, root_post_id, reply_post_id) do
+  def notify_thread_reply(user_id, replier, root_post_id, reply_post_id, reply_ref_id \\ nil) do
     notify(
       user_id,
       Map.merge(actor_fields(replier), %{
@@ -500,6 +658,7 @@ defmodule Vutuv.Activity do
         text: "replied in a thread you posted in.",
         root_post_id: root_post_id,
         reply_post_id: reply_post_id,
+        source_id: reply_ref_id,
         at: DateTime.utc_now()
       })
     )
@@ -528,6 +687,7 @@ defmodule Vutuv.Activity do
         text: "replied to your post from another network.",
         post_id: post.id,
         note_id: note.id,
+        source_id: note.id,
         at: note.received_at
       })
     )
@@ -555,6 +715,7 @@ defmodule Vutuv.Activity do
         text: "reacted to your post from another network.",
         post_id: post.id,
         reaction_id: reaction.id,
+        source_id: reaction.id,
         reaction_kind: reaction.kind,
         at: reaction.received_at
       })
@@ -570,20 +731,21 @@ defmodule Vutuv.Activity do
   mention untouched never notifies twice. The durable half is the
   `post_mentions` row written alongside it (`mention_items/3`).
   """
-  def notify_mention(user_id, author, post_id) do
+  def notify_mention(user_id, author, post_id, mention_id \\ nil) do
     notify(
       user_id,
       Map.merge(actor_fields(author), %{
         kind: "mention",
         text: "mentioned you in a post.",
         post_id: post_id,
+        source_id: mention_id,
         at: DateTime.utc_now()
       })
     )
   end
 
   @doc ~S(Convenience: a "liked your post" notification for the post's author.)
-  def notify_like(author_id, liker, post_id) do
+  def notify_like(author_id, liker, post_id, like_id \\ nil) do
     Vutuv.Webhooks.emit(author_id, "post.liked", %{
       "by" => actor_param(liker),
       "post_id" => post_id
@@ -595,6 +757,7 @@ defmodule Vutuv.Activity do
         kind: "like",
         text: "liked your post.",
         post_id: post_id,
+        source_id: like_id,
         at: DateTime.utc_now()
       })
     )
@@ -608,7 +771,7 @@ defmodule Vutuv.Activity do
   new-follower email); only the in-app text/kind announces the connection
   milestone. The derived feed reuses the `"connection"` kind for mutual pairs.
   """
-  def notify_connection(user_id, other) do
+  def notify_connection(user_id, other, follow_id \\ nil) do
     Vutuv.Webhooks.emit(user_id, "connection.created", %{
       "with" => actor_param(other)
     })
@@ -618,6 +781,9 @@ defmodule Vutuv.Activity do
       Map.merge(actor_fields(other), %{
         kind: "connection",
         text: "is now connected with you.",
+        # The pair's id is the later of its two follows, which is the one just
+        # written — see `count_connections/3`.
+        source_id: follow_id,
         at: DateTime.utc_now()
       })
     )
@@ -632,12 +798,13 @@ defmodule Vutuv.Activity do
   @their_handle. The durable counterpart is derived from the severance rows
   (see `report_protection_items/3`).
   """
-  def notify_report_protection(reporter_id, reported_user, status) do
+  def notify_report_protection(reporter_id, reported_user, status, severance_id \\ nil) do
     notify(
       reporter_id,
       Map.merge(actor_fields(reported_user), %{
         kind: "report_protection",
         status: status,
+        source_id: severance_id,
         at: DateTime.utc_now()
       })
     )
@@ -744,9 +911,10 @@ defmodule Vutuv.Activity do
   defp after?(at, %NaiveDateTime{} = since),
     do: after?(at, DateTime.from_naive!(since, "Etc/UTC"))
 
-  # THE registry of notification kinds. Every kind declares all three of its
-  # derivations here — read-marker MAX arm(s), feed source, count query(ies) —
-  # so a kind can no longer join one structure and silently miss another,
+  # THE registry of notification kinds. Every kind declares all four of its
+  # derivations here — read-marker MAX arm(s), feed source, count query(ies),
+  # dismissal shape — so a kind can no longer join one structure and silently
+  # miss another,
   # which is exactly the badge-never-clears bug that shipped three times
   # (#980, #930, v7.200.1). `latest_event_at/1`, `notifications_page/2` and
   # `total_count/4` all read from this table and nowhere else.
@@ -758,6 +926,15 @@ defmodule Vutuv.Activity do
   #     (the merge sort is stable), so treat it as part of the interface.
   #   * `counts` — count queries summed into the badge tally, bounded by the
   #     same `read_at` the marker wrote.
+  #   * `dismiss` — one entry per `counts` query saying how a per-event
+  #     dismissal (`mark_notification_seen/3`) is excluded from it: `{kind,
+  #     :id}` for the ordinary case, where the event's own row is the query's
+  #     first binding, or `nil` for a kind with no single source row. The
+  #     `kind` in the tuple is the dismissal's namespace and usually the kind
+  #     itself; `report_protection` needs two because one row emits two
+  #     events. Declaring it here rather than inside each count query is what
+  #     makes `dismissable_kinds/0` derivable and stops a new kind from
+  #     storing dismissals the tally then ignores.
   #   * `email_pref` — the `Vutuv.Accounts.User` field a member turns off to
   #     stop this kind reaching the digest mail (`Vutuv.Activity.Digest`), or
   #     `nil` for a kind that is shown in the app and never mailed. It lives
@@ -772,11 +949,12 @@ defmodule Vutuv.Activity do
   #     (severed / restored) with different timestamp columns — so two max
   #     arms and two counts. That is why both list-valued keys are lists.
   #   * `unread?` marks the badge tally, as opposed to the pager's total, and
-  #     switches on the two "the member already knows this" exceptions. It
-  #     reaches reply / thread / mention (drop events about posts the member
-  #     engaged with, `mark_post_seen/2` — the kinds whose subject is somebody
-  #     else's post, `subject_post_id/1`) and `connection` (drop the pair the
-  #     member made mutual themselves); every other kind ignores it.
+  #     switches on the "the member already knows this" exceptions. Two are
+  #     per-kind: reply / thread / mention drop events about posts the member
+  #     engaged with (`mark_post_seen/2` — the kinds whose subject is somebody
+  #     else's post, `subject_post_id/1`), and `connection` drops the pair the
+  #     member made mutual themselves. The third, `dismiss`, is applied to
+  #     every kind at once in `total_count/4`.
   #   * `cv_update` counts sittings, not rows: its read-marker filter lives
   #     inside the grouped query (`CvUpdates.count_query/2`), not in `since/2`.
   #   * The fediverse kinds key on `received_at` (a :utc_datetime), `username`
@@ -801,119 +979,143 @@ defmodule Vutuv.Activity do
         email_pref: :email_on_follower?,
         max_arms: [follower_max(user_id)],
         items: &follower_items(user_id, &1, &2),
-        counts: [count_followers(user_id, read_at)]
+        counts: [count_followers(user_id, read_at)],
+        dismiss: [{"follower", :id}]
       },
       %{
         kind: "endorsement",
         email_pref: :email_on_endorsement?,
         max_arms: [endorsement_max(user_id)],
         items: &endorsement_items(user_id, &1, &2),
-        counts: [count_endorsements(user_id, read_at)]
+        counts: [count_endorsements(user_id, read_at)],
+        dismiss: [{"endorsement", :id}]
       },
       %{
         kind: "connection",
         email_pref: :email_on_follower?,
         max_arms: [connection_max(user_id)],
         items: &connection_items(user_id, &1, &2),
-        counts: [count_connections(user_id, read_at, unread?)]
+        counts: [count_connections(user_id, read_at, unread?)],
+        # A pair has no row of its own: its id, here and on the entry
+        # `connection_items/3` builds, is the later of the two follows.
+        dismiss: [{"connection", :later_follow}]
       },
       %{
         kind: "reply",
         email_pref: nil,
         max_arms: [reply_max(user_id)],
         items: &reply_items(user_id, &1, &2),
-        counts: [count_replies(user_id, read_at, unread?)]
+        counts: [count_replies(user_id, read_at, unread?)],
+        dismiss: [{"reply", :id}]
       },
       %{
         kind: "thread",
         email_pref: nil,
         max_arms: [thread_max(user_id)],
         items: &thread_items(user_id, &1, &2),
-        counts: [count_thread_replies(user_id, read_at, unread?)]
+        counts: [count_thread_replies(user_id, read_at, unread?)],
+        dismiss: [{"thread", :id}]
       },
       %{
         kind: "mention",
         email_pref: nil,
         max_arms: [mention_max(user_id)],
         items: &mention_items(user_id, &1, &2),
-        counts: [count_mentions(user_id, read_at, unread?)]
+        counts: [count_mentions(user_id, read_at, unread?)],
+        dismiss: [{"mention", :id}]
       },
       %{
         kind: "fediverse_reply",
         email_pref: nil,
         max_arms: [fediverse_reply_max(user_id)],
         items: &fediverse_reply_items(user_id, &1, &2),
-        counts: [count_fediverse_replies(user_id, read_at)]
+        counts: [count_fediverse_replies(user_id, read_at)],
+        dismiss: [{"fediverse_reply", :id}]
       },
       %{
         kind: "fediverse_reaction",
         email_pref: nil,
         max_arms: [fediverse_reaction_max(user_id)],
         items: &fediverse_reaction_items(user_id, &1, &2),
-        counts: [count_fediverse_reactions(user_id, read_at)]
+        counts: [count_fediverse_reactions(user_id, read_at)],
+        dismiss: [{"fediverse_reaction", :id}]
       },
       %{
         kind: "like",
         email_pref: nil,
         max_arms: [like_max(user_id)],
         items: &like_items(user_id, &1, &2),
-        counts: [count_likes(user_id, read_at)]
+        counts: [count_likes(user_id, read_at)],
+        dismiss: [{"like", :id}]
       },
       %{
         kind: "organization_role",
         email_pref: nil,
         max_arms: [organization_role_max(user_id)],
         items: &organization_role_items(user_id, &1, &2),
-        counts: [count_organization_roles(user_id, read_at)]
+        counts: [count_organization_roles(user_id, read_at)],
+        dismiss: [{"organization_role", :id}]
       },
       %{
         kind: "moderation",
         email_pref: nil,
         max_arms: [moderation_max(user_id)],
         items: &moderation_items(user_id, &1, &2),
-        counts: [count_moderation(user_id, read_at)]
+        counts: [count_moderation(user_id, read_at)],
+        dismiss: [{"moderation", :id}]
       },
       %{
         kind: "image_rejected",
         email_pref: nil,
         max_arms: [image_rejected_max(user_id)],
         items: &image_rejected_items(user_id, &1, &2),
-        counts: [count_image_rejections(user_id, read_at)]
+        counts: [count_image_rejections(user_id, read_at)],
+        dismiss: [{"image_rejected", :id}]
       },
       %{
         kind: "report_protection",
         email_pref: nil,
         max_arms: [severance_max(user_id), severance_restore_max(user_id)],
         items: &report_protection_items(user_id, &1, &2),
-        counts: [count_severances(user_id, read_at), count_severance_restores(user_id, read_at)]
+        counts: [count_severances(user_id, read_at), count_severance_restores(user_id, read_at)],
+        # One severance row, two events: the restore half needs a namespace of
+        # its own or dismissing the severance would dismiss it too.
+        dismiss: [{"report_protection", :id}, {"report_protection_restored", :id}]
       },
       %{
         kind: "handle_change",
         email_pref: nil,
         max_arms: [handle_change_max(user_id)],
         items: &handle_change_items(user_id, &1, &2),
-        counts: [count_handle_changes(user_id, read_at)]
+        counts: [count_handle_changes(user_id, read_at)],
+        dismiss: [{"handle_change", :id}]
       },
       %{
         kind: "cv_update",
         email_pref: nil,
         max_arms: [cv_update_max(user_id)],
         items: &cv_update_items(user_id, &1, &2),
-        counts: [count_cv_updates(user_id, read_at)]
+        counts: [count_cv_updates(user_id, read_at)],
+        # The one kind with no source row: an item is a *sitting*, several CV
+        # rows grouped in Elixir under a synthesised id, so there is nothing
+        # for the tally to exclude and clicking its popup leaves the badge be.
+        dismiss: [nil]
       },
       %{
         kind: "username",
         email_pref: nil,
         max_arms: [username_max(user_id)],
         items: &username_items(user_id, &1, &2),
-        counts: [count_username(user_id, read_at)]
+        counts: [count_username(user_id, read_at)],
+        dismiss: [{"username", :id}]
       },
       %{
         kind: "reference_check",
         email_pref: :email_on_reference_check?,
         max_arms: [reference_check_max(user_id)],
         items: &reference_check_items(user_id, &1, &2),
-        counts: [count_reference_checks(user_id, read_at)]
+        counts: [count_reference_checks(user_id, read_at)],
+        dismiss: [{"reference_check", :id}]
       }
     ]
   end
@@ -995,8 +1197,8 @@ defmodule Vutuv.Activity do
     counts =
       for spec <- kind_specs(user_id, read_at, unread?),
           kinds == nil or spec.kind in kinds,
-          count <- spec.counts,
-          do: count
+          {count, dismiss} <- Enum.zip(spec.counts, spec.dismiss),
+          do: unless_dismissed(count, user_id, dismiss, unread?)
 
     case counts do
       [] ->
@@ -1047,7 +1249,7 @@ defmodule Vutuv.Activity do
     |> select([e, f, o], {e.id, e.at, struct(f, ^User.listing_fields()), o})
     |> Repo.all()
     |> Enum.map(fn {id, at, follower, organization} ->
-      actor_item("follower-#{id}", "follower", at, follower || organization)
+      actor_item(event_id("follower", id), "follower", at, follower || organization)
     end)
   end
 
@@ -1065,7 +1267,7 @@ defmodule Vutuv.Activity do
     |> at_or_before(cursor)
     |> Repo.all()
     |> Enum.map(fn {id, at, endorser, tag_name} ->
-      "endorsement-#{id}"
+      event_id("endorsement", id)
       |> actor_item("endorsement", at, endorser)
       |> Map.put(:tag, tag_name)
     end)
@@ -1127,7 +1329,7 @@ defmodule Vutuv.Activity do
     )
     |> Repo.all()
     |> Enum.map(fn %{id: id, at: at, friend: friend, self_closed: self_closed} ->
-      "connection-#{id}"
+      event_id("connection", id)
       |> actor_item("connection", at, friend)
       |> Map.put(:self_triggered?, self_closed)
     end)
@@ -1148,7 +1350,7 @@ defmodule Vutuv.Activity do
     |> at_or_before(cursor)
     |> Repo.all()
     |> Enum.map(fn {id, at, replier, parent_post_id, reply_post_id} ->
-      "reply-#{id}"
+      event_id("reply", id)
       |> actor_item("reply", at, replier)
       # The parent (the recipient's own post the row links to) and the reply
       # itself, so the row can quote both.
@@ -1175,7 +1377,7 @@ defmodule Vutuv.Activity do
     |> at_or_before(cursor)
     |> Repo.all()
     |> Enum.map(fn {id, at, replier, root_post_id, reply_post_id} ->
-      "thread-#{id}"
+      event_id("thread", id)
       |> actor_item("thread", at, replier)
       # The thread (grouping key) and the reply itself (the quote + link).
       |> Map.put(:root_post_id, root_post_id)
@@ -1212,7 +1414,7 @@ defmodule Vutuv.Activity do
     |> Enum.map(fn {id, at, author, organization, post_id} ->
       actor = mention_actor(author, organization)
 
-      "mention-#{id}"
+      event_id("mention", id)
       |> actor_item("mention", at, actor)
       # The post that named them — the author's, not the recipient's.
       |> Map.put(:post_id, post_id)
@@ -1253,7 +1455,7 @@ defmodule Vutuv.Activity do
       note
       |> remote_actor_fields()
       |> Map.merge(%{
-        id: "fediverse_reply-#{note.id}",
+        id: event_id("fediverse_reply", note.id),
         kind: "fediverse_reply",
         # The merged feed sorts and cursors on NaiveDateTime (Vutuv.FeedPage);
         # this is the one source whose column is a DateTime.
@@ -1298,7 +1500,7 @@ defmodule Vutuv.Activity do
       reaction
       |> remote_actor_fields()
       |> Map.merge(%{
-        id: "fediverse_reaction-#{reaction.id}",
+        id: event_id("fediverse_reaction", reaction.id),
         kind: "fediverse_reaction",
         at: DateTime.to_naive(reaction.received_at),
         post_id: reaction.post_id,
@@ -1469,7 +1671,7 @@ defmodule Vutuv.Activity do
     |> at_or_before(cursor)
     |> Repo.all()
     |> Enum.map(fn {id, at, liker, page, post_id} ->
-      "like-#{id}"
+      event_id("like", id)
       |> actor_item("like", at, liker || page)
       |> Map.put(:post_id, post_id)
     end)
@@ -1494,7 +1696,7 @@ defmodule Vutuv.Activity do
     |> at_or_before(cursor)
     |> Repo.all()
     |> Enum.map(fn {id, at, granter, role, name, slug} ->
-      "organization-role-#{id}"
+      event_id("organization_role", id)
       |> actor_item("organization_role", at, granter)
       |> Map.merge(%{role: role, organization_name: name, organization_slug: slug})
     end)
@@ -1512,7 +1714,7 @@ defmodule Vutuv.Activity do
     |> Repo.all()
     |> Enum.map(fn {id, at, status} ->
       %{
-        id: "moderation-#{id}",
+        id: event_id("moderation", id),
         kind: "moderation",
         at: at,
         case_id: id,
@@ -1534,7 +1736,7 @@ defmodule Vutuv.Activity do
     |> Repo.all()
     |> Enum.map(fn {id, at, kind, category} ->
       %{
-        id: "image-rejected-#{id}",
+        id: event_id("image_rejected", id),
         kind: "image_rejected",
         at: at,
         image_kind: kind,
@@ -1558,7 +1760,7 @@ defmodule Vutuv.Activity do
       |> select([s, u], {s.id, s.inserted_at, struct(u, ^User.listing_fields())})
       |> Repo.all()
       |> Enum.map(fn {id, at, reported} ->
-        protection_item("report-protection-#{id}", "severed", at, reported)
+        protection_item(event_id("report_protection", id), "severed", at, reported)
       end)
 
     restored =
@@ -1571,7 +1773,7 @@ defmodule Vutuv.Activity do
       |> select([s, u], {s.id, s.restored_at, struct(u, ^User.listing_fields())})
       |> Repo.all()
       |> Enum.map(fn {id, at, reported} ->
-        protection_item("report-protection-restored-#{id}", "restored", at, reported)
+        protection_item(event_id("report_protection_restored", id), "restored", at, reported)
       end)
 
     severed ++ restored
@@ -1596,7 +1798,7 @@ defmodule Vutuv.Activity do
     |> at_or_before(cursor)
     |> Repo.all()
     |> Enum.map(fn {id, at, actor, old_handle, new_handle, post_ids} ->
-      "handle-change-#{id}"
+      event_id("handle_change", id)
       |> actor_item("handle_change", at, actor)
       |> Map.merge(%{old_handle: old_handle, new_handle: new_handle, post_ids: post_ids})
     end)
@@ -1664,7 +1866,7 @@ defmodule Vutuv.Activity do
     |> Repo.all()
     |> Enum.map(fn {id, at, reference_id, title, grade} ->
       %{
-        id: "reference-check-#{id}",
+        id: event_id("reference_check", id),
         kind: "reference_check",
         at: at,
         job_reference_id: reference_id,
@@ -1705,7 +1907,7 @@ defmodule Vutuv.Activity do
     |> at_or_before_welcome(cursor)
     |> Repo.all()
     |> Enum.map(fn {id, at, username} ->
-      %{id: "username-#{id}", kind: "username", at: at, username: username}
+      %{id: event_id("username", id), kind: "username", at: at, username: username}
     end)
   end
 
@@ -1882,6 +2084,37 @@ defmodule Vutuv.Activity do
   defp unless_seen(query, user_id, true) do
     seen = from(s in NotificationPostRead, where: s.user_id == ^user_id, select: s.post_id)
     where(query, [event], event.post_id not in subquery(seen))
+  end
+
+  # Drops the one event the member acknowledged by clicking its browser
+  # notification (`mark_notification_seen/3`). Same division of labour as
+  # `unless_seen/3`: only the badge tally asks, the page keeps listing the row.
+  #
+  # The `:id` shape covers every kind but one, because a count query counts
+  # rows of the source table it is named after and that table is its first
+  # binding — the assumption `since/2` already makes. The exception is the
+  # connection pair, which is two rows and names itself by the later of them.
+  # Which shape a kind uses is declared in `kind_specs/3`, so this is applied
+  # once in `total_count/4` rather than inside seventeen count queries.
+  defp unless_dismissed(query, _user_id, _dismiss, false), do: query
+  defp unless_dismissed(query, _user_id, nil, true), do: query
+
+  defp unless_dismissed(query, user_id, {kind, :id}, true),
+    do: where(query, [event], event.id not in subquery(dismissed_ids(user_id, kind)))
+
+  defp unless_dismissed(query, user_id, {kind, :later_follow}, true) do
+    where(
+      query,
+      [out, back],
+      fragment("GREATEST(?, ?)", out.id, back.id) not in subquery(dismissed_ids(user_id, kind))
+    )
+  end
+
+  defp dismissed_ids(user_id, kind) do
+    from(d in NotificationDismissal,
+      where: d.user_id == ^user_id and d.kind == ^kind,
+      select: d.source_id
+    )
   end
 
   # No self-like filter: a member cannot like their own post (enforced in

--- a/lib/vutuv/activity/notification_dismissal.ex
+++ b/lib/vutuv/activity/notification_dismissal.ex
@@ -1,0 +1,27 @@
+defmodule Vutuv.Activity.NotificationDismissal do
+  @moduledoc """
+  One member has seen one notification — the per-event read mark behind
+  `Vutuv.Activity.mark_notification_seen/3`, whose docs say why it exists.
+
+  `kind` and `source_id` together name the event: the notification kind (or,
+  for the two families `report_protection` emits, the pseudo-kind
+  `"report_protection_restored"`) and the id of the row the feed derives that
+  event from — the follow, the like, the endorsement, the scan. That pair is
+  also the feed item's own id (`Vutuv.Activity.event_id/2`), so the
+  notifications page renders the row as read from the same two columns.
+
+  Nothing ever updates a row: it is written once and dropped when the read
+  marker moves past it.
+  """
+
+  use VutuvWeb, :model
+
+  schema "notification_dismissals" do
+    field(:kind, :string)
+    field(:source_id, Vutuv.UUIDv7)
+
+    belongs_to(:user, Vutuv.Accounts.User)
+
+    timestamps(updated_at: false)
+  end
+end

--- a/lib/vutuv/moderation.ex
+++ b/lib/vutuv/moderation.ex
@@ -887,21 +887,27 @@ defmodule Vutuv.Moderation do
       # A mutual follow is what made the pair vernetzt, so recording the two
       # follow edges is enough to restore the connection on a rejected case.
       # There is no separate connection state to capture any more.
-      Repo.insert!(%Severance{
-        case_id: case_record.id,
-        reporter_id: reporter.id,
-        owner_id: owner_id,
-        had_follow_reporter_to_owner?: ties.follow_a_to_b,
-        had_follow_owner_to_reporter?: ties.follow_b_to_a,
-        conversation_id: conversation && conversation.id
-      })
+      severance =
+        Repo.insert!(%Severance{
+          case_id: case_record.id,
+          reporter_id: reporter.id,
+          owner_id: owner_id,
+          had_follow_reporter_to_owner?: ties.follow_a_to_b,
+          had_follow_owner_to_reporter?: ties.follow_b_to_a,
+          conversation_id: conversation && conversation.id
+        })
 
       log(case_record, reporter, "relationship_severed", %{
         "follows" => Enum.count([ties.follow_a_to_b, ties.follow_b_to_a], & &1),
         "conversation" => conversation != nil
       })
 
-      Vutuv.Activity.notify_report_protection(reporter.id, Repo.get(User, owner_id), "severed")
+      Vutuv.Activity.notify_report_protection(
+        reporter.id,
+        Repo.get(User, owner_id),
+        "severed",
+        severance.id
+      )
     end
 
     :ok
@@ -935,7 +941,8 @@ defmodule Vutuv.Moderation do
         Vutuv.Activity.notify_report_protection(
           severance.reporter_id,
           Repo.get(User, severance.owner_id),
-          "restored"
+          "restored",
+          severance.id
         )
       end
     end

--- a/lib/vutuv/moderation/notifier.ex
+++ b/lib/vutuv/moderation/notifier.ex
@@ -60,6 +60,7 @@ defmodule Vutuv.Moderation.Notifier do
         Activity.notify(owner.id, %{
           kind: "image_rejected",
           image_kind: scan.kind,
+          source_id: scan.id,
           at: DateTime.utc_now()
         })
 
@@ -117,6 +118,7 @@ defmodule Vutuv.Moderation.Notifier do
       kind: "moderation",
       text: text,
       case_id: case_record.id,
+      source_id: case_record.id,
       at: DateTime.utc_now()
     })
   end

--- a/lib/vutuv/organizations.ex
+++ b/lib/vutuv/organizations.ex
@@ -714,7 +714,14 @@ defmodule Vutuv.Organizations do
     |> Repo.insert()
     |> case do
       {:ok, role_row} ->
-        Vutuv.Activity.notify_organization_role(user.id, granted_by, organization, role)
+        Vutuv.Activity.notify_organization_role(
+          user.id,
+          granted_by,
+          organization,
+          role,
+          role_row.id
+        )
+
         {:ok, role_row}
 
       {:error, %{errors: errors} = changeset} ->
@@ -777,8 +784,13 @@ defmodule Vutuv.Organizations do
         granted_by_user_id: actor.id
       })
       |> Repo.insert(on_conflict: :nothing)
+      |> case do
+        {:ok, row} ->
+          Vutuv.Activity.notify_organization_role(user.id, actor, organization, role, row.id)
 
-      Vutuv.Activity.notify_organization_role(user.id, actor, organization, role)
+        {:error, _changeset} ->
+          :ok
+      end
     end)
 
     {:ok, rank_roles(wanted)}

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -1284,8 +1284,8 @@ defmodule Vutuv.Posts do
 
   defp do_page_like(%Organization{} = page, %User{} = acting_user, %Post{} = post) do
     case engage(PostLike, :like, page, post, acting_user) do
-      {:ok, %PostLike{}} ->
-        Vutuv.Activity.notify_like(post.user_id, page, post.id)
+      {:ok, %PostLike{} = like} ->
+        Vutuv.Activity.notify_like(post.user_id, page, post.id, like.id)
         :ok
 
       {:ok, :noop} ->
@@ -1305,10 +1305,10 @@ defmodule Vutuv.Posts do
 
   defp do_like_post(%User{} = user, %Post{} = post) do
     case engage(PostLike, :like, user, post) do
-      {:ok, %PostLike{}} ->
+      {:ok, %PostLike{} = like} ->
         # A fresh like is news for the author; the idempotent repeat is not.
         # Self-likes never reach here (`like_post/2` rejects them upstream).
-        Vutuv.Activity.notify_like(post.user_id, user, post.id)
+        Vutuv.Activity.notify_like(post.user_id, user, post.id, like.id)
         :ok
 
       {:ok, :noop} ->
@@ -5892,7 +5892,13 @@ defmodule Vutuv.Posts do
     broadcast_reply_count(parent.id)
 
     if is_binary(parent.user_id) and parent.user_id != reply.user_id do
-      Vutuv.Activity.notify_reply(parent.user_id, reply.user, parent.id, reply.id)
+      Vutuv.Activity.notify_reply(
+        parent.user_id,
+        reply.user,
+        parent.id,
+        reply.id,
+        reply.reply_ref && reply.reply_ref.id
+      )
     end
 
     notify_thread_participants(parent, reply)
@@ -5932,7 +5938,15 @@ defmodule Vutuv.Posts do
       # so pushing a live badge here would leave them a count with nothing
       # behind it. One query keeps only the members who still want the push.
       |> thread_notifiable_ids()
-      |> Enum.each(&Vutuv.Activity.notify_thread_reply(&1, reply.user, root_id, reply.id))
+      |> Enum.each(
+        &Vutuv.Activity.notify_thread_reply(
+          &1,
+          reply.user,
+          root_id,
+          reply.id,
+          reply.reply_ref.id
+        )
+      )
     end
 
     :ok
@@ -5978,8 +5992,8 @@ defmodule Vutuv.Posts do
     added = Enum.reject(wanted, &(&1.id in existing))
 
     drop_mentions(post, existing -- Enum.map(wanted, & &1.id))
-    insert_mentions(post, added)
-    Enum.each(added, &notify_mentioned(post, &1))
+    mention_ids = insert_mentions(post, added)
+    Enum.each(added, &notify_mentioned(post, &1, mention_ids[&1.id]))
     sync_organization_mentions(post)
     :ok
   end
@@ -6048,7 +6062,11 @@ defmodule Vutuv.Posts do
     :ok
   end
 
-  defp insert_mentions(_post, []), do: :ok
+  # Returns the new rows as `%{user_id => mention_id}`: the ids are minted here
+  # (UUID v7, client-side), so the live push can name the very row the feed
+  # will count without reading it back — which is what lets a member dismiss
+  # that one mention by clicking its browser notification.
+  defp insert_mentions(_post, []), do: %{}
 
   defp insert_mentions(%Post{} = post, users) do
     now = NaiveDateTime.utc_now(:second)
@@ -6068,7 +6086,7 @@ defmodule Vutuv.Posts do
     # A concurrent save of the same post (a double-submitted edit) must not
     # raise on the unique index; the row is the same fact either way.
     Repo.insert_all(PostMention, rows, on_conflict: :nothing)
-    :ok
+    Map.new(rows, &{&1.user_id, &1.id})
   end
 
   # The actor is whoever the post is BY — the organization on an organization
@@ -6078,9 +6096,9 @@ defmodule Vutuv.Posts do
   #
   # A block only guards the member case: a block is a relationship between two
   # people, and `blocked_between?/2` already answers false for a nil id.
-  defp notify_mentioned(%Post{} = post, %User{} = mentioned) do
+  defp notify_mentioned(%Post{} = post, %User{} = mentioned, mention_id) do
     unless Vutuv.Social.blocked_between?(mentioned.id, post.user_id) do
-      Vutuv.Activity.notify_mention(mentioned.id, author(post), post.id)
+      Vutuv.Activity.notify_mention(mentioned.id, author(post), post.id, mention_id)
     end
   end
 

--- a/lib/vutuv/profiles/cv_updates.ex
+++ b/lib/vutuv/profiles/cv_updates.ex
@@ -310,7 +310,11 @@ defmodule Vutuv.Profiles.CvUpdates do
   # doubling it (the start is what does not move; the newest timestamp does).
   defp group_item(author_id, started_at, at, entries, count) do
     %{
-      id: "cv-update-#{author_id}-#{NaiveDateTime.diff(started_at, ~N[1970-01-01 00:00:00])}",
+      id:
+        Activity.event_id(
+          "cv_update",
+          "#{author_id}-#{NaiveDateTime.diff(started_at, ~N[1970-01-01 00:00:00])}"
+        ),
       at: at,
       entry_count: count,
       entries: Enum.take(entries, @preview_entries)

--- a/lib/vutuv/social.ex
+++ b/lib/vutuv/social.ex
@@ -77,7 +77,7 @@ defmodule Vutuv.Social do
       |> Follow.changeset(%{follower_id: follower_id, followee_id: followee_id})
       |> Repo.insert()
 
-    with {:ok, _follow} <- result do
+    with {:ok, follow} <- result do
       actor = follower_struct(follower)
 
       # A follow-back that completes a mutual follow makes the pair "vernetzt"
@@ -85,9 +85,9 @@ defmodule Vutuv.Social do
       # of a second plain "started following you". A first/one-way follow stays
       # the ordinary new-follower event.
       if user_follows_user?(followee_id, follower_id) do
-        Vutuv.Activity.notify_connection(followee_id, actor)
+        Vutuv.Activity.notify_connection(followee_id, actor, follow.id)
       else
-        Vutuv.Activity.notify_new_follower(followee_id, actor)
+        Vutuv.Activity.notify_new_follower(followee_id, actor, follow.id)
       end
 
       # Bump the live counts on both members' open profiles (follower / following

--- a/lib/vutuv/tags.ex
+++ b/lib/vutuv/tags.ex
@@ -1036,7 +1036,7 @@ defmodule Vutuv.Tags do
     # Endorsing your own tag is possible but not news.
     if owner_id != endorsement.user_id do
       endorser = Repo.get(Vutuv.Accounts.User, endorsement.user_id)
-      Vutuv.Activity.notify_endorsement(owner_id, endorser, tag.name)
+      Vutuv.Activity.notify_endorsement(owner_id, endorser, tag.name, endorsement.id)
     end
 
     owner_id

--- a/lib/vutuv_web/live/notification_live/index.ex
+++ b/lib/vutuv_web/live/notification_live/index.ex
@@ -120,6 +120,12 @@ defmodule VutuvWeb.NotificationLive.Index do
     read_marker = user.notifications_read_at
     new_count = if connected?(socket), do: Activity.unread_notification_count(user), else: 0
 
+    # The rows the member already acknowledged one by one, from the browser
+    # notifications they clicked — captured here for the same reason as the
+    # marker above: `mark_notifications_read/1` drops them a line further down,
+    # and this visit should still show them as read rather than as news.
+    dismissed = Activity.dismissed_event_ids(user.id)
+
     if connected?(socket) do
       Activity.subscribe(user.id)
       Activity.mark_notifications_read(user.id)
@@ -132,6 +138,7 @@ defmodule VutuvWeb.NotificationLive.Index do
      |> assign(:page_title, gettext("Notifications"))
      |> assign(:read_marker, read_marker)
      |> assign(:new_count, new_count)
+     |> assign(:dismissed, dismissed)
      |> assign(:today, ViewerClock.today())
      |> assign(:quote_lines, User.notification_post_lines(user))
      |> assign_rail(connected?(socket))}
@@ -181,10 +188,11 @@ defmodule VutuvWeb.NotificationLive.Index do
       notification
       |> Map.put_new(:kind, "activity")
       |> Map.put_new(:at, DateTime.utc_now())
-      # Pushed events carry no row id, so mint one outside the derived
-      # "<kind>-<row id>" namespace. A CV update brings its own derived group
-      # id, so a second entry within the grouping window replaces the row an
-      # open page already shows instead of stacking another.
+      # `Activity.notify/2` gives a push the same id its derived row will have,
+      # so an event that arrives twice (a CV sitting growing, a reconnect)
+      # replaces the row an open page already shows instead of stacking
+      # another. Only a kind with no source row behind it falls through to a
+      # minted id outside that namespace.
       |> Map.put_new(:id, "live-#{System.unique_integer([:positive, :monotonic])}")
 
     cond do
@@ -268,7 +276,10 @@ defmodule VutuvWeb.NotificationLive.Index do
     %{
       page: page,
       total: total,
-      items: feed.entries |> with_seen_flags(user) |> with_post_previews(user)
+      items:
+        feed.entries
+        |> with_seen_flags(user, socket.assigns.dismissed)
+        |> with_post_previews(user)
     }
   end
 
@@ -284,7 +295,7 @@ defmodule VutuvWeb.NotificationLive.Index do
   # counting it. They stay listed — the page is the log of what happened — they
   # just no longer render as new, so the list and the badge tell one story. One
   # query per page.
-  defp with_seen_flags(entries, viewer) do
+  defp with_seen_flags(entries, viewer, dismissed) do
     seen =
       entries
       |> Enum.map(&Activity.subject_post_id/1)
@@ -292,7 +303,11 @@ defmodule VutuvWeb.NotificationLive.Index do
       |> then(&Activity.seen_post_ids(viewer.id, &1))
 
     Enum.map(entries, fn entry ->
-      Map.put(entry, :seen?, MapSet.member?(seen, Activity.subject_post_id(entry)))
+      read? =
+        MapSet.member?(seen, Activity.subject_post_id(entry)) or
+          MapSet.member?(dismissed, entry[:id])
+
+      Map.put(entry, :seen?, read?)
     end)
   end
 

--- a/lib/vutuv_web/live/shell_live.ex
+++ b/lib/vutuv_web/live/shell_live.ex
@@ -573,6 +573,22 @@ defmodule VutuvWeb.ShellLive do
      })}
   end
 
+  # The member clicked a browser notification, so they have seen exactly the
+  # event it announced — and nothing else on the bell. Recording it drops that
+  # one from the unread tally; the recount then comes back through
+  # `:notifications_changed` like every other change, so the badge is never
+  # decremented by hand and cannot drift from the feed.
+  #
+  # Whatever the browser sends is scoped to this socket's member and checked
+  # against the kind vocabulary in `Vutuv.Activity`, so the worst a forged
+  # payload can do is mark one of the sender's own notifications read.
+  def handle_event("notify:seen", %{"kind" => kind, "source_id" => source_id}, socket) do
+    Activity.mark_notification_seen(socket.assigns.user_id, kind, source_id)
+    {:noreply, socket}
+  end
+
+  def handle_event("notify:seen", _params, socket), do: {:noreply, socket}
+
   defp push_notify(%{assigns: %{browser_notifications?: false}} = socket, _payload), do: socket
 
   defp push_notify(socket, payload), do: push_event(socket, "notify:show", payload)
@@ -581,6 +597,11 @@ defmodule VutuvWeb.ShellLive do
     {title, body} = NotificationLine.title_and_body(notification)
 
     push_notify(socket, %{
+      # What the hook hands back when the popup is clicked, so the bell can
+      # drop this one event and keep the rest (`handle_event("notify:seen")`).
+      # nil for a kind the tally cannot single out again — the hook then just
+      # navigates.
+      ack: Activity.dismiss_ref(notification),
       # One tag for the whole activity stream, so a burst of ten likes replaces
       # itself into a single popup instead of stacking ten - and so a member
       # with four vutuv tabs open gets one notification rather than four (the

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.357.1",
+      version: "7.359.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260825115842_create_notification_dismissals.exs
+++ b/priv/repo/migrations/20260825115842_create_notification_dismissals.exs
@@ -1,0 +1,28 @@
+defmodule Vutuv.Repo.Migrations.CreateNotificationDismissals do
+  use Ecto.Migration
+
+  # The per-event read exception behind `Vutuv.Activity.mark_notification_seen/3`
+  # (`notification_post_reads` is its per-post sibling); that function's docs
+  # carry the reasoning.
+  #
+  # `source_id` is the id of the row the feed derives the event from — a
+  # follow, a like, an endorsement, an image scan — so it deliberately carries
+  # no foreign key: it points at a different table per kind. Nothing breaks
+  # when the source row is deleted; the event disappears with it and the
+  # dismissal simply stops matching anything.
+  #
+  # Write-once, so no `updated_at`. The unique index serves all three readers:
+  # the tally's per-kind subquery, the page's whole-member read, and the delete
+  # `mark_notifications_read/1` runs once the marker covers them.
+  def change do
+    create table(:notification_dismissals) do
+      add(:user_id, references(:users, on_delete: :delete_all), null: false)
+      add(:kind, :string, null: false)
+      add(:source_id, :binary_id, null: false)
+
+      timestamps(updated_at: false)
+    end
+
+    create(unique_index(:notification_dismissals, [:user_id, :kind, :source_id]))
+  end
+end

--- a/test/vutuv/notification_dismissal_test.exs
+++ b/test/vutuv/notification_dismissal_test.exs
@@ -1,0 +1,199 @@
+defmodule Vutuv.NotificationDismissalTest do
+  @moduledoc """
+  Clicking a browser notification marks that one event read
+  (`Vutuv.Activity.mark_notification_seen/3`; its docs say why).
+
+  What the per-kind table below guards is the **seam**: the live push names a
+  row with `:source_id`, the tally excludes a row by id, and the two are
+  written in different modules from different arguments. So each kind asserts
+  that the pushed event and the derived feed item name the *same* row
+  (`event_id/2`) and that dismissing it moves the count by exactly one. A kind
+  whose push forgets the id, or names the wrong one, passes neither.
+  """
+  use Vutuv.DataCase, async: true
+
+  import Vutuv.PostsHelpers
+
+  alias Vutuv.Activity
+  alias Vutuv.Posts
+  alias Vutuv.Social
+  alias Vutuv.Tags
+
+  defp mentionable(attrs \\ []) do
+    insert(:activated_user, Keyword.put_new(attrs, :username, unique_username()))
+  end
+
+  # Runs `fun`, then hands back the notification it pushed to `me`.
+  defp pushed(me, fun) do
+    Activity.subscribe(me.id)
+    fun.()
+    assert_receive {:new_notification, notification}
+    notification
+  end
+
+  defp item_of_kind(user_id, kind) do
+    user_id
+    |> Activity.notifications_page(limit: 50)
+    |> Map.fetch!(:entries)
+    |> Enum.find(&(&1.kind == kind))
+  end
+
+  # One event of every everyday kind, each as the member on the receiving end
+  # would get it: `{recipient, fun_that_makes_it_happen}`.
+  defp fixture(:like) do
+    me = insert(:user)
+    other = insert(:user)
+    mine = insert(:post, user: me)
+
+    {me, fn -> :ok = Posts.like_post(other, mine) end}
+  end
+
+  defp fixture(:reply) do
+    me = insert(:user)
+    other = insert(:user)
+    mine = insert(:post, user: me)
+
+    {me, fn -> {:ok, _} = Posts.create_reply(other, mine, %{body: "Good point."}) end}
+  end
+
+  defp fixture(:mention) do
+    me = mentionable()
+    other = mentionable()
+
+    {me, fn -> create_post!(other, %{body: "Ask @#{me.username} about it."}) end}
+  end
+
+  defp fixture(:follower) do
+    me = insert(:user)
+    other = insert(:user)
+
+    {me, fn -> {:ok, _} = Social.follow(other, me.id) end}
+  end
+
+  defp fixture(:connection) do
+    me = insert(:user)
+    other = insert(:user)
+    {:ok, _} = Social.follow(me, other.id)
+
+    {me, fn -> {:ok, _} = Social.follow(other, me.id) end}
+  end
+
+  defp fixture(:endorsement) do
+    me = insert(:user)
+    other = insert(:user)
+    user_tag = insert(:user_tag, user: me, tag: insert(:tag))
+
+    {me,
+     fn -> {:ok, _} = Tags.create_endorsement(%{user_id: other.id, user_tag_id: user_tag.id}) end}
+  end
+
+  describe "a live push names the row the feed counts" do
+    for kind <- ~w(like reply mention follower connection endorsement) do
+      test "#{kind}" do
+        kind = unquote(kind)
+        {me, act} = fixture(String.to_existing_atom(kind))
+
+        notification = pushed(me, act)
+        ref = Activity.dismiss_ref(notification)
+
+        assert %{kind: ^kind} = ref,
+               "the #{kind} push carries no dismissable reference"
+
+        assert Activity.event_id(ref.kind, ref.source_id) == item_of_kind(me.id, kind).id,
+               "the #{kind} push and its feed item name different rows"
+      end
+    end
+  end
+
+  describe "dismissing one notification" do
+    for kind <- ~w(like reply mention follower connection endorsement) do
+      test "#{kind} drops it from the unread count" do
+        kind = unquote(kind)
+        {me, act} = fixture(String.to_existing_atom(kind))
+
+        ref = me |> pushed(act) |> Activity.dismiss_ref()
+        before = Activity.unread_notification_count(me.id)
+        assert before >= 1
+
+        Activity.mark_notification_seen(me.id, ref.kind, ref.source_id)
+
+        assert Activity.unread_notification_count(me.id) == before - 1
+      end
+    end
+
+    test "leaves the member's other notifications alone" do
+      {me, act} = fixture(:like)
+      first = me |> pushed(act) |> Activity.dismiss_ref()
+      other = insert(:user)
+      {:ok, _} = Social.follow(other, me.id)
+
+      assert Activity.unread_notification_count(me.id) == 2
+
+      Activity.mark_notification_seen(me.id, first.kind, first.source_id)
+
+      assert Activity.unread_notification_count(me.id) == 1
+    end
+
+    test "is idempotent, and only the first one asks for a recount" do
+      {me, act} = fixture(:like)
+      ref = me |> pushed(act) |> Activity.dismiss_ref()
+
+      Activity.mark_notification_seen(me.id, ref.kind, ref.source_id)
+      assert_receive :notifications_changed
+
+      Activity.mark_notification_seen(me.id, ref.kind, ref.source_id)
+      refute_receive :notifications_changed, 50
+
+      assert Activity.unread_notification_count(me.id) == 0
+    end
+
+    test "ignores a kind or an id the browser made up" do
+      {me, act} = fixture(:like)
+      ref = me |> pushed(act) |> Activity.dismiss_ref()
+
+      Activity.mark_notification_seen(me.id, "not_a_kind", ref.source_id)
+      Activity.mark_notification_seen(me.id, ref.kind, "no-such-uuid")
+      Activity.mark_notification_seen(me.id, ref.kind, nil)
+      Activity.mark_notification_seen(nil, ref.kind, ref.source_id)
+
+      assert Activity.unread_notification_count(me.id) == 1
+    end
+
+    test "still shows the row on the notifications page, marked read" do
+      {me, act} = fixture(:like)
+      notification = pushed(me, act)
+      ref = Activity.dismiss_ref(notification)
+
+      Activity.mark_notification_seen(me.id, ref.kind, ref.source_id)
+
+      assert MapSet.member?(Activity.dismissed_event_ids(me.id), item_of_kind(me.id, "like").id)
+      assert length(Activity.notifications_page(me.id, limit: 50).entries) == 1
+    end
+
+    test "opening /notifications clears the dismissals it has made redundant" do
+      {me, act} = fixture(:like)
+      ref = me |> pushed(act) |> Activity.dismiss_ref()
+      Activity.mark_notification_seen(me.id, ref.kind, ref.source_id)
+
+      Activity.mark_notifications_read(me.id)
+
+      assert Activity.dismissed_event_ids(me.id) == MapSet.new()
+      assert Activity.unread_notification_count(me.id) == 0
+    end
+  end
+
+  describe "dismissable_kinds/0" do
+    # Both halves come off the registry's `dismiss` entries, so a kind cannot
+    # store dismissals the tally ignores. What is worth pinning is the shape of
+    # the vocabulary: exactly one opt-out, and the extra name the two-event
+    # severance needs. A new kind declaring `dismiss: [nil]` by rote fails
+    # here and has to justify itself.
+    test "every kind but the grouped one can be dismissed" do
+      assert Activity.kinds() -- Activity.dismissable_kinds() == ["cv_update"]
+    end
+
+    test "the report-protection restore half has a name of its own" do
+      assert "report_protection_restored" in Activity.dismissable_kinds()
+    end
+  end
+end

--- a/test/vutuv_web/live/shell_live_browser_notifications_test.exs
+++ b/test/vutuv_web/live/shell_live_browser_notifications_test.exs
@@ -170,6 +170,50 @@ defmodule VutuvWeb.ShellLiveBrowserNotificationsTest do
     end
   end
 
+  describe "clicking the popup" do
+    test "carries back what it takes to mark that one event read", %{conn: conn} do
+      user = insert(:user, browser_notifications?: true)
+      liker = insert(:user)
+      post = insert(:post, user: user)
+      view = mount_shell(conn, user)
+
+      :ok = Vutuv.Posts.like_post(liker, post)
+
+      assert_push_event(view, "notify:show", %{ack: ack}, @push_timeout)
+      assert %{kind: "like", source_id: source_id} = ack
+
+      assert Activity.unread_notification_count(user.id) == 1
+      render_hook(view, "notify:seen", %{"kind" => ack.kind, "source_id" => source_id})
+      assert Activity.unread_notification_count(user.id) == 0
+    end
+
+    test "carries no reference for a kind the tally cannot single out", %{conn: conn} do
+      user = insert(:user, browser_notifications?: true)
+      view = mount_shell(conn, user)
+
+      # No `source_id` in the push means no row for a dismissal to name; the
+      # hook then simply navigates. The popup still goes out.
+      Activity.broadcast(user.id, {:new_notification, like_notification("Anna Klein")})
+
+      assert_push_event(view, "notify:show", %{ack: nil}, @push_timeout)
+    end
+
+    test "a forged payload can only touch the sender's own bell", %{conn: conn} do
+      user = insert(:user, browser_notifications?: true)
+      other = insert(:user)
+      liker = insert(:user)
+      post = insert(:post, user: other)
+      view = mount_shell(conn, user)
+
+      :ok = Vutuv.Posts.like_post(liker, post)
+      like = Vutuv.Repo.one!(Vutuv.Posts.PostLike)
+
+      render_hook(view, "notify:seen", %{"kind" => "like", "source_id" => like.id})
+
+      assert Activity.unread_notification_count(other.id) == 1
+    end
+  end
+
   describe "the test notification" do
     test "travels the same path a real one does", %{conn: conn} do
       user = insert(:user, browser_notifications?: true)


### PR DESCRIPTION
**Symptom** The bell badge kept counting a notification you had demonstrably read: the browser popup announced it, you clicked, you landed on the post — and the count only moved when you opened `/notifications`, which then cleared everything at once.

**What changed** Clicking a popup now marks that one event read. The push carries an `ack`; the `WebNotify` hook in `assets/js/app.js` sends it back as `notify:seen` before navigating, and `Vutuv.Activity.mark_notification_seen/3` writes a per-event exception to the new `notification_dismissals` table. The badge recounts from source, so it drops by one rather than to zero, and `/notifications` renders that row as read.

**Where** `Vutuv.Activity` — its `kind_specs/3` registry gains a `dismiss:` key per kind, applied once in `total_count/4` — plus `VutuvWeb.ShellLive` and the hook.

**To decide** Nothing blocking. One kind opts out: a CV sitting is a group of rows, not a row, so there is nothing to exclude.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_014x991S7CNxTKHPsgRBLDSF
