### PR TITLE
feat(fediverse): show a quote post from another network [20m ?]

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -501,10 +501,12 @@ config :vutuv, :fediverse_media_max_bytes, 8_000_000
 config :vutuv, :fediverse_media_fetch, true
 
 # Whether the background task that resolves what an incoming post QUOTES runs
-# (issue #1609). Off in tests, where it would touch the SQL sandbox from
-# outside; tests call Vutuv.Fediverse.resolve_quote/1 directly. Off also makes
-# every quote render as the plain link it was before this existed, which is the
-# right thing for an installation that must not make outbound requests at all.
+# (issue #1609), and with it the Vutuv.Fediverse.QuoteResolver that goes back
+# for the attempts a deploy or a crash cut short. Off in tests, where it would
+# touch the SQL sandbox from outside; tests call Vutuv.Fediverse.resolve_quote/1
+# and resume_quote_resolutions/1 directly. Off also makes every quote render as
+# the plain link it was before this existed, which is the right thing for an
+# installation that must not make outbound requests at all.
 config :vutuv, :fediverse_quote_resolve, true
 
 config :vutuv, :fediverse_remote_follow_limit, 30

--- a/config/config.exs
+++ b/config/config.exs
@@ -500,6 +500,13 @@ config :vutuv, :fediverse_media_max_bytes, 8_000_000
 # this switch is about the download, not about the display.
 config :vutuv, :fediverse_media_fetch, true
 
+# Whether the background task that resolves what an incoming post QUOTES runs
+# (issue #1609). Off in tests, where it would touch the SQL sandbox from
+# outside; tests call Vutuv.Fediverse.resolve_quote/1 directly. Off also makes
+# every quote render as the plain link it was before this existed, which is the
+# right thing for an installation that must not make outbound requests at all.
+config :vutuv, :fediverse_quote_resolve, true
+
 config :vutuv, :fediverse_remote_follow_limit, 30
 config :vutuv, :fediverse_max_remote_follows, 1_000
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -75,6 +75,7 @@ config :vutuv, :fediverse_counts, false
 # which would sit outside the SQL sandbox; tests call
 # Vutuv.Fediverse.Media.fetch_now/1 directly with a stubbed HTTP layer.
 config :vutuv, :fediverse_media_fetch, false
+config :vutuv, :fediverse_quote_resolve, false
 # Post link-screenshots drain via a polling GenServer that would touch the
 # sandbox from outside; tests call Vutuv.Posts.Screenshots.deliver_due/1 directly
 # with a stubbed capture. ScreenshotWorker.nudge/0 casts into the void then.

--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -209,7 +209,12 @@ for single-link posts, including cached
 fediverse posts in the feed — admins watch the
 capture queue and browse the gallery at `/admin/screenshots`; a YouTube video
 link stores the video's published thumbnail instead of a capture, fetched
-server-side from YouTube under this same flag), and
+server-side from YouTube under this same flag),
+`:fediverse_quote_resolve` (resolving what an incoming fediverse post
+**quotes** — see [fediverse.md](architecture/fediverse.md); on, it fetches the
+quoted post and its consent stamp so the quote renders as a card, off it stays
+the plain link it arrived as, and either way nothing happens while
+`FEDIVERSE_ENABLED` is false), and
 `:serve_uploads_locally` (see nginx below).
 
 ## systemd

--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -214,7 +214,8 @@ server-side from YouTube under this same flag),
 **quotes** — see [fediverse.md](architecture/fediverse.md); on, it fetches the
 quoted post and its consent stamp so the quote renders as a card, off it stays
 the plain link it arrived as, and either way nothing happens while
-`FEDIVERSE_ENABLED` is false), and
+`FEDIVERSE_ENABLED` is false; the flag also runs the two-minute sweeper that
+picks up the resolutions a deploy or a crash interrupted), and
 `:serve_uploads_locally` (see nginx below).
 
 ## systemd

--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -2366,13 +2366,33 @@ unapproved and sends an `Update` the moment the stamp is granted; the same
 `Update` is how a **withdrawn** stamp reaches us. So `update_remote_post/2`
 re-resolves whenever either URI moved, and an edit that takes the quote back
 clears the card immediately, with no request at all — a withdrawal is the one
-thing that must not wait for a queue.
+thing that must not wait for a queue. An edit that moves the quote somewhere
+else puts the row back to unresolved *before* the new resolution starts
+(`requeue_quote/1`), so the window in between shows a link rather than a card
+still naming the post that was quoted a minute ago.
+
+**An interrupted resolution is started again.** The resolution is fire and
+forget on `Vutuv.TaskSupervisor`, so a blue/green deploy stops it mid-fetch and
+nothing is logged, because nothing failed as far as the inbox is concerned. The
+unfinished work is therefore a row: every resolution that *does* run to its end
+stamps `quote_checked_at` — refusals included, since that column is the
+scheduler's clock and not a claim that a card came of it — so a post that quotes
+something, resolved to nothing and carries no stamp is one whose task died.
+`Vutuv.Fediverse.QuoteResolver` sweeps for exactly that every two minutes
+(`due_quote_resolutions/1`, a partial index that matches nothing in a healthy
+minute) and gives each row **one** more attempt. One, not a ladder: the retry
+stamps the clock whatever it decides, so a quote of a post that is gone leaves
+the queue by being tried, and cannot hold the front of every batch the way
+#1316's starved objects did. A consent stamp granted later needs none of this —
+it arrives as an `Update`.
 
 Deliberately **not** here: issuing our own stamps so a vutuv post can be quoted
 from outside (#1608), a quote button of our own (#1610, #1611), and a sweeper
-that re-checks a stamp still resolves. The last one is a real gap — a revoked
-stamp reaches us as an `Update` in practice, and a server that revokes silently
-keeps its card until the post expires.
+that re-checks a stamp *that already verified* (#1796). The last one is a real
+gap — a revoked stamp reaches us as an `Update` in practice, and a server that
+revokes silently keeps its card until the post expires. It reuses the clock
+above: `quote_checked_at` is where a recheck records that it looked, and its due
+query is the same query widened to the rows that did resolve.
 
 ## Saying this installation exists: NodeInfo (issue #1448)
 

--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -2273,6 +2273,107 @@ Deliberately **not** built: backfilling an account's outbox history. The lookup
 is one post the member named; walking somebody's archive because a member
 followed them is a different bargain.
 
+### What a post quotes (issue #1609)
+
+Mastodon 4.5 (October 2025) writes quote posts, and a growing share of what
+reaches the feed is one. Until this existed we ignored the property entirely, so
+a reader saw the commentary and a bare link — or, when the author wrote no link
+beside the quote, the commentary and nothing at all.
+
+**Three property names, one thing.** `quote` is FEP-044f's canonical spelling,
+`quoteUri` is Fedibird's and `_misskey_quote` is Misskey's, and a server
+commonly writes all three. Read tolerantly in that order, each either an
+embedded object or a bare id. Beside it rides `quoteAuthorization`: the URL of a
+`QuoteAuthorization` document — the "stamp" — that the **quoted** author's
+server issued for this exact quote.
+
+**The delivery only writes down what it was told.** `record_remote_post/2`
+stores `quote_uri` and `quote_authorization_uri` and resolves nothing: the
+resolution makes up to three requests to two other servers, and the inbox owes
+its 202 long before those answer. `Vutuv.Fediverse.resolve_quote/1` runs in a
+background task off `finish_stored_post/3` (the chokepoint every path that mints
+a cached post goes through), gated by `FEDIVERSE_QUOTE_RESOLVE` so an air-gapped
+installation simply keeps the link.
+
+**A card needs consent; everything else is a link.** Two ways to establish it:
+
+* a **self-quote** — the quoted post is by the same account. Nobody's consent is
+  needed and no request is made. It is also the commonest quote there is.
+* a **stamp that checks out**. It must live on the quoted object's own host (a
+  stamp served by the quoting server is that server marking its own homework, so
+  the host is checked *before* the request), and the document must name both
+  sides: `type` `QuoteAuthorization`, `interactionTarget` the quoted object,
+  `interactingObject` the quoting post, `attributedTo` the quoted object's
+  author. A genuine authorization for some *other* quote authorizes nothing
+  here, which is why both sides are in it.
+
+Anything else keeps the URI and renders as a plain link. That is not a failure
+mode to be minimised — it is what a quote without demonstrable consent is
+allowed to look like, and it is strictly better than the nothing a reader had
+before. A quote of one of **our** posts is in that bucket today for a reason
+worth stating: the stamp would have to be ours, and this installation issues
+none until #1608. We store the local post's id anyway, because it turns the
+fallback into a working vutuv permalink instead of a foreign spelling of one of
+our own URLs.
+
+**Resolving what was quoted.** Ours first (matched on host plus path, resolved
+by the **id** in the path and never by the handle beside it — `local_post_id/1`,
+which the URL lookup reads too) — without that branch this would sign a request
+to *this installation* for a URL that is plainly ours, the failure v7.197.0
+already produced once through the `www.` alias. Then a copy we already hold.
+Only then a fetch, through `fetch_and_store_object/3` — literally the announce
+path's fence, shared rather than copied, because it is a security boundary and a
+boost and a quote must not be able to drift apart on what they check: signed,
+SSRF-checked, size-capped, metered per host
+(`FEDIVERSE_ANNOUNCE_FETCH_LIMIT`), `own_object?/3` so a server may speak only
+for itself, public and unlisted only. The key is `counts_signer/1`'s, resolved
+once for both requests; a copy nobody follows and nobody boosted has no signer,
+and its quote stays a link.
+
+**Where the card's data comes from.** `RemotePost.quoted/1` is the single answer
+to "what does this quote" — `{:remote, post}`, `{:local, post}`, `{:uri, uri}`
+or nil, dispatched on the id **columns** so a caller that forgot the preload
+gets the honest `{:uri, _}` rather than a clause that silently does not match.
+The card, the link fallback and the agent-format doc builders all read it.
+`RemotePost.quote_preload/0` says what to load; the feed batches it once per
+**page** in `Vutuv.Posts.decorate_remote/2`, after the sources are merged and
+trimmed, and `Fediverse.with_quotes/1` is what a non-feed surface calls.
+
+**One level, and only one.** The quoted copy is stored with
+`finish_stored_post(_, _, false)`, so its own quote stays unresolved and its
+card shows no nested card. A chain of quotes is a chain of strangers' servers,
+and no reader asked to descend it.
+
+**Every format, not only the card.** The profile, the post archive and
+`/tags/:slug` render this card and all three have `.md`/`.txt`/`.json`/`.xml`
+siblings, so `PostDoc.quoted_entry/1` puts the quote in each of them as
+`%{url:, author:, network:}`. Consent decides how a **person** is shown a quote,
+not whether a machine is told about one — a link-only quote is the same fact to
+an agent as a card. Without it an entry whose whole content is a reaction
+("genau das") reads as a post with nothing in it, which is the gap `pictures:`
+was added to close.
+
+**Retention.** `fediverse_posts.quoted_post_id` is the holder: the quoted author
+is usually somebody nobody here follows, so without it
+`purge_unfollowed_remote_posts/0` would sweep the copy within the hour and turn
+a card in somebody's feed into a bare link while they were looking at it. It is
+the fourth exemption in `spare_held/1` beside a reshare (#1166), a boost (#1167)
+and a lookup (#1211), under the same rule — the right to live out the ordinary
+clock, never extra time.
+
+**An edit is where the quote usually arrives.** Mastodon publishes a quote
+unapproved and sends an `Update` the moment the stamp is granted; the same
+`Update` is how a **withdrawn** stamp reaches us. So `update_remote_post/2`
+re-resolves whenever either URI moved, and an edit that takes the quote back
+clears the card immediately, with no request at all — a withdrawal is the one
+thing that must not wait for a queue.
+
+Deliberately **not** here: issuing our own stamps so a vutuv post can be quoted
+from outside (#1608), a quote button of our own (#1610, #1611), and a sweeper
+that re-checks a stamp still resolves. The last one is a real gap — a revoked
+stamp reaches us as an `Update` in practice, and a server that revokes silently
+keeps its card until the post expires.
+
 ## Saying this installation exists: NodeInfo (issue #1448)
 
 Everything above is federation between servers that already know about each

--- a/lib/vutuv/application.ex
+++ b/lib/vutuv/application.ex
@@ -135,6 +135,7 @@ defmodule Vutuv.Application do
         optional_child(:fediverse_note_sweeping, Vutuv.Fediverse.NoteSweeper) ++
         optional_child(:fediverse_counts, Vutuv.Fediverse.CountsRefresher) ++
         optional_child(:fediverse_media_fetch, Vutuv.Fediverse.MediaRefetcher) ++
+        optional_child(:fediverse_quote_resolve, Vutuv.Fediverse.QuoteResolver) ++
         optional_child(:post_screenshot_worker, Vutuv.Posts.ScreenshotWorker) ++
         optional_child(:organization_screenshot_worker, Vutuv.Organizations.ScreenshotWorker) ++
         optional_child(:image_scan_worker, Vutuv.Moderation.ImageScanWorker) ++

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -2204,6 +2204,26 @@ defmodule Vutuv.Fediverse do
 
   def local_path(_), do: nil
 
+  @doc """
+  The **id** of one of our own posts named by `url`, or nil — for both shapes
+  `VutuvWeb.Fediverse.Docs.note_url/2` mints: a member's under their handle, a
+  page's under its slug.
+
+  Deliberately id-only. The handle beside it goes stale the moment its owner
+  renames, so a reader following a year-old link still lands on the post, and
+  every caller here wants the record rather than the spelling. `local_note_post/1`
+  is the one place that does pin the handle to the id, because it decides
+  whether a member's post may be **redistributed** on a remote actor's say-so
+  rather than where to send a reader who is already here.
+  """
+  def local_post_id(url) do
+    case local_path(url) do
+      ["organizations", _slug, "posts", post_id] -> post_id
+      [_handle, "posts", post_id] -> post_id
+      _ -> nil
+    end
+  end
+
   # `www.` is not another installation. Serving a site at both the apex and its
   # `www.` alias is the oldest convention on the web, and every caller here asks
   # "is this us", never "is this byte-identical to the configured host" — so an
@@ -2627,7 +2647,7 @@ defmodule Vutuv.Fediverse do
          :ok <- check_inbound_cap(actor_uri),
          true <- own_thread?(object, account),
          {:ok, post} <- insert_remote_post(account, object, audience) do
-      attach_pictures(post, object)
+      finish_stored_post(post, object)
       # Only the row this delivery really wrote: the same post arrives once per
       # local follower until every server speaks to our shared inbox, and each
       # redelivery leaves the `with` as a `:skip` above, so open feeds are
@@ -2641,25 +2661,37 @@ defmodule Vutuv.Fediverse do
 
   def record_remote_post(_activity, _actor_uri), do: :skip
 
-  # The post's pictures (issue #1163): recorded here, downloaded afterwards.
-  # The inbox must answer 202 without waiting on a third party's image server,
-  # and nothing renders before the AI gate has seen the bytes anyway, so the
-  # delivery only writes down what it wants.
+  # Everything a freshly minted cached post still needs, in one place: its
+  # pictures, its link screenshot, and what it quotes. Here rather than beside
+  # the callers, so every path that mints one — a follower delivery, a boost, a
+  # URL lookup, a quote — gets all three by construction.
   #
-  # `sensitive` is the author's own call and covers every picture under the
-  # post: their explicit flag, or a content warning, which is the same request
-  # in different words.
-  defp attach_pictures(%RemotePost{} = post, object) do
+  # The post's pictures (issue #1163) are recorded here and downloaded
+  # afterwards. The inbox must answer 202 without waiting on a third party's
+  # image server, and nothing renders before the AI gate has seen the bytes
+  # anyway, so the delivery only writes down what it wants. `sensitive` is the
+  # author's own call and covers every picture under the post: their explicit
+  # flag, or a content warning, which is the same request in different words.
+  #
+  # With the picture set on record the post's link screenshot can be decided: a
+  # single-URL, picture-less, unwarned post enqueues the same durable capture
+  # job a member post gets (`Vutuv.Posts.Screenshots`).
+  #
+  # `quotes?` is how the recursion stops. Resolving a quote stores the quoted
+  # post through this very function, and that copy may quote something in turn
+  # — so the quoted one is stored with `false` and its own quote is left
+  # unresolved. That is the same "only one level" rule the card draws by: a
+  # quote of a quote shows the inner one as a link.
+  defp finish_stored_post(%RemotePost{} = post, object, quotes? \\ true) do
     post
     |> Media.record_attachments(List.wrap(object["attachment"]), RemotePost.warned?(post))
     |> Media.fetch_async()
 
-    # With the picture set on record the post's link screenshot can be decided:
-    # a single-URL, picture-less, unwarned post enqueues the same durable
-    # capture job a member post gets (`Vutuv.Posts.Screenshots`). Here rather
-    # than beside the callers, so every path that mints a cached post — a
-    # follower delivery, a boost, a URL lookup — gets it by construction.
     Screenshots.reconcile(post)
+
+    if quotes?, do: resolve_quote_async(post)
+
+    post
   end
 
   @doc """
@@ -3490,6 +3522,17 @@ defmodule Vutuv.Fediverse do
     |> Map.new(&{{&1.object_uri, &1.remote_account_id}, &1})
   end
 
+  @doc """
+  Loads what `subject` quotes (issue #1609) — a cached post, a list of them, or
+  nil — for a surface that is about to render cards.
+
+  Beside the lean readers rather than inside them: `get_remote_post/1` and
+  `account_posts/2` also serve the client API, a composer and a delete path,
+  none of which draws a card and all of which would pay for the read.
+  """
+  def with_quotes(nil), do: nil
+  def with_quotes(subject), do: Repo.preload(subject, RemotePost.quote_preload())
+
   @doc "One cached remote post with its account and screenshot, or nil."
   def get_remote_post(id) do
     UUIDv7.with_cast(id, &Repo.get(RemotePost, &1))
@@ -3703,19 +3746,25 @@ defmodule Vutuv.Fediverse do
   #     on any account: a copy fetched precisely because nobody follows its
   #     author would otherwise be swept within the hour, while the member who
   #     asked for it is still reading it.
+  #   * another cached post **quotes** it (issue #1609) — again the normal case
+  #     for a quote, since the quoted author is usually a stranger here, and
+  #     sweeping the copy would turn a card in somebody's feed back into a bare
+  #     link while they are looking at it.
   #
-  # None of the three buys extra time: they only buy the right to live out the
+  # None of the four buys extra time: they only buy the right to live out the
   # ordinary clock instead of being swept the moment the last follower of the
   # author walks away. The `:post` alias comes from `spare_reposted/2`, which is
-  # why the other two are added on top of it rather than beside it.
+  # why the others are added on top of it rather than beside it.
   defp spare_held(query) do
     boosted = from(b in PostBoost, where: b.remote_post_id == parent_as(:post).id)
     looked_up = from(l in PostLookup, where: l.remote_post_id == parent_as(:post).id)
+    quoted = from(q in RemotePost, where: q.quoted_post_id == parent_as(:post).id)
 
     query
     |> spare_reposted(RemotePost)
     |> where([p], not exists(boosted))
     |> where([p], not exists(looked_up))
+    |> where([p], not exists(quoted))
   end
 
   @doc """
@@ -4005,9 +4054,36 @@ defmodule Vutuv.Fediverse do
       summary: remote_text(object["summary"], RemotePost.max_summary()),
       language: as2_language(object),
       sensitive: object["sensitive"] == true,
-      audience: audience
+      audience: audience,
+      quote_uri: quoted_object_uri(object),
+      quote_authorization_uri:
+        object["quoteAuthorization"] |> SearchText.normalize_search() |> within_uri_cap()
     }
   end
+
+  # What the post says it quotes (issue #1609). Three property names for one
+  # thing: `quote` is FEP-044f's canonical spelling, `quoteUri` is Fedibird's
+  # and `_misskey_quote` is Misskey's, and a server commonly writes all three.
+  # Read tolerantly, in that order — each may be an embedded object or a bare
+  # id, which `activity_object_id/1` already flattens.
+  defp quoted_object_uri(object) do
+    ~w(quote quoteUri _misskey_quote)
+    |> Enum.find_value(&activity_object_id(object[&1]))
+    |> SearchText.normalize_search()
+    |> within_uri_cap()
+  end
+
+  # Anything past the column's changeset cap is dropped **here**, so the post is
+  # stored without its quote. Left to `RemotePost.changeset/2` it would fail the
+  # whole insert instead (`insert_remote_post/3` turns any changeset error into
+  # `:error`), and one 3 KB `quoteUri` would take an otherwise perfectly good
+  # post — and every later post from that server — out of its followers' feeds
+  # with nothing in the log to say why. The validation stays as the backstop.
+  defp within_uri_cap(uri) when is_binary(uri) do
+    if byte_size(uri) <= RemotePost.max_uri_bytes(), do: uri
+  end
+
+  defp within_uri_cap(_uri), do: nil
 
   @doc """
   The language an AS2 object declares (issue #1488): the first key of
@@ -4141,25 +4217,292 @@ defmodule Vutuv.Fediverse do
       # "stop showing this" signal a `Delete` carries, just spelled differently.
       delete_cached_post(post)
     else
-      with {:ok, updated} <-
-             post
-             |> RemotePost.changeset(remote_post_attrs(object, text, audience))
-             |> Repo.update() do
-        # An edit is also where a hashtag is added or taken out, so the filings
-        # are re-synced rather than left at what the original text said — a post
-        # that drops `#berlin` drops off that tag page.
-        Hashtags.sync(updated, object)
+      post
+      |> RemotePost.changeset(remote_post_attrs(object, text, audience))
+      |> Repo.update()
+      |> apply_remote_post_edit(post, object)
+    end
+  end
 
-        # An edit is where a picture is added, dropped, described or covered —
-        # see `Media.sync_attachments/3`.
-        updated
-        |> Media.sync_attachments(List.wrap(object["attachment"]), RemotePost.warned?(updated))
-        |> Media.fetch_async()
+  # Everything an edit can have changed besides the row's own columns.
+  defp apply_remote_post_edit({:ok, %RemotePost{} = updated}, %RemotePost{} = before, object) do
+    # An edit is where a hashtag is added or taken out, so the filings are
+    # re-synced rather than left at what the original text said — a post that
+    # drops `#berlin` drops off that tag page.
+    Hashtags.sync(updated, object)
 
-        # …and where the single URL, the picture set or the content warning can
-        # change, each of which enqueues, refreshes or cancels the screenshot.
-        Screenshots.reconcile(updated)
-      end
+    # …where a picture is added, dropped, described or covered — see
+    # `Media.sync_attachments/3`.
+    updated
+    |> Media.sync_attachments(List.wrap(object["attachment"]), RemotePost.warned?(updated))
+    |> Media.fetch_async()
+
+    # …where the single URL, the picture set or the content warning can change,
+    # each of which enqueues, refreshes or cancels the screenshot.
+    Screenshots.reconcile(updated)
+
+    # …and where a **quote** arrives and where it is taken back (issue #1609).
+    # Mastodon publishes a quote unapproved and sends an `Update` the moment the
+    # stamp is granted, and the same `Update` is how a withdrawn stamp reaches
+    # us — so a quote is far likelier to change here than to arrive complete
+    # with the `Create`.
+    if quote_moved?(before, updated), do: resolve_quote_async(updated)
+
+    :ok
+  end
+
+  defp apply_remote_post_edit(_error, _before, _object), do: :ok
+
+  ## What a post from another network quotes (issue #1609)
+
+  # Nothing resolved, nothing consented — the state a row starts in and the one
+  # every refusal writes back, so a quote that stops verifying stops carrying a
+  # card in the same breath.
+  @no_quote %{quoted_post_id: nil, quoted_local_post_id: nil, quote_verified: false}
+
+  defp resolve_quotes?, do: Application.get_env(:vutuv, :fediverse_quote_resolve, true)
+
+  @doc """
+  Resolves what a cached post quotes and decides whether it may be drawn as a
+  **card** rather than as a plain link.
+
+  Two questions, in this order. *What* is quoted: one of our own posts (matched
+  on host plus path and resolved by the **id** in it, never by the handle beside
+  it), a copy we already hold, or a post on some other server, fetched through
+  exactly the announce path's fence — signed, SSRF-checked, size-capped, metered
+  per host, public or unlisted only, and `own_object?/3` so a server may speak
+  only for itself. And *whether the quoted author agreed*: a self-quote needs
+  nobody's consent, and anything else needs a FEP-044f `QuoteAuthorization` that
+  lives on the quoted object's own host and names this exact pair.
+
+  Everything else keeps the URI and renders as a link. That is not a failure
+  mode to be minimised — it is what a quote without demonstrable consent is
+  allowed to look like, and it is strictly better than the nothing a reader got
+  before this existed.
+
+  Runs in a background task off the inbox (`resolve_quote_async/1`): it makes up
+  to three requests to two other servers, and the inbox owes its 202 long before
+  those answer. Called directly by tests and by the `Update` path.
+
+  Returns `:ok` when the row was written, `:skip` when there was nothing to do.
+  """
+  def resolve_quote(%RemotePost{} = post) do
+    if RemotePost.quoting?(post) do
+      write_quote(post, quote_resolution(post))
+      :ok
+    else
+      clear_quote(post)
+    end
+  end
+
+  # The kick-off. The clearing half is deliberately **not** deferred: it is one
+  # write and no network at all, and leaving a stale card standing until a task
+  # gets around to it is exactly the wrong way round for a withdrawal.
+  defp resolve_quote_async(%RemotePost{} = post) do
+    cond do
+      # `resolve_quote/1`'s own no-quote branch, run here rather than deferred:
+      # it is one write and no network at all.
+      not RemotePost.quoting?(post) ->
+        resolve_quote(post)
+
+      resolve_quotes?() ->
+        Task.Supervisor.start_child(Vutuv.TaskSupervisor, fn -> resolve_quote(post) end)
+
+      true ->
+        :ok
+    end
+
+    :ok
+  end
+
+  # Whether an edit touched the quote at all. Both URIs, because the second one
+  # moving on its own is the *normal* case: the text is unchanged and the stamp
+  # has just been granted or revoked.
+  defp quote_moved?(%RemotePost{} = before, %RemotePost{} = now) do
+    before.quote_uri != now.quote_uri or
+      before.quote_authorization_uri != now.quote_authorization_uri
+  end
+
+  defp quote_resolution(%RemotePost{} = post) do
+    if instance_blocked?(post.quote_uri) do
+      @no_quote
+    else
+      # Passed as a **thunk**, not a value: `counts_signer/1` is a three-table
+      # join plus an actor read, and four of the five outcomes never make a
+      # request at all — a quote of one of our posts, a copy we already hold
+      # whose author is the quoting account, one with no stamp beside it, and a
+      # URL on our own host. Only the two branches that really go to the wire
+      # pay for it. Resolving it twice on the one path that fetches both an
+      # object and a stamp is the cheaper trade.
+      signer = fn -> counts_signer(post) end
+      quote_target_resolution(post, resolve_quoted_object(post, signer), signer)
+    end
+  end
+
+  defp quote_target_resolution(_post, {:local, %Post{id: id}}, _signer) do
+    # A vutuv post, quoted from out there. The consent stamp would have to be
+    # **ours**, and this installation issues none yet (issue #1608) — so the id
+    # is stored, because it turns the fallback into a working vutuv permalink
+    # rather than a foreign spelling of one of our own URLs, and the card waits
+    # for the day we can honestly say we agreed.
+    %{@no_quote | quoted_local_post_id: id}
+  end
+
+  # A post naming **itself** as what it quotes. Nothing to render, and left
+  # unguarded it is a storage pin: `spare_held/1` asks "does any post quote this
+  # one", the row answers with itself, and it survives every unfollow purge
+  # until its ceiling. Matched on the resolved row rather than on the URI,
+  # because `cached_lookup_post/1` also matches the display spelling.
+  defp quote_target_resolution(%RemotePost{id: id}, {:remote, %RemotePost{id: id}}, _signer),
+    do: @no_quote
+
+  defp quote_target_resolution(%RemotePost{} = post, {:remote, %RemotePost{} = quoted}, signer) do
+    %{
+      @no_quote
+      | quoted_post_id: quoted.id,
+        quote_verified: quote_consented?(post, quoted, signer)
+    }
+  end
+
+  defp quote_target_resolution(_post, _unresolved, _signer), do: @no_quote
+
+  # Ours, held already, or somebody else's and worth one fetch. The local branch
+  # is not an optimisation: without it this would sign a request to **this
+  # installation** for a URL that is plainly ours, which is the failure
+  # v7.197.0 already produced once through the `www.` alias — so a URL on one of
+  # our hosts that names no post of ours ends here rather than on the wire.
+  defp resolve_quoted_object(%RemotePost{quote_uri: uri}, signer) do
+    case local_quoted_post(uri) do
+      %Post{} = local -> {:local, local}
+      nil -> if own_host?(uri), do: :error, else: quoted_remote_post(uri, signer)
+    end
+  end
+
+  # The URL lookup's own resolver, plus the one gate a quote adds: anonymous
+  # visibility. The link is offered to a reader whose relationship to the author
+  # we know nothing about, and the permalink itself re-asks the question when
+  # they follow it.
+  defp local_quoted_post(uri) do
+    with %Post{} = post <- local_lookup_post(uri),
+         true <- Posts.visible_to?(post, nil) do
+      post
+    else
+      _ -> nil
+    end
+  end
+
+  # With the author attached, because `Posts.visible_to?/2` and `Posts.path/1`
+  # both dispatch on it — one query rather than a `Repo.get` and a preload.
+  defp load_local_post(id) do
+    Repo.one(from(p in Post, where: p.id == ^id, preload: [:user, :organization]))
+  end
+
+  # A copy we already hold under **either** of the two URLs one post is written
+  # as — the canonical object id servers exchange, and the display URL people
+  # copy out of their browser, which is what `quoteUri` and `_misskey_quote`
+  # routinely carry. Matching only the first sent a post that was already on
+  # disk to the wire, where it spent a host fetch slot and a signed GET before
+  # colliding on the unique index and handing back that same row.
+  #
+  # `false` is the one-level rule: the quoted copy's own quote stays unresolved,
+  # so a quote of a quote shows the inner one as a link.
+  defp quoted_remote_post(uri, signer) do
+    case cached_lookup_post(uri) do
+      # **Audience-gated, exactly like the fetch below.** A cached copy can be
+      # followers-only: `record_remote_post/2` stores that audience for the
+      # members who follow its author. Rendering it inside somebody else's quote
+      # card would hand it to everybody who can see the *quoting* post — on the
+      # anonymous tag timeline, the whole internet. `announced_audience/1` and
+      # `lookup_audience/1` guard the two fetch paths for the same reason; this
+      # is the third way in and needs the same gate.
+      %RemotePost{} = quoted ->
+        if RemotePost.open?(quoted), do: {:remote, quoted}, else: :error
+
+      nil ->
+        with key when not is_nil(key) <- signer.(),
+             {:ok, quoted} <- fetch_and_store_object(uri, key, false) do
+          {:remote, quoted}
+        else
+          # No key means no signature, and an authorized-fetch server answers an
+          # unsigned GET with a 403 — so asking would spend a slot of the host's
+          # fetch budget on a request that could not have worked.
+          _unreachable -> :error
+        end
+    end
+  end
+
+  # Did the quoted author agree to this? Two ways to be able to say yes.
+  defp quote_consented?(%RemotePost{} = post, %RemotePost{} = quoted, signer),
+    do: self_quote?(post, quoted) or stamp_valid?(post, quoted, signer)
+
+  # Quoting yourself needs nobody's consent, which is also the one case that
+  # costs no request at all — and it is the commonest quote there is.
+  defp self_quote?(%RemotePost{remote_account_id: id}, %RemotePost{remote_account_id: id})
+       when is_binary(id),
+       do: true
+
+  defp self_quote?(%RemotePost{}, %RemotePost{}), do: false
+
+  # The FEP-044f stamp. Fetched from the **quoted object's own host** and from
+  # nowhere else: a document the quoting server serves about somebody else's
+  # consent is the quoting server marking its own homework, so the host check
+  # comes before the request rather than after it.
+  defp stamp_valid?(
+         %RemotePost{quote_authorization_uri: stamp} = post,
+         %RemotePost{} = quoted,
+         signer
+       )
+       when is_binary(stamp) do
+    # Everything free comes first, so the signer is only resolved for a stamp
+    # that is worth asking about at all.
+    with false <- own_host?(stamp),
+         true <- same_host?(quoted.object_uri, stamp),
+         false <- instance_blocked?(stamp),
+         key when not is_nil(key) <- signer.(),
+         # The generic signed AP GET, pointed at a stamp instead of a note.
+         {:ok, doc} <- fetch_remote_note(stamp, key) do
+      stamp_matches?(doc, stamp, post, quoted)
+    else
+      _ -> false
+    end
+  end
+
+  defp stamp_valid?(%RemotePost{}, %RemotePost{}, _signer), do: false
+
+  # What the stamp has to say, in full. Anything less and it is not a proof of
+  # anything: a genuine authorization for some *other* quote would otherwise
+  # authorize this one, which is the whole reason both sides are named in it.
+  defp stamp_matches?(doc, stamp, %RemotePost{} = post, %RemotePost{} = quoted) do
+    author = actor_uri_of(quoted)
+
+    as2_type?(doc, "QuoteAuthorization") and
+      activity_object_id(doc["interactionTarget"]) == quoted.object_uri and
+      activity_object_id(doc["interactingObject"]) == post.object_uri and
+      is_binary(author) and activity_object_id(doc["attributedTo"]) == author and
+      same_host?(quoted.object_uri, SearchText.normalize_search(doc["id"]) || stamp)
+  end
+
+  # An AS2 `type` is one string or a list of them (a JSON-LD document may carry
+  # both the compacted term and something else beside it).
+  defp as2_type?(doc, type), do: type in normalize_uri_list(doc["type"])
+
+  # Written with `update_all` rather than a changeset: the fetches above take as
+  # long as two strangers' servers take, and the post can be gone by the time
+  # they answer — expiry, an upstream `Delete`, a member's report. A statement
+  # that matches no row is a no-op; a changeset would raise `StaleEntryError`.
+  defp write_quote(%RemotePost{id: id}, attrs) do
+    Repo.update_all(from(p in RemotePost, where: p.id == ^id), set: Map.to_list(attrs))
+    :ok
+  end
+
+  defp clear_quote(%RemotePost{} = post) do
+    # Read off `@no_quote` rather than repeated as a literal pattern, so a fifth
+    # quote column cannot be forgotten here.
+    if Map.take(post, Map.keys(@no_quote)) == @no_quote do
+      :skip
+    else
+      write_quote(post, @no_quote)
+      :ok
     end
   end
 
@@ -7316,6 +7659,7 @@ defmodule Vutuv.Fediverse do
     |> limit(^(limit + 1))
     |> offset(^offset)
     |> Repo.all()
+    |> Repo.preload(remote_post: RemotePost.quote_preload())
     |> Enum.map(&saved_entry/1)
   end
 
@@ -8194,12 +8538,29 @@ defmodule Vutuv.Fediverse do
   end
 
   defp fetch_and_store_announced(%RemoteAccount{} = booster, uri) do
+    with %User{} = follower <- any_follower_of(booster, ["accepted"]),
+         key when not is_nil(key) <- signer(follower) do
+      fetch_and_store_object(uri, key, true)
+    else
+      _ -> :skip
+    end
+  end
+
+  # The fence every object fetched on a **third party's** say-so passes: a post
+  # nobody here follows, on a server we may never have spoken to, reached
+  # because somebody pointed at it. One definition, because it is a security
+  # boundary and not a convenience — a boost (issue #1167) and a quote (issue
+  # #1609) reach it by different routes and must not be able to drift apart on
+  # what they check. Two things differ per caller and nothing else: whose key
+  # signs the request, and whether the copy resolves its own quote.
+  #
+  # The object-type gate is the `Create` path's: a `Video`, an `Article` or an
+  # `Event` with a `content` field is not a post. `own_object?/3` is what stops
+  # a server speaking for anybody but itself, and the audience gate keeps a
+  # followers-only post out entirely.
+  defp fetch_and_store_object(uri, key, quotes?) do
     with :ok <- claim_announce_fetch(uri),
-         %User{} = follower <- any_follower_of(booster, ["accepted"]),
-         key when not is_nil(key) <- signer(follower),
          {:ok, doc} <- fetch_remote_note(uri, key),
-         # The same object-type gate the `Create` path applies: a `Video`, an
-         # `Article` or an `Event` with a `content` field is not a post.
          %{} = doc <- remote_post_object(doc),
          author_uri when is_binary(author_uri) <- announced_author(doc),
          true <- own_object?(uri, doc, author_uri),
@@ -8207,8 +8568,7 @@ defmodule Vutuv.Fediverse do
          audience when is_binary(audience) <- announced_audience(doc),
          %RemoteAccount{} = author <- announced_author_account(author_uri, key),
          {:ok, post} <- insert_remote_post(author, doc, audience) do
-      attach_pictures(post, doc)
-      {:ok, post}
+      {:ok, finish_stored_post(post, doc, quotes?)}
     else
       # Another delivery stored it while this one was fetching; the row is what
       # we wanted either way, and its pictures are that delivery's business.
@@ -8528,10 +8888,10 @@ defmodule Vutuv.Fediverse do
   # say-so, where this only decides where to send a reader who is already here.
   # What they may see when they arrive is the permalink's own business.
   defp local_lookup_post(url) do
-    with [_username, "posts", post_id] <- local_path(url),
-         %Post{} = post <- UUIDv7.with_cast(post_id, &Repo.get(Post, &1)) do
-      # With its author attached: the caller's next move is `Posts.path/1`.
-      Repo.preload(post, :user)
+    with post_id when is_binary(post_id) <- local_post_id(url),
+         # With its author attached: the caller's next move is `Posts.path/1`.
+         %Post{} = post <- UUIDv7.with_cast(post_id, &load_local_post/1) do
+      post
     else
       _ -> nil
     end
@@ -8542,7 +8902,7 @@ defmodule Vutuv.Fediverse do
          :ok <- check_lookup_url(url),
          {:ok, post} <- fetch_looked_up_post(user, url) do
       hold_looked_up_post(user, post)
-      {:ok, Repo.preload(post, :remote_account)}
+      {:ok, post |> Repo.preload(:remote_account) |> with_quotes()}
     end
   end
 
@@ -8674,7 +9034,7 @@ defmodule Vutuv.Fediverse do
   defp store_looked_up_post(%RemoteAccount{} = author, doc, audience) do
     case insert_remote_post(author, doc, audience) do
       {:ok, post} ->
-        attach_pictures(post, doc)
+        finish_stored_post(post, doc)
         {:ok, post}
 
       # Another lookup (or a delivery) stored it while this one was fetching.

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -2689,7 +2689,10 @@ defmodule Vutuv.Fediverse do
 
     Screenshots.reconcile(post)
 
-    if quotes?, do: resolve_quote_async(post)
+    # The `false` side stamps the clock rather than leaving it null, which is
+    # the difference between "we decided not to resolve this one" and "an
+    # attempt died here" — see `decline_quote/1`.
+    if quotes?, do: resolve_quote_async(post), else: decline_quote(post)
 
     post
   end
@@ -4246,7 +4249,7 @@ defmodule Vutuv.Fediverse do
     # stamp is granted, and the same `Update` is how a withdrawn stamp reaches
     # us — so a quote is far likelier to change here than to arrive complete
     # with the `Create`.
-    if quote_moved?(before, updated), do: resolve_quote_async(updated)
+    if quote_moved?(before, updated), do: requeue_quote(updated)
 
     :ok
   end
@@ -4261,6 +4264,24 @@ defmodule Vutuv.Fediverse do
   @no_quote %{quoted_post_id: nil, quoted_local_post_id: nil, quote_verified: false}
 
   defp resolve_quotes?, do: Application.get_env(:vutuv, :fediverse_quote_resolve, true)
+
+  # How long after a post arrives a row with no stamp on its clock is left
+  # alone before the resolver treats the attempt as dead. Comfortably longer
+  # than a resolution takes (up to three requests, each under the HTTP client's
+  # own timeout), so the sweeper does not race a task that is merely slow.
+  @quote_resume_grace_seconds 300
+
+  # One tick's worth. Half `Vutuv.Fediverse.Media`'s batch on the same two-minute
+  # interval, because a row here costs up to **three** requests to two servers
+  # where a picture costs one, and only the first of the three passes the
+  # per-host fetch budget — `stamp_valid?/3` reads the stamp through
+  # `fetch_remote_note/2`, which no limiter meters.
+  #
+  # No per-host cap on top of that, for the reason `Media.refetch_due/1` writes
+  # down: a cap over an already-sorted, already-capped batch is what starves the
+  # healthy rows behind one blocked host, and it buys nothing here because every
+  # row leaves this queue after a single attempt whatever the outcome.
+  @quote_resume_batch 10
 
   @doc """
   Resolves what a cached post quotes and decides whether it may be drawn as a
@@ -4313,6 +4334,101 @@ defmodule Vutuv.Fediverse do
     end
 
     :ok
+  end
+
+  @doc """
+  The quotes whose resolution never finished, newest first (issue #1609).
+
+  A row qualifies on the clock alone: it says it quotes something, nothing was
+  resolved from it, and `quote_checked_at` is null. Since **every** finished
+  resolution stamps that column, refusals included, a null one cannot mean "we
+  looked and there was nothing there" — it means the background task died
+  before it wrote, which is what a blue/green deploy does to whatever is running
+  in the slot it stops, without an error anywhere to say so.
+
+  Newest first, because the reader who might still be looking at that post is
+  looking at a recent one; and not until `@quote_resume_grace_seconds` after the
+  post arrived, so the first attempt — which may be waiting on two other servers
+  — is not run a second time beside itself. `received_at` is the anchor because
+  this table keeps no `updated_at`: an **edited** post therefore has no grace of
+  its own and can be picked up on the next tick after `requeue_quote/1` cleared
+  its clock. That is the right way round. The edit path is where a stamp usually
+  arrives, so finishing it promptly matters more than the rare duplicate fetch
+  of a task that is somehow still running two minutes on, which resolves to the
+  same row and writes the same thing.
+  """
+  def due_quote_resolutions(limit \\ @quote_resume_batch) do
+    cutoff = DateTime.add(DateTime.utc_now(:second), -@quote_resume_grace_seconds, :second)
+
+    from(p in RemotePost,
+      where: not is_nil(p.quote_uri),
+      where: is_nil(p.quoted_post_id) and is_nil(p.quoted_local_post_id),
+      where: is_nil(p.quote_checked_at),
+      where: p.received_at < ^cutoff,
+      # Ids are UUID v7, so id order is creation order.
+      order_by: [desc: p.id],
+      limit: ^limit
+    )
+    |> Repo.all()
+  end
+
+  @doc """
+  Finishes every quote resolution that was left unfinished and returns how many
+  were tried (issue #1609). The standing job behind `due_quote_resolutions/1`,
+  run by `Vutuv.Fediverse.QuoteResolver`.
+
+  Each row is tried **once**: the attempt stamps the clock whatever it decides,
+  so a quote that cannot be resolved at all — a server that is gone, a post
+  taken down, an instance we block — leaves the queue by being tried rather
+  than by succeeding, and can never hold the front of the next batch. A quote
+  whose consent arrives later does not need this path at all: a granted or
+  withdrawn stamp reaches us as an `Update`, which resolves it again by itself.
+
+  The one thing that would break that promise is a **raise**: an attempt that
+  dies inside `resolve_quote/1` never reaches its write, and the row it left
+  behind is the newest one in the queue, so it would take the front of every
+  batch from then on. Each row therefore carries its own `try`, which stamps the
+  clock and lets the rest of the batch run — the invariant `Media.refetch_due/1`
+  spells out as "no row can sit in the queue with no clock on it".
+
+  Bounded by the batch and by one attempt each, so a host that is merely
+  rate-capped this hour loses its quote to a plain link. That is the same answer
+  the first attempt gives today; a second look at a capped host belongs to the
+  recheck sweeper in #1796, which needs a strike ladder for it either way.
+  """
+  def resume_quote_resolutions(limit \\ @quote_resume_batch) do
+    due = due_quote_resolutions(limit)
+
+    Enum.each(due, &try_resolving/1)
+    length(due)
+  end
+
+  defp try_resolving(%RemotePost{} = post) do
+    resolve_quote(post)
+  rescue
+    error ->
+      Logger.warning("quote resolve for #{post.object_uri} raised: #{inspect(error)}")
+      write_quote(post, @no_quote)
+  end
+
+  # The quoted copy's own quote, declined rather than left open. Stamping the
+  # clock is what makes the one-level rule hold: an unstamped row is what the
+  # resolver goes looking for, so the copy would be picked up two minutes later
+  # and the chain of strangers' servers walked one hop per tick.
+  defp decline_quote(%RemotePost{} = post), do: write_quote(post, @no_quote)
+
+  # An edit that moved the quote or its stamp invalidates whatever the old one
+  # resolved to, so the row is put back to unresolved **before** the new
+  # resolution starts rather than after it finishes. Both in-between states are
+  # the reason: a card is never left standing over a quote it no longer belongs
+  # to, and a task that dies in this window leaves the null clock that hands the
+  # row to `Vutuv.Fediverse.QuoteResolver`. The struct is put back with it, so
+  # the no-quote branch below sees the row as it now is.
+  defp requeue_quote(%RemotePost{} = post) do
+    pending = Map.put(@no_quote, :quote_checked_at, nil)
+    write_quote(post, pending)
+
+    post |> struct(pending) |> resolve_quote_async()
   end
 
   # Whether an edit touched the quote at all. Both URIs, because the second one
@@ -4490,7 +4606,17 @@ defmodule Vutuv.Fediverse do
   # long as two strangers' servers take, and the post can be gone by the time
   # they answer — expiry, an upstream `Delete`, a member's report. A statement
   # that matches no row is a no-op; a changeset would raise `StaleEntryError`.
+  #
+  # **The clock rides along with every write**, refusals included: it says the
+  # resolution ran to its end, never that a card came of it. That is what makes
+  # the null clock mean exactly one thing to `due_quote_resolutions/1`, and it
+  # is what keeps a quote nobody can resolve from being retried for ever — the
+  # starvation #1316 paid for. `put_new`, so the one caller that means the
+  # opposite (`requeue_quote/1`, putting a row *back* in the queue) can say nil
+  # and still write through here.
   defp write_quote(%RemotePost{id: id}, attrs) do
+    attrs = Map.put_new(attrs, :quote_checked_at, DateTime.utc_now(:second))
+
     Repo.update_all(from(p in RemotePost, where: p.id == ^id), set: Map.to_list(attrs))
     :ok
   end

--- a/lib/vutuv/fediverse/quote_resolver.ex
+++ b/lib/vutuv/fediverse/quote_resolver.ex
@@ -1,0 +1,75 @@
+defmodule Vutuv.Fediverse.QuoteResolver do
+  @moduledoc """
+  Finishes the quote resolutions whose first attempt never got to the end
+  (issue #1609).
+
+  `Vutuv.Fediverse.resolve_quote/1` runs off the inbox on
+  `Vutuv.TaskSupervisor`, fire and forget, because it makes up to three requests
+  to two other servers and the inbox owes its 202 long before those answer. What
+  that shape has no answer for is the attempt that dies: a blue/green deploy
+  stops the slot mid-fetch, a crash takes the task with it, a node goes away
+  between the insert and the task's first line. Nothing is logged, because
+  nothing failed as far as the inbox is concerned — and the row then keeps a
+  `quote_uri` nobody ever went back to, so a quote that would have drawn a card
+  stays a plain link for as long as the cached copy lives.
+
+  So the unfinished work is a row and this is the thing whose standing job is to
+  find it and run it again, the shape `Vutuv.Fediverse.MediaRefetcher` and
+  `Vutuv.Newsletters.BroadcastResumer` use. It is cheap because the queue is
+  almost always empty: `Vutuv.Fediverse.due_quote_resolutions/1` is a partial
+  index lookup that matches nothing in a healthy minute.
+
+  **One retry per row, not a ladder.** Every finished resolution stamps
+  `quote_checked_at` whatever it decided, so a row leaves this queue by being
+  tried rather than by succeeding — a quote of a post that is gone cannot come
+  back on the next tick and hold the front of every batch, which is the
+  starvation issue #1316 cost us. A consent stamp that is granted *later* never
+  needs this path either: it arrives as an `Update`, which resolves the quote
+  again by itself.
+
+  Gated like the other fediverse sweepers: the child starts only when
+  `:fediverse_quote_resolve` is on (off in tests, where it would reach outside
+  the SQL sandbox, and off on an installation that must not call out at all),
+  and a run is a no-op while `:fediverse_enabled` is off.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias Vutuv.Fediverse
+
+  # Deliberately shorter than the grace a row waits before it counts as
+  # abandoned (5 min), so ticks cannot beat against that wait and run the queue
+  # at half speed — the interval trap `Vutuv.Fediverse.CountsRefresher` records.
+  @interval :timer.minutes(2)
+
+  def start_link(_opts), do: GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+
+  @impl true
+  def init(:ok) do
+    schedule()
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_info(:sweep, state) do
+    try do
+      case sweep() do
+        0 -> :ok
+        count -> Logger.info("Fediverse quotes: resumed #{count} unfinished resolution(s)")
+      end
+    rescue
+      error -> Logger.error("Fediverse quote resume failed: #{inspect(error)}")
+    end
+
+    schedule()
+    {:noreply, state}
+  end
+
+  defp sweep do
+    if Fediverse.enabled?(), do: Fediverse.resume_quote_resolutions(), else: 0
+  end
+
+  defp schedule, do: Process.send_after(self(), :sweep, @interval)
+end

--- a/lib/vutuv/fediverse/remote_post.ex
+++ b/lib/vutuv/fediverse/remote_post.ex
@@ -123,9 +123,18 @@ defmodule Vutuv.Fediverse.RemotePost do
     # fetched and matched; false for everything else, including a quote we
     # simply have not resolved yet — so an unchecked row renders as the link it
     # would otherwise have been, never as a card somebody did not agree to.
+    #
+    # `quote_checked_at` is the resume clock, and it answers one question only:
+    # did the resolution ever finish? Every outcome stamps it, the refusals
+    # included — it is the scheduler's clock, not a claim that a card came of
+    # it — so a row with a `quote_uri` and no stamp is one whose background task
+    # died before it wrote anything, and `Vutuv.Fediverse.QuoteResolver` is what
+    # goes back for it. Nothing casts it; an edit that moves the quote clears it
+    # (`Vutuv.Fediverse.resolve_quote/1`).
     field(:quote_uri, :string)
     field(:quote_authorization_uri, :string)
     field(:quote_verified, :boolean, default: false)
+    field(:quote_checked_at, :utc_datetime)
 
     belongs_to(:remote_account, Vutuv.Fediverse.RemoteAccount)
 

--- a/lib/vutuv/fediverse/remote_post.ex
+++ b/lib/vutuv/fediverse/remote_post.ex
@@ -21,6 +21,10 @@ defmodule Vutuv.Fediverse.RemotePost do
       here was addressed in is simply not stored, so only the three public-ish
       audiences exist.
 
+  A post can also **quote** another one (issue #1609, FEP-044f): `quote_uri`
+  says what, `quote_authorization_uri` is the consent stamp beside it, and the
+  card is drawn only once that consent is established — see `quote_card?/1`.
+
   Pictures arrive two ways: the author's own attachments (issue #1163,
   `Vutuv.Fediverse.Media` / `Vutuv.Fediverse.RemoteImage`), and — for a
   single-URL post with no attachment and no content warning — the same auto
@@ -105,7 +109,37 @@ defmodule Vutuv.Fediverse.RemotePost do
     field(:counts_etag, :string)
     field(:counts_failures, :integer, default: 0)
 
+    # What this post quotes (issue #1609), and whether we may draw it as a card.
+    #
+    # `quote_uri` is what the author's server said they quoted — the canonical
+    # id of the quoted object, read from `quote`, `quoteUri` or
+    # `_misskey_quote`, whichever of the three aliases that software writes.
+    # `quote_authorization_uri` is the FEP-044f stamp beside it: a document on
+    # the **quoted** object's host saying its author consented to this exact
+    # quote. Neither is a claim we act on until it has been checked.
+    #
+    # `quote_verified` is the one flag the card reads. True for a self-quote
+    # (the author quoting themselves needs nobody's consent) and for a stamp we
+    # fetched and matched; false for everything else, including a quote we
+    # simply have not resolved yet — so an unchecked row renders as the link it
+    # would otherwise have been, never as a card somebody did not agree to.
+    field(:quote_uri, :string)
+    field(:quote_authorization_uri, :string)
+    field(:quote_verified, :boolean, default: false)
+
     belongs_to(:remote_account, Vutuv.Fediverse.RemoteAccount)
+
+    # The quoted thing once it is resolved: a cached copy of another account's
+    # post, or a vutuv post when the quote points back at this installation.
+    # At most one of the two is set, and neither has to be — a quote of
+    # something we cannot reach keeps its URI and nothing else.
+    #
+    # `quoted_post_id` is also this feature's **holder** against
+    # `Vutuv.Fediverse.purge_unfollowed_remote_posts/0`: the copy exists because
+    # somebody's post quotes it, which is the same claim a reshare (#1166), a
+    # boost (#1167) and a lookup (#1211) make.
+    belongs_to(:quoted_post, __MODULE__)
+    belongs_to(:quoted_local_post, Vutuv.Posts.Post)
 
     # The pictures the author attached (issue #1163) and the auto link
     # screenshot for a single-URL, picture-less post — the exact machinery a
@@ -114,6 +148,15 @@ defmodule Vutuv.Fediverse.RemotePost do
     has_many(:images, Vutuv.Fediverse.RemoteImage)
     has_one(:screenshot, Vutuv.Posts.PostScreenshot, foreign_key: :remote_post_id)
   end
+
+  @doc """
+  The longest URI any of the remote address columns may hold, in bytes.
+
+  Public because the ingestion has to know it *before* the changeset does: a
+  field an over-long value belongs to may be optional (`quote_uri`), and there
+  the value is dropped rather than allowed to fail the whole insert.
+  """
+  def max_uri_bytes, do: @max_uri_bytes
 
   @doc "The longest remote text a post may carry."
   def max_content, do: @max_content
@@ -158,6 +201,81 @@ defmodule Vutuv.Fediverse.RemotePost do
   def question?(%__MODULE__{kind: "question"}), do: true
   def question?(%__MODULE__{}), do: false
 
+  @doc """
+  Whether the post says it quotes something at all (issue #1609) — the flag
+  behind both halves of the rendering, the card and the plain link fallback.
+  """
+  def quoting?(%__MODULE__{quote_uri: uri}), do: is_binary(uri) and uri != ""
+
+  @doc """
+  Whether the quote may be drawn as a **card** rather than as a link.
+
+  Two things have to hold: we checked the consent (`quote_verified`, set for a
+  self-quote or a matched FEP-044f stamp) **and** we hold the quoted post. Either
+  one alone renders the link, which is what a reader had before this existed and
+  is never wrong.
+
+  Deliberately only the cached-post half. A quote of one of **our** posts sets
+  `quoted_local_post_id` and can never set `quote_verified`, because the stamp
+  would have to be one this installation issued and it issues none until issue
+  #1608 — so that column names a link target, not a card.
+
+  **The card is only as fresh as the last fetch.** `quote_verified` records that
+  the stamp matched *when it was read*, and nothing re-reads it: a quoted author
+  who withdraws consent afterwards — deleting the `QuoteAuthorization`, taking
+  the post down, narrowing its audience — keeps their card here until the copy
+  expires. A recheck sweeper is follow-up work, not part of this. Whoever builds
+  it inherits this codebase's clock rule: stamp the `*_checked_at` column on the
+  branch that decides an object **cannot** be checked, or that object holds the
+  front of every batch forever and the sweep silently does nothing (issue #1316).
+  """
+  def quote_card?(%__MODULE__{} = post),
+    do: post.quote_verified and is_binary(post.quoted_post_id)
+
+  @doc """
+  What this post quotes, resolved from what is loaded on the row:
+
+    * `{:remote, %RemotePost{}}` — a cached copy of somebody else's post.
+    * `{:local, %Vutuv.Posts.Post{}}` — a vutuv post.
+    * `{:uri, uri}` — we hold the address and nothing else, either because the
+      quote was never resolved or because the caller did not ask for
+      `quote_preload/0`.
+    * `nil` — the post quotes nothing.
+
+  The **one** answer to "what does this quote", because three surfaces ask it
+  and each would otherwise derive it from the two ids and two associations for
+  itself: the card, the plain-link fallback, and the agent-format doc builders.
+  Dispatched on the id **columns** rather than on the associations, so a caller
+  that forgot the preload gets the honest `{:uri, _}` instead of a clause that
+  silently does not match.
+  """
+  def quoted(%__MODULE__{} = post) do
+    cond do
+      not quoting?(post) -> nil
+      is_binary(post.quoted_local_post_id) -> quoted_record(post.quoted_local_post, :local, post)
+      is_binary(post.quoted_post_id) -> quoted_record(post.quoted_post, :remote, post)
+      true -> {:uri, post.quote_uri}
+    end
+  end
+
+  defp quoted_record(%Ecto.Association.NotLoaded{}, _kind, post), do: {:uri, post.quote_uri}
+  defp quoted_record(nil, _kind, post), do: {:uri, post.quote_uri}
+  defp quoted_record(record, kind, _post), do: {kind, record}
+
+  @doc """
+  What a card needs loaded to draw a quote — one spec, because every surface
+  that renders `remote_post_card/1` reads it and a surface that forgets it
+  would quietly draw the link instead of the card.
+
+  Applied with `Repo.preload/2` after the page's own query rather than folded
+  into it: the card sites reach a cached post through four different shapes
+  (plain, nested under a reshare, under a boost, under a bookmark), and one
+  post-hoc preload works for all of them without any of those queries having to
+  spell this list out again.
+  """
+  def quote_preload,
+    do: [quoted_post: :remote_account, quoted_local_post: [:user, :organization]]
+
   def changeset(%__MODULE__{} = post, attrs) do
     post
     |> cast(attrs, [
@@ -171,7 +289,13 @@ defmodule Vutuv.Fediverse.RemotePost do
       :kind,
       :published_at,
       :received_at,
-      :expires_at
+      :expires_at,
+      # Cast on the edit path too, not only the insert: Mastodon publishes a
+      # quote unapproved and sends an `Update` the moment the stamp arrives, so
+      # `quote_authorization_uri` reaches us as an edit far more often than as
+      # part of the original `Create` (issue #1609).
+      :quote_uri,
+      :quote_authorization_uri
     ])
     # Cast on its own, with no empty values: since issue #1163 a post can be a
     # photograph and nothing else, and its body is then genuinely the empty
@@ -199,6 +323,8 @@ defmodule Vutuv.Fediverse.RemotePost do
     |> validate_length(:origin_url, max: @max_uri_bytes, count: :bytes)
     |> validate_length(:content_text, max: @max_content)
     |> validate_length(:summary, max: @max_summary)
+    |> validate_length(:quote_uri, max: @max_uri_bytes, count: :bytes)
+    |> validate_length(:quote_authorization_uri, max: @max_uri_bytes, count: :bytes)
     # Whoever writes `language` owns its clock (issue #1535) — and an `Update`
     # carrying no `contentMap` writes it as nil, which has to mean "look again"
     # rather than "undeclared forever".

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -3233,6 +3233,7 @@ defmodule Vutuv.Posts do
         by_post =
           unique
           |> attach_remote_images()
+          |> attach_remote_quotes()
           |> attach_remote_follows(viewer)
           |> attach_remote_likes(viewer)
           |> Map.new(&{&1.post_id, &1})
@@ -3365,6 +3366,7 @@ defmodule Vutuv.Posts do
       posts
       |> dedupe_remote()
       |> attach_remote_images()
+      |> attach_remote_quotes()
       |> attach_remote_follows(viewer)
 
     attach_remote_likes(posts ++ replies, viewer)
@@ -3431,6 +3433,19 @@ defmodule Vutuv.Posts do
     by_post = remote |> Enum.map(& &1.remote_post.id) |> Vutuv.Fediverse.list_remote_images()
 
     Enum.map(remote, &Map.put(&1, :images, Map.get(by_post, &1.remote_post.id, [])))
+  end
+
+  # What each cached post quotes (issue #1609), read for the whole page at once
+  # — and **here**, after `dedupe_remote/1`, rather than in the four remote feed
+  # sources that fill it. Every source over-fetches (`Vutuv.FeedPage.paginate/3`
+  # asks each for more rows than the page can hold, then takes the best ones),
+  # so preloading at the source pays four times over for roughly four times the
+  # rows that survive. Ecto skips an association nothing needs, so a page where
+  # nobody quotes anything costs no query at all.
+  defp attach_remote_quotes(remote) do
+    quoted = remote |> Enum.map(& &1.remote_post) |> Vutuv.Fediverse.with_quotes()
+
+    Enum.zip_with(remote, quoted, &Map.put(&1, :remote_post, &2))
   end
 
   @doc """
@@ -4931,6 +4946,7 @@ defmodule Vutuv.Posts do
 
     from(p in RemotePost, where: p.id in ^ids, preload: [:remote_account, :screenshot])
     |> Repo.all()
+    |> Vutuv.Fediverse.with_quotes()
     |> Map.new(&{&1.id, {&1, Map.get(images, &1.id, [])}})
   end
 

--- a/lib/vutuv/tags/timeline.ex
+++ b/lib/vutuv/tags/timeline.ex
@@ -387,6 +387,7 @@ defmodule Vutuv.Tags.Timeline do
       preload: [:screenshot, remote_account: ^from(a in RemoteAccount)]
     )
     |> Repo.all()
+    |> Fediverse.with_quotes()
     |> Map.new(&{&1.id, &1})
   end
 end

--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -1007,7 +1007,7 @@ defmodule VutuvWeb.AgentDocs.Markdown do
 
   defp post_line(post) do
     "- #{post.published_on}#{pin_suffix(post)}#{repost_suffix(post)}: " <>
-      "[#{md_text(entry_label(post))}](#{post.url})"
+      "[#{md_text(entry_label(post))}](#{post.url})#{quote_suffix(post)}"
   end
 
   @doc false
@@ -1026,6 +1026,19 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   end
 
   defp picture_note(count), do: ngettext("(a picture)", "(%{count} pictures)", count)
+
+  @doc false
+  # What the entry quotes (issue #1609), shared with the plain-text renderer.
+  # The card on the page shows the quoted post's author and words; an agent gets
+  # the same two facts as a sentence, because an entry that only reacts to
+  # something ("exactly this") is unreadable without it.
+  def quote_suffix(%{quote: %{url: url, author: nil}}),
+    do: " — " <> gettext("Quotes %{url}", url: url)
+
+  def quote_suffix(%{quote: %{url: url, author: author}}),
+    do: " — " <> gettext("Quotes %{name}: %{url}", name: author, url: url)
+
+  def quote_suffix(_post), do: ""
 
   @doc false
   # The post the member showcases on their profile (issue #1110). Only the

--- a/lib/vutuv_web/agent_docs/post_doc.ex
+++ b/lib/vutuv_web/agent_docs/post_doc.ex
@@ -299,6 +299,7 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       # photo post as an entry with no content at all. The renderers turn the
       # count into a phrase in the reader's own language.
       pictures: Enum.count(entry[:images] || [], &RemoteImage.released?/1),
+      quote: quoted_entry(remote),
       reposted_by: nil,
       reposters: [],
       # What the HTML card says in its footer, as a fact rather than a skin: an
@@ -339,6 +340,46 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
     do: Enum.count(images, &ImageScans.released?(&1.moderation))
 
   defp picture_count(_post), do: 0
+
+  @doc """
+  What a cached post **quotes** (issue #1609) as a doc fact — `%{url:, author:,
+  network:}` or nil.
+
+  The HTML card shows it, so every agent format must too, or a `.md`/`.json`
+  sibling reads as a bare reaction ("this is exactly right") with the thing it
+  reacts to invisible. The same argument `pictures:` above is here for.
+
+  `RemotePost.quoted/1` owns which of the three things is quoted; this only
+  spells each one as a URL and a name. A quote the reader would see as a plain
+  link and a quote drawn as a card are the same fact to an agent — the consent
+  question decides how a **person** is shown it, not whether a machine is told.
+  """
+  def quoted_entry(%RemotePost{} = remote) do
+    case RemotePost.quoted(remote) do
+      {:local, post} ->
+        %{
+          url: AgentDocs.abs_url(Posts.path(post)),
+          author: UserHelpers.author_name(post),
+          network: "vutuv"
+        }
+
+      {:remote, quoted} ->
+        %{
+          url: RemotePost.origin(quoted),
+          author: RemoteAccount.label(quoted.remote_account),
+          network: "fediverse"
+        }
+
+      # Held as an address and nothing else: the URL is still the useful half,
+      # and an absent author is honest rather than a gap — we do not know who
+      # wrote it.
+      {:uri, uri} ->
+        %{url: uri, author: nil, network: "fediverse"}
+
+      nil ->
+        nil
+    end
+  end
 
   # The conversation entries, in `Posts.list_thread/3` reading order.
   # `in_reply_to_author` resolves only inside the thread (a deleted or

--- a/lib/vutuv_web/agent_docs/profile_doc.ex
+++ b/lib/vutuv_web/agent_docs/profile_doc.ex
@@ -31,6 +31,7 @@ defmodule VutuvWeb.AgentDocs.ProfileDoc do
   alias Vutuv.Repo
   alias Vutuv.Tags.UserTag
   alias VutuvWeb.AgentDocs
+  alias VutuvWeb.AgentDocs.PostDoc
   alias VutuvWeb.AgentDocs.SectionDocs
   alias VutuvWeb.Fediverse.Docs
   alias VutuvWeb.PostTeaser
@@ -352,6 +353,9 @@ defmodule VutuvWeb.AgentDocs.ProfileDoc do
       url: RemotePost.origin(remote),
       published_on: DateTime.to_date(remote.published_at),
       excerpt: PostTeaser.line(remote),
+      # What it quotes (issue #1609), through the same builder the archive and
+      # tag-page docs use — the profile renders the identical card.
+      quote: PostDoc.quoted_entry(remote),
       reposted_by: entry.reposted_by && UserHelpers.full_name(entry.reposted_by),
       pinned: false,
       network: "fediverse",

--- a/lib/vutuv_web/agent_docs/text.ex
+++ b/lib/vutuv_web/agent_docs/text.ex
@@ -734,7 +734,7 @@ defmodule VutuvWeb.AgentDocs.Text do
 
   defp post_lines(post) do
     "* #{post.published_on}#{Markdown.pin_suffix(post)}#{Markdown.repost_suffix(post)}: " <>
-      "#{Markdown.entry_label(post)}\n  #{post.url}"
+      "#{Markdown.entry_label(post)}#{Markdown.quote_suffix(post)}\n  #{post.url}"
   end
 
   defp person_line(person, prefix \\ "* ") do

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -45,6 +45,7 @@ defmodule VutuvWeb.PostComponents do
   alias Vutuv.Posts.PostRemoteReply
   alias Vutuv.Posts.PostReview
   alias Vutuv.Posts.PostScreenshot
+  alias Vutuv.Posts.Screenshots
   alias Vutuv.Profiles.VerifiedLinks
   alias Vutuv.RemoteMedia
   alias Vutuv.ReviewCover
@@ -54,6 +55,7 @@ defmodule VutuvWeb.PostComponents do
   alias VutuvWeb.Live.PostTranslations
   alias VutuvWeb.Markdown
   alias VutuvWeb.PostLive.RemoteActionsComponent
+  alias VutuvWeb.PostTeaser
   alias VutuvWeb.UserHelpers
 
   # The idle tint every action control wears while it is off, paired with each
@@ -2478,7 +2480,7 @@ defmodule VutuvWeb.PostComponents do
       # and a second knob for remote posts is one nobody would know to look for.
       |> assign(:body_style, post_body_style(User.post_prefs(assigns.viewer)))
       |> assign(:account, account)
-      |> assign(:initials, name_initials(RemoteAccount.display_name(account) || account.handle))
+      |> assign(:initials, remote_initials(account))
       |> assign_remote_link_screenshot(post, assigns.images)
       |> assign(:permalink, remote_post_permalink(post, assigns.viewer))
       |> assign(:origin, RemotePost.origin(post))
@@ -2598,8 +2600,7 @@ defmodule VutuvWeb.PostComponents do
           <.remote_body
             warning={
               RemotePost.warned?(@remote_post) &&
-                (translated_summary(@translation, @remote_post.summary) ||
-                   gettext("Marked as sensitive by its author"))
+                (translated_summary(@translation, @remote_post.summary) || sensitive_note())
             }
             text={@translation.body_source}
             lang={@translation.lang}
@@ -2623,6 +2624,8 @@ defmodule VutuvWeb.PostComponents do
             subject_id={@remote_post.id}
           />
 
+          <.quoted_post :if={RemotePost.quoting?(@remote_post)} remote_post={@remote_post} />
+
           <.remote_post_images images={@images} />
 
           <%!-- The same bar, from the same component (issues #1164, #1165,
@@ -2641,6 +2644,179 @@ defmodule VutuvWeb.PostComponents do
     </article>
     """
   end
+
+  attr(:remote_post, :map, required: true, doc: "a Vutuv.Fediverse.RemotePost, quotes preloaded")
+
+  @doc """
+  What a post from another network quotes (issue #1609) — a card, a link, or
+  nothing at all.
+
+  The three states are the whole feature, and which one renders is not a matter
+  of taste:
+
+    * **a card**, when the quoted author demonstrably agreed. That is a
+      self-quote, or a FEP-044f `QuoteAuthorization` this installation fetched
+      from the quoted object's own host and matched against both sides
+      (`Vutuv.Fediverse.resolve_quote/1`).
+    * **a link**, for every quote we could not establish that about — an
+      unresolved one, a stamp that did not check out, a quoted post we cannot
+      reach or may not hold, and a quote of one of **our** posts, which will
+      stay a link until this installation issues stamps of its own (issue
+      #1608). Showing somebody else's words inside a card on nothing but the
+      quoting server's say-so is precisely what the consent mechanism exists to
+      prevent; a link says the same thing and claims nothing.
+    * **nothing**, when the author already wrote that link in their own text.
+      The commonest quote today is written by a client that puts the URL in the
+      body *and* in the property, and printing it a second time under it reads
+      as a bug.
+
+  Only ever one level deep: the card renders the quoted post's own text, never
+  the card of whatever *it* quotes. That is also why the resolver stops after
+  one hop — a chain of quotes is a chain of strangers' servers, and no reader
+  asked to descend it.
+  """
+  def quoted_post(assigns) do
+    quoted = RemotePost.quoted(assigns.remote_post)
+    card = if RemotePost.quote_card?(assigns.remote_post), do: card_record(quoted)
+
+    assigns =
+      assigns
+      |> assign(:card, card)
+      |> assign(:link, !card && quoted_link(assigns.remote_post, quoted))
+
+    ~H"""
+    <.quoted_post_card :if={@card} quoted={@card} />
+
+    <%!-- A vutuv target gets its own permalink rather than the spelling the
+    quoting server happened to use, so the reader stays here; anything else
+    leaves in a new tab, like every other way out of a remote card. Which of the
+    two it is rides in the attributes, so the label and its styling are written
+    once. --%>
+    <p :if={@link} class="mb-0 mt-2 text-sm" data-quoted-post-link={@remote_post.quote_uri}>
+      <.link
+        {@link}
+        class="font-medium text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+      >
+        {gettext("Quoted post")}
+      </.link>
+    </p>
+    """
+  end
+
+  # Only a cached post is ever drawn as a card — `RemotePost.quote_card?/1` says
+  # why a vutuv target is not — so anything else answers nil and stays a link.
+  defp card_record({:remote, %RemotePost{} = quoted}), do: quoted
+  defp card_record(_other), do: nil
+
+  attr(:quoted, :map, required: true, doc: "the quoted Vutuv.Fediverse.RemotePost")
+
+  # The quoted post itself, compact: who wrote it, and four lines of what they
+  # wrote. The whole tile is the link to the original, because there is nothing
+  # else to do with it here — the actions belong to the post that quotes it.
+  #
+  # A quoted post its author put behind a content warning shows the warning and
+  # nothing else. There is no reveal here: the card is inside a link, and a
+  # click-to-open lid inside a click-to-leave tile is a control that fights
+  # itself. The reader who wants it has the original one tap away.
+  defp quoted_post_card(assigns) do
+    quoted = assigns.quoted
+    account = quoted.remote_account
+
+    assigns =
+      assigns
+      |> assign(:account, account)
+      |> assign(:initials, remote_initials(account))
+      |> assign(:warning, quoted_warning(quoted))
+      |> assign(:teaser, PostTeaser.plain_line(quoted, length: 320))
+
+    ~H"""
+    <a
+      href={RemotePost.origin(@quoted)}
+      target="_blank"
+      rel="nofollow noopener noreferrer"
+      data-quoted-post={@quoted.id}
+      class="mt-3 block rounded-xl bg-slate-50 p-3 no-underline ring-1 ring-slate-200 hover:bg-slate-100 dark:bg-slate-800/50 dark:ring-slate-700 dark:hover:bg-slate-800"
+    >
+      <span class="flex items-center gap-2">
+        <.remote_avatar initials={@initials} src={RemoteAccount.avatar_url(@account)} />
+        <span class="min-w-0">
+          <span class="block truncate text-sm font-semibold text-slate-900 dark:text-slate-100">
+            {RemoteAccount.label(@account)}
+          </span>
+          <span class="block truncate text-xs text-slate-500 dark:text-slate-400">
+            {RemoteAccount.display_handle(@account)}
+          </span>
+        </span>
+      </span>
+
+      <span :if={@warning} class="mt-2 block text-sm italic text-slate-500 dark:text-slate-400">
+        {@warning}
+      </span>
+
+      <span
+        :if={!@warning and @teaser != ""}
+        class="mt-2 line-clamp-4 block text-sm text-slate-700 dark:text-slate-300"
+      >
+        {@teaser}
+      </span>
+    </a>
+    """
+  end
+
+  defp quoted_warning(%RemotePost{} = quoted) do
+    if RemotePost.warned?(quoted), do: quoted.summary || sensitive_note()
+  end
+
+  # What a post with no content warning of its own says when its author marked
+  # it sensitive. One definition, because the full card and the quoted card both
+  # fall back to it.
+  defp sensitive_note, do: gettext("Marked as sensitive by its author")
+
+  # The monogram on a remote avatar: the display name alone, never falling back
+  # to the handle for the letters — `RemoteAccount.display_name/1` exists for
+  # exactly that distinction, and the full card and the quoted card must draw
+  # the same tile for the same account.
+  defp remote_initials(account),
+    do: name_initials(RemoteAccount.display_name(account) || account.handle)
+
+  # Where the fallback link goes, or nil when there is nothing to add: no quote
+  # at all, or a body that already carries the URL. Both spellings of the quoted
+  # post count as "already there" — the canonical id servers exchange, and the
+  # display URL a person copies out of their browser — because an author who
+  # pasted either one has written this line themselves.
+  defp quoted_link(%RemotePost{} = post, quoted) do
+    if quoted && not quote_in_body?(post, quoted), do: quoted_href(quoted)
+  end
+
+  # Where the link goes, best spelling first: our own permalink, then the quoted
+  # post's **browsable** URL through `RemotePost.origin/1` — on several servers
+  # the canonical AP id is not a page a person can open, and this is the
+  # commoner branch, since an unverified quote is the ordinary case today. The
+  # bare URI is the last resort, for a quote we never resolved.
+  defp quoted_href({:local, local}), do: %{navigate: Posts.path(local)}
+  defp quoted_href({:remote, quoted}), do: external_link(RemotePost.origin(quoted))
+  defp quoted_href({:uri, uri}), do: external_link(uri)
+
+  defp external_link(url),
+    do: %{href: url, target: "_blank", rel: "nofollow noopener noreferrer"}
+
+  # Read as **whole URLs** (`Screenshots.extract_urls/1`, the same reader the
+  # link-screenshot gate runs over this very field) rather than as a substring
+  # search: a body mentioning `…/notes/12` would otherwise swallow the link to
+  # `…/notes/1`. Both spellings of the quoted post count as "already there" —
+  # the id its server exchanges, and the browsable URL a person copies.
+  defp quote_in_body?(%RemotePost{content_text: text} = post, quoted) when is_binary(text) do
+    written = Screenshots.extract_urls(text)
+
+    [post.quote_uri, quoted_browsable_url(quoted)]
+    |> Enum.filter(&is_binary/1)
+    |> Enum.any?(&(&1 in written))
+  end
+
+  defp quote_in_body?(%RemotePost{}, _quoted), do: false
+
+  defp quoted_browsable_url({:remote, %RemotePost{} = quoted}), do: RemotePost.origin(quoted)
+  defp quoted_browsable_url(_other), do: nil
 
   defp origin_label(post) do
     if RemotePost.question?(post),

--- a/lib/vutuv_web/live/fediverse_account_live.ex
+++ b/lib/vutuv_web/live/fediverse_account_live.ex
@@ -90,6 +90,7 @@ defmodule VutuvWeb.FediverseAccountLive do
   defp load_posts(socket) do
     viewer = socket.assigns.current_user
     {posts, more?} = Fediverse.account_posts(socket.assigns.account, viewer)
+    posts = Fediverse.with_quotes(posts)
     ids = Enum.map(posts, & &1.id)
 
     socket

--- a/lib/vutuv_web/live/fediverse_post_live.ex
+++ b/lib/vutuv_web/live/fediverse_post_live.ex
@@ -60,7 +60,7 @@ defmodule VutuvWeb.FediversePostLive do
   @impl true
   def mount(%{"id" => id}, _session, socket) do
     viewer = socket.assigns.current_user
-    post = Fediverse.get_remote_post(id)
+    post = id |> Fediverse.get_remote_post() |> Fediverse.with_quotes()
 
     if post && Fediverse.remote_post_readable?(post, viewer) do
       {:ok, assign_post(socket, post, viewer)}

--- a/lib/vutuv_web/live/post_live/remote_post_reply.ex
+++ b/lib/vutuv_web/live/post_live/remote_post_reply.ex
@@ -40,7 +40,7 @@ defmodule VutuvWeb.PostLive.RemotePostReply do
   @impl true
   def mount(%{"id" => id}, _session, socket) do
     viewer = socket.assigns.current_user
-    post = Fediverse.get_remote_post(id)
+    post = id |> Fediverse.get_remote_post() |> Fediverse.with_quotes()
 
     # Readable, not merely present: this page shows the post it is about, so the
     # same rule that decides whether a member may see it at all decides whether

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -162,7 +162,7 @@ msgstr "Kontakt"
 msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
-#: lib/vutuv_web/components/post_components.ex:3318
+#: lib/vutuv_web/components/post_components.ex:3494
 #: lib/vutuv_web/components/ui.ex:4314
 #: lib/vutuv_web/live/admin/job_live.ex:489
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -211,7 +211,7 @@ msgstr "Inaktivieren"
 msgid "Download"
 msgstr "Download"
 
-#: lib/vutuv_web/components/post_components.ex:3283
+#: lib/vutuv_web/components/post_components.ex:3459
 #: lib/vutuv_web/components/ui.ex:4305
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -475,7 +475,7 @@ msgstr "Mehr"
 msgid "Name"
 msgstr "Name"
 
-#: lib/vutuv_web/components/post_components.ex:655
+#: lib/vutuv_web/components/post_components.ex:657
 #: lib/vutuv_web/live/notification_live/index.ex:699
 #: lib/vutuv_web/live/organization_live/activity.ex:128
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
@@ -657,7 +657,7 @@ msgstr "Speichern"
 msgid "Search"
 msgstr "Suche"
 
-#: lib/vutuv_web/components/post_components.ex:1686
+#: lib/vutuv_web/components/post_components.ex:1688
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -931,7 +931,7 @@ msgid "You follow back %{name}."
 msgstr "Sie folgen %{name} jetzt zurück."
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:164
+#: lib/vutuv_web/live/post_live/feed.ex:165
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1394,7 +1394,7 @@ msgstr "Tag-URLs"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:34
 #: lib/vutuv_web/agent_docs/markdown.ex:503
-#: lib/vutuv_web/agent_docs/markdown.ex:1078
+#: lib/vutuv_web/agent_docs/markdown.ex:1091
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:522
 #: lib/vutuv_web/agent_docs/text.ex:759
@@ -1717,7 +1717,7 @@ msgstr "Empfehlen"
 #: lib/vutuv_web/components/ui.ex:2645
 #: lib/vutuv_web/components/ui.ex:2648
 #: lib/vutuv_web/components/ui.ex:2721
-#: lib/vutuv_web/live/fediverse_account_live.ex:391
+#: lib/vutuv_web/live/fediverse_account_live.ex:392
 #: lib/vutuv_web/live/fediverse_following_live.ex:331
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:323
 #: lib/vutuv_web/live/organization_live/following.ex:331
@@ -1784,7 +1784,7 @@ msgstr "Nachrichten"
 msgid "Network"
 msgstr "Netzwerk"
 
-#: lib/vutuv_web/components/post_components.ex:447
+#: lib/vutuv_web/components/post_components.ex:449
 #: lib/vutuv_web/components/ui.ex:4424
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
@@ -2143,7 +2143,7 @@ msgstr "Upload abbrechen"
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
-#: lib/vutuv_web/components/post_components.ex:3315
+#: lib/vutuv_web/components/post_components.ex:3491
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2158,8 +2158,8 @@ msgstr "Beitrag bearbeiten"
 #: lib/vutuv_web/components/organization_components.ex:254
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:139
-#: lib/vutuv_web/live/post_live/feed.ex:279
-#: lib/vutuv_web/live/post_live/feed.ex:2468
+#: lib/vutuv_web/live/post_live/feed.ex:280
+#: lib/vutuv_web/live/post_live/feed.ex:2542
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1074
 #: lib/vutuv_web/live/shell_live.ex:1373
@@ -2188,8 +2188,8 @@ msgstr "Vor einer bestimmten Person verbergen…"
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
 
-#: lib/vutuv_web/components/post_components.ex:3269
-#: lib/vutuv_web/components/post_components.ex:3271
+#: lib/vutuv_web/components/post_components.ex:3445
+#: lib/vutuv_web/components/post_components.ex:3447
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
@@ -2205,7 +2205,7 @@ msgstr "Nicht eingeloggte Besucher"
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2759
+#: lib/vutuv_web/live/post_live/feed.ex:2834
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2245,7 +2245,7 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/controllers/user_controller.ex:76
 #: lib/vutuv_web/gettext_extraction_anchors.ex:103
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
-#: lib/vutuv_web/live/fediverse_account_live.ex:398
+#: lib/vutuv_web/live/fediverse_account_live.ex:399
 #: lib/vutuv_web/live/notification_live/index.ex:943
 #: lib/vutuv_web/live/organization_live/show.ex:729
 #: lib/vutuv_web/live/post_live/saved.ex:520
@@ -2257,21 +2257,21 @@ msgstr "Beitrag erfolgreich gelöscht."
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:3739
-#: lib/vutuv_web/components/post_components.ex:3743
+#: lib/vutuv_web/components/post_components.ex:3915
+#: lib/vutuv_web/components/post_components.ex:3919
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:3740
-#: lib/vutuv_web/live/fediverse_account_live.ex:336
+#: lib/vutuv_web/components/post_components.ex:3916
+#: lib/vutuv_web/live/fediverse_account_live.ex:337
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr "Weniger anzeigen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:376
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:1288
+#: lib/vutuv_web/components/post_components.ex:1290
 #: lib/vutuv_web/live/admin/screenshot_live.ex:327
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
@@ -2300,7 +2300,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1976
+#: lib/vutuv_web/live/post_live/feed.ex:2050
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2356,27 +2356,27 @@ msgstr "Was gibt's Neues?"
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
 
-#: lib/vutuv_web/components/post_components.ex:3266
+#: lib/vutuv_web/components/post_components.ex:3442
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:5141
+#: lib/vutuv_web/components/post_components.ex:5317
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:5145
+#: lib/vutuv_web/components/post_components.ex:5321
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:5143
+#: lib/vutuv_web/components/post_components.ex:5319
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:5144
+#: lib/vutuv_web/components/post_components.ex:5320
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
@@ -2417,15 +2417,15 @@ msgstr "Alle %{count} Beiträge ansehen"
 msgid "All posts"
 msgstr "Alle Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:1954
-#: lib/vutuv_web/components/post_components.ex:5237
+#: lib/vutuv_web/components/post_components.ex:1956
+#: lib/vutuv_web/components/post_components.ex:5413
 #: lib/vutuv_web/components/ui.ex:3778
 #: lib/vutuv_web/views/user_html.ex:457
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr "Lesezeichen setzen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1116
+#: lib/vutuv_web/agent_docs/markdown.ex:1129
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
 #: lib/vutuv_web/live/shell_live.ex:1204
@@ -2436,8 +2436,8 @@ msgstr "Lesezeichen setzen"
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/vutuv_web/components/post_components.ex:1907
-#: lib/vutuv_web/components/post_components.ex:5473
+#: lib/vutuv_web/components/post_components.ex:1909
+#: lib/vutuv_web/components/post_components.ex:5649
 #: lib/vutuv_web/components/ui.ex:3764
 #: lib/vutuv_web/live/notification_live/index.ex:1089
 #: lib/vutuv_web/views/user_html.ex:467
@@ -2445,8 +2445,8 @@ msgstr "Lesezeichen"
 msgid "Like"
 msgstr "Gefällt mir"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1115
-#: lib/vutuv_web/components/post_components.ex:5483
+#: lib/vutuv_web/agent_docs/markdown.ex:1128
+#: lib/vutuv_web/components/post_components.ex:5659
 #: lib/vutuv_web/live/notification_live/index.ex:1022
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
@@ -2468,40 +2468,40 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:5225
+#: lib/vutuv_web/components/post_components.ex:5401
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
-#: lib/vutuv_web/components/post_components.ex:1953
-#: lib/vutuv_web/components/post_components.ex:5236
+#: lib/vutuv_web/components/post_components.ex:1955
+#: lib/vutuv_web/components/post_components.ex:5412
 #: lib/vutuv_web/live/post_live/saved.ex:806
 #: lib/vutuv_web/views/user_html.ex:457
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
-#: lib/vutuv_web/components/post_components.ex:1935
-#: lib/vutuv_web/components/post_components.ex:5222
+#: lib/vutuv_web/components/post_components.ex:1937
+#: lib/vutuv_web/components/post_components.ex:5398
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
-#: lib/vutuv_web/components/post_components.ex:2200
-#: lib/vutuv_web/components/post_components.ex:4347
+#: lib/vutuv_web/components/post_components.ex:2202
+#: lib/vutuv_web/components/post_components.ex:4523
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:1934
-#: lib/vutuv_web/components/post_components.ex:5221
+#: lib/vutuv_web/components/post_components.ex:1936
+#: lib/vutuv_web/components/post_components.ex:5397
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
-#: lib/vutuv_web/components/post_components.ex:1906
-#: lib/vutuv_web/components/post_components.ex:5472
+#: lib/vutuv_web/components/post_components.ex:1908
+#: lib/vutuv_web/components/post_components.ex:5648
 #: lib/vutuv_web/live/post_live/saved.ex:805
 #: lib/vutuv_web/views/user_html.ex:467
 #, elixir-autogen, elixir-format
@@ -2509,14 +2509,14 @@ msgid "Unlike"
 msgstr "Gefällt mir entfernen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:377
-#: lib/vutuv_web/components/post_components.ex:2569
+#: lib/vutuv_web/components/post_components.ex:2571
 #: lib/vutuv_web/components/ui.ex:2551
 #: lib/vutuv_web/components/ui.ex:2551
 #: lib/vutuv_web/components/ui.ex:2688
 #: lib/vutuv_web/live/organization_live/following.ex:383
 #: lib/vutuv_web/live/organization_live/following.ex:458
 #: lib/vutuv_web/live/organization_live/show.ex:640
-#: lib/vutuv_web/live/post_live/feed.ex:811
+#: lib/vutuv_web/live/post_live/feed.ex:817
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2528,27 +2528,27 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:5527
+#: lib/vutuv_web/components/post_components.ex:5703
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
 
-#: lib/vutuv_web/components/post_components.ex:405
+#: lib/vutuv_web/components/post_components.ex:407
 #: lib/vutuv_web/live/notification_live/index.ex:1023
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:1920
-#: lib/vutuv_web/components/post_components.ex:5510
-#: lib/vutuv_web/components/post_components.ex:5511
+#: lib/vutuv_web/components/post_components.ex:1922
+#: lib/vutuv_web/components/post_components.ex:5686
+#: lib/vutuv_web/components/post_components.ex:5687
 #: lib/vutuv_web/live/notification_live/index.ex:1086
 #: lib/vutuv_web/live/post_live/reply.ex:43
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:3233
+#: lib/vutuv_web/components/post_components.ex:3409
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
@@ -2569,7 +2569,7 @@ msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beitr
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
 
-#: lib/vutuv_web/components/post_components.ex:2769
+#: lib/vutuv_web/components/post_components.ex:2945
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:60
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:57
@@ -2577,14 +2577,14 @@ msgstr "hat auf Ihren Beitrag geantwortet."
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
 
-#: lib/vutuv_web/components/post_components.ex:3207
+#: lib/vutuv_web/components/post_components.ex:3383
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:3198
-#: lib/vutuv_web/components/post_components.ex:3225
-#: lib/vutuv_web/components/post_components.ex:3228
+#: lib/vutuv_web/components/post_components.ex:3374
+#: lib/vutuv_web/components/post_components.ex:3401
+#: lib/vutuv_web/components/post_components.ex:3404
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
@@ -2809,7 +2809,7 @@ msgstr "Ersten Beitrag schreiben"
 msgid "Manage"
 msgstr "Verwalten"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2506
+#: lib/vutuv_web/live/post_live/feed.ex:2580
 #: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2830,7 +2830,7 @@ msgid_plural "%{formatted} connections"
 msgstr[0] "1 Vernetzung"
 msgstr[1] "%{formatted} Vernetzungen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:939
+#: lib/vutuv_web/live/post_live/feed.ex:945
 #: lib/vutuv_web/templates/user/card_list.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -2885,7 +2885,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:5142
+#: lib/vutuv_web/components/post_components.ex:5318
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -3166,7 +3166,7 @@ msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:3174
+#: lib/vutuv_web/components/post_components.ex:3350
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solange eine Meldung zu diesem Beitrag bearbeitet wird, sehen nur Sie ihn."
@@ -3245,9 +3245,9 @@ msgstr "Abgelehnt"
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 
-#: lib/vutuv_web/components/post_components.ex:1298
-#: lib/vutuv_web/components/post_components.ex:2581
-#: lib/vutuv_web/components/post_components.ex:3338
+#: lib/vutuv_web/components/post_components.ex:1300
+#: lib/vutuv_web/components/post_components.ex:2583
+#: lib/vutuv_web/components/post_components.ex:3514
 #: lib/vutuv_web/live/organization_live/show.ex:680
 #: lib/vutuv_web/templates/user/show.html.heex:222
 #, elixir-autogen, elixir-format
@@ -3958,7 +3958,7 @@ msgstr "Im Rahmen scrollen oder klicken, um das ganze Bild zu öffnen."
 msgid "%{count} endorsements"
 msgstr "%{count} Empfehlungen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1237
+#: lib/vutuv_web/agent_docs/markdown.ex:1250
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr "%{count} auf dieser Seite, weitere mit ?page=N"
@@ -3972,7 +3972,7 @@ msgstr "%{count} Beiträge von %{name}"
 #: lib/vutuv_web/agent_docs/markdown.ex:91
 #: lib/vutuv_web/agent_docs/markdown.ex:202
 #: lib/vutuv_web/agent_docs/markdown.ex:216
-#: lib/vutuv_web/agent_docs/markdown.ex:1078
+#: lib/vutuv_web/agent_docs/markdown.ex:1091
 #: lib/vutuv_web/agent_docs/text.ex:86
 #: lib/vutuv_web/agent_docs/text.ex:185
 #: lib/vutuv_web/agent_docs/text.ex:199
@@ -3995,20 +3995,20 @@ msgstr "Follower von %{name}"
 msgid "Images"
 msgstr "Bilder"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1096
+#: lib/vutuv_web/agent_docs/markdown.ex:1109
 #: lib/vutuv_web/agent_docs/text.ex:770
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr "Antwort auf einen gelöschten Beitrag von %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1093
+#: lib/vutuv_web/agent_docs/markdown.ex:1106
 #: lib/vutuv_web/agent_docs/text.ex:767
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr "Antwort auf einen gelöschten Beitrag."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1100
-#: lib/vutuv_web/agent_docs/markdown.ex:1314
+#: lib/vutuv_web/agent_docs/markdown.ex:1113
+#: lib/vutuv_web/agent_docs/markdown.ex:1327
 #: lib/vutuv_web/agent_docs/text.ex:773
 #: lib/vutuv_web/agent_docs/text.ex:817
 #, elixir-autogen, elixir-format
@@ -4065,7 +4065,7 @@ msgstr "Beiträge (insgesamt %{count})"
 msgid "Verified profile: yes"
 msgstr "Verifiziertes Profil: ja"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1047
+#: lib/vutuv_web/agent_docs/markdown.ex:1060
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr "repostet von %{name}"
@@ -4711,7 +4711,7 @@ msgstr "Sie haben niemanden blockiert."
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2764
+#: lib/vutuv_web/live/post_live/feed.ex:2839
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
@@ -4792,8 +4792,8 @@ msgstr ""
 msgid "Similar names"
 msgstr "Ähnliche Namen"
 
-#: lib/vutuv_web/components/post_components.ex:402
-#: lib/vutuv_web/components/post_components.ex:421
+#: lib/vutuv_web/components/post_components.ex:404
+#: lib/vutuv_web/components/post_components.ex:423
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
@@ -5642,9 +5642,9 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:3404
-#: lib/vutuv_web/components/post_components.ex:3459
-#: lib/vutuv_web/components/post_components.ex:3876
+#: lib/vutuv_web/components/post_components.ex:3580
+#: lib/vutuv_web/components/post_components.ex:3635
+#: lib/vutuv_web/components/post_components.ex:4052
 #: lib/vutuv_web/live/notification_live/index.ex:743
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
@@ -6458,8 +6458,8 @@ msgstr "Tagesbericht öffnen"
 msgid "Previous day"
 msgstr "Vorheriger Tag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1115
-#: lib/vutuv_web/components/post_components.ex:404
+#: lib/vutuv_web/agent_docs/markdown.ex:1128
+#: lib/vutuv_web/components/post_components.ex:406
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
@@ -6572,7 +6572,7 @@ msgstr "Noch keine Empfehlungen."
 msgid "and %{count} more"
 msgstr "und %{count} weitere"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1091
+#: lib/vutuv_web/agent_docs/markdown.ex:1104
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr "empfohlen am %{date}"
@@ -6883,10 +6883,10 @@ msgstr ""
 "Schalten Sie einen Schalter aus, geht der passende Opt-out auf den Seiten "
 "und Antworten über Sie mit. Mit beiden aus zum Beispiel:"
 
-#: lib/vutuv_web/components/post_components.ex:2549
-#: lib/vutuv_web/components/post_components.ex:3335
+#: lib/vutuv_web/components/post_components.ex:2551
+#: lib/vutuv_web/components/post_components.ex:3511
 #: lib/vutuv_web/components/ui.ex:2876
-#: lib/vutuv_web/live/fediverse_account_live.ex:385
+#: lib/vutuv_web/live/fediverse_account_live.ex:386
 #: lib/vutuv_web/live/organization_live/following.ex:376
 #: lib/vutuv_web/live/organization_live/following.ex:451
 #: lib/vutuv_web/templates/settings/filters.html.heex:58
@@ -6911,9 +6911,9 @@ msgstr "Neue Nachrichten und neue Vernetzungen"
 msgid "Remove this connection? You will stop following them."
 msgstr "Diese Vernetzung entfernen? Sie folgen der Person dann nicht mehr."
 
-#: lib/vutuv_web/components/post_components.ex:3335
+#: lib/vutuv_web/components/post_components.ex:3511
 #: lib/vutuv_web/components/ui.ex:2875
-#: lib/vutuv_web/live/fediverse_account_live.ex:383
+#: lib/vutuv_web/live/fediverse_account_live.ex:384
 #: lib/vutuv_web/live/organization_live/following.ex:376
 #: lib/vutuv_web/live/organization_live/following.ex:451
 #: lib/vutuv_web/templates/settings/filters.html.heex:81
@@ -7648,7 +7648,7 @@ msgid "applies to the whole list, not just this page"
 msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:5383
+#: lib/vutuv_web/components/post_components.ex:5559
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -7758,7 +7758,7 @@ msgstr ""
 "der Versand läuft weiter."
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3027
+#: lib/vutuv_web/live/post_live/feed.ex:3103
 #, elixir-autogen
 msgid "Done"
 msgstr "Fertig"
@@ -7838,17 +7838,17 @@ msgstr "Feed von %{name}"
 msgid "The vutuv newsfeed of %{name}"
 msgstr "Der vutuv-Newsfeed von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1242
+#: lib/vutuv_web/agent_docs/markdown.ex:1255
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr "Ihr Feed ist leer."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1245
+#: lib/vutuv_web/agent_docs/markdown.ex:1258
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr "%{count} Beiträge auf dieser Seite"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1252
+#: lib/vutuv_web/agent_docs/markdown.ex:1265
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr "weitere Beiträge verfügbar, ?cursor=%{cursor} anhängen"
@@ -8234,7 +8234,7 @@ msgid "Admins"
 msgstr "Administratoren"
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:948
+#: lib/vutuv_web/live/post_live/feed.ex:954
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr "Alle Mitglieder"
@@ -9212,14 +9212,14 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:4350
+#: lib/vutuv_web/components/post_components.ex:4526
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] "Repostet von %{name} und %{formatted} weiteren"
 msgstr[1] "Repostet von %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1050
+#: lib/vutuv_web/agent_docs/markdown.ex:1063
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr "repostet von %{name} und %{count} weiteren"
@@ -13671,7 +13671,7 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "E-Mail-Benachrichtigungen für Ihre gespeicherte Suche „%{label}“ stoppen?"
 
-#: lib/vutuv_web/components/post_components.ex:2728
+#: lib/vutuv_web/components/post_components.ex:2904
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:715
 #: lib/vutuv_web/controllers/settings_controller.ex:733
@@ -14095,22 +14095,22 @@ msgstr "Mobil (privat)"
 msgid "Work mobile"
 msgstr "Mobil (Arbeit)"
 
-#: lib/vutuv_web/components/post_components.ex:444
+#: lib/vutuv_web/components/post_components.ex:446
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr "Noch keine Beiträge."
 
-#: lib/vutuv_web/components/post_components.ex:446
+#: lib/vutuv_web/components/post_components.ex:448
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr "Noch keine Antworten."
 
-#: lib/vutuv_web/components/post_components.ex:445
+#: lib/vutuv_web/components/post_components.ex:447
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr "Noch keine Reposts."
 
-#: lib/vutuv_web/components/post_components.ex:403
+#: lib/vutuv_web/components/post_components.ex:405
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr "Eigene Beiträge"
@@ -14125,7 +14125,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4724
 #: lib/vutuv_web/controllers/settings_controller.ex:634
-#: lib/vutuv_web/live/post_live/feed.ex:633
+#: lib/vutuv_web/live/post_live/feed.ex:639
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
@@ -14285,50 +14285,50 @@ msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch imm
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:4991
+#: lib/vutuv_web/components/post_components.ex:5167
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1204
-#: lib/vutuv_web/components/post_components.ex:4948
+#: lib/vutuv_web/agent_docs/markdown.ex:1217
+#: lib/vutuv_web/components/post_components.ex:5124
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:4992
+#: lib/vutuv_web/components/post_components.ex:5168
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:4994
+#: lib/vutuv_web/components/post_components.ex:5170
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:4990
+#: lib/vutuv_web/components/post_components.ex:5166
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1204
-#: lib/vutuv_web/components/post_components.ex:4947
+#: lib/vutuv_web/agent_docs/markdown.ex:1217
+#: lib/vutuv_web/components/post_components.ex:5123
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Filmbesprechung"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:453
+#: lib/vutuv_web/live/fediverse_account_live.ex:454
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "Look up"
 msgstr "Nachschlagen"
 
-#: lib/vutuv_web/components/post_components.ex:4989
+#: lib/vutuv_web/components/post_components.ex:5165
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
 
-#: lib/vutuv_web/components/post_components.ex:4993
+#: lib/vutuv_web/components/post_components.ex:5169
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14348,7 +14348,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:5030
+#: lib/vutuv_web/components/post_components.ex:5206
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14356,27 +14356,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:5060
+#: lib/vutuv_web/components/post_components.ex:5236
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:5061
+#: lib/vutuv_web/components/post_components.ex:5237
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:5059
+#: lib/vutuv_web/components/post_components.ex:5235
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:5019
+#: lib/vutuv_web/components/post_components.ex:5195
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:5066
+#: lib/vutuv_web/components/post_components.ex:5242
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14406,7 +14406,7 @@ msgstr "Mit Qualifikation:"
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:4833
+#: lib/vutuv_web/components/post_components.ex:5009
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
@@ -14454,7 +14454,7 @@ msgstr "folgen Ihnen jetzt."
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:4824
+#: lib/vutuv_web/components/post_components.ex:5000
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
@@ -14848,14 +14848,14 @@ msgstr "Konto zum Einfrieren suchen"
 msgid "See all frozen accounts"
 msgstr "Alle eingefrorenen Konten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:3001
+#: lib/vutuv_web/components/post_components.ex:3177
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "%{formatted} früheren Beitrag anzeigen"
 msgstr[1] "%{formatted} frühere Beiträge anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:3024
+#: lib/vutuv_web/components/post_components.ex:3200
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14882,7 +14882,7 @@ msgstr "Dieses Profil ist zurzeit nicht verfügbar."
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das Konto zu finden, das eingefroren werden soll."
 
-#: lib/vutuv_web/components/post_components.ex:5482
+#: lib/vutuv_web/components/post_components.ex:5658
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Der eigene Beitrag lässt sich nicht mit „Gefällt mir“ markieren."
@@ -15059,7 +15059,7 @@ msgstr ""
 "Wählen Sie unten einen Abschluss oder eine Schule, um ihn statt eines "
 "Jobtitels oben in Ihrem Profil anzuzeigen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1008
+#: lib/vutuv_web/live/post_live/feed.ex:1014
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr "Trotzdem anzeigen"
@@ -15284,7 +15284,7 @@ msgstr "%{blocked} Server blockiert, am aktivsten eingehend: %{host}."
 msgid "none yet"
 msgstr "noch keiner"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1151
+#: lib/vutuv_web/agent_docs/markdown.ex:1164
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr "Reaktionen aus anderen Netzwerken"
@@ -16041,29 +16041,29 @@ msgstr ""
 "wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
-#: lib/vutuv_web/components/post_components.ex:5428
+#: lib/vutuv_web/components/post_components.ex:5604
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:5432
+#: lib/vutuv_web/components/post_components.ex:5608
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Like"
 msgstr[1] "%{formatted} Likes"
 
-#: lib/vutuv_web/components/post_components.ex:5436
+#: lib/vutuv_web/components/post_components.ex:5612
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
 msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1153
-#: lib/vutuv_web/components/post_components.ex:5387
+#: lib/vutuv_web/agent_docs/markdown.ex:1166
+#: lib/vutuv_web/components/post_components.ex:5563
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Bereits in den Zahlen oben enthalten."
@@ -16073,20 +16073,20 @@ msgstr "Bereits in den Zahlen oben enthalten."
 msgid "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
 msgstr "Antworten, die dort draußen geschrieben werden, erscheinen unter Ihrem Beitrag, gekennzeichnet als aus einem anderen Netzwerk. Wir speichern eine Kopie für bis zu sechs Monate und prüfen ab und zu, ob sie dort noch veröffentlicht ist; löscht sie die Autorin oder der Autor, verschwindet auch unsere. Sie können jede einzelne Antwort entfernen, und wenn Sie das hier ausschalten, werden alle gelöscht."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1335
+#: lib/vutuv_web/agent_docs/markdown.ex:1348
 #: lib/vutuv_web/agent_docs/text.ex:831
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr "Inhaltswarnung"
 
-#: lib/vutuv_web/components/post_components.ex:1413
-#: lib/vutuv_web/components/post_components.ex:2142
-#: lib/vutuv_web/live/fediverse_account_live.ex:298
+#: lib/vutuv_web/components/post_components.ex:1415
+#: lib/vutuv_web/components/post_components.ex:2144
+#: lib/vutuv_web/live/fediverse_account_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr "Aus einem anderen Netzwerk"
 
-#: lib/vutuv_web/components/post_components.ex:1286
+#: lib/vutuv_web/components/post_components.ex:1288
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr "Diese Antwort aus Ihrem Beitrag entfernen?"
@@ -16098,7 +16098,7 @@ msgstr "Vom Mitglied entfernt"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:134
 #: lib/vutuv_web/agent_docs/markdown.ex:165
-#: lib/vutuv_web/agent_docs/markdown.ex:1152
+#: lib/vutuv_web/agent_docs/markdown.ex:1165
 #: lib/vutuv_web/agent_docs/text.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:151
 #, elixir-autogen, elixir-format
@@ -16115,7 +16115,7 @@ msgstr "Antwort aus einem anderen Netzwerk"
 msgid "Reply removed."
 msgstr "Antwort entfernt."
 
-#: lib/vutuv_web/components/post_components.ex:1295
+#: lib/vutuv_web/components/post_components.ex:1297
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
@@ -16125,7 +16125,7 @@ msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
 msgid "Reported as not appropriate"
 msgstr "Als unangemessen gemeldet"
 
-#: lib/vutuv_web/components/post_components.ex:1309
+#: lib/vutuv_web/components/post_components.ex:1311
 #: lib/vutuv_web/live/notification_live/index.ex:597
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -16156,10 +16156,10 @@ msgstr "Danke. Die Antwort wurde sofort gelöscht."
 msgid "That reply is not yours to remove."
 msgstr "Diese Antwort können Sie nicht entfernen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1337
-#: lib/vutuv_web/components/post_components.ex:1344
-#: lib/vutuv_web/components/post_components.ex:1544
-#: lib/vutuv_web/components/post_components.ex:2648
+#: lib/vutuv_web/agent_docs/markdown.ex:1350
+#: lib/vutuv_web/components/post_components.ex:1346
+#: lib/vutuv_web/components/post_components.ex:1546
+#: lib/vutuv_web/components/post_components.ex:2824
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr "Original ansehen"
@@ -16826,22 +16826,22 @@ msgstr "Was sich an welchem Konto geändert hat, wann, von welchem Gerät und wi
 msgid "device or detail"
 msgstr "Gerät oder Detail"
 
-#: lib/vutuv_web/components/post_components.ex:3186
+#: lib/vutuv_web/components/post_components.ex:3362
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Angehefteter Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:3302
+#: lib/vutuv_web/components/post_components.ex:3478
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "An Profil anheften"
 
-#: lib/vutuv_web/components/post_components.ex:3310
+#: lib/vutuv_web/components/post_components.ex:3486
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Vom Profil lösen"
 
-#: lib/vutuv_web/components/post_components.ex:3296
+#: lib/vutuv_web/components/post_components.ex:3472
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr "Es lässt sich nur ein Beitrag an Ihr Profil anheften. Diesen anheften und den anderen lösen?"
@@ -16863,7 +16863,7 @@ msgstr ""
 msgid "Unpinned. The post is a normal post again."
 msgstr "Nicht mehr angeheftet. Der Beitrag ist wieder ein normaler Beitrag."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1033
+#: lib/vutuv_web/agent_docs/markdown.ex:1046
 #, elixir-autogen, elixir-format
 msgid "pinned post"
 msgstr "angehefteter Beitrag"
@@ -16931,7 +16931,7 @@ msgstr "Titelbild"
 msgid "Describe the photo for people who can't see it"
 msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1265
+#: lib/vutuv_web/agent_docs/markdown.ex:1278
 #: lib/vutuv_web/agent_docs/text.ex:798
 #: lib/vutuv_web/components/ui.ex:2930
 #, elixir-autogen, elixir-format
@@ -16973,17 +16973,17 @@ msgstr "Nächstes Foto"
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
 
-#: lib/vutuv_web/components/post_components.ex:2781
+#: lib/vutuv_web/components/post_components.ex:2957
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Fediverse-Einstellungen öffnen"
 
-#: lib/vutuv_web/components/post_components.ex:4005
+#: lib/vutuv_web/components/post_components.ex:4181
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} von %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:4153
+#: lib/vutuv_web/components/post_components.ex:4329
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
@@ -16994,9 +16994,9 @@ msgstr "Foto wird geprüft"
 msgid "Photo options"
 msgstr "Foto-Einstellungen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1298
+#: lib/vutuv_web/agent_docs/markdown.ex:1311
 #: lib/vutuv_web/agent_docs/text.ex:785
-#: lib/vutuv_web/components/post_components.ex:4235
+#: lib/vutuv_web/components/post_components.ex:4411
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Fotos:"
@@ -17022,7 +17022,7 @@ msgstr "Dieselben Bildpunkte, sonst nichts: Ort und Seriennummern entfernt, Qual
 msgid "Show camera settings"
 msgstr "Kameradaten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2834
+#: lib/vutuv_web/components/post_components.ex:3010
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr "Dieser Server ist auf dieser Seite gesperrt, deshalb kann keine Antwort dorthin gesendet werden."
@@ -17042,7 +17042,7 @@ msgstr "Dieses Dateiformat lässt sich nur unverändert weitergeben. Entfernen S
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr "Dieses Foto enthält den Ort, an dem es aufgenommen wurde. Wer die exakte Datei herunterlädt, kann ihn auslesen."
 
-#: lib/vutuv_web/components/post_components.ex:2825
+#: lib/vutuv_web/components/post_components.ex:3001
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht öffentlich beantworten."
@@ -17052,12 +17052,12 @@ msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht �
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr "Diese Antwort wurde in einem anderen Netzwerk geschrieben. Sie zu beantworten heißt, Ihre Worte in dieses Netzwerk zu senden, und das tut vutuv nur für Mitglieder, die die Fediverse-Teilnahme eingeschaltet haben."
 
-#: lib/vutuv_web/components/post_components.ex:2843
+#: lib/vutuv_web/components/post_components.ex:3019
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Diese Seite nimmt nicht am Fediverse teil."
 
-#: lib/vutuv_web/components/post_components.ex:2777
+#: lib/vutuv_web/components/post_components.ex:2953
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Fediverse-Teilnahme einschalten, um zu antworten"
@@ -17072,7 +17072,7 @@ msgstr "Wer diese Fotos weiterverwenden darf"
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke geschickt. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:2838
+#: lib/vutuv_web/components/post_components.ex:3014
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshalb werden von hier aus keine Antworten mehr gesendet."
@@ -17082,7 +17082,7 @@ msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshal
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr "Ihre Fediverse-Einstellungen erlauben es derzeit nicht, eine Antwort zu senden."
 
-#: lib/vutuv_web/components/post_components.ex:2791
+#: lib/vutuv_web/components/post_components.ex:2967
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr "Ihre Antwort geht an %{handle} auf dem eigenen Server und an Ihre Fediverse-Follower. Auf vutuv ist sie ebenfalls ein öffentlicher Beitrag."
@@ -17103,8 +17103,8 @@ msgstr "Fotos hinzufügen"
 msgid "Licence"
 msgstr "Lizenz"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2515
-#: lib/vutuv_web/live/post_live/feed.ex:2516
+#: lib/vutuv_web/live/post_live/feed.ex:2589
+#: lib/vutuv_web/live/post_live/feed.ex:2590
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr "Fotos posten"
@@ -17168,14 +17168,14 @@ msgid_plural "Some of these photos carry the location they were taken at, and th
 msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exakte Datei gibt ihn weiter."
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1171
-#: lib/vutuv_web/components/post_components.ex:5425
+#: lib/vutuv_web/agent_docs/markdown.ex:1184
+#: lib/vutuv_web/components/post_components.ex:5601
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1169
-#: lib/vutuv_web/components/post_components.ex:5422
+#: lib/vutuv_web/agent_docs/markdown.ex:1182
+#: lib/vutuv_web/components/post_components.ex:5598
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} hat das geteilt"
@@ -17185,7 +17185,7 @@ msgstr "%{handle} hat das geteilt"
 msgid "Fediverse reactions"
 msgstr "Fediverse-Reaktionen"
 
-#: lib/vutuv_web/components/post_components.ex:5314
+#: lib/vutuv_web/components/post_components.ex:5490
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
@@ -17285,7 +17285,7 @@ msgstr "Rücknahme"
 msgid "Photo details"
 msgstr "Fotodetails"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:459
+#: lib/vutuv_web/live/fediverse_account_live.ex:460
 #: lib/vutuv_web/live/fediverse_following_live.ex:60
 #: lib/vutuv_web/live/fediverse_following_live.ex:301
 #: lib/vutuv_web/live/fediverse_following_live.ex:314
@@ -17315,7 +17315,7 @@ msgstr "Anfrage zurückziehen"
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr "Konten auf Mastodon folgen, und von dort gefolgt werden"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:120
+#: lib/vutuv_web/live/fediverse_account_live.ex:121
 #: lib/vutuv_web/live/fediverse_following_live.ex:257
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:147
 #, elixir-autogen, elixir-format
@@ -17446,7 +17446,7 @@ msgstr "Dieses vutuv tauscht nichts mit diesem Server aus."
 msgid "To follow an account out there you need a Fediverse identity of your own: the request is signed in your name, so the other server knows who is asking."
 msgstr "Um einem Konto dort draußen zu folgen, brauchen Sie eine eigene Fediverse-Identität: Die Anfrage wird in Ihrem Namen signiert, damit der andere Server weiß, wer fragt."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:136
+#: lib/vutuv_web/live/fediverse_account_live.ex:137
 #: lib/vutuv_web/live/fediverse_following_live.ex:181
 #, elixir-autogen, elixir-format
 msgid "Unfollowed."
@@ -17534,7 +17534,7 @@ msgstr "Von hier aus wird %{follows} Konten in anderen Netzwerken gefolgt, davon
 msgid "Cached posts"
 msgstr "Zwischengespeicherte Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:2590
+#: lib/vutuv_web/components/post_components.ex:2592
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr "Nur für die Follower dieses Kontos"
@@ -17544,7 +17544,7 @@ msgstr "Nur für die Follower dieses Kontos"
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Danke. Unsere Kopie wurde sofort gelöscht."
 
-#: lib/vutuv_web/components/post_components.ex:2647
+#: lib/vutuv_web/components/post_components.ex:2823
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Beim Original abstimmen"
@@ -17564,17 +17564,17 @@ msgstr "Zwischengespeicherter Beitrag gemeldet, hier für alle entfernt"
 msgid "Content from other networks taken down by members"
 msgstr "Von Mitgliedern entfernte Inhalte aus anderen Netzwerken"
 
-#: lib/vutuv_web/components/post_components.ex:1689
+#: lib/vutuv_web/components/post_components.ex:1691
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr "Verbergen"
 
-#: lib/vutuv_web/components/post_components.ex:2602
+#: lib/vutuv_web/components/post_components.ex:2773
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Von der verfassenden Person als sensibel markiert"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:231
+#: lib/vutuv_web/live/fediverse_account_live.ex:232
 #: lib/vutuv_web/live/remote_post_actions.ex:71
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
@@ -17585,7 +17585,7 @@ msgstr "Stummgeschaltet. Sie folgen dem Konto weiterhin; die Beiträge verschwin
 msgid "Nobody has removed or reported anything yet."
 msgstr "Bisher hat niemand etwas entfernt oder gemeldet."
 
-#: lib/vutuv_web/components/post_components.ex:2576
+#: lib/vutuv_web/components/post_components.ex:2578
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr "Diesen Beitrag als unangemessen melden? Unsere Kopie wird sofort für alle auf diesem vutuv gelöscht."
@@ -17605,57 +17605,57 @@ msgstr "Sie folgen dort draußen noch niemandem. Sobald Sie das tun, erscheinen 
 msgid "%{name} (another network)"
 msgstr "%{name} (anderes Netzwerk)"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:281
+#: lib/vutuv_web/live/fediverse_account_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "Account on another network"
 msgstr "Konto in einem anderen Netzwerk"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:443
+#: lib/vutuv_web/live/fediverse_account_live.ex:444
 #, elixir-autogen, elixir-format
 msgid "Look up another account"
 msgstr "Ein anderes Konto nachschlagen"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:373
+#: lib/vutuv_web/live/fediverse_account_live.ex:374
 #, elixir-autogen, elixir-format
 msgid "Muted"
 msgstr "Stummgeschaltet"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:256
+#: lib/vutuv_web/live/fediverse_account_live.ex:257
 #, elixir-autogen, elixir-format
 msgid "Nothing cached yet. Their posts appear here as they publish them."
 msgstr "Noch nichts zwischengespeichert. Die Beiträge erscheinen hier, sobald sie veröffentlicht werden."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:251
+#: lib/vutuv_web/live/fediverse_account_live.ex:252
 #, elixir-autogen, elixir-format
 msgid "Nothing here. vutuv only keeps an account's posts while somebody here follows it, and this page never fetches any."
 msgstr "Hier ist nichts. vutuv behält die Beiträge eines Kontos nur, solange jemand hier ihm folgt, und diese Seite ruft von sich aus keine ab."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:445
+#: lib/vutuv_web/live/fediverse_account_live.ex:446
 #, elixir-autogen, elixir-format
 msgid "Paste an address from Mastodon and friends to open its page here."
 msgstr "Fügen Sie eine Adresse von Mastodon und Co. ein, um die zugehörige Seite hier zu öffnen."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:333
+#: lib/vutuv_web/live/fediverse_account_live.ex:334
 #, elixir-autogen, elixir-format
 msgid "Show the whole description"
 msgstr "Ganze Beschreibung anzeigen"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:428
+#: lib/vutuv_web/live/fediverse_account_live.ex:429
 #, elixir-autogen, elixir-format
 msgid "The most recent %{count} are shown. The rest are on their own server."
 msgstr "Die neuesten %{count} werden angezeigt. Der Rest liegt auf dem eigenen Server."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:233
+#: lib/vutuv_web/live/fediverse_account_live.ex:234
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts are back in your feed."
 msgstr "Stummschaltung aufgehoben. Die Beiträge sind wieder in Ihrem Feed."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:438
+#: lib/vutuv_web/live/fediverse_account_live.ex:439
 #, elixir-autogen, elixir-format
 msgid "View their full profile on %{host}"
 msgstr "Vollständiges Profil auf %{host} ansehen"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:260
+#: lib/vutuv_web/live/fediverse_account_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Waiting for that server to accept your follow. Posts they addressed to their followers appear once it does."
 msgstr "Warten darauf, dass der Server Ihre Follower-Anfrage annimmt. Beiträge, die nur an die Follower gerichtet sind, erscheinen danach."
@@ -17807,27 +17807,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] "(ein Bild)"
 msgstr[1] "(%{count} Bilder)"
 
-#: lib/vutuv_web/components/post_components.ex:2301
+#: lib/vutuv_web/components/post_components.ex:2303
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr "Bild wird geprüft"
 
-#: lib/vutuv_web/components/post_components.ex:2329
+#: lib/vutuv_web/components/post_components.ex:2331
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr "Wieder verdecken"
 
-#: lib/vutuv_web/components/post_components.ex:2324
+#: lib/vutuv_web/components/post_components.ex:2326
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr "Heikles Motiv. Bild anzeigen."
 
-#: lib/vutuv_web/components/post_components.ex:2684
+#: lib/vutuv_web/components/post_components.ex:2860
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Das sind viele Likes in einer Stunde. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:2690
+#: lib/vutuv_web/components/post_components.ex:2866
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Diesen Beitrag gibt es hier nicht mehr."
@@ -17837,7 +17837,7 @@ msgstr "Diesen Beitrag gibt es hier nicht mehr."
 msgid "Back to the feed"
 msgstr "Zurück zum Feed"
 
-#: lib/vutuv_web/components/post_components.ex:2829
+#: lib/vutuv_web/components/post_components.ex:3005
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17996,7 +17996,7 @@ msgstr "Gehört Ihnen noch nicht."
 msgid "Nothing has changed yet."
 msgstr "Noch hat sich nichts geändert."
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:250
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:269
 #: lib/vutuv_web/templates/username/confirm.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Now"
@@ -18551,14 +18551,14 @@ msgstr "Seiten, von denen nie ein Screenshot entsteht, weil ein Browser ohne Anz
 msgid "Screenshot blocklist"
 msgstr "Screenshot-Blockliste"
 
-#: lib/vutuv_web/components/post_components.ex:436
+#: lib/vutuv_web/components/post_components.ex:438
 #, elixir-autogen, elixir-format
 msgid "Nothing from the fediverse yet. Follow accounts out there to fill this tab."
 msgstr ""
 "Noch nichts aus dem Fediverse. Folgen Sie Konten dort draußen, um diesen Tab "
 "zu füllen."
 
-#: lib/vutuv_web/components/post_components.ex:433
+#: lib/vutuv_web/components/post_components.ex:435
 #, elixir-autogen, elixir-format
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
@@ -18601,7 +18601,7 @@ msgstr "Auf vutuv gibt es zu diesem Tag noch keine Beiträge."
 msgid "word in a post"
 msgstr "Wort in einem Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:2687
+#: lib/vutuv_web/components/post_components.ex:2863
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr "Diese Antwort gibt es hier nicht mehr."
@@ -18899,24 +18899,24 @@ msgstr "Höchstens %{max} Tags. Entfernen Sie eines, um ein anderes hinzuzufüge
 msgid "A post's page shows the members who liked it, right under the count. This is whether you are one of the faces."
 msgstr "Auf der Seite eines Beitrags stehen direkt unter der Zahl die Mitglieder, denen er gefällt. Hier legen Sie fest, ob Sie zu diesen Gesichtern gehören."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1139
+#: lib/vutuv_web/agent_docs/markdown.ex:1152
 #, elixir-autogen, elixir-format
 msgid "Liked by"
 msgstr "Gefällt diesen Mitgliedern"
 
-#: lib/vutuv_web/components/post_components.ex:4520
+#: lib/vutuv_web/components/post_components.ex:4696
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Gefällt %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:4522
+#: lib/vutuv_web/components/post_components.ex:4698
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Gefällt %{name} und %{formatted} weiteren"
 msgstr[1] "Gefällt %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/components/post_components.ex:4533
+#: lib/vutuv_web/components/post_components.ex:4709
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr "Nur Sie sehen hier alle: Einige dieser Mitglieder werden anderen Lesern nicht genannt."
@@ -18941,12 +18941,12 @@ msgstr "Wenn aus, sehen andere Mitglieder Sie nicht mehr bei den Likes eines Bei
 msgid "Your likes follow the site default again."
 msgstr "Ihre Likes folgen wieder dem Standardwert der Website."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1194
+#: lib/vutuv_web/agent_docs/markdown.ex:1207
 #, elixir-autogen, elixir-format
 msgid "%{address} (this page only)"
 msgstr "%{address} (nur diese Seite)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1191
+#: lib/vutuv_web/agent_docs/markdown.ex:1204
 #, elixir-autogen, elixir-format
 msgid "%{address} (whole website)"
 msgstr "%{address} (ganze Website)"
@@ -18956,7 +18956,7 @@ msgstr "%{address} (ganze Website)"
 msgid "Verified webpage of the author (%{address})"
 msgstr "Verifizierte Webseite der Autorin oder des Autors (%{address})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1183
+#: lib/vutuv_web/agent_docs/markdown.ex:1196
 #, elixir-autogen, elixir-format
 msgid "Verified webpages of the author linked here: %{addresses}"
 msgstr ""
@@ -19090,7 +19090,7 @@ msgstr "Ausstellungsdatum"
 msgid "Label"
 msgstr "Bezeichnung"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2782
+#: lib/vutuv_web/live/post_live/feed.ex:2857
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -20592,7 +20592,7 @@ msgstr "Suchen Sie so oft Sie möchten und nehmen Sie dazu, was gehört. Abkürz
 msgid "Start over"
 msgstr "Von vorn beginnen"
 
-#: lib/vutuv_web/components/post_components.ex:2717
+#: lib/vutuv_web/components/post_components.ex:2893
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr "Ein Herz oder ein Repost geht zurück in das Netzwerk, aus dem dieser Beitrag stammt. Ihr Konto nimmt derzeit nicht am Fediverse teil. Einschalten können Sie das in den {settings}."
@@ -21493,27 +21493,27 @@ msgstr "Sprache des Beitrags"
 msgid "The language this post is written in"
 msgstr "Die Sprache, in der dieser Beitrag geschrieben ist"
 
-#: lib/vutuv_web/components/post_components.ex:4414
+#: lib/vutuv_web/components/post_components.ex:4590
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Original anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:4450
+#: lib/vutuv_web/components/post_components.ex:4626
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Übersetzen"
 
-#: lib/vutuv_web/components/post_components.ex:4459
+#: lib/vutuv_web/components/post_components.ex:4635
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Übersetzt"
 
-#: lib/vutuv_web/components/post_components.ex:4462
+#: lib/vutuv_web/components/post_components.ex:4638
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Übersetzt aus %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:4439
+#: lib/vutuv_web/components/post_components.ex:4615
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Wird übersetzt …"
@@ -21523,7 +21523,7 @@ msgstr "Wird übersetzt …"
 msgid "Feed language settings reset to the site defaults."
 msgstr "Feed-Spracheinstellungen auf die Website-Vorgaben zurückgesetzt."
 
-#: lib/vutuv_web/components/post_components.ex:4429
+#: lib/vutuv_web/components/post_components.ex:4605
 #: lib/vutuv_web/components/ui.ex:4717
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -21652,20 +21652,20 @@ msgstr "Wir haben den Link in Ihrem Profil noch nicht gefunden. Bitte versuchen 
 msgid "Your username, or paste the address of your profile page."
 msgstr "Ihr Benutzername – oder fügen Sie die Adresse Ihrer Profilseite ein."
 
-#: lib/vutuv_web/components/post_components.ex:4201
+#: lib/vutuv_web/components/post_components.ex:4377
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] "Unsere KI prüft es gerade. Sobald die Prüfung durch ist, erscheint das Foto von selbst."
 msgstr[1] "Unsere KI prüft sie gerade, %{done} von %{total} sind durch. Sobald die letzte durch ist, erscheinen die Fotos von selbst."
 
-#: lib/vutuv_web/components/post_components.ex:4198
+#: lib/vutuv_web/components/post_components.ex:4374
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr "Ihr Beitrag ist veröffentlicht, das Foto noch nicht."
 
-#: lib/vutuv_web/components/post_components.ex:2350
-#: lib/vutuv_web/components/post_components.ex:3519
+#: lib/vutuv_web/components/post_components.ex:2352
+#: lib/vutuv_web/components/post_components.ex:3695
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -21682,7 +21682,7 @@ msgstr "Empfohlen: %{width} × %{height} Pixel (%{ratio})."
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr "Empfohlen: quadratisch, mindestens %{width} × %{height} Pixel."
 
-#: lib/vutuv_web/live/post_live/feed.ex:885
+#: lib/vutuv_web/live/post_live/feed.ex:891
 #: lib/vutuv_web/views/user_html.ex:338
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -22176,7 +22176,7 @@ msgstr "Land suchen"
 msgid "This page is following the most accounts we allow (%{max})."
 msgstr "Diese Seite folgt bereits so vielen Konten, wie hier erlaubt sind (%{max})."
 
-#: lib/vutuv_web/components/post_components.ex:2564
+#: lib/vutuv_web/components/post_components.ex:2566
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr "%{handle} nicht mehr folgen? Die Beiträge verschwinden aus Ihrem Feed."
@@ -22302,12 +22302,12 @@ msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public po
 msgstr ""
 "Folgen Sie #%{tag} von Mastodon oder einer anderen Fediverse-App aus, dann landen die öffentlichen Beiträge in Ihrer Timeline. Ein vutuv-Konto brauchen Sie dafür nicht."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2940
+#: lib/vutuv_web/live/post_live/feed.ex:3016
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Andere Mitglieder begrüßen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:634
+#: lib/vutuv_web/live/post_live/feed.ex:640
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr "Neu dabei"
@@ -22353,7 +22353,7 @@ msgstr "Der beste Weg: Folgen Sie %{name} hier. Neue Beiträge landen in Ihrem F
 msgid "With a vutuv account"
 msgstr "Mit einem vutuv-Konto"
 
-#: lib/vutuv_web/live/post_live/feed.ex:877
+#: lib/vutuv_web/live/post_live/feed.ex:883
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
@@ -22755,7 +22755,7 @@ msgstr "Alle vutuv Mitglieder, alphabetisch nach Nachname sortiert."
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr "Alle vutuv Mitglieder, gruppiert nach dem Anfangsbuchstaben des Nachnamens."
 
-#: lib/vutuv_web/live/post_live/feed.ex:758
+#: lib/vutuv_web/live/post_live/feed.ex:764
 #: lib/vutuv_web/live/post_live/filter_band.ex:292
 #, elixir-autogen, elixir-format
 msgid "A photo"
@@ -22771,7 +22771,7 @@ msgstr "Auch in längeren Wörtern: %{word} trifft auch %{example}."
 msgid "A–Z"
 msgstr "A–Z"
 
-#: lib/vutuv_web/live/post_live/feed.ex:840
+#: lib/vutuv_web/live/post_live/feed.ex:846
 #, elixir-autogen, elixir-format
 msgid "Browse the tags"
 msgstr "Alle Tags ansehen"
@@ -22786,7 +22786,7 @@ msgstr "Aktivste zuerst"
 msgid "Clear all"
 msgstr "Alle löschen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:671
+#: lib/vutuv_web/live/post_live/feed.ex:677
 #, elixir-autogen, elixir-format
 msgid "Drag, or use the arrow keys"
 msgstr "Ziehen, oder die Pfeiltasten benutzen"
@@ -22801,13 +22801,13 @@ msgstr "Auf- und zuklappen"
 msgid "Find an account or a server …"
 msgstr "Konto oder Server suchen …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:695
+#: lib/vutuv_web/live/post_live/feed.ex:701
 #, elixir-autogen, elixir-format
 msgid "Fold %{card}"
 msgstr "%{card} einklappen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:822
-#: lib/vutuv_web/live/post_live/feed.ex:823
+#: lib/vutuv_web/live/post_live/feed.ex:828
+#: lib/vutuv_web/live/post_live/feed.ex:829
 #, elixir-autogen, elixir-format
 msgid "Follow a tag …"
 msgstr "Einem Tag folgen …"
@@ -22824,17 +22824,17 @@ msgstr "Tag ausblenden …"
 msgid "Hide a word or a whole phrase …"
 msgstr "Wort oder ganzen Satz ausblenden …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:632
+#: lib/vutuv_web/live/post_live/feed.ex:638
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr "Tags ausblenden"
 
-#: lib/vutuv_web/live/post_live/feed.ex:631
+#: lib/vutuv_web/live/post_live/feed.ex:637
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr "Wörter ausblenden"
 
-#: lib/vutuv_web/live/post_live/feed.ex:846
+#: lib/vutuv_web/live/post_live/feed.ex:852
 #: lib/vutuv_web/live/post_live/filter_band.ex:331
 #, elixir-autogen, elixir-format
 msgid "In your feed right now:"
@@ -22850,7 +22850,7 @@ msgstr "Trifft gerade nichts in Ihrem Feed — für alles Neue gilt die Regel tr
 msgid "More of your %{formatted} accounts"
 msgstr "Mehr Ihrer %{formatted} Konten"
 
-#: lib/vutuv_web/live/post_live/feed.ex:670
+#: lib/vutuv_web/live/post_live/feed.ex:676
 #, elixir-autogen, elixir-format
 msgid "Move %{card}"
 msgstr "%{card} verschieben"
@@ -22860,12 +22860,12 @@ msgstr "%{card} verschieben"
 msgid "No account found."
 msgstr "Kein Konto gefunden."
 
-#: lib/vutuv_web/live/post_live/feed.ex:835
+#: lib/vutuv_web/live/post_live/feed.ex:841
 #, elixir-autogen, elixir-format
 msgid "No tag called %{name} yet."
 msgstr "Noch kein Tag namens %{name}."
 
-#: lib/vutuv_web/live/post_live/feed.ex:624
+#: lib/vutuv_web/live/post_live/feed.ex:630
 #, elixir-autogen, elixir-format
 msgid "Not read yet"
 msgstr "Noch nicht gelesen"
@@ -22895,13 +22895,13 @@ msgstr "Beiträge mit einem dieser Tags werden genauso zugeklappt."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "Beiträge mit einem dieser Wörter werden auf eine Zeile zugeklappt — nicht gelöscht, und mit einem Weg, sie doch zu lesen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2966
+#: lib/vutuv_web/live/post_live/feed.ex:3042
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr "Weggelegt:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:716
-#: lib/vutuv_web/live/post_live/feed.ex:717
+#: lib/vutuv_web/live/post_live/feed.ex:722
+#: lib/vutuv_web/live/post_live/feed.ex:723
 #, elixir-autogen, elixir-format
 msgid "Remove %{card}"
 msgstr "%{card} entfernen"
@@ -22933,7 +22933,7 @@ msgstr "Nur %{source} anzeigen"
 msgid "Show posts by %{name}"
 msgstr "Beiträge von %{name} anzeigen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:630
+#: lib/vutuv_web/live/post_live/feed.ex:636
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr "Quellen"
@@ -22943,12 +22943,12 @@ msgstr "Quellen"
 msgid "Switching off means muting, not unfollowing. You stay a follower, the posts just stop reaching your feed: permanently and on every device, until you switch them back on here."
 msgstr "Ausschalten heißt stumm schalten, nicht entfolgen. Sie folgen weiter, die Beiträge bleiben nur aus Ihrem Feed: dauerhaft und auf allen Geräten, bis Sie hier wieder einschalten."
 
-#: lib/vutuv_web/live/post_live/feed.ex:694
+#: lib/vutuv_web/live/post_live/feed.ex:700
 #, elixir-autogen, elixir-format
 msgid "Unfold %{card}"
 msgstr "%{card} ausklappen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:812
+#: lib/vutuv_web/live/post_live/feed.ex:818
 #, elixir-autogen, elixir-format
 msgid "Unfollow the tag %{tag}"
 msgstr "Dem Tag %{tag} nicht mehr folgen"
@@ -22972,29 +22972,29 @@ msgid_plural "and %{formatted} more"
 msgstr[0] "und 1 weiterer"
 msgstr[1] "und %{formatted} weitere"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2609
-#: lib/vutuv_web/live/post_live/feed.ex:2626
-#: lib/vutuv_web/live/post_live/feed.ex:3014
-#: lib/vutuv_web/live/post_live/feed.ex:3019
+#: lib/vutuv_web/live/post_live/feed.ex:2684
+#: lib/vutuv_web/live/post_live/feed.ex:2701
+#: lib/vutuv_web/live/post_live/feed.ex:3090
+#: lib/vutuv_web/live/post_live/feed.ex:3095
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
 msgstr "Filter"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1016
+#: lib/vutuv_web/live/post_live/feed.ex:1022
 #, elixir-autogen, elixir-format
 msgctxt "filtered post"
 msgid "Hidden:"
 msgstr "Ausgeblendet:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:768
+#: lib/vutuv_web/live/post_live/feed.ex:774
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} post in the feed"
 msgid_plural "Show %{formatted} posts in the feed"
 msgstr[0] "%{formatted} Beitrag im Feed anzeigen"
 msgstr[1] "%{formatted} Beiträge im Feed anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2272
+#: lib/vutuv_web/components/post_components.ex:2274
 #, elixir-autogen, elixir-format
 msgid "Picture unavailable"
 msgstr "Bild nicht verfügbar"
@@ -23025,31 +23025,31 @@ msgid_plural "You can upload at most %{count} files at a time."
 msgstr[0] "Sie können eine Datei auf einmal hochladen."
 msgstr[1] "Sie können höchstens %{count} Dateien auf einmal hochladen."
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:370
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:392
 #, elixir-autogen, elixir-format
 msgid "%{count} entry on %{day}"
 msgid_plural "%{count} entries on %{day}"
 msgstr[0] "%{count} Eintrag am %{day}"
 msgstr[1] "%{count} Einträge am %{day}"
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:367
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:389
 #, elixir-autogen, elixir-format
 msgid "%{count} post on %{day}"
 msgid_plural "%{count} posts on %{day}"
 msgstr[0] "%{count} Beitrag am %{day}"
 msgstr[1] "%{count} Beiträge am %{day}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2739
+#: lib/vutuv_web/live/post_live/feed.ex:2814
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr "Zurück zu jetzt"
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:234
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:253
 #, elixir-autogen, elixir-format
 msgid "Busy month: the shading counts at least this much."
 msgstr "Voller Monat: die Färbung zählt mindestens so viel."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2785
+#: lib/vutuv_web/live/post_live/feed.ex:2860
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -23061,38 +23061,38 @@ msgstr[1] "Ganzen Tag laden (%{formatted} Beiträge)"
 msgid "My posts"
 msgstr "Meine Beiträge"
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:146
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:161
 #, elixir-autogen, elixir-format
 msgid "Next month"
 msgstr "Nächster Monat"
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:152
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:167
 #, elixir-autogen, elixir-format
 msgid "Next year"
 msgstr "Nächstes Jahr"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2735
+#: lib/vutuv_web/live/post_live/feed.ex:2810
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr "Am %{day} ist nichts in Ihrem Feed angekommen."
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:113
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:128
 #, elixir-autogen, elixir-format
 msgid "Previous month"
 msgstr "Voriger Monat"
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:109
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:124
 #, elixir-autogen, elixir-format
 msgid "Previous year"
 msgstr "Voriges Jahr"
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:222
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:241
 #, elixir-autogen, elixir-format
 msgctxt "heatmap scale"
 msgid "Less"
 msgstr "Weniger"
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:224
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:243
 #, elixir-autogen, elixir-format
 msgctxt "heatmap scale"
 msgid "More"
@@ -23158,9 +23158,24 @@ msgstr "Neue Version bereit."
 msgid "Page management"
 msgstr "Verwaltung"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1970
+#: lib/vutuv_web/live/post_live/feed.ex:2044
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
 msgstr[0] "Neu:"
 msgstr[1] "Neu (%{formatted}):"
+
+#: lib/vutuv_web/components/post_components.ex:2700
+#, elixir-autogen, elixir-format
+msgid "Quoted post"
+msgstr "Zitierter Beitrag"
+
+#: lib/vutuv_web/agent_docs/markdown.ex:1039
+#, elixir-autogen, elixir-format
+msgid "Quotes %{name}: %{url}"
+msgstr "Zitiert %{name}: %{url}"
+
+#: lib/vutuv_web/agent_docs/markdown.ex:1036
+#, elixir-autogen, elixir-format
+msgid "Quotes %{url}"
+msgstr "Zitiert %{url}"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -162,7 +162,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3318
+#: lib/vutuv_web/components/post_components.ex:3494
 #: lib/vutuv_web/components/ui.ex:4314
 #: lib/vutuv_web/live/admin/job_live.ex:489
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -211,7 +211,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3283
+#: lib/vutuv_web/components/post_components.ex:3459
 #: lib/vutuv_web/components/ui.ex:4305
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -475,7 +475,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:655
+#: lib/vutuv_web/components/post_components.ex:657
 #: lib/vutuv_web/live/notification_live/index.ex:699
 #: lib/vutuv_web/live/organization_live/activity.ex:128
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
@@ -657,7 +657,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1686
+#: lib/vutuv_web/components/post_components.ex:1688
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -923,7 +923,7 @@ msgid "You follow back %{name}."
 msgstr ""
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:164
+#: lib/vutuv_web/live/post_live/feed.ex:165
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1369,7 +1369,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:34
 #: lib/vutuv_web/agent_docs/markdown.ex:503
-#: lib/vutuv_web/agent_docs/markdown.ex:1078
+#: lib/vutuv_web/agent_docs/markdown.ex:1091
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:522
 #: lib/vutuv_web/agent_docs/text.ex:759
@@ -1687,7 +1687,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:2645
 #: lib/vutuv_web/components/ui.ex:2648
 #: lib/vutuv_web/components/ui.ex:2721
-#: lib/vutuv_web/live/fediverse_account_live.ex:391
+#: lib/vutuv_web/live/fediverse_account_live.ex:392
 #: lib/vutuv_web/live/fediverse_following_live.ex:331
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:323
 #: lib/vutuv_web/live/organization_live/following.ex:331
@@ -1751,7 +1751,7 @@ msgstr ""
 msgid "Network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:447
+#: lib/vutuv_web/components/post_components.ex:449
 #: lib/vutuv_web/components/ui.ex:4424
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
@@ -2102,7 +2102,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3315
+#: lib/vutuv_web/components/post_components.ex:3491
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2117,8 +2117,8 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:254
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:139
-#: lib/vutuv_web/live/post_live/feed.ex:279
-#: lib/vutuv_web/live/post_live/feed.ex:2468
+#: lib/vutuv_web/live/post_live/feed.ex:280
+#: lib/vutuv_web/live/post_live/feed.ex:2542
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1074
 #: lib/vutuv_web/live/shell_live.ex:1373
@@ -2147,8 +2147,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3269
-#: lib/vutuv_web/components/post_components.ex:3271
+#: lib/vutuv_web/components/post_components.ex:3445
+#: lib/vutuv_web/components/post_components.ex:3447
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2164,7 +2164,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2759
+#: lib/vutuv_web/live/post_live/feed.ex:2834
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2202,7 +2202,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/user_controller.ex:76
 #: lib/vutuv_web/gettext_extraction_anchors.ex:103
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
-#: lib/vutuv_web/live/fediverse_account_live.ex:398
+#: lib/vutuv_web/live/fediverse_account_live.ex:399
 #: lib/vutuv_web/live/notification_live/index.ex:943
 #: lib/vutuv_web/live/organization_live/show.ex:729
 #: lib/vutuv_web/live/post_live/saved.ex:520
@@ -2214,21 +2214,21 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3739
-#: lib/vutuv_web/components/post_components.ex:3743
+#: lib/vutuv_web/components/post_components.ex:3915
+#: lib/vutuv_web/components/post_components.ex:3919
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3740
-#: lib/vutuv_web/live/fediverse_account_live.ex:336
+#: lib/vutuv_web/components/post_components.ex:3916
+#: lib/vutuv_web/live/fediverse_account_live.ex:337
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:376
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:1288
+#: lib/vutuv_web/components/post_components.ex:1290
 #: lib/vutuv_web/live/admin/screenshot_live.ex:327
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
@@ -2255,7 +2255,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1976
+#: lib/vutuv_web/live/post_live/feed.ex:2050
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2311,27 +2311,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3266
+#: lib/vutuv_web/components/post_components.ex:3442
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5141
+#: lib/vutuv_web/components/post_components.ex:5317
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5145
+#: lib/vutuv_web/components/post_components.ex:5321
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5143
+#: lib/vutuv_web/components/post_components.ex:5319
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5144
+#: lib/vutuv_web/components/post_components.ex:5320
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2372,15 +2372,15 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1954
-#: lib/vutuv_web/components/post_components.ex:5237
+#: lib/vutuv_web/components/post_components.ex:1956
+#: lib/vutuv_web/components/post_components.ex:5413
 #: lib/vutuv_web/components/ui.ex:3778
 #: lib/vutuv_web/views/user_html.ex:457
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1116
+#: lib/vutuv_web/agent_docs/markdown.ex:1129
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
 #: lib/vutuv_web/live/shell_live.ex:1204
@@ -2391,8 +2391,8 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1907
-#: lib/vutuv_web/components/post_components.ex:5473
+#: lib/vutuv_web/components/post_components.ex:1909
+#: lib/vutuv_web/components/post_components.ex:5649
 #: lib/vutuv_web/components/ui.ex:3764
 #: lib/vutuv_web/live/notification_live/index.ex:1089
 #: lib/vutuv_web/views/user_html.ex:467
@@ -2400,8 +2400,8 @@ msgstr ""
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1115
-#: lib/vutuv_web/components/post_components.ex:5483
+#: lib/vutuv_web/agent_docs/markdown.ex:1128
+#: lib/vutuv_web/components/post_components.ex:5659
 #: lib/vutuv_web/live/notification_live/index.ex:1022
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
@@ -2423,40 +2423,40 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5225
+#: lib/vutuv_web/components/post_components.ex:5401
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1953
-#: lib/vutuv_web/components/post_components.ex:5236
+#: lib/vutuv_web/components/post_components.ex:1955
+#: lib/vutuv_web/components/post_components.ex:5412
 #: lib/vutuv_web/live/post_live/saved.ex:806
 #: lib/vutuv_web/views/user_html.ex:457
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1935
-#: lib/vutuv_web/components/post_components.ex:5222
+#: lib/vutuv_web/components/post_components.ex:1937
+#: lib/vutuv_web/components/post_components.ex:5398
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2200
-#: lib/vutuv_web/components/post_components.ex:4347
+#: lib/vutuv_web/components/post_components.ex:2202
+#: lib/vutuv_web/components/post_components.ex:4523
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1934
-#: lib/vutuv_web/components/post_components.ex:5221
+#: lib/vutuv_web/components/post_components.ex:1936
+#: lib/vutuv_web/components/post_components.ex:5397
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1906
-#: lib/vutuv_web/components/post_components.ex:5472
+#: lib/vutuv_web/components/post_components.ex:1908
+#: lib/vutuv_web/components/post_components.ex:5648
 #: lib/vutuv_web/live/post_live/saved.ex:805
 #: lib/vutuv_web/views/user_html.ex:467
 #, elixir-autogen, elixir-format
@@ -2464,14 +2464,14 @@ msgid "Unlike"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:377
-#: lib/vutuv_web/components/post_components.ex:2569
+#: lib/vutuv_web/components/post_components.ex:2571
 #: lib/vutuv_web/components/ui.ex:2551
 #: lib/vutuv_web/components/ui.ex:2551
 #: lib/vutuv_web/components/ui.ex:2688
 #: lib/vutuv_web/live/organization_live/following.ex:383
 #: lib/vutuv_web/live/organization_live/following.ex:458
 #: lib/vutuv_web/live/organization_live/show.ex:640
-#: lib/vutuv_web/live/post_live/feed.ex:811
+#: lib/vutuv_web/live/post_live/feed.ex:817
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2483,27 +2483,27 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5527
+#: lib/vutuv_web/components/post_components.ex:5703
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:405
+#: lib/vutuv_web/components/post_components.ex:407
 #: lib/vutuv_web/live/notification_live/index.ex:1023
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1920
-#: lib/vutuv_web/components/post_components.ex:5510
-#: lib/vutuv_web/components/post_components.ex:5511
+#: lib/vutuv_web/components/post_components.ex:1922
+#: lib/vutuv_web/components/post_components.ex:5686
+#: lib/vutuv_web/components/post_components.ex:5687
 #: lib/vutuv_web/live/notification_live/index.ex:1086
 #: lib/vutuv_web/live/post_live/reply.ex:43
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3233
+#: lib/vutuv_web/components/post_components.ex:3409
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2524,7 +2524,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2769
+#: lib/vutuv_web/components/post_components.ex:2945
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:60
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:57
@@ -2532,14 +2532,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3207
+#: lib/vutuv_web/components/post_components.ex:3383
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3198
-#: lib/vutuv_web/components/post_components.ex:3225
-#: lib/vutuv_web/components/post_components.ex:3228
+#: lib/vutuv_web/components/post_components.ex:3374
+#: lib/vutuv_web/components/post_components.ex:3401
+#: lib/vutuv_web/components/post_components.ex:3404
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2762,7 +2762,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2506
+#: lib/vutuv_web/live/post_live/feed.ex:2580
 #: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2783,7 +2783,7 @@ msgid_plural "%{formatted} connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:939
+#: lib/vutuv_web/live/post_live/feed.ex:945
 #: lib/vutuv_web/templates/user/card_list.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -2838,7 +2838,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5142
+#: lib/vutuv_web/components/post_components.ex:5318
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3101,7 +3101,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3174
+#: lib/vutuv_web/components/post_components.ex:3350
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3176,9 +3176,9 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1298
-#: lib/vutuv_web/components/post_components.ex:2581
-#: lib/vutuv_web/components/post_components.ex:3338
+#: lib/vutuv_web/components/post_components.ex:1300
+#: lib/vutuv_web/components/post_components.ex:2583
+#: lib/vutuv_web/components/post_components.ex:3514
 #: lib/vutuv_web/live/organization_live/show.ex:680
 #: lib/vutuv_web/templates/user/show.html.heex:222
 #, elixir-autogen, elixir-format
@@ -3834,7 +3834,7 @@ msgstr ""
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1237
+#: lib/vutuv_web/agent_docs/markdown.ex:1250
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
@@ -3848,7 +3848,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:91
 #: lib/vutuv_web/agent_docs/markdown.ex:202
 #: lib/vutuv_web/agent_docs/markdown.ex:216
-#: lib/vutuv_web/agent_docs/markdown.ex:1078
+#: lib/vutuv_web/agent_docs/markdown.ex:1091
 #: lib/vutuv_web/agent_docs/text.ex:86
 #: lib/vutuv_web/agent_docs/text.ex:185
 #: lib/vutuv_web/agent_docs/text.ex:199
@@ -3871,20 +3871,20 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1096
+#: lib/vutuv_web/agent_docs/markdown.ex:1109
 #: lib/vutuv_web/agent_docs/text.ex:770
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1093
+#: lib/vutuv_web/agent_docs/markdown.ex:1106
 #: lib/vutuv_web/agent_docs/text.ex:767
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1100
-#: lib/vutuv_web/agent_docs/markdown.ex:1314
+#: lib/vutuv_web/agent_docs/markdown.ex:1113
+#: lib/vutuv_web/agent_docs/markdown.ex:1327
 #: lib/vutuv_web/agent_docs/text.ex:773
 #: lib/vutuv_web/agent_docs/text.ex:817
 #, elixir-autogen, elixir-format
@@ -3941,7 +3941,7 @@ msgstr ""
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1047
+#: lib/vutuv_web/agent_docs/markdown.ex:1060
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
@@ -4544,7 +4544,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2764
+#: lib/vutuv_web/live/post_live/feed.ex:2839
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -4621,8 +4621,8 @@ msgstr ""
 msgid "Similar names"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:402
-#: lib/vutuv_web/components/post_components.ex:421
+#: lib/vutuv_web/components/post_components.ex:404
+#: lib/vutuv_web/components/post_components.ex:423
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
@@ -5421,9 +5421,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3404
-#: lib/vutuv_web/components/post_components.ex:3459
-#: lib/vutuv_web/components/post_components.ex:3876
+#: lib/vutuv_web/components/post_components.ex:3580
+#: lib/vutuv_web/components/post_components.ex:3635
+#: lib/vutuv_web/components/post_components.ex:4052
 #: lib/vutuv_web/live/notification_live/index.ex:743
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
@@ -6214,8 +6214,8 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1115
-#: lib/vutuv_web/components/post_components.ex:404
+#: lib/vutuv_web/agent_docs/markdown.ex:1128
+#: lib/vutuv_web/components/post_components.ex:406
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
@@ -6322,7 +6322,7 @@ msgstr ""
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1091
+#: lib/vutuv_web/agent_docs/markdown.ex:1104
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -6608,10 +6608,10 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2549
-#: lib/vutuv_web/components/post_components.ex:3335
+#: lib/vutuv_web/components/post_components.ex:2551
+#: lib/vutuv_web/components/post_components.ex:3511
 #: lib/vutuv_web/components/ui.ex:2876
-#: lib/vutuv_web/live/fediverse_account_live.ex:385
+#: lib/vutuv_web/live/fediverse_account_live.ex:386
 #: lib/vutuv_web/live/organization_live/following.ex:376
 #: lib/vutuv_web/live/organization_live/following.ex:451
 #: lib/vutuv_web/templates/settings/filters.html.heex:58
@@ -6636,9 +6636,9 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3335
+#: lib/vutuv_web/components/post_components.ex:3511
 #: lib/vutuv_web/components/ui.ex:2875
-#: lib/vutuv_web/live/fediverse_account_live.ex:383
+#: lib/vutuv_web/live/fediverse_account_live.ex:384
 #: lib/vutuv_web/live/organization_live/following.ex:376
 #: lib/vutuv_web/live/organization_live/following.ex:451
 #: lib/vutuv_web/templates/settings/filters.html.heex:81
@@ -7348,7 +7348,7 @@ msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:5383
+#: lib/vutuv_web/components/post_components.ex:5559
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -7450,7 +7450,7 @@ msgid "This updates on its own. You can leave this page; the send keeps running.
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3027
+#: lib/vutuv_web/live/post_live/feed.ex:3103
 #, elixir-autogen
 msgid "Done"
 msgstr ""
@@ -7524,17 +7524,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1242
+#: lib/vutuv_web/agent_docs/markdown.ex:1255
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1245
+#: lib/vutuv_web/agent_docs/markdown.ex:1258
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1252
+#: lib/vutuv_web/agent_docs/markdown.ex:1265
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -7890,7 +7890,7 @@ msgid "Admins"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:948
+#: lib/vutuv_web/live/post_live/feed.ex:954
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr ""
@@ -8786,14 +8786,14 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4350
+#: lib/vutuv_web/components/post_components.ex:4526
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1050
+#: lib/vutuv_web/agent_docs/markdown.ex:1063
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -13024,7 +13024,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2728
+#: lib/vutuv_web/components/post_components.ex:2904
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:715
 #: lib/vutuv_web/controllers/settings_controller.ex:733
@@ -13438,22 +13438,22 @@ msgstr ""
 msgid "Work mobile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:444
+#: lib/vutuv_web/components/post_components.ex:446
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:446
+#: lib/vutuv_web/components/post_components.ex:448
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:445
+#: lib/vutuv_web/components/post_components.ex:447
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:403
+#: lib/vutuv_web/components/post_components.ex:405
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr ""
@@ -13465,7 +13465,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4724
 #: lib/vutuv_web/controllers/settings_controller.ex:634
-#: lib/vutuv_web/live/post_live/feed.ex:633
+#: lib/vutuv_web/live/post_live/feed.ex:639
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
@@ -13623,50 +13623,50 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4991
+#: lib/vutuv_web/components/post_components.ex:5167
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1204
-#: lib/vutuv_web/components/post_components.ex:4948
+#: lib/vutuv_web/agent_docs/markdown.ex:1217
+#: lib/vutuv_web/components/post_components.ex:5124
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4992
+#: lib/vutuv_web/components/post_components.ex:5168
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4994
+#: lib/vutuv_web/components/post_components.ex:5170
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4990
+#: lib/vutuv_web/components/post_components.ex:5166
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1204
-#: lib/vutuv_web/components/post_components.ex:4947
+#: lib/vutuv_web/agent_docs/markdown.ex:1217
+#: lib/vutuv_web/components/post_components.ex:5123
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:453
+#: lib/vutuv_web/live/fediverse_account_live.ex:454
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4989
+#: lib/vutuv_web/components/post_components.ex:5165
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4993
+#: lib/vutuv_web/components/post_components.ex:5169
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13686,7 +13686,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5030
+#: lib/vutuv_web/components/post_components.ex:5206
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13694,27 +13694,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5060
+#: lib/vutuv_web/components/post_components.ex:5236
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5061
+#: lib/vutuv_web/components/post_components.ex:5237
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5059
+#: lib/vutuv_web/components/post_components.ex:5235
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5019
+#: lib/vutuv_web/components/post_components.ex:5195
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5066
+#: lib/vutuv_web/components/post_components.ex:5242
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13744,7 +13744,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4833
+#: lib/vutuv_web/components/post_components.ex:5009
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13792,7 +13792,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4824
+#: lib/vutuv_web/components/post_components.ex:5000
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14164,14 +14164,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3001
+#: lib/vutuv_web/components/post_components.ex:3177
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3024
+#: lib/vutuv_web/components/post_components.ex:3200
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14198,7 +14198,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5482
+#: lib/vutuv_web/components/post_components.ex:5658
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14373,7 +14373,7 @@ msgstr ""
 msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1008
+#: lib/vutuv_web/live/post_live/feed.ex:1014
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr ""
@@ -14598,7 +14598,7 @@ msgstr ""
 msgid "none yet"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1151
+#: lib/vutuv_web/agent_docs/markdown.ex:1164
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr ""
@@ -15341,29 +15341,29 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5428
+#: lib/vutuv_web/components/post_components.ex:5604
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5432
+#: lib/vutuv_web/components/post_components.ex:5608
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5436
+#: lib/vutuv_web/components/post_components.ex:5612
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1153
-#: lib/vutuv_web/components/post_components.ex:5387
+#: lib/vutuv_web/agent_docs/markdown.ex:1166
+#: lib/vutuv_web/components/post_components.ex:5563
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15373,20 +15373,20 @@ msgstr ""
 msgid "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1335
+#: lib/vutuv_web/agent_docs/markdown.ex:1348
 #: lib/vutuv_web/agent_docs/text.ex:831
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1413
-#: lib/vutuv_web/components/post_components.ex:2142
-#: lib/vutuv_web/live/fediverse_account_live.ex:298
+#: lib/vutuv_web/components/post_components.ex:1415
+#: lib/vutuv_web/components/post_components.ex:2144
+#: lib/vutuv_web/live/fediverse_account_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1286
+#: lib/vutuv_web/components/post_components.ex:1288
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15398,7 +15398,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:134
 #: lib/vutuv_web/agent_docs/markdown.ex:165
-#: lib/vutuv_web/agent_docs/markdown.ex:1152
+#: lib/vutuv_web/agent_docs/markdown.ex:1165
 #: lib/vutuv_web/agent_docs/text.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:151
 #, elixir-autogen, elixir-format
@@ -15415,7 +15415,7 @@ msgstr ""
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1295
+#: lib/vutuv_web/components/post_components.ex:1297
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15425,7 +15425,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1309
+#: lib/vutuv_web/components/post_components.ex:1311
 #: lib/vutuv_web/live/notification_live/index.ex:597
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -15456,10 +15456,10 @@ msgstr ""
 msgid "That reply is not yours to remove."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1337
-#: lib/vutuv_web/components/post_components.ex:1344
-#: lib/vutuv_web/components/post_components.ex:1544
-#: lib/vutuv_web/components/post_components.ex:2648
+#: lib/vutuv_web/agent_docs/markdown.ex:1350
+#: lib/vutuv_web/components/post_components.ex:1346
+#: lib/vutuv_web/components/post_components.ex:1546
+#: lib/vutuv_web/components/post_components.ex:2824
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -16122,22 +16122,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3186
+#: lib/vutuv_web/components/post_components.ex:3362
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3302
+#: lib/vutuv_web/components/post_components.ex:3478
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3310
+#: lib/vutuv_web/components/post_components.ex:3486
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3296
+#: lib/vutuv_web/components/post_components.ex:3472
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16157,7 +16157,7 @@ msgstr ""
 msgid "Unpinned. The post is a normal post again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1033
+#: lib/vutuv_web/agent_docs/markdown.ex:1046
 #, elixir-autogen, elixir-format
 msgid "pinned post"
 msgstr ""
@@ -16221,7 +16221,7 @@ msgstr ""
 msgid "Describe the photo for people who can't see it"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1265
+#: lib/vutuv_web/agent_docs/markdown.ex:1278
 #: lib/vutuv_web/agent_docs/text.ex:798
 #: lib/vutuv_web/components/ui.ex:2930
 #, elixir-autogen, elixir-format
@@ -16263,17 +16263,17 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2781
+#: lib/vutuv_web/components/post_components.ex:2957
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4005
+#: lib/vutuv_web/components/post_components.ex:4181
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4153
+#: lib/vutuv_web/components/post_components.ex:4329
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16284,9 +16284,9 @@ msgstr ""
 msgid "Photo options"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1298
+#: lib/vutuv_web/agent_docs/markdown.ex:1311
 #: lib/vutuv_web/agent_docs/text.ex:785
-#: lib/vutuv_web/components/post_components.ex:4235
+#: lib/vutuv_web/components/post_components.ex:4411
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr ""
@@ -16312,7 +16312,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2834
+#: lib/vutuv_web/components/post_components.ex:3010
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16332,7 +16332,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2825
+#: lib/vutuv_web/components/post_components.ex:3001
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16342,12 +16342,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2843
+#: lib/vutuv_web/components/post_components.ex:3019
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2777
+#: lib/vutuv_web/components/post_components.ex:2953
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16362,7 +16362,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2838
+#: lib/vutuv_web/components/post_components.ex:3014
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16372,7 +16372,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2791
+#: lib/vutuv_web/components/post_components.ex:2967
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16393,8 +16393,8 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2515
-#: lib/vutuv_web/live/post_live/feed.ex:2516
+#: lib/vutuv_web/live/post_live/feed.ex:2589
+#: lib/vutuv_web/live/post_live/feed.ex:2590
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr ""
@@ -16458,14 +16458,14 @@ msgid_plural "Some of these photos carry the location they were taken at, and th
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1171
-#: lib/vutuv_web/components/post_components.ex:5425
+#: lib/vutuv_web/agent_docs/markdown.ex:1184
+#: lib/vutuv_web/components/post_components.ex:5601
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1169
-#: lib/vutuv_web/components/post_components.ex:5422
+#: lib/vutuv_web/agent_docs/markdown.ex:1182
+#: lib/vutuv_web/components/post_components.ex:5598
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr ""
@@ -16475,7 +16475,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5314
+#: lib/vutuv_web/components/post_components.ex:5490
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr ""
@@ -16566,7 +16566,7 @@ msgstr ""
 msgid "Photo details"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:459
+#: lib/vutuv_web/live/fediverse_account_live.ex:460
 #: lib/vutuv_web/live/fediverse_following_live.ex:60
 #: lib/vutuv_web/live/fediverse_following_live.ex:301
 #: lib/vutuv_web/live/fediverse_following_live.ex:314
@@ -16596,7 +16596,7 @@ msgstr ""
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:120
+#: lib/vutuv_web/live/fediverse_account_live.ex:121
 #: lib/vutuv_web/live/fediverse_following_live.ex:257
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:147
 #, elixir-autogen, elixir-format
@@ -16727,7 +16727,7 @@ msgstr ""
 msgid "To follow an account out there you need a Fediverse identity of your own: the request is signed in your name, so the other server knows who is asking."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:136
+#: lib/vutuv_web/live/fediverse_account_live.ex:137
 #: lib/vutuv_web/live/fediverse_following_live.ex:181
 #, elixir-autogen, elixir-format
 msgid "Unfollowed."
@@ -16815,7 +16815,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2590
+#: lib/vutuv_web/components/post_components.ex:2592
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
@@ -16825,7 +16825,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2647
+#: lib/vutuv_web/components/post_components.ex:2823
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16845,17 +16845,17 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1689
+#: lib/vutuv_web/components/post_components.ex:1691
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2602
+#: lib/vutuv_web/components/post_components.ex:2773
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:231
+#: lib/vutuv_web/live/fediverse_account_live.ex:232
 #: lib/vutuv_web/live/remote_post_actions.ex:71
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
@@ -16866,7 +16866,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2576
+#: lib/vutuv_web/components/post_components.ex:2578
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -16886,57 +16886,57 @@ msgstr ""
 msgid "%{name} (another network)"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:281
+#: lib/vutuv_web/live/fediverse_account_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "Account on another network"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:443
+#: lib/vutuv_web/live/fediverse_account_live.ex:444
 #, elixir-autogen, elixir-format
 msgid "Look up another account"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:373
+#: lib/vutuv_web/live/fediverse_account_live.ex:374
 #, elixir-autogen, elixir-format
 msgid "Muted"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:256
+#: lib/vutuv_web/live/fediverse_account_live.ex:257
 #, elixir-autogen, elixir-format
 msgid "Nothing cached yet. Their posts appear here as they publish them."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:251
+#: lib/vutuv_web/live/fediverse_account_live.ex:252
 #, elixir-autogen, elixir-format
 msgid "Nothing here. vutuv only keeps an account's posts while somebody here follows it, and this page never fetches any."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:445
+#: lib/vutuv_web/live/fediverse_account_live.ex:446
 #, elixir-autogen, elixir-format
 msgid "Paste an address from Mastodon and friends to open its page here."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:333
+#: lib/vutuv_web/live/fediverse_account_live.ex:334
 #, elixir-autogen, elixir-format
 msgid "Show the whole description"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:428
+#: lib/vutuv_web/live/fediverse_account_live.ex:429
 #, elixir-autogen, elixir-format
 msgid "The most recent %{count} are shown. The rest are on their own server."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:233
+#: lib/vutuv_web/live/fediverse_account_live.ex:234
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts are back in your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:438
+#: lib/vutuv_web/live/fediverse_account_live.ex:439
 #, elixir-autogen, elixir-format
 msgid "View their full profile on %{host}"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:260
+#: lib/vutuv_web/live/fediverse_account_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Waiting for that server to accept your follow. Posts they addressed to their followers appear once it does."
 msgstr ""
@@ -17088,27 +17088,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2301
+#: lib/vutuv_web/components/post_components.ex:2303
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2329
+#: lib/vutuv_web/components/post_components.ex:2331
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2324
+#: lib/vutuv_web/components/post_components.ex:2326
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2684
+#: lib/vutuv_web/components/post_components.ex:2860
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2690
+#: lib/vutuv_web/components/post_components.ex:2866
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr ""
@@ -17118,7 +17118,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2829
+#: lib/vutuv_web/components/post_components.ex:3005
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17264,7 +17264,7 @@ msgstr ""
 msgid "Nothing has changed yet."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:250
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:269
 #: lib/vutuv_web/templates/username/confirm.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Now"
@@ -17819,12 +17819,12 @@ msgstr ""
 msgid "Screenshot blocklist"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:436
+#: lib/vutuv_web/components/post_components.ex:438
 #, elixir-autogen, elixir-format
 msgid "Nothing from the fediverse yet. Follow accounts out there to fill this tab."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:433
+#: lib/vutuv_web/components/post_components.ex:435
 #, elixir-autogen, elixir-format
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
@@ -17866,7 +17866,7 @@ msgstr ""
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2687
+#: lib/vutuv_web/components/post_components.ex:2863
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -18164,24 +18164,24 @@ msgstr ""
 msgid "A post's page shows the members who liked it, right under the count. This is whether you are one of the faces."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1139
+#: lib/vutuv_web/agent_docs/markdown.ex:1152
 #, elixir-autogen, elixir-format
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4520
+#: lib/vutuv_web/components/post_components.ex:4696
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4522
+#: lib/vutuv_web/components/post_components.ex:4698
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4533
+#: lib/vutuv_web/components/post_components.ex:4709
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -18206,12 +18206,12 @@ msgstr ""
 msgid "Your likes follow the site default again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1194
+#: lib/vutuv_web/agent_docs/markdown.ex:1207
 #, elixir-autogen, elixir-format
 msgid "%{address} (this page only)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1191
+#: lib/vutuv_web/agent_docs/markdown.ex:1204
 #, elixir-autogen, elixir-format
 msgid "%{address} (whole website)"
 msgstr ""
@@ -18221,7 +18221,7 @@ msgstr ""
 msgid "Verified webpage of the author (%{address})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1183
+#: lib/vutuv_web/agent_docs/markdown.ex:1196
 #, elixir-autogen, elixir-format
 msgid "Verified webpages of the author linked here: %{addresses}"
 msgstr ""
@@ -18353,7 +18353,7 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2782
+#: lib/vutuv_web/live/post_live/feed.ex:2857
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -19837,7 +19837,7 @@ msgstr ""
 msgid "Start over"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2717
+#: lib/vutuv_web/components/post_components.ex:2893
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -20719,27 +20719,27 @@ msgstr ""
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4414
+#: lib/vutuv_web/components/post_components.ex:4590
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4450
+#: lib/vutuv_web/components/post_components.ex:4626
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4459
+#: lib/vutuv_web/components/post_components.ex:4635
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4462
+#: lib/vutuv_web/components/post_components.ex:4638
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4439
+#: lib/vutuv_web/components/post_components.ex:4615
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
@@ -20749,7 +20749,7 @@ msgstr ""
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4429
+#: lib/vutuv_web/components/post_components.ex:4605
 #: lib/vutuv_web/components/ui.ex:4717
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -20878,20 +20878,20 @@ msgstr ""
 msgid "Your username, or paste the address of your profile page."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4201
+#: lib/vutuv_web/components/post_components.ex:4377
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4198
+#: lib/vutuv_web/components/post_components.ex:4374
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2350
-#: lib/vutuv_web/components/post_components.ex:3519
+#: lib/vutuv_web/components/post_components.ex:2352
+#: lib/vutuv_web/components/post_components.ex:3695
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -20908,7 +20908,7 @@ msgstr ""
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:885
+#: lib/vutuv_web/live/post_live/feed.ex:891
 #: lib/vutuv_web/views/user_html.ex:338
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -21402,7 +21402,7 @@ msgstr ""
 msgid "This page is following the most accounts we allow (%{max})."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2564
+#: lib/vutuv_web/components/post_components.ex:2566
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr ""
@@ -21527,12 +21527,12 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2940
+#: lib/vutuv_web/live/post_live/feed.ex:3016
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:634
+#: lib/vutuv_web/live/post_live/feed.ex:640
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr ""
@@ -21578,7 +21578,7 @@ msgstr ""
 msgid "With a vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:877
+#: lib/vutuv_web/live/post_live/feed.ex:883
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
@@ -21955,7 +21955,7 @@ msgstr ""
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:758
+#: lib/vutuv_web/live/post_live/feed.ex:764
 #: lib/vutuv_web/live/post_live/filter_band.ex:292
 #, elixir-autogen, elixir-format
 msgid "A photo"
@@ -21971,7 +21971,7 @@ msgstr ""
 msgid "A–Z"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:840
+#: lib/vutuv_web/live/post_live/feed.ex:846
 #, elixir-autogen, elixir-format
 msgid "Browse the tags"
 msgstr ""
@@ -21986,7 +21986,7 @@ msgstr ""
 msgid "Clear all"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:671
+#: lib/vutuv_web/live/post_live/feed.ex:677
 #, elixir-autogen, elixir-format
 msgid "Drag, or use the arrow keys"
 msgstr ""
@@ -22001,13 +22001,13 @@ msgstr ""
 msgid "Find an account or a server …"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:695
+#: lib/vutuv_web/live/post_live/feed.ex:701
 #, elixir-autogen, elixir-format
 msgid "Fold %{card}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:822
-#: lib/vutuv_web/live/post_live/feed.ex:823
+#: lib/vutuv_web/live/post_live/feed.ex:828
+#: lib/vutuv_web/live/post_live/feed.ex:829
 #, elixir-autogen, elixir-format
 msgid "Follow a tag …"
 msgstr ""
@@ -22024,17 +22024,17 @@ msgstr ""
 msgid "Hide a word or a whole phrase …"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:632
+#: lib/vutuv_web/live/post_live/feed.ex:638
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:631
+#: lib/vutuv_web/live/post_live/feed.ex:637
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:846
+#: lib/vutuv_web/live/post_live/feed.ex:852
 #: lib/vutuv_web/live/post_live/filter_band.ex:331
 #, elixir-autogen, elixir-format
 msgid "In your feed right now:"
@@ -22050,7 +22050,7 @@ msgstr ""
 msgid "More of your %{formatted} accounts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:670
+#: lib/vutuv_web/live/post_live/feed.ex:676
 #, elixir-autogen, elixir-format
 msgid "Move %{card}"
 msgstr ""
@@ -22060,12 +22060,12 @@ msgstr ""
 msgid "No account found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:835
+#: lib/vutuv_web/live/post_live/feed.ex:841
 #, elixir-autogen, elixir-format
 msgid "No tag called %{name} yet."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:624
+#: lib/vutuv_web/live/post_live/feed.ex:630
 #, elixir-autogen, elixir-format
 msgid "Not read yet"
 msgstr ""
@@ -22095,13 +22095,13 @@ msgstr ""
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2966
+#: lib/vutuv_web/live/post_live/feed.ex:3042
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:716
-#: lib/vutuv_web/live/post_live/feed.ex:717
+#: lib/vutuv_web/live/post_live/feed.ex:722
+#: lib/vutuv_web/live/post_live/feed.ex:723
 #, elixir-autogen, elixir-format
 msgid "Remove %{card}"
 msgstr ""
@@ -22133,7 +22133,7 @@ msgstr ""
 msgid "Show posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:630
+#: lib/vutuv_web/live/post_live/feed.ex:636
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr ""
@@ -22143,12 +22143,12 @@ msgstr ""
 msgid "Switching off means muting, not unfollowing. You stay a follower, the posts just stop reaching your feed: permanently and on every device, until you switch them back on here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:694
+#: lib/vutuv_web/live/post_live/feed.ex:700
 #, elixir-autogen, elixir-format
 msgid "Unfold %{card}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:812
+#: lib/vutuv_web/live/post_live/feed.ex:818
 #, elixir-autogen, elixir-format
 msgid "Unfollow the tag %{tag}"
 msgstr ""
@@ -22172,29 +22172,29 @@ msgid_plural "and %{formatted} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2609
-#: lib/vutuv_web/live/post_live/feed.ex:2626
-#: lib/vutuv_web/live/post_live/feed.ex:3014
-#: lib/vutuv_web/live/post_live/feed.ex:3019
+#: lib/vutuv_web/live/post_live/feed.ex:2684
+#: lib/vutuv_web/live/post_live/feed.ex:2701
+#: lib/vutuv_web/live/post_live/feed.ex:3090
+#: lib/vutuv_web/live/post_live/feed.ex:3095
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1016
+#: lib/vutuv_web/live/post_live/feed.ex:1022
 #, elixir-autogen, elixir-format
 msgctxt "filtered post"
 msgid "Hidden:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:768
+#: lib/vutuv_web/live/post_live/feed.ex:774
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} post in the feed"
 msgid_plural "Show %{formatted} posts in the feed"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2272
+#: lib/vutuv_web/components/post_components.ex:2274
 #, elixir-autogen, elixir-format
 msgid "Picture unavailable"
 msgstr ""
@@ -22221,31 +22221,31 @@ msgid_plural "You can upload at most %{count} files at a time."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:370
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:392
 #, elixir-autogen, elixir-format
 msgid "%{count} entry on %{day}"
 msgid_plural "%{count} entries on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:367
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:389
 #, elixir-autogen, elixir-format
 msgid "%{count} post on %{day}"
 msgid_plural "%{count} posts on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2739
+#: lib/vutuv_web/live/post_live/feed.ex:2814
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:234
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:253
 #, elixir-autogen, elixir-format
 msgid "Busy month: the shading counts at least this much."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2785
+#: lib/vutuv_web/live/post_live/feed.ex:2860
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -22257,38 +22257,38 @@ msgstr[1] ""
 msgid "My posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:146
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:161
 #, elixir-autogen, elixir-format
 msgid "Next month"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:152
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:167
 #, elixir-autogen, elixir-format
 msgid "Next year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2735
+#: lib/vutuv_web/live/post_live/feed.ex:2810
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:113
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:128
 #, elixir-autogen, elixir-format
 msgid "Previous month"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:109
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:124
 #, elixir-autogen, elixir-format
 msgid "Previous year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:222
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:241
 #, elixir-autogen, elixir-format
 msgctxt "heatmap scale"
 msgid "Less"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:224
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:243
 #, elixir-autogen, elixir-format
 msgctxt "heatmap scale"
 msgid "More"
@@ -22354,9 +22354,24 @@ msgstr ""
 msgid "Page management"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1970
+#: lib/vutuv_web/live/post_live/feed.ex:2044
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/vutuv_web/components/post_components.ex:2700
+#, elixir-autogen, elixir-format
+msgid "Quoted post"
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:1039
+#, elixir-autogen, elixir-format
+msgid "Quotes %{name}: %{url}"
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:1036
+#, elixir-autogen, elixir-format
+msgid "Quotes %{url}"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -160,7 +160,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3318
+#: lib/vutuv_web/components/post_components.ex:3494
 #: lib/vutuv_web/components/ui.ex:4314
 #: lib/vutuv_web/live/admin/job_live.ex:489
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -209,7 +209,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3283
+#: lib/vutuv_web/components/post_components.ex:3459
 #: lib/vutuv_web/components/ui.ex:4305
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -473,7 +473,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:655
+#: lib/vutuv_web/components/post_components.ex:657
 #: lib/vutuv_web/live/notification_live/index.ex:699
 #: lib/vutuv_web/live/organization_live/activity.ex:128
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
@@ -655,7 +655,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1686
+#: lib/vutuv_web/components/post_components.ex:1688
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -921,7 +921,7 @@ msgid "You follow back %{name}."
 msgstr ""
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:164
+#: lib/vutuv_web/live/post_live/feed.ex:165
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1367,7 +1367,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:34
 #: lib/vutuv_web/agent_docs/markdown.ex:503
-#: lib/vutuv_web/agent_docs/markdown.ex:1078
+#: lib/vutuv_web/agent_docs/markdown.ex:1091
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:522
 #: lib/vutuv_web/agent_docs/text.ex:759
@@ -1685,7 +1685,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:2645
 #: lib/vutuv_web/components/ui.ex:2648
 #: lib/vutuv_web/components/ui.ex:2721
-#: lib/vutuv_web/live/fediverse_account_live.ex:391
+#: lib/vutuv_web/live/fediverse_account_live.ex:392
 #: lib/vutuv_web/live/fediverse_following_live.ex:331
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:323
 #: lib/vutuv_web/live/organization_live/following.ex:331
@@ -1749,7 +1749,7 @@ msgstr ""
 msgid "Network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:447
+#: lib/vutuv_web/components/post_components.ex:449
 #: lib/vutuv_web/components/ui.ex:4424
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
@@ -2100,7 +2100,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3315
+#: lib/vutuv_web/components/post_components.ex:3491
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2115,8 +2115,8 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:254
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:139
-#: lib/vutuv_web/live/post_live/feed.ex:279
-#: lib/vutuv_web/live/post_live/feed.ex:2468
+#: lib/vutuv_web/live/post_live/feed.ex:280
+#: lib/vutuv_web/live/post_live/feed.ex:2542
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1074
 #: lib/vutuv_web/live/shell_live.ex:1373
@@ -2145,8 +2145,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3269
-#: lib/vutuv_web/components/post_components.ex:3271
+#: lib/vutuv_web/components/post_components.ex:3445
+#: lib/vutuv_web/components/post_components.ex:3447
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2162,7 +2162,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2759
+#: lib/vutuv_web/live/post_live/feed.ex:2834
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2200,7 +2200,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/user_controller.ex:76
 #: lib/vutuv_web/gettext_extraction_anchors.ex:103
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
-#: lib/vutuv_web/live/fediverse_account_live.ex:398
+#: lib/vutuv_web/live/fediverse_account_live.ex:399
 #: lib/vutuv_web/live/notification_live/index.ex:943
 #: lib/vutuv_web/live/organization_live/show.ex:729
 #: lib/vutuv_web/live/post_live/saved.ex:520
@@ -2212,21 +2212,21 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3739
-#: lib/vutuv_web/components/post_components.ex:3743
+#: lib/vutuv_web/components/post_components.ex:3915
+#: lib/vutuv_web/components/post_components.ex:3919
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3740
-#: lib/vutuv_web/live/fediverse_account_live.ex:336
+#: lib/vutuv_web/components/post_components.ex:3916
+#: lib/vutuv_web/live/fediverse_account_live.ex:337
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:376
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:1288
+#: lib/vutuv_web/components/post_components.ex:1290
 #: lib/vutuv_web/live/admin/screenshot_live.ex:327
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1976
+#: lib/vutuv_web/live/post_live/feed.ex:2050
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2309,27 +2309,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3266
+#: lib/vutuv_web/components/post_components.ex:3442
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5141
+#: lib/vutuv_web/components/post_components.ex:5317
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5145
+#: lib/vutuv_web/components/post_components.ex:5321
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5143
+#: lib/vutuv_web/components/post_components.ex:5319
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5144
+#: lib/vutuv_web/components/post_components.ex:5320
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2370,15 +2370,15 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1954
-#: lib/vutuv_web/components/post_components.ex:5237
+#: lib/vutuv_web/components/post_components.ex:1956
+#: lib/vutuv_web/components/post_components.ex:5413
 #: lib/vutuv_web/components/ui.ex:3778
 #: lib/vutuv_web/views/user_html.ex:457
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1116
+#: lib/vutuv_web/agent_docs/markdown.ex:1129
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
 #: lib/vutuv_web/live/shell_live.ex:1204
@@ -2389,8 +2389,8 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1907
-#: lib/vutuv_web/components/post_components.ex:5473
+#: lib/vutuv_web/components/post_components.ex:1909
+#: lib/vutuv_web/components/post_components.ex:5649
 #: lib/vutuv_web/components/ui.ex:3764
 #: lib/vutuv_web/live/notification_live/index.ex:1089
 #: lib/vutuv_web/views/user_html.ex:467
@@ -2398,8 +2398,8 @@ msgstr ""
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1115
-#: lib/vutuv_web/components/post_components.ex:5483
+#: lib/vutuv_web/agent_docs/markdown.ex:1128
+#: lib/vutuv_web/components/post_components.ex:5659
 #: lib/vutuv_web/live/notification_live/index.ex:1022
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
@@ -2421,40 +2421,40 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5225
+#: lib/vutuv_web/components/post_components.ex:5401
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1953
-#: lib/vutuv_web/components/post_components.ex:5236
+#: lib/vutuv_web/components/post_components.ex:1955
+#: lib/vutuv_web/components/post_components.ex:5412
 #: lib/vutuv_web/live/post_live/saved.ex:806
 #: lib/vutuv_web/views/user_html.ex:457
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1935
-#: lib/vutuv_web/components/post_components.ex:5222
+#: lib/vutuv_web/components/post_components.ex:1937
+#: lib/vutuv_web/components/post_components.ex:5398
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2200
-#: lib/vutuv_web/components/post_components.ex:4347
+#: lib/vutuv_web/components/post_components.ex:2202
+#: lib/vutuv_web/components/post_components.ex:4523
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1934
-#: lib/vutuv_web/components/post_components.ex:5221
+#: lib/vutuv_web/components/post_components.ex:1936
+#: lib/vutuv_web/components/post_components.ex:5397
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1906
-#: lib/vutuv_web/components/post_components.ex:5472
+#: lib/vutuv_web/components/post_components.ex:1908
+#: lib/vutuv_web/components/post_components.ex:5648
 #: lib/vutuv_web/live/post_live/saved.ex:805
 #: lib/vutuv_web/views/user_html.ex:467
 #, elixir-autogen, elixir-format
@@ -2462,14 +2462,14 @@ msgid "Unlike"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:377
-#: lib/vutuv_web/components/post_components.ex:2569
+#: lib/vutuv_web/components/post_components.ex:2571
 #: lib/vutuv_web/components/ui.ex:2551
 #: lib/vutuv_web/components/ui.ex:2551
 #: lib/vutuv_web/components/ui.ex:2688
 #: lib/vutuv_web/live/organization_live/following.ex:383
 #: lib/vutuv_web/live/organization_live/following.ex:458
 #: lib/vutuv_web/live/organization_live/show.ex:640
-#: lib/vutuv_web/live/post_live/feed.ex:811
+#: lib/vutuv_web/live/post_live/feed.ex:817
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2481,27 +2481,27 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5527
+#: lib/vutuv_web/components/post_components.ex:5703
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:405
+#: lib/vutuv_web/components/post_components.ex:407
 #: lib/vutuv_web/live/notification_live/index.ex:1023
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1920
-#: lib/vutuv_web/components/post_components.ex:5510
-#: lib/vutuv_web/components/post_components.ex:5511
+#: lib/vutuv_web/components/post_components.ex:1922
+#: lib/vutuv_web/components/post_components.ex:5686
+#: lib/vutuv_web/components/post_components.ex:5687
 #: lib/vutuv_web/live/notification_live/index.ex:1086
 #: lib/vutuv_web/live/post_live/reply.ex:43
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3233
+#: lib/vutuv_web/components/post_components.ex:3409
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2522,7 +2522,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2769
+#: lib/vutuv_web/components/post_components.ex:2945
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:60
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:57
@@ -2530,14 +2530,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3207
+#: lib/vutuv_web/components/post_components.ex:3383
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3198
-#: lib/vutuv_web/components/post_components.ex:3225
-#: lib/vutuv_web/components/post_components.ex:3228
+#: lib/vutuv_web/components/post_components.ex:3374
+#: lib/vutuv_web/components/post_components.ex:3401
+#: lib/vutuv_web/components/post_components.ex:3404
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2760,7 +2760,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2506
+#: lib/vutuv_web/live/post_live/feed.ex:2580
 #: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2781,7 +2781,7 @@ msgid_plural "%{formatted} connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:939
+#: lib/vutuv_web/live/post_live/feed.ex:945
 #: lib/vutuv_web/templates/user/card_list.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -2836,7 +2836,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5142
+#: lib/vutuv_web/components/post_components.ex:5318
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3099,7 +3099,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3174
+#: lib/vutuv_web/components/post_components.ex:3350
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3174,9 +3174,9 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1298
-#: lib/vutuv_web/components/post_components.ex:2581
-#: lib/vutuv_web/components/post_components.ex:3338
+#: lib/vutuv_web/components/post_components.ex:1300
+#: lib/vutuv_web/components/post_components.ex:2583
+#: lib/vutuv_web/components/post_components.ex:3514
 #: lib/vutuv_web/live/organization_live/show.ex:680
 #: lib/vutuv_web/templates/user/show.html.heex:222
 #, elixir-autogen, elixir-format
@@ -3832,7 +3832,7 @@ msgstr ""
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1237
+#: lib/vutuv_web/agent_docs/markdown.ex:1250
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
@@ -3846,7 +3846,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:91
 #: lib/vutuv_web/agent_docs/markdown.ex:202
 #: lib/vutuv_web/agent_docs/markdown.ex:216
-#: lib/vutuv_web/agent_docs/markdown.ex:1078
+#: lib/vutuv_web/agent_docs/markdown.ex:1091
 #: lib/vutuv_web/agent_docs/text.ex:86
 #: lib/vutuv_web/agent_docs/text.ex:185
 #: lib/vutuv_web/agent_docs/text.ex:199
@@ -3869,20 +3869,20 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1096
+#: lib/vutuv_web/agent_docs/markdown.ex:1109
 #: lib/vutuv_web/agent_docs/text.ex:770
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1093
+#: lib/vutuv_web/agent_docs/markdown.ex:1106
 #: lib/vutuv_web/agent_docs/text.ex:767
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1100
-#: lib/vutuv_web/agent_docs/markdown.ex:1314
+#: lib/vutuv_web/agent_docs/markdown.ex:1113
+#: lib/vutuv_web/agent_docs/markdown.ex:1327
 #: lib/vutuv_web/agent_docs/text.ex:773
 #: lib/vutuv_web/agent_docs/text.ex:817
 #, elixir-autogen, elixir-format
@@ -3939,7 +3939,7 @@ msgstr ""
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1047
+#: lib/vutuv_web/agent_docs/markdown.ex:1060
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
@@ -4542,7 +4542,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2764
+#: lib/vutuv_web/live/post_live/feed.ex:2839
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -4619,8 +4619,8 @@ msgstr ""
 msgid "Similar names"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:402
-#: lib/vutuv_web/components/post_components.ex:421
+#: lib/vutuv_web/components/post_components.ex:404
+#: lib/vutuv_web/components/post_components.ex:423
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
@@ -5419,9 +5419,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3404
-#: lib/vutuv_web/components/post_components.ex:3459
-#: lib/vutuv_web/components/post_components.ex:3876
+#: lib/vutuv_web/components/post_components.ex:3580
+#: lib/vutuv_web/components/post_components.ex:3635
+#: lib/vutuv_web/components/post_components.ex:4052
 #: lib/vutuv_web/live/notification_live/index.ex:743
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
@@ -6212,8 +6212,8 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1115
-#: lib/vutuv_web/components/post_components.ex:404
+#: lib/vutuv_web/agent_docs/markdown.ex:1128
+#: lib/vutuv_web/components/post_components.ex:406
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
@@ -6320,7 +6320,7 @@ msgstr ""
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1091
+#: lib/vutuv_web/agent_docs/markdown.ex:1104
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -6606,10 +6606,10 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2549
-#: lib/vutuv_web/components/post_components.ex:3335
+#: lib/vutuv_web/components/post_components.ex:2551
+#: lib/vutuv_web/components/post_components.ex:3511
 #: lib/vutuv_web/components/ui.ex:2876
-#: lib/vutuv_web/live/fediverse_account_live.ex:385
+#: lib/vutuv_web/live/fediverse_account_live.ex:386
 #: lib/vutuv_web/live/organization_live/following.ex:376
 #: lib/vutuv_web/live/organization_live/following.ex:451
 #: lib/vutuv_web/templates/settings/filters.html.heex:58
@@ -6634,9 +6634,9 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3335
+#: lib/vutuv_web/components/post_components.ex:3511
 #: lib/vutuv_web/components/ui.ex:2875
-#: lib/vutuv_web/live/fediverse_account_live.ex:383
+#: lib/vutuv_web/live/fediverse_account_live.ex:384
 #: lib/vutuv_web/live/organization_live/following.ex:376
 #: lib/vutuv_web/live/organization_live/following.ex:451
 #: lib/vutuv_web/templates/settings/filters.html.heex:81
@@ -7346,7 +7346,7 @@ msgid "applies to the whole list, not just this page"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:5383
+#: lib/vutuv_web/components/post_components.ex:5559
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -7448,7 +7448,7 @@ msgid "This updates on its own. You can leave this page; the send keeps running.
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3027
+#: lib/vutuv_web/live/post_live/feed.ex:3103
 #, elixir-autogen
 msgid "Done"
 msgstr ""
@@ -7522,17 +7522,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1242
+#: lib/vutuv_web/agent_docs/markdown.ex:1255
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1245
+#: lib/vutuv_web/agent_docs/markdown.ex:1258
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1252
+#: lib/vutuv_web/agent_docs/markdown.ex:1265
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -7888,7 +7888,7 @@ msgid "Admins"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:948
+#: lib/vutuv_web/live/post_live/feed.ex:954
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr ""
@@ -8784,14 +8784,14 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4350
+#: lib/vutuv_web/components/post_components.ex:4526
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1050
+#: lib/vutuv_web/agent_docs/markdown.ex:1063
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -13022,7 +13022,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2728
+#: lib/vutuv_web/components/post_components.ex:2904
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:715
 #: lib/vutuv_web/controllers/settings_controller.ex:733
@@ -13436,22 +13436,22 @@ msgstr ""
 msgid "Work mobile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:444
+#: lib/vutuv_web/components/post_components.ex:446
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:446
+#: lib/vutuv_web/components/post_components.ex:448
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:445
+#: lib/vutuv_web/components/post_components.ex:447
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:403
+#: lib/vutuv_web/components/post_components.ex:405
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr ""
@@ -13463,7 +13463,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4724
 #: lib/vutuv_web/controllers/settings_controller.ex:634
-#: lib/vutuv_web/live/post_live/feed.ex:633
+#: lib/vutuv_web/live/post_live/feed.ex:639
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
@@ -13621,50 +13621,50 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4991
+#: lib/vutuv_web/components/post_components.ex:5167
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1204
-#: lib/vutuv_web/components/post_components.ex:4948
+#: lib/vutuv_web/agent_docs/markdown.ex:1217
+#: lib/vutuv_web/components/post_components.ex:5124
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4992
+#: lib/vutuv_web/components/post_components.ex:5168
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4994
+#: lib/vutuv_web/components/post_components.ex:5170
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4990
+#: lib/vutuv_web/components/post_components.ex:5166
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1204
-#: lib/vutuv_web/components/post_components.ex:4947
+#: lib/vutuv_web/agent_docs/markdown.ex:1217
+#: lib/vutuv_web/components/post_components.ex:5123
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:453
+#: lib/vutuv_web/live/fediverse_account_live.ex:454
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4989
+#: lib/vutuv_web/components/post_components.ex:5165
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4993
+#: lib/vutuv_web/components/post_components.ex:5169
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13684,7 +13684,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5030
+#: lib/vutuv_web/components/post_components.ex:5206
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13692,27 +13692,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5060
+#: lib/vutuv_web/components/post_components.ex:5236
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5061
+#: lib/vutuv_web/components/post_components.ex:5237
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5059
+#: lib/vutuv_web/components/post_components.ex:5235
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5019
+#: lib/vutuv_web/components/post_components.ex:5195
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5066
+#: lib/vutuv_web/components/post_components.ex:5242
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13742,7 +13742,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4833
+#: lib/vutuv_web/components/post_components.ex:5009
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13790,7 +13790,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4824
+#: lib/vutuv_web/components/post_components.ex:5000
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14162,14 +14162,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3001
+#: lib/vutuv_web/components/post_components.ex:3177
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3024
+#: lib/vutuv_web/components/post_components.ex:3200
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14196,7 +14196,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5482
+#: lib/vutuv_web/components/post_components.ex:5658
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14371,7 +14371,7 @@ msgstr ""
 msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1008
+#: lib/vutuv_web/live/post_live/feed.ex:1014
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr ""
@@ -14596,7 +14596,7 @@ msgstr ""
 msgid "none yet"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1151
+#: lib/vutuv_web/agent_docs/markdown.ex:1164
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr ""
@@ -15339,29 +15339,29 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5428
+#: lib/vutuv_web/components/post_components.ex:5604
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5432
+#: lib/vutuv_web/components/post_components.ex:5608
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:5436
+#: lib/vutuv_web/components/post_components.ex:5612
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1153
-#: lib/vutuv_web/components/post_components.ex:5387
+#: lib/vutuv_web/agent_docs/markdown.ex:1166
+#: lib/vutuv_web/components/post_components.ex:5563
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15371,20 +15371,20 @@ msgstr ""
 msgid "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1335
+#: lib/vutuv_web/agent_docs/markdown.ex:1348
 #: lib/vutuv_web/agent_docs/text.ex:831
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1413
-#: lib/vutuv_web/components/post_components.ex:2142
-#: lib/vutuv_web/live/fediverse_account_live.ex:298
+#: lib/vutuv_web/components/post_components.ex:1415
+#: lib/vutuv_web/components/post_components.ex:2144
+#: lib/vutuv_web/live/fediverse_account_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1286
+#: lib/vutuv_web/components/post_components.ex:1288
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15396,7 +15396,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:134
 #: lib/vutuv_web/agent_docs/markdown.ex:165
-#: lib/vutuv_web/agent_docs/markdown.ex:1152
+#: lib/vutuv_web/agent_docs/markdown.ex:1165
 #: lib/vutuv_web/agent_docs/text.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:151
 #, elixir-autogen, elixir-format
@@ -15413,7 +15413,7 @@ msgstr ""
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1295
+#: lib/vutuv_web/components/post_components.ex:1297
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15423,7 +15423,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1309
+#: lib/vutuv_web/components/post_components.ex:1311
 #: lib/vutuv_web/live/notification_live/index.ex:597
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -15454,10 +15454,10 @@ msgstr ""
 msgid "That reply is not yours to remove."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1337
-#: lib/vutuv_web/components/post_components.ex:1344
-#: lib/vutuv_web/components/post_components.ex:1544
-#: lib/vutuv_web/components/post_components.ex:2648
+#: lib/vutuv_web/agent_docs/markdown.ex:1350
+#: lib/vutuv_web/components/post_components.ex:1346
+#: lib/vutuv_web/components/post_components.ex:1546
+#: lib/vutuv_web/components/post_components.ex:2824
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -16120,22 +16120,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3186
+#: lib/vutuv_web/components/post_components.ex:3362
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3302
+#: lib/vutuv_web/components/post_components.ex:3478
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3310
+#: lib/vutuv_web/components/post_components.ex:3486
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3296
+#: lib/vutuv_web/components/post_components.ex:3472
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16155,7 +16155,7 @@ msgstr ""
 msgid "Unpinned. The post is a normal post again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1033
+#: lib/vutuv_web/agent_docs/markdown.ex:1046
 #, elixir-autogen, elixir-format
 msgid "pinned post"
 msgstr ""
@@ -16219,7 +16219,7 @@ msgstr ""
 msgid "Describe the photo for people who can't see it"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1265
+#: lib/vutuv_web/agent_docs/markdown.ex:1278
 #: lib/vutuv_web/agent_docs/text.ex:798
 #: lib/vutuv_web/components/ui.ex:2930
 #, elixir-autogen, elixir-format
@@ -16261,17 +16261,17 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2781
+#: lib/vutuv_web/components/post_components.ex:2957
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4005
+#: lib/vutuv_web/components/post_components.ex:4181
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4153
+#: lib/vutuv_web/components/post_components.ex:4329
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16282,9 +16282,9 @@ msgstr ""
 msgid "Photo options"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1298
+#: lib/vutuv_web/agent_docs/markdown.ex:1311
 #: lib/vutuv_web/agent_docs/text.ex:785
-#: lib/vutuv_web/components/post_components.ex:4235
+#: lib/vutuv_web/components/post_components.ex:4411
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
 msgstr ""
@@ -16310,7 +16310,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2834
+#: lib/vutuv_web/components/post_components.ex:3010
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16330,7 +16330,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2825
+#: lib/vutuv_web/components/post_components.ex:3001
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16340,12 +16340,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2843
+#: lib/vutuv_web/components/post_components.ex:3019
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2777
+#: lib/vutuv_web/components/post_components.ex:2953
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16360,7 +16360,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2838
+#: lib/vutuv_web/components/post_components.ex:3014
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16370,7 +16370,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2791
+#: lib/vutuv_web/components/post_components.ex:2967
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16391,8 +16391,8 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2515
-#: lib/vutuv_web/live/post_live/feed.ex:2516
+#: lib/vutuv_web/live/post_live/feed.ex:2589
+#: lib/vutuv_web/live/post_live/feed.ex:2590
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post photos"
 msgstr ""
@@ -16456,14 +16456,14 @@ msgid_plural "Some of these photos carry the location they were taken at, and th
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1171
-#: lib/vutuv_web/components/post_components.ex:5425
+#: lib/vutuv_web/agent_docs/markdown.ex:1184
+#: lib/vutuv_web/components/post_components.ex:5601
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1169
-#: lib/vutuv_web/components/post_components.ex:5422
+#: lib/vutuv_web/agent_docs/markdown.ex:1182
+#: lib/vutuv_web/components/post_components.ex:5598
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
 msgstr ""
@@ -16473,7 +16473,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:5314
+#: lib/vutuv_web/components/post_components.ex:5490
 #, elixir-autogen, elixir-format, fuzzy
 msgid "From other networks"
 msgstr ""
@@ -16564,7 +16564,7 @@ msgstr ""
 msgid "Photo details"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:459
+#: lib/vutuv_web/live/fediverse_account_live.ex:460
 #: lib/vutuv_web/live/fediverse_following_live.ex:60
 #: lib/vutuv_web/live/fediverse_following_live.ex:301
 #: lib/vutuv_web/live/fediverse_following_live.ex:314
@@ -16594,7 +16594,7 @@ msgstr ""
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:120
+#: lib/vutuv_web/live/fediverse_account_live.ex:121
 #: lib/vutuv_web/live/fediverse_following_live.ex:257
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:147
 #, elixir-autogen, elixir-format
@@ -16725,7 +16725,7 @@ msgstr ""
 msgid "To follow an account out there you need a Fediverse identity of your own: the request is signed in your name, so the other server knows who is asking."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:136
+#: lib/vutuv_web/live/fediverse_account_live.ex:137
 #: lib/vutuv_web/live/fediverse_following_live.ex:181
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Unfollowed."
@@ -16813,7 +16813,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2590
+#: lib/vutuv_web/components/post_components.ex:2592
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
@@ -16823,7 +16823,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2647
+#: lib/vutuv_web/components/post_components.ex:2823
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16843,17 +16843,17 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1689
+#: lib/vutuv_web/components/post_components.ex:1691
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2602
+#: lib/vutuv_web/components/post_components.ex:2773
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Marked as sensitive by its author"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:231
+#: lib/vutuv_web/live/fediverse_account_live.ex:232
 #: lib/vutuv_web/live/remote_post_actions.ex:71
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
@@ -16864,7 +16864,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2576
+#: lib/vutuv_web/components/post_components.ex:2578
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -16884,57 +16884,57 @@ msgstr ""
 msgid "%{name} (another network)"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:281
+#: lib/vutuv_web/live/fediverse_account_live.ex:282
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Account on another network"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:443
+#: lib/vutuv_web/live/fediverse_account_live.ex:444
 #, elixir-autogen, elixir-format
 msgid "Look up another account"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:373
+#: lib/vutuv_web/live/fediverse_account_live.ex:374
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Muted"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:256
+#: lib/vutuv_web/live/fediverse_account_live.ex:257
 #, elixir-autogen, elixir-format
 msgid "Nothing cached yet. Their posts appear here as they publish them."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:251
+#: lib/vutuv_web/live/fediverse_account_live.ex:252
 #, elixir-autogen, elixir-format
 msgid "Nothing here. vutuv only keeps an account's posts while somebody here follows it, and this page never fetches any."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:445
+#: lib/vutuv_web/live/fediverse_account_live.ex:446
 #, elixir-autogen, elixir-format
 msgid "Paste an address from Mastodon and friends to open its page here."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:333
+#: lib/vutuv_web/live/fediverse_account_live.ex:334
 #, elixir-autogen, elixir-format
 msgid "Show the whole description"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:428
+#: lib/vutuv_web/live/fediverse_account_live.ex:429
 #, elixir-autogen, elixir-format
 msgid "The most recent %{count} are shown. The rest are on their own server."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:233
+#: lib/vutuv_web/live/fediverse_account_live.ex:234
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Unmuted. Their posts are back in your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:438
+#: lib/vutuv_web/live/fediverse_account_live.ex:439
 #, elixir-autogen, elixir-format
 msgid "View their full profile on %{host}"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:260
+#: lib/vutuv_web/live/fediverse_account_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Waiting for that server to accept your follow. Posts they addressed to their followers appear once it does."
 msgstr ""
@@ -17086,27 +17086,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2301
+#: lib/vutuv_web/components/post_components.ex:2303
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2329
+#: lib/vutuv_web/components/post_components.ex:2331
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2324
+#: lib/vutuv_web/components/post_components.ex:2326
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2684
+#: lib/vutuv_web/components/post_components.ex:2860
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2690
+#: lib/vutuv_web/components/post_components.ex:2866
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That post is not here any more."
 msgstr ""
@@ -17116,7 +17116,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2829
+#: lib/vutuv_web/components/post_components.ex:3005
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17262,7 +17262,7 @@ msgstr ""
 msgid "Nothing has changed yet."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:250
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:269
 #: lib/vutuv_web/templates/username/confirm.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Now"
@@ -17817,12 +17817,12 @@ msgstr ""
 msgid "Screenshot blocklist"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:436
+#: lib/vutuv_web/components/post_components.ex:438
 #, elixir-autogen, elixir-format
 msgid "Nothing from the fediverse yet. Follow accounts out there to fill this tab."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:433
+#: lib/vutuv_web/components/post_components.ex:435
 #, elixir-autogen, elixir-format
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr ""
@@ -17864,7 +17864,7 @@ msgstr ""
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2687
+#: lib/vutuv_web/components/post_components.ex:2863
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -18162,24 +18162,24 @@ msgstr ""
 msgid "A post's page shows the members who liked it, right under the count. This is whether you are one of the faces."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1139
+#: lib/vutuv_web/agent_docs/markdown.ex:1152
 #, elixir-autogen, elixir-format
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4520
+#: lib/vutuv_web/components/post_components.ex:4696
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4522
+#: lib/vutuv_web/components/post_components.ex:4698
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4533
+#: lib/vutuv_web/components/post_components.ex:4709
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -18204,12 +18204,12 @@ msgstr ""
 msgid "Your likes follow the site default again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1194
+#: lib/vutuv_web/agent_docs/markdown.ex:1207
 #, elixir-autogen, elixir-format
 msgid "%{address} (this page only)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1191
+#: lib/vutuv_web/agent_docs/markdown.ex:1204
 #, elixir-autogen, elixir-format
 msgid "%{address} (whole website)"
 msgstr ""
@@ -18219,7 +18219,7 @@ msgstr ""
 msgid "Verified webpage of the author (%{address})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1183
+#: lib/vutuv_web/agent_docs/markdown.ex:1196
 #, elixir-autogen, elixir-format
 msgid "Verified webpages of the author linked here: %{addresses}"
 msgstr ""
@@ -18351,7 +18351,7 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2782
+#: lib/vutuv_web/live/post_live/feed.ex:2857
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Loading…"
@@ -19835,7 +19835,7 @@ msgstr ""
 msgid "Start over"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2717
+#: lib/vutuv_web/components/post_components.ex:2893
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -20717,27 +20717,27 @@ msgstr ""
 msgid "The language this post is written in"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4414
+#: lib/vutuv_web/components/post_components.ex:4590
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4450
+#: lib/vutuv_web/components/post_components.ex:4626
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4459
+#: lib/vutuv_web/components/post_components.ex:4635
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Translated"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4462
+#: lib/vutuv_web/components/post_components.ex:4638
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4439
+#: lib/vutuv_web/components/post_components.ex:4615
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr ""
@@ -20747,7 +20747,7 @@ msgstr ""
 msgid "Feed language settings reset to the site defaults."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4429
+#: lib/vutuv_web/components/post_components.ex:4605
 #: lib/vutuv_web/components/ui.ex:4717
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -20876,20 +20876,20 @@ msgstr ""
 msgid "Your username, or paste the address of your profile page."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4201
+#: lib/vutuv_web/components/post_components.ex:4377
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4198
+#: lib/vutuv_web/components/post_components.ex:4374
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2350
-#: lib/vutuv_web/components/post_components.ex:3519
+#: lib/vutuv_web/components/post_components.ex:2352
+#: lib/vutuv_web/components/post_components.ex:3695
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -20906,7 +20906,7 @@ msgstr ""
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:885
+#: lib/vutuv_web/live/post_live/feed.ex:891
 #: lib/vutuv_web/views/user_html.ex:338
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -21400,7 +21400,7 @@ msgstr ""
 msgid "This page is following the most accounts we allow (%{max})."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2564
+#: lib/vutuv_web/components/post_components.ex:2566
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr ""
@@ -21525,12 +21525,12 @@ msgstr ""
 msgid "Follow #%{tag} from Mastodon or any other Fediverse app and its public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2940
+#: lib/vutuv_web/live/post_live/feed.ex:3016
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:634
+#: lib/vutuv_web/live/post_live/feed.ex:640
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr ""
@@ -21576,7 +21576,7 @@ msgstr ""
 msgid "With a vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:877
+#: lib/vutuv_web/live/post_live/feed.ex:883
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr ""
@@ -21953,7 +21953,7 @@ msgstr ""
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:758
+#: lib/vutuv_web/live/post_live/feed.ex:764
 #: lib/vutuv_web/live/post_live/filter_band.ex:292
 #, elixir-autogen, elixir-format
 msgid "A photo"
@@ -21969,7 +21969,7 @@ msgstr ""
 msgid "A–Z"
 msgstr "A–Z"
 
-#: lib/vutuv_web/live/post_live/feed.ex:840
+#: lib/vutuv_web/live/post_live/feed.ex:846
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Browse the tags"
 msgstr ""
@@ -21984,7 +21984,7 @@ msgstr "Busiest first"
 msgid "Clear all"
 msgstr "Clear all"
 
-#: lib/vutuv_web/live/post_live/feed.ex:671
+#: lib/vutuv_web/live/post_live/feed.ex:677
 #, elixir-autogen, elixir-format
 msgid "Drag, or use the arrow keys"
 msgstr ""
@@ -21999,13 +21999,13 @@ msgstr "Expand or collapse"
 msgid "Find an account or a server …"
 msgstr "Find an account …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:695
+#: lib/vutuv_web/live/post_live/feed.ex:701
 #, elixir-autogen, elixir-format
 msgid "Fold %{card}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:822
-#: lib/vutuv_web/live/post_live/feed.ex:823
+#: lib/vutuv_web/live/post_live/feed.ex:828
+#: lib/vutuv_web/live/post_live/feed.ex:829
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follow a tag …"
 msgstr ""
@@ -22022,17 +22022,17 @@ msgstr "Hide a tag …"
 msgid "Hide a word or a whole phrase …"
 msgstr "Hide a word or a whole phrase …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:632
+#: lib/vutuv_web/live/post_live/feed.ex:638
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr "Hide tags"
 
-#: lib/vutuv_web/live/post_live/feed.ex:631
+#: lib/vutuv_web/live/post_live/feed.ex:637
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr "Hide words"
 
-#: lib/vutuv_web/live/post_live/feed.ex:846
+#: lib/vutuv_web/live/post_live/feed.ex:852
 #: lib/vutuv_web/live/post_live/filter_band.ex:331
 #, elixir-autogen, elixir-format
 msgid "In your feed right now:"
@@ -22048,7 +22048,7 @@ msgstr "Matches nothing in your feed right now — the rule still holds for what
 msgid "More of your %{formatted} accounts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:670
+#: lib/vutuv_web/live/post_live/feed.ex:676
 #, elixir-autogen, elixir-format
 msgid "Move %{card}"
 msgstr ""
@@ -22058,12 +22058,12 @@ msgstr ""
 msgid "No account found."
 msgstr "No account found."
 
-#: lib/vutuv_web/live/post_live/feed.ex:835
+#: lib/vutuv_web/live/post_live/feed.ex:841
 #, elixir-autogen, elixir-format
 msgid "No tag called %{name} yet."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:624
+#: lib/vutuv_web/live/post_live/feed.ex:630
 #, elixir-autogen, elixir-format
 msgid "Not read yet"
 msgstr "Not read yet"
@@ -22093,13 +22093,13 @@ msgstr "Posts carrying one of these tags are folded the same way."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2966
+#: lib/vutuv_web/live/post_live/feed.ex:3042
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:716
-#: lib/vutuv_web/live/post_live/feed.ex:717
+#: lib/vutuv_web/live/post_live/feed.ex:722
+#: lib/vutuv_web/live/post_live/feed.ex:723
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove %{card}"
 msgstr ""
@@ -22131,7 +22131,7 @@ msgstr ""
 msgid "Show posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:630
+#: lib/vutuv_web/live/post_live/feed.ex:636
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sources"
 msgstr ""
@@ -22141,12 +22141,12 @@ msgstr ""
 msgid "Switching off means muting, not unfollowing. You stay a follower, the posts just stop reaching your feed: permanently and on every device, until you switch them back on here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:694
+#: lib/vutuv_web/live/post_live/feed.ex:700
 #, elixir-autogen, elixir-format
 msgid "Unfold %{card}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:812
+#: lib/vutuv_web/live/post_live/feed.ex:818
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Unfollow the tag %{tag}"
 msgstr ""
@@ -22170,29 +22170,29 @@ msgid_plural "and %{formatted} more"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2609
-#: lib/vutuv_web/live/post_live/feed.ex:2626
-#: lib/vutuv_web/live/post_live/feed.ex:3014
-#: lib/vutuv_web/live/post_live/feed.ex:3019
+#: lib/vutuv_web/live/post_live/feed.ex:2684
+#: lib/vutuv_web/live/post_live/feed.ex:2701
+#: lib/vutuv_web/live/post_live/feed.ex:3090
+#: lib/vutuv_web/live/post_live/feed.ex:3095
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "feed filter sheet"
 msgid "Filter"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1016
+#: lib/vutuv_web/live/post_live/feed.ex:1022
 #, elixir-autogen, elixir-format
 msgctxt "filtered post"
 msgid "Hidden:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:768
+#: lib/vutuv_web/live/post_live/feed.ex:774
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} post in the feed"
 msgid_plural "Show %{formatted} posts in the feed"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2272
+#: lib/vutuv_web/components/post_components.ex:2274
 #, elixir-autogen, elixir-format
 msgid "Picture unavailable"
 msgstr "Picture unavailable"
@@ -22219,31 +22219,31 @@ msgid_plural "You can upload at most %{count} files at a time."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:370
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:392
 #, elixir-autogen, elixir-format
 msgid "%{count} entry on %{day}"
 msgid_plural "%{count} entries on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:367
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:389
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} post on %{day}"
 msgid_plural "%{count} posts on %{day}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2739
+#: lib/vutuv_web/live/post_live/feed.ex:2814
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Back to now"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:234
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:253
 #, elixir-autogen, elixir-format
 msgid "Busy month: the shading counts at least this much."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2785
+#: lib/vutuv_web/live/post_live/feed.ex:2860
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -22255,38 +22255,38 @@ msgstr[1] ""
 msgid "My posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:146
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:161
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Next month"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:152
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:167
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Next year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:2735
+#: lib/vutuv_web/live/post_live/feed.ex:2810
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:113
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:128
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Previous month"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:109
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:124
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Previous year"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:222
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:241
 #, elixir-autogen, elixir-format
 msgctxt "heatmap scale"
 msgid "Less"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:224
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:243
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "heatmap scale"
 msgid "More"
@@ -22352,9 +22352,24 @@ msgstr ""
 msgid "Page management"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1970
+#: lib/vutuv_web/live/post_live/feed.ex:2044
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/vutuv_web/components/post_components.ex:2700
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Quoted post"
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:1039
+#, elixir-autogen, elixir-format
+msgid "Quotes %{name}: %{url}"
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:1036
+#, elixir-autogen, elixir-format
+msgid "Quotes %{url}"
+msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -162,7 +162,7 @@ msgstr "Contatto"
 msgid "Couldn't follow back to %{name}."
 msgstr "Non è stato possibile ricambiare il follow a %{name}."
 
-#: lib/vutuv_web/components/post_components.ex:3318
+#: lib/vutuv_web/components/post_components.ex:3494
 #: lib/vutuv_web/components/ui.ex:4314
 #: lib/vutuv_web/live/admin/job_live.ex:489
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -211,7 +211,7 @@ msgstr "Disattiva"
 msgid "Download"
 msgstr "Scarica"
 
-#: lib/vutuv_web/components/post_components.ex:3283
+#: lib/vutuv_web/components/post_components.ex:3459
 #: lib/vutuv_web/components/ui.ex:4305
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -477,7 +477,7 @@ msgstr "Altro"
 msgid "Name"
 msgstr "Nome"
 
-#: lib/vutuv_web/components/post_components.ex:655
+#: lib/vutuv_web/components/post_components.ex:657
 #: lib/vutuv_web/live/notification_live/index.ex:699
 #: lib/vutuv_web/live/organization_live/activity.ex:128
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
@@ -659,7 +659,7 @@ msgstr "Salva"
 msgid "Search"
 msgstr "Cerca"
 
-#: lib/vutuv_web/components/post_components.ex:1686
+#: lib/vutuv_web/components/post_components.ex:1688
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
@@ -932,7 +932,7 @@ msgid "You follow back %{name}."
 msgstr "Ora segue anche %{name}."
 
 #: lib/vutuv_web/live/init_assigns.ex:54
-#: lib/vutuv_web/live/post_live/feed.ex:164
+#: lib/vutuv_web/live/post_live/feed.ex:165
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1395,7 +1395,7 @@ msgstr "URL dei tag"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:34
 #: lib/vutuv_web/agent_docs/markdown.ex:503
-#: lib/vutuv_web/agent_docs/markdown.ex:1078
+#: lib/vutuv_web/agent_docs/markdown.ex:1091
 #: lib/vutuv_web/agent_docs/text.ex:31
 #: lib/vutuv_web/agent_docs/text.ex:522
 #: lib/vutuv_web/agent_docs/text.ex:759
@@ -1718,7 +1718,7 @@ msgstr "Conferma"
 #: lib/vutuv_web/components/ui.ex:2645
 #: lib/vutuv_web/components/ui.ex:2648
 #: lib/vutuv_web/components/ui.ex:2721
-#: lib/vutuv_web/live/fediverse_account_live.ex:391
+#: lib/vutuv_web/live/fediverse_account_live.ex:392
 #: lib/vutuv_web/live/fediverse_following_live.ex:331
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:323
 #: lib/vutuv_web/live/organization_live/following.ex:331
@@ -1784,7 +1784,7 @@ msgstr "Messaggi"
 msgid "Network"
 msgstr "Rete"
 
-#: lib/vutuv_web/components/post_components.ex:447
+#: lib/vutuv_web/components/post_components.ex:449
 #: lib/vutuv_web/components/ui.ex:4424
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:716
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:753
@@ -2145,7 +2145,7 @@ msgstr "Annulla il caricamento"
 msgid "Delete post"
 msgstr "Elimina il post"
 
-#: lib/vutuv_web/components/post_components.ex:3315
+#: lib/vutuv_web/components/post_components.ex:3491
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2160,8 +2160,8 @@ msgstr "Modifica il post"
 #: lib/vutuv_web/components/organization_components.ex:254
 #: lib/vutuv_web/gettext_extraction_anchors.ex:87
 #: lib/vutuv_web/live/organization_live/feed.ex:139
-#: lib/vutuv_web/live/post_live/feed.ex:279
-#: lib/vutuv_web/live/post_live/feed.ex:2468
+#: lib/vutuv_web/live/post_live/feed.ex:280
+#: lib/vutuv_web/live/post_live/feed.ex:2542
 #: lib/vutuv_web/live/post_live/feed_calendar.ex:46
 #: lib/vutuv_web/live/shell_live.ex:1074
 #: lib/vutuv_web/live/shell_live.ex:1373
@@ -2190,8 +2190,8 @@ msgstr "Nascondi a una persona specifica…"
 msgid "Hide this post from…"
 msgstr "Nascondi questo post a…"
 
-#: lib/vutuv_web/components/post_components.ex:3269
-#: lib/vutuv_web/components/post_components.ex:3271
+#: lib/vutuv_web/components/post_components.ex:3445
+#: lib/vutuv_web/components/post_components.ex:3447
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Pubblico limitato"
@@ -2207,7 +2207,7 @@ msgstr "Visitatori non connessi"
 msgid "No more than %{max} images per post."
 msgstr "Non più di %{max} immagini per post."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2759
+#: lib/vutuv_web/live/post_live/feed.ex:2834
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2247,7 +2247,7 @@ msgstr "Post eliminato."
 #: lib/vutuv_web/controllers/user_controller.ex:76
 #: lib/vutuv_web/gettext_extraction_anchors.ex:103
 #: lib/vutuv_web/live/admin/dashboard_live.ex:155
-#: lib/vutuv_web/live/fediverse_account_live.ex:398
+#: lib/vutuv_web/live/fediverse_account_live.ex:399
 #: lib/vutuv_web/live/notification_live/index.ex:943
 #: lib/vutuv_web/live/organization_live/show.ex:729
 #: lib/vutuv_web/live/post_live/saved.ex:520
@@ -2259,21 +2259,21 @@ msgstr "Post eliminato."
 msgid "Posts"
 msgstr "Post"
 
-#: lib/vutuv_web/components/post_components.ex:3739
-#: lib/vutuv_web/components/post_components.ex:3743
+#: lib/vutuv_web/components/post_components.ex:3915
+#: lib/vutuv_web/components/post_components.ex:3919
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Leggi tutto"
 
-#: lib/vutuv_web/components/post_components.ex:3740
-#: lib/vutuv_web/live/fediverse_account_live.ex:336
+#: lib/vutuv_web/components/post_components.ex:3916
+#: lib/vutuv_web/live/fediverse_account_live.ex:337
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr "Mostra meno"
 
 #: lib/vutuv_web/components/fediverse_components.ex:376
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:1288
+#: lib/vutuv_web/components/post_components.ex:1290
 #: lib/vutuv_web/live/admin/screenshot_live.ex:327
 #: lib/vutuv_web/live/admin/tag_merge_live.ex:711
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
@@ -2302,7 +2302,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Salvataggio…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1976
+#: lib/vutuv_web/live/post_live/feed.ex:2050
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2358,27 +2358,27 @@ msgstr "Che c'è di nuovo?"
 msgid "What's new? Markdown is supported."
 msgstr "Che c'è di nuovo? Markdown è supportato."
 
-#: lib/vutuv_web/components/post_components.ex:3266
+#: lib/vutuv_web/components/post_components.ex:3442
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "modificato"
 
-#: lib/vutuv_web/components/post_components.ex:5141
+#: lib/vutuv_web/components/post_components.ex:5317
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "tutti gli altri"
 
-#: lib/vutuv_web/components/post_components.ex:5145
+#: lib/vutuv_web/components/post_components.ex:5321
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "visitatori non connessi"
 
-#: lib/vutuv_web/components/post_components.ex:5143
+#: lib/vutuv_web/components/post_components.ex:5319
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "persone che non La seguono"
 
-#: lib/vutuv_web/components/post_components.ex:5144
+#: lib/vutuv_web/components/post_components.ex:5320
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "persone che non segue"
@@ -2419,15 +2419,15 @@ msgstr "Vedi tutti i %{count} post"
 msgid "All posts"
 msgstr "Tutti i post"
 
-#: lib/vutuv_web/components/post_components.ex:1954
-#: lib/vutuv_web/components/post_components.ex:5237
+#: lib/vutuv_web/components/post_components.ex:1956
+#: lib/vutuv_web/components/post_components.ex:5413
 #: lib/vutuv_web/components/ui.ex:3778
 #: lib/vutuv_web/views/user_html.ex:457
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr "Salva"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1116
+#: lib/vutuv_web/agent_docs/markdown.ex:1129
 #: lib/vutuv_web/live/post_live/saved.ex:194
 #: lib/vutuv_web/live/post_live/saved.ex:513
 #: lib/vutuv_web/live/shell_live.ex:1204
@@ -2438,8 +2438,8 @@ msgstr "Salva"
 msgid "Bookmarks"
 msgstr "Salvati"
 
-#: lib/vutuv_web/components/post_components.ex:1907
-#: lib/vutuv_web/components/post_components.ex:5473
+#: lib/vutuv_web/components/post_components.ex:1909
+#: lib/vutuv_web/components/post_components.ex:5649
 #: lib/vutuv_web/components/ui.ex:3764
 #: lib/vutuv_web/live/notification_live/index.ex:1089
 #: lib/vutuv_web/views/user_html.ex:467
@@ -2447,8 +2447,8 @@ msgstr "Salvati"
 msgid "Like"
 msgstr "Mi piace"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1115
-#: lib/vutuv_web/components/post_components.ex:5483
+#: lib/vutuv_web/agent_docs/markdown.ex:1128
+#: lib/vutuv_web/components/post_components.ex:5659
 #: lib/vutuv_web/live/notification_live/index.ex:1022
 #: lib/vutuv_web/live/post_live/saved.ex:193
 #: lib/vutuv_web/live/post_live/saved.ex:510
@@ -2470,40 +2470,40 @@ msgstr "Qui non c'è ancora nulla. I post che salva compaiono qui."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Qui non c'è ancora nulla. I post a cui mette Mi piace compaiono qui."
 
-#: lib/vutuv_web/components/post_components.ex:5225
+#: lib/vutuv_web/components/post_components.ex:5401
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Solo i post pubblici possono essere ripubblicati."
 
-#: lib/vutuv_web/components/post_components.ex:1953
-#: lib/vutuv_web/components/post_components.ex:5236
+#: lib/vutuv_web/components/post_components.ex:1955
+#: lib/vutuv_web/components/post_components.ex:5412
 #: lib/vutuv_web/live/post_live/saved.ex:806
 #: lib/vutuv_web/views/user_html.ex:457
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr "Rimuovi dai salvati"
 
-#: lib/vutuv_web/components/post_components.ex:1935
-#: lib/vutuv_web/components/post_components.ex:5222
+#: lib/vutuv_web/components/post_components.ex:1937
+#: lib/vutuv_web/components/post_components.ex:5398
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Ripubblica"
 
-#: lib/vutuv_web/components/post_components.ex:2200
-#: lib/vutuv_web/components/post_components.ex:4347
+#: lib/vutuv_web/components/post_components.ex:2202
+#: lib/vutuv_web/components/post_components.ex:4523
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Ripubblicato da %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:1934
-#: lib/vutuv_web/components/post_components.ex:5221
+#: lib/vutuv_web/components/post_components.ex:1936
+#: lib/vutuv_web/components/post_components.ex:5397
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Annulla la ripubblicazione"
 
-#: lib/vutuv_web/components/post_components.ex:1906
-#: lib/vutuv_web/components/post_components.ex:5472
+#: lib/vutuv_web/components/post_components.ex:1908
+#: lib/vutuv_web/components/post_components.ex:5648
 #: lib/vutuv_web/live/post_live/saved.ex:805
 #: lib/vutuv_web/views/user_html.ex:467
 #, elixir-autogen, elixir-format
@@ -2511,14 +2511,14 @@ msgid "Unlike"
 msgstr "Togli Mi piace"
 
 #: lib/vutuv_web/components/fediverse_components.ex:377
-#: lib/vutuv_web/components/post_components.ex:2569
+#: lib/vutuv_web/components/post_components.ex:2571
 #: lib/vutuv_web/components/ui.ex:2551
 #: lib/vutuv_web/components/ui.ex:2551
 #: lib/vutuv_web/components/ui.ex:2688
 #: lib/vutuv_web/live/organization_live/following.ex:383
 #: lib/vutuv_web/live/organization_live/following.ex:458
 #: lib/vutuv_web/live/organization_live/show.ex:640
-#: lib/vutuv_web/live/post_live/feed.ex:811
+#: lib/vutuv_web/live/post_live/feed.ex:817
 #: lib/vutuv_web/templates/followee/index.html.heex:30
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
@@ -2530,27 +2530,27 @@ msgstr "Non seguire più"
 msgid "Welcome to vutuv!"
 msgstr "Benvenuto su vutuv."
 
-#: lib/vutuv_web/components/post_components.ex:5527
+#: lib/vutuv_web/components/post_components.ex:5703
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Solo ai post pubblici si può rispondere."
 
-#: lib/vutuv_web/components/post_components.ex:405
+#: lib/vutuv_web/components/post_components.ex:407
 #: lib/vutuv_web/live/notification_live/index.ex:1023
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Risposte"
 
-#: lib/vutuv_web/components/post_components.ex:1920
-#: lib/vutuv_web/components/post_components.ex:5510
-#: lib/vutuv_web/components/post_components.ex:5511
+#: lib/vutuv_web/components/post_components.ex:1922
+#: lib/vutuv_web/components/post_components.ex:5686
+#: lib/vutuv_web/components/post_components.ex:5687
 #: lib/vutuv_web/live/notification_live/index.ex:1086
 #: lib/vutuv_web/live/post_live/reply.ex:43
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Rispondi"
 
-#: lib/vutuv_web/components/post_components.ex:3233
+#: lib/vutuv_web/components/post_components.ex:3409
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Risposta a un post eliminato"
@@ -2576,7 +2576,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr "ha risposto al Suo post."
 
-#: lib/vutuv_web/components/post_components.ex:2769
+#: lib/vutuv_web/components/post_components.ex:2945
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:60
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:57
@@ -2584,14 +2584,14 @@ msgstr "ha risposto al Suo post."
 msgid "Reply to %{handle}"
 msgstr "Rispondi a %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:3207
+#: lib/vutuv_web/components/post_components.ex:3383
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Risposta a un post di %{handle} ora eliminato"
 
-#: lib/vutuv_web/components/post_components.ex:3198
-#: lib/vutuv_web/components/post_components.ex:3225
-#: lib/vutuv_web/components/post_components.ex:3228
+#: lib/vutuv_web/components/post_components.ex:3374
+#: lib/vutuv_web/components/post_components.ex:3401
+#: lib/vutuv_web/components/post_components.ex:3404
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "In risposta a %{handle}"
@@ -2816,7 +2816,7 @@ msgstr "Scriva il Suo primo post"
 msgid "Manage"
 msgstr "Gestisci"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2506
+#: lib/vutuv_web/live/post_live/feed.ex:2580
 #: lib/vutuv_web/templates/user/show.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2837,7 +2837,7 @@ msgid_plural "%{formatted} connections"
 msgstr[0] "1 collegamento"
 msgstr[1] "%{formatted} collegamenti"
 
-#: lib/vutuv_web/live/post_live/feed.ex:939
+#: lib/vutuv_web/live/post_live/feed.ex:945
 #: lib/vutuv_web/templates/user/card_list.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "+1 more tag"
@@ -2892,7 +2892,7 @@ msgid_plural "connections"
 msgstr[0] "collegamento"
 msgstr[1] "collegamenti"
 
-#: lib/vutuv_web/components/post_components.ex:5142
+#: lib/vutuv_web/components/post_components.ex:5318
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "persone che non sono Suoi collegamenti"
@@ -3176,7 +3176,7 @@ msgstr "Nudità, violenza o altri contenuti che non hanno posto su vutuv."
 msgid "Only visible to you"
 msgstr "Visibile solo a Lei"
 
-#: lib/vutuv_web/components/post_components.ex:3174
+#: lib/vutuv_web/components/post_components.ex:3350
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solo Lei può vedere questo post finché la segnalazione è in corso."
@@ -3254,9 +3254,9 @@ msgstr "Respinta"
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Lo rimuova. La segnalazione si chiude, senza altre domande."
 
-#: lib/vutuv_web/components/post_components.ex:1298
-#: lib/vutuv_web/components/post_components.ex:2581
-#: lib/vutuv_web/components/post_components.ex:3338
+#: lib/vutuv_web/components/post_components.ex:1300
+#: lib/vutuv_web/components/post_components.ex:2583
+#: lib/vutuv_web/components/post_components.ex:3514
 #: lib/vutuv_web/live/organization_live/show.ex:680
 #: lib/vutuv_web/templates/user/show.html.heex:222
 #, elixir-autogen, elixir-format
@@ -3968,7 +3968,7 @@ msgstr "Scorra dentro il riquadro, o prema per aprire l'immagine intera."
 msgid "%{count} endorsements"
 msgstr "%{count} conferme"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1237
+#: lib/vutuv_web/agent_docs/markdown.ex:1250
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr "%{count} in questa pagina, usi ?page=N"
@@ -3982,7 +3982,7 @@ msgstr "%{count} post di %{name}"
 #: lib/vutuv_web/agent_docs/markdown.ex:91
 #: lib/vutuv_web/agent_docs/markdown.ex:202
 #: lib/vutuv_web/agent_docs/markdown.ex:216
-#: lib/vutuv_web/agent_docs/markdown.ex:1078
+#: lib/vutuv_web/agent_docs/markdown.ex:1091
 #: lib/vutuv_web/agent_docs/text.ex:86
 #: lib/vutuv_web/agent_docs/text.ex:185
 #: lib/vutuv_web/agent_docs/text.ex:199
@@ -4005,20 +4005,20 @@ msgstr "Follower di %{name}"
 msgid "Images"
 msgstr "Immagini"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1096
+#: lib/vutuv_web/agent_docs/markdown.ex:1109
 #: lib/vutuv_web/agent_docs/text.ex:770
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr "In risposta a un post eliminato di %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1093
+#: lib/vutuv_web/agent_docs/markdown.ex:1106
 #: lib/vutuv_web/agent_docs/text.ex:767
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr "In risposta a un post eliminato."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1100
-#: lib/vutuv_web/agent_docs/markdown.ex:1314
+#: lib/vutuv_web/agent_docs/markdown.ex:1113
+#: lib/vutuv_web/agent_docs/markdown.ex:1327
 #: lib/vutuv_web/agent_docs/text.ex:773
 #: lib/vutuv_web/agent_docs/text.ex:817
 #, elixir-autogen, elixir-format
@@ -4075,7 +4075,7 @@ msgstr "Post (%{count} in totale)"
 msgid "Verified profile: yes"
 msgstr "Profilo verificato: sì"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1047
+#: lib/vutuv_web/agent_docs/markdown.ex:1060
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr "ripubblicato da %{name}"
@@ -4722,7 +4722,7 @@ msgstr "Non ha bloccato nessuno."
 msgid "You unblocked @%{slug}."
 msgstr "Ha sbloccato @%{slug}."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2764
+#: lib/vutuv_web/live/post_live/feed.ex:2839
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Scopra persone da seguire"
@@ -4799,8 +4799,8 @@ msgstr "I risultati compaiono dopo almeno tre lettere."
 msgid "Similar names"
 msgstr "Nomi simili"
 
-#: lib/vutuv_web/components/post_components.ex:402
-#: lib/vutuv_web/components/post_components.ex:421
+#: lib/vutuv_web/components/post_components.ex:404
+#: lib/vutuv_web/components/post_components.ex:423
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/import_connections_live.ex:470
@@ -5639,9 +5639,9 @@ msgstr "Navigazione principale"
 msgid "Footer navigation"
 msgstr "Navigazione a piè di pagina"
 
-#: lib/vutuv_web/components/post_components.ex:3404
-#: lib/vutuv_web/components/post_components.ex:3459
-#: lib/vutuv_web/components/post_components.ex:3876
+#: lib/vutuv_web/components/post_components.ex:3580
+#: lib/vutuv_web/components/post_components.ex:3635
+#: lib/vutuv_web/components/post_components.ex:4052
 #: lib/vutuv_web/live/notification_live/index.ex:743
 #: lib/vutuv_web/views/user_html.ex:126
 #, elixir-autogen, elixir-format
@@ -6448,8 +6448,8 @@ msgstr "Apri il rapporto giornaliero"
 msgid "Previous day"
 msgstr "Giorno precedente"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1115
-#: lib/vutuv_web/components/post_components.ex:404
+#: lib/vutuv_web/agent_docs/markdown.ex:1128
+#: lib/vutuv_web/components/post_components.ex:406
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
@@ -6562,7 +6562,7 @@ msgstr "Ancora nessuna conferma."
 msgid "and %{count} more"
 msgstr "e altri %{count}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1091
+#: lib/vutuv_web/agent_docs/markdown.ex:1104
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr "confermato il %{date}"
@@ -6875,10 +6875,10 @@ msgstr ""
 "Se disattiva un'opzione, la relativa esclusione viaggia con le pagine e le "
 "risposte che La riguardano. Con entrambe disattivate, ad esempio:"
 
-#: lib/vutuv_web/components/post_components.ex:2549
-#: lib/vutuv_web/components/post_components.ex:3335
+#: lib/vutuv_web/components/post_components.ex:2551
+#: lib/vutuv_web/components/post_components.ex:3511
 #: lib/vutuv_web/components/ui.ex:2876
-#: lib/vutuv_web/live/fediverse_account_live.ex:385
+#: lib/vutuv_web/live/fediverse_account_live.ex:386
 #: lib/vutuv_web/live/organization_live/following.ex:376
 #: lib/vutuv_web/live/organization_live/following.ex:451
 #: lib/vutuv_web/templates/settings/filters.html.heex:58
@@ -6903,9 +6903,9 @@ msgstr "Nuovi messaggi e nuovi collegamenti"
 msgid "Remove this connection? You will stop following them."
 msgstr "Rimuovere questo collegamento? Smetterà di seguire questa persona."
 
-#: lib/vutuv_web/components/post_components.ex:3335
+#: lib/vutuv_web/components/post_components.ex:3511
 #: lib/vutuv_web/components/ui.ex:2875
-#: lib/vutuv_web/live/fediverse_account_live.ex:383
+#: lib/vutuv_web/live/fediverse_account_live.ex:384
 #: lib/vutuv_web/live/organization_live/following.ex:376
 #: lib/vutuv_web/live/organization_live/following.ex:451
 #: lib/vutuv_web/templates/settings/filters.html.heex:81
@@ -7639,7 +7639,7 @@ msgid "applies to the whole list, not just this page"
 msgstr "vale per l'intero elenco, non solo per questa pagina"
 
 #: lib/vutuv_web/components/job_components.ex:190
-#: lib/vutuv_web/components/post_components.ex:5383
+#: lib/vutuv_web/components/post_components.ex:5559
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -7746,7 +7746,7 @@ msgid "This updates on its own. You can leave this page; the send keeps running.
 msgstr "Si aggiorna da sola. Può lasciare questa pagina: l'invio prosegue."
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:174
-#: lib/vutuv_web/live/post_live/feed.ex:3027
+#: lib/vutuv_web/live/post_live/feed.ex:3103
 #, elixir-autogen
 msgid "Done"
 msgstr "Fatto"
@@ -7826,17 +7826,17 @@ msgstr "Feed di %{name}"
 msgid "The vutuv newsfeed of %{name}"
 msgstr "Il feed di notizie vutuv di %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1242
+#: lib/vutuv_web/agent_docs/markdown.ex:1255
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr "Il Suo feed è vuoto."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1245
+#: lib/vutuv_web/agent_docs/markdown.ex:1258
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr "%{count} post in questa pagina"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1252
+#: lib/vutuv_web/agent_docs/markdown.ex:1265
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr "altri post disponibili, aggiunga ?cursor=%{cursor}"
@@ -8223,7 +8223,7 @@ msgid "Admins"
 msgstr "Amministratori"
 
 #: lib/vutuv_web/live/admin/user_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:948
+#: lib/vutuv_web/live/post_live/feed.ex:954
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr "Tutti i membri"
@@ -9186,14 +9186,14 @@ msgstr ""
 msgid "CV download"
 msgstr "Download del CV"
 
-#: lib/vutuv_web/components/post_components.ex:4350
+#: lib/vutuv_web/components/post_components.ex:4526
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] "Ripubblicato da %{name} e da %{formatted} altro"
 msgstr[1] "Ripubblicato da %{name} e da altri %{formatted}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1050
+#: lib/vutuv_web/agent_docs/markdown.ex:1063
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr "ripubblicato da %{name} e da altri %{count}"
@@ -13705,7 +13705,7 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "Interrompere gli avvisi via e-mail per la Sua ricerca salvata \"%{label}\"?"
 
-#: lib/vutuv_web/components/post_components.ex:2728
+#: lib/vutuv_web/components/post_components.ex:2904
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:715
 #: lib/vutuv_web/controllers/settings_controller.ex:733
@@ -14172,22 +14172,22 @@ msgstr "Cellulare privato"
 msgid "Work mobile"
 msgstr "Cellulare di lavoro"
 
-#: lib/vutuv_web/components/post_components.ex:444
+#: lib/vutuv_web/components/post_components.ex:446
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr "Ancora nessun post."
 
-#: lib/vutuv_web/components/post_components.ex:446
+#: lib/vutuv_web/components/post_components.ex:448
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr "Ancora nessuna risposta."
 
-#: lib/vutuv_web/components/post_components.ex:445
+#: lib/vutuv_web/components/post_components.ex:447
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr "Ancora nessuna ripubblicazione."
 
-#: lib/vutuv_web/components/post_components.ex:403
+#: lib/vutuv_web/components/post_components.ex:405
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr "Post propri"
@@ -14202,7 +14202,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:4724
 #: lib/vutuv_web/controllers/settings_controller.ex:634
-#: lib/vutuv_web/live/post_live/feed.ex:633
+#: lib/vutuv_web/live/post_live/feed.ex:639
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
@@ -14370,50 +14370,50 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr "ha aggiunto %{count} nuove voci al proprio CV:"
 
-#: lib/vutuv_web/components/post_components.ex:4991
+#: lib/vutuv_web/components/post_components.ex:5167
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Audiolibro"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1204
-#: lib/vutuv_web/components/post_components.ex:4948
+#: lib/vutuv_web/agent_docs/markdown.ex:1217
+#: lib/vutuv_web/components/post_components.ex:5124
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Recensione di un libro"
 
-#: lib/vutuv_web/components/post_components.ex:4992
+#: lib/vutuv_web/components/post_components.ex:5168
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Cinema"
 
-#: lib/vutuv_web/components/post_components.ex:4994
+#: lib/vutuv_web/components/post_components.ex:5170
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:4990
+#: lib/vutuv_web/components/post_components.ex:5166
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-book"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1204
-#: lib/vutuv_web/components/post_components.ex:4947
+#: lib/vutuv_web/agent_docs/markdown.ex:1217
+#: lib/vutuv_web/components/post_components.ex:5123
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Recensione di un film"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:453
+#: lib/vutuv_web/live/fediverse_account_live.ex:454
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "Look up"
 msgstr "Cerca"
 
-#: lib/vutuv_web/components/post_components.ex:4989
+#: lib/vutuv_web/components/post_components.ex:5165
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Libro cartaceo"
 
-#: lib/vutuv_web/components/post_components.ex:4993
+#: lib/vutuv_web/components/post_components.ex:5169
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14433,7 +14433,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Anno"
 
-#: lib/vutuv_web/components/post_components.ex:5030
+#: lib/vutuv_web/components/post_components.ex:5206
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14441,27 +14441,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} pagina"
 msgstr[1] "%{formatted} pagine"
 
-#: lib/vutuv_web/components/post_components.ex:5060
+#: lib/vutuv_web/components/post_components.ex:5236
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} h"
 
-#: lib/vutuv_web/components/post_components.ex:5061
+#: lib/vutuv_web/components/post_components.ex:5237
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} h %{minutes} min"
 
-#: lib/vutuv_web/components/post_components.ex:5059
+#: lib/vutuv_web/components/post_components.ex:5235
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} min"
 
-#: lib/vutuv_web/components/post_components.ex:5019
+#: lib/vutuv_web/components/post_components.ex:5195
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(edizione cartacea)"
 
-#: lib/vutuv_web/components/post_components.ex:5066
+#: lib/vutuv_web/components/post_components.ex:5242
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "circa %{duration}"
@@ -14493,7 +14493,7 @@ msgstr "Con certificazione:"
 msgid "With qualification: %{name}"
 msgstr "Con certificazione: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:4833
+#: lib/vutuv_web/components/post_components.ex:5009
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Editore:"
@@ -14541,7 +14541,7 @@ msgstr "ora La seguono."
 msgid "endorsed you for %{tags}."
 msgstr "L'ha confermata per %{tags}."
 
-#: lib/vutuv_web/components/post_components.ex:4824
+#: lib/vutuv_web/components/post_components.ex:5000
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "di:"
@@ -14948,14 +14948,14 @@ msgstr "Cerchi un account da bloccare"
 msgid "See all frozen accounts"
 msgstr "Vedi tutti gli account bloccati"
 
-#: lib/vutuv_web/components/post_components.ex:3001
+#: lib/vutuv_web/components/post_components.ex:3177
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "Mostra %{formatted} post precedente"
 msgstr[1] "Mostra %{formatted} post precedenti"
 
-#: lib/vutuv_web/components/post_components.ex:3024
+#: lib/vutuv_web/components/post_components.ex:3200
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14984,7 +14984,7 @@ msgstr ""
 "Digiti un nome, un @handle o un indirizzo e-mail per trovare un account da "
 "bloccare."
 
-#: lib/vutuv_web/components/post_components.ex:5482
+#: lib/vutuv_web/components/post_components.ex:5658
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Non può mettere Mi piace al Suo stesso post."
@@ -15182,7 +15182,7 @@ msgstr ""
 "Scelga qui sotto un titolo di studio o un istituto da mostrare in cima al "
 "Suo profilo al posto di una qualifica."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1008
+#: lib/vutuv_web/live/post_live/feed.ex:1014
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr "Mostra comunque"
@@ -15433,7 +15433,7 @@ msgstr "%{blocked} server bloccati, il più attivo in entrata: %{host}."
 msgid "none yet"
 msgstr "ancora nessuno"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1151
+#: lib/vutuv_web/agent_docs/markdown.ex:1164
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr "Reazioni da altre reti"
@@ -16248,29 +16248,29 @@ msgstr ""
 " vedere dove va a finire. Modificare o eliminare un post su vutuv è solo una"
 " richiesta rivolta a quei server, e non tutti la rispettano."
 
-#: lib/vutuv_web/components/post_components.ex:5428
+#: lib/vutuv_web/components/post_components.ex:5604
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} risposta"
 msgstr[1] "%{formatted} risposte"
 
-#: lib/vutuv_web/components/post_components.ex:5432
+#: lib/vutuv_web/components/post_components.ex:5608
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Mi piace"
 msgstr[1] "%{formatted} Mi piace"
 
-#: lib/vutuv_web/components/post_components.ex:5436
+#: lib/vutuv_web/components/post_components.ex:5612
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
 msgstr[0] "%{formatted} ripubblicazione"
 msgstr[1] "%{formatted} ripubblicazioni"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1153
-#: lib/vutuv_web/components/post_components.ex:5387
+#: lib/vutuv_web/agent_docs/markdown.ex:1166
+#: lib/vutuv_web/components/post_components.ex:5563
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Già conteggiate nei numeri qui sopra."
@@ -16285,20 +16285,20 @@ msgstr ""
 " se l'autore la elimina, sparisce anche la nostra. Può rimuovere qualsiasi "
 "singola risposta, e disattivando questa opzione vengono eliminate tutte."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1335
+#: lib/vutuv_web/agent_docs/markdown.ex:1348
 #: lib/vutuv_web/agent_docs/text.ex:831
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr "Avviso sul contenuto"
 
-#: lib/vutuv_web/components/post_components.ex:1413
-#: lib/vutuv_web/components/post_components.ex:2142
-#: lib/vutuv_web/live/fediverse_account_live.ex:298
+#: lib/vutuv_web/components/post_components.ex:1415
+#: lib/vutuv_web/components/post_components.ex:2144
+#: lib/vutuv_web/live/fediverse_account_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr "Da un'altra rete"
 
-#: lib/vutuv_web/components/post_components.ex:1286
+#: lib/vutuv_web/components/post_components.ex:1288
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr "Rimuovere questa risposta dal Suo post?"
@@ -16310,7 +16310,7 @@ msgstr "Rimossa dal membro"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:134
 #: lib/vutuv_web/agent_docs/markdown.ex:165
-#: lib/vutuv_web/agent_docs/markdown.ex:1152
+#: lib/vutuv_web/agent_docs/markdown.ex:1165
 #: lib/vutuv_web/agent_docs/text.ex:123
 #: lib/vutuv_web/agent_docs/text.ex:151
 #, elixir-autogen, elixir-format
@@ -16327,7 +16327,7 @@ msgstr "Risposta da un'altra rete"
 msgid "Reply removed."
 msgstr "Risposta rimossa."
 
-#: lib/vutuv_web/components/post_components.ex:1295
+#: lib/vutuv_web/components/post_components.ex:1297
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -16338,7 +16338,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr "Segnalata come non appropriata"
 
-#: lib/vutuv_web/components/post_components.ex:1309
+#: lib/vutuv_web/components/post_components.ex:1311
 #: lib/vutuv_web/live/notification_live/index.ex:597
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -16369,10 +16369,10 @@ msgstr "Grazie. La risposta è stata eliminata subito."
 msgid "That reply is not yours to remove."
 msgstr "Questa risposta non spetta a Lei rimuoverla."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1337
-#: lib/vutuv_web/components/post_components.ex:1344
-#: lib/vutuv_web/components/post_components.ex:1544
-#: lib/vutuv_web/components/post_components.ex:2648
+#: lib/vutuv_web/agent_docs/markdown.ex:1350
+#: lib/vutuv_web/components/post_components.ex:1346
+#: lib/vutuv_web/components/post_components.ex:1546
+#: lib/vutuv_web/components/post_components.ex:2824
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr "Vedi l'originale"
@@ -17067,22 +17067,22 @@ msgstr ""
 msgid "device or detail"
 msgstr "dispositivo o dettaglio"
 
-#: lib/vutuv_web/components/post_components.ex:3186
+#: lib/vutuv_web/components/post_components.ex:3362
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Post fissato"
 
-#: lib/vutuv_web/components/post_components.ex:3302
+#: lib/vutuv_web/components/post_components.ex:3478
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "Fissa sul profilo"
 
-#: lib/vutuv_web/components/post_components.ex:3310
+#: lib/vutuv_web/components/post_components.ex:3486
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Togli dal profilo"
 
-#: lib/vutuv_web/components/post_components.ex:3296
+#: lib/vutuv_web/components/post_components.ex:3472
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -17105,7 +17105,7 @@ msgstr ""
 msgid "Unpinned. The post is a normal post again."
 msgstr "Non più fissato. Il post torna a essere un post normale."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1033
+#: lib/vutuv_web/agent_docs/markdown.ex:1046
 #, elixir-autogen, elixir-format
 msgid "pinned post"
 msgstr "post fissato"
@@ -17173,7 +17173,7 @@ msgstr "Copertina"
 msgid "Describe the photo for people who can't see it"
 msgstr "Descriva la foto per chi non può vederla"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1265
+#: lib/vutuv_web/agent_docs/markdown.ex:1278
 #: lib/vutuv_web/agent_docs/text.ex:798
 #: lib/vutuv_web/components/ui.ex:2930
 #, elixir-autogen, elixir-format
@@ -17217,17 +17217,17 @@ msgstr "Foto successiva"
 msgid "No image description yet"
 msgstr "Ancora nessuna descrizione dell'immagine"
 
-#: lib/vutuv_web/components/post_components.ex:2781
+#: lib/vutuv_web/components/post_components.ex:2957
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Apri le impostazioni del Fediverso"
 
-#: lib/vutuv_web/components/post_components.ex:4005
+#: lib/vutuv_web/components/post_components.ex:4181
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} di %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:4153
+#: lib/vutuv_web/components/post_components.ex:4329
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "La foto è in fase di controllo"
@@ -17238,9 +17238,9 @@ msgstr "La foto è in fase di controllo"
 msgid "Photo options"
 msgstr "Opzioni della foto"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1298
+#: lib/vutuv_web/agent_docs/markdown.ex:1311
 #: lib/vutuv_web/agent_docs/text.ex:785
-#: lib/vutuv_web/components/post_components.ex:4235
+#: lib/vutuv_web/components/post_components.ex:4411
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Foto:"
@@ -17268,7 +17268,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr "Mostra le impostazioni della fotocamera"
 
-#: lib/vutuv_web/components/post_components.ex:2834
+#: lib/vutuv_web/components/post_components.ex:3010
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -17294,7 +17294,7 @@ msgstr ""
 "Questa foto porta con sé il luogo in cui è stata scattata. Chiunque scarichi"
 " il file esatto può leggerlo."
 
-#: lib/vutuv_web/components/post_components.ex:2825
+#: lib/vutuv_web/components/post_components.ex:3001
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -17309,12 +17309,12 @@ msgstr ""
 "inviare le Sue parole a quella rete, cosa che vutuv fa solo per i membri che"
 " hanno attivato la partecipazione al Fediverso."
 
-#: lib/vutuv_web/components/post_components.ex:2843
+#: lib/vutuv_web/components/post_components.ex:3019
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Questo sito non partecipa al Fediverso."
 
-#: lib/vutuv_web/components/post_components.ex:2777
+#: lib/vutuv_web/components/post_components.ex:2953
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Attivi la partecipazione al Fediverso per rispondere"
@@ -17330,7 +17330,7 @@ msgid "You have sent a lot of answers to other networks in the past hour. Please
 msgstr ""
 "Nell'ultima ora ha inviato molte risposte ad altre reti. Riprovi più tardi."
 
-#: lib/vutuv_web/components/post_components.ex:2838
+#: lib/vutuv_web/components/post_components.ex:3014
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -17344,7 +17344,7 @@ msgstr ""
 "Al momento le Sue impostazioni del Fediverso non consentono di inviare una "
 "risposta."
 
-#: lib/vutuv_web/components/post_components.ex:2791
+#: lib/vutuv_web/components/post_components.ex:2967
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -17367,8 +17367,8 @@ msgstr "Aggiungi foto"
 msgid "Licence"
 msgstr "Licenza"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2515
-#: lib/vutuv_web/live/post_live/feed.ex:2516
+#: lib/vutuv_web/live/post_live/feed.ex:2589
+#: lib/vutuv_web/live/post_live/feed.ex:2590
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr "Pubblica foto"
@@ -17438,14 +17438,14 @@ msgstr[1] ""
 "Alcune di queste foto portano con sé il luogo in cui sono state scattate, e "
 "il file esatto lo rivela."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1171
-#: lib/vutuv_web/components/post_components.ex:5425
+#: lib/vutuv_web/agent_docs/markdown.ex:1184
+#: lib/vutuv_web/components/post_components.ex:5601
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "A %{handle} è piaciuto"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1169
-#: lib/vutuv_web/components/post_components.ex:5422
+#: lib/vutuv_web/agent_docs/markdown.ex:1182
+#: lib/vutuv_web/components/post_components.ex:5598
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} lo ha condiviso"
@@ -17455,7 +17455,7 @@ msgstr "%{handle} lo ha condiviso"
 msgid "Fediverse reactions"
 msgstr "Reazioni dal Fediverso"
 
-#: lib/vutuv_web/components/post_components.ex:5314
+#: lib/vutuv_web/components/post_components.ex:5490
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Da altre reti"
@@ -17555,7 +17555,7 @@ msgstr "Richiesta di ritiro"
 msgid "Photo details"
 msgstr "Dettagli della foto"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:459
+#: lib/vutuv_web/live/fediverse_account_live.ex:460
 #: lib/vutuv_web/live/fediverse_following_live.ex:60
 #: lib/vutuv_web/live/fediverse_following_live.ex:301
 #: lib/vutuv_web/live/fediverse_following_live.ex:314
@@ -17585,7 +17585,7 @@ msgstr "Annulla la richiesta"
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr "Segua account su Mastodon, e si faccia seguire da lì"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:120
+#: lib/vutuv_web/live/fediverse_account_live.ex:121
 #: lib/vutuv_web/live/fediverse_following_live.ex:257
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:147
 #, elixir-autogen, elixir-format
@@ -17739,7 +17739,7 @@ msgstr ""
 "richiesta viene firmata a Suo nome, così l'altro server sa chi la sta "
 "facendo."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:136
+#: lib/vutuv_web/live/fediverse_account_live.ex:137
 #: lib/vutuv_web/live/fediverse_following_live.ex:181
 #, elixir-autogen, elixir-format
 msgid "Unfollowed."
@@ -17841,7 +17841,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr "Post in cache"
 
-#: lib/vutuv_web/components/post_components.ex:2590
+#: lib/vutuv_web/components/post_components.ex:2592
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr "Solo per i follower di questo account"
@@ -17851,7 +17851,7 @@ msgstr "Solo per i follower di questo account"
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Grazie. La nostra copia è stata eliminata subito."
 
-#: lib/vutuv_web/components/post_components.ex:2647
+#: lib/vutuv_web/components/post_components.ex:2823
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Vota sull'originale"
@@ -17877,17 +17877,17 @@ msgstr "Post in cache segnalato, rimosso per tutti qui"
 msgid "Content from other networks taken down by members"
 msgstr "Contenuti da altre reti rimossi dai membri"
 
-#: lib/vutuv_web/components/post_components.ex:1689
+#: lib/vutuv_web/components/post_components.ex:1691
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr "Nascondi"
 
-#: lib/vutuv_web/components/post_components.ex:2602
+#: lib/vutuv_web/components/post_components.ex:2773
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Contrassegnato come sensibile dal suo autore"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:231
+#: lib/vutuv_web/live/fediverse_account_live.ex:232
 #: lib/vutuv_web/live/remote_post_actions.ex:71
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
@@ -17898,7 +17898,7 @@ msgstr "Silenziato. Continua a seguirlo; i suoi post spariscono dal Suo feed."
 msgid "Nobody has removed or reported anything yet."
 msgstr "Nessuno ha ancora rimosso o segnalato nulla."
 
-#: lib/vutuv_web/components/post_components.ex:2576
+#: lib/vutuv_web/components/post_components.ex:2578
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -17926,60 +17926,60 @@ msgstr ""
 msgid "%{name} (another network)"
 msgstr "%{name} (altra rete)"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:281
+#: lib/vutuv_web/live/fediverse_account_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "Account on another network"
 msgstr "Account su un'altra rete"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:443
+#: lib/vutuv_web/live/fediverse_account_live.ex:444
 #, elixir-autogen, elixir-format
 msgid "Look up another account"
 msgstr "Cerca un altro account"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:373
+#: lib/vutuv_web/live/fediverse_account_live.ex:374
 #, elixir-autogen, elixir-format
 msgid "Muted"
 msgstr "Silenziato"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:256
+#: lib/vutuv_web/live/fediverse_account_live.ex:257
 #, elixir-autogen, elixir-format
 msgid "Nothing cached yet. Their posts appear here as they publish them."
 msgstr ""
 "Ancora nulla in cache. I loro post compaiono qui man mano che li pubblicano."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:251
+#: lib/vutuv_web/live/fediverse_account_live.ex:252
 #, elixir-autogen, elixir-format
 msgid "Nothing here. vutuv only keeps an account's posts while somebody here follows it, and this page never fetches any."
 msgstr ""
 "Qui non c'è nulla. vutuv conserva i post di un account solo finché qualcuno "
 "qui lo segue, e questa pagina non ne scarica mai."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:445
+#: lib/vutuv_web/live/fediverse_account_live.ex:446
 #, elixir-autogen, elixir-format
 msgid "Paste an address from Mastodon and friends to open its page here."
 msgstr "Incolli un indirizzo da Mastodon e affini per aprirne qui la pagina."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:333
+#: lib/vutuv_web/live/fediverse_account_live.ex:334
 #, elixir-autogen, elixir-format
 msgid "Show the whole description"
 msgstr "Mostra tutta la descrizione"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:428
+#: lib/vutuv_web/live/fediverse_account_live.ex:429
 #, elixir-autogen, elixir-format
 msgid "The most recent %{count} are shown. The rest are on their own server."
 msgstr "Sono mostrati i %{count} più recenti. Gli altri sono sul loro server."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:233
+#: lib/vutuv_web/live/fediverse_account_live.ex:234
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts are back in your feed."
 msgstr "Riattivato. I suoi post sono tornati nel Suo feed."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:438
+#: lib/vutuv_web/live/fediverse_account_live.ex:439
 #, elixir-autogen, elixir-format
 msgid "View their full profile on %{host}"
 msgstr "Veda il suo profilo completo su %{host}"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:260
+#: lib/vutuv_web/live/fediverse_account_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Waiting for that server to accept your follow. Posts they addressed to their followers appear once it does."
 msgstr ""
@@ -18160,27 +18160,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] "(un'immagine)"
 msgstr[1] "(%{count} immagini)"
 
-#: lib/vutuv_web/components/post_components.ex:2301
+#: lib/vutuv_web/components/post_components.ex:2303
 #, elixir-autogen, elixir-format
 msgid "Picture is being checked"
 msgstr "L'immagine è in fase di controllo"
 
-#: lib/vutuv_web/components/post_components.ex:2329
+#: lib/vutuv_web/components/post_components.ex:2331
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr "Coprila di nuovo"
 
-#: lib/vutuv_web/components/post_components.ex:2324
+#: lib/vutuv_web/components/post_components.ex:2326
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr "Contenuto sensibile. Mostra l'immagine."
 
-#: lib/vutuv_web/components/post_components.ex:2684
+#: lib/vutuv_web/components/post_components.ex:2860
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Sono molti Mi piace in un'ora. Riprovi più tardi."
 
-#: lib/vutuv_web/components/post_components.ex:2690
+#: lib/vutuv_web/components/post_components.ex:2866
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Quel post non è più qui."
@@ -18190,7 +18190,7 @@ msgstr "Quel post non è più qui."
 msgid "Back to the feed"
 msgstr "Torna al feed"
 
-#: lib/vutuv_web/components/post_components.ex:2829
+#: lib/vutuv_web/components/post_components.ex:3005
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -18352,7 +18352,7 @@ msgstr "Non ancora Suo."
 msgid "Nothing has changed yet."
 msgstr "Non è ancora cambiato nulla."
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:250
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:269
 #: lib/vutuv_web/templates/username/confirm.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Now"
@@ -18960,14 +18960,14 @@ msgstr ""
 msgid "Screenshot blocklist"
 msgstr "Elenco dei bloccati per gli screenshot"
 
-#: lib/vutuv_web/components/post_components.ex:436
+#: lib/vutuv_web/components/post_components.ex:438
 #, elixir-autogen, elixir-format
 msgid "Nothing from the fediverse yet. Follow accounts out there to fill this tab."
 msgstr ""
 "Ancora nulla dal Fediverso. Segua account là fuori per riempire questa "
 "scheda."
 
-#: lib/vutuv_web/components/post_components.ex:433
+#: lib/vutuv_web/components/post_components.ex:435
 #, elixir-autogen, elixir-format
 msgid "Nothing from vutuv yet. Follow people here to fill this tab."
 msgstr "Ancora nulla da vutuv. Segua persone qui per riempire questa scheda."
@@ -19009,7 +19009,7 @@ msgstr "Nessun post su vutuv porta ancora questo tag."
 msgid "word in a post"
 msgstr "parola in un post"
 
-#: lib/vutuv_web/components/post_components.ex:2687
+#: lib/vutuv_web/components/post_components.ex:2863
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr "Quella risposta non è più qui."
@@ -19383,24 +19383,24 @@ msgstr ""
 "La pagina di un post mostra i membri a cui è piaciuto, subito sotto il "
 "contatore. Questa impostazione decide se Lei è tra quei volti."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1139
+#: lib/vutuv_web/agent_docs/markdown.ex:1152
 #, elixir-autogen, elixir-format
 msgid "Liked by"
 msgstr "Piace a"
 
-#: lib/vutuv_web/components/post_components.ex:4520
+#: lib/vutuv_web/components/post_components.ex:4696
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Piace a %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:4522
+#: lib/vutuv_web/components/post_components.ex:4698
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Piace a %{name} e a %{formatted} altro"
 msgstr[1] "Piace a %{name} e ad altri %{formatted}"
 
-#: lib/vutuv_web/components/post_components.ex:4533
+#: lib/vutuv_web/components/post_components.ex:4709
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -19431,12 +19431,12 @@ msgstr ""
 msgid "Your likes follow the site default again."
 msgstr "I Suoi Mi piace tornano a seguire il valore predefinito del sito."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1194
+#: lib/vutuv_web/agent_docs/markdown.ex:1207
 #, elixir-autogen, elixir-format
 msgid "%{address} (this page only)"
 msgstr "%{address} (solo questa pagina)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1191
+#: lib/vutuv_web/agent_docs/markdown.ex:1204
 #, elixir-autogen, elixir-format
 msgid "%{address} (whole website)"
 msgstr "%{address} (intero sito web)"
@@ -19446,7 +19446,7 @@ msgstr "%{address} (intero sito web)"
 msgid "Verified webpage of the author (%{address})"
 msgstr "Pagina web verificata dell'autore (%{address})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1183
+#: lib/vutuv_web/agent_docs/markdown.ex:1196
 #, elixir-autogen, elixir-format
 msgid "Verified webpages of the author linked here: %{addresses}"
 msgstr "Pagine web verificate dell'autore collegate qui: %{addresses}"
@@ -19581,7 +19581,7 @@ msgstr "Rilasciato il"
 msgid "Label"
 msgstr "Etichetta"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2782
+#: lib/vutuv_web/live/post_live/feed.ex:2857
 #: lib/vutuv_web/live/reference_check_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Loading…"
@@ -21233,7 +21233,7 @@ msgstr ""
 msgid "Start over"
 msgstr "Ricomincia"
 
-#: lib/vutuv_web/components/post_components.ex:2717
+#: lib/vutuv_web/components/post_components.ex:2893
 #, elixir-autogen, elixir-format
 msgid "A like or a repost is sent back to the network this post came from, and your account does not take part in the Fediverse at the moment. You can switch it on in the {settings}."
 msgstr ""
@@ -22209,27 +22209,27 @@ msgstr "Lingua del post"
 msgid "The language this post is written in"
 msgstr "La lingua in cui è scritto questo post"
 
-#: lib/vutuv_web/components/post_components.ex:4414
+#: lib/vutuv_web/components/post_components.ex:4590
 #, elixir-autogen, elixir-format
 msgid "Show the original"
 msgstr "Mostra l'originale"
 
-#: lib/vutuv_web/components/post_components.ex:4450
+#: lib/vutuv_web/components/post_components.ex:4626
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Traduci"
 
-#: lib/vutuv_web/components/post_components.ex:4459
+#: lib/vutuv_web/components/post_components.ex:4635
 #, elixir-autogen, elixir-format
 msgid "Translated"
 msgstr "Tradotto"
 
-#: lib/vutuv_web/components/post_components.ex:4462
+#: lib/vutuv_web/components/post_components.ex:4638
 #, elixir-autogen, elixir-format
 msgid "Translated from %{language}"
 msgstr "Tradotto da %{language}"
 
-#: lib/vutuv_web/components/post_components.ex:4439
+#: lib/vutuv_web/components/post_components.ex:4615
 #, elixir-autogen, elixir-format
 msgid "Translating…"
 msgstr "Traduzione in corso…"
@@ -22240,7 +22240,7 @@ msgid "Feed language settings reset to the site defaults."
 msgstr ""
 "Impostazioni delle lingue del feed riportate ai valori predefiniti del sito."
 
-#: lib/vutuv_web/components/post_components.ex:4429
+#: lib/vutuv_web/components/post_components.ex:4605
 #: lib/vutuv_web/components/ui.ex:4717
 #: lib/vutuv_web/live/feed_languages_live.ex:65
 #: lib/vutuv_web/live/feed_languages_live.ex:200
@@ -22383,7 +22383,7 @@ msgid "Your username, or paste the address of your profile page."
 msgstr ""
 "Il Suo nome utente, oppure incolli l'indirizzo della Sua pagina di profilo."
 
-#: lib/vutuv_web/components/post_components.ex:4201
+#: lib/vutuv_web/components/post_components.ex:4377
 #, elixir-autogen, elixir-format
 msgid "Our AI is still checking it. As soon as it is through, the photo appears by itself."
 msgid_plural "Our AI is still checking them, %{done} of %{total} done. As soon as the last one is through, the photos appear by themselves."
@@ -22394,13 +22394,13 @@ msgstr[1] ""
 "La nostra IA le sta ancora controllando, %{done} su %{total} fatte. Appena "
 "avrà finito con l'ultima, le foto compariranno da sé."
 
-#: lib/vutuv_web/components/post_components.ex:4198
+#: lib/vutuv_web/components/post_components.ex:4374
 #, elixir-autogen, elixir-format
 msgid "Your post is published, the photo is not there yet."
 msgstr "Il Suo post è pubblicato, la foto non c'è ancora."
 
-#: lib/vutuv_web/components/post_components.ex:2350
-#: lib/vutuv_web/components/post_components.ex:3519
+#: lib/vutuv_web/components/post_components.ex:2352
+#: lib/vutuv_web/components/post_components.ex:3695
 #, elixir-autogen, elixir-format
 msgid "Our AI is looking at it. It appears here by itself once it is through."
 msgid_plural "Our AI is looking at them. They appear here by themselves once they are through."
@@ -22419,7 +22419,7 @@ msgstr "Consigliato: %{width} × %{height} pixel (%{ratio})."
 msgid "Recommended: square, at least %{width} × %{height} pixels."
 msgstr "Consigliato: quadrata, almeno %{width} × %{height} pixel."
 
-#: lib/vutuv_web/live/post_live/feed.ex:885
+#: lib/vutuv_web/live/post_live/feed.ex:891
 #: lib/vutuv_web/views/user_html.ex:338
 #, elixir-autogen, elixir-format
 msgid "Profile picture of %{name}"
@@ -22971,7 +22971,7 @@ msgstr ""
 "Questa pagina sta seguendo il numero massimo di account che consentiamo "
 "(%{max})."
 
-#: lib/vutuv_web/components/post_components.ex:2564
+#: lib/vutuv_web/components/post_components.ex:2566
 #, elixir-autogen, elixir-format
 msgid "Stop following %{handle}? Their posts leave your feed."
 msgstr "Smettere di seguire %{handle}? I suoi post spariscono dal Suo feed."
@@ -23114,12 +23114,12 @@ msgstr ""
 "Segua #%{tag} da Mastodon o da qualsiasi altra app del Fediverso e i suoi "
 "post pubblici arriveranno nella Sua cronologia. Non serve un account vutuv."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2940
+#: lib/vutuv_web/live/post_live/feed.ex:3016
 #, elixir-autogen, elixir-format
 msgid "Greet other members"
 msgstr "Saluti gli altri membri"
 
-#: lib/vutuv_web/live/post_live/feed.ex:634
+#: lib/vutuv_web/live/post_live/feed.ex:640
 #, elixir-autogen, elixir-format
 msgid "New here"
 msgstr "Nuovi qui"
@@ -23169,7 +23169,7 @@ msgstr ""
 msgid "With a vutuv account"
 msgstr "Con un account vutuv"
 
-#: lib/vutuv_web/live/post_live/feed.ex:877
+#: lib/vutuv_web/live/post_live/feed.ex:883
 #, elixir-autogen, elixir-format
 msgid "A few of the newest members. Following them is a warm welcome."
 msgstr "Alcuni fra i membri più recenti. Seguirli è un bel benvenuto."
@@ -23555,7 +23555,7 @@ msgstr "Tutti i membri vutuv, in ordine alfabetico per cognome."
 msgid "Every vutuv member, grouped by the first letter of their last name."
 msgstr "Tutti i membri vutuv, raggruppati per la prima lettera del cognome."
 
-#: lib/vutuv_web/live/post_live/feed.ex:758
+#: lib/vutuv_web/live/post_live/feed.ex:764
 #: lib/vutuv_web/live/post_live/filter_band.ex:292
 #, elixir-autogen, elixir-format
 msgid "A photo"
@@ -23571,7 +23571,7 @@ msgstr "Anche dentro parole più lunghe: %{word} trova anche %{example}."
 msgid "A–Z"
 msgstr "A–Z"
 
-#: lib/vutuv_web/live/post_live/feed.ex:840
+#: lib/vutuv_web/live/post_live/feed.ex:846
 #, elixir-autogen, elixir-format
 msgid "Browse the tags"
 msgstr "Sfoglia i tag"
@@ -23586,7 +23586,7 @@ msgstr "Più attivi per primi"
 msgid "Clear all"
 msgstr "Cancella tutto"
 
-#: lib/vutuv_web/live/post_live/feed.ex:671
+#: lib/vutuv_web/live/post_live/feed.ex:677
 #, elixir-autogen, elixir-format
 msgid "Drag, or use the arrow keys"
 msgstr "Trascina, oppure usa i tasti freccia"
@@ -23601,13 +23601,13 @@ msgstr "Espandi o comprimi"
 msgid "Find an account or a server …"
 msgstr "Cerca un account o un server …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:695
+#: lib/vutuv_web/live/post_live/feed.ex:701
 #, elixir-autogen, elixir-format
 msgid "Fold %{card}"
 msgstr "Riduci %{card}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:822
-#: lib/vutuv_web/live/post_live/feed.ex:823
+#: lib/vutuv_web/live/post_live/feed.ex:828
+#: lib/vutuv_web/live/post_live/feed.ex:829
 #, elixir-autogen, elixir-format
 msgid "Follow a tag …"
 msgstr "Segui un tag …"
@@ -23624,17 +23624,17 @@ msgstr "Nascondi un tag …"
 msgid "Hide a word or a whole phrase …"
 msgstr "Nascondi una parola o un'intera frase …"
 
-#: lib/vutuv_web/live/post_live/feed.ex:632
+#: lib/vutuv_web/live/post_live/feed.ex:638
 #, elixir-autogen, elixir-format
 msgid "Hide tags"
 msgstr "Nascondi tag"
 
-#: lib/vutuv_web/live/post_live/feed.ex:631
+#: lib/vutuv_web/live/post_live/feed.ex:637
 #, elixir-autogen, elixir-format
 msgid "Hide words"
 msgstr "Nascondi parole"
 
-#: lib/vutuv_web/live/post_live/feed.ex:846
+#: lib/vutuv_web/live/post_live/feed.ex:852
 #: lib/vutuv_web/live/post_live/filter_band.ex:331
 #, elixir-autogen, elixir-format
 msgid "In your feed right now:"
@@ -23650,7 +23650,7 @@ msgstr "Ora non corrisponde a nulla nel suo feed — la regola vale comunque per
 msgid "More of your %{formatted} accounts"
 msgstr "Altri dei tuoi %{formatted} account"
 
-#: lib/vutuv_web/live/post_live/feed.ex:670
+#: lib/vutuv_web/live/post_live/feed.ex:676
 #, elixir-autogen, elixir-format
 msgid "Move %{card}"
 msgstr "Sposta %{card}"
@@ -23660,12 +23660,12 @@ msgstr "Sposta %{card}"
 msgid "No account found."
 msgstr "Nessun account trovato."
 
-#: lib/vutuv_web/live/post_live/feed.ex:835
+#: lib/vutuv_web/live/post_live/feed.ex:841
 #, elixir-autogen, elixir-format
 msgid "No tag called %{name} yet."
 msgstr "Nessun tag chiamato %{name} finora."
 
-#: lib/vutuv_web/live/post_live/feed.ex:624
+#: lib/vutuv_web/live/post_live/feed.ex:630
 #, elixir-autogen, elixir-format
 msgid "Not read yet"
 msgstr "Non ancora letti"
@@ -23695,13 +23695,13 @@ msgstr "I post con uno di questi tag vengono ridotti allo stesso modo."
 msgid "Posts containing one of these are folded to a single line — not deleted, and with a way to open them anyway."
 msgstr "I post che contengono una di queste parole vengono ridotti a una riga — non eliminati, e con un modo per aprirli comunque."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2966
+#: lib/vutuv_web/live/post_live/feed.ex:3042
 #, elixir-autogen, elixir-format
 msgid "Put away:"
 msgstr "Messe da parte:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:716
-#: lib/vutuv_web/live/post_live/feed.ex:717
+#: lib/vutuv_web/live/post_live/feed.ex:722
+#: lib/vutuv_web/live/post_live/feed.ex:723
 #, elixir-autogen, elixir-format
 msgid "Remove %{card}"
 msgstr "Rimuovi %{card}"
@@ -23733,7 +23733,7 @@ msgstr "Mostra solo %{source}"
 msgid "Show posts by %{name}"
 msgstr "Mostra i post di %{name}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:630
+#: lib/vutuv_web/live/post_live/feed.ex:636
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr "Fonti"
@@ -23743,12 +23743,12 @@ msgstr "Fonti"
 msgid "Switching off means muting, not unfollowing. You stay a follower, the posts just stop reaching your feed: permanently and on every device, until you switch them back on here."
 msgstr "Disattivare significa silenziare, non smettere di seguire. Continui a seguire, ma i post non arrivano più nel tuo feed: in modo permanente e su tutti i dispositivi, finché non li riattivi qui."
 
-#: lib/vutuv_web/live/post_live/feed.ex:694
+#: lib/vutuv_web/live/post_live/feed.ex:700
 #, elixir-autogen, elixir-format
 msgid "Unfold %{card}"
 msgstr "Espandi %{card}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:812
+#: lib/vutuv_web/live/post_live/feed.ex:818
 #, elixir-autogen, elixir-format
 msgid "Unfollow the tag %{tag}"
 msgstr "Smetti di seguire il tag %{tag}"
@@ -23772,29 +23772,29 @@ msgid_plural "and %{formatted} more"
 msgstr[0] "e 1 altro"
 msgstr[1] "e altri %{formatted}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2609
-#: lib/vutuv_web/live/post_live/feed.ex:2626
-#: lib/vutuv_web/live/post_live/feed.ex:3014
-#: lib/vutuv_web/live/post_live/feed.ex:3019
+#: lib/vutuv_web/live/post_live/feed.ex:2684
+#: lib/vutuv_web/live/post_live/feed.ex:2701
+#: lib/vutuv_web/live/post_live/feed.ex:3090
+#: lib/vutuv_web/live/post_live/feed.ex:3095
 #, elixir-autogen, elixir-format
 msgctxt "feed filter sheet"
 msgid "Filter"
 msgstr "Filtri"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1016
+#: lib/vutuv_web/live/post_live/feed.ex:1022
 #, elixir-autogen, elixir-format
 msgctxt "filtered post"
 msgid "Hidden:"
 msgstr "Nascosto:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:768
+#: lib/vutuv_web/live/post_live/feed.ex:774
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} post in the feed"
 msgid_plural "Show %{formatted} posts in the feed"
 msgstr[0] "Mostra %{formatted} post nel feed"
 msgstr[1] "Mostra %{formatted} post nel feed"
 
-#: lib/vutuv_web/components/post_components.ex:2272
+#: lib/vutuv_web/components/post_components.ex:2274
 #, elixir-autogen, elixir-format
 msgid "Picture unavailable"
 msgstr "Immagine non disponibile"
@@ -23825,31 +23825,31 @@ msgid_plural "You can upload at most %{count} files at a time."
 msgstr[0] "Può caricare un file per volta."
 msgstr[1] "Può caricare al massimo %{count} file per volta."
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:370
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:392
 #, elixir-autogen, elixir-format
 msgid "%{count} entry on %{day}"
 msgid_plural "%{count} entries on %{day}"
 msgstr[0] "%{count} voce il %{day}"
 msgstr[1] "%{count} voci il %{day}"
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:367
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:389
 #, elixir-autogen, elixir-format
 msgid "%{count} post on %{day}"
 msgid_plural "%{count} posts on %{day}"
 msgstr[0] "%{count} post il %{day}"
 msgstr[1] "%{count} post il %{day}"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2739
+#: lib/vutuv_web/live/post_live/feed.ex:2814
 #, elixir-autogen, elixir-format
 msgid "Back to now"
 msgstr "Torna al presente"
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:234
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:253
 #, elixir-autogen, elixir-format
 msgid "Busy month: the shading counts at least this much."
 msgstr "Mese intenso: la tonalità indica almeno questo valore."
 
-#: lib/vutuv_web/live/post_live/feed.ex:2785
+#: lib/vutuv_web/live/post_live/feed.ex:2860
 #, elixir-autogen, elixir-format
 msgid "Load the whole day (%{formatted} post)"
 msgid_plural "Load the whole day (%{formatted} posts)"
@@ -23861,38 +23861,38 @@ msgstr[1] "Carica tutto il giorno (%{formatted} post)"
 msgid "My posts"
 msgstr "I miei post"
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:146
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:161
 #, elixir-autogen, elixir-format
 msgid "Next month"
 msgstr "Mese successivo"
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:152
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:167
 #, elixir-autogen, elixir-format
 msgid "Next year"
 msgstr "Anno successivo"
 
-#: lib/vutuv_web/live/post_live/feed.ex:2735
+#: lib/vutuv_web/live/post_live/feed.ex:2810
 #, elixir-autogen, elixir-format
 msgid "Nothing reached your feed on %{day}."
 msgstr "Il %{day} non è arrivato nulla nel Suo feed."
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:113
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:128
 #, elixir-autogen, elixir-format
 msgid "Previous month"
 msgstr "Mese precedente"
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:109
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:124
 #, elixir-autogen, elixir-format
 msgid "Previous year"
 msgstr "Anno precedente"
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:222
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:241
 #, elixir-autogen, elixir-format
 msgctxt "heatmap scale"
 msgid "Less"
 msgstr "Meno"
 
-#: lib/vutuv_web/live/post_live/feed_calendar.ex:224
+#: lib/vutuv_web/live/post_live/feed_calendar.ex:243
 #, elixir-autogen, elixir-format
 msgctxt "heatmap scale"
 msgid "More"
@@ -23958,9 +23958,24 @@ msgstr "È pronta una nuova versione."
 msgid "Page management"
 msgstr "Gestione"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1970
+#: lib/vutuv_web/live/post_live/feed.ex:2044
 #, elixir-autogen, elixir-format
 msgid "New:"
 msgid_plural "New (%{formatted}):"
 msgstr[0] "Nuovo:"
 msgstr[1] "Nuovi (%{formatted}):"
+
+#: lib/vutuv_web/components/post_components.ex:2700
+#, elixir-autogen, elixir-format
+msgid "Quoted post"
+msgstr "Post citato"
+
+#: lib/vutuv_web/agent_docs/markdown.ex:1039
+#, elixir-autogen, elixir-format
+msgid "Quotes %{name}: %{url}"
+msgstr "Cita %{name}: %{url}"
+
+#: lib/vutuv_web/agent_docs/markdown.ex:1036
+#, elixir-autogen, elixir-format
+msgid "Quotes %{url}"
+msgstr "Cita %{url}"

--- a/priv/repo/migrations/20260826190640_add_quotes_to_fediverse_posts.exs
+++ b/priv/repo/migrations/20260826190640_add_quotes_to_fediverse_posts.exs
@@ -1,0 +1,82 @@
+defmodule Vutuv.Repo.Migrations.AddQuotesToFediversePosts do
+  use Ecto.Migration
+
+  # What a post from another network says it is quoting (issue #1609).
+  #
+  # `quote_uri` is the object the author quoted, read from whichever of the
+  # three alias properties their server writes (`quote`, `quoteUri`,
+  # `_misskey_quote`); `quote_authorization_uri` is the FEP-044f stamp that
+  # proves the quoted author consented. Both are **text**: they are URIs a
+  # stranger's server minted, no changeset of ours bounds what they may write,
+  # and a varchar(255) would turn a long id into a 22001 on the delivery path —
+  # the `inbox_uri` lesson from issue #1102. The changeset caps them in bytes
+  # like `object_uri`, but the column is not what does it.
+  #
+  # The two resolved references are the quoted thing itself: a cached copy of
+  # somebody else's post, or a vutuv post when the quote points back here.
+  # Nilify rather than cascade — a quote outlives what it quotes and degrades
+  # to a link, exactly as it does when the stamp is withdrawn. The
+  # `quoted_post_id` reference is also the **holder** that keeps a quoted
+  # remote copy out of `purge_unfollowed_remote_posts/0`, the way a reshare, a
+  # boost and a lookup hold one.
+  #
+  # `quote_verified` is what decides between a card and a link: true only for a
+  # self-quote or a stamp we checked against the quoted object's own host.
+  # Default false, so an unresolved row renders as the link it already was.
+  #
+  # Plain additions, so this is N-1 compatible: the release currently serving
+  # traffic neither reads nor writes any of them.
+  # The two indexes are built CONCURRENTLY, so the migration takes no
+  # transaction and no migrator lock. `fediverse_posts` is the table the inbox
+  # writes to on every delivery, and a migration runs during the blue/green
+  # window while the **previous** release is still serving — an ordinary
+  # `CREATE INDEX` would hold a write lock on it for the duration. The column
+  # additions themselves are metadata-only and safe beside it.
+  #
+  # **Every step is therefore idempotent**, which is the price of giving up the
+  # transaction: a concurrent build that loses a lock race leaves the columns
+  # added and the version unrecorded, and the deploy's retry would otherwise die
+  # on "column already exists" and block every migration behind it.
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  # `up`/`down` rather than `change`, because `add_if_not_exists` carries no
+  # reverse. Nothing is lost: the down side drops exactly what the up side adds.
+  def up do
+    alter table(:fediverse_posts) do
+      add_if_not_exists(:quote_uri, :text)
+      add_if_not_exists(:quote_authorization_uri, :text)
+
+      add_if_not_exists(
+        :quoted_post_id,
+        references(:fediverse_posts, on_delete: :nilify_all, type: :binary_id)
+      )
+
+      add_if_not_exists(
+        :quoted_local_post_id,
+        references(:posts, on_delete: :nilify_all, type: :binary_id)
+      )
+
+      add_if_not_exists(:quote_verified, :boolean, null: false, default: false)
+    end
+
+    # The holder question — "does any post quote this one" — is asked once per
+    # purge run per candidate row, so the reference needs its own index; the
+    # local one covers the same question for a vutuv post.
+    create_if_not_exists(index(:fediverse_posts, [:quoted_post_id], concurrently: true))
+    create_if_not_exists(index(:fediverse_posts, [:quoted_local_post_id], concurrently: true))
+  end
+
+  def down do
+    drop_if_exists(index(:fediverse_posts, [:quoted_post_id], concurrently: true))
+    drop_if_exists(index(:fediverse_posts, [:quoted_local_post_id], concurrently: true))
+
+    alter table(:fediverse_posts) do
+      remove_if_exists(:quote_uri, :text)
+      remove_if_exists(:quote_authorization_uri, :text)
+      remove_if_exists(:quoted_post_id, :binary_id)
+      remove_if_exists(:quoted_local_post_id, :binary_id)
+      remove_if_exists(:quote_verified, :boolean)
+    end
+  end
+end

--- a/priv/repo/migrations/20260826190640_add_quotes_to_fediverse_posts.exs
+++ b/priv/repo/migrations/20260826190640_add_quotes_to_fediverse_posts.exs
@@ -24,6 +24,15 @@ defmodule Vutuv.Repo.Migrations.AddQuotesToFediversePosts do
   # self-quote or a stamp we checked against the quoted object's own host.
   # Default false, so an unresolved row renders as the link it already was.
   #
+  # `quote_checked_at` is the resume clock. Resolving a quote is fire-and-forget
+  # work on `Vutuv.TaskSupervisor`, so a blue/green deploy stops it mid-flight
+  # and nothing anywhere says so — the row would keep a `quote_uri` nobody ever
+  # went back to. Every finished resolution stamps this column, *including* the
+  # ones that resolved to nothing, so a null clock means one thing only: the
+  # attempt never got to the end. `Vutuv.Fediverse.QuoteResolver` picks exactly
+  # those up. The stamp is what stops it being a treadmill (issue #1316): each
+  # row is retried once and then leaves the queue whatever the outcome.
+  #
   # Plain additions, so this is N-1 compatible: the release currently serving
   # traffic neither reads nor writes any of them.
   # The two indexes are built CONCURRENTLY, so the migration takes no
@@ -36,7 +45,9 @@ defmodule Vutuv.Repo.Migrations.AddQuotesToFediversePosts do
   # **Every step is therefore idempotent**, which is the price of giving up the
   # transaction: a concurrent build that loses a lock race leaves the columns
   # added and the version unrecorded, and the deploy's retry would otherwise die
-  # on "column already exists" and block every migration behind it.
+  # on "column already exists" and block every migration behind it. The two
+  # foreign keys need their own guard for that (`add_foreign_key/3`); the
+  # columns' own `if_not_exists` does not cover them.
   @disable_ddl_transaction true
   @disable_migration_lock true
 
@@ -46,30 +57,79 @@ defmodule Vutuv.Repo.Migrations.AddQuotesToFediversePosts do
     alter table(:fediverse_posts) do
       add_if_not_exists(:quote_uri, :text)
       add_if_not_exists(:quote_authorization_uri, :text)
-
-      add_if_not_exists(
-        :quoted_post_id,
-        references(:fediverse_posts, on_delete: :nilify_all, type: :binary_id)
-      )
-
-      add_if_not_exists(
-        :quoted_local_post_id,
-        references(:posts, on_delete: :nilify_all, type: :binary_id)
-      )
-
+      # Bare `:binary_id` here and the foreign key below, because
+      # `add_if_not_exists` guards only the column: handed a `references/2` it
+      # still emits an unguarded `ALTER TABLE … ADD CONSTRAINT` beside it, and
+      # Postgres has no `ADD CONSTRAINT IF NOT EXISTS`. On the retry this
+      # migration is written for, that constraint is the step that dies (42710,
+      # "constraint already exists") and takes every migration behind it down
+      # with it — the failure the columns were made idempotent to avoid.
+      add_if_not_exists(:quoted_post_id, :binary_id)
+      add_if_not_exists(:quoted_local_post_id, :binary_id)
       add_if_not_exists(:quote_verified, :boolean, null: false, default: false)
+      add_if_not_exists(:quote_checked_at, :utc_datetime)
     end
+
+    add_foreign_key("quoted_post_id", "fediverse_posts")
+    add_foreign_key("quoted_local_post_id", "posts")
 
     # The holder question — "does any post quote this one" — is asked once per
     # purge run per candidate row, so the reference needs its own index; the
     # local one covers the same question for a vutuv post.
     create_if_not_exists(index(:fediverse_posts, [:quoted_post_id], concurrently: true))
     create_if_not_exists(index(:fediverse_posts, [:quoted_local_post_id], concurrently: true))
+
+    # The resume queue, asked for every two minutes and empty almost every time.
+    # Partial and on `id`, exactly like `fediverse_posts_language_detection_index`
+    # beside it: the rows it looks for are the rare ones — a quote nobody
+    # finished resolving — and `id` is both the sort key (UUID v7, so id order is
+    # creation order) and all the index has to carry. Without the predicate this
+    # is a sequential scan over every cached post on the installation, every two
+    # minutes, to answer "none".
+    create_if_not_exists(
+      index(:fediverse_posts, [:id],
+        name: :fediverse_posts_unresolved_quotes_index,
+        where:
+          "quote_uri IS NOT NULL AND quote_checked_at IS NULL AND quoted_post_id IS NULL AND quoted_local_post_id IS NULL",
+        concurrently: true
+      )
+    )
+  end
+
+  # The guarded half of a `references/2`, and the only spelling Postgres leaves:
+  # it has no `ADD CONSTRAINT IF NOT EXISTS`, so the existence check is the `DO`
+  # block. The name is the one Ecto would have given it, so a database already
+  # carrying the constraint from a half-finished run is recognised. Both new
+  # columns are NULL on every existing row, so validating the constraint reads a
+  # table it can only agree with.
+  defp add_foreign_key(column, referenced) do
+    name = "fediverse_posts_#{column}_fkey"
+
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = '#{name}' AND conrelid = 'fediverse_posts'::regclass
+      ) THEN
+        ALTER TABLE fediverse_posts
+          ADD CONSTRAINT #{name} FOREIGN KEY (#{column})
+          REFERENCES #{referenced}(id) ON DELETE SET NULL;
+      END IF;
+    END $$;
+    """)
   end
 
   def down do
     drop_if_exists(index(:fediverse_posts, [:quoted_post_id], concurrently: true))
     drop_if_exists(index(:fediverse_posts, [:quoted_local_post_id], concurrently: true))
+
+    drop_if_exists(
+      index(:fediverse_posts, [:id],
+        name: :fediverse_posts_unresolved_quotes_index,
+        concurrently: true
+      )
+    )
 
     alter table(:fediverse_posts) do
       remove_if_exists(:quote_uri, :text)
@@ -77,6 +137,7 @@ defmodule Vutuv.Repo.Migrations.AddQuotesToFediversePosts do
       remove_if_exists(:quoted_post_id, :binary_id)
       remove_if_exists(:quoted_local_post_id, :binary_id)
       remove_if_exists(:quote_verified, :boolean)
+      remove_if_exists(:quote_checked_at, :utc_datetime)
     end
   end
 end

--- a/test/vutuv/fediverse_post_quotes_test.exs
+++ b/test/vutuv/fediverse_post_quotes_test.exs
@@ -126,6 +126,20 @@ defmodule Vutuv.FediversePostQuotesTest do
     end)
   end
 
+  # What a task that died mid-flight leaves behind: the quote the post says it
+  # has, nothing resolved from it, no stamp on the clock — and old enough that
+  # the resolver stops reading it as an attempt still walking two servers.
+  defp abandoned(%RemotePost{} = post) do
+    refute post.quote_checked_at
+
+    stale = DateTime.add(DateTime.utc_now(:second), -3600, :second)
+    Repo.update_all(from(p in RemotePost, where: p.id == ^post.id), set: [received_at: stale])
+
+    Repo.reload!(post)
+  end
+
+  defp due_ids, do: Enum.map(Fediverse.due_quote_resolutions(), & &1.id)
+
   # One document per path, or a 404. The `content-type` is not decoration: Req's
   # decode step branches on it, so a stub without it hands the client a binary
   # where the real server's answer arrives decoded.
@@ -513,6 +527,153 @@ defmodule Vutuv.FediversePostQuotesTest do
       assert cleared.quote_uri == nil
       assert cleared.quoted_post_id == nil
       refute cleared.quote_verified
+    end
+
+    test "that moves the quote drops the old card before the new one is resolved" do
+      serve_third()
+
+      %{post: post} =
+        quoting_post(%{"quote" => @quoted_object, "quoteAuthorization" => @stamp})
+
+      assert :ok = Fediverse.resolve_quote(post)
+      assert Repo.reload!(post).quote_verified
+
+      update = %{
+        "type" => "Update",
+        "actor" => @quoter,
+        "object" => %{
+          "id" => @quoting_object,
+          "type" => "Note",
+          "attributedTo" => @quoter,
+          "content" => "<p>Doch lieber der hier.</p>",
+          "published" => "2026-08-20T09:00:00Z",
+          "to" => [@public],
+          "quote" => "https://third.example/notes/2"
+        }
+      }
+
+      Fediverse.update_remote_post(update, @quoter)
+
+      moved = Repo.reload!(post)
+      # The card is gone in the same write that moved the quote, rather than
+      # standing over a post it no longer belongs to until a task says so.
+      refute moved.quoted_post_id
+      refute moved.quote_verified
+      # …and the cleared clock is what hands the row to the resolver if the task
+      # that should finish this dies too. Ageing it is only how the due query is
+      # asked at all: it deliberately leaves an edit made a moment ago alone.
+      abandoned(moved)
+      assert moved.id in due_ids()
+    end
+  end
+
+  describe "a resolution that never finished" do
+    test "one pass finishes what the killed task did not" do
+      serve_third()
+
+      %{post: post} =
+        quoting_post(%{"quote" => @quoted_object, "quoteAuthorization" => @stamp})
+
+      post = abandoned(post)
+
+      assert post.id in due_ids()
+      assert 1 == Fediverse.resume_quote_resolutions()
+
+      resumed = Repo.reload!(post)
+      assert resumed.quoted_post_id
+      assert resumed.quote_verified
+      assert RemotePost.quote_card?(resumed)
+    end
+
+    test "a quote nobody can resolve is tried once and then leaves the queue" do
+      # The calibration #1316 asks for: an unworkable row must stop being
+      # returned by the due query after one pass, or it holds the front of
+      # every batch for ever and the sweep silently does nothing. The quoted
+      # server answers 404 here, so no pass can ever finish this row.
+      stub(fn _path -> nil end)
+
+      %{post: post} = quoting_post(%{"quote" => @quoted_object})
+      post = abandoned(post)
+
+      assert 1 == Fediverse.resume_quote_resolutions()
+
+      tried = Repo.reload!(post)
+      refute tried.quoted_post_id
+      # Stamped all the same: the clock says the attempt ran, not that a card
+      # came of it.
+      assert tried.quote_checked_at
+
+      assert [] == due_ids()
+      assert 0 == Fediverse.resume_quote_resolutions()
+    end
+
+    test "a resolution that ran is not due again, however it came out" do
+      serve_third()
+
+      # No stamp, so this resolves to a link and never a card — a finished
+      # resolution all the same, and the resolver has no business in it.
+      %{post: post} = quoting_post(%{"quote" => @quoted_object})
+      assert :ok = Fediverse.resolve_quote(post)
+
+      refute Repo.reload!(post).quote_verified
+      assert [] == due_ids()
+    end
+
+    test "an attempt that may still be running is left alone" do
+      serve_third()
+
+      %{post: post} =
+        quoting_post(%{"quote" => @quoted_object, "quoteAuthorization" => @stamp})
+
+      # Seconds old: its task may be halfway through the two servers it asks,
+      # and sweeping it now would spend those requests a second time.
+      refute post.quote_checked_at
+      assert [] == due_ids()
+    end
+
+    test "the quoted copy's own quote is not walked back one hop per tick" do
+      # The one-level rule lives in `finish_stored_post(_, _, false)`, and the
+      # resolver is a second way in: a copy stored with its own quote left
+      # unresolved looks exactly like an attempt that died. It is stamped for
+      # that reason, so it never enters this queue and the chain of strangers'
+      # servers is not walked two minutes at a time.
+      serve_third(%{note: %{"quote" => "https://third.example/notes/99"}})
+
+      %{post: post} = quoting_post(%{"quote" => @quoted_object})
+      assert :ok = Fediverse.resolve_quote(post)
+
+      quoted = Repo.get_by!(RemotePost, object_uri: @quoted_object)
+      assert quoted.quote_uri == "https://third.example/notes/99"
+      refute quoted.quoted_post_id
+      assert quoted.quote_checked_at
+
+      abandoned(post)
+      refute quoted.id in due_ids()
+    end
+
+    test "a row whose attempt raises is still stamped, and the batch goes on" do
+      # The one way a row could keep a null clock after being tried. It is the
+      # newest row in the queue, so without a stamp it would take the front of
+      # every batch from here on — the starvation this design claims immunity
+      # from, arriving by the back door.
+      stub_remote(fn _conn -> raise "the server did something unspeakable" end)
+
+      %{post: post} = quoting_post(%{"quote" => @quoted_object})
+      post = abandoned(post)
+
+      assert 1 == Fediverse.resume_quote_resolutions()
+
+      tried = Repo.reload!(post)
+      assert tried.quote_checked_at
+      refute tried.quoted_post_id
+      assert [] == due_ids()
+    end
+
+    test "a post that quotes nothing is never in the queue" do
+      %{post: post} = quoting_post(%{})
+
+      abandoned(post)
+      assert [] == due_ids()
     end
   end
 

--- a/test/vutuv/fediverse_post_quotes_test.exs
+++ b/test/vutuv/fediverse_post_quotes_test.exs
@@ -1,0 +1,550 @@
+defmodule Vutuv.FediversePostQuotesTest do
+  @moduledoc """
+  What a post from another network says it quotes (issue #1609): what is read
+  off the object, what is resolved, what is allowed to become a card, and what
+  keeps a quoted copy from being swept.
+
+  `async: false` — the per-host fetch budget and the HTTP stub both live in
+  application/ETS state the SQL sandbox does not roll back.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.FediverseHelpers, only: [stub_remote: 1]
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Follow
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemotePost
+  alias VutuvWeb.Fediverse.Docs
+
+  @quoter "https://social.example/users/them"
+  @quoting_object "https://social.example/posts/1"
+  @author "https://third.example/users/autorin"
+  @quoted_object "https://third.example/notes/1"
+  @stamp "https://third.example/quote-authorizations/1"
+  @public "https://www.w3.org/ns/activitystreams#Public"
+
+  setup do
+    Vutuv.RateLimiter.reset()
+    :ok
+  end
+
+  defp quoter_account do
+    Repo.insert!(%RemoteAccount{
+      actor_uri: @quoter,
+      host: "social.example",
+      handle: "them",
+      name: "Them",
+      inbox_uri: @quoter <> "/inbox"
+    })
+  end
+
+  defp follower_of(account) do
+    user = insert(:activated_user, fediverse_followers?: true)
+    {:ok, _actor} = Fediverse.ensure_actor(user)
+
+    Repo.insert!(%Follow{
+      user_id: user.id,
+      remote_account_id: account.id,
+      state: "accepted",
+      follow_activity_id: "https://vutuv.test/#{user.id}/actor#f/#{account.id}"
+    })
+
+    Repo.reload!(user)
+  end
+
+  # A `Create` carrying a quote, as Mastodon 4.5 sends one.
+  defp create_activity(object_overrides) do
+    object =
+      Map.merge(
+        %{
+          "id" => @quoting_object,
+          "type" => "Note",
+          "attributedTo" => @quoter,
+          "content" => "<p>Sehr treffend.</p>",
+          "url" => "https://social.example/@them/1",
+          "published" => "2026-08-20T09:00:00Z",
+          "to" => [@public]
+        },
+        object_overrides
+      )
+
+    %{"type" => "Create", "actor" => @quoter, "object" => object}
+  end
+
+  defp quoting_post(object_overrides) do
+    account = quoter_account()
+    user = follower_of(account)
+
+    assert :ok = Fediverse.record_remote_post(create_activity(object_overrides), @quoter)
+
+    %{account: account, user: user, post: Repo.get_by!(RemotePost, object_uri: @quoting_object)}
+  end
+
+  # The quoted author's server, answering for the note, for the actor and for
+  # the consent stamp.
+  defp serve_third(overrides \\ %{}) do
+    note =
+      Map.merge(
+        %{
+          "id" => @quoted_object,
+          "type" => "Note",
+          "attributedTo" => @author,
+          "content" => "<p>Der zitierte Satz.</p>",
+          "url" => "https://third.example/@autorin/1",
+          "published" => "2026-08-20T08:00:00Z",
+          "to" => [@public]
+        },
+        Map.get(overrides, :note, %{})
+      )
+
+    actor = %{
+      "id" => @author,
+      "type" => "Person",
+      "preferredUsername" => "autorin",
+      "inbox" => @author <> "/inbox"
+    }
+
+    stamp =
+      Map.merge(
+        %{
+          "id" => @stamp,
+          "type" => "QuoteAuthorization",
+          "attributedTo" => @author,
+          "interactionTarget" => @quoted_object,
+          "interactingObject" => @quoting_object
+        },
+        Map.get(overrides, :stamp, %{})
+      )
+
+    stub(fn path ->
+      cond do
+        path =~ "quote-authorizations" -> stamp
+        path =~ "users" -> actor
+        true -> note
+      end
+    end)
+  end
+
+  # One document per path, or a 404. The `content-type` is not decoration: Req's
+  # decode step branches on it, so a stub without it hands the client a binary
+  # where the real server's answer arrives decoded.
+  defp stub(fun) do
+    stub_remote(fn conn ->
+      case fun.(conn.request_path) do
+        nil ->
+          Plug.Conn.send_resp(conn, 404, "")
+
+        body ->
+          conn
+          |> Plug.Conn.put_resp_content_type("application/activity+json")
+          |> Plug.Conn.send_resp(200, Jason.encode!(body))
+      end
+    end)
+  end
+
+  describe "reading the quote off the object" do
+    test "stores the canonical `quote` property and the stamp beside it" do
+      %{post: post} =
+        quoting_post(%{"quote" => @quoted_object, "quoteAuthorization" => @stamp})
+
+      assert post.quote_uri == @quoted_object
+      assert post.quote_authorization_uri == @stamp
+      # Nothing is resolved by the delivery itself: the inbox owes its 202 long
+      # before two other servers answer.
+      assert post.quoted_post_id == nil
+      refute post.quote_verified
+    end
+
+    test "reads Fedibird's `quoteUri`" do
+      %{post: post} = quoting_post(%{"quoteUri" => @quoted_object})
+      assert post.quote_uri == @quoted_object
+    end
+
+    test "reads Misskey's `_misskey_quote`" do
+      %{post: post} = quoting_post(%{"_misskey_quote" => @quoted_object})
+      assert post.quote_uri == @quoted_object
+    end
+
+    test "an embedded quote object is read down to its id" do
+      %{post: post} =
+        quoting_post(%{"quote" => %{"id" => @quoted_object, "type" => "Note"}})
+
+      assert post.quote_uri == @quoted_object
+    end
+
+    test "a post that quotes nothing keeps both columns empty" do
+      %{post: post} = quoting_post(%{})
+
+      assert post.quote_uri == nil
+      assert post.quote_authorization_uri == nil
+      refute RemotePost.quoting?(post)
+    end
+  end
+
+  describe "resolve_quote/1 — a stranger's post" do
+    test "fetches the quoted post, stores it and verifies a matching stamp" do
+      serve_third()
+
+      %{post: post} =
+        quoting_post(%{"quote" => @quoted_object, "quoteAuthorization" => @stamp})
+
+      assert :ok = Fediverse.resolve_quote(post)
+
+      resolved = Repo.reload!(post)
+      quoted = Repo.get_by!(RemotePost, object_uri: @quoted_object)
+
+      assert resolved.quoted_post_id == quoted.id
+      assert resolved.quote_verified
+      assert RemotePost.quote_card?(resolved)
+      assert quoted.content_text == "Der zitierte Satz."
+    end
+
+    test "a stamp served by the QUOTING server is no consent at all" do
+      # The stamp URL is on the quoting account's own host, which is the
+      # quoting server vouching for itself. Refused before any request is made.
+      elsewhere = "https://social.example/quote-authorizations/1"
+
+      serve_third()
+
+      %{post: post} =
+        quoting_post(%{"quote" => @quoted_object, "quoteAuthorization" => elsewhere})
+
+      assert :ok = Fediverse.resolve_quote(post)
+
+      resolved = Repo.reload!(post)
+      # Still resolved — the reader gets a link — but never a card.
+      assert resolved.quoted_post_id
+      refute resolved.quote_verified
+      refute RemotePost.quote_card?(resolved)
+    end
+
+    test "a stamp naming somebody else's quote does not authorize this one" do
+      serve_third(%{stamp: %{"interactingObject" => "https://social.example/posts/999"}})
+
+      %{post: post} =
+        quoting_post(%{"quote" => @quoted_object, "quoteAuthorization" => @stamp})
+
+      assert :ok = Fediverse.resolve_quote(post)
+
+      resolved = Repo.reload!(post)
+      assert resolved.quoted_post_id
+      refute resolved.quote_verified
+    end
+
+    test "a stamp attributed to somebody other than the quoted author is refused" do
+      serve_third(%{stamp: %{"attributedTo" => "https://third.example/users/wer_anders"}})
+
+      %{post: post} =
+        quoting_post(%{"quote" => @quoted_object, "quoteAuthorization" => @stamp})
+
+      assert :ok = Fediverse.resolve_quote(post)
+
+      refute Repo.reload!(post).quote_verified
+    end
+
+    test "a quote with no stamp at all resolves to a link, never a card" do
+      serve_third()
+
+      %{post: post} = quoting_post(%{"quote" => @quoted_object})
+
+      assert :ok = Fediverse.resolve_quote(post)
+
+      resolved = Repo.reload!(post)
+      assert resolved.quoted_post_id
+      refute resolved.quote_verified
+    end
+
+    test "a quoted post its author addressed to followers only is not stored" do
+      serve_third(%{note: %{"to" => [@author <> "/followers"]}})
+
+      %{post: post} = quoting_post(%{"quote" => @quoted_object})
+
+      assert :ok = Fediverse.resolve_quote(post)
+
+      assert Repo.reload!(post).quoted_post_id == nil
+      refute Repo.get_by(RemotePost, object_uri: @quoted_object)
+    end
+
+    test "a server that answers for somebody else's actor is refused" do
+      # `own_object?/3`: the document claims an author on a different host than
+      # the object it answers for.
+      serve_third(%{note: %{"attributedTo" => "https://elsewhere.example/users/opfer"}})
+
+      %{post: post} = quoting_post(%{"quote" => @quoted_object})
+
+      assert :ok = Fediverse.resolve_quote(post)
+
+      assert Repo.reload!(post).quoted_post_id == nil
+    end
+
+    test "a blocked instance is neither fetched nor resolved" do
+      serve_third()
+
+      {:ok, _blocked} =
+        Fediverse.block_instance(
+          %{host: "third.example", reason: "Test"},
+          insert(:activated_user, admin?: true)
+        )
+
+      %{post: post} =
+        quoting_post(%{"quote" => @quoted_object, "quoteAuthorization" => @stamp})
+
+      assert :ok = Fediverse.resolve_quote(post)
+
+      resolved = Repo.reload!(post)
+      assert resolved.quoted_post_id == nil
+      refute resolved.quote_verified
+    end
+  end
+
+  describe "what a quote may not reach" do
+    test "a cached followers-only post is not pulled into a public quote card" do
+      account = quoter_account()
+      _user = follower_of(account)
+
+      # Cached because somebody here follows its author — a legitimate stored
+      # audience — but never ours to show to anybody else.
+      restricted =
+        Repo.insert!(%RemotePost{
+          remote_account_id: account.id,
+          object_uri: "https://social.example/posts/0",
+          content_text: "Nur für meine Follower.",
+          audience: "followers",
+          kind: "note",
+          published_at: DateTime.utc_now(:second),
+          received_at: DateTime.utc_now(:second),
+          expires_at: DateTime.add(DateTime.utc_now(:second), 86_400)
+        })
+
+      stub(fn _path -> nil end)
+
+      assert :ok =
+               Fediverse.record_remote_post(
+                 create_activity(%{"quote" => restricted.object_uri}),
+                 @quoter
+               )
+
+      post = Repo.get_by!(RemotePost, object_uri: @quoting_object)
+      assert :ok = Fediverse.resolve_quote(post)
+
+      resolved = Repo.reload!(post)
+      # Not even as a self-quote, which needs no stamp at all: the quoting post
+      # is public, so a card here would hand a narrowed audience to everyone who
+      # can see it — anonymously, on the tag timeline.
+      assert resolved.quoted_post_id == nil
+      refute resolved.quote_verified
+      refute RemotePost.quote_card?(resolved)
+    end
+
+    test "a post that quotes itself resolves to nothing, and stays purgeable" do
+      account = quoter_account()
+      user = follower_of(account)
+
+      stub(fn _path -> nil end)
+
+      assert :ok =
+               Fediverse.record_remote_post(
+                 create_activity(%{"quote" => @quoting_object}),
+                 @quoter
+               )
+
+      post = Repo.get_by!(RemotePost, object_uri: @quoting_object)
+      assert :ok = Fediverse.resolve_quote(post)
+
+      # Left unguarded the row would hold itself against `spare_held/1` and
+      # survive every unfollow purge until its ceiling.
+      assert Repo.reload!(post).quoted_post_id == nil
+
+      Repo.delete_all(from(f in Follow, where: f.user_id == ^user.id))
+      Fediverse.purge_unfollowed_remote_posts()
+
+      refute Repo.get(RemotePost, post.id)
+    end
+
+    test "an over-long quote URI costs the quote, never the post" do
+      account = quoter_account()
+      _user = follower_of(account)
+
+      too_long = "https://third.example/notes/" <> String.duplicate("a", 2_048)
+
+      assert :ok =
+               Fediverse.record_remote_post(create_activity(%{"quote" => too_long}), @quoter)
+
+      # The post is here, which is the whole point: one oversized optional field
+      # must not take an otherwise perfectly good post out of every feed.
+      post = Repo.get_by!(RemotePost, object_uri: @quoting_object)
+      assert post.content_text == "Sehr treffend."
+      assert post.quote_uri == nil
+    end
+  end
+
+  describe "resolve_quote/1 — a self-quote" do
+    test "needs no stamp and costs no request" do
+      account = quoter_account()
+      _user = follower_of(account)
+
+      earlier =
+        Repo.insert!(%RemotePost{
+          remote_account_id: account.id,
+          object_uri: "https://social.example/posts/0",
+          content_text: "Was ich vorhin schrieb.",
+          audience: "public",
+          kind: "note",
+          published_at: DateTime.utc_now(:second),
+          received_at: DateTime.utc_now(:second),
+          expires_at: DateTime.add(DateTime.utc_now(:second), 86_400)
+        })
+
+      # Nothing is served: a self-quote that reached the wire would fail here.
+      stub(fn _path -> nil end)
+
+      assert :ok =
+               Fediverse.record_remote_post(
+                 create_activity(%{"quote" => earlier.object_uri}),
+                 @quoter
+               )
+
+      post = Repo.get_by!(RemotePost, object_uri: @quoting_object)
+      assert :ok = Fediverse.resolve_quote(post)
+
+      resolved = Repo.reload!(post)
+      assert resolved.quoted_post_id == earlier.id
+      assert resolved.quote_verified
+    end
+  end
+
+  describe "resolve_quote/1 — one of our own posts" do
+    test "is resolved by the id in the path and never fetched from ourselves" do
+      author = insert(:activated_user, fediverse_followers?: true)
+      local = insert(:post, user: author, body: "Ein Beitrag von hier.")
+
+      # Any request at all would be this installation asking itself.
+      stub(fn _path -> nil end)
+
+      %{post: post} = quoting_post(%{"quote" => Docs.note_url(author, local.id)})
+
+      assert :ok = Fediverse.resolve_quote(post)
+
+      resolved = Repo.reload!(post)
+      assert resolved.quoted_local_post_id == local.id
+      assert resolved.quoted_post_id == nil
+      # No card until this installation issues stamps of its own (issue #1608):
+      # we never agreed, so nothing may claim we did.
+      refute resolved.quote_verified
+      refute RemotePost.quote_card?(resolved)
+    end
+
+    test "a URL of ours naming no post of ours resolves to nothing" do
+      stub(fn _path -> nil end)
+
+      %{post: post} =
+        quoting_post(%{
+          "quote" => Docs.note_url(insert(:activated_user), Vutuv.UUIDv7.generate())
+        })
+
+      assert :ok = Fediverse.resolve_quote(post)
+
+      resolved = Repo.reload!(post)
+      assert resolved.quoted_local_post_id == nil
+      assert resolved.quoted_post_id == nil
+    end
+  end
+
+  describe "an edit" do
+    test "brings the stamp that turns the link into a card" do
+      serve_third()
+
+      %{post: post} = quoting_post(%{"quote" => @quoted_object})
+      assert :ok = Fediverse.resolve_quote(post)
+      refute Repo.reload!(post).quote_verified
+
+      update = %{
+        "type" => "Update",
+        "actor" => @quoter,
+        "object" => %{
+          "id" => @quoting_object,
+          "type" => "Note",
+          "attributedTo" => @quoter,
+          "content" => "<p>Sehr treffend.</p>",
+          "published" => "2026-08-20T09:00:00Z",
+          "to" => [@public],
+          "quote" => @quoted_object,
+          "quoteAuthorization" => @stamp
+        }
+      }
+
+      Fediverse.update_remote_post(update, @quoter)
+
+      edited = Repo.reload!(post)
+      assert edited.quote_authorization_uri == @stamp
+      # The resolution itself runs in a task the test does not start.
+      assert :ok = Fediverse.resolve_quote(edited)
+      assert Repo.reload!(post).quote_verified
+    end
+
+    test "that takes the quote back clears the card without any request" do
+      serve_third()
+
+      %{post: post} =
+        quoting_post(%{"quote" => @quoted_object, "quoteAuthorization" => @stamp})
+
+      assert :ok = Fediverse.resolve_quote(post)
+      assert Repo.reload!(post).quote_verified
+
+      stub(fn _path -> nil end)
+
+      update = %{
+        "type" => "Update",
+        "actor" => @quoter,
+        "object" => %{
+          "id" => @quoting_object,
+          "type" => "Note",
+          "attributedTo" => @quoter,
+          "content" => "<p>Doch nicht.</p>",
+          "published" => "2026-08-20T09:00:00Z",
+          "to" => [@public]
+        }
+      }
+
+      Fediverse.update_remote_post(update, @quoter)
+
+      cleared = Repo.reload!(post)
+      assert cleared.quote_uri == nil
+      assert cleared.quoted_post_id == nil
+      refute cleared.quote_verified
+    end
+  end
+
+  describe "retention" do
+    test "a quoted copy survives the purge of posts nobody follows" do
+      serve_third()
+
+      %{account: account, user: user, post: post} =
+        quoting_post(%{"quote" => @quoted_object, "quoteAuthorization" => @stamp})
+
+      assert :ok = Fediverse.resolve_quote(post)
+      quoted = Repo.get_by!(RemotePost, object_uri: @quoted_object)
+
+      # Nobody here follows the quoted author — the normal case for a quote —
+      # so only the holding reference keeps this copy alive. Without it the
+      # sweep takes it and the card in the reader's feed becomes a bare link
+      # while they are looking at it.
+      Fediverse.purge_unfollowed_remote_posts()
+
+      assert Repo.get(RemotePost, quoted.id)
+      assert Repo.get(RemotePost, post.id)
+
+      # And it is really the quote that holds it: once the quoting post goes,
+      # the next sweep takes the quoted copy with it.
+      Repo.delete_all(from(p in RemotePost, where: p.id == ^post.id))
+      Fediverse.purge_unfollowed_remote_posts()
+
+      refute Repo.get(RemotePost, quoted.id)
+
+      # The quoting post's own author is still followed, so nothing about the
+      # follow explains the two results above.
+      assert Repo.get_by(Follow, remote_account_id: account.id, user_id: user.id)
+    end
+  end
+end

--- a/test/vutuv_web/agent_docs/remote_quote_doc_test.exs
+++ b/test/vutuv_web/agent_docs/remote_quote_doc_test.exs
@@ -1,0 +1,157 @@
+defmodule VutuvWeb.AgentDocs.RemoteQuoteDocTest do
+  @moduledoc """
+  What a cached post's **quote** (issue #1609) reads as in the agent formats.
+
+  The HTML card shows the quoted author and their words, so the `.md`/`.txt`/
+  `.json`/`.xml` siblings of the three public pages that render that card — the
+  profile, the post archive and `/tags/:slug` — have to carry the same fact.
+  Without it an entry whose whole content is a reaction ("genau das") reads as a
+  post with nothing in it, the same gap `pictures:` was added to close.
+
+  Consent decides how a **person** is shown a quote, not whether a machine is
+  told about one: a link-only quote is the same fact to an agent as a card.
+  """
+  use ExUnit.Case, async: true
+
+  alias Vutuv.Accounts.User
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.Posts.Post
+  alias VutuvWeb.AgentDocs
+  alias VutuvWeb.AgentDocs.JSON
+  alias VutuvWeb.AgentDocs.Markdown
+  alias VutuvWeb.AgentDocs.PostDoc
+  alias VutuvWeb.AgentDocs.Text
+  alias VutuvWeb.AgentDocs.Xml
+
+  @quoted_uri "https://third.example/notes/1"
+
+  setup do
+    Gettext.put_locale(VutuvWeb.Gettext, "en")
+    :ok
+  end
+
+  defp author,
+    do: %RemoteAccount{
+      actor_uri: "https://third.example/users/autorin",
+      host: "third.example",
+      handle: "autorin",
+      name: "Die Autorin"
+    }
+
+  defp quoted,
+    do: %RemotePost{
+      id: "01a0-quoted",
+      object_uri: @quoted_uri,
+      origin_url: "https://third.example/@autorin/1",
+      content_text: "Der zitierte Satz.",
+      remote_account: author()
+    }
+
+  defp quoting(attrs) do
+    Map.merge(
+      %RemotePost{
+        id: "01a0-quoting",
+        object_uri: "https://social.example/posts/1",
+        origin_url: "https://social.example/@them/1",
+        content_text: "Genau das.",
+        published_at: ~U[2026-08-20 09:00:00Z],
+        remote_account: %RemoteAccount{
+          actor_uri: "https://social.example/users/them",
+          host: "social.example",
+          handle: "them",
+          name: "Them"
+        }
+      },
+      attrs
+    )
+  end
+
+  defp entry(post), do: PostDoc.timeline_entry(%{remote_post: post})
+
+  test "a post that quotes nothing carries no quote fact" do
+    assert entry(quoting(%{})).quote == nil
+    refute Markdown.quote_suffix(entry(quoting(%{}))) =~ "Quotes"
+  end
+
+  test "a resolved quote names where it lives and who wrote it" do
+    fact =
+      entry(
+        quoting(%{quote_uri: @quoted_uri, quoted_post_id: "01a0-quoted", quoted_post: quoted()})
+      ).quote
+
+    # The browsable URL, not the canonical AP id: on several servers the id is
+    # not a page a reader can open.
+    assert fact == %{
+             url: "https://third.example/@autorin/1",
+             author: "Die Autorin",
+             network: "fediverse"
+           }
+  end
+
+  test "an unresolved quote still hands over the address" do
+    fact = entry(quoting(%{quote_uri: @quoted_uri})).quote
+
+    assert fact == %{url: @quoted_uri, author: nil, network: "fediverse"}
+  end
+
+  test "a quote of one of our posts is named as a vutuv post" do
+    local = %Post{id: "01a0-local", organization_id: nil, user: %User{username: "stefan"}}
+
+    fact =
+      entry(
+        quoting(%{
+          quote_uri: "https://www.vutuv.test/stefan/posts/01a0-local",
+          quoted_local_post_id: local.id,
+          quoted_local_post: local
+        })
+      ).quote
+
+    assert fact.network == "vutuv"
+    assert fact.url =~ "/stefan/posts/01a0-local"
+  end
+
+  test "all four formats say it" do
+    doc =
+      AgentDocs.doc_meta("post_archive", "/stefan/posts")
+      |> Map.merge(%{
+        title: "Stefan · Posts",
+        description: "Post archive",
+        author: %{name: "Stefan", url: "https://vutuv.test/stefan"},
+        period: nil,
+        total: 1,
+        posts: [
+          entry(
+            quoting(%{
+              quote_uri: @quoted_uri,
+              quoted_post_id: "01a0-quoted",
+              quoted_post: quoted()
+            })
+          )
+        ]
+      })
+
+    for {name, rendered} <- [
+          {"markdown", Markdown.render(doc)},
+          {"text", Text.render(doc)},
+          {"json", JSON.render(doc)},
+          {"xml", Xml.render(doc)}
+        ] do
+      assert rendered =~ "third.example/@autorin/1", "#{name} lost the quoted URL"
+      assert rendered =~ "Die Autorin", "#{name} lost the quoted author"
+    end
+  end
+
+  test "German names it a quote rather than a reply" do
+    Gettext.put_locale(VutuvWeb.Gettext, "de")
+
+    suffix =
+      Markdown.quote_suffix(
+        entry(
+          quoting(%{quote_uri: @quoted_uri, quoted_post_id: "01a0-quoted", quoted_post: quoted()})
+        )
+      )
+
+    assert suffix =~ "Zitiert"
+  end
+end

--- a/test/vutuv_web/components/quoted_post_test.exs
+++ b/test/vutuv_web/components/quoted_post_test.exs
@@ -1,0 +1,175 @@
+defmodule VutuvWeb.QuotedPostTest do
+  @moduledoc """
+  What a post from another network shows for what it quotes (issue #1609).
+
+  The three states are the point: a card only where the quoted author's consent
+  was established, a link everywhere else, and nothing at all where the author
+  already wrote that link into their own text. The German is asserted by name
+  because "Quoted post" is exactly the kind of short string a `gettext.extract
+  --merge` fuzzy-fills with somebody else's translation.
+  """
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.Accounts.User
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.Posts.Post
+  alias VutuvWeb.PostComponents
+
+  @quoted_uri "https://third.example/notes/1"
+
+  setup do
+    Gettext.put_locale(VutuvWeb.Gettext, "en")
+    :ok
+  end
+
+  defp author,
+    do: %RemoteAccount{
+      id: "01a0-account",
+      actor_uri: "https://third.example/users/autorin",
+      host: "third.example",
+      handle: "autorin",
+      name: "Die Autorin"
+    }
+
+  defp quoted(attrs \\ %{}) do
+    Map.merge(
+      %RemotePost{
+        id: "01a0-quoted",
+        object_uri: @quoted_uri,
+        origin_url: "https://third.example/@autorin/1",
+        content_text: "Der zitierte Satz.",
+        audience: "public",
+        remote_account: author()
+      },
+      attrs
+    )
+  end
+
+  defp quoting(attrs) do
+    Map.merge(
+      %RemotePost{
+        id: "01a0-quoting",
+        object_uri: "https://social.example/posts/1",
+        content_text: "Sehr treffend.",
+        audience: "public"
+      },
+      attrs
+    )
+  end
+
+  defp render_quote(post), do: render_component(&PostComponents.quoted_post/1, remote_post: post)
+
+  test "a post that quotes nothing renders nothing" do
+    html = render_quote(quoting(%{}))
+
+    refute html =~ "data-quoted-post"
+    refute html =~ "Quoted post"
+  end
+
+  test "an unverified quote is a link, never a card" do
+    html = render_quote(quoting(%{quote_uri: @quoted_uri, quoted_post: quoted()}))
+
+    assert html =~ ~s(data-quoted-post-link="#{@quoted_uri}")
+    assert html =~ "Quoted post"
+    assert html =~ @quoted_uri
+    # The quoted author's words are not shown on the quoting server's say-so.
+    refute html =~ "Der zitierte Satz."
+  end
+
+  test "a verified quote is the card, with who wrote it and what it says" do
+    html =
+      render_quote(
+        quoting(%{
+          quote_uri: @quoted_uri,
+          quote_verified: true,
+          quoted_post_id: "01a0-quoted",
+          quoted_post: quoted()
+        })
+      )
+
+    assert html =~ ~s(data-quoted-post="01a0-quoted")
+    assert html =~ "Die Autorin"
+    assert html =~ "@autorin@third.example"
+    assert html =~ "Der zitierte Satz."
+    # The whole tile is the way out; there is no second link beside it.
+    assert html =~ "https://third.example/@autorin/1"
+    refute html =~ "Quoted post"
+  end
+
+  test "a warned quoted post shows the warning instead of its text" do
+    warned = quoted(%{summary: "Spoiler zum Tatort", sensitive: true})
+
+    html =
+      render_quote(
+        quoting(%{
+          quote_uri: @quoted_uri,
+          quote_verified: true,
+          quoted_post_id: "01a0-quoted",
+          quoted_post: warned
+        })
+      )
+
+    assert html =~ "Spoiler zum Tatort"
+    refute html =~ "Der zitierte Satz."
+  end
+
+  test "a quote of one of our posts links to the vutuv permalink, not the pasted URL" do
+    local = %Post{id: "01a0-local", organization_id: nil, user: %User{username: "stefan"}}
+
+    html =
+      render_quote(
+        quoting(%{
+          quote_uri: "https://www.vutuv.test/stefan/posts/01a0-local",
+          quoted_local_post_id: local.id,
+          quoted_local_post: local
+        })
+      )
+
+    assert html =~ "/stefan/posts/01a0-local"
+    assert html =~ "Quoted post"
+  end
+
+  test "a longer URL in the body does not swallow the link to a shorter one" do
+    # The body names `…/notes/12`, the quote points at `…/notes/1`. A substring
+    # search reads that as "already written" and drops the link; whole URLs do
+    # not.
+    post =
+      quoting(%{
+        content_text: "Siehe auch #{@quoted_uri}2",
+        quote_uri: @quoted_uri
+      })
+
+    assert render_quote(post) =~ "Quoted post"
+  end
+
+  test "nothing is added when the author already wrote the link themselves" do
+    post =
+      quoting(%{
+        content_text: "Sehr treffend: #{@quoted_uri}",
+        quote_uri: @quoted_uri
+      })
+
+    refute render_quote(post) =~ "Quoted post"
+  end
+
+  test "a missing preload costs the card, not the page" do
+    # No `quoted_post:` given, so the association is the `NotLoaded` a bare
+    # struct carries — exactly what a query without `RemotePost.quote_preload/0`
+    # hands the card.
+    post = quoting(%{quote_uri: @quoted_uri, quote_verified: true, quoted_post_id: "01a0-quoted"})
+
+    html = render_quote(post)
+
+    refute html =~ "data-quoted-post="
+    assert html =~ "Quoted post"
+  end
+
+  test "German names the quoted post as a quote, not as a reply or a share" do
+    Gettext.put_locale(VutuvWeb.Gettext, "de")
+
+    assert render_quote(quoting(%{quote_uri: @quoted_uri})) =~ "Zitierter Beitrag"
+  end
+end

--- a/test/vutuv_web/live/feed_remote_posts_test.exs
+++ b/test/vutuv_web/live/feed_remote_posts_test.exs
@@ -54,6 +54,33 @@ defmodule VutuvWeb.FeedRemotePostsTest do
     )
   end
 
+  # A second account, on a third server, whose post the followed one quotes.
+  # Nobody here follows them — the normal case for a quote.
+  defp quoted_post do
+    author =
+      Repo.insert!(%RemoteAccount{
+        actor_uri: "https://third.example/users/autorin",
+        host: "third.example",
+        handle: "autorin",
+        name: "Die Autorin",
+        inbox_uri: "https://third.example/users/autorin/inbox"
+      })
+
+    now = DateTime.utc_now(:second)
+
+    Repo.insert!(%RemotePost{
+      remote_account_id: author.id,
+      object_uri: "https://third.example/notes/1",
+      origin_url: "https://third.example/@autorin/1",
+      content_text: "Der zitierte Satz.",
+      audience: "public",
+      kind: "note",
+      published_at: now,
+      received_at: now,
+      expires_at: DateTime.add(now, 86_400)
+    })
+  end
+
   test "a followed account's post renders with the remote skin and no action bar", %{conn: conn} do
     {conn, user} = create_and_login_user(conn)
     post = cached_post(user)
@@ -67,6 +94,52 @@ defmodule VutuvWeb.FeedRemotePostsTest do
     # action bar — replying and resharing are #1165/#1166.
     assert has_element?(view, "[data-remote-origin][href='https://social.example/@them/1']")
     refute has_element?(view, "[data-remote-post='#{post.id}'] [data-post-actions]")
+  end
+
+  describe "a quoted post in the feed (issue #1609)" do
+    test "a verified quote renders as a card inside the quoting post", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      quoted = quoted_post()
+
+      post =
+        cached_post(user, %{
+          quote_uri: quoted.object_uri,
+          quote_verified: true,
+          quoted_post_id: quoted.id
+        })
+
+      {:ok, view, html} = live(conn, ~p"/feed")
+
+      # The preload really reaches the card: without it the association arrives
+      # as NotLoaded and the card silently degrades to the link below.
+      assert has_element?(
+               view,
+               "[data-remote-post='#{post.id}'] [data-quoted-post='#{quoted.id}']"
+             )
+
+      assert html =~ "Der zitierte Satz."
+      assert html =~ "Die Autorin"
+    end
+
+    test "an unverified quote renders as a link, not a card", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      quoted = quoted_post()
+
+      post =
+        cached_post(user, %{quote_uri: quoted.object_uri, quoted_post_id: quoted.id})
+
+      {:ok, view, html} = live(conn, ~p"/feed")
+
+      refute has_element?(view, "[data-quoted-post='#{quoted.id}']")
+
+      assert has_element?(
+               view,
+               "[data-remote-post='#{post.id}'] [data-quoted-post-link='#{quoted.object_uri}']"
+             )
+
+      # The quoted author's words are not shown on the quoting server's say-so.
+      refute html =~ "Der zitierte Satz."
+    end
   end
 
   test "an author's custom-emoji shortcode never reaches the card", %{conn: conn} do


### PR DESCRIPTION
**Symptom:** vutuv ignored `quote`, `quoteUri` and `_misskey_quote`, so a Mastodon 4.5 quote post reached the feed as commentary and a bare link, or commentary alone.

**Change:** the quoted URI and its `quoteAuthorization` are stored, and `resolve_quote/1` resolves the target off the inbox through the announce path's fence, shared rather than copied. A **card** is drawn only where the quoted author demonstrably agreed: a self-quote, or a FEP-044f stamp fetched from the quoted object's own host naming both sides. Anything else stays a link. The quoted copy is held against the unfollowed purge like a reshare.

**Resume:** that task dies with the slot a deploy stops, and says nothing. So every finished resolution stamps `quote_checked_at`, refusals included, and `Fediverse.QuoteResolver` retries the unstamped rows, once each (#1316). The migration's two foreign keys were not idempotent either.

**Not included:** quoting a vutuv post stays a link until we issue stamps (#1608); nothing re-checks a stamp that verified (#1796).

**Verified:** `mix precommit` green (9403), the resume calibrated against the un-fixed code, both states driven in a browser — screenshot below.

Closes #1609.

*An AI agent wrote this text in my name. I know that is problematic.*
