### PR TITLE
fix(ui): make the sticky top bar actually stick [2m]

### DIFF
--- a/lib/vutuv_web/live/shell_live.ex
+++ b/lib/vutuv_web/live/shell_live.ex
@@ -829,7 +829,12 @@ defmodule VutuvWeb.ShellLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <div id="app-shell">
+    <%!-- `contents`: the second half of the sticky fix in the `app` layout
+    (issue #1727). This div and the `live_render` container around it are the
+    two boxes between the sticky top bar and `<body>`; removing only one still
+    leaves the bar trapped in a 65px-tall parent. The layout comment carries the
+    full reasoning and the measurements. --%>
+    <div id="app-shell" class="contents">
       <%!-- Drives the green "online" dot on every avatar in the page. Receives
       this viewer's online-id set from ShellLive (push_event "presence:set") and
       writes a generated stylesheet that reveals each online member's

--- a/lib/vutuv_web/live/shell_live.ex
+++ b/lib/vutuv_web/live/shell_live.ex
@@ -12,7 +12,25 @@ defmodule VutuvWeb.ShellLive do
   read marker), messages via `Vutuv.Chat.unread_conversations_count/1`
   (conversations holding unread messages).
   """
-  use Phoenix.LiveView
+  # `container:` is what makes the top bar's `sticky top-0` mean anything
+  # (issue #1727), and it is declared here rather than at the embeddings because
+  # "my wrapper must not be a box" is a property of this shell, not of who
+  # renders it.
+  #
+  # A sticky element can only slide inside its own parent's box, and `<main>` —
+  # the entire page — is a SIBLING of this shell, not a descendant (see the
+  # moduledoc above: it has to be, because a `live_render`ed LiveView cannot
+  # take the layout's `@inner_content` as its own). So the shell's box is the
+  # top bar and nothing else: the tab bar below it is `fixed` and out of flow,
+  # the hook divs are hidden. Measured before the fix: document 5342px, wrapper
+  # 65px, top bar 65px — zero pixels of travel, and at `scrollY 1200` the bar
+  # sat at `top: -1200`, moving one-to-one with the page.
+  #
+  # `display: contents` drops the wrapper's box without touching the node, so
+  # the containing block becomes `<body>`. `#app-shell` in `render/1` carries
+  # the same class for the same reason: both boxes sit between the bar and the
+  # body, and removing only one still leaves it trapped.
+  use Phoenix.LiveView, container: {:div, class: "contents"}
 
   use Phoenix.VerifiedRoutes,
     endpoint: VutuvWeb.Endpoint,
@@ -829,11 +847,9 @@ defmodule VutuvWeb.ShellLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <%!-- `contents`: the second half of the sticky fix in the `app` layout
-    (issue #1727). This div and the `live_render` container around it are the
-    two boxes between the sticky top bar and `<body>`; removing only one still
-    leaves the bar trapped in a 65px-tall parent. The layout comment carries the
-    full reasoning and the measurements. --%>
+    <%!-- `contents`: the inner half of the sticky fix, whose reasoning and
+    measurements sit with the `container:` option at the top of this module
+    (issue #1727). --%>
     <div id="app-shell" class="contents">
       <%!-- Drives the green "online" dot on every avatar in the page. Receives
       this viewer's online-id set from ShellLive (push_event "presence:set") and

--- a/lib/vutuv_web/templates/layout/app.html.heex
+++ b/lib/vutuv_web/templates/layout/app.html.heex
@@ -3,10 +3,28 @@ classic controller pages and LiveViews. The shell (top bar + mobile bottom tab
 bar, with the live unread badges) is an embedded `ShellLive` so the badges stay
 live even on classic pages. `assigns[:conn]` is present on dead requests;
 LiveViews fall through to `@socket`. --%>
+<%!-- `container: {:div, class: "contents"}` is what makes the top bar's
+`sticky top-0` mean anything (issue #1727), and it has to be said here because
+the wrapper is LiveView's, not ours.
+
+A sticky element can only slide inside its own parent's box, and `<main>` — the
+entire page — is a SIBLING of this embed, not a descendant. So the shell's box
+is the top bar and nothing else: the tab bar below is `fixed` and out of flow,
+the hook divs are hidden. Measured before the fix: document 5342px, wrapper
+65px, top bar 65px, i.e. **zero pixels of travel** — at `scrollY 1200` the bar
+sat at `top: -1200`, moving one-to-one with the page. `position: sticky` was
+doing literally nothing, on every platform and since the class was written.
+
+`display: contents` drops the wrapper's box without touching the node, so the
+containing block becomes `<body>` and the bar holds at `top: 0`. `#app-shell`
+inside carries the same class for the same reason — one box removed is not
+enough, both wrappers sit between the bar and the body. The fixed tab bar is
+unaffected either way: a fixed element's containing block is the viewport, not
+the parent box. --%>
 <%= if assigns[:conn] do %>
-  {live_render(@conn, VutuvWeb.ShellLive, id: "app-shell-lv", session: shell_session(assigns))}
+  {live_render(@conn, VutuvWeb.ShellLive, id: "app-shell-lv", container: {:div, class: "contents"}, session: shell_session(assigns))}
 <% else %>
-  {live_render(@socket, VutuvWeb.ShellLive, id: "app-shell-lv", sticky: true, session: shell_session(assigns))}
+  {live_render(@socket, VutuvWeb.ShellLive, id: "app-shell-lv", sticky: true, container: {:div, class: "contents"}, session: shell_session(assigns))}
 <% end %>
 
 <%!-- Flash as top-right toasts. Every toast auto-dismisses after a few seconds

--- a/lib/vutuv_web/templates/layout/app.html.heex
+++ b/lib/vutuv_web/templates/layout/app.html.heex
@@ -3,28 +3,13 @@ classic controller pages and LiveViews. The shell (top bar + mobile bottom tab
 bar, with the live unread badges) is an embedded `ShellLive` so the badges stay
 live even on classic pages. `assigns[:conn]` is present on dead requests;
 LiveViews fall through to `@socket`. --%>
-<%!-- `container: {:div, class: "contents"}` is what makes the top bar's
-`sticky top-0` mean anything (issue #1727), and it has to be said here because
-the wrapper is LiveView's, not ours.
-
-A sticky element can only slide inside its own parent's box, and `<main>` — the
-entire page — is a SIBLING of this embed, not a descendant. So the shell's box
-is the top bar and nothing else: the tab bar below is `fixed` and out of flow,
-the hook divs are hidden. Measured before the fix: document 5342px, wrapper
-65px, top bar 65px, i.e. **zero pixels of travel** — at `scrollY 1200` the bar
-sat at `top: -1200`, moving one-to-one with the page. `position: sticky` was
-doing literally nothing, on every platform and since the class was written.
-
-`display: contents` drops the wrapper's box without touching the node, so the
-containing block becomes `<body>` and the bar holds at `top: 0`. `#app-shell`
-inside carries the same class for the same reason — one box removed is not
-enough, both wrappers sit between the bar and the body. The fixed tab bar is
-unaffected either way: a fixed element's containing block is the viewport, not
-the parent box. --%>
+<%!-- The shell's wrapper generates no box, so the top bar's `sticky top-0`
+sticks to `<body>` rather than to a 65px-tall parent (issue #1727). That is
+declared on `ShellLive` itself, with the reasoning and the measurements. --%>
 <%= if assigns[:conn] do %>
-  {live_render(@conn, VutuvWeb.ShellLive, id: "app-shell-lv", container: {:div, class: "contents"}, session: shell_session(assigns))}
+  {live_render(@conn, VutuvWeb.ShellLive, id: "app-shell-lv", session: shell_session(assigns))}
 <% else %>
-  {live_render(@socket, VutuvWeb.ShellLive, id: "app-shell-lv", sticky: true, container: {:div, class: "contents"}, session: shell_session(assigns))}
+  {live_render(@socket, VutuvWeb.ShellLive, id: "app-shell-lv", sticky: true, session: shell_session(assigns))}
 <% end %>
 
 <%!-- Flash as top-right toasts. Every toast auto-dismisses after a few seconds

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.556.0",
+      version: "7.558.4",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/sticky_top_bar_test.exs
+++ b/test/vutuv_web/sticky_top_bar_test.exs
@@ -1,0 +1,76 @@
+defmodule VutuvWeb.StickyTopBarTest do
+  use VutuvWeb.ConnCase, async: true
+
+  # The top bar carries `sticky top-0` and still scrolled away with the page
+  # (issue #1727). A sticky element only slides inside its own parent's box, and
+  # both wrappers between the bar and `<body>` — the `live_render` container and
+  # `#app-shell` — were exactly as tall as the bar, so there were zero pixels to
+  # slide in. `display: contents` drops those boxes without touching the nodes.
+  # The full reasoning and the measurements live on `ShellLive` itself.
+  #
+  # Why this test exists at all: the failure is invisible. `sticky top-0` stays
+  # in the markup and reads as if it works, the page looks right until somebody
+  # scrolls, and no test the repo had would have gone red. The next person to
+  # put a box back between the bar and the body — a wrapper `<div>` around the
+  # embedding, a `class=` on the container that is not `contents`, a stray
+  # `display: block` — needs something that fails.
+  #
+  # So this asserts the RENDERED markup rather than the source: `container:` is
+  # a `use` option whose effect only exists once Phoenix has built the wrapper,
+  # and a source grep would pass on an option that some later refactor stopped
+  # applying. Both wrappers are checked, because removing the box from only one
+  # of them still leaves the bar trapped in the other.
+  #
+  # Calibration (do this by patch, and put it back): drop `container:` from
+  # `ShellLive` and the first assertion goes red; drop `class="contents"` from
+  # `#app-shell` in `render/1` and the second does.
+  #
+  # Both embeddings are covered because the layout has two of them — `@conn` for
+  # a dead render, `@socket` with `sticky: true` inside a `live_session` — and
+  # the fix has to hold for both. It does so by construction now that the option
+  # sits on the LiveView instead of at each call site, which is exactly the
+  # property worth pinning down.
+
+  defp shell_wrappers(conn, path) do
+    html = conn |> get(path) |> html_response(200)
+
+    assert [_, container] = Regex.run(~r/(<div[^>]*>)\s*<div id="app-shell"/s, html),
+           "no `#app-shell` in the page at #{path}, so the shell did not render"
+
+    assert [_, shell] = Regex.run(~r/(<div id="app-shell"[^>]*>)/, html)
+
+    {container, shell}
+  end
+
+  describe "the shell generates no box between the top bar and <body>" do
+    test "on a dead render embedded with @conn", %{conn: conn} do
+      {container, shell} = shell_wrappers(conn, "/")
+
+      assert container =~ ~r/class="[^"]*\bcontents\b/,
+             """
+             The `live_render` wrapper around ShellLive is a box again, so the
+             top bar's `sticky top-0` has a 65px-tall parent to stick to and
+             scrolls away with the page (issue #1727). Restore
+             `container: {:div, class: "contents"}` on ShellLive.
+
+             Got: #{container}
+             """
+
+      assert shell =~ ~r/class="[^"]*\bcontents\b/,
+             """
+             `#app-shell` is a box again. Dropping only the outer wrapper's box
+             leaves the bar trapped in this one — both have to go
+             (issue #1727).
+
+             Got: #{shell}
+             """
+    end
+
+    test "on a live_session page embedded with @socket", %{conn: conn} do
+      {container, shell} = shell_wrappers(conn, "/search")
+
+      assert container =~ ~r/class="[^"]*\bcontents\b/
+      assert shell =~ ~r/class="[^"]*\bcontents\b/
+    end
+  end
+end


### PR DESCRIPTION
**What changed:** `use Phoenix.LiveView, container: {:div, class: "contents"}` on `ShellLive`, plus `class="contents"` on `#app-shell`.

**Why there:** a sticky element only slides inside its own parent's box, and both wrappers between the top bar and `<body>` were exactly as tall as the bar — zero travel. Dropping their boxes, without touching the nodes, makes `<body>` the containing block. Both are needed; removing one still leaves the bar trapped. It sits on the LiveView, not at each embedding: "my wrapper must not be a box" is a property of this shell.

**Test:** `sticky_top_bar_test.exs` asserts the rendered wrappers on both embeddings — a source grep would pass on an option a refactor stopped applying. Calibrated: dropping either half turns both cases red.

**Also verified on a running server:** desktop and 375 px, socket connected, bar at `top: 0` at `scrollY 1400`.

**Left alone:** the bar keeps `bg-white/90 backdrop-blur`.

<img width="1728" height="1920" alt="Before and after at the same scroll position: the top bar is gone, then it stays" src="https://github.com/user-attachments/assets/c87f7a6b-0e2f-4b13-bf90-f8ea59099abe" />

Closes #1727.

