### PR TITLE
Fix the browser tab teaser going silent after a socket reconnect

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -745,6 +745,20 @@ const Hooks = {
       this.reportVisibility()
       this.apply()
     },
+    // A rejoin runs ShellLive's `mount/3` again, and a fresh mount starts
+    // `tab_hidden?` at **false** — the socket has no memory of what this tab
+    // said before it dropped. Nothing here volunteers the answer twice on its
+    // own: `mounted()` runs once (the element survives the patch) and a tab
+    // hidden throughout fires no `visibilitychange`. So without this the server
+    // takes every reconnected background tab for one being read and spends
+    // nothing on it, for good — and since a deploy, a laptop waking or any
+    // network blip reconnects the socket, that is the normal state of a
+    // long-lived tab, not an edge case. The dot kept working the whole time
+    // (pushed unconditionally, gated in the browser), which is why the feature
+    // read as simply broken while every test stayed green.
+    reconnected() {
+      this.reportVisibility()
+    },
     reportVisibility() {
       this.pushEvent("tab:visibility", { hidden: document.hidden })
     },

--- a/docs/architecture/realtime.md
+++ b/docs/architecture/realtime.md
@@ -427,6 +427,17 @@ same instant. Four rules bound it, and only the first is about taste:
   connect param for (issue #1679): only a bundle carrying this hook can send
   the event, so a document loaded before this release simply never teases,
   however many deploys behind it is.
+
+  It reports on `reconnected()` too, and that is not belt and braces:
+  `tab_hidden?` lives in the socket, so a rejoin runs `mount/3` again and starts
+  it at **false**. Nothing on the client volunteers the answer twice by itself —
+  `mounted()` runs once (the element survives the patch) and a tab hidden
+  throughout fires no `visibilitychange`. Without that callback every long-lived
+  background tab fell silent after its first deploy, sleep or network blip, and
+  stayed silent. The *dot* kept working (`tab:new_post` is pushed
+  unconditionally and gated in the browser), which is why the feature read as
+  simply broken while every test stayed green — found 2026-08-25 by driving a
+  real headless Chrome across a forced reconnect.
 * **One quote per window.** From the second arrival the quote gives up and
   becomes a count (`tab:teaser_more`, "+2 more posts") — no query, and the
   window is not extended, or a busy source would own the tab.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.361.1",
+      version: "7.363.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/browser_tab_teaser_test.exs
+++ b/test/vutuv_web/live/browser_tab_teaser_test.exs
@@ -26,6 +26,8 @@ defmodule VutuvWeb.BrowserTabTeaserTest do
   alias Vutuv.Sessions
   alias Vutuv.Social
 
+  @app_js "assets/js/app.js"
+
   setup do
     # `record_remote_post/2` claims the shared inbound cap, which lives in the
     # RateLimiter's ETS table and outlives a test.
@@ -244,6 +246,66 @@ defmodule VutuvWeb.BrowserTabTeaserTest do
 
       {:ok, _other} = Posts.create_post(author, %{body: "etwas ganz anderes"})
       refute_push_event(view, "tab:teaser", %{})
+    end
+  end
+
+  # The gap that made the whole feature read as broken in production while every
+  # test above stayed green (fixed 2026-08-25). `tab_hidden?` lives in the
+  # socket, so a rejoin — a deploy, a laptop waking, any network blip — starts
+  # it at false again, and nothing on the client volunteers the answer a second
+  # time: `mounted()` runs once (the element survives the patch) and a tab that
+  # was hidden throughout fires no `visibilitychange`. So every long-lived
+  # background tab fell silent after its first reconnect, and stayed silent.
+  #
+  # It hid well because the *dot* kept working: `tab:new_post` is pushed
+  # unconditionally and gated in the browser, so the tab still said that
+  # something had landed and only the teaser was gone.
+  describe "a socket that rejoins while the tab stays hidden" do
+    test "a shell that has not heard from the hook spends nothing", %{conn: conn} do
+      user = insert(:user)
+      author = followed_author(user)
+
+      # No `tab:visibility` at all — the state a reconnected tab is in until it
+      # reports again, and the reason the hook must report on `reconnected()`.
+      {token, _session} = Sessions.start_session(user, build_conn(), alert: false)
+
+      {:ok, view, _html} =
+        live_isolated(conn, VutuvWeb.ShellLive, session: %{"session_token" => token})
+
+      {:ok, _post} = Posts.create_post(author, %{body: "nach dem Reconnect"})
+
+      assert_push_event(view, "tab:new_post", %{})
+      refute_push_event(view, "tab:teaser", %{})
+
+      # …and the very same shell teases the moment the hook speaks, which is
+      # what `reconnected()` restores.
+      render_hook(view, "tab:visibility", %{"hidden" => true})
+      {:ok, _second} = Posts.create_post(author, %{body: "und jetzt doch"})
+      assert_push_event(view, "tab:teaser", %{frames: _})
+    end
+
+    test "the hook re-reports on reconnect" do
+      assert Regex.match?(
+               ~r/reconnected\(\)\s*\{[^}]*this\.reportVisibility\(\)/,
+               tab_badge_hook()
+             ),
+             """
+             TabBadge in #{@app_js} must re-report visibility from a \
+             `reconnected()` callback. Neither `mounted()` nor \
+             `visibilitychange` fires for a tab that stayed hidden across a \
+             rejoin, and the server's `tab_hidden?` resets to false on every \
+             one — so without it the teaser goes quiet for good on the first \
+             deploy that reconnects the socket.\
+             """
+    end
+  end
+
+  # Just the TabBadge hook, so the assertion above cannot be satisfied by some
+  # other hook's `reconnected()` further down the file.
+  defp tab_badge_hook do
+    case String.split(File.read!(@app_js), "\n  TabBadge: {\n", parts: 2) do
+      [_before, rest] -> rest |> String.split("\n  },\n", parts: 2) |> hd()
+      [_whole] -> flunk("No `TabBadge: {` hook in #{@app_js} — was it renamed?")
     end
   end
 end


### PR DESCRIPTION
The browser tab's teaser (#1681, v7.360.0) never fired in practice — only the bare dot did.

`tab_hidden?` lives in the ShellLive socket, so a rejoin runs `mount/3` again and starts it at `false`. Nothing on the client says otherwise a second time: `mounted()` runs once (the element survives the patch), and a tab that stayed hidden across the reconnect fires no `visibilitychange`. So the server took every reconnected background tab for one being read and refused the lookup, permanently. A deploy, a laptop waking or any network blip reconnects the socket, so that is the normal state of a long-lived tab.

It hid well: `tab:new_post` is pushed unconditionally and gated in the browser, so the dot kept appearing and only the teaser was missing.

Fix: `TabBadge` (`assets/js/app.js`) re-reports visibility from `reconnected()`.

Verified by driving a real headless Chrome across a forced reconnect: before, round 2 gave `"• Feed - vutuv"` and nothing else; after, it pages through `@author: …` as round 1 does. Guarded by two tests in `test/vutuv_web/live/browser_tab_teaser_test.exs`, calibrated red without the fix.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01GrfZcxovGbfH87qfdxYd8n
