### PR TITLE
Cap the reposter roster, and make a live arrival pass the same gates as a query

### DIFF
--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -358,6 +358,27 @@ fan-out never reached the person whose post it was, and the feed only caught up
 on the next load. Whoever the fan-out already told is subtracted rather than told
 twice — a second copy counts twice behind the "N new posts" pill.
 
+**The roster is capped, its tail counted in SQL.** The banner draws
+`Posts.reposter_roster_cap/0` faces (5) and then a `+N` chip, so the query loads
+exactly that many rows per post and carries `reposters_total` from a
+`count(*) over (partition by post_id)` in the same statement — over the *gated*
+set, so the figure counts only what this reader may be shown. Both numbers ride
+the entry, and the banner reads the **total** for its "and N others" and the list
+only for the faces; letting the list grow while the total stood still is how a
+live restack once answered `-1` and took the page down inside `ngettext`. Until
+the cap the roster was bounded by the reader's follow set — widening it to a post
+of their own made "load every resharer to draw five" a real cost.
+
+**A post arriving live passes the same gates as one fetched by a query.** The
+feed decides who sees a post twice: in SQL for a page, and in memory for a
+PubSub arrival. `Posts.reaches_feed?/2` is the in-memory twin — blocks either
+way, the post's audience, a mute the reader placed, and their language filter,
+in the order the query asks them. While the two disagreed, the pill counted
+posts the next read then dropped, so pressing it showed fewer than it promised.
+The **tab** filter is a different question and stays with the caller: it decides
+which list a post belongs in, not whether it reaches the reader, and an arrival
+for the other tab lights that tab's dot instead of being dropped (issue #1503).
+
 **What keeps that first source cheap.** The local posts source ("mine plus the
 people I follow", newest first) has to stay a *page*-sized read as the posts
 table grows, and two things make it one. `posts_recency_index` covers its sort

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -103,6 +103,21 @@ defmodule Vutuv.Posts do
   alias Vutuv.UUIDv7
 
   @default_feed_limit 20
+
+  # How many resharers a feed entry carries. The "Reposted by" banner draws this
+  # many faces and then a `+N` chip, so loading more would be rows fetched to be
+  # thrown away — and on a post of the reader's own, where the roster is no
+  # longer bounded by their follow set, a widely reshared post would fetch
+  # thousands of them to draw five. The tail is counted in SQL instead
+  # (`reposters_total`), so the chip's figure stays honest.
+  @roster_cap 5
+
+  @doc """
+  How many resharers a feed entry's roster holds — the cap the banner's avatar
+  stack draws up to (`VutuvWeb.PostComponents`). One number, or the query would
+  fetch fewer faces than the stack wants to show.
+  """
+  def reposter_roster_cap, do: @roster_cap
   @default_profile_limit 3
   @default_thread_limit 100
   # The permalink conversation's cap (issue #1006): strictly above the
@@ -1059,6 +1074,53 @@ defmodule Vutuv.Posts do
   end
 
   defp organization_author?(_post, _viewer), do: false
+
+  @doc """
+  Whether a post **arriving live** reaches `viewer`'s feed — the in-memory twin
+  of what a feed source's query would have decided about it.
+
+  The feed answers that question twice: in SQL when a page is fetched, and here
+  when a post arrives over PubSub. While the two disagreed, the pill counted
+  posts the next read then dropped — a muted member's, or one in a language the
+  reader filters out — so pressing it showed fewer posts than it promised, or
+  none. Four gates, in the order the query asks them:
+
+    * the author is not blocked, either way (`scope_visible/2` never checks
+      blocks, which is why the caller used to ask this one separately),
+    * the post's own audience lets this reader in (`visible_to?/2`),
+    * the reader has not muted the author (`followees_of/1`'s `muted == false`),
+    * and it is in a language they chose (`language_scope/2`).
+
+  The tab filter is a **different** question and stays with the caller: it
+  decides which of two lists a post belongs in, not whether it reaches the
+  reader at all, and an arrival for the other tab lights that tab's dot rather
+  than being dropped (issue #1503).
+  """
+  def reaches_feed?(%Post{} = post, %User{} = viewer) do
+    not Vutuv.Social.blocked_between?(viewer.id, post.user_id) and
+      visible_to?(post, viewer) and not muted_author?(post, viewer) and
+      language_allowed?(post, viewer)
+  end
+
+  defp muted_author?(%Post{user_id: author_id}, %User{id: viewer_id})
+       when is_binary(author_id) do
+    Repo.exists?(
+      from(f in Follow,
+        where: f.follower_id == ^viewer_id and f.followee_id == ^author_id and f.muted
+      )
+    )
+  end
+
+  defp muted_author?(_post, _viewer), do: false
+
+  # The `language_scope/2` clause, asked of one post: an undeclared language
+  # never hides (the same NOT-IN/NULL lesson), and no filter means no question.
+  defp language_allowed?(%Post{language: language}, %User{} = viewer) do
+    case feed_language_filter(viewer) do
+      nil -> true
+      chosen -> is_nil(language) or language in chosen
+    end
+  end
 
   @doc """
   Whether `viewer` (a `%User{}` or `nil` for anonymous) may see `post`.
@@ -3730,7 +3792,8 @@ defmodule Vutuv.Posts do
   # A page reading its OWN feed carries no reposts (it does not read the
   # members' repost source), so there is no roster to attach and no viewer whose
   # follow graph would scope one. Nil is a real case here, not a slip.
-  defp attach_reposters(entries, nil), do: Enum.map(entries, &Map.put(&1, :reposters, []))
+  defp attach_reposters(entries, nil),
+    do: Enum.map(entries, &(&1 |> Map.put(:reposters, []) |> Map.put(:reposters_total, 0)))
 
   defp attach_reposters(entries, %User{} = viewer) do
     # Keyed on "there is a resharer", not on "the resharer is a member": since
@@ -3751,11 +3814,16 @@ defmodule Vutuv.Posts do
 
     Enum.map(entries, fn
       %{reposted_by: nil} = entry ->
-        Map.put(entry, :reposters, [])
+        entry |> Map.put(:reposters, []) |> Map.put(:reposters_total, 0)
 
       entry ->
-        reposters = Map.get(rosters, entry.post.id, [entry.reposted_by])
-        entry |> Map.put(:reposters, reposters) |> Map.put(:reposted_by, hd(reposters))
+        %{names: names, total: total} =
+          Map.get(rosters, entry.post.id, %{names: [entry.reposted_by], total: 1})
+
+        entry
+        |> Map.put(:reposters, names)
+        |> Map.put(:reposters_total, total)
+        |> Map.put(:reposted_by, hd(names))
     end)
   end
 
@@ -3772,23 +3840,52 @@ defmodule Vutuv.Posts do
     # reshare in the roster and the stranger's missing, the newest name was
     # replaced by the reader's own. Blocked and muted resharers stay out, the
     # same gate that source applies.
-    from(r in PostRepost,
+    ranked =
+      from(r in PostRepost,
+        left_join: u in User,
+        on: u.id == r.user_id,
+        left_join: rp in assoc(r, :organization),
+        where: r.post_id in ^post_ids,
+        where: ^roster_holds(viewer_id, own_ids),
+        # Scoped per actor kind — see the note in `feed_repost_items/3`: a bare
+        # `account_confirmed_row(u)` is TRUE on a left-joined missing row.
+        where:
+          r.user_id == ^viewer_id or
+            (not is_nil(r.user_id) and account_confirmed_row(u)) or
+            (not is_nil(r.organization_id) and organization_public_row(rp)),
+        # Ids and the two window figures only: Ecto refuses a struct as a map
+        # value inside a subquery, and the rows are hydrated by the outer query
+        # below. The windows are computed over the **gated** set, so the total
+        # counts what this reader may be shown and nothing else.
+        select: %{
+          id: r.id,
+          post_id: r.post_id,
+          rank:
+            over(row_number(),
+              partition_by: r.post_id,
+              order_by: [desc: r.inserted_at, desc: r.id]
+            ),
+          total: over(count(r.id), partition_by: r.post_id)
+        }
+      )
+
+    from(row in subquery(ranked),
+      join: r in PostRepost,
+      on: r.id == row.id,
       left_join: u in User,
       on: u.id == r.user_id,
       left_join: rp in assoc(r, :organization),
-      where: r.post_id in ^post_ids,
-      where: ^roster_holds(viewer_id, own_ids),
-      # Scoped per actor kind — see the note in `feed_repost_items/3`: a bare
-      # `account_confirmed_row(u)` is TRUE on a left-joined missing row.
-      where:
-        r.user_id == ^viewer_id or
-          (not is_nil(r.user_id) and account_confirmed_row(u)) or
-          (not is_nil(r.organization_id) and organization_public_row(rp)),
-      order_by: [desc: r.inserted_at, desc: r.id],
-      select: {r.post_id, u, rp}
+      where: row.rank <= ^@roster_cap,
+      order_by: [asc: row.post_id, asc: row.rank],
+      select: {row.post_id, row.total, u, rp}
     )
     |> Repo.all()
-    |> Enum.group_by(&elem(&1, 0), fn {_post_id, user, page} -> user || page end)
+    |> Enum.group_by(&elem(&1, 0))
+    |> Map.new(fn {post_id, rows} ->
+      names = for {_post_id, _total, user, page} <- rows, do: user || page
+      {_post_id, total, _user, _page} = hd(rows)
+      {post_id, %{names: names, total: total}}
+    end)
   end
 
   # Whose reshare of these posts the banner may name: the reader's own, a

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -64,7 +64,11 @@ defmodule VutuvWeb.PostComponents do
   # How many reposter faces the "Reposted by" avatar stack shows before the
   # rest collapse into a `+N` chip. Five keeps the strip to one tidy line even
   # on a phone (5 × 20px avatars, overlapped, plus the chip and the sentence).
-  @repost_stack_cap 5
+  #
+  # It comes from `Vutuv.Posts` because the roster query loads exactly this many
+  # rows (`reposter_roster_cap/0`): a larger number here would ask the stack to
+  # draw faces the query never fetched.
+  @repost_stack_cap Posts.reposter_roster_cap()
 
   # A single preview image counts as "roughly square" when its aspect ratio sits
   # inside a 5:4 / 4:5 envelope (a factor of 1.25 either side of 1:1). Such an
@@ -140,6 +144,13 @@ defmodule VutuvWeb.PostComponents do
       "every reposter behind the entry (newest first, from Posts.feed_page/2) — " <>
         "renders the banner's avatar stack. nil falls back to [reposted_by], so " <>
         "single-reposter callers (profile, dead lists) need not pass it"
+  )
+
+  attr(:reposters_total, :integer,
+    default: nil,
+    doc:
+      "how many resharers the roster stands for when it was capped " <>
+        "(`Vutuv.Posts.reposter_roster_cap/0`); nil means the list is the total"
   )
 
   attr(:entry_id, :string,
@@ -811,6 +822,7 @@ defmodule VutuvWeb.PostComponents do
 
   attr(:reposted_by, :any, default: nil)
   attr(:reposters, :any, default: nil)
+  attr(:reposters_total, :integer, default: nil)
   attr(:entry_id, :string, default: nil)
   attr(:surface, :atom, default: :flat, values: [:card, :flat])
   attr(:conn_or_socket, :any, required: true)
@@ -844,6 +856,7 @@ defmodule VutuvWeb.PostComponents do
         engagement={@engagement}
         reposted_by={@reposted_by}
         reposters={@reposters}
+        reposters_total={@reposters_total}
         entry_id={@entry_id}
         surface={@surface}
         conn_or_socket={@conn_or_socket}
@@ -884,6 +897,7 @@ defmodule VutuvWeb.PostComponents do
           viewer_follow: nil,
           reposted_by: nil,
           reposters: nil,
+          reposters_total: nil,
           entry_id: "#{leaf_key}-parent-#{post.id}"
         }
       end)
@@ -894,6 +908,7 @@ defmodule VutuvWeb.PostComponents do
       viewer_follow: assigns.viewer_follow,
       reposted_by: assigns.reposted_by,
       reposters: assigns.reposters,
+      reposters_total: assigns.reposters_total,
       entry_id: assigns.entry_id
     }
 
@@ -1089,6 +1104,7 @@ defmodule VutuvWeb.PostComponents do
               engagement={node.engagement}
               reposted_by={node.reposted_by}
               reposters={node.reposters}
+              reposters_total={node[:reposters_total]}
               entry_id={node.entry_id}
               surface={@surface}
               conn_or_socket={@conn_or_socket}
@@ -3022,7 +3038,7 @@ defmodule VutuvWeb.PostComponents do
         {gettext("Pinned post")}
       </p>
 
-      <.reposted_banner reposters={@reposters} />
+      <.reposted_banner reposters={@reposters} reposters_total={@reposters_total} />
 
       <%!-- The reply banner: the live parent links its permalink; a deleted
       parent degrades to the author's profile, a deleted account to a
@@ -4095,6 +4111,11 @@ defmodule VutuvWeb.PostComponents do
   # "Reposted by NAME" — byte-compatible with the old single-name banner.
   attr(:reposters, :list, required: true)
 
+  attr(:reposters_total, :integer,
+    default: nil,
+    doc: "the uncapped count behind the roster; nil means the list is all of them"
+  )
+
   # The banner's avatar stack: single-reposter callers (the profile, the dead
   # archive/permalink lists) pass only `reposted_by`, which folds into a
   # one-avatar roster; the feed passes the whole `reposters` list.
@@ -4139,12 +4160,20 @@ defmodule VutuvWeb.PostComponents do
   defp reposted_banner(assigns) do
     reposters = assigns.reposters
 
+    # The roster is capped (`Vutuv.Posts.reposter_roster_cap/0`), so the tail is
+    # counted from the total the query reported and never from the list's own
+    # length — otherwise a post reshared two thousand times would say "and 4
+    # others". A caller that passes no total (the profile, the dead archive and
+    # permalink lists, each with a single resharer) has the list as its total.
+    total = assigns.reposters_total || length(reposters)
+
     assigns =
       assigns
       |> assign(:primary, hd(reposters))
       |> assign(:cap, @repost_stack_cap)
+      |> assign(:total, total)
       # Everyone besides the named (newest) reposter — the "and N others" tail.
-      |> assign(:others, length(reposters) - 1)
+      |> assign(:others, total - 1)
 
     ~H"""
     <div
@@ -4154,7 +4183,7 @@ defmodule VutuvWeb.PostComponents do
       <.icon_repost class="h-4 w-4 shrink-0" />
       <%!-- The stack's avatars link to each reposter; the sentence beside it
       names them, so the stack itself is decorative for assistive tech. --%>
-      <.avatar_stack users={@reposters} cap={@cap} />
+      <.avatar_stack users={@reposters} cap={@cap} total={@total} />
       <span class="min-w-0 truncate">
         <%!-- `author_name/1` / `author_path/1`, not `full_name/1` / `~p`: a
         reposter can be a page (`Posts.reposter_rosters/2`), which crashed the

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -1090,17 +1090,15 @@ defmodule VutuvWeb.PostLive.Feed do
          |> stream_insert(:posts, decorated, at: 0)
          |> prune_threaded_parent(entry)}
 
-      # Mirror the pull path's blocked-author filter: a third party's repost
-      # must not carry a blocked author's post into the feed (blocking already
-      # severed the direct follow). visible_to?/2 alone never checks blocks.
-      Social.blocked_between?(user.id, entry.post.user_id) ->
-        {:noreply, socket}
-
-      # Visibility is asked FIRST, and the order is the whole correctness of
-      # the dot below (issue #1503): the tab check used to come first and drop
-      # the arrival, which cost nothing while the answer was "do nothing" and
-      # would now light a tab for a post this reader is not allowed to read.
-      not Posts.visible_to?(entry.post, user) ->
+      # Does this post reach the reader at all — blocks, audience, mute and
+      # their language filter, the in-memory twin of what the query decides
+      # (`Posts.reaches_feed?/2`).
+      #
+      # It is asked FIRST, and the order is the whole correctness of the dot
+      # below (issue #1503): the tab check used to come first and drop the
+      # arrival, which cost nothing while the answer was "do nothing" and would
+      # now light a tab for a post this reader is not allowed to read.
+      not Posts.reaches_feed?(entry.post, user) ->
         {:noreply, socket}
 
       # A post nobody on this tab asked for must not be counted by the pill
@@ -1555,9 +1553,18 @@ defmodule VutuvWeb.PostLive.Feed do
 
   # nil when this reposter is already counted (idempotent re-broadcast), else the
   # entry with the reposter folded into its roster and named as the newest.
+  #
+  # The **total** grows with it and the list stays capped
+  # (`Posts.reposter_roster_cap/0`): the banner reads the total for its "and N
+  # others" and the list only for the faces, so letting the list grow while the
+  # total stood still made the tail count backwards — a post with no roster yet
+  # answered `-1` and took the page down on `ngettext`.
   defp restacked_entry(entry, reposter) do
     unless Enum.any?(entry.reposters, &(&1.id == reposter.id)) do
-      %{entry | reposters: [reposter | entry.reposters], reposted_by: reposter}
+      roster = Enum.take([reposter | entry.reposters], Posts.reposter_roster_cap())
+
+      %{entry | reposters: roster, reposted_by: reposter}
+      |> Map.put(:reposters_total, (entry[:reposters_total] || length(entry.reposters)) + 1)
     end
   end
 
@@ -1775,6 +1782,7 @@ defmodule VutuvWeb.PostLive.Feed do
                     remote_parents={entry[:remote_parents] || %{}}
                     reposted_by={entry.reposted_by}
                     reposters={entry[:reposters]}
+                    reposters_total={entry[:reposters_total]}
                     entry_id={entry.id}
                     conn_or_socket={@socket}
                     engagement={entry.engagement}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.379.1",
+      version: "7.379.3",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/posts_test.exs
+++ b/test/vutuv/posts_test.exs
@@ -812,6 +812,30 @@ defmodule Vutuv.PostsTest do
       assert entry.reposted_by.id == stranger.id
     end
 
+    test "a wildly reshared post loads a capped roster and an honest total" do
+      # The banner draws five faces and a "+N", so the query has no business
+      # loading two thousand `%User{}` rows to answer it. What it must not do is
+      # shrink the number: the total comes from the same statement, counted in
+      # SQL over every row the cap left out.
+      viewer = user()
+      post = create_post!(viewer, %{body: "reshared a lot"})
+      backdate_post!(post, 600)
+
+      resharers = for _ <- 1..8, do: user()
+
+      for {resharer, i} <- Enum.with_index(resharers) do
+        :ok = Posts.repost_post(resharer, post)
+        backdate_repost!(resharer, post, 500 - i * 10)
+      end
+
+      assert %{entries: [entry]} = Posts.feed_page(viewer)
+
+      assert length(entry.reposters) == Posts.reposter_roster_cap()
+      assert entry.reposters_total == 8
+      # Newest first, so the banner names the most recent resharer.
+      assert entry.reposted_by.id == List.last(resharers).id
+    end
+
     test "plain post entries carry an empty roster" do
       viewer = user()
       create_post!(viewer, %{body: "no reposts"})

--- a/test/vutuv_web/live/feed_arrival_gates_test.exs
+++ b/test/vutuv_web/live/feed_arrival_gates_test.exs
@@ -1,0 +1,125 @@
+defmodule VutuvWeb.FeedArrivalGatesTest do
+  @moduledoc """
+  A post arriving live must pass the same gates the query would have applied.
+
+  The feed decides twice who sees a post: once in SQL, when a page is fetched,
+  and once in memory, when one arrives over PubSub. The two answered differently
+  — the live path asked only about blocks and the post's own audience, so a
+  **muted** member's post and a post in a language the reader filters out both
+  lit the "N new posts" pill, and vanished again the moment they pressed it and
+  the page was re-read. A control that promises posts and then shows none is
+  worse than no control.
+  """
+  use VutuvWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.Posts
+  alias Vutuv.Social
+
+  # A member the viewer follows, plus one older post so the feed has content.
+  defp followed_author(viewer, body) do
+    author = insert(:activated_user)
+    Social.follow(viewer, author.id)
+    {:ok, _post} = Posts.create_post(author, %{body: body})
+    author
+  end
+
+  defp timeline(view) do
+    if has_element?(view, "#feed-posts"), do: render(element(view, "#feed-posts")), else: ""
+  end
+
+  describe "a muted member's post" do
+    test "does not fill the pill", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      author = followed_author(user, "an older post")
+      Social.toggle_follow_mute!(user.id, Social.follow_id(user.id, author.id))
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      {:ok, _fresh} = Posts.create_post(author, %{body: "arriving from a muted member"})
+
+      refute has_element?(view, "#show-new-posts")
+      refute timeline(view) =~ "arriving from a muted member"
+    end
+
+    test "the same post arrives once the mute is lifted", %{conn: conn} do
+      # The other side of the gate, so the test cannot pass by dropping
+      # everything.
+      {conn, user} = create_and_login_user(conn)
+      author = followed_author(user, "an older post")
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      {:ok, _fresh} = Posts.create_post(author, %{body: "arriving unmuted"})
+
+      assert has_element?(view, "#show-new-posts")
+      render_click(view, "show-new")
+      assert timeline(view) =~ "arriving unmuted"
+    end
+  end
+
+  describe "a post in a language the reader filters out" do
+    setup %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      {:ok, user} =
+        Vutuv.Accounts.update_user(user, %{
+          "feed_languages" => ["de"],
+          "feed_foreign_posts" => "hide"
+        })
+
+      %{conn: conn, user: user}
+    end
+
+    test "does not fill the pill", %{conn: conn, user: user} do
+      author = followed_author(user, "ein aelterer Beitrag")
+      fresh = post_in(author, "arriving in another language", "fr")
+
+      # The query already leaves it out, which is what the pill then has to
+      # agree with — so the page opens without it.
+      {:ok, view, _html} = live(conn, ~p"/feed")
+      refute timeline(view) =~ "arriving in another language"
+
+      announce(user, fresh)
+
+      refute has_element?(view, "#show-new-posts")
+      refute timeline(view) =~ "arriving in another language"
+    end
+
+    test "a post in a chosen language still arrives", %{conn: conn, user: user} do
+      author = followed_author(user, "ein aelterer Beitrag")
+      fresh = post_in(author, "ein neuer Beitrag auf Deutsch", "de")
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      announce(user, fresh)
+
+      # Already on the page from the query, so the pill is not the claim here —
+      # what matters is that the arrival was not dropped as foreign.
+      assert timeline(view) =~ "ein neuer Beitrag auf Deutsch"
+    end
+
+    # Language detection runs off the request path (`Vutuv.Languages`), so a
+    # post is announced with none and only later carries one. These tests are
+    # about the announcement of a post that already does: they stamp it and
+    # then re-announce it the way the detector's own write would.
+    defp post_in(author, body, language) do
+      {:ok, post} = Posts.create_post(author, %{body: body})
+
+      Repo.update_all(
+        from(p in Posts.Post, where: p.id == ^post.id),
+        set: [language: language]
+      )
+
+      %{post | language: language}
+    end
+
+    defp announce(user, post) do
+      Vutuv.Activity.broadcast(
+        user.id,
+        {:new_post, %{post_id: post.id, author_id: post.user_id, at: post.inserted_at}}
+      )
+    end
+  end
+end


### PR DESCRIPTION
Two loose ends from the feed work, both noted in the last PR.

**The roster had no cap.** The "Reposted by" banner draws five faces and a `+N`, but the query loaded *every* resharer of the post to answer it. That was bounded by the reader's follow set until v7.370.0 widened it to their own posts — where a widely reshared post would fetch thousands of `%User{}` rows to draw five. It now loads exactly `Posts.reposter_roster_cap/0` rows and carries the tail as `reposters_total`, counted by a window function in the same statement over the already-gated set, so the chip's figure stays honest.

**The feed decided who sees a post twice, and the two disagreed.** In SQL when a page is fetched; in memory when one arrives over PubSub — and the second only asked about blocks and the post's audience. So a **muted** member's post and a post in a language the reader filters out both lit the "N new posts" pill and vanished when they pressed it. `Posts.reaches_feed?/2` is now the in-memory twin of the query's gates. The tab filter stays a separate question, so an arrival for the other tab still lights that tab's dot rather than being dropped (issue #1503).

**Found while building:** the live restack grew the roster list without growing the total, so a post with no roster yet answered `-1` others and took the page down inside `ngettext`.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_015DASCqmKUaE4Lx3iWvSvab