### PR TITLE
feat(mobile): pull a list down to refresh it [5m]

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -42,6 +42,9 @@ import "./lightbox"
 // (self-contained; marks <html>, which is outside every LiveView root, so no
 // patch can drop the state. See scroll_top_tab.js).
 import "./scroll_top_tab"
+// Pull a list down to refresh it (issue #1730). Opt-in per page: the LiveView
+// that owns the list renders the hook and handles `pwa:refresh`.
+import PullToRefresh from "./pull_to_refresh"
 
 // LiveSocket drives the incremental LiveView shell (live unread badges, the
 // notifications/messages pages, presence). The CSRF token is rendered into the
@@ -698,6 +701,7 @@ const Hooks = {
   MarkdownEditor,
   TagInput,
   FeedUrl,
+  PullToRefresh,
   LocalTime: {
     mounted() {
       localizeTime(this.el)
@@ -1576,7 +1580,12 @@ const NAV_PRESSING = "data-nav-pressing"
 const KEEP_OPEN = "data-keep-open"
 
 const liveSocket = new LiveSocket("/live", Socket, {
-  params: { _csrf_token: csrfToken() },
+  // `pull_refresh` is a capability, not a setting (issue #1730): only a bundle
+  // carrying the PullToRefresh hook can send this key, so a page reconnecting
+  // into a document from before that deploy never renders a hook its
+  // JavaScript does not have. A deploy reloads no open tab — it only
+  // reconnects the socket into hours-old markup. Retire it with the hook.
+  params: { _csrf_token: csrfToken(), pull_refresh: true },
   hooks: Hooks,
   dom: {
     // Both navs live inside ShellLive, so a patch that has nothing to do with

--- a/assets/js/pull_to_refresh.js
+++ b/assets/js/pull_to_refresh.js
@@ -1,0 +1,254 @@
+import { reducedMotion } from "./util"
+
+// Pull to refresh (issue #1730).
+//
+// Content already arrives by itself over PubSub, so this gesture is not a
+// transport — it is a **reassurance**. It answers "have I seen everything?",
+// which no push channel can answer, and it is the single most over-learned
+// interaction on a phone: its absence reads as breakage even when nothing is
+// broken.
+//
+// Two rules the implementation is built around.
+//
+// **Never `location.reload()`.** That throws away the LiveView, rebuilds the
+// socket and re-fetches the whole document — the "refresh" would cost more
+// than the state it refreshes, and on a slow line it is visibly worse than
+// having no gesture at all. The release pushes `pwa:refresh` over the existing
+// socket and the page re-queries its own list; the chrome, the scroll
+// container and the socket all stay.
+//
+// **It is opt-in per page.** A page that does not implement
+// `handle_event("pwa:refresh", …)` simply does not render the hook's element,
+// so the gesture never appears where it would do nothing. `/feed`,
+// `/messages` and `/notifications` implement it today.
+//
+// The indicator is built here rather than rendered by the server, and it wears
+// its animation through the Web Animations API rather than a keyframe: the
+// element only ever exists in a document whose bundle contains this file, so
+// there is nothing for an older stylesheet to get wrong. The colours are
+// ordinary Tailwind utilities — `@source "../js"` in `app.css` means classes
+// written here are scanned like any others.
+
+// Finger travel is halved and hard-capped, which is what reads as "native": a
+// 1:1 drag feels like the page came loose. The threshold is measured on the
+// resisted distance, i.e. ~140px of actual finger.
+const RESISTANCE = 0.5
+const THRESHOLD = 70
+const MAX = 120
+
+// A dead line must not leave the spinner up forever. Long enough that a slow
+// answer still lands inside it.
+const TIMEOUT_MS = 8000
+
+const PullToRefresh = {
+  mounted() {
+    // `data-pull-scroller="self"` says this element scrolls itself (the
+    // messages page is a full-viewport chat and the document does not move);
+    // otherwise the document is the scroller. A gesture that engages on the
+    // wrong element is worse than none, so this is stated rather than guessed.
+    this.scroller =
+      this.el.dataset.pullScroller === "self" ? this.el : document.documentElement
+
+    // Chrome runs its own pull-to-refresh on the same gesture. `contain` stops
+    // it from firing underneath ours — set here, not in the stylesheet, so it
+    // is scoped to exactly the pages that replace it and lifted again when
+    // this hook goes away.
+    this.overscrollWas = this.scroller.style.overscrollBehaviorY
+    this.scroller.style.overscrollBehaviorY = "contain"
+
+    this.pull = null
+    this.busy = false
+    this.moving = false
+    this.frame = null
+    this.pending = 0
+    this.indicator = null
+    this.spin = null
+
+    this.onStart = (e) => this.begin(e)
+    // Non-passive, because the point is to `preventDefault()` the native
+    // scroll while the finger is pulling. Same reason the composer's reorder
+    // drag registers one — and the reason it is NOT registered up front: a
+    // non-passive touchmove on a page-sized element makes the browser wait for
+    // the main thread before it may scroll at all, so leaving one standing
+    // would tax every ordinary scroll of the feed for a gesture that starts
+    // only at the very top. It goes on when a pull becomes possible and comes
+    // off again with the finger.
+    this.onMove = (e) => this.track(e)
+    this.onEnd = () => this.release()
+
+    this.el.addEventListener("touchstart", this.onStart, { passive: true })
+    this.el.addEventListener("touchend", this.onEnd)
+    this.el.addEventListener("touchcancel", this.onEnd)
+  },
+
+  destroyed() {
+    this.el.removeEventListener("touchstart", this.onStart)
+    this.el.removeEventListener("touchend", this.onEnd)
+    this.el.removeEventListener("touchcancel", this.onEnd)
+    this.unwatchMoves()
+    this.scroller.style.overscrollBehaviorY = this.overscrollWas
+    clearTimeout(this.timer)
+    if (this.frame) cancelAnimationFrame(this.frame)
+    if (this.indicator) this.indicator.remove()
+  },
+
+  watchMoves() {
+    if (this.moving) return
+    this.moving = true
+    this.el.addEventListener("touchmove", this.onMove, { passive: false })
+  },
+
+  unwatchMoves() {
+    if (!this.moving) return
+    this.moving = false
+    this.el.removeEventListener("touchmove", this.onMove)
+  },
+
+  atTop() {
+    return this.scroller.scrollTop <= 0
+  },
+
+  begin(e) {
+    if (this.busy || e.touches.length !== 1) return
+    if (!this.atTop()) return
+    const touch = e.touches[0]
+    // The container cannot move while the pull runs (the native scroll is
+    // prevented), so its top edge is measured once here. Reading it per move
+    // would be a layout flush per frame, right after this frame's writes.
+    this.pull = {
+      y: touch.clientY,
+      x: touch.clientX,
+      top: Math.max(0, this.el.getBoundingClientRect().top),
+      armed: false,
+      crossed: false,
+    }
+    this.watchMoves()
+  },
+
+  track(e) {
+    if (!this.pull || e.touches.length !== 1) return
+
+    const touch = e.touches[0]
+    const dy = touch.clientY - this.pull.y
+    const dx = Math.abs(touch.clientX - this.pull.x)
+
+    // The first movement decides whose gesture this is. Upward, or more
+    // sideways than down, and it was never ours — let the browser scroll.
+    if (!this.pull.armed) {
+      if (dy <= 0 || dy < dx) return this.collapse()
+      this.pull.armed = true
+    }
+
+    // Momentum can have carried the container off the top between frames.
+    if (!this.atTop()) return this.collapse()
+
+    e.preventDefault()
+    const distance = Math.min(MAX, dy * RESISTANCE)
+    this.draw(distance)
+
+    // The confirmation has to arrive at the moment the threshold is crossed,
+    // not on release — by then the decision is already made. Android taps;
+    // iOS ignores `vibrate` without error.
+    const crossed = distance >= THRESHOLD
+    if (crossed && !this.pull.crossed && navigator.vibrate) navigator.vibrate(10)
+    this.pull.crossed = crossed
+  },
+
+  release() {
+    if (!this.pull) return
+    const armed = this.pull.crossed
+    const top = this.pull.top
+    this.pull = null
+    this.unwatchMoves()
+    if (!armed) return this.collapse()
+
+    // Hold the spinner until the server answers, then collapse. A `noreply`
+    // still acks, so this callback runs on every handled event.
+    this.busy = true
+    this.paint(top, THRESHOLD, true)
+    this.timer = setTimeout(() => this.finish(), TIMEOUT_MS)
+    this.pushEvent("pwa:refresh", {}, () => this.finish())
+  },
+
+  finish() {
+    clearTimeout(this.timer)
+    this.busy = false
+    this.collapse()
+  },
+
+  collapse() {
+    this.pull = null
+    this.unwatchMoves()
+    if (this.busy || !this.indicator) return
+    this.indicator.style.opacity = "0"
+    this.indicator.style.transform = "translate(-50%, 0) scale(0.8)"
+    if (this.spin) {
+      this.spin.cancel()
+      this.spin = null
+    }
+  },
+
+  // The indicator has to appear DURING the pull, not after release: the whole
+  // point is that it tells you the gesture exists before you commit to it.
+  //
+  // A touch screen can deliver moves faster than it paints (120 Hz ProMotion,
+  // coalesced Android events), so the distance is stashed and written once per
+  // frame instead of once per event.
+  draw(distance) {
+    // The frame reads the LATEST distance, not the one that scheduled it —
+    // otherwise a coalesced burst paints the first value of the burst and the
+    // indicator lags the finger by a frame.
+    this.pending = distance
+    if (this.frame) return
+    this.frame = requestAnimationFrame(() => {
+      this.frame = null
+      if (this.pull) this.paint(this.pull.top, this.pending, false)
+    })
+  },
+
+  // Only `transform` and `opacity` are written, and both are compositor
+  // properties: the offset of the container's top edge is folded into the
+  // translate rather than set as `top`, which would dirty layout every frame.
+  paint(top, distance, spinning) {
+    const node = this.indicator || this.build()
+
+    node.style.opacity = `${Math.min(1, distance / THRESHOLD)}`
+    node.style.transform = `translate(-50%, ${top + distance}px) scale(${Math.min(1, 0.6 + distance / THRESHOLD / 2)})`
+
+    if (spinning) {
+      // A reader who asked for less motion still gets the spinner's presence,
+      // just not its rotation (`reducedMotion` in util.js is the app's gate).
+      if (!this.spin && !reducedMotion()) {
+        this.spin = node.firstChild.animate(
+          [{ transform: "rotate(0deg)" }, { transform: "rotate(360deg)" }],
+          { duration: 800, iterations: Infinity }
+        )
+      }
+    } else {
+      // Before release the arc turns with the finger, so the control reports
+      // how far along the gesture is rather than only whether it fired.
+      node.firstChild.style.transform = `rotate(${distance * 3}deg)`
+    }
+  },
+
+  build() {
+    const node = document.createElement("div")
+    node.setAttribute("aria-hidden", "true")
+    node.className =
+      "pointer-events-none fixed left-1/2 top-0 z-20 flex h-9 w-9 items-center justify-center " +
+      "rounded-full bg-white text-brand-600 shadow-md ring-1 ring-slate-200 " +
+      "dark:bg-slate-800 dark:text-brand-300 dark:ring-slate-700"
+    if (!reducedMotion()) {
+      node.style.transition = "opacity 200ms ease-out, transform 200ms ease-out"
+    }
+    node.style.opacity = "0"
+    node.innerHTML =
+      '<svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">' +
+      '<path stroke-linecap="round" d="M21 12a9 9 0 1 1-6.219-8.56" /></svg>'
+    document.body.appendChild(node)
+    this.indicator = node
+    return node
+  },
+}
+
+export default PullToRefresh

--- a/docs/architecture/realtime.md
+++ b/docs/architecture/realtime.md
@@ -103,6 +103,62 @@ silently on exactly the devices nobody is testing on. The same holds for the
 cache: `activate` deletes every key that is not its own, so two releases never
 share one, but the old cache lives as long as the old worker does.
 
+### Pull to refresh (issue #1730)
+
+Pulling a list down is the most over-learned interaction on a phone, and its
+absence reads as breakage even when nothing is broken. Worth writing down,
+because it will come up: yes, content already arrives by itself over PubSub.
+The gesture is not a transport, it is a **reassurance** — it answers "have I
+seen everything?", which no push channel can answer.
+
+The gesture is `assets/js/pull_to_refresh.js` (`PullToRefresh`), and its
+ending is the whole design. It **never calls `location.reload()`**: that would
+throw away the LiveView, rebuild the socket and re-fetch the document, so the
+refresh would cost more than the state it refreshes. It pushes
+**`pwa:refresh`** over the existing socket, and whichever LiveView owns the
+list re-queries it. The chrome, the scroll container and the socket all stay.
+
+That makes it a small contract rather than one component, and it is **opt-in
+per page** — a page that does not implement the event never renders the hook,
+so the gesture is never offered where it would do nothing:
+
+| page | LiveView | what a refresh means |
+|---|---|---|
+| `/feed` | `PostLive.Feed` | re-run the timeline query for the tab on screen |
+| `/messages` | `MessageLive.Index` | reload the conversation list |
+| `/notifications` | `NotificationLive.Index` | reload the page, mark what came in as read |
+
+Mechanics: the gesture engages only while the scroll container is at the top
+**and** the first movement is downward (otherwise the browser scrolls, and a
+sideways swipe is not ours); finger travel is halved and capped at 120px,
+because tracking 1:1 feels like the page came loose; the threshold is 70px of
+that resisted travel; `navigator.vibrate(10)` fires the moment it is crossed,
+not on release (Android taps, iOS ignores it without error); and the indicator
+appears **during** the pull, since its job is to tell you the gesture exists
+before you commit to it. The `touchmove` listener is non-passive so the native
+scroll can be prevented — the same reason the composer's photo-reorder drag
+registers one. The hook sets `overscroll-behavior-y: contain` on its own
+scroller while it lives, which stops Chrome's own pull-to-refresh firing
+underneath ours; doing it here rather than in the stylesheet scopes it to the
+pages that actually replace the native gesture.
+
+Two things to know before adding a fourth page. **Which element scrolls is
+stated, not guessed:** `data-pull-scroller="self"` says the hook's own element
+is the scroll container, which is how `/messages` works — that page is a
+full-viewport chat, the document does not move, and a gesture engaging on the
+wrong element is worse than none. Without the attribute the document is the
+scroller (`/feed`, `/notifications`). And **the browser has to be able to run
+it at all:** a deploy reloads no open tab, so `app.js` sends `pull_refresh:
+true` as a connect param and `VutuvWeb.Live.PullRefresh` gates the hook on it —
+only a bundle carrying the hook can make that claim. That is the seam the
+feed's tab ticker used before v7.483.0 retired it, and deliberately not
+`static_changed?/1`, which turns true after *every* asset deploy.
+
+The gesture is invisible to keyboard and screen-reader users and impossible
+without a touch screen, so it is an addition: whatever visible refresh path a
+page already has stays. `test/vutuv_web/live/pull_refresh_test.exs` covers the
+contract, including that the hook never reaches for a page reload.
+
 The **Messages** (`/messages`), **Notifications** (`/notifications`) and
 **Search** (`/search`) pages are LiveViews under a `live_session`. The search
 page itself is described in [search.md](search.md).

--- a/lib/vutuv_web/live/message_live/index.ex
+++ b/lib/vutuv_web/live/message_live/index.ex
@@ -22,6 +22,7 @@ defmodule VutuvWeb.MessageLive.Index do
   alias Vutuv.Organizations
   alias Vutuv.Organizations.Organization
   alias Vutuv.Posts
+  alias VutuvWeb.Live.PullRefresh
   alias VutuvWeb.{Markdown, Presence}
 
   @typing_clear_ms 2500
@@ -55,6 +56,9 @@ defmodule VutuvWeb.MessageLive.Index do
      |> assign(:more?, false)
      |> assign(:cursor, nil)
      |> assign_sidebar()
+     # Can this browser run the pull-to-refresh gesture (issue #1730)? Connect
+     # params are readable in mount only — see `VutuvWeb.Live.PullRefresh`.
+     |> PullRefresh.assign_capability()
      |> stream(:messages, [], dom_id: &"message-#{&1.id}")
      |> assign(:editor_seed, 0)
      |> assign_form()}
@@ -295,6 +299,16 @@ defmodule VutuvWeb.MessageLive.Index do
       {:error, :not_recipient} ->
         {:noreply, socket}
     end
+  end
+
+  # Pull to refresh (issue #1730). Only the conversation LIST is reloaded, and
+  # only its own scroller carries the gesture: this page is a full-viewport
+  # chat, the document itself does not move, and the open thread is a separate
+  # scroll context that already streams its messages live and scrolls the wrong
+  # way for this gesture. A pull that engaged on the wrong element would be
+  # worse than none.
+  def handle_event("pwa:refresh", _params, socket) do
+    {:noreply, assign_lists(socket)}
   end
 
   def handle_event("load-older", _params, socket) do
@@ -635,7 +649,16 @@ defmodule VutuvWeb.MessageLive.Index do
       <%!-- Conversation list. Full-width on mobile while no thread is open;
             once one is, the thread takes over and the list moves behind the
             back link (md+ always shows both). --%>
+      <%!-- `data-pull-scroller="self"`: this card is its own scroll container
+      (the document does not move on this page), so the pull-to-refresh gesture
+      has to read ITS `scrollTop`, not the window's. Rendered only when the
+      browser's own bundle claims the hook — see `VutuvWeb.Live.PullRefresh`.
+      While a thread is open the card is `hidden`, which takes the gesture with
+      it, and that is the intent: refreshing here means the list. --%>
       <aside
+        id="conversations"
+        phx-hook={@pull_refresh? && "PullToRefresh"}
+        data-pull-scroller="self"
         aria-busy={!@loaded? && "true"}
         class={[
           "w-full shrink-0 overflow-y-auto rounded-2xl bg-white ring-1 ring-slate-200 md:block md:w-64 dark:bg-slate-900 dark:ring-slate-800",

--- a/lib/vutuv_web/live/notification_live/index.ex
+++ b/lib/vutuv_web/live/notification_live/index.ex
@@ -83,6 +83,7 @@ defmodule VutuvWeb.NotificationLive.Index do
   alias Vutuv.Social
   alias Vutuv.ViewerClock
   alias VutuvWeb.Live.MountHandoff
+  alias VutuvWeb.Live.PullRefresh
   alias VutuvWeb.Markdown
   alias VutuvWeb.NotificationLive.Groups
   alias VutuvWeb.PostTeaser
@@ -143,6 +144,9 @@ defmodule VutuvWeb.NotificationLive.Index do
      |> assign(:dismissed, dismissed)
      |> assign(:today, ViewerClock.today())
      |> assign(:quote_lines, User.notification_post_lines(user))
+     # Can this browser run the pull-to-refresh gesture (issue #1730)? Connect
+     # params are readable in mount only — see `VutuvWeb.Live.PullRefresh`.
+     |> PullRefresh.assign_capability()
      |> assign_rail(connected?(socket))}
   end
 
@@ -162,9 +166,37 @@ defmodule VutuvWeb.NotificationLive.Index do
      |> load_page()}
   end
 
+  # Pull to refresh (issue #1730): re-query this tab's page and recompute the
+  # rail. It deliberately goes past `load_page/1` to `page_payload/1` — the
+  # handoff stash exists to spare the connected mount a repeat of the dead
+  # render's queries, and a member who pulled the list down is asking for
+  # exactly the thing a cache must not answer.
+  #
+  # The rows it brings in are being looked at, so they stop counting in the
+  # shell's bell — the same write the live `:new_notification` path makes, for
+  # the same reason. `:read_marker` and `:new_count` are NOT recomputed: they
+  # say "since your last visit", and a pull is still this visit, so the
+  # divider stays where the member left it.
+  #
+  # The rail is recomputed even though the gesture is about the list, and that
+  # is deliberate: its "Follow back" pills are drawn from followers, so the
+  # very row a pull brings in is often a new candidate. It is also the
+  # expensive half (three more queries per pull), so if this handler ever has
+  # to get cheaper, the rail is the first thing to drop.
+  @impl true
+  def handle_event("pwa:refresh", _params, socket) do
+    user = socket.assigns.current_user
+    Activity.mark_notifications_read(user.id)
+
+    {:noreply,
+     socket
+     |> assign(:dismissed, Activity.dismissed_event_ids(user.id))
+     |> apply_page(page_payload(socket))
+     |> assign_rail(true)}
+  end
+
   # The rail's "Follow back" pill (user_row live?): follow with no reload,
   # then recompute the rail so the new followee drops out.
-  @impl true
   def handle_event("follow", %{"followee" => followee_id}, socket) do
     case Social.follow(socket.assigns.current_user, followee_id) do
       {:ok, _} -> {:noreply, assign_rail(socket, true)}
@@ -365,7 +397,10 @@ defmodule VutuvWeb.NotificationLive.Index do
   @impl true
   def render(assigns) do
     ~H"""
-    <div id="notifications" class="py-6 md:py-8">
+    <%!-- Pull the list down to refresh it (issue #1730). Rendered only when the
+    browser's own bundle claims the hook (`VutuvWeb.Live.PullRefresh`); the
+    document is this page's scroll container, so no `data-pull-scroller`. --%>
+    <div id="notifications" phx-hook={@pull_refresh? && "PullToRefresh"} class="py-6 md:py-8">
       <div class="grid gap-6 md:grid-cols-3">
         <%!-- `data-filter-scope` pairs the tabs with the list they replace: the
         in-flight paint in `app.css` dims every `[data-filter-list]` inside this

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -50,6 +50,7 @@ defmodule VutuvWeb.PostLive.Feed do
   alias VutuvWeb.Live.InitAssigns
   alias VutuvWeb.Live.MountHandoff
   alias VutuvWeb.Live.PostTranslations
+  alias VutuvWeb.Live.PullRefresh
   alias VutuvWeb.Live.RemoteImages
   alias VutuvWeb.Live.RemotePostActions
   alias VutuvWeb.Live.RemoteReplyActions
@@ -167,6 +168,16 @@ defmodule VutuvWeb.PostLive.Feed do
   end
 
   defp mount_feed(socket, user, {day, open?}) do
+    # Can this browser run the pull-to-refresh gesture? A deploy does not
+    # reload an open feed — the socket reconnects to the new release and
+    # patches into a document downloaded hours ago — so the question is not
+    # which release that document came from but what it is able to render. The
+    # bundle answers it itself: `pull_refresh` is a LiveSocket param
+    # (assets/js/app.js), so only a bundle carrying the hook can claim the
+    # capability. Read here because connect params exist only during mount —
+    # see `VutuvWeb.Live.PullRefresh`.
+    socket = PullRefresh.assign_capability(socket)
+
     # The sources they left on (issue #1499). It opens the page *and* keys the
     # handoff below: the stash holds one entry per member, so two devices
     # opening /feed within its 15s TTL would otherwise let one take a page the
@@ -1362,6 +1373,21 @@ defmodule VutuvWeb.PostLive.Feed do
     {:noreply, assign(socket, :band_sheet?, false)}
   end
 
+  # Pull to refresh (issue #1730). The gesture is a reassurance rather than a
+  # transport: posts already arrive over PubSub, but nothing on a push channel
+  # can answer "have I seen everything?", and that is the question a thumb is
+  # asking. So it re-runs the timeline query for the tab on screen and replaces
+  # the list from the top — the same thing pressing the tab does, and the same
+  # reason the pending batch is dropped with it.
+  #
+  # This has to be a socket round trip. The obvious client-side ending,
+  # `location.reload()`, throws away this LiveView, rebuilds the socket and
+  # re-fetches the whole document, so the refresh would cost more than the
+  # state it refreshes — on a slow line, visibly worse than having no gesture.
+  def handle_event("pwa:refresh", _params, socket) do
+    {:noreply, load_source_filter(socket, socket.assigns.feed_filter)}
+  end
+
   def handle_event("show-new", _params, socket) do
     pending = socket.assigns.pending_posts
 
@@ -2351,11 +2377,22 @@ defmodule VutuvWeb.PostLive.Feed do
   @impl true
   def render(assigns) do
     ~H"""
-    <%!-- `FeedUrl` writes the calendar's day into the address bar (see
-    `sync_url/1`). It hangs off the page root rather than off the calendar
-    because there are two calendars, one per breakpoint, and the URL has one
-    owner. --%>
-    <div id="feed" phx-hook="FeedUrl" class="py-6">
+    <%!-- Pull the feed down to refresh it (issue #1730) — on its own wrapper,
+    because `#feed` already carries `FeedUrl` and LiveView reads `phx-hook` as
+    a single name. The wrapper works as well: touch events bubble up from the
+    list, the indicator is `position: fixed` on `document.body`, and the only
+    thing measured off this element is its top edge, which a wrapper with no
+    padding of its own shares with `#feed`. The hook is rendered only when the
+    browser's own bundle says it carries it — see `VutuvWeb.Live.PullRefresh`
+    — so a feed reconnecting into a document from before that deploy simply
+    keeps the behaviour it had. The document is this page's scroll container,
+    so the hook needs no `data-pull-scroller`. --%>
+    <div id="feed-pull" phx-hook={@pull_refresh? && "PullToRefresh"}>
+      <%!-- `FeedUrl` writes the calendar's day into the address bar (see
+      `sync_url/1`). It hangs off the page root rather than off the calendar
+      because there are two calendars, one per breakpoint, and the URL has one
+      owner. --%>
+      <div id="feed" phx-hook="FeedUrl" class="py-6">
       <%!-- Two columns on desktop: the feed, plus the rail that uses the
       otherwise-empty side space. The rail is desktop-only (the grid collapses
       to one column under md, and the rail is hidden anyway). --%>
@@ -3000,6 +3037,7 @@ defmodule VutuvWeb.PostLive.Feed do
             </.card>
           </div>
         </div>
+      </div>
       </div>
     </div>
     """

--- a/lib/vutuv_web/live/pull_refresh.ex
+++ b/lib/vutuv_web/live/pull_refresh.ex
@@ -1,0 +1,54 @@
+defmodule VutuvWeb.Live.PullRefresh do
+  @moduledoc """
+  The one place that knows whether this browser can run the pull-to-refresh
+  gesture (issue #1730).
+
+  Pulling a list down is the most over-learned interaction on a phone, and its
+  absence reads as breakage even when nothing is broken — content already
+  arrives over PubSub, but no push channel can answer "have I seen
+  everything?". The gesture answers it, and it answers it over the **existing
+  socket**: the release pushes `pwa:refresh`, and whichever LiveView owns the
+  list re-queries and re-streams it. Never `location.reload()`, which would
+  throw away the LiveView and re-fetch the document — a refresh that costs more
+  than the state it refreshes.
+
+  Two gates decide whether the gesture appears at all, and both are deliberate.
+
+  **The page has to want it.** A LiveView that does not implement
+  `handle_event("pwa:refresh", …)` never renders the hook, so the gesture is
+  never offered where it would do nothing. `PostLive.Feed`, `MessageLive.Index`
+  and `NotificationLive.Index` implement it.
+
+  **The bundle has to carry it.** A deploy reloads no open tab — it reconnects
+  the socket into hours-old markup — so newly patched-in markup meets the
+  *previous* release's JavaScript. `app.js` therefore sends `pull_refresh: true`
+  as a connect param, and only a bundle that ships the `PullToRefresh` hook can
+  send it, so the claim proves itself and cannot go stale. That is the same
+  seam the feed's tab ticker uses, and for the same reason it is a capability
+  the bundle asserts rather than `static_changed?/1`, which answers the wider
+  question "is anything in this document older than the running release?" and
+  therefore turns true after *every* asset deploy (v7.347.1 learned that the
+  expensive way).
+
+  Retire the param together with the hook.
+
+  This is the only capability of its shape right now: the feed's tab ticker
+  used the same seam for `feed_ticker` until v7.483.0 retired the source tabs
+  and the hook with them. If a second one appears, fold both into a shared
+  `BundleCapability` module rather than copying this file.
+  """
+
+  import Phoenix.Component, only: [assign: 3]
+  import Phoenix.LiveView, only: [get_connect_params: 1]
+
+  @doc """
+  Assigns `:pull_refresh?` — read it in the template as
+  `phx-hook={@pull_refresh? && "PullToRefresh"}` on the element the gesture
+  belongs to. Call it in `mount/3`; `get_connect_params/1` is only valid there,
+  and answers `nil` on the dead render, which is correct: the throwaway static
+  paint has no socket to push over anyway.
+  """
+  def assign_capability(socket) do
+    assign(socket, :pull_refresh?, match?(%{"pull_refresh" => true}, get_connect_params(socket)))
+  end
+end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -9,6 +9,7 @@ defmodule VutuvWeb.ConnCase do
     quote do
       import Plug.Conn
       import Phoenix.ConnTest
+      import VutuvWeb.LiveTestHelpers
 
       alias Vutuv.Repo
       import Ecto.Changeset

--- a/test/support/live_test_helpers.ex
+++ b/test/support/live_test_helpers.ex
@@ -1,0 +1,33 @@
+defmodule VutuvWeb.LiveTestHelpers do
+  @moduledoc """
+  Shared test helpers that do NOT need the calling module's `@endpoint`,
+  imported by `VutuvWeb.ConnCase`.
+
+  A module of its own rather than more lines inside ConnCase's `using` quote:
+  that quote is compiled into every test module in the suite and is already
+  long enough that credo asks for it back (`Avoid long quote blocks`). What
+  cannot move here is anything reaching for `@endpoint` — `live_at/3` dispatches
+  a request and therefore has to stay generated per module.
+  """
+
+  import ExUnit.Assertions
+
+  @doc """
+  Asserts that `assets/js/app.js` sends the connect param `key` and still
+  carries `hook`.
+
+  This is the half a LiveView test cannot reach. `put_connect_params/2` hands
+  the server whatever a test says, so every test of a bundle-gated feature
+  would keep passing if `app.js` never sent the key and the feature were dead
+  in every browser. So assert the source, the way `mobile_tab_bar_css_test.exs`
+  does — and assert the hook too, because the param has to be retired with it.
+  """
+  def assert_bundle_capability(key, hook) do
+    app_js = File.read!("assets/js/app.js")
+
+    assert app_js =~ ~r/params:\s*\{[^}]*#{key}:\s*true/,
+           "the LiveSocket params in assets/js/app.js must send `#{key}: true`"
+
+    assert app_js =~ hook, "retire the `#{key}` param together with the #{hook} hook"
+  end
+end

--- a/test/vutuv_web/live/pull_refresh_test.exs
+++ b/test/vutuv_web/live/pull_refresh_test.exs
@@ -1,0 +1,224 @@
+defmodule VutuvWeb.PullRefreshTest do
+  @moduledoc """
+  Pull a list down to refresh it (issue #1730).
+
+  Content already arrives over PubSub, so what is worth testing is not that a
+  refresh brings *something* — it is the three rules that make this gesture
+  worth having at all:
+
+    * it is a **socket round trip**, never a page reload;
+    * it is **opt-in per page**, so it never appears where nothing handles it;
+    * and it is **not offered to a browser whose bundle predates the hook**,
+      because a deploy reloads no open tab.
+
+  Each page's refresh is driven with rows created the way the *live* path
+  cannot see them (a factory insert rather than the context function that
+  broadcasts), so a green assertion can only mean the refresh ran the query.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.Chat
+  alias Vutuv.Social
+
+  # `get/2` recycles a conn that has already been sent, and recycling drops
+  # `private` — connect params included. Recycling first is what gets them as
+  # far as the join. (`feed_tab_ticker_test.exs` says the same thing over its
+  # own two lines; sharing six lines was not worth a macro to reach the
+  # caller's `@endpoint`.)
+  defp live_at(conn, path, connect_params) do
+    {:ok, view, _html} =
+      conn |> recycle() |> put_connect_params(connect_params) |> live(path)
+
+    view
+  end
+
+  # What a current bundle sends on join. `app.js` puts the key there, and only
+  # a bundle carrying the PullToRefresh hook can — see
+  # `VutuvWeb.Live.PullRefresh`.
+  @current %{"pull_refresh" => true}
+
+  describe "the feed" do
+    test "offers the gesture and re-runs its query on the push", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      author = insert(:user, email_confirmed?: true)
+      Social.follow(user, author.id)
+
+      view = live_at(conn, ~p"/feed", @current)
+      # On its own wrapper, not on `#feed` itself: `#feed` carries `FeedUrl`
+      # since v7.600.0, and LiveView reads `phx-hook` as a single name.
+      assert has_element?(view, ~s(#feed-pull[phx-hook="PullToRefresh"]))
+
+      # A bare row: `Posts.create_post/2` would broadcast and the open feed
+      # would take it live, which would prove nothing about the refresh.
+      insert(:post, user: author, body: "gezogen, nicht geschoben")
+      refute render(view) =~ "gezogen, nicht geschoben"
+
+      render_hook(view, "pwa:refresh", %{})
+      assert render(view) =~ "gezogen, nicht geschoben"
+    end
+  end
+
+  describe "notifications" do
+    test "offers the gesture and reloads the list on the push", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      view = live_at(conn, ~p"/notifications", @current)
+      assert has_element?(view, ~s(#notifications[phx-hook="PullToRefresh"]))
+
+      # `follow!/2` inserts the edge without `Social.follow/2`'s broadcast, so
+      # the open page cannot have seen it arrive.
+      follower = insert(:user, first_name: "Nachgezogen", last_name: "Test")
+      follow!(follower, user)
+      refute render(view) =~ "Nachgezogen"
+
+      render_hook(view, "pwa:refresh", %{})
+      assert render(view) =~ "Nachgezogen"
+    end
+  end
+
+  describe "messages" do
+    # This page is a full-viewport chat: the document does not scroll, the
+    # conversation list is its own scroll container, and a gesture that engaged
+    # on the wrong element would be worse than none. So the hook sits on the
+    # list and says so.
+    test "arms the conversation list, not the page", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+
+      view = live_at(conn, ~p"/messages", @current)
+
+      assert has_element?(
+               view,
+               ~s(#conversations[phx-hook="PullToRefresh"][data-pull-scroller="self"])
+             )
+
+      refute has_element?(view, ~s(#messages[phx-hook="PullToRefresh"]))
+    end
+
+    test "reloads the conversation list on the push", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      other = insert(:user, first_name: "Nachzuegler", last_name: "Test")
+
+      view = live_at(conn, ~p"/messages", @current)
+      refute render(view) =~ "Nachzuegler"
+
+      conversation = insert_conversation_between(other, user)
+      {:ok, _} = Chat.send_message(other, conversation.id, "spaet dran")
+
+      render_hook(view, "pwa:refresh", %{})
+      assert render(view) =~ "Nachzuegler"
+    end
+  end
+
+  # One test for all three pages: a browser whose bundle predates the hook is
+  # not a per-page condition, it is the same claim missing from the join, and
+  # three copies of it only made the list of pages harder to extend.
+  test "no page offers the gesture to a bundle that predates the hook", %{conn: conn} do
+    {conn, _user} = create_and_login_user(conn)
+
+    for {path, id} <- [
+          {~p"/feed", "feed-pull"},
+          {~p"/notifications", "notifications"},
+          {~p"/messages", "conversations"}
+        ] do
+      view = live_at(conn, path, %{})
+
+      assert has_element?(view, "##{id}"), "#{path} did not render at all"
+      refute has_element?(view, ~s(##{id}[phx-hook="PullToRefresh"]))
+    end
+  end
+
+  describe "the client half a LiveView test cannot reach" do
+    test "the bundle declares the capability the gate reads" do
+      assert_bundle_capability("pull_refresh", "PullToRefresh")
+    end
+
+    # The one mistake this feature exists to avoid. `location.reload()` throws
+    # away the LiveView, rebuilds the socket and re-fetches the whole document,
+    # so the "refresh" costs more than the state it refreshes — on a slow line,
+    # worse than not having the gesture at all.
+    test "the gesture ends in a socket push, never a page reload" do
+      # Comments stripped first: the file explains at length why the reload is
+      # wrong, and naming the mistake must not count as making it.
+      code =
+        "assets/js/pull_to_refresh.js"
+        |> File.read!()
+        |> String.replace(~r{^\s*//.*$}m, "")
+
+      refute code =~ ~r/location\s*\.\s*reload/,
+             "pull-to-refresh must push `pwa:refresh` over the socket, not reload the page"
+
+      assert code =~ ~S|pushEvent("pwa:refresh"|,
+             "the release has to push the event whichever LiveView owns the list handles"
+
+      assert code =~ "passive: false",
+             "the touchmove listener has to be non-passive, or the native scroll cannot be prevented"
+    end
+
+    # The two states a pull-to-refresh gets wrong, neither of which shows up in
+    # a screenshot: a list that is already scrolled down, and a pull the finger
+    # abandons half way. Both are decided in the client, so they are asserted
+    # here rather than through the socket — the LiveView only ever sees the
+    # event that these guards decide not to send.
+    test "a list that is already scrolled never starts the gesture" do
+      code = js()
+
+      # The guard has to sit in `begin`, before any state is built: a pull that
+      # starts mid-list belongs to the browser's own scrolling, and stealing it
+      # would fight the scroll the reader actually asked for.
+      begin_body = body_of(code, "begin(e) {")
+
+      assert begin_body =~ ~r/if\s*\(!this\.atTop\(\)\)\s*return/,
+             "begin() must bail out unless the scroller is at the top"
+
+      assert code =~ ~r/atTop\(\)\s*\{\s*return this\.scroller\.scrollTop <= 0/,
+             "atTop/0 must read the scroller's own scrollTop, not the window's"
+
+      # And again during the pull: momentum can carry the container off the top
+      # between two frames, and from there on the gesture is not ours either.
+      track_body = body_of(code, "track(e) {")
+
+      assert track_body =~ ~r/if\s*\(!this\.atTop\(\)\)\s*return this\.collapse\(\)/,
+             "track() must collapse if the list has scrolled away from the top mid-pull"
+    end
+
+    test "a pull released below the threshold refreshes nothing" do
+      code = js()
+      release_body = body_of(code, "release() {")
+
+      # `crossed` is set in track() at the moment the threshold is passed, so
+      # release() reads a decision already made rather than re-measuring a
+      # distance the finger may have given back.
+      assert release_body =~ ~r/const armed = this\.pull\.crossed/,
+             "release() must read the crossed flag, not re-measure the distance"
+
+      assert release_body =~ ~r/if\s*\(!armed\)\s*return this\.collapse\(\)/,
+             "an unarmed release must collapse and return before any pushEvent"
+
+      # The push must sit *after* that early return, or an abandoned pull would
+      # still refresh the list.
+      [before_push, _] = String.split(release_body, ~S|pushEvent("pwa:refresh"|, parts: 2)
+
+      assert before_push =~ "if (!armed) return this.collapse()",
+             "the unarmed guard has to precede the push, not follow it"
+
+      # An interrupted gesture is not only a short pull: the system can take the
+      # touch away (a call, a notification, the edge-swipe back). touchcancel
+      # has to end the pull the same way touchend does.
+      assert code =~ ~S|addEventListener("touchcancel", this.onEnd)|,
+             "touchcancel must run the same release path as touchend"
+    end
+  end
+
+  defp js, do: File.read!("assets/js/pull_to_refresh.js")
+
+  # The body of one object-literal method, from its opening line to the closing
+  # brace at the same indentation. Cheap on purpose: it only has to keep an
+  # assertion about `begin` from being satisfied by a line in `track`.
+  defp body_of(code, header) do
+    [_, rest] = String.split(code, header, parts: 2)
+    [body, _] = String.split(rest, "\n  },", parts: 2)
+    body
+  end
+end


### PR DESCRIPTION
**Gap:** pulling a list down on a phone did nothing. That gesture is how people ask "is that really everything?", and no push channel answers that question — posts arrive over PubSub, but nothing confirms you have seen them all.

**Change:** a new hook (`assets/js/pull_to_refresh.js`) plus one `handle_event("pwa:refresh", …)` each in `PostLive.Feed`, `MessageLive.Index` and `NotificationLive.Index`. The release is a socket round trip, never `location.reload()` — a reload throws away the LiveView and re-fetches the document to refresh state the socket already owns. Opt-in per page: a LiveView that does not handle the event never renders the hook.

**Not included:** the visible refresh paths a page already has. The gesture is unreachable by keyboard and screen reader, so it is an addition, not a replacement.

**Verified:** tests cover the two states a still cannot show — a list already scrolled, and a pull abandoned mid-way — each calibrated against its removed guard. Driven end to end with synthetic touch events in Chrome. Screenshot in the comment below.

Closes #1730.

*An AI agent wrote this text in my name. I know that is problematic.*
