### PR TITLE
A line of nothing but hashtags is not a teaser

### DIFF
--- a/lib/vutuv_web/post_teaser.ex
+++ b/lib/vutuv_web/post_teaser.ex
@@ -27,9 +27,16 @@ defmodule VutuvWeb.PostTeaser do
     * **A line with no words in it** — a `---` rule, a lone code fence, a line
       that is nothing but inline images. Teasing a post with `![](…)` says less
       than nothing.
+    * **A line that is nothing but hashtags** — the filing a post opens or
+      closes with (`#Solarpunk #klimakrise #klimawandel …`). It says which
+      shelf the post belongs on, never what it says.
 
-  A post that is *nothing but* skippable lines keeps its first line: a URL
-  makes a poor teaser, an empty one is worse.
+  A post that is *nothing but* skippable lines keeps the best line it has, and
+  they are not equally bad: hashtags are words a reader can read, a quoted URL
+  and a horizontal rule are not. So a post whose whole body is a `RE: <url>`
+  and a row of hashtags is teased with the hashtags — which is a real shape in
+  the data, not a hypothetical. Below that, the first line, whatever it is: a
+  URL makes a poor teaser, an empty one is worse.
 
   Both functions pick the **same** line — the choice is made on the source — so
   no two surfaces can quote one post differently. They differ only in how they
@@ -77,6 +84,18 @@ defmodule VutuvWeb.PostTeaser do
     ~r/\A(?:```|~~~)/,
     ~r/\A(?:!\[[^\]]*\]\([^)]*\)\s*)+\z/
   ]
+
+  # A line of nothing but hashtags — skipped like the rest, but the one that
+  # wins the fallback in `pick/1`, because a reader gets *something* out of
+  # "#Solarpunk #klimakrise" and nothing at all out of a status URL.
+  #
+  # The token is `Vutuv.Mentions`' canonical `#[A-Za-z0-9_]+`, so this and the
+  # renderer cannot disagree about what a hashtag is. Being ASCII-only, a line
+  # carrying `#Grüne` does not match and is kept — the safe direction, since
+  # skipping a line the reader wanted is the expensive mistake. A Markdown
+  # heading cannot match either: `# Titel` has a space after the `#`, and this
+  # demands a word character.
+  @hashtags_only ~r/\A(?:#[A-Za-z0-9_]+[\s,]*)+\z/
 
   # How wide one browser-tab frame is written. A tab in a window holding a
   # handful of others shows roughly twenty characters of its title, and the
@@ -262,14 +281,20 @@ defmodule VutuvWeb.PostTeaser do
     |> Stream.reject(&(&1 == ""))
   end
 
+  # Real prose if there is any; else the hashtags, which at least name the
+  # subject; else the first line, whatever it turned out to be. `lines/1` is a
+  # re-enumerable stream, so the two extra passes cost nothing on the common
+  # case — they only run for a post that had no prose to find.
   defp pick(lines) do
-    case Enum.find(lines, &(not skippable?(&1))) do
-      nil -> Enum.at(lines, 0) || ""
-      line -> line
-    end
+    Enum.find(lines, &(not skippable?(&1))) ||
+      Enum.find(lines, &hashtags_only?/1) ||
+      Enum.at(lines, 0) || ""
   end
 
-  defp skippable?(line), do: Enum.any?(@skippable, &Regex.match?(&1, line))
+  defp skippable?(line),
+    do: hashtags_only?(line) or Enum.any?(@skippable, &Regex.match?(&1, line))
+
+  defp hashtags_only?(line), do: Regex.match?(@hashtags_only, line)
 
   defp flatten(line), do: line |> Markdown.to_plain_text() |> fold()
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.360.1",
+      version: "7.360.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/post_teaser_test.exs
+++ b/test/vutuv_web/post_teaser_test.exs
@@ -106,6 +106,31 @@ defmodule VutuvWeb.PostTeaserTest do
       assert PostTeaser.line(%Post{body: "![](a.jpg) ![](b.jpg)\n\nDer Rest"}) == "Der Rest"
     end
 
+    test "skips a line that is nothing but hashtags" do
+      post = %Post{body: "#Solarpunk #klimakrise #noafd\n\nDas Dach ist fertig."}
+
+      assert PostTeaser.line(post) == "Das Dach ist fertig."
+    end
+
+    test "keeps a line where the hashtags are part of a sentence" do
+      post = %Post{body: "Endlich Strom vom Dach #Solarpunk\n\nMehr dazu"}
+
+      assert PostTeaser.line(post) == "Endlich Strom vom Dach #Solarpunk"
+    end
+
+    test "does not mistake a Markdown heading for hashtags" do
+      assert PostTeaser.line(%Post{body: "# Titel\n\nDer Rest"}) == "# Titel"
+      assert PostTeaser.line(%Post{body: "## Zwischentitel\n\nDer Rest"}) == "## Zwischentitel"
+    end
+
+    test "keeps a hashtag line the canonical grammar does not cover, rather than guessing" do
+      # `Vutuv.Mentions` reads `#[A-Za-z0-9_]+`, so `#Grüne` is not one token to
+      # it. Skipping a line the reader wanted is the expensive mistake.
+      post = %Post{body: "#Grüne #Klima\n\nDer Rest"}
+
+      assert PostTeaser.line(post) == "#Grüne #Klima"
+    end
+
     test "reads a remote post and a remote reply off their own text column" do
       assert PostTeaser.line(%RemotePost{content_text: "Von drüben"}) == "Von drüben"
       assert PostTeaser.line(%Note{content_text: "Geantwortet"}) == "Geantwortet"
@@ -138,6 +163,14 @@ defmodule VutuvWeb.PostTeaserTest do
 
     test "but keeps it when it is all the post has: a URL beats an empty teaser" do
       assert PostTeaser.line(%RemotePost{content_text: @quoted}) == @quoted
+    end
+
+    test "and where only hashtags follow it, they are the teaser rather than the URL" do
+      # A real shape in the data: a quote post whose whole body is the
+      # reference and a row of filing. Hashtags are words, a status URL is not.
+      post = %RemotePost{content_text: @quoted <> "\n\n#Solarpunk #klimakrise #noafd"}
+
+      assert PostTeaser.line(post) == "#Solarpunk #klimakrise #noafd"
     end
 
     test "only where the post opens with it, never mid-body" do


### PR DESCRIPTION
**Symptom.** Some posts open with their filing rather than their content: `#Solarpunk #klimakrise #klimawandel`. That says which shelf the post belongs on, never what it says — and it was the teaser in the ticker, the RSS `<description>`, Open Graph, `/search` and the agent docs.

**What changed.** Second exception in `VutuvWeb.PostTeaser.@skippable`, so all nine surfaces get it at once. The token follows `Vutuv.Mentions`' canonical `#[A-Za-z0-9_]+`, so a line with `#Grüne` is kept rather than guessed at, and `# Titel` cannot be mistaken for one.

**The exceptions are now ranked.** Where a post is *nothing but* skippable lines, hashtags win: they are words, a quoted status URL is not. A real shape in the data — a quote post whose whole body is `RE: <url>` plus a row of hashtags — was otherwise teased with the URL again.

**Where.** `lib/vutuv_web/post_teaser.ex`. Hot deploy, v7.360.2.

*An AI agent wrote this text in my name. I know that is problematic.*
