### PR TITLE
refactor(core): one Vutuv.EtsCache.Snapshot for the copied refresh loop [5m after #1757]

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -70,6 +70,16 @@ installing and operating vutuv in [Running your own vutuv](../ADMINS.md).
   exception is the people counter — the top bar's total of members here plus
   the Fediverse accounts following them — which shows the **exact** figure via
   `delimited_count/1` so it visibly ticks (see [realtime.md](realtime.md))
+- **In-memory caches**: every ETS-backed cache is a GenServer that owns one
+  named table and shares one shell, `Vutuv.EtsCache` (its moduledoc is the
+  reference): `use Vutuv.EtsCache, access: :protected | :public` generates the
+  `start_link/1` and the `open_table/1` the module's `init/1` calls, and the
+  reads go through `EtsCache.fetch/2` / `lookup/2`, which answer a **miss**
+  rather than raising when the table is not up yet. Its two options answer two
+  questions — `access:` is who may write, `created_by:` is who calls
+  `:ets.new/2` — and a cache whose readers may need the table before the
+  GenServer has it sets `created_by: :any_process`. A cold cache is never an
+  error: every caller has the direct query the cache exists to spare
 - **Ids**: all database ids are UUID v7 (`Vutuv.UUIDv7`): time-ordered, minted
   in the app, never integers or UUID v4.
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -79,7 +79,14 @@ installing and operating vutuv in [Running your own vutuv](../ADMINS.md).
   questions — `access:` is who may write, `created_by:` is who calls
   `:ets.new/2` — and a cache whose readers may need the table before the
   GenServer has it sets `created_by: :any_process`. A cold cache is never an
-  error: every caller has the direct query the cache exists to spare
+  error: every caller has the direct query the cache exists to spare. They all
+  tick; what differs is what the tick does. The ones whose contents are a pure
+  function of the database throw the whole table away and rebuild it, and those
+  add `Vutuv.EtsCache.Snapshot` on top — `refresh_every:` plus a `refresh_flag:`
+  naming the `config :vutuv` switch that stops the timer in tests — and
+  implement its one `snapshot(table)` callback. The rest sweep rows other
+  processes wrote and would be destroyed by a rebuild, so they stay on plain
+  `Vutuv.EtsCache`
 - **Ids**: all database ids are UUID v7 (`Vutuv.UUIDv7`): time-ordered, minted
   in the app, never integers or UUID v4.
 

--- a/lib/vutuv/ets_cache.ex
+++ b/lib/vutuv/ets_cache.ex
@@ -1,0 +1,138 @@
+defmodule Vutuv.EtsCache do
+  @moduledoc """
+  The shell every ETS-backed cache in this application shares: a GenServer that
+  owns one named table, and reads that answer a **miss** rather than crashing
+  when the table is not there.
+
+  `use Vutuv.EtsCache, access: :protected` generates the `start_link/1` (whose
+  `name: nil` starts an unregistered instance, which is how a test runs one
+  beside the application singleton) and the private `open_table/1` that the
+  module's own `init/1` calls with the table it wants. The reads are the plain
+  functions `fetch/2` and `lookup/2` here. What stays with each cache is what
+  actually differs: its payload, its refresh policy, and what it does with a
+  miss.
+
+  ## Two questions, two options
+
+  **`access:` is the ETS access level — who may write.** `:protected` means the
+  owning GenServer writes and every process reads (what a snapshot cache wants);
+  `:public` means any process writes, which is also why a public table is
+  created with both concurrency hints and a protected one with only the read
+  hint.
+
+  **`created_by:` is who calls `:ets.new/2`, and it is a separate question.**
+  The default `:owner` creates the table outright, so a second owner of the same
+  name raises at `init/1` instead of quietly sharing a table it may not be able
+  to write. `:any_process` (public tables only) is race-tolerant — an existing
+  table is reused and a lost creation race counts as success — which is what
+  lets `Vutuv.RateLimiter`'s readers open the table before, or without, the
+  owner process. Most public caches do **not** want this: `VutuvWeb.Live.MountHandoff`
+  is written only from its own module, so it keeps the duplicate-owner check.
+
+  ## Why a miss and not a crash
+
+  Reading a table that does not exist raises `ArgumentError`, so a cold cache
+  (application boot, a test that never started the owner, a script running
+  without the supervision tree) would turn into a 500 at the reader. `fetch/2`
+  and `lookup/2` answer `:miss` and `[]` instead; every caller already owns the
+  fallback a cold cache needs — the direct query the cache exists to spare. A
+  cache that writes from outside its own process, or reads with something other
+  than `:ets.lookup/2`, still rescues at that call site (see `MountHandoff`).
+  """
+
+  @doc """
+  The value stored under `key` as `{:ok, value}`, or `:miss` when the row is
+  absent or the table does not exist. For the `{key, value}` rows a snapshot
+  cache stores; reach for `lookup/2` when the row carries more than that.
+  """
+  def fetch(table, key) do
+    case lookup(table, key) do
+      [{^key, value}] -> {:ok, value}
+      [] -> :miss
+    end
+  end
+
+  @doc """
+  `:ets.lookup/2`, except that a table which does not exist answers `[]` the
+  same way an empty one does. For rows the caller has to read itself — an
+  expiry stamp beside the value, say.
+  """
+  def lookup(table, key) do
+    :ets.lookup(table, key)
+  rescue
+    ArgumentError -> []
+  end
+
+  # The two openers `open_table/1` is bound to; public only because generated
+  # code calls them across the module boundary. The way in is `use`, so that a
+  # cache cannot quietly open its table on terms of its own.
+  @doc false
+  def open(name, access), do: :ets.new(name, options(access))
+
+  @doc false
+  def ensure(name, access) do
+    case :ets.whereis(name) do
+      :undefined ->
+        try do
+          :ets.new(name, options(access))
+        rescue
+          # Lost the race to another process creating it, which is the point.
+          ArgumentError -> name
+        end
+
+      _tid ->
+        name
+    end
+  end
+
+  # Only the owner writes a protected table, so there is no write concurrency
+  # to buy there; a public one is written by whoever holds the caller's process.
+  defp options(:protected), do: [:named_table, :protected, :set, read_concurrency: true]
+
+  defp options(:public),
+    do: [:named_table, :public, :set, read_concurrency: true, write_concurrency: true]
+
+  defmacro __using__(opts) do
+    access = Keyword.fetch!(opts, :access)
+    created_by = Keyword.get(opts, :created_by, :owner)
+
+    if access not in [:public, :protected] do
+      raise ArgumentError, "access: must be :public or :protected, got: #{inspect(access)}"
+    end
+
+    if created_by not in [:owner, :any_process] do
+      raise ArgumentError,
+            "created_by: must be :owner or :any_process, got: #{inspect(created_by)}"
+    end
+
+    if created_by == :any_process and access == :protected do
+      raise ArgumentError,
+            "created_by: :any_process needs access: :public — a process that may not " <>
+              "write the table has no business creating it"
+    end
+
+    opener = if created_by == :any_process, do: :ensure, else: :open
+
+    quote do
+      use GenServer
+
+      @doc """
+      Starts the cache. `name: nil` starts it unregistered, which is half of how
+      a test runs an isolated instance beside the application singleton — the
+      other half is a `table:` of its own, and only a cache whose `init/1` reads
+      that option has one. Every other option is passed on to `init/1`.
+      """
+      def start_link(opts \\ []) do
+        {name, opts} = Keyword.pop(opts, :name, __MODULE__)
+        gen_opts = if name, do: [name: name], else: []
+        GenServer.start_link(__MODULE__, opts, gen_opts)
+      end
+
+      # Opens the cache's table and returns it: the module's own name, unless
+      # `init/1` was handed another one (an isolated test instance).
+      defp open_table(name \\ __MODULE__) do
+        unquote(__MODULE__).unquote(opener)(name, unquote(access))
+      end
+    end
+  end
+end

--- a/lib/vutuv/ets_cache/snapshot.ex
+++ b/lib/vutuv/ets_cache/snapshot.ex
@@ -1,0 +1,140 @@
+defmodule Vutuv.EtsCache.Snapshot do
+  @moduledoc """
+  The shell every *periodically rebuilt* ETS cache in this application shares: a
+  `Vutuv.EtsCache` whose owner recomputes the whole table on a timer.
+
+  `Vutuv.EtsCache` answers who owns the table and what a read does when it is
+  missing. That leaves a second question it deliberately does not answer — when
+  the contents are recomputed — and three caches were spelling out the same
+  answer by hand: `refresh/1`, an `init/1` that reads `refresh_every:` and fires
+  a `refresh?`-gated 0ms seed, `handle_call(:refresh, …)`,
+  `handle_info(:refresh, …)`, the `handle_info(_other, …)` catch-all,
+  `schedule/1` and `enabled?/0`. Only the config key and the body of
+  `snapshot/1` ever differed.
+
+      use Vutuv.EtsCache.Snapshot,
+        refresh_every: :timer.minutes(10),
+        refresh_flag: :refresh_popular_users
+
+  The module then implements the one callback, and nothing else:
+
+      @impl true
+      def snapshot(table) do
+        :ets.insert(table, {:pool, Vutuv.Social.compute_most_followed(@pool_size)})
+      end
+
+  `refresh_flag:` must be a **literal** atom — it is read at compile time, so a
+  module attribute does not work there. Naming it is mandatory rather than
+  defaulted because it is the switch that stops the timer under test, and a
+  cache that forgets it would query the Repo from a process owning no sandbox
+  connection.
+
+  ## Why a separate module and not another option on `use Vutuv.EtsCache`
+
+  Not because the others have no timer — **all** of this application's ETS
+  caches tick. The difference is what the tick does. A snapshot's contents are a
+  pure function of the database, so the whole table can be thrown away and
+  rebuilt, which is exactly what `snapshot/1` does. The rest *sweep*:
+  `Vutuv.RateLimiter` and `VutuvWeb.Live.MountHandoff` hold rows written by
+  other processes, and `Vutuv.SocialFeed.Cache` fills per entry on demand and
+  expires by TTL — for all three a wholesale rebuild would destroy the very
+  rows they exist to keep. They also must keep working under test, so they want
+  neither the `refresh_flag:` kill switch nor a synchronous `refresh/1`.
+
+  Folding "rebuild me every N" into the ownership `use` would hand those three
+  options they must decline, which is the mistake `Vutuv.EtsCache` avoided when
+  it kept `access:` and `created_by:` apart. A cache that owns a table takes
+  `Vutuv.EtsCache`; one that also rebuilds it wholesale on a clock takes this.
+
+  ## Why `:protected`, and why the seed is a message
+
+  A snapshot has exactly one writer — the owning GenServer, from `snapshot/1` —
+  so the table is always `access: :protected`. That is the shape, not a choice
+  left open: a value written from outside would be thrown away by the next
+  rebuild anyway.
+
+  The seed is a 0ms `Process.send_after/3` rather than an inline call in
+  `init/1`, because the recompute is the expensive scan the cache exists to
+  amortise and it must not block the supervisor at boot. Until it lands, reads
+  miss and every caller falls back to the direct query — exactly the pre-cache
+  behaviour, which is also what tests get: `refresh_flag:` names the
+  `config :vutuv, <flag>` that is `false` in `config/test.exs`, so the
+  application singleton never ticks under test and an isolated instance is
+  started with `refresh?: false` and driven by `refresh/1` by hand.
+
+  The `handle_info(_other, …)` catch-all is emitted after the using module's own
+  code, so a cache that needs to listen for something else (a PubSub event that
+  should re-rank early, say) can still add its own clauses.
+  """
+
+  @doc """
+  Recomputes the cache's contents into `table`. Called in the owning
+  GenServer, both for the boot seed and for every scheduled refresh; its return
+  value is ignored. Raising takes the cache process down with it, which is the
+  supervisor's problem to solve — the readers meanwhile miss and fall back.
+  """
+  @callback snapshot(:ets.table()) :: any()
+
+  defmacro __using__(opts) do
+    refresh_every = Keyword.fetch!(opts, :refresh_every)
+    refresh_flag = Keyword.fetch!(opts, :refresh_flag)
+
+    if not is_atom(refresh_flag) do
+      raise ArgumentError,
+            "refresh_flag: must be a literal atom, got: #{inspect(refresh_flag)}"
+    end
+
+    quote do
+      # A snapshot is written only by its owner, from snapshot/1.
+      use Vutuv.EtsCache, access: :protected
+
+      @behaviour unquote(__MODULE__)
+      @before_compile unquote(__MODULE__)
+
+      @doc "The ETS table the application-wide snapshot lives in."
+      def default_table, do: __MODULE__
+
+      @doc "Recompute the snapshot now (synchronous; used by tests)."
+      def refresh(server \\ __MODULE__), do: GenServer.call(server, :refresh)
+
+      @impl GenServer
+      def init(opts) do
+        table = open_table(Keyword.get(opts, :table, default_table()))
+        interval = Keyword.get(opts, :refresh_every, unquote(refresh_every))
+
+        # The seed is a 0ms refresh rather than an inline recompute: the scan
+        # must not block the supervisor at boot. Until it lands, readers miss
+        # and fall back to the direct query — exactly the pre-cache behaviour.
+        if Keyword.get(opts, :refresh?, enabled?()), do: schedule(0)
+
+        {:ok, %{table: table, interval: interval}}
+      end
+
+      @impl GenServer
+      def handle_call(:refresh, _from, state) do
+        snapshot(state.table)
+        {:reply, :ok, state}
+      end
+
+      @impl GenServer
+      def handle_info(:refresh, state) do
+        snapshot(state.table)
+        schedule(state.interval)
+        {:noreply, state}
+      end
+
+      defp schedule(interval), do: Process.send_after(self(), :refresh, interval)
+
+      defp enabled?, do: Application.get_env(:vutuv, unquote(refresh_flag), true)
+    end
+  end
+
+  @doc false
+  defmacro __before_compile__(_env) do
+    # Last, so a cache may define handle_info clauses of its own in between.
+    quote do
+      @impl GenServer
+      def handle_info(_other, state), do: {:noreply, state}
+    end
+  end
+end

--- a/lib/vutuv/posts/top_posters.ex
+++ b/lib/vutuv/posts/top_posters.ex
@@ -16,7 +16,10 @@ defmodule Vutuv.Posts.TopPosters do
   transparently falls back to the live query, so behaviour is unchanged, only
   cheaper. The per-viewer exclusions stay per-request in the profile.
   """
-  use GenServer
+
+  use Vutuv.EtsCache, access: :protected
+
+  alias Vutuv.EtsCache
 
   @table __MODULE__
   # The one posting window the profile asks for; any other window is a :miss.
@@ -40,32 +43,15 @@ defmodule Vutuv.Posts.TopPosters do
   def top(days, limit, _table) when days != @window_days or limit > @pool_size, do: :miss
 
   def top(_days, limit, table) do
-    case :ets.lookup(table, :pool) do
-      [{:pool, users}] -> {:ok, Enum.take(users, limit)}
-      [] -> :miss
-    end
-  rescue
-    ArgumentError -> :miss
+    with {:ok, users} <- EtsCache.fetch(table, :pool), do: {:ok, Enum.take(users, limit)}
   end
 
   @doc "Recompute the snapshot now (synchronous; used by tests)."
   def refresh(server \\ __MODULE__), do: GenServer.call(server, :refresh)
 
-  def start_link(opts \\ []) do
-    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
-    # `name: nil` (isolated test instances) starts the process unregistered.
-    gen_opts = if name, do: [name: name], else: []
-    GenServer.start_link(__MODULE__, opts, gen_opts)
-  end
-
   @impl true
   def init(opts) do
-    table =
-      :ets.new(Keyword.get(opts, :table, @table), [
-        :named_table,
-        :protected,
-        read_concurrency: true
-      ])
+    table = open_table(Keyword.get(opts, :table, @table))
 
     interval = Keyword.get(opts, :refresh_interval, @refresh_interval)
 

--- a/lib/vutuv/posts/top_posters.ex
+++ b/lib/vutuv/posts/top_posters.ex
@@ -17,15 +17,15 @@ defmodule Vutuv.Posts.TopPosters do
   cheaper. The per-viewer exclusions stay per-request in the profile.
   """
 
-  use Vutuv.EtsCache, access: :protected
+  use Vutuv.EtsCache.Snapshot,
+    refresh_every: :timer.minutes(10),
+    refresh_flag: :refresh_top_posters
 
   alias Vutuv.EtsCache
 
-  @table __MODULE__
   # The one posting window the profile asks for; any other window is a :miss.
   @window_days 28
   @pool_size 100
-  @refresh_interval :timer.minutes(10)
 
   @doc "The snapshot's posting window in days (the profile rail's window)."
   def window_days, do: @window_days
@@ -38,7 +38,7 @@ defmodule Vutuv.Posts.TopPosters do
   `:miss` when the snapshot cannot answer (a different window, not seeded
   yet, table absent, or `limit` beyond the pool).
   """
-  def top(days, limit, table \\ @table)
+  def top(days, limit, table \\ default_table())
 
   def top(days, limit, _table) when days != @window_days or limit > @pool_size, do: :miss
 
@@ -46,46 +46,11 @@ defmodule Vutuv.Posts.TopPosters do
     with {:ok, users} <- EtsCache.fetch(table, :pool), do: {:ok, Enum.take(users, limit)}
   end
 
-  @doc "Recompute the snapshot now (synchronous; used by tests)."
-  def refresh(server \\ __MODULE__), do: GenServer.call(server, :refresh)
-
   @impl true
-  def init(opts) do
-    table = open_table(Keyword.get(opts, :table, @table))
-
-    interval = Keyword.get(opts, :refresh_interval, @refresh_interval)
-
-    # The seed is a 0ms refresh rather than an inline query: the ranking scan
-    # must not block the supervisor at boot. Until it lands, readers miss and
-    # fall back to the direct query — exactly the pre-cache behaviour.
-    if Keyword.get(opts, :refresh?, enabled?()), do: schedule(0)
-
-    {:ok, %{table: table, interval: interval}}
-  end
-
-  @impl true
-  def handle_call(:refresh, _from, state) do
-    snapshot(state.table)
-    {:reply, :ok, state}
-  end
-
-  @impl true
-  def handle_info(:refresh, state) do
-    snapshot(state.table)
-    schedule(state.interval)
-    {:noreply, state}
-  end
-
-  def handle_info(_other, state), do: {:noreply, state}
-
-  defp snapshot(table) do
+  def snapshot(table) do
     :ets.insert(
       table,
       {:pool, Vutuv.Posts.compute_top_recent_posters(@window_days, @pool_size)}
     )
   end
-
-  defp schedule(interval), do: Process.send_after(self(), :refresh, interval)
-
-  defp enabled?, do: Application.get_env(:vutuv, :refresh_top_posters, true)
 end

--- a/lib/vutuv/rate_limiter.ex
+++ b/lib/vutuv/rate_limiter.ex
@@ -12,16 +12,15 @@ defmodule Vutuv.RateLimiter do
   enumeration mitigation the issue asks for; it is not a distributed quota.
   """
 
-  use GenServer
+  # Every request process counts its own hits, and whichever gets there first
+  # creates the table — including before (or without) this GenServer, which is
+  # what lets a unit test call `hit/3` with nothing supervised.
+  use Vutuv.EtsCache, access: :public, created_by: :any_process
 
   @table __MODULE__
   @sweep_interval :timer.minutes(5)
 
   # ── Public API ──
-
-  def start_link(opts) do
-    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
-  end
 
   @doc """
   Records one hit for `key` and returns `:ok` while at or under `limit` within
@@ -42,13 +41,13 @@ defmodule Vutuv.RateLimiter do
   """
   def hit_remaining(key, limit, window_ms)
       when is_integer(limit) and limit > 0 and is_integer(window_ms) and window_ms > 0 do
-    ensure_table()
+    table = open_table()
     now = System.system_time(:millisecond)
     window = div(now, window_ms)
     window_end = (window + 1) * window_ms
     bucket = {key, window}
 
-    count = :ets.update_counter(@table, bucket, {2, 1}, {bucket, 0, window_end})
+    count = :ets.update_counter(table, bucket, {2, 1}, {bucket, 0, window_end})
 
     if count <= limit, do: {:ok, limit - count}, else: {:error, :rate_limited}
   end
@@ -60,11 +59,11 @@ defmodule Vutuv.RateLimiter do
   member's cold-outreach counter — without moving the counter.
   """
   def peek(key, window_ms) when is_integer(window_ms) and window_ms > 0 do
-    ensure_table()
+    table = open_table()
     now = System.system_time(:millisecond)
     window = div(now, window_ms)
 
-    case :ets.lookup(@table, {key, window}) do
+    case :ets.lookup(table, {key, window}) do
       [{_bucket, count, _window_end}] -> count
       [] -> 0
     end
@@ -73,8 +72,7 @@ defmodule Vutuv.RateLimiter do
   @doc false
   # Test helper: forget every recorded hit.
   def reset do
-    ensure_table()
-    :ets.delete_all_objects(@table)
+    :ets.delete_all_objects(open_table())
     :ok
   end
 
@@ -82,7 +80,7 @@ defmodule Vutuv.RateLimiter do
 
   @impl true
   def init(_opts) do
-    ensure_table()
+    open_table()
     schedule_sweep()
     {:ok, %{}}
   end
@@ -95,27 +93,6 @@ defmodule Vutuv.RateLimiter do
   end
 
   # ── Internals ──
-
-  defp ensure_table do
-    case :ets.whereis(@table) do
-      :undefined ->
-        try do
-          :ets.new(@table, [
-            :named_table,
-            :public,
-            :set,
-            read_concurrency: true,
-            write_concurrency: true
-          ])
-        rescue
-          # Lost a race with another process creating the table; that is fine.
-          ArgumentError -> @table
-        end
-
-      _tid ->
-        @table
-    end
-  end
 
   defp sweep do
     now = System.system_time(:millisecond)

--- a/lib/vutuv/social/popular_users.ex
+++ b/lib/vutuv/social/popular_users.ex
@@ -18,7 +18,10 @@ defmodule Vutuv.Social.PopularUsers do
   and `Social.most_followed_users/1` transparently falls back to the query,
   so behaviour is unchanged, only cheaper.
   """
-  use GenServer
+
+  use Vutuv.EtsCache, access: :protected
+
+  alias Vutuv.EtsCache
 
   @table __MODULE__
   @pool_size 1000
@@ -36,32 +39,15 @@ defmodule Vutuv.Social.PopularUsers do
   def top(limit, _table) when limit > @pool_size, do: :miss
 
   def top(limit, table) do
-    case :ets.lookup(table, :pool) do
-      [{:pool, users}] -> {:ok, Enum.take(users, limit)}
-      [] -> :miss
-    end
-  rescue
-    ArgumentError -> :miss
+    with {:ok, users} <- EtsCache.fetch(table, :pool), do: {:ok, Enum.take(users, limit)}
   end
 
   @doc "Recompute the snapshot now (synchronous; used by tests)."
   def refresh(server \\ __MODULE__), do: GenServer.call(server, :refresh)
 
-  def start_link(opts \\ []) do
-    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
-    # `name: nil` (isolated test instances) starts the process unregistered.
-    gen_opts = if name, do: [name: name], else: []
-    GenServer.start_link(__MODULE__, opts, gen_opts)
-  end
-
   @impl true
   def init(opts) do
-    table =
-      :ets.new(Keyword.get(opts, :table, @table), [
-        :named_table,
-        :protected,
-        read_concurrency: true
-      ])
+    table = open_table(Keyword.get(opts, :table, @table))
 
     interval = Keyword.get(opts, :refresh_interval, @refresh_interval)
 

--- a/lib/vutuv/social/popular_users.ex
+++ b/lib/vutuv/social/popular_users.ex
@@ -19,13 +19,13 @@ defmodule Vutuv.Social.PopularUsers do
   so behaviour is unchanged, only cheaper.
   """
 
-  use Vutuv.EtsCache, access: :protected
+  use Vutuv.EtsCache.Snapshot,
+    refresh_every: :timer.minutes(10),
+    refresh_flag: :refresh_popular_users
 
   alias Vutuv.EtsCache
 
-  @table __MODULE__
   @pool_size 1000
-  @refresh_interval :timer.minutes(10)
 
   @doc "How many members the snapshot ranks (the largest servable limit)."
   def pool_size, do: @pool_size
@@ -34,7 +34,7 @@ defmodule Vutuv.Social.PopularUsers do
   The cached top `limit` as `{:ok, users}`, or `:miss` when the snapshot
   cannot answer (not seeded yet, table absent, or `limit` beyond the pool).
   """
-  def top(limit, table \\ @table)
+  def top(limit, table \\ default_table())
 
   def top(limit, _table) when limit > @pool_size, do: :miss
 
@@ -42,43 +42,8 @@ defmodule Vutuv.Social.PopularUsers do
     with {:ok, users} <- EtsCache.fetch(table, :pool), do: {:ok, Enum.take(users, limit)}
   end
 
-  @doc "Recompute the snapshot now (synchronous; used by tests)."
-  def refresh(server \\ __MODULE__), do: GenServer.call(server, :refresh)
-
   @impl true
-  def init(opts) do
-    table = open_table(Keyword.get(opts, :table, @table))
-
-    interval = Keyword.get(opts, :refresh_interval, @refresh_interval)
-
-    # The seed is a 0ms refresh rather than an inline query: the ranking scan
-    # must not block the supervisor at boot. Until it lands, readers miss and
-    # fall back to the direct query — exactly the pre-cache behaviour.
-    if Keyword.get(opts, :refresh?, enabled?()), do: schedule(0)
-
-    {:ok, %{table: table, interval: interval}}
-  end
-
-  @impl true
-  def handle_call(:refresh, _from, state) do
-    snapshot(state.table)
-    {:reply, :ok, state}
-  end
-
-  @impl true
-  def handle_info(:refresh, state) do
-    snapshot(state.table)
-    schedule(state.interval)
-    {:noreply, state}
-  end
-
-  def handle_info(_other, state), do: {:noreply, state}
-
-  defp snapshot(table) do
+  def snapshot(table) do
     :ets.insert(table, {:pool, Vutuv.Social.compute_most_followed(@pool_size)})
   end
-
-  defp schedule(interval), do: Process.send_after(self(), :refresh, interval)
-
-  defp enabled?, do: Application.get_env(:vutuv, :refresh_popular_users, true)
 end

--- a/lib/vutuv/social_feed/cache.ex
+++ b/lib/vutuv/social_feed/cache.ex
@@ -23,10 +23,12 @@ defmodule Vutuv.SocialFeed.Cache do
   does no work until a page requests a fetch, and the per-provider feature
   flags gate that in tests).
   """
-  use GenServer
+
+  use Vutuv.EtsCache, access: :protected
 
   require Logger
 
+  alias Vutuv.EtsCache
   alias Vutuv.SocialFeed
   alias Vutuv.SocialFeed.Feed
 
@@ -43,15 +45,13 @@ defmodule Vutuv.SocialFeed.Cache do
   yet). A caller-side ETS read; expired rows are left for the sweep.
   """
   def lookup({_provider, _handle} = key, table \\ @table) do
-    case :ets.lookup(table, key) do
+    case EtsCache.lookup(table, key) do
       [{^key, result, expires_at}] ->
         if System.monotonic_time(:millisecond) < expires_at, do: result, else: :miss
 
       [] ->
         :miss
     end
-  rescue
-    ArgumentError -> :miss
   end
 
   @doc """
@@ -66,21 +66,9 @@ defmodule Vutuv.SocialFeed.Cache do
   @doc "Drops every cached entry (tests)."
   def reset(server \\ __MODULE__), do: GenServer.call(server, :reset)
 
-  def start_link(opts \\ []) do
-    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
-    # `name: nil` (isolated test instances) starts the process unregistered.
-    gen_opts = if name, do: [name: name], else: []
-    GenServer.start_link(__MODULE__, opts, gen_opts)
-  end
-
   @impl true
   def init(opts) do
-    table =
-      :ets.new(Keyword.get(opts, :table, @table), [
-        :named_table,
-        :protected,
-        read_concurrency: true
-      ])
+    table = open_table(Keyword.get(opts, :table, @table))
 
     state = %{
       table: table,

--- a/lib/vutuv_web/live/mount_handoff.ex
+++ b/lib/vutuv_web/live/mount_handoff.ex
@@ -37,7 +37,10 @@ defmodule VutuvWeb.Live.MountHandoff do
   load per visit.
   """
 
-  use GenServer
+  # Public because the dead render stashes from the request process; the table
+  # is still this GenServer's to create, so a second owner raises rather than
+  # sharing (`stash/4` and `take/2` rescue instead of creating).
+  use Vutuv.EtsCache, access: :public
 
   @table __MODULE__
   @ttl_ms 15_000
@@ -87,20 +90,9 @@ defmodule VutuvWeb.Live.MountHandoff do
 
   ## Table owner + sweeper
 
-  def start_link(_opts) do
-    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
-  end
-
   @impl true
-  def init(nil) do
-    :ets.new(@table, [
-      :named_table,
-      :public,
-      :set,
-      read_concurrency: true,
-      write_concurrency: true
-    ])
-
+  def init(_opts) do
+    open_table()
     schedule_sweep()
     {:ok, nil}
   end

--- a/test/vutuv/ets_cache/snapshot_test.exs
+++ b/test/vutuv/ets_cache/snapshot_test.exs
@@ -1,0 +1,184 @@
+defmodule Vutuv.EtsCache.SnapshotTest.Counted do
+  @moduledoc false
+  use Vutuv.EtsCache.Snapshot,
+    refresh_every: :timer.minutes(10),
+    refresh_flag: :refresh_ets_cache_snapshot_test
+
+  alias Vutuv.EtsCache
+
+  @doc "How often `snapshot/1` has run against `table`, or `:miss` when never."
+  def runs(table), do: EtsCache.fetch(table, :runs)
+
+  @impl true
+  def snapshot(table) do
+    runs =
+      case EtsCache.fetch(table, :runs) do
+        {:ok, n} -> n
+        :miss -> 0
+      end
+
+    :ets.insert(table, {:runs, runs + 1})
+  end
+end
+
+defmodule Vutuv.EtsCache.SnapshotTest.Listening do
+  @moduledoc false
+  use Vutuv.EtsCache.Snapshot,
+    refresh_every: :timer.minutes(10),
+    refresh_flag: :refresh_ets_cache_snapshot_listening_test
+
+  @impl true
+  def snapshot(table), do: :ets.insert(table, {:runs, :snapshotted})
+
+  # The clause the catch-all used to make impossible.
+  @impl GenServer
+  def handle_info(:heard_it, state) do
+    :ets.insert(state.table, {:heard, true})
+    {:noreply, state}
+  end
+end
+
+defmodule Vutuv.EtsCache.SnapshotTest do
+  use ExUnit.Case, async: true
+
+  alias Vutuv.EtsCache.SnapshotTest.Counted
+  alias Vutuv.EtsCache.SnapshotTest.Listening
+
+  @flag :refresh_ets_cache_snapshot_test
+
+  defp unique_table(prefix), do: :"snapshot_#{prefix}_#{System.unique_integer([:positive])}"
+
+  # Polls until `fun` holds. The caches answer within milliseconds, so this only
+  # ever spins on a real failure — and `refute eventually(…)` states "this never
+  # happened" as a bounded window rather than a mailbox-ordering argument.
+  defp eventually(fun, tries \\ 100)
+  defp eventually(_fun, 0), do: false
+
+  defp eventually(fun, tries) do
+    if fun.() do
+      true
+    else
+      Process.sleep(10)
+      eventually(fun, tries - 1)
+    end
+  end
+
+  defp with_flag(value) do
+    previous = Application.fetch_env(:vutuv, @flag)
+    Application.put_env(:vutuv, @flag, value)
+
+    on_exit(fn ->
+      case previous do
+        {:ok, was} -> Application.put_env(:vutuv, @flag, was)
+        :error -> Application.delete_env(:vutuv, @flag)
+      end
+    end)
+  end
+
+  describe "the boot seed" do
+    test "fires once at 0ms, so a reader is warm without waiting for the interval" do
+      table = unique_table("seeded")
+      start_supervised!({Counted, name: nil, table: table, refresh?: true})
+
+      assert eventually(fn -> Counted.runs(table) == {:ok, 1} end)
+    end
+
+    test "`refresh?: false` starts cold, which is what every test wants" do
+      table = unique_table("cold")
+      start_supervised!({Counted, name: nil, table: table, refresh?: false})
+
+      refute eventually(fn -> Counted.runs(table) != :miss end, 50)
+    end
+
+    test "the refresh_flag turns it off without touching the call site" do
+      with_flag(false)
+      table = unique_table("flagged_off")
+      start_supervised!({Counted, name: nil, table: table})
+
+      refute eventually(fn -> Counted.runs(table) != :miss end, 50)
+    end
+
+    test "an explicit `refresh?:` beats the flag" do
+      with_flag(false)
+      table = unique_table("opt_wins")
+      start_supervised!({Counted, name: nil, table: table, refresh?: true})
+
+      assert eventually(fn -> Counted.runs(table) == {:ok, 1} end)
+    end
+  end
+
+  describe "refresh/1" do
+    test "recomputes synchronously, so a test needs no sleep" do
+      table = unique_table("manual")
+      pid = start_supervised!({Counted, name: nil, table: table, refresh?: false})
+
+      assert :ok = Counted.refresh(pid)
+      assert Counted.runs(table) == {:ok, 1}
+      assert :ok = Counted.refresh(pid)
+      assert Counted.runs(table) == {:ok, 2}
+    end
+  end
+
+  describe "the scheduled refresh" do
+    test "schedules the next one, so the cache keeps ticking" do
+      table = unique_table("ticking")
+
+      start_supervised!({Counted, name: nil, table: table, refresh?: true, refresh_every: 5})
+
+      assert eventually(fn ->
+               match?({:ok, n} when n >= 3, Counted.runs(table))
+             end)
+    end
+  end
+
+  describe "the catch-all" do
+    test "a stray message neither crashes the cache nor refreshes it" do
+      table = unique_table("stray")
+      pid = start_supervised!({Counted, name: nil, table: table, refresh?: false})
+
+      send(pid, :something_else)
+      send(pid, {:tagged, :tuple})
+
+      _ = :sys.get_state(pid)
+      assert Process.alive?(pid)
+      assert Counted.runs(table) == :miss
+    end
+  end
+
+  describe "a cache may add handle_info clauses of its own" do
+    test "its clause runs, and unknown messages still fall through the catch-all" do
+      table = unique_table("listening")
+      pid = start_supervised!({Listening, name: nil, table: table, refresh?: false})
+
+      send(pid, :heard_it)
+      send(pid, :never_heard_of_it)
+      _ = :sys.get_state(pid)
+
+      assert Process.alive?(pid)
+      assert Vutuv.EtsCache.fetch(table, :heard) == {:ok, true}
+    end
+  end
+
+  describe "default_table/0" do
+    test "is the module's own name" do
+      assert Counted.default_table() == Counted
+    end
+  end
+
+  describe "the use options are checked at compile time" do
+    test "a refresh_flag that is not an atom is refused" do
+      assert_raise ArgumentError, ~r/refresh_flag: must be a literal atom/, fn ->
+        Code.eval_string("""
+        defmodule Vutuv.EtsCache.SnapshotTest.BadFlag do
+          use Vutuv.EtsCache.Snapshot,
+            refresh_every: 1_000,
+            refresh_flag: "refresh_me"
+
+          @impl true
+          def snapshot(_table), do: :ok
+        end
+        """)
+      end
+    end
+  end
+end

--- a/test/vutuv/ets_cache_test.exs
+++ b/test/vutuv/ets_cache_test.exs
@@ -1,0 +1,151 @@
+defmodule Vutuv.EtsCacheTest.Snapshot do
+  @moduledoc false
+  use Vutuv.EtsCache, access: :protected
+
+  alias Vutuv.EtsCache
+
+  @table __MODULE__
+
+  def top(table \\ @table), do: EtsCache.fetch(table, :pool)
+
+  def put(server, value), do: GenServer.call(server, {:put, value})
+
+  @impl true
+  def init(opts), do: {:ok, %{table: open_table(Keyword.get(opts, :table, @table))}}
+
+  @impl true
+  def handle_call({:put, value}, _from, state) do
+    :ets.insert(state.table, {:pool, value})
+    {:reply, :ok, state}
+  end
+end
+
+defmodule Vutuv.EtsCacheTest.Counter do
+  @moduledoc false
+  use Vutuv.EtsCache, access: :public, created_by: :any_process
+
+  @doc "The reader-side lazy create a `created_by: :any_process` cache leans on."
+  def ensure(name \\ __MODULE__), do: open_table(name)
+
+  # Nothing starts this one; the stub only satisfies the GenServer behaviour.
+  @impl true
+  def init(_opts), do: {:ok, %{}}
+end
+
+defmodule Vutuv.EtsCacheTest do
+  use ExUnit.Case, async: true
+
+  alias Vutuv.EtsCache
+  alias Vutuv.EtsCacheTest.Counter
+  alias Vutuv.EtsCacheTest.Snapshot
+
+  defp unique_table(prefix), do: :"#{prefix}_#{System.unique_integer([:positive])}"
+
+  describe "reads without a table" do
+    test "fetch/2 answers :miss instead of raising" do
+      assert EtsCache.fetch(:vutuv_ets_cache_test_no_such_table, :pool) == :miss
+    end
+
+    test "lookup/2 answers [] instead of raising" do
+      assert EtsCache.lookup(:vutuv_ets_cache_test_no_such_table, :pool) == []
+    end
+  end
+
+  describe "reads with a table" do
+    setup do
+      table = :ets.new(unique_table("rows"), [:set])
+      :ets.insert(table, {:pool, [1, 2, 3]})
+      :ets.insert(table, {:stamped, :value, 42})
+      %{table: table}
+    end
+
+    test "fetch/2 unwraps a {key, value} row", %{table: table} do
+      assert EtsCache.fetch(table, :pool) == {:ok, [1, 2, 3]}
+    end
+
+    test "fetch/2 answers :miss for a key the table does not hold", %{table: table} do
+      assert EtsCache.fetch(table, :absent) == :miss
+    end
+
+    test "lookup/2 hands a wider row back whole", %{table: table} do
+      assert EtsCache.lookup(table, :stamped) == [{:stamped, :value, 42}]
+    end
+  end
+
+  describe "the table an access level opens" do
+    test "a public table carries both concurrency hints, a protected one only the read hint" do
+      public = EtsCache.open(unique_table("hints_public"), :public)
+      protected = EtsCache.open(unique_table("hints_protected"), :protected)
+
+      assert :ets.info(public, :write_concurrency) == true
+      assert :ets.info(protected, :write_concurrency) == false
+      assert :ets.info(public, :protection) == :public
+      assert :ets.info(protected, :protection) == :protected
+    end
+  end
+
+  describe "the generated start_link/1" do
+    test "registers the module's own name by default" do
+      {:ok, pid} = start_supervised({Snapshot, table: unique_table("registered")})
+
+      assert Process.whereis(Snapshot) == pid
+    end
+
+    test "`name: nil` starts an unregistered instance" do
+      start_supervised!({Snapshot, name: nil, table: unique_table("isolated")})
+
+      assert Process.whereis(Snapshot) == nil
+    end
+
+    test "the table `init/1` opens is the one it was handed" do
+      table = unique_table("injected")
+      pid = start_supervised!({Snapshot, name: nil, table: table})
+
+      assert :ok = Snapshot.put(pid, [:one])
+      assert Snapshot.top(table) == {:ok, [:one]}
+      # The module-named table was never created, so its reader still misses.
+      assert Snapshot.top() == :miss
+    end
+  end
+
+  describe "created_by:" do
+    test "the default owner refuses a second owner of the same table" do
+      table = unique_table("owner")
+      start_supervised!({Snapshot, name: nil, table: table})
+
+      Process.flag(:trap_exit, true)
+      # `:ets.new/2` refuses the taken name; Elixir spells that badarg
+      # `ArgumentError` where it is rescued, but an exit reason carries it raw.
+      assert {:error, {:badarg, _stack}} = Snapshot.start_link(name: nil, table: table)
+    end
+
+    test ":any_process opens the table from whoever asks first" do
+      table = unique_table("any_process")
+
+      assert Counter.ensure(table) == table
+      assert Counter.ensure(table) == table
+    end
+  end
+
+  describe "the use options are checked at compile time" do
+    test "an unknown access is refused" do
+      assert_raise ArgumentError, ~r/must be :public or :protected/, fn ->
+        Code.eval_string("""
+        defmodule Vutuv.EtsCacheTest.BadAccess do
+          use Vutuv.EtsCache, access: :secret
+        end
+        """)
+      end
+    end
+
+    test "a protected table may not be created by any process" do
+      assert_raise ArgumentError, ~r/needs access: :public/, fn ->
+        Code.eval_string("""
+        defmodule Vutuv.EtsCacheTest.BadPolicy do
+          use Vutuv.EtsCache, access: :protected, created_by: :any_process
+        end
+        """)
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Symptom:** `Vutuv.Social.PopularUsers` and `Vutuv.Posts.TopPosters` each spell out the same refresh shell — `refresh/1`, a `refresh?`-gated 0ms seed in `init/1`, both `:refresh` handlers, the catch-all, `schedule/1` and `enabled?/0`. Some 30 lines apiece, differing only in a config key and the body of `snapshot/1`.

**Change:** `Vutuv.EtsCache.Snapshot` owns that loop, declaring `@callback snapshot(table)` and taking `refresh_every:` / `refresh_flag:`. Each cache keeps its read path and the callback. A second `use` on top of `Vutuv.EtsCache`, not another option on it: owning a table and rebuilding it wholesale on a clock are separate decisions, and `RateLimiter`, `MountHandoff` and `SocialFeed.Cache` sweep rather than rebuild.

**Not included:** `Posts.PopularPosts` was the third such cache until #1793 removed it; that deletion is taken over here.

**Verified:** compile with `--warnings-as-errors`, `mix format --check-formatted`, ETS suites green. Every test calibrated against the broken code — dropping the seed, the reschedule, or moving the catch-all back into `__using__` each turns a specific test red.

**Merge order:** #1757 → this → #1772; reasoning in the pinned comment.

Closes #1763.

*An AI agent wrote this text in my name. I know that is problematic.*
