### PR TITLE
A named parent status is one the reader can actually fetch

### DIFF
--- a/docs/architecture/mastodon-api.md
+++ b/docs/architecture/mastodon-api.md
@@ -371,19 +371,31 @@ narrowed afterwards and its id would answer 404 to everybody but that member.
 **A status itself names its parent too, not only `/context`** (issue #1622):
 `in_reply_to_id`/`in_reply_to_account_id` used to fill only for a local reply, so
 a client received `null` on every answer that crossed the border and drew it as
-a standalone post. `Presenter.status/2` now fills the same three border-crossing
-shapes `/context` already walks — a cached reply (`%Note{}`) names the local
-post it answers, a followed account's self-reply names its cached parent
-(scoped to the same account, `own_thread?/2`'s own rule), and a vutuv reply into
-another network names the cached post its `remote_reply_ref` continues. Both
-surfaces share one rule: a parent is named only when `viewer` may actually read
-it (`Posts.note_parent_posts/2`'s `scope_visible/2` for the local case,
-`RemotePost.open?/1` or an accepted follow for a cached one) — an id that
-answers 404 for the reader holding it is worse than none, and naming a
-followers-only parent's id at all would leak that it exists to a reader who
-cannot fetch it. Batched for a whole page (`Presenter.page_context/2`'s
-`note_parents`/`remote_parents`/`followed_remote_ids`), not a query per row —
-the same shape `answered_notes/1` and `list_remote_images/1` already use.
+a standalone post — while `/context` beside it named the parent, which is worse
+for a client than both being empty. `Presenter.status/3` now fills the same
+three border-crossing shapes `/context` walks: a cached reply (`%Note{}`) names
+the local post it answers, a followed account's self-reply names its cached
+parent (same account, `own_thread?/2`'s own rule), and a vutuv post answering a
+cached post names that post.
+
+One rule governs all three: **name a parent only when the reader may actually
+fetch it.** For the local case that is `Posts.visible_posts_by_ids/2` — the
+note's own visibility says nothing about the post it answers, which its author
+can have narrowed since. For a cached one it is
+`Fediverse.readable_remote_post_ids/2`, `remote_post_readable?/2` asked once for
+a whole page: an open audience, or this reader's own **accepted** follow. A
+pending follow does not count, and the near-namesake
+`followed_remote_account_ids/2` is not the gate — that one is the card menus'
+question, which counts a follow that has only been asked for because Mute and
+Unfollow both act on a pending row. An id that answers 404 for the reader
+holding it is worse than none, and naming a followers-only parent at all tells
+that reader it exists.
+
+Everything is read for the whole page (`Presenter.page_context/2`), never a
+query per row, and the parents come from the `post_remote_replies` sidecar via
+`Fediverse.answered_objects/1` rather than off a `:remote_reply_ref` preload —
+a parent that silently depends on whether a caller remembered a preload is a
+shape that has bitten this codebase before.
 
 ### Photos
 

--- a/docs/architecture/mastodon-api.md
+++ b/docs/architecture/mastodon-api.md
@@ -368,6 +368,23 @@ a direct read, and a cached reply is named only while it is public: a reply
 addressed to one member cannot be answered at all, so a private one here was
 narrowed afterwards and its id would answer 404 to everybody but that member.
 
+**A status itself names its parent too, not only `/context`** (issue #1622):
+`in_reply_to_id`/`in_reply_to_account_id` used to fill only for a local reply, so
+a client received `null` on every answer that crossed the border and drew it as
+a standalone post. `Presenter.status/2` now fills the same three border-crossing
+shapes `/context` already walks — a cached reply (`%Note{}`) names the local
+post it answers, a followed account's self-reply names its cached parent
+(scoped to the same account, `own_thread?/2`'s own rule), and a vutuv reply into
+another network names the cached post its `remote_reply_ref` continues. Both
+surfaces share one rule: a parent is named only when `viewer` may actually read
+it (`Posts.note_parent_posts/2`'s `scope_visible/2` for the local case,
+`RemotePost.open?/1` or an accepted follow for a cached one) — an id that
+answers 404 for the reader holding it is worse than none, and naming a
+followers-only parent's id at all would leak that it exists to a reader who
+cannot fetch it. Batched for a whole page (`Presenter.page_context/2`'s
+`note_parents`/`remote_parents`/`followed_remote_ids`), not a query per row —
+the same shape `answered_notes/1` and `list_remote_images/1` already use.
+
 ### Photos
 
 `POST /api/v1/media` and `POST /api/v2/media` (multipart, the file in `file`,

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -3036,6 +3036,27 @@ defmodule Vutuv.Fediverse do
     )
   end
 
+  @doc """
+  The same lookup as `remote_parent_post/1`, batched for a whole page of
+  `%RemotePost{}` items (issue #1622's Mastodon-adapter case, which — unlike
+  `/context`'s one-post-at-a-time walk — renders many self-replies at once and
+  cannot afford a query per row).
+
+  `pairs` is a list of `{in_reply_to_uri, remote_account_id}`, exactly what
+  `own_thread?/2` gates a stored reply's parent by — so the result keys the
+  same way, and a caller with no candidate pairs pays no query.
+  """
+  def remote_parent_posts([]), do: %{}
+
+  def remote_parent_posts(pairs) when is_list(pairs) do
+    uris = pairs |> Enum.map(&elem(&1, 0)) |> Enum.uniq()
+    account_ids = pairs |> Enum.map(&elem(&1, 1)) |> Enum.uniq()
+
+    from(p in RemotePost, where: p.object_uri in ^uris and p.remote_account_id in ^account_ids)
+    |> Repo.all()
+    |> Map.new(&{{&1.object_uri, &1.remote_account_id}, &1})
+  end
+
   @doc "One cached remote post with its account and screenshot, or nil."
   def get_remote_post(id) do
     UUIDv7.with_cast(id, &Repo.get(RemotePost, &1))

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -1440,8 +1440,17 @@ defmodule Vutuv.Fediverse do
   feed carries posts by accounts nobody here follows (a boost by a followed
   account, a member's reshare). Offering either one there is a control that does
   nothing and a flash that says otherwise.
+
+  A follow that has only been **asked** for counts here, because both those
+  controls still act on a pending row — which is exactly why this is not a read
+  gate. `readable_remote_post_ids/2` is the one that answers what may be read.
   """
-  def followed_remote_account_ids(party, account_ids) do
+  def followed_remote_account_ids(party, account_ids),
+    do: remote_follow_account_ids(party, account_ids, :any)
+
+  # The shared body of the two questions above and below: which of `account_ids`
+  # this party holds a follow of, either any follow at all or an accepted one.
+  defp remote_follow_account_ids(party, account_ids, state) do
     case account_ids |> Enum.filter(&is_binary/1) |> Enum.uniq() do
       [] ->
         MapSet.new()
@@ -1451,10 +1460,14 @@ defmodule Vutuv.Fediverse do
           where: party_is(f, party) and f.remote_account_id in ^ids,
           select: f.remote_account_id
         )
+        |> scope_follow_state(state)
         |> Repo.all()
         |> MapSet.new()
     end
   end
+
+  defp scope_follow_state(query, :accepted), do: where(query, [f], f.state == "accepted")
+  defp scope_follow_state(query, :any), do: query
 
   @doc """
   Mutes (or unmutes) the member's follow of one remote account.
@@ -3037,14 +3050,17 @@ defmodule Vutuv.Fediverse do
   end
 
   @doc """
-  The same lookup as `remote_parent_post/1`, batched for a whole page of
-  `%RemotePost{}` items (issue #1622's Mastodon-adapter case, which — unlike
-  `/context`'s one-post-at-a-time walk — renders many self-replies at once and
-  cannot afford a query per row).
+  `remote_parent_post/1`'s lookup batched for a whole page of `%RemotePost{}`
+  items (issue #1622's Mastodon-adapter case, which — unlike `/context`'s
+  one-post-at-a-time walk — renders many self-replies at once and cannot afford
+  a query per row). The **same rows**, without the singular's `remote_account`:
+  the callers here name an id and never render the account.
 
   `pairs` is a list of `{in_reply_to_uri, remote_account_id}`, exactly what
   `own_thread?/2` gates a stored reply's parent by — so the result keys the
-  same way, and a caller with no candidate pairs pays no query.
+  same way, and a caller with no candidate pairs pays no query. `object_uri`
+  carries a unique index, so the two `IN` lists can only narrow each other; the
+  same-account rule is the map key, which is what a caller looks a pair up by.
   """
   def remote_parent_posts([]), do: %{}
 
@@ -6357,7 +6373,9 @@ defmodule Vutuv.Fediverse do
   a cached post — the feed's own source, a boost, a member's repost, the account
   page — is a subset of this one, so a gate built from the feed question denies
   the other three; that is what broke the pictures on boosted posts. Keep new
-  read-side callers on this function.
+  read-side callers on this function — `readable_remote_post_ids/2` below is the
+  same rule for a caller holding a whole page, so needing a batch is not a
+  reason to spell the two arms again somewhere else.
   """
   def remote_post_readable?(%RemotePost{} = post, %User{id: viewer_id}) do
     RemotePost.open?(post) or
@@ -6371,6 +6389,36 @@ defmodule Vutuv.Fediverse do
   end
 
   def remote_post_readable?(_post, _viewer), do: false
+
+  @doc """
+  Which of these cached posts `party` may read, as a `MapSet` of post ids —
+  `remote_post_readable?/2` asked once for a whole page rather than once per
+  row, and the answer to that function's own "keep new read-side callers on
+  this function" for a caller holding a page of them
+  (`Vutuv.MastodonApi.Presenter`, naming each reply's parent).
+
+  Same rule, same two arms, composed here so the audience question keeps one
+  owner: an open audience is readable outright, a followers-only one needs this
+  party's own **accepted** follow — a pending one reads nothing yet, so it would
+  name an id the reader's very next request is refused for. Only the closed
+  posts put the follow question at all, so a page of public parents pays no
+  query. Party-shaped rather than member-only, because a page reads cached posts
+  too (`VutuvWeb.MastodonApi.Statuses.visible?/2`), and — faithful to the
+  singular — nobody signed in reads nothing.
+  """
+  def readable_remote_post_ids(_posts, nil), do: MapSet.new()
+
+  def readable_remote_post_ids(posts, party) do
+    closed_account_ids =
+      posts |> Enum.reject(&RemotePost.open?/1) |> Enum.map(& &1.remote_account_id)
+
+    accepted = remote_follow_account_ids(party, closed_account_ids, :accepted)
+
+    for post <- posts,
+        RemotePost.open?(post) or MapSet.member?(accepted, post.remote_account_id),
+        into: MapSet.new(),
+        do: post.id
+  end
 
   # Claims one slot from the member's hourly like budget. `:ok`, or
   # `{:error, :like_capped}`.

--- a/lib/vutuv/mastodon_api/presenter.ex
+++ b/lib/vutuv/mastodon_api/presenter.ex
@@ -955,7 +955,10 @@ defmodule Vutuv.MastodonApi.Presenter do
     case Map.get(context.remote_parents, {uri, account_id}) do
       %RemotePost{} = parent ->
         if readable_remote_parent?(parent, context) do
-          %{in_reply_to_id: "remote-" <> parent.id, in_reply_to_account_id: "remote-" <> account_id}
+          %{
+            in_reply_to_id: "remote-" <> parent.id,
+            in_reply_to_account_id: "remote-" <> account_id
+          }
         else
           %{}
         end
@@ -966,7 +969,9 @@ defmodule Vutuv.MastodonApi.Presenter do
   end
 
   defp readable_remote_parent?(%RemotePost{} = parent, context),
-    do: RemotePost.open?(parent) or MapSet.member?(context.followed_remote_ids, parent.remote_account_id)
+    do:
+      RemotePost.open?(parent) or
+        MapSet.member?(context.followed_remote_ids, parent.remote_account_id)
 
   @doc """
   One freshly uploaded picture, for the media endpoints.

--- a/lib/vutuv/mastodon_api/presenter.ex
+++ b/lib/vutuv/mastodon_api/presenter.ex
@@ -19,7 +19,6 @@ defmodule Vutuv.MastodonApi.Presenter do
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostImage
-  alias Vutuv.Posts.PostRemoteReply
   alias Vutuv.Profiles.Url
   alias Vutuv.Profiles.VerifiedLinks
   alias Vutuv.RemoteMedia
@@ -138,51 +137,48 @@ defmodule Vutuv.MastodonApi.Presenter do
     remote_ids = items |> Enum.map(&remote_post_id/1) |> Enum.reject(&is_nil/1)
     note_parent_ids = items |> Enum.map(&note_parent_post_id/1) |> Enum.reject(&is_nil/1)
     self_reply_pairs = items |> Enum.map(&self_reply_pair/1) |> Enum.reject(&is_nil/1)
-    reply_ref_parents = items |> Enum.map(&reply_ref_parent/1) |> Enum.reject(&is_nil/1)
 
+    # Both halves of the sidecar, in one map (issue #1622): the cached reply a
+    # post answers (#1641) and the cached **post** it answers (#1165). Read from
+    # the sidecar table rather than off the `:remote_reply_ref` preload, which
+    # is what `answered_notes/1`'s own doc asks for — a parent that silently
+    # depends on whether somebody remembered a preload is a shape that has
+    # bitten this codebase before.
+    answered = Fediverse.answered_objects(post_ids)
     remote_parents = Fediverse.remote_parent_posts(self_reply_pairs)
-
-    followed_remote_ids =
-      (Map.values(remote_parents) ++ reply_ref_parents)
-      |> Enum.map(& &1.remote_account_id)
-      |> Enum.uniq()
-      |> followed_remote_ids(viewer)
 
     %{
       viewer: viewer,
       engagements: Posts.post_engagement_map(post_ids, viewer),
       mentions: Posts.mention_map(post_ids),
-      # Which cached fediverse reply each post answers, if any (issue #1641).
-      answered: Fediverse.answered_notes(post_ids),
+      answered: answered,
       # The photographs on the cached posts this page shows (issue #1626).
       # `:images` is never preloaded on a `%RemotePost{}` — every surface in this
       # codebase batches them by id, and so does this one.
       remote_images: Fediverse.list_remote_images(remote_ids),
       # The local post each cached reply answers (issue #1622), batched and
-      # already scoped to what `viewer` may see (`Posts.note_parent_posts/2`).
-      note_parents: Posts.note_parent_posts(note_parent_ids, viewer),
+      # already scoped to what `viewer` may see.
+      note_parents: Posts.visible_posts_by_ids(viewer, note_parent_ids),
       # The cached parent of a followed account's self-reply, batched the same
-      # way (`Fediverse.remote_parent_posts/1`) — visibility is checked at
-      # render time against `followed_remote_ids` below, since two different
-      # callers here (a self-reply's own parent, a vutuv answer's
-      # `remote_reply_ref`) both read this same audience gate.
+      # way (`Fediverse.remote_parent_posts/1`).
       remote_parents: remote_parents,
-      followed_remote_ids: followed_remote_ids
+      # Which of those cached parents `viewer` may actually read — the half
+      # `answered_objects/1` hands over ungated on purpose, because only the
+      # renderer knows the reader. One `Fediverse.remote_post_readable?/2` for
+      # the whole page, and no query at all when every parent is public.
+      readable_parents:
+        Fediverse.readable_remote_post_ids(
+          Map.values(remote_parents) ++ answered_remote_posts(answered),
+          viewer
+        )
     }
   end
 
-  # `viewer` is never a party `Fediverse.followed_remote_account_ids/2` can
-  # take when nobody is signed in — `Vutuv.Identity.Query.party_is/2` has no
-  # `nil` clause and raises — and an anonymous reader follows nothing anyway,
-  # so every restricted parent is simply unreadable for them.
-  defp followed_remote_ids([], _viewer), do: MapSet.new()
-  defp followed_remote_ids(_account_ids, nil), do: MapSet.new()
-
-  defp followed_remote_ids(account_ids, viewer),
-    do: Fediverse.followed_remote_account_ids(viewer, account_ids)
+  defp answered_remote_posts(answered),
+    do: for({_post_id, %RemotePost{} = post} <- answered, do: post)
 
   # What a single status rendered outside `statuses/2` gets. Built by the same
-  # function rather than spelled out again, so a sixth batch cannot be added to
+  # function rather than spelled out again, so the next batch cannot be added to
   # one shape and forgotten in the other; every batch short-circuits on an empty
   # id list, so it costs no query.
   defp no_page, do: page_context([], nil)
@@ -287,27 +283,6 @@ defmodule Vutuv.MastodonApi.Presenter do
        do: {uri, account_id}
 
   defp self_reply_pair(_other), do: nil
-
-  # The cached post a vutuv reply's `remote_reply_ref` continues (issue #1165),
-  # read off the preload rather than queried — `Posts.render_preloads/0`
-  # already carries it on every `%Post{}` this adapter renders, so collecting
-  # it here costs no query; only its audience needs a batch (`followed_remote_ids`).
-  defp reply_ref_parent(%Post{
-         remote_reply_ref: %PostRemoteReply{remote_post: %RemotePost{} = parent}
-       }),
-       do: parent
-
-  defp reply_ref_parent(
-         %{
-           post: %Post{
-             remote_reply_ref: %PostRemoteReply{remote_post: %RemotePost{} = parent}
-           }
-         } = entry
-       )
-       when not is_struct(entry),
-       do: parent
-
-  defp reply_ref_parent(_other), do: nil
 
   defp rendered_status(%Post{} = post, context), do: status(post, context)
 
@@ -883,7 +858,14 @@ defmodule Vutuv.MastodonApi.Presenter do
   defp reply_fields(_post, %Note{} = note, _context),
     do: %{in_reply_to_id: status_id(note), in_reply_to_account_id: note_account_id(note)}
 
-  defp reply_fields(post, _no_cached_reply, context) do
+  # The other half of the sidecar (issue #1165): a top-level vutuv post that
+  # answers a followed account's post out there threads under the cached copy of
+  # it, a status the same client can fetch. There is no local parent to prefer
+  # here — the shape exists precisely because nothing of ours sits underneath.
+  defp reply_fields(_post, %RemotePost{} = parent, context),
+    do: remote_parent_fields(parent, context)
+
+  defp reply_fields(post, _no_cached_parent, _context) do
     case Posts.reply_ref_state(post) do
       {:parent, %Post{} = parent} ->
         %{
@@ -892,50 +874,24 @@ defmodule Vutuv.MastodonApi.Presenter do
         }
 
       _not_a_live_local_parent ->
-        # Not a local reply — but it may answer a followed account's post on
-        # another network (issue #1165), which threads under the cached copy of
-        # that post, a status the same client can fetch (`remote-<id>`). The
-        # #1070 shape (an answer that is *also* a local reply) already resolved
-        # to its local parent above, so only the top-level case reaches here;
-        # `remote_reply_ref` is preloaded with its `remote_post` and account.
-        remote_reply_fields(post, context)
+        %{}
     end
   end
-
-  # **Gated the same way `StatusController.status_visible?/2` gates the
-  # single-status case** — a followers-only cached post named here must be one
-  # `context.followed_remote_ids` actually holds, or a client would be handed
-  # an id that answers 404 (or worse, silently confirms a restricted post
-  # exists) to every reader but the ones this installation itself follows that
-  # account for. `open?/1` covers the common case with no set membership check
-  # at all.
-  defp remote_reply_fields(
-         %Post{remote_reply_ref: %PostRemoteReply{remote_post: %RemotePost{} = parent}},
-         context
-       ) do
-    if readable_remote_parent?(parent, context) do
-      %{
-        in_reply_to_id: "remote-" <> parent.id,
-        in_reply_to_account_id: "remote-" <> parent.remote_account_id
-      }
-    else
-      %{}
-    end
-  end
-
-  defp remote_reply_fields(_post, _context), do: %{}
 
   # Names the local post a cached reply answers, read off `context.note_parents`
-  # (`Posts.note_parent_posts/2` — batched for the whole page and already
+  # (`Posts.visible_posts_by_ids/2` — batched for the whole page and already
   # scoped to what `context.viewer` may see, the note's own visibility being no
-  # proof that its narrower parent still is). The account id is the post
-  # author's, which `author_id/1` already is (a member or a page), so no
-  # account struct is built; `%{}` (both nil) when the post is gone or not
-  # visible to this viewer.
+  # proof that its narrower parent still is). Both author kinds ride that
+  # preload, so the two ids are minted by the same pair the local-reply branch
+  # above uses rather than read off the columns; `%{}` (both nil) when the post
+  # is gone or not visible to this viewer.
   defp note_reply_fields(note, context) do
     case Map.get(context.note_parents, note.post_id) do
       %Post{} = parent ->
-        %{in_reply_to_id: parent.id, in_reply_to_account_id: Posts.author_id(parent)}
+        %{
+          in_reply_to_id: status_id(parent),
+          in_reply_to_account_id: account_id(Posts.author(parent))
+        }
 
       nil ->
         %{}
@@ -944,34 +900,41 @@ defmodule Vutuv.MastodonApi.Presenter do
 
   # Names the cached parent post a stored reply continues, read off
   # `context.remote_parents` (`Fediverse.remote_parent_posts/1` — batched for
-  # the whole page rather than a query per row) and gated on audience the same
-  # way `remote_reply_fields/2` above is. `%{}` when the parent is not (or no
-  # longer) held, or is one `context.viewer` may not read: an id no client can
-  # resolve or is refused for is worse than none (the issue's own rule).
+  # the whole page rather than a query per row).
   defp remote_post_reply_fields(
          %RemotePost{in_reply_to_uri: uri, remote_account_id: account_id},
          context
-       ) do
-    case Map.get(context.remote_parents, {uri, account_id}) do
-      %RemotePost{} = parent ->
-        if readable_remote_parent?(parent, context) do
-          %{
-            in_reply_to_id: "remote-" <> parent.id,
-            in_reply_to_account_id: "remote-" <> account_id
-          }
-        else
-          %{}
-        end
+       ),
+       do: remote_parent_fields(Map.get(context.remote_parents, {uri, account_id}), context)
 
-      nil ->
-        %{}
+  # The one place a cached parent becomes the two fields, for both callers
+  # above. **Gated the same way `VutuvWeb.MastodonApi.Statuses.visible?/2` gates
+  # the single-status read** (`context.readable_parents`): naming a
+  # followers-only post hands a client an id that answers 404 — or worse,
+  # silently confirms a restricted post exists — to every reader but the ones
+  # this installation follows that account for. `%{}`, i.e. both nil, when the
+  # parent is not (or no longer) held or may not be read: an id no client can
+  # resolve or is refused for is worse than none, which is the issue's own rule.
+  defp remote_parent_fields(%RemotePost{} = parent, context) do
+    if MapSet.member?(context.readable_parents, parent.id) do
+      %{
+        in_reply_to_id: status_id(parent),
+        in_reply_to_account_id: remote_account_id(parent)
+      }
+    else
+      %{}
     end
   end
 
-  defp readable_remote_parent?(%RemotePost{} = parent, context),
-    do:
-      RemotePost.open?(parent) or
-        MapSet.member?(context.followed_remote_ids, parent.remote_account_id)
+  defp remote_parent_fields(nil, _context), do: %{}
+
+  # `account_id/1` where the account itself is loaded (`answered_objects/1`
+  # selects it in), and the same spelling from the bare column where it is not
+  # (`remote_parent_posts/1` reads ids, not accounts).
+  defp remote_account_id(%RemotePost{remote_account: %RemoteAccount{} = account}),
+    do: account_id(account)
+
+  defp remote_account_id(%RemotePost{remote_account_id: id}), do: "remote-" <> id
 
   @doc """
   One freshly uploaded picture, for the media endpoints.

--- a/lib/vutuv/mastodon_api/presenter.ex
+++ b/lib/vutuv/mastodon_api/presenter.ex
@@ -19,6 +19,7 @@ defmodule Vutuv.MastodonApi.Presenter do
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostImage
+  alias Vutuv.Posts.PostRemoteReply
   alias Vutuv.Profiles.Url
   alias Vutuv.Profiles.VerifiedLinks
   alias Vutuv.RemoteMedia
@@ -135,6 +136,17 @@ defmodule Vutuv.MastodonApi.Presenter do
   defp page_context(items, viewer) do
     post_ids = items |> Enum.map(&engaged_post_id/1) |> Enum.reject(&is_nil/1)
     remote_ids = items |> Enum.map(&remote_post_id/1) |> Enum.reject(&is_nil/1)
+    note_parent_ids = items |> Enum.map(&note_parent_post_id/1) |> Enum.reject(&is_nil/1)
+    self_reply_pairs = items |> Enum.map(&self_reply_pair/1) |> Enum.reject(&is_nil/1)
+    reply_ref_parents = items |> Enum.map(&reply_ref_parent/1) |> Enum.reject(&is_nil/1)
+
+    remote_parents = Fediverse.remote_parent_posts(self_reply_pairs)
+
+    followed_remote_ids =
+      (Map.values(remote_parents) ++ reply_ref_parents)
+      |> Enum.map(& &1.remote_account_id)
+      |> Enum.uniq()
+      |> followed_remote_ids(viewer)
 
     %{
       viewer: viewer,
@@ -145,9 +157,29 @@ defmodule Vutuv.MastodonApi.Presenter do
       # The photographs on the cached posts this page shows (issue #1626).
       # `:images` is never preloaded on a `%RemotePost{}` — every surface in this
       # codebase batches them by id, and so does this one.
-      remote_images: Fediverse.list_remote_images(remote_ids)
+      remote_images: Fediverse.list_remote_images(remote_ids),
+      # The local post each cached reply answers (issue #1622), batched and
+      # already scoped to what `viewer` may see (`Posts.note_parent_posts/2`).
+      note_parents: Posts.note_parent_posts(note_parent_ids, viewer),
+      # The cached parent of a followed account's self-reply, batched the same
+      # way (`Fediverse.remote_parent_posts/1`) — visibility is checked at
+      # render time against `followed_remote_ids` below, since two different
+      # callers here (a self-reply's own parent, a vutuv answer's
+      # `remote_reply_ref`) both read this same audience gate.
+      remote_parents: remote_parents,
+      followed_remote_ids: followed_remote_ids
     }
   end
+
+  # `viewer` is never a party `Fediverse.followed_remote_account_ids/2` can
+  # take when nobody is signed in — `Vutuv.Identity.Query.party_is/2` has no
+  # `nil` clause and raises — and an anonymous reader follows nothing anyway,
+  # so every restricted parent is simply unreadable for them.
+  defp followed_remote_ids([], _viewer), do: MapSet.new()
+  defp followed_remote_ids(_account_ids, nil), do: MapSet.new()
+
+  defp followed_remote_ids(account_ids, viewer),
+    do: Fediverse.followed_remote_account_ids(viewer, account_ids)
 
   # What a single status rendered outside `statuses/2` gets. Built by the same
   # function rather than spelled out again, so a sixth batch cannot be added to
@@ -229,6 +261,53 @@ defmodule Vutuv.MastodonApi.Presenter do
     do: id
 
   defp remote_post_id(_other), do: nil
+
+  # The local post id a cached reply's `Note.post_id` names, for the
+  # `note_parents` batch — same map-vs-struct shape as every other extractor
+  # here.
+  defp note_parent_post_id(%Note{post_id: id}) when is_binary(id), do: id
+
+  defp note_parent_post_id(%{note: %Note{post_id: id}} = entry)
+       when not is_struct(entry) and is_binary(id),
+       do: id
+
+  defp note_parent_post_id(_other), do: nil
+
+  # The `{in_reply_to_uri, remote_account_id}` pair `own_thread?/2` gated a
+  # cached post's own parent by, for the `remote_parents` batch.
+  defp self_reply_pair(%RemotePost{in_reply_to_uri: uri, remote_account_id: account_id})
+       when is_binary(uri),
+       do: {uri, account_id}
+
+  defp self_reply_pair(
+         %{remote_post: %RemotePost{in_reply_to_uri: uri, remote_account_id: account_id}} =
+           entry
+       )
+       when not is_struct(entry) and is_binary(uri),
+       do: {uri, account_id}
+
+  defp self_reply_pair(_other), do: nil
+
+  # The cached post a vutuv reply's `remote_reply_ref` continues (issue #1165),
+  # read off the preload rather than queried — `Posts.render_preloads/0`
+  # already carries it on every `%Post{}` this adapter renders, so collecting
+  # it here costs no query; only its audience needs a batch (`followed_remote_ids`).
+  defp reply_ref_parent(%Post{
+         remote_reply_ref: %PostRemoteReply{remote_post: %RemotePost{} = parent}
+       }),
+       do: parent
+
+  defp reply_ref_parent(
+         %{
+           post: %Post{
+             remote_reply_ref: %PostRemoteReply{remote_post: %RemotePost{} = parent}
+           }
+         } = entry
+       )
+       when not is_struct(entry),
+       do: parent
+
+  defp reply_ref_parent(_other), do: nil
 
   defp rendered_status(%Post{} = post, context), do: status(post, context)
 
@@ -343,24 +422,28 @@ defmodule Vutuv.MastodonApi.Presenter do
         tags: status_tags(post),
         mentions: status_mentions(post, context.mentions[post.id])
       }
-      |> Map.merge(reply_fields(post, context.answered[post.id]))
+      |> Map.merge(reply_fields(post, context.answered[post.id], context))
       |> Map.merge(engagement_fields(engagement))
 
     base_status(fields)
   end
 
   defp status(%RemotePost{} = post, context) do
-    base_status(%{
-      id: status_id(post),
-      created_at: timestamp(post.published_at),
-      content: remote_content_html(post.content_text),
-      url: post.origin_url || post.object_uri,
-      uri: post.object_uri,
-      account: account(post.remote_account),
-      media_attachments: remote_attachments(post, context),
-      sensitive: post.sensitive,
-      spoiler_text: post.summary || ""
-    })
+    fields =
+      %{
+        id: status_id(post),
+        created_at: timestamp(post.published_at),
+        content: remote_content_html(post.content_text),
+        url: post.origin_url || post.object_uri,
+        uri: post.object_uri,
+        account: account(post.remote_account),
+        media_attachments: remote_attachments(post, context),
+        sensitive: post.sensitive,
+        spoiler_text: post.summary || ""
+      }
+      |> Map.merge(remote_post_reply_fields(post, context))
+
+    base_status(fields)
   end
 
   # A cached **reply** carries no pictures at all: there is no note-image table
@@ -368,19 +451,23 @@ defmodule Vutuv.MastodonApi.Presenter do
   # picture is not copied here (`Vutuv.Fediverse.Note`). So this head has nothing
   # to name, and an empty `media_attachments` is the true answer rather than an
   # unfinished one.
-  defp status(%Note{} = note, _context) do
-    base_status(%{
-      id: status_id(note),
-      created_at: timestamp(note.received_at),
-      content: remote_content_html(note.content_text),
-      url: Note.origin(note),
-      uri: note.object_uri,
-      account: note_account(note),
-      sensitive: Note.warned?(note),
-      spoiler_text: note.summary || "",
-      favourites_count: note.likes_count || 0,
-      reblogs_count: note.shares_count || 0
-    })
+  defp status(%Note{} = note, context) do
+    fields =
+      %{
+        id: status_id(note),
+        created_at: timestamp(note.received_at),
+        content: remote_content_html(note.content_text),
+        url: Note.origin(note),
+        uri: note.object_uri,
+        account: note_account(note),
+        sensitive: Note.warned?(note),
+        spoiler_text: note.summary || "",
+        favourites_count: note.likes_count || 0,
+        reblogs_count: note.shares_count || 0
+      }
+      |> Map.merge(note_reply_fields(note, context))
+
+    base_status(fields)
   end
 
   @doc """
@@ -793,10 +880,10 @@ defmodule Vutuv.MastodonApi.Presenter do
   #
   # Either way the id named is one this client can fetch, and nothing is named
   # that we hold no row for — an id no client can resolve is worse than none.
-  defp reply_fields(_post, %Note{} = note),
+  defp reply_fields(_post, %Note{} = note, _context),
     do: %{in_reply_to_id: status_id(note), in_reply_to_account_id: note_account_id(note)}
 
-  defp reply_fields(post, _no_cached_reply) do
+  defp reply_fields(post, _no_cached_reply, context) do
     case Posts.reply_ref_state(post) do
       {:parent, %Post{} = parent} ->
         %{
@@ -804,10 +891,82 @@ defmodule Vutuv.MastodonApi.Presenter do
           in_reply_to_account_id: account_id(Posts.author(parent))
         }
 
-      _not_a_live_parent ->
+      _not_a_live_local_parent ->
+        # Not a local reply — but it may answer a followed account's post on
+        # another network (issue #1165), which threads under the cached copy of
+        # that post, a status the same client can fetch (`remote-<id>`). The
+        # #1070 shape (an answer that is *also* a local reply) already resolved
+        # to its local parent above, so only the top-level case reaches here;
+        # `remote_reply_ref` is preloaded with its `remote_post` and account.
+        remote_reply_fields(post, context)
+    end
+  end
+
+  # **Gated the same way `StatusController.status_visible?/2` gates the
+  # single-status case** — a followers-only cached post named here must be one
+  # `context.followed_remote_ids` actually holds, or a client would be handed
+  # an id that answers 404 (or worse, silently confirms a restricted post
+  # exists) to every reader but the ones this installation itself follows that
+  # account for. `open?/1` covers the common case with no set membership check
+  # at all.
+  defp remote_reply_fields(
+         %Post{remote_reply_ref: %PostRemoteReply{remote_post: %RemotePost{} = parent}},
+         context
+       ) do
+    if readable_remote_parent?(parent, context) do
+      %{
+        in_reply_to_id: "remote-" <> parent.id,
+        in_reply_to_account_id: "remote-" <> parent.remote_account_id
+      }
+    else
+      %{}
+    end
+  end
+
+  defp remote_reply_fields(_post, _context), do: %{}
+
+  # Names the local post a cached reply answers, read off `context.note_parents`
+  # (`Posts.note_parent_posts/2` — batched for the whole page and already
+  # scoped to what `context.viewer` may see, the note's own visibility being no
+  # proof that its narrower parent still is). The account id is the post
+  # author's, which `author_id/1` already is (a member or a page), so no
+  # account struct is built; `%{}` (both nil) when the post is gone or not
+  # visible to this viewer.
+  defp note_reply_fields(note, context) do
+    case Map.get(context.note_parents, note.post_id) do
+      %Post{} = parent ->
+        %{in_reply_to_id: parent.id, in_reply_to_account_id: Posts.author_id(parent)}
+
+      nil ->
         %{}
     end
   end
+
+  # Names the cached parent post a stored reply continues, read off
+  # `context.remote_parents` (`Fediverse.remote_parent_posts/1` — batched for
+  # the whole page rather than a query per row) and gated on audience the same
+  # way `remote_reply_fields/2` above is. `%{}` when the parent is not (or no
+  # longer) held, or is one `context.viewer` may not read: an id no client can
+  # resolve or is refused for is worse than none (the issue's own rule).
+  defp remote_post_reply_fields(
+         %RemotePost{in_reply_to_uri: uri, remote_account_id: account_id},
+         context
+       ) do
+    case Map.get(context.remote_parents, {uri, account_id}) do
+      %RemotePost{} = parent ->
+        if readable_remote_parent?(parent, context) do
+          %{in_reply_to_id: "remote-" <> parent.id, in_reply_to_account_id: "remote-" <> account_id}
+        else
+          %{}
+        end
+
+      nil ->
+        %{}
+    end
+  end
+
+  defp readable_remote_parent?(%RemotePost{} = parent, context),
+    do: RemotePost.open?(parent) or MapSet.member?(context.followed_remote_ids, parent.remote_account_id)
 
   @doc """
   One freshly uploaded picture, for the media endpoints.

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -5465,6 +5465,27 @@ defmodule Vutuv.Posts do
 
   def reply_ref_state(_post), do: nil
 
+  @doc """
+  The local post each of `post_ids` (`Note.post_id`) names, scoped to what
+  `viewer` may see — one query for a whole page rather than a `Repo.get` per
+  cached reply, and gated the same way `StatusController.context_payload/2`
+  gates the single-note case (`status_visible?/2`): a note's own visibility
+  (a public reply) says nothing about the local post it answers, which its
+  author can since have narrowed. The Mastodon adapter reads this to name a
+  cached reply's `in_reply_to_id` — a parent `viewer` may not see is left out
+  of the map entirely, because an id no client can resolve or is refused for
+  is worse than none. A bare primary-key scan, no preload — the caller reads
+  only `id` and `author_id/1` (both plain columns).
+  """
+  def note_parent_posts([]), do: %{}
+
+  def note_parent_posts(post_ids, viewer) when is_list(post_ids) do
+    from(p in Post, where: p.id in ^post_ids)
+    |> scope_visible(viewer)
+    |> Repo.all()
+    |> Map.new(&{&1.id, &1})
+  end
+
   defp preload_post(nil), do: nil
   defp preload_post(%Post{} = post), do: Repo.preload(post, post_preloads(), force: true)
 

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -5445,6 +5445,13 @@ defmodule Vutuv.Posts do
   that a reply/like is about is always quotable), while another member's post (a
   reply quoted alongside it) passes only when the deny-based visibility rules
   would show it, so a restricted reply never leaks through the notification.
+
+  The Mastodon adapter reads it for a second reason (issue #1622): the local
+  post a cached fediverse reply answers, to name as that reply's
+  `in_reply_to_id`. The gate is the point there too — the note's own visibility
+  (a public reply) says nothing about the post it answers, which its author can
+  since have narrowed, and an id the reader's next request is refused for is
+  worse than none.
   """
   def visible_posts_by_ids(viewer, ids) do
     ids = ids |> Enum.filter(&is_binary/1) |> Enum.uniq()
@@ -5483,27 +5490,6 @@ defmodule Vutuv.Posts do
   end
 
   def reply_ref_state(_post), do: nil
-
-  @doc """
-  The local post each of `post_ids` (`Note.post_id`) names, scoped to what
-  `viewer` may see — one query for a whole page rather than a `Repo.get` per
-  cached reply, and gated the same way `StatusController.context_payload/2`
-  gates the single-note case (`status_visible?/2`): a note's own visibility
-  (a public reply) says nothing about the local post it answers, which its
-  author can since have narrowed. The Mastodon adapter reads this to name a
-  cached reply's `in_reply_to_id` — a parent `viewer` may not see is left out
-  of the map entirely, because an id no client can resolve or is refused for
-  is worse than none. A bare primary-key scan, no preload — the caller reads
-  only `id` and `author_id/1` (both plain columns).
-  """
-  def note_parent_posts([], _viewer), do: %{}
-
-  def note_parent_posts(post_ids, viewer) when is_list(post_ids) do
-    from(p in Post, where: p.id in ^post_ids)
-    |> scope_visible(viewer)
-    |> Repo.all()
-    |> Map.new(&{&1.id, &1})
-  end
 
   defp preload_post(nil), do: nil
   defp preload_post(%Post{} = post), do: Repo.preload(post, post_preloads(), force: true)

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -1197,6 +1197,19 @@ defmodule Vutuv.Posts do
     |> scope_unfrozen(nil)
   end
 
+  # A page as the VIEWER (issue #1336, mirroring `visible_to?/2`'s own
+  # Organization clauses): it is not a member, so no denial can name it and it
+  # sees exactly what an anonymous reader sees, plus its own posts while
+  # moderation holds them — the way an author sees theirs.
+  def scope_visible(query, %Organization{id: organization_id} = viewer) do
+    from(p in query,
+      where:
+        p.organization_id == ^organization_id or
+          fragment("NOT EXISTS (SELECT 1 FROM post_denials d WHERE d.post_id = ?)", p.id)
+    )
+    |> scope_unfrozen(viewer)
+  end
+
   def scope_visible(query, %User{id: viewer_id} = viewer) do
     from(p in query,
       where:
@@ -1249,8 +1262,14 @@ defmodule Vutuv.Posts do
 
     filter =
       case viewer do
-        %User{id: viewer_id} -> dynamic([p], p.user_id == ^viewer_id or ^passes)
-        nil -> passes
+        %User{id: viewer_id} ->
+          dynamic([p], p.user_id == ^viewer_id or ^passes)
+
+        %Organization{id: organization_id} ->
+          dynamic([p], p.organization_id == ^organization_id or ^passes)
+
+        nil ->
+          passes
       end
 
     where(query, ^filter)
@@ -5477,7 +5496,7 @@ defmodule Vutuv.Posts do
   is worse than none. A bare primary-key scan, no preload — the caller reads
   only `id` and `author_id/1` (both plain columns).
   """
-  def note_parent_posts([]), do: %{}
+  def note_parent_posts([], _viewer), do: %{}
 
   def note_parent_posts(post_ids, viewer) when is_list(post_ids) do
     from(p in Post, where: p.id in ^post_ids)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.372.0",
+      version: "7.374.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/controllers/mastodon_api/status_parent_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/status_parent_test.exs
@@ -14,8 +14,10 @@ defmodule VutuvWeb.MastodonApi.StatusParentTest do
   import Vutuv.MastodonHelpers
 
   alias Vutuv.Fediverse.Follow
+  alias Vutuv.Organizations
   alias Vutuv.Posts
   alias Vutuv.Posts.PostRemoteReply
+  alias Vutuv.Social
 
   defp show(conn, token, id) do
     conn
@@ -24,16 +26,32 @@ defmodule VutuvWeb.MastodonApi.StatusParentTest do
     |> json_response(200)
   end
 
-  test "a local reply names its local parent", %{conn: conn} do
-    author = insert(:activated_user)
-    {:ok, parent} = Posts.create_post(author, %{body: "Die Ausgangsfrage"})
-    {:ok, reply} = Posts.create_reply(author, parent, %{body: "Die Antwort"})
+  # A vutuv post answering a followed account's post out there — the sidecar
+  # `Posts.create_remote_post_reply/3` writes, built by hand because going
+  # through it claims the shared outbound budget and this file stays async
+  # (`thread_parents_test.exs` is the sync one that drives the real call).
+  defp answer_to_cached_post(author, account, remote_post) do
+    {:ok, post} = Posts.create_post(author, %{body: "Meine Antwort nach drüben"})
 
-    token = mastodon_token(insert(:activated_user), ["read"])
-    status = show(conn, token, reply.id)
+    Repo.insert!(%PostRemoteReply{
+      post_id: post.id,
+      remote_post_id: remote_post.id,
+      in_reply_to_uri: remote_post.object_uri,
+      actor_uri: account.actor_uri,
+      inbox_uri: account.inbox_uri,
+      handle: account.handle <> "@social.example"
+    })
 
-    assert status["in_reply_to_id"] == parent.id
-    assert status["in_reply_to_account_id"] == author.id
+    post
+  end
+
+  defp follow_remote(reader, account, state) do
+    Repo.insert!(%Follow{
+      user_id: reader.id,
+      remote_account_id: account.id,
+      state: state,
+      follow_activity_id: "https://vutuv.test/#{reader.id}/actor#f/#{account.id}"
+    })
   end
 
   test "a cached remote reply names the member's post it answers", %{conn: conn} do
@@ -72,33 +90,143 @@ defmodule VutuvWeb.MastodonApi.StatusParentTest do
     assert status["in_reply_to_account_id"] == nil
   end
 
+  # `own_thread?/2`'s rule, which this reads the same way: a cached post names
+  # its parent only inside its **own** account's thread. Somebody else's post at
+  # that address is a conversation we hold one arbitrary side of, and we cache
+  # it because a member follows its author, not because we followed the thread.
+  test "a cached reply does not reach across accounts for its parent", %{conn: conn} do
+    stranger = remote_account(handle: "greta")
+    parent = cached_post(stranger)
+
+    author = remote_account(handle: "hugo")
+    reply = cached_post(author, in_reply_to_uri: parent.object_uri)
+
+    token = mastodon_token(insert(:activated_user), ["read"])
+    status = show(conn, token, "remote-" <> reply.id)
+
+    assert status["in_reply_to_id"] == nil
+  end
+
   test "a vutuv answer to a followed account's post names the cached post", %{conn: conn} do
     author = insert(:activated_user)
     account = remote_account(handle: "carol")
     remote_post = cached_post(account)
-
-    Repo.insert!(%Follow{
-      user_id: author.id,
-      remote_account_id: account.id,
-      state: "accepted",
-      follow_activity_id: "https://vutuv.test/#{author.id}/actor#f/#{account.id}"
-    })
-
-    {:ok, post} = Posts.create_post(author, %{body: "Meine Antwort nach drüben"})
-
-    Repo.insert!(%PostRemoteReply{
-      post_id: post.id,
-      remote_post_id: remote_post.id,
-      in_reply_to_uri: remote_post.object_uri,
-      actor_uri: account.actor_uri,
-      inbox_uri: account.inbox_uri,
-      handle: "carol@social.example"
-    })
+    follow_remote(author, account, "accepted")
+    post = answer_to_cached_post(author, account, remote_post)
 
     token = mastodon_token(insert(:activated_user), ["read"])
     status = show(conn, token, post.id)
 
     assert status["in_reply_to_id"] == "remote-" <> remote_post.id
     assert status["in_reply_to_account_id"] == "remote-" <> account.id
+  end
+
+  # The same answer on a list, not only on the single status a client asks for
+  # by id: the three border-crossing shapes are read off preloads and batches
+  # that `statuses/2` fills for a whole page, and a timeline is where a client
+  # actually threads a conversation.
+  test "the home timeline names the same parent the single status does", %{conn: conn} do
+    reader = insert(:activated_user)
+    author = insert(:activated_user)
+    {:ok, _} = Social.follow(reader, author.id)
+
+    account = remote_account(handle: "frida")
+    remote_post = cached_post(account)
+    post = answer_to_cached_post(author, account, remote_post)
+    follow_remote(reader, account, "accepted")
+
+    token = mastodon_token(reader, ["read"])
+
+    # The timeline carries the cached post itself too, since the reader follows
+    # that account — the answer is the entry to read here.
+    statuses =
+      conn
+      |> mastodon_conn(token)
+      |> get("/api/v1/timelines/home")
+      |> json_response(200)
+
+    status = Enum.find(statuses, &(&1["id"] == post.id))
+
+    assert status["in_reply_to_id"] == "remote-" <> remote_post.id
+    assert status["in_reply_to_account_id"] == "remote-" <> account.id
+  end
+
+  # The gate, calibrated against the un-fixed code: take `scope_visible/2` out
+  # of `Posts.note_parent_posts/2` and the first assertion goes green while the
+  # second still 404s — which is the contradiction the rule above forbids. A
+  # stranger's reply is usually public and says nothing about the post it
+  # answers, whose author can have narrowed it since.
+  test "a cached reply does not name a local parent the reader may not read", %{conn: conn} do
+    member = insert(:activated_user)
+
+    {:ok, parent} =
+      Posts.create_post(member, %{
+        body: "Nur für Follower",
+        denials: [%{wildcard: "non_followers"}]
+      })
+
+    note = insert(:note, post: parent)
+    token = mastodon_token(insert(:activated_user), ["read"])
+    status = show(conn, token, "remote-note-" <> note.id)
+
+    assert status["in_reply_to_id"] == nil
+    assert status["in_reply_to_account_id"] == nil
+
+    assert conn
+           |> mastodon_conn(token)
+           |> get("/api/v1/statuses/#{parent.id}")
+           |> response(404)
+  end
+
+  # A page reading the same status. `Posts.scope_visible/2` knew only `nil` and
+  # `%User{}`, so a page identity raised `FunctionClauseError` — a 500 on a
+  # plain read. It is not a member, so it sees what an anonymous reader sees.
+  test "a page reading a cached reply gets an answer, not a crash", %{conn: conn} do
+    member = insert(:activated_user)
+    organization = insert(:organization)
+    {:ok, _} = Organizations.add_role(organization, member, "publisher", member)
+    {:ok, parent} = Posts.create_post(member, %{body: "Womit die Frage begann"})
+    note = insert(:note, post: parent)
+
+    token = mastodon_token(member, ["read"], organization)
+    status = show(conn, token, "remote-note-" <> note.id)
+
+    assert status["in_reply_to_id"] == parent.id
+  end
+
+  test "a followers-only cached parent stays unnamed for a reader who does not follow",
+       %{conn: conn} do
+    account = remote_account(handle: "dora")
+    parent = cached_post(account, audience: "followers")
+    reply = cached_post(account, in_reply_to_uri: parent.object_uri)
+
+    token = mastodon_token(insert(:activated_user), ["read"])
+    status = show(conn, token, "remote-" <> reply.id)
+
+    assert status["in_reply_to_id"] == nil
+    assert status["in_reply_to_account_id"] == nil
+  end
+
+  # A follow that has been asked for but not granted reads nothing yet — both
+  # `Fediverse.remote_post_readable?/2` and `Statuses.visible?/2` want
+  # `state: "accepted"` — so naming the parent here hands the client an id its
+  # very next request is refused for.
+  test "a follow still pending does not open a followers-only parent", %{conn: conn} do
+    reader = insert(:activated_user)
+    account = remote_account(handle: "emil")
+    parent = cached_post(account, audience: "followers")
+    reply = cached_post(account, in_reply_to_uri: parent.object_uri)
+
+    follow_remote(reader, account, "pending")
+
+    token = mastodon_token(reader, ["read"])
+    status = show(conn, token, "remote-" <> reply.id)
+
+    assert status["in_reply_to_id"] == nil
+
+    assert conn
+           |> mastodon_conn(token)
+           |> get("/api/v1/statuses/remote-#{parent.id}")
+           |> response(404)
   end
 end

--- a/test/vutuv_web/controllers/mastodon_api/status_parent_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/status_parent_test.exs
@@ -1,0 +1,139 @@
+defmodule VutuvWeb.MastodonApi.StatusParentTest do
+  @moduledoc """
+  A status a Mastodon client reads must carry `in_reply_to_id` so the client can
+  thread the reply under the post it answers (issue #1622). The website shows
+  the parent on all four shapes below; before this the API said `null` on the
+  three that cross a network boundary, so a reply looked like a standalone post.
+
+  The rule: name the parent only when it is a status the same client could fetch
+  — a local post id, or a `remote-<id>` we hold. A parent we hold no row for
+  stays `null`, because an id no client can resolve is worse than none.
+  """
+  use VutuvWeb.ConnCase, async: true
+
+  import Vutuv.MastodonHelpers
+
+  alias Vutuv.Fediverse.Follow
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.Posts
+  alias Vutuv.Posts.PostRemoteReply
+
+  defp show(conn, token, id) do
+    conn
+    |> mastodon_conn(token)
+    |> get("/api/v1/statuses/#{id}")
+    |> json_response(200)
+  end
+
+  defp remote_account(handle) do
+    actor = "https://social.example/users/#{handle}"
+
+    Repo.insert!(%RemoteAccount{
+      actor_uri: actor,
+      host: "social.example",
+      handle: handle,
+      name: String.capitalize(handle),
+      inbox_uri: actor <> "/inbox"
+    })
+  end
+
+  defp cached_post(account, overrides \\ %{}) do
+    now = DateTime.utc_now(:second)
+
+    Repo.insert!(
+      struct(
+        %RemotePost{
+          remote_account_id: account.id,
+          object_uri: "https://social.example/p/#{System.unique_integer([:positive])}",
+          origin_url: "https://social.example/@them/1",
+          content_text: "Ein Gedanke von drüben.",
+          audience: "public",
+          kind: "note",
+          published_at: now,
+          received_at: now,
+          expires_at: DateTime.add(now, 86_400)
+        },
+        overrides
+      )
+    )
+  end
+
+  test "a local reply names its local parent", %{conn: conn} do
+    author = insert(:activated_user)
+    {:ok, parent} = Posts.create_post(author, %{body: "Die Ausgangsfrage"})
+    {:ok, reply} = Posts.create_reply(author, parent, %{body: "Die Antwort"})
+
+    token = mastodon_token(insert(:activated_user), ["read"])
+    status = show(conn, token, reply.id)
+
+    assert status["in_reply_to_id"] == parent.id
+    assert status["in_reply_to_account_id"] == author.id
+  end
+
+  test "a cached remote reply names the member's post it answers", %{conn: conn} do
+    member = insert(:activated_user)
+    {:ok, parent} = Posts.create_post(member, %{body: "Womit die Frage begann"})
+    note = insert(:note, post: parent)
+
+    token = mastodon_token(insert(:activated_user), ["read"])
+    status = show(conn, token, "remote-note-" <> note.id)
+
+    assert status["in_reply_to_id"] == parent.id
+    assert status["in_reply_to_account_id"] == member.id
+  end
+
+  test "a followed account's self-reply names its cached parent, same account",
+       %{conn: conn} do
+    account = remote_account("alice")
+    parent = cached_post(account)
+    reply = cached_post(account, %{in_reply_to_uri: parent.object_uri})
+
+    token = mastodon_token(insert(:activated_user), ["read"])
+    status = show(conn, token, "remote-" <> reply.id)
+
+    assert status["in_reply_to_id"] == "remote-" <> parent.id
+    assert status["in_reply_to_account_id"] == "remote-" <> account.id
+  end
+
+  test "a cached reply whose parent we never held stays orphaned", %{conn: conn} do
+    account = remote_account("bob")
+    reply = cached_post(account, %{in_reply_to_uri: "https://social.example/p/never-held"})
+
+    token = mastodon_token(insert(:activated_user), ["read"])
+    status = show(conn, token, "remote-" <> reply.id)
+
+    assert status["in_reply_to_id"] == nil
+    assert status["in_reply_to_account_id"] == nil
+  end
+
+  test "a vutuv answer to a followed account's post names the cached post", %{conn: conn} do
+    author = insert(:activated_user)
+    account = remote_account("carol")
+    remote_post = cached_post(account)
+
+    Repo.insert!(%Follow{
+      user_id: author.id,
+      remote_account_id: account.id,
+      state: "accepted",
+      follow_activity_id: "https://vutuv.test/#{author.id}/actor#f/#{account.id}"
+    })
+
+    {:ok, post} = Posts.create_post(author, %{body: "Meine Antwort nach drüben"})
+
+    Repo.insert!(%PostRemoteReply{
+      post_id: post.id,
+      remote_post_id: remote_post.id,
+      in_reply_to_uri: remote_post.object_uri,
+      actor_uri: account.actor_uri,
+      inbox_uri: account.inbox_uri,
+      handle: "carol@social.example"
+    })
+
+    token = mastodon_token(insert(:activated_user), ["read"])
+    status = show(conn, token, post.id)
+
+    assert status["in_reply_to_id"] == "remote-" <> remote_post.id
+    assert status["in_reply_to_account_id"] == "remote-" <> account.id
+  end
+end

--- a/test/vutuv_web/controllers/mastodon_api/status_parent_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/status_parent_test.exs
@@ -14,8 +14,6 @@ defmodule VutuvWeb.MastodonApi.StatusParentTest do
   import Vutuv.MastodonHelpers
 
   alias Vutuv.Fediverse.Follow
-  alias Vutuv.Fediverse.RemoteAccount
-  alias Vutuv.Fediverse.RemotePost
   alias Vutuv.Posts
   alias Vutuv.Posts.PostRemoteReply
 
@@ -24,39 +22,6 @@ defmodule VutuvWeb.MastodonApi.StatusParentTest do
     |> mastodon_conn(token)
     |> get("/api/v1/statuses/#{id}")
     |> json_response(200)
-  end
-
-  defp remote_account(handle) do
-    actor = "https://social.example/users/#{handle}"
-
-    Repo.insert!(%RemoteAccount{
-      actor_uri: actor,
-      host: "social.example",
-      handle: handle,
-      name: String.capitalize(handle),
-      inbox_uri: actor <> "/inbox"
-    })
-  end
-
-  defp cached_post(account, overrides \\ %{}) do
-    now = DateTime.utc_now(:second)
-
-    Repo.insert!(
-      struct(
-        %RemotePost{
-          remote_account_id: account.id,
-          object_uri: "https://social.example/p/#{System.unique_integer([:positive])}",
-          origin_url: "https://social.example/@them/1",
-          content_text: "Ein Gedanke von drüben.",
-          audience: "public",
-          kind: "note",
-          published_at: now,
-          received_at: now,
-          expires_at: DateTime.add(now, 86_400)
-        },
-        overrides
-      )
-    )
   end
 
   test "a local reply names its local parent", %{conn: conn} do
@@ -85,9 +50,9 @@ defmodule VutuvWeb.MastodonApi.StatusParentTest do
 
   test "a followed account's self-reply names its cached parent, same account",
        %{conn: conn} do
-    account = remote_account("alice")
+    account = remote_account(handle: "alice")
     parent = cached_post(account)
-    reply = cached_post(account, %{in_reply_to_uri: parent.object_uri})
+    reply = cached_post(account, in_reply_to_uri: parent.object_uri)
 
     token = mastodon_token(insert(:activated_user), ["read"])
     status = show(conn, token, "remote-" <> reply.id)
@@ -97,8 +62,8 @@ defmodule VutuvWeb.MastodonApi.StatusParentTest do
   end
 
   test "a cached reply whose parent we never held stays orphaned", %{conn: conn} do
-    account = remote_account("bob")
-    reply = cached_post(account, %{in_reply_to_uri: "https://social.example/p/never-held"})
+    account = remote_account(handle: "bob")
+    reply = cached_post(account, in_reply_to_uri: "https://social.example/p/never-held")
 
     token = mastodon_token(insert(:activated_user), ["read"])
     status = show(conn, token, "remote-" <> reply.id)
@@ -109,7 +74,7 @@ defmodule VutuvWeb.MastodonApi.StatusParentTest do
 
   test "a vutuv answer to a followed account's post names the cached post", %{conn: conn} do
     author = insert(:activated_user)
-    account = remote_account("carol")
+    account = remote_account(handle: "carol")
     remote_post = cached_post(account)
 
     Repo.insert!(%Follow{

--- a/test/vutuv_web/controllers/mastodon_api/thread_parents_test.exs
+++ b/test/vutuv_web/controllers/mastodon_api/thread_parents_test.exs
@@ -4,11 +4,11 @@ defmodule VutuvWeb.MastodonApi.ThreadParentsTest do
   network border — issues #1640 and #1641.
 
   Two surfaces carry that relation and a client threads from whichever it has:
-  `in_reply_to_id` on the single status, and `ancestors` in its `/context`. For
-  a cached *reply* both are asserted here and they name the same thing. For a
-  cached *post* only `/context` names it: filling `in_reply_to_id` there is
-  issue #1622, in flight as a separate change, so this file pins the half that
-  is done rather than pretending both are.
+  `in_reply_to_id` on the single status, and `ancestors` in its `/context`. Both
+  name the same thing on every shape now — filling `in_reply_to_id` where a
+  network border is crossed was issue #1622, and the cases that turn on **who
+  is reading** (a parent narrowed since, a followers-only cached post, a page as
+  the reader) are pinned next door in `status_parent_test.exs`.
 
   Calibrated against the un-fixed adapter: drop the answered-object lookup out
   of `Vutuv.MastodonApi.Presenter` or out of
@@ -209,8 +209,10 @@ defmodule VutuvWeb.MastodonApi.ThreadParentsTest do
   describe "an answer written here to a cached post" do
     # Issue #1640: the answer is a top-level vutuv post (there is nothing local
     # underneath it), so without the fix its context was empty although the post
-    # it addresses is one we serve.
-    test "carries that cached post as its ancestor", %{conn: conn} do
+    # it addresses is one we serve. Issue #1622 is the other surface of the same
+    # relation — for a while `/context` named the parent and the status itself
+    # still said `null`, which is worse for a client than both being empty.
+    test "carries that cached post as its ancestor, and says so on the status too", %{conn: conn} do
       remote = cached_post(remote_account())
 
       {:ok, answer} =
@@ -221,6 +223,14 @@ defmodule VutuvWeb.MastodonApi.ThreadParentsTest do
       context = conn |> get("/api/v1/statuses/#{answer.id}/context") |> json_response(200)
 
       assert Enum.map(context["ancestors"], & &1["id"]) == ["remote-" <> remote.id]
+
+      status =
+        conn
+        |> recycle_mastodon()
+        |> get("/api/v1/statuses/#{answer.id}")
+        |> json_response(200)
+
+      assert status["in_reply_to_id"] == "remote-" <> remote.id
     end
   end
 end


### PR DESCRIPTION
**Symptom:** a reply that crosses a network border reached a Mastodon client with `in_reply_to_id: null`, so it drew as a standalone post — while `/context` beside it named the parent. Two surfaces of the same relation, contradicting each other.

**Change:** `Presenter.status/3` fills the three border-crossing shapes `/context` already walks (`GET /api/v1/statuses/:id`, and every timeline). A parent is named only when the reader may fetch it — `Posts.visible_posts_by_ids/2` for a local parent, the new `Fediverse.readable_remote_post_ids/2` for a cached one, which is `remote_post_readable?/2` asked once per page rather than per row.

**What I changed against the submitted branch:** the gate read `followed_remote_account_ids/2`, the card menus' question, which counts a follow that has only been *asked* for. A followers-only parent was therefore named to a reader whose next request 404s. Also: `Posts.scope_visible/2` had no `%Organization{}` clause, so a page identity crashed it; and five tests, where round 2 shipped the visibility fix with none. Each is calibrated — take the fix back out and it goes red.

Supersedes #1623 (jpawlowski's commits kept, rebased). Closes #1622.

*An AI agent wrote this text in my name. I know that is problematic.*
