### PR TITLE
Gate the Italian catalog the way German is gated

### DIFF
--- a/docs/architecture/i18n.md
+++ b/docs/architecture/i18n.md
@@ -101,6 +101,12 @@ anything but `0` comes from your own merge rather than from old debt. The `en`
 catalog is different: its entries carry no translation at all (English falls
 back to the msgid), so the flags left on 310 of them mean nothing.
 
+`test/vutuv_web/translated_catalogs_test.exs` fails the build on either half of
+that — a missing translation or a fuzzy flag — for both locales, but only over
+the surfaces named in its `@covered` list. Everything outside that list is
+still yours to notice: the catalogs carry a long tail of untranslated legacy
+prose, and gating all of it would only get the test deleted.
+
 And one trap grep cannot see at all: **a msgid is a key, not a phrase.**
 `gettext("Following")` is translated "Folge ich" (*I* follow), written for a
 member's own list; reusing it under an organization's navigation made the page
@@ -203,7 +209,10 @@ a GPU bill attached.
 2. `lib/vutuv/cldr.ex`: add it to `locales:`, compile once online, commit
    `priv/cldr/locales/<locale>.json`.
 3. `mix gettext.merge priv/gettext --locale <locale>`, then translate
-   `default.po` and `errors.po` and clear every fuzzy flag.
+   `default.po` and `errors.po` and clear every fuzzy flag. Add the code to
+   `@locales` in `test/vutuv_web/translated_catalogs_test.exs`, which is what
+   keeps the new language from drifting the way Italian did in its first
+   fortnight.
 4. Both email bodies for every member-facing mail, plus
    `_signature_<locale>.text.eex`, the two `EmailComponents` clauses and an
    `email_greeting/1` clause.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.355.2",
+      version: "7.357.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/translated_catalogs_test.exs
+++ b/test/vutuv_web/translated_catalogs_test.exs
@@ -1,14 +1,16 @@
-defmodule VutuvWeb.GermanCatalogTest do
+defmodule VutuvWeb.TranslatedCatalogsTest do
   @moduledoc """
-  vutuv is a German site, so a feature whose labels were never translated ships
-  an English interface to nearly every real visitor. That is what happened to
-  the whole photo-post UI (issue #1104): the code was written, `mix
-  gettext.extract` was never run, and the composer's photo panel, the lightbox
-  and the "not public yet" banner all rendered in English on vutuv.de.
+  vutuv is a German site with an Italian interface beside it, so a feature whose
+  labels were never translated ships an English page to nearly every real
+  visitor. That is what happened to the whole photo-post UI (issue #1104): the
+  code was written, `mix gettext.extract` was never run, and the composer's
+  photo panel, the lightbox and the "not public yet" banner all rendered in
+  English on vutuv.de.
 
-  Two things are checked here, both of which failed silently:
+  Two things are checked here, per translated locale, both of which failed
+  silently:
 
-  1. **Every string on the interactive surfaces is in the German catalog with a
+  1. **Every string on the interactive surfaces is in the catalog with a
      translation.** A missing `msgstr` is invisible in tests and in review —
      Gettext just falls through to the English msgid.
 
@@ -18,15 +20,23 @@ defmodule VutuvWeb.GermanCatalogTest do
      the German for "Remove logo" and "Show camera settings" with "Search
      settings" — and a fuzzy entry looks translated to anyone skimming the file.
 
+  Italian joined in v7.355.1 and paid for its seat on the way in: it had shipped
+  in v7.353.0 and drifted within two releases, so the feed-language page stood
+  15 strings untranslated with 8 more fuzzy-filled from unrelated entries
+  ("Suggested:" as "Post consigliati", "Every language" as "Modifica la
+  lingua"). Nothing failed, because only German was gated. `en` is deliberately
+  not here: its entries carry no translation at all — English *is* the msgid.
+
   Scoped to the modules a member actually clicks through, deliberately: the
-  catalog carries a long tail of untranslated legacy prose (long help
-  paragraphs on old pages), and failing the build on all of it would just get
-  this test deleted. Widen the list when a surface is cleaned up, never narrow
-  it to make a red build green.
+  catalogs carry a long tail of untranslated legacy prose (long help paragraphs
+  on old pages), and failing the build on all of it would just get this test
+  deleted. Widen the list when a surface is cleaned up, never narrow it to make
+  a red build green.
   """
   use ExUnit.Case, async: true
 
-  @catalog "priv/gettext/de/LC_MESSAGES/default.po"
+  # Every locale whose catalog holds real translations. `en` is excluded above.
+  @locales ~w(de it)
 
   # Sources whose user-facing strings must be fully translated. `ui.ex` cannot
   # join as it stands: the scan is textual, so the `gettext("Add entry")` in
@@ -62,8 +72,11 @@ defmodule VutuvWeb.GermanCatalogTest do
   # runtime cannot be checked here and is not the failure mode this guards.
   @call ~r/\bn?gettext\(\s*"((?:[^"\\]|\\.)+)"/
 
-  defp catalog_blocks do
-    @catalog
+  defp catalog(locale), do: "priv/gettext/#{locale}/LC_MESSAGES/default.po"
+
+  defp catalog_blocks(locale) do
+    locale
+    |> catalog()
     |> File.read!()
     |> String.split("\n\n")
   end
@@ -126,42 +139,46 @@ defmodule VutuvWeb.GermanCatalogTest do
     |> Enum.uniq()
   end
 
-  test "every label on the post composer, card and licence select is translated into German" do
-    by_id = Map.new(catalog_blocks(), &{msgid(&1), &1})
+  for locale <- @locales do
+    test "every label on the post composer, card and licence select is translated into #{locale}" do
+      locale = unquote(locale)
+      by_id = Map.new(catalog_blocks(locale), &{msgid(&1), &1})
 
-    untranslated =
-      Enum.reject(used_strings(), fn string ->
-        case Map.fetch(by_id, string) do
-          {:ok, block} -> translated?(block)
-          :error -> false
-        end
-      end)
+      untranslated =
+        Enum.reject(used_strings(), fn string ->
+          case Map.fetch(by_id, string) do
+            {:ok, block} -> translated?(block)
+            :error -> false
+          end
+        end)
 
-    assert untranslated == [],
-           """
-           These strings have no German translation, so they render in English
-           on a German site:
+      assert untranslated == [],
+             """
+             These strings have no #{locale} translation, so they render in
+             English on a page that asked for that language:
 
-           #{Enum.map_join(untranslated, "\n", &"  - #{&1}")}
+             #{Enum.map_join(untranslated, "\n", &"  - #{&1}")}
 
-           Run `mix gettext.extract --merge`, then translate them in
-           #{@catalog}. Check for `#, fuzzy` flags while you are there — a
-           merge guesses translations for new strings from similar old ones,
-           and its guesses are often wrong.
-           """
-  end
+             Run `mix gettext.extract --merge`, then translate them in
+             #{catalog(locale)}. Check for `#, fuzzy` flags while you are
+             there — a merge guesses translations for new strings from similar
+             old ones, and its guesses are often wrong.
+             """
+    end
 
-  test "no string on those surfaces is missing from the catalog entirely" do
-    known = MapSet.new(catalog_blocks(), &msgid/1)
-    missing = Enum.reject(used_strings(), &MapSet.member?(known, &1))
+    test "no string on those surfaces is missing from the #{locale} catalog entirely" do
+      locale = unquote(locale)
+      known = MapSet.new(catalog_blocks(locale), &msgid/1)
+      missing = Enum.reject(used_strings(), &MapSet.member?(known, &1))
 
-    assert missing == [],
-           """
-           These strings are not in the German catalog at all, which means
-           `mix gettext.extract --merge` has not been run since they were
-           written:
+      assert missing == [],
+             """
+             These strings are not in the #{locale} catalog at all, which means
+             `mix gettext.extract --merge` has not been run since they were
+             written:
 
-           #{Enum.map_join(missing, "\n", &"  - #{&1}")}
-           """
+             #{Enum.map_join(missing, "\n", &"  - #{&1}")}
+             """
+    end
   end
 end


### PR DESCRIPTION
Only the German catalog was gated, which is how Italian shipped in v7.353.0 and drifted within two releases without anything going red: the feed-language page stood 15 strings untranslated with 8 more fuzzy-filled from unrelated entries (fixed in v7.355.1).

**What changed:** `german_catalog_test.exs` becomes `translated_catalogs_test.exs` and loops `de` and `it` over the same `@covered` list — a missing translation and a fuzzy flag each fail the build, per locale. `en` stays out: its entries carry no translation, English *is* the msgid.

Calibrated on both halves. Emptying one Italian msgstr, and separately setting a fuzzy flag on it, each turns the Italian branch red while German stays green.

The cost is real and worth knowing: from here a new user-facing string on one of those surfaces needs its Italian before CI goes green.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01W1mgbhkL5UpV2uRByEQM6c
