### PR TITLE
Let a push to the GitHub wiki past the precommit gate

### DIFF
--- a/.claude/hooks/precommit-before-push.sh
+++ b/.claude/hooks/precommit-before-push.sh
@@ -178,8 +178,20 @@ toplevel=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null)
 [ -n "$toplevel" ] ||
   block "cannot tell which git worktree this push comes from (looked in: ${dir:-<empty>}). Refusing to guess."
 
-[ -f "$toplevel/mix.exs" ] ||
+# A GitHub wiki lives in a repository of its own (`<repo>.wiki.git`) and can
+# never hold a mix.exs: no suite, no CI, no deploy, so precommit has nothing to
+# vouch for here and the gate would only make a wiki page unpublishable. Scoped
+# to that one shape, the remote URL ENDING in `.wiki.git`, and a remote that
+# cannot be read is not an exemption but an unanswered question, so it falls
+# through to the block below.
+if [ ! -f "$toplevel/mix.exs" ]; then
+  origin=$(git -C "$toplevel" remote get-url origin 2>/dev/null)
+  case "$origin" in
+    *.wiki.git) allow ;;
+  esac
+
   block "$toplevel is not the vutuv project root (no mix.exs), so the precommit gate cannot vouch for this push."
+fi
 
 if [ "$explain" -eq 1 ]; then
   echo "PUSH $toplevel"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.381.3",
+      version: "7.393.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/precommit_hook_test.exs
+++ b/test/vutuv/precommit_hook_test.exs
@@ -90,14 +90,10 @@ defmodule Vutuv.PrecommitHookTest do
 
     test "a push from a tree that is not the project blocks", ctx do
       # Resolvable as a git repo is not enough — it must be the vutuv checkout,
-      # or precommit would vouch for the wrong thing.
-      tmp =
-        System.tmp_dir!()
-        |> Path.join("precommit-hook-test-#{System.unique_integer([:positive])}")
-
-      File.mkdir_p!(tmp)
-      on_exit(fn -> File.rm_rf!(tmp) end)
-      {_, 0} = System.cmd("git", ["init", "--quiet", tmp])
+      # or precommit would vouch for the wrong thing. This repository has no
+      # remote, so it is also the degraded path of the wiki exemption below:
+      # an unreadable remote is an unanswered question, not an exemption.
+      tmp = tmp_repo()
 
       decision = decide(ctx, "git -C #{tmp} push")
 
@@ -115,6 +111,34 @@ defmodule Vutuv.PrecommitHookTest do
       # A harmless command still gets through, so a missing jq does not brick
       # every Bash call in the session.
       assert decide(ctx, "echo hello", path: path) == "ALLOW"
+    end
+  end
+
+  describe "the wiki exemption" do
+    # A GitHub wiki lives in a repository of its own (`<repo>.wiki.git`): no
+    # mix.exs, no suite, no deploy, so precommit has nothing to vouch for and
+    # the gate would make a wiki page unpublishable. The exemption is scoped to
+    # that one shape, and every other reading of it still blocks.
+    test "a push from a wiki clone is allowed, ssh or https", ctx do
+      ssh = tmp_repo(remote: "git@github.com:wintermeyer/vutuv.wiki.git")
+      https = tmp_repo(remote: "https://github.com/wintermeyer/vutuv.wiki.git")
+
+      assert decide(ctx, "git -C #{ssh} push origin master") == "ALLOW"
+      assert decide(ctx, "git -C #{https} push") == "ALLOW"
+    end
+
+    test "a remote that only looks like one still blocks", ctx do
+      # Calibration against a false positive: the URL has to *end* in
+      # `.wiki.git`, not merely mention it. The repository with no remote at
+      # all is the test above this describe block.
+      backup = tmp_repo(remote: "git@github.com:wintermeyer/vutuv.wiki.git.backup")
+      foreign = tmp_repo(remote: "git@github.com:someone/something.git")
+
+      decision = decide(ctx, "git -C #{backup} push")
+
+      assert decision =~ "BLOCK", "expected a block, got: #{decision}"
+      assert decision =~ "not the vutuv project root"
+      assert decide(ctx, "git -C #{foreign} push") =~ "BLOCK"
     end
   end
 
@@ -146,6 +170,27 @@ defmodule Vutuv.PrecommitHookTest do
       System.cmd("sh", ["-c", script], cd: ctx.root, env: env, stderr_to_stdout: true)
 
     String.trim(out)
+  end
+
+  # A throwaway git repository, optionally carrying an `origin` remote.
+  defp tmp_repo(opts \\ []) do
+    tmp =
+      System.tmp_dir!()
+      |> Path.join("precommit-hook-test-#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(tmp)
+    on_exit(fn -> File.rm_rf!(tmp) end)
+    {_, 0} = System.cmd("git", ["init", "--quiet", tmp])
+
+    case Keyword.fetch(opts, :remote) do
+      {:ok, url} ->
+        {_, 0} = System.cmd("git", ["-C", tmp, "remote", "add", "origin", url])
+
+      :error ->
+        :ok
+    end
+
+    tmp
   end
 
   defp shell_quote(value), do: "'" <> String.replace(value, "'", ~S('\'')) <> "'"


### PR DESCRIPTION
**Symptom:** the pre-push gate blocks every push from a tree without `mix.exs`. A GitHub wiki is a repository of its own (`vutuv.wiki.git`) and can never have one, so a wiki page could not be published at all.

**Change:** `.claude/hooks/precommit-before-push.sh` now allows a push whose `origin` URL ends in `.wiki.git`. No suite, no CI and no deploy sit behind such a repo, so precommit has nothing to vouch for there. Everything else still blocks, an unreadable remote included.

`test/vutuv/precommit_hook_test.exs` covers both directions: the wiki clone over ssh and https is allowed, `vutuv.wiki.git.backup` and a foreign remote are not. Calibrated by watching the allow cases fail before the hook change.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01LKtRysRJGyoKSGPcjRCXt4