### PR TITLE
fix(fediverse): an answer says, out there, that it is an answer [3m]

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -1180,6 +1180,49 @@ that `live_render` their page get it inside
 A URL that already named an agent document is exempt, so `/jobs.md` keeps
 answering Markdown whatever `Accept` rode along with it.
 
+## An answer says it is an answer (issue #1739)
+
+An answer written here used to arrive in a Mastodon timeline looking like the
+start of a new conversation. `inReplyTo` was written only when the answered
+author federates, and `fediverse_followers?` defaults to off — so most answers
+left without it. Mastodon does hide an answer to somebody you do not follow
+(`filter_from_home` in `app/lib/feed_manager.rb`), but only once it knows a post
+*is* an answer, so these were pushed to every follower as fresh threads.
+
+Two halves, and they answer two different questions.
+
+**Does the answer say what it answers?** Always, now. `put_in_reply_to/3` names
+the parent's URL whether or not anything serves a Note at it, so the reference
+may **dangle** — that is the deliberate trade. What it costs: a reader cannot
+open the post being answered, and Mastodon drops such an answer from its *home*
+timelines outright (the `in_reply_to_id.nil?` branch of the same rule) rather
+than merely filtering it by who you follow, so it lives on the profile and at
+its own link. What it buys: nothing pretends to open a conversation it did not
+open. The member being answered kept out of the Fediverse, so their post is not
+findable out there either way.
+
+The one exception is not about resolvability but about privacy: a **restricted**
+parent is not public, and its id is a UUID v7, so publishing the URL would tell
+readers who may not see the post that it exists and the minute it was written.
+An answer under one of those still travels; it is the one shape left that
+travels without saying what it answers.
+
+**Is the answered account named?** Only when it can be resolved. A non-federating
+member serves no actor document (`with_federated_user/3` 404s it), so a handle
+in the visible text would link a reader to nothing. Where it *does* resolve, an
+answer to one of our own posts now carries the same three things an answer to a
+remote note has carried since #1070 — the account in `cc`, a `Mention` of them
+in `tag`, and their handle leading the wire copy. `Docs.answered_account/2`
+resolves that account once per Note and hands the three consumers a
+`{actor_uri, handle}` pair, past which nothing can tell the two networks apart,
+because the act is the same either way.
+
+Neither half gates **delivery**: an answer travels like any other public post.
+The earlier attempt at this issue held answers back instead, so that no id was
+ever named that could not be fetched; a dangling `inReplyTo` was judged the
+cheaper of the two, because keeping the answer here hides it from the answering
+member's own followers as well.
+
 ## Mentions on the way out
 
 A member writes `@ada`, and on the server this post lands on that names *their*

--- a/lib/vutuv_web/fediverse/docs.ex
+++ b/lib/vutuv_web/fediverse/docs.ex
@@ -705,22 +705,50 @@ defmodule VutuvWeb.Fediverse.Docs do
   @doc "The Note a public post federates as."
   def note(%Post{} = post, user) do
     remote = remote_target(post)
+    # Resolved **once** and threaded from here. `reply_parent/1` ends in a
+    # `Posts.restricted?/1` lookup and four things in this build want the answer
+    # (issue #1739) — asking each of them separately cost three needless queries
+    # per published answer, on the member's own request. Skipped entirely when
+    # the post answers another network: `inReplyTo` names that note then, not
+    # the vutuv post underneath, and every consumer below follows suit.
+    parent = if is_nil(remote), do: reply_parent(post), else: nil
+    answered = answered_account(remote, parent)
     hashtags = hashtags(post)
 
     %{
       "id" => note_url(user, post.id),
       "type" => "Note",
       "attributedTo" => actor_url(user),
-      "content" => content_html(post, remote, hashtags),
+      "content" => content_html(post, answered, hashtags),
       "published" => iso8601(post.inserted_at),
       "to" => [@public],
-      "cc" => cc(user, remote),
+      "cc" => cc(user, answered),
       "url" => note_url(user, post.id)
     }
     |> put_content_map(post)
-    |> put_in_reply_to(post, remote)
-    |> put_tag(post, remote, hashtags)
+    |> put_in_reply_to(remote, parent)
+    |> put_tag(post, answered, hashtags)
     |> put_attachments(post)
+  end
+
+  # The account this post answers, reduced to the two fields every consumer
+  # below needs: the actor URI a receiving server resolves, and the handle a
+  # reader sees. Two sources — a note on another server (issue #1070) or a post
+  # of ours (issue #1739) — and past this function nothing can tell them apart,
+  # which is the point: the `cc`, the `Mention` and the leading handle are the
+  # same act whichever network the answered account is on.
+  defp answered_account(%PostRemoteReply{} = ref, _parent),
+    do: {ref.actor_uri, mention_handle(ref)}
+
+  defp answered_account(nil, nil), do: nil
+
+  # The one thing the `inReplyTo` above does **not** ask: whether the answered
+  # member is out there at all. A non-federating member serves no actor document
+  # (`with_federated_user/3` 404s it), so naming them would put a handle in the
+  # visible text of the post linking to a URL that answers nothing — while the
+  # dangling `inReplyTo` beside it costs a reader nothing but the missing parent.
+  defp answered_account(nil, {author, _id}) do
+    if Vutuv.Fediverse.federated?(author), do: {actor_url(author), handle(author)}
   end
 
   # The author's declared language federates as AS2 `contentMap` (issue
@@ -740,13 +768,18 @@ defmodule VutuvWeb.Fediverse.Docs do
   defp remote_target(%Post{}), do: nil
 
   # A public answer is addressed like any other public post, plus the person it
-  # answers. Naming them in `cc` (rather than `to`) is what Mastodon does for a
-  # public reply: the post stays public, and the mentioned actor is delivered to
-  # directly so it lands in their notifications.
+  # answers — whichever network they are on. Naming them in `cc` (rather than
+  # `to`) is what Mastodon does for a public reply: the post stays public, and
+  # the mentioned actor is delivered to directly so it lands in their
+  # notifications.
+  #
+  # The local branch is issue #1739. An answer to a **vutuv** post used to name
+  # nobody at all, so the answered member's own remote followers never received
+  # it and no reader out there was told who was being answered — while an answer
+  # to a remote note had carried exactly this since #1070. One act, two shapes,
+  # and the vutuv-facing one was the poorer of them.
   defp cc(user, nil), do: [followers_url(user)]
-
-  defp cc(user, %PostRemoteReply{actor_uri: actor_uri}),
-    do: [followers_url(user), actor_uri]
+  defp cc(user, {actor_uri, _handle}), do: [followers_url(user), actor_uri]
 
   # The `Mention` tag is what makes the remote server notify the person answered
   # and thread the reply under theirs.
@@ -758,8 +791,17 @@ defmodule VutuvWeb.Fediverse.Docs do
   #
   # It shares the array with the post's hashtags (issue #1421), so both are
   # written here rather than each overwriting the other's key.
-  defp put_tag(note, post, remote, hashtags) do
-    case mention_tag(remote) ++ local_mention_tags(post) ++ Enum.map(hashtags, &hashtag_tag/1) do
+  defp put_tag(note, post, answered, hashtags) do
+    tags =
+      mention_tag(answered) ++
+        local_mention_tags(post) ++ Enum.map(hashtags, &hashtag_tag/1)
+
+    # The answered author may *also* be named in the body, and then
+    # `local_mention_tags/1` mints a second, identical `Mention` for them.
+    # Deduplicated by what a receiving server actually resolves — type plus
+    # href — so each account is announced once however many ways the post
+    # happens to name it.
+    case Enum.uniq_by(tags, &{&1["type"], &1["href"]}) do
       [] -> note
       tags -> Map.put(note, "tag", tags)
     end
@@ -783,7 +825,7 @@ defmodule VutuvWeb.Fediverse.Docs do
   defp local_mention_tags(%Post{body: body}) when is_binary(body) do
     (Mentions.mentioned_users(body) ++ mentioned_pages(body))
     |> Enum.filter(&Vutuv.Fediverse.federated?/1)
-    |> Enum.map(&%{"type" => "Mention", "href" => actor_url(&1), "name" => handle(&1)})
+    |> Enum.map(&mention(actor_url(&1), handle(&1)))
   end
 
   defp local_mention_tags(_post), do: []
@@ -802,16 +844,13 @@ defmodule VutuvWeb.Fediverse.Docs do
   end
 
   defp mention_tag(nil), do: []
+  defp mention_tag({actor_uri, handle}), do: [mention(actor_uri, handle)]
 
-  defp mention_tag(%PostRemoteReply{} = ref) do
-    [
-      %{
-        "type" => "Mention",
-        "href" => ref.actor_uri,
-        "name" => mention_handle(ref)
-      }
-    ]
-  end
+  # The one owner of the `Mention` shape. It was written out three times — the
+  # answered account on either network, and each account the body names — so the
+  # next field a receiving server wants would have had to be remembered three
+  # times too.
+  defp mention(href, name), do: %{"type" => "Mention", "href" => href, "name" => name}
 
   defp hashtag_tag(%{name: name, href: href}),
     do: %{"type" => "Hashtag", "href" => href, "name" => name}
@@ -925,19 +964,19 @@ defmodule VutuvWeb.Fediverse.Docs do
   # sidecar is rendered INTO the content: the Note is one more rendering of
   # the post (like the agent docs), so a Mastodon reader gets the reviewed
   # work's facts even though remote software knows nothing of review cards.
-  defp content_html(post, remote, hashtags) do
+  defp content_html(post, answered, hashtags) do
     body_html =
       post.body
       |> VutuvWeb.Markdown.render_post(images(post), mention_form: :address)
       |> Phoenix.HTML.safe_to_string()
 
-    (mention_html(remote) <>
+    (mention_html(answered) <>
        body_html <> PostComponents.review_content_html(post) <> hashtag_line(hashtags))
     |> absolutize()
   end
 
   # The chips as a closing line of `#hashtags`, added **here, on the wire, only**
-  # (issue #1421) — the same seam `mention_html/1` above uses, and for the same
+  # (issue #1421) — the same seam `mention_html/1` below uses, and for the same
   # reason: on vutuv these are chips under the post, and nobody's stored body
   # grows a line it was not written with. Only the tags the body does not
   # already name, or the post would print them twice.
@@ -969,18 +1008,19 @@ defmodule VutuvWeb.Fediverse.Docs do
   # It is added **here, on the wire, only** — the member's stored body does not
   # carry it. On vutuv the answer shows a "Replying to" line instead, so a member
   # who has never heard of Mastodon does not have to type a handle in a foreign
-  # format, and their post does not read like a foreign one. The handle is remote
-  # supplied, so it is escaped.
+  # format, and their post does not read like a foreign one.
+  #
+  # Both halves of the pair are escaped. One of them is remote supplied, and the
+  # other only looks safe: a handle of ours is a username, and what a username
+  # may contain is a rule in another module's changeset, not a promise to this
+  # one. Issue #1739 is the vutuv branch — an answer to a member here used to
+  # open with nothing, so a Mastodon reader saw a post that read like the start
+  # of a conversation.
   defp mention_html(nil), do: ""
 
-  defp mention_html(%PostRemoteReply{} = ref) do
-    handle =
-      ref |> mention_handle() |> Phoenix.HTML.html_escape() |> Phoenix.HTML.safe_to_string()
-
-    href = ref.actor_uri |> Phoenix.HTML.html_escape() |> Phoenix.HTML.safe_to_string()
-
-    ~s(<p><span class="h-card"><a href="#{href}" class="u-url mention">#{handle}</a></span></p>)
-  end
+  defp mention_html({href, handle}),
+    do:
+      ~s(<p><span class="h-card"><a href="#{escape(href)}" class="u-url mention">#{escape(handle)}</a></span></p>)
 
   # Remote servers are anonymous viewers: only AI-released images may render
   # inline (released_images/1 also handles an un-preloaded association).
@@ -1001,27 +1041,46 @@ defmodule VutuvWeb.Fediverse.Docs do
   # own `inReplyTo` back to our post, so this is what puts the answer in the right
   # place in the conversation on the other server. The URI is the durable copy
   # from the sidecar, so it still resolves after the cached note is collected.
-  defp put_in_reply_to(note, _post, %PostRemoteReply{in_reply_to_uri: uri}),
+  defp put_in_reply_to(note, %PostRemoteReply{in_reply_to_uri: uri}, _parent),
     do: Map.put(note, "inReplyTo", uri)
 
-  # Otherwise inReplyTo only when the parent's author federates too — a
-  # non-federating author serves no Note at that id, and remote servers could
-  # drop the post over an id that does not resolve.
-  defp put_in_reply_to(note, post, nil) do
-    case reply_parent(post) do
-      nil -> note
-      {parent_author, parent_id} -> Map.put(note, "inReplyTo", note_url(parent_author, parent_id))
-    end
-  end
+  # Otherwise: an answer says it is an answer, **whatever stands at the other end
+  # of the field** (issue #1739). It used to be written only when the answered
+  # author federates, and `fediverse_followers?` defaults to off — so most answers
+  # travelled stripped of the one field saying they *were* answers, and every
+  # receiving server filed them as fresh threads. Mastodon does hide an answer to
+  # somebody you do not follow (`filter_from_home` in `app/lib/feed_manager.rb`),
+  # but only once it knows a post is an answer.
+  #
+  # So the id is named even when nothing serves a Note at it. That reference
+  # dangles by design, and the two things it costs are worth knowing: a reader
+  # cannot open the post being answered, and Mastodon drops such an answer from
+  # its **home** timelines entirely rather than merely filtering it by who you
+  # follow (same rule, the `in_reply_to_id.nil?` branch) — it stays on the
+  # profile and at its own link. The member being answered kept out of the
+  # Fediverse, so their post is not findable out there either way; what changes
+  # is that the answer no longer pretends to open a conversation.
+  defp put_in_reply_to(note, nil, nil), do: note
 
+  defp put_in_reply_to(note, nil, {parent_author, parent_id}),
+    do: Map.put(note, "inReplyTo", note_url(parent_author, parent_id))
+
+  # The post this one answers, as the pair that names it: the author whose
+  # handle spells the URL, and the id. Nothing is asked about the author — see
+  # `put_in_reply_to/3` — with one exception, which is not about resolvability
+  # but about privacy: a **restricted** parent is not public, so publishing its
+  # URL would put its id (and, the id being a UUID v7, the minute it was
+  # written) in front of readers who may not see the post itself. An answer
+  # under one of those still travels; it is the one shape left that travels
+  # without saying what it answers.
   defp reply_parent(%Post{reply_ref: %Ecto.Association.NotLoaded{}}), do: nil
   defp reply_parent(%Post{reply_ref: nil}), do: nil
 
   defp reply_parent(%Post{reply_ref: reply_ref}) do
     with author when not is_nil(author) <- parent_author(reply_ref),
-         true <- Vutuv.Fediverse.federated?(author),
-         false <- Vutuv.Posts.restricted?(%Post{id: reply_ref.parent_post_id}) do
-      {author, reply_ref.parent_post_id}
+         parent_id when is_binary(parent_id) <- reply_ref.parent_post_id,
+         false <- Vutuv.Posts.restricted?(%Post{id: parent_id}) do
+      {author, parent_id}
     else
       _ -> nil
     end

--- a/test/vutuv/fediverse_reply_representation_test.exs
+++ b/test/vutuv/fediverse_reply_representation_test.exs
@@ -1,0 +1,170 @@
+defmodule Vutuv.FediverseReplyRepresentationTest do
+  @moduledoc """
+  What an answer written here says about itself on the way out (issue #1739).
+
+  Two halves of one symptom. `inReplyTo` was written only when the answered
+  author federates — and `fediverse_followers?` defaults to off, so most answers
+  travelled without the one field saying they *were* answers, and every
+  receiving server filed them as fresh threads. And an answer to a **vutuv**
+  post carried no `Mention`, no `cc` and no leading handle at all, while an
+  answer to a note on another server has carried all three since #1070.
+
+  The rule now: an answer always names what it answers, even when nothing serves
+  a Note at that id. That reference dangles by design — the answered member
+  chose to stay out of the Fediverse, so their post is not findable out there
+  either way. The account beside it is named only when it can be resolved.
+
+  Calibrated against the un-fixed code — put the `federated?` gate back into
+  `reply_parent/1`, or take the local `Mention`/`cc`/handle back out, and the
+  cases below go red.
+  """
+  use Vutuv.DataCase, async: true
+
+  import Vutuv.MastodonHelpers
+
+  import Ecto.Query, only: [order_by: 2]
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Delivery
+  alias Vutuv.Posts
+  alias Vutuv.Posts.PostDenial
+  alias VutuvWeb.Fediverse.Docs
+
+  setup do
+    author = member()
+
+    {:ok, _follower} =
+      Fediverse.add_follower(author, %{
+        actor_uri: "https://follower.example/users/f",
+        inbox_uri: "https://follower.example/inbox"
+      })
+
+    %{author: author}
+  end
+
+  # `unique_username/1` and not the factory default: the mention grammar stops at
+  # a hyphen, so a `user-4` would silently make the "@ in the body" case below
+  # test nothing.
+  defp member, do: federating_member(username: unique_username())
+
+  defp create_reply!(author, parent) do
+    {:ok, reply} = Posts.create_reply(author, parent, %{body: "Antwort."})
+    reply
+  end
+
+  defp queued_notes do
+    Delivery
+    |> order_by(asc: :id)
+    |> Repo.all()
+    |> Enum.map(&(&1.activity_json |> Jason.decode!() |> Map.get("object")))
+  end
+
+  describe "answering a member who federates" do
+    setup do
+      parent_author = member()
+      %{parent_author: parent_author, parent: insert(:post, user: parent_author, body: "Frage?")}
+    end
+
+    test "names them every way a receiving server reads", ctx do
+      {:ok, _reply} = Posts.create_reply(ctx.author, ctx.parent, %{body: "Sehe ich auch so."})
+
+      assert [note] = queued_notes()
+
+      # The field that makes it a reply at all — without it Mastodon files the
+      # post as a fresh thread and shows it to everybody.
+      assert note["inReplyTo"] == Docs.note_url(ctx.parent_author, ctx.parent.id)
+
+      # Addressed to them directly, so it reaches their server and their
+      # notifications, the way the remote-reply path has done since #1070.
+      assert Docs.actor_url(ctx.parent_author) in note["cc"]
+
+      assert Enum.any?(
+               note["tag"],
+               &(&1["type"] == "Mention" and &1["href"] == Docs.actor_url(ctx.parent_author))
+             )
+
+      # And the reader is told in the body who is being answered.
+      assert note["content"] =~ Docs.handle(ctx.parent_author)
+    end
+
+    test "announces them once even when the body names them too", ctx do
+      {:ok, _reply} =
+        Posts.create_reply(ctx.author, ctx.parent, %{
+          body: "@#{ctx.parent_author.username} sehe ich auch so."
+        })
+
+      assert [note] = queued_notes()
+
+      mentions =
+        Enum.filter(note["tag"], &(&1["href"] == Docs.actor_url(ctx.parent_author)))
+
+      assert length(mentions) == 1
+    end
+  end
+
+  describe "answering a member who keeps out of the Fediverse" do
+    setup do
+      # `fediverse_followers?` defaults to false, which is most members.
+      parent_author = insert(:activated_user, username: unique_username())
+      %{parent_author: parent_author, parent: insert(:post, user: parent_author, body: "Frage?")}
+    end
+
+    test "still says what it answers, and names nobody", ctx do
+      {:ok, _reply} = Posts.create_reply(ctx.author, ctx.parent, %{body: "Sehe ich auch so."})
+
+      assert [note] = queued_notes()
+
+      # Dangling on purpose: nothing serves a Note at that id, and a reader
+      # cannot open it. What it buys is that the post no longer reads as the
+      # start of a conversation.
+      assert note["inReplyTo"] == Docs.note_url(ctx.parent_author, ctx.parent.id)
+
+      # But the account itself is not named: their actor document 404s, so a
+      # handle in the body would link a reader to nothing.
+      assert note["cc"] == [Docs.followers_url(ctx.author)]
+      refute Map.has_key?(note, "tag")
+      refute note["content"] =~ Docs.handle(ctx.parent_author)
+    end
+  end
+
+  describe "answering a post that is not public" do
+    test "says nothing about it", ctx do
+      parent_author = member()
+      parent = insert(:post, user: parent_author, body: "Nur für wenige.")
+      reply = create_reply!(ctx.author, parent)
+
+      Repo.insert!(%PostDenial{post_id: parent.id, wildcard: "everyone"})
+
+      note = Docs.note(Repo.preload(reply, Docs.note_preloads()), ctx.author)
+
+      # The one shape left that travels without saying what it answers, and the
+      # reason is privacy rather than resolvability: the id is a UUID v7, so
+      # publishing the URL would tell readers who may not see the post that it
+      # exists and when it was written.
+      refute Map.has_key?(note, "inReplyTo")
+    end
+  end
+
+  describe "what must keep travelling" do
+    test "a post that answers nothing", ctx do
+      {:ok, _post} = Posts.create_post(ctx.author, %{body: "Ein eigener Gedanke."})
+
+      assert [note] = queued_notes()
+      refute Map.has_key?(note, "inReplyTo")
+
+      # And nobody is addressed or mentioned who was never answered — the guard
+      # on resolving the answered account once for the whole Note.
+      assert note["cc"] == [Docs.followers_url(ctx.author)]
+      refute Map.has_key?(note, "tag")
+    end
+
+    test "an answer under a post of the author's own", ctx do
+      own = insert(:post, user: ctx.author, body: "Erster Teil.")
+
+      {:ok, _reply} = Posts.create_reply(ctx.author, own, %{body: "Zweiter Teil."})
+
+      assert [note] = queued_notes()
+      assert note["inReplyTo"] == Docs.note_url(ctx.author, own.id)
+    end
+  end
+end

--- a/test/vutuv_web/controllers/post_note_reply_test.exs
+++ b/test/vutuv_web/controllers/post_note_reply_test.exs
@@ -1,0 +1,50 @@
+defmodule VutuvWeb.PostNoteReplyTest do
+  @moduledoc """
+  The permalink half of issue #1739.
+
+  The same post is served as an ActivityPub Note at its own URL, and anything
+  that reaches it there — a boost, a search, somebody pasting the link — must
+  get back what the delivery queue sent, not a second opinion. So this pins the
+  two ends of the rule on that surface: an answer always carries `inReplyTo`,
+  and the answered account is named beside it only when it can be resolved.
+  """
+  use VutuvWeb.ConnCase, async: true
+
+  import Vutuv.MastodonHelpers
+
+  alias Vutuv.Posts
+  alias VutuvWeb.Fediverse.Docs
+
+  defp member, do: federating_member(username: unique_username())
+
+  defp get_note(conn, post) do
+    conn
+    |> put_req_header("accept", "application/activity+json")
+    |> get(Posts.path(post))
+  end
+
+  test "an answer under a federating member's post names them too", %{conn: conn} do
+    parent_author = member()
+    parent = insert(:post, user: parent_author, body: "Frage?")
+    {:ok, reply} = Posts.create_reply(member(), parent, %{body: "Antwort."})
+
+    note = conn |> get_note(Repo.preload(reply, :user)) |> json_response(200)
+
+    assert note["inReplyTo"] == Docs.note_url(parent_author, parent.id)
+    assert Docs.actor_url(parent_author) in note["cc"]
+  end
+
+  test "an answer under a non-federating member's post still says it is one", %{conn: conn} do
+    # Keeps out of the Fediverse, which is the default and most members.
+    parent_author = insert(:activated_user, username: unique_username())
+    parent = insert(:post, user: parent_author, body: "Frage?")
+    {:ok, reply} = Posts.create_reply(member(), parent, %{body: "Antwort."})
+
+    note = conn |> get_note(Repo.preload(reply, :user)) |> json_response(200)
+
+    # The reference dangles — that id serves no Note — but the post no longer
+    # pretends to open a conversation. Nobody is named beside it.
+    assert note["inReplyTo"] == Docs.note_url(parent_author, parent.id)
+    assert note["cc"] == [Docs.followers_url(Repo.preload(reply, :user).user)]
+  end
+end


### PR DESCRIPTION
Symptom: a reply written on vutuv arrives in a Mastodon timeline as a new thread. `inReplyTo` was written only when the answered author federates, and that opt-in is off by default, so `filter_from_home` never saw a reply to hide. An answer to a vutuv post also carried no `Mention` and no `cc`.

Change: `put_in_reply_to/3` in `lib/vutuv_web/fediverse/docs.ex` now names the parent URL always. Where nobody serves a Note there, the reference dangles, deliberately: Mastodon then drops the answer from home timelines and leaves it on the profile, which beats publishing it as a fresh thread. The answered account is named in `cc`, `tag` and the leading handle only when its actor document resolves.

Not included: a restricted parent URL. Its UUID v7 id would tell readers who may not see the post that it exists and when.

Verified: `mix precommit` green; each half goes red with its fix reverted. Delivery is not gated, so `lib/vutuv/fediverse.ex` is untouched.

Closes #1739.