### PR TITLE
Fediverse content belongs on the feed's vutuv tab, and inside its threads

### DIFF
--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -357,22 +357,36 @@ that source from 76.7 ms to 0.53 ms.
 segmented control the profile's post-type tabs use
 (`PostComponents.post_filter_tabs/1`, here with `feed_filter_options/0` and the
 `filter-source` event). The split is `feed_page/2`'s `filter:` option, which
-picks the sources rather than filtering their rows: **vutuv** runs the three
-local sources plus the boosts of a *local* post, **Fediverse** the cached posts,
-the local reshares of one and the boosts of a *remote* post. The rule is what
-kind of post an entry carries (`Posts.remote_feed_entry?/1`, the same question
-the renderer asks to pick a card), so every entry lands on exactly one tab and
-the two together are "All" — a member's post that an account out there boosted
-is a vutuv post, however it arrived. The one source producing both kinds
-(`Fediverse.feed_remote_boosts/4`, issue #1167) is narrowed by `only:` **inside
-its query**, not by dropping rows afterwards, so a narrowed page is as full as
-an unnarrowed one and `more?` stays honest.
+picks the sources rather than filtering their rows: **vutuv** runs the four
+local sources, the boosts of a *local* post and the reader's **own** reshares of
+remote content; **Fediverse** the cached posts, everybody else's reshares of one
+and the boosts of a *remote* post.
+
+The rule is who an entry belongs to, which is two questions in order. What kind
+of post it carries decides most of it (`Posts.remote_feed_entry?/1`, the same
+question the renderer asks to pick a card), and **a vutuv act on remote content
+beats that**: pressing Reshare happened here, so what the reader passed on is on
+the vutuv tab, where they go to look for what they did — the reported gap, since
+their own reshare showing only under "Fediverse" reads as vutuv having had no
+part in it. Somebody else's reshare is not theirs and stays on the Fediverse
+tab. Either way every entry lands on exactly one tab and the two together are
+"All" — a member's post that an account out there boosted is a vutuv post,
+however it arrived.
+
+Three sources produce both kinds and are narrowed by `only:` **inside their
+query**, not by dropping rows afterwards, so a narrowed page is as full as an
+unnarrowed one and `more?` stays honest: `Fediverse.feed_remote_boosts/4`
+(issue #1167) on what the boosted thing is, and the two reshare sources
+(`feed_remote_reposts/4` and `feed_remote_reply_reposts/4`, issues #1166 and
+#1275) on who did the resharing — `:mine` against `:others`, one `scope_resharer`
+clause each.
 
 Switching a tab reloads the timeline from the top (`stream reset: true`) — the
 tab decides what the query pulls, so it cannot be applied to what is already on
 screen — and drops the pending batch with it, since the fresh page already
 carries whatever waited behind the pill. Live arrivals are gated by the
-in-memory twin `Posts.feed_filter_accepts?/2`: a followed member's post neither
+in-memory twin `Posts.feed_filter_accepts?/3` — which takes the viewer, because
+"did *you* reshare this" is half the rule: a followed member's post neither
 appears nor counts toward the pill while the Fediverse tab is open. The one
 exception is the **viewer's own** post, which must be visible after they press
 Post — there the feed switches back to "All" rather than swallowing it. The
@@ -1058,6 +1072,37 @@ posts, authors or branches a thread spans it renders once; the archive and saved
 lists fall back to nesting the single direct parent.
 
 All read the same (each a single card of flat `divide-y` rows).
+
+**A conversation does not stop at the site's edge.** The permalink has woven the
+replies written on other networks in among the vutuv ones since issue #1069; the
+feed walked local `reply_ref` links alone, so a thread that ran through another
+network reached the reader with its middle missing — and a member answering such
+a reply looked like they were talking to themselves. `feed_page/2` now decorates
+its entries with both remote halves (`decorate_feed_entries/3`'s `threads: true`,
+which the flat-card surfaces leave off), and `post_thread_entry/1` takes them:
+
+* **`remote_replies`** — the notes under the thread's posts, hung under the post
+  each answers by the same `weave_remote_replies/4` the permalink uses, which
+  also moves a member's answer to a note under that note rather than beside it.
+  Capped at the newest 3 per post (`Fediverse.list_feed_notes/3`), since a post
+  that went round out there is a page to open, not a row to scroll past;
+  exempt from the cap are the notes a post on the page answers, which are
+  load-bearing.
+* **`remote_parents`** — the cached post an answer answers (issue #1165), drawn
+  as the head of that branch in place of its "Replying to @user@host" line.
+
+**One card per thing per page** is the rule both obey, the one `dedupe_remote/1`
+and `collapse_reposts/1` already hold: a reply that is on the page as a reshared
+row of its own is not drawn a second time inside a thread (nor a cached post
+that has its own card), and within the threads the first claim wins. A second
+card is not merely repetition — the action bar is a LiveComponent keyed by the
+subject, so a duplicate id takes the render down.
+
+A surface that draws these cards **owes their events**: the ⋯ menu's
+`remove-remote-reply` / `report-remote-reply` (`VutuvWeb.Live.RemoteReplyActions`,
+the sibling of `RemotePostActions`) and the cached card's three. An unhandled
+`phx-click` kills the LiveView, and the feed had been drawing the reply card for
+a reshared reply (issue #1275) without either handler.
 
 The notification page reuses the compact `post_preview/1` for the post a
 like/reply quotes.

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -2619,8 +2619,17 @@ defmodule Vutuv.Fediverse do
   through somebody here vouching for it — so it is scoped to the reposter, not
   to any follow of the author. Stamped with the repost time, like a local
   repost: what is new is the sharing, not the post.
+
+  `only:` keeps just one of the two resharers this source carries — `:mine`
+  for the viewer's own reshares, `:others` for everybody else's — which is how
+  the feed's source tabs split it (`Vutuv.Posts.feed_page/2`): pressing that
+  button is a vutuv act, so what the reader themselves passed on belongs on the
+  vutuv tab. It narrows the **query**, not the rows it returns, so a narrowed
+  page is as full as an unnarrowed one and `more?` stays honest.
   """
-  def feed_remote_reposts(%User{id: viewer_id} = viewer, fetch_n, cursor) do
+  def feed_remote_reposts(viewer, fetch_n, cursor, opts \\ [])
+
+  def feed_remote_reposts(%User{id: viewer_id} = viewer, fetch_n, cursor, opts) do
     if enabled?() do
       from(r in PostRepost,
         join: p in RemotePost,
@@ -2629,16 +2638,8 @@ defmodule Vutuv.Fediverse do
         join: a in RemoteAccount,
         on: a.id == p.remote_account_id,
         join: reposter in User,
+        as: :resharer,
         on: reposter.id == r.user_id,
-        where: r.user_id == ^viewer_id or r.user_id in subquery(unmuted_followees(viewer_id)),
-        # A resharer who is not in good standing amplifies nothing. Stricter
-        # than the local repost source, deliberately: that one only asks about
-        # a confirmed address, and carrying a *third party's* post into other
-        # people's feeds is exactly what a frozen or suspended account must not
-        # be able to keep doing while its case is open.
-        where:
-          r.user_id == ^viewer_id or
-            (account_confirmed_row(reposter) and not account_hidden_row(reposter)),
         # Only ever what the reposter could have shared: the audience gate is
         # the same one that let them press the button.
         where: p.audience in ^RemotePost.open_audiences(),
@@ -2646,6 +2647,7 @@ defmodule Vutuv.Fediverse do
         limit: ^fetch_n,
         preload: [remote_post: {p, [:screenshot, remote_account: a]}, user: reposter]
       )
+      |> scope_resharer(viewer_id, Keyword.get(opts, :only))
       |> Vutuv.Posts.named_language_scope(Vutuv.Posts.feed_language_filter(viewer))
       |> remote_reposts_at_or_before(cursor)
       |> Repo.all()
@@ -2653,6 +2655,35 @@ defmodule Vutuv.Fediverse do
     else
       []
     end
+  end
+
+  # Who may have carried a third party's words into this feed, for both reshare
+  # sources (a cached post and a reply are the same act one table over).
+  #
+  # The viewer's own row needs no standing check — they are reading their own
+  # act — while somebody else's is held to a stricter rule than the local repost
+  # source applies: that one only asks about a confirmed address, and passing a
+  # stranger's post into other people's feeds is exactly what a frozen or
+  # suspended account must not be able to keep doing while its case is open.
+  defp scope_resharer(query, viewer_id, :mine), do: where(query, [r], r.user_id == ^viewer_id)
+
+  defp scope_resharer(query, viewer_id, :others) do
+    where(
+      query,
+      [r, resharer: resharer],
+      r.user_id != ^viewer_id and r.user_id in subquery(unmuted_followees(viewer_id)) and
+        account_confirmed_row(resharer) and not account_hidden_row(resharer)
+    )
+  end
+
+  defp scope_resharer(query, viewer_id, _both) do
+    where(
+      query,
+      [r, resharer: resharer],
+      r.user_id == ^viewer_id or
+        (r.user_id in subquery(unmuted_followees(viewer_id)) and
+           account_confirmed_row(resharer) and not account_hidden_row(resharer))
+    )
   end
 
   # The same rule the local feed uses: a muted follow keeps the relationship and
@@ -4710,6 +4741,57 @@ defmodule Vutuv.Fediverse do
     )
     |> Repo.all()
     |> Enum.group_by(& &1.post_id)
+  end
+
+  @doc """
+  The same replies as `list_notes/2`, capped at the newest `:per_post` of each
+  post — what the **feed** weaves into its threads, where the permalink shows
+  every one.
+
+  The cap is what keeps a post that went round out there from taking over a
+  timeline: a conversation with forty answers is a page to open, not a row to
+  scroll past. `:keep` names ids the cap must not drop — a note that one of the
+  page's own posts answers, which would otherwise leave that answer hanging
+  under nothing — and it is applied **inside** the visibility scope, so a
+  private note stays private even when its answer is on the page.
+  """
+  def list_feed_notes(post_ids, viewer, opts \\ [])
+
+  def list_feed_notes([], _viewer, _opts), do: %{}
+
+  def list_feed_notes(post_ids, viewer, opts) do
+    if enabled?() do
+      per_post = Keyword.get(opts, :per_post, 3)
+      keep = Keyword.get(opts, :keep, [])
+
+      ranked =
+        from(n in Note,
+          join: p in Post,
+          on: p.id == n.post_id,
+          where: n.post_id in ^post_ids,
+          where: n.audience == "public" or p.user_id == ^note_viewer_id(viewer),
+          select: %{
+            id: n.id,
+            rank:
+              over(row_number(),
+                partition_by: n.post_id,
+                order_by: [desc: n.received_at, desc: n.id]
+              )
+          }
+        )
+
+      wanted =
+        from(r in subquery(ranked), where: r.rank <= ^per_post or r.id in ^keep, select: r.id)
+
+      from(n in notes_with_account(),
+        where: n.id in subquery(wanted),
+        order_by: [asc: n.received_at, asc: n.id]
+      )
+      |> Repo.all()
+      |> Enum.group_by(& &1.post_id)
+    else
+      %{}
+    end
   end
 
   # Notes carrying `account_id`: whether we hold a row for the actor who wrote
@@ -7113,28 +7195,23 @@ defmodule Vutuv.Fediverse do
   The seventh feed source (issue #1275): **replies** from another network that
   people the viewer follows **here** have passed on.
 
-  The exact twin of `feed_remote_reposts/3` one table over, and scoped the same
+  The exact twin of `feed_remote_reposts/4` one table over, and scoped the same
   way — to the resharer, never to any follow of the author, because being
   vouched for by somebody here is the whole reason this row reaches a member who
   follows nobody out there. Stamped with the reshare time: what is new is the
-  sharing.
+  sharing. `only:` splits it between the source tabs exactly as it does there.
   """
-  def feed_remote_reply_reposts(%User{id: viewer_id} = viewer, fetch_n, cursor) do
+  def feed_remote_reply_reposts(viewer, fetch_n, cursor, opts \\ [])
+
+  def feed_remote_reply_reposts(%User{id: viewer_id} = viewer, fetch_n, cursor, opts) do
     if enabled?() do
       from(r in NoteRepost,
         join: n in Note,
         as: :language_source,
         on: n.id == r.note_id,
         join: resharer in User,
+        as: :resharer,
         on: resharer.id == r.user_id,
-        where: r.user_id == ^viewer_id or r.user_id in subquery(unmuted_followees(viewer_id)),
-        # A resharer who is not in good standing amplifies nothing — the same
-        # stricter rule the cached-post reshare source applies, and for the same
-        # reason: carrying a third party's words into other people's feeds is
-        # exactly what a frozen or suspended account must not keep doing.
-        where:
-          r.user_id == ^viewer_id or
-            (account_confirmed_row(resharer) and not account_hidden_row(resharer)),
         # Only ever what the resharer could have shared: the audience gate is the
         # same one that let them press the button, re-asked here because a note's
         # audience can be narrowed by an upstream `Update` after the fact.
@@ -7142,6 +7219,7 @@ defmodule Vutuv.Fediverse do
         order_by: [desc: r.inserted_at, desc: r.id],
         preload: [note: n, user: resharer]
       )
+      |> scope_resharer(viewer_id, Keyword.get(opts, :only))
       |> Vutuv.Posts.named_language_scope(Vutuv.Posts.feed_language_filter(viewer))
       |> limit(^fetch_n)
       |> note_reposts_at_or_before(cursor)

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -2611,37 +2611,45 @@ defmodule Vutuv.Posts do
 
     page = Vutuv.FeedPage.paginate(feed_sources(viewer, filter), limit, cursor)
 
-    %{page | entries: decorate_feed_entries(page.entries, viewer)}
+    %{page | entries: decorate_feed_entries(page.entries, viewer, threads: true)}
   end
 
   # The six sources the merged feed pulls from, narrowed to the reader's tab.
   #
-  # The two tabs partition the feed by **what kind of post an entry carries**
-  # (`remote_feed_entry?/1`) — the same question the renderer asks to pick a
-  # card, so every entry lands on exactly one tab and the two together are
-  # "All". That rule decides the one source that produces both kinds:
-  # `feed_remote_boosts/4` (issue #1167) carries a cached remote post when the
-  # boosted thing lives out there, and a plain vutuv post when a followed
-  # account passed a member's post on — the latter *is* a vutuv post, so it
-  # belongs on the vutuv tab even though it arrived through the fediverse.
-  # `:only` narrows that source inside its own query rather than by filtering
-  # rows afterwards, so a page is never short of what the paginator fetched
-  # for it (which is what decides `more?`).
+  # The two tabs partition the feed by **who the entry belongs to**, which is
+  # two questions in order. What kind of post it carries decides most of it
+  # (`remote_feed_entry?/1` — the same question the renderer asks to pick a
+  # card), and a **vutuv act on remote content beats that**: pressing Reshare
+  # is something that happened here, so the reader's own reshare of a post from
+  # another network is on the vutuv tab, where they go to see what they did.
+  # Somebody else's reshare is not theirs and stays on the Fediverse tab.
+  # Either way every entry lands on exactly one tab and the two together are
+  # "All".
+  #
+  # Two sources produce both kinds, and both are narrowed by `:only` **inside
+  # their own query** rather than by dropping rows afterwards, so a page is
+  # never short of what the paginator fetched for it (which is what decides
+  # `more?`). `feed_remote_boosts/4` (issue #1167) carries a cached remote post
+  # when the boosted thing lives out there and a plain vutuv post when a
+  # followed account passed a member's post on — the latter *is* a vutuv post.
+  # The two reshare sources (issues #1166 and #1275) split on the resharer.
   defp feed_sources(viewer, :vutuv) do
     [
       &feed_post_items(viewer, &1, &2),
       &feed_organization_post_items(viewer, &1, &2),
       &feed_repost_items(viewer, &1, &2),
       &feed_tag_items(viewer, &1, &2),
-      &Vutuv.Fediverse.feed_remote_boosts(viewer, &1, &2, only: :local)
+      &Vutuv.Fediverse.feed_remote_boosts(viewer, &1, &2, only: :local),
+      &Vutuv.Fediverse.feed_remote_reposts(viewer, &1, &2, only: :mine),
+      &Vutuv.Fediverse.feed_remote_reply_reposts(viewer, &1, &2, only: :mine)
     ]
   end
 
   defp feed_sources(viewer, :fediverse) do
     [
       &Vutuv.Fediverse.feed_remote_posts(viewer, &1, &2),
-      &Vutuv.Fediverse.feed_remote_reposts(viewer, &1, &2),
-      &Vutuv.Fediverse.feed_remote_reply_reposts(viewer, &1, &2),
+      &Vutuv.Fediverse.feed_remote_reposts(viewer, &1, &2, only: :others),
+      &Vutuv.Fediverse.feed_remote_reply_reposts(viewer, &1, &2, only: :others),
       &Vutuv.Fediverse.feed_remote_boosts(viewer, &1, &2, only: :remote)
     ]
   end
@@ -2727,13 +2735,28 @@ defmodule Vutuv.Posts do
   end
 
   @doc """
-  Whether the feed tab `filter` shows `entry` — the in-memory twin of the
-  source split in `feed_sources/2`, for the entries that arrive live over
+  Whether the feed tab `filter` shows `entry` for `viewer` — the in-memory twin
+  of the source split in `feed_sources/2`, for the entries that arrive live over
   PubSub rather than through a query.
+
+  `viewer` is what makes it a twin rather than a near-miss: the split is not
+  "which kind of post" alone, it is that a reshare the reader pressed
+  themselves counts as a vutuv act (see `feed_sources/2`), and only the reader
+  can say whether they pressed it.
   """
-  def feed_filter_accepts?(:vutuv, entry), do: not remote_feed_entry?(entry)
-  def feed_filter_accepts?(:fediverse, entry), do: remote_feed_entry?(entry)
-  def feed_filter_accepts?(_all, _entry), do: true
+  def feed_filter_accepts?(:vutuv, entry, viewer),
+    do: not remote_feed_entry?(entry) or own_reshare?(entry, viewer)
+
+  def feed_filter_accepts?(:fediverse, entry, viewer),
+    do: remote_feed_entry?(entry) and not own_reshare?(entry, viewer)
+
+  def feed_filter_accepts?(_all, _entry, _viewer), do: true
+
+  # Whether this entry is here because the reader passed it on.
+  defp own_reshare?(entry, %User{id: viewer_id}),
+    do: entry[:reposted_by] != nil and entry.reposted_by.id == viewer_id
+
+  defp own_reshare?(_entry, _viewer), do: false
 
   @doc """
   Whether `viewer`'s feed can show anything from another network at all — the
@@ -2845,7 +2868,12 @@ defmodule Vutuv.Posts do
   # below free of "unless this is a remote entry" branches, and the merge is
   # needed (rather than a guarded map) because `collapse_threads/1` and
   # `collapse_reposts/1` drop and fold entries, so the local half is not 1:1.
-  defp decorate_feed_entries(entries, viewer) do
+  # `threads: true` adds the two reads only a surface that draws the nested
+  # conversation can use (`<.post_thread_entry>`): the replies from other
+  # networks under this page's posts, and the cached posts they answer. The
+  # organization feed renders flat `<.post_card>`s and the tab ticker quotes a
+  # single row, so both would pay for something they cannot show.
+  defp decorate_feed_entries(entries, viewer, opts \\ []) do
     {remote, local} = Enum.split_with(entries, &remote_feed_entry?/1)
 
     local =
@@ -2854,9 +2882,145 @@ defmodule Vutuv.Posts do
       |> collapse_threads()
       |> collapse_reposts()
       |> attach_reposters(viewer)
+      |> attach_remote_thread(viewer, remote, Keyword.get(opts, :threads, false))
 
     Vutuv.FeedPage.sort_entries(local ++ decorate_remote(remote, viewer))
   end
+
+  defp attach_remote_thread(local, _viewer, _remote, false), do: local
+
+  defp attach_remote_thread(local, viewer, remote, true) do
+    local
+    |> attach_thread_notes(viewer, standalone_note_ids(remote))
+    |> attach_remote_parents(viewer, standalone_remote_post_ids(remote))
+  end
+
+  # The cached post a member's answer answers (issue #1165), so the feed can
+  # draw it above them instead of the bare "Replying to @user@host" line an
+  # answer with nothing to read above it used to be.
+  #
+  # It rides `remote_reply_ref`, already preloaded with its account
+  # (`post_preloads/0`), so this costs no lookup — only the same three batch
+  # reads a remote card needs anywhere (its pictures, the reader's marks, the
+  # reader's follow), run once for the page. `taken` keeps a post that already
+  # has a card of its own from getting a second one, exactly as for a reply.
+  defp attach_remote_parents(entries, viewer, taken) do
+    taken = MapSet.new(taken)
+
+    parents =
+      for entry <- entries,
+          post <- thread_posts(entry),
+          %RemotePost{} = parent <- [remote_parent(post)],
+          parent.id not in taken,
+          do: %{post_id: post.id, remote_post: parent}
+
+    case Enum.uniq_by(parents, & &1.remote_post.id) do
+      [] ->
+        entries
+
+      unique ->
+        decorated =
+          unique
+          |> attach_remote_images()
+          |> attach_remote_follows(viewer)
+          |> attach_remote_likes(viewer)
+          |> Map.new(&{&1.remote_post.id, &1})
+
+        # Back onto every post that answers one — `unique` dropped the repeats
+        # the batch reads must not pay for, not the places they render.
+        by_post = Map.new(parents, &{&1.post_id, decorated[&1.remote_post.id]})
+
+        Enum.map(entries, &claim_remote_parents(&1, by_post))
+    end
+  end
+
+  defp claim_remote_parents(entry, by_post) do
+    case Map.take(by_post, Enum.map(thread_posts(entry), & &1.id)) do
+      mine when mine == %{} -> entry
+      mine -> Map.put(entry, :remote_parents, mine)
+    end
+  end
+
+  defp remote_parent(%Post{remote_reply_ref: %PostRemoteReply{remote_post: %RemotePost{} = p}}),
+    do: p
+
+  defp remote_parent(_post), do: nil
+
+  # The cached posts that already have a card of their own on this page.
+  defp standalone_remote_post_ids(remote),
+    do: for(entry <- remote, entry[:remote_post], do: entry.remote_post.id)
+
+  # The replies from other networks (issues #1069/#1071) that belong inside the
+  # threads on this page, read once for the whole page and hung on the entries
+  # that carry them.
+  #
+  # A conversation does not stop at the site's edge: somebody answers a member's
+  # post from their own server, a member here answers *that*, and until this the
+  # feed drew the two vutuv posts as one thread with the middle missing — which
+  # reads as a member talking to themselves. The permalink has woven these in
+  # since #1069; this is the same weave one surface over, and the renderer's
+  # `weave_remote_replies/4` does the nesting for both.
+  #
+  # Capped per post (`Fediverse.list_feed_notes/3`), except for the ones a post
+  # on the page answers: those are load-bearing, not decoration.
+  #
+  # **One card per reply per page**, the rule `dedupe_remote/1` and
+  # `collapse_reposts/1` already hold for the other two kinds. A reply can reach
+  # one page twice — as a row of its own because somebody here reshared it
+  # (issue #1275), and inside the thread under the post it answers — and a
+  # second card is not merely repetition: its action bar is a LiveComponent
+  # keyed by the note, so the duplicate id takes the render down. The standalone
+  # row wins, since it carries the reshare that put it there; within the threads
+  # the first claim wins, because a post nested as an ancestor under one entry
+  # can be the carrier of another.
+  defp attach_thread_notes(entries, viewer, taken) do
+    posts = for entry <- entries, post <- thread_posts(entry), do: post
+
+    case Vutuv.Fediverse.list_feed_notes(Enum.map(posts, & &1.id), viewer,
+           keep: Enum.flat_map(posts, &answered_note_ids/1)
+         ) do
+      empty when empty == %{} ->
+        entries
+
+      notes ->
+        marks = notes |> Map.values() |> List.flatten() |> Vutuv.Fediverse.mark_lookup(viewer)
+
+        {entries, _seen} =
+          Enum.map_reduce(entries, MapSet.new(taken), &claim_thread_notes(&1, &2, notes, marks))
+
+        entries
+    end
+  end
+
+  defp claim_thread_notes(entry, seen, notes, marks) do
+    mine =
+      entry
+      |> thread_posts()
+      |> Map.new(fn post -> {post.id, Enum.reject(notes[post.id] || [], &(&1.id in seen))} end)
+      |> Map.reject(fn {_post_id, notes} -> notes == [] end)
+
+    if mine == %{} do
+      {entry, seen}
+    else
+      claimed = for {_post_id, notes} <- mine, note <- notes, into: seen, do: note.id
+
+      {entry |> Map.put(:remote_replies, mine) |> Map.put(:note_marks, marks), claimed}
+    end
+  end
+
+  # The notes that already have a row of their own on this page (issue #1275).
+  defp standalone_note_ids(remote), do: for(entry <- remote, entry[:note], do: entry.note.id)
+
+  # Every vutuv post an entry draws: the carrier and the thread nested under it.
+  defp thread_posts(%{post: %Post{} = post} = entry), do: [post | entry[:ancestors] || []]
+  defp thread_posts(_entry), do: []
+
+  # The remote reply this post answers (issue #1070), if it answers one at all.
+  defp answered_note_ids(%Post{remote_reply_ref: %PostRemoteReply{note_id: id}})
+       when is_binary(id),
+       do: [id]
+
+  defp answered_note_ids(_post), do: []
 
   defp decorate_remote([], _viewer), do: []
 

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -793,6 +793,25 @@ defmodule VutuvWeb.PostComponents do
     doc: "%{post_id => engagement} for the ancestor cards' action bars; missing = self-load"
   )
 
+  attr(:remote_replies, :map,
+    default: %{},
+    doc:
+      "`%{post_id => [%Note{}]}` for the thread's posts (`Vutuv.Posts.attach_thread_notes/2`), " <>
+        "woven in among the vutuv replies; empty on a surface that does not host their events"
+  )
+
+  attr(:note_marks, :any,
+    default: nil,
+    doc: "the viewer's like/repost/bookmark flags per note (`Vutuv.Fediverse.mark_lookup/2`)"
+  )
+
+  attr(:remote_parents, :map,
+    default: %{},
+    doc:
+      "`%{post_id => decorated cached post}` (`Vutuv.Posts.attach_remote_parents/3`) for the " <>
+        "posts here that answer one out there (issue #1165) — drawn above them as a card"
+  )
+
   attr(:reposted_by, :any, default: nil)
   attr(:reposters, :any, default: nil)
   attr(:entry_id, :string, default: nil)
@@ -816,7 +835,10 @@ defmodule VutuvWeb.PostComponents do
     assigns = assign(assigns, :roots, thread_entry_roots(assigns))
 
     ~H"""
-    <%= if @ancestors == [] do %>
+    <%!-- Content from another network makes a lone post a conversation too —
+    replies under it (issue #1069), or the post it answers out there (issue
+    #1165) — so the flat card is only for a post that has none of the three. --%>
+    <%= if @ancestors == [] and @remote_replies == %{} and @remote_parents == %{} do %>
       <.post_card
         post={@post}
         viewer={@viewer}
@@ -878,7 +900,31 @@ defmodule VutuvWeb.PostComponents do
       entry_id: assigns.entry_id
     }
 
-    (ancestors ++ [leaf]) |> Posts.thread_forest() |> banner_on_roots()
+    (ancestors ++ [leaf])
+    |> Posts.thread_forest()
+    |> banner_on_roots()
+    |> weave_remote_replies(
+      assigns.remote_replies,
+      assigns.viewer,
+      assigns.note_marks || fn _note -> nil end
+    )
+    |> nest_remote_parents(assigns.remote_parents)
+  end
+
+  # Puts the cached post an answer answers above it, as the root of that branch
+  # (issue #1165). Only a root can have one: a post that answers something out
+  # there has no parent *here*, so `thread_forest/1` never nests it under
+  # anything. The answer keeps its own card and loses its "Replying to" line,
+  # the card above now being what that line was pointing at.
+  defp nest_remote_parents(roots, parents) when parents == %{}, do: roots
+
+  defp nest_remote_parents(roots, parents) do
+    Enum.map(roots, fn root ->
+      case parents[root.post.id] do
+        nil -> root
+        parent -> Map.put(parent, :children, [%{root | show_reply_banner: false}])
+      end
+    end)
   end
 
   # A card that hangs under the post it answers needs no "Replying to @handle"
@@ -1004,40 +1050,56 @@ defmodule VutuvWeb.PostComponents do
           aria-hidden="true"
         >
         </span>
-        <%!-- A node is either a vutuv post or a reply from another network
-        (issue #1069), which sits among them as an ordinary sibling in time
-        order and wears its own skin. --%>
-        <%= if Map.has_key?(node, :note) do %>
-          <%!-- `acts?` unconditionally: the conversation is only ever rendered
-          by `VutuvWeb.PostLive.Thread`, which handles the heart's events — and
-          on its throwaway dead render the buttons are as live as every other
-          `phx-click` on the page, which is to say the moment the socket
-          connects. --%>
-          <.remote_reply_card
-            note={node.note}
-            owner?={node.owner?}
-            viewer={@viewer}
-            marks={node.marks}
-            translations={@translations}
-            live?
-          />
-        <% else %>
-          <.post_card
-            post={node.post}
-            viewer={@viewer}
-            acting_as={@acting_as}
-            viewer_follow={node.viewer_follow}
-            engagement={node.engagement}
-            reposted_by={node.reposted_by}
-            reposters={node.reposters}
-            entry_id={node.entry_id}
-            surface={@surface}
-            conn_or_socket={@conn_or_socket}
-            mode={Map.get(node, :mode, :preview)}
-            likers={Map.get(node, :likers)}
-            translations={@translations}
-            show_reply_banner={reply_banner?(node, @connected?, @indent?)}
-          />
+        <%!-- A node is a vutuv post, a reply from another network (issue #1069)
+        sitting among them as an ordinary sibling in time order, or the cached
+        post an answer answers (issue #1165) at the head of its branch. The last
+        two wear their own skin. --%>
+        <%= cond do %>
+          <% Map.has_key?(node, :remote_post) -> %>
+            <%!-- The head of the branch, so no reshare line and no ⋯ owner
+            item: what it says is "this is what is being answered". Its own
+            menu's three events are the cached card's everywhere
+            (`VutuvWeb.Live.RemotePostActions`), which every host of this
+            chain already handles. --%>
+            <.remote_post_card
+              live?
+              remote_post={node.remote_post}
+              images={node[:images] || []}
+              marks={node[:marks]}
+              following?={node[:following?] == true}
+              viewer={@viewer}
+              translations={@translations}
+            />
+          <% Map.has_key?(node, :note) -> %>
+            <%!-- `acts?` unconditionally: the conversation is only ever rendered
+            by a LiveView that handles the heart's events — and on a throwaway
+            dead render the buttons are as live as every other `phx-click` on
+            the page, which is to say the moment the socket connects. --%>
+            <.remote_reply_card
+              note={node.note}
+              owner?={node.owner?}
+              viewer={@viewer}
+              marks={node.marks}
+              translations={@translations}
+              live?
+            />
+          <% true -> %>
+            <.post_card
+              post={node.post}
+              viewer={@viewer}
+              acting_as={@acting_as}
+              viewer_follow={node.viewer_follow}
+              engagement={node.engagement}
+              reposted_by={node.reposted_by}
+              reposters={node.reposters}
+              entry_id={node.entry_id}
+              surface={@surface}
+              conn_or_socket={@conn_or_socket}
+              mode={Map.get(node, :mode, :preview)}
+              likers={Map.get(node, :likers)}
+              translations={@translations}
+              show_reply_banner={reply_banner?(node, @connected?, @indent?)}
+            />
         <% end %>
       </div>
       <.thread_chain

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -46,6 +46,7 @@ defmodule VutuvWeb.PostLive.Feed do
   alias VutuvWeb.Live.MountHandoff
   alias VutuvWeb.Live.PostTranslations
   alias VutuvWeb.Live.RemotePostActions
+  alias VutuvWeb.Live.RemoteReplyActions
   alias VutuvWeb.Markdown
   alias VutuvWeb.PostTeaser
   alias VutuvWeb.UserHelpers
@@ -669,6 +670,18 @@ defmodule VutuvWeb.PostLive.Feed do
     RemotePostActions.unfollow(socket, account_id, &drop_remote_entries_of(&1, account_id))
   end
 
+  # The same two acts on a reply from another network, which the feed now draws
+  # both as a row of its own (a reshare, issue #1275) and inside a thread. Its
+  # menu is rendered here, so its events are owed here — see
+  # `VutuvWeb.Live.RemoteReplyActions`.
+  def handle_event("remove-remote-reply", %{"id" => id}, socket) do
+    take_down_note(socket, id, &RemoteReplyActions.remove/2)
+  end
+
+  def handle_event("report-remote-reply", %{"id" => id}, socket) do
+    take_down_note(socket, id, &RemoteReplyActions.report/2)
+  end
+
   # The "New here" card's Follow button: welcome the newcomer with no reload.
   #
   # The row deliberately **stays** afterwards, flipped to its "Following" state,
@@ -1058,7 +1071,8 @@ defmodule VutuvWeb.PostLive.Feed do
       # vutuv post, so on the Fediverse tab there is no row to put it in — the
       # feed switches back to All and reloads rather than swallowing the post,
       # which from the composer reads as the post having been lost.
-      actor_id == user.id and not Posts.feed_filter_accepts?(socket.assigns.feed_filter, entry) ->
+      actor_id == user.id and
+          not Posts.feed_filter_accepts?(socket.assigns.feed_filter, entry, user) ->
         {:noreply,
          socket
          |> assign(:composer_open?, false)
@@ -1092,7 +1106,7 @@ defmodule VutuvWeb.PostLive.Feed do
       # A post nobody on this tab asked for must not be counted by the pill
       # either: the pill's whole promise is that clicking it shows those posts
       # right here.
-      Posts.feed_filter_accepts?(socket.assigns.feed_filter, entry) ->
+      Posts.feed_filter_accepts?(socket.assigns.feed_filter, entry, user) ->
         {:noreply, update(socket, :pending_posts, &[decorate(entry, user, socket) | &1])}
 
       # It belongs on a tab the reader is not looking at, so say so there
@@ -1416,6 +1430,51 @@ defmodule VutuvWeb.PostLive.Feed do
     |> then(&assign(&1, :empty?, &1.assigns.entries == [] and &1.assigns.pending_posts == []))
   end
 
+  # A reply that is gone leaves the page in the same round trip, wherever it was
+  # showing: its own row goes, and a thread that nested it re-renders without
+  # it. Both, not either — the same reply can be on the page as a reshared row
+  # while a *different* entry's thread holds another one under the post it
+  # answers.
+  defp take_down_note(socket, note_id, fun) do
+    case fun.(note_id, socket.assigns.current_user) do
+      {:ok, done} -> {:noreply, socket |> put_flash(:info, done) |> drop_note(note_id)}
+      {:error, nil} -> {:noreply, socket}
+      {:error, message} -> {:noreply, put_flash(socket, :error, message)}
+    end
+  end
+
+  defp drop_note(socket, note_id) do
+    {going, rest} = Enum.split_with(socket.assigns.entries, &note_entry?(&1, note_id))
+    kept = Enum.map(rest, &without_note(&1, note_id))
+    changed = for {before, now} <- Enum.zip(rest, kept), before != now, do: now
+
+    socket
+    |> assign(:entries, kept)
+    |> then(fn socket ->
+      Enum.reduce(going, socket, &stream_delete_by_dom_id(&2, :posts, "feed-#{&1.id}"))
+    end)
+    |> then(fn socket ->
+      Enum.reduce(changed, socket, &stream_insert(&2, :posts, &1, update_only: true))
+    end)
+    |> then(&assign(&1, :empty?, &1.assigns.entries == [] and &1.assigns.pending_posts == []))
+  end
+
+  defp note_entry?(entry, note_id),
+    do: Posts.remote_reply_entry?(entry) and entry.note.id == note_id
+
+  defp without_note(%{remote_replies: replies} = entry, note_id) do
+    kept =
+      replies
+      |> Map.new(fn {post_id, notes} -> {post_id, Enum.reject(notes, &(&1.id == note_id))} end)
+      |> Map.reject(fn {_post_id, notes} -> notes == [] end)
+
+    # An entry with none left goes back to being a plain card, so the key goes
+    # rather than holding an empty map: `post_thread_entry/1` reads its presence.
+    if kept == %{}, do: Map.delete(entry, :remote_replies), else: %{entry | remote_replies: kept}
+  end
+
+  defp without_note(entry, _note_id), do: entry
+
   # Both toggles on a remote card, one shape: the heart (issue #1164) and the
   # reshare (issue #1166). The entry is re-inserted into the stream rather than
   # an assign being flipped: a stream item redraws only when its own entry is
@@ -1711,6 +1770,9 @@ defmodule VutuvWeb.PostLive.Feed do
                     viewer_follow={entry[:viewer_follow]}
                     ancestors={entry[:ancestors]}
                     ancestor_engagement={entry[:ancestor_engagement] || %{}}
+                    remote_replies={entry[:remote_replies] || %{}}
+                    note_marks={entry[:note_marks]}
+                    remote_parents={entry[:remote_parents] || %{}}
                     reposted_by={entry.reposted_by}
                     reposters={entry[:reposters]}
                     entry_id={entry.id}

--- a/lib/vutuv_web/live/post_live/thread.ex
+++ b/lib/vutuv_web/live/post_live/thread.ex
@@ -54,6 +54,7 @@ defmodule VutuvWeb.PostLive.Thread do
   alias VutuvWeb.Live.InitAssigns
   alias VutuvWeb.Live.MountHandoff
   alias VutuvWeb.Live.PostTranslations
+  alias VutuvWeb.Live.RemoteReplyActions
   alias VutuvWeb.PostLive.ActionsComponent
 
   # The origin's like/repost figures on a card from another network tick
@@ -148,17 +149,11 @@ defmodule VutuvWeb.PostLive.Thread do
   # freezer, because unlike a member's own post this is a cache of something
   # that still exists at its origin.
   def handle_event("remove-remote-reply", %{"id" => id}, socket) do
-    {:noreply, take_down(socket, id, &Fediverse.remove_note/2, gettext("Reply removed."))}
+    {:noreply, take_down(socket, id, &RemoteReplyActions.remove/2)}
   end
 
   def handle_event("report-remote-reply", %{"id" => id}, socket) do
-    {:noreply,
-     take_down(
-       socket,
-       id,
-       &Fediverse.report_note/2,
-       gettext("Thank you. The reply was deleted right away.")
-     )}
+    {:noreply, take_down(socket, id, &RemoteReplyActions.report/2)}
   end
 
   @impl true
@@ -339,26 +334,14 @@ defmodule VutuvWeb.PostLive.Thread do
   #
   # A successful takedown says so by the card vanishing, which is why it clears
   # the notice rather than setting one.
-  defp take_down(socket, id, fun, _message) do
-    case socket.assigns.current_user do
-      nil ->
-        socket
-
-      viewer ->
-        case fun.(id, viewer) do
-          :ok ->
-            socket |> assign(:notice, nil) |> load_window()
-
-          {:error, :rate_limited} ->
-            assign(
-              socket,
-              :notice,
-              gettext("You have reported a lot today. Please try again tomorrow.")
-            )
-
-          _ ->
-            assign(socket, :notice, gettext("That reply is not yours to remove."))
-        end
+  # The page says nothing on success — the reply is gone from the conversation,
+  # which is the answer — and shows the refusal in its own `:notice` assign
+  # rather than a flash, this being a `live_render`ed child.
+  defp take_down(socket, id, fun) do
+    case fun.(id, socket.assigns.current_user) do
+      {:ok, _done} -> socket |> assign(:notice, nil) |> load_window()
+      {:error, nil} -> socket
+      {:error, message} -> assign(socket, :notice, message)
     end
   end
 

--- a/lib/vutuv_web/live/remote_reply_actions.ex
+++ b/lib/vutuv_web/live/remote_reply_actions.ex
@@ -1,0 +1,69 @@
+defmodule VutuvWeb.Live.RemoteReplyActions do
+  @moduledoc """
+  The two acts a remote reply's ⋯ menu offers — the post's author removes it,
+  anybody who can read it reports it — once, for every surface that renders
+  `VutuvWeb.PostComponents.remote_reply_card/1`.
+
+  The sibling of `VutuvWeb.Live.RemotePostActions` one subject over, and it
+  exists for the same reason: **an unhandled `phx-click` takes the LiveView
+  down**, so a card whose host forgot one of its events is a button that kills
+  the page. That had already happened — the feed drew this card for a reshared
+  reply (issue #1275) while only the permalink handled `remove-remote-reply` /
+  `report-remote-reply`, so Report was a page-killer there for anyone who
+  pressed it.
+
+  Both acts **delete our copy at once** (`Vutuv.Fediverse`), which is the whole
+  workflow: unlike a member's own post this is a cache of something that still
+  exists at its origin, so there is no case and no freezer. A report also goes
+  out to that origin as a `Flag`.
+
+  What differs per surface is only how the answer is shown — the permalink
+  writes its own `:notice` assign, the feed a flash — and what to do with the
+  space the card leaves. So this returns the outcome and its sentence, and each
+  host says it its own way; sharing the sentences is the point, since they are
+  what drifts when the same act is spelled twice.
+  """
+
+  use Gettext, backend: VutuvWeb.Gettext
+
+  alias Vutuv.Accounts.User
+  alias Vutuv.Fediverse
+
+  @doc """
+  The member takes a reply from another network off their own post.
+
+  Returns `{:ok, message}` when it is gone, `{:error, message}` when it is not,
+  and `{:error, nil}` for a viewer who is not signed in at all — nothing to say
+  to somebody the menu was never rendered for.
+  """
+  def remove(note_id, viewer),
+    do: take_down(&Fediverse.remove_note/2, note_id, viewer, gettext("Reply removed."))
+
+  @doc """
+  Anybody who can see the reply marks it as not appropriate. Same shape as
+  `remove/2`.
+  """
+  def report(note_id, viewer) do
+    take_down(
+      &Fediverse.report_note/2,
+      note_id,
+      viewer,
+      gettext("Thank you. The reply was deleted right away.")
+    )
+  end
+
+  defp take_down(fun, note_id, %User{} = viewer, done) do
+    case fun.(note_id, viewer) do
+      :ok ->
+        {:ok, done}
+
+      {:error, :rate_limited} ->
+        {:error, gettext("You have reported a lot today. Please try again tomorrow.")}
+
+      _ ->
+        {:error, gettext("That reply is not yours to remove.")}
+    end
+  end
+
+  defp take_down(_fun, _note_id, _viewer, _done), do: {:error, nil}
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.365.4",
+      version: "7.366.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/feed_remote_thread_test.exs
+++ b/test/vutuv_web/live/feed_remote_thread_test.exs
@@ -1,0 +1,230 @@
+defmodule VutuvWeb.FeedRemoteThreadTest do
+  @moduledoc """
+  Replies written on other networks inside the **feed's** threads.
+
+  The permalink has shown them since issue #1069, woven among the vutuv replies
+  in time order; the feed's nested thread walked local `reply_ref` links only,
+  so a conversation that ran through another network arrived at the reader with
+  its middle missing — and a member who answered such a reply looked like they
+  were talking to themselves.
+
+  Not async: `Vutuv.RateLimiter` is a shared ETS table the SQL sandbox does not
+  roll back, and answering a note claims from it.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Note
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.Posts
+  alias Vutuv.Social
+
+  setup do
+    Vutuv.RateLimiter.reset()
+    :ok
+  end
+
+  # The viewer, who follows somebody — /feed sends a member who follows nobody
+  # to their own profile instead, so the timeline would never render.
+  defp reader(conn) do
+    {conn, user} = create_and_login_user(conn)
+    Social.follow(user, insert(:user, email_confirmed?: true).id)
+    {conn, user}
+  end
+
+  defp note_under(post, body, attrs \\ []) do
+    now = DateTime.utc_now(:second)
+    unique = System.unique_integer([:positive])
+    handle = attrs[:handle] || "them"
+
+    Repo.insert!(%Note{
+      post_id: post.id,
+      object_uri: "https://social.example/n/#{unique}",
+      actor_uri: "https://social.example/users/#{handle}",
+      origin_url: "https://social.example/@#{handle}/#{unique}",
+      handle: handle,
+      display_name: String.capitalize(handle),
+      content_text: body,
+      audience: attrs[:audience] || "public",
+      inbox_uri: "https://social.example/users/#{handle}/inbox",
+      received_at: attrs[:received_at] || now,
+      checked_at: now,
+      expires_at: DateTime.add(now, 86_400)
+    })
+  end
+
+  # A post out there, cached here because somebody follows its author.
+  defp cached_post(body) do
+    now = DateTime.utc_now(:second)
+    unique = System.unique_integer([:positive])
+
+    account =
+      Repo.insert!(%RemoteAccount{
+        actor_uri: "https://social.example/users/them",
+        host: "social.example",
+        handle: "them",
+        name: "Thea Remote",
+        inbox_uri: "https://social.example/users/them/inbox"
+      })
+
+    Repo.insert!(%RemotePost{
+      remote_account_id: account.id,
+      object_uri: "https://social.example/p/#{unique}",
+      origin_url: "https://social.example/@them/#{unique}",
+      content_text: body,
+      audience: "public",
+      kind: "note",
+      published_at: now,
+      received_at: now,
+      expires_at: DateTime.add(now, 86_400)
+    })
+    |> Repo.preload(:remote_account)
+  end
+
+  defp timeline(view) do
+    if has_element?(view, "#feed-posts"), do: render(element(view, "#feed-posts")), else: ""
+  end
+
+  describe "a reply from another network is part of the thread the feed shows" do
+    test "it renders under the post it answers", %{conn: conn} do
+      {conn, user} = reader(conn)
+      {:ok, post} = Posts.create_post(user, %{body: "eine Frage in die Runde"})
+      note_under(post, "die Antwort von draussen")
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      assert timeline(view) =~ "eine Frage in die Runde"
+      assert timeline(view) =~ "die Antwort von draussen"
+      # The card names who said it, so the reader can tell it apart from a
+      # vutuv voice without reading the skin.
+      assert timeline(view) =~ "@them@social.example"
+    end
+
+    test "a member's answer to such a reply hangs under it, not beside it", %{conn: conn} do
+      # The gap that read as talking to oneself: both halves were local posts,
+      # so the feed drew them as one conversation with nothing in between.
+      {conn, user} = reader(conn)
+      answerer = insert(:activated_user, fediverse_followers?: true)
+      {:ok, _actor} = Fediverse.ensure_actor(answerer)
+      Social.follow(user, answerer.id)
+
+      {:ok, post} = Posts.create_post(user, %{body: "eine Frage in die Runde"})
+      note = note_under(post, "die Antwort von draussen")
+
+      {:ok, _reply} =
+        Posts.create_remote_reply(Repo.reload!(answerer), note, %{body: "und mein Nachsatz"})
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      html = timeline(view)
+      assert html =~ "eine Frage in die Runde"
+      assert html =~ "die Antwort von draussen"
+      assert html =~ "und mein Nachsatz"
+
+      # Reading order is the nesting: the note sits between the two vutuv posts.
+      assert :binary.match(html, "die Antwort von draussen") <
+               :binary.match(html, "und mein Nachsatz")
+    end
+
+    test "a reply addressed to the author alone reaches nobody else", %{conn: conn} do
+      # `Fediverse.list_notes/2`'s viewer scope (issue #1071) has to survive the
+      # trip through the feed, where the reader is not always the author.
+      {conn, user} = reader(conn)
+      author = insert(:user, email_confirmed?: true)
+      Social.follow(user, author.id)
+      {:ok, post} = Posts.create_post(author, %{body: "ein Beitrag von jemand anderem"})
+      note_under(post, "nur fuer die Autorin", audience: "direct")
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      assert timeline(view) =~ "ein Beitrag von jemand anderem"
+      refute timeline(view) =~ "nur fuer die Autorin"
+    end
+
+    test "its ⋯ menu works here, instead of taking the page down", %{conn: conn} do
+      # The card's menu offers Report to every signed-in reader and Remove to
+      # the post's author, and an unhandled `phx-click` kills the LiveView — so
+      # a surface that renders the card owes both events. The feed already drew
+      # this card for a reshared reply (issue #1275) without them.
+      {conn, user} = reader(conn)
+      {:ok, post} = Posts.create_post(user, %{body: "eine Frage in die Runde"})
+      note = note_under(post, "die Antwort von draussen")
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      assert timeline(view) =~ "die Antwort von draussen"
+
+      render_click(view, "remove-remote-reply", %{"id" => note.id})
+
+      refute timeline(view) =~ "die Antwort von draussen"
+      assert timeline(view) =~ "eine Frage in die Runde"
+      assert render(view) =~ "Reply removed."
+    end
+
+    test "reporting a reshared reply takes its row off the feed", %{conn: conn} do
+      {conn, user} = reader(conn)
+      author = insert(:user, email_confirmed?: true)
+      Social.follow(user, author.id)
+      {:ok, post} = Posts.create_post(author, %{body: "ein Beitrag von jemand anderem"})
+      note = note_under(post, "eine weitergereichte Antwort")
+      Repo.insert!(%Vutuv.Fediverse.NoteRepost{user_id: author.id, note_id: note.id})
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      assert timeline(view) =~ "eine weitergereichte Antwort"
+
+      render_click(view, "report-remote-reply", %{"id" => note.id})
+
+      refute timeline(view) =~ "eine weitergereichte Antwort"
+    end
+
+    test "answering a post out there shows that post above the answer", %{conn: conn} do
+      # The other half of the same gap (issue #1165): the answer is an ordinary
+      # vutuv post here, so the feed drew it alone, over a one-line "Replying to
+      # @them@social.example" — a reply with nothing to read above it.
+      {conn, user} = reader(conn)
+      answerer = insert(:activated_user, fediverse_followers?: true)
+      {:ok, _actor} = Fediverse.ensure_actor(answerer)
+      Social.follow(user, answerer.id)
+
+      remote = cached_post("was da draussen steht")
+
+      {:ok, _post} =
+        Posts.create_remote_post_reply(Repo.reload!(answerer), remote, %{
+          body: "meine Antwort darauf"
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      html = timeline(view)
+      assert html =~ "meine Antwort darauf"
+      assert html =~ "was da draussen steht"
+
+      assert :binary.match(html, "was da draussen steht") <
+               :binary.match(html, "meine Antwort darauf")
+    end
+
+    test "a post that got many keeps the newest few, not all of them", %{conn: conn} do
+      # A post that goes round out there can collect dozens of answers, and the
+      # feed is not the place to read them: the permalink is.
+      {conn, user} = reader(conn)
+      {:ok, post} = Posts.create_post(user, %{body: "eine Frage in die Runde"})
+      now = DateTime.utc_now(:second)
+
+      for i <- 1..6 do
+        note_under(post, "Antwort Nummer #{i}",
+          handle: "user#{i}",
+          received_at: DateTime.add(now, i)
+        )
+      end
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      html = timeline(view)
+      assert html =~ "Antwort Nummer 6"
+      assert html =~ "Antwort Nummer 4"
+      refute html =~ "Antwort Nummer 1"
+    end
+  end
+end

--- a/test/vutuv_web/live/feed_remote_thread_test.exs
+++ b/test/vutuv_web/live/feed_remote_thread_test.exs
@@ -205,6 +205,27 @@ defmodule VutuvWeb.FeedRemoteThreadTest do
                :binary.match(html, "meine Antwort darauf")
     end
 
+    test "a reader who does not federate may read it but not pass it on", %{conn: conn} do
+      # These cards now reach members who have nothing to do with the
+      # fediverse, since the thread they sit in is an ordinary vutuv thread. The
+      # bar still offers both acts, and the refusal is what teaches: a heart or
+      # a reshare travels back out, so it names the switch and links to it
+      # (issue #1349) instead of failing silently.
+      {conn, user} = reader(conn)
+      refute Fediverse.federated?(user), "the reader must not federate, or this proves nothing"
+
+      {:ok, post} = Posts.create_post(user, %{body: "eine Frage in die Runde"})
+      note_under(post, "die Antwort von draussen")
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      html = view |> element("[data-remote-act='repost']") |> render_click()
+
+      assert html =~ "does not take part in the Fediverse"
+      assert html =~ ~p"/settings/fediverse"
+      assert Repo.aggregate(Vutuv.Fediverse.NoteRepost, :count) == 0
+    end
+
     test "a post that got many keeps the newest few, not all of them", %{conn: conn} do
       # A post that goes round out there can collect dozens of answers, and the
       # feed is not the place to read them: the permalink is.

--- a/test/vutuv_web/live/feed_source_tabs_test.exs
+++ b/test/vutuv_web/live/feed_source_tabs_test.exs
@@ -19,6 +19,8 @@ defmodule VutuvWeb.FeedSourceTabsTest do
   alias Vutuv.Accounts.User
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.Follow
+  alias Vutuv.Fediverse.Note
+  alias Vutuv.Fediverse.NoteRepost
   alias Vutuv.Fediverse.PostBoost
   alias Vutuv.Fediverse.PostRepost
   alias Vutuv.Fediverse.RemoteAccount
@@ -66,6 +68,27 @@ defmodule VutuvWeb.FeedSourceTabsTest do
       kind: "note",
       published_at: now,
       received_at: now,
+      expires_at: DateTime.add(now, 86_400)
+    })
+  end
+
+  # A reply written out there under some member's post (issues #1069/#1071).
+  defp remote_reply(body) do
+    now = DateTime.utc_now(:second)
+    unique = System.unique_integer([:positive])
+
+    Repo.insert!(%Note{
+      post_id: insert(:post, user: insert(:user, email_confirmed?: true)).id,
+      object_uri: "https://social.example/n/#{unique}",
+      actor_uri: "https://social.example/users/them",
+      origin_url: "https://social.example/@them/#{unique}",
+      handle: "them",
+      display_name: "Thea Remote",
+      content_text: body,
+      audience: "public",
+      inbox_uri: "https://social.example/users/them/inbox",
+      received_at: now,
+      checked_at: now,
       expires_at: DateTime.add(now, 86_400)
     })
   end
@@ -358,6 +381,81 @@ defmodule VutuvWeb.FeedSourceTabsTest do
 
       assert timeline(view) =~ "written out there"
       refute timeline(view) =~ "written here on vutuv"
+    end
+  end
+
+  describe "what a member here did with remote content is theirs" do
+    # The reported bug: a member reshares a post from another network and it
+    # shows up only under "Fediverse", which reads as vutuv having had no part
+    # in it — but pressing that button *is* a vutuv act, and the reader looking
+    # for what happened here looks on the vutuv tab.
+    test "the viewer's own reshare of a remote post sits on the vutuv tab", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      # Something out there they follow, so the bar has both halves to show.
+      cached_post(remote_account(user, "them"), "written out there")
+
+      mine = cached_post(remote_account("stranger"), "I passed this on")
+      Repo.insert!(%PostRepost{user_id: user.id, remote_post_id: mine.id})
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      render_click(view, "filter-source", %{"type" => "vutuv"})
+      assert timeline(view) =~ "I passed this on"
+      refute timeline(view) =~ "written out there"
+
+      # And it is on that tab *instead of*, not as well as, the other one.
+      render_click(view, "filter-source", %{"type" => "fediverse"})
+      assert timeline(view) =~ "written out there"
+      refute timeline(view) =~ "I passed this on"
+    end
+
+    test "somebody else's reshare stays on the Fediverse tab", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      sharer = insert(:user, email_confirmed?: true)
+      Social.follow(user, sharer.id)
+
+      post = cached_post(remote_account("stranger"), "passed on by a friend")
+      Repo.insert!(%PostRepost{user_id: sharer.id, remote_post_id: post.id})
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      render_click(view, "filter-source", %{"type" => "vutuv"})
+      refute timeline(view) =~ "passed on by a friend"
+
+      render_click(view, "filter-source", %{"type" => "fediverse"})
+      assert timeline(view) =~ "passed on by a friend"
+    end
+
+    test "the same holds for a reply the viewer passed on", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      cached_post(remote_account(user, "them"), "written out there")
+
+      note = remote_reply("I passed this reply on")
+      Repo.insert!(%NoteRepost{user_id: user.id, note_id: note.id})
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      render_click(view, "filter-source", %{"type" => "vutuv"})
+      assert timeline(view) =~ "I passed this reply on"
+
+      render_click(view, "filter-source", %{"type" => "fediverse"})
+      refute timeline(view) =~ "I passed this reply on"
+    end
+
+    test "an own reshare alone leaves the Fediverse tab empty, so no bar", %{conn: conn} do
+      # Nothing reaches this member from out there except what they carried in
+      # themselves — so "Fediverse" can never fill, and three tabs over one
+      # timeline is exactly what issue #1267 took away.
+      {conn, user} = create_and_login_user(conn)
+
+      mine = cached_post(remote_account("stranger"), "I passed this on")
+      Repo.insert!(%PostRepost{user_id: user.id, remote_post_id: mine.id})
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      refute has_element?(view, "#feed-source-tabs")
+      assert timeline(view) =~ "I passed this on"
     end
   end
 


### PR DESCRIPTION
**Symptom** (reported): on `/feed`, the **vutuv** tab hid two things that happened here. A post from another network that *you* reshared showed only under "Fediverse", and the nested thread never contained a fediverse post at all — so a conversation that ran through another network arrived with its middle missing, and a member answering such a reply looked like they were talking to themselves.

**What changed**

* The tab rule now asks *who an entry belongs to*, not only what kind of post it carries: a reshare the reader pressed themselves is a vutuv act and sits on the vutuv tab; somebody else's stays on Fediverse. `Fediverse.feed_remote_reposts/4` and `feed_remote_reply_reposts/4` take `only: :mine | :others`, narrowed inside the query so `more?` stays honest.
* `post_thread_entry/1` takes `remote_replies` (woven in by the permalink's own `weave_remote_replies/4`, capped at 3 per post) and `remote_parents` (the cached post an answer answers, issue #1165, in place of its "Replying to" line). One card per thing per page — a duplicate would collide on the action bar's LiveComponent id.

**Found while building, fixed here:** the feed had been drawing the remote reply card since issue #1275 without `remove-remote-reply` / `report-remote-reply`, so its Report item killed the page. Both now live in `VutuvWeb.Live.RemoteReplyActions`, the sibling of `RemotePostActions`.

Smoke-tested at `/feed` in a browser against a copy of production: both tabs, the woven reply, the ⋯ menu.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_015DASCqmKUaE4Lx3iWvSvab