### PR TITLE
Hashtags create the tags they name, in vutuv posts and fediverse posts

### DIFF
--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -13,14 +13,20 @@ member's name as a hover tooltip, and a **`#hashtag` is auto-linked** to that
 tag's `/tags/:slug` page **only when that page has something to show** — the tag
 exists here and carries either at least one visible member or at least one
 visible post (`Vutuv.Tags.linkable_slugs/1`), so a link never lands on an empty
-tag page. This runs everywhere the Markdown renderer does (`VutuvWeb.Markdown`:
+tag page. Written hashtag and target slug need not match: the lookup runs on the
+folded key (`Vutuv.Tags.MatchKey`) over the tag's name as well as its slug, so
+`#Thüringen` links to `/tags/thueringen` and `#ruby_on_rails` to the spaced tag
+— the same question filing asks, so a post can never be listed on a page its own
+hashtag refuses to link to. This runs everywhere the Markdown renderer does (`VutuvWeb.Markdown`:
 posts, chat messages, ads, the RSS/JSON renderings), skipping entities typed
 inside code spans/blocks or existing links and resolving all of a body's
 mentions and hashtags in one batched query each.
 
 A hashtag also **files the post under that tag**, so the link points both ways:
 `Vutuv.Posts.PostHashtag` (table `post_hashtags`, re-derived from the body on
-every save, existing tags only — a typo never leaves a tag page behind). It is a
+every save), **minting the tag** when the body is the first thing here to name
+it (`Vutuv.Tags.tag_ids_for_hashtags/2` — five new tags per body, and only names
+whose slug names them; see [social-graph.md](social-graph.md)). It is a
 separate table from `post_tags` on purpose: `post_tags` is what the card renders
 as tag chips, and a hashtag is already visible in the sentence it was written
 in, so filing it there would print it twice.
@@ -35,8 +41,9 @@ they typed to a post that publishes anyway. The count is taken after the dedupe,
 so repeating a tag never trips it, and the composer's pill box refuses the sixth
 pill client-side (`<.tag_input max={…}>`) so it rarely gets that far. Everything
 else the parser drops is still dropped silently — punctuation, a bare link, a
-repeat — because none of those can become a tag at all. Filing by hashtag is
-uncapped: a body may name as many tags as it mentions.
+repeat — because none of those can become a tag at all. Filing by hashtag has
+its own, looser ceilings: twenty tags resolved per body, five of them newly
+minted.
 
 A **bare `http(s)://` URL is auto-linked too**, with its display text shortened
 to host + first path directory — but only *outside* code. Inside a fenced block

--- a/docs/architecture/social-graph.md
+++ b/docs/architecture/social-graph.md
@@ -98,10 +98,19 @@ The timeline is `Vutuv.Tags.Timeline`, a SQL union of two sources:
   the post off its discovery surfaces, and a topic page crawlers read is exactly
   such a surface — and a followers-only post is not ours to publish at all.
 
-Neither ingestion path **mints** a tag: a hashtag files a post only under a tag
-that already exists here. A table a stranger's server can extend is a table a
-stranger's server can flood with pages on our own domain, and the tag namespace
-is what members chose to call things.
+Both ingestion paths **mint** a tag the site does not have yet: writing
+`#Eisenach` declares a topic as plainly as typing it into the composer's tag
+field, and resolving hashtags against existing tags only meant the catalog grew
+from that field alone. Three bounds keep it from becoming an open write. A body
+may mint at most `Vutuv.Tags.max_minted_hashtags_per_body/0` (five) tags against
+`max_hashtags_per_body/0` (twenty) filings. `Vutuv.Tags.mintable_hashtag?/1`
+refuses a name whose slug would not name it — `#2026` and a CJK hashtag both
+produce a URL that says nothing about the page. And the fediverse side never
+sees a stranger: `Vutuv.Fediverse.record_remote_post/2` stores a post only from
+an account somebody here already follows, so what arrives is what our own
+members chose to read. A minted page also stays `noindex` and out of the sitemap
+until a **local** member or a **local** public post carries it, so a remote post
+can leave a tag page behind but never a crawled one.
 
 The reader's controls are the embedded `VutuvWeb.TagLive.Timeline` LiveView
 (`live_render` from `VutuvWeb.TagController.show/2`, the profile's and the post

--- a/lib/vutuv/fediverse/hashtags.ex
+++ b/lib/vutuv/fediverse/hashtags.ex
@@ -10,11 +10,23 @@ defmodule Vutuv.Fediverse.Hashtags do
   objects at all, and the plain-text bodies we store). Neither source is
   authoritative on its own, and both are cheap to read.
 
-  Only tags that **already exist here** are filed
-  (`Vutuv.Tags.tag_ids_for_hashtags/1`): ingestion mints nothing. A table a
-  stranger's server can extend is a table a stranger's server can flood with
-  pages on our own domain, and a tag namespace assembled from whatever the
-  fediverse trends on is not the one members chose.
+  A hashtag naming a topic nobody here has written about yet **mints** it
+  (`Vutuv.Tags.tag_ids_for_hashtags/2`, `create: true`). This used to be the one
+  hard no in the whole tag catalog, on the grounds that a table a stranger's
+  server can extend is a table a stranger's server can flood. What changed is
+  the reading of "a stranger": nothing reaches this module unless a member here
+  follows the account that sent it — `Vutuv.Fediverse.record_remote_post/2`
+  requires an accepted follow before a post is stored at all — so the hashtags
+  arriving are the topics our own members chose to read about, not an open
+  write. The cost of the old rule was silent and daily: a post about
+  `#Eisenach` and `#Thüringen` could be shown but never filed, so vutuv learned
+  a topic only when a member typed it into the composer's tag field.
+
+  What still holds the line is in `Vutuv.Tags.tag_ids_for_hashtags/2`: five
+  minted tags per post, a slug that has to name the tag, and a page that stays
+  `noindex` and out of the sitemap until a **local** member or a **local**
+  public post carries it. A remote post can leave a tag page behind; it cannot
+  put one in front of a crawler.
 
   `sync/2` runs on the two paths that can change a post's hashtags — the
   original `Create` and an upstream `Update` — and is idempotent: it inserts
@@ -39,7 +51,9 @@ defmodule Vutuv.Fediverse.Hashtags do
   `content_text` supplies the rest.
   """
   def sync(%RemotePost{} = post, object) do
-    wanted = post |> names(object) |> Tags.tag_ids_for_hashtags() |> MapSet.new()
+    wanted =
+      post |> names(object) |> Tags.tag_ids_for_hashtags(create: true) |> MapSet.new()
+
     held = post |> held_tag_ids() |> MapSet.new()
 
     insert(post, MapSet.difference(wanted, held))
@@ -50,14 +64,19 @@ defmodule Vutuv.Fediverse.Hashtags do
 
   @doc """
   The hashtag names a post carries: the AP `tag` array's `Hashtag` objects plus
-  the `#hashtags` in its stored text, lowercased and deduplicated.
+  the `#hashtags` in its stored text, **as written** and deduplicated
+  case-insensitively (the first spelling wins).
+
+  The casing survives because these names can now mint a tag, and a tag is
+  stored the way whoever names it first wrote it. A remote `#Thüringen` is how
+  that topic should read on its own page here; `thüringen` is not.
 
   Public so a backfill can read the text side of an already-stored post without
   the delivery that brought it.
   """
   def names(%RemotePost{} = post, object \\ %{}) do
-    (object_hashtags(object) ++ Mentions.hashtags(post.content_text || ""))
-    |> Enum.uniq()
+    (object_hashtags(object) ++ Mentions.written_hashtags(post.content_text || ""))
+    |> Enum.uniq_by(&String.downcase/1)
   end
 
   # A `Hashtag` in the AP `tag` array carries its name with the `#` still on it
@@ -71,7 +90,7 @@ defmodule Vutuv.Fediverse.Hashtags do
   end
 
   defp hashtag_name(%{"type" => "Hashtag", "name" => name}) when is_binary(name) do
-    case name |> String.trim() |> String.trim_leading("#") |> String.downcase() do
+    case name |> String.trim() |> String.trim_leading("#") do
       "" -> []
       tag -> [tag]
     end

--- a/lib/vutuv/mentions.ex
+++ b/lib/vutuv/mentions.ex
@@ -85,7 +85,20 @@ defmodule Vutuv.Mentions do
   # regex (which excludes `/` for both forms) misses it. Inside a real URL the
   # renderer never reaches it, because an autolinked address is an `<a>` by the
   # time the entity pass runs and that pass skips anchors.
-  @entity ~r{(?<![\w@])@([A-Za-z0-9_]+)@([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)+)|(?<![\w@/])@([A-Za-z0-9_]+)|(?<![\w#/&])#([A-Za-z0-9_]+)}
+  #
+  # A **hashtag** spans Unicode letters, marks and digits, a handle does not.
+  # The two are not the same alphabet: a handle is an address and lives in the
+  # narrowest local part every server accepts, while a hashtag is a word of the
+  # language the post is written in. ASCII-only, `#Thüringen` ended at the `ü`
+  # and named the tag `th` — on a German site, where `#München`, `#ÖPNV` and
+  # `#Grüne` are ordinary tags, that is most of them. The class is the one
+  # Mastodon uses, so a tag written over there is read the same here.
+  #
+  # The `u` modifier is what makes `\p{…}` see characters rather than bytes. It
+  # also turns the `\w` in the two lookbehinds Unicode-aware, which is the
+  # intended reading of "not mid-token": `Grüße@ada` is as much one word as
+  # `Gruesse@ada`, and neither is a mention.
+  @entity ~r"(?<![\w@])@([A-Za-z0-9_]+)@([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)+)|(?<![\w@/])@([A-Za-z0-9_]+)|(?<![\w#/&])#([\p{L}\p{M}\p{Nd}_]+)"u
 
   # Code spans/blocks are skipped everywhere: a handle inside them is sample
   # text, never a link (the same call the renderer makes for `<code>`/`<pre>`).
@@ -119,6 +132,21 @@ defmodule Vutuv.Mentions do
   @doc "The canonical entity regex, so the renderer shares this module's grammar."
   def entity_regex, do: @entity
 
+  # One whole `#hashtag` and nothing else, in the same alphabet `@entity` reads.
+  # Split out so `VutuvWeb.Markdown.split_trailing_hashtags/1` — which asks of a
+  # *token* what `@entity` asks of a body — cannot answer it with a second,
+  # slightly different class. The two had already drifted (`\p{N}` against
+  # `\p{Nd}\p{M}`), which decided differently on a decomposed `#Thüringen`.
+  @hashtag_token ~r"\A#([\p{L}\p{M}\p{Nd}_]+)\z"u
+
+  @doc """
+  Matches a single token that is one whole hashtag, capturing the name.
+
+  The token twin of `entity_regex/0`, for a caller deciding whether a *line*
+  is nothing but hashtags rather than finding them inside prose.
+  """
+  def hashtag_token_regex, do: @hashtag_token
+
   @doc "How many distinct local accounts one post may mention."
   def max_post_mentions, do: @max_post_mentions
 
@@ -150,34 +178,54 @@ defmodule Vutuv.Mentions do
   def local_handles(_), do: []
 
   @doc """
-  The unique, lowercased `#hashtags` in `text` — the tag **slugs** they name.
+  The unique, lowercased `#hashtags` in `text` — the tag **names** they write.
 
   The `@handle` twin of `local_handles/1`, reading the same grammar and skipping
   code spans/blocks for the same reason, so what this returns is exactly what
   `VutuvWeb.Markdown` would turn into a `/tags/:slug` link. That equality is the
   point: it is what lets a post be *filed* under the tag its own hashtag points
-  at (`Vutuv.Tags.tag_ids_for_hashtags/1`), instead of a reader clicking
+  at (`Vutuv.Tags.tag_ids_for_hashtags/2`), instead of a reader clicking
   `#berlin` and not finding the post they clicked it in.
 
-  Lowercased because the slug is: `#Berlin`, `#berlin` and `#BERLIN` are one
+  A written name is not always a slug — `#Thüringen` names the tag whose slug is
+  `thueringen` — so both sides resolve it through the folded key
+  `Vutuv.Tags.MatchKey` rather than by string equality.
+
+  Lowercased because the match is: `#Berlin`, `#berlin` and `#BERLIN` are one
   tag, which is also how the renderer resolves them. A topic's Fediverse address
   `@berlin@<our tag host>` (issue #1330) names the same tag and is counted with
   them, for the same reason: that is what the renderer links.
   """
-  def hashtags(text) when is_binary(text) do
+  # `written_hashtags/1` is already unique by `String.downcase/1`, so downcasing
+  # its answer cannot produce a repeat.
+  def hashtags(text), do: text |> written_hashtags() |> Enum.map(&String.downcase/1)
+
+  @doc """
+  The `#hashtags` in `text` **as they were written**, deduplicated
+  case-insensitively with the first spelling kept.
+
+  `hashtags/1` reads the same hits and lowercases them, which is all a *lookup*
+  needs. Minting needs the other half: vutuv keeps a tag's name exactly as its
+  first writer typed it (`Vutuv.Tags.Tag.find_by_value/1`), so a post that
+  introduces `#Thüringen` has to hand that spelling to
+  `Vutuv.Tags.tag_ids_for_hashtags/2` — otherwise the topic arrives on the site
+  named `thüringen`, in a language that capitalises its nouns, and no later
+  writer can correct it.
+  """
+  def written_hashtags(text) when is_binary(text) do
     # `@` as well as `#`, because a tag can be named by its address — a body
     # carrying `@berlin@tags.<our host>` and no `#` at all still names one.
     if String.contains?(text, "#") or String.contains?(text, "@") do
       text
       |> text_chunks()
       |> Enum.flat_map(&scan_hashtags/1)
-      |> Enum.uniq()
+      |> Enum.uniq_by(&String.downcase/1)
     else
       []
     end
   end
 
-  def hashtags(_), do: []
+  def written_hashtags(_), do: []
 
   @doc "Whether `text` mentions `handle` (case-insensitive; a leading `@` is optional)."
   def mentions?(text, handle) when is_binary(text) do
@@ -515,11 +563,14 @@ defmodule Vutuv.Mentions do
   # which the renderer links to `/tags/:slug` exactly like the `#php` that means
   # the same thing. So it names a tag here too, and a post writing it is filed
   # under that tag instead of pointing readers at a page it is not on.
+  #
+  # Both heads answer with the spelling the body used; `hashtags/1` lowercases
+  # for the lookups and `written_hashtags/1` keeps it for the mint.
   defp hashtag_of([user, host | _]) when user != "" and host != "" do
-    if Fediverse.tag_host?(host), do: [String.downcase(user)], else: []
+    if Fediverse.tag_host?(host), do: [user], else: []
   end
 
-  defp hashtag_of([_, _, _, hashtag]) when hashtag != "", do: [String.downcase(hashtag)]
+  defp hashtag_of([_, _, _, hashtag]) when hashtag != "", do: [hashtag]
   defp hashtag_of(_), do: []
 
   defp rewrite_chunk(chunk, old_n, new_n, acc) do

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -100,7 +100,6 @@ defmodule Vutuv.Posts do
   alias Vutuv.Translations
   alias Vutuv.Uploads.Crop
   alias Vutuv.UUIDv7
-  alias Vutuv.WebAddress
 
   @default_feed_limit 20
   @default_profile_limit 3
@@ -559,15 +558,17 @@ defmodule Vutuv.Posts do
   defp build_changeset(post_or_struct, attrs, denials, image_ids) do
     tag_values = attrs |> fetch(:tags) |> parse_tag_values()
     # Over the cap the post does not save at all, so nothing is minted for it
-    # either: find-or-create runs only on a set that can be kept.
-    tag_ids = if too_many_tags?(tag_values), do: [], else: tag_ids_for(tag_values)
+    # either — by the chip row **or** by the body's hashtags: find-or-create runs
+    # only on a set that can be kept, and `put_body_hashtags/3` is told the same.
+    keepable? = not too_many_tags?(tag_values)
+    tag_ids = if keepable?, do: tag_ids_for(tag_values), else: []
 
     changeset =
       post_or_struct
       |> Post.changeset(post_params(attrs))
       |> Ecto.Changeset.put_assoc(:denials, Enum.map(denials, &struct(PostDenial, &1)))
       |> Ecto.Changeset.put_assoc(:post_tags, Enum.map(tag_ids, &%PostTag{tag_id: &1}))
-      |> put_body_hashtags(tag_ids)
+      |> put_body_hashtags(tag_ids, keepable?)
       |> put_review(post_or_struct, fetch(attrs, :review))
       |> require_content(image_ids)
       |> validate_tag_count(tag_values)
@@ -606,17 +607,25 @@ defmodule Vutuv.Posts do
   # on the page it took them to.
   #
   # Re-derived from the body on every save (so an edit that drops a hashtag
-  # drops the filing), existing tags only (`Tags.tag_ids_for_hashtags/1` mints
-  # nothing — a typo must not leave a tag page behind), and never a tag the
-  # composer's field already filed: that one is a chip on the card, and one
-  # filing per (post, tag) is all the tag page can use.
-  defp put_body_hashtags(changeset, field_tag_ids) do
+  # drops the filing), and never a tag the composer's field already filed: that
+  # one is a chip on the card, and one filing per (post, tag) is all the tag
+  # page can use.
+  #
+  # `mint?` (true unless the post is already doomed by its tag count, see
+  # `build_changeset/4`) lets a hashtag naming a topic nobody here has written
+  # about yet mint it — writing `#Eisenach` in a sentence declares the tag as plainly
+  # as typing it into the tag field does, and the chip row is capped at five
+  # while a body is not. The hashtags go in **as written**
+  # (`Mentions.written_hashtags/1`, not `hashtags/1`): a minted tag keeps the
+  # spelling of whoever names it first, and lowercasing here would name it for
+  # everybody after.
+  defp put_body_hashtags(changeset, field_tag_ids, mint?) do
     hashtag_ids =
       changeset
       |> Ecto.Changeset.get_field(:body)
       |> to_string()
-      |> Mentions.hashtags()
-      |> Tags.tag_ids_for_hashtags()
+      |> Mentions.written_hashtags()
+      |> Tags.tag_ids_for_hashtags(create: mint?)
       |> Enum.reject(&(&1 in field_tag_ids))
 
     Ecto.Changeset.put_assoc(
@@ -5751,33 +5760,20 @@ defmodule Vutuv.Posts do
   defp parse_tag_values(values) when is_list(values) do
     values
     |> Enum.map(&Tag.normalize_value/1)
-    |> Enum.reject(&(Tag.punctuation_only?(&1) or WebAddress.link_only?(&1)))
+    |> Enum.filter(&Tag.names_a_topic?/1)
     |> Tags.canonical_tag_names()
   end
 
   # Find-or-create by name/slug (case-insensitive), racing gracefully.
   # Unresolvable values (e.g. names whose slug exceeds the limit) are skipped:
-  # a post must not fail because one tag was odd.
+  # a post must not fail because one tag was odd. `Tags.find_or_create_tag_id/1`
+  # owns the find-or-create, so a tag minted from a chip and one minted from a
+  # `#hashtag` in the body are made — and raced — the same way.
   defp tag_ids_for(values) do
     values
-    |> Enum.map(&tag_for_value/1)
+    |> Enum.map(&Tags.find_or_create_tag_id/1)
     |> Enum.reject(&is_nil/1)
     |> Enum.uniq()
-  end
-
-  defp tag_for_value(value) do
-    case Tag.find_by_value(value) do
-      %Tag{id: id} -> id
-      nil -> insert_tag_for_value(value)
-    end
-  end
-
-  defp insert_tag_for_value(value) do
-    case Repo.insert(Tag.changeset(%Tag{}, %{"value" => value})) do
-      {:ok, tag} -> tag.id
-      # Lost a race or invalid value — one more lookup, then give up.
-      {:error, _} -> with(%Tag{id: id} <- Tag.find_by_value(value), do: id)
-    end
   end
 
   ## Broadcasts

--- a/lib/vutuv/posts/post_hashtag.ex
+++ b/lib/vutuv/posts/post_hashtag.ex
@@ -12,8 +12,9 @@ defmodule Vutuv.Posts.PostHashtag do
   neither surface changes.
 
   There is deliberately no changeset: the tag ids come from
-  `Vutuv.Tags.tag_ids_for_hashtags/1` (existing tags only, never minted), and
-  the rows are re-derived from the body on every save.
+  `Vutuv.Tags.tag_ids_for_hashtags/2`, which mints the topics the body is the
+  first thing here to name, and the rows are re-derived from the body on every
+  save.
   """
 
   use VutuvWeb, :model

--- a/lib/vutuv/tags.ex
+++ b/lib/vutuv/tags.ex
@@ -17,6 +17,7 @@ defmodule Vutuv.Tags do
   alias Vutuv.Posts
   alias Vutuv.Repo
   alias Vutuv.SearchText
+  alias Vutuv.SlugHelpers
   require Vutuv.Tags.MatchKey
 
   alias Vutuv.Tags.MatchKey
@@ -24,7 +25,6 @@ defmodule Vutuv.Tags do
   alias Vutuv.Tags.TagFollow
   alias Vutuv.Tags.UserTag
   alias Vutuv.Tags.UserTagEndorsement
-  alias Vutuv.WebAddress
 
   # The endorsers list: which columns it can be sorted by, and a denser page
   # size than the site-wide default so a popular tag's list actually paginates.
@@ -36,6 +36,14 @@ defmodule Vutuv.Tags do
   # ceiling on the pathological case: a body listing two hundred hashtags is
   # reaching for two hundred tag pages, not writing about two hundred topics.
   @max_hashtags_per_body 20
+
+  # How many of those may be **minted** — tags the body is the first thing here
+  # to name. Filing under a tag that already exists costs a join row; minting
+  # creates a public page, so the two get different ceilings. Five is what the
+  # composer's own tag field allows a post to declare (`Vutuv.Posts.max_tags_per_post/0`),
+  # and a post introducing more than five topics nobody here has ever written
+  # about is padding its reach, not naming its subject.
+  @max_minted_hashtags_per_body 5
 
   # The most tags one profile may carry. A handful of members overdid it, so a
   # profile is capped here. The cap bites only when tags *change*: a profile
@@ -123,8 +131,8 @@ defmodule Vutuv.Tags do
       # The same folded key the single lookup uses (`Vutuv.Tags.MatchKey`), or a
       # batch goes on counting spellings where one lookup counts topics — which
       # is what sign-up's three-tag minimum and the composer's cap of five are
-      # counting. A name with nothing to key on stands for itself.
-      key = MatchKey.normalize(name) || String.downcase(name)
+      # counting.
+      key = match_key(name)
       Map.get(resolved, key, {{:new, key}, name})
     end)
     |> Enum.uniq_by(&elem(&1, 0))
@@ -146,12 +154,30 @@ defmodule Vutuv.Tags do
          coalesce(c.name, t.name)}
     )
     |> Repo.all()
-    |> Enum.flat_map(fn {name_key, slug_key, id, name} ->
-      entry = {{:tag, id}, name}
-      for key <- Enum.uniq([name_key, slug_key]), is_binary(key), do: {key, entry}
+    |> Enum.map(fn {name_key, slug_key, id, name} ->
+      {name_key, slug_key, {{:tag, id}, name}}
+    end)
+    |> index_by_match_keys()
+  end
+
+  @doc false
+  # A tag is reachable under both of its folded keys, and both point at the same
+  # payload — the rule `resolution_by_key/1` and `linkable_slugs/1` share, so it
+  # is written once. `Map.new/1` collapses the two when they are equal.
+  def index_by_match_keys(rows) do
+    rows
+    |> Enum.flat_map(fn {name_key, slug_key, payload} ->
+      [name_key, slug_key] |> Enum.filter(&is_binary/1) |> Enum.map(&{&1, payload})
     end)
     |> Map.new()
   end
+
+  # The batch key for a typed value: the folded `MatchKey`, or the downcased
+  # value when there is nothing to fold (`"-"`, `"."`), so such a name stands
+  # for itself instead of bucketing with every other keyless one. Every batch
+  # lookup against `resolution_by_key/1` must ask with this, or it asks a
+  # different question than the index answers.
+  defp match_key(name), do: MatchKey.normalize(name) || String.downcase(name)
 
   @doc """
   The **topic** a slug names, or nil.
@@ -207,7 +233,7 @@ defmodule Vutuv.Tags do
   def preview_tag_names(value) do
     value
     |> parse_tag_names()
-    |> Enum.reject(&(WebAddress.link_only?(&1) or Tag.punctuation_only?(&1)))
+    |> Enum.filter(&Tag.names_a_topic?/1)
     |> canonical_tag_names()
   end
 
@@ -562,20 +588,31 @@ defmodule Vutuv.Tags do
   end
 
   @doc """
-  Given candidate tag slugs (the `#hashtags` in a Markdown body), returns a map
-  from each written slug to the slug its link should point at — for those whose
-  `/tags/:slug` page actually shows something: a real tag with **at least one
-  visible member** (a confirmed, non-hidden user carries it, the same gate the
-  tag page lists by) **or at least one publicly visible post** filed under it
+  Given the `#hashtags` written in a Markdown body, returns a map from each
+  written name (lowercased) to the slug its link should point at — for those
+  whose `/tags/:slug` page actually shows something: a real tag with **at least
+  one visible member** (a confirmed, non-hidden user carries it, the same gate
+  the tag page lists by) **or at least one publicly visible post** filed under it
   (`Posts.visible_tagged_posts_query/0`, the tag page's own posts gate). Powers
   the hashtag links `VutuvWeb.Markdown` writes; an unknown or empty tag is
   absent from the map, so it stays plain text.
 
-  The two slugs differ exactly when the written one names an **alternative name**
-  for a topic (issue #1338): `#rubyonrails` links straight to `/tags/ruby_on_rails`
-  rather than to a URL that redirects there, and the gate is applied to the
-  canonical tag, which is where the members and posts of an absorbed tag now sit.
-  That is also why the answer is a map and not a set.
+  Written name and target slug differ in two ways, which is why the answer is a
+  map and not a set. The written one may be an **alternative name** for a topic
+  (issue #1338): `#rubyonrails` links straight to `/tags/ruby_on_rails` rather
+  than to a URL that redirects there, and the gate is applied to the canonical
+  tag, which is where the members and posts of an absorbed tag now sit. Or it
+  may simply not be spelled the way a URL can be: `#Thüringen` names the tag
+  whose slug is `thueringen`, because a slug is transliterated down to
+  `[a-z0-9_]` and a German tag rarely survives that unchanged.
+
+  That second case is why the match runs on `MatchKey` — the folded key
+  `Tag.find_by_value/1` and `tag_ids_for_hashtags/2` use — over the tag's **name
+  as well as its slug**, rather than on the slug alone. Filing has always
+  matched the name too, so slug-only linking meant a body could be filed under a
+  topic whose page its own hashtag refused to link to: `#München` sat as plain
+  text in a post the München page listed. Every source of `#hashtags` now asks
+  one question, so what is linked and what is filed cannot drift.
 
   The post arm is what keeps the link and the listing honest in both directions:
   a post is filed under the tag its own `#hashtag` names, so a tag nobody has on
@@ -588,87 +625,227 @@ defmodule Vutuv.Tags do
   One query per body (two arms of a union); an empty input skips the DB so the
   renderer's no-hashtag path stays query-free.
   """
-  def linkable_slugs(slugs) when is_list(slugs) do
+  def linkable_slugs(written) when is_list(written) do
     import Vutuv.Moderation.Query, only: [account_hidden_row: 1, account_confirmed_row: 1]
 
-    case slugs |> Enum.map(&String.downcase/1) |> Enum.uniq() do
-      [] ->
-        %{}
+    keys = written |> Enum.map(&MatchKey.normalize/1) |> Enum.reject(&is_nil/1) |> Enum.uniq()
 
-      normalized ->
-        held =
-          from(t in Tag,
-            left_join: c in assoc(t, :merged_into),
-            join: ut in UserTag,
-            on: ut.tag_id == coalesce(c.id, t.id),
-            join: u in assoc(ut, :user),
-            where: t.slug in ^normalized,
-            where: account_confirmed_row(u) and not account_hidden_row(u),
-            select: %{slug: t.slug, target: coalesce(c.slug, t.slug)}
-          )
-
-        posted =
-          from([post_tag: pt] in Posts.visible_tagged_posts_query(),
-            join: t in Tag,
-            on: pt.tag_id == coalesce(t.merged_into_id, t.id),
-            left_join: c in assoc(t, :merged_into),
-            where: t.slug in ^normalized,
-            select: %{slug: t.slug, target: coalesce(c.slug, t.slug)}
-          )
-
-        from(row in subquery(union_all(held, ^posted)),
-          distinct: true,
-          select: {row.slug, row.target}
+    if keys == [] do
+      %{}
+    else
+      held =
+        from(t in Tag,
+          as: :tag,
+          left_join: c in assoc(t, :merged_into),
+          as: :canonical,
+          join: ut in UserTag,
+          on: ut.tag_id == coalesce(c.id, t.id),
+          join: u in assoc(ut, :user),
+          where: account_confirmed_row(u) and not account_hidden_row(u)
         )
-        |> Repo.all()
-        |> Map.new()
+        |> keyed_target(keys)
+
+      posted =
+        from([post_tag: pt] in Posts.visible_tagged_posts_query(),
+          join: t in Tag,
+          as: :tag,
+          on: pt.tag_id == coalesce(t.merged_into_id, t.id),
+          left_join: c in assoc(t, :merged_into),
+          as: :canonical
+        )
+        |> keyed_target(keys)
+
+      from(row in subquery(union_all(held, ^posted)),
+        distinct: true,
+        select: {row.name, row.slug, row.target}
+      )
+      |> Repo.all()
+      |> Enum.map(fn {name, slug, target} ->
+        {MatchKey.normalize(name), MatchKey.normalize(slug), target}
+      end)
+      |> index_by_match_keys()
+      |> targets_for(written)
     end
   end
 
-  @doc """
-  The ids of the tags `hashtags` names here — **existing tags only**, matched on
-  the slug, which is exactly what `VutuvWeb.Markdown` links a `#hashtag` to.
-
-  Feeds both hashtag filing paths: a member's post body
-  (`Vutuv.Posts.create_post/2`) and a cached remote post
-  (`Vutuv.Fediverse.Hashtags`). Neither mints a tag. For a member post that is
-  merely conservative — the composer's own tag field is where a member deliberately
-  names a new tag, and a typo in a body should not leave a page behind. For a
-  remote post it is a rule: a table a stranger's server can extend is a table a
-  stranger's server can flood with pages on our own domain.
-
-  Matched case-insensitively on **name or slug**, the predicate
-  `Tag.find_by_value/1` uses, so `#PostgreSQL` reaches the `postgresql` tag and a
-  remote `#München` reaches the tag a member spelled that way (whose slug is
-  transliterated and would never match on its own). Capped at
-  `max_hashtags_per_body/0` so one hostile body cannot file itself under every
-  tag on the site; an empty input skips the DB.
-  """
-  def tag_ids_for_hashtags([]), do: []
-
-  def tag_ids_for_hashtags(hashtags) when is_list(hashtags) do
-    names =
-      hashtags
-      |> Enum.map(&String.downcase/1)
-      |> Enum.uniq()
-      |> Enum.take(@max_hashtags_per_body)
-
-    Repo.all(
-      from(t in Tag,
-        # A body that writes an alternative name files the post under the topic
-        # (issue #1338), so `#rubyonrails` and `#RubyOnRails` land in the same
-        # timeline. `distinct` because two written spellings can now resolve to
-        # one tag, and `post_tags` has a unique index on (post_id, tag_id).
-        left_join: c in assoc(t, :merged_into),
-        where: fragment("lower(?)", t.name) in ^names or t.slug in ^names,
-        distinct: true,
-        select: coalesce(c.id, t.id)
-      )
+  # The half both arms of the union share. Written once because the two
+  # `select:` maps must stay column-for-column identical or the union fails at
+  # runtime, and nothing local would say so.
+  #
+  # The `where:` folds in SQL (that is what the two expression indexes are for);
+  # the `select:` deliberately does **not**, and hands back the raw columns for
+  # `MatchKey.normalize/1` to fold in Elixir. A fold in the select is evaluated
+  # once per **joined** row — every `user_tags` and `post_tags` row the arms
+  # produce — to feed a `distinct` that then collapses them to a handful, so its
+  # cost tracks how popular the named tags are rather than how many were named.
+  # Measured on the dev catalog: a body naming five popular tags fans out to
+  # ~1,900 rows and paid 4.0 ms against 2.3 ms folding in Elixir, on a path that
+  # runs once per rendered body and therefore once per card on a feed page.
+  defp keyed_target(query, keys) do
+    from([tag: t, canonical: c] in query,
+      where: MatchKey.sql(t.name) in ^keys or MatchKey.sql(t.slug) in ^keys,
+      select: %{name: t.name, slug: t.slug, target: coalesce(c.slug, t.slug)}
     )
   end
 
-  @doc "How many `#hashtags` of one body are resolved to tags (see `tag_ids_for_hashtags/1`)."
+  defp targets_for(by_key, written) do
+    written
+    |> Enum.flat_map(fn name ->
+      case Map.get(by_key, match_key(name)) do
+        nil -> []
+        target -> [{String.downcase(name), target}]
+      end
+    end)
+    |> Map.new()
+  end
+
+  @doc """
+  The ids of the tags `hashtags` names here, optionally **minting** the ones
+  nothing here names yet (`create: true`).
+
+  Feeds both hashtag filing paths: a member's post body
+  (`Vutuv.Posts.create_post/2`) and a cached remote post
+  (`Vutuv.Fediverse.Hashtags`). Both now mint. A hashtag *is* how the rest of
+  the network declares a tag — a post arriving with `#Eisenach` and `#Thüringen`
+  has named two topics as plainly as the composer's tag field does — and
+  resolving it against existing tags only meant vutuv could file a post under a
+  topic but never learn one, so the catalog grew only from the tag field and
+  every hashtag naming something new fell on the floor.
+
+  What that gives up is deliberate, and worth writing down because it reverses
+  the rule this function shipped with. A hashtag can now leave a page behind:
+  a member's typo, or a topic only somebody else's server cares about. Three
+  things bound it. `mintable_hashtag?/1` refuses anything whose slug would not
+  name it. `max_minted_hashtags_per_body/0` caps one body at five new tags,
+  against `max_hashtags_per_body/0` filings. And nothing reaches the remote path
+  unless a member here follows the account that sent it
+  (`Vutuv.Fediverse.record_remote_post/2` requires an accepted follow), so this
+  is not a table a stranger can write to — it is the topics the accounts our
+  members chose to read are writing about. A minted tag also stays out of the
+  sitemap and carries `noindex` until a *local* member holds it or a *local*
+  public post carries it (`indexable_tags_query/0`), so what a remote post can
+  create is a page, never a crawled one.
+
+  Names are matched through `MatchKey`, the same folded key `Tag.find_by_value/1`
+  uses, so `#PostgreSQL` reaches the `postgresql` tag, `#München` reaches the tag
+  a member spelled that way (its slug is transliterated and would never match on
+  its own), `#ruby_on_rails` reaches `Ruby on Rails`, and an alternative name
+  reaches its topic (issue #1338). Matching this well is what makes minting safe:
+  every spelling a lookup misses is a duplicate page it would otherwise create.
+
+  Hand it the hashtags **as written** (`Vutuv.Mentions.written_hashtags/1`) when
+  minting — the name is stored as typed, and a lowercased `#thüringen` would
+  name the topic for everyone after. Capped at `max_hashtags_per_body/0`; an
+  empty input skips the DB.
+  """
+  def tag_ids_for_hashtags(hashtags, opts \\ [])
+
+  def tag_ids_for_hashtags([], _opts), do: []
+
+  def tag_ids_for_hashtags(hashtags, opts) when is_list(hashtags) do
+    written =
+      hashtags
+      |> Enum.uniq_by(&String.downcase/1)
+      |> Enum.take(@max_hashtags_per_body)
+
+    resolved = resolution_by_key(written)
+
+    {found, missing} =
+      written
+      |> Enum.map(&{&1, Map.get(resolved, match_key(&1))})
+      |> Enum.split_with(fn {_name, hit} -> hit end)
+
+    minted =
+      if Keyword.get(opts, :create, false),
+        do: missing |> Enum.map(&elem(&1, 0)) |> mint_hashtag_tags(),
+        else: []
+
+    # `uniq` because two written spellings can resolve to one tag (an alias and
+    # its topic in one body), and both filing tables carry a unique index on
+    # (post, tag).
+    Enum.uniq(Enum.map(found, fn {_name, hit} -> tag_id(hit) end) ++ minted)
+  end
+
+  defp tag_id({{:tag, id}, _display_name}), do: id
+
+  # The hashtags no tag here answers to yet. `find_or_create_tag_id/1` looks each
+  # one up again before inserting, which the batch above has already answered —
+  # the cost is at most five queries on the one path that is about to write
+  # anyway, and it buys the mint a single owner rather than a second insert
+  # spelled slightly differently. A racer is caught by the insert itself
+  # (`Tag.insert_new/1`'s `ON CONFLICT`), not by that lookup.
+  defp mint_hashtag_tags(names) do
+    names
+    |> Enum.map(&Tag.normalize_value/1)
+    |> Enum.filter(&mintable_hashtag?/1)
+    |> Enum.take(@max_minted_hashtags_per_body)
+    |> Enum.map(&find_or_create_tag_id/1)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  @doc """
+  Whether a `#hashtag` may become a tag of its own.
+
+  `Tag.names_a_topic?/1` first, the same early filter the composer's tag field
+  and the add-tag preview apply, so the hashtag path mints exactly what they
+  would. The grammar keeps most of those out anyway.
+
+  On top of that a minted tag has to produce a **slug that names it**. The slug
+  is the tag's URL and its fediverse actor (#1330), it is transliterated down to
+  `[a-z0-9_]`, and `Vutuv.SlugHelpers.gen_tag_slug_unique/3` hands anything left
+  empty a random hex string. So `#2026` would file a page at `/tags/2026` and
+  `#日本語` one at `/tags/9f3c1a20` — neither says what it is about, and neither
+  is what a reader clicking that hashtag expects to land on. A member who
+  genuinely wants such a tag can still create it by hand on the tags page; a
+  hashtag in passing does not.
+  """
+  def mintable_hashtag?(name) when is_binary(name) do
+    Tag.names_a_topic?(name) and name |> SlugHelpers.tagify() |> String.match?(~r/[a-z]/)
+  end
+
+  def mintable_hashtag?(_), do: false
+
+  @doc """
+  The id of the tag `value` names, creating it when nothing here answers to it.
+
+  The one find-or-create for a typed tag name: the composer's tag field
+  (`Vutuv.Posts`) and the hashtag paths above both come through here, so a tag
+  minted from a chip and one minted from a `#hashtag` are made the same way and
+  race the same way — through `Tag.insert_new/1`, whose `ON CONFLICT` is what
+  keeps a request minting several tags at once off the 40P01 its doc describes.
+  `nil` when the value cannot be a tag at all (a name whose slug overruns the
+  column, say) — a caller must not fail a post over one odd value.
+  """
+  def find_or_create_tag_id(value) when is_binary(value) do
+    case Tag.find_by_value(value) do
+      %Tag{id: id} -> id
+      nil -> insert_tag_for_value(value)
+    end
+  end
+
+  defp insert_tag_for_value(value) do
+    tag =
+      %Tag{}
+      |> Tag.changeset(%{"value" => value})
+      |> Tag.insert_new()
+
+    case tag do
+      %Tag{id: id} ->
+        id
+
+      # Invalid name, or a racer whose row `insert_new/1` could not read back by
+      # slug because `gen_tag_slug_unique/3` gave ours a collision suffix. One
+      # more lookup by value, then give up.
+      nil ->
+        with(%Tag{id: id} <- Tag.find_by_value(value), do: id)
+    end
+  end
+
+  @doc "How many `#hashtags` of one body are resolved to tags (see `tag_ids_for_hashtags/2`)."
   def max_hashtags_per_body, do: @max_hashtags_per_body
+
+  @doc "How many tags one body may mint (see `tag_ids_for_hashtags/2`)."
+  def max_minted_hashtags_per_body, do: @max_minted_hashtags_per_body
 
   # --- Tag follows (issue #872) --------------------------------------------
   #

--- a/lib/vutuv/tags/tag.ex
+++ b/lib/vutuv/tags/tag.ex
@@ -237,6 +237,24 @@ defmodule Vutuv.Tags.Tag do
     end
   end
 
+  @doc """
+  Whether `name` names a topic at all — the two refusals every tag path applies
+  before it looks anything up: a value that is nothing but a web or email
+  address, and one that is only punctuation.
+
+  One predicate because four places ask it and they must not drift: this
+  module's `create_or_link_tag/2` (which refuses with a *reason*, so it keeps
+  its own `cond`), `Vutuv.Tags.preview_tag_names/1`, `Vutuv.Posts`' composer tag
+  field and `Vutuv.Tags.mintable_hashtag?/1` — the last three quietly drop such
+  a value rather than failing the save. `changeset/2` refuses them again at the
+  insert, so this is the early filter, never the only one.
+  """
+  def names_a_topic?(name) when is_binary(name) do
+    not (punctuation_only?(name) or WebAddress.link_only?(name))
+  end
+
+  def names_a_topic?(_), do: false
+
   # Every `#` the value opens with, plus the whitespace between them: the class
   # is greedy up to the last `#` it can still reach, so `"## # Elixir"` loses
   # all three while `"#fitness#stuff"` loses only the first (`f` ends the run).
@@ -397,47 +415,57 @@ defmodule Vutuv.Tags.Tag do
   end
 
   # No committed tag matches the typed value, so mint one and link its id.
-  #
-  # The tag is INSERTed here in its own `ON CONFLICT DO NOTHING` statement rather
-  # than deferred into the caller's `user_tag` insert as a nested `put_assoc`.
-  # That is the deadlock fix: two concurrent sign-ups sharing a tag both reach
-  # here with `find_by_value/1 == nil` (neither row is committed yet). The old
-  # put_assoc path had each transaction INSERT the same `tags.slug`, and with
-  # several tags per registration those unique-index waits chained into a cycle —
-  # Postgres 40P01, the intermittent async-suite flake from register_user. With
-  # ON CONFLICT the loser no-ops and re-reads the winner's row, and because the
-  # tag insert is its own autocommit statement no transaction ever holds two
-  # contended tag rows at once, so no cycle can form.
-  #
-  # That autocommit premise holds only in production. Under the test SQL
-  # sandbox nothing commits: each test is one transaction that keeps the
-  # unique-index lock on every slug it inserts until rollback, so two async
-  # test modules minting the SAME tag name still convoy on it — and deadlock
-  # when two contended slugs are acquired in opposite orders (the historical
-  # 40P01 flake in register_user). The test-side rule is therefore that async
-  # test modules never share literal tag names (see test/support/conn_case.ex
-  # and the test guidelines in .claude/rules/elixir.md).
+  # `insert_new/1` owns the insert (and the deadlock fix its doc explains);
+  # this head only decides what to do with the changeset either way.
   defp put_created_tag(changeset, params) do
     tag_changeset = __MODULE__.changeset(%__MODULE__{}, params)
 
+    case insert_new(tag_changeset) do
+      %__MODULE__{} = tag ->
+        put_change(changeset, :tag_id, tag.id)
+
+      # Invalid name (blank, too long, stray control char), or a racer whose row
+      # we could not read back: keep the nested-assoc path so the user_tag
+      # changeset carries the tag's validation errors out.
+      nil ->
+        put_assoc(changeset, :tag, tag_changeset)
+    end
+  end
+
+  @doc """
+  Inserts the tag `tag_changeset` builds and returns it, or `nil` when the
+  changeset is invalid.
+
+  **The one place a tag row is created**, because the `ON CONFLICT` above is not
+  an optimisation but the fix for a Postgres 40P01: two concurrent callers
+  minting the same tag both reach here with `find_by_value/1 == nil` (neither
+  row is committed yet), and with several tags per request the unique-index
+  waits chained into a cycle — the intermittent async-suite flake from
+  `register_user`. With `ON CONFLICT` the loser no-ops and re-reads the winner's
+  row, and because the insert is its own autocommit statement no transaction
+  ever holds two contended tag rows at once, so no cycle can form.
+
+  That matters more since a `#hashtag` mints too (`Vutuv.Tags.tag_ids_for_hashtags/2`):
+  one post can now create the composer's five chips *and* five tags its body
+  names, in one request — exactly the shape the deadlock needs. So both mints
+  come through here rather than each spelling its own insert.
+
+  That autocommit premise holds only in production. Under the test SQL sandbox
+  nothing commits: each test is one transaction that keeps the unique-index lock
+  on every slug it inserts until rollback, so two async test modules minting the
+  SAME tag name still convoy on it. The test-side rule is therefore that async
+  test modules never share literal tag names (see `test/support/conn_case.ex`
+  and the test guidelines in `.claude/rules/elixir.md`).
+  """
+  def insert_new(%Ecto.Changeset{} = tag_changeset) do
     if tag_changeset.valid? do
       slug = get_field(tag_changeset, :slug)
 
-      tag =
-        case Repo.insert(tag_changeset, on_conflict: :nothing, conflict_target: :slug) do
-          {:ok, %__MODULE__{id: id} = tag} when not is_nil(id) -> tag
-          # ON CONFLICT no-op'd (a racer committed this slug first): read its row.
-          _ -> Repo.get_by(__MODULE__, slug: slug)
-        end
-
-      case tag do
-        %__MODULE__{} = tag -> put_change(changeset, :tag_id, tag.id)
-        nil -> put_assoc(changeset, :tag, tag_changeset)
+      case Repo.insert(tag_changeset, on_conflict: :nothing, conflict_target: :slug) do
+        {:ok, %__MODULE__{id: id} = tag} when not is_nil(id) -> tag
+        # ON CONFLICT no-op'd (a racer committed this slug first): read its row.
+        _ -> Repo.get_by(__MODULE__, slug: slug)
       end
-    else
-      # Invalid name (blank, too long, stray control char): keep the nested-assoc
-      # path so the user_tag changeset carries the tag's validation errors out.
-      put_assoc(changeset, :tag, tag_changeset)
     end
   end
 

--- a/lib/vutuv_web/fediverse/docs.ex
+++ b/lib/vutuv_web/fediverse/docs.ex
@@ -33,6 +33,7 @@ defmodule VutuvWeb.Fediverse.Docs do
   alias Vutuv.Posts.PostReply
   alias Vutuv.Posts.PostReview
   alias Vutuv.ReviewCover
+  alias Vutuv.Tags.MatchKey
   alias Vutuv.Tags.Tag
   alias VutuvWeb.PostComponents
   alias VutuvWeb.UserHelpers
@@ -786,7 +787,7 @@ defmodule VutuvWeb.Fediverse.Docs do
   # composer's chips are not. Deduplicated by tag with the in-body spelling
   # winning, so a tag that is both is announced once and printed once.
   defp hashtags(%Post{} = post) do
-    written = written_hashtags(post)
+    written = body_hashtag_keys(post)
 
     in_body = for %{tag: %Tag{} = tag} <- loaded(post.post_hashtags), do: {tag, true}
     chips = for %Tag{} = tag <- loaded(post.tags), do: {tag, written?(tag, written)}
@@ -800,16 +801,27 @@ defmodule VutuvWeb.Fediverse.Docs do
   # `post_hashtags` rows alone cannot answer: `Vutuv.Posts.put_body_hashtags/2`
   # deliberately skips a hashtag the composer's field already filed, so a tag
   # that is *both* a chip and written in the sentence has a `post_tags` row and
-  # no `post_hashtags` row at all. Reading the body settles it, and both of the
-  # keys a hashtag resolves by (`Tag.find_by_value/1`: the name and the slug)
-  # are checked, so a `#elixir` in the text covers the chip named `Elixir`.
-  defp written_hashtags(%Post{body: body}) do
-    body |> to_string() |> Mentions.hashtags() |> Enum.map(&String.downcase/1) |> MapSet.new()
+  # no `post_hashtags` row at all. Reading the body settles it.
+  #
+  # Both sides fold through `Vutuv.Tags.MatchKey`, the key every other "does
+  # this hashtag name this tag" now asks with (`Tag.find_by_value/1`,
+  # `Tags.linkable_slugs/1`, `Tags.tag_ids_for_hashtags/2`), so a `#elixir` in
+  # the text covers the chip named `Elixir` and a `#ruby_on_rails` covers
+  # `Ruby on Rails` — which the old raw downcase did not. Named for the keys,
+  # not for "as written": `Vutuv.Mentions.written_hashtags/1` is the opposite
+  # question (the spelling, which the mint path needs).
+  defp body_hashtag_keys(%Post{body: body}) do
+    body
+    |> to_string()
+    |> Mentions.hashtags()
+    |> Enum.flat_map(&List.wrap(MatchKey.normalize(&1)))
+    |> MapSet.new()
   end
 
   defp written?(%Tag{name: name, slug: slug}, written) do
-    MapSet.member?(written, String.downcase(to_string(name))) or
-      MapSet.member?(written, String.downcase(to_string(slug)))
+    [name, slug]
+    |> Enum.flat_map(&List.wrap(MatchKey.normalize(to_string(&1))))
+    |> Enum.any?(&MapSet.member?(written, &1))
   end
 
   defp hashtag({%Tag{} = tag, in_body?}) do

--- a/lib/vutuv_web/markdown.ex
+++ b/lib/vutuv_web/markdown.ex
@@ -30,6 +30,7 @@ defmodule VutuvWeb.Markdown do
 
   alias Vutuv.Accounts
   alias Vutuv.Fediverse
+  alias Vutuv.Mentions
   alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
   alias Vutuv.Posts.PostImage
@@ -369,9 +370,12 @@ defmodule VutuvWeb.Markdown do
   `render_remote/1`. Hashtags come back in reading order, in the case the
   author typed, with repeats dropped case-insensitively.
 
-  The grammar is deliberately wider than the `@entity` regex's ASCII
-  `[A-Za-z0-9_]`: `#München` is an ordinary German hashtag and a line holding
-  one must split like any other. Whether a pill then *links* is a separate
+  The grammar is `Vutuv.Mentions.hashtag_token_regex/0`, so a line splits on
+  exactly what the body's own `#hashtag` linking reads — `#München` is an
+  ordinary German hashtag and a line holding one must split like any other.
+  (It used to carry its own wider class, because the shared grammar was
+  ASCII-only; that is no longer true, and two Unicode classes had already
+  drifted apart on `\\p{N}` against `\\p{Nd}`.) Whether a pill then *links* is a separate
   question the caller asks `Vutuv.Tags.linkable_slugs/1` — the same gate the
   body's `#hashtag` linking uses, so a pill links exactly where the inline
   hashtag would have.
@@ -405,11 +409,11 @@ defmodule VutuvWeb.Markdown do
     end
   end
 
-  # A `#` followed by at least one word character, the Unicode reading of
-  # "word" (see `split_trailing_hashtags/1`). Punctuation is not part of a
-  # hashtag, so a line like "Mehr dazu: #Berlin." keeps its full stop and is
-  # therefore not a hashtag line — which is right, it is a sentence.
-  @hashtag_token ~r/^#([\p{L}\p{N}_]+)$/u
+  # `Vutuv.Mentions` owns what a hashtag is; this asks it of a whole token.
+  # Punctuation is not part of a hashtag, so a line like "Mehr dazu: #Berlin."
+  # keeps its full stop and is therefore not a hashtag line — which is right,
+  # it is a sentence.
+  @hashtag_token Mentions.hashtag_token_regex()
 
   defp hashtag_line?(line) do
     case String.split(line, ~r/\s+/u, trim: true) do

--- a/lib/vutuv_web/post_teaser.ex
+++ b/lib/vutuv_web/post_teaser.ex
@@ -89,12 +89,14 @@ defmodule VutuvWeb.PostTeaser do
   # wins the fallback in `pick/1`, because a reader gets *something* out of
   # "#Solarpunk #klimakrise" and nothing at all out of a status URL.
   #
-  # The token is `Vutuv.Mentions`' canonical `#[A-Za-z0-9_]+`, so this and the
-  # renderer cannot disagree about what a hashtag is. Being ASCII-only, a line
-  # carrying `#Grüne` does not match and is kept — the safe direction, since
-  # skipping a line the reader wanted is the expensive mistake. A Markdown
-  # heading cannot match either: `# Titel` has a space after the `#`, and this
-  # demands a word character.
+  # The token is deliberately **narrower** than `Vutuv.Mentions`' canonical one,
+  # which spans Unicode letters so that `#Thüringen` names a tag rather than
+  # `#Th`. Here ASCII-only is the safe direction and stays: this regex decides
+  # what to *drop*, and skipping a line the reader wanted is the expensive
+  # mistake, so a line carrying `#Grüne` does not match and is kept. Widen it
+  # only together with a test that says what a German hashtag line should do.
+  # A Markdown heading cannot match either: `# Titel` has a space after the `#`,
+  # and this demands a word character.
   @hashtags_only ~r/\A(?:#[A-Za-z0-9_]+[\s,]*)+\z/
 
   # How wide one browser-tab frame is written. A tab in a window holding a

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.363.1",
+      version: "7.364.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/hashtag_filing_test.exs
+++ b/test/vutuv/hashtag_filing_test.exs
@@ -4,8 +4,10 @@ defmodule Vutuv.HashtagFilingTest do
   a member's post body (`Vutuv.Posts.PostHashtag`) and a cached remote post
   (`Vutuv.Fediverse.Hashtags`).
 
-  The rule both sides share is that ingestion **mints nothing**: an unknown
-  hashtag files nothing and leaves no tag page behind.
+  The rule both sides share is that a hashtag naming a topic nobody here has
+  written about yet **mints** it — writing `#Eisenach` declares a tag as plainly
+  as typing it into the composer's tag field — bounded by
+  `Vutuv.Tags.mintable_hashtag?/1` and `Tags.max_minted_hashtags_per_body/0`.
   """
   use Vutuv.DataCase
 
@@ -16,16 +18,18 @@ defmodule Vutuv.HashtagFilingTest do
   alias Vutuv.Mentions
   alias Vutuv.Posts
   alias Vutuv.Posts.PostHashtag
+  alias Vutuv.SlugHelpers
   alias Vutuv.Tags
+  alias Vutuv.Tags.Tag
 
   defp confirmed_user, do: insert(:user, email_confirmed?: true)
 
   # A tag whose slug is a valid hashtag. The factory's `unique_tag_name/1`
-  # separates with a hyphen, which the `#hashtag` grammar (`[A-Za-z0-9_]+`) ends
-  # the tag at — so `#berlin-7` would name the tag `berlin`, not this one.
+  # separates with a hyphen, which the `#hashtag` grammar ends the tag at — so
+  # `#berlin-7` would name the tag `berlin`, not this one.
   defp tag_named(base) do
     name = "#{base}_#{System.unique_integer([:positive])}"
-    insert(:tag, name: name, slug: Vutuv.SlugHelpers.tagify(name))
+    insert(:tag, name: name, slug: SlugHelpers.tagify(name))
   end
 
   defp filed_tag_ids(%Vutuv.Posts.Post{} = post) do
@@ -73,6 +77,32 @@ defmodule Vutuv.HashtagFilingTest do
       # so the filing must too or a post is filed under the wrong tag.
       assert Mentions.hashtags("about #elixir\\_lang") == ["elixir_lang"]
     end
+
+    test "a hashtag runs to the end of the word in any language" do
+      # ASCII-only, `#Thüringen` stopped at the `ü` and named the tag `th`. On a
+      # German site that is most hashtags, so the grammar spans Unicode letters,
+      # marks and digits — the class Mastodon uses, where these arrive from.
+      assert Mentions.hashtags("#Eisenach und #Thüringen") == ["eisenach", "thüringen"]
+      assert Mentions.hashtags("#ÖPNV #Grüße #straße") == ["öpnv", "grüße", "straße"]
+      assert Mentions.hashtags("#日本語") == ["日本語"]
+    end
+
+    test "the fediverse address form still names a mention, not a hashtag" do
+      # The lookbehinds now read `\\w` as Unicode too, which is the intended
+      # meaning of "not mid-token" — but a full `@user@host` after a slash is
+      # still the address itself (issue #1694).
+      assert Mentions.hashtags("Bündnis 90/@gruenebundestag@gruene.social") == []
+    end
+  end
+
+  describe "Mentions.written_hashtags/1" do
+    test "keeps the spelling the body used, deduped case-insensitively" do
+      # A minted tag is stored the way whoever names it first wrote it, so the
+      # mint path needs the written form; `hashtags/1` lowercases for lookups.
+      assert Mentions.written_hashtags("#Thüringen and #Eisenach") == ["Thüringen", "Eisenach"]
+      assert Mentions.written_hashtags("#Berlin #berlin #BERLIN") == ["Berlin"]
+      assert Mentions.written_hashtags(nil) == []
+    end
   end
 
   describe "a member's post body" do
@@ -85,14 +115,86 @@ defmodule Vutuv.HashtagFilingTest do
       assert filed_tag_ids(post) == [tag.id]
     end
 
-    test "files nothing for an unknown hashtag and mints no tag" do
+    test "mints the tag an unknown hashtag names, and files the post under it" do
       user = confirmed_user()
-      unknown = "nosuchtag_#{System.unique_integer([:positive])}"
+      unknown = "Nosuchtag_#{System.unique_integer([:positive])}"
 
       {:ok, post} = Posts.create_post(user, %{body: "About ##{unknown}."})
 
+      assert [tag_id] = filed_tag_ids(post)
+      tag = Repo.get!(Tag, tag_id)
+      # Stored as written: vutuv keeps a tag's name the way its first writer
+      # typed it, and a hashtag is now one of the ways a tag is first written.
+      assert tag.name == unknown
+      assert tag.slug == String.downcase(unknown)
+    end
+
+    test "mints a German hashtag under the slug it transliterates to" do
+      user = confirmed_user()
+      name = "Thueringen#{System.unique_integer([:positive])}"
+      written = String.replace(name, "ue", "\u00fc", global: false)
+
+      {:ok, post} = Posts.create_post(user, %{body: "Neu in ##{written}."})
+
+      assert [tag_id] = filed_tag_ids(post)
+      tag = Repo.get!(Tag, tag_id)
+      # The name keeps the umlaut; the slug is the URL and the fediverse actor
+      # name, so it transliterates. This is the pair the old ASCII-only grammar
+      # could not produce at all - it read the hashtag as `#Th`.
+      assert tag.name == written
+      assert tag.slug == String.downcase(name)
+    end
+
+    test "a second post writing the same hashtag re-uses the minted tag" do
+      user = confirmed_user()
+      name = "Eisenach#{System.unique_integer([:positive])}"
+
+      {:ok, first} = Posts.create_post(user, %{body: "Aus ##{name}."})
+      {:ok, second} = Posts.create_post(user, %{body: "Wieder ##{String.downcase(name)}!"})
+
+      assert filed_tag_ids(first) == filed_tag_ids(second)
+      assert Repo.aggregate(from(t in Tag, where: ilike(t.name, ^name)), :count) == 1
+    end
+
+    test "mints nothing for a hashtag whose slug would not name it" do
+      user = confirmed_user()
+
+      # `#2026` slugs to `2026` and a CJK hashtag transliterates to nothing at
+      # all (which `gen_tag_slug_unique/3` fills with random hex). Neither URL
+      # says what the page is about, so neither is minted in passing - a member
+      # who wants such a tag can still create it by hand on the tags page.
+      {:ok, post} = Posts.create_post(user, %{body: "Im #2026 und #\u65e5\u672c\u8a9e."})
+
       assert filed_tag_ids(post) == []
-      refute Repo.exists?(from(t in Vutuv.Tags.Tag, where: t.slug == ^unknown))
+      refute Repo.exists?(from(t in Tag, where: t.slug == "2026"))
+    end
+
+    test "mints nothing when the post is refused for having too many chips" do
+      user = confirmed_user()
+      name = "Doomed#{System.unique_integer([:positive])}"
+      chips = for n <- 1..(Posts.max_tags_per_post() + 1), do: "#{name}chip#{n}"
+
+      # The sixth chip fails the save (issue #1237), so the body's hashtag must
+      # not leave a tag page behind for a post that never published. Minting
+      # happens while the changeset is built, before that error is added, so the
+      # decision has to be handed down rather than discovered.
+      assert {:error, _changeset} =
+               Posts.create_post(user, %{body: "About ##{name}.", tags: chips})
+
+      refute Repo.exists?(from(t in Tag, where: ilike(t.name, ^name)))
+    end
+
+    test "mints at most five tags from one body" do
+      user = confirmed_user()
+      run = System.unique_integer([:positive])
+      names = for n <- 1..(Tags.max_minted_hashtags_per_body() + 3), do: "Minted#{run}x#{n}"
+      body = "Ueber " <> Enum.map_join(names, " ", &"##{&1}")
+
+      {:ok, post} = Posts.create_post(user, %{body: body})
+
+      # Filing under existing tags is cheap; minting creates a public page, so
+      # the two carry different ceilings.
+      assert length(filed_tag_ids(post)) == Tags.max_minted_hashtags_per_body()
     end
 
     test "does not duplicate a tag the composer field already filed" do
@@ -169,14 +271,39 @@ defmodule Vutuv.HashtagFilingTest do
       assert filed_tag_ids(post) == [tag.id]
     end
 
-    test "mints no tag from a stranger's hashtag" do
-      unknown = "fromoverthere_#{System.unique_integer([:positive])}"
-      post = remote_post("Trending: ##{unknown}")
+    test "mints the tag a followed account's hashtag names" do
+      # Nothing reaches this module unless a member here follows the sender
+      # (`Fediverse.record_remote_post/2` requires an accepted follow), so these
+      # are the topics our own members chose to read about.
+      name = "Fromoverthere#{System.unique_integer([:positive])}"
+      post = remote_post("Trending: ##{name}")
 
-      Hashtags.sync(post, %{"tag" => [%{"type" => "Hashtag", "name" => "#" <> unknown}]})
+      Hashtags.sync(post, %{"tag" => [%{"type" => "Hashtag", "name" => "#" <> name}]})
 
-      assert filed_tag_ids(post) == []
-      refute Repo.exists?(from(t in Vutuv.Tags.Tag, where: t.slug == ^unknown))
+      assert [tag_id] = filed_tag_ids(post)
+      assert Repo.get!(Tag, tag_id).name == name
+    end
+
+    test "keeps the casing the AP tag array sent" do
+      name = "Gr\u00fcne#{System.unique_integer([:positive])}"
+      post = remote_post("Nothing in the text.")
+
+      Hashtags.sync(post, %{"tag" => [%{"type" => "Hashtag", "name" => "#" <> name}]})
+
+      assert [tag_id] = filed_tag_ids(post)
+      assert Repo.get!(Tag, tag_id).name == name
+    end
+
+    test "a minted tag page stays out of the sitemap until something local carries it" do
+      # The bound that makes minting from another network safe: a remote post
+      # can leave a tag page behind, it cannot put one in front of a crawler.
+      name = "Remoteonly#{System.unique_integer([:positive])}"
+      post = remote_post("About ##{name}")
+
+      Hashtags.sync(post, %{})
+
+      assert [tag_id] = filed_tag_ids(post)
+      refute Tags.indexable_tag?(Repo.get!(Tag, tag_id))
     end
 
     test "an upstream edit re-syncs the filings both ways" do
@@ -205,7 +332,7 @@ defmodule Vutuv.HashtagFilingTest do
     end
   end
 
-  describe "Tags.tag_ids_for_hashtags/1" do
+  describe "Tags.tag_ids_for_hashtags/2" do
     test "matches an existing tag by name as well as by slug" do
       # A member spelled it "München"; the slug is transliterated, so a remote
       # `#münchen` would never match on the slug alone.
@@ -214,6 +341,59 @@ defmodule Vutuv.HashtagFilingTest do
       assert Tags.tag_ids_for_hashtags([String.downcase(tag.name)]) == [tag.id]
       assert Tags.tag_ids_for_hashtags(["muenchen"]) == [tag.id]
       assert Tags.tag_ids_for_hashtags([]) == []
+    end
+
+    test "an underscore in a hashtag reaches the spaced tag it names" do
+      # The folded key (`Vutuv.Tags.MatchKey`) collapses space, hyphen and
+      # underscore alike, so `#ruby_on_rails` is the tag "Ruby on Rails" rather
+      # than a second page for it. Matching this well is what makes minting
+      # safe: every spelling a lookup misses is a duplicate it would create.
+      name = "Ruby on Rails #{System.unique_integer([:positive])}"
+      tag = insert(:tag, name: name, slug: SlugHelpers.tagify(name))
+
+      assert Tags.tag_ids_for_hashtags([String.replace(name, " ", "_")], create: true) == [tag.id]
+    end
+
+    test "without create: true it still mints nothing" do
+      unknown = "Neverminted#{System.unique_integer([:positive])}"
+
+      assert Tags.tag_ids_for_hashtags([unknown]) == []
+      refute Repo.exists?(from(t in Tag, where: ilike(t.name, ^unknown)))
+    end
+  end
+
+  describe "Tags.mintable_hashtag?/1" do
+    test "refuses what would not make a tag, or would not make a slug" do
+      assert Tags.mintable_hashtag?("Th\u00fcringen")
+      assert Tags.mintable_hashtag?("elixir_lang")
+
+      # No letter survives into the slug, so the URL would not name the page.
+      refute Tags.mintable_hashtag?("2026")
+      refute Tags.mintable_hashtag?("\u65e5\u672c\u8a9e")
+
+      # The rules `Tag.changeset/2` applies, asked before the insert.
+      refute Tags.mintable_hashtag?("...")
+      refute Tags.mintable_hashtag?("example.com")
+      refute Tags.mintable_hashtag?(nil)
+    end
+  end
+
+  describe "the renderer and the filing agree" do
+    test "a hashtag links to the page its post was filed under" do
+      # Filing has always matched a tag by name as well as slug while
+      # `linkable_slugs/1` matched the slug alone, so `#München` sat as plain
+      # text in a post the München page listed. Minting made that the common
+      # case, since every German hashtag has a transliterated slug.
+      user = confirmed_user()
+      name = "Th\u00fcringen#{System.unique_integer([:positive])}"
+
+      {:ok, post} = Posts.create_post(user, %{body: "Neu in ##{name}."})
+      assert [tag_id] = filed_tag_ids(post)
+      tag = Repo.get!(Tag, tag_id)
+
+      # The post itself is what makes the page worth a click.
+      written = String.downcase(name)
+      assert Tags.linkable_slugs([written]) == %{written => tag.slug}
     end
   end
 end


### PR DESCRIPTION
A `#hashtag` could only file a post under a tag that already existed. Anything new fell on the floor, so the catalog only ever grew from the composer's tag field — and a Mastodon post about `#Eisenach` and `#Thüringen` taught vutuv nothing.

Both paths now mint the tag (`Vutuv.Tags.tag_ids_for_hashtags/2`, `create: true`): member posts and cached fediverse posts. Bounds: five new tags per body, a name whose slug actually names it (so no `/tags/2026`), and the remote side only ever sees accounts a member here already follows. A minted page stays `noindex` until something local carries it.

Two bugs surfaced on the way. The hashtag grammar was ASCII-only — `#Thüringen` ended at the umlaut and named the tag `th`. And `linkable_slugs/1` matched slugs while filing matched names too, so `#München` sat as plain text in a post the München page listed; both sides now use the same folded key.

Worth your call: minting from another network reverses a rule that was written down as deliberate.

*An AI agent wrote this text in my name. I know that is problematic.*
