### PR TITLE
feat(fediverse): advertise a quote policy and answer QuoteRequest (FEP-044f) [15m ?]

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -1339,6 +1339,100 @@ us. Asking it over the network would be vutuv WebFingering itself and could only
 route the visitor back here, so a signed-in member naming it simply gets the
 plain vutuv tag follow. That is `own_host?/1` again, in its third caller.
 
+## Letting other networks quote a post (issue #1608)
+
+Mastodon 4.5 authors quote posts, and it does so under **FEP-044f, "consent-
+respecting quote posts"** — the one part of the fediverse where showing somebody
+else's words is gated on that author's server saying yes. Two properties decide
+whether a vutuv post can be quoted at all, and until this issue we had neither,
+which is why a member could not quote a vutuv post from Ivory: the button was
+not offered, and forcing it would have produced a quote that stayed "pending"
+forever.
+
+**The policy is advertised, in both directions.** Every Note now carries
+
+```json
+"interactionPolicy": {"canQuote": {"automaticApproval": ["…#Public"], "manualApproval": []}}
+```
+
+when the author allows quoting, and `automaticApproval` naming the **author
+themselves** when they do not. Silence was not an option: Mastodon maps an
+absent policy to "nobody", so saying nothing is already a decision — and one a
+reader cannot tell apart from "this server has never heard of quoting". Naming
+the author rather than sending an empty list keeps it a true statement, since a
+self-quote is permitted regardless.
+
+The terms live in the document's `@context` (`gts:` for the interaction
+vocabulary, the FEP's own for the quote vocabulary — that split is Mastodon's
+and not ours to tidy), which is why the permalink's Note now goes through
+`Docs.note_document/2` instead of having a bare activitystreams context stamped
+onto it at the controller. A context that does not define the terms makes a
+conforming consumer drop them, so the page would have promised nothing while
+the delivered copy promised quoting.
+
+**The stamp is the permission, not the Accept.** A `QuoteRequest` arriving at
+the inbox is answered with an `Accept` whose `result` points at a
+`QuoteAuthorization` document we serve at
+`/:slug/posts/:id/quote-authorizations/:auth_id`. Third servers — ones that have
+often never spoken to us — fetch that URL before rendering the quote, and fetch
+it again on every render. That is what makes withdrawal real rather than
+advisory: delete the row and the URL answers `404`, and the quote stops
+rendering everywhere that checks.
+
+It answers `404` and not `410` deliberately. Once the row is gone we cannot tell
+a withdrawn permission from one that never existed, and `410 Gone` would be a
+claim about history we cannot support; every consumer treats any non-200 the
+same way.
+
+**What the gates are.** In order: the installation switch, the author federates
+and has `fediverse_quotes?` on, the object really is one of *their* posts, that
+post is public (`Posts.restricted?/1`), not frozen and not still behind the
+image gate, the request names a quoting post, that post is **not hosted here**,
+and the sender is within its inbound cap.
+
+The last of those is worth its own line. A `QuoteRequest` whose `instrument` is
+a vutuv URL would have us stamp one of our own posts as the quote of another —
+a document vouching for a pairing nobody here ever made, minted on a stranger's
+say-so. It is refused.
+
+**Two silences, and the difference is the point.** A request we identified as
+ours and refused gets a `Reject`, because the other side has a pending quote in
+its interface and an answer is the difference between "no" and "that server is
+broken". A request naming a post that is not ours gets **nothing at all**:
+answering would confirm which posts exist here and who holds them.
+
+**The switch is on by default** (`users.fediverse_quotes?`, and the same on a
+page), unlike `fediverse_replies?` beside it. The asymmetry is deliberate: a
+quote redistributes a post that is already public to anybody, which is what a
+reshare has always done here, while holding text written by somebody who never
+signed up is a different kind of ask. Switching it off flips the advertised
+policy to the author alone and answers every request with a `Reject`.
+
+**Withdrawal rides the takedown path.** `revoke_quote_authorizations/1` is
+called from `revoke_post/1`, so a deletion, a freeze *and a narrowed audience*
+all take the outstanding permissions with them — the audience case matters most,
+because it leaves the post in place and nothing else would have cleared them.
+The rows go first and a `Delete(QuoteAuthorization)` follows to whichever
+inboxes we hold, which is a courtesy on top of the `404`, not the mechanism.
+
+Like `fediverse_post_deliveries`, the table carries **no foreign key** to
+`posts`: the withdrawal runs after the post row is gone, so a cascade would
+erase the rows moments before they are needed. And like that table it records
+the Note id **as published**, because an id rebuilt from today's username names
+nothing the other server stored after a rename (issue #1086).
+
+### What is not built here
+
+`manualApproval` — "ask me each time" — is not offered. It needs a queue of
+pending requests with its own interface, the way follow requests have one, and
+half of it would be a notification surface rather than a protocol question.
+
+Neither half of quoting **from** vutuv exists yet: showing a remote quote post
+in the feed (issue #1609), quoting a vutuv post with your own words (#1610), and
+quoting a remote one (#1611), which needs this same handshake in the outbound
+direction. This issue is only the answering side — but it is the half that makes
+vutuv posts quotable from every client that already supports it.
+
 ## Deliberate v1 limits
 
 Inbound **reply text** is stored now (issues #1069 and #1071, see the bullet

--- a/lib/vutuv/accounts.ex
+++ b/lib/vutuv/accounts.ex
@@ -928,6 +928,7 @@ defmodule Vutuv.Accounts do
     # copies themselves are covered by the actor `Delete`, which asks remote
     # servers to purge the actor *and* its posts.
     Vutuv.Fediverse.drop_post_deliveries(user)
+    Vutuv.Fediverse.drop_quote_authorizations(user)
 
     # Kill every device's live sockets before the cascade removes the session
     # rows (after which their per-session topics are unknowable), so open tabs

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -262,6 +262,14 @@ defmodule Vutuv.Accounts.User do
     # messages work. Switching it off deletes every stored note
     # (`Vutuv.Fediverse.drop_notes/1`).
     field(:fediverse_replies?, :boolean, default: false)
+    # Whether other accounts may quote the member's posts (FEP-044f, issue
+    # #1608). **On** by default, like the reaction counts and unlike the reply
+    # storage above, and the difference is the same one: a quote redistributes a
+    # post that is already public to anybody — which is what a reshare has
+    # always done here — while holding a stranger's words on our server is a
+    # different kind of ask. Off means the `interactionPolicy` on every outgoing
+    # Note says nobody, and every `QuoteRequest` is answered with a `Reject`.
+    field(:fediverse_quotes?, :boolean, default: true)
     # The Fediverse account(s) the member is migrating *from* (issue #986,
     # half 1): actor URIs rendered as `alsoKnownAs` on the actor document. A
     # remote server (Mastodon) checks this before it moves a member's followers
@@ -525,7 +533,7 @@ defmodule Vutuv.Accounts.User do
   # :email_confirmed? is NOT here either: it flips only via the login-PIN path
   # (Accounts.activate_user/1, its own narrow cast) — castable, it would let a
   # registration self-activate without ever proving control of an email.
-  @optional_fields ~w(noindex? noai? notification_emails? dm_email_each_message? dm_email_delay_minutes email_on_endorsement? email_on_follower? email_on_reference_check? newsletter_emails? saved_search_emails? cv_update_notifications? thread_notifications? browser_notifications? show_online_status? show_mastodon_feed? mastodon_clients? show_code_stats? fediverse_followers? fediverse_reactions? fediverse_replies? also_known_as_input map_google? map_openstreetmap? map_apple? default_map_service post_lines_desktop post_lines_mobile post_hyphenate_desktop post_hyphenate_mobile notification_post_lines like_attribution? headline employment_status employment_status_visibility desired_salary_min desired_salary_currency desired_salary_period desired_salary_visibility desired_workplace_types first_name last_name middle_name nickname honorific_prefix honorific_suffix name_pronunciation gender birthdate birthdate_visibility locale date_region time_zone tag_list auto_post_deletion? auto_post_deletion_after_days auto_post_deletion_keep_photos? auto_post_deletion_keep_answered? auto_post_deletion_keep_bookmarked? auto_post_deletion_delete_replies? auto_post_deletion_min_likes auto_post_deletion_min_bookmarks auto_post_deletion_min_reposts feed_foreign_posts feed_languages feed_tab_ticker? feed_tab_ticker_seconds browser_tab_teaser?)a
+  @optional_fields ~w(noindex? noai? notification_emails? dm_email_each_message? dm_email_delay_minutes email_on_endorsement? email_on_follower? email_on_reference_check? newsletter_emails? saved_search_emails? cv_update_notifications? thread_notifications? browser_notifications? show_online_status? show_mastodon_feed? mastodon_clients? show_code_stats? fediverse_followers? fediverse_reactions? fediverse_replies? fediverse_quotes? also_known_as_input map_google? map_openstreetmap? map_apple? default_map_service post_lines_desktop post_lines_mobile post_hyphenate_desktop post_hyphenate_mobile notification_post_lines like_attribution? headline employment_status employment_status_visibility desired_salary_min desired_salary_currency desired_salary_period desired_salary_visibility desired_workplace_types first_name last_name middle_name nickname honorific_prefix honorific_suffix name_pronunciation gender birthdate birthdate_visibility locale date_region time_zone tag_list auto_post_deletion? auto_post_deletion_after_days auto_post_deletion_keep_photos? auto_post_deletion_keep_answered? auto_post_deletion_keep_bookmarked? auto_post_deletion_delete_replies? auto_post_deletion_min_likes auto_post_deletion_min_bookmarks auto_post_deletion_min_reposts feed_foreign_posts feed_languages feed_tab_ticker? feed_tab_ticker_seconds browser_tab_teaser?)a
 
   # The ages the automatic post deletion offers (issue #1255), in days. A fixed
   # list rather than a free number field on purpose: this setting deletes

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -71,6 +71,7 @@ defmodule Vutuv.Fediverse do
   alias Vutuv.Fediverse.PostLike
   alias Vutuv.Fediverse.PostLookup
   alias Vutuv.Fediverse.PostRepost
+  alias Vutuv.Fediverse.QuoteAuthorization
   alias Vutuv.Fediverse.Reaction
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Fediverse.RemoteFollow
@@ -4078,13 +4079,22 @@ defmodule Vutuv.Fediverse do
     {post_deliveries, _} =
       Repo.delete_all(from(d in PostDelivery, where: uri_host(d.inbox_uri) == ^host))
 
+    # A permission to quote is the same shape of record and goes for the same
+    # reason (issue #1608): the stamp URL is what a third server checks, and a
+    # blocked server's quotes stop being vouched for the moment its rows go.
+    # Nothing is delivered — a blocked server is not talked to, and the stamp's
+    # `404` carries it anyway.
+    {quote_authorizations, _} =
+      Repo.delete_all(from(a in QuoteAuthorization, where: uri_host(a.actor_uri) == ^host))
+
     %{
       followers: followers,
       remote_accounts: remote_accounts,
       cached_posts: cached_posts,
       notes: notes,
       deliveries: deliveries,
-      post_deliveries: post_deliveries
+      post_deliveries: post_deliveries,
+      quote_authorizations: quote_authorizations
     }
   end
 
@@ -4593,6 +4603,233 @@ defmodule Vutuv.Fediverse do
   defp activity_object_id(%{"id" => id}) when is_binary(id), do: id
   defp activity_object_id(id) when is_binary(id), do: id
   defp activity_object_id(_), do: nil
+
+  ## Inbound quote requests (issue #1608)
+
+  @doc """
+  Answers a `QuoteRequest`: somebody on another network wants to quote one of
+  our posts, and FEP-044f says they may not show it until we say so.
+
+  On yes this mints a **stamp** (`Vutuv.Fediverse.QuoteAuthorization`) and
+  delivers an `Accept` whose `result` is the stamp's URL. Third servers fetch
+  that URL before rendering the quote, so the stamp — not the Accept — is what
+  actually carries the permission, and deleting it is what takes it back.
+
+  The gates, in order: the installation switch, the author federates and has not
+  switched quoting off, the object really is one of *their* posts, that post is
+  public (no audience denial), not frozen, not still behind the image gate, the
+  request names a quoting post at all, and the sender is within its inbound cap.
+
+  Two different silences, deliberately:
+
+    * a request we **identified as ours and refused** gets a `Reject`, because
+      the other side has a pending quote sitting in its UI and an answer is the
+      difference between "no" and "that server is broken";
+    * a request naming a post that is not ours, or that we could not parse, gets
+      **nothing at all** — answering would confirm which posts exist here and
+      which member holds them.
+
+  Idempotent: a redelivered request finds the existing stamp and re-sends the
+  same `Accept`, rather than minting a second permission for one quote.
+  """
+  def record_quote_request(subject, activity, actor) do
+    with true <- enabled?(),
+         true <- federated?(subject),
+         true <- quotes_allowed?(subject),
+         %Post{} = post <- resolve_own_note(subject, activity["object"]),
+         true <- quotable_post?(post) do
+      answer_quote_request(subject, post, activity, actor)
+    else
+      _ -> :skip
+    end
+  end
+
+  # Past the point where we know the post is ours and quotable, every remaining
+  # refusal is one the requester is entitled to hear.
+  defp answer_quote_request(subject, %Post{} = post, activity, actor) do
+    actor_uri = quote_actor_uri(actor)
+    inbox = quote_requester_inbox(actor)
+
+    with instrument when is_binary(instrument) <- Docs.quote_request_instrument_id(activity),
+         false <- local_host?(instrument),
+         :ok <- check_inbound_cap(actor_uri),
+         {:ok, authorization} <-
+           upsert_quote_authorization(subject, post, activity, instrument, actor_uri, inbox) do
+      deliver_quote_answer(
+        subject,
+        inbox,
+        Docs.accept_quote_activity(authorization, subject, activity)
+      )
+    else
+      _ ->
+        deliver_quote_answer(subject, inbox, Docs.reject_quote_activity(subject, activity))
+    end
+  end
+
+  # The inbox carries the fetched, signature-verified actor document, so both
+  # the id and the inbox URL are already in hand — asked for here rather than
+  # re-fetched. `own_inbox/1` is the anti-spoofing check every other path uses:
+  # an actor may only name an inbox on its own host.
+  defp quote_actor_uri(%{uri: uri}), do: uri
+  defp quote_actor_uri(uri) when is_binary(uri), do: uri
+  defp quote_actor_uri(_actor), do: nil
+
+  defp quote_requester_inbox(%{uri: _uri, inbox: _inbox} = actor) do
+    own_inbox(actor) || stored_requester_inbox(quote_actor_uri(actor))
+  end
+
+  defp quote_requester_inbox(actor), do: stored_requester_inbox(quote_actor_uri(actor))
+
+  # An author who has not opted into quoting refuses every request, and the
+  # `interactionPolicy` on the Note said so in advance — this is the enforcement
+  # behind that advertisement, not a second opinion.
+  #
+  # A struct built by the previous release mid-deploy carries `nil` here; read
+  # that as the column default rather than as a refusal, so a blue/green window
+  # does not silently answer Reject to everyone.
+  defp quotes_allowed?(%{fediverse_quotes?: false}), do: false
+  defp quotes_allowed?(_subject), do: true
+
+  # Everything about the post itself that decides whether it may be
+  # redistributed under somebody else's commentary. `restricted?/1` is the same
+  # audience test that keeps a narrowed post off the fediverse altogether; the
+  # other two are states in which the post is not public *here* either, and
+  # consenting to a quote of something nobody can currently read would publish
+  # it by the back door.
+  defp quotable_post?(%Post{} = post),
+    do: not Posts.restricted?(post) and is_nil(post.frozen_at) and not post.images_pending?
+
+  defp upsert_quote_authorization(subject, %Post{} = post, activity, instrument, actor_uri, inbox) do
+    attrs = %{
+      post_id: post.id,
+      user_id: quote_owner_id(subject, :user),
+      organization_id: quote_owner_id(subject, :organization),
+      interacting_object_uri: instrument,
+      actor_uri: actor_uri,
+      inbox_uri: inbox,
+      request_activity_id: activity["id"],
+      note_uri: Docs.note_url(subject, post.id),
+      accepted_at: DateTime.utc_now(:second)
+    }
+
+    case existing_quote_authorization(post.id, instrument) do
+      %QuoteAuthorization{} = existing -> {:ok, existing}
+      nil -> insert_quote_authorization(attrs)
+    end
+  end
+
+  defp existing_quote_authorization(post_id, instrument),
+    do: Repo.get_by(QuoteAuthorization, post_id: post_id, interacting_object_uri: instrument)
+
+  defp insert_quote_authorization(attrs) do
+    %QuoteAuthorization{}
+    |> QuoteAuthorization.changeset(attrs)
+    |> Repo.insert()
+    |> case do
+      {:ok, authorization} -> {:ok, authorization}
+      {:error, _changeset} -> recover_raced_authorization(attrs)
+    end
+  end
+
+  # Two deliveries of one request racing: the loser reads the winner's row
+  # rather than reporting a failure the sender could not act on anyway.
+  defp recover_raced_authorization(%{post_id: post_id, interacting_object_uri: instrument}) do
+    case existing_quote_authorization(post_id, instrument) do
+      %QuoteAuthorization{} = authorization -> {:ok, authorization}
+      nil -> :error
+    end
+  end
+
+  defp quote_owner_id(%User{id: id}, :user), do: id
+  defp quote_owner_id(%Organization{id: id}, :organization), do: id
+  defp quote_owner_id(_subject, _kind), do: nil
+
+  # An account we already hold is the fallback for a caller that has no document
+  # in hand (an `Undo` path, a test). Nothing is fetched: the stamp's own `404`
+  # carries the withdrawal to everyone who checks it, so a signed request per
+  # quote would buy a courtesy, not the mechanism.
+  defp stored_requester_inbox(actor_uri) when is_binary(actor_uri) do
+    case Repo.get_by(RemoteAccount, actor_uri: actor_uri) do
+      %RemoteAccount{inbox_uri: inbox} when is_binary(inbox) -> inbox
+      _ -> nil
+    end
+  end
+
+  defp stored_requester_inbox(_actor_uri), do: nil
+
+  # A requester whose document names no usable inbox still gets its stamp — the
+  # answer simply has nowhere to go, and the stamp URL is what a third server
+  # reads anyway.
+  defp deliver_quote_answer(subject, inbox, activity) when is_binary(inbox) do
+    enqueue(subject, [inbox], activity)
+    :ok
+  end
+
+  defp deliver_quote_answer(_subject, _inbox, _activity), do: :skip
+
+  @doc """
+  The stamp behind a `/quote-authorizations/:id` URL, for the endpoint that
+  serves it.
+
+  Scoped to the post in the path as well as to the id: an id alone would let one
+  post's stamp be served from another post's URL, which is a document making a
+  claim about a pair that was never authorized.
+  """
+  def get_quote_authorization(post_id, authorization_id) do
+    UUIDv7.with_cast(authorization_id, fn id ->
+      Repo.get_by(QuoteAuthorization, id: id, post_id: post_id)
+    end)
+  end
+
+  @doc """
+  Withdraws every quote permission a post has given out (issue #1608).
+
+  Called wherever the post stops being publicly readable — deletion, freeze, a
+  narrowed audience — from the same place the post's own `Delete` goes out. The
+  rows go first and the `Delete(QuoteAuthorization)` follows: the stamp URL
+  answering `410` is what actually stops a third-party render, and the activity
+  only saves the quoting server from finding out the slow way.
+  """
+  def revoke_quote_authorizations(%Post{id: post_id}) do
+    authorizations = Repo.all(from(a in QuoteAuthorization, where: a.post_id == ^post_id))
+
+    case authorizations do
+      [] ->
+        :skip
+
+      [_ | _] ->
+        subject =
+          Posts.author(
+            Repo.preload(Posts.get_post(post_id) || %Post{id: post_id}, [:user, :organization])
+          )
+
+        Enum.each(authorizations, fn authorization ->
+          maybe_enqueue_quote_delete(subject, authorization)
+        end)
+
+        Repo.delete_all(from(a in QuoteAuthorization, where: a.post_id == ^post_id))
+        :ok
+    end
+  end
+
+  # The post may already be gone by the time this runs (deletion federates after
+  # the commit), and then there is no author struct to sign with — the stamp's
+  # `410` still does the work.
+  defp maybe_enqueue_quote_delete(nil, _authorization), do: :ok
+
+  defp maybe_enqueue_quote_delete(subject, %QuoteAuthorization{inbox_uri: inbox} = authorization)
+       when is_binary(inbox) do
+    enqueue(subject, [inbox], Docs.delete_quote_authorization_activity(authorization, subject))
+  end
+
+  defp maybe_enqueue_quote_delete(_subject, _authorization), do: :ok
+
+  @doc "Drops every stamp a member issued, on account deletion."
+  def drop_quote_authorizations(%User{id: user_id}),
+    do: Repo.delete_all(from(a in QuoteAuthorization, where: a.user_id == ^user_id))
+
+  def drop_quote_authorizations(%Organization{id: id}),
+    do: Repo.delete_all(from(a in QuoteAuthorization, where: a.organization_id == ^id))
 
   ## Inbound replies (issues #1069 and #1071)
 
@@ -8408,6 +8645,12 @@ defmodule Vutuv.Fediverse do
   def revoke_post(%Post{user_id: nil}), do: :skip
 
   def revoke_post(%Post{} = post) do
+    # First, and outside the `with`: a post whose author never federated still
+    # cannot have handed out a stamp, but one whose *audience* just narrowed can
+    # — and that path leaves the post in place, so nothing else would clear
+    # them. Consent to quote a post nobody may read any more has to go with it.
+    revoke_quote_authorizations(post)
+
     with true <- enabled?(),
          %User{} = user <- Repo.get(User, post.user_id),
          true <- ever_federated?(user),

--- a/lib/vutuv/fediverse/quote_authorization.ex
+++ b/lib/vutuv/fediverse/quote_authorization.ex
@@ -1,0 +1,91 @@
+defmodule Vutuv.Fediverse.QuoteAuthorization do
+  @moduledoc """
+  One standing permission for a post on another network to quote a post of ours
+  (issue #1608) — the "stamp" FEP-044f calls a `QuoteAuthorization`.
+
+  Quoting in the fediverse is consent-first by design, and the consent is a
+  **document, not a message**: the quoting server publishes our stamp's URL
+  beside its quote, and every third server that renders that quote fetches the
+  URL to check the permission is still live. Withdrawal is therefore not a
+  request anybody may ignore — deleting the row makes the URL answer `410`, and
+  the quote stops rendering everywhere that checks.
+
+  That is also why the row holds so much: it is the whole of what the withdrawal
+  needs, long after the thing it describes is gone.
+
+    * `interacting_object_uri` — the remote post doing the quoting. Half of the
+      identity (with `post_id`), and what a third party's stamp fetch is checked
+      against.
+    * `actor_uri` / `inbox_uri` — who quoted us and where a
+      `Delete(QuoteAuthorization)` reaches them. Nullable inbox: an actor
+      document without a usable inbox still gets its answer, it simply cannot be
+      told later, and the stamp's `410` carries the withdrawal on its own.
+    * `request_activity_id` — the `QuoteRequest` this answers, so a redelivery
+      finds this row instead of minting a second stamp for one quote.
+    * `note_uri` — our own Note id **as published at the time**. A Note id is
+      built from the author's username, so after a rename (issue #1086) an id
+      rebuilt from the current one names nothing the other server stored; the
+      stamp has to keep naming what it named when it was issued.
+
+  Like `Vutuv.Fediverse.PostDelivery` beside it, and for the same reason, the
+  ids are plain columns and **not** foreign keys: the withdrawal runs after the
+  post row is gone, so a cascade would erase these rows moments before they are
+  needed. `Vutuv.Fediverse` clears them explicitly instead.
+  """
+
+  use VutuvWeb, :model
+
+  # Remote URIs are unbounded in theory. Capped in **bytes**, like every other
+  # one here, because `interacting_object_uri` is half of a unique index whose
+  # btree entry has a hard size limit — a hostile multi-kilobyte id must fail
+  # the changeset, never the insert, which would be a 500 out of the inbox.
+  @max_uri_bytes 2_048
+
+  schema "fediverse_quote_authorizations" do
+    field(:post_id, :binary_id)
+    field(:user_id, :binary_id)
+    field(:organization_id, :binary_id)
+
+    field(:interacting_object_uri, :string)
+    field(:actor_uri, :string)
+    field(:inbox_uri, :string)
+    field(:request_activity_id, :string)
+    field(:note_uri, :string)
+    field(:accepted_at, :utc_datetime)
+
+    timestamps(updated_at: false)
+  end
+
+  @doc "The longest remote URI a stamp may carry."
+  def max_uri_bytes, do: @max_uri_bytes
+
+  def changeset(%__MODULE__{} = authorization, attrs) do
+    authorization
+    |> cast(attrs, [
+      :post_id,
+      :user_id,
+      :organization_id,
+      :interacting_object_uri,
+      :actor_uri,
+      :inbox_uri,
+      :request_activity_id,
+      :note_uri,
+      :accepted_at
+    ])
+    |> validate_required([
+      :post_id,
+      :interacting_object_uri,
+      :actor_uri,
+      :note_uri,
+      :accepted_at
+    ])
+    |> validate_length(:interacting_object_uri, max: @max_uri_bytes, count: :bytes)
+    |> validate_length(:actor_uri, max: @max_uri_bytes, count: :bytes)
+    |> validate_length(:inbox_uri, max: @max_uri_bytes, count: :bytes)
+    |> validate_length(:request_activity_id, max: @max_uri_bytes, count: :bytes)
+    |> validate_length(:note_uri, max: @max_uri_bytes, count: :bytes)
+    |> unique_constraint([:post_id, :interacting_object_uri],
+      name: :fediverse_quote_authorizations_post_object_index
+    )
+  end
+end

--- a/lib/vutuv/organizations/organization.ex
+++ b/lib/vutuv/organizations/organization.ex
@@ -64,6 +64,10 @@ defmodule Vutuv.Organizations.Organization do
     # every externally visible part of that half is gated on it, and federating
     # cannot be fully taken back once a remote server holds a copy.
     field(:fediverse_followers?, :boolean, default: false)
+    # Whether other accounts may quote the page's posts (issue #1608). Mirrors
+    # `users.fediverse_quotes?`, on by default for the same reason: a page that
+    # deliberately publishes outward is publishing.
+    field(:fediverse_quotes?, :boolean, default: true)
     field(:mastodon_clients?, :boolean, default: false)
     field(:status, :string, default: "pending")
     field(:verified_at, :naive_datetime)

--- a/lib/vutuv_web/controllers/fediverse_controller.ex
+++ b/lib/vutuv_web/controllers/fediverse_controller.ex
@@ -86,6 +86,39 @@ defmodule VutuvWeb.FediverseController do
     end)
   end
 
+  @doc """
+  One quote stamp (FEP-044f, issue #1608): the document a third server fetches
+  before it renders somebody's quote of a vutuv post.
+
+  Absence is the withdrawal. A stamp that was never issued and one the author
+  has taken back both answer `404`, and that is deliberate rather than lazy —
+  we cannot tell the two apart once the row is gone, and `410 Gone` would be a
+  claim about history we cannot support. Every consumer treats any non-200 the
+  same way: no permission, do not show the quote.
+
+  The post id in the path is checked as well as the stamp id, so one post's
+  stamp can never be served from another post's URL — that pairing is the whole
+  content of the document.
+  """
+  def quote_authorization(conn, %{"slug" => slug, "post_id" => post_id, "id" => id}) do
+    with_federated_user(conn, slug, &send_quote_authorization(conn, &1, post_id, id))
+  end
+
+  def organization_quote_authorization(conn, %{
+        "slug" => slug,
+        "post_id" => post_id,
+        "id" => id
+      }) do
+    with_federated_organization(conn, slug, &send_quote_authorization(conn, &1, post_id, id))
+  end
+
+  defp send_quote_authorization(conn, subject, post_id, id) do
+    case Fediverse.get_quote_authorization(post_id, id) do
+      nil -> send_resp(conn, 404, "")
+      authorization -> send_activity_json(conn, Docs.quote_authorization(authorization, subject))
+    end
+  end
+
   def followers(conn, %{"slug" => slug}) do
     with_federated_user(conn, slug, fn user ->
       send_activity_json(
@@ -310,6 +343,20 @@ defmodule VutuvWeb.FediverseController do
        when type in ["Like", "Announce"] do
     user
     |> Fediverse.record_reaction(object, reaction_kind(type), reacting_actor(remote))
+    |> remember_actor_if_stored(remote)
+  end
+
+  # Somebody on another network wants to quote one of the member's posts
+  # (FEP-044f, issue #1608). Answering is the whole feature: Mastodon will not
+  # render a quote until the quoted server has issued a stamp, so a `QuoteRequest`
+  # that falls through to the catch-all below leaves that quote pending forever.
+  #
+  # Every gate — the member's own quoting switch among them — lives in
+  # `Fediverse.record_quote_request/3`, which decides between an `Accept`, a
+  # `Reject` and saying nothing at all. The HTTP answer is 202 either way.
+  defp perform(user, %{"type" => "QuoteRequest"} = activity, remote) do
+    user
+    |> Fediverse.record_quote_request(activity, remote_author(remote))
     |> remember_actor_if_stored(remote)
   end
 
@@ -784,6 +831,13 @@ defmodule VutuvWeb.FediverseController do
   # completing #1069 for pages). Stored under the same retention model as a
   # member's: the text expires unless its origin keeps confirming it, and the
   # takedown ledger can reach it.
+  # The same for a page's post (issue #1608). A page that publishes outward is
+  # publishing, so it answers quote requests exactly as a member does.
+  defp perform_for_organization(organization, %{"type" => "QuoteRequest"} = activity, remote) do
+    Fediverse.record_quote_request(organization, activity, remote_author(remote))
+    :ok
+  end
+
   defp perform_for_organization(organization, %{"type" => "Create"} = activity, remote) do
     Fediverse.record_organization_reply(organization, activity, %{
       uri: remote.id,

--- a/lib/vutuv_web/controllers/post_controller.ex
+++ b/lib/vutuv_web/controllers/post_controller.ex
@@ -328,10 +328,7 @@ defmodule VutuvWeb.PostController do
   defp send_note(conn, author, post) do
     post = Repo.preload(post, FediverseDocs.note_preloads())
 
-    note =
-      post
-      |> FediverseDocs.note(author)
-      |> Map.put("@context", "https://www.w3.org/ns/activitystreams")
+    note = FediverseDocs.note_document(post, author)
 
     conn
     |> put_resp_content_type("application/activity+json")

--- a/lib/vutuv_web/fediverse/docs.ex
+++ b/lib/vutuv_web/fediverse/docs.ex
@@ -24,6 +24,7 @@ defmodule VutuvWeb.Fediverse.Docs do
 
   alias Vutuv.Accounts.User
   alias Vutuv.Fediverse.Actor
+  alias Vutuv.Fediverse.QuoteAuthorization
   alias Vutuv.Mentions
   alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
@@ -40,6 +41,39 @@ defmodule VutuvWeb.Fediverse.Docs do
   alias VutuvWeb.UserHelpers
 
   @public "https://www.w3.org/ns/activitystreams#Public"
+
+  # FEP-044f, consent-respecting quote posts (issue #1608). Two JSON-LD
+  # fragments rather than one, because the two documents that carry them are
+  # read by different code on the other side and a term a document does not use
+  # is noise a validator has to walk.
+  #
+  # The interaction vocabulary is GoToSocial's (`gts:`) and the quote vocabulary
+  # is the FEP's own. That split is not ours to tidy: Mastodon reads exactly
+  # these names, and a prettier namespace would simply not be understood.
+  @gts "https://gotosocial.org/ns#"
+
+  # What a Note says about who may quote it.
+  @policy_context %{
+    "gts" => @gts,
+    "interactionPolicy" => %{"@id" => "gts:interactionPolicy", "@type" => "@id"},
+    "canQuote" => %{"@id" => "gts:canQuote", "@type" => "@id"},
+    "automaticApproval" => %{"@id" => "gts:automaticApproval", "@type" => "@id"},
+    "manualApproval" => %{"@id" => "gts:manualApproval", "@type" => "@id"}
+  }
+
+  # What a stamp says about the quote it permits.
+  @authorization_context %{
+    "gts" => @gts,
+    "QuoteAuthorization" => %{
+      "@id" => "https://w3id.org/fep/044f#QuoteAuthorization",
+      "@type" => "@id"
+    },
+    "interactingObject" => %{"@id" => "gts:interactingObject", "@type" => "@id"},
+    "interactionTarget" => %{"@id" => "gts:interactionTarget", "@type" => "@id"}
+  }
+
+  # What an Accept/Reject says about the request it answers.
+  @quote_request_context %{"QuoteRequest" => "https://w3id.org/fep/044f#QuoteRequest"}
 
   # Everything note/2 reads off a post. Kept here, beside the builder that needs
   # it, because two call sites load it (the delivery queue and the permalink's
@@ -369,6 +403,7 @@ defmodule VutuvWeb.Fediverse.Docs do
     note = note(post, user)
 
     envelope(user, "Create", note["id"] <> "#create", note)
+    |> Map.put("@context", note_context())
     |> Map.put("published", note["published"])
   end
 
@@ -378,6 +413,7 @@ defmodule VutuvWeb.Fediverse.Docs do
     stamp = post.updated_at |> NaiveDateTime.truncate(:second) |> NaiveDateTime.to_iso8601()
 
     envelope(user, "Update", note["id"] <> "#update-#{stamp}", note)
+    |> Map.put("@context", note_context())
   end
 
   @doc "Delete(Tombstone): a removed post (or one whose audience closed)."
@@ -689,6 +725,119 @@ defmodule VutuvWeb.Fediverse.Docs do
   defp cc_author(activity, author_actor_uri),
     do: Map.update!(activity, "cc", &(&1 ++ [author_actor_uri]))
 
+  @doc """
+  The JSON-LD context every document that carries one of our Notes needs: the
+  core vocabulary plus the interaction-policy terms (issue #1608).
+  """
+  def note_context, do: ["https://www.w3.org/ns/activitystreams", @policy_context]
+
+  @doc """
+  Where a stamp lives: beside the post it authorizes.
+
+  Deliberately under the Note's own path rather than at some `/system/` route
+  of its own. A stamp is only ever meaningful for one post, third parties
+  dereference it without ever having spoken to us, and a URL that carries its
+  subject is one a human reading a raw activity can follow.
+  """
+  def quote_authorization_url(subject, post_id, authorization_id),
+    do: note_url(subject, post_id) <> "/quote-authorizations/" <> authorization_id
+
+  @doc """
+  The stamp itself: the document a third server fetches to check that a quote of
+  one of our posts really was permitted.
+
+  `interactionTarget` is our post, `interactingObject` is the quote — both
+  named as the ids they were when consent was given, never rebuilt from today's
+  handle (see `Vutuv.Fediverse.QuoteAuthorization`).
+  """
+  def quote_authorization(%QuoteAuthorization{} = authorization, subject) do
+    %{
+      "@context" => ["https://www.w3.org/ns/activitystreams", @authorization_context],
+      "id" => quote_authorization_url(subject, authorization.post_id, authorization.id),
+      "type" => "QuoteAuthorization",
+      "attributedTo" => actor_url(subject),
+      "interactionTarget" => authorization.note_uri,
+      "interactingObject" => authorization.interacting_object_uri
+    }
+  end
+
+  @doc """
+  Accept(QuoteRequest): the answer that permits a quote.
+
+  `result` points at the stamp and **must match its URL exactly** — that is the
+  whole mechanism. The `object` echoes the request rather than naming it by id
+  alone, because the requesting server matches the answer against what it sent.
+  """
+  def accept_quote_activity(%QuoteAuthorization{} = authorization, subject, request) do
+    %{
+      "@context" => ["https://www.w3.org/ns/activitystreams", @quote_request_context],
+      "id" => actor_url(subject) <> "#accepts/quote/" <> authorization.id,
+      "type" => "Accept",
+      "actor" => actor_url(subject),
+      "to" => [authorization.actor_uri],
+      "object" => echoed_quote_request(request),
+      "result" => quote_authorization_url(subject, authorization.post_id, authorization.id)
+    }
+  end
+
+  @doc "Reject(QuoteRequest): the answer that refuses one."
+  def reject_quote_activity(subject, request) do
+    %{
+      "@context" => ["https://www.w3.org/ns/activitystreams", @quote_request_context],
+      "id" => actor_url(subject) <> "#rejects/quote/" <> Vutuv.UUIDv7.generate(),
+      "type" => "Reject",
+      "actor" => actor_url(subject),
+      "to" => [request["actor"]] |> Enum.filter(&is_binary/1),
+      "object" => echoed_quote_request(request)
+    }
+  end
+
+  @doc """
+  Delete(QuoteAuthorization): consent withdrawn.
+
+  Belt to the stamp URL's braces. The `410` is what actually stops a
+  third-party render, because every server that shows the quote re-checks it;
+  this tells the quoting server directly, so it can stop showing the quote
+  without waiting to notice.
+  """
+  def delete_quote_authorization_activity(%QuoteAuthorization{} = authorization, subject) do
+    url = quote_authorization_url(subject, authorization.post_id, authorization.id)
+
+    %{
+      "@context" => ["https://www.w3.org/ns/activitystreams", @authorization_context],
+      "id" => url <> "#delete",
+      "type" => "Delete",
+      "actor" => actor_url(subject),
+      "to" => [authorization.actor_uri],
+      "object" => %{"id" => url, "type" => "Tombstone", "formerType" => "QuoteAuthorization"}
+    }
+  end
+
+  # The request as the answer echoes it: the fields the requesting server needs
+  # to match its own pending record, and nothing a stranger sent us that we have
+  # not checked. `instrument` is flattened to its id — the full object came from
+  # them, and quoting it back verbatim would mean re-publishing unvalidated
+  # remote content in a document we sign.
+  defp echoed_quote_request(request) do
+    %{
+      "type" => "QuoteRequest",
+      "id" => request["id"],
+      "actor" => request["actor"],
+      "object" => request["object"],
+      "instrument" => quote_request_instrument_id(request)
+    }
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Map.new()
+  end
+
+  @doc """
+  The id of the post a `QuoteRequest` proposes — its `instrument`, which arrives
+  either as a full object or as a bare id depending on the sender.
+  """
+  def quote_request_instrument_id(%{"instrument" => %{"id" => id}}) when is_binary(id), do: id
+  def quote_request_instrument_id(%{"instrument" => id}) when is_binary(id), do: id
+  def quote_request_instrument_id(_request), do: nil
+
   @doc "Accept(Follow): the answer that seals a remote follow."
   def accept_activity(user, follow_object) do
     id = actor_url(user) <> "#accepts/" <> Vutuv.UUIDv7.generate()
@@ -721,7 +870,47 @@ defmodule VutuvWeb.Fediverse.Docs do
     |> put_in_reply_to(post, remote)
     |> put_tag(post, remote, hashtags)
     |> put_attachments(post)
+    |> put_interaction_policy(user)
   end
+
+  @doc """
+  The Note as a **standalone document**, with the JSON-LD context it needs.
+
+  The permalink serves the same object the `Create` carries, and until issue
+  #1608 it stamped a bare activitystreams context onto it by hand at the
+  controller. That was survivable while the Note used only core terms; the
+  moment it advertises an interaction policy, a context that does not define
+  those terms makes a conforming consumer drop them — so the page would promise
+  nothing while the delivered copy promised quoting, which is the worst of the
+  three possible answers.
+  """
+  def note_document(%Post{} = post, author),
+    do: post |> note(author) |> Map.put("@context", note_context())
+
+  # Who may quote this post (FEP-044f, issue #1608).
+  #
+  # Always emitted, in both directions. Mastodon maps an **absent** policy to
+  # "nobody", so silence would already be a decision — and one a reader could
+  # not tell apart from "this server has never heard of quoting". Saying it
+  # outright means the author's answer travels either way.
+  #
+  # `automaticApproval` names the public collection when the author allows
+  # quoting, and the author themselves when they do not: a self-quote is
+  # permitted regardless (Mastodon does not even ask), so naming them is the
+  # narrowest true statement rather than an empty list nobody has to interpret.
+  defp put_interaction_policy(note, author) do
+    approval = if quotes_allowed?(author), do: @public, else: actor_url(author)
+
+    Map.put(note, "interactionPolicy", %{
+      "canQuote" => %{"automaticApproval" => [approval], "manualApproval" => []}
+    })
+  end
+
+  # A subject minted before the column existed reads `nil` from a struct built
+  # by an older release mid-deploy; treat that as the column default rather than
+  # as a refusal.
+  defp quotes_allowed?(%{fediverse_quotes?: false}), do: false
+  defp quotes_allowed?(_author), do: true
 
   # The author's declared language federates as AS2 `contentMap` (issue
   # #1488) — the field Mastodon reads a Note's language from, and without

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -644,6 +644,19 @@ defmodule VutuvWeb.Router do
     # The pinned post (issue #1110), at the path other servers already look for.
     get("/:slug/actor/collections/featured", FediverseController, :featured)
     post("/:slug/actor/inbox", FediverseController, :inbox)
+    # The quote stamps a member's post has handed out (FEP-044f, issue #1608).
+    # Machine-to-machine like everything else in this scope: a third server that
+    # renders somebody's quote of a vutuv post fetches this URL to check the
+    # permission is still live, and it has usually never spoken to us otherwise.
+    # Sits under the Note's own path so a human reading a raw activity can
+    # follow it, and before the `/:slug/posts/:id` permalink is ever consulted,
+    # because the longer path has to win.
+    get(
+      "/:slug/posts/:post_id/quote-authorizations/:id",
+      FediverseController,
+      :quote_authorization
+    )
+
     # A page's ActivityPub identity (issue #1334). Under /organizations/ rather
     # than at a root word, like every other page URL: the root belongs to member
     # handles. 404s until the page opts in.
@@ -651,6 +664,13 @@ defmodule VutuvWeb.Router do
     get("/organizations/:slug/actor/followers", FediverseController, :organization_followers)
     get("/organizations/:slug/actor/outbox", FediverseController, :organization_outbox)
     post("/organizations/:slug/actor/inbox", FediverseController, :organization_inbox)
+
+    get(
+      "/organizations/:slug/posts/:post_id/quote-authorizations/:id",
+      FediverseController,
+      :organization_quote_authorization
+    )
+
     # The installation-wide inbox (issue #1073), so a server with many
     # followers here delivers a broadcast once instead of once per member.
     # Under /system/ rather than at a root word, which profiles own; remote

--- a/lib/vutuv_web/templates/settings/fediverse.html.heex
+++ b/lib/vutuv_web/templates/settings/fediverse.html.heex
@@ -101,6 +101,22 @@ subpage now (/settings/fediverse/move), linked from the footer below. --%>
           )}
         </.setting_toggle>
 
+        <%!-- Quoting (FEP-044f, issue #1608): on by default, unlike the reply
+              storage above. A quote redistributes a post that is already public
+              to anyone, which is what a reshare has always done here — the
+              wording therefore leads with what a quote *is* rather than with a
+              warning, and names the one thing that is genuinely new: that
+              taking it back reaches the copies out there. --%>
+        <.setting_toggle
+          :if={Vutuv.Fediverse.federated?(@user)}
+          label={gettext("Let other networks quote your posts")}
+        >
+          <:checkbox><%= checkbox f, :fediverse_quotes?, class: checkbox_class() %></:checkbox>
+          {gettext(
+            "Someone on Mastodon can share one of your public posts with their own comment above it, the way a reshare works, but with their words beside yours. Your server is asked first every time and answers automatically while this is on. You can withdraw a single quote later, and switching this off refuses new ones."
+          )}
+        </.setting_toggle>
+
         <div class="pt-1">
           <.button type="submit">{gettext("Save")}</.button>
         </div>

--- a/lib/vutuv_web/views/account_event_text.ex
+++ b/lib/vutuv_web/views/account_event_text.ex
@@ -245,6 +245,7 @@ defmodule VutuvWeb.AccountEventText do
   def field_label("thread_notifications?"), do: gettext("Thread notifications")
   def field_label("fediverse_followers?"), do: gettext("Fediverse participation")
   def field_label("fediverse_reactions?"), do: gettext("Fediverse reactions")
+  def field_label("fediverse_quotes?"), do: gettext("Fediverse quotes")
   def field_label("fediverse_replies?"), do: gettext("Fediverse replies")
   def field_label("also_known_as_input"), do: gettext("Fediverse aliases")
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.393.1",
+      version: "7.405.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -124,7 +124,7 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/templates/import/preview.html.heex:113
 #: lib/vutuv_web/templates/report/new.html.heex:103
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:276
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:259
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:275
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:26
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
 #: lib/vutuv_web/templates/user/edit.html.heex:53
@@ -162,7 +162,7 @@ msgstr "Kontakt"
 msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
-#: lib/vutuv_web/components/post_components.ex:3153
+#: lib/vutuv_web/components/post_components.ex:3170
 #: lib/vutuv_web/components/ui.ex:4106
 #: lib/vutuv_web/live/admin/job_live.ex:489
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -211,7 +211,7 @@ msgstr "Inaktivieren"
 msgid "Download"
 msgstr "Download"
 
-#: lib/vutuv_web/components/post_components.ex:3118
+#: lib/vutuv_web/components/post_components.ex:3135
 #: lib/vutuv_web/components/ui.ex:4097
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -475,7 +475,7 @@ msgstr "Mehr"
 msgid "Name"
 msgstr "Name"
 
-#: lib/vutuv_web/components/post_components.ex:629
+#: lib/vutuv_web/components/post_components.ex:640
 #: lib/vutuv_web/live/notification_live/index.ex:699
 #: lib/vutuv_web/live/organization_live/activity.ex:128
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
@@ -622,7 +622,7 @@ msgstr "Öffentlich"
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:196
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:105
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:121
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:73
 #: lib/vutuv_web/templates/settings/notifications.html.heex:79
 #: lib/vutuv_web/templates/settings/preferences.html.heex:84
@@ -657,7 +657,7 @@ msgstr "Speichern"
 msgid "Search"
 msgstr "Suche"
 
-#: lib/vutuv_web/components/post_components.ex:1627
+#: lib/vutuv_web/components/post_components.ex:1643
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -1783,7 +1783,7 @@ msgstr "Nachrichten"
 msgid "Network"
 msgstr "Netzwerk"
 
-#: lib/vutuv_web/components/post_components.ex:436
+#: lib/vutuv_web/components/post_components.ex:447
 #: lib/vutuv_web/components/ui.ex:4216
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
@@ -2142,7 +2142,7 @@ msgstr "Upload abbrechen"
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
-#: lib/vutuv_web/components/post_components.ex:3150
+#: lib/vutuv_web/components/post_components.ex:3167
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2158,7 +2158,7 @@ msgstr "Beitrag bearbeiten"
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:114
 #: lib/vutuv_web/live/post_live/feed.ex:206
-#: lib/vutuv_web/live/post_live/feed.ex:1591
+#: lib/vutuv_web/live/post_live/feed.ex:1598
 #: lib/vutuv_web/live/shell_live.ex:973
 #: lib/vutuv_web/live/shell_live.ex:1272
 #: lib/vutuv_web/templates/layout/app.html.heex:171
@@ -2186,8 +2186,8 @@ msgstr "Vor einer bestimmten Person verbergen…"
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
 
-#: lib/vutuv_web/components/post_components.ex:3104
-#: lib/vutuv_web/components/post_components.ex:3106
+#: lib/vutuv_web/components/post_components.ex:3121
+#: lib/vutuv_web/components/post_components.ex:3123
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
@@ -2203,7 +2203,7 @@ msgstr "Nicht eingeloggte Besucher"
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1802
+#: lib/vutuv_web/live/post_live/feed.ex:1810
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2255,13 +2255,13 @@ msgstr "Beitrag erfolgreich gelöscht."
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:3568
-#: lib/vutuv_web/components/post_components.ex:3572
+#: lib/vutuv_web/components/post_components.ex:3585
+#: lib/vutuv_web/components/post_components.ex:3589
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:3569
+#: lib/vutuv_web/components/post_components.ex:3586
 #: lib/vutuv_web/live/fediverse_account_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2269,7 +2269,7 @@ msgstr "Weniger anzeigen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:376
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:1249
+#: lib/vutuv_web/components/post_components.ex:1265
 #: lib/vutuv_web/live/admin/screenshot_live.ex:327
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
@@ -2297,7 +2297,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1703
+#: lib/vutuv_web/live/post_live/feed.ex:1710
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2353,27 +2353,27 @@ msgstr "Was gibt's Neues?"
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
 
-#: lib/vutuv_web/components/post_components.ex:3101
+#: lib/vutuv_web/components/post_components.ex:3118
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:4957
+#: lib/vutuv_web/components/post_components.ex:4987
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:4961
+#: lib/vutuv_web/components/post_components.ex:4991
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:4959
+#: lib/vutuv_web/components/post_components.ex:4989
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:4960
+#: lib/vutuv_web/components/post_components.ex:4990
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
@@ -2414,8 +2414,8 @@ msgstr "Alle %{count} Beiträge ansehen"
 msgid "All posts"
 msgstr "Alle Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:1842
-#: lib/vutuv_web/components/post_components.ex:5053
+#: lib/vutuv_web/components/post_components.ex:1858
+#: lib/vutuv_web/components/post_components.ex:5083
 #: lib/vutuv_web/components/ui.ex:3629
 #: lib/vutuv_web/views/user_html.ex:457
 #, elixir-autogen, elixir-format
@@ -2433,8 +2433,8 @@ msgstr "Lesezeichen setzen"
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/vutuv_web/components/post_components.ex:1795
-#: lib/vutuv_web/components/post_components.ex:5289
+#: lib/vutuv_web/components/post_components.ex:1811
+#: lib/vutuv_web/components/post_components.ex:5319
 #: lib/vutuv_web/components/ui.ex:3615
 #: lib/vutuv_web/live/notification_live/index.ex:1089
 #: lib/vutuv_web/views/user_html.ex:467
@@ -2443,7 +2443,7 @@ msgid "Like"
 msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1115
-#: lib/vutuv_web/components/post_components.ex:5299
+#: lib/vutuv_web/components/post_components.ex:5329
 #: lib/vutuv_web/live/notification_live/index.ex:1022
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
@@ -2465,40 +2465,40 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:5041
+#: lib/vutuv_web/components/post_components.ex:5071
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
-#: lib/vutuv_web/components/post_components.ex:1841
-#: lib/vutuv_web/components/post_components.ex:5052
+#: lib/vutuv_web/components/post_components.ex:1857
+#: lib/vutuv_web/components/post_components.ex:5082
 #: lib/vutuv_web/live/post_live/saved.ex:806
 #: lib/vutuv_web/views/user_html.ex:457
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
-#: lib/vutuv_web/components/post_components.ex:1823
-#: lib/vutuv_web/components/post_components.ex:5038
+#: lib/vutuv_web/components/post_components.ex:1839
+#: lib/vutuv_web/components/post_components.ex:5068
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
-#: lib/vutuv_web/components/post_components.ex:2088
-#: lib/vutuv_web/components/post_components.ex:4163
+#: lib/vutuv_web/components/post_components.ex:2104
+#: lib/vutuv_web/components/post_components.ex:4193
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:1822
-#: lib/vutuv_web/components/post_components.ex:5037
+#: lib/vutuv_web/components/post_components.ex:1838
+#: lib/vutuv_web/components/post_components.ex:5067
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
-#: lib/vutuv_web/components/post_components.ex:1794
-#: lib/vutuv_web/components/post_components.ex:5288
+#: lib/vutuv_web/components/post_components.ex:1810
+#: lib/vutuv_web/components/post_components.ex:5318
 #: lib/vutuv_web/live/post_live/saved.ex:805
 #: lib/vutuv_web/views/user_html.ex:467
 #, elixir-autogen, elixir-format
@@ -2506,14 +2506,14 @@ msgid "Unlike"
 msgstr "Gefällt mir entfernen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:377
-#: lib/vutuv_web/components/post_components.ex:2407
+#: lib/vutuv_web/components/post_components.ex:2424
 #: lib/vutuv_web/components/ui.ex:2484
 #: lib/vutuv_web/components/ui.ex:2484
 #: lib/vutuv_web/components/ui.ex:2621
 #: lib/vutuv_web/live/organization_live/following.ex:383
 #: lib/vutuv_web/live/organization_live/following.ex:458
 #: lib/vutuv_web/live/organization_live/show.ex:489
-#: lib/vutuv_web/live/post_live/feed.ex:1851
+#: lib/vutuv_web/live/post_live/feed.ex:1859
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2525,27 +2525,27 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:5343
+#: lib/vutuv_web/components/post_components.ex:5373
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
 
-#: lib/vutuv_web/components/post_components.ex:394
+#: lib/vutuv_web/components/post_components.ex:405
 #: lib/vutuv_web/live/notification_live/index.ex:1023
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:1808
-#: lib/vutuv_web/components/post_components.ex:5326
-#: lib/vutuv_web/components/post_components.ex:5327
+#: lib/vutuv_web/components/post_components.ex:1824
+#: lib/vutuv_web/components/post_components.ex:5356
+#: lib/vutuv_web/components/post_components.ex:5357
 #: lib/vutuv_web/live/notification_live/index.ex:1086
 #: lib/vutuv_web/live/post_live/reply.ex:43
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:3068
+#: lib/vutuv_web/components/post_components.ex:3085
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
@@ -2566,7 +2566,7 @@ msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beitr
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
 
-#: lib/vutuv_web/components/post_components.ex:2604
+#: lib/vutuv_web/components/post_components.ex:2621
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:60
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:57
@@ -2574,14 +2574,14 @@ msgstr "hat auf Ihren Beitrag geantwortet."
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
 
-#: lib/vutuv_web/components/post_components.ex:3042
+#: lib/vutuv_web/components/post_components.ex:3059
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:3033
-#: lib/vutuv_web/components/post_components.ex:3060
-#: lib/vutuv_web/components/post_components.ex:3063
+#: lib/vutuv_web/components/post_components.ex:3050
+#: lib/vutuv_web/components/post_components.ex:3077
+#: lib/vutuv_web/components/post_components.ex:3080
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
@@ -2806,7 +2806,7 @@ msgstr "Ersten Beitrag schreiben"
 msgid "Manage"
 msgstr "Verwalten"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1629
+#: lib/vutuv_web/live/post_live/feed.ex:1636
 #: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2827,7 +2827,7 @@ msgid_plural "%{formatted} connections"
 msgstr[0] "1 Vernetzung"
 msgstr[1] "%{formatted} Vernetzungen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1953
+#: lib/vutuv_web/live/post_live/feed.ex:1961
 #: lib/vutuv_web/templates/user/card_list.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -2882,7 +2882,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:4958
+#: lib/vutuv_web/components/post_components.ex:4988
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -3163,7 +3163,7 @@ msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:3009
+#: lib/vutuv_web/components/post_components.ex:3026
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solange eine Meldung zu diesem Beitrag bearbeitet wird, sehen nur Sie ihn."
@@ -3242,9 +3242,9 @@ msgstr "Abgelehnt"
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 
-#: lib/vutuv_web/components/post_components.ex:1259
-#: lib/vutuv_web/components/post_components.ex:2419
-#: lib/vutuv_web/components/post_components.ex:3173
+#: lib/vutuv_web/components/post_components.ex:1275
+#: lib/vutuv_web/components/post_components.ex:2436
+#: lib/vutuv_web/components/post_components.ex:3190
 #: lib/vutuv_web/live/organization_live/show.ex:562
 #: lib/vutuv_web/templates/user/show.html.heex:222
 #, elixir-autogen, elixir-format
@@ -4708,7 +4708,7 @@ msgstr "Sie haben niemanden blockiert."
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1807
+#: lib/vutuv_web/live/post_live/feed.ex:1815
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
@@ -4789,8 +4789,8 @@ msgstr ""
 msgid "Similar names"
 msgstr "Ähnliche Namen"
 
-#: lib/vutuv_web/components/post_components.ex:391
-#: lib/vutuv_web/components/post_components.ex:410
+#: lib/vutuv_web/components/post_components.ex:402
+#: lib/vutuv_web/components/post_components.ex:421
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
@@ -5640,11 +5640,11 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:3239
-#: lib/vutuv_web/components/post_components.ex:3294
-#: lib/vutuv_web/components/post_components.ex:3705
+#: lib/vutuv_web/components/post_components.ex:3256
+#: lib/vutuv_web/components/post_components.ex:3311
+#: lib/vutuv_web/components/post_components.ex:3722
 #: lib/vutuv_web/live/notification_live/index.ex:743
-#: lib/vutuv_web/live/post_live/feed.ex:1994
+#: lib/vutuv_web/live/post_live/feed.ex:2002
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -6458,7 +6458,7 @@ msgid "Previous day"
 msgstr "Vorheriger Tag"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1115
-#: lib/vutuv_web/components/post_components.ex:393
+#: lib/vutuv_web/components/post_components.ex:404
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
@@ -6882,8 +6882,8 @@ msgstr ""
 "Schalten Sie einen Schalter aus, geht der passende Opt-out auf den Seiten "
 "und Antworten über Sie mit. Mit beiden aus zum Beispiel:"
 
-#: lib/vutuv_web/components/post_components.ex:2387
-#: lib/vutuv_web/components/post_components.ex:3170
+#: lib/vutuv_web/components/post_components.ex:2404
+#: lib/vutuv_web/components/post_components.ex:3187
 #: lib/vutuv_web/components/ui.ex:2809
 #: lib/vutuv_web/live/fediverse_account_live.ex:381
 #: lib/vutuv_web/live/organization_live/following.ex:376
@@ -6910,7 +6910,7 @@ msgstr "Neue Nachrichten und neue Vernetzungen"
 msgid "Remove this connection? You will stop following them."
 msgstr "Diese Vernetzung entfernen? Sie folgen der Person dann nicht mehr."
 
-#: lib/vutuv_web/components/post_components.ex:3170
+#: lib/vutuv_web/components/post_components.ex:3187
 #: lib/vutuv_web/components/ui.ex:2808
 #: lib/vutuv_web/live/fediverse_account_live.ex:379
 #: lib/vutuv_web/live/organization_live/following.ex:376
@@ -7645,7 +7645,7 @@ msgid "applies to the whole list, not just this page"
 msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:5199
+#: lib/vutuv_web/components/post_components.ex:5229
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8230,7 +8230,7 @@ msgid "Admins"
 msgstr "Administratoren"
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:1962
+#: lib/vutuv_web/live/post_live/feed.ex:1970
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr "Alle Mitglieder"
@@ -8310,8 +8310,8 @@ msgstr "Identität verifiziert. Das Mitglied wurde per E-Mail benachrichtigt."
 msgid "Identity-verified"
 msgstr "Identität verifiziert"
 
-#: lib/vutuv/accounts.ex:1445
-#: lib/vutuv/accounts.ex:1494
+#: lib/vutuv/accounts.ex:1446
+#: lib/vutuv/accounts.ex:1495
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -8352,7 +8352,7 @@ msgstr "Nicht bestätigt"
 msgid "Open the member browser"
 msgstr "Mitgliederübersicht öffnen"
 
-#: lib/vutuv/accounts.ex:1462
+#: lib/vutuv/accounts.ex:1463
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -8837,12 +8837,12 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr "Geben Sie zur Bestätigung Ihren Benutzernamen ein:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1979
+#: lib/vutuv_web/live/post_live/feed.ex:1987
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr "Andere Beiträge anzeigen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1975
+#: lib/vutuv_web/live/post_live/feed.ex:1983
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr "Vorgeschlagene Beiträge"
@@ -9094,17 +9094,17 @@ msgstr ""
 msgid "Fediverse settings saved."
 msgstr "Fediverse-Einstellungen gespeichert."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:225
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:241
 #, elixir-autogen, elixir-format
 msgid "Manage social media accounts"
 msgstr "Social-Media-Konten verwalten"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:115
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse handle"
 msgstr "Ihr Fediverse-Handle"
 
-#: lib/vutuv/accounts.ex:1457
+#: lib/vutuv/accounts.ex:1458
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -9218,7 +9218,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:4166
+#: lib/vutuv_web/components/post_components.ex:4196
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9908,7 +9908,7 @@ msgstr "Yoruba"
 msgid "Employment status"
 msgstr "Beschäftigungsstatus"
 
-#: lib/vutuv/accounts/user.ex:1173
+#: lib/vutuv/accounts/user.ex:1181
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9919,7 +9919,7 @@ msgstr "Auf Jobsuche"
 msgid "Not open to work"
 msgstr "Nicht offen für Angebote"
 
-#: lib/vutuv/accounts/user.ex:1170
+#: lib/vutuv/accounts/user.ex:1178
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -11398,19 +11398,19 @@ msgstr ""
 " Konto anlegen kann. Wählen Sie „Niemand“, um den Status zu speichern, ohne "
 "ihn anzuzeigen."
 
-#: lib/vutuv/accounts/user.ex:1211
+#: lib/vutuv/accounts/user.ex:1219
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Alle, auch nicht angemeldete Besucher"
 
-#: lib/vutuv/accounts/user.ex:1216
+#: lib/vutuv/accounts/user.ex:1224
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Niemand"
 
-#: lib/vutuv/accounts/user.ex:1214
+#: lib/vutuv/accounts/user.ex:1222
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:771
 #, elixir-autogen, elixir-format
@@ -12594,32 +12594,32 @@ msgstr ""
 "Suchergebnissen erscheinen oder von KI verwendet werden soll. Seriöse "
 "Suchmaschinen und KI-Anbieter befolgen das; erzwingen können wir es nicht."
 
-#: lib/vutuv/organizations/organization.ex:105
+#: lib/vutuv/organizations/organization.ex:109
 #, elixir-autogen, elixir-format
 msgid "Association"
 msgstr "Verein / Verband"
 
-#: lib/vutuv/organizations/organization.ex:104
+#: lib/vutuv/organizations/organization.ex:108
 #, elixir-autogen, elixir-format
 msgid "Business"
 msgstr "Unternehmen"
 
-#: lib/vutuv/organizations/organization.ex:107
+#: lib/vutuv/organizations/organization.ex:111
 #, elixir-autogen, elixir-format
 msgid "Education / research"
 msgstr "Bildung / Forschung"
 
-#: lib/vutuv/organizations/organization.ex:108
+#: lib/vutuv/organizations/organization.ex:112
 #, elixir-autogen, elixir-format
 msgid "NGO / foundation"
 msgstr "NGO / Stiftung"
 
-#: lib/vutuv/organizations/organization.ex:109
+#: lib/vutuv/organizations/organization.ex:113
 #, elixir-autogen, elixir-format
 msgid "Other organization"
 msgstr "Sonstige"
 
-#: lib/vutuv/organizations/organization.ex:106
+#: lib/vutuv/organizations/organization.ex:110
 #, elixir-autogen, elixir-format
 msgid "Public authority"
 msgstr "Behörde / Öffentlich"
@@ -12776,7 +12776,7 @@ msgstr "Hervorgehobene Tags passen zu Ihrem Profil."
 msgid "How to apply"
 msgstr "So bewerben Sie sich"
 
-#: lib/vutuv/accounts/user.ex:1185
+#: lib/vutuv/accounts/user.ex:1193
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12895,7 +12895,7 @@ msgstr "Hier ist noch nichts. Jobs, die Ihnen gefallen, erscheinen hier."
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) für KI-Agenten anbieten."
 
-#: lib/vutuv/accounts/user.ex:1184
+#: lib/vutuv/accounts/user.ex:1192
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12977,7 +12977,7 @@ msgstr "Anzeige nicht gefunden."
 msgid "Publish"
 msgstr "Veröffentlichen"
 
-#: lib/vutuv/accounts/user.ex:1186
+#: lib/vutuv/accounts/user.ex:1194
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:565
 #: lib/vutuv_web/agent_docs/markdown.ex:466
@@ -13704,7 +13704,7 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "E-Mail-Benachrichtigungen für Ihre gespeicherte Suche „%{label}“ stoppen?"
 
-#: lib/vutuv_web/components/post_components.ex:2563
+#: lib/vutuv_web/components/post_components.ex:2580
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:695
 #: lib/vutuv_web/controllers/settings_controller.ex:713
@@ -14006,7 +14006,7 @@ msgstr "Screenshot entfernt."
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr "Dieser Screenshot wurde automatisch aus dem Link in Ihrem Beitrag erstellt. Falls er unbrauchbar ist (zum Beispiel weil ein Cookie-Banner die Seite verdeckt), können Sie ihn entfernen."
 
-#: lib/vutuv/accounts/user.ex:1229
+#: lib/vutuv/accounts/user.ex:1237
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -14017,19 +14017,19 @@ msgstr "Nur das Alter, ohne das Datum"
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr "Wählen Sie, wie viel von Ihrem Geburtstag Ihr Profil zeigt. „Nur das Alter“ verbirgt das genaue Datum, „Tag und Monat“ verbirgt das Jahr (und Ihr Alter), und „Nicht anzeigen“ speichert ihn weiterhin, hält ihn aber von Ihrem Profil fern."
 
-#: lib/vutuv/accounts/user.ex:1232
+#: lib/vutuv/accounts/user.ex:1240
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Tag und Monat, ohne das Jahr"
 
-#: lib/vutuv/accounts/user.ex:1235
+#: lib/vutuv/accounts/user.ex:1243
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Geburtstag nicht anzeigen"
 
-#: lib/vutuv/accounts/user.ex:1226
+#: lib/vutuv/accounts/user.ex:1234
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -14128,22 +14128,22 @@ msgstr "Mobil (privat)"
 msgid "Work mobile"
 msgstr "Mobil (Arbeit)"
 
-#: lib/vutuv_web/components/post_components.ex:433
+#: lib/vutuv_web/components/post_components.ex:444
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr "Noch keine Beiträge."
 
-#: lib/vutuv_web/components/post_components.ex:435
+#: lib/vutuv_web/components/post_components.ex:446
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr "Noch keine Antworten."
 
-#: lib/vutuv_web/components/post_components.ex:434
+#: lib/vutuv_web/components/post_components.ex:445
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr "Noch keine Reposts."
 
-#: lib/vutuv_web/components/post_components.ex:392
+#: lib/vutuv_web/components/post_components.ex:403
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr "Eigene Beiträge"
@@ -14158,14 +14158,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4516
 #: lib/vutuv_web/controllers/settings_controller.ex:614
-#: lib/vutuv_web/live/post_live/feed.ex:1837
+#: lib/vutuv_web/live/post_live/feed.ex:1845
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr "Tags, denen Sie folgen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1852
+#: lib/vutuv_web/live/post_live/feed.ex:1860
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr "#%{tag} entfolgen"
@@ -14323,34 +14323,34 @@ msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch imm
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:4807
+#: lib/vutuv_web/components/post_components.ex:4837
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1204
-#: lib/vutuv_web/components/post_components.ex:4764
+#: lib/vutuv_web/components/post_components.ex:4794
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:4808
+#: lib/vutuv_web/components/post_components.ex:4838
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:4810
+#: lib/vutuv_web/components/post_components.ex:4840
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:4806
+#: lib/vutuv_web/components/post_components.ex:4836
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1204
-#: lib/vutuv_web/components/post_components.ex:4763
+#: lib/vutuv_web/components/post_components.ex:4793
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Filmbesprechung"
@@ -14361,12 +14361,12 @@ msgstr "Filmbesprechung"
 msgid "Look up"
 msgstr "Nachschlagen"
 
-#: lib/vutuv_web/components/post_components.ex:4805
+#: lib/vutuv_web/components/post_components.ex:4835
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
 
-#: lib/vutuv_web/components/post_components.ex:4809
+#: lib/vutuv_web/components/post_components.ex:4839
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14386,7 +14386,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:4846
+#: lib/vutuv_web/components/post_components.ex:4876
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14394,27 +14394,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:4876
+#: lib/vutuv_web/components/post_components.ex:4906
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:4877
+#: lib/vutuv_web/components/post_components.ex:4907
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:4875
+#: lib/vutuv_web/components/post_components.ex:4905
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:4835
+#: lib/vutuv_web/components/post_components.ex:4865
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:4882
+#: lib/vutuv_web/components/post_components.ex:4912
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14444,7 +14444,7 @@ msgstr "Mit Qualifikation:"
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:4649
+#: lib/vutuv_web/components/post_components.ex:4679
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
@@ -14492,7 +14492,7 @@ msgstr "folgen Ihnen jetzt."
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:4640
+#: lib/vutuv_web/components/post_components.ex:4670
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
@@ -14886,14 +14886,14 @@ msgstr "Konto zum Einfrieren suchen"
 msgid "See all frozen accounts"
 msgstr "Alle eingefrorenen Konten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2836
+#: lib/vutuv_web/components/post_components.ex:2853
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "%{formatted} früheren Beitrag anzeigen"
 msgstr[1] "%{formatted} frühere Beiträge anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2859
+#: lib/vutuv_web/components/post_components.ex:2876
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14920,7 +14920,7 @@ msgstr "Dieses Profil ist zurzeit nicht verfügbar."
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das Konto zu finden, das eingefroren werden soll."
 
-#: lib/vutuv_web/components/post_components.ex:5298
+#: lib/vutuv_web/components/post_components.ex:5328
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Der eigene Beitrag lässt sich nicht mit „Gefällt mir“ markieren."
@@ -15378,36 +15378,36 @@ msgstr "Am Fediverse teilnehmen"
 msgid "Off means your profile cannot be found there and nothing is sent. Posts already delivered may stay on those servers, beyond our reach."
 msgstr "Ausgeschaltet ist Ihr Profil dort nicht auffindbar und es wird nichts zugestellt. Bereits ausgelieferte Beiträge können auf jenen Servern verbleiben, außerhalb unseres Zugriffs."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:117
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:133
 #, elixir-autogen, elixir-format
 msgid "Give this out the way you give out an email address. Anyone on Mastodon and friends can paste it into their search and follow you from there."
 msgstr "Geben Sie es weiter wie eine E-Mail-Adresse. Jeder bei Mastodon und Co. kann es in die Suche einfügen und Ihnen von dort folgen."
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:187
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:138
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:154
 #, elixir-autogen, elixir-format
 msgid "Nobody yet. Post your handle where people can see it, and the first follows will show up here."
 msgstr "Noch niemand. Posten Sie Ihr Handle dort, wo andere es sehen, dann tauchen die ersten Follower hier auf."
 
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:327
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:192
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:208
 #, elixir-autogen, elixir-format
 msgid "Related"
 msgstr "Verwandte Themen"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:195
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:211
 #, elixir-autogen, elixir-format
 msgid "Moving to or away from another Fediverse account?"
 msgstr "Ziehen Sie zu einem anderen Fediverse-Konto um oder von dort zu vutuv?"
 
 #: lib/vutuv_web/controllers/settings_controller.ex:377
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:201
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:217
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Move your account"
 msgstr "Konto umziehen"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:218
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:234
 #, elixir-autogen, elixir-format
 msgid "Want the checkmark on your Mastodon profile? That works without taking part here: your vutuv profile links your listed accounts with rel=\"me\"."
 msgstr "Sie möchten das Häkchen in Ihrem Mastodon-Profil? Das geht ohne Teilnahme hier: Ihr vutuv-Profil verlinkt Ihre eingetragenen Konten mit rel=\"me\"."
@@ -15464,7 +15464,7 @@ msgstr "Schicken Sie Ihre Fediverse-Follower zu einem anderen Konto. Sie werden 
 msgid "Back to Fediverse settings"
 msgstr "Zurück zu den Fediverse-Einstellungen"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:124
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:140
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower from other networks"
 msgid_plural "%{formatted} followers from other networks"
@@ -16028,13 +16028,13 @@ msgstr "Benutzernamen ändern"
 msgid "This link always opens your profile, even after you change your username. It is built from a fixed id, so it never breaks on a rename. For everyday sharing the short address above is friendlier."
 msgstr "Dieser Link öffnet immer Ihr Profil, auch nachdem Sie Ihren Benutzernamen geändert haben. Er wird aus einer festen Id gebildet und geht bei einer Umbenennung nie kaputt. Für den Alltag ist die kurze Adresse oben freundlicher."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:269
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:285
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:35
 #, elixir-autogen, elixir-format
 msgid "I understand, switch off"
 msgstr "Verstanden, abschalten"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:267
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:283
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "I understand, take part"
@@ -16084,21 +16084,21 @@ msgstr ""
 "wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
-#: lib/vutuv_web/components/post_components.ex:5244
+#: lib/vutuv_web/components/post_components.ex:5274
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:5248
+#: lib/vutuv_web/components/post_components.ex:5278
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Like"
 msgstr[1] "%{formatted} Likes"
 
-#: lib/vutuv_web/components/post_components.ex:5252
+#: lib/vutuv_web/components/post_components.ex:5282
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -16106,7 +16106,7 @@ msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1153
-#: lib/vutuv_web/components/post_components.ex:5203
+#: lib/vutuv_web/components/post_components.ex:5233
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Bereits in den Zahlen oben enthalten."
@@ -16122,14 +16122,14 @@ msgstr "Antworten, die dort draußen geschrieben werden, erscheinen unter Ihrem 
 msgid "Content warning"
 msgstr "Inhaltswarnung"
 
-#: lib/vutuv_web/components/post_components.ex:1371
-#: lib/vutuv_web/components/post_components.ex:2030
+#: lib/vutuv_web/components/post_components.ex:1387
+#: lib/vutuv_web/components/post_components.ex:2046
 #: lib/vutuv_web/live/fediverse_account_live.ex:294
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr "Aus einem anderen Netzwerk"
 
-#: lib/vutuv_web/components/post_components.ex:1247
+#: lib/vutuv_web/components/post_components.ex:1263
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr "Diese Antwort aus Ihrem Beitrag entfernen?"
@@ -16158,7 +16158,7 @@ msgstr "Antwort aus einem anderen Netzwerk"
 msgid "Reply removed."
 msgstr "Antwort entfernt."
 
-#: lib/vutuv_web/components/post_components.ex:1256
+#: lib/vutuv_web/components/post_components.ex:1272
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
@@ -16168,7 +16168,7 @@ msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
 msgid "Reported as not appropriate"
 msgstr "Als unangemessen gemeldet"
 
-#: lib/vutuv_web/components/post_components.ex:1270
+#: lib/vutuv_web/components/post_components.ex:1286
 #: lib/vutuv_web/live/notification_live/index.ex:597
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -16200,9 +16200,9 @@ msgid "That reply is not yours to remove."
 msgstr "Diese Antwort können Sie nicht entfernen."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1337
-#: lib/vutuv_web/components/post_components.ex:1302
-#: lib/vutuv_web/components/post_components.ex:1502
-#: lib/vutuv_web/components/post_components.ex:2483
+#: lib/vutuv_web/components/post_components.ex:1318
+#: lib/vutuv_web/components/post_components.ex:1518
+#: lib/vutuv_web/components/post_components.ex:2500
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr "Original ansehen"
@@ -16225,7 +16225,7 @@ msgstr "Sie haben heute schon viel gemeldet. Bitte versuchen Sie es morgen wiede
 msgid "replied to your post from another network."
 msgstr "hat aus einem anderen Netzwerk auf Ihren Beitrag geantwortet."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:144
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:160
 #, elixir-autogen, elixir-format
 msgid "All followers"
 msgstr "Alle Follower"
@@ -16550,7 +16550,7 @@ msgstr "E-Mails zu Empfehlungen"
 msgid "Every change to your account: what changed, exactly when, from which device, and how it was confirmed. If a line surprises you, follow the link at the end of it."
 msgstr "Jede Änderung an Ihrem Konto: was geändert wurde, wann genau, von welchem Gerät und wie es bestätigt wurde. Wenn Sie eine Zeile überrascht, folgen Sie dem Link an ihrem Ende."
 
-#: lib/vutuv_web/views/account_event_text.ex:249
+#: lib/vutuv_web/views/account_event_text.ex:250
 #, elixir-autogen, elixir-format
 msgid "Fediverse aliases"
 msgstr "Fediverse-Aliase"
@@ -16560,7 +16560,7 @@ msgstr "Fediverse-Aliase"
 msgid "Fediverse participation"
 msgstr "Fediverse-Teilnahme"
 
-#: lib/vutuv_web/views/account_event_text.ex:248
+#: lib/vutuv_web/views/account_event_text.ex:249
 #, elixir-autogen, elixir-format
 msgid "Fediverse replies"
 msgstr "Fediverse-Antworten"
@@ -16869,22 +16869,22 @@ msgstr "Was sich an welchem Konto geändert hat, wann, von welchem Gerät und wi
 msgid "device or detail"
 msgstr "Gerät oder Detail"
 
-#: lib/vutuv_web/components/post_components.ex:3021
+#: lib/vutuv_web/components/post_components.ex:3038
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Angehefteter Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:3137
+#: lib/vutuv_web/components/post_components.ex:3154
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "An Profil anheften"
 
-#: lib/vutuv_web/components/post_components.ex:3145
+#: lib/vutuv_web/components/post_components.ex:3162
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Vom Profil lösen"
 
-#: lib/vutuv_web/components/post_components.ex:3131
+#: lib/vutuv_web/components/post_components.ex:3148
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr "Es lässt sich nur ein Beitrag an Ihr Profil anheften. Diesen anheften und den anderen lösen?"
@@ -17016,17 +17016,17 @@ msgstr "Nächstes Foto"
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
 
-#: lib/vutuv_web/components/post_components.ex:2616
+#: lib/vutuv_web/components/post_components.ex:2633
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Fediverse-Einstellungen öffnen"
 
-#: lib/vutuv_web/components/post_components.ex:3834
+#: lib/vutuv_web/components/post_components.ex:3851
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} von %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:3982
+#: lib/vutuv_web/components/post_components.ex:3999
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
@@ -17039,7 +17039,7 @@ msgstr "Foto-Einstellungen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1298
 #: lib/vutuv_web/agent_docs/text.ex:785
-#: lib/vutuv_web/components/post_components.ex:4064
+#: lib/vutuv_web/components/post_components.ex:4081
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Fotos:"
@@ -17065,7 +17065,7 @@ msgstr "Dieselben Bildpunkte, sonst nichts: Ort und Seriennummern entfernt, Qual
 msgid "Show camera settings"
 msgstr "Kameradaten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2669
+#: lib/vutuv_web/components/post_components.ex:2686
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr "Dieser Server ist auf dieser Seite gesperrt, deshalb kann keine Antwort dorthin gesendet werden."
@@ -17085,7 +17085,7 @@ msgstr "Dieses Dateiformat lässt sich nur unverändert weitergeben. Entfernen S
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr "Dieses Foto enthält den Ort, an dem es aufgenommen wurde. Wer die exakte Datei herunterlädt, kann ihn auslesen."
 
-#: lib/vutuv_web/components/post_components.ex:2660
+#: lib/vutuv_web/components/post_components.ex:2677
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht öffentlich beantworten."
@@ -17095,12 +17095,12 @@ msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht �
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr "Diese Antwort wurde in einem anderen Netzwerk geschrieben. Sie zu beantworten heißt, Ihre Worte in dieses Netzwerk zu senden, und das tut vutuv nur für Mitglieder, die die Fediverse-Teilnahme eingeschaltet haben."
 
-#: lib/vutuv_web/components/post_components.ex:2678
+#: lib/vutuv_web/components/post_components.ex:2695
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Diese Seite nimmt nicht am Fediverse teil."
 
-#: lib/vutuv_web/components/post_components.ex:2612
+#: lib/vutuv_web/components/post_components.ex:2629
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Fediverse-Teilnahme einschalten, um zu antworten"
@@ -17115,7 +17115,7 @@ msgstr "Wer diese Fotos weiterverwenden darf"
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke geschickt. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:2673
+#: lib/vutuv_web/components/post_components.ex:2690
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshalb werden von hier aus keine Antworten mehr gesendet."
@@ -17125,7 +17125,7 @@ msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshal
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr "Ihre Fediverse-Einstellungen erlauben es derzeit nicht, eine Antwort zu senden."
 
-#: lib/vutuv_web/components/post_components.ex:2626
+#: lib/vutuv_web/components/post_components.ex:2643
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr "Ihre Antwort geht an %{handle} auf dem eigenen Server und an Ihre Fediverse-Follower. Auf vutuv ist sie ebenfalls ein öffentlicher Beitrag."
@@ -17146,8 +17146,8 @@ msgstr "Fotos hinzufügen"
 msgid "Licence"
 msgstr "Lizenz"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1638
-#: lib/vutuv_web/live/post_live/feed.ex:1639
+#: lib/vutuv_web/live/post_live/feed.ex:1645
+#: lib/vutuv_web/live/post_live/feed.ex:1646
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr "Fotos posten"
@@ -17212,13 +17212,13 @@ msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exak
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1171
-#: lib/vutuv_web/components/post_components.ex:5241
+#: lib/vutuv_web/components/post_components.ex:5271
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1169
-#: lib/vutuv_web/components/post_components.ex:5238
+#: lib/vutuv_web/components/post_components.ex:5268
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} hat das geteilt"
@@ -17228,7 +17228,7 @@ msgstr "%{handle} hat das geteilt"
 msgid "Fediverse reactions"
 msgstr "Fediverse-Reaktionen"
 
-#: lib/vutuv_web/components/post_components.ex:5130
+#: lib/vutuv_web/components/post_components.ex:5160
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
@@ -17333,7 +17333,7 @@ msgstr "Fotodetails"
 #: lib/vutuv_web/live/fediverse_following_live.ex:301
 #: lib/vutuv_web/live/fediverse_following_live.ex:314
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:336
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:159
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:175
 #, elixir-autogen, elixir-format
 msgid "Accounts you follow elsewhere"
 msgstr "Konten, denen Sie anderswo folgen"
@@ -17365,7 +17365,7 @@ msgstr "Konten auf Mastodon folgen, und von dort gefolgt werden"
 msgid "Follow request sent to %{account}."
 msgstr "Follower-Anfrage an %{account} gesendet."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:180
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "Follow somebody out there"
 msgstr "Jemandem dort draußen folgen"
@@ -17375,14 +17375,14 @@ msgstr "Jemandem dort draußen folgen"
 msgid "Follow this account"
 msgstr "Diesem Konto folgen"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:161
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:177
 #, elixir-autogen, elixir-format
 msgid "It works the other way round too: paste somebody's address from Mastodon and friends, and you follow them from here."
 msgstr "Es geht auch andersherum: Fügen Sie die Adresse von jemandem bei Mastodon und Co. ein, und Sie folgen dieser Person von hier aus."
 
 #: lib/vutuv/api_auth/scopes.ex:84
 #: lib/vutuv/api_auth/scopes.ex:87
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:182
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Manage who you follow"
 msgstr "Verwalten, wem Sie folgen"
@@ -17535,7 +17535,7 @@ msgstr "Sie nehmen derzeit nicht am Fediverse teil, deshalb gibt es keine Identi
 msgid "You can follow accounts there yourself, straight from vutuv."
 msgstr "Sie können dort selbst Konten folgen, direkt von vutuv aus."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:170
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "You follow %{formatted} account on another network"
 msgid_plural "You follow %{formatted} accounts on other networks"
@@ -17577,7 +17577,7 @@ msgstr "Von hier aus wird %{follows} Konten in anderen Netzwerken gefolgt, davon
 msgid "Cached posts"
 msgstr "Zwischengespeicherte Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:2428
+#: lib/vutuv_web/components/post_components.ex:2445
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr "Nur für die Follower dieses Kontos"
@@ -17587,7 +17587,7 @@ msgstr "Nur für die Follower dieses Kontos"
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Danke. Unsere Kopie wurde sofort gelöscht."
 
-#: lib/vutuv_web/components/post_components.ex:2482
+#: lib/vutuv_web/components/post_components.ex:2499
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Beim Original abstimmen"
@@ -17607,12 +17607,12 @@ msgstr "Zwischengespeicherter Beitrag gemeldet, hier für alle entfernt"
 msgid "Content from other networks taken down by members"
 msgstr "Von Mitgliedern entfernte Inhalte aus anderen Netzwerken"
 
-#: lib/vutuv_web/components/post_components.ex:1630
+#: lib/vutuv_web/components/post_components.ex:1646
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr "Verbergen"
 
-#: lib/vutuv_web/components/post_components.ex:2447
+#: lib/vutuv_web/components/post_components.ex:2464
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Von der verfassenden Person als sensibel markiert"
@@ -17628,7 +17628,7 @@ msgstr "Stummgeschaltet. Sie folgen dem Konto weiterhin; die Beiträge verschwin
 msgid "Nobody has removed or reported anything yet."
 msgstr "Bisher hat niemand etwas entfernt oder gemeldet."
 
-#: lib/vutuv_web/components/post_components.ex:2414
+#: lib/vutuv_web/components/post_components.ex:2431
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr "Diesen Beitrag als unangemessen melden? Unsere Kopie wird sofort für alle auf diesem vutuv gelöscht."
@@ -17850,27 +17850,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] "(ein Bild)"
 msgstr[1] "(%{count} Bilder)"
 
-#: lib/vutuv_web/components/post_components.ex:2150
+#: lib/vutuv_web/components/post_components.ex:2167
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr "Bild wird geprüft"
 
-#: lib/vutuv_web/components/post_components.ex:2179
+#: lib/vutuv_web/components/post_components.ex:2196
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr "Wieder verdecken"
 
-#: lib/vutuv_web/components/post_components.ex:2174
+#: lib/vutuv_web/components/post_components.ex:2191
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr "Heikles Motiv. Bild anzeigen."
 
-#: lib/vutuv_web/components/post_components.ex:2519
+#: lib/vutuv_web/components/post_components.ex:2536
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Das sind viele Likes in einer Stunde. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:2525
+#: lib/vutuv_web/components/post_components.ex:2542
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Diesen Beitrag gibt es hier nicht mehr."
@@ -17880,7 +17880,7 @@ msgstr "Diesen Beitrag gibt es hier nicht mehr."
 msgid "Back to the feed"
 msgstr "Zurück zum Feed"
 
-#: lib/vutuv_web/components/post_components.ex:2664
+#: lib/vutuv_web/components/post_components.ex:2681
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -18162,7 +18162,7 @@ msgid "Its author published this post to their followers alone, so vutuv does no
 msgstr "Die verfassende Person hat diesen Beitrag nur an ihre Follower veröffentlicht, deshalb behält vutuv keine Kopie davon."
 
 #: lib/vutuv_web/live/fediverse_following_live.ex:495
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:214
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:230
 #, elixir-autogen, elixir-format
 msgid "Look up a post by its address"
 msgstr "Einen Beitrag über seine Adresse nachschlagen"
@@ -18183,7 +18183,7 @@ msgstr "Suchen Sie ein Konto statt eines einzelnen Beitrags?"
 msgid "Paste the address of a post on Mastodon and friends. vutuv fetches it, shows it here, and you can answer, like or repost it as if it had arrived on its own."
 msgstr "Fügen Sie die Adresse eines Beitrags aus Mastodon und Co. ein. vutuv holt ihn, zeigt ihn hier an, und Sie können darauf antworten, ihn mögen oder teilen, als wäre er von selbst hier gelandet."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:208
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:224
 #, elixir-autogen, elixir-format
 msgid "Read something out there that you want to answer from here?"
 msgstr "Etwas dort draußen gelesen, worauf Sie von hier aus antworten möchten?"
@@ -18593,14 +18593,14 @@ msgstr "Seiten, von denen nie ein Screenshot entsteht, weil ein Browser ohne Anz
 msgid "Screenshot blocklist"
 msgstr "Screenshot-Blockliste"
 
-#: lib/vutuv_web/components/post_components.ex:425
+#: lib/vutuv_web/components/post_components.ex:436
 #, elixir-autogen, elixir-format
 msgid "Nothing from the fediverse yet. Follow accounts out there to fill this tab."
 msgstr ""
 "Noch nichts aus dem Fediverse. Folgen Sie Konten dort draußen, um diesen Tab "
 "zu füllen."
 
-#: lib/vutuv_web/components/post_components.ex:422
+#: lib/vutuv_web/components/post_components.ex:433
 #, elixir-autogen, elixir-format
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
@@ -18643,7 +18643,7 @@ msgstr "Auf vutuv gibt es zu diesem Tag noch keine Beiträge."
 msgid "word in a post"
 msgstr "Wort in einem Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:2522
+#: lib/vutuv_web/components/post_components.ex:2539
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr "Diese Antwort gibt es hier nicht mehr."
@@ -18946,19 +18946,19 @@ msgstr "Auf der Seite eines Beitrags stehen direkt unter der Zahl die Mitglieder
 msgid "Liked by"
 msgstr "Gefällt diesen Mitgliedern"
 
-#: lib/vutuv_web/components/post_components.ex:4336
+#: lib/vutuv_web/components/post_components.ex:4366
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Gefällt %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:4338
+#: lib/vutuv_web/components/post_components.ex:4368
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Gefällt %{name} und %{formatted} weiteren"
 msgstr[1] "Gefällt %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/components/post_components.ex:4349
+#: lib/vutuv_web/components/post_components.ex:4379
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr "Nur Sie sehen hier alle: Einige dieser Mitglieder werden anderen Lesern nicht genannt."
@@ -19934,17 +19934,17 @@ msgstr ""
 "Kommt keine PIN an? Ist die E-Mail-Adresse {email} korrekt? Haben Sie einmal "
 "in Ihren Spam-Ordner geschaut?"
 
-#: lib/vutuv/accounts/user.ex:1332
+#: lib/vutuv/accounts/user.ex:1340
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/vutuv/accounts/user.ex:1330
+#: lib/vutuv/accounts/user.ex:1338
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr "Weiblich"
 
-#: lib/vutuv/accounts/user.ex:1331
+#: lib/vutuv/accounts/user.ex:1339
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Männlich"
@@ -20057,7 +20057,7 @@ msgstr "Immer behalten"
 #: lib/vutuv_web/controllers/settings_controller.ex:324
 #: lib/vutuv_web/controllers/settings_controller.ex:336
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:20
-#: lib/vutuv_web/views/account_event_text.ex:254
+#: lib/vutuv_web/views/account_event_text.ex:255
 #, elixir-autogen, elixir-format
 msgid "Automatic post deletion"
 msgstr "Automatisches Löschen von Beiträgen"
@@ -20067,7 +20067,7 @@ msgstr "Automatisches Löschen von Beiträgen"
 msgid "Automatic post deletion changed"
 msgstr "Automatisches Löschen von Beiträgen geändert"
 
-#: lib/vutuv_web/views/account_event_text.ex:261
+#: lib/vutuv_web/views/account_event_text.ex:262
 #, elixir-autogen, elixir-format
 msgid "Bookmark floor"
 msgstr "Mindestzahl Lesezeichen"
@@ -20109,7 +20109,7 @@ msgstr "Meine Beiträge automatisch löschen"
 msgid "Delete posts older than"
 msgstr "Beiträge löschen, die älter sind als"
 
-#: lib/vutuv_web/views/account_event_text.ex:259
+#: lib/vutuv_web/views/account_event_text.ex:260
 #, elixir-autogen, elixir-format
 msgid "Delete replies too"
 msgstr "Antworten mitlöschen"
@@ -20129,17 +20129,17 @@ msgstr "Wenn Sie einen Beitrag löschen, aus dem ein Gespräch entstanden ist, s
 msgid "If a post of yours reached other networks (Mastodon and the rest), we ask every server that received it to delete its copy. We cannot make them. A server that is switched off, that no longer talks to us, or that simply ignores the request keeps what it has."
 msgstr "Wenn ein Beitrag von Ihnen in andere Netzwerke gelangt ist (Mastodon und die übrigen), bitten wir jeden Server, der ihn bekommen hat, seine Kopie zu löschen. Zwingen können wir ihn nicht. Ein Server, der abgeschaltet ist, der nicht mehr mit uns spricht oder der die Bitte schlicht ignoriert, behält, was er hat."
 
-#: lib/vutuv_web/views/account_event_text.ex:257
+#: lib/vutuv_web/views/account_event_text.ex:258
 #, elixir-autogen, elixir-format
 msgid "Keep answered posts"
 msgstr "Beantwortete Beiträge behalten"
 
-#: lib/vutuv_web/views/account_event_text.ex:258
+#: lib/vutuv_web/views/account_event_text.ex:259
 #, elixir-autogen, elixir-format
 msgid "Keep bookmarked posts"
 msgstr "Beiträge mit Lesezeichen behalten"
 
-#: lib/vutuv_web/views/account_event_text.ex:256
+#: lib/vutuv_web/views/account_event_text.ex:257
 #, elixir-autogen, elixir-format
 msgid "Keep photo posts"
 msgstr "Fotobeiträge behalten"
@@ -20154,7 +20154,7 @@ msgstr "Beiträge behalten, die gut liefen"
 msgid "Let your posts age out after a time you set"
 msgstr "Ihre Beiträge nach einer selbst gewählten Zeit auslaufen lassen"
 
-#: lib/vutuv_web/views/account_event_text.ex:260
+#: lib/vutuv_web/views/account_event_text.ex:261
 #, elixir-autogen, elixir-format
 msgid "Like floor"
 msgstr "Mindestzahl Likes"
@@ -20179,7 +20179,7 @@ msgstr "Standardmäßig aus: Eine Antwort ist ein Beitrag zu einem Gespräch, da
 msgid "Photo posts and book or film reviews are kept whatever their age."
 msgstr "Fotobeiträge sowie Buch- und Filmkritiken bleiben unabhängig vom Alter erhalten."
 
-#: lib/vutuv_web/views/account_event_text.ex:255
+#: lib/vutuv_web/views/account_event_text.ex:256
 #, elixir-autogen, elixir-format
 msgid "Post age"
 msgstr "Alter der Beiträge"
@@ -20204,7 +20204,7 @@ msgstr "Beiträge mit Fotos oder einer Kritik"
 msgid "Posts you bookmarked yourself"
 msgstr "Beiträge, auf die Sie selbst ein Lesezeichen gesetzt haben"
 
-#: lib/vutuv_web/views/account_event_text.ex:262
+#: lib/vutuv_web/views/account_event_text.ex:263
 #, elixir-autogen, elixir-format
 msgid "Repost floor"
 msgstr "Mindestzahl Reposts"
@@ -20632,7 +20632,7 @@ msgstr "Suchen Sie so oft Sie möchten und nehmen Sie dazu, was gehört. Abkürz
 msgid "Start over"
 msgstr "Von vorn beginnen"
 
-#: lib/vutuv_web/components/post_components.ex:2552
+#: lib/vutuv_web/components/post_components.ex:2569
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr "Ein Herz oder ein Repost geht zurück in das Netzwerk, aus dem dieser Beitrag stammt. Ihr Konto nimmt derzeit nicht am Fediverse teil. Einschalten können Sie das in den {settings}."
@@ -21548,27 +21548,27 @@ msgstr "Sprache des Beitrags"
 msgid "The language this post is written in"
 msgstr "Die Sprache, in der dieser Beitrag geschrieben ist"
 
-#: lib/vutuv_web/components/post_components.ex:4230
+#: lib/vutuv_web/components/post_components.ex:4260
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Original anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:4266
+#: lib/vutuv_web/components/post_components.ex:4296
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Übersetzen"
 
-#: lib/vutuv_web/components/post_components.ex:4275
+#: lib/vutuv_web/components/post_components.ex:4305
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Übersetzt"
 
-#: lib/vutuv_web/components/post_components.ex:4278
+#: lib/vutuv_web/components/post_components.ex:4308
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Übersetzt aus %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:4255
+#: lib/vutuv_web/components/post_components.ex:4285
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Wird übersetzt …"
@@ -21578,7 +21578,7 @@ msgstr "Wird übersetzt …"
 msgid "Feed language settings reset to the site defaults."
 msgstr "Feed-Spracheinstellungen auf die Website-Vorgaben zurückgesetzt."
 
-#: lib/vutuv_web/components/post_components.ex:4245
+#: lib/vutuv_web/components/post_components.ex:4275
 #: lib/vutuv_web/components/ui.ex:4509
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -21707,20 +21707,20 @@ msgstr "Wir haben den Link in Ihrem Profil noch nicht gefunden. Bitte versuchen 
 msgid "Your username, or paste the address of your profile page."
 msgstr "Ihr Benutzername – oder fügen Sie die Adresse Ihrer Profilseite ein."
 
-#: lib/vutuv_web/components/post_components.ex:4030
+#: lib/vutuv_web/components/post_components.ex:4047
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] "Unsere KI prüft es gerade. Sobald die Prüfung durch ist, erscheint das Foto von selbst."
 msgstr[1] "Unsere KI prüft sie gerade, %{done} von %{total} sind durch. Sobald die letzte durch ist, erscheinen die Fotos von selbst."
 
-#: lib/vutuv_web/components/post_components.ex:4027
+#: lib/vutuv_web/components/post_components.ex:4044
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr "Ihr Beitrag ist veröffentlicht, das Foto noch nicht."
 
-#: lib/vutuv_web/components/post_components.ex:2201
-#: lib/vutuv_web/components/post_components.ex:3354
+#: lib/vutuv_web/components/post_components.ex:2218
+#: lib/vutuv_web/components/post_components.ex:3371
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -21737,7 +21737,7 @@ msgstr "Empfohlen: %{width} × %{height} Pixel (%{ratio})."
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr "Empfohlen: quadratisch, mindestens %{width} × %{height} Pixel."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1894
+#: lib/vutuv_web/live/post_live/feed.ex:1902
 #: lib/vutuv_web/views/user_html.ex:338
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -22231,7 +22231,7 @@ msgstr "Land suchen"
 msgid "This page is following the most accounts we allow (%{max})."
 msgstr "Diese Seite folgt bereits so vielen Konten, wie hier erlaubt sind (%{max})."
 
-#: lib/vutuv_web/components/post_components.ex:2402
+#: lib/vutuv_web/components/post_components.ex:2419
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr "%{handle} nicht mehr folgen? Die Beiträge verschwinden aus Ihrem Feed."
@@ -22357,12 +22357,12 @@ msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public po
 msgstr ""
 "Folgen Sie #%{tag} von Mastodon oder einer anderen Fediverse-App aus, dann landen die öffentlichen Beiträge in Ihrer Timeline. Ein vutuv-Konto brauchen Sie dafür nicht."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1876
+#: lib/vutuv_web/live/post_live/feed.ex:1884
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Andere Mitglieder begrüßen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1872
+#: lib/vutuv_web/live/post_live/feed.ex:1880
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr "Neu dabei"
@@ -22408,33 +22408,33 @@ msgstr "Der beste Weg: Folgen Sie %{name} hier. Neue Beiträge landen in Ihrem F
 msgid "With a vutuv account"
 msgstr "Mit einem vutuv-Konto"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1886
+#: lib/vutuv_web/live/post_live/feed.ex:1894
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
 "Ein paar der neuesten Mitglieder. Ihnen zu folgen ist eine herzliche "
 "Begrüßung."
 
-#: lib/vutuv_web/components/post_components.ex:602
+#: lib/vutuv_web/components/post_components.ex:613
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new post"
 msgid_plural "%{formatted} new posts"
 msgstr[0] "%{formatted} neuer Beitrag"
 msgstr[1] "%{formatted} neue Beiträge"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1314
+#: lib/vutuv_web/live/post_live/feed.ex:1312
 #, elixir-autogen, elixir-format
 msgid "%{source}: %{formatted} new post"
 msgid_plural "%{source}: %{formatted} new posts"
 msgstr[0] "%{source}: %{formatted} neuer Beitrag"
 msgstr[1] "%{source}: %{formatted} neue Beiträge"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1311
+#: lib/vutuv_web/live/post_live/feed.ex:1309
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post"
 msgstr "%{source}: neuer Beitrag"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1308
+#: lib/vutuv_web/live/post_live/feed.ex:1306
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post from %{who}"
 msgstr "%{source}: neuer Beitrag von %{who}"
@@ -22733,3 +22733,18 @@ msgstr "Ihr LinkedIn-Profil kann mitkommen."
 #, elixir-autogen, elixir-format
 msgid "Being checked"
 msgstr "Wird geprüft"
+
+#: lib/vutuv_web/views/account_event_text.ex:248
+#, elixir-autogen, elixir-format
+msgid "Fediverse quotes"
+msgstr "Fediverse-Zitate"
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:112
+#, elixir-autogen, elixir-format
+msgid "Let other networks quote your posts"
+msgstr "Andere Netzwerke dürfen Ihre Beiträge zitieren"
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:115
+#, elixir-autogen, elixir-format
+msgid "Someone on Mastodon can share one of your public posts with their own comment above it, the way a reshare works, but with their words beside yours. Your server is asked first every time and answers automatically while this is on. You can withdraw a single quote later, and switching this off refuses new ones."
+msgstr "Jemand auf Mastodon kann einen Ihrer öffentlichen Beiträge mit einem eigenen Kommentar darüber teilen — wie bei einem Repost, nur mit seinen Worten neben Ihren. Ihr Server wird jedes Mal vorher gefragt und antwortet automatisch, solange dies eingeschaltet ist. Sie können ein einzelnes Zitat später zurückziehen, und ausgeschaltet lehnt er neue Anfragen ab."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -126,7 +126,7 @@ msgstr ""
 #: lib/vutuv_web/templates/import/preview.html.heex:113
 #: lib/vutuv_web/templates/report/new.html.heex:103
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:276
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:259
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:275
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:26
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
 #: lib/vutuv_web/templates/user/edit.html.heex:53
@@ -162,7 +162,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3153
+#: lib/vutuv_web/components/post_components.ex:3170
 #: lib/vutuv_web/components/ui.ex:4106
 #: lib/vutuv_web/live/admin/job_live.ex:489
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -211,7 +211,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3118
+#: lib/vutuv_web/components/post_components.ex:3135
 #: lib/vutuv_web/components/ui.ex:4097
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -475,7 +475,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:629
+#: lib/vutuv_web/components/post_components.ex:640
 #: lib/vutuv_web/live/notification_live/index.ex:699
 #: lib/vutuv_web/live/organization_live/activity.ex:128
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
@@ -622,7 +622,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:196
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:105
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:121
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:73
 #: lib/vutuv_web/templates/settings/notifications.html.heex:79
 #: lib/vutuv_web/templates/settings/preferences.html.heex:84
@@ -657,7 +657,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1627
+#: lib/vutuv_web/components/post_components.ex:1643
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -1750,7 +1750,7 @@ msgstr ""
 msgid "Network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:436
+#: lib/vutuv_web/components/post_components.ex:447
 #: lib/vutuv_web/components/ui.ex:4216
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
@@ -2101,7 +2101,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3150
+#: lib/vutuv_web/components/post_components.ex:3167
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2117,7 +2117,7 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:114
 #: lib/vutuv_web/live/post_live/feed.ex:206
-#: lib/vutuv_web/live/post_live/feed.ex:1591
+#: lib/vutuv_web/live/post_live/feed.ex:1598
 #: lib/vutuv_web/live/shell_live.ex:973
 #: lib/vutuv_web/live/shell_live.ex:1272
 #: lib/vutuv_web/templates/layout/app.html.heex:171
@@ -2145,8 +2145,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3104
-#: lib/vutuv_web/components/post_components.ex:3106
+#: lib/vutuv_web/components/post_components.ex:3121
+#: lib/vutuv_web/components/post_components.ex:3123
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2162,7 +2162,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1802
+#: lib/vutuv_web/live/post_live/feed.ex:1810
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2212,13 +2212,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3568
-#: lib/vutuv_web/components/post_components.ex:3572
+#: lib/vutuv_web/components/post_components.ex:3585
+#: lib/vutuv_web/components/post_components.ex:3589
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3569
+#: lib/vutuv_web/components/post_components.ex:3586
 #: lib/vutuv_web/live/fediverse_account_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2226,7 +2226,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:376
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:1249
+#: lib/vutuv_web/components/post_components.ex:1265
 #: lib/vutuv_web/live/admin/screenshot_live.ex:327
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
@@ -2252,7 +2252,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1703
+#: lib/vutuv_web/live/post_live/feed.ex:1710
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2308,27 +2308,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3101
+#: lib/vutuv_web/components/post_components.ex:3118
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4957
+#: lib/vutuv_web/components/post_components.ex:4987
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4961
+#: lib/vutuv_web/components/post_components.ex:4991
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4959
+#: lib/vutuv_web/components/post_components.ex:4989
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4960
+#: lib/vutuv_web/components/post_components.ex:4990
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2369,8 +2369,8 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1842
-#: lib/vutuv_web/components/post_components.ex:5053
+#: lib/vutuv_web/components/post_components.ex:1858
+#: lib/vutuv_web/components/post_components.ex:5083
 #: lib/vutuv_web/components/ui.ex:3629
 #: lib/vutuv_web/views/user_html.ex:457
 #, elixir-autogen, elixir-format
@@ -2388,8 +2388,8 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1795
-#: lib/vutuv_web/components/post_components.ex:5289
+#: lib/vutuv_web/components/post_components.ex:1811
+#: lib/vutuv_web/components/post_components.ex:5319
 #: lib/vutuv_web/components/ui.ex:3615
 #: lib/vutuv_web/live/notification_live/index.ex:1089
 #: lib/vutuv_web/views/user_html.ex:467
@@ -2398,7 +2398,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1115
-#: lib/vutuv_web/components/post_components.ex:5299
+#: lib/vutuv_web/components/post_components.ex:5329
 #: lib/vutuv_web/live/notification_live/index.ex:1022
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
@@ -2420,40 +2420,40 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5041
+#: lib/vutuv_web/components/post_components.ex:5071
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1841
-#: lib/vutuv_web/components/post_components.ex:5052
+#: lib/vutuv_web/components/post_components.ex:1857
+#: lib/vutuv_web/components/post_components.ex:5082
 #: lib/vutuv_web/live/post_live/saved.ex:806
 #: lib/vutuv_web/views/user_html.ex:457
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1823
-#: lib/vutuv_web/components/post_components.ex:5038
+#: lib/vutuv_web/components/post_components.ex:1839
+#: lib/vutuv_web/components/post_components.ex:5068
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2088
-#: lib/vutuv_web/components/post_components.ex:4163
+#: lib/vutuv_web/components/post_components.ex:2104
+#: lib/vutuv_web/components/post_components.ex:4193
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1822
-#: lib/vutuv_web/components/post_components.ex:5037
+#: lib/vutuv_web/components/post_components.ex:1838
+#: lib/vutuv_web/components/post_components.ex:5067
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1794
-#: lib/vutuv_web/components/post_components.ex:5288
+#: lib/vutuv_web/components/post_components.ex:1810
+#: lib/vutuv_web/components/post_components.ex:5318
 #: lib/vutuv_web/live/post_live/saved.ex:805
 #: lib/vutuv_web/views/user_html.ex:467
 #, elixir-autogen, elixir-format
@@ -2461,14 +2461,14 @@ msgid "Unlike"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:377
-#: lib/vutuv_web/components/post_components.ex:2407
+#: lib/vutuv_web/components/post_components.ex:2424
 #: lib/vutuv_web/components/ui.ex:2484
 #: lib/vutuv_web/components/ui.ex:2484
 #: lib/vutuv_web/components/ui.ex:2621
 #: lib/vutuv_web/live/organization_live/following.ex:383
 #: lib/vutuv_web/live/organization_live/following.ex:458
 #: lib/vutuv_web/live/organization_live/show.ex:489
-#: lib/vutuv_web/live/post_live/feed.ex:1851
+#: lib/vutuv_web/live/post_live/feed.ex:1859
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2480,27 +2480,27 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5343
+#: lib/vutuv_web/components/post_components.ex:5373
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:394
+#: lib/vutuv_web/components/post_components.ex:405
 #: lib/vutuv_web/live/notification_live/index.ex:1023
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1808
-#: lib/vutuv_web/components/post_components.ex:5326
-#: lib/vutuv_web/components/post_components.ex:5327
+#: lib/vutuv_web/components/post_components.ex:1824
+#: lib/vutuv_web/components/post_components.ex:5356
+#: lib/vutuv_web/components/post_components.ex:5357
 #: lib/vutuv_web/live/notification_live/index.ex:1086
 #: lib/vutuv_web/live/post_live/reply.ex:43
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3068
+#: lib/vutuv_web/components/post_components.ex:3085
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2521,7 +2521,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2604
+#: lib/vutuv_web/components/post_components.ex:2621
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:60
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:57
@@ -2529,14 +2529,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3042
+#: lib/vutuv_web/components/post_components.ex:3059
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3033
-#: lib/vutuv_web/components/post_components.ex:3060
-#: lib/vutuv_web/components/post_components.ex:3063
+#: lib/vutuv_web/components/post_components.ex:3050
+#: lib/vutuv_web/components/post_components.ex:3077
+#: lib/vutuv_web/components/post_components.ex:3080
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2759,7 +2759,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1629
+#: lib/vutuv_web/live/post_live/feed.ex:1636
 #: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2780,7 +2780,7 @@ msgid_plural "%{formatted} connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1953
+#: lib/vutuv_web/live/post_live/feed.ex:1961
 #: lib/vutuv_web/templates/user/card_list.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -2835,7 +2835,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4958
+#: lib/vutuv_web/components/post_components.ex:4988
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3098,7 +3098,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3009
+#: lib/vutuv_web/components/post_components.ex:3026
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3173,9 +3173,9 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1259
-#: lib/vutuv_web/components/post_components.ex:2419
-#: lib/vutuv_web/components/post_components.ex:3173
+#: lib/vutuv_web/components/post_components.ex:1275
+#: lib/vutuv_web/components/post_components.ex:2436
+#: lib/vutuv_web/components/post_components.ex:3190
 #: lib/vutuv_web/live/organization_live/show.ex:562
 #: lib/vutuv_web/templates/user/show.html.heex:222
 #, elixir-autogen, elixir-format
@@ -4541,7 +4541,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1807
+#: lib/vutuv_web/live/post_live/feed.ex:1815
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -4618,8 +4618,8 @@ msgstr ""
 msgid "Similar names"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:391
-#: lib/vutuv_web/components/post_components.ex:410
+#: lib/vutuv_web/components/post_components.ex:402
+#: lib/vutuv_web/components/post_components.ex:421
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
@@ -5419,11 +5419,11 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3239
-#: lib/vutuv_web/components/post_components.ex:3294
-#: lib/vutuv_web/components/post_components.ex:3705
+#: lib/vutuv_web/components/post_components.ex:3256
+#: lib/vutuv_web/components/post_components.ex:3311
+#: lib/vutuv_web/components/post_components.ex:3722
 #: lib/vutuv_web/live/notification_live/index.ex:743
-#: lib/vutuv_web/live/post_live/feed.ex:1994
+#: lib/vutuv_web/live/post_live/feed.ex:2002
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -6214,7 +6214,7 @@ msgid "Previous day"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1115
-#: lib/vutuv_web/components/post_components.ex:393
+#: lib/vutuv_web/components/post_components.ex:404
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
@@ -6607,8 +6607,8 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2387
-#: lib/vutuv_web/components/post_components.ex:3170
+#: lib/vutuv_web/components/post_components.ex:2404
+#: lib/vutuv_web/components/post_components.ex:3187
 #: lib/vutuv_web/components/ui.ex:2809
 #: lib/vutuv_web/live/fediverse_account_live.ex:381
 #: lib/vutuv_web/live/organization_live/following.ex:376
@@ -6635,7 +6635,7 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3170
+#: lib/vutuv_web/components/post_components.ex:3187
 #: lib/vutuv_web/components/ui.ex:2808
 #: lib/vutuv_web/live/fediverse_account_live.ex:379
 #: lib/vutuv_web/live/organization_live/following.ex:376
@@ -7345,7 +7345,7 @@ msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:5199
+#: lib/vutuv_web/components/post_components.ex:5229
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -7886,7 +7886,7 @@ msgid "Admins"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:1962
+#: lib/vutuv_web/live/post_live/feed.ex:1970
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr ""
@@ -7959,8 +7959,8 @@ msgstr ""
 msgid "Identity-verified"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1445
-#: lib/vutuv/accounts.ex:1494
+#: lib/vutuv/accounts.ex:1446
+#: lib/vutuv/accounts.ex:1495
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -7999,7 +7999,7 @@ msgstr ""
 msgid "Open the member browser"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1462
+#: lib/vutuv/accounts.ex:1463
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -8443,12 +8443,12 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1979
+#: lib/vutuv_web/live/post_live/feed.ex:1987
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1975
+#: lib/vutuv_web/live/post_live/feed.ex:1983
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr ""
@@ -8675,17 +8675,17 @@ msgstr ""
 msgid "Fediverse settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:225
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:241
 #, elixir-autogen, elixir-format
 msgid "Manage social media accounts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:115
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse handle"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1457
+#: lib/vutuv/accounts.ex:1458
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -8792,7 +8792,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4166
+#: lib/vutuv_web/components/post_components.ex:4196
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9455,7 +9455,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1173
+#: lib/vutuv/accounts/user.ex:1181
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9466,7 +9466,7 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1170
+#: lib/vutuv/accounts/user.ex:1178
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -10821,19 +10821,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1211
+#: lib/vutuv/accounts/user.ex:1219
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1216
+#: lib/vutuv/accounts/user.ex:1224
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1214
+#: lib/vutuv/accounts/user.ex:1222
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:771
 #, elixir-autogen, elixir-format
@@ -11949,32 +11949,32 @@ msgstr ""
 msgid "We can't stop a search engine or AI service from reading a page it can open. What we can do is tell them, in the machine-readable way they look for, that you don't want your profile listed in search results or used by AI. Reputable search engines and AI companies follow that request; we can't force the rest."
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:105
+#: lib/vutuv/organizations/organization.ex:109
 #, elixir-autogen, elixir-format
 msgid "Association"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:104
+#: lib/vutuv/organizations/organization.ex:108
 #, elixir-autogen, elixir-format
 msgid "Business"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:107
+#: lib/vutuv/organizations/organization.ex:111
 #, elixir-autogen, elixir-format
 msgid "Education / research"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:108
+#: lib/vutuv/organizations/organization.ex:112
 #, elixir-autogen, elixir-format
 msgid "NGO / foundation"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:109
+#: lib/vutuv/organizations/organization.ex:113
 #, elixir-autogen, elixir-format
 msgid "Other organization"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:106
+#: lib/vutuv/organizations/organization.ex:110
 #, elixir-autogen, elixir-format
 msgid "Public authority"
 msgstr ""
@@ -12131,7 +12131,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1185
+#: lib/vutuv/accounts/user.ex:1193
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12250,7 +12250,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1184
+#: lib/vutuv/accounts/user.ex:1192
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12332,7 +12332,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1186
+#: lib/vutuv/accounts/user.ex:1194
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:565
 #: lib/vutuv_web/agent_docs/markdown.ex:466
@@ -13053,7 +13053,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2563
+#: lib/vutuv_web/components/post_components.ex:2580
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:695
 #: lib/vutuv_web/controllers/settings_controller.ex:713
@@ -13347,7 +13347,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1229
+#: lib/vutuv/accounts/user.ex:1237
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13358,19 +13358,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1232
+#: lib/vutuv/accounts/user.ex:1240
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1235
+#: lib/vutuv/accounts/user.ex:1243
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1226
+#: lib/vutuv/accounts/user.ex:1234
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13467,22 +13467,22 @@ msgstr ""
 msgid "Work mobile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:433
+#: lib/vutuv_web/components/post_components.ex:444
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:435
+#: lib/vutuv_web/components/post_components.ex:446
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:434
+#: lib/vutuv_web/components/post_components.ex:445
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:392
+#: lib/vutuv_web/components/post_components.ex:403
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr ""
@@ -13494,14 +13494,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4516
 #: lib/vutuv_web/controllers/settings_controller.ex:614
-#: lib/vutuv_web/live/post_live/feed.ex:1837
+#: lib/vutuv_web/live/post_live/feed.ex:1845
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1852
+#: lib/vutuv_web/live/post_live/feed.ex:1860
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr ""
@@ -13657,34 +13657,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4807
+#: lib/vutuv_web/components/post_components.ex:4837
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1204
-#: lib/vutuv_web/components/post_components.ex:4764
+#: lib/vutuv_web/components/post_components.ex:4794
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4808
+#: lib/vutuv_web/components/post_components.ex:4838
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4810
+#: lib/vutuv_web/components/post_components.ex:4840
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4806
+#: lib/vutuv_web/components/post_components.ex:4836
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1204
-#: lib/vutuv_web/components/post_components.ex:4763
+#: lib/vutuv_web/components/post_components.ex:4793
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13695,12 +13695,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4805
+#: lib/vutuv_web/components/post_components.ex:4835
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4809
+#: lib/vutuv_web/components/post_components.ex:4839
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13720,7 +13720,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4846
+#: lib/vutuv_web/components/post_components.ex:4876
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13728,27 +13728,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4876
+#: lib/vutuv_web/components/post_components.ex:4906
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4877
+#: lib/vutuv_web/components/post_components.ex:4907
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4875
+#: lib/vutuv_web/components/post_components.ex:4905
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4835
+#: lib/vutuv_web/components/post_components.ex:4865
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4882
+#: lib/vutuv_web/components/post_components.ex:4912
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13778,7 +13778,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4649
+#: lib/vutuv_web/components/post_components.ex:4679
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13826,7 +13826,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4640
+#: lib/vutuv_web/components/post_components.ex:4670
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14198,14 +14198,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2836
+#: lib/vutuv_web/components/post_components.ex:2853
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2859
+#: lib/vutuv_web/components/post_components.ex:2876
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14232,7 +14232,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5298
+#: lib/vutuv_web/components/post_components.ex:5328
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14688,36 +14688,36 @@ msgstr ""
 msgid "Off means your profile cannot be found there and nothing is sent. Posts already delivered may stay on those servers, beyond our reach."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:117
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:133
 #, elixir-autogen, elixir-format
 msgid "Give this out the way you give out an email address. Anyone on Mastodon and friends can paste it into their search and follow you from there."
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:187
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:138
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:154
 #, elixir-autogen, elixir-format
 msgid "Nobody yet. Post your handle where people can see it, and the first follows will show up here."
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:327
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:192
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:208
 #, elixir-autogen, elixir-format
 msgid "Related"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:195
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:211
 #, elixir-autogen, elixir-format
 msgid "Moving to or away from another Fediverse account?"
 msgstr ""
 
 #: lib/vutuv_web/controllers/settings_controller.ex:377
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:201
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:217
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Move your account"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:218
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:234
 #, elixir-autogen, elixir-format
 msgid "Want the checkmark on your Mastodon profile? That works without taking part here: your vutuv profile links your listed accounts with rel=\"me\"."
 msgstr ""
@@ -14774,7 +14774,7 @@ msgstr ""
 msgid "Back to Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:124
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:140
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower from other networks"
 msgid_plural "%{formatted} followers from other networks"
@@ -15338,13 +15338,13 @@ msgstr ""
 msgid "This link always opens your profile, even after you change your username. It is built from a fixed id, so it never breaks on a rename. For everyday sharing the short address above is friendlier."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:269
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:285
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:35
 #, elixir-autogen, elixir-format
 msgid "I understand, switch off"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:267
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:283
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "I understand, take part"
@@ -15380,21 +15380,21 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5244
+#: lib/vutuv_web/components/post_components.ex:5274
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5248
+#: lib/vutuv_web/components/post_components.ex:5278
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5252
+#: lib/vutuv_web/components/post_components.ex:5282
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15402,7 +15402,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1153
-#: lib/vutuv_web/components/post_components.ex:5203
+#: lib/vutuv_web/components/post_components.ex:5233
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15418,14 +15418,14 @@ msgstr ""
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1371
-#: lib/vutuv_web/components/post_components.ex:2030
+#: lib/vutuv_web/components/post_components.ex:1387
+#: lib/vutuv_web/components/post_components.ex:2046
 #: lib/vutuv_web/live/fediverse_account_live.ex:294
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1247
+#: lib/vutuv_web/components/post_components.ex:1263
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15454,7 +15454,7 @@ msgstr ""
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1256
+#: lib/vutuv_web/components/post_components.ex:1272
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15464,7 +15464,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1270
+#: lib/vutuv_web/components/post_components.ex:1286
 #: lib/vutuv_web/live/notification_live/index.ex:597
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -15496,9 +15496,9 @@ msgid "That reply is not yours to remove."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1337
-#: lib/vutuv_web/components/post_components.ex:1302
-#: lib/vutuv_web/components/post_components.ex:1502
-#: lib/vutuv_web/components/post_components.ex:2483
+#: lib/vutuv_web/components/post_components.ex:1318
+#: lib/vutuv_web/components/post_components.ex:1518
+#: lib/vutuv_web/components/post_components.ex:2500
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -15521,7 +15521,7 @@ msgstr ""
 msgid "replied to your post from another network."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:144
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:160
 #, elixir-autogen, elixir-format
 msgid "All followers"
 msgstr ""
@@ -15842,7 +15842,7 @@ msgstr ""
 msgid "Every change to your account: what changed, exactly when, from which device, and how it was confirmed. If a line surprises you, follow the link at the end of it."
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:249
+#: lib/vutuv_web/views/account_event_text.ex:250
 #, elixir-autogen, elixir-format
 msgid "Fediverse aliases"
 msgstr ""
@@ -15852,7 +15852,7 @@ msgstr ""
 msgid "Fediverse participation"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:248
+#: lib/vutuv_web/views/account_event_text.ex:249
 #, elixir-autogen, elixir-format
 msgid "Fediverse replies"
 msgstr ""
@@ -16161,22 +16161,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3021
+#: lib/vutuv_web/components/post_components.ex:3038
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3137
+#: lib/vutuv_web/components/post_components.ex:3154
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3145
+#: lib/vutuv_web/components/post_components.ex:3162
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3131
+#: lib/vutuv_web/components/post_components.ex:3148
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16302,17 +16302,17 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2616
+#: lib/vutuv_web/components/post_components.ex:2633
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3834
+#: lib/vutuv_web/components/post_components.ex:3851
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3982
+#: lib/vutuv_web/components/post_components.ex:3999
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16325,7 +16325,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1298
 #: lib/vutuv_web/agent_docs/text.ex:785
-#: lib/vutuv_web/components/post_components.ex:4064
+#: lib/vutuv_web/components/post_components.ex:4081
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr ""
@@ -16351,7 +16351,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2669
+#: lib/vutuv_web/components/post_components.ex:2686
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16371,7 +16371,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2660
+#: lib/vutuv_web/components/post_components.ex:2677
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16381,12 +16381,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2678
+#: lib/vutuv_web/components/post_components.ex:2695
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2612
+#: lib/vutuv_web/components/post_components.ex:2629
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16401,7 +16401,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2673
+#: lib/vutuv_web/components/post_components.ex:2690
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16411,7 +16411,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2626
+#: lib/vutuv_web/components/post_components.ex:2643
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16432,8 +16432,8 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1638
-#: lib/vutuv_web/live/post_live/feed.ex:1639
+#: lib/vutuv_web/live/post_live/feed.ex:1645
+#: lib/vutuv_web/live/post_live/feed.ex:1646
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr ""
@@ -16498,13 +16498,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1171
-#: lib/vutuv_web/components/post_components.ex:5241
+#: lib/vutuv_web/components/post_components.ex:5271
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1169
-#: lib/vutuv_web/components/post_components.ex:5238
+#: lib/vutuv_web/components/post_components.ex:5268
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr ""
@@ -16514,7 +16514,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5130
+#: lib/vutuv_web/components/post_components.ex:5160
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr ""
@@ -16610,7 +16610,7 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_following_live.ex:301
 #: lib/vutuv_web/live/fediverse_following_live.ex:314
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:336
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:159
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:175
 #, elixir-autogen, elixir-format
 msgid "Accounts you follow elsewhere"
 msgstr ""
@@ -16642,7 +16642,7 @@ msgstr ""
 msgid "Follow request sent to %{account}."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:180
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "Follow somebody out there"
 msgstr ""
@@ -16652,14 +16652,14 @@ msgstr ""
 msgid "Follow this account"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:161
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:177
 #, elixir-autogen, elixir-format
 msgid "It works the other way round too: paste somebody's address from Mastodon and friends, and you follow them from here."
 msgstr ""
 
 #: lib/vutuv/api_auth/scopes.ex:84
 #: lib/vutuv/api_auth/scopes.ex:87
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:182
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Manage who you follow"
 msgstr ""
@@ -16812,7 +16812,7 @@ msgstr ""
 msgid "You can follow accounts there yourself, straight from vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:170
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "You follow %{formatted} account on another network"
 msgid_plural "You follow %{formatted} accounts on other networks"
@@ -16854,7 +16854,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2428
+#: lib/vutuv_web/components/post_components.ex:2445
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
@@ -16864,7 +16864,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2482
+#: lib/vutuv_web/components/post_components.ex:2499
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16884,12 +16884,12 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1630
+#: lib/vutuv_web/components/post_components.ex:1646
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2447
+#: lib/vutuv_web/components/post_components.ex:2464
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr ""
@@ -16905,7 +16905,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2414
+#: lib/vutuv_web/components/post_components.ex:2431
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -17127,27 +17127,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2150
+#: lib/vutuv_web/components/post_components.ex:2167
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2179
+#: lib/vutuv_web/components/post_components.ex:2196
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2174
+#: lib/vutuv_web/components/post_components.ex:2191
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2519
+#: lib/vutuv_web/components/post_components.ex:2536
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2525
+#: lib/vutuv_web/components/post_components.ex:2542
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr ""
@@ -17157,7 +17157,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2664
+#: lib/vutuv_web/components/post_components.ex:2681
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17426,7 +17426,7 @@ msgid "Its author published this post to their followers alone, so vutuv does no
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_following_live.ex:495
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:214
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:230
 #, elixir-autogen, elixir-format
 msgid "Look up a post by its address"
 msgstr ""
@@ -17447,7 +17447,7 @@ msgstr ""
 msgid "Paste the address of a post on Mastodon and friends. vutuv fetches it, shows it here, and you can answer, like or repost it as if it had arrived on its own."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:208
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:224
 #, elixir-autogen, elixir-format
 msgid "Read something out there that you want to answer from here?"
 msgstr ""
@@ -17857,12 +17857,12 @@ msgstr ""
 msgid "Screenshot blocklist"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:425
+#: lib/vutuv_web/components/post_components.ex:436
 #, elixir-autogen, elixir-format
 msgid "Nothing from the fediverse yet. Follow accounts out there to fill this tab."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:422
+#: lib/vutuv_web/components/post_components.ex:433
 #, elixir-autogen, elixir-format
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
@@ -17904,7 +17904,7 @@ msgstr ""
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2522
+#: lib/vutuv_web/components/post_components.ex:2539
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -18207,19 +18207,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4336
+#: lib/vutuv_web/components/post_components.ex:4366
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4338
+#: lib/vutuv_web/components/post_components.ex:4368
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4349
+#: lib/vutuv_web/components/post_components.ex:4379
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -19177,17 +19177,17 @@ msgstr ""
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1332
+#: lib/vutuv/accounts/user.ex:1340
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1330
+#: lib/vutuv/accounts/user.ex:1338
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1331
+#: lib/vutuv/accounts/user.ex:1339
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -19298,7 +19298,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/settings_controller.ex:324
 #: lib/vutuv_web/controllers/settings_controller.ex:336
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:20
-#: lib/vutuv_web/views/account_event_text.ex:254
+#: lib/vutuv_web/views/account_event_text.ex:255
 #, elixir-autogen, elixir-format
 msgid "Automatic post deletion"
 msgstr ""
@@ -19308,7 +19308,7 @@ msgstr ""
 msgid "Automatic post deletion changed"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:261
+#: lib/vutuv_web/views/account_event_text.ex:262
 #, elixir-autogen, elixir-format
 msgid "Bookmark floor"
 msgstr ""
@@ -19350,7 +19350,7 @@ msgstr ""
 msgid "Delete posts older than"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:259
+#: lib/vutuv_web/views/account_event_text.ex:260
 #, elixir-autogen, elixir-format
 msgid "Delete replies too"
 msgstr ""
@@ -19370,17 +19370,17 @@ msgstr ""
 msgid "If a post of yours reached other networks (Mastodon and the rest), we ask every server that received it to delete its copy. We cannot make them. A server that is switched off, that no longer talks to us, or that simply ignores the request keeps what it has."
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:257
+#: lib/vutuv_web/views/account_event_text.ex:258
 #, elixir-autogen, elixir-format
 msgid "Keep answered posts"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:258
+#: lib/vutuv_web/views/account_event_text.ex:259
 #, elixir-autogen, elixir-format
 msgid "Keep bookmarked posts"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:256
+#: lib/vutuv_web/views/account_event_text.ex:257
 #, elixir-autogen, elixir-format
 msgid "Keep photo posts"
 msgstr ""
@@ -19395,7 +19395,7 @@ msgstr ""
 msgid "Let your posts age out after a time you set"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:260
+#: lib/vutuv_web/views/account_event_text.ex:261
 #, elixir-autogen, elixir-format
 msgid "Like floor"
 msgstr ""
@@ -19420,7 +19420,7 @@ msgstr ""
 msgid "Photo posts and book or film reviews are kept whatever their age."
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:255
+#: lib/vutuv_web/views/account_event_text.ex:256
 #, elixir-autogen, elixir-format
 msgid "Post age"
 msgstr ""
@@ -19445,7 +19445,7 @@ msgstr ""
 msgid "Posts you bookmarked yourself"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:262
+#: lib/vutuv_web/views/account_event_text.ex:263
 #, elixir-autogen, elixir-format
 msgid "Repost floor"
 msgstr ""
@@ -19873,7 +19873,7 @@ msgstr ""
 msgid "Start over"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2552
+#: lib/vutuv_web/components/post_components.ex:2569
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -20765,27 +20765,27 @@ msgstr ""
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4230
+#: lib/vutuv_web/components/post_components.ex:4260
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4266
+#: lib/vutuv_web/components/post_components.ex:4296
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4275
+#: lib/vutuv_web/components/post_components.ex:4305
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4278
+#: lib/vutuv_web/components/post_components.ex:4308
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4255
+#: lib/vutuv_web/components/post_components.ex:4285
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
@@ -20795,7 +20795,7 @@ msgstr ""
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4245
+#: lib/vutuv_web/components/post_components.ex:4275
 #: lib/vutuv_web/components/ui.ex:4509
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -20924,20 +20924,20 @@ msgstr ""
 msgid "Your username, or paste the address of your profile page."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4030
+#: lib/vutuv_web/components/post_components.ex:4047
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4027
+#: lib/vutuv_web/components/post_components.ex:4044
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2201
-#: lib/vutuv_web/components/post_components.ex:3354
+#: lib/vutuv_web/components/post_components.ex:2218
+#: lib/vutuv_web/components/post_components.ex:3371
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -20954,7 +20954,7 @@ msgstr ""
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1894
+#: lib/vutuv_web/live/post_live/feed.ex:1902
 #: lib/vutuv_web/views/user_html.ex:338
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -21448,7 +21448,7 @@ msgstr ""
 msgid "This page is following the most accounts we allow (%{max})."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2402
+#: lib/vutuv_web/components/post_components.ex:2419
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr ""
@@ -21573,12 +21573,12 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1876
+#: lib/vutuv_web/live/post_live/feed.ex:1884
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1872
+#: lib/vutuv_web/live/post_live/feed.ex:1880
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr ""
@@ -21624,31 +21624,31 @@ msgstr ""
 msgid "With a vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1886
+#: lib/vutuv_web/live/post_live/feed.ex:1894
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:602
+#: lib/vutuv_web/components/post_components.ex:613
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new post"
 msgid_plural "%{formatted} new posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1314
+#: lib/vutuv_web/live/post_live/feed.ex:1312
 #, elixir-autogen, elixir-format
 msgid "%{source}: %{formatted} new post"
 msgid_plural "%{source}: %{formatted} new posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1311
+#: lib/vutuv_web/live/post_live/feed.ex:1309
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1308
+#: lib/vutuv_web/live/post_live/feed.ex:1306
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post from %{who}"
 msgstr ""
@@ -21923,4 +21923,19 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1029
 #, elixir-autogen, elixir-format
 msgid "Being checked"
+msgstr ""
+
+#: lib/vutuv_web/views/account_event_text.ex:248
+#, elixir-autogen, elixir-format
+msgid "Fediverse quotes"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:112
+#, elixir-autogen, elixir-format
+msgid "Let other networks quote your posts"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:115
+#, elixir-autogen, elixir-format
+msgid "Someone on Mastodon can share one of your public posts with their own comment above it, the way a reshare works, but with their words beside yours. Your server is asked first every time and answers automatically while this is on. You can withdraw a single quote later, and switching this off refuses new ones."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -124,7 +124,7 @@ msgstr ""
 #: lib/vutuv_web/templates/import/preview.html.heex:113
 #: lib/vutuv_web/templates/report/new.html.heex:103
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:276
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:259
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:275
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:26
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
 #: lib/vutuv_web/templates/user/edit.html.heex:53
@@ -160,7 +160,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3153
+#: lib/vutuv_web/components/post_components.ex:3170
 #: lib/vutuv_web/components/ui.ex:4106
 #: lib/vutuv_web/live/admin/job_live.ex:489
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -209,7 +209,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3118
+#: lib/vutuv_web/components/post_components.ex:3135
 #: lib/vutuv_web/components/ui.ex:4097
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -473,7 +473,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:629
+#: lib/vutuv_web/components/post_components.ex:640
 #: lib/vutuv_web/live/notification_live/index.ex:699
 #: lib/vutuv_web/live/organization_live/activity.ex:128
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
@@ -620,7 +620,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:196
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:105
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:121
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:73
 #: lib/vutuv_web/templates/settings/notifications.html.heex:79
 #: lib/vutuv_web/templates/settings/preferences.html.heex:84
@@ -655,7 +655,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1627
+#: lib/vutuv_web/components/post_components.ex:1643
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -1748,7 +1748,7 @@ msgstr ""
 msgid "Network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:436
+#: lib/vutuv_web/components/post_components.ex:447
 #: lib/vutuv_web/components/ui.ex:4216
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3150
+#: lib/vutuv_web/components/post_components.ex:3167
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2115,7 +2115,7 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:114
 #: lib/vutuv_web/live/post_live/feed.ex:206
-#: lib/vutuv_web/live/post_live/feed.ex:1591
+#: lib/vutuv_web/live/post_live/feed.ex:1598
 #: lib/vutuv_web/live/shell_live.ex:973
 #: lib/vutuv_web/live/shell_live.ex:1272
 #: lib/vutuv_web/templates/layout/app.html.heex:171
@@ -2143,8 +2143,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3104
-#: lib/vutuv_web/components/post_components.ex:3106
+#: lib/vutuv_web/components/post_components.ex:3121
+#: lib/vutuv_web/components/post_components.ex:3123
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2160,7 +2160,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1802
+#: lib/vutuv_web/live/post_live/feed.ex:1810
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2210,13 +2210,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3568
-#: lib/vutuv_web/components/post_components.ex:3572
+#: lib/vutuv_web/components/post_components.ex:3585
+#: lib/vutuv_web/components/post_components.ex:3589
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3569
+#: lib/vutuv_web/components/post_components.ex:3586
 #: lib/vutuv_web/live/fediverse_account_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2224,7 +2224,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:376
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:1249
+#: lib/vutuv_web/components/post_components.ex:1265
 #: lib/vutuv_web/live/admin/screenshot_live.ex:327
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
@@ -2250,7 +2250,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1703
+#: lib/vutuv_web/live/post_live/feed.ex:1710
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2306,27 +2306,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3101
+#: lib/vutuv_web/components/post_components.ex:3118
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4957
+#: lib/vutuv_web/components/post_components.ex:4987
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4961
+#: lib/vutuv_web/components/post_components.ex:4991
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4959
+#: lib/vutuv_web/components/post_components.ex:4989
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4960
+#: lib/vutuv_web/components/post_components.ex:4990
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2367,8 +2367,8 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1842
-#: lib/vutuv_web/components/post_components.ex:5053
+#: lib/vutuv_web/components/post_components.ex:1858
+#: lib/vutuv_web/components/post_components.ex:5083
 #: lib/vutuv_web/components/ui.ex:3629
 #: lib/vutuv_web/views/user_html.ex:457
 #, elixir-autogen, elixir-format
@@ -2386,8 +2386,8 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1795
-#: lib/vutuv_web/components/post_components.ex:5289
+#: lib/vutuv_web/components/post_components.ex:1811
+#: lib/vutuv_web/components/post_components.ex:5319
 #: lib/vutuv_web/components/ui.ex:3615
 #: lib/vutuv_web/live/notification_live/index.ex:1089
 #: lib/vutuv_web/views/user_html.ex:467
@@ -2396,7 +2396,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1115
-#: lib/vutuv_web/components/post_components.ex:5299
+#: lib/vutuv_web/components/post_components.ex:5329
 #: lib/vutuv_web/live/notification_live/index.ex:1022
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
@@ -2418,40 +2418,40 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5041
+#: lib/vutuv_web/components/post_components.ex:5071
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1841
-#: lib/vutuv_web/components/post_components.ex:5052
+#: lib/vutuv_web/components/post_components.ex:1857
+#: lib/vutuv_web/components/post_components.ex:5082
 #: lib/vutuv_web/live/post_live/saved.ex:806
 #: lib/vutuv_web/views/user_html.ex:457
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1823
-#: lib/vutuv_web/components/post_components.ex:5038
+#: lib/vutuv_web/components/post_components.ex:1839
+#: lib/vutuv_web/components/post_components.ex:5068
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2088
-#: lib/vutuv_web/components/post_components.ex:4163
+#: lib/vutuv_web/components/post_components.ex:2104
+#: lib/vutuv_web/components/post_components.ex:4193
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1822
-#: lib/vutuv_web/components/post_components.ex:5037
+#: lib/vutuv_web/components/post_components.ex:1838
+#: lib/vutuv_web/components/post_components.ex:5067
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1794
-#: lib/vutuv_web/components/post_components.ex:5288
+#: lib/vutuv_web/components/post_components.ex:1810
+#: lib/vutuv_web/components/post_components.ex:5318
 #: lib/vutuv_web/live/post_live/saved.ex:805
 #: lib/vutuv_web/views/user_html.ex:467
 #, elixir-autogen, elixir-format
@@ -2459,14 +2459,14 @@ msgid "Unlike"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:377
-#: lib/vutuv_web/components/post_components.ex:2407
+#: lib/vutuv_web/components/post_components.ex:2424
 #: lib/vutuv_web/components/ui.ex:2484
 #: lib/vutuv_web/components/ui.ex:2484
 #: lib/vutuv_web/components/ui.ex:2621
 #: lib/vutuv_web/live/organization_live/following.ex:383
 #: lib/vutuv_web/live/organization_live/following.ex:458
 #: lib/vutuv_web/live/organization_live/show.ex:489
-#: lib/vutuv_web/live/post_live/feed.ex:1851
+#: lib/vutuv_web/live/post_live/feed.ex:1859
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2478,27 +2478,27 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5343
+#: lib/vutuv_web/components/post_components.ex:5373
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:394
+#: lib/vutuv_web/components/post_components.ex:405
 #: lib/vutuv_web/live/notification_live/index.ex:1023
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1808
-#: lib/vutuv_web/components/post_components.ex:5326
-#: lib/vutuv_web/components/post_components.ex:5327
+#: lib/vutuv_web/components/post_components.ex:1824
+#: lib/vutuv_web/components/post_components.ex:5356
+#: lib/vutuv_web/components/post_components.ex:5357
 #: lib/vutuv_web/live/notification_live/index.ex:1086
 #: lib/vutuv_web/live/post_live/reply.ex:43
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3068
+#: lib/vutuv_web/components/post_components.ex:3085
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2519,7 +2519,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2604
+#: lib/vutuv_web/components/post_components.ex:2621
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:60
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:57
@@ -2527,14 +2527,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3042
+#: lib/vutuv_web/components/post_components.ex:3059
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3033
-#: lib/vutuv_web/components/post_components.ex:3060
-#: lib/vutuv_web/components/post_components.ex:3063
+#: lib/vutuv_web/components/post_components.ex:3050
+#: lib/vutuv_web/components/post_components.ex:3077
+#: lib/vutuv_web/components/post_components.ex:3080
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2757,7 +2757,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1629
+#: lib/vutuv_web/live/post_live/feed.ex:1636
 #: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2778,7 +2778,7 @@ msgid_plural "%{formatted} connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1953
+#: lib/vutuv_web/live/post_live/feed.ex:1961
 #: lib/vutuv_web/templates/user/card_list.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -2833,7 +2833,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4958
+#: lib/vutuv_web/components/post_components.ex:4988
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3096,7 +3096,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3009
+#: lib/vutuv_web/components/post_components.ex:3026
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3171,9 +3171,9 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1259
-#: lib/vutuv_web/components/post_components.ex:2419
-#: lib/vutuv_web/components/post_components.ex:3173
+#: lib/vutuv_web/components/post_components.ex:1275
+#: lib/vutuv_web/components/post_components.ex:2436
+#: lib/vutuv_web/components/post_components.ex:3190
 #: lib/vutuv_web/live/organization_live/show.ex:562
 #: lib/vutuv_web/templates/user/show.html.heex:222
 #, elixir-autogen, elixir-format
@@ -4539,7 +4539,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1807
+#: lib/vutuv_web/live/post_live/feed.ex:1815
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -4616,8 +4616,8 @@ msgstr ""
 msgid "Similar names"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:391
-#: lib/vutuv_web/components/post_components.ex:410
+#: lib/vutuv_web/components/post_components.ex:402
+#: lib/vutuv_web/components/post_components.ex:421
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
@@ -5417,11 +5417,11 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3239
-#: lib/vutuv_web/components/post_components.ex:3294
-#: lib/vutuv_web/components/post_components.ex:3705
+#: lib/vutuv_web/components/post_components.ex:3256
+#: lib/vutuv_web/components/post_components.ex:3311
+#: lib/vutuv_web/components/post_components.ex:3722
 #: lib/vutuv_web/live/notification_live/index.ex:743
-#: lib/vutuv_web/live/post_live/feed.ex:1994
+#: lib/vutuv_web/live/post_live/feed.ex:2002
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -6212,7 +6212,7 @@ msgid "Previous day"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1115
-#: lib/vutuv_web/components/post_components.ex:393
+#: lib/vutuv_web/components/post_components.ex:404
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
@@ -6605,8 +6605,8 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2387
-#: lib/vutuv_web/components/post_components.ex:3170
+#: lib/vutuv_web/components/post_components.ex:2404
+#: lib/vutuv_web/components/post_components.ex:3187
 #: lib/vutuv_web/components/ui.ex:2809
 #: lib/vutuv_web/live/fediverse_account_live.ex:381
 #: lib/vutuv_web/live/organization_live/following.ex:376
@@ -6633,7 +6633,7 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3170
+#: lib/vutuv_web/components/post_components.ex:3187
 #: lib/vutuv_web/components/ui.ex:2808
 #: lib/vutuv_web/live/fediverse_account_live.ex:379
 #: lib/vutuv_web/live/organization_live/following.ex:376
@@ -7343,7 +7343,7 @@ msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:5199
+#: lib/vutuv_web/components/post_components.ex:5229
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -7884,7 +7884,7 @@ msgid "Admins"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:1962
+#: lib/vutuv_web/live/post_live/feed.ex:1970
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr ""
@@ -7957,8 +7957,8 @@ msgstr ""
 msgid "Identity-verified"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1445
-#: lib/vutuv/accounts.ex:1494
+#: lib/vutuv/accounts.ex:1446
+#: lib/vutuv/accounts.ex:1495
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -7997,7 +7997,7 @@ msgstr ""
 msgid "Open the member browser"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1462
+#: lib/vutuv/accounts.ex:1463
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -8441,12 +8441,12 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1979
+#: lib/vutuv_web/live/post_live/feed.ex:1987
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1975
+#: lib/vutuv_web/live/post_live/feed.ex:1983
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr ""
@@ -8673,17 +8673,17 @@ msgstr ""
 msgid "Fediverse settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:225
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:241
 #, elixir-autogen, elixir-format
 msgid "Manage social media accounts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:115
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse handle"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1457
+#: lib/vutuv/accounts.ex:1458
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -8790,7 +8790,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4166
+#: lib/vutuv_web/components/post_components.ex:4196
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9453,7 +9453,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1173
+#: lib/vutuv/accounts/user.ex:1181
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9464,7 +9464,7 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1170
+#: lib/vutuv/accounts/user.ex:1178
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -10819,19 +10819,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1211
+#: lib/vutuv/accounts/user.ex:1219
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1216
+#: lib/vutuv/accounts/user.ex:1224
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1214
+#: lib/vutuv/accounts/user.ex:1222
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:771
 #, elixir-autogen, elixir-format
@@ -11947,32 +11947,32 @@ msgstr ""
 msgid "We can't stop a search engine or AI service from reading a page it can open. What we can do is tell them, in the machine-readable way they look for, that you don't want your profile listed in search results or used by AI. Reputable search engines and AI companies follow that request; we can't force the rest."
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:105
+#: lib/vutuv/organizations/organization.ex:109
 #, elixir-autogen, elixir-format
 msgid "Association"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:104
+#: lib/vutuv/organizations/organization.ex:108
 #, elixir-autogen, elixir-format
 msgid "Business"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:107
+#: lib/vutuv/organizations/organization.ex:111
 #, elixir-autogen, elixir-format
 msgid "Education / research"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:108
+#: lib/vutuv/organizations/organization.ex:112
 #, elixir-autogen, elixir-format
 msgid "NGO / foundation"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:109
+#: lib/vutuv/organizations/organization.ex:113
 #, elixir-autogen, elixir-format
 msgid "Other organization"
 msgstr ""
 
-#: lib/vutuv/organizations/organization.ex:106
+#: lib/vutuv/organizations/organization.ex:110
 #, elixir-autogen, elixir-format
 msgid "Public authority"
 msgstr ""
@@ -12129,7 +12129,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1185
+#: lib/vutuv/accounts/user.ex:1193
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12248,7 +12248,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1184
+#: lib/vutuv/accounts/user.ex:1192
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12330,7 +12330,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1186
+#: lib/vutuv/accounts/user.ex:1194
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:565
 #: lib/vutuv_web/agent_docs/markdown.ex:466
@@ -13051,7 +13051,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2563
+#: lib/vutuv_web/components/post_components.ex:2580
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:695
 #: lib/vutuv_web/controllers/settings_controller.ex:713
@@ -13345,7 +13345,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1229
+#: lib/vutuv/accounts/user.ex:1237
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13356,19 +13356,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1232
+#: lib/vutuv/accounts/user.ex:1240
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1235
+#: lib/vutuv/accounts/user.ex:1243
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1226
+#: lib/vutuv/accounts/user.ex:1234
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13465,22 +13465,22 @@ msgstr ""
 msgid "Work mobile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:433
+#: lib/vutuv_web/components/post_components.ex:444
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:435
+#: lib/vutuv_web/components/post_components.ex:446
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:434
+#: lib/vutuv_web/components/post_components.ex:445
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:392
+#: lib/vutuv_web/components/post_components.ex:403
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr ""
@@ -13492,14 +13492,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4516
 #: lib/vutuv_web/controllers/settings_controller.ex:614
-#: lib/vutuv_web/live/post_live/feed.ex:1837
+#: lib/vutuv_web/live/post_live/feed.ex:1845
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1852
+#: lib/vutuv_web/live/post_live/feed.ex:1860
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr ""
@@ -13655,34 +13655,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4807
+#: lib/vutuv_web/components/post_components.ex:4837
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1204
-#: lib/vutuv_web/components/post_components.ex:4764
+#: lib/vutuv_web/components/post_components.ex:4794
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4808
+#: lib/vutuv_web/components/post_components.ex:4838
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4810
+#: lib/vutuv_web/components/post_components.ex:4840
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4806
+#: lib/vutuv_web/components/post_components.ex:4836
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1204
-#: lib/vutuv_web/components/post_components.ex:4763
+#: lib/vutuv_web/components/post_components.ex:4793
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13693,12 +13693,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4805
+#: lib/vutuv_web/components/post_components.ex:4835
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4809
+#: lib/vutuv_web/components/post_components.ex:4839
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13718,7 +13718,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4846
+#: lib/vutuv_web/components/post_components.ex:4876
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13726,27 +13726,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4876
+#: lib/vutuv_web/components/post_components.ex:4906
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4877
+#: lib/vutuv_web/components/post_components.ex:4907
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4875
+#: lib/vutuv_web/components/post_components.ex:4905
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4835
+#: lib/vutuv_web/components/post_components.ex:4865
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4882
+#: lib/vutuv_web/components/post_components.ex:4912
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13776,7 +13776,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4649
+#: lib/vutuv_web/components/post_components.ex:4679
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13824,7 +13824,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4640
+#: lib/vutuv_web/components/post_components.ex:4670
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14196,14 +14196,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2836
+#: lib/vutuv_web/components/post_components.ex:2853
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2859
+#: lib/vutuv_web/components/post_components.ex:2876
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14230,7 +14230,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5298
+#: lib/vutuv_web/components/post_components.ex:5328
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14686,36 +14686,36 @@ msgstr ""
 msgid "Off means your profile cannot be found there and nothing is sent. Posts already delivered may stay on those servers, beyond our reach."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:117
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:133
 #, elixir-autogen, elixir-format
 msgid "Give this out the way you give out an email address. Anyone on Mastodon and friends can paste it into their search and follow you from there."
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:187
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:138
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:154
 #, elixir-autogen, elixir-format
 msgid "Nobody yet. Post your handle where people can see it, and the first follows will show up here."
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:327
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:192
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:208
 #, elixir-autogen, elixir-format
 msgid "Related"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:195
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:211
 #, elixir-autogen, elixir-format
 msgid "Moving to or away from another Fediverse account?"
 msgstr ""
 
 #: lib/vutuv_web/controllers/settings_controller.ex:377
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:201
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:217
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Move your account"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:218
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:234
 #, elixir-autogen, elixir-format
 msgid "Want the checkmark on your Mastodon profile? That works without taking part here: your vutuv profile links your listed accounts with rel=\"me\"."
 msgstr ""
@@ -14772,7 +14772,7 @@ msgstr ""
 msgid "Back to Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:124
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:140
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower from other networks"
 msgid_plural "%{formatted} followers from other networks"
@@ -15336,13 +15336,13 @@ msgstr ""
 msgid "This link always opens your profile, even after you change your username. It is built from a fixed id, so it never breaks on a rename. For everyday sharing the short address above is friendlier."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:269
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:285
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:35
 #, elixir-autogen, elixir-format
 msgid "I understand, switch off"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:267
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:283
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "I understand, take part"
@@ -15378,21 +15378,21 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5244
+#: lib/vutuv_web/components/post_components.ex:5274
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5248
+#: lib/vutuv_web/components/post_components.ex:5278
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5252
+#: lib/vutuv_web/components/post_components.ex:5282
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15400,7 +15400,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1153
-#: lib/vutuv_web/components/post_components.ex:5203
+#: lib/vutuv_web/components/post_components.ex:5233
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15416,14 +15416,14 @@ msgstr ""
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1371
-#: lib/vutuv_web/components/post_components.ex:2030
+#: lib/vutuv_web/components/post_components.ex:1387
+#: lib/vutuv_web/components/post_components.ex:2046
 #: lib/vutuv_web/live/fediverse_account_live.ex:294
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1247
+#: lib/vutuv_web/components/post_components.ex:1263
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15452,7 +15452,7 @@ msgstr ""
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1256
+#: lib/vutuv_web/components/post_components.ex:1272
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15462,7 +15462,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1270
+#: lib/vutuv_web/components/post_components.ex:1286
 #: lib/vutuv_web/live/notification_live/index.ex:597
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -15494,9 +15494,9 @@ msgid "That reply is not yours to remove."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1337
-#: lib/vutuv_web/components/post_components.ex:1302
-#: lib/vutuv_web/components/post_components.ex:1502
-#: lib/vutuv_web/components/post_components.ex:2483
+#: lib/vutuv_web/components/post_components.ex:1318
+#: lib/vutuv_web/components/post_components.ex:1518
+#: lib/vutuv_web/components/post_components.ex:2500
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -15519,7 +15519,7 @@ msgstr ""
 msgid "replied to your post from another network."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:144
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:160
 #, elixir-autogen, elixir-format
 msgid "All followers"
 msgstr ""
@@ -15840,7 +15840,7 @@ msgstr ""
 msgid "Every change to your account: what changed, exactly when, from which device, and how it was confirmed. If a line surprises you, follow the link at the end of it."
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:249
+#: lib/vutuv_web/views/account_event_text.ex:250
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Fediverse aliases"
 msgstr ""
@@ -15850,7 +15850,7 @@ msgstr ""
 msgid "Fediverse participation"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:248
+#: lib/vutuv_web/views/account_event_text.ex:249
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Fediverse replies"
 msgstr ""
@@ -16159,22 +16159,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3021
+#: lib/vutuv_web/components/post_components.ex:3038
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3137
+#: lib/vutuv_web/components/post_components.ex:3154
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3145
+#: lib/vutuv_web/components/post_components.ex:3162
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3131
+#: lib/vutuv_web/components/post_components.ex:3148
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16300,17 +16300,17 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2616
+#: lib/vutuv_web/components/post_components.ex:2633
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3834
+#: lib/vutuv_web/components/post_components.ex:3851
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3982
+#: lib/vutuv_web/components/post_components.ex:3999
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16323,7 +16323,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1298
 #: lib/vutuv_web/agent_docs/text.ex:785
-#: lib/vutuv_web/components/post_components.ex:4064
+#: lib/vutuv_web/components/post_components.ex:4081
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
 msgstr ""
@@ -16349,7 +16349,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2669
+#: lib/vutuv_web/components/post_components.ex:2686
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16369,7 +16369,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2660
+#: lib/vutuv_web/components/post_components.ex:2677
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16379,12 +16379,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2678
+#: lib/vutuv_web/components/post_components.ex:2695
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2612
+#: lib/vutuv_web/components/post_components.ex:2629
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16399,7 +16399,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2673
+#: lib/vutuv_web/components/post_components.ex:2690
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16409,7 +16409,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2626
+#: lib/vutuv_web/components/post_components.ex:2643
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16430,8 +16430,8 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1638
-#: lib/vutuv_web/live/post_live/feed.ex:1639
+#: lib/vutuv_web/live/post_live/feed.ex:1645
+#: lib/vutuv_web/live/post_live/feed.ex:1646
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post photos"
 msgstr ""
@@ -16496,13 +16496,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1171
-#: lib/vutuv_web/components/post_components.ex:5241
+#: lib/vutuv_web/components/post_components.ex:5271
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1169
-#: lib/vutuv_web/components/post_components.ex:5238
+#: lib/vutuv_web/components/post_components.ex:5268
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
 msgstr ""
@@ -16512,7 +16512,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5130
+#: lib/vutuv_web/components/post_components.ex:5160
 #, elixir-autogen, elixir-format, fuzzy
 msgid "From other networks"
 msgstr ""
@@ -16608,7 +16608,7 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_following_live.ex:301
 #: lib/vutuv_web/live/fediverse_following_live.ex:314
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:336
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:159
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:175
 #, elixir-autogen, elixir-format
 msgid "Accounts you follow elsewhere"
 msgstr ""
@@ -16640,7 +16640,7 @@ msgstr ""
 msgid "Follow request sent to %{account}."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:180
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "Follow somebody out there"
 msgstr ""
@@ -16650,14 +16650,14 @@ msgstr ""
 msgid "Follow this account"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:161
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:177
 #, elixir-autogen, elixir-format
 msgid "It works the other way round too: paste somebody's address from Mastodon and friends, and you follow them from here."
 msgstr ""
 
 #: lib/vutuv/api_auth/scopes.ex:84
 #: lib/vutuv/api_auth/scopes.ex:87
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:182
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Manage who you follow"
 msgstr ""
@@ -16810,7 +16810,7 @@ msgstr ""
 msgid "You can follow accounts there yourself, straight from vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:170
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "You follow %{formatted} account on another network"
 msgid_plural "You follow %{formatted} accounts on other networks"
@@ -16852,7 +16852,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2428
+#: lib/vutuv_web/components/post_components.ex:2445
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
@@ -16862,7 +16862,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2482
+#: lib/vutuv_web/components/post_components.ex:2499
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16882,12 +16882,12 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1630
+#: lib/vutuv_web/components/post_components.ex:1646
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2447
+#: lib/vutuv_web/components/post_components.ex:2464
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Marked as sensitive by its author"
 msgstr ""
@@ -16903,7 +16903,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2414
+#: lib/vutuv_web/components/post_components.ex:2431
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -17125,27 +17125,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2150
+#: lib/vutuv_web/components/post_components.ex:2167
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2179
+#: lib/vutuv_web/components/post_components.ex:2196
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2174
+#: lib/vutuv_web/components/post_components.ex:2191
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2519
+#: lib/vutuv_web/components/post_components.ex:2536
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2525
+#: lib/vutuv_web/components/post_components.ex:2542
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That post is not here any more."
 msgstr ""
@@ -17155,7 +17155,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2664
+#: lib/vutuv_web/components/post_components.ex:2681
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17424,7 +17424,7 @@ msgid "Its author published this post to their followers alone, so vutuv does no
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_following_live.ex:495
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:214
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:230
 #, elixir-autogen, elixir-format
 msgid "Look up a post by its address"
 msgstr ""
@@ -17445,7 +17445,7 @@ msgstr ""
 msgid "Paste the address of a post on Mastodon and friends. vutuv fetches it, shows it here, and you can answer, like or repost it as if it had arrived on its own."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:208
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:224
 #, elixir-autogen, elixir-format
 msgid "Read something out there that you want to answer from here?"
 msgstr ""
@@ -17855,12 +17855,12 @@ msgstr ""
 msgid "Screenshot blocklist"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:425
+#: lib/vutuv_web/components/post_components.ex:436
 #, elixir-autogen, elixir-format
 msgid "Nothing from the fediverse yet. Follow accounts out there to fill this tab."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:422
+#: lib/vutuv_web/components/post_components.ex:433
 #, elixir-autogen, elixir-format
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
@@ -17902,7 +17902,7 @@ msgstr ""
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2522
+#: lib/vutuv_web/components/post_components.ex:2539
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -18205,19 +18205,19 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4336
+#: lib/vutuv_web/components/post_components.ex:4366
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4338
+#: lib/vutuv_web/components/post_components.ex:4368
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4349
+#: lib/vutuv_web/components/post_components.ex:4379
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -19175,17 +19175,17 @@ msgstr ""
 msgid "PIN not arriving? Is the email address {email} correct? Have you checked your spam folder?"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1332
+#: lib/vutuv/accounts/user.ex:1340
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1330
+#: lib/vutuv/accounts/user.ex:1338
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1331
+#: lib/vutuv/accounts/user.ex:1339
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -19296,7 +19296,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/settings_controller.ex:324
 #: lib/vutuv_web/controllers/settings_controller.ex:336
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:20
-#: lib/vutuv_web/views/account_event_text.ex:254
+#: lib/vutuv_web/views/account_event_text.ex:255
 #, elixir-autogen, elixir-format
 msgid "Automatic post deletion"
 msgstr ""
@@ -19306,7 +19306,7 @@ msgstr ""
 msgid "Automatic post deletion changed"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:261
+#: lib/vutuv_web/views/account_event_text.ex:262
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Bookmark floor"
 msgstr ""
@@ -19348,7 +19348,7 @@ msgstr ""
 msgid "Delete posts older than"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:259
+#: lib/vutuv_web/views/account_event_text.ex:260
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Delete replies too"
 msgstr ""
@@ -19368,17 +19368,17 @@ msgstr ""
 msgid "If a post of yours reached other networks (Mastodon and the rest), we ask every server that received it to delete its copy. We cannot make them. A server that is switched off, that no longer talks to us, or that simply ignores the request keeps what it has."
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:257
+#: lib/vutuv_web/views/account_event_text.ex:258
 #, elixir-autogen, elixir-format
 msgid "Keep answered posts"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:258
+#: lib/vutuv_web/views/account_event_text.ex:259
 #, elixir-autogen, elixir-format
 msgid "Keep bookmarked posts"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:256
+#: lib/vutuv_web/views/account_event_text.ex:257
 #, elixir-autogen, elixir-format
 msgid "Keep photo posts"
 msgstr ""
@@ -19393,7 +19393,7 @@ msgstr ""
 msgid "Let your posts age out after a time you set"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:260
+#: lib/vutuv_web/views/account_event_text.ex:261
 #, elixir-autogen, elixir-format
 msgid "Like floor"
 msgstr ""
@@ -19418,7 +19418,7 @@ msgstr ""
 msgid "Photo posts and book or film reviews are kept whatever their age."
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:255
+#: lib/vutuv_web/views/account_event_text.ex:256
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post age"
 msgstr ""
@@ -19443,7 +19443,7 @@ msgstr ""
 msgid "Posts you bookmarked yourself"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:262
+#: lib/vutuv_web/views/account_event_text.ex:263
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Repost floor"
 msgstr ""
@@ -19871,7 +19871,7 @@ msgstr ""
 msgid "Start over"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2552
+#: lib/vutuv_web/components/post_components.ex:2569
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -20763,27 +20763,27 @@ msgstr ""
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4230
+#: lib/vutuv_web/components/post_components.ex:4260
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4266
+#: lib/vutuv_web/components/post_components.ex:4296
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4275
+#: lib/vutuv_web/components/post_components.ex:4305
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4278
+#: lib/vutuv_web/components/post_components.ex:4308
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4255
+#: lib/vutuv_web/components/post_components.ex:4285
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
@@ -20793,7 +20793,7 @@ msgstr ""
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4245
+#: lib/vutuv_web/components/post_components.ex:4275
 #: lib/vutuv_web/components/ui.ex:4509
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -20922,20 +20922,20 @@ msgstr ""
 msgid "Your username, or paste the address of your profile page."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4030
+#: lib/vutuv_web/components/post_components.ex:4047
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4027
+#: lib/vutuv_web/components/post_components.ex:4044
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2201
-#: lib/vutuv_web/components/post_components.ex:3354
+#: lib/vutuv_web/components/post_components.ex:2218
+#: lib/vutuv_web/components/post_components.ex:3371
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -20952,7 +20952,7 @@ msgstr ""
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1894
+#: lib/vutuv_web/live/post_live/feed.ex:1902
 #: lib/vutuv_web/views/user_html.ex:338
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -21446,7 +21446,7 @@ msgstr ""
 msgid "This page is following the most accounts we allow (%{max})."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2402
+#: lib/vutuv_web/components/post_components.ex:2419
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr ""
@@ -21571,12 +21571,12 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1876
+#: lib/vutuv_web/live/post_live/feed.ex:1884
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1872
+#: lib/vutuv_web/live/post_live/feed.ex:1880
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr ""
@@ -21622,31 +21622,31 @@ msgstr ""
 msgid "With a vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1886
+#: lib/vutuv_web/live/post_live/feed.ex:1894
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:602
+#: lib/vutuv_web/components/post_components.ex:613
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} new post"
 msgid_plural "%{formatted} new posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1314
+#: lib/vutuv_web/live/post_live/feed.ex:1312
 #, elixir-autogen, elixir-format
 msgid "%{source}: %{formatted} new post"
 msgid_plural "%{source}: %{formatted} new posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1311
+#: lib/vutuv_web/live/post_live/feed.ex:1309
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1308
+#: lib/vutuv_web/live/post_live/feed.ex:1306
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post from %{who}"
 msgstr ""
@@ -21921,4 +21921,19 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1029
 #, elixir-autogen, elixir-format
 msgid "Being checked"
+msgstr ""
+
+#: lib/vutuv_web/views/account_event_text.ex:248
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Fediverse quotes"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:112
+#, elixir-autogen, elixir-format
+msgid "Let other networks quote your posts"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:115
+#, elixir-autogen, elixir-format
+msgid "Someone on Mastodon can share one of your public posts with their own comment above it, the way a reshare works, but with their words beside yours. Your server is asked first every time and answers automatically while this is on. You can withdraw a single quote later, and switching this off refuses new ones."
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -126,7 +126,7 @@ msgstr "Compleanno"
 #: lib/vutuv_web/templates/import/preview.html.heex:113
 #: lib/vutuv_web/templates/report/new.html.heex:103
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:276
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:259
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:275
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:26
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
 #: lib/vutuv_web/templates/user/edit.html.heex:53
@@ -162,7 +162,7 @@ msgstr "Contatto"
 msgid "Couldn't follow back to %{name}."
 msgstr "Non è stato possibile ricambiare il follow a %{name}."
 
-#: lib/vutuv_web/components/post_components.ex:3153
+#: lib/vutuv_web/components/post_components.ex:3170
 #: lib/vutuv_web/components/ui.ex:4106
 #: lib/vutuv_web/live/admin/job_live.ex:489
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -211,7 +211,7 @@ msgstr "Disattiva"
 msgid "Download"
 msgstr "Scarica"
 
-#: lib/vutuv_web/components/post_components.ex:3118
+#: lib/vutuv_web/components/post_components.ex:3135
 #: lib/vutuv_web/components/ui.ex:4097
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -477,7 +477,7 @@ msgstr "Altro"
 msgid "Name"
 msgstr "Nome"
 
-#: lib/vutuv_web/components/post_components.ex:629
+#: lib/vutuv_web/components/post_components.ex:640
 #: lib/vutuv_web/live/notification_live/index.ex:699
 #: lib/vutuv_web/live/organization_live/activity.ex:128
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
@@ -624,7 +624,7 @@ msgstr "Pubblico"
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/apps.html.heex:63
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:196
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:105
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:121
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:73
 #: lib/vutuv_web/templates/settings/notifications.html.heex:79
 #: lib/vutuv_web/templates/settings/preferences.html.heex:84
@@ -659,7 +659,7 @@ msgstr "Salva"
 msgid "Search"
 msgstr "Cerca"
 
-#: lib/vutuv_web/components/post_components.ex:1627
+#: lib/vutuv_web/components/post_components.ex:1643
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -1783,7 +1783,7 @@ msgstr "Messaggi"
 msgid "Network"
 msgstr "Rete"
 
-#: lib/vutuv_web/components/post_components.ex:436
+#: lib/vutuv_web/components/post_components.ex:447
 #: lib/vutuv_web/components/ui.ex:4216
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
@@ -2144,7 +2144,7 @@ msgstr "Annulla il caricamento"
 msgid "Delete post"
 msgstr "Elimina il post"
 
-#: lib/vutuv_web/components/post_components.ex:3150
+#: lib/vutuv_web/components/post_components.ex:3167
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2160,7 +2160,7 @@ msgstr "Modifica il post"
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:114
 #: lib/vutuv_web/live/post_live/feed.ex:206
-#: lib/vutuv_web/live/post_live/feed.ex:1591
+#: lib/vutuv_web/live/post_live/feed.ex:1598
 #: lib/vutuv_web/live/shell_live.ex:973
 #: lib/vutuv_web/live/shell_live.ex:1272
 #: lib/vutuv_web/templates/layout/app.html.heex:171
@@ -2188,8 +2188,8 @@ msgstr "Nascondi a una persona specifica…"
 msgid "Hide this post from…"
 msgstr "Nascondi questo post a…"
 
-#: lib/vutuv_web/components/post_components.ex:3104
-#: lib/vutuv_web/components/post_components.ex:3106
+#: lib/vutuv_web/components/post_components.ex:3121
+#: lib/vutuv_web/components/post_components.ex:3123
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Pubblico limitato"
@@ -2205,7 +2205,7 @@ msgstr "Visitatori non connessi"
 msgid "No more than %{max} images per post."
 msgstr "Non più di %{max} immagini per post."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1802
+#: lib/vutuv_web/live/post_live/feed.ex:1810
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2257,13 +2257,13 @@ msgstr "Post eliminato."
 msgid "Posts"
 msgstr "Post"
 
-#: lib/vutuv_web/components/post_components.ex:3568
-#: lib/vutuv_web/components/post_components.ex:3572
+#: lib/vutuv_web/components/post_components.ex:3585
+#: lib/vutuv_web/components/post_components.ex:3589
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Leggi tutto"
 
-#: lib/vutuv_web/components/post_components.ex:3569
+#: lib/vutuv_web/components/post_components.ex:3586
 #: lib/vutuv_web/live/fediverse_account_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2271,7 +2271,7 @@ msgstr "Mostra meno"
 
 #: lib/vutuv_web/components/fediverse_components.ex:376
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:1249
+#: lib/vutuv_web/components/post_components.ex:1265
 #: lib/vutuv_web/live/admin/screenshot_live.ex:327
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
@@ -2299,7 +2299,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Salvataggio…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1703
+#: lib/vutuv_web/live/post_live/feed.ex:1710
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2355,27 +2355,27 @@ msgstr "Che c'è di nuovo?"
 msgid "What's new? Markdown is supported."
 msgstr "Che c'è di nuovo? Markdown è supportato."
 
-#: lib/vutuv_web/components/post_components.ex:3101
+#: lib/vutuv_web/components/post_components.ex:3118
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "modificato"
 
-#: lib/vutuv_web/components/post_components.ex:4957
+#: lib/vutuv_web/components/post_components.ex:4987
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "tutti gli altri"
 
-#: lib/vutuv_web/components/post_components.ex:4961
+#: lib/vutuv_web/components/post_components.ex:4991
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "visitatori non connessi"
 
-#: lib/vutuv_web/components/post_components.ex:4959
+#: lib/vutuv_web/components/post_components.ex:4989
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "persone che non La seguono"
 
-#: lib/vutuv_web/components/post_components.ex:4960
+#: lib/vutuv_web/components/post_components.ex:4990
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "persone che non segue"
@@ -2416,8 +2416,8 @@ msgstr "Vedi tutti i %{count} post"
 msgid "All posts"
 msgstr "Tutti i post"
 
-#: lib/vutuv_web/components/post_components.ex:1842
-#: lib/vutuv_web/components/post_components.ex:5053
+#: lib/vutuv_web/components/post_components.ex:1858
+#: lib/vutuv_web/components/post_components.ex:5083
 #: lib/vutuv_web/components/ui.ex:3629
 #: lib/vutuv_web/views/user_html.ex:457
 #, elixir-autogen, elixir-format
@@ -2435,8 +2435,8 @@ msgstr "Salva"
 msgid "Bookmarks"
 msgstr "Salvati"
 
-#: lib/vutuv_web/components/post_components.ex:1795
-#: lib/vutuv_web/components/post_components.ex:5289
+#: lib/vutuv_web/components/post_components.ex:1811
+#: lib/vutuv_web/components/post_components.ex:5319
 #: lib/vutuv_web/components/ui.ex:3615
 #: lib/vutuv_web/live/notification_live/index.ex:1089
 #: lib/vutuv_web/views/user_html.ex:467
@@ -2445,7 +2445,7 @@ msgid "Like"
 msgstr "Mi piace"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1115
-#: lib/vutuv_web/components/post_components.ex:5299
+#: lib/vutuv_web/components/post_components.ex:5329
 #: lib/vutuv_web/live/notification_live/index.ex:1022
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
@@ -2467,40 +2467,40 @@ msgstr "Qui non c'è ancora nulla. I post che salva compaiono qui."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Qui non c'è ancora nulla. I post a cui mette Mi piace compaiono qui."
 
-#: lib/vutuv_web/components/post_components.ex:5041
+#: lib/vutuv_web/components/post_components.ex:5071
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Solo i post pubblici possono essere ripubblicati."
 
-#: lib/vutuv_web/components/post_components.ex:1841
-#: lib/vutuv_web/components/post_components.ex:5052
+#: lib/vutuv_web/components/post_components.ex:1857
+#: lib/vutuv_web/components/post_components.ex:5082
 #: lib/vutuv_web/live/post_live/saved.ex:806
 #: lib/vutuv_web/views/user_html.ex:457
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr "Rimuovi dai salvati"
 
-#: lib/vutuv_web/components/post_components.ex:1823
-#: lib/vutuv_web/components/post_components.ex:5038
+#: lib/vutuv_web/components/post_components.ex:1839
+#: lib/vutuv_web/components/post_components.ex:5068
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Ripubblica"
 
-#: lib/vutuv_web/components/post_components.ex:2088
-#: lib/vutuv_web/components/post_components.ex:4163
+#: lib/vutuv_web/components/post_components.ex:2104
+#: lib/vutuv_web/components/post_components.ex:4193
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Ripubblicato da %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:1822
-#: lib/vutuv_web/components/post_components.ex:5037
+#: lib/vutuv_web/components/post_components.ex:1838
+#: lib/vutuv_web/components/post_components.ex:5067
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Annulla la ripubblicazione"
 
-#: lib/vutuv_web/components/post_components.ex:1794
-#: lib/vutuv_web/components/post_components.ex:5288
+#: lib/vutuv_web/components/post_components.ex:1810
+#: lib/vutuv_web/components/post_components.ex:5318
 #: lib/vutuv_web/live/post_live/saved.ex:805
 #: lib/vutuv_web/views/user_html.ex:467
 #, elixir-autogen, elixir-format
@@ -2508,14 +2508,14 @@ msgid "Unlike"
 msgstr "Togli Mi piace"
 
 #: lib/vutuv_web/components/fediverse_components.ex:377
-#: lib/vutuv_web/components/post_components.ex:2407
+#: lib/vutuv_web/components/post_components.ex:2424
 #: lib/vutuv_web/components/ui.ex:2484
 #: lib/vutuv_web/components/ui.ex:2484
 #: lib/vutuv_web/components/ui.ex:2621
 #: lib/vutuv_web/live/organization_live/following.ex:383
 #: lib/vutuv_web/live/organization_live/following.ex:458
 #: lib/vutuv_web/live/organization_live/show.ex:489
-#: lib/vutuv_web/live/post_live/feed.ex:1851
+#: lib/vutuv_web/live/post_live/feed.ex:1859
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2527,27 +2527,27 @@ msgstr "Non seguire più"
 msgid "Welcome to vutuv!"
 msgstr "Benvenuto su vutuv."
 
-#: lib/vutuv_web/components/post_components.ex:5343
+#: lib/vutuv_web/components/post_components.ex:5373
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Solo ai post pubblici si può rispondere."
 
-#: lib/vutuv_web/components/post_components.ex:394
+#: lib/vutuv_web/components/post_components.ex:405
 #: lib/vutuv_web/live/notification_live/index.ex:1023
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Risposte"
 
-#: lib/vutuv_web/components/post_components.ex:1808
-#: lib/vutuv_web/components/post_components.ex:5326
-#: lib/vutuv_web/components/post_components.ex:5327
+#: lib/vutuv_web/components/post_components.ex:1824
+#: lib/vutuv_web/components/post_components.ex:5356
+#: lib/vutuv_web/components/post_components.ex:5357
 #: lib/vutuv_web/live/notification_live/index.ex:1086
 #: lib/vutuv_web/live/post_live/reply.ex:43
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Rispondi"
 
-#: lib/vutuv_web/components/post_components.ex:3068
+#: lib/vutuv_web/components/post_components.ex:3085
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Risposta a un post eliminato"
@@ -2573,7 +2573,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr "ha risposto al Suo post."
 
-#: lib/vutuv_web/components/post_components.ex:2604
+#: lib/vutuv_web/components/post_components.ex:2621
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:60
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:57
@@ -2581,14 +2581,14 @@ msgstr "ha risposto al Suo post."
 msgid "Reply to %{handle}"
 msgstr "Rispondi a %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:3042
+#: lib/vutuv_web/components/post_components.ex:3059
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Risposta a un post di %{handle} ora eliminato"
 
-#: lib/vutuv_web/components/post_components.ex:3033
-#: lib/vutuv_web/components/post_components.ex:3060
-#: lib/vutuv_web/components/post_components.ex:3063
+#: lib/vutuv_web/components/post_components.ex:3050
+#: lib/vutuv_web/components/post_components.ex:3077
+#: lib/vutuv_web/components/post_components.ex:3080
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "In risposta a %{handle}"
@@ -2813,7 +2813,7 @@ msgstr "Scriva il Suo primo post"
 msgid "Manage"
 msgstr "Gestisci"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1629
+#: lib/vutuv_web/live/post_live/feed.ex:1636
 #: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2834,7 +2834,7 @@ msgid_plural "%{formatted} connections"
 msgstr[0] "1 collegamento"
 msgstr[1] "%{formatted} collegamenti"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1953
+#: lib/vutuv_web/live/post_live/feed.ex:1961
 #: lib/vutuv_web/templates/user/card_list.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -2889,7 +2889,7 @@ msgid_plural "connections"
 msgstr[0] "collegamento"
 msgstr[1] "collegamenti"
 
-#: lib/vutuv_web/components/post_components.ex:4958
+#: lib/vutuv_web/components/post_components.ex:4988
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "persone che non sono Suoi collegamenti"
@@ -3173,7 +3173,7 @@ msgstr "Nudità, violenza o altri contenuti che non hanno posto su vutuv."
 msgid "Only visible to you"
 msgstr "Visibile solo a Lei"
 
-#: lib/vutuv_web/components/post_components.ex:3009
+#: lib/vutuv_web/components/post_components.ex:3026
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solo Lei può vedere questo post finché la segnalazione è in corso."
@@ -3251,9 +3251,9 @@ msgstr "Respinta"
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Lo rimuova. La segnalazione si chiude, senza altre domande."
 
-#: lib/vutuv_web/components/post_components.ex:1259
-#: lib/vutuv_web/components/post_components.ex:2419
-#: lib/vutuv_web/components/post_components.ex:3173
+#: lib/vutuv_web/components/post_components.ex:1275
+#: lib/vutuv_web/components/post_components.ex:2436
+#: lib/vutuv_web/components/post_components.ex:3190
 #: lib/vutuv_web/live/organization_live/show.ex:562
 #: lib/vutuv_web/templates/user/show.html.heex:222
 #, elixir-autogen, elixir-format
@@ -4719,7 +4719,7 @@ msgstr "Non ha bloccato nessuno."
 msgid "You unblocked @%{slug}."
 msgstr "Ha sbloccato @%{slug}."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1807
+#: lib/vutuv_web/live/post_live/feed.ex:1815
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Scopra persone da seguire"
@@ -4796,8 +4796,8 @@ msgstr "I risultati compaiono dopo almeno tre lettere."
 msgid "Similar names"
 msgstr "Nomi simili"
 
-#: lib/vutuv_web/components/post_components.ex:391
-#: lib/vutuv_web/components/post_components.ex:410
+#: lib/vutuv_web/components/post_components.ex:402
+#: lib/vutuv_web/components/post_components.ex:421
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
@@ -5637,11 +5637,11 @@ msgstr "Navigazione principale"
 msgid "Footer navigation"
 msgstr "Navigazione a piè di pagina"
 
-#: lib/vutuv_web/components/post_components.ex:3239
-#: lib/vutuv_web/components/post_components.ex:3294
-#: lib/vutuv_web/components/post_components.ex:3705
+#: lib/vutuv_web/components/post_components.ex:3256
+#: lib/vutuv_web/components/post_components.ex:3311
+#: lib/vutuv_web/components/post_components.ex:3722
 #: lib/vutuv_web/live/notification_live/index.ex:743
-#: lib/vutuv_web/live/post_live/feed.ex:1994
+#: lib/vutuv_web/live/post_live/feed.ex:2002
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -6448,7 +6448,7 @@ msgid "Previous day"
 msgstr "Giorno precedente"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1115
-#: lib/vutuv_web/components/post_components.ex:393
+#: lib/vutuv_web/components/post_components.ex:404
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
@@ -6874,8 +6874,8 @@ msgstr ""
 "Se disattiva un'opzione, la relativa esclusione viaggia con le pagine e le "
 "risposte che La riguardano. Con entrambe disattivate, ad esempio:"
 
-#: lib/vutuv_web/components/post_components.ex:2387
-#: lib/vutuv_web/components/post_components.ex:3170
+#: lib/vutuv_web/components/post_components.ex:2404
+#: lib/vutuv_web/components/post_components.ex:3187
 #: lib/vutuv_web/components/ui.ex:2809
 #: lib/vutuv_web/live/fediverse_account_live.ex:381
 #: lib/vutuv_web/live/organization_live/following.ex:376
@@ -6902,7 +6902,7 @@ msgstr "Nuovi messaggi e nuovi collegamenti"
 msgid "Remove this connection? You will stop following them."
 msgstr "Rimuovere questo collegamento? Smetterà di seguire questa persona."
 
-#: lib/vutuv_web/components/post_components.ex:3170
+#: lib/vutuv_web/components/post_components.ex:3187
 #: lib/vutuv_web/components/ui.ex:2808
 #: lib/vutuv_web/live/fediverse_account_live.ex:379
 #: lib/vutuv_web/live/organization_live/following.ex:376
@@ -7636,7 +7636,7 @@ msgid "applies to the whole list, not just this page"
 msgstr "vale per l'intero elenco, non solo per questa pagina"
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:5199
+#: lib/vutuv_web/components/post_components.ex:5229
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8219,7 +8219,7 @@ msgid "Admins"
 msgstr "Amministratori"
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:1962
+#: lib/vutuv_web/live/post_live/feed.ex:1970
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr "Tutti i membri"
@@ -8299,8 +8299,8 @@ msgstr "Identità verificata. Il membro è stato avvisato per e-mail."
 msgid "Identity-verified"
 msgstr "Identità verificata"
 
-#: lib/vutuv/accounts.ex:1445
-#: lib/vutuv/accounts.ex:1494
+#: lib/vutuv/accounts.ex:1446
+#: lib/vutuv/accounts.ex:1495
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -8341,7 +8341,7 @@ msgstr "Non confermato"
 msgid "Open the member browser"
 msgstr "Apri l'elenco dei membri"
 
-#: lib/vutuv/accounts.ex:1462
+#: lib/vutuv/accounts.ex:1463
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -8819,12 +8819,12 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr "Digiti il Suo nome utente per confermare:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1979
+#: lib/vutuv_web/live/post_live/feed.ex:1987
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr "Mostra altri post"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1975
+#: lib/vutuv_web/live/post_live/feed.ex:1983
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr "Post consigliati"
@@ -9070,17 +9070,17 @@ msgstr ""
 msgid "Fediverse settings saved."
 msgstr "Impostazioni del Fediverso salvate."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:225
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:241
 #, elixir-autogen, elixir-format
 msgid "Manage social media accounts"
 msgstr "Gestisci gli account social"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:115
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse handle"
 msgstr "Il Suo handle nel Fediverso"
 
-#: lib/vutuv/accounts.ex:1457
+#: lib/vutuv/accounts.ex:1458
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -9192,7 +9192,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Download del CV"
 
-#: lib/vutuv_web/components/post_components.ex:4166
+#: lib/vutuv_web/components/post_components.ex:4196
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9879,7 +9879,7 @@ msgstr "Yoruba"
 msgid "Employment status"
 msgstr "Situazione lavorativa"
 
-#: lib/vutuv/accounts/user.ex:1173
+#: lib/vutuv/accounts/user.ex:1181
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9890,7 +9890,7 @@ msgstr "In cerca di lavoro"
 msgid "Not open to work"
 msgstr "Non in cerca di lavoro"
 
-#: lib/vutuv/accounts/user.ex:1170
+#: lib/vutuv/accounts/user.ex:1178
 #: lib/vutuv_web/gettext_extraction_anchors.ex:46
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -11366,19 +11366,19 @@ msgstr ""
 "Sua disponibilità ma non può garantirla, perché chiunque può creare un "
 "account. Scelga \"Nessuno\" per conservare lo stato senza mostrarlo."
 
-#: lib/vutuv/accounts/user.ex:1211
+#: lib/vutuv/accounts/user.ex:1219
 #: lib/vutuv_web/gettext_extraction_anchors.ex:50
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Tutti, compresi i visitatori non connessi"
 
-#: lib/vutuv/accounts/user.ex:1216
+#: lib/vutuv/accounts/user.ex:1224
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Nessuno"
 
-#: lib/vutuv/accounts/user.ex:1214
+#: lib/vutuv/accounts/user.ex:1222
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #: lib/vutuv_web/live/job_posting_live/form.ex:771
 #, elixir-autogen, elixir-format
@@ -12579,32 +12579,32 @@ msgstr ""
 " le aziende di IA seri rispettano questa richiesta; gli altri non possiamo "
 "obbligarli."
 
-#: lib/vutuv/organizations/organization.ex:105
+#: lib/vutuv/organizations/organization.ex:109
 #, elixir-autogen, elixir-format
 msgid "Association"
 msgstr "Associazione"
 
-#: lib/vutuv/organizations/organization.ex:104
+#: lib/vutuv/organizations/organization.ex:108
 #, elixir-autogen, elixir-format
 msgid "Business"
 msgstr "Azienda"
 
-#: lib/vutuv/organizations/organization.ex:107
+#: lib/vutuv/organizations/organization.ex:111
 #, elixir-autogen, elixir-format
 msgid "Education / research"
 msgstr "Istruzione / ricerca"
 
-#: lib/vutuv/organizations/organization.ex:108
+#: lib/vutuv/organizations/organization.ex:112
 #, elixir-autogen, elixir-format
 msgid "NGO / foundation"
 msgstr "ONG / fondazione"
 
-#: lib/vutuv/organizations/organization.ex:109
+#: lib/vutuv/organizations/organization.ex:113
 #, elixir-autogen, elixir-format
 msgid "Other organization"
 msgstr "Altra organizzazione"
 
-#: lib/vutuv/organizations/organization.ex:106
+#: lib/vutuv/organizations/organization.ex:110
 #, elixir-autogen, elixir-format
 msgid "Public authority"
 msgstr "Ente pubblico"
@@ -12763,7 +12763,7 @@ msgstr "I tag evidenziati corrispondono al Suo profilo."
 msgid "How to apply"
 msgstr "Come candidarsi"
 
-#: lib/vutuv/accounts/user.ex:1185
+#: lib/vutuv/accounts/user.ex:1193
 #: lib/vutuv/jobs/job_posting.ex:165
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12885,7 +12885,7 @@ msgstr ""
 "Offri i formati leggibili dalle macchine (.md/.txt/.json/.xml) agli agenti "
 "IA."
 
-#: lib/vutuv/accounts/user.ex:1184
+#: lib/vutuv/accounts/user.ex:1192
 #: lib/vutuv/jobs/job_posting.ex:164
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12969,7 +12969,7 @@ msgstr "Annuncio non trovato."
 msgid "Publish"
 msgstr "Pubblica"
 
-#: lib/vutuv/accounts/user.ex:1186
+#: lib/vutuv/accounts/user.ex:1194
 #: lib/vutuv/jobs/job_posting.ex:166
 #: lib/vutuv/notifications/emailer.ex:565
 #: lib/vutuv_web/agent_docs/markdown.ex:466
@@ -13738,7 +13738,7 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "Interrompere gli avvisi via e-mail per la Sua ricerca salvata \"%{label}\"?"
 
-#: lib/vutuv_web/components/post_components.ex:2563
+#: lib/vutuv_web/components/post_components.ex:2580
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:695
 #: lib/vutuv_web/controllers/settings_controller.ex:713
@@ -14069,7 +14069,7 @@ msgstr ""
 "Se è venuto male (ad esempio con un avviso sui cookie che copre la pagina), "
 "può rimuoverlo."
 
-#: lib/vutuv/accounts/user.ex:1229
+#: lib/vutuv/accounts/user.ex:1237
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -14083,19 +14083,19 @@ msgstr ""
 "la data esatta, \"Giorno e mese\" nasconde l'anno (e la Sua età) e \"Non "
 "mostrare\" lo conserva ma lo tiene fuori dal profilo."
 
-#: lib/vutuv/accounts/user.ex:1232
+#: lib/vutuv/accounts/user.ex:1240
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Giorno e mese, senza l'anno"
 
-#: lib/vutuv/accounts/user.ex:1235
+#: lib/vutuv/accounts/user.ex:1243
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Non mostrare il mio compleanno"
 
-#: lib/vutuv/accounts/user.ex:1226
+#: lib/vutuv/accounts/user.ex:1234
 #: lib/vutuv_web/gettext_extraction_anchors.ex:55
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -14205,22 +14205,22 @@ msgstr "Cellulare privato"
 msgid "Work mobile"
 msgstr "Cellulare di lavoro"
 
-#: lib/vutuv_web/components/post_components.ex:433
+#: lib/vutuv_web/components/post_components.ex:444
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr "Ancora nessun post."
 
-#: lib/vutuv_web/components/post_components.ex:435
+#: lib/vutuv_web/components/post_components.ex:446
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr "Ancora nessuna risposta."
 
-#: lib/vutuv_web/components/post_components.ex:434
+#: lib/vutuv_web/components/post_components.ex:445
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr "Ancora nessuna ripubblicazione."
 
-#: lib/vutuv_web/components/post_components.ex:392
+#: lib/vutuv_web/components/post_components.ex:403
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr "Post propri"
@@ -14235,14 +14235,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4516
 #: lib/vutuv_web/controllers/settings_controller.ex:614
-#: lib/vutuv_web/live/post_live/feed.ex:1837
+#: lib/vutuv_web/live/post_live/feed.ex:1845
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr "Tag che segue"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1852
+#: lib/vutuv_web/live/post_live/feed.ex:1860
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr "Smetti di seguire #%{tag}"
@@ -14408,34 +14408,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr "ha aggiunto %{count} nuove voci al proprio CV:"
 
-#: lib/vutuv_web/components/post_components.ex:4807
+#: lib/vutuv_web/components/post_components.ex:4837
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Audiolibro"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1204
-#: lib/vutuv_web/components/post_components.ex:4764
+#: lib/vutuv_web/components/post_components.ex:4794
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Recensione di un libro"
 
-#: lib/vutuv_web/components/post_components.ex:4808
+#: lib/vutuv_web/components/post_components.ex:4838
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Cinema"
 
-#: lib/vutuv_web/components/post_components.ex:4810
+#: lib/vutuv_web/components/post_components.ex:4840
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:4806
+#: lib/vutuv_web/components/post_components.ex:4836
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1204
-#: lib/vutuv_web/components/post_components.ex:4763
+#: lib/vutuv_web/components/post_components.ex:4793
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Recensione di un film"
@@ -14446,12 +14446,12 @@ msgstr "Recensione di un film"
 msgid "Look up"
 msgstr "Cerca"
 
-#: lib/vutuv_web/components/post_components.ex:4805
+#: lib/vutuv_web/components/post_components.ex:4835
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Libro cartaceo"
 
-#: lib/vutuv_web/components/post_components.ex:4809
+#: lib/vutuv_web/components/post_components.ex:4839
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14471,7 +14471,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Anno"
 
-#: lib/vutuv_web/components/post_components.ex:4846
+#: lib/vutuv_web/components/post_components.ex:4876
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14479,27 +14479,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} pagina"
 msgstr[1] "%{formatted} pagine"
 
-#: lib/vutuv_web/components/post_components.ex:4876
+#: lib/vutuv_web/components/post_components.ex:4906
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} h"
 
-#: lib/vutuv_web/components/post_components.ex:4877
+#: lib/vutuv_web/components/post_components.ex:4907
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} h %{minutes} min"
 
-#: lib/vutuv_web/components/post_components.ex:4875
+#: lib/vutuv_web/components/post_components.ex:4905
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} min"
 
-#: lib/vutuv_web/components/post_components.ex:4835
+#: lib/vutuv_web/components/post_components.ex:4865
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(edizione cartacea)"
 
-#: lib/vutuv_web/components/post_components.ex:4882
+#: lib/vutuv_web/components/post_components.ex:4912
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "circa %{duration}"
@@ -14531,7 +14531,7 @@ msgstr "Con certificazione:"
 msgid "With qualification: %{name}"
 msgstr "Con certificazione: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:4649
+#: lib/vutuv_web/components/post_components.ex:4679
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Editore:"
@@ -14579,7 +14579,7 @@ msgstr "ora La seguono."
 msgid "endorsed you for %{tags}."
 msgstr "L'ha confermata per %{tags}."
 
-#: lib/vutuv_web/components/post_components.ex:4640
+#: lib/vutuv_web/components/post_components.ex:4670
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "di:"
@@ -14986,14 +14986,14 @@ msgstr "Cerchi un account da bloccare"
 msgid "See all frozen accounts"
 msgstr "Vedi tutti gli account bloccati"
 
-#: lib/vutuv_web/components/post_components.ex:2836
+#: lib/vutuv_web/components/post_components.ex:2853
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "Mostra %{formatted} post precedente"
 msgstr[1] "Mostra %{formatted} post precedenti"
 
-#: lib/vutuv_web/components/post_components.ex:2859
+#: lib/vutuv_web/components/post_components.ex:2876
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -15022,7 +15022,7 @@ msgstr ""
 "Digiti un nome, un @handle o un indirizzo e-mail per trovare un account da "
 "bloccare."
 
-#: lib/vutuv_web/components/post_components.ex:5298
+#: lib/vutuv_web/components/post_components.ex:5328
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Non può mettere Mi piace al Suo stesso post."
@@ -15534,7 +15534,7 @@ msgstr ""
 "inviato nulla. I post già consegnati possono restare su quei server, fuori "
 "dalla nostra portata."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:117
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:133
 #, elixir-autogen, elixir-format
 msgid "Give this out the way you give out an email address. Anyone on Mastodon and friends can paste it into their search and follow you from there."
 msgstr ""
@@ -15542,7 +15542,7 @@ msgstr ""
 "Mastodon e affini può incollarlo nella ricerca e seguirla da lì."
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:187
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:138
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:154
 #, elixir-autogen, elixir-format
 msgid "Nobody yet. Post your handle where people can see it, and the first follows will show up here."
 msgstr ""
@@ -15550,24 +15550,24 @@ msgstr ""
 " primi follow compariranno qui."
 
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:327
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:192
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:208
 #, elixir-autogen, elixir-format
 msgid "Related"
 msgstr "Correlati"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:195
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:211
 #, elixir-autogen, elixir-format
 msgid "Moving to or away from another Fediverse account?"
 msgstr "Si sta spostando verso o da un altro account del Fediverso?"
 
 #: lib/vutuv_web/controllers/settings_controller.ex:377
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:201
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:217
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Move your account"
 msgstr "Sposti il Suo account"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:218
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:234
 #, elixir-autogen, elixir-format
 msgid "Want the checkmark on your Mastodon profile? That works without taking part here: your vutuv profile links your listed accounts with rel=\"me\"."
 msgstr ""
@@ -15641,7 +15641,7 @@ msgstr ""
 msgid "Back to Fediverse settings"
 msgstr "Torna alle impostazioni del Fediverso"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:124
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:140
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower from other networks"
 msgid_plural "%{formatted} followers from other networks"
@@ -16235,13 +16235,13 @@ msgstr ""
 " nome. Per condividerlo tutti i giorni, l'indirizzo breve qui sopra è più "
 "comodo."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:269
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:285
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:35
 #, elixir-autogen, elixir-format
 msgid "I understand, switch off"
 msgstr "Ho capito, disattiva"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:267
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:283
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "I understand, take part"
@@ -16291,21 +16291,21 @@ msgstr ""
 " vedere dove va a finire. Modificare o eliminare un post su vutuv è solo una"
 " richiesta rivolta a quei server, e non tutti la rispettano."
 
-#: lib/vutuv_web/components/post_components.ex:5244
+#: lib/vutuv_web/components/post_components.ex:5274
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} risposta"
 msgstr[1] "%{formatted} risposte"
 
-#: lib/vutuv_web/components/post_components.ex:5248
+#: lib/vutuv_web/components/post_components.ex:5278
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Mi piace"
 msgstr[1] "%{formatted} Mi piace"
 
-#: lib/vutuv_web/components/post_components.ex:5252
+#: lib/vutuv_web/components/post_components.ex:5282
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -16313,7 +16313,7 @@ msgstr[0] "%{formatted} ripubblicazione"
 msgstr[1] "%{formatted} ripubblicazioni"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1153
-#: lib/vutuv_web/components/post_components.ex:5203
+#: lib/vutuv_web/components/post_components.ex:5233
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Già conteggiate nei numeri qui sopra."
@@ -16334,14 +16334,14 @@ msgstr ""
 msgid "Content warning"
 msgstr "Avviso sul contenuto"
 
-#: lib/vutuv_web/components/post_components.ex:1371
-#: lib/vutuv_web/components/post_components.ex:2030
+#: lib/vutuv_web/components/post_components.ex:1387
+#: lib/vutuv_web/components/post_components.ex:2046
 #: lib/vutuv_web/live/fediverse_account_live.ex:294
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr "Da un'altra rete"
 
-#: lib/vutuv_web/components/post_components.ex:1247
+#: lib/vutuv_web/components/post_components.ex:1263
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr "Rimuovere questa risposta dal Suo post?"
@@ -16370,7 +16370,7 @@ msgstr "Risposta da un'altra rete"
 msgid "Reply removed."
 msgstr "Risposta rimossa."
 
-#: lib/vutuv_web/components/post_components.ex:1256
+#: lib/vutuv_web/components/post_components.ex:1272
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -16381,7 +16381,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr "Segnalata come non appropriata"
 
-#: lib/vutuv_web/components/post_components.ex:1270
+#: lib/vutuv_web/components/post_components.ex:1286
 #: lib/vutuv_web/live/notification_live/index.ex:597
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -16413,9 +16413,9 @@ msgid "That reply is not yours to remove."
 msgstr "Questa risposta non spetta a Lei rimuoverla."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1337
-#: lib/vutuv_web/components/post_components.ex:1302
-#: lib/vutuv_web/components/post_components.ex:1502
-#: lib/vutuv_web/components/post_components.ex:2483
+#: lib/vutuv_web/components/post_components.ex:1318
+#: lib/vutuv_web/components/post_components.ex:1518
+#: lib/vutuv_web/components/post_components.ex:2500
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr "Vedi l'originale"
@@ -16438,7 +16438,7 @@ msgstr "Oggi ha fatto molte segnalazioni. Riprovi domani."
 msgid "replied to your post from another network."
 msgstr "ha risposto al Suo post da un'altra rete."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:144
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:160
 #, elixir-autogen, elixir-format
 msgid "All followers"
 msgstr "Tutti i follower"
@@ -16775,7 +16775,7 @@ msgstr ""
 "dispositivo e come è stato confermato. Se una riga La sorprende, segua il "
 "link in fondo."
 
-#: lib/vutuv_web/views/account_event_text.ex:249
+#: lib/vutuv_web/views/account_event_text.ex:250
 #, elixir-autogen, elixir-format
 msgid "Fediverse aliases"
 msgstr "Alias nel Fediverso"
@@ -16785,7 +16785,7 @@ msgstr "Alias nel Fediverso"
 msgid "Fediverse participation"
 msgstr "Partecipazione al Fediverso"
 
-#: lib/vutuv_web/views/account_event_text.ex:248
+#: lib/vutuv_web/views/account_event_text.ex:249
 #, elixir-autogen, elixir-format
 msgid "Fediverse replies"
 msgstr "Risposte dal Fediverso"
@@ -17110,22 +17110,22 @@ msgstr ""
 msgid "device or detail"
 msgstr "dispositivo o dettaglio"
 
-#: lib/vutuv_web/components/post_components.ex:3021
+#: lib/vutuv_web/components/post_components.ex:3038
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Post fissato"
 
-#: lib/vutuv_web/components/post_components.ex:3137
+#: lib/vutuv_web/components/post_components.ex:3154
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "Fissa sul profilo"
 
-#: lib/vutuv_web/components/post_components.ex:3145
+#: lib/vutuv_web/components/post_components.ex:3162
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Togli dal profilo"
 
-#: lib/vutuv_web/components/post_components.ex:3131
+#: lib/vutuv_web/components/post_components.ex:3148
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -17260,17 +17260,17 @@ msgstr "Foto successiva"
 msgid "No image description yet"
 msgstr "Ancora nessuna descrizione dell'immagine"
 
-#: lib/vutuv_web/components/post_components.ex:2616
+#: lib/vutuv_web/components/post_components.ex:2633
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Apri le impostazioni del Fediverso"
 
-#: lib/vutuv_web/components/post_components.ex:3834
+#: lib/vutuv_web/components/post_components.ex:3851
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} di %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:3982
+#: lib/vutuv_web/components/post_components.ex:3999
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "La foto è in fase di controllo"
@@ -17283,7 +17283,7 @@ msgstr "Opzioni della foto"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1298
 #: lib/vutuv_web/agent_docs/text.ex:785
-#: lib/vutuv_web/components/post_components.ex:4064
+#: lib/vutuv_web/components/post_components.ex:4081
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Foto:"
@@ -17311,7 +17311,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr "Mostra le impostazioni della fotocamera"
 
-#: lib/vutuv_web/components/post_components.ex:2669
+#: lib/vutuv_web/components/post_components.ex:2686
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -17337,7 +17337,7 @@ msgstr ""
 "Questa foto porta con sé il luogo in cui è stata scattata. Chiunque scarichi"
 " il file esatto può leggerlo."
 
-#: lib/vutuv_web/components/post_components.ex:2660
+#: lib/vutuv_web/components/post_components.ex:2677
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -17352,12 +17352,12 @@ msgstr ""
 "inviare le Sue parole a quella rete, cosa che vutuv fa solo per i membri che"
 " hanno attivato la partecipazione al Fediverso."
 
-#: lib/vutuv_web/components/post_components.ex:2678
+#: lib/vutuv_web/components/post_components.ex:2695
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Questo sito non partecipa al Fediverso."
 
-#: lib/vutuv_web/components/post_components.ex:2612
+#: lib/vutuv_web/components/post_components.ex:2629
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Attivi la partecipazione al Fediverso per rispondere"
@@ -17373,7 +17373,7 @@ msgid "You have sent a lot of answers to other networks in the past hour. Please
 msgstr ""
 "Nell'ultima ora ha inviato molte risposte ad altre reti. Riprovi più tardi."
 
-#: lib/vutuv_web/components/post_components.ex:2673
+#: lib/vutuv_web/components/post_components.ex:2690
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -17387,7 +17387,7 @@ msgstr ""
 "Al momento le Sue impostazioni del Fediverso non consentono di inviare una "
 "risposta."
 
-#: lib/vutuv_web/components/post_components.ex:2626
+#: lib/vutuv_web/components/post_components.ex:2643
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -17410,8 +17410,8 @@ msgstr "Aggiungi foto"
 msgid "Licence"
 msgstr "Licenza"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1638
-#: lib/vutuv_web/live/post_live/feed.ex:1639
+#: lib/vutuv_web/live/post_live/feed.ex:1645
+#: lib/vutuv_web/live/post_live/feed.ex:1646
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr "Pubblica foto"
@@ -17482,13 +17482,13 @@ msgstr[1] ""
 "il file esatto lo rivela."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1171
-#: lib/vutuv_web/components/post_components.ex:5241
+#: lib/vutuv_web/components/post_components.ex:5271
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "A %{handle} è piaciuto"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1169
-#: lib/vutuv_web/components/post_components.ex:5238
+#: lib/vutuv_web/components/post_components.ex:5268
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} lo ha condiviso"
@@ -17498,7 +17498,7 @@ msgstr "%{handle} lo ha condiviso"
 msgid "Fediverse reactions"
 msgstr "Reazioni dal Fediverso"
 
-#: lib/vutuv_web/components/post_components.ex:5130
+#: lib/vutuv_web/components/post_components.ex:5160
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Da altre reti"
@@ -17603,7 +17603,7 @@ msgstr "Dettagli della foto"
 #: lib/vutuv_web/live/fediverse_following_live.ex:301
 #: lib/vutuv_web/live/fediverse_following_live.ex:314
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:336
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:159
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:175
 #, elixir-autogen, elixir-format
 msgid "Accounts you follow elsewhere"
 msgstr "Account che segue altrove"
@@ -17635,7 +17635,7 @@ msgstr "Segua account su Mastodon, e si faccia seguire da lì"
 msgid "Follow request sent to %{account}."
 msgstr "Richiesta di follow inviata a %{account}."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:180
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "Follow somebody out there"
 msgstr "Segua qualcuno là fuori"
@@ -17645,7 +17645,7 @@ msgstr "Segua qualcuno là fuori"
 msgid "Follow this account"
 msgstr "Segui questo account"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:161
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:177
 #, elixir-autogen, elixir-format
 msgid "It works the other way round too: paste somebody's address from Mastodon and friends, and you follow them from here."
 msgstr ""
@@ -17654,7 +17654,7 @@ msgstr ""
 
 #: lib/vutuv/api_auth/scopes.ex:84
 #: lib/vutuv/api_auth/scopes.ex:87
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:182
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Manage who you follow"
 msgstr "Gestisca chi segue"
@@ -17832,7 +17832,7 @@ msgstr ""
 msgid "You can follow accounts there yourself, straight from vutuv."
 msgstr "Può seguire quegli account da sé, direttamente da vutuv."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:170
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "You follow %{formatted} account on another network"
 msgid_plural "You follow %{formatted} accounts on other networks"
@@ -17884,7 +17884,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr "Post in cache"
 
-#: lib/vutuv_web/components/post_components.ex:2428
+#: lib/vutuv_web/components/post_components.ex:2445
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr "Solo per i follower di questo account"
@@ -17894,7 +17894,7 @@ msgstr "Solo per i follower di questo account"
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Grazie. La nostra copia è stata eliminata subito."
 
-#: lib/vutuv_web/components/post_components.ex:2482
+#: lib/vutuv_web/components/post_components.ex:2499
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Vota sull'originale"
@@ -17920,12 +17920,12 @@ msgstr "Post in cache segnalato, rimosso per tutti qui"
 msgid "Content from other networks taken down by members"
 msgstr "Contenuti da altre reti rimossi dai membri"
 
-#: lib/vutuv_web/components/post_components.ex:1630
+#: lib/vutuv_web/components/post_components.ex:1646
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr "Nascondi"
 
-#: lib/vutuv_web/components/post_components.ex:2447
+#: lib/vutuv_web/components/post_components.ex:2464
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Contrassegnato come sensibile dal suo autore"
@@ -17941,7 +17941,7 @@ msgstr "Silenziato. Continua a seguirlo; i suoi post spariscono dal Suo feed."
 msgid "Nobody has removed or reported anything yet."
 msgstr "Nessuno ha ancora rimosso o segnalato nulla."
 
-#: lib/vutuv_web/components/post_components.ex:2414
+#: lib/vutuv_web/components/post_components.ex:2431
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -18203,27 +18203,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] "(un'immagine)"
 msgstr[1] "(%{count} immagini)"
 
-#: lib/vutuv_web/components/post_components.ex:2150
+#: lib/vutuv_web/components/post_components.ex:2167
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr "L'immagine è in fase di controllo"
 
-#: lib/vutuv_web/components/post_components.ex:2179
+#: lib/vutuv_web/components/post_components.ex:2196
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr "Coprila di nuovo"
 
-#: lib/vutuv_web/components/post_components.ex:2174
+#: lib/vutuv_web/components/post_components.ex:2191
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr "Contenuto sensibile. Mostra l'immagine."
 
-#: lib/vutuv_web/components/post_components.ex:2519
+#: lib/vutuv_web/components/post_components.ex:2536
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Sono molti Mi piace in un'ora. Riprovi più tardi."
 
-#: lib/vutuv_web/components/post_components.ex:2525
+#: lib/vutuv_web/components/post_components.ex:2542
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Quel post non è più qui."
@@ -18233,7 +18233,7 @@ msgstr "Quel post non è più qui."
 msgid "Back to the feed"
 msgstr "Torna al feed"
 
-#: lib/vutuv_web/components/post_components.ex:2664
+#: lib/vutuv_web/components/post_components.ex:2681
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -18533,7 +18533,7 @@ msgstr ""
 "vutuv non ne conserva una copia."
 
 #: lib/vutuv_web/live/fediverse_following_live.ex:495
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:214
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:230
 #, elixir-autogen, elixir-format
 msgid "Look up a post by its address"
 msgstr "Cerchi un post dal suo indirizzo"
@@ -18557,7 +18557,7 @@ msgstr ""
 "mostra qui e Lei può rispondere, mettere Mi piace o ripubblicarlo come se "
 "fosse arrivato da sé."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:208
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:224
 #, elixir-autogen, elixir-format
 msgid "Read something out there that you want to answer from here?"
 msgstr "Ha letto qualcosa là fuori a cui vuole rispondere da qui?"
@@ -19002,14 +19002,14 @@ msgstr ""
 msgid "Screenshot blocklist"
 msgstr "Elenco dei bloccati per gli screenshot"
 
-#: lib/vutuv_web/components/post_components.ex:425
+#: lib/vutuv_web/components/post_components.ex:436
 #, elixir-autogen, elixir-format
 msgid "Nothing from the fediverse yet. Follow accounts out there to fill this tab."
 msgstr ""
 "Ancora nulla dal Fediverso. Segua account là fuori per riempire questa "
 "scheda."
 
-#: lib/vutuv_web/components/post_components.ex:422
+#: lib/vutuv_web/components/post_components.ex:433
 #, elixir-autogen, elixir-format
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr "Ancora nulla da vutuv. Segua persone qui per riempire questa scheda."
@@ -19051,7 +19051,7 @@ msgstr "Nessun post su vutuv porta ancora questo tag."
 msgid "word in a post"
 msgstr "parola in un post"
 
-#: lib/vutuv_web/components/post_components.ex:2522
+#: lib/vutuv_web/components/post_components.ex:2539
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr "Quella risposta non è più qui."
@@ -19430,19 +19430,19 @@ msgstr ""
 msgid "Liked by"
 msgstr "Piace a"
 
-#: lib/vutuv_web/components/post_components.ex:4336
+#: lib/vutuv_web/components/post_components.ex:4366
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Piace a %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:4338
+#: lib/vutuv_web/components/post_components.ex:4368
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Piace a %{name} e a %{formatted} altro"
 msgstr[1] "Piace a %{name} e ad altri %{formatted}"
 
-#: lib/vutuv_web/components/post_components.ex:4349
+#: lib/vutuv_web/components/post_components.ex:4379
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -20503,17 +20503,17 @@ msgstr ""
 "Il PIN non arriva? L'indirizzo e-mail {email} è corretto? Ha controllato la "
 "cartella dello spam?"
 
-#: lib/vutuv/accounts/user.ex:1332
+#: lib/vutuv/accounts/user.ex:1340
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Non binario"
 
-#: lib/vutuv/accounts/user.ex:1330
+#: lib/vutuv/accounts/user.ex:1338
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr "Femminile"
 
-#: lib/vutuv/accounts/user.ex:1331
+#: lib/vutuv/accounts/user.ex:1339
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Maschile"
@@ -20632,7 +20632,7 @@ msgstr "Conserva sempre"
 #: lib/vutuv_web/controllers/settings_controller.ex:324
 #: lib/vutuv_web/controllers/settings_controller.ex:336
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:20
-#: lib/vutuv_web/views/account_event_text.ex:254
+#: lib/vutuv_web/views/account_event_text.ex:255
 #, elixir-autogen, elixir-format
 msgid "Automatic post deletion"
 msgstr "Eliminazione automatica dei post"
@@ -20642,7 +20642,7 @@ msgstr "Eliminazione automatica dei post"
 msgid "Automatic post deletion changed"
 msgstr "Eliminazione automatica dei post modificata"
 
-#: lib/vutuv_web/views/account_event_text.ex:261
+#: lib/vutuv_web/views/account_event_text.ex:262
 #, elixir-autogen, elixir-format
 msgid "Bookmark floor"
 msgstr "Soglia dei salvataggi"
@@ -20689,7 +20689,7 @@ msgstr "Elimina automaticamente i miei post"
 msgid "Delete posts older than"
 msgstr "Elimina i post più vecchi di"
 
-#: lib/vutuv_web/views/account_event_text.ex:259
+#: lib/vutuv_web/views/account_event_text.ex:260
 #, elixir-autogen, elixir-format
 msgid "Delete replies too"
 msgstr "Elimina anche le risposte"
@@ -20717,17 +20717,17 @@ msgstr ""
 "obbligarli. Un server spento, che non parla più con noi o che semplicemente "
 "ignora la richiesta si tiene quello che ha."
 
-#: lib/vutuv_web/views/account_event_text.ex:257
+#: lib/vutuv_web/views/account_event_text.ex:258
 #, elixir-autogen, elixir-format
 msgid "Keep answered posts"
 msgstr "Conserva i post con risposte"
 
-#: lib/vutuv_web/views/account_event_text.ex:258
+#: lib/vutuv_web/views/account_event_text.ex:259
 #, elixir-autogen, elixir-format
 msgid "Keep bookmarked posts"
 msgstr "Conserva i post salvati"
 
-#: lib/vutuv_web/views/account_event_text.ex:256
+#: lib/vutuv_web/views/account_event_text.ex:257
 #, elixir-autogen, elixir-format
 msgid "Keep photo posts"
 msgstr "Conserva i post con foto"
@@ -20742,7 +20742,7 @@ msgstr "Conserva i post andati bene"
 msgid "Let your posts age out after a time you set"
 msgstr "Lasci scadere i Suoi post dopo un tempo che decide Lei"
 
-#: lib/vutuv_web/views/account_event_text.ex:260
+#: lib/vutuv_web/views/account_event_text.ex:261
 #, elixir-autogen, elixir-format
 msgid "Like floor"
 msgstr "Soglia dei Mi piace"
@@ -20773,7 +20773,7 @@ msgstr ""
 "I post con foto e le recensioni di libri o film vengono conservati a "
 "prescindere dalla loro età."
 
-#: lib/vutuv_web/views/account_event_text.ex:255
+#: lib/vutuv_web/views/account_event_text.ex:256
 #, elixir-autogen, elixir-format
 msgid "Post age"
 msgstr "Età del post"
@@ -20798,7 +20798,7 @@ msgstr "Post con foto o con una recensione"
 msgid "Posts you bookmarked yourself"
 msgstr "Post che ha salvato Lei stesso"
 
-#: lib/vutuv_web/views/account_event_text.ex:262
+#: lib/vutuv_web/views/account_event_text.ex:263
 #, elixir-autogen, elixir-format
 msgid "Repost floor"
 msgstr "Soglia delle ripubblicazioni"
@@ -21273,7 +21273,7 @@ msgstr ""
 msgid "Start over"
 msgstr "Ricomincia"
 
-#: lib/vutuv_web/components/post_components.ex:2552
+#: lib/vutuv_web/components/post_components.ex:2569
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -22264,27 +22264,27 @@ msgstr "Lingua del post"
 msgid "The language this post is written in"
 msgstr "La lingua in cui è scritto questo post"
 
-#: lib/vutuv_web/components/post_components.ex:4230
+#: lib/vutuv_web/components/post_components.ex:4260
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Mostra l'originale"
 
-#: lib/vutuv_web/components/post_components.ex:4266
+#: lib/vutuv_web/components/post_components.ex:4296
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Traduci"
 
-#: lib/vutuv_web/components/post_components.ex:4275
+#: lib/vutuv_web/components/post_components.ex:4305
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Tradotto"
 
-#: lib/vutuv_web/components/post_components.ex:4278
+#: lib/vutuv_web/components/post_components.ex:4308
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Tradotto da %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:4255
+#: lib/vutuv_web/components/post_components.ex:4285
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Traduzione in corso…"
@@ -22295,7 +22295,7 @@ msgid "Feed language settings reset to the site defaults."
 msgstr ""
 "Impostazioni delle lingue del feed riportate ai valori predefiniti del sito."
 
-#: lib/vutuv_web/components/post_components.ex:4245
+#: lib/vutuv_web/components/post_components.ex:4275
 #: lib/vutuv_web/components/ui.ex:4509
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -22438,7 +22438,7 @@ msgid "Your username, or paste the address of your profile page."
 msgstr ""
 "Il Suo nome utente, oppure incolli l'indirizzo della Sua pagina di profilo."
 
-#: lib/vutuv_web/components/post_components.ex:4030
+#: lib/vutuv_web/components/post_components.ex:4047
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
@@ -22449,13 +22449,13 @@ msgstr[1] ""
 "La nostra IA le sta ancora controllando, %{done} su %{total} fatte. Appena "
 "avrà finito con l'ultima, le foto compariranno da sé."
 
-#: lib/vutuv_web/components/post_components.ex:4027
+#: lib/vutuv_web/components/post_components.ex:4044
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr "Il Suo post è pubblicato, la foto non c'è ancora."
 
-#: lib/vutuv_web/components/post_components.ex:2201
-#: lib/vutuv_web/components/post_components.ex:3354
+#: lib/vutuv_web/components/post_components.ex:2218
+#: lib/vutuv_web/components/post_components.ex:3371
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -22474,7 +22474,7 @@ msgstr "Consigliato: %{width} × %{height} pixel (%{ratio})."
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr "Consigliato: quadrata, almeno %{width} × %{height} pixel."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1894
+#: lib/vutuv_web/live/post_live/feed.ex:1902
 #: lib/vutuv_web/views/user_html.ex:338
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -23026,7 +23026,7 @@ msgstr ""
 "Questa pagina sta seguendo il numero massimo di account che consentiamo "
 "(%{max})."
 
-#: lib/vutuv_web/components/post_components.ex:2402
+#: lib/vutuv_web/components/post_components.ex:2419
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr "Smettere di seguire %{handle}? I suoi post spariscono dal Suo feed."
@@ -23169,12 +23169,12 @@ msgstr ""
 "Segua #%{tag} da Mastodon o da qualsiasi altra app del Fediverso e i suoi "
 "post pubblici arriveranno nella Sua cronologia. Non serve un account vutuv."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1876
+#: lib/vutuv_web/live/post_live/feed.ex:1884
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Saluti gli altri membri"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1872
+#: lib/vutuv_web/live/post_live/feed.ex:1880
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr "Nuovi qui"
@@ -23224,31 +23224,31 @@ msgstr ""
 msgid "With a vutuv account"
 msgstr "Con un account vutuv"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1886
+#: lib/vutuv_web/live/post_live/feed.ex:1894
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr "Alcuni fra i membri più recenti. Seguirli è un bel benvenuto."
 
-#: lib/vutuv_web/components/post_components.ex:602
+#: lib/vutuv_web/components/post_components.ex:613
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new post"
 msgid_plural "%{formatted} new posts"
 msgstr[0] "%{formatted} nuovo post"
 msgstr[1] "%{formatted} nuovi post"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1314
+#: lib/vutuv_web/live/post_live/feed.ex:1312
 #, elixir-autogen, elixir-format
 msgid "%{source}: %{formatted} new post"
 msgid_plural "%{source}: %{formatted} new posts"
 msgstr[0] "%{source}: %{formatted} nuovo post"
 msgstr[1] "%{source}: %{formatted} nuovi post"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1311
+#: lib/vutuv_web/live/post_live/feed.ex:1309
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post"
 msgstr "%{source}: nuovo post"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1308
+#: lib/vutuv_web/live/post_live/feed.ex:1306
 #, elixir-autogen, elixir-format
 msgid "%{source}: new post from %{who}"
 msgstr "%{source}: nuovo post di %{who}"
@@ -23537,3 +23537,18 @@ msgstr "Il suo profilo LinkedIn può venire con lei."
 #, elixir-autogen, elixir-format
 msgid "Being checked"
 msgstr "In verifica"
+
+#: lib/vutuv_web/views/account_event_text.ex:248
+#, elixir-autogen, elixir-format
+msgid "Fediverse quotes"
+msgstr "Citazioni nel Fediverso"
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:112
+#, elixir-autogen, elixir-format
+msgid "Let other networks quote your posts"
+msgstr "Consenti ad altre reti di citare i tuoi post"
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:115
+#, elixir-autogen, elixir-format
+msgid "Someone on Mastodon can share one of your public posts with their own comment above it, the way a reshare works, but with their words beside yours. Your server is asked first every time and answers automatically while this is on. You can withdraw a single quote later, and switching this off refuses new ones."
+msgstr "Qualcuno su Mastodon può condividere uno dei tuoi post pubblici con un proprio commento sopra, come per un repost, ma con le sue parole accanto alle tue. Il tuo server viene interpellato ogni volta e risponde automaticamente finché questa opzione è attiva. Puoi ritirare una singola citazione in seguito, e disattivandola le nuove richieste vengono rifiutate."

--- a/priv/repo/migrations/20260826172430_add_fediverse_quote_authorizations.exs
+++ b/priv/repo/migrations/20260826172430_add_fediverse_quote_authorizations.exs
@@ -1,0 +1,86 @@
+defmodule Vutuv.Repo.Migrations.AddFediverseQuoteAuthorizations do
+  use Ecto.Migration
+
+  # The consent half of FEP-044f quote posts (issue #1608): who was allowed to
+  # quote which of our posts, and where to send the withdrawal.
+  #
+  # Additions only — a new table and two new booleans with defaults — so the
+  # currently deployed release keeps working through the migration window.
+  def change do
+    create table(:fediverse_quote_authorizations) do
+      # Deliberately plain ids, NOT references: the withdrawal runs *after* the
+      # post row is gone (`Vutuv.Posts.delete_post/1` federates its Delete once
+      # the transaction has committed), so a cascade would erase these rows
+      # moments before they are needed. Cleared explicitly instead — by
+      # `Vutuv.Fediverse.revoke_quote_authorizations/1`, by account deletion and
+      # by an instance block. Exactly the reasoning behind
+      # `fediverse_post_deliveries`, and for exactly the same failure.
+      add(:post_id, :binary_id, null: false)
+      # The author, in the usual nullable pair: a member or a page, never both.
+      # An invariant of the context function that writes these, not of the
+      # schema, because the row has to outlive whichever one it names.
+      add(:user_id, :binary_id)
+      add(:organization_id, :binary_id)
+
+      # The remote post doing the quoting, its author, and where a
+      # `Delete(QuoteAuthorization)` reaches that author. All three are remote
+      # URIs and none of them is ours to bound, so `:text` — the type
+      # `fediverse_followers.inbox_uri` already carries. A varchar(255) here
+      # would raise Postgres 22001 out of the inbox for a perfectly ordinary
+      # long status id, and no changeset would have caught it because nothing
+      # user-facing writes this column.
+      add(:interacting_object_uri, :text, null: false)
+      add(:actor_uri, :text, null: false)
+      add(:inbox_uri, :text)
+
+      # The `QuoteRequest` this answers, so a redelivery of the same request
+      # finds its row instead of minting a second stamp.
+      add(:request_activity_id, :text)
+
+      # The published Note id at the time consent was given. Same reason
+      # `fediverse_post_deliveries` records it: a Note id carries the username,
+      # and after a rename an id rebuilt from the current one names nothing the
+      # other server stored.
+      add(:note_uri, :text, null: false)
+
+      add(:accepted_at, :utc_datetime, null: false)
+
+      timestamps(updated_at: false)
+    end
+
+    # One stamp per (post, quoting object): a redelivered QuoteRequest upserts
+    # rather than handing the same quote a second authorization.
+    #
+    # Both columns are hashed rather than indexed directly: `interacting_object_uri`
+    # is unbounded `:text`, and a btree entry has a hard ~2704-byte ceiling, so a
+    # hostile multi-kilobyte id would fail the INSERT (a 500 out of the inbox)
+    # instead of the changeset. The changeset caps it at 2048 bytes as well; this
+    # is the belt to that pair of braces.
+    create(
+      unique_index(:fediverse_quote_authorizations, [:post_id, :interacting_object_uri],
+        name: :fediverse_quote_authorizations_post_object_index
+      )
+    )
+
+    # The withdrawal path reads by post; the instance block reads by author host
+    # through `actor_uri`.
+    create(index(:fediverse_quote_authorizations, [:user_id]))
+    create(index(:fediverse_quote_authorizations, [:organization_id]))
+
+    # May other accounts quote my posts? Read by the `interactionPolicy` the
+    # Note advertises and by the inbox gate that answers a QuoteRequest.
+    #
+    # Default **true**, unlike `fediverse_replies?` beside it: a quote
+    # redistributes a post that is already public to anyone, which is what a
+    # reshare has always done here, whereas holding text written by somebody who
+    # never signed up is a different kind of ask. Switching it off means the
+    # policy says `nobody` and every QuoteRequest is rejected.
+    alter table(:users) do
+      add(:fediverse_quotes?, :boolean, null: false, default: true)
+    end
+
+    alter table(:organizations) do
+      add(:fediverse_quotes?, :boolean, null: false, default: true)
+    end
+  end
+end

--- a/test/vutuv/fediverse_blocklist_test.exs
+++ b/test/vutuv/fediverse_blocklist_test.exs
@@ -153,7 +153,8 @@ defmodule Vutuv.FediverseBlocklistTest do
                cached_posts: 0,
                deliveries: 1,
                notes: 0,
-               post_deliveries: 0
+               post_deliveries: 0,
+               quote_authorizations: 0
              }
 
       assert [%Follower{actor_uri: "https://social.example/users/alice"}] = Repo.all(Follower)

--- a/test/vutuv/fediverse_quote_authorization_test.exs
+++ b/test/vutuv/fediverse_quote_authorization_test.exs
@@ -1,0 +1,278 @@
+defmodule Vutuv.FediverseQuoteAuthorizationTest do
+  @moduledoc """
+  Consent-respecting quote posts, the answering half (FEP-044f, issue #1608).
+
+  The thing under test is a **permission**, so most of these assert what does
+  *not* happen: no stamp for a post whose audience is narrowed, none for a
+  frozen one, none for a member who switched quoting off, and — the one that is
+  easy to get wrong — no stamp for a "quote" hosted on our own installation,
+  which would be a stranger talking us into authorizing one of our own posts
+  against another.
+
+  async: false — the inbound caps live in the shared `Vutuv.RateLimiter` ETS
+  table, which the SQL sandbox does not roll back.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Ecto.Query
+  import Vutuv.PostsHelpers
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Delivery
+  alias Vutuv.Fediverse.QuoteAuthorization
+  alias Vutuv.Posts
+  alias VutuvWeb.Fediverse.Docs
+
+  @public "https://www.w3.org/ns/activitystreams#Public"
+  @actor "https://social.example/users/alice"
+  @inbox "https://social.example/users/alice/inbox"
+  @quote_post "https://social.example/users/alice/statuses/1"
+
+  setup do
+    Vutuv.RateLimiter.reset()
+    Repo.delete_all(Delivery)
+
+    user = insert(:activated_user, fediverse_followers?: true)
+    {:ok, _actor} = Fediverse.ensure_actor(user)
+    post = create_post!(user, %{"body" => "Worth quoting."})
+
+    {:ok, user: user, post: post}
+  end
+
+  defp requester(overrides \\ %{}) do
+    Map.merge(%{uri: @actor, handle: "alice", name: "Alice", inbox: @inbox}, overrides)
+  end
+
+  defp quote_request(user, post, overrides \\ %{}) do
+    Map.merge(
+      %{
+        "type" => "QuoteRequest",
+        "id" => "#{@actor}/quote_requests/1",
+        "actor" => @actor,
+        "object" => Docs.note_url(user, post.id),
+        "instrument" => %{
+          "id" => @quote_post,
+          "type" => "Note",
+          "attributedTo" => @actor,
+          "quote" => Docs.note_url(user, post.id)
+        }
+      },
+      overrides
+    )
+  end
+
+  defp stamps, do: Repo.all(from(a in QuoteAuthorization, order_by: a.id))
+
+  defp delivered do
+    Delivery
+    |> Repo.all()
+    |> Enum.map(&Jason.decode!(&1.activity_json))
+  end
+
+  describe "the policy a Note advertises" do
+    test "names the public collection while the member allows quoting", %{
+      user: user,
+      post: post
+    } do
+      note = Docs.note(post, user)
+
+      assert %{"canQuote" => %{"automaticApproval" => [@public], "manualApproval" => []}} =
+               note["interactionPolicy"]
+    end
+
+    test "names only the author once the member switches quoting off", %{post: post} do
+      user = insert(:activated_user, fediverse_followers?: true, fediverse_quotes?: false)
+      note = Docs.note(post, user)
+
+      assert %{"canQuote" => %{"automaticApproval" => [approval]}} = note["interactionPolicy"]
+      assert approval == Docs.actor_url(user)
+      refute approval == @public
+    end
+
+    test "the standalone document defines the policy terms it uses", %{user: user, post: post} do
+      # Without the JSON-LD terms a conforming consumer drops the policy, so the
+      # page would promise nothing while the delivered copy promised quoting.
+      context = Docs.note_document(post, user)["@context"]
+
+      assert is_list(context)
+      assert "https://www.w3.org/ns/activitystreams" in context
+      assert Enum.any?(context, &(is_map(&1) and Map.has_key?(&1, "interactionPolicy")))
+    end
+  end
+
+  describe "answering a QuoteRequest" do
+    test "issues a stamp and an Accept whose result is that stamp", %{user: user, post: post} do
+      request = quote_request(user, post)
+
+      assert :ok = Fediverse.record_quote_request(user, request, requester())
+
+      assert [%QuoteAuthorization{} = stamp] = stamps()
+      assert stamp.post_id == post.id
+      assert stamp.user_id == user.id
+      assert stamp.interacting_object_uri == @quote_post
+      assert stamp.actor_uri == @actor
+      assert stamp.inbox_uri == @inbox
+      assert stamp.note_uri == Docs.note_url(user, post.id)
+
+      assert [accept] = delivered()
+      assert accept["type"] == "Accept"
+      assert accept["object"]["type"] == "QuoteRequest"
+      assert accept["object"]["id"] == request["id"]
+
+      # The whole mechanism: `result` has to be the stamp's own URL, exactly.
+      assert accept["result"] == Docs.quote_authorization_url(user, post.id, stamp.id)
+    end
+
+    test "the echoed request carries the quoting post as an id, not as their document",
+         %{user: user, post: post} do
+      :ok = Fediverse.record_quote_request(user, quote_request(user, post), requester())
+
+      assert [accept] = delivered()
+      assert accept["object"]["instrument"] == @quote_post
+    end
+
+    test "a redelivered request re-answers without minting a second permission", %{
+      user: user,
+      post: post
+    } do
+      request = quote_request(user, post)
+
+      assert :ok = Fediverse.record_quote_request(user, request, requester())
+      assert :ok = Fediverse.record_quote_request(user, request, requester())
+
+      assert [_only_one] = stamps()
+      assert length(delivered()) == 2
+    end
+
+    test "a second quoting post gets its own stamp", %{user: user, post: post} do
+      :ok = Fediverse.record_quote_request(user, quote_request(user, post), requester())
+
+      other =
+        quote_request(user, post, %{
+          "id" => "#{@actor}/quote_requests/2",
+          "instrument" => %{"id" => "#{@actor}/statuses/2", "attributedTo" => @actor}
+        })
+
+      :ok = Fediverse.record_quote_request(user, other, requester())
+
+      assert length(stamps()) == 2
+    end
+  end
+
+  describe "refusals the requester is told about" do
+    test "a member who switched quoting off gets a Reject and grants nothing", %{post: post} do
+      user = insert(:activated_user, fediverse_followers?: true, fediverse_quotes?: false)
+      {:ok, _actor} = Fediverse.ensure_actor(user)
+      post = create_post!(user, %{"body" => post.body})
+
+      assert :skip = Fediverse.record_quote_request(user, quote_request(user, post), requester())
+      assert stamps() == []
+    end
+
+    test "a request naming no quoting post at all is rejected", %{user: user, post: post} do
+      request = quote_request(user, post) |> Map.delete("instrument")
+
+      assert :ok = Fediverse.record_quote_request(user, request, requester())
+
+      assert stamps() == []
+      assert [reject] = delivered()
+      assert reject["type"] == "Reject"
+    end
+
+    test "a quoting post hosted here is rejected rather than authorized", %{
+      user: user,
+      post: post
+    } do
+      # A stranger must not be able to talk this installation into stamping one
+      # of its own posts as the quote: the stamp would then vouch for a pairing
+      # nobody here ever made.
+      local = Docs.note_url(user, post.id)
+      request = quote_request(user, post, %{"instrument" => %{"id" => local}})
+
+      assert :ok = Fediverse.record_quote_request(user, request, requester())
+
+      assert stamps() == []
+      assert [%{"type" => "Reject"}] = delivered()
+    end
+  end
+
+  describe "silence, because answering would disclose something" do
+    test "a post whose audience is narrowed grants nothing and says nothing", %{
+      user: user,
+      post: post
+    } do
+      {:ok, _} =
+        Posts.update_post(post, %{
+          "body" => post.body,
+          "denials" => [%{"wildcard" => "logged_out"}]
+        })
+
+      assert :skip = Fediverse.record_quote_request(user, quote_request(user, post), requester())
+      assert stamps() == []
+      assert delivered() == []
+    end
+
+    test "a frozen post grants nothing", %{user: user, post: post} do
+      frozen = %{post | frozen_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)}
+
+      Repo.update_all(from(p in Posts.Post, where: p.id == ^post.id),
+        set: [frozen_at: frozen.frozen_at]
+      )
+
+      assert :skip = Fediverse.record_quote_request(user, quote_request(user, post), requester())
+      assert stamps() == []
+      assert delivered() == []
+    end
+
+    test "a request naming somebody else's post grants nothing", %{user: user, post: post} do
+      stranger = insert(:activated_user, fediverse_followers?: true)
+
+      assert :skip =
+               Fediverse.record_quote_request(stranger, quote_request(user, post), requester())
+
+      assert stamps() == []
+      assert delivered() == []
+    end
+  end
+
+  describe "withdrawal" do
+    test "revoking a post drops its stamps and tells the quoting server", %{
+      user: user,
+      post: post
+    } do
+      :ok = Fediverse.record_quote_request(user, quote_request(user, post), requester())
+      assert [stamp] = stamps()
+      Repo.delete_all(Delivery)
+
+      assert :ok = Fediverse.revoke_quote_authorizations(post)
+
+      assert stamps() == []
+
+      assert Enum.any?(delivered(), fn activity ->
+               activity["type"] == "Delete" and
+                 activity["object"]["formerType"] == "QuoteAuthorization" and
+                 activity["object"]["id"] ==
+                   Docs.quote_authorization_url(user, post.id, stamp.id)
+             end)
+    end
+
+    test "deleting the post takes the permission with it", %{user: user, post: post} do
+      :ok = Fediverse.record_quote_request(user, quote_request(user, post), requester())
+      assert [_stamp] = stamps()
+
+      {:ok, _} = Posts.delete_post(post)
+
+      assert stamps() == []
+    end
+
+    test "the stamp is findable only under its own post", %{user: user, post: post} do
+      :ok = Fediverse.record_quote_request(user, quote_request(user, post), requester())
+      assert [stamp] = stamps()
+
+      other = create_post!(user, %{"body" => "Another post entirely."})
+
+      assert %QuoteAuthorization{} = Fediverse.get_quote_authorization(post.id, stamp.id)
+      assert is_nil(Fediverse.get_quote_authorization(other.id, stamp.id))
+    end
+  end
+end

--- a/test/vutuv_web/controllers/fediverse_quote_authorization_test.exs
+++ b/test/vutuv_web/controllers/fediverse_quote_authorization_test.exs
@@ -1,0 +1,125 @@
+defmodule VutuvWeb.FediverseQuoteAuthorizationTest do
+  @moduledoc """
+  The endpoint a third server fetches before it renders somebody's quote of a
+  vutuv post (FEP-044f, issue #1608).
+
+  This URL is the permission. It is read by servers that have never spoken to
+  us, it is read again on every render, and its **absence** is how an author
+  takes a quote back — so "what does it answer when the row is gone" is as much
+  the feature as "what does it answer when the row is there".
+  """
+  use VutuvWeb.ConnCase, async: true
+
+  import Vutuv.PostsHelpers
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.QuoteAuthorization
+  alias VutuvWeb.Fediverse.Docs
+
+  @actor "https://social.example/users/alice"
+  @quote_post "https://social.example/users/alice/statuses/1"
+
+  setup do
+    user = insert(:activated_user, fediverse_followers?: true)
+    {:ok, _actor} = Fediverse.ensure_actor(user)
+    post = create_post!(user, %{"body" => "Worth quoting."})
+
+    {:ok, stamp} =
+      %QuoteAuthorization{}
+      |> QuoteAuthorization.changeset(%{
+        post_id: post.id,
+        user_id: user.id,
+        interacting_object_uri: @quote_post,
+        actor_uri: @actor,
+        note_uri: Docs.note_url(user, post.id),
+        accepted_at: DateTime.utc_now(:second)
+      })
+      |> Repo.insert()
+
+    {:ok, user: user, post: post, stamp: stamp}
+  end
+
+  defp stamp_path(user, post, id),
+    do: "/#{user.username}/posts/#{post.id}/quote-authorizations/#{id}"
+
+  test "serves the stamp as ActivityPub", %{conn: conn, user: user, post: post, stamp: stamp} do
+    conn = get(conn, stamp_path(user, post, stamp.id))
+
+    assert response_content_type(conn, :json) =~ "application/activity+json"
+    doc = json_response(conn, 200)
+
+    assert doc["type"] == "QuoteAuthorization"
+    assert doc["id"] == Docs.quote_authorization_url(user, post.id, stamp.id)
+    assert doc["attributedTo"] == Docs.actor_url(user)
+    assert doc["interactionTarget"] == Docs.note_url(user, post.id)
+    assert doc["interactingObject"] == @quote_post
+  end
+
+  test "defines the terms the document uses", %{conn: conn, user: user, post: post, stamp: stamp} do
+    doc = conn |> get(stamp_path(user, post, stamp.id)) |> json_response(200)
+
+    assert Enum.any?(doc["@context"], fn entry ->
+             is_map(entry) and Map.has_key?(entry, "QuoteAuthorization")
+           end)
+  end
+
+  test "a withdrawn permission is gone", %{conn: conn, user: user, post: post, stamp: stamp} do
+    :ok = Fediverse.revoke_quote_authorizations(post)
+
+    assert conn |> get(stamp_path(user, post, stamp.id)) |> response(404)
+  end
+
+  test "one post's stamp cannot be served from another post's URL", %{
+    conn: conn,
+    user: user,
+    stamp: stamp
+  } do
+    other = create_post!(user, %{"body" => "Another post entirely."})
+
+    assert conn |> get(stamp_path(user, other, stamp.id)) |> response(404)
+  end
+
+  test "a malformed id is a miss, not a crash", %{conn: conn, user: user, post: post} do
+    assert conn |> get(stamp_path(user, post, "not-a-uuid")) |> response(404)
+  end
+
+  test "a member who does not federate serves no stamps at all", %{conn: conn, post: post} do
+    quiet = insert(:activated_user, fediverse_followers?: false)
+
+    assert conn |> get(stamp_path(quiet, post, Vutuv.UUIDv7.generate())) |> response(404)
+  end
+
+  describe "the switch on /settings/fediverse" do
+    setup %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      {:ok, _} =
+        Vutuv.Accounts.update_user(user, %{"fediverse_followers?" => true})
+
+      {:ok, conn: conn}
+    end
+
+    test "offers the quoting switch", %{conn: conn} do
+      body = conn |> get(~p"/settings/fediverse") |> html_response(200)
+
+      assert body =~ ~s(name="user[fediverse_quotes?]")
+    end
+
+    test "says so in German, in words rather than a fuzzy match", %{conn: conn} do
+      # `gettext.extract --merge` filled this label with the translation of an
+      # unrelated string ("Fediverse quotes" -> "Fediverse") before it was
+      # written by hand. Nothing fails the build on that, so the German has to
+      # be asserted by name — including the short label, which is the one most
+      # likely to be fuzzy-matched and least likely to be noticed.
+      body =
+        conn
+        |> recycle()
+        |> put_req_header("accept-language", "de-DE,de")
+        |> get(~p"/settings/fediverse")
+        |> html_response(200)
+
+      assert body =~ "Andere Netzwerke dürfen Ihre Beiträge zitieren"
+      assert body =~ "wie bei einem Repost"
+    end
+  end
+end


### PR DESCRIPTION
**Symptom** Ivory offers no quote button on a vutuv post. Closes #1608.

**Why** Mastodon reads `interactionPolicy.canQuote` and maps an absent policy to "nobody", so no button appears. Forced, the quote stays pending forever: nothing answered the `QuoteRequest` our inbox got.

**Change** Every Note now advertises that policy — the public collection when quoting is allowed, the author alone when not. A `QuoteRequest` gets an `Accept` plus a `QuoteAuthorization` at `/:slug/posts/:id/quote-authorizations/:auth_id`. Deleting that row withdraws consent; `revoke_post/1` does it on delete, freeze and a narrowed audience. New switch on `/settings/fediverse`.

**Scope** Phase 1 of four: the answering side. Others may quote us, vutuv still cannot quote. Stands alone, merges alone — the comment says how #1609–#1611 fit.

**Decide** the default: on, because a quote redistributes an already-public post the way a reshare does.

*An AI agent wrote this text in my name. I know that is problematic.*
