### PR TITLE
Link a fediverse address that follows a slash

### DIFF
--- a/lib/vutuv/mentions.ex
+++ b/lib/vutuv/mentions.ex
@@ -76,7 +76,16 @@ defmodule Vutuv.Mentions do
   # the **host** then decides whose it is. Captures: 1 = fediverse
   # user, 2 = fediverse host, 3 = local handle, 4 = hashtag (exactly one kind is
   # set per hit).
-  @entity ~r{(?<![\w@/])@([A-Za-z0-9_]+)@([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)+)|(?<![\w@/])@([A-Za-z0-9_]+)|(?<![\w#/&])#([A-Za-z0-9_]+)}
+  #
+  # A preceding `/` blocks the **bare** and `#` forms only. `/@user` is the
+  # Mastodon-web path to a profile, so a lone handle glued to a slash is far
+  # more often a URL than a mention. A full `@user@host` after one is not: it is
+  # the address itself, sitting where German prose puts a slash — `Bündnis
+  # 90/@gruenebundestag@gruene.social` names that account, and Mastodon's own
+  # regex (which excludes `/` for both forms) misses it. Inside a real URL the
+  # renderer never reaches it, because an autolinked address is an `<a>` by the
+  # time the entity pass runs and that pass skips anchors.
+  @entity ~r{(?<![\w@])@([A-Za-z0-9_]+)@([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)+)|(?<![\w@/])@([A-Za-z0-9_]+)|(?<![\w#/&])#([A-Za-z0-9_]+)}
 
   # Code spans/blocks are skipped everywhere: a handle inside them is sample
   # text, never a link (the same call the renderer makes for `<code>`/`<pre>`).

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.360.2",
+      version: "7.361.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/mentions_local_address_test.exs
+++ b/test/vutuv/mentions_local_address_test.exs
@@ -57,6 +57,10 @@ defmodule Vutuv.MentionsLocalAddressTest do
       assert Mentions.local_handles("@php@tags.vutuv.test") == []
     end
 
+    test "a slash in front of the address does not hide the member" do
+      assert Mentions.local_handles("Bündnis 90/@ada@vutuv.test") == ["ada"]
+    end
+
     test "an address inside a code span is sample text" do
       assert Mentions.local_handles("type `@ada@vutuv.test` to mention") == []
     end

--- a/test/vutuv_web/markdown_test.exs
+++ b/test/vutuv_web/markdown_test.exs
@@ -463,5 +463,37 @@ defmodule VutuvWeb.MarkdownTest do
       # a bare @name in remote content stays plain text (it is ambiguous)
       refute html =~ ~s(href="/localguy")
     end
+
+    test "links an address glued to a preceding slash" do
+      # German prose writes the party as "Bündnis 90/Die Grünen", so a boosted
+      # Mastodon post named the fraction as `Bündnis 90/@gruenebundestag@…`.
+      # Mastodon's own regex refuses a `/` in front of a handle and left it as
+      # dead text; here the full address still names the account.
+      html =
+        Markdown.render_remote(
+          "MdBs von Bündnis 90/@gruenebundestag@gruene.social schaffen ein Büro"
+        )
+
+      assert html =~ ~s(href="https://gruene.social/@gruenebundestag")
+      assert html =~ ">@gruenebundestag@gruene.social</a>"
+    end
+
+    test "an address inside a URL stays part of that URL's own link" do
+      # `https://<host>/@user@host` is how Mastodon addresses a remote profile.
+      # The autolink pass turns it into an `<a>` before entities are linked,
+      # and that pass skips anchors — so the tail is never split off.
+      html = render("profile: https://mastodon.social/@hostsharing@geno.social here")
+
+      assert html =~ ~s(href="https://mastodon.social/@hostsharing@geno.social")
+      refute html =~ ~s(href="https://geno.social/@hostsharing")
+      assert length(String.split(html, "<a ")) == 2
+    end
+
+    test "a bare handle after a slash is still read as a URL path" do
+      html = render("mastodon.social/@hostsharing is the page")
+
+      refute html =~ "<a"
+      assert html =~ "mastodon.social/@hostsharing"
+    end
   end
 end


### PR DESCRIPTION
**Symptom:** a boosted Mastodon post named the Greens' Bundestag account as `Bündnis 90/@gruenebundestag@gruene.social`. Every `@` behind a slash was blocked, so the account name rendered as dead text.

**What changed:** the entity grammar in `Vutuv.Mentions` (`@entity`, read by `VutuvWeb.Markdown` through `entity_regex/0`). The `/` in the negative lookbehind now guards the bare `@handle` form only — `/@user` is the Mastodon path to a profile, so a lone handle at a slash is usually a URL. A full `@user@host` after one is the address itself.

Inside a real URL the entity pass never reaches it: the autolink turns `https://host/@a@b.social` into an anchor first, and anchors are skipped. Covered by three cases in `markdown_test.exs` plus one in `mentions_local_address_test.exs`.

Hot deploy, v7.361.1.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01JgC26UZoGVuz1jeZHupNnU