### PR TITLE
A reshare is a vutuv act, whoever pressed the button

### DIFF
--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -400,36 +400,42 @@ segmented control the profile's post-type tabs use
 (`PostComponents.post_filter_tabs/1`, here with `feed_filter_options/0` and the
 `filter-source` event). The split is `feed_page/2`'s `filter:` option, which
 picks the sources rather than filtering their rows: **vutuv** runs the four
-local sources, the boosts of a *local* post and the reader's **own** reshares of
-remote content; **Fediverse** the cached posts, everybody else's reshares of one
-and the boosts of a *remote* post.
+local sources, every reshare of remote content (`feed_remote_reposts/3`,
+`feed_remote_reply_reposts/3`) and the boosts of a *local* post; **Fediverse**
+the cached posts and the boosts of a *remote* post.
 
-The rule is who an entry belongs to, which is two questions in order. What kind
-of post it carries decides most of it (`Posts.remote_feed_entry?/1`, the same
-question the renderer asks to pick a card), and **a vutuv act on remote content
-beats that**: pressing Reshare happened here, so what the reader passed on is on
-the vutuv tab, where they go to look for what they did — the reported gap, since
-their own reshare showing only under "Fediverse" reads as vutuv having had no
-part in it. Somebody else's reshare is not theirs and stays on the Fediverse
-tab. Either way every entry lands on exactly one tab and the two together are
-"All" — a member's post that an account out there boosted is a vutuv post,
+**The rule is whether somebody here did something.** "Fediverse" is what arrives
+from another network with nobody on this site lifting a finger — the posts of
+accounts the reader follows out there, and what those accounts boosted.
+Everything a member here did is "vutuv": their posts, their replies, and every
+**reshare**, whoever pressed the button and whatever they passed on. Every entry
+lands on exactly one tab and the two together are "All".
+
+The reshare is the whole point of that split, and it took two goes to get right.
+Filing it by the *content* — a Mastodon post is a Mastodon post — put a friend's
+reshare under "Fediverse", so a reader looking for their own network's activity
+had to find it under the other network's name, and their **own** reshare read as
+vutuv having had no part in it. Filing it by *who pressed the button* is the
+answer, and it also fixes a case #1166 had to work around: a member with no
+fediverse follows of their own now has a genuinely empty Fediverse tab, so the
+bar disappears (issue #1267) instead of offering three names for one timeline.
+
+One source produces both kinds and is narrowed by `only:` **inside its query**,
+not by dropping rows afterwards, so a narrowed page is as full as an unnarrowed
+one and `more?` stays honest: `Fediverse.feed_remote_boosts/4` (issue #1167)
+carries a cached post when the boost came from out there and a vutuv post when a
+followed account passed a member's post on — the latter being a vutuv post
 however it arrived.
-
-Three sources produce both kinds and are narrowed by `only:` **inside their
-query**, not by dropping rows afterwards, so a narrowed page is as full as an
-unnarrowed one and `more?` stays honest: `Fediverse.feed_remote_boosts/4`
-(issue #1167) on what the boosted thing is, and the two reshare sources
-(`feed_remote_reposts/4` and `feed_remote_reply_reposts/4`, issues #1166 and
-#1275) on who did the resharing — `:mine` against `:others`, one `scope_resharer`
-clause each.
 
 Switching a tab reloads the timeline from the top (`stream reset: true`) — the
 tab decides what the query pulls, so it cannot be applied to what is already on
 screen — and drops the pending batch with it, since the fresh page already
 carries whatever waited behind the pill. Live arrivals are gated by the
-in-memory twin `Posts.feed_filter_accepts?/3` — which takes the viewer, because
-"did *you* reshare this" is half the rule: a followed member's post neither
-appears nor counts toward the pill while the Fediverse tab is open. The one
+in-memory twin `Posts.feed_filter_accepts?/2`, which asks the same question the
+sources do — is there a `reposted_by`, i.e. did a member here put this in front
+of the reader: a followed member's post neither appears nor counts toward the
+pill while the Fediverse tab is open. (`boosted_by` deliberately does not count;
+that is an account out there passing something on.) The one
 exception is the **viewer's own** post, which must be visible after they press
 Post — there the feed switches back to "All" rather than swallowing it. The
 choice has no URL behind it (this LiveView is off-router and cannot patch), and

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -2633,16 +2633,11 @@ defmodule Vutuv.Fediverse do
   to any follow of the author. Stamped with the repost time, like a local
   repost: what is new is the sharing, not the post.
 
-  `only:` keeps just one of the two resharers this source carries — `:mine`
-  for the viewer's own reshares, `:others` for everybody else's — which is how
-  the feed's source tabs split it (`Vutuv.Posts.feed_page/2`): pressing that
-  button is a vutuv act, so what the reader themselves passed on belongs on the
-  vutuv tab. It narrows the **query**, not the rows it returns, so a narrowed
-  page is as full as an unnarrowed one and `more?` stays honest.
+  It feeds the **vutuv** tab, the reader's own reshares and everybody else's
+  alike: pressing that button is something that happened here, whoever pressed
+  it (`Vutuv.Posts.feed_sources/2`).
   """
-  def feed_remote_reposts(viewer, fetch_n, cursor, opts \\ [])
-
-  def feed_remote_reposts(%User{id: viewer_id} = viewer, fetch_n, cursor, opts) do
+  def feed_remote_reposts(%User{id: viewer_id} = viewer, fetch_n, cursor) do
     if enabled?() do
       from(r in PostRepost,
         join: p in RemotePost,
@@ -2660,7 +2655,7 @@ defmodule Vutuv.Fediverse do
         limit: ^fetch_n,
         preload: [remote_post: {p, [:screenshot, remote_account: a]}, user: reposter]
       )
-      |> scope_resharer(viewer_id, Keyword.get(opts, :only))
+      |> scope_resharer(viewer_id)
       |> Vutuv.Posts.named_language_scope(Vutuv.Posts.feed_language_filter(viewer))
       |> remote_reposts_at_or_before(cursor)
       |> Repo.all()
@@ -2678,18 +2673,7 @@ defmodule Vutuv.Fediverse do
   # source applies: that one only asks about a confirmed address, and passing a
   # stranger's post into other people's feeds is exactly what a frozen or
   # suspended account must not be able to keep doing while its case is open.
-  defp scope_resharer(query, viewer_id, :mine), do: where(query, [r], r.user_id == ^viewer_id)
-
-  defp scope_resharer(query, viewer_id, :others) do
-    where(
-      query,
-      [r, resharer: resharer],
-      r.user_id != ^viewer_id and r.user_id in subquery(unmuted_followees(viewer_id)) and
-        account_confirmed_row(resharer) and not account_hidden_row(resharer)
-    )
-  end
-
-  defp scope_resharer(query, viewer_id, _both) do
+  defp scope_resharer(query, viewer_id) do
     where(
       query,
       [r, resharer: resharer],
@@ -7264,15 +7248,13 @@ defmodule Vutuv.Fediverse do
   The seventh feed source (issue #1275): **replies** from another network that
   people the viewer follows **here** have passed on.
 
-  The exact twin of `feed_remote_reposts/4` one table over, and scoped the same
+  The exact twin of `feed_remote_reposts/3` one table over, and scoped the same
   way — to the resharer, never to any follow of the author, because being
   vouched for by somebody here is the whole reason this row reaches a member who
   follows nobody out there. Stamped with the reshare time: what is new is the
-  sharing. `only:` splits it between the source tabs exactly as it does there.
+  sharing, and it lands on the vutuv tab for the same reason.
   """
-  def feed_remote_reply_reposts(viewer, fetch_n, cursor, opts \\ [])
-
-  def feed_remote_reply_reposts(%User{id: viewer_id} = viewer, fetch_n, cursor, opts) do
+  def feed_remote_reply_reposts(%User{id: viewer_id} = viewer, fetch_n, cursor) do
     if enabled?() do
       from(r in NoteRepost,
         join: n in Note,
@@ -7288,7 +7270,7 @@ defmodule Vutuv.Fediverse do
         order_by: [desc: r.inserted_at, desc: r.id],
         preload: [note: n, user: resharer]
       )
-      |> scope_resharer(viewer_id, Keyword.get(opts, :only))
+      |> scope_resharer(viewer_id)
       |> Vutuv.Posts.named_language_scope(Vutuv.Posts.feed_language_filter(viewer))
       |> limit(^fetch_n)
       |> note_reposts_at_or_before(cursor)

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -2698,23 +2698,26 @@ defmodule Vutuv.Posts do
 
   # The six sources the merged feed pulls from, narrowed to the reader's tab.
   #
-  # The two tabs partition the feed by **who the entry belongs to**, which is
-  # two questions in order. What kind of post it carries decides most of it
-  # (`remote_feed_entry?/1` — the same question the renderer asks to pick a
-  # card), and a **vutuv act on remote content beats that**: pressing Reshare
-  # is something that happened here, so the reader's own reshare of a post from
-  # another network is on the vutuv tab, where they go to see what they did.
-  # Somebody else's reshare is not theirs and stays on the Fediverse tab.
-  # Either way every entry lands on exactly one tab and the two together are
-  # "All".
+  # The two tabs partition the feed by **whether somebody here did something**.
+  # "Fediverse" is what arrives from another network without anybody on this
+  # site lifting a finger: the posts of accounts the reader follows out there,
+  # and what those accounts boosted. Everything a member here did is "vutuv" —
+  # their posts, their replies, and every **reshare**, whoever pressed the
+  # button and whatever they passed on.
   #
-  # Two sources produce both kinds, and both are narrowed by `:only` **inside
-  # their own query** rather than by dropping rows afterwards, so a page is
-  # never short of what the paginator fetched for it (which is what decides
-  # `more?`). `feed_remote_boosts/4` (issue #1167) carries a cached remote post
-  # when the boosted thing lives out there and a plain vutuv post when a
-  # followed account passed a member's post on — the latter *is* a vutuv post.
-  # The two reshare sources (issues #1166 and #1275) split on the resharer.
+  # The reshare is the whole point of the split. Filing a friend's reshare under
+  # "Fediverse" because the *content* came from there sent the reader looking
+  # for their own network's activity under the other network's name — and left
+  # a member with no fediverse follows of their own with a permanently empty
+  # Fediverse tab beside a vutuv tab that was simply "All" again.
+  #
+  # One source produces both kinds and is narrowed by `:only` **inside its own
+  # query** rather than by dropping rows afterwards, so a page is never short of
+  # what the paginator fetched for it (which is what decides `more?`):
+  # `feed_remote_boosts/4` (issue #1167) carries a cached remote post when the
+  # boosted thing lives out there — nobody here did that — and a plain vutuv
+  # post when a followed account passed a member's post on, which *is* a vutuv
+  # post however it arrived.
   defp feed_sources(viewer, :vutuv) do
     [
       &feed_post_items(viewer, &1, &2),
@@ -2724,16 +2727,14 @@ defmodule Vutuv.Posts do
       &feed_reply_to_me_items(viewer, &1, &2),
       &feed_repost_of_mine_items(viewer, &1, &2),
       &Vutuv.Fediverse.feed_remote_boosts(viewer, &1, &2, only: :local),
-      &Vutuv.Fediverse.feed_remote_reposts(viewer, &1, &2, only: :mine),
-      &Vutuv.Fediverse.feed_remote_reply_reposts(viewer, &1, &2, only: :mine)
+      &Vutuv.Fediverse.feed_remote_reposts(viewer, &1, &2),
+      &Vutuv.Fediverse.feed_remote_reply_reposts(viewer, &1, &2)
     ]
   end
 
   defp feed_sources(viewer, :fediverse) do
     [
       &Vutuv.Fediverse.feed_remote_posts(viewer, &1, &2),
-      &Vutuv.Fediverse.feed_remote_reposts(viewer, &1, &2, only: :others),
-      &Vutuv.Fediverse.feed_remote_reply_reposts(viewer, &1, &2, only: :others),
       &Vutuv.Fediverse.feed_remote_boosts(viewer, &1, &2, only: :remote)
     ]
   end
@@ -2823,28 +2824,26 @@ defmodule Vutuv.Posts do
   end
 
   @doc """
-  Whether the feed tab `filter` shows `entry` for `viewer` — the in-memory twin
-  of the source split in `feed_sources/2`, for the entries that arrive live over
-  PubSub rather than through a query.
+  Whether the feed tab `filter` shows `entry` — the in-memory twin of the source
+  split in `feed_sources/2`, for the entries that arrive live over PubSub rather
+  than through a query.
 
-  `viewer` is what makes it a twin rather than a near-miss: the split is not
-  "which kind of post" alone, it is that a reshare the reader pressed
-  themselves counts as a vutuv act (see `feed_sources/2`), and only the reader
-  can say whether they pressed it.
+  The split is not "which kind of post" alone: an entry carrying remote content
+  is a **vutuv** entry as soon as a member here passed it on (`reposted_by`),
+  whoever that was. See `feed_sources/2` for why.
   """
-  def feed_filter_accepts?(:vutuv, entry, viewer),
-    do: not remote_feed_entry?(entry) or own_reshare?(entry, viewer)
+  def feed_filter_accepts?(:vutuv, entry),
+    do: not remote_feed_entry?(entry) or reshared_here?(entry)
 
-  def feed_filter_accepts?(:fediverse, entry, viewer),
-    do: remote_feed_entry?(entry) and not own_reshare?(entry, viewer)
+  def feed_filter_accepts?(:fediverse, entry),
+    do: remote_feed_entry?(entry) and not reshared_here?(entry)
 
-  def feed_filter_accepts?(_all, _entry, _viewer), do: true
+  def feed_filter_accepts?(_all, _entry), do: true
 
-  # Whether this entry is here because the reader passed it on.
-  defp own_reshare?(entry, %User{id: viewer_id}),
-    do: entry[:reposted_by] != nil and entry.reposted_by.id == viewer_id
-
-  defp own_reshare?(_entry, _viewer), do: false
+  # Whether a member here put this entry in front of the reader. `boosted_by` is
+  # deliberately not it: that is an account out there passing something on, and
+  # nobody here did anything.
+  defp reshared_here?(entry), do: entry[:reposted_by] != nil
 
   @doc """
   Whether `viewer`'s feed can show anything from another network at all — the

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -1072,7 +1072,7 @@ defmodule VutuvWeb.PostLive.Feed do
       # feed switches back to All and reloads rather than swallowing the post,
       # which from the composer reads as the post having been lost.
       actor_id == user.id and
-          not Posts.feed_filter_accepts?(socket.assigns.feed_filter, entry, user) ->
+          not Posts.feed_filter_accepts?(socket.assigns.feed_filter, entry) ->
         {:noreply,
          socket
          |> assign(:composer_open?, false)
@@ -1104,7 +1104,7 @@ defmodule VutuvWeb.PostLive.Feed do
       # A post nobody on this tab asked for must not be counted by the pill
       # either: the pill's whole promise is that clicking it shows those posts
       # right here.
-      Posts.feed_filter_accepts?(socket.assigns.feed_filter, entry, user) ->
+      Posts.feed_filter_accepts?(socket.assigns.feed_filter, entry) ->
         {:noreply, update(socket, :pending_posts, &[decorate(entry, user, socket) | &1])}
 
       # It belongs on a tab the reader is not looking at, so say so there

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.379.3",
+      version: "7.381.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/feed_source_tabs_test.exs
+++ b/test/vutuv_web/live/feed_source_tabs_test.exs
@@ -165,12 +165,16 @@ defmodule VutuvWeb.FeedSourceTabsTest do
       refute has_element?(view, "#feed-source-tabs")
     end
 
-    test "somebody here resharing a remote post is enough, with no fediverse account of one's own",
-         %{conn: conn} do
-      # The case a member-level flag would get wrong (issue #1166): this viewer
-      # follows nobody out there and has no actor, but a member they follow
-      # *here* reshared a remote post, so remote posts really are in their feed
-      # and the tabs have work to do.
+    test "a friend's reshare alone is vutuv content, so there are no tabs", %{conn: conn} do
+      # This viewer follows nobody out there and has no actor: everything from
+      # another network reaches them because a member they follow *here* passed
+      # it on — and pressing that button is a vutuv act. So "Fediverse" holds
+      # nothing, "vutuv" is the same list as "All", and three tabs over one
+      # timeline is exactly what issue #1267 took away.
+      #
+      # Until the reshare sources moved to the vutuv tab, this was the case that
+      # proved the bar had work to do (issue #1166). The bar is gone; the
+      # content is not.
       {conn, user} = create_and_login_user(conn)
       sharer = insert(:user, email_confirmed?: true)
       Social.follow(user, sharer.id)
@@ -184,7 +188,7 @@ defmodule VutuvWeb.FeedSourceTabsTest do
 
       {:ok, view, _html} = live(conn, ~p"/feed")
 
-      assert has_element?(view, "#feed-source-tabs")
+      refute has_element?(view, "#feed-source-tabs")
       assert timeline(view) =~ "passed on by a friend"
     end
   end
@@ -410,10 +414,17 @@ defmodule VutuvWeb.FeedSourceTabsTest do
       refute timeline(view) =~ "I passed this on"
     end
 
-    test "somebody else's reshare stays on the Fediverse tab", %{conn: conn} do
+    test "somebody else's reshare is a vutuv act too", %{conn: conn} do
+      # The reader did not press the button, but a member here did — and that is
+      # what the tab is about. "Fediverse" is what arrives without anybody here
+      # doing anything; filing a friend's reshare there sent the reader looking
+      # for their own network's activity under the other network's name.
       {conn, user} = create_and_login_user(conn)
       sharer = insert(:user, email_confirmed?: true)
       Social.follow(user, sharer.id)
+
+      # Something the reader follows out there, so the bar has both halves.
+      cached_post(remote_account(user, "them"), "written out there")
 
       post = cached_post(remote_account("stranger"), "passed on by a friend")
       Repo.insert!(%PostRepost{user_id: sharer.id, remote_post_id: post.id})
@@ -421,10 +432,11 @@ defmodule VutuvWeb.FeedSourceTabsTest do
       {:ok, view, _html} = live(conn, ~p"/feed")
 
       render_click(view, "filter-source", %{"type" => "vutuv"})
-      refute timeline(view) =~ "passed on by a friend"
+      assert timeline(view) =~ "passed on by a friend"
 
       render_click(view, "filter-source", %{"type" => "fediverse"})
-      assert timeline(view) =~ "passed on by a friend"
+      refute timeline(view) =~ "passed on by a friend"
+      assert timeline(view) =~ "written out there"
     end
 
     test "the same holds for a reply the viewer passed on", %{conn: conn} do


### PR DESCRIPTION
**Symptom**: on `/feed`, a reshare by somebody you follow was filed under **Fediverse** — so you went looking for your own network's activity under the other network's name. Only your *own* reshares sat on the vutuv tab (#1708), which made the rule "what kind of post is this, except when I did it".

**The rule is now one thing:** "Fediverse" is what arrives from another network with nobody here lifting a finger — the posts of accounts you follow out there, and what those accounts boosted. Everything a member here did is "vutuv", including every reshare, whoever pressed the button.

That also removes a case #1166 had to work around: a member with no fediverse follows of their own now has a genuinely empty Fediverse tab, so the bar disappears (#1267) instead of offering three names for one timeline. The test that pinned the old promise is rewritten rather than deleted, and says why.

Falls out of it: `feed_remote_reposts/3` and `feed_remote_reply_reposts/3` lose their `only:` option, `scope_resharer/2` is one clause again, and the live twin `feed_filter_accepts?/2` no longer needs the viewer — it just asks whether the entry has a `reposted_by`.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_015DASCqmKUaE4Lx3iWvSvab