### PR TITLE
PR review: measure the conflict instead of reading it off the status

### DIFF
--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -145,6 +145,10 @@ scan on it wastes tokens.
 **3. Merge state.** `CONFLICTING`/`DIRTY` → hand back and ask for a rebase onto
 `origin/main`, and say *why* it matters: a conflicting PR gets no CI run at all,
 because GitHub cannot build the merge ref, which reads like broken Actions.
+**Measure the conflict, never read it off the status:** `git fetch origin
+pull/N/head:pr<N>` then `git merge-tree --write-tree origin/main pr<N>` names the
+actual conflicting files in seconds, and `DIRTY` on a PR that sat for weeks is
+usually nothing but the version line.
 **One carve-out:** when the only conflict is the version line in `mix.exs`, that
 collision is our merge rate, not their mistake — rebase it yourself, re-bump,
 and do not count a round.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.365.2",
+      version: "7.365.3",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Four lines in `.claude/commands/pr-review.md`, the review workflow's merge-state
step.

`mergeStateStatus: DIRTY` says only that something collides. On a PR that sat
for a while that is almost always the `mix.exs` version line alone, which the
step right below already carves out as our merge rate rather than the
contributor's mistake. Read without measuring, the same status looks like an
expensive rebase and sends a usable contribution back to its author.

`git fetch origin pull/N/head:prN` plus `git merge-tree --write-tree
origin/main prN` names the actual conflicting files in seconds and without a
worktree, so the handle now sits beside the carve-out it triggers.

Written on 2026-08-24 (branch `pr-review-measure-conflict`), pushed, and never
opened as a PR. Rebased onto main here and re-bumped, since 7.342.2 was long
gone. Found while checking what else had stalled after the same version-line
collision quietly parked #1695.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01E1bxUCLUtzz7rRPqPDHjTW
