### PR TITLE
Mentions of our own accounts read short on vutuv and travel in full

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -1113,6 +1113,34 @@ now, with the page's own gates in front of it: the page must federate, the post
 must not be held by moderation, and a page that switched federation off gets the
 same `410`/`404` refusal its actor endpoint gives.
 
+## Mentions on the way out
+
+A member writes `@ada`, and on the server this post lands on that names *their*
+@ada. So the Note spells every mention of one of our accounts out in full —
+`@ada@vutuv.de`, the only spelling that means the same person on every server —
+while the same body keeps reading `@ada` on the page here. Nothing is rewritten
+in the database: `Docs.content_html/3` renders with `mention_form: :address` and
+`VutuvWeb.Markdown` writes the label, the same seam the closing hashtag line and
+the answered account's `@user@host` use. The address a member typed in full
+travels as they wrote it; the link under both keeps pointing at the profile page,
+made absolute like every other link in the content.
+
+Beside it in the `tag` array goes one **`Mention`** per named account of ours
+(`href` the actor URI, `name` the `@handle@host`), which is what has the
+receiving server resolve the account, notify where it applies, and draw the name
+as a mention instead of a bare link. That array is otherwise built from *stored*
+actor URIs and never from parsing the body, so that nobody can put
+`@someone@anywhere` in a post and have vutuv mint a verified-looking Mention at
+an actor nobody checked. Parsing is safe **only** for the local half: every
+handle is resolved against our own tables, so the actor it points at is one this
+installation serves. An account that keeps out of the Fediverse is left out of
+the tags — it serves no actor document, and naming it would send every receiving
+server after a 404 — but the text still names it, because the address is who is
+meant whether or not they federate.
+
+The mirror direction is `Vutuv.Mentions.to_local_form/1`; the whole picture is
+in [mentions.md](mentions.md).
+
 ## A topic federates too (issue #1330)
 
 A tag is an ActivityPub `Group` actor, so anybody on any server can follow a

--- a/docs/architecture/mentions.md
+++ b/docs/architecture/mentions.md
@@ -29,6 +29,40 @@ does not serve. So the one clickable thing in a sentence naming a member 404ed
 on our own domain, being named that way notified nobody, and a rename left the
 address behind pointing at a handle its owner had given up.
 
+## Which form is shown where
+
+Both spellings mean the same account, and each is right exactly where it was
+written. On a vutuv page the reader is already on the host the address names, so
+writing it out says nothing; on mastodon.social a bare `@ada` names *their*
+member of that name, who is somebody else entirely. So neither spelling is
+stored — the form is chosen at render time, per surface:
+
+| Surface | `@ada` becomes | `@ada@vutuv.de` becomes |
+|---|---|---|
+| a vutuv page, a plain-text quote, the tab teaser | `@ada` | `@ada` |
+| the Note that federates the post | `@ada@vutuv.de` | `@ada@vutuv.de` |
+
+`VutuvWeb.Markdown` shortens by default (`mention_form: :local`) and spells out
+for `VutuvWeb.Fediverse.Docs`, which passes `mention_form: :address`; the
+surfaces that flatten a body to text instead of rendering it go through
+`Mentions.to_local_form/1`. Only resolved accounts are expanded, because only
+they are accounts — a stray `@word` is left as written, and an address nobody
+holds is shortened without becoming a link.
+
+The stored body keeps whatever was typed, so the same row reads correctly in
+both places and a member who wrote one form never finds the other saved over it.
+It is still shown verbatim in one place, deliberately: `body_markdown` in the
+agent-format siblings is the post's Markdown source, not a rendering of it.
+
+The outgoing Note also carries a `Mention` **tag** per account of ours the body
+names — actor URI plus `@handle@host` — which is what makes the receiving server
+resolve the account and draw a mention rather than a bare link. Minting one from
+typed text is safe *here only*, because every handle is resolved against our own
+tables; an address on somebody else's server is nobody we have checked, so it is
+left to the reader's own server (see [fediverse.md](fediverse.md)). An account
+that keeps out of the Fediverse serves no actor document, so it is named in the
+text and left out of the tags.
+
 ## The mention surfaces
 
 Every field whose stored `@handle` linkifies is one `{schema, field}` entry in
@@ -207,7 +241,8 @@ posts (the newest five, plus an "and N more" count).
 - `lib/vutuv_web/live/notification_live/index.ex` — the `mention` and
   `handle_change` renderings.
 - `test/vutuv/mentions_test.exs`, `mentions_local_address_test.exs`,
-  `vutuv_web/markdown_local_address_test.exs`, `mention_existence_test.exs`,
+  `vutuv_web/markdown_local_address_test.exs`, `vutuv_web/mention_form_test.exs`,
+  `mention_existence_test.exs`,
   `mention_limit_test.exs`,
   `mention_notifications_test.exs`, `handle_availability_test.exs`,
   `accounts/handle_change_propagation_test.exs`,

--- a/docs/architecture/mentions.md
+++ b/docs/architecture/mentions.md
@@ -49,6 +49,16 @@ surfaces that flatten a body to text instead of rendering it go through
 they are accounts — a stray `@word` is left as written, and an address nobody
 holds is shortened without becoming a link.
 
+One thing the shortening steps over: a **URL**. The entity grammar reads a full
+address after a slash on purpose (German prose writes
+`Bündnis 90/@gruenebundestag@gruene.social` and means that account), and
+`https://mastodon.social/@ada@vutuv.de` wears the same shape without being a
+mention — it is Mastodon's web path to a remote profile, and shortened it would
+read `https://mastodon.social/@ada`, naming *their* member of that name. The
+renderer is safe without a guard, because the autolinker has made the URL an
+`<a>` before the entity pass runs and that pass skips anchors; the plain-text
+route has no anchor to skip, so `to_local_form/1` splits URLs out first.
+
 The stored body keeps whatever was typed, so the same row reads correctly in
 both places and a member who wrote one form never finds the other saved over it.
 It is still shown verbatim in one place, deliberately: `body_markdown` in the

--- a/lib/vutuv/mentions.ex
+++ b/lib/vutuv/mentions.ex
@@ -4,7 +4,7 @@ defmodule Vutuv.Mentions do
 
   A mention is plain text `@handle` inside a Markdown body — nothing structured
   is stored, it becomes a profile link only at render time
-  (`VutuvWeb.Markdown`). Four concerns therefore have to agree on *what counts
+  (`VutuvWeb.Markdown`). Five concerns therefore have to agree on *what counts
   as a mention*, so they share one definition here:
 
     * **Rendering** — `VutuvWeb.Markdown` links each local `@handle` and calls
@@ -23,6 +23,11 @@ defmodule Vutuv.Mentions do
       (`validate_mention_limit/2`), because every one of them is a
       notification: an advert followed by a list of handles is spam delivered
       through our own notification feed.
+    * **Display** — the same account is `@ada` here and `@ada@vutuv.de` on every
+      other server, so which spelling is shown is decided per surface at render
+      time and never stored: `to_local_form/1` (and `VutuvWeb.Markdown`'s
+      default) shortens for vutuv, `mention_form: :address` spells out for the
+      Note that federates the post.
     * **Propagation** — when a member renames, every stored `@old` is rewritten
       to `@new` across all mention surfaces (`rewrite_everywhere/3`), and the
       new handle is only claimable when it is used in no content
@@ -271,6 +276,48 @@ defmodule Vutuv.Mentions do
       handles -> handles |> Organizations.get_organizations_by_usernames() |> Map.values()
     end
   end
+
+  ## Display form ----------------------------------------------------------
+
+  @doc """
+  `text` with every address on **our own** host shortened to the bare handle:
+  `@ada@vutuv.de` reads `@ada`.
+
+  Each environment gets the spelling that is right for it, and nothing is
+  stored either way. Here the reader is already on the host the address names,
+  so writing it out says nothing and only pushes the sentence around — a member
+  writes `@ada` and a remote server writes `@ada@vutuv.de` for the same person,
+  and both should read as `@ada` on this page. The Fediverse is the mirror
+  image: `VutuvWeb.Fediverse.Docs` renders an outgoing Note with
+  `mention_form: :address`, because over there a bare `@ada` names an account on
+  the *reader's* server — somebody else entirely.
+
+  This is the plain-text half, for the surfaces that flatten a body instead of
+  rendering it (`VutuvWeb.Markdown.to_plain_text/1`: the tab teaser, the
+  notification quote lines). The HTML renderer does the same shortening
+  structurally, so there the link survives and only its label changes.
+
+  Another server's address is somebody else's account and stays whole, our tag
+  host names a topic (`@php@tags.vutuv.de`) and stays whole too, and a code span
+  or block is sample text — the same three exceptions the rest of this module
+  makes. Free of queries by design: whether the handle exists is not asked, so a
+  body naming a departed member reads `@ada` here exactly as a bare mention of
+  them would.
+  """
+  def to_local_form(text) when is_binary(text) do
+    if String.contains?(text, "@") do
+      text
+      |> chunks()
+      |> Enum.map_join(fn
+        {:code, chunk} -> chunk
+        {:text, chunk} -> shorten_addresses(chunk)
+      end)
+    else
+      text
+    end
+  end
+
+  def to_local_form(text), do: text
 
   ## Rewrite ----------------------------------------------------------------
 
@@ -572,6 +619,18 @@ defmodule Vutuv.Mentions do
 
   defp hashtag_of([_, _, _, hashtag]) when hashtag != "", do: [hashtag]
   defp hashtag_of(_), do: []
+
+  # Only the fediverse form on our own host has anything to shorten; a bare
+  # handle, a hashtag and every other host fall through as written.
+  defp shorten_addresses(chunk) do
+    Regex.replace(@entity, chunk, fn
+      whole, user, host, "", "" ->
+        if user != "" and Fediverse.local_host?(host), do: "@" <> user, else: whole
+
+      whole, _user, _host, _handle, _hashtag ->
+        whole
+    end)
+  end
 
   defp rewrite_chunk(chunk, old_n, new_n, acc) do
     hits =

--- a/lib/vutuv/mentions.ex
+++ b/lib/vutuv/mentions.ex
@@ -113,6 +113,10 @@ defmodule Vutuv.Mentions do
   # original — so `rewrite/3` can never corrupt a body.
   @code ~r/```[\s\S]*?```|~~~[\s\S]*?~~~|`[^`\n]*`/
 
+  # A bare URL, the shape `VutuvWeb.Markdown` autolinks. Only the display form
+  # steps over one (`to_local_form/1`); see `shorten_addresses/1` for why.
+  @url ~r{https?://[^\s<>]+}
+
   # Every Markdown surface whose stored `@handle` becomes a link — the single
   # list the existence validation, the content scan and the rename rewrite all
   # read, kept in step with the `VutuvWeb.Markdown` render call sites.
@@ -622,8 +626,29 @@ defmodule Vutuv.Mentions do
 
   # Only the fediverse form on our own host has anything to shorten; a bare
   # handle, a hashtag and every other host fall through as written.
+  #
+  # A bare URL is stepped over first, because `@entity` reads a full address
+  # after a slash on purpose — German prose writes
+  # `Bündnis 90/@gruenebundestag@gruene.social` and means that account — and
+  # `https://mastodon.social/@ada@vutuv.de` is the same shape without being a
+  # mention: it is Mastodon's web path to a *remote* profile. Shortened, it
+  # would read `https://mastodon.social/@ada`, which over there names their own
+  # member of that name — a different person, and a link that goes to them. The
+  # renderer needs no such guard: by the time its entity pass runs the
+  # autolinker has made the URL an `<a>`, and that pass skips anchors. This is
+  # the plain-text route, where there is no anchor to skip.
   defp shorten_addresses(chunk) do
-    Regex.replace(@entity, chunk, fn
+    @url
+    |> Regex.split(chunk, include_captures: true)
+    |> Enum.with_index()
+    |> Enum.map_join(fn
+      {url, index} when rem(index, 2) == 1 -> url
+      {text, _index} -> shorten_addresses_in_text(text)
+    end)
+  end
+
+  defp shorten_addresses_in_text(text) do
+    Regex.replace(@entity, text, fn
       whole, user, host, "", "" ->
         if user != "" and Fediverse.local_host?(host), do: "@" <> user, else: whole
 

--- a/lib/vutuv_web/fediverse/docs.ex
+++ b/lib/vutuv_web/fediverse/docs.ex
@@ -25,6 +25,7 @@ defmodule VutuvWeb.Fediverse.Docs do
   alias Vutuv.Accounts.User
   alias Vutuv.Fediverse.Actor
   alias Vutuv.Mentions
+  alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
@@ -718,7 +719,7 @@ defmodule VutuvWeb.Fediverse.Docs do
     }
     |> put_content_map(post)
     |> put_in_reply_to(post, remote)
-    |> put_tag(remote, hashtags)
+    |> put_tag(post, remote, hashtags)
     |> put_attachments(post)
   end
 
@@ -757,11 +758,47 @@ defmodule VutuvWeb.Fediverse.Docs do
   #
   # It shares the array with the post's hashtags (issue #1421), so both are
   # written here rather than each overwriting the other's key.
-  defp put_tag(note, remote, hashtags) do
-    case mention_tag(remote) ++ Enum.map(hashtags, &hashtag_tag/1) do
+  defp put_tag(note, post, remote, hashtags) do
+    case mention_tag(remote) ++ local_mention_tags(post) ++ Enum.map(hashtags, &hashtag_tag/1) do
       [] -> note
       tags -> Map.put(note, "tag", tags)
     end
+  end
+
+  # The accounts of **ours** the body names. The other half of writing the
+  # mention out in full: the text tells a reader who is meant, this tells their
+  # server, which resolves the `href` and only then draws the name as a mention
+  # and links it to the account rather than to a bare URL.
+  #
+  # Parsing the body is safe **here and only here**, which is what separates it
+  # from the rule above: every handle is resolved against our own tables, so the
+  # actor it points at is one this installation serves and vouching for it costs
+  # nothing. A `@someone@anywhere` in the same sentence is left to the reader's
+  # server, exactly as before.
+  #
+  # Gated on `federated?/1`: an account that keeps out of the Fediverse serves no
+  # actor document, and naming one would send every receiving server after a
+  # 404. The **text** still spells it out — the address is who is meant whether
+  # or not they federate, and it links to the profile page either way.
+  defp local_mention_tags(%Post{body: body}) when is_binary(body) do
+    (Mentions.mentioned_users(body) ++ mentioned_pages(body))
+    |> Enum.filter(&Vutuv.Fediverse.federated?/1)
+    |> Enum.map(&%{"type" => "Mention", "href" => actor_url(&1), "name" => handle(&1)})
+  end
+
+  defp local_mention_tags(_post), do: []
+
+  # `mentioned_organizations/1` answers with the four columns the *renderer*
+  # needs (id, name, slug, username), and `federated?/1` asks about two it does
+  # not carry — a partial struct answers from the schema default, which reads as
+  # "this page keeps out of the Fediverse" for every page there is, silently and
+  # for good. So the ids are read back in full, in one more query on a path that
+  # runs once per published post.
+  defp mentioned_pages(body) do
+    body
+    |> Mentions.mentioned_organizations()
+    |> Enum.map(& &1.id)
+    |> Organizations.list_organizations_by_ids()
   end
 
   defp mention_tag(nil), do: []
@@ -880,14 +917,18 @@ defmodule VutuvWeb.Fediverse.Docs do
   end
 
   # The same rendering members see, with every relative link/image made
-  # absolute (remote servers render this HTML on their own domain). A review
+  # absolute (remote servers render this HTML on their own domain) and every
+  # mention of one of our accounts written out in full: on vutuv a member writes
+  # `@ada`, but on the server this lands on that names *their* @ada, so the wire
+  # spells it `@ada@vutuv.de` (`mention_form: :address`). Nothing about the
+  # stored body changes — the same post reads `@ada` again on the page. A review
   # sidecar is rendered INTO the content: the Note is one more rendering of
   # the post (like the agent docs), so a Mastodon reader gets the reviewed
   # work's facts even though remote software knows nothing of review cards.
   defp content_html(post, remote, hashtags) do
     body_html =
       post.body
-      |> VutuvWeb.Markdown.render_post(images(post))
+      |> VutuvWeb.Markdown.render_post(images(post), mention_form: :address)
       |> Phoenix.HTML.safe_to_string()
 
     (mention_html(remote) <>

--- a/lib/vutuv_web/markdown.ex
+++ b/lib/vutuv_web/markdown.ex
@@ -85,7 +85,7 @@ defmodule VutuvWeb.Markdown do
   # points; handles/tags match permissively and are validated against the
   # DB by `linkify_entities/1`. Captures: 1 = fediverse user, 2 = fediverse
   # host, 3 = local handle, 4 = hashtag (exactly one kind is set per hit).
-  @entity Vutuv.Mentions.entity_regex()
+  @entity Mentions.entity_regex()
 
   # Inside these elements an entity is left as plain text (a handle/hashtag in a
   # code span/block is sample text, and we never nest a link inside a link).
@@ -127,6 +127,12 @@ defmodule VutuvWeb.Markdown do
   also what an installation with `:verify_user_links` off gets: no member
   has a verified link there, so the list is always empty.
 
+  `:mention_form` (opts) picks how a mention of one of our own accounts is
+  **written**: `:local` (the default) shortens an address on our host to the
+  bare handle, `:address` spells a bare handle out in full. Neither touches the
+  stored body — see `Vutuv.Mentions.to_local_form/1` for why each environment
+  wants the other one.
+
   `:image_query` (opts) is a `(image -> query | nil)` appended to each inline
   picture's URL, for a caller serving this HTML where the reader brings no
   session: the Mastodon adapter passes the same `VutuvWeb.RemoteMediaToken`
@@ -146,7 +152,7 @@ defmodule VutuvWeb.Markdown do
     |> render_pipeline(breaks: false)
     |> open_links_in_new_tab()
     |> mark_verified_author_links(Keyword.get(opts, :verified_links, []))
-    |> linkify_entities()
+    |> linkify_entities(:all, Keyword.get(opts, :mention_form, :local))
     |> inject_inline_images(replacements)
     |> Phoenix.HTML.raw()
   end
@@ -439,10 +445,14 @@ defmodule VutuvWeb.Markdown do
   markers disappear instead of being shown (`**bold**` reads as `bold`), a
   link keeps its label, and blocks become plain line breaks.
 
-  Entities are **not** linkified, so this costs no DB query.
+  Entities are **not** linkified, so this costs no DB query. An address on our
+  own host is still shortened to the bare handle
+  (`Vutuv.Mentions.to_local_form/1`), the same as in the rendered body: these
+  are the surfaces that quote a post *inside* vutuv, and a tab title has less
+  room for a host than anything else on the site.
   """
   def to_plain_text(text) when is_binary(text) do
-    text |> render_pipeline() |> html_to_plain_text()
+    text |> Mentions.to_local_form() |> render_pipeline() |> html_to_plain_text()
   end
 
   def to_plain_text(_), do: ""
@@ -974,17 +984,17 @@ defmodule VutuvWeb.Markdown do
   # Each body resolves its handles and its hashtags in **one** DB query each;
   # a body with no `@`/`#` at all does no work (so the pure, DB-free unit tests
   # in `markdown_test.exs` keep working without a sandbox).
-  defp linkify_entities(html, mode \\ :all) do
+  defp linkify_entities(html, mode \\ :all, form \\ :local) do
     # Cheap bail-out for the common case: no `@`/`#` means no entity to link,
     # so the feed hot path skips tokenizing and scanning entirely.
     if String.contains?(html, "@") or String.contains?(html, "#") do
-      linkify_present_entities(html, mode)
+      linkify_present_entities(html, mode, form)
     else
       html
     end
   end
 
-  defp linkify_present_entities(html, mode) do
+  defp linkify_present_entities(html, mode, form) do
     tokens = tokenize_html(html)
 
     case entity_candidates(tokens) do
@@ -1007,7 +1017,7 @@ defmodule VutuvWeb.Markdown do
         tags = Tags.linkable_slugs(hashtags)
 
         tokens
-        |> map_linkable_text(&link_entities_in_text(&1, bare_users, targets, tags))
+        |> map_linkable_text(&link_entities_in_text(&1, bare_users, targets, tags, form))
         |> IO.iodata_to_binary()
     end
   end
@@ -1102,10 +1112,10 @@ defmodule VutuvWeb.Markdown do
 
   defp skip_tag?(name), do: String.downcase(name) in @entity_skip_tags
 
-  defp link_entities_in_text(text, bare_users, address_users, tags) do
+  defp link_entities_in_text(text, bare_users, address_users, tags, form) do
     Regex.replace(@entity, text, fn
-      whole, user, host, "", "" -> fediverse_link(whole, user, host, address_users, tags)
-      whole, "", "", handle, "" -> mention_link(whole, handle, bare_users)
+      whole, user, host, "", "" -> fediverse_link(whole, user, host, address_users, tags, form)
+      whole, "", "", handle, "" -> mention_link(whole, handle, bare_users, form)
       whole, "", "", "", hashtag -> hashtag_link(whole, hashtag, tags)
     end)
   end
@@ -1114,10 +1124,10 @@ defmodule VutuvWeb.Markdown do
   # account — but two of our own hosts wear the same shape, and for both the
   # reader wants a page here rather than a trip to another server: our tag host
   # names a topic, and our main host names a member or a page of ours.
-  defp fediverse_link(whole, user, host, users, tags) do
+  defp fediverse_link(whole, user, host, users, tags, form) do
     cond do
       Fediverse.tag_host?(host) -> tag_actor_link(whole, user, tags)
-      Fediverse.local_host?(host) -> local_address_link(whole, user, host, users)
+      Fediverse.local_host?(host) -> local_address_link(whole, user, host, users, form)
       true -> remote_actor_link(user, host)
     end
   end
@@ -1129,13 +1139,21 @@ defmodule VutuvWeb.Markdown do
   # that is not Mastodon: that path is not a page vutuv serves, so the one
   # clickable thing in a sentence naming a member 404ed on our own domain.
   #
-  # The **address stays the visible text**: the author wrote it in full so a
-  # reader on another network can copy it, and shortening it to `@ada` would
-  # take that away. An unresolved handle stays plain text, like a bare mention.
-  defp local_address_link(whole, user, host, users) do
-    case Map.get(users, String.downcase(user)) do
-      nil -> whole
-      target -> mention_anchor(target, "#{user}@#{host}")
+  # On the site the address is **shortened to the handle**: the reader is
+  # already on the host it names, so `@ada@vutuv.de` and `@ada` are the same
+  # person written long and short, and the long one only pushes the sentence
+  # around. The stored body keeps whatever was typed — a post arriving from
+  # another server names us in full, and this is what makes it read like one of
+  # ours. `mention_form: :address` (the outgoing Note) keeps it whole instead,
+  # because over there the short form names somebody else. An unresolved handle
+  # stays plain text, like a bare mention, and is shortened the same way: a
+  # handle nobody holds reads no better for being spelled out.
+  defp local_address_link(whole, user, host, users, form) do
+    case {Map.get(users, String.downcase(user)), form} do
+      {nil, :local} -> "@" <> user
+      {nil, :address} -> whole
+      {target, :local} -> mention_anchor(target, user)
+      {target, :address} -> mention_anchor(target, "#{user}@#{host}")
     end
   end
 
@@ -1174,12 +1192,21 @@ defmodule VutuvWeb.Markdown do
     ~s(<a href="#{href}" target="_blank" rel="noopener noreferrer" class="mention">@#{user}@#{host}</a>)
   end
 
-  defp mention_link(whole, handle, users) do
+  # A bare `@ada` is the everyday spelling here and the wrong one everywhere
+  # else: on the server this post is federated to, `@ada` names *their* member
+  # of that name. So `mention_form: :address` writes it out as `@ada@vutuv.de`,
+  # which is the same account under a name that means the same thing on every
+  # server. Only a handle that resolves is expanded — a stray `@word` is not an
+  # account here, and inventing an address for it would name one.
+  defp mention_link(whole, handle, users, form) do
     case Map.get(users, String.downcase(handle)) do
       nil -> whole
-      target -> mention_anchor(target, handle)
+      target -> mention_anchor(target, mention_label(handle, form))
     end
   end
+
+  defp mention_label(handle, :local), do: handle
+  defp mention_label(handle, :address), do: handle <> "@" <> VutuvWeb.Endpoint.host()
 
   # Members and organizations share one handle namespace (the `handles`
   # registry, issue #941), so a handle belongs to at most one of them and the

--- a/lib/vutuv_web/post_teaser.ex
+++ b/lib/vutuv_web/post_teaser.ex
@@ -65,6 +65,7 @@ defmodule VutuvWeb.PostTeaser do
   alias Vutuv.Fediverse.Handle
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Identity
+  alias Vutuv.Mentions
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias VutuvWeb.Markdown
@@ -300,7 +301,18 @@ defmodule VutuvWeb.PostTeaser do
 
   defp flatten(line), do: line |> Markdown.to_plain_text() |> fold()
 
-  defp fold(line), do: line |> String.replace(~r/\s+/u, " ") |> String.trim()
+  # A mention of one of our accounts reads short here, as it does in the post
+  # itself: `to_local_form/1` turns `@ada@vutuv.de` back into `@ada`. Every
+  # teaser passes through this step, which is what makes a body from another
+  # network — where naming us in full is the only spelling there is — read like
+  # one of ours. A local body arrives already shortened through
+  # `to_plain_text/1` and has nothing left to change.
+  defp fold(line) do
+    line
+    |> Mentions.to_local_form()
+    |> String.replace(~r/\s+/u, " ")
+    |> String.trim()
+  end
 
   # A page that never claimed a root handle has none to show, so it is named.
   defp local_who(author) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.364.2",
+      version: "7.365.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/markdown_local_address_test.exs
+++ b/test/vutuv_web/markdown_local_address_test.exs
@@ -4,10 +4,14 @@ defmodule VutuvWeb.MarkdownLocalAddressTest do
 
   `@ada@vutuv.de` is the member `@ada` written out in full — the spelling every
   other server uses to name one of us — so it links to the profile, in the same
-  tab, keeping the address as its visible text. It used to be sent through the
+  tab, and reads there as the short `@ada` a member would have typed: the reader
+  is already on the host the address names. It used to be sent through the
   Mastodon-web convention `https://<host>/@<user>`, a path vutuv does not serve,
   so the one clickable thing in a sentence naming a member 404ed on our own
   domain and opened in a second tab to do it.
+
+  The mirror image — an outgoing Note spelling `@ada` out in full — lives in
+  `mention_form_test.exs`.
 
   `async: false` and its own file because `with_endpoint_host/1` changes global
   endpoint config the SQL sandbox does not roll back; the test endpoint's
@@ -33,13 +37,14 @@ defmodule VutuvWeb.MarkdownLocalAddressTest do
     handle
   end
 
-  test "an address on our host links to the profile, same tab, address intact" do
+  test "an address on our host links to the profile, same tab, short label" do
     handle = ada()
     html = render("Thanks @#{handle}@vutuv.test for the help!")
 
     assert html =~ ~s(href="/#{handle}")
     assert html =~ ~s(title="Ada Lovelace")
-    assert html =~ ">@#{handle}@vutuv.test</a>"
+    assert html =~ ">@#{handle}</a>"
+    refute html =~ "vutuv.test</a>"
     refute html =~ "target=\"_blank\""
     refute html =~ "vutuv.test/@"
   end
@@ -49,7 +54,7 @@ defmodule VutuvWeb.MarkdownLocalAddressTest do
     html = render("cc @#{handle}@www.vutuv.test")
 
     assert html =~ ~s(href="/#{handle}")
-    assert html =~ ">@#{handle}@www.vutuv.test</a>"
+    assert html =~ ">@#{handle}</a>"
   end
 
   test "an organization on our host links to its page" do
@@ -61,11 +66,14 @@ defmodule VutuvWeb.MarkdownLocalAddressTest do
     assert html =~ ~s(title="Acme GmbH")
   end
 
+  # Not linked, because nobody holds it — but still shortened: a handle of ours
+  # that leads nowhere reads no better for being spelled out.
   test "an address of a handle nobody holds stays plain text" do
     html = render("hi @nobody_here@vutuv.test")
 
     refute html =~ "<a"
-    assert html =~ "@nobody_here@vutuv.test"
+    assert html =~ "@nobody_here"
+    refute html =~ "vutuv.test"
   end
 
   test "an address on another server still leaves the site" do
@@ -89,9 +97,11 @@ defmodule VutuvWeb.MarkdownLocalAddressTest do
     handle = ada()
     html = Markdown.render_remote("hallo @#{handle}@vutuv.test und @#{handle}")
 
-    assert html =~ ~s(href="/#{handle}")
-    assert html =~ ">@#{handle}@vutuv.test</a>"
-    refute html =~ ">@#{handle}</a>"
+    # One anchor: the address. The bare handle beside it stays plain text, and
+    # the address reads short, the way the same person is named in a vutuv post.
+    assert [_one] = Regex.scan(~r/<a /, html)
+    assert html =~ ~s(<a href="/#{handle}" title="Ada Lovelace" class="mention">@#{handle}</a>)
+    assert String.ends_with?(html, "und @#{handle}</p>\n")
   end
 
   test "our own profile link in remote content is not nofollowed" do

--- a/test/vutuv_web/mention_form_test.exs
+++ b/test/vutuv_web/mention_form_test.exs
@@ -1,0 +1,184 @@
+defmodule VutuvWeb.MentionFormTest do
+  @moduledoc """
+  One stored body, two spellings of the same mention: short inside vutuv, in
+  full on the way out.
+
+  A member writes `@ada`; a server on the other side of the Fediverse writes
+  `@ada@vutuv.de` for the same person. Each spelling is the right one exactly
+  where it was written and wrong where the other one lives — a bare `@ada` on
+  mastodon.social names *their* member of that name, and `@ada@vutuv.de` on a
+  vutuv page spells out the host the reader is already on. So the form is
+  decided at render time, on both sides, and the post itself is never rewritten:
+  the body keeps whatever was typed, which is what lets the same row read
+  correctly in both places.
+
+  `async: false` and its own file because `with_endpoint_host/1` changes global
+  endpoint config the SQL sandbox does not roll back; the test endpoint's
+  "localhost" has no dot and cannot match the address grammar at all.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.EndpointHostHelper
+  import Vutuv.Factory
+
+  alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.Posts.Post
+  alias VutuvWeb.Fediverse.Docs
+  alias VutuvWeb.Markdown
+  alias VutuvWeb.PostTeaser
+
+  setup do
+    with_endpoint_host("vutuv.test")
+    :ok
+  end
+
+  defp member(attrs \\ []) do
+    handle = "ada#{System.unique_integer([:positive])}"
+
+    insert(
+      :activated_user,
+      Keyword.merge(
+        [
+          username: handle,
+          first_name: "Ada",
+          last_name: "Lovelace",
+          fediverse_followers?: true
+        ],
+        attrs
+      )
+    )
+  end
+
+  defp page(%Post{body: body}), do: body |> Markdown.render_post([]) |> safe_to_string()
+
+  defp safe_to_string(safe), do: Phoenix.HTML.safe_to_string(safe)
+
+  defp note(post, author), do: Docs.create_activity(post, author)["object"]
+
+  defp mention_tags(note) do
+    note["tag"] |> List.wrap() |> Enum.filter(&(&1["type"] == "Mention"))
+  end
+
+  describe "a bare @handle" do
+    test "stays short on the page and is spelled out in the Note" do
+      author = member()
+      ada = member()
+      post = insert(:post, user: author, body: "Hallo @#{ada.username}, willkommen!")
+
+      assert page(post) =~ ~s(class="mention">@#{ada.username}</a>)
+
+      content = note(post, author)["content"]
+      assert content =~ ~s(>@#{ada.username}@vutuv.test</a>)
+      # The link still points at the profile page — absolute, because a remote
+      # server renders this HTML on its own domain.
+      assert content =~ ~s(href="#{VutuvWeb.Endpoint.url()}/#{ada.username}")
+    end
+
+    test "of a handle nobody holds is left alone in both places" do
+      author = member()
+      post = insert(:post, user: author, body: "Hallo @nobody_here!")
+
+      assert page(post) =~ "@nobody_here"
+      refute page(post) =~ "<a"
+
+      content = note(post, author)["content"]
+      assert content =~ "@nobody_here"
+      refute content =~ "@nobody_here@vutuv.test"
+    end
+  end
+
+  describe "an address on our own host" do
+    test "reads short on the page and travels whole" do
+      author = member()
+      ada = member()
+      post = insert(:post, user: author, body: "Hallo @#{ada.username}@vutuv.test, willkommen!")
+
+      html = page(post)
+      assert html =~ ~s(class="mention">@#{ada.username}</a>)
+      refute html =~ "vutuv.test"
+
+      assert note(post, author)["content"] =~ ~s(>@#{ada.username}@vutuv.test</a>)
+    end
+
+    test "leaves the stored body untouched, whichever way it was rendered" do
+      author = member()
+      ada = member()
+      body = "Hallo @#{ada.username}@vutuv.test und @#{ada.username}!"
+      post = insert(:post, user: author, body: body)
+
+      page(post)
+      note(post, author)
+
+      assert Repo.get!(Post, post.id).body == body
+    end
+
+    test "is shortened in the plain-text surfaces too" do
+      ada = member()
+
+      assert Markdown.to_plain_text("Hallo @#{ada.username}@vutuv.test!") ==
+               "Hallo @#{ada.username}!"
+    end
+
+    # The one spelling a post from another network has for us, on the surface
+    # with the least room for it. No lookup happens: the handle here is nobody.
+    test "reads short in the tab teaser of a post from another network" do
+      remote = %RemotePost{content_text: "Hallo @patrick@vutuv.test, willkommen!"}
+
+      assert PostTeaser.text(%{remote_post: remote}) == "Hallo @patrick, willkommen!"
+    end
+  end
+
+  describe "the Mention tags on an outgoing Note" do
+    test "name our own accounts by their actor, so the other side can resolve them" do
+      author = member()
+      ada = member()
+      post = insert(:post, user: author, body: "Hallo @#{ada.username}!")
+
+      assert [mention] = mention_tags(note(post, author))
+      assert mention["href"] == Docs.actor_url(ada)
+      assert mention["name"] == "@#{ada.username}@vutuv.test"
+    end
+
+    test "cover a page named by its handle as well" do
+      author = member()
+      handle = "acme#{System.unique_integer([:positive])}"
+
+      organization =
+        insert(:organization, username: handle, name: "Acme GmbH", fediverse_followers?: true)
+
+      post = insert(:post, user: author, body: "Wir bauen mit @#{handle}.")
+
+      assert [mention] = mention_tags(note(post, author))
+      assert mention["href"] == Docs.actor_url(organization)
+      assert mention["name"] == "@#{handle}@vutuv.test"
+    end
+
+    # The address is who is meant whether or not they federate, and it links to
+    # the profile page either way. A Mention would point every receiving server
+    # at an actor document this member does not serve.
+    test "leave out a member who keeps out of the Fediverse — the text still names them" do
+      author = member()
+      quiet = member(fediverse_followers?: false)
+      post = insert(:post, user: author, body: "Hallo @#{quiet.username}!")
+
+      note = note(post, author)
+
+      assert note["content"] =~ ~s(>@#{quiet.username}@vutuv.test</a>)
+      assert mention_tags(note) == []
+    end
+
+    # Minting a Mention from typed text is only safe because every handle here
+    # is resolved against our own tables. An account on somebody else's server
+    # is nobody we have checked, and vouching for it with our signature is what
+    # mention spam looks like.
+    test "are never minted for an address on another server" do
+      author = member()
+      post = insert(:post, user: author, body: "Hallo @bob@geno.social!")
+
+      note = note(post, author)
+
+      assert note["content"] =~ ~s(href="https://geno.social/@bob")
+      assert mention_tags(note) == []
+    end
+  end
+end

--- a/test/vutuv_web/mention_form_test.exs
+++ b/test/vutuv_web/mention_form_test.exs
@@ -126,6 +126,71 @@ defmodule VutuvWeb.MentionFormTest do
 
       assert PostTeaser.text(%{remote_post: remote}) == "Hallo @patrick, willkommen!"
     end
+
+    # The card a reply from another network is read in — the surface that shows
+    # our members named in full more often than any other, because over there
+    # the full address is the only way to name us. It renders through
+    # `render_remote/1` rather than `render_post/2`, a second pipeline with its
+    # own linkify call, so it needs its own test: everything else here could be
+    # green while the one card a member actually reads a mention of themselves
+    # in still spelled out the host.
+    test "reads short in the body of a reply from another network" do
+      ada = member()
+
+      html = Markdown.render_remote("@#{ada.username}@vutuv.test Ggf. reicht es aus.")
+
+      assert html =~ ~s(class="mention">@#{ada.username}</a>)
+      refute html =~ "vutuv.test"
+    end
+
+    # A handle nobody here holds — the member has left, or the remote server
+    # named a page of ours that never existed. Shortened too: a dead handle
+    # reads no better for carrying our host, and the alternative is one
+    # sentence spelling two mentions two different ways.
+    test "of a handle nobody holds still reads short in remote content" do
+      html = Markdown.render_remote("@departed@vutuv.test war hier.")
+
+      assert html =~ "@departed"
+      refute html =~ "vutuv.test"
+    end
+
+    # Somebody else's account, in the same sentence. The rule is about *our*
+    # host and nothing else: shortening this one would name a vutuv member of
+    # that name, who is a different person.
+    test "on another server is left whole" do
+      html = Markdown.render_remote("@feb@social.example und @patrick@vutuv.test")
+
+      assert html =~ "@feb@social.example"
+      assert html =~ "@patrick"
+      refute html =~ "@patrick@vutuv.test"
+    end
+
+    # `https://mastodon.social/@ada@vutuv.test` is Mastodon's web path to a
+    # remote profile, not a mention — and shortened it names *their* @ada, who
+    # is somebody else. The rendered body is safe by accident (the autolinker
+    # has made it an anchor and the entity pass skips those), so the plain-text
+    # route is where this has to be tested.
+    test "inside a URL is left alone, address and prose in the same line" do
+      ada = member()
+
+      # The URL's own display drops the scheme (the autolinker's doing), so the
+      # path is what this asserts on: it still names the account it did.
+      text =
+        Markdown.to_plain_text(
+          "Siehe https://mastodon.social/@#{ada.username}@vutuv.test — oder @#{ada.username}@vutuv.test fragen."
+        )
+
+      assert text =~ "mastodon.social/@#{ada.username}@vutuv.test"
+      assert text =~ "oder @#{ada.username} fragen"
+    end
+
+    # The slash that is not a URL. German prose writes an account name straight
+    # after one, and there the short form is right — the same account, spelled
+    # the way this site spells it.
+    test "after a slash in prose still reads short" do
+      assert Markdown.to_plain_text("Bündnis 90/@gruene@vutuv.test dazu") ==
+               "Bündnis 90/@gruene dazu"
+    end
   end
 
   describe "the Mention tags on an outgoing Note" do


### PR DESCRIPTION
A reply from another network names our members in full: `@wintermeyer@vutuv.de`.
On a vutuv page that host says nothing; on mastodon.social a bare
`@wintermeyer` is somebody else. So the spelling is chosen at render time and
the stored body is never touched. `VutuvWeb.Markdown` shortens by default,
`VutuvWeb.Fediverse.Docs` passes `mention_form: :address` plus a `Mention` tag
per account named. Visible at any post permalink carrying a fediverse reply.

Two commits. The first was written on 2026-08-25, never opened as a PR, and lost
with its worktree; I recovered it from the dangling object. The second fixes a
bug in it. The entity grammar reads a full address after a slash on purpose
(#1694), and Mastodon's path to a remote profile wears that same shape, so
`https://mastodon.social/@ada@vutuv.de` was shortened to `.../@ada`, which names
a different account. The renderer was safe (anchors are skipped); the plain-text
route was not.

15 tests, including the remote card (`render_remote/1`), which had none. All
calibrated red against the unfixed code.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01E1bxUCLUtzz7rRPqPDHjTW
