### PR TITLE
refactor(core): one Vutuv.EtsCache for five copies of the ETS-owner GenServer [5m]

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -70,6 +70,12 @@ installing and operating vutuv in [Running your own vutuv](../ADMINS.md).
   exception is the people counter — the top bar's total of members here plus
   the Fediverse accounts following them — which shows the **exact** figure via
   `delimited_count/1` so it visibly ticks (see [realtime.md](realtime.md))
+- **In-memory caches**: every ETS-backed cache is a GenServer that owns one
+  named table and shares one shell, `use Vutuv.EtsCache` — its moduledoc is the
+  reference for the options. The rule worth knowing from here: a cold cache is
+  never an error. Reads go through `EtsCache.fetch/2` / `lookup/2`, which answer
+  a **miss** rather than raising when the table is not up yet, and every caller
+  has the direct query the cache exists to spare
 - **Ids**: all database ids are UUID v7 (`Vutuv.UUIDv7`): time-ordered, minted
   in the app, never integers or UUID v4.
 

--- a/lib/vutuv/ets_cache.ex
+++ b/lib/vutuv/ets_cache.ex
@@ -1,0 +1,139 @@
+defmodule Vutuv.EtsCache do
+  @moduledoc """
+  The shell every ETS-backed cache in this application shares: a GenServer that
+  owns one named table, and reads that answer a **miss** rather than crashing
+  when the table is not there.
+
+  `use Vutuv.EtsCache, access: :protected` generates the `start_link/1` and the
+  private `open_table/1` that the module's own `init/1` calls with the table it
+  wants. The reads are the plain functions `fetch/2` and `lookup/2` here. What
+  stays with each cache is what actually differs: its payload, its refresh
+  policy, and what it does with a miss.
+
+  ## Two questions, two options
+
+  **`access:` is the ETS access level — who may write.** `:protected` means the
+  owning GenServer writes and every process reads, which is what a snapshot
+  cache wants; `:public` means any process writes.
+
+  **`created_by:` is who calls `:ets.new/2`, and it is a separate question.**
+  The default `:owner` creates the table outright, so a second owner of the same
+  name raises at `init/1` instead of quietly sharing a table it may not be able
+  to write. `:any_process` (public tables only) is race-tolerant — an existing
+  table is reused and a lost creation race counts as success — and is for the
+  cache whose readers may need the table before the owner has started. Most
+  public caches do not want it: one that is written only from its own module
+  keeps the duplicate-owner check.
+
+  ## Why a miss and not a crash
+
+  Reading a table that does not exist raises `ArgumentError`, so a cold cache —
+  application boot, a test that never started the owner, a script running
+  without the supervision tree — would turn into a 500 at the reader. `fetch/2`
+  and `lookup/2` answer `:miss` and `[]` instead; every caller already owns the
+  fallback a cold cache needs, the direct query the cache exists to spare. A
+  cache that writes from outside its own process, or reads with something other
+  than `:ets.lookup/2`, still rescues at that call site.
+
+  ## Isolated instances in tests
+
+  `name: nil` starts the cache unregistered, beside the application singleton.
+  That isolates the **process**. Isolating the **table** takes a `table:` that
+  the cache's own `init/1` reads and hands to `open_table/1` — which the
+  snapshot-shaped caches do, and which a cache whose readers name the table at
+  module level cannot offer.
+  """
+
+  @doc """
+  The value stored under `key` as `{:ok, value}`, or `:miss` when the row is
+  absent or the table does not exist. For the `{key, value}` rows a snapshot
+  cache stores; reach for `lookup/2` when the row carries more than that.
+  """
+  def fetch(table, key) do
+    case lookup(table, key) do
+      [{^key, value}] -> {:ok, value}
+      [] -> :miss
+    end
+  end
+
+  @doc """
+  `:ets.lookup/2`, except that a table which does not exist answers `[]` the
+  same way an empty one does. For rows the caller has to read itself — an
+  expiry stamp beside the value, say.
+  """
+  def lookup(table, key) do
+    :ets.lookup(table, key)
+  rescue
+    ArgumentError -> []
+  end
+
+  # The two openers `open_table/1` binds to; public only because generated code
+  # calls them across the module boundary, and hidden from the docs so a cache
+  # reaches them through `use` rather than opening its table on its own terms.
+  @doc false
+  def open(name, access), do: :ets.new(name, options(access))
+
+  @doc false
+  def ensure(name, access) do
+    case :ets.whereis(name) do
+      :undefined ->
+        try do
+          open(name, access)
+        rescue
+          # Lost the race to another process creating it, which is the point.
+          ArgumentError -> name
+        end
+
+      _tid ->
+        name
+    end
+  end
+
+  # Only the owner writes a protected table, so there is no write concurrency
+  # to buy there; a public one is written by whoever holds the caller's process.
+  defp options(:protected), do: [:named_table, :protected, :set, read_concurrency: true]
+
+  defp options(:public),
+    do: [:named_table, :public, :set, read_concurrency: true, write_concurrency: true]
+
+  defmacro __using__(opts) do
+    access = Keyword.fetch!(opts, :access)
+    created_by = Keyword.get(opts, :created_by, :owner)
+
+    if access not in [:public, :protected] do
+      raise ArgumentError, "access: must be :public or :protected, got: #{inspect(access)}"
+    end
+
+    if created_by not in [:owner, :any_process] do
+      raise ArgumentError,
+            "created_by: must be :owner or :any_process, got: #{inspect(created_by)}"
+    end
+
+    if created_by == :any_process and access == :protected do
+      raise ArgumentError,
+            "created_by: :any_process needs access: :public — a process that may not " <>
+              "write the table has no business creating it"
+    end
+
+    opener = if created_by == :any_process, do: :ensure, else: :open
+
+    quote do
+      use GenServer
+
+      @doc """
+      Starts the cache. `name: nil` starts it unregistered; every other option
+      is passed on to `init/1`.
+      """
+      def start_link(opts \\ []) do
+        {name, opts} = Keyword.pop(opts, :name, __MODULE__)
+        gen_opts = if name, do: [name: name], else: []
+        GenServer.start_link(__MODULE__, opts, gen_opts)
+      end
+
+      # Opens the cache's table and returns it.
+      defp open_table(name \\ __MODULE__) do
+        unquote(__MODULE__).unquote(opener)(name, unquote(access))
+      end
+    end
+  end
+end

--- a/lib/vutuv/posts/top_posters.ex
+++ b/lib/vutuv/posts/top_posters.ex
@@ -16,7 +16,10 @@ defmodule Vutuv.Posts.TopPosters do
   transparently falls back to the live query, so behaviour is unchanged, only
   cheaper. The per-viewer exclusions stay per-request in the profile.
   """
-  use GenServer
+
+  use Vutuv.EtsCache, access: :protected
+
+  alias Vutuv.EtsCache
 
   @table __MODULE__
   # The one posting window the profile asks for; any other window is a :miss.
@@ -40,32 +43,15 @@ defmodule Vutuv.Posts.TopPosters do
   def top(days, limit, _table) when days != @window_days or limit > @pool_size, do: :miss
 
   def top(_days, limit, table) do
-    case :ets.lookup(table, :pool) do
-      [{:pool, users}] -> {:ok, Enum.take(users, limit)}
-      [] -> :miss
-    end
-  rescue
-    ArgumentError -> :miss
+    with {:ok, users} <- EtsCache.fetch(table, :pool), do: {:ok, Enum.take(users, limit)}
   end
 
   @doc "Recompute the snapshot now (synchronous; used by tests)."
   def refresh(server \\ __MODULE__), do: GenServer.call(server, :refresh)
 
-  def start_link(opts \\ []) do
-    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
-    # `name: nil` (isolated test instances) starts the process unregistered.
-    gen_opts = if name, do: [name: name], else: []
-    GenServer.start_link(__MODULE__, opts, gen_opts)
-  end
-
   @impl true
   def init(opts) do
-    table =
-      :ets.new(Keyword.get(opts, :table, @table), [
-        :named_table,
-        :protected,
-        read_concurrency: true
-      ])
+    table = open_table(Keyword.get(opts, :table, @table))
 
     interval = Keyword.get(opts, :refresh_interval, @refresh_interval)
 

--- a/lib/vutuv/rate_limiter.ex
+++ b/lib/vutuv/rate_limiter.ex
@@ -12,16 +12,15 @@ defmodule Vutuv.RateLimiter do
   enumeration mitigation the issue asks for; it is not a distributed quota.
   """
 
-  use GenServer
+  # Every request process counts its own hits, and whichever gets there first
+  # creates the table — including before (or without) this GenServer, which is
+  # what lets a unit test call `hit/3` with nothing supervised.
+  use Vutuv.EtsCache, access: :public, created_by: :any_process
 
   @table __MODULE__
   @sweep_interval :timer.minutes(5)
 
   # ── Public API ──
-
-  def start_link(opts) do
-    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
-  end
 
   @doc """
   Records one hit for `key` and returns `:ok` while at or under `limit` within
@@ -42,13 +41,13 @@ defmodule Vutuv.RateLimiter do
   """
   def hit_remaining(key, limit, window_ms)
       when is_integer(limit) and limit > 0 and is_integer(window_ms) and window_ms > 0 do
-    ensure_table()
+    table = open_table()
     now = System.system_time(:millisecond)
     window = div(now, window_ms)
     window_end = (window + 1) * window_ms
     bucket = {key, window}
 
-    count = :ets.update_counter(@table, bucket, {2, 1}, {bucket, 0, window_end})
+    count = :ets.update_counter(table, bucket, {2, 1}, {bucket, 0, window_end})
 
     if count <= limit, do: {:ok, limit - count}, else: {:error, :rate_limited}
   end
@@ -60,11 +59,11 @@ defmodule Vutuv.RateLimiter do
   member's cold-outreach counter — without moving the counter.
   """
   def peek(key, window_ms) when is_integer(window_ms) and window_ms > 0 do
-    ensure_table()
+    table = open_table()
     now = System.system_time(:millisecond)
     window = div(now, window_ms)
 
-    case :ets.lookup(@table, {key, window}) do
+    case :ets.lookup(table, {key, window}) do
       [{_bucket, count, _window_end}] -> count
       [] -> 0
     end
@@ -73,8 +72,7 @@ defmodule Vutuv.RateLimiter do
   @doc false
   # Test helper: forget every recorded hit.
   def reset do
-    ensure_table()
-    :ets.delete_all_objects(@table)
+    :ets.delete_all_objects(open_table())
     :ok
   end
 
@@ -82,7 +80,7 @@ defmodule Vutuv.RateLimiter do
 
   @impl true
   def init(_opts) do
-    ensure_table()
+    open_table()
     schedule_sweep()
     {:ok, %{}}
   end
@@ -95,27 +93,6 @@ defmodule Vutuv.RateLimiter do
   end
 
   # ── Internals ──
-
-  defp ensure_table do
-    case :ets.whereis(@table) do
-      :undefined ->
-        try do
-          :ets.new(@table, [
-            :named_table,
-            :public,
-            :set,
-            read_concurrency: true,
-            write_concurrency: true
-          ])
-        rescue
-          # Lost a race with another process creating the table; that is fine.
-          ArgumentError -> @table
-        end
-
-      _tid ->
-        @table
-    end
-  end
 
   defp sweep do
     now = System.system_time(:millisecond)

--- a/lib/vutuv/social/popular_users.ex
+++ b/lib/vutuv/social/popular_users.ex
@@ -18,7 +18,10 @@ defmodule Vutuv.Social.PopularUsers do
   and `Social.most_followed_users/1` transparently falls back to the query,
   so behaviour is unchanged, only cheaper.
   """
-  use GenServer
+
+  use Vutuv.EtsCache, access: :protected
+
+  alias Vutuv.EtsCache
 
   @table __MODULE__
   @pool_size 1000
@@ -36,32 +39,15 @@ defmodule Vutuv.Social.PopularUsers do
   def top(limit, _table) when limit > @pool_size, do: :miss
 
   def top(limit, table) do
-    case :ets.lookup(table, :pool) do
-      [{:pool, users}] -> {:ok, Enum.take(users, limit)}
-      [] -> :miss
-    end
-  rescue
-    ArgumentError -> :miss
+    with {:ok, users} <- EtsCache.fetch(table, :pool), do: {:ok, Enum.take(users, limit)}
   end
 
   @doc "Recompute the snapshot now (synchronous; used by tests)."
   def refresh(server \\ __MODULE__), do: GenServer.call(server, :refresh)
 
-  def start_link(opts \\ []) do
-    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
-    # `name: nil` (isolated test instances) starts the process unregistered.
-    gen_opts = if name, do: [name: name], else: []
-    GenServer.start_link(__MODULE__, opts, gen_opts)
-  end
-
   @impl true
   def init(opts) do
-    table =
-      :ets.new(Keyword.get(opts, :table, @table), [
-        :named_table,
-        :protected,
-        read_concurrency: true
-      ])
+    table = open_table(Keyword.get(opts, :table, @table))
 
     interval = Keyword.get(opts, :refresh_interval, @refresh_interval)
 

--- a/lib/vutuv/social_feed/cache.ex
+++ b/lib/vutuv/social_feed/cache.ex
@@ -23,10 +23,12 @@ defmodule Vutuv.SocialFeed.Cache do
   does no work until a page requests a fetch, and the per-provider feature
   flags gate that in tests).
   """
-  use GenServer
+
+  use Vutuv.EtsCache, access: :protected
 
   require Logger
 
+  alias Vutuv.EtsCache
   alias Vutuv.SocialFeed
   alias Vutuv.SocialFeed.Feed
 
@@ -43,15 +45,13 @@ defmodule Vutuv.SocialFeed.Cache do
   yet). A caller-side ETS read; expired rows are left for the sweep.
   """
   def lookup({_provider, _handle} = key, table \\ @table) do
-    case :ets.lookup(table, key) do
+    case EtsCache.lookup(table, key) do
       [{^key, result, expires_at}] ->
         if System.monotonic_time(:millisecond) < expires_at, do: result, else: :miss
 
       [] ->
         :miss
     end
-  rescue
-    ArgumentError -> :miss
   end
 
   @doc """
@@ -66,21 +66,9 @@ defmodule Vutuv.SocialFeed.Cache do
   @doc "Drops every cached entry (tests)."
   def reset(server \\ __MODULE__), do: GenServer.call(server, :reset)
 
-  def start_link(opts \\ []) do
-    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
-    # `name: nil` (isolated test instances) starts the process unregistered.
-    gen_opts = if name, do: [name: name], else: []
-    GenServer.start_link(__MODULE__, opts, gen_opts)
-  end
-
   @impl true
   def init(opts) do
-    table =
-      :ets.new(Keyword.get(opts, :table, @table), [
-        :named_table,
-        :protected,
-        read_concurrency: true
-      ])
+    table = open_table(Keyword.get(opts, :table, @table))
 
     state = %{
       table: table,

--- a/lib/vutuv_web/live/mount_handoff.ex
+++ b/lib/vutuv_web/live/mount_handoff.ex
@@ -37,7 +37,10 @@ defmodule VutuvWeb.Live.MountHandoff do
   load per visit.
   """
 
-  use GenServer
+  # Public because the dead render stashes from the request process; the table
+  # is still this GenServer's to create, so a second owner raises rather than
+  # sharing (`stash/4` and `take/2` rescue instead of creating).
+  use Vutuv.EtsCache, access: :public
 
   @table __MODULE__
   @ttl_ms 15_000
@@ -87,20 +90,9 @@ defmodule VutuvWeb.Live.MountHandoff do
 
   ## Table owner + sweeper
 
-  def start_link(_opts) do
-    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
-  end
-
   @impl true
-  def init(nil) do
-    :ets.new(@table, [
-      :named_table,
-      :public,
-      :set,
-      read_concurrency: true,
-      write_concurrency: true
-    ])
-
+  def init(_opts) do
+    open_table()
     schedule_sweep()
     {:ok, nil}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.610.0",
+      version: "7.614.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/ets_cache_test.exs
+++ b/test/vutuv/ets_cache_test.exs
@@ -1,0 +1,151 @@
+defmodule Vutuv.EtsCacheTest.Snapshot do
+  @moduledoc false
+  use Vutuv.EtsCache, access: :protected
+
+  alias Vutuv.EtsCache
+
+  @table __MODULE__
+
+  def top(table \\ @table), do: EtsCache.fetch(table, :pool)
+
+  def put(server, value), do: GenServer.call(server, {:put, value})
+
+  @impl true
+  def init(opts), do: {:ok, %{table: open_table(Keyword.get(opts, :table, @table))}}
+
+  @impl true
+  def handle_call({:put, value}, _from, state) do
+    :ets.insert(state.table, {:pool, value})
+    {:reply, :ok, state}
+  end
+end
+
+defmodule Vutuv.EtsCacheTest.Counter do
+  @moduledoc false
+  use Vutuv.EtsCache, access: :public, created_by: :any_process
+
+  @doc "The reader-side lazy create a `created_by: :any_process` cache leans on."
+  def ensure(name \\ __MODULE__), do: open_table(name)
+
+  # Nothing starts this one; the stub only satisfies the GenServer behaviour.
+  @impl true
+  def init(_opts), do: {:ok, %{}}
+end
+
+defmodule Vutuv.EtsCacheTest do
+  use ExUnit.Case, async: true
+
+  alias Vutuv.EtsCache
+  alias Vutuv.EtsCacheTest.Counter
+  alias Vutuv.EtsCacheTest.Snapshot
+
+  defp unique_table(prefix), do: :"#{prefix}_#{System.unique_integer([:positive])}"
+
+  describe "reads without a table" do
+    test "fetch/2 answers :miss instead of raising" do
+      assert EtsCache.fetch(:vutuv_ets_cache_test_no_such_table, :pool) == :miss
+    end
+
+    test "lookup/2 answers [] instead of raising" do
+      assert EtsCache.lookup(:vutuv_ets_cache_test_no_such_table, :pool) == []
+    end
+  end
+
+  describe "reads with a table" do
+    setup do
+      table = :ets.new(unique_table("rows"), [:set])
+      :ets.insert(table, {:pool, [1, 2, 3]})
+      :ets.insert(table, {:stamped, :value, 42})
+      %{table: table}
+    end
+
+    test "fetch/2 unwraps a {key, value} row", %{table: table} do
+      assert EtsCache.fetch(table, :pool) == {:ok, [1, 2, 3]}
+    end
+
+    test "fetch/2 answers :miss for a key the table does not hold", %{table: table} do
+      assert EtsCache.fetch(table, :absent) == :miss
+    end
+
+    test "lookup/2 hands a wider row back whole", %{table: table} do
+      assert EtsCache.lookup(table, :stamped) == [{:stamped, :value, 42}]
+    end
+  end
+
+  describe "the table an access level opens" do
+    test "a public table carries both concurrency hints, a protected one only the read hint" do
+      public = EtsCache.open(unique_table("hints_public"), :public)
+      protected = EtsCache.open(unique_table("hints_protected"), :protected)
+
+      assert :ets.info(public, :write_concurrency) == true
+      assert :ets.info(protected, :write_concurrency) == false
+      assert :ets.info(public, :protection) == :public
+      assert :ets.info(protected, :protection) == :protected
+    end
+  end
+
+  describe "the generated start_link/1" do
+    test "registers the module's own name by default" do
+      {:ok, pid} = start_supervised({Snapshot, table: unique_table("registered")})
+
+      assert Process.whereis(Snapshot) == pid
+    end
+
+    test "`name: nil` starts an unregistered instance" do
+      start_supervised!({Snapshot, name: nil, table: unique_table("isolated")})
+
+      assert Process.whereis(Snapshot) == nil
+    end
+
+    test "the table `init/1` opens is the one it was handed" do
+      table = unique_table("injected")
+      pid = start_supervised!({Snapshot, name: nil, table: table})
+
+      assert :ok = Snapshot.put(pid, [:one])
+      assert Snapshot.top(table) == {:ok, [:one]}
+      # The module-named table was never created, so its reader still misses.
+      assert Snapshot.top() == :miss
+    end
+  end
+
+  describe "created_by:" do
+    test "the default owner refuses a second owner of the same table" do
+      table = unique_table("owner")
+      start_supervised!({Snapshot, name: nil, table: table})
+
+      Process.flag(:trap_exit, true)
+      # `:ets.new/2` refuses the taken name; Elixir spells that badarg
+      # `ArgumentError` where it is rescued, but an exit reason carries it raw.
+      assert {:error, {:badarg, _stack}} = Snapshot.start_link(name: nil, table: table)
+    end
+
+    test ":any_process reuses a table that is already there" do
+      table = unique_table("any_process")
+
+      assert Counter.ensure(table) == table
+      assert Counter.ensure(table) == table
+    end
+  end
+
+  describe "the use options are checked at compile time" do
+    test "an unknown access is refused" do
+      assert_raise ArgumentError, ~r/must be :public or :protected/, fn ->
+        Code.eval_string("""
+        defmodule Vutuv.EtsCacheTest.BadAccess do
+          use Vutuv.EtsCache, access: :secret
+        end
+        """)
+      end
+    end
+
+    test "a protected table may not be created by any process" do
+      assert_raise ArgumentError, ~r/needs access: :public/, fn ->
+        Code.eval_string("""
+        defmodule Vutuv.EtsCacheTest.BadPolicy do
+          use Vutuv.EtsCache, access: :protected, created_by: :any_process
+        end
+        """)
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Symptom:** Five GenServers each spelled out the same `start_link/1`, the same `init/1` table creation and the same `rescue ArgumentError -> :miss` read shell — five places to touch for any change to how these tables are owned.

**Change:** New `lib/vutuv/ets_cache.ex`. `use Vutuv.EtsCache, access: :protected | :public` generates `start_link/1` and the `open_table/1` that `init/1` calls; reads go through `EtsCache.fetch/2` and `lookup/2`. `created_by:` keeps "who may write" apart from "who calls `:ets.new/2`" — only `RateLimiter` needs it. Converted: `RateLimiter`, `Social.PopularUsers`, `Posts.TopPosters`, `SocialFeed.Cache`, `Live.MountHandoff`. No behaviour change; cold deploy.

**Not included:** the shared refresh loop (#1763) and the per-hit table probe (#1765, #1772) — each its own change.

**Merge order:** this one before #1772. It ports that probe unchanged, so landing it second would silently undo #1772. #1712 adds `Uploads.AvatarCache`; whoever lands second converts it.

**Verified:** `mix precommit` green; the four cache test files 29/29.

Closes #1747.

*An AI agent wrote this text in my name. I know that is problematic.*
